### PR TITLE
Unicode accent replacing

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -245,7 +245,7 @@ class ImportConfig(object):
                'quiet_fallback', 'copy', 'move', 'write', 'delete',
                'choose_match_func', 'should_resume_func', 'threaded',
                'autot', 'singletons', 'timid', 'choose_item_func',
-               'query', 'incremental', 'ignore',
+               'query', 'incremental', 'unicrep', 'ignore',
                'resolve_duplicate_func', 'per_disc_numbering']
     def __init__(self, **kwargs):
         for slot in self._fields:
@@ -744,7 +744,7 @@ def manipulate_files(config):
             if config.move:
                 # Just move the file.
                 old_path = item.path
-                config.lib.move(item, False)
+                config.lib.move(item, False, unicrep=config.unicrep)
                 task.prune(old_path)
             elif config.copy:
                 # If it's a reimport, move in-library files and copy
@@ -755,16 +755,16 @@ def manipulate_files(config):
                     # This is a reimport. Move in-library files and copy
                     # out-of-library files.
                     if config.lib.directory in util.ancestry(old_path):
-                        config.lib.move(item, False)
+                        config.lib.move(item, False, unicrep=config.unicrep)
                         # We moved the item, so remove the
                         # now-nonexistent file from old_paths.
                         task.old_paths.remove(old_path)
                     else:
-                        config.lib.move(item, True)
+                        config.lib.move(item, True, unicrep=config.unicrep)
                 else:
                     # A normal import. Just copy files and keep track of
                     # old paths.
-                    config.lib.move(item, True)
+                    config.lib.move(item, True, unicrep=config.unicrep)
 
             if config.write and task.should_write_tags():
                 item.write()

--- a/beets/library.py
+++ b/beets/library.py
@@ -1080,7 +1080,7 @@ class Library(BaseLibrary):
         return Transaction(self)
 
     def destination(self, item, pathmod=None, fragment=False,
-                    basedir=None, platform=None):
+                    basedir=None, platform=None, unicrep=False):
         """Returns the path in the library directory designated for item
         item (i.e., where the file ought to be). fragment makes this
         method return just the path fragment underneath the root library
@@ -1115,6 +1115,13 @@ class Library(BaseLibrary):
 
         # Evaluate the selected template.
         subpath = item.evaluate_template(subpath_tmpl, self, True, pathmod)
+
+        # Replace Unicode characters into its ASCII equivalents
+        if unicrep:
+            nkfd_form = unicodedata.normalize('NFKD', subpath)
+            removed_accents= u"".join([c for c in nkfd_form if not unicodedata.combining(c)])
+            only_ascii = removed_accents.encode('ASCII', 'ignore')
+            subpath= unicode( only_ascii )
 
         # Prepare path for output: normalize Unicode characters.
         if platform == 'darwin':
@@ -1234,7 +1241,7 @@ class Library(BaseLibrary):
         self._memotable = {}
 
     def move(self, item, copy=False, basedir=None,
-             with_album=True):
+             with_album=True, unicrep=False):
         """Move the item to its designated location within the library
         directory (provided by destination()). Subdirectories are
         created as needed. If the operation succeeds, the item's path
@@ -1254,7 +1261,7 @@ class Library(BaseLibrary):
         side effect. You probably want to call save() to commit the DB
         transaction.
         """
-        dest = self.destination(item, basedir=basedir)
+        dest = self.destination(item, basedir=basedir, unicrep=unicrep)
 
         # Create necessary ancestry for the move.
         util.mkdirall(dest)

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -109,6 +109,7 @@ DEFAULT_IMPORT_QUIET          = False
 DEFAULT_IMPORT_QUIET_FALLBACK = 'skip'
 DEFAULT_IMPORT_RESUME         = None # "ask"
 DEFAULT_IMPORT_INCREMENTAL    = False
+DEFAULT_IMPORT_UNICREP        = False
 DEFAULT_THREADED              = True
 DEFAULT_COLOR                 = True
 DEFAULT_IGNORE                = [
@@ -626,7 +627,8 @@ def resolve_duplicate(task, config):
 
 def import_files(lib, paths, copy, move, write, autot, logpath, threaded,
                  color, delete, quiet, resume, quiet_fallback, singletons,
-                 timid, query, incremental, ignore, per_disc_numbering):
+                 timid, query, incremental, unicrep, ignore,
+                 per_disc_numbering):
     """Import the files in the given list of paths, tagging each leaf
     directory as an album. If copy, then the files are copied into the
     library folder. If write, then new metadata is written to the files
