### PR TITLE
Update type of last_played to library.DateType().

### DIFF
--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -313,7 +313,7 @@ class MPDStatsPlugin(plugins.BeetsPlugin):
     item_types = {
         'play_count':  types.INTEGER,
         'skip_count':  types.INTEGER,
-        'last_played': library.Date(),
+        'last_played': library.DateType(),
         'rating':      types.FLOAT,
     }
 


### PR DESCRIPTION
Fixes the following exception:

```
** error loading plugin mpdstats
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/beets/plugins.py", line 201, in load_plugins
    namespace = __import__(modname, None, None)
  File "/usr/lib/python2.7/site-packages/beetsplug/mpdstats.py", line 311, in <module>
    class MPDStatsPlugin(plugins.BeetsPlugin):
  File "/usr/lib/python2.7/site-packages/beetsplug/mpdstats.py", line 316, in MPDStatsPlugin
    'last_played': library.Date(),
AttributeError: 'module' object has no attribute 'Date'
```
