### PR TITLE
Add missing parenthesis in docs

### DIFF
--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -213,7 +213,7 @@ stats
     beet stats [QUERY]
 
 Show some statistics on your entire library (if you don't provide a
-:doc:`query <query>` or the matched items (if you do).
+:doc:`query <query>`) or the matched items (if you do).
 
 fields
 ``````


### PR DESCRIPTION
Hi! Thanks for beets! Here's a little doc fix for you.
