### PR TITLE
Fix unicode error

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -643,9 +643,11 @@ def import_files(lib, paths, query):
     for path in paths:
         fullpath = syspath(normpath(path))
         if not config['import']['singletons'] and not os.path.isdir(fullpath):
-            raise ui.UserError('not a directory: ' + path)
+            raise ui.UserError(u'not a directory: {0}'.format(
+                displayable_path(path)))
         elif config['import']['singletons'] and not os.path.exists(fullpath):
-            raise ui.UserError('no such file: ' + path)
+            raise ui.UserError(u'no such file: {0}'.format(
+                displayable_path(path)))
 
     # Check parameter consistency.
     if config['import']['quiet'] and config['import']['timid']:


### PR DESCRIPTION
When import couldn't find the dir or file to be imported, the error message with the path wasn't using `util.displayable_path()`
