### PR TITLE
Transcode files during import

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -168,7 +168,7 @@ class ConvertPlugin(BeetsPlugin):
             u'opts': u'-aq 2',
             u'max_bitrate': 500,
             u'embed': True,
-            u'auto_convert': False
+            u'auto': False
         })
         self.import_stages = [self.auto_convert]
 
@@ -188,7 +188,7 @@ class ConvertPlugin(BeetsPlugin):
         return [cmd]
 
     def auto_convert(self, config, task):
-        if self.config['auto_convert'].get():
+        if self.config['auto'].get():
             if not task.is_album:
                 convert_on_import(config.lib, task.item)
             else:

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -57,6 +57,8 @@ The plugin offers several configuration options, all of which live under the
   "-aq 2". (Note that "-aq <num>" is equivalent to the LAME option "-V
   <num>".) If you want to specify a bitrate, use "-ab <bitrate>". Refer to the
   `FFmpeg`_ documentation for more details.
+* ``auto`` gives you the option to import transcoded versions of your files
+  automatically during the ``import`` command.
 * Finally, ``threads`` determines the number of threads to use for parallel
   encoding. By default, the plugin will detect the number of processors
   available and use them all.


### PR DESCRIPTION
This is a reference to issue #135.

I chose to implement this feature using the convert plugin because I thought it would make sense to not duplicate some functionality and configuration.

There had to be some hack, using a global variable to cleanup temporary files. Maybe this too will need some clean-up/refactoring.
