### PR TITLE
convert: copy album art when copying or transcoding.

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -369,7 +369,7 @@ class ConvertPlugin(BeetsPlugin):
             u'embed': True,
             u'paths': {},
             u'never_convert_lossy_files': False,
-            u'copy_album_art': False
+            u'copy_album_art': False,
         })
         self.import_stages = [self.auto_convert]
 

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -79,6 +79,8 @@ file. The available options are:
 - ``threads``: The number of threads to use for parallel encoding.
   By default, the plugin will detect the number of processors available and use
   them all.
+- ``copy_album_art``: Copy album art when copying or transcoding albums matched
+  using the ``-a`` option. Default: ``no``.
 
 You can also configure the format to use for transcoding.
 


### PR DESCRIPTION
Only implemented to work when matching albums instead of tracks (-a option).
Disabled by default in the configuration of 'convert'.

Please, @sampsyo , take a look at the code.

Referencing #1050.
