### PR TITLE
embedart: Windows fix

### DIFF
--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -150,7 +150,7 @@ def embed_album(album, maxwidth=None, quiet=False):
         log.info(u'No album art present: {0} - {1}'.
                  format(album.albumartist, album.album))
         return
-    if not os.path.isfile(imagepath):
+    if not os.path.isfile(syspath(imagepath)):
         log.error(u'Album art not found at {0}'
                   .format(displayable_path(imagepath)))
         return


### PR DESCRIPTION
According to the [wiki](https://github.com/sampsyo/beets/wiki/Hacking#coding-conventions) paths need to be converted using `syspath` before being sent to the OS. I was getting [this](https://github.com/sampsyo/beets/blob/master/beetsplug/embedart.py#L154) error before when `import`ing an album, but it seems to work now.
