### PR TITLE
When storing an object, empty flexible fields are removed from the xxx_a...

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -257,7 +257,15 @@ class Model(object):
 
             # Flexible attributes.
             for key, value in self._values_flex.items():
-                if key in self._dirty:
+                # Remove any empty field
+                if value == '':
+                    tx.mutate(
+                        'DELETE FROM {0} WHERE '
+                        'entity_id=? AND key=?;'.format(self._flex_table),
+                        (self.id, key),
+                    )
+                elif key in self._dirty:
+                    # Insert/update only created/modified fields
                     tx.mutate(
                         'INSERT INTO {0} '
                         '(entity_id, key, value) '


### PR DESCRIPTION
...ttributes DB table.

There was no way to remove empty (useless) fields in item_attributes/album_attributes tables (these two tables keep growing endlessly).
In the proposed modification, I consider that any empty flexible field should not exist in the DB.

Existing empty flexible fields (of all objects) are not cleaned yet. For my part, I ran two SQL requests manually on the DB:
remove from item_attributes where value='';
remove from album_attributes where value='';
There should be a way to integrate these requests in the code.
