### PR TITLE
Make _formatted_mapping lazy and an object

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -390,12 +390,7 @@ class Model(object):
         """Get a mapping containing all values on this object formatted
         as human-readable strings.
         """
-        # In the future, this could be made "lazy" to avoid computing
-        # fields unnecessarily.
-        out = {}
-        for key in self.keys(True):
-            out[key] = self._get_formatted(key, for_path)
-        return out
+        return FormattedMapping(self, for_path)
 
     def evaluate_template(self, template, for_path=False):
         """Evaluate a template (a string or a `Template` object) using
@@ -428,6 +423,30 @@ class Model(object):
         else:
             # Fall back to unparsed string.
             return string
+
+
+class FormattedMapping(object):
+    """A `dict`-like formatted view of a model.
+
+    The accessor ``mapping[key]`` returns the formated version of
+    ``model[key]``. The formatting is handled by `model._format()`.
+    """
+    # TODO Move all formatting logic here
+    # TODO Add caching
+
+    def __init__(self, model, for_path=False):
+        self.for_path = for_path
+        self.model = model
+        self.model_keys = model.keys(True)
+
+    def __getitem__(self, key):
+        if key in self.model_keys:
+            return self.model._get_formatted(key, self.for_path)
+        else:
+            raise KeyError(key)
+
+    def __contains__(self, key):
+        return key in self.model_keys
 
 
 # Database controller and supporting interfaces.


### PR DESCRIPTION
The motivation for this is to increase the performance of template evalutation (see #724). It is an alternative solution to #745. All credits for pinning down this bottleneck go to @PierreRust.

Previously, the `model._formatted_mapping()` method returned a dictionary that served as the environment (mapping of variable names to values) when evaluating a template. To populate the dictionary, we iterated over all keys in the model, formatted the values, and assigned it to the dictionary. This meant we formatted every field, even if the template did not require it.

With this commit `_formatted_mapping()` does not return a populated dictionary but a proxy (or view) instance. The object only knows about the model and the keys it provides the formatted view for. If a variable is requested by the template it computes the formatted value on the fly.

For me (~650 albums) the performance gain with `./beet list -af '$album: $tracktotal - $year'` is in the order of a magnitude.

The class-based approach has one additional advantage: In the future, we can separate the formatting logic from the database logic.
