### PR TITLE
NULL fields and tag removal

### DIFF
--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -66,7 +66,7 @@ def current_metadata(items):
               'mb_albumid', 'label', 'catalognum', 'country', 'media',
               'albumdisambig']
     for key in fields:
-        values = [getattr(item, key) for item in items if item]
+        values = [item.get(key) for item in items if item]
         likelies[key], freq = plurality(values)
         consensus[key] = (freq == len(values))
 

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -374,7 +374,7 @@ class Model(object):
 
                 # None values are stored as NULL
                 if value is not None:
-                    value = self._type(key).to_sql(value)
+                    value = self._to_sql(key, value)
                 subvars.append(value)
                 assignments.append(key + '=?')
 
@@ -392,7 +392,7 @@ class Model(object):
                 if key in self._dirty or all:
                     if key in self._dirty:
                         self._dirty.remove(key)
-                    value = self._type(key).to_sql(value)
+                    value = self._to_sql(key, value)
                     tx.mutate(
                         'INSERT INTO {0} '
                         '(entity_id, key, value) '

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -211,6 +211,12 @@ class Model(object):
         if value is not None:
             return cls._type(key).to_sql(value)
 
+    @classmethod
+    def parse(cls, key, string):
+        if not isinstance(string, unicode):
+            raise TypeError(u'{0!r} must be a unicode object')
+        return cls._type(key).parse(string)
+
     # Essential field accessors.
 
     def __getitem__(self, key):
@@ -310,11 +316,7 @@ class Model(object):
     def set(self, key, string):
         """Parse a string as a value for the given key.
         """
-        if not isinstance(string, unicode):
-            raise TypeError(u'{0!r} must be a unicode object')
-
-        value = self._type(key).parse(string)
-        self[key] = value
+        self[key] = self.parse(key, string)
 
     def __contains__(self, key):
         """Determine whether `key` is an attribute on this object.

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -251,7 +251,8 @@ class Model(object):
         elif key in self._getters():  # Computed.
             raise KeyError('computed field {0} cannot be deleted'.format(key))
         elif key in self._fields:  # Fixed.
-            raise KeyError('fixed field {0} cannot be deleted'.format(key))
+            self._values_fixed[key] = None
+            self._dirty.add(key)  # Mark for dropping on store.
         else:
             raise KeyError('no such field {0}'.format(key))
 

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -14,7 +14,6 @@
 
 """The central Model and Database constructs for DBCore.
 """
-import time
 import os
 from collections import defaultdict
 import threading
@@ -24,8 +23,8 @@ import collections
 
 import beets
 from beets.util.functemplate import Template
-from .query import MatchQuery, build_sql
-from .types import BASE_TYPE
+from .query import MatchQuery, TrueQuery, build_sql
+from .types import STRING
 
 
 class FormattedMapping(collections.Mapping):
@@ -43,28 +42,18 @@ class FormattedMapping(collections.Mapping):
         self.model = model
         self.model_keys = model.keys(True)
 
-    def __getitem__(self, key):
-        if key in self.model_keys:
-            return self._get_formatted(self.model, key)
-        else:
-            raise KeyError(key)
-
     def __iter__(self):
         return iter(self.model_keys)
 
     def __len__(self):
         return len(self.model_keys)
 
+    def __getitem__(self, key):
+        return self.get(key)
+
     def get(self, key, default=None):
-        if default is None:
-            default = self.model._type(key).format(None)
-        return super(FormattedMapping, self).get(key, default)
-
-    def _get_formatted(self, model, key):
-        value = model._type(key).format(model.get(key))
-        if isinstance(value, bytes):
-            value = value.decode('utf8', 'ignore')
-
+        value = self.model.get(key, default)
+        value = self.model._type(key).format(value)
         if self.for_path:
             sep_repl = beets.config['path_sep_replace'].get(unicode)
             for sep in (os.path.sep, os.path.altsep):
@@ -115,11 +104,6 @@ class Model(object):
     keys are field names and the values are `Type` objects.
     """
 
-    _bytes_keys = ()
-    """Keys whose values should be stored as raw bytes blobs rather than
-    strings.
-    """
-
     _search_fields = ()
     """The fields that should be queried by default by unqualified query
     terms.
@@ -152,29 +136,27 @@ class Model(object):
         """
         self._db = db
         self._dirty = set()
-        self._values_fixed = {}
         self._values_flex = {}
+        self._values_fixed = {}
+        for key in self._fields:
+            self._values_fixed[key] = None
 
         # Initial contents.
         self.update(values)
         self.clear_dirty()
 
     @classmethod
-    def _awaken(cls, db=None, fixed_values=None, flex_values=None):
+    def _awaken(cls, db=None, fixed_values={}, flex_values={}):
         """Create an object with values drawn from the database.
 
         This is a performance optimization: the checks involved with
         ordinary construction are bypassed.
         """
         obj = cls(db)
-        if fixed_values:
-            for key, value in fixed_values.items():
-                obj._values_fixed[key] = cls._fields[key].normalize(value)
-        if flex_values:
-            for key, value in flex_values.items():
-                if key in cls._types:
-                    value = cls._types[key].normalize(value)
-                obj._values_flex[key] = value
+        for key, value in fixed_values.iteritems():
+            obj._values_fixed[key] = cls._from_sql(key, value)
+        for key, value in flex_values.iteritems():
+            obj._values_flex[key] = cls._from_sql(key, value)
         return obj
 
     def __repr__(self):
@@ -199,8 +181,6 @@ class Model(object):
         if need_id and not self.id:
             raise ValueError('{0} has no id'.format(type(self).__name__))
 
-    # Essential field accessors.
-
     @classmethod
     def _type(self, key):
         """Get the type of a field, a `Type` instance.
@@ -208,24 +188,39 @@ class Model(object):
         If the field has no explicit type, it is given the base `Type`,
         which does no conversion.
         """
-        return self._fields.get(key) or self._types.get(key) or BASE_TYPE
+        return self._fields.get(key) or self._types.get(key) or STRING
+
+    @classmethod
+    def _from_sql(cls, key, value):
+        if value is not None:
+            return cls._type(key).from_sql(value)
+
+    @classmethod
+    def _to_sql(cls, key, value):
+        if value is not None:
+            return cls._type(key).to_sql(value)
+
+    # Essential field accessors.
 
     def __getitem__(self, key):
-        """Get the value for a field. Raise a KeyError if the field is
-        not available.
+        """Get the value for a field.
+
+        Raise a KeyError if flex field is not available.
         """
         getters = self._getters()
-        if key in getters:  # Computed.
+        if key in getters:
             return getters[key](self)
-        elif key in self._fields:  # Fixed.
-            return self._values_fixed.get(key)
-        elif key in self._values_flex:  # Flexible.
+        elif key in self._values_fixed:
+            return self._values_fixed[key]
+        elif key in self._values_flex:
             return self._values_flex[key]
         else:
             raise KeyError(key)
 
     def __setitem__(self, key, value):
         """Assign the value for a field.
+
+        Uses `Type.normalize()` to convert values other than `None`.
         """
         # Choose where to place the value.
         if key in self._fields:
@@ -234,7 +229,8 @@ class Model(object):
             source = self._values_flex
 
         # If the field has a type, filter the value.
-        value = self._type(key).normalize(value)
+        if value is not None:
+            value = self._type(key).normalize(value)
 
         # Assign value and possibly mark as dirty.
         old_value = source.get(key)
@@ -243,23 +239,25 @@ class Model(object):
             self._dirty.add(key)
 
     def __delitem__(self, key):
-        """Remove a flexible attribute from the model.
+        """Remove a flexible attribute from the model and set fixed
+        values to `None`.
         """
         if key in self._values_flex:  # Flexible.
             del self._values_flex[key]
             self._dirty.add(key)  # Mark for dropping on store.
-        elif key in self._getters():  # Computed.
-            raise KeyError('computed field {0} cannot be deleted'.format(key))
         elif key in self._fields:  # Fixed.
             self._values_fixed[key] = None
             self._dirty.add(key)  # Mark for dropping on store.
+        elif key in self._getters():  # Computed.
+            raise KeyError('computed field {0} cannot be deleted'.format(key))
         else:
             raise KeyError('no such field {0}'.format(key))
 
     def keys(self, computed=False):
-        """Get a list of available field names for this object. The
-        `computed` parameter controls whether computed (plugin-provided)
-        fields are included in the key list.
+        """Get a list of available field names for this object.
+
+        The `computed` parameter controls whether computed
+        (plugin-provided) fields are included in the key list.
         """
         base_keys = list(self._fields) + self._values_flex.keys()
         if computed:
@@ -277,6 +275,7 @@ class Model(object):
 
     def items(self):
         """Iterate over (key, value) pairs that this object contains.
+
         Computed fields are not included.
         """
         for key in self:
@@ -286,10 +285,25 @@ class Model(object):
         """Get the value for a given key or `default` if it does not
         exist.
         """
-        if key in self:
-            return self[key]
-        else:
+        if default is None:
+            default = self._type(key).default
+        try:
+            value = self[key]
+            if value is None:
+                return default
+            else:
+                return value
+        except KeyError:
             return default
+
+    def set(self, key, string):
+        """Parse a string as a value for the given key.
+        """
+        if not isinstance(string, unicode):
+            raise TypeError(u'{0!r} must be a unicode object')
+
+        value = self._type(key).parse(string)
+        self[key] = value
 
     def __contains__(self, key):
         """Determine whether `key` is an attribute on this object.
@@ -327,39 +341,45 @@ class Model(object):
 
     # Database interaction (CRUD methods).
 
-    def store(self):
+    def store(self, all=False):
         """Save the object's metadata into the library database.
+
+        By default, updates only dirty fields. If `all` is `True`,
+        updates all fields.
         """
         self._check_db()
 
         # Build assignments for query.
-        assignments = ''
+        assignments = []
         subvars = []
-        for key in self._fields:
-            if key != 'id' and key in self._dirty:
-                self._dirty.remove(key)
-                assignments += key + '=?,'
-                value = self[key]
-                # Wrap path strings in buffers so they get stored
-                # "in the raw".
-                if key in self._bytes_keys and isinstance(value, str):
-                    value = buffer(value)
+        for key, value in self._values_fixed.iteritems():
+            if key == 'id':
+                continue
+            if key in self._dirty or all:
+                if key in self._dirty:
+                    self._dirty.remove(key)
+
+                # None values are stored as NULL
+                if value is not None:
+                    value = self._type(key).to_sql(value)
                 subvars.append(value)
-        assignments = assignments[:-1]  # Knock off last ,
+                assignments.append(key + '=?')
 
         with self._db.transaction() as tx:
             # Main table update.
             if assignments:
                 query = 'UPDATE {0} SET {1} WHERE id=?'.format(
-                    self._table, assignments
+                    self._table, ','.join(assignments)
                 )
                 subvars.append(self.id)
                 tx.mutate(query, subvars)
 
             # Modified/added flexible attributes.
             for key, value in self._values_flex.items():
-                if key in self._dirty:
-                    self._dirty.remove(key)
+                if key in self._dirty or all:
+                    if key in self._dirty:
+                        self._dirty.remove(key)
+                    value = self._type(key).to_sql(value)
                     tx.mutate(
                         'INSERT INTO {0} '
                         '(entity_id, key, value) '
@@ -381,11 +401,9 @@ class Model(object):
         """Refresh the object's metadata from the library database.
         """
         self._check_db()
-        stored_obj = self._db._get(type(self), self.id)
-        assert stored_obj is not None, "object {0} not in DB".format(self.id)
-        self._values_fixed = {}
-        self._values_flex = {}
-        self.update(dict(stored_obj))
+        stored = self._db._get(type(self), self.id)
+        self._values_fixed = stored._values_fixed
+        self._values_flex = stored._values_flex
         self.clear_dirty()
 
     def remove(self):
@@ -419,13 +437,7 @@ class Model(object):
                 'INSERT INTO {0} DEFAULT VALUES'.format(self._table)
             )
             self.id = new_id
-            self.added = time.time()
-
-            # Mark every non-null field as dirty and store.
-            for key in self:
-                if self[key] is not None:
-                    self._dirty.add(key)
-            self.store()
+            self.store(all=True)
 
     # Formatting and templating.
 
@@ -447,17 +459,6 @@ class Model(object):
             template = Template(template)
         return template.substitute(self.formatted(for_path),
                                    self._template_funcs())
-
-    # Parsing.
-
-    @classmethod
-    def _parse(cls, key, string):
-        """Parse a string as a value for the given key.
-        """
-        if not isinstance(string, basestring):
-            raise TypeError("_parse() argument must be a string")
-
-        return cls._type(key).parse(string)
 
 
 # Database controller and supporting interfaces.
@@ -746,7 +747,7 @@ class Database(object):
 
     # Querying.
 
-    def _fetch(self, model_cls, query, sort_order=None):
+    def _fetch(self, model_cls, query=TrueQuery(), sort_order=None):
         """Fetch the objects of type `model_cls` matching the given
         query. The query may be given as a string, string sequence, a
         Query object, or None (to fetch everything). If provided,

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -204,7 +204,10 @@ class NumericQuery(FieldQuery):
             self.rangemax = self._convert(parts[1])
 
     def match(self, item):
-        value = getattr(item, self.field)
+        value = item.get(self.field, default=None)
+        if value is None:
+            return False
+
         if isinstance(value, basestring):
             value = self._convert(value)
 

--- a/beets/dbcore/types.py
+++ b/beets/dbcore/types.py
@@ -168,6 +168,12 @@ class Boolean(Type):
     def parse(self, string):
         return str2bool(string)
 
+    def from_sql(self, value):
+        if isinstance(value, unicode):
+            return str2bool(value)
+        else:
+            return bool(value)
+
 
 class Bytes(Type):
 

--- a/beets/dbcore/types.py
+++ b/beets/dbcore/types.py
@@ -144,12 +144,6 @@ class String(Type):
         else:
             return value.decode('utf-8')
 
-    def to_sql(self, value):
-        return value.encode('utf-8')
-
-    def from_sql(self, value):
-        return value.decode('utf-8')
-
 
 class Boolean(Type):
     """A boolean type.

--- a/beets/dbcore/types.py
+++ b/beets/dbcore/types.py
@@ -161,6 +161,7 @@ class Boolean(Type):
     def parse(self, string):
         return str2bool(string)
 
+
 class Bytes(Type):
 
     sql = u'BLOB'

--- a/beets/library.py
+++ b/beets/library.py
@@ -29,6 +29,7 @@ from beets.util import bytestring_path, syspath, normpath, samefile
 from beets.util.functemplate import Template
 from beets import dbcore
 from beets.dbcore import types
+from beets.dbcore.db import COLUMN_DEFAULT
 import beets
 
 
@@ -62,29 +63,31 @@ class PathQuery(dbcore.FieldQuery):
 
 
 class DateType(types.Type):
+    """Dates are represented by floats.
+    """
+    # TODO representation should be struct_time
     sql = u'REAL'
     query = dbcore.query.DateQuery
-    null = 0.0
+    default = 0.0
 
     def format(self, value):
-        return time.strftime(beets.config['time_format'].get(unicode),
-                             time.localtime(value or 0))
+        fmt = beets.config['time_format'].get(unicode)
+        return time.strftime(fmt, time.localtime(value or 0))
 
     def parse(self, string):
         try:
             # Try a formatted date string.
-            return time.mktime(
-                time.strptime(string, beets.config['time_format'].get(unicode))
-            )
+            fmt = beets.config['time_format'].get(unicode)
+            return time.mktime(time.strptime(string, fmt))
         except ValueError:
             # Fall back to a plain timestamp number.
-            try:
-                return float(string)
-            except ValueError:
-                return self.null
+            return float(string)
 
 
 class PathType(types.Type):
+    """Paths are stored as `str` internally
+    """
+
     sql = u'BLOB'
     query = PathQuery
 
@@ -92,20 +95,22 @@ class PathType(types.Type):
         return util.displayable_path(value)
 
     def parse(self, string):
-        return normpath(bytestring_path(string))
+        return self.normalize(normpath(bytestring_path(string)))
 
     def normalize(self, value):
         if isinstance(value, unicode):
-            # Paths stored internally as encoded bytes.
             return bytestring_path(value)
-
-        elif isinstance(value, buffer):
-            # SQLite must store bytestings as buffers to avoid decoding.
-            # We unwrap buffers to bytes.
-            return bytes(value)
-
         else:
-            return value
+            return str(value)
+
+    def from_sql(self, sql_value):
+        if isinstance(sql_value, unicode):
+            # For backwards compatibility.
+            return bytestring_path(sql_value)
+        return bytes(sql_value)
+
+    def to_sql(self, local_value):
+        return buffer(local_value)
 
 
 class MusicalKey(types.String):
@@ -129,10 +134,7 @@ class MusicalKey(types.String):
         return key.capitalize()
 
     def normalize(self, key):
-        if key is None:
-            return None
-        else:
-            return self.parse(key)
+        return self.parse(key)
 
 
 # Special path format key.
@@ -203,8 +205,8 @@ class LibModel(dbcore.Model):
         funcs.update(plugins.template_funcs())
         return funcs
 
-    def store(self):
-        super(LibModel, self).store()
+    def store(self, all=False):
+        super(LibModel, self).store(all)
         plugins.send('database_change', lib=self._db)
 
     def remove(self):
@@ -224,6 +226,7 @@ class FormattedItemMapping(dbcore.db.FormattedMapping):
 
     def __init__(self, item, for_path=False):
         super(FormattedItemMapping, self).__init__(item, for_path)
+        self.item = item
         self.album = item.get_album()
         self.album_keys = []
         if self.album:
@@ -232,33 +235,50 @@ class FormattedItemMapping(dbcore.db.FormattedMapping):
                     self.album_keys.append(key)
         self.all_keys = set(self.model_keys).union(self.album_keys)
 
-    def _get(self, key):
-        """Get the value for a key, either from the album or the item.
-        Raise a KeyError for invalid keys.
-        """
+    def _model_for_key(self, key):
         if self.for_path and key in self.album_keys:
-            return self._get_formatted(self.album, key)
+            return self.album
         elif key in self.model_keys:
-            return self._get_formatted(self.model, key)
+            return self.item
         elif key in self.album_keys:
-            return self._get_formatted(self.album, key)
+            return self.album
         else:
-            raise KeyError(key)
+            return self.item
 
     def __getitem__(self, key):
-        """Get the value for a key. Certain unset values are remapped.
-        """
-        value = self._get(key)
+        key = self._translate_key(key)
+        model = self._model_for_key(key)
+        value = model[key]
+        if value is None:
+            raise KeyError(key)
+        value = model._type(key).format(value)
+        return self._path_replace(value)
 
+    def get(self, key, default=COLUMN_DEFAULT):
+        key = self._translate_key(key)
+        model = self._model_for_key(key)
+        value = model.get(key, default)
+        value = model._type(key).format(value)
+        if self.for_path:
+            sep_repl = beets.config['path_sep_replace'].get(unicode)
+            for sep in (os.path.sep, os.path.altsep):
+                if sep:
+                    value = value.replace(sep, sep_repl)
+        return value
+
+    def _missing_value(self, key):
+        return not (key in self.item and self.item[key] or
+                    key in self.album_keys and self.album[key])
+
+    def _translate_key(self, key):
         # `artist` and `albumartist` fields fall back to one another.
         # This is helpful in path formats when the album artist is unset
         # on as-is imports.
-        if key == 'artist' and not value:
-            return self._get('albumartist')
-        elif key == 'albumartist' and not value:
-            return self._get('artist')
-        else:
-            return value
+        if self._missing_value('artist'):
+            return 'albumartist'
+        elif self._missing_value('albumartist'):
+            return 'artist'
+        return key
 
     def __iter__(self):
         return iter(self.all_keys)
@@ -872,7 +892,7 @@ class Album(LibModel):
             util.move(path, artdest)
         self.artpath = artdest
 
-    def store(self):
+    def store(self, all=False):
         """Update the database with the album information. The album's
         tracks are also updated.
         """
@@ -883,7 +903,7 @@ class Album(LibModel):
                 track_updates[key] = self[key]
 
         with self._db.transaction():
-            super(Album, self).store()
+            super(Album, self).store(all)
             if track_updates:
                 for item in self.items():
                     for key, value in track_updates.items():

--- a/beets/library.py
+++ b/beets/library.py
@@ -274,9 +274,9 @@ class FormattedItemMapping(dbcore.db.FormattedMapping):
         # `artist` and `albumartist` fields fall back to one another.
         # This is helpful in path formats when the album artist is unset
         # on as-is imports.
-        if self._missing_value('artist'):
+        if key == 'artist' and self._missing_value('artist'):
             return 'albumartist'
-        elif self._missing_value('albumartist'):
+        elif key == 'albumartist' and self._missing_value('albumartist'):
             return 'artist'
         return key
 

--- a/beets/library.py
+++ b/beets/library.py
@@ -257,14 +257,17 @@ class FormattedItemMapping(dbcore.db.FormattedMapping):
     def get(self, key, default=COLUMN_DEFAULT):
         key = self._translate_key(key)
         model = self._model_for_key(key)
-        value = model.get(key, default)
-        value = model._type(key).format(value)
-        if self.for_path:
-            sep_repl = beets.config['path_sep_replace'].get(unicode)
-            for sep in (os.path.sep, os.path.altsep):
-                if sep:
-                    value = value.replace(sep, sep_repl)
-        return value
+        if default == COLUMN_DEFAULT:
+            value = model.get(key, default)
+            value = model._type(key).format(value)
+        else:
+            value = model.get(key, None)
+            if value is None:
+                value = default
+            else:
+                value = model._type(key).format(value)
+
+        return self._path_replace(value)
 
     def _missing_value(self, key):
         return not (key in self.item and self.item[key] or

--- a/beets/library.py
+++ b/beets/library.py
@@ -62,13 +62,11 @@ class PathQuery(dbcore.FieldQuery):
 # Library-specific field types.
 
 
-class DateType(types.Type):
+class DateType(types.Float):
     """Dates are represented by floats.
     """
     # TODO representation should be struct_time
-    sql = u'REAL'
     query = dbcore.query.DateQuery
-    default = 0.0
 
     def format(self, value):
         fmt = beets.config['time_format'].get(unicode)
@@ -84,12 +82,12 @@ class DateType(types.Type):
             return float(string)
 
 
-class PathType(types.Type):
+class PathType(types.Bytes):
     """Paths are stored as `str` internally
     """
 
-    sql = u'BLOB'
     query = PathQuery
+    model_type = str
 
     def format(self, value):
         return util.displayable_path(value)
@@ -102,12 +100,6 @@ class PathType(types.Type):
             return bytestring_path(value)
         else:
             return str(value)
-
-    def from_sql(self, sql_value):
-        if isinstance(sql_value, unicode):
-            # For backwards compatibility.
-            return bytestring_path(sql_value)
-        return bytes(sql_value)
 
     def to_sql(self, local_value):
         return buffer(local_value)

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1261,7 +1261,7 @@ def modify_items(lib, mods, dels, query, write, move, album, confirm):
     model_cls = library.Album if album else library.Item
 
     for key, value in mods.items():
-        mods[key] = model_cls._parse(key, value)
+        mods[key] = model_cls.parse(key, value)
 
     # Get the items to modify.
     items, albums = _do_query(lib, query, album, False)

--- a/beetsplug/echonest.py
+++ b/beetsplug/echonest.py
@@ -450,7 +450,7 @@ class EchonestMetadataPlugin(plugins.BeetsPlugin):
                 if field == 'bpm':
                     item[field] = int(v)
                 else:
-                    item[field] = v
+                    item[field] = unicode(v)
         if 'key' in values and 'mode' in values:
             key = MUSICAL_SCALE[values['key'] - 1]
             if values['mode'] == 0:  # Minor key

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -98,13 +98,11 @@ def embed_item(item, imagepath, maxwidth=None, itempath=None):
     """Embed an image into the item's media file.
     """
     try:
-        item['images'] = [_mediafile_image(imagepath, maxwidth)]
-        item.try_write(itempath)
-    except IOError as exc:
+        mf = mediafile.MediaFile(itempath or item.path)
+        mf.images = [_mediafile_image(imagepath, maxwidth)]
+        mf.save()
+    except (IOError, OSError, mediafile.MutagenError) as exc:
         log.error(u'embedart: could not read image file: {0}'.format(exc))
-    finally:
-        # We don't want to store the image in the database
-        del item['images']
 
 
 def embed_album(album, maxwidth=None):

--- a/beetsplug/info.py
+++ b/beetsplug/info.py
@@ -102,7 +102,10 @@ def library_data(lib, args):
 
 def library_data_emitter(item):
     def emitter():
-        data = dict(item.formatted())
+        data = {}
+        formatted = item.formatted()
+        for k in formatted:
+            data[k] = formatted.get(k, None)
         data['path'] = displayable_path(item.path)
         return data
     return emitter

--- a/beetsplug/zero.py
+++ b/beetsplug/zero.py
@@ -86,11 +86,11 @@ class ZeroPlugin(BeetsPlugin):
 
         for field, patterns in self.patterns.items():
             try:
-                value = getattr(item, field)
-            except AttributeError:
+                value = item[field]
+            except KeyError:
                 log.error(u'[zero] no such field: {0}'.format(field))
                 continue
 
             if self.match_patterns(value, patterns):
                 log.debug(u'[zero] {0}: {1} -> None'.format(field, value))
-                setattr(item, field, None)
+                del item[field]

--- a/test/test_autotag.py
+++ b/test/test_autotag.py
@@ -81,14 +81,21 @@ class PluralityTest(_common.TestCase):
         self.assertFalse(consensus['artist'])
 
     def test_current_metadata_likelies(self):
-        fields = ['artist', 'album', 'albumartist', 'year', 'disctotal',
-                  'mb_albumid', 'label', 'catalognum', 'country', 'media',
-                  'albumdisambig']
-        items = [Item(**dict((f, '%s_%s' % (f, i or 1)) for f in fields))
-                 for i in range(5)]
-        likelies, _ = match.current_metadata(items)
-        for f in fields:
+        string_fields = ['artist', 'album', 'albumartist', 'mb_albumid',
+                         'label', 'catalognum', 'country', 'media',
+                         'albumdisambig']
+        int_fields = ['year', 'disctotal']
+
+        def item(i):
+            return Item(**dict(
+                [(f, '%s_%s' % (f, i or 1)) for f in string_fields] +
+                [(f, i or 1) for f in int_fields]
+            ))
+        likelies, _ = match.current_metadata([item(i) for i in range(5)])
+        for f in string_fields:
             self.assertEqual(likelies[f], '%s_1' % f)
+        for f in int_fields:
+            self.assertEqual(likelies[f], 1)
 
 
 def _make_item(title, track, artist=u'some artist'):

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -231,8 +231,23 @@ class ModelTest(unittest.TestCase):
 
     def test_delete_fixed_attribute(self):
         model = TestModel1()
-        with self.assertRaises(KeyError):
-            del model['field_one']
+        del model['field_one']
+        self.assertIsNone(model['field_one'])
+
+    def test_deleted_attribute_is_normalized_after_load(self):
+        model = TestModel1()
+        del model['field_one']
+        model.add(self.db)
+        model.load()
+        self.assertEqual(model['field_one'], 0)
+
+    def test_deleted_attribute_is_normalized_when_fetching(self):
+        model = TestModel1()
+        del model['field_one']
+        model.add(self.db)
+
+        model = self.db._get(TestModel1, model.id)
+        self.assertEqual(model['field_one'], 0)
 
     def test_null_value_normalization_by_type(self):
         model = TestModel1()

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -269,28 +269,9 @@ class ModelTest(unittest.TestCase):
         del model['some_float_field']
         self.assertEqual(model.get('some_float_field'), 0.0)
 
-
-class FormattedMappingTest(unittest.TestCase):
-
-    def test_keys_equal_model_keys(self):
-        model = TestModel1()
-        formatted = model.formatted()
-        self.assertEqual(set(model.keys(True)), set(formatted.keys()))
-
-    def test_unset_flex_with_string_default(self):
-        model = TestModel1()
-        formatted = model.formatted()
-        self.assertEqual(formatted['flex_field'], u'')
-        self.assertEqual(formatted.get('flex_field'), u'')
-
-    def test_unset_flex_with_custom_default(self):
-        model = TestModel1()
-        formatted = model.formatted()
-        self.assertEqual(formatted.get('flex_field', 'default'), 'default')
-
     def test_load_deleted_flex_field(self):
         model1 = TestModel1()
-        model1['flex_field'] = True
+        model1['flex_field'] = 'str'
         model1.add(self.db)
 
         model2 = self.db._get(TestModel1, model1.id)
@@ -303,7 +284,29 @@ class FormattedMappingTest(unittest.TestCase):
         self.assertNotIn('flex_field', model2)
 
 
-class FormatTest(unittest.TestCase):
+class FormattedMappingTest(unittest.TestCase):
+
+    def test_keys_equal_model_keys(self):
+        model = TestModel1()
+        formatted = model.formatted()
+        self.assertEqual(set(model.keys(True)), set(formatted.keys()))
+
+    def test_unset_flex_raises(self):
+        model = TestModel1()
+        formatted = model.formatted()
+        with self.assertRaises(KeyError):
+            formatted['flex_field']
+
+    def test_unset_flex_with_string_default(self):
+        model = TestModel1()
+        formatted = model.formatted()
+        self.assertEqual(formatted.get('flex_field'), u'')
+
+    def test_unset_flex_with_custom_default(self):
+        model = TestModel1()
+        formatted = model.formatted()
+        self.assertEqual(formatted.get('flex_field', 'default'), 'default')
+
     def test_format_fixed_field(self):
         model = TestModel1()
         model.field_one = u'caf\xe9'

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -31,6 +31,7 @@ class TestModel1(dbcore.Model):
     _fields = {
         'id': dbcore.types.PRIMARY_ID,
         'field_one': dbcore.types.INTEGER,
+        'string_field': dbcore.types.STRING
     }
     _types = {
         'some_float_field': dbcore.types.FLOAT,
@@ -54,6 +55,7 @@ class TestModel2(TestModel1):
         'id': dbcore.types.PRIMARY_ID,
         'field_one': dbcore.types.INTEGER,
         'field_two': dbcore.types.INTEGER,
+        'string_field': dbcore.types.STRING
     }
 
 
@@ -68,6 +70,7 @@ class TestModel3(TestModel1):
         'field_one': dbcore.types.INTEGER,
         'field_two': dbcore.types.INTEGER,
         'field_three': dbcore.types.INTEGER,
+        'string_field': dbcore.types.STRING
     }
 
 
@@ -83,6 +86,7 @@ class TestModel4(TestModel1):
         'field_two': dbcore.types.INTEGER,
         'field_three': dbcore.types.INTEGER,
         'field_four': dbcore.types.INTEGER,
+        'string_field': dbcore.types.STRING
     }
 
 
