### PR TITLE
Add support for multiple genres in tags

### DIFF
--- a/beets/mediafile.py
+++ b/beets/mediafile.py
@@ -460,8 +460,11 @@ class MediaField(object):
             except KeyError:
                 return None
 
+        if obj.type == 'mp3' and style.is_genre:
+            return entry
+        
         # Possibly index the list.
-        if style.list_elem and not style.is_genre:
+        if style.list_elem:
             if entry:  # List must have at least one value.
                 # Handle Mutagen bugs when reading values (#356).
                 try:


### PR DESCRIPTION
This converts the comma-delimited string into a list when writing tags
and vice-versa when reading.
This way it adds support for media browsers separating genres without
breaking database storage or querying.

Should help with #119
