### PR TITLE
Add after_write plugin event

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -392,6 +392,7 @@ class Item(LibModel):
 
         # The file has a new mtime.
         self.mtime = self.current_mtime()
+        plugins.send('after_write', item=self)
 
 
     # Files themselves.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,7 @@ New stuff:
 * :doc:`/plugins/echonest`: Echo Nest similarity now weights the tempo in
   better proportion to other metrics. Also, options were added to specify
   custom thresholds and output formats. Thanks to Adam M.
+* Added the :ref:`after_write <plugin_events>` plugin event.
 
 Fixes:
 

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -90,6 +90,8 @@ You can add command-line options to your new command using the ``parser`` member
 of the ``Subcommand`` class, which is an ``OptionParser`` instance. Just use it
 like you would a normal ``OptionParser`` in an independent script.
 
+.. _plugin_events:
+
 Listen for Events
 ^^^^^^^^^^^^^^^^^
 
@@ -140,6 +142,9 @@ currently available are:
 
 * *write*: called with an ``Item`` object just before a file's metadata is
   written to disk (i.e., just before the file on disk is opened).
+
+* *after_write*: called with an ``Item`` object after a file's metadata is
+  written to disk (i.e., just after the file on disk is closed).
 
 * *import_task_start*: called when before an import task begins processing.
   Parameters: ``task`` (an `ImportTask`) and ``session`` (an `ImportSession`).


### PR DESCRIPTION
I wrote a plugin to [verify checksums](https://github.com/geigerzaehler/beets-check). The plugin should update checksums if beets writes the tags of a file. Since the checksum should be computed after the data was written, we need an additional event. I am open to suggestions for a better name.
