### PR TITLE
Fix bug causing autoscrubber to be ineffective

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -392,13 +392,14 @@ class Item(LibModel):
             path = self.path
         else:
             path = normpath(path)
+
+        plugins.send('write', item=self, path=path)
+
         try:
             mediafile = MediaFile(syspath(path),
                                   id3v23=beets.config['id3v23'].get(bool))
         except (OSError, IOError) as exc:
             raise ReadError(self.path, exc)
-
-        plugins.send('write', item=self, path=path)
 
         mediafile.update(self)
         try:


### PR DESCRIPTION
I noticed the autoscrubber (in beetsplug/scrub.py) was silently failing to remove the PRIV ID3 tag, which is a random cruft tag that comes with Amazon MP3s. After some investigation, I determined that the problem was that the 'write' signal is emitted only after the MediaFile is loaded into memory. The autoscrubber runs only when it receives the 'write' signal, stripping all the tags in file on disk, but not touching the MediaFile. When the MediaFile is written back out to disk, however, it restores everything the autoscrubber had deleted in the file on disk, thereby undoing scrub.py's work. This pull request re-orders the 'write' signal to be emitted before the MediaFile is loaded into memory. 
