### PR TITLE
zero: Can delete embedded images

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ New:
   files as they are imported. Thanks to :user:`xsteadfastx`. :bug:`1098`
 * A new :doc:`/plugins/plexupdate` lets you notify a `Plex`_ server when the
   database changes. Thanks again to xsteadfastx. :bug:`1120`
+* :doc:`/plugins/zero` can remove embedded images.
 
 Fixed:
 

--- a/docs/plugins/zero.rst
+++ b/docs/plugins/zero.rst
@@ -16,7 +16,9 @@ Make a ``zero:`` section in your configuration file. You can specify the
 fields to nullify and the conditions for nullifying them:
 
 * Set ``fields`` to a whitespace-separated list of fields to change. You can
-  get the list of all available fields by running ``beet fields``.
+  get the list of all available fields by running ``beet fields``. In
+  addition, the ``images`` field allows you to remove any images
+  embedded in the media file.
 * To conditionally filter a field, use ``field: [regexp, regexp]`` to specify
   regular expressions.
 

--- a/test/helper.py
+++ b/test/helper.py
@@ -47,7 +47,7 @@ import beets.plugins
 from beets.library import Library, Item, Album
 from beets import importer
 from beets.autotag.hooks import AlbumInfo, TrackInfo
-from beets.mediafile import MediaFile
+from beets.mediafile import MediaFile, Image
 
 # TODO Move AutotagMock here
 import _common
@@ -346,17 +346,32 @@ class TestHelper(object):
             items.append(item)
         return self.lib.add_album(items)
 
-    def create_mediafile_fixture(self, ext='mp3'):
+    def create_mediafile_fixture(self, ext='mp3', images=[]):
         """Copies a fixture mediafile with the extension to a temporary
         location and returns the path.
 
         It keeps track of the created locations and will delete the with
         `remove_mediafile_fixtures()`
+
+        `images` is a subset of 'png', 'jpg', and 'tiff'. For each
+        specified extension a cover art image is added to the media
+        file.
         """
         src = os.path.join(_common.RSRC, 'full.' + ext)
         handle, path = mkstemp()
         os.close(handle)
         shutil.copyfile(src, path)
+
+        if images:
+            mediafile = MediaFile(path)
+            imgs = []
+            for img_ext in images:
+                img_path = os.path.join(_common.RSRC,
+                                        'image-2x3.{0}'.format(img_ext))
+                with open(img_path, 'rb') as f:
+                    imgs.append(Image(f.read()))
+            mediafile.images = imgs
+            mediafile.save()
 
         if not hasattr(self, '_mediafile_fixtures'):
             self._mediafile_fixtures = []

--- a/test/test_zero.py
+++ b/test/test_zero.py
@@ -82,6 +82,20 @@ class ZeroPluginTest(unittest.TestCase, TestHelper):
         self.assertEqual(item['year'], 2000)
         self.assertIsNone(mediafile.year)
 
+    def test_album_art(self):
+        path = self.create_mediafile_fixture(images=['jpg'])
+        item = Item.from_path(path)
+
+        mediafile = MediaFile(item.path)
+        self.assertNotEqual(0, len(mediafile.images))
+
+        config['zero'] = {'fields': ['images']}
+        self.load_plugins('zero')
+
+        item.write()
+        mediafile = MediaFile(item.path)
+        self.assertEqual(0, len(mediafile.images))
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)


### PR DESCRIPTION
Fixes #1100.

I also propose we add the media file fields to the output of `beet fields`. Currently the documentation for the zero plugin refers to the ouput of `beet fields` for a list of tags that can be zeroed. This is not quite correct as not all fields are written to the tags.
