### PR TITLE
fix MatchQuery('path', ...) for unicode value

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -1026,7 +1026,10 @@ class MatchQuery(FieldQuery):
     """A query that looks for exact matches in an item field."""
     def col_clause(self):
         pattern = self.pattern
-        if self.field == 'path' and isinstance(pattern, str):
+        if self.field == 'path':
+          if isinstance(pattern, unicode):
+              pattern = bytestring_path(pattern)
+          if isinstance(pattern, str):
             pattern = buffer(pattern)
         return self.field + " = ?", [pattern]
 


### PR DESCRIPTION
I found this when trying out the new mpdstats plugin. There a `unicode(...)` path is passed to `MatchQuery` so this change was necessary for me to get any results. However I do not know if this is the most general fix, so feel free to nudge me in the right direction.
