### PR TITLE
Local search with beet fetchart / Do not write file tags when db tags are not modified

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -98,3 +98,5 @@ match:
     ignored: []
     track_length_grace: 10
     track_length_max: 30
+
+dont_write_if_unchanged: no

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -212,7 +212,8 @@ def batch_fetch_art(lib, albums, force, maxwidth=None):
         if album.artpath and not force:
             message = 'has album art'
         else:
-            path = art_for_album(album, None, maxwidth)
+            lookuppath = None if force else [album.path]
+            path = art_for_album(album, lookuppath, maxwidth)
 
             if path:
                 album.set_art(path, False)

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -219,8 +219,12 @@ def batch_fetch_art(lib, albums, force, maxwidth=None):
                 album.set_art(path, False)
                 album.store()
                 message = 'found album art'
+                if config['color']:
+                    message = ui.colorize('red', message)
             else:
                 message = 'no art found'
+                if config['color']:
+                    message = ui.colorize('turquoise', message)
         log.info(u'{0} - {1}: {2}'.format(album.albumartist, album.album,
                                           message))
 


### PR DESCRIPTION
A very modest contribution.

Three little modifications:
1) When running beet fetchart, look again in album folder (unless force mode is used).
2) Colorized output of beet fetchart, so missing covers are easier to see.
3) When running beet modify, added a config option for not writing tags to file, when db tags are not modified.
