### PR TITLE
Dropping unused argument introduced in #1011

### DIFF
--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -72,7 +72,7 @@ def update_metadata(item, feat_part, drop_feat):
         item.title = new_title
 
 
-def ft_in_title(item, drop_feat, write):
+def ft_in_title(item, drop_feat):
     """Look for featured artists in the item's artist fields and move
     them to the title.
     """


### PR DESCRIPTION
#1011 added the argument 'write' to ft_in_title, which isn't used in that function.

So simply removing it again seems to have fixed the below issue.

```
Traceback (most recent call last):
  File "/usr/bin/beet", line 9, in <module>
    load_entry_point('beets==1.3.9', 'console_scripts', 'beet')()
  File "/usr/lib/python2.7/site-packages/beets-1.3.9-py2.7.egg/beets/ui/__init__.py", line 935, in main
    _raw_main(args)
  File "/usr/lib/python2.7/site-packages/beets-1.3.9-py2.7.egg/beets/ui/__init__.py", line 925, in _raw_main
    subcommand.func(lib, suboptions, subargs)
  File "/usr/lib/python2.7/site-packages/beets-1.3.9-py2.7.egg/beetsplug/ftintitle.py", line 148, in func
    ft_in_title(item, drop_feat)
TypeError: ft_in_title() takes exactly 3 arguments (2 given)
```
