### PR TITLE
Improved multi-disc album detection.

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -511,7 +511,7 @@ class TerminalImportSession(importer.ImportSession):
         """
         # Show what we're tagging.
         print_()
-        print_(task.path)
+        print_(displayable_path(task.path, u'\n'))
 
         # Take immediate action if appropriate.
         action = _summary_judment(task.rec)

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -169,8 +169,9 @@ def sorted_walk(path, ignore=()):
         else:
             files.append(base)
 
-    # Sort lists and yield the current level.
-    dirs.sort()
+    # Sort lists and yield the current level. Do case insensitve sort on dirs,
+    # to improve multi-disc album detection.
+    dirs = [d2 for d1, d2 in sorted([(d.lower(), d) for d in dirs])]
     files.sort()
     yield (path, dirs, files)
 
@@ -295,10 +296,12 @@ def bytestring_path(path, pathmod=None):
     except (UnicodeError, LookupError):
         return path.encode('utf8')
 
-def displayable_path(path):
+def displayable_path(path, separator=u'; '):
     """Attempts to decode a bytestring path to a unicode object for the
     purpose of displaying it to the user.
     """
+    if isinstance(path, list):
+        return separator.join(displayable_path(p) for p in path)
     if isinstance(path, unicode):
         return path
     elif not isinstance(path, str):

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -162,7 +162,7 @@ def _source_urls(album):
         if url:
             yield url
 
-def art_for_album(album, path, maxwidth=None, local_only=False):
+def art_for_album(album, paths, maxwidth=None, local_only=False):
     """Given an Album object, returns a path to downloaded art for the
     album (or None if no art is found). If `maxwidth`, then images are
     resized to this maximum pixel size. If `local_only`, then only local
@@ -172,8 +172,11 @@ def art_for_album(album, path, maxwidth=None, local_only=False):
     out = None
 
     # Local art.
-    if isinstance(path, basestring):
-        out = art_in_path(path)
+    if paths:
+        for path in paths:
+            out = art_in_path(path)
+            if out:
+                break
 
     # Web art sources.
     if not local_only and not out:

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -105,26 +105,26 @@ class CombinedTest(unittest.TestCase):
         _common.touch(os.path.join(self.dpath, 'a.jpg'))
         fetchart.urllib.urlretrieve = MockUrlRetrieve('image/jpeg')
         album = _common.Bag(asin='xxxx')
-        artpath = fetchart.art_for_album(album, self.dpath)
+        artpath = fetchart.art_for_album(album, [self.dpath])
         self.assertEqual(artpath, os.path.join(self.dpath, 'a.jpg'))
 
     def test_main_interface_falls_back_to_amazon(self):
         fetchart.urllib.urlretrieve = MockUrlRetrieve('image/jpeg')
         album = _common.Bag(asin='xxxx')
-        artpath = fetchart.art_for_album(album, self.dpath)
+        artpath = fetchart.art_for_album(album, [self.dpath])
         self.assertNotEqual(artpath, None)
         self.assertFalse(artpath.startswith(self.dpath))
 
     def test_main_interface_tries_amazon_before_aao(self):
         fetchart.urllib.urlretrieve = MockUrlRetrieve('image/jpeg')
         album = _common.Bag(asin='xxxx')
-        fetchart.art_for_album(album, self.dpath)
+        fetchart.art_for_album(album, [self.dpath])
         self.assertFalse(self.urlopen_called)
 
     def test_main_interface_falls_back_to_aao(self):
         fetchart.urllib.urlretrieve = MockUrlRetrieve('text/html')
         album = _common.Bag(asin='xxxx')
-        fetchart.art_for_album(album, self.dpath)
+        fetchart.art_for_album(album, [self.dpath])
         self.assertTrue(self.urlopen_called)
 
     def test_main_interface_uses_caa_when_mbid_available(self):
@@ -139,7 +139,7 @@ class CombinedTest(unittest.TestCase):
         mock_retrieve = MockUrlRetrieve('image/jpeg')
         fetchart.urllib.urlretrieve = mock_retrieve
         album = _common.Bag(mb_albumid='releaseid', asin='xxxx')
-        artpath = fetchart.art_for_album(album, self.dpath, local_only=True)
+        artpath = fetchart.art_for_album(album, [self.dpath], local_only=True)
         self.assertEqual(artpath, None)
         self.assertFalse(self.urlopen_called)
         self.assertFalse(mock_retrieve.fetched)
@@ -149,7 +149,7 @@ class CombinedTest(unittest.TestCase):
         mock_retrieve = MockUrlRetrieve('image/jpeg')
         fetchart.urllib.urlretrieve = mock_retrieve
         album = _common.Bag(mb_albumid='releaseid', asin='xxxx')
-        artpath = fetchart.art_for_album(album, self.dpath, local_only=True)
+        artpath = fetchart.art_for_album(album, [self.dpath], local_only=True)
         self.assertEqual(artpath, os.path.join(self.dpath, 'a.jpg'))
         self.assertFalse(self.urlopen_called)
         self.assertFalse(mock_retrieve.fetched)


### PR DESCRIPTION
- Remove "part", "volume", "vol." multi-disc markers. These are often
  part of album titles, and not necessarily indicative of a multi-disc
  album. Only look for "CD X" and "disc X" (case insensitive), ignoring
  white space and other non-word characters.
- Don't only expect each disc to be in a subdirectory of a common parent
  directory, with all siblings belonging to the same release. Also match
  any consecutive siblings (even when the parent contains other albums)
  that are named with the same prefix and multi-disc marker.
- The `albums_in_dir(path)` function now always yields a list of paths
  along with each list of items. `ItemTask.path` is now always a list of
  paths.
- The `displayable_path(path)` function now accepts a list of paths, and
  will join them with "; " by default. This can be changed with the
  `separator` argument.
- The `sorted_walk()` function now does a case insensitive sort on
  directories, but still returns case sensitive results. This allows
  better multi-disc album detection.
- The `art_for_album()` function now takes a list of paths as its second
  argument, instead of a single path.
