### PR TITLE
Check `none_rec_action` setting instead of `quiet_fallback` during inter...

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -272,7 +272,7 @@ def _summary_judment(rec):
             })
 
     elif rec == autotag.RECOMMEND_NONE:
-        action = config['import']['quiet_fallback'].as_choice({
+        action = config['import']['none_rec_action'].as_choice({
             'skip': importer.action.SKIP,
             'asis': importer.action.ASIS,
             'ask': None,


### PR DESCRIPTION
...active import.

I think this was a simple copy/paste error which caused two test failures and made the new `none_rec_action` setting redundant. Fixed.
