### PR TITLE
Add before_item_moved event

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -397,6 +397,8 @@ class Item(LibModel):
             plugins.send("item_copied", item=self, source=self.path,
                          destination=dest)
         else:
+            plugins.send("before_item_moved", item=self, source=self.path,
+                         destination=dest)
             util.move(self.path, dest)
             plugins.send("item_moved", item=self, source=self.path,
                          destination=dest)

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -133,6 +133,9 @@ currently available are:
   singleton to the library (not called for full-album imports). Parameters:
   ``lib``, ``item``
 
+* *before_item_moved*: called with an ``Item`` object immediately before its
+  file is moved. Parameters: ``item``, ``source`` path, ``destination`` path
+
 * *item_moved*: called with an ``Item`` object whenever its file is moved.
   Parameters: ``item``, ``source`` path, ``destination`` path
 


### PR DESCRIPTION
This event gets called just before `util.move` with the same arguments as the `item_moved` event.

This might seem useless, but I had a specific use case for it. I still use iTunes to organize and play my music (I know, I know), but beets' organization and renaming really appeals to me, so I wanted to start moving towards that. Problem is, when beets moves a file on the filesystem iTunes picks up the change but then immediately forgets it as soon as the app closes. The next time you play the file it says it can't find it.

I've found the only way to get around this is to tell iTunes, through Applescript, to set the new location for the file after it's moved. I wrote a beetsplugin to do this on each `item_moved` event, but the problem is Applescript provides no good way to look up a file by its path. The only reliable way to find a track by its path is to "add" the file to iTunes. If the file already exists, iTunes returns a reference to the track which we can then update.

Still following? :hand: You can't add a file to iTunes that doesn't exist, even a file it already has in its library, so by the time we get to `item_moved` it's already too late. I needed `before_item_moved` so I can add the file in its old location, store its reference, and then after it's moved tell iTunes its new location.

If anyone's interested, this is the plugin I came up with:

``` python
import logging
import appscript
from beets.plugins import BeetsPlugin

# Global logger.
log = logging.getLogger('beets')

# Global variable to store the iTunes track reference of a file before it's moved
track_ref = None

class ItunesMover(BeetsPlugin):
    pass

def hfspath(posix):
    return appscript.mactypes.File(posix).hfspath

@ItunesMover.listen('before_item_moved')
def before_move(item, source, destination):
    global track_ref

    # Convert the POSIX path to an HFS one
    source_hfs = hfspath(source)

    # iTunes fuckery:
    #
    # We tell iTunes to add the file. Hopefully it's already in iTunes, in
    # which case iTunes just returns the track reference. This is the only way
    # to look up a file by its path without looping through a bunch of tracks.
    track_ref = appscript.app("iTunes").add(source_hfs)

@ItunesMover.listen('item_moved')
def moved(item, source, destination):
    global track_ref

    try:
        track_ref.location.set(hfspath(destination))
        track_ref = None
    except appscript.CommandError:
        log.debug(u"Could not set iTunes location to %s (probably doesn't exist)" % destination)
```
