### PR TITLE
Fix "RuntimeWarning: Argument <type 'str'… …> is not an unicode object"

### DIFF
--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -93,8 +93,8 @@ def _string_dist_basic(str1, str2):
     transliteration/lowering to ASCII characters. Normalized by string
     length.
     """
-    if type(str1) == 'unicode': str1 = unidecode(str1)
-    if type(str2) == 'unicode': str2 = unidecode(str2)
+    if type(str1) == unicode: str1 = unidecode(str1)
+    if type(str2) == unicode: str2 = unidecode(str2)
     str1 = re.sub(r'[^a-z0-9]', '', str1.lower())
     str2 = re.sub(r'[^a-z0-9]', '', str2.lower())
     if not str1 and not str2:


### PR DESCRIPTION
For files with no tags I got the RuntimeWarning:
/usr/local/lib/python2.7/dist-packages/beets-1.1.0_beta.2-py2.7.egg/beets/autotag/match.py:104: RuntimeWarning: Argument <type 'str'> is not an unicode object. Passing an encoded string will likely have unexpected results.
  unidecode(str1)

Adding some debug output to _string_dist_basic in match.py (print(u'STR1 {} {}'.format(type(str1), str1))...) showed the following:
`[ ... ]
STR1 <type 'unicode'> 
STR2 <type 'unicode'> cavalier eternal
STR1 <type 'str'> 
STR2 <type 'unicode'> against me!
STR1 <type 'str'> 
STR2 <type 'unicode'> as the eternal cowboy
STR1 <type 'unicode'> 
STR2 <type 'unicode'> slurring the rhythms
[ ... ]`

This commit probably doesn't fix the root cause, but anyways...
