### PR TITLE
Marker for fast default format altering (-f ui option)

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -55,6 +55,7 @@ ui:
 list_format_item: $artist - $album - $title
 list_format_album: $albumartist - $album
 time_format: '%Y-%m-%d %H:%M:%S'
+format_edge_marker: '|'
 
 sort_album: albumartist+ album+
 sort_item: artist+ album+ disc+ track+

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -501,10 +501,7 @@ def print_obj(obj, lib, fmt=None):
     """
     album = isinstance(obj, library.Album)
     fmt = _pick_format(album, fmt)
-    if isinstance(fmt, Template):
-        template = fmt
-    else:
-        template = Template(fmt)
+    template = Template(fmt)
     print_(obj.evaluate_template(template))
 
 
@@ -521,11 +518,7 @@ def print_objs(objs, lib, fmt=None):
 
     album = isinstance(objs[0], library.Album)
     fmt = _pick_format(album, fmt)
-    if isinstance(fmt, Template):
-        template = fmt
-    else:
-        template = Template(fmt)
-
+    template = Template(fmt)
     for obj in objs:
         print_(obj.evaluate_template(template))
 

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -480,10 +480,10 @@ def _pick_format(album, fmt=None):
         config_fmt = config['list_format_item'].get(unicode)
 
     if fmt:
-        marker = config['format_edge_marker'].get(unicode)
-        if fmt.startswith(marker):
+        marker = config['format_edge_marker'].get(unicode).strip()
+        if len(marker) and fmt.startswith(marker):
             return config_fmt + fmt[len(marker):]
-        elif fmt.endswith(marker):
+        elif len(marker) and fmt.endswith(marker):
             return fmt[:-len(marker)] + config_fmt
         else:
             return fmt

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -34,7 +34,6 @@ from beets import plugins
 from beets import importer
 from beets import util
 from beets.util import syspath, normpath, ancestry, displayable_path
-from beets.util.functemplate import Template
 from beets import library
 from beets import config
 from beets.util.confit import _package_path
@@ -953,13 +952,10 @@ def list_items(lib, query, album, fmt):
     """Print out items in lib matching query. If album, then search for
     albums instead of single items.
     """
-    tmpl = Template(ui._pick_format(album, fmt))
     if album:
-        for album in lib.albums(query):
-            ui.print_obj(album, lib, tmpl)
+        ui.print_objs(lib.albums(query), lib, fmt)
     else:
-        for item in lib.items(query):
-            ui.print_obj(item, lib, tmpl)
+        ui.print_objs(lib.items(query), lib, fmt)
 
 
 def list_func(lib, opts, args):

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1119,8 +1119,7 @@ def remove_items(lib, query, album, delete):
                  len(items)
 
     # Show all the items.
-    for item in items:
-        ui.print_obj(item, lib, fmt)
+    ui.print_objs(items, lib, fmt)
 
     # Confirm with user.
     if not ui.input_yn(prompt, True):

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -977,7 +977,7 @@ list_cmd.parser.add_option(
 )
 list_cmd.parser.add_option(
     '-f', '--format', action='store',
-    help='print with custom format', default=None
+    help='print with custom format (try -f \'$year |\')', default=None
 )
 list_cmd.func = list_func
 default_commands.append(list_cmd)

--- a/beetsplug/random.py
+++ b/beetsplug/random.py
@@ -16,8 +16,7 @@
 """
 from __future__ import absolute_import
 from beets.plugins import BeetsPlugin
-from beets.ui import Subcommand, decargs, print_obj
-from beets.util.functemplate import Template
+from beets.ui import Subcommand, decargs, print_objs
 import random
 from operator import attrgetter
 from itertools import groupby
@@ -29,7 +28,6 @@ def random_item(lib, opts, args):
         fmt = '$path'
     else:
         fmt = opts.format
-    template = Template(fmt) if fmt else None
 
     if opts.album:
         objs = list(lib.albums(query))
@@ -65,8 +63,7 @@ def random_item(lib, opts, args):
         number = min(len(objs), opts.number)
         objs = random.sample(objs, number)
 