@@ -309,8 +313,8 @@ class FormattedMappingTest(unittest.TestCase):
 
     def test_format_fixed_field(self):
         model = TestModel1()
-        model.field_one = u'caf\xe9'
-        value = model.formatted().get('field_one')
+        model.string_field = u'caf\xe9'
+        value = model.formatted().get('string_field')
         self.assertEqual(value, u'caf\xe9')
 
     def test_format_flex_field(self):

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -169,18 +169,9 @@ class ModelTest(unittest.TestCase):
         self.db._connection().close()
 
     def test_add_model(self):
-        model = TestModel1()
-        model.add(self.db)
-        rows = self.db._connection().execute('select * from test').fetchall()
-        self.assertEqual(len(rows), 1)
-
-    def test_store_fixed_field(self):
-        model = TestModel1()
-        model.add(self.db)
-        model.field_one = 123
-        model.store()
-        row = self.db._connection().execute('select * from test').fetchone()
-        self.assertEqual(row['field_one'], 123)
+        self.assertEqual(0, len(self.db._fetch(TestModel1)))
+        TestModel1().add(self.db)
+        self.assertEqual(1, len(self.db._fetch(TestModel1)))
 
     def test_retrieve_by_id(self):
         model = TestModel1()
@@ -188,14 +179,31 @@ class ModelTest(unittest.TestCase):
         other_model = self.db._get(TestModel1, model.id)
         self.assertEqual(model.id, other_model.id)
 
