### PR TITLE
Include beetsplug in coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,7 +4,6 @@ omit =
     */python?.?/*
     */site-packages/nose/*
     */test/*
-    */beetsplug/*
 exclude_lines =
     assert False
     raise NotImplementedError


### PR DESCRIPTION
Is there a reasons not to? We test the plugins, so we should report the coverage.
