### PR TITLE
play command is now interactive

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -1188,21 +1188,27 @@ class Library(dbcore.Database):
             model_cls, query, sort
         )
 
+    def get_default_album_sort(self):
+        """Get a :class:`Sort` object for albums from the config option.
+        """
+        return dbcore.sort_from_strings(
+            Album, beets.config['sort_album'].as_str_seq())
+
+    def get_default_item_sort(self):
+        """Get a :class:`Sort` object for items from the config option.
+        """
+        return dbcore.sort_from_strings(
+            Item, beets.config['sort_item'].as_str_seq())
+
     def albums(self, query=None, sort=None):
         """Get :class:`Album` objects matching the query.
         """
-        sort = sort or dbcore.sort_from_strings(
-            Album, beets.config['sort_album'].as_str_seq()
-        )
-        return self._fetch(Album, query, sort)
+        return self._fetch(Album, query, sort or self.get_default_album_sort())
 
     def items(self, query=None, sort=None):
         """Get :class:`Item` objects matching the query.
         """
-        sort = sort or dbcore.sort_from_strings(
-            Item, beets.config['sort_item'].as_str_seq()
-        )
-        return self._fetch(Item, query, sort)
+        return self._fetch(Item, query, sort or self.get_default_item_sort())
 
     # Convenience accessors.
 

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -21,7 +21,6 @@ from __future__ import (division, absolute_import, print_function,
 
 import os
 import re
-import shlex
 
 import beets
 from beets import ui
@@ -1494,24 +1493,14 @@ def config_edit():
     """
     path = config.user_config_path()
 
-    if 'EDITOR' in os.environ:
-        editor = os.environ['EDITOR'].encode('utf8')
-        try:
-            editor = [e.decode('utf8') for e in shlex.split(editor)]
-        except ValueError:  # Malformed shell tokens.
-            editor = [editor]
-        args = editor + [path]
-        args.insert(1, args[0])
-    else:
-        base = util.open_anything()
-        args = [base, base, path]
-
+    editor = os.environ.get('EDITOR')
     try:
-        os.execlp(*args)
-    except OSError:
-        raise ui.UserError("Could not edit configuration. Please "
-                           "set the EDITOR environment variable.")
-
+        util.interactive_open(path, editor)
+    except OSError as exc:
+        message = "Could not edit configuration: {0}".format(exc)
+        if not editor:
+            message += ". Please set the EDITOR environment variable"
+        raise ui.UserError(message)
 
 config_cmd = ui.Subcommand('config',
                            help='show or edit the user configuration')

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -20,7 +20,6 @@ from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 
 import os
-import platform
 import re
 import shlex
 
@@ -1503,15 +1502,9 @@ def config_edit():
             editor = [editor]
         args = editor + [path]
         args.insert(1, args[0])
-    elif platform.system() == 'Darwin':
-        args = ['open', 'open', '-n', path]
-    elif platform.system() == 'Windows':
-        # On windows we can execute arbitrary files. The os will
-        # take care of starting an appropriate application
-        args = [path, path]
     else:
-        # Assume Unix
-        args = ['xdg-open', 'xdg-open', path]
+        base = util.open_anything()
+        args = [base, base, path]
 
     try:
         os.execlp(*args)

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -26,6 +26,7 @@ from collections import defaultdict
 import traceback
 import subprocess
 import platform
+import shlex
 
 
 MAX_FILENAME_LENGTH = 200
@@ -697,3 +698,26 @@ def open_anything():
     else:  # Assume Unix
         base_cmd = 'xdg-open'
     return base_cmd
+
+
+def interactive_open(target, command=None):
+    """Open `target` file with `command` or, in not available, ask the OS to
+    deal with it.
+
+    The executed program will have stdin, stdout and stderr.
+    OSError may be raised, it is left to the caller to catch them.
+    """
+    if command:
+        command = command.encode('utf8')
+        try:
+            command = [c.decode('utf8')
+                       for c in shlex.split(command)]
+        except ValueError:  # Malformed shell tokens.
+            command = [command]
+        command.insert(0, command[0])  # for argv[0]
+    else:
+        base_cmd = open_anything()
+        command = [base_cmd, base_cmd]
+
+    command.append(target)
+    return os.execlp(*command)

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -683,3 +683,17 @@ def max_filename_length(path, limit=MAX_FILENAME_LENGTH):
         return min(res[9], limit)
     else:
         return limit
+
+
+def open_anything():
+    """Return the system command that dispatches execution to the correct
+    program.
+    """
+    sys_name = platform.system()
+    if sys_name == 'Darwin':
+        base_cmd = 'open'
+    elif sys_name == 'Windows':
+        base_cmd = 'start'
+    else:  # Assume Unix
+        base_cmd = 'xdg-open'
+    return base_cmd

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -60,23 +60,22 @@ class PlayPlugin(BeetsPlugin):
         if relative_to:
             relative_to = util.normpath(relative_to)
 
-        # Preform search by album and add folders rather than tracks to
+        # Perform search by album and add folders rather than tracks to
         # playlist.
         if opts.album:
             selection = lib.albums(ui.decargs(args))
             paths = []
 
+            sort = lib.get_default_album_sort()
             for album in selection:
                 if use_folders:
                     paths.append(album.item_dir())
                 else:
-                    # TODO use core's sorting functionality
-                    paths.extend([item.path for item in sorted(
-                        album.items(),
-                        key=lambda item: (item.disc, item.track))])
+                    paths.extend(item.path
+                                 for item in sort.sort(album.items()))
             item_type = 'album'
 
-        # Preform item query and add tracks to playlist.
+        # Perform item query and add tracks to playlist.
         else:
             selection = lib.items(ui.decargs(args))
             paths = [item.path for item in selection]

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -23,7 +23,6 @@ from beets import config
 from beets import ui
 from beets import util
 from os.path import relpath
-import platform
 import shlex
 from tempfile import NamedTemporaryFile
 
@@ -64,16 +63,7 @@ class PlayPlugin(BeetsPlugin):
         if command_str:
             command = shlex.split(command_str)
         else:
-            # If a command isn't set, then let the OS decide how to open the
-            # playlist.
-            sys_name = platform.system()
-            if sys_name == 'Darwin':
-                command = ['open']
-            elif sys_name == 'Windows':
-                command = ['start']
-            else:
-                # If not Mac or Windows, then assume Unixy.
-                command = ['xdg-open']
+            command = [util.open_anything()]
 
         # Preform search by album and add folders rather than tracks to
         # playlist.

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -17,8 +17,6 @@
 from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 
-from functools import partial
-
 from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand
 from beets import config
@@ -28,91 +26,6 @@ from os.path import relpath
 import platform
 import shlex
 from tempfile import NamedTemporaryFile
-
-
-def play_music(lib, opts, args, log):
-    """Execute query, create temporary playlist and execute player
-    command passing that playlist.
-    """
-    command_str = config['play']['command'].get()
-    use_folders = config['play']['use_folders'].get(bool)
-    relative_to = config['play']['relative_to'].get()
-    if relative_to:
-        relative_to = util.normpath(relative_to)
-    if command_str:
-        command = shlex.split(command_str)
-    else:
-        # If a command isn't set, then let the OS decide how to open the
-        # playlist.
-        sys_name = platform.system()
-        if sys_name == 'Darwin':
-            command = ['open']
-        elif sys_name == 'Windows':
-            command = ['start']
-        else:
-            # If not Mac or Windows, then assume Unixy.
-            command = ['xdg-open']
-
-    # Preform search by album and add folders rather then tracks to playlist.
-    if opts.album:
-        selection = lib.albums(ui.decargs(args))
-        paths = []
-
-        for album in selection:
-            if use_folders:
-                paths.append(album.item_dir())
-            else:
-                # TODO use core's sorting functionality
-                paths.extend([item.path for item in sorted(
-                    album.items(), key=lambda item: (item.disc, item.track))])
-        item_type = 'album'
-
-    # Preform item query and add tracks to playlist.
-    else:
-        selection = lib.items(ui.decargs(args))
-        paths = [item.path for item in selection]
-        item_type = 'track'
-
-    item_type += 's' if len(selection) > 1 else ''
-
-    if not selection:
-        ui.print_(ui.colorize('text_warning',
-                              'No {0} to play.'.format(item_type)))
-        return
-
-    # Warn user before playing any huge playlists.
-    if len(selection) > 100:
-        ui.print_(ui.colorize(
-            'text_warning',
-            'You are about to queue {0} {1}.'.format(len(selection), item_type)
-        ))
-
-        if ui.input_options(('Continue', 'Abort')) == 'a':
-            return
-
-    # Create temporary m3u file to hold our playlist.
-    m3u = NamedTemporaryFile('w', suffix='.m3u', delete=False)
-    for item in paths:
-        if relative_to:
-            m3u.write(relpath(item, relative_to) + b'\n')
-        else:
-            m3u.write(item + b'\n')
-    m3u.close()
-
-    command.append(m3u.name)
-
-    # Invoke the command and log the output.
-    output = util.command_output(command)
-    if output:
-        log.debug(u'Output of {0}: {1}',
-                  util.displayable_path(command[0]),
-                  output.decode('utf8', 'ignore'))
-    else:
-        log.debug(u'no output')
-
-    ui.print_(u'Playing {0} {1}.'.format(len(selection), item_type))
-
-    util.remove(m3u.name)
 
 
 class PlayPlugin(BeetsPlugin):
@@ -136,5 +49,92 @@ class PlayPlugin(BeetsPlugin):
             action='store_true', default=False,
             help='query and load albums rather than tracks'
         )
-        play_command.func = partial(play_music, log=self._log)
+        play_command.func = self.play_music
         return [play_command]
+
+    def play_music(self, lib, opts, args):
+        """Execute query, create temporary playlist and execute player
+        command passing that playlist.
+        """
+        command_str = config['play']['command'].get()
+        use_folders = config['play']['use_folders'].get(bool)
+        relative_to = config['play']['relative_to'].get()
+        if relative_to:
+            relative_to = util.normpath(relative_to)
+        if command_str:
+            command = shlex.split(command_str)
+        else:
+            # If a command isn't set, then let the OS decide how to open the
+            # playlist.
+            sys_name = platform.system()
+            if sys_name == 'Darwin':
+                command = ['open']
+            elif sys_name == 'Windows':
+                command = ['start']
+            else:
+                # If not Mac or Windows, then assume Unixy.
+                command = ['xdg-open']
+
+        # Preform search by album and add folders rather than tracks to
+        # playlist.
+        if opts.album:
+            selection = lib.albums(ui.decargs(args))
+            paths = []
+
+            for album in selection:
+                if use_folders:
+                    paths.append(album.item_dir())
+                else:
+                    # TODO use core's sorting functionality
+                    paths.extend([item.path for item in sorted(
+                        album.items(),
+                        key=lambda item: (item.disc, item.track))])
+            item_type = 'album'
+
+        # Preform item query and add tracks to playlist.
+        else:
+            selection = lib.items(ui.decargs(args))
+            paths = [item.path for item in selection]
+            item_type = 'track'
+
+        item_type += 's' if len(selection) > 1 else ''
+
+        if not selection:
+            ui.print_(ui.colorize('text_warning',
+                                  'No {0} to play.'.format(item_type)))
+            return
+
+        # Warn user before playing any huge playlists.
+        if len(selection) > 100:
+            ui.print_(ui.colorize(
+                'text_warning',
+                'You are about to queue {0} {1}.'.format(len(selection),
+                                                         item_type)
+            ))
+
+            if ui.input_options(('Continue', 'Abort')) == 'a':
+                return
+
+        # Create temporary m3u file to hold our playlist.
+        m3u = NamedTemporaryFile('w', suffix='.m3u', delete=False)
+        for item in paths:
+            if relative_to:
+                m3u.write(relpath(item, relative_to) + b'\n')
+            else:
+                m3u.write(item + b'\n')
+        m3u.close()
+
+        command.append(m3u.name)
+
+        # Invoke the command and log the output.
+        output = util.command_output(command)
+        if output:
+            self._log.debug(u'Output of {0}: {1}',
+                            util.displayable_path(command[0]),
+                            output.decode('utf8', 'ignore'))
+        else:
+            self._log.debug(u'no output')
+
+        ui.print_(u'Playing {0} {1}.'.format(len(selection), item_type))
+
+        util.remove(m3u.name)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 
 Features:
 
+* :doc:`/plugins/play` will sort items according to the configured option when
+  used in album mode.
 * :doc:`/plugins/play` gives full interaction with the command invoked.
   :bug:`1321`
 * The summary shown to compare duplicate albums during import now displays

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 
 Features:
 
+* :doc:`/plugins/play` gives full interaction with the command invoked.
+  :bug:`1321`
 * The summary shown to compare duplicate albums during import now displays
   the old and new filesizes. :bug:`1291`
 * The colors used are now configurable via the new config option ``colors``,

--- a/docs/plugins/play.rst
+++ b/docs/plugins/play.rst
@@ -26,8 +26,8 @@ would on the command-line)::
     play:
         command: /usr/bin/command --option1 --option2 some_other_option
 
-Enable beets' verbose logging to see the command's output if you need to
-debug.
+While playing you'll be able to interact with the player if it is a
+command-line oriented, and you'll get its output in real time.
 
 Configuration
 -------------

--- a/test/test_config_command.py
+++ b/test/test_config_command.py
@@ -81,25 +81,13 @@ class ConfigCommandTest(unittest.TestCase, TestHelper):
         execlp.assert_called_once_with(
             'myeditor', 'myeditor', self.config_path)
 
-    def test_edit_config_with_open(self):
-        with _common.system_mock('Darwin'):
+    def test_edit_config_with_automatic_open(self):
+        with patch('beets.util.open_anything') as open:
+            open.return_value = 'please_open'
             with patch('os.execlp') as execlp:
                 self.run_command('config', '-e')
         execlp.assert_called_once_with(
-            'open', 'open', '-n', self.config_path)
-
-    def test_edit_config_with_xdg_open(self):
-        with _common.system_mock('Linux'):
-            with patch('os.execlp') as execlp:
-                self.run_command('config', '-e')
-        execlp.assert_called_once_with(
-            'xdg-open', 'xdg-open', self.config_path)
-
-    def test_edit_config_with_windows_exec(self):
-        with _common.system_mock('Windows'):
-            with patch('os.execlp') as execlp:
-                self.run_command('config', '-e')
-        execlp.assert_called_once_with(self.config_path, self.config_path)
+            'please_open', 'please_open', self.config_path)
 
     def test_config_editor_not_found(self):
         with self.assertRaises(ui.UserError) as user_error:

--- a/test/test_config_command.py
+++ b/test/test_config_command.py
@@ -92,10 +92,11 @@ class ConfigCommandTest(unittest.TestCase, TestHelper):
     def test_config_editor_not_found(self):
         with self.assertRaises(ui.UserError) as user_error:
             with patch('os.execlp') as execlp:
-                execlp.side_effect = OSError()
+                execlp.side_effect = OSError('here is problem')
                 self.run_command('config', '-e')
         self.assertIn('Could not edit configuration',
-                      unicode(user_error.exception.args[0]))
+                      unicode(user_error.exception))
+        self.assertIn('here is problem', unicode(user_error.exception))
 
     def test_edit_invalid_config_file(self):
         self.lib = Library(':memory:')

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -240,27 +240,6 @@ class DestinationTest(_common.TestCase):
         self.assertFalse('two \\ three' in p)
         self.assertFalse('two / three' in p)
 
-    def test_sanitize_unix_replaces_leading_dot(self):
-        with _common.platform_posix():
-            p = util.sanitize_path(u'one/.two/three')
-        self.assertFalse('.' in p)
-
-    def test_sanitize_windows_replaces_trailing_dot(self):
-        with _common.platform_windows():
-            p = util.sanitize_path(u'one/two./three')
-        self.assertFalse('.' in p)
-
-    def test_sanitize_windows_replaces_illegal_chars(self):
-        with _common.platform_windows():
-            p = util.sanitize_path(u':*?"<>|')
-        self.assertFalse(':' in p)
-        self.assertFalse('*' in p)
-        self.assertFalse('?' in p)
-        self.assertFalse('"' in p)
-        self.assertFalse('<' in p)
-        self.assertFalse('>' in p)
-        self.assertFalse('|' in p)
-
     def test_path_with_format(self):
         self.lib.path_formats = [('default', '$artist/$album ($format)')]
         p = self.i.destination()
@@ -337,11 +316,6 @@ class DestinationTest(_common.TestCase):
         ]
         self.assertEqual(self.i.destination(), np('one/three'))
 
-    def test_sanitize_windows_replaces_trailing_space(self):
-        with _common.platform_windows():
-            p = util.sanitize_path(u'one/two /three')
-        self.assertFalse(' ' in p)
-
     def test_get_formatted_does_not_replace_separators(self):
         with _common.platform_posix():
             name = os.path.join('a', 'b')
@@ -407,25 +381,6 @@ class DestinationTest(_common.TestCase):
         p = self.i.destination()
         self.assertEqual(p.rsplit(os.path.sep, 1)[1], 'something')
 
-    def test_sanitize_path_works_on_empty_string(self):
-        with _common.platform_posix():
-            p = util.sanitize_path(u'')
-        self.assertEqual(p, u'')
-
-    def test_sanitize_with_custom_replace_overrides_built_in_sub(self):
-        with _common.platform_posix():
-            p = util.sanitize_path(u'a/.?/b', [
-                (re.compile(r'foo'), u'bar'),
-            ])
-        self.assertEqual(p, u'a/.?/b')
-
-    def test_sanitize_with_custom_replace_adds_replacements(self):
-        with _common.platform_posix():
-            p = util.sanitize_path(u'foo/bar', [
-                (re.compile(r'foo'), u'bar'),
-            ])
-        self.assertEqual(p, u'bar/bar')
-
     def test_unicode_normalized_nfd_on_mac(self):
         instr = unicodedata.normalize('NFC', u'caf\xe9')
         self.lib.path_formats = [('default', instr)]
@@ -473,14 +428,6 @@ class DestinationTest(_common.TestCase):
         self.i.album = 'bar'
         self.assertEqual(self.i.destination(),
                          np('base/ber/foo'))
-
-    @unittest.skip('unimplemented: #359')
-    def test_sanitize_empty_component(self):
-        with _common.platform_posix():
-            p = util.sanitize_path(u'foo//bar', [
-                (re.compile(r'^$'), u'_'),
-            ])
-        self.assertEqual(p, u'foo/_/bar')
 
     @unittest.skip('unimplemented: #359')
     def test_destination_with_empty_component(self):
@@ -698,49 +645,6 @@ class DisambiguationTest(_common.TestCase, PathFormattingMixin):
         album1.store()
         self._setf(u'foo%aunique{albumartist album,albumtype}/$title')
         self._assert_dest('/base/foo [foo_bar]/the title', self.i1)
-
-
-class PathConversionTest(_common.TestCase):
-    def test_syspath_windows_format(self):
-        with _common.platform_windows():
-            path = os.path.join('a', 'b', 'c')
-            outpath = util.syspath(path)
-        self.assertTrue(isinstance(outpath, unicode))
-        self.assertTrue(outpath.startswith(u'\\\\?\\'))
-
-    def test_syspath_windows_format_unc_path(self):
-        # The \\?\ prefix on Windows behaves differently with UNC
-        # (network share) paths.
-        path = '\\\\server\\share\\file.mp3'
-        with _common.platform_windows():
-            outpath = util.syspath(path)
-        self.assertTrue(isinstance(outpath, unicode))
-        self.assertEqual(outpath, u'\\\\?\\UNC\\server\\share\\file.mp3')
-
-    def test_syspath_posix_unchanged(self):
-        with _common.platform_posix():
-            path = os.path.join('a', 'b', 'c')
-            outpath = util.syspath(path)
-        self.assertEqual(path, outpath)
-
-    def _windows_bytestring_path(self, path):
-        old_gfse = sys.getfilesystemencoding
-        sys.getfilesystemencoding = lambda: 'mbcs'
-        try:
-            with _common.platform_windows():
-                return util.bytestring_path(path)
-        finally:
-            sys.getfilesystemencoding = old_gfse
-
-    def test_bytestring_path_windows_encodes_utf8(self):
-        path = u'caf\xe9'
-        outpath = self._windows_bytestring_path(path)
-        self.assertEqual(path, outpath.decode('utf8'))
-
-    def test_bytesting_path_windows_removes_magic_prefix(self):
-        path = u'\\\\?\\C:\\caf\xe9'
-        outpath = self._windows_bytestring_path(path)
-        self.assertEqual(outpath, u'C:\\caf\xe9'.encode('utf8'))
 
 
 class PluginDestinationTest(_common.TestCase):
@@ -1002,23 +906,6 @@ class PathStringTest(_common.TestCase):
         )
         alb = self.lib.get_album(alb.id)
         self.assert_(isinstance(alb.artpath, bytes))
-
-
-class PathTruncationTest(_common.TestCase):
-    def test_truncate_bytestring(self):
-        with _common.platform_posix():
-            p = util.truncate_path(b'abcde/fgh', 4)
-        self.assertEqual(p, b'abcd/fgh')
-
-    def test_truncate_unicode(self):
-        with _common.platform_posix():
-            p = util.truncate_path(u'abcde/fgh', 4)
-        self.assertEqual(p, u'abcd/fgh')
-
-    def test_truncate_preserves_extension(self):
-        with _common.platform_posix():
-            p = util.truncate_path(u'abcde/fgh.ext', 5)
-        self.assertEqual(p, u'abcde/f.ext')
 
 
 class MtimeTest(_common.TestCase):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,0 +1,23 @@
+from test._common import unittest
+from test import _common
+
+from beets import util
+
+
+class UtilTest(unittest.TestCase):
+    def test_open_anything(self):
+        with _common.system_mock('Windows'):
+            self.assertEqual(util.open_anything(), 'start')
+
+        with _common.system_mock('Darwin'):
+            self.assertEqual(util.open_anything(), 'open')
+
+        with _common.system_mock('Tagada'):
+            self.assertEqual(util.open_anything(), 'xdg-open')
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromName(__name__)
+
+if __name__ == b'__main__':
+    unittest.main(defaultTest='suite')

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -20,6 +20,8 @@ import sys
 import re
 import os
 
+from mock import patch
+
 from test._common import unittest
 from test import _common
 from beets import util
@@ -35,6 +37,17 @@ class UtilTest(unittest.TestCase):
 
         with _common.system_mock('Tagada'):
             self.assertEqual(util.open_anything(), 'xdg-open')
+
+    @patch('os.execlp')
+    @patch('beets.util.open_anything')
+    def test_interactive_open(self, mock_open, mock_execlp):
+        mock_open.return_value = 'tagada'
+        util.interactive_open('foo')
+        mock_execlp.assert_called_once_with('tagada', 'tagada', 'foo')
+        mock_execlp.reset_mock()
+
+        util.interactive_open('foo', 'bar')
+        mock_execlp.assert_called_once_with('bar', 'bar', 'foo')
 
     def test_sanitize_unix_replaces_leading_dot(self):
         with _common.platform_posix():

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,6 +1,27 @@
+# This file is part of beets.
+# Copyright 2015, Adrian Sampson.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+"""Tests for base utils from the beets.util package.
+"""
+from __future__ import (division, absolute_import, print_function,
+                        unicode_literals)
+
+import sys
+import re
+import os
+
 from test._common import unittest
 from test import _common
-
 from beets import util
 
 
@@ -14,6 +35,119 @@ class UtilTest(unittest.TestCase):
 
         with _common.system_mock('Tagada'):
             self.assertEqual(util.open_anything(), 'xdg-open')
+
+    def test_sanitize_unix_replaces_leading_dot(self):
+        with _common.platform_posix():
+            p = util.sanitize_path(u'one/.two/three')
+        self.assertFalse('.' in p)
+
+    def test_sanitize_windows_replaces_trailing_dot(self):
+        with _common.platform_windows():
+            p = util.sanitize_path(u'one/two./three')
+        self.assertFalse('.' in p)
+
+    def test_sanitize_windows_replaces_illegal_chars(self):
+        with _common.platform_windows():
+            p = util.sanitize_path(u':*?"<>|')
+        self.assertFalse(':' in p)
+        self.assertFalse('*' in p)
+        self.assertFalse('?' in p)
+        self.assertFalse('"' in p)
+        self.assertFalse('<' in p)
+        self.assertFalse('>' in p)
+        self.assertFalse('|' in p)
+
+    def test_sanitize_windows_replaces_trailing_space(self):
+        with _common.platform_windows():
+            p = util.sanitize_path(u'one/two /three')
+        self.assertFalse(' ' in p)
+
+    def test_sanitize_path_works_on_empty_string(self):
+        with _common.platform_posix():
+            p = util.sanitize_path(u'')
+        self.assertEqual(p, u'')
+
+    def test_sanitize_with_custom_replace_overrides_built_in_sub(self):
+        with _common.platform_posix():
+            p = util.sanitize_path(u'a/.?/b', [
+                (re.compile(r'foo'), u'bar'),
+            ])
+        self.assertEqual(p, u'a/.?/b')
+
+    def test_sanitize_with_custom_replace_adds_replacements(self):
+        with _common.platform_posix():
+            p = util.sanitize_path(u'foo/bar', [
+                (re.compile(r'foo'), u'bar'),
+            ])
+        self.assertEqual(p, u'bar/bar')
+
+    @unittest.skip('unimplemented: #359')
+    def test_sanitize_empty_component(self):
+        with _common.platform_posix():
+            p = util.sanitize_path(u'foo//bar', [
+                (re.compile(r'^$'), u'_'),
+            ])
+        self.assertEqual(p, u'foo/_/bar')
+
+
+class PathConversionTest(_common.TestCase):
+    def test_syspath_windows_format(self):
+        with _common.platform_windows():
+            path = os.path.join('a', 'b', 'c')
+            outpath = util.syspath(path)
+        self.assertTrue(isinstance(outpath, unicode))
+        self.assertTrue(outpath.startswith(u'\\\\?\\'))
+
+    def test_syspath_windows_format_unc_path(self):
+        # The \\?\ prefix on Windows behaves differently with UNC
+        # (network share) paths.
+        path = '\\\\server\\share\\file.mp3'
+        with _common.platform_windows():
+            outpath = util.syspath(path)
+        self.assertTrue(isinstance(outpath, unicode))
+        self.assertEqual(outpath, u'\\\\?\\UNC\\server\\share\\file.mp3')
+
+    def test_syspath_posix_unchanged(self):
+        with _common.platform_posix():
+            path = os.path.join('a', 'b', 'c')
+            outpath = util.syspath(path)
+        self.assertEqual(path, outpath)
+
+    def _windows_bytestring_path(self, path):
+        old_gfse = sys.getfilesystemencoding
+        sys.getfilesystemencoding = lambda: 'mbcs'
+        try:
+            with _common.platform_windows():
+                return util.bytestring_path(path)
+        finally:
+            sys.getfilesystemencoding = old_gfse
+
+    def test_bytestring_path_windows_encodes_utf8(self):
+        path = u'caf\xe9'
+        outpath = self._windows_bytestring_path(path)
+        self.assertEqual(path, outpath.decode('utf8'))
+
+    def test_bytesting_path_windows_removes_magic_prefix(self):
+        path = u'\\\\?\\C:\\caf\xe9'
+        outpath = self._windows_bytestring_path(path)
+        self.assertEqual(outpath, u'C:\\caf\xe9'.encode('utf8'))
+
+
+class PathTruncationTest(_common.TestCase):
+    def test_truncate_bytestring(self):
+        with _common.platform_posix():
+            p = util.truncate_path(b'abcde/fgh', 4)
+        self.assertEqual(p, b'abcd/fgh')
+
+    def test_truncate_unicode(self):
+        with _common.platform_posix():
+            p = util.truncate_path(u'abcde/fgh', 4)
+        self.assertEqual(p, u'abcd/fgh')
+
+    def test_truncate_preserves_extension(self):
+        with _common.platform_posix():
+            p = util.truncate_path(u'abcde/fgh.ext', 5)
+        self.assertEqual(p, u'abcde/f.ext')
 
 
 def suite():


### PR DESCRIPTION
In the quest for an interactive play command, several changes came to be:
- abstract the start/open/xdg-open command name in `beets.util.open_anything()` (used by play and config edition).
- manage command lexing in `beets.util.interactive_open()`.
- move many tests from `beets/test_library.py` to the newly created `beets/test_util.py`.

This fixes #1321.