-    for item in objs:
-        print_obj(item, lib, template)
+    print_objs(objs, lib, fmt)
 
 random_cmd = Subcommand('random',
                         help='chose a random track or album')

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -190,9 +190,11 @@ be useful for piping into other Unix commands (such as `xargs`_). Similarly, the
 ``-f`` option lets you specify a specific format with which to print every album
 or track. This uses the same template syntax as beets' :doc:`path formats
 <pathformat>`. For example, the command ``beet ls -af '$album: $tracktotal'
-beatles`` prints out the number of tracks on each Beatles album. In Unix shells,
-remember to enclose the template argument in single quotes to avoid environment
-variable expansion.
+beatles`` prints out the number of tracks on each Beatles album. The ``|``
+symbol at the edge of format string is a shortcut to your default format. For
+example, ``-f '$year |'`` will prepend familiar output lines with release year.
+In Unix shells, remember to enclose the template argument in single quotes to
+avoid environment variable expansion.
 
 .. _xargs: http://en.wikipedia.org/wiki/Xargs
 

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -997,6 +997,58 @@ class CompletionTest(_common.TestCase):
             self.fail('test/test_completion.sh did not execute properly')
 
 
+class PrintObjTest(unittest.TestCase):
+    def setUp(self):
+        self.lib = library.Library(':memory:')
+        self.i = _common.item()
+        self.lib.add(self.i)
+
+        with capture_stdout() as stdout:
+            ui.print_obj(self.i, self.lib)
+        self.ref_out = stdout.getvalue()
+        self.edge_marker = config['format_edge_marker'].get(unicode)
+        self.meth = getattr(ui, 'print_obj')
+        self.arg1 = self.i
+
+    def test_empty_format(self):
+        with capture_stdout() as stdout:
+            self.meth(self.arg1, self.lib, '')
+        self.assertEqual(self.ref_out, stdout.getvalue())
+
+    def test_one_space_format(self):
+        with capture_stdout() as stdout:
+            self.meth(self.arg1, self.lib, ' ')
+        self.assertEqual(u' \n', stdout.getvalue())
+
+    def test_edge_marker_on_the_left(self):
+        with capture_stdout() as stdout:
+            self.meth(self.arg1, self.lib, u'test' + self.edge_marker)
+        self.assertEqual(u'test' + self.ref_out, stdout.getvalue())
+
+    def test_edge_marker_on_the_right(self):
+        with capture_stdout() as stdout:
+            self.meth(self.arg1, self.lib, self.edge_marker + u'test')
+        self.assertEqual(self.ref_out.strip() + u'test\n', stdout.getvalue())
+
+    def test_edge_marker_in_the_middle(self):
+        with capture_stdout() as stdout:
+            self.meth(self.arg1, self.lib, u'a' + self.edge_marker + u'b')
+        self.assertEqual(u'a' + self.edge_marker + u'b\n', stdout.getvalue())
+
+
+class PrintObjsTest(PrintObjTest):
+    def setUp(self):
+        super(PrintObjsTest, self).setUp()
+        self.meth = getattr(ui, 'print_objs')
+        self.arg1 = [self.i]
+        pass
+
+    def test_prints_many(self):
+        with capture_stdout() as stdout:
+            ui.print_objs([self.i, self.i], self.lib)
+        self.assertEqual(self.ref_out + self.ref_out, stdout.getvalue())
+
+
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -1027,8 +1027,8 @@ class PrintObjTest(unittest.TestCase):
 
     def test_edge_marker_on_the_right(self):
         with capture_stdout() as stdout:
-            self.meth(self.arg1, self.lib, self.edge_marker + u'test')
-        self.assertEqual(self.ref_out.strip() + u'test\n', stdout.getvalue())
+            self.meth(self.arg1, self.lib, self.edge_marker + u' test')
+        self.assertEqual(self.ref_out.strip() + u' test\n', stdout.getvalue())
 
     def test_edge_marker_in_the_middle(self):
         with capture_stdout() as stdout:

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -1003,12 +1003,20 @@ class PrintObjTest(unittest.TestCase):
         self.i = _common.item()
         self.lib.add(self.i)
 
+        self.marker = config['format_edge_marker'].get(unicode)
+
         with capture_stdout() as stdout:
             ui.print_obj(self.i, self.lib)
         self.ref_out = stdout.getvalue()
-        self.edge_marker = config['format_edge_marker'].get(unicode)
+        # self.edge_marker = config['format_edge_marker'].get(unicode)
         self.meth = getattr(ui, 'print_obj')
         self.arg1 = self.i
+
+    def tearDown(self):
+        config['format_edge_marker'] = self.marker
+
+    def edge_marker(self):
+        return self.marker
 
     def test_empty_format(self):
         with capture_stdout() as stdout:
@@ -1022,18 +1030,25 @@ class PrintObjTest(unittest.TestCase):
 
     def test_edge_marker_on_the_left(self):
         with capture_stdout() as stdout:
-            self.meth(self.arg1, self.lib, u'test' + self.edge_marker)
+            self.meth(self.arg1, self.lib, u'test' + self.edge_marker())
         self.assertEqual(u'test' + self.ref_out, stdout.getvalue())
 
     def test_edge_marker_on_the_right(self):
         with capture_stdout() as stdout:
-            self.meth(self.arg1, self.lib, self.edge_marker + u' test')
+            self.meth(self.arg1, self.lib, self.edge_marker() + u' test')
         self.assertEqual(self.ref_out.strip() + u' test\n', stdout.getvalue())
 
     def test_edge_marker_in_the_middle(self):
         with capture_stdout() as stdout:
-            self.meth(self.arg1, self.lib, u'a' + self.edge_marker + u'b')
-        self.assertEqual(u'a' + self.edge_marker + u'b\n', stdout.getvalue())
+            self.meth(self.arg1, self.lib, u'a' + self.edge_marker() + u'b')
+        self.assertEqual(u'a' + self.edge_marker() + u'b\n', stdout.getvalue())
+
+    def test_empty_strings_option_in_config(self):
+        for mark in ['', ' ', '\t', ' \t ']:
+            config['format_edge_marker'] = mark
+            with capture_stdout() as stdout:
+                self.meth(self.arg1, self.lib, u'a' + mark)
+            self.assertEqual(u'a' + mark + '\n', stdout.getvalue())
 
 
 class PrintObjsTest(PrintObjTest):


### PR DESCRIPTION
New config option `format_edge_marker` gives a string, which should be on the edge of `-f FORMAT` string, to turn into default/configured format. When format string ends with edge marker (e.g. `-f '$energy |'`) effective format becomes `$energy $artist - $album - $title` (when user didn't alter default item format). Prepending format with marker (e.g. `-f '| $energy'`) gives `$artist - $album - $title $energy`.

My rationale is to avoid regular editing of `list_format_items` option in config file.

This feature can be implemented via plugin, but template function requires at least 4 symbols (`%E{}`) which is many times slower to type and a long way uglier. It would be great to find one symbol for this (right now it's `|`).

Implementing this feature also introduces `print_objs(...)` method, which is like `print_obj(...)` but take collection instead of single object. It gives ability to remove some `beets.util.functemplate.Template` dependencies.
