### PR TITLE
Fix bug where a null value for lengthMS would crash an import. Added a fallback to parse the standard min:sec length field.

### DIFF
--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -139,8 +139,10 @@ class BeatportTrack(BeatportObject):
             self.title = unicode(data['title'])
         if 'mixName' in data:
             self.mix_name = unicode(data['mixName'])
-        if 'length' in data:
-            self.length = timedelta(milliseconds=data['lengthMs'])
+        self.length = timedelta(milliseconds=data.get('lengthMs',0) or 0)
+        if self.length == 0:
+            (min, sec) = data.get('length','0:0').split(':')
+            self.length = timedelta(minutes=min, seconds=sec)
         if 'slug' in data:
             self.url = "http://beatport.com/track/{0}/{1}".format(data['slug'],
                                                                   data['id'])


### PR DESCRIPTION
This addresses issue #318 that I reported.