+    def test_store_fixed_field(self):
+        model = TestModel1()
+        model.add(self.db)
+        model['field_one'] = 123
+        model.store()
+
+        model = self.db._get(TestModel1, model.id)
+        self.assertEqual(model['field_one'], 123)
+
+    def test_add_fields(self):
+        model = TestModel1()
+        model['field_one'] = 123
+        model.add(self.db)
+
+        model = self.db._get(TestModel1, model.id)
+        self.assertEqual(model['field_one'], 123)
+
     def test_store_and_retrieve_flexattr(self):
         model = TestModel1()
         model.add(self.db)
-        model.foo = 'bar'
+        model['foo'] = 'bar'
         model.store()
 
         other_model = self.db._get(TestModel1, model.id)
-        self.assertEqual(other_model.foo, 'bar')
+        self.assertEqual(other_model['foo'], 'bar')
 
     def test_delete_flexattr(self):
         model = TestModel1()
@@ -204,17 +212,10 @@ class ModelTest(unittest.TestCase):
         del model['foo']
         self.assertFalse('foo' in model)
 
-    def test_delete_flexattr_via_dot(self):
-        model = TestModel1()
-        model['foo'] = 'bar'
-        self.assertTrue('foo' in model)
-        del model.foo
-        self.assertFalse('foo' in model)
-
     def test_delete_flexattr_persists(self):
         model = TestModel1()
         model.add(self.db)
