### PR TITLE
Add a plugin for preserving file modification times during copy imports.

### DIFF
--- a/beetsplug/importadded.py
+++ b/beetsplug/importadded.py
@@ -14,17 +14,17 @@ from beets.plugins import BeetsPlugin
 log = logging.getLogger('beets')
 
 
-class ImportMtimesPlugin(BeetsPlugin):
+class ImportAddedPlugin(BeetsPlugin):
     def __init__(self):
-        super(ImportMtimesPlugin, self).__init__()
+        super(ImportAddedPlugin, self).__init__()
         self.config.add({
             'preserve_mtimes': False,
         })
 
 
-@ImportMtimesPlugin.listen('import_task_start')
+@ImportAddedPlugin.listen('import_task_start')
 def check_config(task, session):
-    config['importmtimes']['preserve_mtimes'].get(bool)
+    config['importadded']['preserve_mtimes'].get(bool)
 
 
 def write_file_mtime(path, mtime):
@@ -53,8 +53,8 @@ def write_item_mtime(item, mtime):
     item.mtime = mtime
 
 
-@ImportMtimesPlugin.listen('before_item_moved')
-@ImportMtimesPlugin.listen('item_copied')
+@ImportAddedPlugin.listen('before_item_moved')
+@ImportAddedPlugin.listen('item_copied')
 def record_import_mtime(item, source, destination):
     """Record the file mtime of an item's path before import.
     """
@@ -70,14 +70,14 @@ def record_import_mtime(item, source, destination):
               util.displayable_path(source))
 
 
-@ImportMtimesPlugin.listen('album_imported')
+@ImportAddedPlugin.listen('album_imported')
 def update_album_times(lib, album):
     album_mtimes = []
     for item in album.items():
         mtime = item_mtime[item.path]
         if mtime is not None:
             album_mtimes.append(mtime)
-            if config['importmtimes']['preserve_mtimes'].get(bool):
+            if config['importadded']['preserve_mtimes'].get(bool):
                 write_item_mtime(item, mtime)
                 item.store()
             del item_mtime[item.path]
@@ -86,12 +86,12 @@ def update_album_times(lib, album):
     album.store()
 
 
-@ImportMtimesPlugin.listen('item_imported')
+@ImportAddedPlugin.listen('item_imported')
 def update_item_times(lib, item):
     mtime = item_mtime[item.path]
     if mtime is not None:
         item.added = mtime
-        if config['importmtimes']['preserve_mtimes'].get(bool):
+        if config['importadded']['preserve_mtimes'].get(bool):
             write_item_mtime(item, mtime)
         item.store()
         del item_mtime[item.path]

--- a/docs/plugins/importadded.rst
+++ b/docs/plugins/importadded.rst
@@ -1,7 +1,7 @@
-ImportMtimes Plugin
-===================
+ImportAdded Plugin
+==================
 
-The ``importmtimes`` plugin is useful when an existing collection is imported
+The ``importadded`` plugin is useful when an existing collection is imported
 and the time when albums and items were added should be preserved.
 
 The :abbr:`mtime (modification time)` of files that are imported into the
@@ -18,7 +18,7 @@ The ``item.added`` field is populated as follows:
 
 This plugin can optionally be configured to also preserve mtimes::
 
-    importmtimes:
+    importadded:
         preserve_mtimes: yes # default: no
 
 File modification times are preserved as follows:
@@ -29,5 +29,5 @@ File modification times are preserved as follows:
     from which the item is imported from.
   * The mtime of the file ``item.path`` is set to ``item.mtime``.
 
-Note that albums doesn't have an mtime field. The mtime of album
-directories are not preserved.
+Note that there is no ``album.mtime`` field in the database and that the mtime
+of album directories on disk aren't preserved.

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -59,7 +59,7 @@ by typing ``beet version``.
    ftintitle
    keyfinder
    bucket
-   importmtimes
+   importadded
 
 Autotagger Extensions
 ---------------------
@@ -92,8 +92,8 @@ Metadata
   statistics (last_played, play_count, skip_count, rating).
 * :doc:`keyfinder`: Use the `KeyFinder`_ program to detect the musical
   key from the audio.
-* :doc:`importmtimes`: Preserve file modification times and use them as values
-  for the `added` and `mtime` fields in the database.
+* :doc:`importadded`: Use file modification times for guessing the value for
+  the `added` field in the database.
 
 .. _Acoustic Attributes: http://developer.echonest.com/acoustic-attributes.html
 .. _the Echo Nest: http://www.echonest.com


### PR DESCRIPTION
My existing music collection contains information about when I added music into the collection in the files' modified times. I don't want to loose this information if I import my collection into Beets.

This plugin will preserve file modification times and also store them in the 'added' and 'mtime' fields in the Beets database.

Please review the code and let me know if anything should be changed.
