### PR TITLE
Lastgenre plugin whitelist

### DIFF
--- a/beetsplug/lastgenre.py
+++ b/beetsplug/lastgenre.py
@@ -65,7 +65,9 @@ class LastGenrePlugin(plugins.BeetsPlugin):
     def configure(self, config):
         genres_whitelist = ui.config_val(config, 'lastgenre',
                                          'genres_whitelist', None)
-        options['genres_whitelist'] = genres_whitelist.lower().split(',')
+        if genres_whitelist :
+            genres_whitelist = genres_whitelist.lower().split(',')
+        options['genres_whitelist'] = genres_whitelist
         
 @LastGenrePlugin.listen('album_imported')
 def album_imported(lib, album):


### PR DESCRIPTION
After reading http://beets.readthedocs.org/en/latest/plugins/lastgenre.html I decided to try to implement the genres whitelist.
I opted for a list entered by user in the config file. Because genre name can contain spaces, genres must be separated by **comma**. That's not homogeneous with the plugins names option of the _[beets]_ section where separator is space, do you see a better solution ?

```
[lastgenre]
genres_whitelist: blues,acid jazz,afro-beat,afro-cuban jazz
```
