### PR TITLE
Fix inconsistent three-space indentation

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -489,7 +489,7 @@ def manual_id(singleton):
     # Find the first thing that looks like a UUID/MBID.
     match = re.search('[a-f0-9]{8}(-[a-f0-9]{4}){3}-[a-f0-9]{12}', entry)
     if match:
-       return match.group()
+        return match.group()
     else:
         log.error('Invalid MBID.')
         return None

--- a/beets/util/pipeline.py
+++ b/beets/util/pipeline.py
@@ -432,7 +432,7 @@ if __name__ == '__main__':
             print('processing %i' % num)
             time.sleep(3)
             if num == 3:
-               raise Exception()
+                raise Exception()
             num = yield num * 2
     def exc_consume():
         while True:


### PR DESCRIPTION
Really tiny nitpick, but in some places code blocks are indented with three spaces instead of four and emacs' develock-mode picked it up.
My python seem to allow that (might not be the case with other versions), but it's still probably an unintentional inconsistency, so I think it's fix-worthy.
