### PR TITLE
Refactor mpdstats plugin

### DIFF
--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -187,6 +187,7 @@ class MPDStats(object):
             return
 
         if increment is not None:
+            item.load()
             value = type(increment)(item.get(attribute, 0)) + increment
 
         if value is not None:
@@ -202,6 +203,7 @@ class MPDStats(object):
     def update_rating(self, item, skipped):
         """Update the rating for a beets item.
         """
+        item.load()
         rating = self.rating(
             int(item.get('play_count', 0)),
             int(item.get('skip_count', 0)),


### PR DESCRIPTION
I spent some time with the nice mpdstats plugin yesterday and ended up refactoring it quite a bit. All extra logic used to get information from MPD now is in `MPDClientWrapper` and the core logic has its own class `MPDStats`. There I split off most actions into separate functions that are called from a lean event loop. The last commit fixes the 'caching' behavior mentioned on IRC. Sorry for this huge diff, but I think it ended up both clearer and more extendable.
