### PR TITLE
mbcollection: Automatically update collection on import #793

### DIFF
--- a/docs/plugins/mbcollection.rst
+++ b/docs/plugins/mbcollection.rst
@@ -18,3 +18,17 @@ Then, use the ``beet mbupdate`` command to send your albums to MusicBrainz. The
 command automatically adds all of your albums to the first collection it finds.
 If you don't have a MusicBrainz collection yet, you may need to add one to your
 profile first.
+
+Auto Update Mode
+----------------
+
+You can now add each imported album to your MusicBrainz collection, without 
+needing a separate ``beet mbupdate`` command.  To do this, first enable the 
+plugin and add your MusicBrainz account using the instructions above.  Then, 
+add a block for the ``mbcollection`` plugin to enable ``auto`` configuration::
+
+    mbcollection:
+        auto: yes
+
+During future imports, your default collection will be updated with the
+imported album.


### PR DESCRIPTION
Minor change to add optional musicbrainz update on import of an album.  Also updated the doc for the plugin.

Note the first commit (2118a41) was no longer relevant after merging with master.
