### PR TITLE
Improved change alignment. Align "->" when possible, otherwise split acr...

### DIFF
--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -701,15 +701,15 @@ class ShowChangeTest(_common.TestCase):
 
     def test_item_data_change_title_missing(self):
         self.items[0].title = ''
-        msg = self._show_change()
-        self.assertTrue('file.mp3         -> the title' in msg)
+        msg = re.sub(r'  +', ' ', self._show_change())
+        self.assertTrue('file.mp3 -> the title' in msg)
 
     def test_item_data_change_title_missing_with_unicode_filename(self):
         self.items[0].title = ''
         self.items[0].path = u'/path/to/caf\xe9.mp3'.encode('utf8')
-        msg = self._show_change().decode('utf8')
-        self.assertTrue(u'caf\xe9.mp3         -> the title' in msg
-                        or u'caf.mp3         ->' in msg)
+        msg = re.sub(r'  +', ' ', self._show_change().decode('utf8'))
+        self.assertTrue(u'caf\xe9.mp3 -> the title' in msg
+                        or u'caf.mp3 ->' in msg)
 
 class PathFormatTest(_common.TestCase):
     def test_custom_paths_prepend(self):


### PR DESCRIPTION
...oss two lines.

I think this is a good compromise. It will either display all changed tracks aligned in two columns, or all split across two lines.

I tried a few different ways to mix the two methods, including aligning the second line for tracks with long names on the right, adding blank lines above and/or below, moving the "->" to the second line, etc. But it always looked convoluted and messy in anything but the simplest case.

At least this way all the changes for a release are displayed consistently and neatly, even if it changes between releases. For short track names, I think two columns is _much_ more useful, and people with wider terminals can benefit even more.
