### PR TITLE
Do not write file tags when DB tags are not modified

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -75,6 +75,9 @@ def _do_query(lib, query, album, also_items=True):
 
 FLOAT_EPSILON = 0.01
 def _different(val1, val2):
+    """Says if the two values are considered different."""
+    # Considering floats incomparable for perfect equality, introduce
+    # an epsilon tolerance.
     if (val1 == val2) or \
             ( isinstance(val1, float) and isinstance(val2, float) and \
             abs(val1 - val2) < FLOAT_EPSILON ):
@@ -85,13 +88,7 @@ def _different(val1, val2):
 
 def _showdiff(field, oldval, newval):
     """Prints out a human-readable field difference line."""
-    # Considering floats incomparable for perfect equality, introduce
-    # an epsilon tolerance.
-    if isinstance(oldval, float) and isinstance(newval, float) and \
-            abs(oldval - newval) < FLOAT_EPSILON:
-        return
-
-    if newval != oldval:
+    if _different(newval, oldval):
         oldval, newval = ui.colordiff(oldval, newval)
         print_(u'  %s: %s -> %s' % (field, oldval, newval))
 


### PR DESCRIPTION
As recommended I submit again my second proposal as a separate pull request.

In summary: during beet modify processing, don't write file tags unless DB tags are modified.

Advantages:
- Optimization: fewer file write operations
- We don't have anymore the situation where the modification time on the file system is changed whereas the content of the file is not

Additional comments:
The second advantage was the driver for me: I regularly update lots of files (audio but also video and photos) between my PC and my media server, using rsync -u. For ex. launching "beet modify beatles genre=pop" was not only updating the files of the last added album, but all the previous ones, causing a lot of files to be updated during the following rsync.

At the beginning I put a configuration parameter to disable this "optimization" because I thought the Beets philosophy was that the file tags must always be consistent with what is in the DB (so my optimization was not for general use). But to obtain this, we just need to launch "beet write". The configuration parameter is now removed and the optimization is always performed.