-        model.foo = 'bar'
+        model['foo'] = 'bar'
         model.store()
 
         model = self.db._get(TestModel1, model.id)
@@ -222,7 +223,7 @@ class ModelTest(unittest.TestCase):
         model.store()
 
         model = self.db._get(TestModel1, model.id)
-        self.assertFalse('foo' in model)
+        self.assertNotIn('foo', model)
 
     def test_delete_non_existent_attribute(self):
         model = TestModel1()
@@ -230,39 +231,62 @@ class ModelTest(unittest.TestCase):
             del model['foo']
 
     def test_delete_fixed_attribute(self):
-        model = TestModel1()
+        model = TestModel1(field_one=True)
+        self.assertIsNotNone(model['field_one'])
         del model['field_one']
         self.assertIsNone(model['field_one'])
 
-    def test_deleted_attribute_is_normalized_after_load(self):
+    def test_delete_fixed_attribute_persists(self):
+        model = TestModel1(db=self.db, field_one=True)
+        model.add()
+
+        model = self.db._get(TestModel1, model.id)
+        self.assertIsNotNone(model['field_one'])
+        del model['field_one']
+        model.store()
+
+        model = self.db._get(TestModel1, model.id)
+        self.assertIsNone(model['field_one'])
+
+    def test_deleted_attribute_has_default_after_load(self):
         model = TestModel1()
         del model['field_one']
         model.add(self.db)
         model.load()
