### PR TITLE
Look at many more metadata fields when calculating distance.

### DIFF
--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -102,8 +102,8 @@ class AlbumInfo(object):
         constituent `TrackInfo` objects, are decoded to Unicode.
         """
         for fld in ['album', 'artist', 'albumtype', 'label', 'artist_sort',
-                    'script', 'language', 'country', 'albumstatus',
-                    'albumdisambig', 'artist_credit', 'media']:
+                    'catalognum', 'script', 'language', 'country',
+                    'albumstatus', 'albumdisambig', 'artist_credit', 'media']:
             value = getattr(self, fld)
             if isinstance(value, str):
                 setattr(self, fld, value.decode(codec, 'ignore'))

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -72,10 +72,15 @@ match:
         partial: medium
         tracklength: strong
         tracknumber: strong
+    preferred_media: CD
     weight:
-        source: 3.0
+        source: 2.0
         artist: 3.0
         album: 3.0
+        year: 1.0
+        media: 1.0
+        album_id: 5.0
+        minor: 0.5
         track: 1.0
         missing: 0.9
         unmatched: 0.6

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -53,6 +53,19 @@ Changelog
     together for better readability.
   * Indicate MusicBrainz ID mismatches.
 
+* Improve calculation of similarity score:
+
+  * Strongly prefer releases with a matching MusicBrainz album ID. This helps
+    beets re-identify the same release when re-importing existing files.
+  * Prefer releases that are closest to the tagged ``year``. Tolerate files
+    tagged with release or original year.
+  * Prefer CD releases by default, when there is no ``media`` tagged in the
+    files being imported. This can be changed with the :ref:`preferred_media`
+    setting.
+  * Apply minor penalties across a range of fields to differentiate between
+    nearly identical releases: ``disctotal``, ``label``, ``catalognum``,
+    ``country`` and ``albumdisambig``.
+
 .. _Discogs: http://discogs.com/
 
 1.1.0 (April 29, 203)

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -420,6 +420,15 @@ recommendation is ``strong``, no "downgrading" occurs for that situation.
 
 The above example shows the default ``max_rec`` settings.
 
+.. _preferred_media:
+
+preferred_media
+~~~~~~~~~~~~~~~
+
+When comparing files that have no ``media`` tagged, prefer releases that more
+closely resemble this media (using a string distance). When files are already
+tagged with media, this setting is ignored. Default: ``CD``.
+
 .. _path-format-config:
 
 Path Format Configuration

--- a/test/test_autotag.py
+++ b/test/test_autotag.py
@@ -55,7 +55,7 @@ class PluralityTest(unittest.TestCase):
         items = [Item({'artist': 'The Beetles', 'album': 'The White Album'}),
                  Item({'artist': 'The Beatles', 'album': 'The White Album'}),
                  Item({'artist': 'The Beatles', 'album': 'Teh White Album'})]
-        l_artist, l_album, artist_consensus = match.current_metadata(items)
+        l_artist, l_album, artist_consensus, _ = match.current_metadata(items)
         self.assertEqual(l_artist, 'The Beatles')
         self.assertEqual(l_album, 'The White Album')
         self.assertFalse(artist_consensus)
@@ -64,7 +64,7 @@ class PluralityTest(unittest.TestCase):
         items = [Item({'artist': 'The Beatles', 'album': 'The White Album'}),
                  Item({'artist': 'The Beatles', 'album': 'The White Album'}),
                  Item({'artist': 'The Beatles', 'album': 'Teh White Album'})]
-        l_artist, l_album, artist_consensus = match.current_metadata(items)
+        l_artist, l_album, artist_consensus, _ = match.current_metadata(items)
         self.assertEqual(l_artist, 'The Beatles')
         self.assertEqual(l_album, 'The White Album')
         self.assertTrue(artist_consensus)
@@ -76,9 +76,19 @@ class PluralityTest(unittest.TestCase):
                        'albumartist': 'aartist'}),
                  Item({'artist': 'tartist3', 'album': 'album',
                        'albumartist': 'aartist'})]
-        l_artist, l_album, artist_consensus = match.current_metadata(items)
+        l_artist, l_album, artist_consensus, _ = match.current_metadata(items)
         self.assertEqual(l_artist, 'aartist')
         self.assertFalse(artist_consensus)
+
+    def test_current_metadata_likelies(self):
+        fields = ['artist', 'album', 'albumartist', 'year', 'disctotal',
+                  'mb_albumid', 'label', 'catalognum', 'country', 'media',
+                  'albumdisambig']
+        items = [Item(dict((f, '%s_%s' % (f, i or 1)) for f in fields))
+                 for i in range(5)]
+        _, _, _, likelies = match.current_metadata(items)
+        for f in fields:
+            self.assertEqual(likelies[f], '%s_1' % f)
 
 def _make_item(title, track, artist=u'some artist'):
     return Item({


### PR DESCRIPTION
Produce slightly more varied similarity score to prioritise extremely
similar releases.
