### PR TITLE
Append plugin template fields to 'beet fields' output with -p, --plugins

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -91,11 +91,20 @@ def _showdiff(field, oldval, newval):
 
 fields_cmd = ui.Subcommand('fields',
     help='show fields available for queries and format strings')
+fields_cmd.parser.add_option('-p', '--plugins', dest='plugins',
+                             action='store_true',
+                             help='show available plugin fields as well')
+
 def fields_func(lib, opts, args):
     print("Available item fields:")
     print("  " + "\n  ".join([key for key in library.ITEM_KEYS]))
     print("\nAvailable album fields:")
     print("  " + "\n  ".join([key for key in library.ALBUM_KEYS]))
+    if opts.plugins:
+        print("\nAvailable plugin fields:")
+        for plugin in plugins.find_plugins():
+            fields = plugin.template_fields.iteritems()
+            print("  " + "\n  ".join([key for (key, value) in fields]))
 
 fields_cmd.func = fields_func
 default_commands.append(fields_cmd)

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -250,11 +250,13 @@ fields
 ``````
 ::
 
-    beet fields
+    beet fields [-p]
 
 Show the item and album metadata fields available for use in :doc:`query` and
 :doc:`pathformat`.
 
+The ``-p`` (``--plugins``) option shows available plugin fields in
+addition to the standard ones.
 
 Global Flags
 ------------


### PR DESCRIPTION
Because I'm making available a custom template field in my 'missing' plugin, I thought it would be nice to be able to display all other fields registered by activated plugins.
