### PR TITLE
Fixed bug when running subset of testcases

### DIFF
--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -632,7 +632,8 @@ class ConfigTest(unittest.TestCase, TestHelper):
     def tearDown(self):
         commands.default_commands.pop()
         os.chdir(self._orig_cwd)
-        os.environ['HOME'] = self._old_home
+        if self._old_home is not None:
+            os.environ['HOME'] = self._old_home
         self.teardown_beets()
 
     def _make_test_cmd(self):


### PR DESCRIPTION
Happens when invoking `tox -e py27 test.test_ui` directly.
`os.environ.get('HOME')` seems to return None and raises an Exception
in tearDown of class

Before merge: Why isn't ConfigTest derived from _common.TestCase as it would automatically set up Home environment?