### PR TITLE
Human-friendly error messages

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -802,7 +802,7 @@ def update_items(lib, query, album, move, pretend):
                 item.read()
             except Exception as exc:
                 log.error(u'error reading {0}: {1}'.format(
-                    repr(item.path), exc))
+                    displayable_path(item.path), exc))
                 continue
 
             # Special-case album artist when it matches track artist. (Hacky

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -20,7 +20,7 @@ from beets.plugins import BeetsPlugin
 from beets import mediafile
 from beets import ui
 from beets.ui import decargs
-from beets.util import syspath, normpath
+from beets.util import syspath, normpath, displayable_path
 from beets.util.artresizer import ArtResizer
 from beets import config
 
@@ -46,7 +46,7 @@ def _embed(path, items, maxwidth=0):
             f = mediafile.MediaFile(syspath(item.path))
         except mediafile.UnreadableFileError as exc:
             log.warn('Could not embed art in {0}: {1}'.format(
-                repr(item.path), exc
+                displayable_path(item.path), exc
             ))
             continue
         f.art = data
@@ -143,8 +143,8 @@ def extract(lib, outpath, query):
     try:
         mf = mediafile.MediaFile(syspath(item.path))
     except mediafile.UnreadableFileError as exc:
-        log.error('Could not extract art from {0}: {1}'.format(
-            repr(item.path), exc
+        log.error(u'Could not extract art from {0}: {1}'.format(
+            displayable_path(item.path), exc
         ))
         return
 
@@ -175,8 +175,8 @@ def clear(lib, query):
         try:
             mf = mediafile.MediaFile(syspath(item.path))
         except mediafile.UnreadableFileError as exc:
-            log.error('Could not clear art from {0}: {1}'.format(
-                repr(item.path), exc
+            log.error(u'Could not clear art from {0}: {1}'.format(
+                displayable_path(item.path), exc
             ))
             continue
         mf.art = None

--- a/beetsplug/mbsync.py
+++ b/beetsplug/mbsync.py
@@ -51,7 +51,7 @@ def _print_and_apply_changes(lib, item, move, pretend, write):
                 item.write()
             except Exception as exc:
                 log.error(u'could not sync {0}: {1}'.format(
-                    repr(item.path), exc))
+                    util.displayable_path(item.path), exc))
                 return False
         lib.store(item)
 


### PR DESCRIPTION
Related to the #125.

Couldn't find other cases where this could be done.

There's an interesting situation though, there are some errors that are not predicted in the pyacoustid and it wouldn't fit in beets. In my tests, I found an `EOFError`.
