### PR TITLE
Add 'disk' spelling as a multidisc marker.

### DIFF
--- a/beets/autotag/__init__.py
+++ b/beets/autotag/__init__.py
@@ -30,7 +30,7 @@ from .match import recommendation
 log = logging.getLogger('beets')
 
 # Constants for directory walker.
-MULTIDISC_MARKERS = (r'disc', r'cd')
+MULTIDISC_MARKERS = (r'dis[ck]', r'cd')
 MULTIDISC_PAT_FMT = r'^(.*%s[\W_]*)\d'
 
 


### PR DESCRIPTION
I've encountered "disk 1", "disk 2" a few times as an alternate spelling for disc. I think its unlikely to find 'disk' in an album title otherwise.
