### PR TITLE
fix mpdupdate plugin

### DIFF
--- a/beetsplug/mpdupdate.py
+++ b/beetsplug/mpdupdate.py
@@ -103,5 +103,5 @@ class MPDUpdatePlugin(BeetsPlugin):
             ui.config_val(config, 'mpdupdate', 'password', '')
 
 @MPDUpdatePlugin.listen('import')
-def update(lib=None):
+def update(lib=None, paths=None):
     update_mpd(options['host'], options['port'], options['password'])


### PR DESCRIPTION
The mpdupdate plugin broke with the latest release because the `update` function (which listen to the `import` event) didn't have the `path` argument.

see also: https://groups.google.com/forum/?fromgroups#!topic/beets-users/WEz6DyHXhmo
