### PR TITLE
Handle unicode in replacement config

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -460,7 +460,8 @@ def _get_replacements(config):
     repl_string = config_val(config, 'beets', 'replace', None)
     if not repl_string:
         return
-    repl_string = repl_string.decode('utf8')
+    if not isinstance(repl_string, unicode):
+        repl_string = repl_string.decode('utf8')
 
     parts = repl_string.strip().split()
     if not parts:

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -547,6 +547,14 @@ class ConfigTest(unittest.TestCase):
             [beets]
             replace=[xy] z"""), func)
 
+    def test_replacements_parsed_unicode(self):
+        def func(lib, config, opts, args):
+            replacements = lib.replacements
+            self.assertEqual(replacements, [(re.compile(ur'\u2019'), u'z')])
+        self._run_main([], textwrap.dedent(u"""
+            [beets]
+            replace=\u2019 z"""), func)
+
     def test_empty_replacements_produce_none(self):
         def func(lib, config, opts, args):
             replacements = lib.replacements


### PR DESCRIPTION
The 'decode' call fails in what is already a unicode string. I'm not sure
under what circumstances the string is or isn't unicode (apparently it
varies), so I added a check. The test passes with the patch, at least.