-        self.assertEqual(model['field_one'], 0)
+        self.assertEqual(model.get('field_one'), 0)
 
-    def test_deleted_attribute_is_normalized_when_fetching(self):
+    def test_deleted_attribute_has_default_when_fetching(self):
         model = TestModel1()
         del model['field_one']
         model.add(self.db)
 
         model = self.db._get(TestModel1, model.id)
-        self.assertEqual(model['field_one'], 0)
+        self.assertEqual(model.get('field_one'), 0)
 
-    def test_null_value_normalization_by_type(self):
+    def test_flex_default(self):
         model = TestModel1()
-        model.field_one = None
-        self.assertEqual(model.field_one, 0)
+        model['some_float_field'] = 1
+        del model['some_float_field']
+        self.assertEqual(model.get('some_float_field'), 0.0)
 
-    def test_null_value_stays_none_for_untyped_field(self):
-        model = TestModel1()
-        model.foo = None
-        self.assertEqual(model.foo, None)
 
-    def test_normalization_for_typed_flex_fields(self):
+class FormattedMappingTest(unittest.TestCase):
+
+    def test_keys_equal_model_keys(self):
         model = TestModel1()
-        model.some_float_field = None
-        self.assertEqual(model.some_float_field, 0.0)
+        formatted = model.formatted()
+        self.assertEqual(set(model.keys(True)), set(formatted.keys()))
+
+    def test_unset_flex_with_string_default(self):
+        model = TestModel1()
+        formatted = model.formatted()
+        self.assertEqual(formatted['flex_field'], u'')
+        self.assertEqual(formatted.get('flex_field'), u'')
+
+    def test_unset_flex_with_custom_default(self):
+        model = TestModel1()
+        formatted = model.formatted()
+        self.assertEqual(formatted.get('flex_field', 'default'), 'default')
 
     def test_load_deleted_flex_field(self):
         model1 = TestModel1()
