### PR TITLE
Utility to run tasks concurrently

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -25,6 +25,8 @@ import traceback
 import subprocess
 import platform
 
+from beets.util.queue import Queue, CommandQueue
+
 
 MAX_FILENAME_LENGTH = 200
 WINDOWS_MAGIC_PREFIX = u'\\\\?\\'

--- a/beets/util/queue.py
+++ b/beets/util/queue.py
@@ -74,7 +74,6 @@ class Queue(object):
             self._queue()
 
     def wait(self):
-        self._start()
         for future in self.sync():
             pass
 
@@ -145,13 +144,13 @@ class CommandQueue(Queue):
     @asyncio.coroutine
     def make_command(self, args, data):
         stdout, stderr, returncode = yield From(exec_cmd(args))
-        raise Return(stdout, stderr, process.returncode, *data)
+        raise Return(stdout, stderr, returncode, *data)
 
 
 @asyncio.coroutine
 def exec_cmd(args):
     args = map(str, args)
-    log.debug('running {}'.format(' '.join(args)))
+    log.debug('running {0}'.format(' '.join(args)))
 
     process = yield From(asyncio.create_subprocess_exec(
         *args,

--- a/beets/util/queue.py
+++ b/beets/util/queue.py
@@ -1,0 +1,152 @@
+# This file is part of beets.
+# Copyright 2014, Thomas Scholtes.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+import logging
+import asyncio
+from asyncio import From, Return, Future
+
+log = logging.getLogger('beets')
+
+
+class Queue(object):
+    """Run all coroutines but only a specified number concurrently.::
+
+        queue = Queue(concurrency=2)
+        for coro in expensive_coroutines:
+            queue.push(coro)
+
+        for task in queue:
+            result = yield From(task)
+
+    You can attach specific data to each task. The results are then
+    tuples. The first value is the return value of the coroutine and the
+    rest are the data. ::
+
+          for coro in expensive_coroutines:
+              queue.push(coro, True)
+          for task in queue:
+              result, ran = yield From(task)
+
+    To use the iterator you have to run it in a asyncio coroutine. If
+    you don't care about that, then there is a synchronous method. ::
+
+          for result in queue.run_sync():
+              print result
+
+    This blocks the execution of the iterator until the next result is
+    available and then yields it.
+    """
+
+    def __init__(self, concurrency=1):
+        self.concurrency = concurrency
+        self._tasks = []
+        self._futures = []
+        self._futures_index = 0
+
+    def push(self, future_or_coro, *data):
+        """Add a future or coroutine to the queue.
+
+        The result of the future and ``data`` will be yielded from the
+        futures in the iterator.
+        """
+        self._tasks.append((future_or_coro, data))
+        self._futures.append(Future())
+
+    def __iter__(self):
+        self._start()
+        return self._futures.__iter__()
+
+    def _start(self):
+        """Starts the first concurrent coroutines.
+        """
+        for i in range(self.concurrency):
+            self._queue()
+
+    def sync(self):
+        """Yield the results of the tasks as soon as they are finished.
+
+        This runs the coroutines in the default event loop.
+        """
+        self._loop = asyncio.get_event_loop()
+        self._start()
+        for future in self._futures:
+            yield self._loop.run_until_complete(future)
+
+    def _queue(self, *_):
+        """Run the first coroutine the has not been started yet.
+
+        Connects the the result to one of the futures returned by the
+        iterator.
+        """
+        if len(self._tasks) == 0:
+            return
+        task, data = self._tasks.pop(0)
+        task_completed = asyncio.async(task)
+        task_completed.add_done_callback(self._queue)
+        task_completed.add_done_callback(self._dequeue)
+
+    def _dequeue(self, completed):
+        """Resolves the next future exposed by the iterator with the
+        results from the completed future.
+        """
+        future = self._futures[self._futures_index]
+        try:
+            res = completed.result()
+        except Exception as e:
+            future.set_exception(e)
+        else:
+            future.set_result(res)
+        self._futures_index += 1
+
+
+class CommandQueue(Queue):
+    """Spawn programs and collect there result.
+
+    Instead of pushing coroutines to the queue we can push command line
+    arguments to it. ``queue.sync()`` then runs these commands and
+    collects their results.
+
+    >>> queue = CommandQueue(concurrency=3)
+    >>> queue.push(['sleep', 0.3], 'first')
+    >>> queue.push(['sleep', 0.2], 'second')
+    >>> queue.push(['sleep', 0.1], 'third')
+    >>> for stdout, stderr, returncode, data in queue.sync():
+    ...     print(data)
+    third
+    second
+    first
+    """
+
+    def push(self, args, *data):
+        """Add a command to the queue.
+
+        ``args`` is a list of command arguments. The first value is the
+        name of the command to run and the remaining are passed to the
+        command.
+        """
+        super(CommandQueue, self).push(self.make_command(args, data))
+
+    @asyncio.coroutine
+    def make_command(self, args, data):
+        args = map(str, args)
+        log.debug('running {}'.format(' '.join(args)))
+
+        process = yield From(asyncio.create_subprocess_exec(
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE
+        ))
+        stdout, stderr = yield From(process.communicate())
+        yield From(process.wait())
+        raise Return(stdout, stderr, process.returncode, *data)

--- a/docs/plugins/replaygain.rst
+++ b/docs/plugins/replaygain.rst
@@ -90,6 +90,11 @@ These options only work with the "command" backend:
   whatever amount would keep clipping from occurring.
 
 
+If you use *mp3gain* or *aacgain* as your backend, the plugin will run multiple
+instances of these commands in parallel to increase speed on multi-core systems.
+You can customize the number of simultaneous process with the ``concurrency``
+option. By default its value is the number of CPU cores.
+
 Manual Analysis
 ---------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [nosetests]
 verbosity=1
 logging-clear-handlers=1
+logging-filter=-asyncio
 
 [flake8]
 # F401  module imported but unused

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
         'unidecode',
         'musicbrainzngs>=0.4',
         'pyyaml',
+        'trollius',
     ]
     + (['colorama'] if (sys.platform == 'win32') else [])
     + (['ordereddict'] if sys.version_info < (2, 7, 0) else []),

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,0 +1,47 @@
+# This file is part of beets.
+# Copyright 2014, Thomas Scholtes.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+import asyncio
+import logging
+
+from _common import unittest
+
+from beets.util import CommandQueue
+
+log = logging.getLogger('asyncio')
+log.setLevel(logging.WARNING)
+
+
+class CommandQueueTest(unittest.TestCase):
+
+    def test_run_sequential(self):
+        queue = CommandQueue(concurrency=1)
+        for i in range(4):
+            queue.push(['printf', i])
+        results = [out for out, _, _ in queue.sync()]
+        self.assertEqual(results, map(str, [0, 1, 2, 3]))
+
+    def test_run_all_parallel(self):
+        queue = CommandQueue(concurrency=4)
+        for i in range(4):
+            queue.push(['sleep', (4 - i) * 0.04], i)
+        results = [i for out, _, _, i in queue.sync()]
+        self.assertEqual(results, [3, 2, 1, 0])
+
+    def test_run_in_pairs(self):
+        queue = CommandQueue(concurrency=2)
+        for i in range(4):
+            queue.push(['sleep', (4 - i) * 0.04], i)
+        results = [i for out, _, _, i in queue.sync()]
+        self.assertEqual(results, [1, 0, 3, 2])

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
     pylast
     flask
     responses
+    trollius
 commands =
     nosetests {posargs}
 


### PR DESCRIPTION
This commit adds a new `util.Queue` class that allows one to run several tasks concurrently. In particular we can expensive computations in multiple threads and spawn several processes in parallel. This addresses #663. The code is backed by _trollius_, a backport of the Python 3.4 `asyncio` module (see #621).

The _convert_ and _replaygain_ plugins have been extended to use the new utility. They run multiple instances of the `ffmpeg` and `mp3gain` commands.
