### PR TITLE
Fix discogs disc field is set to zero

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -299,6 +299,7 @@ class DiscogsPlugin(BeetsPlugin):
                 medium_count += 1
                 index_count = 0
             index_count += 1
+            medium_count = 1 if medium_count == 0 else medium_count
             track.medium, track.medium_index = medium_count, index_count
 
         # Get `disctitle` from Discogs index tracks. Assume that an index track


### PR DESCRIPTION
Fix for #587. Disc field is only zero when there is only one medium, so this will do the trick. I wasn't able to reproduce the real problem within the code. This is just a small workaround.