### PR TITLE
beet fields: Print flexible attributes

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -79,6 +79,14 @@ def _do_query(lib, query, album, also_items=True):
     return items, albums
 
 
+def _print_sqlite(query):
+    """Gets the result of the query, transforms the sqlite3.Row in dictionary
+    entries and print the values of it, with identation of 2 spaces.
+    """
+    for row in query:
+        print_(' ' * 2 + dict(zip(row.keys(), row))['key'])
+
+
 # fields: Shows a list of available fields for queries and format strings.
 
 def fields_func(lib, opts, args):
@@ -92,6 +100,15 @@ def fields_func(lib, opts, args):
     print_("Album fields:")
     _print_rows(library.Album.all_keys())
 
+    with lib.transaction() as tx:
+        # The SQL uses the DISTINCT to get unique values from the query
+        unique_fields = 'SELECT DISTINCT key FROM (%s)'
+
+        print_("Item flexible attributes:")
+        _print_sqlite(tx.query(unique_fields % library.Item._flex_table))
+
+        print_("Album flexible attributes:")
+        _print_sqlite(tx.query(unique_fields % library.Album._flex_table))
 
 fields_cmd = ui.Subcommand(
     'fields',

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,8 @@ New:
   session. :bug:`1779`
 * :doc:`/plugins/info`: A new option will print only fields' names and not
   their values. Thanks to :user:`GuilhermeHideki`. :bug:`1812`
+* The :ref:`fields-cmd` command now displays flexible attributes. 
+  Thanks to :user:`GuilhermeHideki`. :bug:`1818`
 
 .. _AcousticBrainz: http://acousticbrainz.org/
 


### PR DESCRIPTION
Tries to solve #544.

I'm not sure if this needs an flag, since isn't slow (at least to me), but would avoid one db access.
If needs, what could be a good single letter/long option?
- `-x` for `--flexattr/--flexible-attributes` ?
- `-f` is usually `format`, so maybe not
- `-a` is usually `album`

Should I add 'flexible' in 'item/album attributes' ?
