### PR TITLE
Fix the "list <tag>" command in BPD

### DIFF
--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -998,7 +998,7 @@ class Server(BaseServer):
         c.execute(statement, subvals)
         
         for row in c:
-            conn.send(show_tag_canon + u': ' + unicode(row[0]))
+            yield show_tag_canon + u': ' + unicode(row[0])
     
     def cmd_count(self, conn, tag, value):
         """Returns the number and total time of songs matching the


### PR DESCRIPTION
The cmd_list method wasn't a generator as run() expected, but instead
loaded directly the data onto the connection without actually sending it.
Fixed by yielding the data instead of using conn.send()

This command is notably used by the NCMPCPP client in its library explorer.
