### PR TITLE
mpdstats: update last_played

### DIFF
--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -281,6 +281,9 @@ class MPDStats(object):
             'beets_item': self.get_item(path),
         }
 
+        self.update_item(self.now_playing['beets_item'],
+                         'last_played', value=int(time.time()))
+
     def run(self):
         self.mpd.connect()
         events = ['player']


### PR DESCRIPTION
This fixes #529 and brings back the old behaviour of setting last_played
on every song change regardless of whether it is played to the end or skipped.
