### PR TITLE
Lastimport:  Try to fix "broken" last.fm artist name and title by looking them up in MusicBrainz

### DIFF
--- a/beetsplug/lastimport.py
+++ b/beetsplug/lastimport.py
@@ -30,7 +30,6 @@ API_URL = 'http://ws.audioscrobbler.com/2.0/'
 musicbrainzngs.set_useragent('beets', __version__,
                              'http://beets.radbox.org/')
 
-# FIXME: is this to early for setup
 musicbrainzngs.set_hostname(config['musicbrainz']['host'].get(unicode))
 musicbrainzngs.set_rate_limit(
     config['musicbrainz']['ratelimit_interval'].as_number(),
@@ -70,8 +69,8 @@ def get_mb_artistname(artist):
         raise MusicBrainzAPIError(exc, 'artist search', artist,
                                   traceback.format_exc())
     if 'artist-list' in res:
-        # FIXME: can this be empty?
-        return res['artist-list'][0]['name']
+        if len(res['artist-list'])>0 and 'name' in res['artist-list'][0]:
+            return res['artist-list'][0]['name']
     return artist
 
 
@@ -83,8 +82,8 @@ def get_mb_title(artist, title):
         raise MusicBrainzAPIError(exc, 'work search', artist, title,
                                   traceback.format_exc())
     if 'work-list' in res:
-        # FIXME: can this be empty?
-        return res['work-list'][0]['title']
+        if len(res['work-list'])>0 and 'title' in res['work-list'][0]:
+            return res['work-list'][0]['title']
     return title
 
 

--- a/beetsplug/lastimport.py
+++ b/beetsplug/lastimport.py
@@ -62,16 +62,22 @@ class LastImportPlugin(plugins.BeetsPlugin):
         return [cmd]
 
 
+mb_artistname_cache = {}
+
+
 def get_mb_artistname(artist):
+    if artist in mb_artistname_cache:
+        return mb_artistname_cache[artist]
     try:
         res = musicbrainzngs.search_artists(artist=artist)
     except musicbrainzngs.MusicBrainzError as exc:
         raise MusicBrainzAPIError(exc, 'artist search', artist,
                                   traceback.format_exc())
+    mb_artistname_cache[artist] = artist
     if 'artist-list' in res:
         if len(res['artist-list']) > 0 and 'name' in res['artist-list'][0]:
-            return res['artist-list'][0]['name']
-    return artist
+            mb_artistname_cache[artist] = res['artist-list'][0]['name']
+    return mb_artistname_cache[artist]
 
 
 def get_mb_title(artist, title):

--- a/beetsplug/lastimport.py
+++ b/beetsplug/lastimport.py
@@ -69,7 +69,7 @@ def get_mb_artistname(artist):
         raise MusicBrainzAPIError(exc, 'artist search', artist,
                                   traceback.format_exc())
     if 'artist-list' in res:
-        if len(res['artist-list'])>0 and 'name' in res['artist-list'][0]:
+        if len(res['artist-list']) > 0 and 'name' in res['artist-list'][0]:
             return res['artist-list'][0]['name']
     return artist
 
@@ -82,7 +82,7 @@ def get_mb_title(artist, title):
         raise MusicBrainzAPIError(exc, 'work search', artist, title,
                                   traceback.format_exc())
     if 'work-list' in res:
-        if len(res['work-list'])>0 and 'title' in res['work-list'][0]:
+        if len(res['work-list']) > 0 and 'title' in res['work-list'][0]:
             return res['work-list'][0]['title']
     return title
 


### PR DESCRIPTION
I played a little with lastimport and it had trouble with some of the "broken" artist names and titles it receives from last.fm.  For example it couldn't find `blink‐182` (I couldn't find it with `beet ls blink-182` also.  Damn you ndash! ;)).  It also couldn't find `Ever Fallen in Love (With Someone You Shouldn't've)?`.  This time the question mark was too much.

So if all fails, lastimport now looks up artist name and title in MusicBrainz and can match a few more tracks.