@@ -311,43 +335,23 @@ class FormatTest(unittest.TestCase):
         self.assertEqual(value, u'3.1')
 
 
-class FormattedMappingTest(unittest.TestCase):
-    def test_keys_equal_model_keys(self):
-        model = TestModel1()
-        formatted = model.formatted()
-        self.assertEqual(set(model.keys(True)), set(formatted.keys()))
-
-    def test_get_unset_field(self):
-        model = TestModel1()
-        formatted = model.formatted()
-        with self.assertRaises(KeyError):
-            formatted['other_field']
-
-    def test_get_method_with_default(self):
-        model = TestModel1()
-        formatted = model.formatted()
-        self.assertEqual(formatted.get('other_field'), u'')
-
-    def test_get_method_with_specified_default(self):
-        model = TestModel1()
-        formatted = model.formatted()
-        self.assertEqual(formatted.get('other_field', 'default'), 'default')
-
-
 class ParseTest(unittest.TestCase):
     def test_parse_fixed_field(self):
-        value = TestModel1._parse('field_one', u'2')
-        self.assertIsInstance(value, int)
-        self.assertEqual(value, 2)
+        model = TestModel1()
+        model.set('field_one', u'2')
+        self.assertIsInstance(model['field_one'], int)
+        self.assertEqual(model['field_one'], 2)
 
     def test_parse_flex_field(self):
