### PR TITLE
Show media in candidates disambiguation

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -342,18 +342,16 @@ def choose_candidate(candidates, singleton, rec, cur_artist=None,
                     line = '%i. %s - %s' % (i + 1, match.info.artist,
                                             match.info.album)
 
-                    # Label and year disambiguation, if available.
-                    label, year = None, None
+                    # Label, year and media disambiguation, if available.
+                    info = []
                     if match.info.label:
-                        label = match.info.label
+                        info.append(match.info.label)
                     if match.info.year:
-                        year = unicode(match.info.year)
-                    if label and year:
-                        line += u' [%s, %s]' % (label, year)
-                    elif label:
-                        line += u' [%s]' % label
-                    elif year:
-                        line += u' [%s]' % year
+                        info.append(unicode(match.info.year))
+                    if match.info.media:
+                        info.append(match.info.media)
+                    if len(info) > 0:
+                        line += u' [%s]' % u', '.join(info)
 
                     line += ' (%s)' % dist_string(match.distance)
 


### PR DESCRIPTION
Tried to import an album today and picked the Cassette version.  Added match.info.media to the Candidates list.

Before:
Candidates:
1. 808 State - Don Solaris [Hypnotic, 1996](53.3%)
2. 808 State - Don Solaris [ZTT, 1996](53.3%)
3. 808 State - Don Solaris [ZTT, 1996](53.3%)
4. 808 State - Don Solaris (bonus disc: 808: Archives, Part IV) [ZTT, 1996](33.3%) (partial match!)

After:
Candidates:
1. 808 State - Don Solaris [Hypnotic, 1996, CD](53.3%)
2. 808 State - Don Solaris [ZTT, 1996, Cassette](53.3%)
3. 808 State - Don Solaris [ZTT, 1996, CD](53.3%)
4. 808 State - Don Solaris (bonus disc: 808: Archives, Part IV) [ZTT, 1996, CD](33.3%) (partial match!)

Might be useful for others too ;)
