### PR TITLE
Fix unrestored AutotagStub on two TestCases

### DIFF
--- a/test/test_mbsubmit.py
+++ b/test/test_mbsubmit.py
@@ -34,6 +34,7 @@ class MBSubmitPluginTest(TerminalImportSessionSetup, unittest.TestCase,
     def tearDown(self):
         self.unload_plugins()
         self.teardown_beets()
+        self.matcher.restore()
 
     def test_print_tracks_output(self):
         """Test the output of the "print tracks" choice."""

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -419,6 +419,7 @@ class PromptChoicesTest(TerminalImportSessionSetup, unittest.TestCase,
         self.input_options_patcher.stop()
         self.teardown_plugin_loader()
         self.teardown_beets()
+        self.matcher.restore()
 
     def test_plugin_choices_in_ui_input_options_album(self):
         """Test the presence of plugin choices on the prompt (album)."""


### PR DESCRIPTION
An attempt to fix #1827, by appending the missing `self.matcher.restore()` calls to the `tearDown()` of `test_mbsubmit.MBSubmitPluginTest` and `test_plugins.PromptChoicesTest`.

I have also double-checked the rest of the tests that use `AutotagStub`, and all seems to be in good order. I'll make sure to triple-check in the future should I need to use `AutotagStub` again!