### PR TITLE
Add support for artist aliases (fixes GC-354)

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -48,6 +48,11 @@ RELEASE_INCLUDES = ['artists', 'media', 'recordings', 'release-groups',
                     'labels', 'artist-credits']
 TRACK_INCLUDES = ['artists']
 
+# only versions >= 0.3 support artist aliases
+if musicbrainzngs.musicbrainz._version >= '0.3':
+    RELEASE_INCLUDES.append('aliases')
+    TRACK_INCLUDES.append('aliases')
+
 def configure():
     """Set up the python-musicbrainz-ngs module according to settings
     from the beets configuration. This should be called at startup.
@@ -74,12 +79,42 @@ def _flatten_artist_credit(credit):
             artist_sort_parts.append(el)
 
         else:
+            prefered_locales = config['import']['artist_aliases'].as_str_seq()
+            chosen_alias = None
+            if 'alias-list' in el['artist']:
+                alias_list = el['artist']['alias-list']
+                # Get a list of the aliases that have set locales
+                set_locales = [a for a in alias_list if 'locale' in a]
+                # Search locales in order
+                for locale in prefered_locales:
+                    # Does anything match 
+                    matches = [a for a in set_locales if a['locale'] == locale]
+                    # Skip to next locale if no matches
+                    if len(matches) == 0: 
+                        continue
+                    # Find the aliases that have the primary flag set
+                    primaries = [a for a in matches if 'primary' in a]
+                    # Take the primary if we have it, otherwise take the first
+                    # match with the correct locale
+                    if len(primaries) > 0:
+                        chosen_alias = primaries[0]
+                    else:
+                        chosen_alias = matches[0]
+                    # If we get here we must have found an acceptable alias
+                    # so stop looking
+                    break
+                    
             # An artist.
-            cur_artist_name = el['artist']['name']
+            if chosen_alias is not None:
+                cur_artist_name = chosen_alias['alias']
+            else:
+                cur_artist_name = el['artist']['name']
             artist_parts.append(cur_artist_name)
 
             # Artist sort name.
-            if 'sort-name' in el['artist']:
+            if chosen_alias is not None:
+                artist_sort_parts.append(chosen_alias['sort-name'])
+            elif 'sort-name' in el['artist']:
                 artist_sort_parts.append(el['artist']['sort-name'])
             else:
                 artist_sort_parts.append(cur_artist_name)

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -16,6 +16,7 @@ import:
     quiet: no
     singletons: no
     default_action: apply
+    artist_aliases: []
 
 clutter: ["Thumbs.DB", ".DS_Store"]
 ignore: [".*", "*~"]


### PR DESCRIPTION
### Use MusicBrainz artist aliases to import files with artist names in an appriorate locale

Fixes GC-354: https://code.google.com/p/beets/issues/detail?id=354

This is my attempt at fixing GC-354, it requires the HEAD of the master branch of [alastair/python-musicbrainz-ngs](https://github.com/alastair/python-musicbrainz-ngs) to work in order to retrieve [MusicBrainz aliases](http://musicbrainz.org/doc/Aliases). See [here](http://musicbrainz.org/ws/2/release/a6286a41-5b4f-47d4-825f-a52fac1d343f?inc=artists+aliases+artist-credits+labels) for an XML example of an `artist-credit` block that contains aliases.

As it stands, the body of the change is implemented via the `_flatten_artist_credit` function, which AFAIK is called whenever an `artist-credit` block needs to be consumed. The alias must at the very least have a locale set in order to be considered.

A config variable `artist_aliases` has been added which specifies the user's preferred locales in descending order, for example, from my own config file:

``` yaml
import:
    artist_aliases: en_GB en
```

See [Yazoo](http://musicbrainz.org/ws/2/artist/42922db2-2e80-44b8-9cdf-0b3a6634c124?inc=aliases) for an example of an alias that uses `language_country`.
### Todo:
- [x] unit tests (in `test_mb.ArtistFlatteningTest`?)
- [x] rename config variable?
- [ ] documentation (must mention locale formats, and how to edit MusicBrainz for adding missing translations)

If anyone wants to help with the unit tests or documentation I'd be grateful, I'd also be happy if someone wants to reimplement this entirely (I've got a 7 month old baby and my brain is addled), otherwise, assuming everyone is happy with the implementation, I will work my way through the todo items over the next few weeks.
