### PR TITLE
Adds support for Replay Gain tags on MP4 files

### DIFF
--- a/beets/mediafile.py
+++ b/beets/mediafile.py
@@ -1104,25 +1104,29 @@ class MediaFile(object):
     # ReplayGain fields.
     rg_track_gain = FloatValueField(2, 'dB',
         mp3 = StorageStyle('TXXX', id3_desc=u'REPLAYGAIN_TRACK_GAIN'),
-        mp4 = StorageStyle('---:com.apple.iTunes:replaygain_track_gain'),
+        mp4 = StorageStyle('----:com.apple.iTunes:replaygain_track_gain',
+                           as_type=str),
         etc = StorageStyle(u'REPLAYGAIN_TRACK_GAIN'),
         asf = StorageStyle(u'replaygain_track_gain'),
     )
     rg_album_gain = FloatValueField(2, 'dB',
         mp3 = StorageStyle('TXXX', id3_desc=u'REPLAYGAIN_ALBUM_GAIN'),
-        mp4 = StorageStyle('---:com.apple.iTunes:replay_gain_album_gain'),
+        mp4 = StorageStyle('----:com.apple.iTunes:replaygain_album_gain',
+                           as_type=str),
         etc = StorageStyle(u'REPLAYGAIN_ALBUM_GAIN'),
         asf = StorageStyle(u'replaygain_album_gain'),
     )
     rg_track_peak = FloatValueField(6, None,
         mp3 = StorageStyle('TXXX', id3_desc=u'REPLAYGAIN_TRACK_PEAK'),
-        mp4 = StorageStyle('---:com.apple.iTunes:replaygain_track_peak'),
+        mp4 = StorageStyle('----:com.apple.iTunes:replaygain_track_peak',
+                           as_type=str),
         etc = StorageStyle(u'REPLAYGAIN_TRACK_PEAK'),
         asf = StorageStyle(u'replaygain_track_peak'),
     )
     rg_album_peak = FloatValueField(6, None,
         mp3 = StorageStyle('TXXX', id3_desc=u'REPLAYGAIN_ALBUM_PEAK'),
-        mp4 = StorageStyle('---:com.apple.iTunes:replaygain_album_peak'),
+        mp4 = StorageStyle('----:com.apple.iTunes:replaygain_album_peak',
+                           as_type=str),
         etc = StorageStyle(u'REPLAYGAIN_ALBUM_PEAK'),
         asf = StorageStyle(u'replaygain_album_peak'),
     )


### PR DESCRIPTION
- Stores Replay Gain info in MP4 files using the format
  '---:com.apple.iTunes:replaygain_*' which is used by FB2K

This also in preparation for reading/writing SoundCheck tags and being able to convert between RG and SC.
