### PR TITLE
library: don't set/update item mtime if read-path is passed to read()

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -277,11 +277,12 @@ class Item(object):
 
         for key in ITEM_KEYS_META:
             setattr(self, key, getattr(f, key))
-        self.path = read_path
 
         # Database's mtime should now reflect the on-disk value.
         if read_path == self.path:
             self.mtime = self.current_mtime()
+
+        self.path = read_path
 
     def write(self):
         """Writes the item's metadata to the associated file.


### PR DESCRIPTION
While working on #59, found this strange thing in the code:

```
....
self.path = read_path

# Database's mtime should now reflect the on-disk value.
if read_path == self.path:
    ....
```

Guess threading can make this snippet more sensible, but since the only Item.read(path) I've found was in library.py:208, which is followed by mtime setting, it looks just like a plain oversight.
