### PR TITLE
Disable video feed in ffmpeg's flac conversion

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -255,34 +255,34 @@ class ConvertPlugin(BeetsPlugin):
             u'format': u'mp3',
             u'formats': {
                 u'aac': {
-                    u'command': u'ffmpeg -i $source -y -acodec libfaac '
+                    u'command': u'ffmpeg -i $source -y -vn -acodec libfaac '
                                 u'-aq 100 $dest',
                     u'extension': u'm4a',
                 },
                 u'alac': {
-                    u'command': u'ffmpeg -i $source -y -acodec alac $dest',
+                    u'command': u'ffmpeg -i $source -y -vn -acodec alac $dest',
                     u'extension': u'm4a',
                 },
                 u'flac': {
-                    u'command': u'ffmpeg -i $source -y -acodec flac -vn $dest',
+                    u'command': u'ffmpeg -i $source -y -vn -acodec flac $dest',
                     u'extension': u'flac',
                 },
                 u'mp3': {
-                    u'command': u'ffmpeg -i $source -y -aq 2 $dest',
+                    u'command': u'ffmpeg -i $source -y -vn -aq 2 $dest',
                     u'extension': u'mp3',
                 },
                 u'opus': {
-                    u'command': u'ffmpeg -i $source -y -acodec libopus -vn '
+                    u'command': u'ffmpeg -i $source -y -vn -acodec libopus '
                                 u'-ab 96k $dest',
                     u'extension': u'opus',
                 },
                 u'ogg': {
-                    u'command': u'ffmpeg -i $source -y -acodec libvorbis -vn '
+                    u'command': u'ffmpeg -i $source -y -vn -acodec libvorbis '
                                 u'-aq 2 $dest',
                     u'extension': u'ogg',
                 },
                 u'windows media': {
-                    u'command': u'ffmpeg -i $source -y -acodec wmav2 '
+                    u'command': u'ffmpeg -i $source -y -vn -acodec wmav2 '
                                 u'-vn $dest',
                     u'extension': u'wma',
                 },

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,8 +21,8 @@ Fixes:
   non-ASCII characters.
 * The ``%if{}`` template function now appropriately interprets the condition
   as false when it contains the string "false". Thanks to Ayberk Yilmaz.
-* :doc:`/plugins/convert`: Disable a potential video stream in flac files
-  conversion with ffmpeg
+* :doc:`/plugins/convert`: Fix conversion for files that include a video
+  stream by ignoring it.
 
 
 1.3.5 (April 15, 2014)


### PR DESCRIPTION
Fix issue #712

Video feeds may be found in flac files, and the current ffmpeg
conversion command does not ignore them, causing beets to fail
to convert the file.

Add `-vn` to the command line to fix the problem.
