### PR TITLE
Enable downscaling cover arts for 'fetchart' and 'embedart' plugins

### DIFF
--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -1,0 +1,172 @@
+# This file is part of beets.
+# Copyright 2012, Fabrice Laporte
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+import urllib
+import subprocess
+import os
+import glob
+import shutil
+from tempfile import NamedTemporaryFile
+import logging
+
+"""Abstraction layer to resize an image without requiring additional dependency
+"""
+# Resizing methods
+PIL = 1
+IMAGEMAGICK = 2
+WEBPROXY = 3
+
+log = logging.getLogger('beets')
+
+class ArtResizerError(Exception):
+    """Raised when an error occurs during image resizing
+    """
+
+def call(args):
+    """Execute the command indicated by `args` (a list of strings) and
+    return the command's output. The stderr stream is ignored. If the
+    command exits abnormally, a ArtResizerError is raised.
+    """
+    try:
+        with open(os.devnull, 'w') as devnull:
+            return subprocess.check_output(args, stderr=devnull)
+    except subprocess.CalledProcessError as e:
+        raise ArtResizerError(
+            "{0} exited with status {1}".format(args[0], e.returncode)
+        )
+
+
+def resize_url(url, maxwidth):
+    """Return a new url with image of original url resized to maxwidth (keep 
+       aspect ratio)"""
+
+    PROXY_URL = 'http://images.weserv.nl/?url=%s&w=%s'
+    reqUrl = PROXY_URL % (url.replace('http://',''), maxwidth)
+    log.debug("Requesting proxy image at %s" % reqUrl)
+    try:
+        urllib.urlopen(reqUrl)
+    except IOError:
+        log.info('Cannot get resized image via web proxy. '
+                 'Using original image url.')
+        return url
+    return reqUrl
+
+
+def get_temp_file_out(path_in):
+    """Return an unused filename with correct extension.
+    """
+    with NamedTemporaryFile(suffix=os.path.splitext(path_in)[1]) as f:
+        path_out = f.name
+    return path_out
+
+
+class PilResizer(object):
+    def resize(self, maxwidth, path_in, path_out=None) :
+        """Resize using Python Imaging Library (PIL).  Return the output path 
+        of resized image.
+        """
+        if not path_out:
+            path_out = get_temp_file_out(path_in)
+        try:
+            im = Image.open(path_in)
+            size = maxwidth, maxwidth
+            im.thumbnail(size, Image.ANTIALIAS)
+            im.save(path_out)
+            return path_out
+        except IOError:
+            log.error("Cannot create thumbnail for '%s'" % path)
+
+
+class ImageMagickResizer(object):
+    def resize(self, maxwidth, path_in, path_out=None):
+        """Resize using ImageMagick <http://www.imagemagick.org> command-line 
+        tool. Return the output path of resized image.
+        """
+        if not path_out:
+            path_out = get_temp_file_out(path_in)
+
+        # widthxheight> Shrinks images with dimension(s) larger than the 
+        # corresponding width and/or height dimension(s).
+        # "only shrink flag" is prefixed by ^ escape char for Windows compat.
+        cmd = [self.convert_path, path_in, '-resize', '%sx^>' % \
+               maxwidth, path_out]
+        call(cmd)
+        return path_out
+
+
+class ArtResizer(object):
+
+    convert_path = None 
+
+    def __init__(self, detect=True):
+        """ArtResizer factory method"""
+
+        self.method = WEBPROXY
+        if detect:
+            self.method = self.set_method()
+
+            if self.method == PIL :
+                self.__class__ = PilResizer
+            elif self.method == IMAGEMAGICK :
+                self.__class__ = ImageMagickResizer
+            log.debug("ArtResizer method is %s" % self.__class__)        
+
+
+    def set_method(self):
+        """Set the most appropriate resize method. Use PIL if present, else 
+        check if ImageMagick is installed.
+        If none is available, use a web proxy."""
+
+        try:
+            from PIL import Image
+            return PIL
+        except ImportError as e:
+            pass
+
+        for dir in os.environ['PATH'].split(os.pathsep):
+            if glob.glob(os.path.join(dir, 'convert*')):
+                convert = os.path.join(dir, 'convert')
+                cmd = [convert, '--version']
+                try:
+                    out = subprocess.check_output(cmd).lower()
+                    if 'imagemagick' in out:
+                        self.convert_path = convert  
+                        return IMAGEMAGICK
+                except subprocess.CalledProcessError as e:
+                    pass # system32/convert.exe may be interfering 
+
+        return WEBPROXY
+
+
+    def resize(self, maxwidth, url, path_out=None):
+        """Resize using web proxy. Return the output path of resized image.
+        """
+
+        reqUrl = resize_url(url, maxwidth)
+        try:
+            fn, headers = urllib.urlretrieve(reqUrl)
+        except IOError:
+            log.debug('error fetching resized image')
+            return
+
+        if not path_out:
+            path_out = get_temp_file_out(fn)
+        shutil.copy(fn, path_out)
+        return path_out
+
+# module-as-singleton instanciation
+inst = ArtResizer()
+
+
+

--- a/docs/plugins/embedart.rst
+++ b/docs/plugins/embedart.rst
@@ -40,8 +40,14 @@ embedded album art:
 Configuring
 -----------
 
-The plugin has one configuration option, ``autoembed``, which lets you disable
-automatic album art embedding. To do so, add this to your ``~/.beetsconfig``::
+``autoembed`` option  lets you disable automatic album art embedding. 
+To do so, add this to your ``~/.beetsconfig``::
 
     [embedart]
     autoembed: no
+
+A maximum image width can be defined to downscale images before embedding them 
+(source image on filesystem is not altered). The resize operation reduces image width to 
+``maxwidth`` pixels and height is recomputed so that aspect ratio is preserved.  
+The [PIL](http://www.pythonware.com/products/pil/) or [ImageMagick](www.imagemagick.org/) is required 
+to use the ``maxwidth`` config option. 

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -4,6 +4,7 @@ FetchArt Plugin
 The ``fetchart`` plugin retrieves album art images from various sources on the
 Web and stores them as image files.
 
+
 Fetching Album Art During Import
 --------------------------------
 
@@ -14,6 +15,12 @@ plugin by putting ``fetchart`` on your config file's ``plugins`` line (see
 By default, beets stores album art image files alongside the music files for an
 album in a file called ``cover.jpg``. To customize the name of this file, use
 the :ref:`art-filename` config option.
+
+A maximum image width can be defined to downscale fetched images if they are too
+big. The resize operation reduces image width to ``maxwidth`` pixels and 
+height is recomputed so that aspect ratio is preserved.  
+When using ``maxwidth`` config option, please consider installing 
+[ImageMagick](www.imagemagick.org/) first for optimal performance. 
 
 To disable automatic art downloading, just put this in your configuration
 file::


### PR DESCRIPTION
artresizer.py instances an ArtResizer object that uses internally the PIL, ImageMagick
or a web proxy service to perform the resizing operations.
Because embedart works on input images located on filesystem it requires PIL or ImageMagick, whereas fetchart is able to do the job with the fallback webproxy resizer.
