### PR TITLE
Fix Python 2.6 compatibility

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -98,10 +98,10 @@ class DiscogsPlugin(BeetsPlugin):
         # cause a query to return no results, even if they match the artist or
         # album title. Use `re.UNICODE` flag to avoid stripping non-english
         # word characters.
-        query = re.sub(r'\W+', ' ', query, re.UNICODE)
+        query = re.sub(r'(?u)\W+', ' ', query)
         # Strip medium information from query, Things like "CD1" and "disk 1"
         # can also negate an otherwise positive result.
-        query = re.sub(r'\b(CD|disc)\s*\d+', '', query, re.I)
+        query = re.sub(r'(?i)\b(CD|disc)\s*\d+', '', query)
         albums = []
         for result in Search(query).results():
             if isinstance(result, Release):


### PR DESCRIPTION
This should fix the following traceback when using beets/discogs plugin with python2.6

<pre>Traceback (most recent call last):
  File "/usr/local/bin/beet", line 9, in <module>
    load_entry_point('beets==1.1.1', 'console_scripts', 'beet')()
  File "/home/jayme/coding/beets/beets/ui/__init__.py", line 771, in main
    _raw_main(args)
  File "/home/jayme/coding/beets/beets/ui/__init__.py", line 763, in _raw_main
    subcommand.func(lib, suboptions, subargs)
  File "/home/jayme/coding/beets/beets/ui/commands.py", line 835, in import_func
    import_files(lib, paths, query)
  File "/home/jayme/coding/beets/beets/ui/commands.py", line 773, in import_files
    session.run()
  File "/home/jayme/coding/beets/beets/importer.py", line 337, in run
    pl.run_parallel(QUEUE_SIZE)
  File "/home/jayme/coding/beets/beets/util/pipeline.py", line 243, in run
    out = self.coro.send(msg)
  File "/home/jayme/coding/beets/beets/importer.py", line 646, in initial_lookup
    *autotag.tag_album(task.items)
  File "/home/jayme/coding/beets/beets/autotag/match.py", line 523, in tag_album
    va_likely)
  File "/home/jayme/coding/beets/beets/autotag/hooks.py", line 207, in _album_candidates
    out.extend(plugins.candidates(items, artist, album, va_likely))
  File "/home/jayme/coding/beets/beets/plugins.py", line 258, in candidates
    out.extend(plugin.candidates(items, artist, album, va_likely))
  File "/home/jayme/coding/beets/beetsplug/discogs.py", line 65, in candidates
    return self.get_albums(query)
  File "/home/jayme/coding/beets/beetsplug/discogs.py", line 84, in get_albums
    albums.append(self.get_album_info(result))
  File "/home/jayme/coding/beets/beetsplug/discogs.py", line 94, in get_album_info
    artist, artist_id = self.get_artist(result.data['artists'])
  File "/home/jayme/coding/beets/beetsplug/discogs.py", line 136, in get_artist
    name = re.sub(r'^(.*?), (a|an|the)$', r'\2 \1', name, flags=re.I)
TypeError: sub() got an unexpected keyword argument 'flags'</pre>