@@ -692,6 +694,7 @@ def import_files(lib, paths, copy, move, write, autot, logpath, threaded,
             choose_item_func = choose_item,
             query = query,
             incremental = incremental,
+            unicrep = unicrep,
             ignore = ignore,
             resolve_duplicate_func = resolve_duplicate,
             per_disc_numbering = per_disc_numbering,
@@ -739,6 +742,9 @@ import_cmd.parser.add_option('-i', '--incremental', dest='incremental',
     action='store_true', help='skip already-imported directories')
 import_cmd.parser.add_option('-I', '--noincremental', dest='incremental',
     action='store_false', help='do not skip already-imported directories')
+import_cmd.parser.add_option('-u', '--unicrep', dest='unicrep',
+    action='store_true',
+    help="replace unicode paths by its ASCII equivalents")
 def import_func(lib, config, opts, args):
     copy  = opts.copy  if opts.copy  is not None else \
         ui.config_val(config, 'beets', 'import_copy',
@@ -766,6 +772,9 @@ def import_func(lib, config, opts, args):
     incremental = opts.incremental if opts.incremental is not None else \
         ui.config_val(config, 'beets', 'import_incremental',
             DEFAULT_IMPORT_INCREMENTAL, bool)
+    unicrep = opts.unicrep if opts.unicrep is not None else \
+        ui.config_val(config, 'beets', 'unicode_replace',
+            DEFAULT_IMPORT_UNICREP, bool)
     ignore = ui.config_val(config, 'beets', 'ignore', DEFAULT_IGNORE, list)
     per_disc_numbering = ui.config_val(config, 'beets', 'per_disc_numbering',
                                        DEFAULT_PER_DISC_NUMBERING, bool)
@@ -800,7 +809,7 @@ def import_func(lib, config, opts, args):
 
     import_files(lib, paths, copy, move, write, autot, logpath, threaded,
                  color, delete, quiet, resume, quiet_fallback, singletons,
-                 timid, query, incremental, ignore, per_disc_numbering)
+                 timid, query, incremental, unicrep, ignore, per_disc_numbering)
 import_cmd.func = import_func
 default_commands.append(import_cmd)
 

--- a/test/_common.py
+++ b/test/_common.py
@@ -94,6 +94,7 @@ def iconfig(lib, **kwargs):
         timid = False,
         query = None,
         incremental = False,
+        unicrep = False,
         ignore = [],
         resolve_duplicate_func = lambda x, y: None,
         per_disc_numbering = False,

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -104,6 +104,7 @@ class NonAutotaggedImportTest(unittest.TestCase):
             timid = False,
             query = None,
             incremental = False,
+            unicrep = False,
             ignore = [],
             resolve_duplicate_func = None,
             per_disc_numbering = False,

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -480,7 +480,7 @@ class ImportTest(unittest.TestCase):
         self.assertRaises(ui.UserError, commands.import_files,
                           None, [], False, False, False, False, None,
                           False, False, False, True, False, None, False, True,
-                          None, False, [], False)
+                          None, False, False, [], False)
 
 class InputTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Adds an --unicode_replace/-u option to the  import option parser and config file, so that (when set, defaults to False) imported paths are saved in plain ASCII, with accents properly removed. This could be useful for the people who don't want "strange" filenames,  and for legacy software without unicode support.

AFAIK, this can't easily be done with the "replace" regexes.

All tests (that passed before) pass.
I tried my best to write this cleanly, but I'm very new to beets (usage and codebase), so let me know if there's anything at all I should change.
