### PR TITLE
bash completion documentation fix for GNU Bash-4.2

### DIFF
--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -361,7 +361,7 @@ Beets includes support for shell command completion. The command ``beet
 completion`` prints out a `bash`_ 3.2 script; to enable completion put a line
 like this into your ``.bashrc`` or similar file::
 
-    eval $(beet completion)
+    eval "$(beet completion)"
 
 Or, to avoid slowing down your shell startup time, you can pipe the ``beet
 completion`` output to a file and source that instead.


### PR DESCRIPTION
In GNU Bash-4.2, I have to put quotes around the eval statement for the shell to correctly interpret the output of the beet completion command.

On https://github.com/sampsyo/beets/pull/553, geigerzaehler original post actually describes the command with the quotes.
