### PR TITLE
ProximitySortPlugin for distance-based sorting

### DIFF
--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -175,7 +175,19 @@ def parse_sorted_query(model_cls, parts, query_prefixes={}, sort_prefixes={},
     query_parts = []
     sort_parts = []
     for part in parts:
-        if (u'+' in part or u'-' in part) and u':' not in part:
+        plusminus_index = (part.find(u'+') + 1 or part.find(u'-') + 1) - 1
+        if plusminus_index == -1:  # early query token desicion
+            query_parts.append(part)
+            continue
+
+        # Match term after plus or minus against sort prefixes
+        valid_sort_prefix = False
+        for prefix in sort_prefixes.keys():
+            if part[plusminus_index + 1:].startswith(prefix):
+                valid_sort_prefix = True
+                break
+
+        if valid_sort_prefix:
             sort_parts.append(part)
         else:
             query_parts.append(part)

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -142,8 +142,8 @@ def construct_sort_part(model_cls, part):
     if tail:
         for prefix, sort_class in plugins.sorts().items():
             if tail.startswith(prefix):
-                return sort_class(model_cls, field, \
-                                  is_ascending, tail[len(prefix):])
+                return (sort_class(model_cls, field,
+                        is_ascending, tail[len(prefix):]))
 
     if field in model_cls._sorts:
         sort = model_cls._sorts[field](model_cls, is_ascending)

--- a/beets/library.py
+++ b/beets/library.py
@@ -960,8 +960,11 @@ def parse_query_parts(parts, model_cls):
     special path query detection.
     """
     # Get query types and their prefix characters.
-    prefixes = {':': dbcore.query.RegexpQuery}
-    prefixes.update(plugins.queries())
+    query_prefixes = {':': dbcore.query.RegexpQuery}
+    query_prefixes.update(plugins.queries())
+
+    # Get sort types and their prefix characters.
+    sort_prefixes = plugins.sorts()
 
     # Special-case path-like queries, which are non-field queries
     # containing path separators (/).
@@ -979,7 +982,7 @@ def parse_query_parts(parts, model_cls):
         non_path_parts = parts
 
     query, sort = dbcore.parse_sorted_query(
-        model_cls, non_path_parts, prefixes
+        model_cls, non_path_parts, query_prefixes, sort_prefixes
     )
 
     # Add path queries to aggregate query.
@@ -1088,7 +1091,7 @@ class Library(dbcore.Database):
         """Get :class:`Album` objects matching the query.
         """
         sort = sort or dbcore.sort_from_strings(
-            Album, beets.config['sort_album'].as_str_seq()
+            Album, plugins.sorts(), beets.config['sort_album'].as_str_seq()
         )
         return self._fetch(Album, query, sort)
 
@@ -1096,7 +1099,7 @@ class Library(dbcore.Database):
         """Get :class:`Item` objects matching the query.
         """
         sort = sort or dbcore.sort_from_strings(
-            Item, beets.config['sort_item'].as_str_seq()
+            Item, plugins.sorts(), beets.config['sort_item'].as_str_seq()
         )
         return self._fetch(Item, query, sort)
 

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -70,6 +70,11 @@ class BeetsPlugin(object):
         """
         return {}
 
+    def sorts(self):
+        """Should return a dict mapping prefixes to Sort subclasses.
+        """
+        return {}
+
     def track_distance(self, item, info):
         """Should return a Distance object to be added to the
         distance for every track comparison.
@@ -254,6 +259,14 @@ def queries():
         out.update(plugin.queries())
     return out
 
+def sorts():
+    """Returns a dict mapping prefix strings to Sort subclasses for all loaded
+    plugins.
+    """
+    out = {}
+    for plugin in find_plugins():
+        out.update(plugin.sorts())
+    return out
 
 def types(model_cls):
     # Gives us `item_types` and `album_types`

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -259,6 +259,7 @@ def queries():
         out.update(plugin.queries())
     return out
 
+
 def sorts():
     """Returns a dict mapping prefix strings to Sort subclasses for all loaded
     plugins.
@@ -267,6 +268,7 @@ def sorts():
     for plugin in find_plugins():
         out.update(plugin.sorts())
     return out
+
 
 def types(model_cls):
     # Gives us `item_types` and `album_types`

--- a/beetsplug/proximitysort.py
+++ b/beetsplug/proximitysort.py
@@ -39,7 +39,10 @@ class ProximitySort(Sort):
 
     def sort(self, objs):
         fieldgetter = attrgetter(self.field)
-        def key(o): return abs(fieldgetter(o)-self.value)
+
+        def key(o):
+            return abs(fieldgetter(o) - self.value)
+
         return sorted(objs, key=key)
 
     def is_slow(self):

--- a/beetsplug/proximitysort.py
+++ b/beetsplug/proximitysort.py
@@ -1,0 +1,60 @@
+# This file is part of beets.
+# Copyright 2014, Sergei Zimakov.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""Adds support for distance-based sorting. This allows to find
+values close to defined point.
+"""
+
+from operator import attrgetter
+
+from beets import plugins
+from beets.dbcore.query import Sort
+
+
+class ProximitySort(Sort):
+    """Sort by distance from some numeric value
+    """
+    def __init__(self, model_cls, field, ascending, tail):
+        self.model_cls = model_cls
+        self.field = field
+        self.field_type = model_cls._type(field)
+        self.value = self.field_type.parse(tail)
+
+    def order_clause(self):
+        if self.is_slow():
+            return None
+        else:
+            return "abs({0}-{1})".format(self.field, self.value)
+
+    def sort(self, objs):
+        fieldgetter = attrgetter(self.field)
+        def key(o): return abs(fieldgetter(o)-self.value)
+        return sorted(objs, key=key)
+
+    def is_slow(self):
+        """Fast for fixed fields and slow for the rest
+        """
+        return self.field not in self.model_cls._fields
+
+    def __repr__(self):
+        return u'<{0}: {1} near {2}>'.format(
+            type(self).__name__,
+            self.field,
+            self.value
+        )
+
+
+class ProximitySortPlugin(plugins.BeetsPlugin):
+    def sorts(self):
+        return {'^': ProximitySort}

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -119,6 +119,7 @@ class TestPluginSort(dbcore.query.Sort):
         self.ascending = ascending
         self.value = value
 
+
 class TestPlugin(plugins.BeetsPlugin):
     def sorts(self):
         return {'~': TestPluginSort}
@@ -499,6 +500,7 @@ class SortFromStringsTest(unittest.TestCase):
         self.assertEqual(s.sorts[0].value, 'parameters')
 
         self.assertEqual(s.sorts[1].ascending, False)
+
 
 class ResultsIteratorTest(unittest.TestCase):
     def setUp(self):

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1096,6 +1096,15 @@ class ItemReadTest(unittest.TestCase):
             item.read('/thisfiledoesnotexist')
 
 
+class ParseQueryStringTest(unittest.TestCase):
+    def test_plus_and_minus_in_field_name(self):
+        for field in ['foo+bar:7', 'foo-bar:7']:
+            query, sort = beets.library.parse_query_string(field,
+                                                           beets.library.Item)
+            self.assertEqual(query.subqueries[0].field, field[:7])
+            self.assertEqual(type(sort).__name__, 'NullSort')
+
+
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 

--- a/test/test_proximitysort.py
+++ b/test/test_proximitysort.py
@@ -16,6 +16,7 @@
 """
 
 import _common
+from _common import unittest
 import beets.library
 from beets import plugins
 from beets.dbcore import types

--- a/test/test_proximitysort.py
+++ b/test/test_proximitysort.py
@@ -1,0 +1,104 @@
+# This file is part of beets.
+# Copyright 2014, Sergei Zimakov.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""Tests for proximity sort.
+"""
+
+import _common
+import beets.library
+from beets import plugins
+from beets.dbcore import types
+from beets.library import Item
+from beetsplug import proximitysort
+
+
+# A test case class providing a library with some dummy data and some
+# assertions involving that data.
+class ProximitySortTestCase(_common.TestCase):
+    def setUp(self):
+        super(ProximitySortTestCase, self).setUp()
+        self.lib = beets.library.Library(':memory:')
+        plugins._classes.add(proximitysort.ProximitySortPlugin)
+        Item._types['flex'] = types.FLOAT
+
+        items = [_common.item() for _ in range(5)]
+
+        items[0].bpm = 100
+        items[1].bpm = 110
+        items[2].bpm = 120
+        items[3].bpm = 130
+        items[4].bpm = 0
+
+        items[0].flex = 1.1
+        items[1].flex = 1.3
+        items[2].flex = 1.5
+        items[3].flex = 1.7
+        items[4].flex = 0
+
+        for item in items:
+            self.lib.add(item)
+
+    def tearDown(self):
+        plugins._classes.remove(proximitysort.ProximitySortPlugin)
+        super(ProximitySortTestCase, self).tearDown()
+
+
+class SortFixedFieldTest(ProximitySortTestCase):
+    def test_sort_fixed_middle(self):
+        items = self.lib.items('bpm+^111')
+        bpms = [o.bpm for o in items]
+        self.assertEqual(bpms, [110, 120, 100, 130, 0])
+
+    def test_sort_fixed_right(self):
+        items = self.lib.items('bpm+^200')
+        bpms = [o.bpm for o in items]
+        self.assertEqual(bpms, [130, 120, 110, 100, 0])
+
+    def test_sort_fixed_left(self):
+        items = self.lib.items('bpm+^90')
+        bpms = [o.bpm for o in items]
+        self.assertEqual(bpms, [100, 110, 120, 130, 0])
+
+    def test_sort_fixed_near_to_0(self):
+        items = self.lib.items('bpm+^1')
+        bpms = [o.bpm for o in items]
+        self.assertEqual(bpms, [0, 100, 110, 120, 130])
+
+    def test_sort_flex_middle(self):
+        items = self.lib.items('flex+^1.49')
+        flexes = [o.flex for o in items]
+        self.assertEqual(flexes, [1.5, 1.3, 1.7, 1.1, 0])
+
+    def test_sort_flex_right(self):
+        items = self.lib.items('flex+^1.8')
+        flexes = [o.flex for o in items]
+        self.assertEqual(flexes, [1.7, 1.5, 1.3, 1.1, 0])
+
+    def test_sort_flex_left(self):
+        items = self.lib.items('flex+^1.0')
+        flexes = [o.flex for o in items]
+        self.assertEqual(flexes, [1.1, 1.3, 1.5, 1.7, 0])
+
+    def test_sort_flex_near_to_0(self):
+        items = self.lib.items('flex+^0.1')
+        flexes = [o.flex for o in items]
+        self.assertEqual(flexes, [0, 1.1, 1.3, 1.5, 1.7])
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromName(__name__)
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')


### PR DESCRIPTION
This plugin allows to find values close to some point. For example DJ can look for tracks with bpm 120 and around. My rationale is to find closest values of self-defined flex field.

Sort plugin hook is based on query plugin idea. Providing something after `+` or `-` in the sort term will force appropriate plugin to handle this sorting. ProximitySortPlugin registers itself on the `^` symbol. 
In this case `beet ls bpm+^90` command will list tracks with bpm 90, 89, 91, 88, 92, etc.

ProximitySortPlugin sorts fixed fields in DB. Flex and computed fields are sorted using python.
