### PR TITLE
Supporting ANSI escape codes on Windows

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -32,6 +32,9 @@ from beets import library
 from beets import plugins
 from beets import util
 
+import colorama
+colorama.init()
+
 # Constants.
 CONFIG_PATH_VAR = 'BEETSCONFIG'
 DEFAULT_CONFIG_FILENAME_UNIX = '.beetsconfig'


### PR DESCRIPTION
By default Windows does not support ANSI escape sequences. Other solutions, such as ANSICON are not reliable. Adding colorama [http://pypi.python.org/pypi/colorama] as a dependency resolves this problem and doesn't require any major fiddling.

I hope this is a suitable solution? :)
