### PR TITLE
Send a plug-in event when file is moved

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -370,7 +370,8 @@ class Item(object):
             util.copy(self.path, dest)
         else:
             util.move(self.path, dest)
-            plugins.send("item_moved", source=self.path, destination=dest)
+            plugins.send("item_moved", item=self, source=self.path,
+                         destination=dest)
 
         # Either copying or moving succeeded, so update the stored path.
         self.path = dest

--- a/docs/plugins/writing.rst
+++ b/docs/plugins/writing.rst
@@ -126,8 +126,8 @@ currently available are:
   singleton to the library (not called for full-album imports). Parameters:
   ``lib``, ``item``
 
-* *item_moved*: called whenever an ``Item`` is moved.  Parameters: ``source``
-  and ``destination`` paths
+* *item_moved*: called with an ``Item`` object whenever its file is moved.
+  Parameters: ``item``, ``source`` path, ``destination`` path
 
 * *write*: called with an ``Item`` object just before a file's metadata is
   written to disk (i.e., just before the file on disk is opened).


### PR DESCRIPTION
I use this in one of my plug-ins to notice when I've moved all the audio
files in an album from one directory to another, at which point I move
any associated non-album files to the new directory and delete the old
directory.
