### PR TITLE
Added `betterlisting` plugin for extended queries and listing formats.

### DIFF
--- a/beetsplug/betterlisting.py
+++ b/beetsplug/betterlisting.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+
+import re
+from beets import ui, plugins
+from beets.library import Item, Album
+
+# Other fields can be:
+#   bitrate, bpm, lyrics,
+
+
+def _int_arg(s):
+    """Convert a string argument to an integer for use in a template
+    function.  May raise a ValueError.
+    """
+    return int(s.strip())
+
+
+def printed_length(s):
+    """Printed length of string after removing ansi escape sequences. This is
+    useful in getting the number of characters occupied by the string on
+    terminal, for example."""
+    ansi_escape = re.compile(r'\x1b[^m]*m')
+    return len(ansi_escape.sub('', s))
+
+
+def is_album(item):
+    """Check if the given item represents an album"""
+    return isinstance(item, Album)
+
+
+def is_singleton(item):
+    """Check if the given item represents a singleton"""
+    return isinstance(item, Item) and not item.album_id
+
+
+def config_icon(item, view):
+    """Get either the unicode special character for the integer specified, or
+    the format string from the user configured formatting. This is useful to
+    display special unicode characters like :greenbook: in listings."""
+    fmt = None
+    if view:
+        try:
+            fmt = ("\\U%08x" % view.get(int)).decode('unicode-escape')
+        except:
+            fmt = view.get(unicode)
+    return format(item, fmt) if fmt else u''
+
+
+class BetterListingPlugin(plugins.BeetsPlugin):
+    """ Provide template functions, and fields for better listing of queries."""
+
+    # Tuples containing the hook, prefix, and a list of all mathcing functions
+    # for passing the template functions and fields to beet.
+    _prop_names = []
+
+    # Store the prefix used in this class for the given hooks. `all_fields`
+    # refers to template fields that can be used by both items and albums.
+    _prefixes = {
+        'template_funcs': u'tmpl_',
+        'template_fields': u'tmpl_field_',
+        'album_template_fields': u'album_field_',
+        'all_fields': u'field_'
+    }
+
+    def __init__(self):
+        super(BetterListingPlugin, self).__init__()
+
+        self.config.add({
+            'sparks': u'▇▆▅▄▃▂▁ ',
+            'track_length': 360,
+            'icon_missing_none': u'',
+            'icon_missing_some': u'%colorize{◎,red}',
+            'icon_lyrics_all':  128215,                 # unicode :green book:
+            'icon_lyrics_some': 128217,                 # unicode :orange book:
+            'icon_lyrics_none': 128213,                 # unicode :red book:
+            'duration_format': '{mins:02d}:{secs:02d}',
+            'format_item': "$lyrics_icon %colorize{$duration_bar,blue}",
+            'format_album': "$lyrics_icon %colorize{$duration_bar,blue} $missing_icon",
+        })
+
+        # Extract tuples containing a list of functions for appropriate beet
+        # hooks, and pass them over to that hook.
+        for hook, prefix, props in self._prop_names:
+            for prop in props:
+                key, val = prop[len(prefix):], getattr(self, prop)
+                if prefix == self._prefixes["all_fields"]:
+                    self.template_fields[key] = val
+                    self.album_template_fields[key] = val
+                else:
+                    getattr(self, hook)[key] = val
+
+    # TEMPLATE FUNCTIONS #####
+
+    @staticmethod
+    def tmpl_rpad(s, chars):
+        """Right pad a given string with spaces."""
+        return s + (u' ' * (_int_arg(chars) - printed_length(s)))
+
+    @staticmethod
+    def tmpl_lpad(s, chars, delim=r' '):
+        """Left pad a given string with spaces."""
+        return (u' ' * (_int_arg(chars) - printed_length(s))) + s
+
+    @staticmethod
+    def tmpl_rtrimpad(s, chars):
+        """Right pad a given string and/or trim it, if required."""
+        if _int_arg(chars) > 0:
+            return u'%-*s' % (_int_arg(chars), s[0:_int_arg(chars)])
+        else:
+            return u''
+
+    @staticmethod
+    def tmpl_ltrimpad(s, chars, delim=r' '):
+        """Left pad a given string and/or trim it, if required."""
+        if _int_arg(chars) > 0:
+            return u'%*s' % (_int_arg(chars), s[-_int_arg(chars):])
+        else:
+            return u''
+
+    @staticmethod
+    def tmpl_colorize(message, color=u''):
+        """Colorize a given string with the given color"""
+        return ui._colorize(color.strip(), message) if color.strip() else message
+
+    def tmpl_sparkbar(self, count, total, color=u''):
+        """Produce a spark bar for given count based on a given total. A third
+        argument can be provided to colorize the spark bar."""
+        count = float(str(count).strip()) if count else 0
+        total = float(str(total).strip()) if total else 0
+
+        sparks = self.config["sparks"].get(unicode)[::-1]
+        spark = sparks[0] if len(sparks) > 0 else u''
+
+        if len(sparks) > 0:
+            if count > 0 and total > 0:
+                index = int(count/total*len(sparks))
+                spark = sparks[index] if index < len(sparks) else sparks[-1]
+            elif total == 0:
+                spark = sparks[-1]
+
+        return ui._colorize(color, spark) if color else spark
+
+    # TEMPLATE FIELDS ########
+
+    def field_icons(self, item):
+        fmt = self.config['format_album' if is_album(item) else 'format_item']
+        return format(item, fmt.get(unicode))
+
+    def field_duration(self, item):
+        mins, secs = divmod(self.field_duration_sort(item), 60)
+        fmt = self.config['duration_format'].get(unicode)
+        return fmt.format(mins=mins, secs=secs)
+
+    def field_duration_sort(self, item):
+        duration = 0
+        if is_album(item):
+            duration = sum([x.length for x in item.items()])
+        elif hasattr(item, 'length') and item.length:
+            duration = item.length
+        return int(duration)
+
+    def field_duration_bar(self, item):
+        duration = 0
+        total = self.config['track_length'].get(int)
+        if is_album(item):
+            duration = self.album_field_avg_duration_sort(item)
+        else:
+            duration = self.field_duration_sort(item)
+        return self.tmpl_sparkbar(duration, total)
+
+    def field_lyrics_sort(self, item):
+        lyrics = 0
+        if is_album(item):
+            lyrics = sum(1 if x.lyrics else 0 for x in item.items())
+            lyrics = lyrics/float(len(item.items()))
+        else:
+            lyrics = 1 if hasattr(item, u'lyrics') and item.lyrics else 0
+        return lyrics
+
+    def field_lyrics_icon(self, item):
+        lyrics = self.field_lyrics_sort(item)
+        icon   = self.config['icon_lyrics_some']
+        if lyrics == 1:
+            icon = self.config["icon_lyrics_all"]
+        elif lyrics == 0:
+            icon = self.config["icon_lyrics_none"]
+        return config_icon(item, icon)
+
+    # ALBUM TEMPLATE FIELDS ########
+
+    def album_field_avg_duration(self, item):
+        mins, secs = divmod(self.album_field_avg_duration_sort(item), 60)
+        fmt = self.config['duration_format'].get(unicode)
+        return fmt.format(mins=mins, secs=secs)
+
+    def album_field_avg_duration_sort(self, item):
+        return int(sum([x.length for x in item.items()])/len(item.items()))
+
+    def album_field_missing(self, item):
+        return (item.albumtotal or 0) - len(item.items())
+
+    def album_field_missing_icon(self, item):
+        missing = self.config['icon_missing_some']
+        none_missing = self.config['icon_missing_none']
+        icon = missing if self.album_field_missing(item) > 0 else none_missing
+        return config_icon(item, icon)
+
+    def album_field_missing_bar(self, item):
+        return self.tmpl_sparkbar(self.album_field_missing(item),
+                                            self.album_field_total(item))
+
+    def album_field_available(self, item):
+        return len(item.items())
+
+    def album_field_available_bar(self, item):
+        return self.tmpl_sparkbar(self.album_field_available(item),
+                                            self.album_field_total(item))
+
+    def album_field_total(self, item):
+        return (item.albumtotal or 0)
+
+for prefix, name in BetterListingPlugin._prefixes.iteritems():
+    matching_props = [s for s in dir(BetterListingPlugin) if s.startswith(name)]
+    BetterListingPlugin._prop_names.append((prefix, name, matching_props))
+

