### PR TITLE
Ability to gather the result of several queries into a smartplaylist

### DIFF
--- a/docs/plugins/smartplaylist.rst
+++ b/docs/plugins/smartplaylist.rst
@@ -44,6 +44,14 @@ For more advanced usage, you can use template syntax (see
 This will query all the songs in 2010 and 2011 and generate the two playlist
 files `ReleasedIn2010.m3u` and `ReleasedIn2011.m3u` using those songs.
 
+You can also gather the results of several queries by putting them in a list. By
+default duplicates are removed, but you can keep all of them with the
+``keep_duplicate: yes`` additional directive. For example::
+
+    - query: ['artist:beatles', 'genre:"beatles cover"']
+      name: 'BeatlesUniverse.m3u'
+      keep_duplicate: yes
+
 By default, all playlists are regenerated after every beets command that
 changes the library database. To force regeneration, you can invoke it manually
 from the command line::


### PR DESCRIPTION
In config, we can now indicate:

```
smartplaylist:
[...]
  - query: ['artist:beatles', 'genre:"beatles cover"']
    name: 'BeatlesUniverse.m3u'
```

The resulting m3u will contain the output of all the queries in the list.
By default there will be no duplicates, but you can specify `keep_duplicate: yes`.

NB: I was not sure how to handle default parameter value for keep_duplicate.
This time I did not forget to update the doc.

Without this change, the queries in the list were combined with an AND logical operator. Now they are combined with an OR logical operator. To obtain an AND combination, we must just put all the criterion in the same query string (in the example above: `query: 'artist:beatles genre:"beatles cover"']`).

Feel free to modify any of this to your convenience (I'm not a Python expert -- and concerning the doc English is not my native language).
