### PR TITLE
Default value for link title for page searches.

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -393,7 +393,7 @@ def fetch_google(artist, title):
     if 'items' in data.keys():
         for item in data['items']:
             urlLink = item['link']
-            urlTitle = item['title']
+            urlTitle = item.get('title', u'')
             if not is_page_candidate(urlLink, urlTitle, title, artist):
                 continue
 


### PR DESCRIPTION
Google API may not return results with a title attribute.

I added `log.debug(item)` to line 395 for https://github.com/sampsyo/beets/blob/590b106ed0f43e84533d5f40f16b2692b21ac74b/beetsplug/lyrics.py to see what's going on.

Debug output:

```
...
Sending event: database_change
Sending event: database_change
{u'kind': u'customsearch#result', u'displayLink': u'www.maxilyrics.com', u'cacheId': u'1kGkPOSfpVQJ', u'snippet': u'', u'htmlSnippet': u'', u'link': u'http://www.maxilyrics.com/nine-muses-%ED%8B%B0%EC%BC%93(ticket)-lyrics-c8b8.html'}
Traceback (most recent call last):
  File "/usr/local/bin/beet", line 9, in <module>
    load_entry_point('beets==1.3.9', 'console_scripts', 'beet')()
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/beets/ui/__init__.py", line 935, in main
    _raw_main(args)
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/beets/ui/__init__.py", line 925, in _raw_main
    subcommand.func(lib, suboptions, subargs)
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/beets/ui/commands.py", line 872, in import_func
    import_files(lib, paths, query)
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/beets/ui/commands.py", line 844, in import_files
    session.run()
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/beets/importer.py", line 299, in run
    pl.run_parallel(QUEUE_SIZE)
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/beets/util/pipeline.py", line 299, in run
    out = self.coro.send(msg)
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/beets/util/pipeline.py", line 181, in coro
    func(*(args + (task,)))
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/beets/importer.py", line 1258, in plugin_stage
    func(session, task)
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/beetsplug/lyrics.py", line 458, in imported
    False, False)
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/beetsplug/lyrics.py", line 474, in fetch_item_lyrics
    lyrics = [self.get_lyrics(artist, title) for title in titles]
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/beetsplug/lyrics.py", line 503, in get_lyrics
    lyrics = backend(artist, title)
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/beetsplug/lyrics.py", line 397, in fetch_google
    urlTitle = item['title'] or ''
KeyError: 'title'
```
