### PR TITLE
Added instructions on how to run manually from CLI

### DIFF
--- a/docs/plugins/echonest.rst
+++ b/docs/plugins/echonest.rst
@@ -86,3 +86,10 @@ Echoprint or ENMFP codegen binary. Use the ``codegen`` key under the
         codegen: /usr/bin/echoprint-codegen
 
 .. _apply for your own: http://developer.echonest.com/account/register
+
+Running Manually
+----------------
+
+In addition to running automatically on import, the plugin can also be run manually
+from the command line. Use the command ``beet echonest [QUERY]`` to fetch
+acoustic attributes for albums matching a certain query.


### PR DESCRIPTION
Hi, I couldn't figure out from the current documentation how to run echonest manually without tying it to import, so I took a look at the code, figured it out, and added it to the docs. This is basically the same thing as the instructions for the lastgenre plugin, so it should fit in stylistically.
