### PR TITLE
Labels plugin

### DIFF
--- a/beetsplug/labels.py
+++ b/beetsplug/labels.py
@@ -208,18 +208,18 @@ def do_labels(lib, opts, args):
         list_labels(lib)
         return
     args = ui.decargs(args)
-    if opts.give_labels:
-        q = ui.decargs(opts.give_labels)
+    if opts.attach_query:
+        q = ui.decargs(opts.attach_query)
         set_labels(lib, q, args, albums=opts.albums)
-    elif opts.strip_labels:
-        q = ui.decargs(opts.strip_labels)
+    elif opts.remove_query:
+        q = ui.decargs(opts.remove_query)
         remove_labels(lib, q, args, albums=opts.albums)
     else:
         list_items(lib, args, albums=opts.albums)
 
 class LabelsPlugin(BeetsPlugin):
     def commands(self):
-        usage = 'beet labels [labels] [-a][-s query]\n'\
+        usage = 'beet labels args [--albums][-a|-r query]\n'\
         +'You can provide multiple labels separated by space.\n'\
         +'When no options orarguments are provided, a list '\
         +'of labels currently in the database is outputted.'
@@ -228,19 +228,19 @@ class LabelsPlugin(BeetsPlugin):
             help='Get and set labels for your music.')
         cmd.parser.set_usage(usage)
         cmd.parser.add_option(
-            '-a', '--albums', action='store_true', dest='albums',
+            '-a', '--attach-to', dest='attach_query',
+            callback=vararg_callback, action='callback',
+            help='Attaches the given labels to all items matching '\
+                +'the following query.\n'\
+                +'(Everything after -a will be treated as part of the query).')
+        cmd.parser.add_option(
+            '-r', '--remove-from', dest='remove_query',
+            callback=vararg_callback, action='callback',
+            help='Same as -a, but removes labels from matching items '\
+                 +'instead of adding them.')
+        cmd.parser.add_option(
+            '--albums', action='store_true', dest='albums',
             help='Deal in albums instead of individual tracks.')
-        cmd.parser.add_option(
-            '-g', '--give-labels', dest='give_labels',
-            callback=vararg_callback, action='callback',
-            help='Adds the given labels to all items matching '\
-                +'a following query.\n'\
-                +'(Everything after -g will be treated as part of the query).')
-        cmd.parser.add_option(
-            '-s', '--strip-labels', dest='strip_labels',
-            callback=vararg_callback, action='callback',
-            help='Same as -g, but removes labels from matching items '\
-                 +'instead of giving them.')
         cmd.func = do_labels
         return [cmd]
 

--- a/beetsplug/labels.py
+++ b/beetsplug/labels.py
@@ -1,4 +1,15 @@
-import logging
+# Copyright 2013, Steinthor Palsson <steinitzu@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
 
 from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand
@@ -81,34 +92,13 @@ class LabelQuery(Query):
         clause = 'WHERE'+' AND '.join(clauses)
         return clause,self.labels
 
-def _check_env(lib):
-    """
-    Returns True if labels tables exist in the beets database.
-    """
-    t = lib.transaction()
-    r = t.query(
-        """SELECT name FROM sqlite_master 
-        WHERE type='table' and name='labels' 
-        OR name='labels_items'
-        OR name='labels_albums';
-        """)
-    return len(r)==3
-
-def _set_env(lib):
-    """
-    Create labels tables.
-    """
-    t = lib.transaction()
-    t.script(TABLES)
-
 def make_env(lib):
     """
     Set up the environment.
     Create labels tables in the beets database if they don't exist.
     """
     t = lib.transaction()
-    t.script(TABLES)
-    
+    t.script(TABLES)    
 
 def make_label(lib, label):
     """
@@ -128,8 +118,8 @@ def make_label(lib, label):
 
 def set_labels(lib, query, labels, albums=False):
     """
-    Set labels for items matching a query.
-    `query` can be any kind of object accepted by `lib.items()`.
+    Set labels for items or albums matching a query.
+    `query` can be a `Query` like object or a beets query string.
     """
     if albums:
         table = 'labels_albums'
@@ -151,7 +141,7 @@ def set_labels(lib, query, labels, albums=False):
 
 def get_items(lib, labels, albums=False):
     """
