### PR TITLE
Fix beet web search with non-ascii characters

### DIFF
--- a/beetsplug/web/static/beets.js
+++ b/beetsplug/web/static/beets.js
@@ -229,7 +229,7 @@ var AppView = Backbone.View.extend({
     },
     querySubmit: function(ev) {
         ev.preventDefault();
-        router.navigate('item/query/' + escape($('#query').val()), true);
+        router.navigate('item/query/' + encodeURIComponent($('#query').val()), true);
     },
     initialize: function() {
         this.playingItem = null;


### PR DESCRIPTION
Beet web's search is broken when searching for non-ascii characters. This is because the combination of beet.js' escape() and backbone.js' decodeURIComponent() is incapable of processing strange characters (in my case, japanese).

Also, escape() is heavily deprecated.
