### PR TITLE
setup.py: update version of mutagen dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(name='beets',
       },
 
       install_requires=[
-          'mutagen>=1.21',
+          'mutagen>=1.22',
           'munkres',
           'unidecode',
           'musicbrainzngs>=0.4',


### PR DESCRIPTION
We actually need 1.22 due to usage of update_to_v23