--- a/docs/plugins/betterlisting.rst
+++ b/docs/plugins/betterlisting.rst
@@ -1,0 +1,297 @@
+BetterListing Plugin
+====================
+
+The ``betterlisting`` plugin allows you to query and list your collection
+with extended queries and listing formats. This plugin provides several
+query modifiers, template fields and functions for use in your beets
+configuration. Please, note that, this plugin is intended for advanced
+users, and may confuse initial users.
+
+Installation
+------------
+
+To use the ``betterlisting`` plugin, first enable it in your configuration
+(see :ref:`using-plugins`). Then, read on to know the various fields and
+functions provided by this plugin. For getting a taste of what this plugin
+can do for you, please add ``$icons`` in ``format_item`` and
+``format_album`` configuration option for ``beets``.
+
+Template Functions
+------------------
+
+This plugin provides several template functions (see
+:ref:`template-functions`) to perfectly layout your queries on the
+terminal.
+
+* ``%colorize{text,color}``: Color ``text`` using ``color`` for the
+  terminal. Available colors are: ``black darkred darkgreen brown
+  darkblue purple teal lightgray darkgray red green yellow blue fuchsia
+  turquoise white``
+
+  For example, you can colorize your albums in a blue color like this::
+
+    format_album: %colorize{$album,blue}
+
+* ``%rpad{text,n}``: Right pad the given ``text`` to ``n`` characters.
+  This is useful in aligning your query results, and hence, display them
+  in a tabular format. Note that, if the ``text`` exceeds this length, the
+  whole ``text`` will be displayed, which can skew your tabular listing.
+
+  For example, you can align your query results in a table format::
+
+    format_album: [$year] %rpad{$title,40} $artist
+
+* ``%lpad{text,n}``: Left pad the given ``text`` to ``n`` characters.
+
+* ``%rtrimpad{text,n}``: Right pad the given ``text`` to ``n`` characters.
+  If the ``text`` exceeds ``n`` characters, trim it so that it only
+  occupies ``n`` characters in the results. This is useful in tabular
+  formatting of your results, and ensuring that no column exceeds the
+  given width. Also, to properly align your ``text``, all ANSI escape
+  codes will be ignored for calculating the text width.
+
+  For example, you can align your query results in a table format like
+  this (note that if ``$title`` exceeds ``40`` chars, it will be
+  truncated in this example)::
+
+    format_album: [$year] %rtrimpad{$title,40} $artist
+
+* ``%ltrimpad{text,n}``: Left pad the given ``text`` to ``n`` characters.
+  If the ``text`` exceeds ``n`` charaacters, trim it so that it only
+  occupies ``n`` characters in the results.
+
+* ``%sparkbar{count,total}``: Print out unicode histogram for the given
+  ``count`` and ``total`` using `spark`_.
+  
+  For example, with the defaults, calling something like
+  ``%sparkbar{$missing,$total}`` will produce a unicode character from the
+  following characters ``▇▆▅▄▃▂▁`` as per the ratio between missing and
+  total tracks of the album.
+
+Template Fields
+---------------
+
+This plugin, also, provides several template fields that you can use for
+formatting your query results. For example, you can use ``$duration`` in
+your format to display the total duration of that item or album. Available
+template fields are:
+
+* ``$duration``: track length (duration) for the corresponding item, or in
+  case of albums, the total length of the tracks for the given album in a
+  human readable time format. Time format is customizable using the
+  ``duration_format`` config option.
+
+  For example, if you want to search for tracks sorted according to their
+  track length, you can say::
+
+    beet ls -f '$duration %rpad{$artist,30} $title | sort -nr
+
+  which produces the following for my library::
+
+    06:54 Lana Del Rey                   Summertime Sadness (Cedric Gervais vocal down mix)
+    06:34 Elbow                          One Day Like This
+    06:31 DJ Khaled                      Hold You Down ft. Chris Brown, August Alsina, Future & Jeremih
+    05:58 Romeo Santos                   Yo también ft. Marc Anthony
+    05:55 Justin Timberlake              Take Back the Night
+    05:51 Muse                           Psycho
+    05:47 Florence + the Machine         What Kind of Man
+    05:46 Action Bronson                 Baby Blue feat. Chance the Rapper
+    05:40 Disclosure                     White Noise ft. AlunaGeorge
+    05:38 JAY Z                          Holy Grail ft. Justin Timberlake
+    ....
+
+* ``$duration_sort``: track length for a single item or total length of
+  tracks for the album as an integer. Useful in sorting and querying the
+  collection based on the duration of the items/albums.
+
+  For example, in the above example, we could have simply used
+  ``duration_sort-`` to sort the results, like this::
+
+    beet ls -f '$duration %rpad{$artist,30} $title duration_sort-
+
+* ``$lyrics_sort``: floating point value indicating if the lyrics are
+  present for a particular item. If lyrics are present, ``$lyrics_sort``
+  will be ``1.0``, and if they are absent, it will be ``0.0``. In case of
+  albums, if some of the lyrics are present but not all, value will be the
+  ratio of tracks with lyrics vs total tracks for that album.
+
+  For example, we can ask the :doc:`lyrics` to only fetch information for
+  tracks that are missing the lyrics (thereby, saving time on a large
+  collection)::
+
+    beet lyrics lyrics_sort:0
+
+  Or, we can simply query the collection for albums which have more than
+  half of the tracks without lyrics::
+
+    beet lyrics lyrics_sort:0..0.5
+
+* ``$avg_duration``: for albums, expands to the average track length of
+  the songs in that album that are present in the library. Like
+  ``$duration`` field, time format is customizable using the
+  ``duration_format`` config option.
+
+* ``$avg_duration_sort``: expands to average track length of the album as
+  an integer. Useful in sorting and querying the collection based on the
+  average duration of albums.
+
+* ``$missing``: expands to the number of missing tracks in the album.
+  Same as the ``$missing`` field provided by the :doc:`missing`.
+  Note that, this plugin does not provide the functionality to query the
+  missing tracks via musicbrainz.
+
+* ``$available``: expands to the number of tracks in the album, that are
+  available in the library.
+
+* ``$total``: expands to the total number of tracks in the album, as
+  reported by musicbrainz (requires :doc:`missing`), or from the
+  ``tracktotal`` field of the individual tracks in that album.
+
+**Note that template fields and functions can, also, be used inside custom
+path formats, and inside your beet configuration. Also, all template
+fields can also be used to query the library, and for sorting thanks to
+the new query feature of ``beets``**
+
+.. _icon-template-fields:
+
+Icon Template Fields
+--------------------
+
+:doc:`betterlisting` provides some customizable template fields that print
+icons to your console when used in path format strings. For example, you
+can display a red ``L`` in front of tracks that don't have any lyrics
+associated with them, when listing your collection.
+
+* ``$icons``: When used in path format strings, expands to all the icons
+  provided by this plugin. This field is customizable via the
+  ``format_item`` and ``format_album`` configuration options of this
+  plugin.
+
+* ``$missing_icon``: Icon/string to display when an album has some or no
+  tracks missing. This field is customizable via the ``icon_missing_some``
+  and ``icon_missing_none`` configuration options for this plugin.
+
+* ``$lyrics_icon``: Icon/string  to display when an album has lyrics
+  present for all, none or some of the tracks. For an item, it displays
+  icons according to whether it has lyrics associated with it.
+  Customizable via the configuration options.
+
+.. _sparkbar-fields:
+
+SparkBar Fields
+---------------
+
+* ``$duration_bar``: track length of the item (and, average track length
+  in case of albums) as a spark bar plotted against a customizable
+  duration (via the ``track_length`` configuration option).
+
+* ``$missing_bar``: number of missing tracks for the album plotted, as a
+  spark bar, against the total number of tracks in that album according to
+  the musicbrainz database (requires :doc:`missing`), or according to the
+  ``tracktotal`` field of individual tracks in that album.
+
+* ``$available_bar``: number of available tracks in your library plotted,
+  as a spark bar, against the total number of tracks in that album.
+
+Configuration
+-------------
+
+The plugin provides several configuration options that you can define in
+the ``betterlisting:`` section of the config file. The defaults look like
+this::
+
+    betterlisting:
+        sparks:             '▇▆▅▄▃▂▁ '
+        track_length:       360
+        duration_format:    '{mins:02d}:{secs:02d}',
+        format_item:        $lyrics_icon %colorize{$duration_bar,blue}
+        format_album:       $lyrics_icon %colorize{$duration_bar,blue} $missing_icon
+        icon_missing_none:  ''
+        icon_missing_some:  %colorize{◎,red}
+        icon_lyrics_all:    128215
+        icon_lyrics_some:   128217
+        icon_lyrics_none:   128213
+
+Yeah, that's a lot of configuration options, but this plugin allows you to
+customize everything to suite your needs. Here is a description of all
+these configuration options:
+
+- **sparks**: defines that characters to use for generating the spark bars
+  for fields like ``$duration_bar``, ``$missing_bar``, etc. You can add
+  more characters or remove from the default to customize the spark bar.
+  Allows unicode characters. See :ref:`sparkbar-fields`
+- **track_length**: Base track length (in seconds) to use for generating
+  the ``$duration_bar``. The spark bar will be full when track length of
+  the individual items (or average track length in case of albums) will be
+  above this duration.
+- **duration_format**: python string formatting tempalte to use for
+  formatting the track length of the items before displaying it on the
+  terminal. By default, duration will be listed as: ``MM::SS``.
+- **format_item**: path format string to use when generating ``$icons``
+  for the individual items in your library. You can use any template field
+  or functions here, and simply, add ``$icons`` in your path format string
+  for items. See :ref:`icon-template-fields`
+- **format_album**: same as above, but for albums.
+- **icon_missing_none**: icon to use for ``$missing_icon`` when no track
+  is missing from the album. You can use template functions and fields
+  here, or simply provide an integer which will be converted to special
+  unicode characters. See: :ref:`unicode-special-characters`
+- **icon_missing_some**: icon to use for ``$missing_icon`` when some of
+  the tracks are missing from the album. You can use template functions
+  and fields here, or simply provide an integer which will be converted to
+  special unicode characters. See: :ref:`unicode-special-characters`
+- **icon_lyrics_all**: icon to use for ``$lyrics_icon`` when the track has
+  lyrics, or in case of albums when all tracks have lyrics. You can use
+  template functions and fields here, or simply provide an integer which
+  will be converted to special unicode characters. See:
+  :ref:`unicode-special-characters`
+- **icon_lyrics_none**: icon to use for ``$lyrics_icon`` when the track
+  does not have lyrics, or in case of albums when no tracks have lyrics.
+  You can use template functions and fields here, or simply provide an
+  integer which will be converted to special unicode characters. See:
+  :ref:`unicode-special-characters`
+- **icon_lyrics_somee**: icon to use for ``$lyrics_icon`` in case of
+  albums when some of the tracks have lyrics missing. You can use template
+  functions and fields here, or simply provide an integer which will be
+  converted to special unicode characters. See:
+  :ref:`unicode-special-characters`
+
+.. _unicode-special-characters:
+
+Unicode Special Characters
+--------------------------
+
+Though, most unicode characters are supported by the beet configuration,
+yet, it does not allow special characters (eg. certain emojis etc.), which
+are sometimes a perfect fit as an icon. For example, a ``:greenbook:``
+unicode character can be used as a means to denote tracks that have lyrics
+with them, while a ``:redbook:`` unicode character can denote tracks that
+don't have lyrics with them.
+
+In order to add these icons/unicode characters, you can use the integer
+representation of these unicode characters. For example, we can find the
+integer representation of ``:greenbook:`` `on this page`_. Under the
+``UTF-32 (decimal)`` field, we can find that this unicode character is
+represented by the number ``128215``, which we can use in our
+configuration.
+
+Please, note that you can not use any template field or functions when
+using integers for these fields.
+
+Easier Querying
+---------------
+
+This plugin provides several fields that can be used for sorting or
+querying the database. You can use :doc:`types` and specify the following
+configuration for easiery querying::
+
+    types:
+      lyrics_sort: float
+      duration_sort: int
+      avg_duration_sort: int
+      missing: int
+      available: int
+      total: int
+
+.. _spark: https://github.com/holman/spark
+.. _on this page: http://www.fileformat.info/info/unicode/char/1f4d7/index.htm

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -31,6 +31,7 @@ Each plugin has its own set of options that can be defined in a section bearing 
 .. toctree::
    :hidden:
 
