### PR TITLE
Skip GStreamer tests if plugins are missing

### DIFF
--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -43,6 +43,11 @@ class FatalReplayGainError(Exception):
     """
 
 
+class FatalGstreamerPluginReplayGainError(FatalReplayGainError):
+    """Raised when a fatal error occurs in the GStreamerBackend when
+    loading the required plugins."""
+
+
 def call(args):
     """Execute the command and return its output or raise a
     ReplayGainError on failure.
@@ -391,7 +396,7 @@ class GStreamerBackend(Backend):
 
         if self._src is None or self._decbin is None or self._conv is None \
            or self._res is None or self._rg is None:
-            raise FatalReplayGainError(
+            raise FatalGstreamerPluginReplayGainError(
                 "Failed to load required GStreamer plugins"
             )
 

--- a/test/test_replaygain.py
+++ b/test/test_replaygain.py
@@ -20,7 +20,9 @@ from __future__ import (division, absolute_import, print_function,
 from test._common import unittest
 from test.helper import TestHelper, has_program
 
+from beets import config
 from beets.mediafile import MediaFile
+from beetsplug.replaygain import FatalReplayGainError, GStreamerBackend
 
 try:
     import gi
@@ -87,6 +89,13 @@ class ReplayGainCliTestBase(TestHelper):
             self.assertIsNone(mediafile.rg_track_gain)
 
         self.run_command('replaygain')
+
+        # Skip the test if rg_track_peak and rg_track gain is None, assuming
+        # that it could only happen if the decoder plugins are missing.
+        if all(i.rg_track_peak is None and i.rg_track_gain is None
+               for i in self.lib.items()):
+            self.skipTest('decoder plugins could not be loaded.')
+
         for item in self.lib.items():
             self.assertIsNotNone(item.rg_track_peak)
             self.assertIsNotNone(item.rg_track_gain)
@@ -131,6 +140,20 @@ class ReplayGainCliTestBase(TestHelper):
 @unittest.skipIf(not GST_AVAILABLE, 'gstreamer cannot be found')
 class ReplayGainGstCliTest(ReplayGainCliTestBase, unittest.TestCase):
     backend = u'gstreamer'
+
+    def setUp(self):
+        try:
+            # Check if required plugins can be loaded by instantiating a
+            # GStreamerBackend (via its .__init__).
+            config['replaygain']['targetlevel'] = 89
+            GStreamerBackend(config['replaygain'], None)
+        except FatalReplayGainError as e:
+            # Skip the test if plugins could not be loaded.
+            if str(e) == "Failed to load required GStreamer plugins":
+                self.skipTest(str(e))
+            else:
+                raise e
+        super(ReplayGainGstCliTest, self).setUp()
 
 
 @unittest.skipIf(not GAIN_PROG_AVAILABLE, 'no *gain command found')

--- a/test/test_replaygain.py
+++ b/test/test_replaygain.py
@@ -22,7 +22,8 @@ from test.helper import TestHelper, has_program
 
 from beets import config
 from beets.mediafile import MediaFile
-from beetsplug.replaygain import FatalReplayGainError, GStreamerBackend
+from beetsplug.replaygain import (FatalGstreamerPluginReplayGainError,
+                                  GStreamerBackend)
 
 try:
     import gi
@@ -147,12 +148,10 @@ class ReplayGainGstCliTest(ReplayGainCliTestBase, unittest.TestCase):
             # GStreamerBackend (via its .__init__).
             config['replaygain']['targetlevel'] = 89
             GStreamerBackend(config['replaygain'], None)
-        except FatalReplayGainError as e:
+        except FatalGstreamerPluginReplayGainError as e:
             # Skip the test if plugins could not be loaded.
-            if str(e) == "Failed to load required GStreamer plugins":
-                self.skipTest(str(e))
-            else:
-                raise e
+            self.skipTest(str(e))
+
         super(ReplayGainGstCliTest, self).setUp()
 
 


### PR DESCRIPTION
* Add a check to ReplayGainGstCliTest that ensures that the required
initial gstreamer plugins can be loaded, skipping the test if it is not
the case instead of running it.
* Add a check to ReplayGainGstCliTest.test_cli_saves_track_gain for
checking if item.rg_track_peak and item.rg_track_gain is not None. If
they are None, it is assumed that the decoder plugins could not be
found, and the tests is skipped, as discussed on #1830.