### PR TITLE
fix RewritePlugin initialization

### DIFF
--- a/beetsplug/rewrite.py
+++ b/beetsplug/rewrite.py
@@ -43,7 +43,7 @@ def rewriter(field, rules):
 
 class RewritePlugin(BeetsPlugin):
     def __init__(self):
-        super(BeetsPlugin, self).__init__()
+        super(RewritePlugin, self).__init__()
         BeetsPlugin.template_fields = {}
 
         self.config.add({})


### PR DESCRIPTION
enabling the rewrite plugin causes an error on init

```
$ beet
Traceback (most recent call last):
  File "/home/jhawthorn/code/beets/beet", line 20, in <module>
    beets.ui.main()
  File "/home/jhawthorn/code/beets/beets/ui/__init__.py", line 725, in main
    _raw_main(args)
  File "/home/jhawthorn/code/beets/beets/ui/__init__.py", line 666, in _raw_main
    plugins.send("pluginload")
  File "/home/jhawthorn/code/beets/beets/plugins.py", line 309, in send
    handlers = event_handlers()[event]
  File "/home/jhawthorn/code/beets/beets/plugins.py", line 295, in event_handlers
    for plugin in find_plugins():
  File "/home/jhawthorn/code/beets/beets/plugins.py", line 193, in find_plugins
    _instances[cls] = cls()
  File "/home/jhawthorn/code/beets/beetsplug/rewrite.py", line 49, in __init__
    self.config.add({})
AttributeError: 'RewritePlugin' object has no attribute 'config'
```
