### PR TITLE
Make sure bpm values coming from echonest are stored as integers.

### DIFF
--- a/beetsplug/echonest.py
+++ b/beetsplug/echonest.py
@@ -360,7 +360,10 @@ class EchonestMetadataPlugin(plugins.BeetsPlugin):
             if k in ATTRIBUTES:
                 field = ATTRIBUTES[k]
                 log.debug(u'echonest: metadata: {0} = {1}'.format(field, v))
-                item[field] = v
+                if field == 'bpm':
+                    item[field] = int(v)
+                else:
+                    item[field] = v
         if 'id' in values:
             enid = values['id']
             log.debug(u'echonest: metadata: {0} = {1}'.format(ID_KEY, enid))

--- a/beetsplug/echonest_tempo.py
+++ b/beetsplug/echonest_tempo.py
@@ -53,7 +53,7 @@ def fetch_item_tempo(lib, loglevel, item, write):
 
     log.log(loglevel, u'fetched tempo: %s - %s' %
                       (item.artist, item.title))
-    item.bpm = tempo
+    item.bpm = int(tempo)
     if write:
         item.write()
     item.store()


### PR DESCRIPTION
Echonest returns BPM values as floats, while they get stored as integers in file tags. With this we make sure they are also stored as integers in the database, avoiding showing differences between file and db data.
