### PR TITLE
Remove from DB any flexible attribute that is None

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -257,7 +257,15 @@ class Model(object):
 
             # Flexible attributes.
             for key, value in self._values_flex.items():
-                if key in self._dirty:
+                # Remove any flexible attribute that is None
+                if value is None:
+                    tx.mutate(
+                        'DELETE FROM {0} WHERE '
+                        'entity_id=? AND key=?;'.format(self._flex_table),
+                        (self.id, key),
+                    )
+                elif key in self._dirty:
+                    # Insert/update only created/modified flexible attributes
                     tx.mutate(
                         'INSERT INTO {0} '
                         '(entity_id, key, value) '


### PR DESCRIPTION
Modification at API level: a attribute with None value should not appear in DB when it is a flexible attribute.
Otherwise there is no way to remove a flexible attribute (i.e. from xxx_attributes DB tables).
