### PR TITLE
Problem with non-ascii characters when using the discogs plugin and oauth PR

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -149,7 +149,7 @@ class DiscogsPlugin(BeetsPlugin):
         # cause a query to return no results, even if they match the artist or
         # album title. Use `re.UNICODE` flag to avoid stripping non-english
         # word characters.
-        query = re.sub(r'(?u)\W+', ' ', query).encode('utf8')
+        query = re.sub(r'(?u)\W+', ' ', query).encode('ascii', "replace")
         # Strip medium information from query, Things like "CD1" and "disk 1"
         # can also negate an otherwise positive result.
         query = re.sub(r'(?i)\b(CD|disc)\s*\d+', '', query)


### PR DESCRIPTION
This PR fixes hopes to fix #1051.
It seems to work for me, i've succeeded to import albums with apostrophes that failed previously.
