### PR TITLE
Clarify debian/ubuntu pip installation.

### DIFF
--- a/docs/guides/main.rst
+++ b/docs/guides/main.rst
@@ -21,8 +21,9 @@ You will need Python. (Beets is written for `Python 2.7`_, but it works with
   official package (`Debian details`_, `Ubuntu details`_), so try typing:
   ``apt-get install beets``. But the version in the repositories might lag
   behind, so make sure you read the right version of these docs. If you want
-  the latest version, you can get everything you need by running:
-  ``apt-get install python-dev python-setuptools python-pip``
+  the latest version, you can get everything you need to install with pip
+  as described below by running:
+  ``apt-get install python-dev python-pip``
 
 * On **Arch Linux**, `beets is in [community]`_, so just run ``pacman -S
   beets``. (There's also a bleeding-edge `dev package`_ in the AUR, which will


### PR DESCRIPTION
I removed python-setuptools from the apt-get command. Is is a dependency of pip, and so it is redundant and unhelpful added complexity.
