### PR TITLE
Write tags only when changed

### DIFF
--- a/test/test_mediafile.py
+++ b/test/test_mediafile.py
@@ -165,7 +165,6 @@ class ExtendedImageStructureTestMixin(ImageStructureTestMixin):
                 desc='the composer', type=Image.TYPES.composer)
 
 
-# TODO include this in ReadWriteTestBase if implemented
 class LazySaveTestMixin(object):
     """Mediafile should only write changes when tags have changed
     """
@@ -196,6 +195,20 @@ class LazySaveTestMixin(object):
         mediafile.album = 'another'
         mediafile.save()
         self.assertNotEqual(os.stat(mediafile.path).st_mtime, mtime)
+
+    def test_delete_tags(self):
+        mediafile = self._mediafile_fixture('full')
+        mtime = self._set_past_mtime(mediafile.path)
+        self.assertEqual(mediafile.title, 'full')
+        self.assertEqual(os.stat(mediafile.path).st_mtime, mtime)
+
+        mediafile.delete()
+        mediafile.save()
+
+        mediafile = MediaFile(mediafile.path)
+        self.assertNotEqual(os.stat(mediafile.path).st_mtime, mtime)
+        self.assertEqual(mediafile.title, '')
+
 
     def _set_past_mtime(self, path):
         mtime = round(time.time()-10000)
@@ -237,7 +250,7 @@ class GenreListTestMixin(object):
         self.assertItemsEqual(mediafile.genres, [u'the genre', u'another'])
 
 
-class ReadWriteTestBase(ArtTestMixin, GenreListTestMixin):
+class ReadWriteTestBase(ArtTestMixin, LazySaveTestMixin, GenreListTestMixin):
     """Test writing and reading tags. Subclasses must set ``extension`` and
     ``audio_properties``.
     """


### PR DESCRIPTION
This was previously discussed in #527 and some questions came up.

>  Unintentionally capturing modifications to other fields, such as when mgfile is assigned

It’s better to be on the safe side and perform unnecessary writes instead of missing necessary ones. Also
`mgfile` should never ever be changed.

> Missing changes when doing other kinds of modifications, like the delete operation used by the scrub plugin

`delete` is handled [here](https://github.com/geigerzaehler/beets/commit/b16eb61eb7232727646944ac2514db9976ec328f#diff-9f32ae8136422d861cc3215f657f1e1cR1219) and tested [here](https://github.com/geigerzaehler/beets/commit/b16eb61eb7232727646944ac2514db9976ec328f#diff-19d66b8d5e80f862f273212a6a1698e2R199)

> The potential inefficiency of reading each field twice on each write, especially for images

Files are not read twice since all tags are cached when the `mgfile` is created.
