### PR TITLE
lastgenre: force real lookup during import only if no custom whitelist set

### DIFF
--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -202,7 +202,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
             'fallback': None,
             'canonical': None,
             'source': 'album',
-            'force': False,
+            'force': True,
             'auto': True,
         })
 
@@ -315,6 +315,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         lastgenre_cmd = ui.Subcommand('lastgenre', help='fetch genres')
         lastgenre_cmd.parser.add_option('-f', '--force', dest='force',
                               action='store_true',
+                              default=False,
                               help='re-download genre when already present')
         lastgenre_cmd.parser.add_option('-s', '--source', dest='source',
                               type='string',
@@ -347,9 +348,6 @@ class LastGenrePlugin(plugins.BeetsPlugin):
 
     def imported(self, session, task):
         """Event hook called when an import task finishes."""
-        # Always force a "real" lookup during import.
-        if not self.config['force']:
-            self.config['force'] = True
 
         if task.is_album:
             album = session.lib.get_album(task.album_id)

--- a/docs/plugins/lastgenre.rst
+++ b/docs/plugins/lastgenre.rst
@@ -35,6 +35,9 @@ Wikipedia`_.
 .. _pylast: http://code.google.com/p/pylast/
 .. _script that scrapes Wikipedia: https://gist.github.com/1241307
 
+Switch ``force`` flag to False to keep the original genre when member 
+of the whitelist.
+
 If no genre is found, the file will be left unchanged. To instead specify a
 fallback genre, use the ``fallback`` configuration option. You can, of
 course, use the empty string as a fallback, like so::


### PR DESCRIPTION
I activate lastgenre plugin on import so it fetches correct genre if I haven't done it already.
Forcing real lookup in all cases had bad side-effect in my workflow as it overruled a (allowed) genre that I had picked manually by another (allowed) less relevant one.

The reasoning of this PR is to consider that if user defines a custom whitelist and current track is allowed then it's highly likely that it had been manually set and a change is not desired.
