### PR TITLE
Fixes a warning coming up when you "pip install beets":

### DIFF
--- a/beetsplug/__init__.py
+++ b/beetsplug/__init__.py
@@ -15,5 +15,4 @@
 """A namespace package for beets plugins."""
 
 # Make this a namespace package.
-from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)
+__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
WARNING: beetsplug is a namespace package, but its **init**.py does
    not declare_namespace(); setuptools 0.7 will REQUIRE this!
    (See the setuptools manual under "Namespace Packages" for details.)

See also: PEP-382
