### PR TITLE
Re: issue #1028: "embedart: Resize images only once per album

### DIFF
--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -126,7 +126,7 @@ def embed_item(item, imagepath, maxwidth=None, itempath=None,
                 displayable_path(imagepath)
             ))
             return
-    if not asalbum:
+    if maxwidth and not asalbum:
         imagepath = resize_image(imagepath, maxwidth)
 
     try:
@@ -165,7 +165,7 @@ def embed_album(album, maxwidth=None, quiet=False):
     for item in album.items():
         embed_item(item, imagepath, maxwidth, None,
                    config['embedart']['compare_threshold'].get(int),
-                   config['embedart']['ifempty'], asalbum=True)
+                   config['embedart']['ifempty'].get(bool), asalbum=True)
 
 
 def resize_image(imagepath, maxwidth):


### PR DESCRIPTION
Added function resize_image. embedart now calls resize_image once in embed_album before it calls embed_item once per track. resize_image is also called in embed_item if embed_item is not being called from embed_album.
