### PR TITLE
ftintitle: Add option: `broad`.

### DIFF
--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -41,7 +41,7 @@ def split_on_feat(artist):
         return tuple(parts)
 
 
-def contains_feat(title):
+def title_contains_feat(title):
     """Determine whether the title contains a "featured" marker.
     """
     return bool(re.search(
@@ -64,7 +64,7 @@ def update_metadata(item, feat_part, drop_feat, loglevel=logging.DEBUG):
 
     # Only update the title if it does not already contain a featured
     # artist and if we do not drop featuring information.
-    if not drop_feat and not contains_feat(item.title):
+    if not drop_feat and not title_contains_feat(item.title):
         new_title = u"{0} feat. {1}".format(item.title, feat_part)
         log.log(loglevel, u'title: {0} -> {1}'.format(item.title, new_title))
         item.title = new_title

--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -31,7 +31,9 @@ def split_on_feat(artist):
     may be a string or None if none is present.
     """
     # split on the first "feat".
-    regex = re.compile(plugins.feat_tokens(), re.IGNORECASE)
+    regex = re.compile(
+        plugins.feat_tokens(config['ftintitle']['broad'].get(bool)),
+        re.IGNORECASE)
     parts = [s.strip() for s in regex.split(artist, 1)]
     if len(parts) == 1:
         return parts[0], None
@@ -42,7 +44,9 @@ def split_on_feat(artist):
 def contains_feat(title):
     """Determine whether the title contains a "featured" marker.
     """
-    return bool(re.search(plugins.feat_tokens(), title, flags=re.IGNORECASE))
+    return bool(re.search(
+        plugins.feat_tokens(config['ftintitle']['broad'].get(bool)),
+        title, flags=re.IGNORECASE))
 
 
 def update_metadata(item, feat_part, drop_feat, loglevel=logging.DEBUG):
@@ -116,6 +120,7 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
         self.config.add({
             'auto': True,
             'drop': False,
+            'broad': True,
         })
 
         self._command = ui.Subcommand(

--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -119,8 +119,8 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
 
         self.config.add({
             'auto': True,
-            'drop': False,
             'broad': True,
+            'drop': False,
         })
 
         self._command = ui.Subcommand(

--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -45,8 +45,7 @@ def contains_feat(title):
     """Determine whether the title contains a "featured" marker.
     """
     return bool(re.search(
-        plugins.feat_tokens(config['ftintitle']['broad'].get(bool)),
-        title, flags=re.IGNORECASE))
+        plugins.feat_tokens(for_artist=False), title, flags=re.IGNORECASE))
 
 
 def update_metadata(item, feat_part, drop_feat, loglevel=logging.DEBUG):

--- a/docs/plugins/ftintitle.rst
+++ b/docs/plugins/ftintitle.rst
@@ -24,6 +24,8 @@ file. The available options are:
 - **drop**: Remove featured artists entirely instead of adding them to the
   title field.
   Default: ``no``.
+- **broad**: Also work on similar strings, like "&", "with", etc.
+  Default: ``yes``
 
 Running Manually
 ----------------

--- a/docs/plugins/ftintitle.rst
+++ b/docs/plugins/ftintitle.rst
@@ -21,11 +21,11 @@ file. The available options are:
 
 - **auto**: Enable metadata rewriting during import.
   Default: ``yes``.
+- **broad**: Also work on similar strings, like "&", "with", etc.
+  Default: ``yes``
 - **drop**: Remove featured artists entirely instead of adding them to the
   title field.
   Default: ``no``.
-- **broad**: Also work on similar strings, like "&", "with", etc.
-  Default: ``yes``
 
 Running Manually
 ----------------

--- a/test/test_ftintitle.py
+++ b/test/test_ftintitle.py
@@ -41,18 +41,27 @@ class FtInTitlePluginTest(unittest.TestCase):
         parts = ftintitle.split_on_feat('Alice defeat Bob')
         self.assertEqual(parts, ('Alice defeat Bob', None))
 
-    def test_contains_feat(self):
+    def test_title_contains_feat(self):
         """Test for detecting "feat." in a given title.
         """
-        self.assertTrue(ftintitle.contains_feat('Lumberjack Song ft. Bob'))
-        self.assertTrue(ftintitle.contains_feat('Lumberjack Song feat. Bob'))
-        self.assertTrue(ftintitle.contains_feat('Lumberjack Song feat Bob'))
-        self.assertTrue(ftintitle.contains_feat('Lumberjack Song featuring Bob'))
-        self.assertFalse(ftintitle.contains_feat('All Things Dull & Ugly'))
-        self.assertFalse(ftintitle.contains_feat('All Things Dull and Ugly'))
-        self.assertFalse(ftintitle.contains_feat('Lumberjack Song With Bob'))
-        self.assertFalse(ftintitle.contains_feat('Alice defeat Bob'))
-        self.assertFalse(ftintitle.contains_feat('LumberjackSongft.Bob'))
+        self.assertTrue(
+            ftintitle.title_contains_feat('Lumberjack Song ft. Bob'))
+        self.assertTrue(
+            ftintitle.title_contains_feat('Lumberjack Song feat. Bob'))
+        self.assertTrue(
+            ftintitle.title_contains_feat('Lumberjack Song feat Bob'))
+        self.assertTrue(
+            ftintitle.title_contains_feat('Lumberjack Song featuring Bob'))
+        self.assertFalse(
+            ftintitle.title_contains_feat('All Things Dull & Ugly'))
+        self.assertFalse(
+            ftintitle.title_contains_feat('All Things Dull and Ugly'))
+        self.assertFalse(
+            ftintitle.title_contains_feat('Lumberjack Song With Bob'))
+        self.assertFalse(
+            ftintitle.title_contains_feat('Alice defeat Bob'))
+        self.assertFalse(
+            ftintitle.title_contains_feat('LumberjackSongft.Bob'))
 
 
 def suite():

--- a/test/test_ftintitle.py
+++ b/test/test_ftintitle.py
@@ -42,15 +42,17 @@ class FtInTitlePluginTest(unittest.TestCase):
         self.assertEqual(parts, ('Alice defeat Bob', None))
 
     def test_contains_feat(self):
-        self.assertTrue(ftintitle.contains_feat('Alice ft. Bob'))
-        self.assertTrue(ftintitle.contains_feat('Alice feat. Bob'))
-        self.assertTrue(ftintitle.contains_feat('Alice feat Bob'))
-        self.assertTrue(ftintitle.contains_feat('Alice featuring Bob'))
-        self.assertTrue(ftintitle.contains_feat('Alice & Bob'))
-        self.assertTrue(ftintitle.contains_feat('Alice and Bob'))
-        self.assertTrue(ftintitle.contains_feat('Alice With Bob'))
+        """Test for detecting "feat." in a given title.
+        """
+        self.assertTrue(ftintitle.contains_feat('Lumberjack Song ft. Bob'))
+        self.assertTrue(ftintitle.contains_feat('Lumberjack Song feat. Bob'))
+        self.assertTrue(ftintitle.contains_feat('Lumberjack Song feat Bob'))
+        self.assertTrue(ftintitle.contains_feat('Lumberjack Song featuring Bob'))
+        self.assertFalse(ftintitle.contains_feat('All Things Dull & Ugly'))
+        self.assertFalse(ftintitle.contains_feat('All Things Dull and Ugly'))
+        self.assertFalse(ftintitle.contains_feat('Lumberjack Song With Bob'))
         self.assertFalse(ftintitle.contains_feat('Alice defeat Bob'))
-        self.assertFalse(ftintitle.contains_feat('Aliceft.Bob'))
+        self.assertFalse(ftintitle.contains_feat('LumberjackSongft.Bob'))
 
 
 def suite():


### PR DESCRIPTION
Determines how lenient ftintitle should be when catching "feat." strings. If set to False, it will not catch "with", "&", "vs", etc. The exact strings are defined in beets/plugins.py's `feat_tokens()`.

Defaults to current behaviour if not set.

See also #1184.
