### PR TITLE
Set album art type attribute to front cover for FLAC

### DIFF
--- a/beets/mediafile.py
+++ b/beets/mediafile.py
@@ -815,6 +815,7 @@ class ImageField(object):
             if val is not None:
                 pic = mutagen.flac.Picture()
                 pic.data = val
+                pic.type = 3    # Front cover.
                 pic.mime = self._mime(val)
                 obj.mgfile.add_picture(pic)
 


### PR DESCRIPTION
It would be useful to have the picture type set to front cover when adding artwork to FLAC files.  This is already done for mp3 files.
