### PR TITLE
lastgenre: Optionally replace unicode characters when performing lookups

### DIFF
--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -242,9 +242,10 @@ class LastGenrePlugin(plugins.BeetsPlugin):
     def _cached_lookup(self, entity, method, *args):
         """Get a genre based on the named entity using the callable `method`
         whose arguments are given in the sequence `args`. The genre lookup
-        is cached based on the entity name and the arguments. Before the lookup,
-        each argument is has some Unicode characters replaced with rough ASCII
-        equivalents in order to return better results from the Last.fm database.
+        is cached based on the entity name and the arguments. Before the
+        lookup, each argument is has some Unicode characters replaced with
+        rough ASCII equivalents in order to return better results from the
+        Last.fm database.
         """
         # Shortcut if we're missing metadata.
         if any(not s for s in args):


### PR DESCRIPTION
It looks like there's a bug in lastgenre plugin that causes artists/albums with Unicode characters to be skipped:

```
$ beet lastgenre 'albumartist:Sleater‐Kinney'
genre for album Sleater‐Kinney - The Woods (None):
$
```

My quick fix for this was to patch the plugin to add a new `asciify` option which, if `True`, runs unidecode() over the arguments before passing them onto the underlying pylast library:

```
# post-patch
$ beet lastgenre 'albumartist:Sleater‐Kinney'
genre for album Sleater‐Kinney - The Woods (album): Rock
$
```

I'm not sure if this the best solution. There could be cases where substituting characters returns an entirely different result than the one you expect.

A more thorough approach would be to try once with regular characters then again with `asciify`-ed characters if nothing is found (maybe prompt the user to confirm the new results are correct?). It shouldn't be too difficult to add this later if it's required.
