### PR TITLE
Fix problems with new discogs_client version

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -109,9 +109,9 @@ class DiscogsPlugin(BeetsPlugin):
     def get_album_info(self, result):
         """Returns an AlbumInfo object for a discogs Release object.
         """
+        artist, artist_id = self.get_artist([a.data for a in result.artists])
         album = re.sub(r' +', ' ', result.title)
         album_id = result.data['id']
-        artist, artist_id = self.get_artist([a.data for a in result.artists])
         # Use `.data` to access the tracklist directly instead of the
         # convenient `.tracklist` property, which will strip out useful artist
         # information and leave us with skeleton `Artist` objects that will


### PR DESCRIPTION
I just noticed that discogs_client changed module structure a little but, so I got this.

``` python
** error loading plugin discogs
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/beets/plugins.py", line 193, in load_plugins
    namespace = __import__(modname, None, None)
  File "/usr/lib/python2.7/site-packages/beetsplug/discogs.py", line 20, in <module>
    from discogs_client import DiscogsAPIError, Release, Search
ImportError: cannot import name DiscogsAPIError
```
