### PR TITLE
- changes to mediafile.py. Provides a delete method which allows the user to clear current metadata information...

### DIFF
--- a/beets/mediafile.py
+++ b/beets/mediafile.py
@@ -903,6 +903,10 @@ class MediaFile(object):
     def save(self):
         self.mgfile.save()
 
+    def delete(self):
+        """Removes current metadata information associated with the path/file."""
+        self.mgfile.delete()
+
 
     # Field definitions.
 


### PR DESCRIPTION
Add a change to mediafile.py. Provides a delete method which allows the user
      to remove all audio metadata from the mutagen call "delete"

example :

``` python
 mediafileobject.delete()
```

I am using this great mediafile.py library in other tagging project. Adding the delete method, yields a quick means to start from a fresh/clean audio file and build from there.
