### PR TITLE
readme: fix readthedocs.org links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,11 +31,11 @@ imagine for your music collection. Via `plugins`_, beets becomes a panacea:
 If beets doesn't do what you want yet, `writing your own plugin`_ is
 shockingly simple if you know a little Python.
 
-.. _plugins: http://readthedocs.org/docs/beets/-/plugins/
+.. _plugins: http://beets.readthedocs.org/en/latest/plugins/
 .. _MPD: http://mpd.wikia.com/
 .. _MusicBrainz music collection: http://musicbrainz.org/show/collection/
 .. _writing your own plugin:
-    http://readthedocs.org/docs/beets/-/plugins/#writing-plugins
+    http://beets.readthedocs.org/en/latest/plugins/#writing-plugins
 .. _HTML5 Audio:
     http://www.w3.org/TR/html-markup/audio.html
 
@@ -50,7 +50,7 @@ cutting edge, type ``pip install beets==dev`` for the `latest source`_.) Check
 out the `Getting Started`_ guide to learn more about installing and using beets.
 
 .. _its Web site: http://beets.radbox.org/
-.. _Getting Started: http://readthedocs.org/docs/beets/-/guides/main.html
+.. _Getting Started: http://beets.readthedocs.org/en/latest/guides/main.html
 .. _@b33ts: http://twitter.com/b33ts/
 .. _latest source: https://github.com/sampsyo/beets/tarball/master#egg=beets-dev
 


### PR DESCRIPTION
Links like http://readthedocs.org/docs/beets/-/plugins/ seem to be outdated and don't work anymore, though they lead to a cool ascii-art maze, but I don't think that's intentional ;)
