### PR TITLE
Add a link to whitelist raw file in lastgenre documentation

### DIFF
--- a/docs/plugins/lastgenre.rst
+++ b/docs/plugins/lastgenre.rst
@@ -21,9 +21,8 @@ your ``plugins`` line in :doc:`config file </reference/config>`.
 The plugin chooses genres based on a *whitelist*, meaning that only certain
 tags can be considered genres. This way, tags like "my favorite music" or "seen
 live" won't be considered genres. The plugin ships with a fairly extensive
-[internal whitelist](https://raw.githubusercontent.com/sampsyo/beets/master/beetsplug/lastgenre/genres.txt), 
-but you can set your own in the config file using the ``whitelist`` configuration
-value::
+`internal whitelist`_, but you can set your own in the config file using the 
+``whitelist`` configuration value::
 
     lastgenre:
         whitelist: /path/to/genres.txt
@@ -37,6 +36,7 @@ Wikipedia`_.
 .. _pip: http://www.pip-installer.org/
 .. _pylast: http://code.google.com/p/pylast/
 .. _script that scrapes Wikipedia: https://gist.github.com/1241307
+.. _internal whitelist: https://raw.githubusercontent.com/sampsyo/beets/master/beetsplug/lastgenre/genres.txt
 
 By default, beets will always fetch new genres, even if the files already have
 once. To instead leave genres in place in when they pass the whitelist, set


### PR DESCRIPTION
it makes it easier to copy for someone wanting to create a custom whitelist, but not from scratch.

An alternative is to mention the curl command to use as proposed by @sampsyo 

> We might be better off just documenting 
>     curl -O https://raw.githubusercontent.com/sampsyo/beets/master/beetsplug/lastgenre/genres.txt 
> as the canonical way to obtain/edit the whitelist. 

but I thought a discreet link was sufficient.
