### PR TITLE
mpdstats: update rating on 'stop' (e.g. last song in playlist)

### DIFF
--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -245,6 +245,10 @@ class MPDStats(object):
 
     def on_stop(self, status):
         log.info(u'mpdstats: stop')
+
+        if self.now_playing:
+            self.handle_song_change(self.now_playing)
+
         self.now_playing = None
 
     def on_pause(self, status):


### PR DESCRIPTION
This fixes #772. When MPD sends a 'stop' event (e.g. by reaching the end of the playlist) the play/skip count and rating will be updated. As a byproduct stopping (instead of pausing) a track will be interpreted as a 'skip'. This sounds reasonable to me, but I'm happy to amend this PR if you disagree.
