### PR TITLE
edit: allow interactive editing during the importer

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -672,7 +672,8 @@ class ImportTask(BaseImportTask):
                     # old paths.
                     item.move(copy, link)
 
-            if write and self.apply:
+            # TODO: the EDIT_FLAG field is a hack!
+            if write and (self.apply or getattr(self, 'EDIT_FLAG', False)):
                 item.try_write()
 
         with session.lib.transaction():

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -621,8 +621,12 @@ class ImportTask(BaseImportTask):
         """Make some album fields equal across `self.items`.
         """
         changes = {}
+        # Determine where to gather the info from for the RETAG action.
+        retag_asis = (self.choice_flag == action.RETAG and
+                      not self.items[0].artist and
+                      not self.items[0].mb_artistid)
 
-        if self.choice_flag == action.ASIS:
+        if self.choice_flag == action.ASIS or retag_asis:
             # Taking metadata "as-is". Guess whether this album is VA.
             plur_albumartist, freq = util.plurality(
                 [i.albumartist or i.artist for i in self.items]
@@ -808,8 +812,8 @@ class SingletonImportTask(ImportTask):
         self.paths = [item.path]
 
     def chosen_ident(self):
-        assert self.choice_flag in (action.ASIS, action.APPLY)
-        if self.choice_flag is action.ASIS:
+        assert self.choice_flag in (action.ASIS, action.APPLY, action.RETAG)
+        if self.choice_flag in (action.ASIS, action.RETAG):
             return (self.item.artist, self.item.title)
         elif self.choice_flag is action.APPLY:
             return (self.match.info.artist, self.match.info.title)

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -853,7 +853,9 @@ class TerminalImportSession(importer.ImportSession):
         checking the right conditions and returning a list of `PromptChoice`s,
         which is flattened and checked for conflicts.
 
-        Raises `ValueError` if two of the choices have the same short letter.
+        If two or more choices have the same short letter, a warning is
+        emitted and all but one choices are discarded, giving preference
+        to the default importer choices.
 
         Returns a list of `PromptChoice`s.
         """

--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -399,7 +399,7 @@ class EditPlugin(plugins.BeetsPlugin):
         # Prompt the user for a candidate, and simulate matching.
         sel = ui.input_options([], numrange=(1, len(task.candidates)))
         # Force applying the candidate on the items.
-        task.match = task.candidates[sel-1]
+        task.match = task.candidates[sel - 1]
         task.apply_metadata()
 
         return self.importer_edit(session, task)

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -585,10 +585,11 @@ album has no candidates, the relevant checks against ``task.candidates`` should
 be performed inside the plugin's ``before_choose_candidate_event`` accordingly.
 
 Please make sure that the short letter for each of the choices provided by the
-plugin is not already in use: the importer will raise an exception if two or
-more choices try to use the same short letter. As a reference, the following
-characters are used by the choices on the core importer prompt, and hence
-should not be used: ``a``, ``s``, ``u``, ``t``, ``g``, ``e``, ``i``, ``b``.
+plugin is not already in use: the importer will emit a warning and discard
+all but one of the choices using the same letter, giving priority to the
+core importer prompt choices. As a reference, the following characters are used
+by the choices on the core importer prompt, and hence should not be used:
+``a``, ``s``, ``u``, ``t``, ``g``, ``e``, ``i``, ``b``.
 
 Additionally, the callback function can optionally specify the next action to
 be performed by returning one of the values from ``importer.action``, which

--- a/docs/plugins/edit.rst
+++ b/docs/plugins/edit.rst
@@ -23,6 +23,30 @@ The ``edit`` command has these command-line options:
   (in addition to the defaults set in the configuration).
 - ``--all``: Edit *all* available fields.
 
+Interactive Usage
+-----------------
+
+The ``edit`` plugin can also be invoked during an import session. If enabled, it
+adds two new options to the user prompt::
+
+    [A]pply, More candidates, Skip, Use as-is, as Tracks, Group albums, Enter search, enter Id, aBort, eDit, edit Candidates?
+
+- ``eDit``: use this option for using the original items' metadata as the
+  starting point for your edits.
+- ``edit Candidates``: use this option for using a candidate's metadata as the
+  starting point for your edits.
+
+Please note that currently the interactive usage of the plugin will only allow
+you to change the item-level fields. In case you need to edit the album-level
+fields, the recommended approach is to invoke the plugin via the command line
+in album mode (``beet edit -a QUERY``) after the import.
+
+Also, please be aware that the ``edit Candidates`` choice can only be used with
+the matches found during the initial search (and currently not supporting the
+candidates found via the ``Enter search`` or ``enter Id`` choices). You might
+find the ``--search-id SEARCH_ID`` :ref:`import-cmd` option useful for those
+cases where you already have a specific candidate ID that you want to edit.
+
 Configuration
 -------------
 

--- a/test/test_edit.py
+++ b/test/test_edit.py
@@ -20,11 +20,15 @@ from mock import patch
 from test import _common
 from test._common import unittest
 from test.helper import TestHelper, control_stdin
+from test.test_ui_importer import TerminalImportSessionSetup
+from test.test_importer import ImportHelper, AutotagStub
+from beets.library import Item
 
 
 class ModifyFileMocker(object):
     """Helper for modifying a file, replacing or editing its contents. Used for
-    mocking the calls to the external editor during testing."""
+    mocking the calls to the external editor during testing.
+    """
 
     def __init__(self, contents=None, replacements=None):
         """ `self.contents` and `self.replacements` are initalized here, in
@@ -63,52 +67,8 @@ class ModifyFileMocker(object):
             f.write(contents)
 
 
-@_common.slow_test()
-class EditCommandTest(unittest.TestCase, TestHelper):
-    """ Black box tests for `beetsplug.edit`. Command line interaction is
-    simulated using `test.helper.control_stdin()`, and yaml editing via an
-    external editor is simulated using `ModifyFileMocker`.
-    """
-    ALBUM_COUNT = 1
-    TRACK_COUNT = 10
-
-    def setUp(self):
-        self.setup_beets()
-        self.load_plugins('edit')
-        # make sure that we avoid invoking the editor except for making changes
-        self.config['edit']['diff_method'] = ''
-        # add an album, storing the original fields for comparison
-        self.album = self.add_album_fixture(track_count=self.TRACK_COUNT)
-        self.album_orig = {f: self.album[f] for f in self.album._fields}
-        self.items_orig = [{f: item[f] for f in item._fields} for
-                           item in self.album.items()]
-
-        # keep track of write()s
-        self.write_patcher = patch('beets.library.Item.write')
-        self.mock_write = self.write_patcher.start()
-
-    def tearDown(self):
-        self.write_patcher.stop()
-        self.teardown_beets()
-        self.unload_plugins()
-
-    def run_mocked_command(self, modify_file_args={}, stdin=[], args=[]):
-        """Run the edit command, with mocked stdin and yaml writing, and
-        passing `args` to `run_command`."""
-        m = ModifyFileMocker(**modify_file_args)
-        with patch('beetsplug.edit.edit', side_effect=m.action):
-            with control_stdin('\n'.join(stdin)):
-                self.run_command('edit', *args)
-
-    def assertCounts(self, album_count=ALBUM_COUNT, track_count=TRACK_COUNT,
-                     write_call_count=TRACK_COUNT, title_starts_with=''):
-        """Several common assertions on Album, Track and call counts."""
-        self.assertEqual(len(self.lib.albums()), album_count)
-        self.assertEqual(len(self.lib.items()), track_count)
-        self.assertEqual(self.mock_write.call_count, write_call_count)
-        self.assertTrue(all(i.title.startswith(title_starts_with)
-                            for i in self.lib.items()))
-
+class EditMixin(object):
+    """Helper containing some common functionality used for the Edit tests."""
     def assertItemFieldsModified(self, library_items, items, fields=[],
                                  allowed=['path']):
         """Assert that items in the library (`lib_items`) have different values
@@ -125,9 +85,63 @@ class EditCommandTest(unittest.TestCase, TestHelper):
             self.assertEqual(set(diff_fields).difference(allowed),
                              set(fields))
 
+    def run_mocked_interpreter(self, modify_file_args={}, stdin=[]):
+        """Run the edit command during an import session, with mocked stdin and
+        yaml writing.
+        """
+        m = ModifyFileMocker(**modify_file_args)
+        with patch('beetsplug.edit.edit', side_effect=m.action):
+            with control_stdin('\n'.join(stdin)):
+                self.importer.run()
+
+    def run_mocked_command(self, modify_file_args={}, stdin=[], args=[]):
+        """Run the edit command, with mocked stdin and yaml writing, and
+        passing `args` to `run_command`."""
+        m = ModifyFileMocker(**modify_file_args)
+        with patch('beetsplug.edit.edit', side_effect=m.action):
+            with control_stdin('\n'.join(stdin)):
+                self.run_command('edit', *args)
+
+
+@_common.slow_test()
+class EditCommandTest(unittest.TestCase, TestHelper, EditMixin):
+    """Black box tests for `beetsplug.edit`. Command line interaction is
+    simulated using `test.helper.control_stdin()`, and yaml editing via an
+    external editor is simulated using `ModifyFileMocker`.
+    """
+    ALBUM_COUNT = 1
+    TRACK_COUNT = 10
+
+    def setUp(self):
+        self.setup_beets()
+        self.load_plugins('edit')
+        # Add an album, storing the original fields for comparison.
+        self.album = self.add_album_fixture(track_count=self.TRACK_COUNT)
+        self.album_orig = {f: self.album[f] for f in self.album._fields}
+        self.items_orig = [{f: item[f] for f in item._fields} for
+                           item in self.album.items()]
+
+        # Keep track of write()s.
+        self.write_patcher = patch('beets.library.Item.write')
+        self.mock_write = self.write_patcher.start()
+
+    def tearDown(self):
+        self.write_patcher.stop()
+        self.teardown_beets()
+        self.unload_plugins()
+
+    def assertCounts(self, album_count=ALBUM_COUNT, track_count=TRACK_COUNT,
+                     write_call_count=TRACK_COUNT, title_starts_with=''):
+        """Several common assertions on Album, Track and call counts."""
+        self.assertEqual(len(self.lib.albums()), album_count)
+        self.assertEqual(len(self.lib.items()), track_count)
+        self.assertEqual(self.mock_write.call_count, write_call_count)
+        self.assertTrue(all(i.title.startswith(title_starts_with)
+                            for i in self.lib.items()))
+
     def test_title_edit_discard(self):
-        """Edit title for all items in the library, then discard changes-"""
-        # edit titles
+        """Edit title for all items in the library, then discard changes."""
+        # Edit track titles.
         self.run_mocked_command({'replacements': {u't\u00eftle':
                                                   u'modified t\u00eftle'}},
                                 # Cancel.
@@ -139,7 +153,7 @@ class EditCommandTest(unittest.TestCase, TestHelper):
 
     def test_title_edit_apply(self):
         """Edit title for all items in the library, then apply changes."""
-        # edit titles
+        # Edit track titles.
         self.run_mocked_command({'replacements': {u't\u00eftle':
                                                   u'modified t\u00eftle'}},
                                 # Apply changes.
@@ -152,14 +166,14 @@ class EditCommandTest(unittest.TestCase, TestHelper):
 
     def test_single_title_edit_apply(self):
         """Edit title for one item in the library, then apply changes."""
-        # edit title
+        # Edit one track title.
         self.run_mocked_command({'replacements': {u't\u00eftle 9':
                                                   u'modified t\u00eftle 9'}},
                                 # Apply changes.
                                 ['a'])
 
         self.assertCounts(write_call_count=1,)
-        # no changes except on last item
+        # No changes except on last item.
         self.assertItemFieldsModified(list(self.album.items())[:-1],
                                       self.items_orig[:-1], [])
         self.assertEqual(list(self.album.items())[-1].title,
@@ -167,9 +181,9 @@ class EditCommandTest(unittest.TestCase, TestHelper):
 
     def test_noedit(self):
         """Do not edit anything."""
-        # do not edit anything
+        # Do not edit anything.
         self.run_mocked_command({'contents': None},
-                                # no stdin
+                                # No stdin.
                                 [])
 
         self.assertCounts(write_call_count=0,
@@ -180,7 +194,7 @@ class EditCommandTest(unittest.TestCase, TestHelper):
         """Edit the album field for all items in the library, apply changes.
         By design, the album should not be updated.""
         """
-        # edit album
+        # Edit album.
         self.run_mocked_command({'replacements': {u'\u00e4lbum':
                                                   u'modified \u00e4lbum'}},
                                 # Apply changes.
@@ -189,14 +203,14 @@ class EditCommandTest(unittest.TestCase, TestHelper):
         self.assertCounts(write_call_count=self.TRACK_COUNT)
         self.assertItemFieldsModified(self.album.items(), self.items_orig,
                                       ['album'])
-        # ensure album is *not* modified
+        # Ensure album is *not* modified.
         self.album.load()
         self.assertEqual(self.album.album, u'\u00e4lbum')
 
     def test_single_edit_add_field(self):
         """Edit the yaml file appending an extra field to the first item, then
         apply changes."""
-        # append "foo: bar" to item with id == 1
+        # Append "foo: bar" to item with id == 1.
         self.run_mocked_command({'replacements': {u"id: 1":
                                                   u"id: 1\nfoo: bar"}},
                                 # Apply changes.
@@ -237,7 +251,7 @@ class EditCommandTest(unittest.TestCase, TestHelper):
     def test_malformed_yaml(self):
         """Edit the yaml file incorrectly (resulting in a malformed yaml
         document)."""
-        # edit the yaml file to an invalid file
+        # Edit the yaml file to an invalid file.
         self.run_mocked_command({'contents': '!MALFORMED'},
                                 # Edit again to fix? No.
                                 ['n'])
@@ -248,13 +262,159 @@ class EditCommandTest(unittest.TestCase, TestHelper):
     def test_invalid_yaml(self):
         """Edit the yaml file incorrectly (resulting in a well-formed but
         invalid yaml document)."""
-        # edit the yaml file to an invalid file
+        # Edit the yaml file to an invalid but parseable file.
         self.run_mocked_command({'contents': 'wellformed: yes, but invalid'},
-                                # no stdin
+                                # No stdin.
                                 [])
 
         self.assertCounts(write_call_count=0,
                           title_starts_with=u't\u00eftle')
+
+
+@_common.slow_test()
+class EditDuringImporterTest(TerminalImportSessionSetup, unittest.TestCase,
+                             ImportHelper, TestHelper, EditMixin):
+    """TODO
+    """
+    IGNORED = ['added', 'album_id', 'id', 'mtime', 'path']
+
+    def setUp(self):
+        self.setup_beets()
+        self.load_plugins('edit')
+        # Create some mediafiles, and store them for comparison.
+        self._create_import_dir(3)
+        self.items_orig = [Item.from_path(f.path) for f in self.media_files]
+        self.matcher = AutotagStub().install()
+        self.matcher.matching = AutotagStub.GOOD
+        self.config['import']['timid'] = True
+
+    def tearDown(self):
+        self.unload_plugins()
+        self.teardown_beets()
+        self.matcher.restore()
+
+    def test_edit_apply_asis(self):
+        """Edit the album field for all items in the library, apply changes,
+        using the original item tags.
+        """
+        self._setup_import_session()
+        # Edit track titles.
+        self.run_mocked_interpreter({'replacements': {u'Tag Title':
+                                                      u'Edited Title'}},
+                                    # eDit, Apply changes.
+                                    ['d', 'a'])
+
+        # Check that only the 'title' field is modified.
+        self.assertItemFieldsModified(self.lib.items(), self.items_orig,
+                                      ['title'],
+                                      self.IGNORED + ['albumartist',
+                                                      'mb_albumartistid'])
+        self.assertTrue(all('Edited Title' in i.title
+                            for i in self.lib.items()))
+
+        # Ensure album is *not* fetched from a candidate.
+        self.assertEqual(self.lib.albums()[0].mb_albumid, u'')
+
+    def test_edit_discard_asis(self):
+        """Edit the album field for all items in the library, discard changes,
+        using the original item tags.
+        """
+        self._setup_import_session()
+        # Edit track titles.
+        self.run_mocked_interpreter({'replacements': {u'Tag Title':
+                                                      u'Edited Title'}},
+                                    # eDit, Cancel, Use as-is.
+                                    ['d', 'c', 'u'])
+
+        # Check that nothing is modified, the album is imported ASIS.
+        self.assertItemFieldsModified(self.lib.items(), self.items_orig,
+                                      [],
+                                      self.IGNORED + ['albumartist',
+                                                      'mb_albumartistid'])
+        self.assertTrue(all('Tag Title' in i.title
+                            for i in self.lib.items()))
+
+        # Ensure album is *not* fetched from a candidate.
+        self.assertEqual(self.lib.albums()[0].mb_albumid, u'')
+
+    def test_edit_apply_candidate(self):
+        """Edit the album field for all items in the library, apply changes,
+        using a candidate.
+        """
+        self._setup_import_session()
+        # Edit track titles.
+        self.run_mocked_interpreter({'replacements': {u'Applied Title':
+                                                      u'Edited Title'}},
+                                    # edit Candidates, 1, Apply changes.
+                                    ['c', '1', 'a'])
+
+        # Check that 'title' field is modified, and other fields come from
+        # the candidate.
+        self.assertTrue(all('Edited Title ' in i.title
+                            for i in self.lib.items()))
+        self.assertTrue(all('match ' in i.mb_trackid
+                            for i in self.lib.items()))
+
+        # Ensure album is fetched from a candidate.
+        self.assertIn('albumid', self.lib.albums()[0].mb_albumid)
+
+    def test_edit_discard_candidate(self):
+        """Edit the album field for all items in the library, discard changes,
+        using a candidate.
+        """
+        self._setup_import_session()
+        # Edit track titles.
+        self.run_mocked_interpreter({'replacements': {u'Applied Title':
+                                                      u'Edited Title'}},
+                                    # edit Candidates, 1, Apply changes.
+                                    ['c', '1', 'a'])
+
+        # Check that 'title' field is modified, and other fields come from
+        # the candidate.
+        self.assertTrue(all('Edited Title ' in i.title
+                            for i in self.lib.items()))
+        self.assertTrue(all('match ' in i.mb_trackid
+                            for i in self.lib.items()))
+
+        # Ensure album is fetched from a candidate.
+        self.assertIn('albumid', self.lib.albums()[0].mb_albumid)
+
+    def test_edit_apply_asis_singleton(self):
+        """Edit the album field for all items in the library, apply changes,
+        using the original item tags and singleton mode.
+        """
+        self._setup_import_session(singletons=True)
+        # Edit track titles.
+        self.run_mocked_interpreter({'replacements': {u'Tag Title':
+                                                      u'Edited Title'}},
+                                    # eDit, Apply changes, aBort.
+                                    ['d', 'a', 'b'])
+
+        # Check that only the 'title' field is modified.
+        self.assertItemFieldsModified(self.lib.items(), self.items_orig,
+                                      ['title'],
+                                      self.IGNORED + ['albumartist',
+                                                      'mb_albumartistid'])
+        self.assertTrue(all('Edited Title' in i.title
+                            for i in self.lib.items()))
+
+    def test_edit_apply_candidate_singleton(self):
+        """Edit the album field for all items in the library, apply changes,
+        using a candidate and singleton mode.
+        """
+        self._setup_import_session()
+        # Edit track titles.
+        self.run_mocked_interpreter({'replacements': {u'Applied Title':
+                                                      u'Edited Title'}},
+                                    # edit Candidates, 1, Apply changes, aBort.
+                                    ['c', '1', 'a', 'b'])
+
+        # Check that 'title' field is modified, and other fields come from
+        # the candidate.
+        self.assertTrue(all('Edited Title ' in i.title
+                            for i in self.lib.items()))
+        self.assertTrue(all('match ' in i.mb_trackid
+                            for i in self.lib.items()))
 
 
 def suite():

--- a/test/test_edit.py
+++ b/test/test_edit.py
@@ -23,6 +23,7 @@ from test.helper import TestHelper, control_stdin
 from test.test_ui_importer import TerminalImportSessionSetup
 from test.test_importer import ImportHelper, AutotagStub
 from beets.library import Item
+from beetsplug.edit import EditPlugin
 
 
 class ModifyFileMocker(object):
@@ -126,6 +127,7 @@ class EditCommandTest(unittest.TestCase, TestHelper, EditMixin):
         self.mock_write = self.write_patcher.start()
 
     def tearDown(self):
+        EditPlugin.listeners = None
         self.write_patcher.stop()
         self.teardown_beets()
         self.unload_plugins()
@@ -289,6 +291,7 @@ class EditDuringImporterTest(TerminalImportSessionSetup, unittest.TestCase,
         self.config['import']['timid'] = True
 
     def tearDown(self):
+        EditPlugin.listeners = None
         self.unload_plugins()
         self.teardown_beets()
         self.matcher.restore()


### PR DESCRIPTION
As a follow up to #396, an attempt to allow the user to launch the edit plugin during an interactive import session.

At the moment the code is still not complete and rather unpolished and full of TODOs and other comments - but hopefully it will serve as a way to discussing some issues that are not as straight-forward as I'd hoped:
* during an interactive import, the `Items` do not have a valid `id` field, as they are not on the database - and the `edit` plugin relied on it for reconciling back the user changes and other internal functionality. I have resorted to using the `path` field instead of `id` when the plugin is invoked on interactive mode, as it seems to satisfy the requirements for a "reference/mapping" field (unique for each item, non-editable by the user). This is done mainly via the introduction of the `EditPlugin.mapping_field` (and using the original items for showing changes during `edit_objects`).
* I have tried to allow the user two main choices - edit based the tags of the files to be imported directly (currently `eDit` -> `importer_edit`) and edit based on a candidate (currently `edit Candidate` -> `importer_edit_candidate`), as they seemed to be two rather common use cases (cleanup files, and fix MusicBrainz problems).
  * The main challenge is the first one, as I could not really find a way to implement it while keeping all the code within the plugin (hence the dirty modification to `importer.py`): editing the Item tags is similar to ASIS ... but not quite. If marked as an ASIS, I could not find an importer code path where the `Items` are really written(), making the changes to be stored correctly on the database but not on the files. If marked as an APPLY, the candidate takes preference and hence the user edits are discarded in favor of the first candidate.
  * For the second one, the implementation currently simply forces an `task.apply_metadata()` before invoking the edits so the `Items` are modified temporarily, and then proceed as in the first case. It is probably more correct (and doable!) to just set a flag on the plugin during `importer_edit_candidate`, let the importer proceed, and actually invoke the editor later (on `import_task_apply` or a new pipeline stage), which would also get rid of the current extra prompt for selecting a candidate.

I'm wondering if you could point me in the right direction for solving the "edit item tags" properly? I have played around with delaying the invoking of the editor until another event for that case as well, but unfortunately could not find an event that is launched at the right moment reliably (using ASIS, and taking into account the different write/copy/link options). Also, the pipeline stage (which could be a good candidate) does not seem to be reachable for an ASIS choice.
