### PR TITLE
fix mpdstats plugin after query restructuring

### DIFF
--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -23,7 +23,7 @@ import os
 from beets import ui
 from beets import config
 from beets import plugins
-from beets import dbcore
+from beets import library
 from beets.util import displayable_path
 
 log = logging.getLogger('beets')
@@ -165,7 +165,7 @@ class MPDStats(object):
     def get_item(self, path):
         """Return the beets item related to path.
         """
-        query = dbcore.query.BytesQuery('path', path)
+        query = library.PathQuery('path', path)
         item = self.lib.items(query).get()
         if item:
             return item


### PR DESCRIPTION
BytesQuery does not handle unicode strings correctly at the moment (see issue #517)
and PathQuery seems like a reasonable query to use.
