### PR TITLE
Perform template field substitution on albums

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -1754,6 +1754,10 @@ class Album(BaseAlbum):
         mapping['artpath'] = displayable_path(mapping['artpath'])
         mapping['path'] = displayable_path(self.item_dir())
 
+        # Get values from plugins.
+        for key, value in plugins.template_values(self).iteritems():
+            mapping[key] = value
+
         # Get template functions.
         funcs = DefaultTemplateFunctions().functions()
         funcs.update(plugins.template_funcs())

--- a/docs/plugins/writing.rst
+++ b/docs/plugins/writing.rst
@@ -261,6 +261,17 @@ that adds a ``$disc_and_track`` field::
 With this plugin enabled, templates can reference ``$disc_and_track`` as they
 can any standard metadata field.
 
+Note that the above idiom expects the argument ``item`` to be an
+actual *track* item. If you'd like to provide a template field for
+*albums*, you'll need to check the argument::
+
+    @MyPlugin.template_field('field')
+    def _tmpl_field(album):
+        """Return stuff.
+        """
+        if isinstance(album, beets.library.Album):
+            return 'stuff'
+
 Extend MediaFile
 ^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
- adds another traversal through all plugins' template_fields for each
  'evaluate_template' call.
- requires the following idiom (or equivalent):
  
  @Plugin.template_field(field')
  def _tmpl_field(album):
      """Return stuff.
      """
      if isinstance(album, Album):
          return stuff
