### PR TITLE
Fixed an issue with a readline from socket in bpd

### DIFF
--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -587,6 +587,8 @@ class Connection(object):
             if not line:
                 break
             line = line.strip()
+            if not line:
+                break
             log.debug(line)
                
             if clist is not None:


### PR DESCRIPTION
in several situations I got a crash due to having the strip() called on a None object. This simple change should solve that.

Regards,
Matteo
