### PR TITLE
Fix not using musicbrainz artist alias in some cases.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,7 @@ Fixes:
 * Remove the ``beatport`` plugin. `Beatport`_ has shut off public access to
   their API and denied our request for an account. We have not heard from the
   company since 2013, so we are assuming access will not be restored.
+* Fix not using musicbrainz artist alias in some cases.
 
 For developers: The logging system in beets has been overhauled. Plugins now
 each have their own logger, which helps by automatically adjusting the


### PR DESCRIPTION
A missing alias does not actually indicate that there is no alias.
Track artist information can override recording artist information,
but when it does, it does not contain the artist aliases. So we need
to check the artist itself for it to be sure.

An example for this behavior is http://musicbrainz.org/ws/2/release/1058cc07-d4c0-4db2-8841-31f2daa0589a?inc=artists+media+recordings+release-groups+labels+artist-credits+aliases
In the XML output you can see that track 15 has an artist credit different from the associated recording. While the artist is the same as for the other tracks on the album, the artist information lacks the alias list.