### PR TITLE
Print number of tracks when importing

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -517,7 +517,7 @@ class TerminalImportSession(importer.ImportSession):
         """
         # Show what we're tagging.
         print_()
-        print_(displayable_path(task.paths, u'\n'))
+        print_(displayable_path(task.paths, u'\n') + u' ({0} items)'.format(len(task.items)))
 
         # Take immediate action if appropriate.
         action = _summary_judment(task.rec)


### PR DESCRIPTION
I have a very cluttered and fragmented collection of mp3's to import.
This little patch helps me alot to decide if I should switch to singleton mode (because the directory to import only contains two or three files) or if I should check if there "should" be a complete album (with some/many files missing, crap inside or album splitted up into different directories).
