### PR TITLE
Fix: Rare bug in directory and filename encoding on Windows

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -108,7 +108,7 @@ def normpath(path):
     """Provide the canonical form of the path suitable for storing in
     the database.
     """
-    unicode_path = syspath(path)
+    unicode_path = syspath(path, magicprefix=False)
     norm_path = os.path.normpath(os.path.abspath(os.path.expanduser(unicode_path)))
     return bytestring_path(norm_path)
 
@@ -289,7 +289,7 @@ def displayable_path(path):
     except (UnicodeError, LookupError):
         return path.decode('utf8', 'ignore')
 
-def syspath(path, pathmod=None):
+def syspath(path, pathmod=None, magicprefix=True):
     """Convert a path for use by the operating system. In particular,
     paths on Windows must receive a magic prefix and must be converted
     to unicode before they are sent to the OS.
@@ -314,7 +314,7 @@ def syspath(path, pathmod=None):
             path = path.decode(encoding, 'replace')
 
     # Add the magic prefix if it isn't already there
-    if not path.startswith(u'\\\\?\\'):
+    if not path.startswith(u'\\\\?\\') and magicprefix:
         path = u'\\\\?\\' + path
 
     return path


### PR DESCRIPTION
This is a small fix that fixes the encoding problems that occur when a Windows installation uses a non-latin locale setting and characters of this locale are used in music metadata.

Due to the way beets handles Windows encoding there was a bug in beets.util.normpath causing invalid characters in the locale in our filepath (which is utf-8) to be removed.
