### PR TITLE
Add option to strip certain strings from album search

### DIFF
--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -421,7 +421,8 @@ def tag_album(items, search_artist=None, search_album=None,
         if not (search_artist and search_album):
             # No explicit search terms -- use current metadata.
             search_artist, search_album = cur_artist, cur_album
-            search_album = re.sub(config['strip_album_search'].get(), '', search_album)
+            search_album = re.sub(config['strip_album_search'].get(), '', 
+                                  search_album)
         log.debug(u'Search terms: {0} - {1}', search_artist, search_album)
 
         # Is this album likely to be a "various artist" release?

--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -421,7 +421,7 @@ def tag_album(items, search_artist=None, search_album=None,
         if not (search_artist and search_album):
             # No explicit search terms -- use current metadata.
             search_artist, search_album = cur_artist, cur_album
-            search_album = re.sub(config['strip_album_search'].get(), '', 
+            search_album = re.sub(config['strip_album_search'].get(), '',
                                   search_album)
         log.debug(u'Search terms: {0} - {1}', search_artist, search_album)
 

--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -421,6 +421,7 @@ def tag_album(items, search_artist=None, search_album=None,
         if not (search_artist and search_album):
             # No explicit search terms -- use current metadata.
             search_artist, search_album = cur_artist, cur_album
+            search_album = re.sub(config['strip_album_search'].get(), '', search_album)
         log.debug(u'Search terms: {0} - {1}', search_artist, search_album)
 
         # Is this album likely to be a "various artist" release?

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -48,6 +48,7 @@ terminal_encoding:
 original_date: no
 id3v23: no
 va_name: "Various Artists"
+strip_album_search: ''
 
 ui:
     terminal_width: 80


### PR DESCRIPTION
I would like to have the ability to strip certain strings from the album search strings that are passed to musicbrainz/discogs.

For example, I often found albums with the following album name:
'Some album name WEB'. With the proposed changes 'WEB' can be stripped from the album search queries if you configure it like this:
`strip_album_search: '(WEB)\Z'`
In the end, searches should be more accurate (especially the searches done by discogs).
