### PR TITLE
Rewrite Plugin: Back-referencing a matched substring

### DIFF
--- a/beetsplug/rewrite.py
+++ b/beetsplug/rewrite.py
@@ -34,9 +34,7 @@ def rewriter(field, rules):
     def fieldfunc(item):
         value = item._values_fixed[field]
         for pattern, replacement in rules:
-            if pattern.match(value.lower()):
-                # Rewrite activated.
-                return replacement
+            return re.sub(pattern, replacement, value)
         # Not activated; return original value.
         return value
     return fieldfunc
@@ -60,7 +58,7 @@ class RewritePlugin(BeetsPlugin):
                 raise ui.UserError("invalid field name (%s) in rewriter" %
                                    fieldname)
             self._log.debug(u'adding template field {0}', key)
-            pattern = re.compile(pattern.lower())
+            pattern = re.compile(pattern)
             rules[fieldname].append((pattern, value))
             if fieldname == 'artist':
                 # Special case for the artist field: apply the same

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,8 @@ New:
   various-artists albums. The setting defaults to "Various Artists," the
   MusicBrainz standard. In order to match MusicBrainz, the
   :doc:`/plugins/discogs` also adopts the same setting.
+* The rewrite plugin now accepts back-references to matched substrings in the
+  replacement pattern. :bug:`1452`
 
 
 For developers:

--- a/docs/plugins/rewrite.rst
+++ b/docs/plugins/rewrite.rst
@@ -26,6 +26,18 @@ might use::
     rewrite:
         artist .*jimi hendrix.*: Jimi Hendrix
 
+As of v1.3.14 the replacement pattern may also consist of a regular expression
+in order to back-reference matched substrings. For example, you might want to
+replace certain characters in a tag. The following rewrite rule modifies the
+title to replace a trailing year in parentheses with the trailing year in
+brackets::
+
+    rewrite:
+        title (.*)\(([0-9]{4})\)$: '\1\[\2\]'
+
+This example will transform Jimi Hendrix' ``$title`` "Hey Joe (1969)" to "Hey
+Joe [1969]".
+
 As a convenience, the plugin applies patterns for the ``artist`` field to the
 ``albumartist`` field as well. (Otherwise, you would probably want to duplicate
 every rule for ``artist`` and ``albumartist``.)

--- a/docs/plugins/rewrite.rst
+++ b/docs/plugins/rewrite.rst
@@ -26,11 +26,10 @@ might use::
     rewrite:
         artist .*jimi hendrix.*: Jimi Hendrix
 
-As of v1.3.14 the replacement pattern may also consist of a regular expression
-in order to back-reference matched substrings. For example, you might want to
-replace certain characters in a tag. The following rewrite rule modifies the
-title to replace a trailing year in parentheses with the trailing year in
-brackets::
+The replacement pattern may also consist of a regular expression in order to
+back-reference matched substrings. For example, you might want to replace
+certain characters in a tag. The following rewrite rule modifies the title to
+replace a trailing year in parentheses with the year in brackets::
 
     rewrite:
         title (.*)\(([0-9]{4})\)$: '\1\[\2\]'


### PR DESCRIPTION
Hi there,

The rewrite plugin is currently able to only replace patterns with static strings. This PR makes it possible to refer a matching sub-string from the pattern and insert it into the replacement pattern.

For example:

```
rewrite:
    title (.*)\(([0-9]{4})\): '\1[\2]'
```

transforms Stevie Nicks' title `Rhiannon (2005)` to `Rhiannon [2005]`.