+   betterlisting
    bpd
    bpm
    bucket
@@ -119,6 +120,9 @@ Metadata
 Path Formats
 ------------
 
+* :doc:`betterlisting`: Extensive template functions and fields to
+  customize path format strings, and, also extended queries and nicer
+  looking listings of your search results.
 * :doc:`bucket`: Group your files into bucket directories that cover different
   field values ranges.
 * :doc:`inline`: Use Python snippets to customize path format strings.

--- a/test/test_betterlisting.py
+++ b/test/test_betterlisting.py
@@ -1,0 +1,331 @@
+# -*- coding: utf-8 -*-
+# This file is part of beets.
+# Copyright 2015, Nikhil Gupta.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""Tests for the 'betterlisting' plugin."""
+
+from __future__ import (division, absolute_import, print_function,
+                        unicode_literals)
+
+from test import _common
+from test._common import unittest
+from beetsplug import betterlisting
+from beets import config
+
+from test.helper import TestHelper
+
+
+class BetterListingPluginTest(unittest.TestCase, TestHelper):
+    def setUp(self):
+        self.setup_beets()
+        self.load_plugins('betterlisting')
+        self.plugin = betterlisting.BetterListingPlugin()
+        default_config = { key:val.get() for key, val in
+                          self.plugin.config.items()}
+        self._setup_config(**default_config)
+
+    def tearDown(self):
+        self.teardown_beets()
+        self.unload_plugins()
+
+    def _setup_config(self, **values):
+        for key, val in values.iteritems():
+            self.plugin.config[key] = val
+
+
+class TemplateFunctionsForStringPaddingTest(BetterListingPluginTest):
+
+    def test_template_function_for_right_padding(self):
+        """If a string and width is given, right pads that string correctly."""
+        self.assertEqual(self.plugin.tmpl_rpad(u'text', "9"), u'text     ')
+        self.assertEqual(self.plugin.tmpl_rpad(u'text', "0"), u'text')
+        self.assertEqual(self.plugin.tmpl_rpad(u'text▃ ', "9"), u'text▃    ')
+        self.assertEqual(self.plugin.tmpl_rpad(u'textⓂ️ ', "9"), u'textⓂ️   ')
+
+    def test_template_function_for_left_padding(self):
+        """If a string and width is given, left pads that string correctly."""
+        self.assertEqual(self.plugin.tmpl_lpad(u'text', "9"), u'     text')
+        self.assertEqual(self.plugin.tmpl_lpad(u'text', "0"), u'text')
+        self.assertEqual(self.plugin.tmpl_lpad(u'text▃ ', "9"), u'   text▃ ')
+        self.assertEqual(self.plugin.tmpl_lpad(u'textⓂ️ ', "9"), u'  textⓂ️ ')
+
+    def test_template_function_for_right_padding_with_trimming(self):
+        """If a string and width is given, right pads that string while trimming
+        it to the specified width."""
+        self.assertEqual(self.plugin.tmpl_rtrimpad(u'text', "9"), u'text     ')
+        self.assertEqual(self.plugin.tmpl_rtrimpad(u'text', "3"), u'tex')
+        self.assertEqual(self.plugin.tmpl_rtrimpad(u'text', "0"), u'')
+        self.assertEqual(self.plugin.tmpl_rtrimpad(u'text', "-2"), u'')
+        self.assertEqual(self.plugin.tmpl_rtrimpad(u'text▃ ', "5"), u'text▃')
+        self.assertEqual(self.plugin.tmpl_rtrimpad(u'textⓂ️ ', "5"), u'textⓂ')
+
+    def test_template_function_for_left_padding_with_trimming(self):
+        """If a string and width is given, left pads that string while trimming
+        it to the specified width."""
+        self.assertEqual(self.plugin.tmpl_ltrimpad(u'text', "9"), u'     text')
+        self.assertEqual(self.plugin.tmpl_ltrimpad(u'text', "3"), u'ext')
+        self.assertEqual(self.plugin.tmpl_ltrimpad(u'text', "0"), u'')
+        self.assertEqual(self.plugin.tmpl_ltrimpad(u'text', "-2"), u'')
+        self.assertEqual(self.plugin.tmpl_ltrimpad(u'text▃ ', "5"), u'ext▃ ')
+        self.assertEqual(self.plugin.tmpl_ltrimpad(u'textⓂ️ ', "5"), u'xtⓂ️ ')
+
+
+class TemplateFunctionsForColoredStringTest(BetterListingPluginTest):
+
+    def test_template_function_for_coloring_strings(self):
+        """If a string and color is given, colorize string with that color"""
+        self.assertEqual(self.plugin.tmpl_colorize(u'a'), u'a')
+        self.assertEqual(self.plugin.tmpl_colorize(u'a', u'  '), u'a')
+
+        expected = u'\x1b[37;01ma\x1b[39;49;00m'
+        self.assertEqual(self.plugin.tmpl_colorize(u'a', u'white'), expected)
+        self.assertEqual(self.plugin.tmpl_colorize(u'a', u' white  '), expected)
+
+        expected = u'\x1b[35ma\x1b[39;49;00m'
+        self.assertEqual(self.plugin.tmpl_colorize(u'a', u'purple'), expected)
+
+
+class TemplateFunctionsForSparkBarsTest(BetterListingPluginTest):
+
+    def test_template_function_for_spark_bar(self):
+        """If a count and total is given, produce a spark bar for that ratio"""
+        self.assertEqual(self.plugin.tmpl_sparkbar(9, 80), u' ')
+        self.assertEqual(self.plugin.tmpl_sparkbar(10, 80), u'\u2581')
+        self.assertEqual(self.plugin.tmpl_sparkbar(8, 8), u'\u2587')
+
+    def test_template_function_for_colored_spark_bar(self):
+        """If count, total and color is given, produce a colored spark bar"""
+        expected = u'\x1b[35m\u2583\x1b[39;49;00m'
+        self.assertEqual(self.plugin.tmpl_sparkbar(4, 10, u'purple'), expected)
+
+    def test_template_function_for_used_configured_spark_bar(self):
+        """If user has specified spark bars, produce spark bar from them"""
+        self._setup_config(sparks=u'▆▄▂ ')
+        self.assertEqual(self.plugin.tmpl_sparkbar(4, 20), u' ')
+        self.assertEqual(self.plugin.tmpl_sparkbar(15, 20), u'\u2586')
+        self.assertEqual(self.plugin.tmpl_sparkbar(23, 18), u'\u2586')
+
+
+class TemplateFieldsForDurationTest(BetterListingPluginTest):
+
+    def setUp(self):
+        super(self.__class__, self).setUp()
+
+    def add_fixtures(self, *lengths):
+        """Add fixtures for the current tests."""
+        items = []
+
+        for length in lengths:
+            if length:
+                items.append(self.add_item(path="/", length=length))
+            else:
+                items.append(self.add_item(path="/"))
+
+        return [self.lib.add_album(items), items]
+
+    def test_template_fields_for_duration(self):
+        """Duration fields should return time in human readable format"""
+        album, items = self.add_fixtures(0, 210, 430, 9000)
+        self.assertEqual(self.plugin.field_duration(items[0]), "00:00")
+        self.assertEqual(self.plugin.field_duration(items[1]), "03:30")
+        self.assertEqual(self.plugin.field_duration(items[2]), "07:10")
+        self.assertEqual(self.plugin.field_duration(items[3]), "150:00")
+        self.assertEqual(self.plugin.field_duration(album), "160:40")
+        self.assertEqual(self.plugin.album_field_avg_duration(album), "40:10")
+
+        album, _ = self.add_fixtures(5998, 5999, 6000, 6001, 6002)
+        self.assertEqual(self.plugin.field_duration(album), "500:00")
+        self.assertEqual(self.plugin.album_field_avg_duration(album), "100:00")
+
+    def test_template_fields_for_duration_with_custom_format(self):
+        """Time format for duration fields should be configurable by the user"""
+        album, items = self.add_fixtures(0, 210, 300, 10000)
+
+        self._setup_config(duration_format=u'{mins:04d}m')
+        self.assertEqual(self.plugin.field_duration(album), "0175m")
+        self.assertEqual(self.plugin.album_field_avg_duration(album), "0043m")
+
+        self._setup_config(duration_format=u'{mins:2d}m{secs:03d}s')
+        self.assertEqual(self.plugin.field_duration(album), "175m010s")
+        self.assertEqual(self.plugin.album_field_avg_duration(album), "43m047s")
+
+    def test_template_fields_for_duration_usable_in_sorting(self):
+        """For sorting, duration sort fields should return integer values"""
+        album, items = self.add_fixtures(0, 100, 505)
+        self.assertEqual(self.plugin.field_duration_sort(items[0]), 0)
+        self.assertEqual(self.plugin.field_duration_sort(items[1]), 100)
+        self.assertEqual(self.plugin.field_duration_sort(album), 605)
+        self.assertEqual(self.plugin.album_field_avg_duration_sort(album), 201)
+
+        album, _ = self.add_fixtures(None, 5998, 5999, 6000, 6001, 6002)
+        self.assertEqual(self.plugin.album_field_avg_duration_sort(album), 5000)
+
+    def test_template_field_for_duration_based_spark_bar(self):
+        """For listing purpose, duration bar fields should return spark bar"""
+        album, items = self.add_fixtures(20, 80, 91, 340, 720)
+        self.assertEqual(self.plugin.field_duration_bar(items[0]), u' ')
+        self.assertEqual(self.plugin.field_duration_bar(items[1]), u'\u2581')
+        self.assertEqual(self.plugin.field_duration_bar(items[2]), u'\u2582')
+        self.assertEqual(self.plugin.field_duration_bar(items[3]), u'\u2587')
+        self.assertEqual(self.plugin.field_duration_bar(items[4]), u'\u2587')
+        self.assertEqual(self.plugin.field_duration_bar(album), u'\u2585')
+
+    def test_template_field_for_duration_based_custom_spark_bar(self):
+        """Spark bar for duration fields should be configurable by the user"""
+        album, _ = self.add_fixtures(20, 80, 91, 340, 720)
+        self._setup_config(track_length=800)
+        self.assertEqual(self.plugin.field_duration_bar(album), u'\u2582')
+        self._setup_config(track_length=600, sparks=u'▆▄▂')
+        self.assertEqual(self.plugin.field_duration_bar(album), u'\u2584')
+        self._setup_config(sparks=u'')
+        self.assertEqual(self.plugin.field_duration_bar(album), u'')
+
+class BetterListingPluginLyricsFieldsTest(BetterListingPluginTest):
+    def add_fixtures(self, lyrics=3, total=3):
+        """Add fixtures for the current tests."""
+        items = []
+        for i in range(total):
+            text = None if i + 1 > lyrics else "Some lyrics"
+            items.append(self.add_item(path="/", lyrics=text))
+        return [self.lib.add_album(items), items]
+
+    def test_template_field_for_lyrics_sort(self):
+        """For sorting queries, lyrics_sort field should return float value"""
+        album, items = self.add_fixtures(lyrics=3, total=5)
+        self.assertEqual(self.plugin.field_lyrics_sort(items[0]), 1)
+        self.assertEqual(self.plugin.field_lyrics_sort(items[4]), 0)
+        self.assertEqual(self.plugin.field_lyrics_sort(album), 0.6)
+        album, _ = self.add_fixtures(lyrics=3, total=3)
+        self.assertEqual(self.plugin.field_lyrics_sort(album), 1)
+        album, _ = self.add_fixtures(lyrics=0, total=3)
+        self.assertEqual(self.plugin.field_lyrics_sort(album), 0)
+
+    def test_template_field_for_lyrics_icon(self):
+        """For listing, lyrics_icon should return corresponding icon"""
+        album, items = self.add_fixtures(lyrics=3, total=5)
+        self.assertEqual(self.plugin.field_lyrics_icon(items[0]), u'\U0001f4d7')
+        self.assertEqual(self.plugin.field_lyrics_icon(items[4]), u'\U0001f4d5')
+        self.assertEqual(self.plugin.field_lyrics_icon(album), u'\U0001f4d9')
+        album, _ = self.add_fixtures(lyrics=3, total=3)
+        self.assertEqual(self.plugin.field_lyrics_icon(album), u'\U0001f4d7')
+        album, _ = self.add_fixtures(lyrics=0, total=3)
+        self.assertEqual(self.plugin.field_lyrics_icon(album), u'\U0001f4d5')
+
+    def test_template_field_for_lyrics_icon_with_custom_format_strings(self):
+        """lyrics_icon field should be configurable by the user"""
+        album, items = self.add_fixtures(lyrics=3, total=5)
+        self._setup_config(icon_lyrics_all=u'%colorize{◎ , green}',
+                           icon_lyrics_none=u'%colorize{◎ , red}',
+                           icon_lyrics_some=u'%colorize{◎ , yellow}')
+        expected = u'\x1b[32;01m\u25ce \x1b[39;49;00m'
+        self.assertEqual(self.plugin.field_lyrics_icon(items[0]), expected)
+        expected = u'\x1b[31;01m\u25ce \x1b[39;49;00m'
+        self.assertEqual(self.plugin.field_lyrics_icon(items[4]), expected)
+        expected = u'\x1b[33;01m\u25ce \x1b[39;49;00m'
+        self.assertEqual(self.plugin.field_lyrics_icon(album), expected)
+        album, _ = self.add_fixtures(lyrics=3, total=3)
+        expected = u'\x1b[32;01m\u25ce \x1b[39;49;00m'
+        self.assertEqual(self.plugin.field_lyrics_icon(album), expected)
+        album, _ = self.add_fixtures(lyrics=0, total=3)
+        expected = u'\x1b[31;01m\u25ce \x1b[39;49;00m'
+        self.assertEqual(self.plugin.field_lyrics_icon(album), expected)
+
+    def test_template_field_for_lyrics_icon_with_unicode_special_chars(self):
+        """lyrics_icon field should be configurable by the user"""
+        album, items = self.add_fixtures(lyrics=3, total=5)
+        self._setup_config(icon_lyrics_all=127477, icon_lyrics_none=127462,
+                           icon_lyrics_some=127474)
+        self.assertEqual(self.plugin.field_lyrics_icon(items[0]), u'\U0001f1f5')
+        self.assertEqual(self.plugin.field_lyrics_icon(items[4]), u'\U0001f1e6')
+        self.assertEqual(self.plugin.field_lyrics_icon(album), u'\U0001f1f2')
+        album, _ = self.add_fixtures(lyrics=3, total=3)
+        self.assertEqual(self.plugin.field_lyrics_icon(album), u'\U0001f1f5')
+        album, _ = self.add_fixtures(lyrics=0, total=3)
+        self.assertEqual(self.plugin.field_lyrics_icon(album), u'\U0001f1e6')
+
+
+class BetterListingPluginFieldsForAlbumTotalTest(BetterListingPluginTest):
+    def add_fixtures(self, available=3, total=5):
+        """Add fixtures for the current tests."""
+        items = []
+        for _ in range(available):
+            items.append(self.add_item(path="/", tracktotal=total))
+        return self.lib.add_album(items)
+
+    def test_album_fields_when_some_tracks_missing(self):
+        """Fields should return correct values when some tracks are missing"""
+        album = self.add_fixtures(available=4, total=10)
+        self.assertEqual(self.plugin.album_field_available(album), 4)
+        self.assertEqual(self.plugin.album_field_missing(album), 6)
+        self.assertEqual(self.plugin.album_field_total(album), 10)
+
+    def test_album_fields_when_all_tracks_present(self):
+        """Fields should return correct values when no track is missing"""
+        album = self.add_fixtures(available=10, total=10)
+        self.assertEqual(self.plugin.album_field_missing_icon(album), u'')
+        self.assertEqual(self.plugin.album_field_missing_bar(album), u' ')
+        self.assertEqual(self.plugin.album_field_available_bar(album), u'\u2587')
+
+    def test_album_fields_for_missing_icon(self):
+        """missing_icon field should return corresponding icon"""
+        album = self.add_fixtures(available=4, total=10)
+        expected = u'\x1b[31;01m\u25ce\x1b[39;49;00m'
+        self.assertEqual(self.plugin.album_field_missing_icon(album), expected)
+
+        album = self.add_fixtures(available=10, total=10)
+        self.assertEqual(self.plugin.album_field_missing_icon(album), u'')
+
+    def test_album_fields_for_missing_icon_with_custom_config_format(self):
+        """missing_icon field should be configurable by the user"""
+        self._setup_config(icon_missing_some=u'%colorize{ɱ,red}',
+                           icon_missing_none=u'%colorize{ɱ,green}')
+        album = self.add_fixtures(available=4, total=10)
+        expected = u'\x1b[31;01m\u0271\x1b[39;49;00m'
+        self.assertEqual(self.plugin.album_field_missing_icon(album), expected)
+
+        expected = u'\x1b[32;01m\u0271\x1b[39;49;00m'
+        album = self.add_fixtures(available=10, total=10)
+        self.assertEqual(self.plugin.album_field_missing_icon(album), expected)
+
+    def test_album_fields_for_missing_icon_with_unicode_special_chars(self):
+        """missing_icon field should be configurable by the user"""
+        self._setup_config(icon_missing_some=127477, icon_missing_none=127474)
+        album = self.add_fixtures(available=4, total=10)
+        self.assertEqual(self.plugin.album_field_missing_icon(album), u'\U0001f1f5')
+
+        album = self.add_fixtures(available=10, total=10)
+        self.assertEqual(self.plugin.album_field_missing_icon(album), u'\U0001f1f2')
+
+    def test_album_fields_for_missing_bar(self):
+        """missing_bar should return a spark bar for number of tracks missing"""
+        album = self.add_fixtures(available=5, total=8)
+        self.assertEqual(self.plugin.album_field_missing_bar(album), u'\u2583')
+
+        album = self.add_fixtures(available=8, total=8)
+        self.assertEqual(self.plugin.album_field_missing_bar(album), u' ')
+
+    def test_album_fields_for_available_bar(self):
+        """available_bar should return a spark bar for number of tracks present"""
+        album = self.add_fixtures(available=2, total=8)
+        self.assertEqual(self.plugin.album_field_available_bar(album), u'\u2582')
+
+        album = self.add_fixtures(available=8, total=8)
+        self.assertEqual(self.plugin.album_field_available_bar(album), u'\u2587')
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromName(__name__)
+
+if __name__ == b'__main__':
+    unittest.main(defaultTest='suite')

