### PR TITLE
add picture fetch over google search

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -22,10 +22,6 @@ from tempfile import NamedTemporaryFile
 
 import requests
 
-import urllib
-import urllib2
-import simplejson
-
 from beets.plugins import BeetsPlugin
 from beets.util.artresizer import ArtResizer
 from beets import importer
@@ -128,21 +124,21 @@ def aao_art(asin):
 
 # googleapis.org scraper.
 
+GOOGLE_URL = 'https://ajax.googleapis.com/ajax/services/search/images'
+
 def google_art(album):
     """Return art URL from google.org given an album title and interpreter"""
+     
     search_string = (album.albumartist + ',' + album.album).encode('utf-8')
-    url = ('https://ajax.googleapis.com/ajax/services/search/images?' + 'v=1.0&q='+ urllib.quote_plus(search_string)  +'&start='+str(0))
-    request = urllib2.Request(url, None, {'Referer': 'testing'})
-    response = urllib2.urlopen(request)
-
+    response = requests_session.get(GOOGLE_URL, params={'v': '1.0','q': search_string, 'start':'0'})
     # Get results using JSON
     try:
-        results = simplejson.load(response)
+        results = response.json()
         data = results['responseData']
-    	dataInfo = data['results']
-    	for myUrl in dataInfo:
-		return myUrl['unescapedUrl']
-    except requests.RequestException:
+        dataInfo = data['results']
+        for myUrl in dataInfo:
+            return myUrl['unescapedUrl']
+    except:
         log.debug(u'fetchart: error scraping art page')
         return
 
@@ -205,9 +201,9 @@ def _source_urls(album):
 
     google_search = config['fetchart']['google_search'].get(bool)
     if google_search == True:
-	 url = google_art(album)
-	 if url:
-	    yield url
+        url = google_art(album)
+        if url:
+            yield url
 
 
 def art_for_album(album, paths, maxwidth=None, local_only=False):

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -96,6 +96,21 @@ When you choose to apply changes during an import, beets will search for art as
 described above.  For "as-is" imports (and non-autotagged imports using the
 ``-A`` flag), beets only looks for art on the local filesystem.
 
+Album Art with Google Image Search
+-----------------------------------
+
+If no art is found on the common sources there is the possibility get "the" or "a" album 
+art form google image search.
+
+If enabled this function take the first hit with the search text "<artist>,<album_name>" on google image search as album art
+
+To enable art gathering form google, just put this in your configuration
+file::
+
+    fetchart:
+        google_search: true
+        
+
 Embedding Album Art
 -------------------
 

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -187,7 +187,32 @@ class AAOTest(_common.TestCase):
         self.mock_response(self.AAO_URL, 'blah blah')
         res = fetchart.aao_art(self.ASIN)
         self.assertEqual(res, None)
+        
+class GoogleImageTest(_common.TestCase):
 
+    GOOGLE_URL = 'https://ajax.googleapis.com/ajax/services/search/images'
+
+    @responses.activate
+    def run(self, *args, **kwargs):
+        super(GoogleImageTest, self).run(*args, **kwargs)
+
+    def mock_response(self, url, json):
+        responses.add(responses.GET, url, body=json, content_type='application/json')
+                      
+
+    def test_google_art_finds_image(self):
+        album = _common.Bag(albumartist="some artist",album="some album")
+        json = """{"responseData": {"results": [{"unescapedUrl": "url_to_the_image"}]}}"""
+        self.mock_response(self.GOOGLE_URL, json)
+        result_url = fetchart.google_art(album)
+        self.assertEqual(result_url, 'url_to_the_image')
+
+    def test_google_art_dont_finds_image(self):
+        album = _common.Bag(albumartist="some artist",album="some album")
+        json = """bla blup"""
+        self.mock_response(self.GOOGLE_URL, json)
+        result_url = fetchart.google_art(album)
+        self.assertEqual(result_url, None)
 
 class ArtImporterTest(_common.TestCase):
     def setUp(self):


### PR DESCRIPTION
If cover-art search don't find the correct cover, then first picture from google search with the search phrase "<album name> - <artist>" will be taken as cover art.
feature is in default of.
can be switch on with configure entry "google_search"