-        value = TestModel1._parse('some_float_field', u'2')
-        self.assertIsInstance(value, float)
-        self.assertEqual(value, 2.0)
+        model = TestModel1()
+        model.set('some_float_field', u'2')
+        self.assertIsInstance(model['some_float_field'], float)
+        self.assertEqual(model['some_float_field'], 2.0)
 
     def test_parse_untyped_field(self):
-        value = TestModel1._parse('field_nine', u'2')
-        self.assertEqual(value, u'2')
+        model = TestModel1()
+        model.set('unknown_flex', u'2')
+        self.assertEqual(model['unknown_flex'], u'2')
 
 
 class QueryParseTest(unittest.TestCase):

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -368,7 +368,7 @@ class ArtFileTest(_common.TestCase):
 
     def test_move_not_last_file_does_not_move_albumart(self):
         i2 = item()
-        i2.albumid = self.ai.id
+        i2.album_id = self.ai.id
         self.lib.add(i2)
 
         oldartpath = self.lib.albums()[0].artpath

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -402,7 +402,7 @@ class IntQueryTest(unittest.TestCase, TestHelper):
     def test_flex_range_match(self):
         Item._types = {'myint': types.Integer()}
         item = self.add_item(myint=2)
-        matched = self.lib.items('myint:2').get()
+        matched = self.lib.items('myint:1..3').get()
         self.assertEqual(item.id, matched.id)
 
     def test_flex_dont_match_missing(self):

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -16,8 +16,12 @@
 """
 import _common
 from _common import unittest
+from helper import TestHelper
+
 import beets.library
 from beets import dbcore
+from beets.dbcore import types
+from beets.library import Library, Item
 
 
 class AnyFieldQueryTest(_common.LibTestCase):
@@ -372,6 +376,50 @@ class PathQueryTest(_common.LibTestCase, AssertsMixin):
         q = 'path::\\.mp3$'
         results = self.lib.items(q)
         self.assert_matched(results, ['path item'])
+
+
+class IntQueryTest(unittest.TestCase, TestHelper):
+
+    def setUp(self):
+        self.lib = Library(':memory:')
+
+    def tearDown(self):
+        Item._types = {}
+
+    def test_exact_value_match(self):
+        item = self.add_item(bpm=120)
+        matched = self.lib.items('bpm:120').get()
+        self.assertEqual(item.id, matched.id)
+
+    def test_range_match(self):
+        item = self.add_item(bpm=120)
+        self.add_item(bpm=130)
+
+        matched = self.lib.items('bpm:110..125')
+        self.assertEqual(1, len(matched))
+        self.assertEqual(item.id, matched.get().id)
+
+    def test_flex_range_match(self):
+        Item._types = {'myint': types.Integer()}
+        item = self.add_item(myint=2)
+        matched = self.lib.items('myint:2').get()
+        self.assertEqual(item.id, matched.id)
+
+    def test_flex_dont_match_missing(self):
+        Item._types = {'myint': types.Integer()}
+        self.add_item()
+        matched = self.lib.items('myint:2').get()
+        self.assertIsNone(matched)
+
+    def test_no_substring_match(self):
+        self.add_item(bpm=120)
+        matched = self.lib.items('bpm:12').get()
+        self.assertIsNone(matched)
+
+    def add_item(self, **values):
+        item = Item(db=self.lib, **values)
+        item.add()
+        return item
 
 
 class DefaultSearchFieldsTest(DummyDataTestCase):

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -183,6 +183,20 @@ class ModifyTest(unittest.TestCase, TestHelper):
         item = self.lib.items().get()
         self.assertNotIn('newTitle', item.path)
 
+    def test_set_flexattr(self):
+        self.modify("flexattr=testAttr")
+        item = self.lib.items().get()
+        self.assertEqual(item.flexattr, 'testAttr')
+
+    def test_remove_flexattr(self):
+        item = self.lib.items().get()
+        item.flexattr = 'testAttr'
+        item.store()
+
+        self.modify("flexattr!")
+        item = self.lib.items().get()
+        self.assertNotIn("flexattr", item)
+
     # Album Tests
 
     def test_modify_album(self):
@@ -214,7 +228,17 @@ class ModifyTest(unittest.TestCase, TestHelper):
         item.read()
         self.assertNotIn('newAlbum', item.path)
 
-    # Misc
+    def test_album_delete_art_path(self):
+        album = self.lib.albums().get()
+        self.assertIsNone(album['artpath'])
+        album['artpath'] = '/path/to/cover.jpg'
+        album.store()
+
+        self.modify("--album", "artpath!")
+        album = self.lib.albums().get()
+        self.assertIsNone(album['artpath'])
+
+    # Misc (initial_key)
 
     def test_write_initial_key_tag(self):
         self.modify("initial_key=C#m")
@@ -222,21 +246,6 @@ class ModifyTest(unittest.TestCase, TestHelper):
         mediafile = MediaFile(item.path)
         self.assertEqual(mediafile.initial_key, 'C#m')
 
-    def test_set_flexattr(self):
-        self.modify("flexattr=testAttr")
-        item = self.lib.items().get()
-        self.assertEqual(item.flexattr, 'testAttr')
-
-    def test_remove_flexattr(self):
-        item = self.lib.items().get()
-        item.flexattr = 'testAttr'
-        item.store()
-
-        self.modify("flexattr!")
-        item = self.lib.items().get()
-        self.assertNotIn("flexattr", item)
-
-    @unittest.skip('not yet implemented')
     def test_delete_initial_key_tag(self):
         item = self.lib.items().get()
         item.initial_key = 'C#m'
@@ -249,6 +258,8 @@ class ModifyTest(unittest.TestCase, TestHelper):
         self.modify("initial_key!")
         mediafile = MediaFile(item.path)
         self.assertIsNone(mediafile.initial_key)
+
+    # Test `modify_parse_args()`
 
     def test_arg_parsing_colon_query(self):
         (query, mods, dels) = commands.modify_parse_args(["title:oldTitle",

--- a/test/test_zero.py
+++ b/test/test_zero.py
@@ -4,7 +4,6 @@ from _common import unittest
 from helper import TestHelper
 
 from beets.library import Item
-from beets import config
 from beetsplug.zero import ZeroPlugin
 from beets.mediafile import MediaFile
 
@@ -12,42 +11,39 @@ from beets.mediafile import MediaFile
 class ZeroPluginTest(unittest.TestCase, TestHelper):
     def setUp(self):
         self.setup_beets()
+        self.zero = self.config['zero']
 
     def tearDown(self):
         self.teardown_beets()
         self.unload_plugins()
 
-    def test_no_patterns(self):
+    def test_remove_item_fields(self):
         i = Item(
             comments='test comment',
             day=13,
             month=3,
             year=2012,
         )
-        z = ZeroPlugin()
-        z.debug = False
-        z.fields = ['comments', 'month', 'day']
-        z.patterns = {'comments': ['.'],
-                      'month': ['.'],
-                      'day': ['.']}
-        z.write_event(i)
-        self.assertEqual(i.comments, '')
-        self.assertEqual(i.day, 0)
-        self.assertEqual(i.month, 0)
+        self.zero['fields'] = ['comments', 'month', 'day']
+        ZeroPlugin().write_event(i)
+        self.assertIsNone(i.comments)
+        self.assertIsNone(i.day)
+        self.assertIsNone(i.month)
         self.assertEqual(i.year, 2012)
 
-    def test_patterns(self):
+    def test_remove_fields_on_patterns(self):
         i = Item(
             comments='from lame collection, ripped by eac',
             year=2012,
         )
-        z = ZeroPlugin()
-        z.debug = False
-        z.fields = ['comments', 'year']
-        z.patterns = {'comments': 'eac lame'.split(),
-                      'year': '2098 2099'.split()}
-        z.write_event(i)
-        self.assertEqual(i.comments, '')
+        self.zero['fields'] = ['comments', 'day']
+        self.zero['patterns'] = {
+            'comments': 'eac lame'.split(),
+            'year': '2098 2099'.split()
+        }
+
+        ZeroPlugin().write_event(i)
+        self.assertIsNone(i.comments)
         self.assertEqual(i.year, 2012)
 
     def test_delete_replaygain_tag(self):
@@ -60,15 +56,42 @@ class ZeroPluginTest(unittest.TestCase, TestHelper):
         self.assertIsNotNone(mediafile.rg_track_peak)
         self.assertIsNotNone(mediafile.rg_track_gain)
 
-        config['zero'] = {
-            'fields': ['rg_track_peak', 'rg_track_gain'],
-        }
+        self.zero['fields'] = ['rg_track_peak', 'rg_track_gain']
         self.load_plugins('zero')
 
         item.write()
         mediafile = MediaFile(item.path)
         self.assertIsNone(mediafile.rg_track_peak)
         self.assertIsNone(mediafile.rg_track_gain)
+
+    def test_delete_composer_and_comments_tag(self):
+        path = self.create_mediafile_fixture('mp3')
+        item = Item.from_path(path)
+        item.composer = 'somebody'
+        item.comments = 'comment'
+        item.write()
+        # We user mutagen to make sure that the tag is (non)existent.
+        self.assertIn("TCOM", MediaFile(item.path).mgfile)
+        self.assertIn("COMM::'eng'", MediaFile(item.path).mgfile)
+
+        self.zero['fields'] = ['composer', 'comments']
+        self.load_plugins('zero')
+
+        item.write()
+        self.assertNotIn("TCOM", MediaFile(item.path).mgfile)
+        self.assertNotIn("COMM::'eng'", MediaFile(item.path).mgfile)
+
+    def test_delete_track_tags(self):
+        path = self.create_mediafile_fixture('mp3')
+        item = Item.from_path(path)
+        self.assertIn('TRCK', MediaFile(item.path).mgfile)
+
+        self.zero['fields'] = ['track', 'tracktotal']
+        self.load_plugins('zero')
+
+        item.write()
+        self.assertNotIn('TRCK', MediaFile(item.path).mgfile)
+
 
 
 def suite():

--- a/test/test_zero.py
+++ b/test/test_zero.py
@@ -93,7 +93,6 @@ class ZeroPluginTest(unittest.TestCase, TestHelper):
         self.assertNotIn('TRCK', MediaFile(item.path).mgfile)
 
 
-
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 


### PR DESCRIPTION
1. Deleting fields works by setting them to `NULL` in the database
2. The Zero plugin completely removes tags instead of storing the empty string (see #157).