--- a/test/test_betterlisting.py
+++ b/test/test_betterlisting.py
@@ -18,10 +18,8 @@
 from __future__ import (division, absolute_import, print_function,
                         unicode_literals)
 
-from test import _common
 from test._common import unittest
 from beetsplug import betterlisting
-from beets import config
 
 from test.helper import TestHelper
 
@@ -31,7 +29,7 @@ class BetterListingPluginTest(unittest.TestCase, TestHelper):
         self.setup_beets()
         self.load_plugins('betterlisting')
         self.plugin = betterlisting.BetterListingPlugin()
-        default_config = { key:val.get() for key, val in
+        default_config = {key: val.get() for key, val in
                           self.plugin.config.items()}
         self._setup_config(**default_config)
 
@@ -191,6 +189,7 @@ class TemplateFieldsForDurationTest(BetterListingPluginTest):
         self._setup_config(sparks=u'')
         self.assertEqual(self.plugin.field_duration_bar(album), u'')
 
+
 class BetterListingPluginLyricsFieldsTest(BetterListingPluginTest):
     def add_fixtures(self, lyrics=3, total=3):
         """Add fixtures for the current tests."""
@@ -275,7 +274,8 @@ class BetterListingPluginFieldsForAlbumTotalTest(BetterListingPluginTest):
         album = self.add_fixtures(available=10, total=10)
         self.assertEqual(self.plugin.album_field_missing_icon(album), u'')
         self.assertEqual(self.plugin.album_field_missing_bar(album), u' ')
-        self.assertEqual(self.plugin.album_field_available_bar(album), u'\u2587')
+        self.assertEqual(self.plugin.album_field_available_bar(album),
+                         u'\u2587')
 
     def test_album_fields_for_missing_icon(self):
         """missing_icon field should return corresponding icon"""
@@ -302,10 +302,12 @@ class BetterListingPluginFieldsForAlbumTotalTest(BetterListingPluginTest):
         """missing_icon field should be configurable by the user"""
         self._setup_config(icon_missing_some=127477, icon_missing_none=127474)
         album = self.add_fixtures(available=4, total=10)
-        self.assertEqual(self.plugin.album_field_missing_icon(album), u'\U0001f1f5')
+        self.assertEqual(self.plugin.album_field_missing_icon(album),
+                         u'\U0001f1f5')
 
         album = self.add_fixtures(available=10, total=10)
-        self.assertEqual(self.plugin.album_field_missing_icon(album), u'\U0001f1f2')
+        self.assertEqual(self.plugin.album_field_missing_icon(album),
+                         u'\U0001f1f2')
 
     def test_album_fields_for_missing_bar(self):
         """missing_bar should return a spark bar for number of tracks missing"""
@@ -316,12 +318,15 @@ class BetterListingPluginFieldsForAlbumTotalTest(BetterListingPluginTest):
         self.assertEqual(self.plugin.album_field_missing_bar(album), u' ')
 
     def test_album_fields_for_available_bar(self):
-        """available_bar should return a spark bar for number of tracks present"""
+        """available_bar should return a spark bar for number of tracks
+        present"""
         album = self.add_fixtures(available=2, total=8)
-        self.assertEqual(self.plugin.album_field_available_bar(album), u'\u2582')
+        self.assertEqual(self.plugin.album_field_available_bar(album),
+                         u'\u2582')
 
         album = self.add_fixtures(available=8, total=8)
-        self.assertEqual(self.plugin.album_field_available_bar(album), u'\u2587')
+        self.assertEqual(self.plugin.album_field_available_bar(album),
+                         u'\u2587')
 
 
 def suite():


### PR DESCRIPTION
This PR adds a plugin to provide more template fields, functions, and query parameters. Specifically, it allows for tabularization of list results, and querying based on more fields than default ones.

Here is an example of what I have been able to achieve using this plugin:

```
± ➲ beet ls will duration_sort-
📗 ▅      04:22      01 Blurred Lines ft. T.I. & Pharrell Willia   [2013] Robin Thicke
📗 ▅      04:07      03 Get Lucky (radio edit) ft. Pharrell Will   [2013] Daft Punk
📗 ▅      04:06      40 This Is Love ft. Eva Simons                [2012] will.i.am
📗 ▅      03:52      19 Get Like Me ft. Nicki Minaj & Pharrell W   [2013] Nelly
📗 ▄      03:40      10 Something Really Bad ft. will.i.am         [2013] Dizzee Rascal
📗 ▄      03:40      16 Sonnentanz (Sun Don't Shine) ft. Will He   [2013] Klangkarussell
📗 ▄      03:22      02 Hall of Fame ft. will.i.am                 [2012] The Script
📕 ▃      02:18      16 I Will Survive                             [2013] Leah McFall
```

The first column represents whether the items have lyrics associated with them, and the second column displays the spark bars for the track duration of that item, and so on. This is just one of the examples. A simple format may look like this:

```
± ➲ beet ls will -f '$duration %rpad{$title,50} $year $artist' duration_sort-
04:22 Blurred Lines ft. T.I. & Pharrell Williams         2013 Robin Thicke
04:07 Get Lucky (radio edit) ft. Pharrell Williams       2013 Daft Punk
04:06 This Is Love ft. Eva Simons                        2012 will.i.am
03:52 Get Like Me ft. Nicki Minaj & Pharrell Williams    2013 Nelly
03:40 Something Really Bad ft. will.i.am                 2013 Dizzee Rascal
03:40 Sonnentanz (Sun Don't Shine) ft. Will Heard        2013 Klangkarussell
03:22 Hall of Fame ft. will.i.am                         2012 The Script
02:18 I Will Survive                                     2013 Leah McFall
```

Furthermore, plugin allows querying the database for fields such as ratio of lyrics present vs total tracks, average duration of tracks in an album, total duration of track/album, number of tracks missing/available/total from an album, etc.

I plan to add more fields and functions to this plugin, if it gets an okay from you guys. Note that this is the first time I have written in Python, and hence, this PR may come with a grain of salt. Do let me know what needs to be changed, and if I understand that much Python, I will try to improve upon the PR by pushing more commits.
