### PR TITLE
Send a plugin event when a file is copied.

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -350,6 +350,8 @@ class Item(LibModel):
             dest = util.unique_path(dest)
         if copy:
             util.copy(self.path, dest)
+            plugins.send("item_copied", item=self, source=self.path,
+                         destination=dest)
         else:
             util.move(self.path, dest)
             plugins.send("item_moved", item=self, source=self.path,

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -124,6 +124,9 @@ currently available are:
   command finishes adding an album to the library. Parameters: ``lib``,
   ``album``
 
+* *item_copied*: called with an ``Item`` object whenever its file is copied.
+  Parameters: ``item``, ``source`` path, ``destination`` path
+
 * *item_imported*: called with an ``Item`` object every time the importer adds a
   singleton to the library (not called for full-album imports). Parameters:
   ``lib``, ``item``


### PR DESCRIPTION
I use this event in a plugin that needs to know which file outside the
library an item was copied from during import.
