### PR TITLE
documention for overriding the default last.fm api key with a custom …

### DIFF
--- a/docs/plugins/lastimport.rst
+++ b/docs/plugins/lastimport.rst
@@ -55,6 +55,7 @@ options under the ``lastimport:`` section:
   Default: 3.
 
 By default lastimport will use beets Last.fm API key. If you wish you can
-override this with your own API key.
-  lastfm:
+override this with your own API key.::
+
+    lastfm:
       api_key: your_api_key

--- a/docs/plugins/lastimport.rst
+++ b/docs/plugins/lastimport.rst
@@ -53,3 +53,8 @@ options under the ``lastimport:`` section:
 * **retry_limit**: How many times should we re-send requests to Last.fm on
   failure?
   Default: 3.
+
+By default lastimport will use beets Last.fm API key. If you wish you can
+override this with your own API key.
+  lastfm:
+      api_key: your_api_key


### PR DESCRIPTION
…one in lastimport

The lastimport plugin now supports custom api keys. However I didn't see it documented anywhere currently.