### PR TITLE
Update database mtimes in modify and write commands

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -470,6 +470,21 @@ class Item(LibModel):
             log.error(exc)
             return False
 
+    def try_sync(self, write=None):
+        """Synchronizes the current state with the database and the
+        media file tags.
+
+        If `write` is `None` or `True` the method tries to write the
+        tags to `self.path`.  If `write` is `False` it does not write
+        tags. Otherwise it interprets `write` as a path and tries to
+        write the tags to that file.
+        """
+        if write is True:
+            write = None
+        if write is not False:
+            self.try_write(path=write)
+        self.store()
+
     # Files themselves.
 
     def move_file(self, dest, copy=False):
@@ -881,6 +896,18 @@ class Album(LibModel):
                     for key, value in track_updates.items():
                         item[key] = value
                     item.store()
+
+    def try_sync(self, write=True):
+        """Synchronizes the current state with the database, propagates
+        it to the items and synchronizes them with the database and
+        their files.
+
+        The `write` parameter is a boolean indicating whether to write
+        tags to the item files.
+        """
+        self.store()
+        for item in self.items():
+            item.try_sync(bool(write))
 
 
 # Query construction helper.

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -20,7 +20,6 @@ from __future__ import print_function
 import logging
 import os
 import time
-import itertools
 import codecs
 import platform
 import re
@@ -1298,7 +1297,7 @@ def modify_items(lib, mods, dels, query, write, move, album, confirm):
         if not ui.input_yn('Really modify%s (Y/n)?' % extra):
             return
 
-    # Apply changes to database.
+    # Apply changes to database and files
     with lib.transaction():
         for obj in changed:
             if move:
@@ -1307,16 +1306,7 @@ def modify_items(lib, mods, dels, query, write, move, album, confirm):
                     log.debug('moving object %s' % cur_path)
                     obj.move()
 
-            obj.store()
-
-    # Apply tags if requested.
-    if write:
-        if album:
-            changed_items = itertools.chain(*(a.items() for a in changed))
-        else:
-            changed_items = changed
-        for item in changed_items:
-            item.try_write()
+            obj.try_sync(write)
 
 
 def modify_parse_args(args):
@@ -1457,7 +1447,7 @@ def write_items(lib, query, pretend, force):
         changed = ui.show_model_changes(item, clean_item,
                                         library.Item._media_fields, force)
         if (changed or force) and not pretend:
-            item.try_write()
+            item.try_sync()
 
 
 def write_func(lib, opts, args):


### PR DESCRIPTION
First commit implements tests that are derived from the [specification in the wiki](https://github.com/sampsyo/beets/wiki/Architecture#modification-times-mtime).

Second commit tries to pass the tests by introducing a `try_sync()` method as discussed in #937.
