### PR TITLE
Compute Content-Length to make tracks seekable in most players via the web plugin

### DIFF
--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -76,7 +76,9 @@ def all_items():
 @app.route('/item/<int:item_id>/file')
 def item_file(item_id):
     item = g.lib.get_item(item_id)
-    return flask.send_file(item.path, as_attachment=True, attachment_filename=os.path.basename(item.path))
+    response = flask.send_file(item.path, as_attachment=True, attachment_filename=os.path.basename(item.path))
+    response.headers['Content-Length'] = os.path.getsize(item.path)
+    return response
 
 @app.route('/item/query/<path:query>')
 def item_query(query):


### PR DESCRIPTION
Flask only adds a Content-Length header if X-Sendfile is used. Media players like vlc (and Tomahawk which uses vlc as a backend) only enable seeking in a track if the Content-Length header is present.
