### PR TITLE
Implement `--pretend` option for the move command

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -615,6 +615,44 @@ def show_model_changes(new, old=None, fields=None, always=False):
     return bool(changes)
 
 
+def show_path_changes(path_changes):
+    """ Given a list of tuples (source, destination) that indicate the path
+    changes, the changes are shown. Output is guaranteed to be unicode.
+
+    Every tuple is shown on a single line if the terminal width permits it,
+    else it is split over two lines. E.g.,
+
+    Source -> Destination
+
+    vs.
+
+    Source
+      -> Destination
+    """
+    sources, destinations = zip(*path_changes)
+
+    # Ensure unicode output
+    sources = map(util.displayable_path, sources)
+    destinations = map(util.displayable_path, destinations)
+
+    # Calculate widths for terminal split
+    col_width = (term_width() - len(' -> ')) // 2
+    max_width = len(max(sources + destinations, key=len))
+
+    if max_width > col_width:
+        # Print every change over two lines
+        for source, dest in zip(sources, destinations):
+            log.info(u'{0} \n  -> {1}', source, dest)
+    else:
+        # Print every change on a single line, and add a header
+        title_pad = max_width - len('Source ') + len(' -> ')
+
+        log.info(u'Source {0} Destination', ' ' * title_pad)
+        for source, dest in zip(sources, destinations):
+            pad = max_width - len(source)
+            log.info(u'{0} {1} -> {2}', source, ' ' * pad, dest)
+
+
 class CommonOptionsParser(optparse.OptionParser, object):
     """Offers a simple way to add common formatting options.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,8 @@ New features:
   This plugin is still in an experimental phase. :bug:`1450`
 * The :doc:`/plugins/fetchart` plugin will now complain for the `enforce_ratio`
   and `min_width` options if no local imaging backend is available. :bug:`1460`
+* The `move` command has a new `-p/--pretend` option, making the command show
+  how the items will be moved, without modifying the files on disk.
 
 
 Fixes:

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -245,7 +245,7 @@ move
 ````
 ::
 
-    beet move [-ca] [-d DIR] QUERY
+    beet move [-cap] [-d DIR] QUERY
 
 Move or copy items in your library.
 
@@ -254,6 +254,10 @@ query are renamed into your library directory structure. By specifying a
 destination directory with ``-d`` manually, you can move items matching a query
 anywhere in your filesystem. The ``-c`` option copies files instead of moving
 them. As with other commands, the ``-a`` option matches albums instead of items.
+
+To perform a "dry run", just use the ``-p`` (for "pretend") flag. This will
+show you all how the files would be moved but won't actually change anything
+on disk.
 
 .. _update-cmd:
 

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -373,8 +373,9 @@ class MoveTest(_common.TestCase):
         # Alternate destination directory.
         self.otherdir = os.path.join(self.temp_dir, 'testotherdir')
 
-    def _move(self, query=(), dest=None, copy=False, album=False):
-        commands.move_items(self.lib, dest, query, copy, album)
+    def _move(self, query=(), dest=None, copy=False, album=False,
+              pretend=False):
+        commands.move_items(self.lib, dest, query, copy, album, pretend)
 
     def test_move_item(self):
         self._move()
@@ -417,6 +418,16 @@ class MoveTest(_common.TestCase):
         self.assertTrue('testotherdir' in self.i.path)
         self.assertExists(self.i.path)
         self.assertNotExists(self.itempath)
+
+    def test_pretend_move_item(self):
+        self._move(dest=self.otherdir, pretend=True)
+        self.i.load()
+        self.assertIn('srcfile', self.i.path)
+
+    def test_pretend_move_album(self):
+        self._move(album=True, pretend=True)
+        self.i.load()
+        self.assertIn('srcfile', self.i.path)
 
 
 class UpdateTest(_common.TestCase):


### PR DESCRIPTION
This very old issue (#247) came up again recently (#1455). This patch gets it done, and can also close the related PR #304 that is almost 2 years old.

I've implemented the `show_path_changes` method as proposed in issue #1405 (for showing destination during import) such that changes are printed over 1 or 2 lines depending on terminal width.
