### PR TITLE
Added "None" check to miscellaneous metadata.

### DIFF
--- a/beets/autotag/__init__.py
+++ b/beets/autotag/__init__.py
@@ -221,15 +221,25 @@ def apply_metadata(album_info, mapping):
         item.comp = album_info.va
 
         # Miscellaneous metadata.
-        item.albumtype = album_info.albumtype
-        if album_info.label:
+        if album_info.albumtype is not None:
+            item.albumtype = album_info.albumtype
+        if album_info.label is not None:
             item.label = album_info.label
-        item.asin = album_info.asin
-        item.catalognum = album_info.catalognum
-        item.script = album_info.script
-        item.language = album_info.language
-        item.country = album_info.country
-        item.albumstatus = album_info.albumstatus
-        item.media = album_info.media
-        item.albumdisambig = album_info.albumdisambig
-        item.disctitle = track_info.disctitle
+        if album_info.asin is not None:
+            item.asin = album_info.asin
+        if album_info.catalognum is not None:
+            item.catalognum = album_info.catalognum
+        if album_info.script is not None:
+            item.script = album_info.script
+        if album_info.language is not None:
+            item.language = album_info.language
+        if album_info.country is not None:
+            item.country = album_info.country
+        if album_info.albumstatus is not None:
+            item.albumstatus = album_info.albumstatus
+        if album_info.media is not None:
+            item.media = album_info.media
+        if album_info.albumdisambig is not None:
+            item.albumdisambig = album_info.albumdisambig
+        if track_info.disctitle is not None:
+            item.disctitle = track_info.disctitle


### PR DESCRIPTION
Without a "None" check in those fields, the plugin MBSync and the "update"
command  may incur in a loop: While the MBSync plugin insists in the value
"None" (not the string "None"!) for some of the optional and misc metadata
(change which is propagated to the beets database, while maintaining the actual
value equal to an empty string in the file), the "update" command in beet
change the database back, as an empty string is found in that field in the
file. These changes are repeated every time a "mbsync" command is followed by
an "update" command.
