### PR TITLE
allow and expand home directory in mpdupdate socket

### DIFF
--- a/beetsplug/mpdupdate.py
+++ b/beetsplug/mpdupdate.py
@@ -23,6 +23,7 @@ Put something like the following in your config.yaml to configure:
 from __future__ import print_function
 
 from beets.plugins import BeetsPlugin
+import os
 import socket
 from beets import config
 
@@ -36,9 +37,9 @@ database_changed = False
 class BufferedSocket(object):
     """Socket abstraction that allows reading by line."""
     def __init__(self, host, port, sep='\n'):
-        if host[0] == '/':
+        if host[0] in ['/', '~']:
             self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            self.sock.connect(host)
+            self.sock.connect(os.path.expanduser(host))
         else:
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.sock.connect((host, port))

--- a/docs/plugins/mpdupdate.rst
+++ b/docs/plugins/mpdupdate.rst
@@ -20,5 +20,5 @@ With that all in place, you'll see beets send the "update" command to your MPD s
 
 If you want to communicate with MPD over a Unix domain socket instead over
 TCP, just give the path to the socket in the filesystem for the ``host``
-setting. (Any ``host`` value starting with a slash is interpreted as a domain
+setting. (Any ``host`` value starting with a slash or a tilde is interpreted as a domain
 socket.)


### PR DESCRIPTION
This allows you to use a socket in your home directory (e.g.
`~/.mpd/socket`) without having to specify the full path including the
username (which can change from machine to machine).