-    Returns a `ResultIterator` of items matching given `*labels`.
+    Returns an iterable of items or albums matching given labels.
     """
     q = LabelQuery(labels, albums=albums)
     sql,subvals = q.statement()
@@ -164,7 +154,7 @@ def get_items(lib, labels, albums=False):
             items = ResultIterator(tx.query(sql, subvals))
     return items
 
-def get_labels(lib, albums=False):
+def get_labels(lib):
     """
     Returns a tuple(id,label) list of all existing labels.
     """
@@ -175,14 +165,14 @@ def get_labels(lib, albums=False):
 
 def list_items(lib, labels, albums=False):
     """
-    Print items matching given `*labels`.
+    Print items or albums matching given list of labels.
     """
     tmpl = Template(ui._pick_format(albums, None))
     items = get_items(lib, labels, albums=albums)
     for item in items:
         ui.print_obj(item, lib, tmpl)
 
-def list_labels(lib, albums=False):
+def list_labels(lib):
     """
     List all labels in the database.
     """

--- a/beetsplug/labels.py
+++ b/beetsplug/labels.py
@@ -193,22 +193,23 @@ def do_labels(lib, opts, args):
 
 class LabelsPlugin(BeetsPlugin):
     def commands(self):
-        usage = '''
-        beet labels [labels] [-a][-s query]
-        When no arguments are provided, a list of labels currently in 
-        the database is returned.
-        '''
+        usage = 'beet labels [labels] [-a][-s query]\n'\
+        +'You can provide multiple labels separated by space.\n'\
+        +'When no options orarguments are provided, a list '\
+        +'of labels currently in the database is outputted.'
         cmd = Subcommand(
             'labels', 
             help='Get and set labels for your music.')
         cmd.parser.set_usage(usage)
         cmd.parser.add_option(
-            '-s', '--set-labels', dest='set_labels',
-            callback=vararg_callback, action='callback',
-            help='The given labels are set to all items matching a query.')
-        cmd.parser.add_option(
             '-a', '--albums', action='store_true', dest='albums',
             help='Deal in albums instead of individual tracks.')
+        cmd.parser.add_option(
+            '-s', '--set-labels', dest='set_labels',
+            callback=vararg_callback, action='callback',
+            help='The given labels are set to all items matching '\
+                +'a following query.\n'\
+                +'(Everything after -s will be treated as part of the query).')
         cmd.func = do_labels
         return [cmd]
 

--- a/beetsplug/labels.py
+++ b/beetsplug/labels.py
@@ -1,0 +1,225 @@
+import logging
+
+from beets.plugins import BeetsPlugin
+from beets.ui import Subcommand
+from beets.library import Query, ResultIterator, Album
+from beets import ui
+from beets.ui import Template
+
+"""
+A plugin which lets users give arbitrary labels 
+to the music in the beets library.
+"""
+
+TABLES = """
+CREATE TABLE IF NOT EXISTS labels (
+        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+        label VARCHAR NOT NULL);
+CREATE TABLE IF NOT EXISTS labels_items(
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        label_id INTEGER,
+        item_id INTEGER,
+        FOREIGN KEY (label_id) REFERENCES labels(id),
+        FOREIGN KEY (item_id) REFERENCES items(id));
+CREATE TABLE IF NOT EXISTS labels_albums(
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        label_id INTEGER,
+        album_id INTEGER,
+        FOREIGN KEY (label_id) REFERENCES labels(id),
+        FOREIGN KEY (album_id) REFERENCES albums(id));
+"""
+
+#Taken from 
+#docs.python.org/2/library/optparse.html#callback-example-6-variable-arguments
+#To allow variable number of arguments 
+#for an option without creating an argparse (python2.7) dependency.
+def vararg_callback(option, opt_str, value, parser):
+    assert value is None
+    value = []
+    def floatable(str):
+        try:
+            float(str)
+            return True
+        except ValueError:
+            return False
+    for arg in parser.rargs:
+        # stop on --foo like options
+        if arg[:2] == "--" and len(arg) > 2:
+            break
+        # stop on -a, but not on -3 or -3.0
+        if arg[:1] == "-" and len(arg) > 1 and not floatable(arg):
+            break
+        value.append(arg)
+    del parser.rargs[:len(value)]
+    setattr(parser.values, option.dest, value)
+
+class LabelQuery(Query):
+    """
+    A query which looks for all items matching a list of labels.
+    Only items matching all labels are returned.
+    """    
+    def __init__(self, labels, albums=False):
+        self.labels=[l.lower() for l in labels]
+        self.mode = 'album' if albums else 'item'
+
+    def statement(self, columns='*'):
+        columns = ','.join(['i.'+c for c in columns.split(',')])
+        clause, subvals = self.clause()
+        q = 'SELECT DISTINCT %s FROM %ss AS i ' % (columns, self.mode)
+        q+=clause
+        return q, subvals
+
+    def clause(self):
+        if not self.labels:
+            return ''
+        c = """
+            EXISTS (SELECT 1 FROM labels_%ss AS li
+            LEFT JOIN labels AS l ON li.label_id = l.id
+            WHERE l.label = ? AND li.%s_id = i.id)
+            """ % (self.mode, self.mode)
+        clauses = [c for l in self.labels]
+        clause = 'WHERE'+' AND '.join(clauses)
+        return clause,self.labels
+
+def _check_env(lib):
+    """
+    Returns True if labels tables exist in the beets database.
+    """
+    t = lib.transaction()
+    r = t.query(
+        """SELECT name FROM sqlite_master 
+        WHERE type='table' and name='labels' 
+        OR name='labels_items'
+        OR name='labels_albums';
+        """)
+    return len(r)==3
+
+def _set_env(lib):
+    """
+    Create labels tables.
+    """
+    t = lib.transaction()
+    t.script(TABLES)
+
+def make_env(lib):
+    """
+    Set up the environment.
+    Create labels tables in the beets database if they don't exist.
+    """
+    t = lib.transaction()
+    t.script(TABLES)
+    
+
+def make_label(lib, label):
+    """
+    Create a new label and return its id.
+    If label with same name exists, its id is returned without 
+    any changes to the database.
+    """
+    label = label.lower()
+    qget = 'SELECT id FROM labels WHERE label = ?;'
+    qset = 'INSERT INTO labels (label) VALUES (?);'
+    with lib.transaction() as tx:
+        exlb = tx.query(qget, (label,))
+        if exlb:
+            return exlb[0]['id']
+        else:
+            return tx.mutate(qset, (label,))
+
+def set_labels(lib, query, labels, albums=False):
+    """
+    Set labels for items matching a query.
+    `query` can be any kind of object accepted by `lib.items()`.
+    """
+    if albums:
+        table = 'labels_albums'
+        func = lib.albums
+        field = 'album_id'
+    else:
+        table = 'labels_items'
+        func = lib.items
+        field = 'item_id'
+    qset = 'INSERT INTO %s (%s, label_id) VALUES (?, ?);' % (table, field)
+    labelids = [make_label(lib, a) for a in labels]
+    items = func(query=query)
+    for item in items:
+        itemid = item.id
+        with lib.transaction() as tx:
+            for lid in labelids:
+                subvals = (itemid, lid)
+                tx.mutate(qset, subvals)
+
+def get_items(lib, labels, albums=False):
+    """
+    Returns a `ResultIterator` of items matching given `*labels`.
+    """
+    q = LabelQuery(labels, albums=albums)
+    sql,subvals = q.statement()
+    if albums:
+        with lib.transaction() as tx:
+            rows = tx.query(sql, subvals)
+            items = [Album(lib, dict(row)) for row in rows]
+    else:
+        with lib.transaction() as tx:
+            items = ResultIterator(tx.query(sql, subvals))
+    return items
+
+def get_labels(lib, albums=False):
+    """
+    Returns a tuple(id,label) list of all existing labels.
+    """
+    q = 'SELECT id,label FROM labels ORDER BY label ASC;'
+    with lib.transaction() as tx:
+        res = [(row['id'], row['label']) for row in tx.query(q)]
+    return res
+
+def list_items(lib, labels, albums=False):
+    """
+    Print items matching given `*labels`.
+    """
+    tmpl = Template(ui._pick_format(albums, None))
+    items = get_items(lib, labels, albums=albums)
+    for item in items:
+        ui.print_obj(item, lib, tmpl)
+
+def list_labels(lib, albums=False):
+    """
+    List all labels in the database.
+    """
+    for l in get_labels(lib):
+        ui.print_(l[1])
+
+def do_labels(lib, opts, args):
+    make_env(lib)
+    if not args:
+        list_labels(lib)
+        return
+    args = ui.decargs(args)
+    if opts.set_labels:
+        q = ui.decargs(opts.set_labels)
+        set_labels(lib, q, args, albums=opts.albums)
+    else:
+        list_items(lib, args, albums=opts.albums)
+
+class LabelsPlugin(BeetsPlugin):
+    def commands(self):
+        usage = '''
+        beet labels [labels] [-a][-s query]
+        When no arguments are provided, a list of labels currently in 
+        the database is returned.
+        '''
+        cmd = Subcommand(
+            'labels', 
+            help='Get and set labels for your music.')
+        cmd.parser.set_usage(usage)
+        cmd.parser.add_option(
+            '-s', '--set-labels', dest='set_labels',
+            callback=vararg_callback, action='callback',
+            help='The given labels are set to all items matching a query.')
+        cmd.parser.add_option(
+            '-a', '--albums', action='store_true', dest='albums',
+            help='Deal in albums instead of individual tracks.')
+        cmd.func = do_labels
+        return [cmd]
+
+

--- a/docs/plugins/labels.rst
+++ b/docs/plugins/labels.rst
@@ -1,0 +1,70 @@
+Labels plugin
+=============
+
+``labels`` is a plugin which allows you to give multiple, arbitrary tags or ``labels`` 
+to the music in your library.
+It's a different way to search and filter the library.
+
+You can think of this as having multiple genre tags, 
+or a way to associate feelings, places, experiences, activities or 
+anything you can think of to your music.
+
+So to start with, we want to enable the plugin.
+This is done by adding something like
+
+::
+
+    plugins: labels
+
+To your beets config file. (details :doc: `/plugins/index`).
+This will activate the ``beet labels`` command.
+
+Without any arguments, it just prints a list of the labels you have created.
+But since you're most likely using ``labels`` for the first time, you don't have any labels yet.
+
+Don't worry, labeling things is easy.
+A couple of examples:
+
+::
+
+    $ beet labels irish punk rock drinking -a flogging molly
+    $ beet labels crunchy rock happy-depressing -a albumartist:eels album:souljacker
+
+So everything between ``beet labels`` and ``-a`` are labels. 
+Just words or phrases separated by a whitespace.
+
+``-a`` (or ``--attach-to``) is the option that attaches those labels to some 
+tracks from the library. Everything after ``-a`` is 
+treated as a query (see :doc: `/reference/query` ).
+
+That means, in the first example, all tracks containing the phrase "flogging molly" 
+in their metadata are given the 4 tags: "irish", "punk", "rock" and "drinking".  
+The "Souljacker" album gets "crunchy", "rock" and "happy-depressing".
+
+Now we can filter the library based on these labels:
+
+::
+
+    $ beet labels irish
+
+Easy as pie, this will list all the stuff you've labeled as "irish" (in this case "Flogging Molly").
+Or you can do:
+
+::
+
+   $ beet labels rock crunchy
+
+This returns all the tracks from "Souljacker", but even though "Flogging Molly" also has 
+the "rock" label, it's not "crunchy" so it's not treated as a match.
+
+
+If you'd like to label full albums instead of tracks, you can include the ``--albums`` option.
+
+Removing labels from items is done the same way as attaching them, except 
+you substitute ``-a`` with ``-r`` (``--remove-from``). e.g. 
+
+::
+
+   $ beet labels punk -r flogging molly
+
+That strips the "punk" label from Flogging Molly.


### PR DESCRIPTION
This plugin lets you attach arbitrary text labels to your music and use them to filter the library.

Adds a new command ``labels`` which either filters by labels or attaches them to items (or albums) matching a query.

Labels are stored in a pretty straight forward many-to-many tagging system in the database using three new tables: `labels` which contains the label strings + join tables `labels_items` and `labels_albums`.

Just has the most basic features for now, but I thought this might be a nice way to generate playlists and other things.