### PR TITLE
Initial support for ALAC encoded audio files

### DIFF
--- a/beets/mediafile.py
+++ b/beets/mediafile.py
@@ -885,6 +885,8 @@ class MediaFile(object):
             raise FileTypeError('file type unsupported by Mutagen')
         elif type(self.mgfile).__name__ == 'M4A' or \
              type(self.mgfile).__name__ == 'MP4':
+            # This hack differentiates aac and alac until we find a more
+            # deterministic approach.
             if hasattr(self.mgfile.info, 'sample_rate') and \
                self.mgfile.info.sample_rate > 0:
                 self.type = 'aac'


### PR DESCRIPTION
Both AAC and ALAC are normally embedded in an .m4a container. For
this reason I have split the m4a type into aac and alac types.

To distinguish between the two encodings I have taken advantage
of the fact that, in my collection, ALAC don't have a sample_rate
set. I could not find verification if this is always the case
or not. Would bitrate be a more reliable determining factor?
e.g. if bitrate > 320000: type = 'alac'

Signed-off-by: Simon Luijk simon@simonluijk.com

Initial issue #142
