### PR TITLE
importfeeds plugin: use os.path.expanduser

### DIFF
--- a/beetsplug/importfeeds.py
+++ b/beetsplug/importfeeds.py
@@ -34,7 +34,10 @@ class ImportFeedsPlugin(BeetsPlugin):
 
         _feeds_formats = ui.config_val(config, 'importfeeds', 'feeds_formats',
                                        '').split()
+
         _feeds_dir = ui.config_val(config, 'importfeeds', 'feeds_dir', None)
+        _feeds_dir = os.path.expanduser(_feeds_dir)
+
         _m3u_name = ui.config_val(config, 'importfeeds', 'm3u_name', 
                                  M3U_DEFAULT_NAME)
         


### PR DESCRIPTION
Use os.path.expanduser on the feeds_dir setting so that you can use the `~` character instead of writing the full path of your home directory
