### PR TITLE
lyrics: google backend should turn up (even) more results 

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -231,11 +231,6 @@ def is_page_candidate(urlLink, urlTitle, title, artist):
              [artist, sitename, sitename.replace('www.','')] + LYRICS_TRANS
     songTitle = re.sub(u'(%s)' % u'|'.join(tokens) ,u'', urlTitle).strip('%20')
 
-    if songTitle:
-        log.debug("Match ratio of '%s' with title: %s" %
-                  (songTitle,
-                   difflib.SequenceMatcher(None, songTitle, title).ratio()))
-
     typoRatio = .8
     return difflib.SequenceMatcher(None, songTitle, title).ratio() >= typoRatio
 
@@ -374,6 +369,7 @@ def fetch_google(artist, title):
             lyrics = sanitize_lyrics(lyrics)
 
             if is_lyrics(lyrics, artist):
+                log.debug(u'got lyrics from %s' % item['displayLink'])
                 return lyrics
 
 


### PR DESCRIPTION
I spent one hour attacking my _Latin_ folder with lyrics plugin :  
- added 2 new sources websites to the default beets Google Custom Engine, noticeably maxilyrics.com seems to have a good portion of latin lyrics
- tweaked the plugin code to find more results by skipping text between parentheses when comparing titles and dissociating valid lyrics containing lyrics credits from invalid lyrics text placeholder  
