### PR TITLE
doc: add section listing template functions/fields provided by plugins

### DIFF
--- a/docs/reference/pathformat.rst
+++ b/docs/reference/pathformat.rst
@@ -237,7 +237,7 @@ Remember to activate corresponding plugin before using one of those additional
 fields/functions :
 
 * missing by :doc:`/plugins/missing`: number of missing tracks per album
-* ``%the{text}`` by :doc:`/plugins/fetchart`: moves english articles to end of
+* ``%the{text}`` by :doc:`/plugins/the`: moves english articles to end of
   strings
 
 In case you would need a field not mentioned hereabove,


### PR DESCRIPTION
This PR adds a section at the end of the `reference/pathformat.html` page to list functions/fields provided by plugins.  

Plugins related to path-formats are already listed [here](http://beets.readthedocs.org/en/v1.3.5/plugins/index.html#path-formats) but :  
- list is (understandably) incomplete as some plugins belongs to many categories cf `missing` plugin
- it still requires reader to click each plugin link to go grab the functions/fields
