### PR TITLE
Fix handling of duplicate album artists in ftintitle

### DIFF
--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -83,7 +83,7 @@ def ft_in_title(item, drop_feat):
 
         # Look for the album artist in the artist field. If it's not
         # present, give up.
-        albumartist_split = artist.split(albumartist)
+        albumartist_split = artist.split(albumartist, 1)
         if len(albumartist_split) <= 1:
             ui.print_('album artist not present in artist')
 


### PR DESCRIPTION
The code that determines the featured artist part of the artist only
handles two element lists. When the album artist is duplicated, it
splits into a three element list causing no featured artist to be found.

This ensures the albumartist_split can ever only have 2 elements.

Fixes #1179
