### PR TITLE
Catch UnreadableFileError when reading files in a (try_)write context

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -398,7 +398,7 @@ class Item(LibModel):
         try:
             mediafile = MediaFile(syspath(path),
                                   id3v23=beets.config['id3v23'].get(bool))
-        except (OSError, IOError) as exc:
+        except (OSError, IOError, UnreadableFileError) as exc:
             raise ReadError(self.path, exc)
 
         mediafile.update(self)


### PR DESCRIPTION
This fix allows some plugins not to crash when using try_write() to update a file.

Example with the lastgenre plugin:

```
Traceback (most recent call last):
  File "/usr/bin/beet", line 9, in <module>
    load_entry_point('beets==1.3.7', 'console_scripts', 'beet')()
  File "/usr/lib/python2.7/site-packages/beets/ui/__init__.py", line 966, in main
    _raw_main(args)
  File "/usr/lib/python2.7/site-packages/beets/ui/__init__.py", line 957, in _raw_main
    subcommand.func(lib, suboptions, subargs)
  File "/usr/lib/python2.7/site-packages/beetsplug/lastgenre/__init__.py", line 378, in lastgenre_func
    item.try_write()
  File "/usr/lib/python2.7/site-packages/beets/library.py", line 422, in try_write
    self.write(path)
  File "/usr/lib/python2.7/site-packages/beets/library.py", line 400, in write
    id3v23=beets.config['id3v23'].get(bool))
  File "/usr/lib/python2.7/site-packages/beets/mediafile.py", line 1252, in __init__
    raise UnreadableFileError(path)
```
