### PR TITLE
A more detailed output of the `--pretend` option

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -1305,7 +1305,7 @@ def log_files(session, task):
     elif task.items:
         log.info('Album {0}'.format(displayable_path(task.paths[0])))
         for item in task.items:
-            log.info(displayable_path(item['path']))
+            log.info('  {0}'.format(displayable_path(item['path'])))
 
 
 def group_albums(session):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1599,9 +1599,9 @@ class ImportPretendTest(_common.TestCase, ImportHelper):
 
         self.assertEqual(logs, [
             'Album %s' % displayable_path(self.import_paths[0]),
-            self.import_files[0],
+            '  %s' % self.import_files[0],
             'Album %s' % displayable_path(self.import_paths[1]),
-            self.import_paths[1]])
+            '  %s' % self.import_paths[1]])
 
     def test_import_pretend_empty(self):
         logs = self.__run([self.empty_path])


### PR DESCRIPTION
I've added a new flag `--detailed` to get a more detailed output when using `--pretend`. This can be useful if one wants to know which files beets think belong to an album. It's also very useful if there is an automatic singleton detection like requested with #1167 :wink:.
