### PR TITLE
#282: Add option to set a base path for the web plugin

### DIFF
--- a/docs/plugins/web.rst
+++ b/docs/plugins/web.rst
@@ -31,16 +31,17 @@ http://localhost:8337/. This is what it looks like:
 
 .. image:: beetsweb.png
 
-You can also specify the hostname and port number used by the Web server. These
-can be specified on the command line or in the ``[web]`` section of your
-:doc:`configuration file </reference/config>`.
+You can also specify the hostname, port number and base path used by the Web
+server. These can be specified on the command line or in the ``[web]`` section
+of your :doc:`configuration file </reference/config>`.
 
-On the command line, use ``beet web [HOSTNAME] [PORT]``. In the config file, use
-something like this::
+On the command line, use ``beet web [HOSTNAME] [PORT] [BASE_URL]``. In the
+config file, use something like this::
 
     web:
         host: 127.0.0.1
         port: 8888
+        base_url: /beets
 
 Usage
 -----


### PR DESCRIPTION
This implements the feature request from issue #282.
The changes are relatively minor, I added a configuration parameter 'base_path' to the web plugin and refactored the plugin to use Werkzeug's DispatcherMiddleware (with a dummy app that returns 404 for '/' if a custom base_path is used).
