### PR TITLE
library: log path, reading of which has raised an exception

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -273,7 +273,10 @@ class Item(object):
             read_path = self.path
         else:
             read_path = normpath(read_path)
-        f = MediaFile(syspath(read_path))
+        try: f = MediaFile(syspath(read_path))
+        except Exception as err:
+            log.error('Failed processing file: {!r}'.format(read_path))
+            raise
 
         for key in ITEM_KEYS_META:
             setattr(self, key, getattr(f, key))


### PR DESCRIPTION
Fairly simple trick, but very useful on large updates, which otherwise don't tell which file has caused the problem, even with -v option.
Adding logging of every scanned path to -v is another way to do that, but it'd also greatly increase verbosity of it, so I think proposed solution is preferrable to that one.
