### PR TITLE
Allow SQL preselection on queries

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -28,7 +28,7 @@ import collections
 import beets
 from beets.util.functemplate import Template
 from beets.dbcore import types
-from .query import MatchQuery, NullSort, TrueQuery
+from .query import MatchQuery, NullSort, TrueQuery, NoneQuery
 
 
 class FormattedMapping(collections.Mapping):
@@ -485,6 +485,8 @@ class Results(object):
         self.rows = rows
         self.db = db
         self.query = query
+        if isinstance(query, NoneQuery):
+            self.query = None
         self.sort = sort
 
         # We keep a queue of rows we haven't yet consumed for
@@ -809,10 +811,9 @@ class Database(object):
 
         with self.transaction() as tx:
             rows = tx.query(sql, subvals)
-
         return Results(
             model_cls, rows, self,
-            None if where else query,  # Slow query component.
+            query,
             sort if sort.is_slow() else None,  # Slow sort component.
         )
 

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -107,6 +107,15 @@ class FieldQuery(Query):
         return self.value_match(self.pattern, item.get(self.field))
 
 
+    def __repr__(self):
+        pattern = getattr(self.pattern, 'pattern', self.pattern)
+        return u'<{0}: {1} {2}>'.format(
+            type(self).__name__,
+            self.field,
+            repr(pattern),
+        )
+
+
 class MatchQuery(FieldQuery):
     """A query that looks for exact matches in an item field."""
     def col_clause(self):
@@ -330,7 +339,13 @@ class CollectionQuery(Query):
         for subq in self.subqueries:
             subq_clause, subq_subvals = subq.clause()
             if not subq_clause:
-                pass
+                if joiner == 'or':
+                    # No prefiltering clause if any subquery has no clause.
+                    # in 'or' query
+                    return None, ()
+                else:
+                    # Let other subqueries build a prefiltering clause, if any.
+                    pass
             else:
                 clause_parts.append('(' + subq_clause + ')')
                 subvals += subq_subvals

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -330,10 +330,10 @@ class CollectionQuery(Query):
         for subq in self.subqueries:
             subq_clause, subq_subvals = subq.clause()
             if not subq_clause:
-                # Fall back to slow query.
-                return None, ()
-            clause_parts.append('(' + subq_clause + ')')
-            subvals += subq_subvals
+                pass
+            else:
+                clause_parts.append('(' + subq_clause + ')')
+                subvals += subq_subvals
         clause = (' ' + joiner + ' ').join(clause_parts)
         return clause, subvals
 

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -438,6 +438,12 @@ class QueryFromStringsTest(unittest.TestCase):
         q = self.qfs([''])
         self.assertIsInstance(q.subqueries[0], dbcore.query.TrueQuery)
 
+    def test_mixed_query(self):
+        q = self.qfs(['field_one:123', 'other_attr:bar'])
+        self.assertIsInstance(q.subqueries[0], dbcore.query.NumericQuery)
+        self.assertIsInstance(q.subqueries[1], dbcore.query.SubstringQuery)
+        self.assertEqual(q.clause(), (u'(field_one=?)', [123]))
+
 
 class SortFromStringsTest(unittest.TestCase):
     def sfs(self, strings):


### PR DESCRIPTION
Not sure this patch really makes sense. But still, on my db with 12000 tracks, it speeds up a lot a specific kind of queries: queries with a filter that can be handled by a normal SQL filter, plus another subquery trying to match some other item attributes (those stored in item_attributes).

The increase in query speed is important, I go from a 6 s. query time on master, to a much faster 0.2 s query time with this patch.

However, I am not sure this patch is not breaking some other use case I don't know of (and is not covered in a test case). 
