### PR TITLE
Use newly defined '$missing' template field instead of hardcoded format (-c)

### DIFF
--- a/beetsplug/missing.py
+++ b/beetsplug/missing.py
@@ -17,7 +17,7 @@
 import logging
 
 from beets.autotag import hooks
-from beets.library import Item
+from beets.library import Item, Album
 from beets.plugins import BeetsPlugin
 from beets.ui import decargs, print_obj, Subcommand
 
@@ -139,8 +139,9 @@ class MissingPlugin(BeetsPlugin):
                 if count:
                     missing = _missing_count(album)
                     if missing:
-                        fmt = "$album: {}".format(missing)
-                        print_obj(album, lib, fmt=fmt)
+                        if not fmt:
+                            fmt = '$albumartist - $album: $missing'
+                        print_obj(album, lib, fmt=fmt.format(missing))
                     continue
 
                 for item in _missing(album):
@@ -148,3 +149,13 @@ class MissingPlugin(BeetsPlugin):
 
         self._command.func = _miss
         return [self._command]
+
+
+@MissingPlugin.template_field('missing')
+def _tmpl_missing(album):
+    """Return number of missing items in 'album'.
+    """
+    if isinstance(album, Album):
+        return _missing_count(album)
+    else:
+        return ''

--- a/docs/plugins/missing.rst
+++ b/docs/plugins/missing.rst
@@ -2,9 +2,10 @@ Missing Plugin
 ==============
 
 This plugin adds a new command, ``missing`` or ``miss``, which finds
-and lists, for every album in your collection, which tracks are
-missing. Listing missing files requires one network call to
-MusicBrainz.
+and lists, for every album in your collection, which or how many
+tracks are missing. Listing missing files requires one network call to
+MusicBrainz. Merely counting missing files avoids any network calls.
+
 
 Installation
 ------------
@@ -49,8 +50,9 @@ inspired by, and therefore similar to, the :ref:`list <list-cmd>` command.
 count
 ~~~~~
 
-The ``count`` option (default: false) prints a count of missing
-tracks per album, with ``format`` hard-coded to ``'$album: $count'``.
+The ``count`` option (default: false) prints a count of missing tracks
+per album, with ``format`` defaulting to ``$albumartist - $album:
+$missing``.
 
 total
 ~~~~~
@@ -58,6 +60,12 @@ total
 The ``total`` option (default: false) prints a single
 count of missing tracks in all albums
 
+Metadata fields
+---------------
+
+With this plugin enabled, templates can reference ``$missing`` as they
+can any standard metadata field for use in :doc:`Queries
+</reference/query>` and :doc:`Path Formats </reference/pathformat>`.
 
 Examples
 --------
@@ -83,6 +91,9 @@ Print out a count of the total number of missing tracks::
 
   beet missing -t
 
+Call this plugin from other beet commands::
+
+  beet ls -a -f '$albumartist - $album: $missing'
 
 TODO
 ----


### PR DESCRIPTION
(Sorry for so many pull requests. I figured you'd prefer them bite-sized).

This depends on commit 106ad99556c808468944e6563e0101cf9fdda9e1 (#274)
