### PR TITLE
Add __future__ import style checker

### DIFF
--- a/beet
+++ b/beet
@@ -15,6 +15,8 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
+from __future__ import print_function
+
 import beets.ui
 
 if __name__ == '__main__':

--- a/beet
+++ b/beet
@@ -15,7 +15,7 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
-from __future__ import absolute_import, print_function
+from __future__ import division, absolute_import, print_function
 
 import beets.ui
 

--- a/beet
+++ b/beet
@@ -15,7 +15,7 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 import beets.ui
 

--- a/beets/art.py
+++ b/beets/art.py
@@ -17,7 +17,7 @@
 music and items' embedded album art.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import division, absolute_import, print_function
 
 import subprocess
 import platform

--- a/beets/art.py
+++ b/beets/art.py
@@ -17,6 +17,8 @@
 music and items' embedded album art.
 """
 
+from __future__ import print_function
+
 import subprocess
 import platform
 from tempfile import NamedTemporaryFile

--- a/beets/art.py
+++ b/beets/art.py
@@ -17,7 +17,7 @@
 music and items' embedded album art.
 """
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 import subprocess
 import platform

--- a/beetsplug/cue.py
+++ b/beetsplug/cue.py
@@ -2,6 +2,8 @@
 # Copyright 2016 Bruno Cauet
 # Split an album-file in tracks thanks a cue file
 
+from __future__ import print_function
+
 import subprocess
 from os import path
 from glob import glob

--- a/beetsplug/cue.py
+++ b/beetsplug/cue.py
@@ -2,7 +2,7 @@
 # Copyright 2016 Bruno Cauet
 # Split an album-file in tracks thanks a cue file
 
-from __future__ import absolute_import, print_function
+from __future__ import division, absolute_import, print_function
 
 import subprocess
 from os import path

--- a/beetsplug/cue.py
+++ b/beetsplug/cue.py
@@ -2,7 +2,7 @@
 # Copyright 2016 Bruno Cauet
 # Split an album-file in tracks thanks a cue file
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 import subprocess
 from os import path

--- a/beetsplug/filefilter.py
+++ b/beetsplug/filefilter.py
@@ -16,6 +16,8 @@
 """Filter imported files using a regular expression.
 """
 
+from __future__ import print_function
+
 import re
 from beets import config
 from beets.plugins import BeetsPlugin

--- a/beetsplug/filefilter.py
+++ b/beetsplug/filefilter.py
@@ -16,7 +16,7 @@
 """Filter imported files using a regular expression.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import division, absolute_import, print_function
 
 import re
 from beets import config

--- a/beetsplug/filefilter.py
+++ b/beetsplug/filefilter.py
@@ -16,7 +16,7 @@
 """Filter imported files using a regular expression.
 """
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 import re
 from beets import config

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -14,6 +14,9 @@
 
 """Adds support for ipfs. Requires go-ipfs and a running ipfs daemon
 """
+
+from __future__ import print_function
+
 from beets import ui, util, library, config
 from beets.plugins import BeetsPlugin
 

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -15,7 +15,7 @@
 """Adds support for ipfs. Requires go-ipfs and a running ipfs daemon
 """
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 from beets import ui, util, library, config
 from beets.plugins import BeetsPlugin

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -15,7 +15,7 @@
 """Adds support for ipfs. Requires go-ipfs and a running ipfs daemon
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import division, absolute_import, print_function
 
 from beets import ui, util, library, config
 from beets.plugins import BeetsPlugin

--- a/beetsplug/metasync/__init__.py
+++ b/beetsplug/metasync/__init__.py
@@ -16,7 +16,7 @@
 """Synchronize information from music player libraries
 """
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 from abc import abstractmethod, ABCMeta
 from importlib import import_module

--- a/beetsplug/metasync/__init__.py
+++ b/beetsplug/metasync/__init__.py
@@ -16,7 +16,7 @@
 """Synchronize information from music player libraries
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import division, absolute_import, print_function
 
 from abc import abstractmethod, ABCMeta
 from importlib import import_module

--- a/beetsplug/metasync/__init__.py
+++ b/beetsplug/metasync/__init__.py
@@ -15,6 +15,9 @@
 
 """Synchronize information from music player libraries
 """
+
+from __future__ import print_function
+
 from abc import abstractmethod, ABCMeta
 from importlib import import_module
 

--- a/beetsplug/metasync/amarok.py
+++ b/beetsplug/metasync/amarok.py
@@ -16,7 +16,7 @@
 """Synchronize information from amarok's library via dbus
 """
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 from os.path import basename
 from datetime import datetime

--- a/beetsplug/metasync/amarok.py
+++ b/beetsplug/metasync/amarok.py
@@ -16,6 +16,8 @@
 """Synchronize information from amarok's library via dbus
 """
 
+from __future__ import print_function
+
 from os.path import basename
 from datetime import datetime
 from time import mktime

--- a/beetsplug/metasync/amarok.py
+++ b/beetsplug/metasync/amarok.py
@@ -16,7 +16,7 @@
 """Synchronize information from amarok's library via dbus
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import division, absolute_import, print_function
 
 from os.path import basename
 from datetime import datetime

--- a/beetsplug/metasync/itunes.py
+++ b/beetsplug/metasync/itunes.py
@@ -15,6 +15,9 @@
 
 """Synchronize information from iTunes's library
 """
+
+from __future__ import print_function
+
 from contextlib import contextmanager
 import os
 import shutil

--- a/beetsplug/metasync/itunes.py
+++ b/beetsplug/metasync/itunes.py
@@ -16,7 +16,7 @@
 """Synchronize information from iTunes's library
 """
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 from contextlib import contextmanager
 import os

--- a/beetsplug/metasync/itunes.py
+++ b/beetsplug/metasync/itunes.py
@@ -16,7 +16,7 @@
 """Synchronize information from iTunes's library
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import division, absolute_import, print_function
 
 from contextlib import contextmanager
 import os

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 AUTHOR = u'Adrian Sampson'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import, print_function
+from __future__ import division, absolute_import, print_function
 
 AUTHOR = u'Adrian Sampson'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+
 AUTHOR = u'Adrian Sampson'
 
 # General configuration

--- a/docs/serve.py
+++ b/docs/serve.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import absolute_import, print_function
+from __future__ import division, absolute_import, print_function
 
 from livereload import Server, shell
 

--- a/docs/serve.py
+++ b/docs/serve.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 from livereload import Server, shell
 

--- a/docs/serve.py
+++ b/docs/serve.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python
+
+from __future__ import print_function
+
 from livereload import Server, shell
+
 server = Server()
 server.watch('*.rst', shell('make html'))
 server.serve(root='_build/html')

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,11 @@ logging-clear-handlers=1
 eval-attr="!=slow"
 
 [flake8]
-# E241  missing whitespace after ',' (used to align visually)
-# E221  multiple spaces before operator (used to align visually)
-# E731  do not assign a lambda expression, use a def
-ignore=E241,E221,E731
+# Default pyflakes errors we ignore:
+# - E241: missing whitespace after ',' (used to align visually)
+# - E221: multiple spaces before operator (used to align visually)
+# - E731: do not assign a lambda expression, use a def
+#
+# And for `flake8-future-import`, we define the set of imports we require:
+# division, absolute_import, and print_function.
+ignore=E241,E221,E731,FI50,FI51,FI12,FI53,FI14,FI15

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,11 @@ eval-attr="!=slow"
 # - E241: missing whitespace after ',' (used to align visually)
 # - E221: multiple spaces before operator (used to align visually)
 # - E731: do not assign a lambda expression, use a def
-#
-# And for `flake8-future-import`, we define the set of imports we require:
-# division, absolute_import, and print_function.
+# `flake8-future-import` errors we ignore:
+# - FI50: `__future__` import "division" present
+# - FI51: `__future__` import "absolute_import" present
+# - FI12: `__future__` import "with_statement" missing
+# - FI53: `__future__` import "print_function" present
+# - FI14: `__future__` import "unicode_literals" missing
+# - FI15: `__future__` import "generator_stop" missing
 ignore=E241,E221,E731,FI50,FI51,FI12,FI53,FI14,FI15

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -2,4 +2,4 @@
 
 # Make python -m testall.py work.
 
-from __future__ import absolute_import, print_function
+from __future__ import division, absolute_import, print_function

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,3 +1,5 @@
 # -*- coding: utf-8 -*-
 
 # Make python -m testall.py work.
+
+from __future__ import print_function

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -2,4 +2,4 @@
 
 # Make python -m testall.py work.
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function

--- a/test/test_filefilter.py
+++ b/test/test_filefilter.py
@@ -16,19 +16,19 @@
 """Tests for the `filefilter` plugin.
 """
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 import os
 import shutil
 
-from _common import unittest
+from test import _common
+from test._common import unittest
+from test.helper import capture_log
+from test.test_importer import ImportHelper
 from beets import config
 from beets.mediafile import MediaFile
 from beets.util import displayable_path
 from beetsplug.filefilter import FileFilterPlugin
-from test import _common
-from test.helper import capture_log
-from test.test_importer import ImportHelper
 
 
 class FileFilterPluginTest(unittest.TestCase, ImportHelper):

--- a/test/test_filefilter.py
+++ b/test/test_filefilter.py
@@ -15,6 +15,9 @@
 
 """Tests for the `filefilter` plugin.
 """
+
+from __future__ import print_function
+
 import os
 import shutil
 

--- a/test/test_filefilter.py
+++ b/test/test_filefilter.py
@@ -16,7 +16,7 @@
 """Tests for the `filefilter` plugin.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import division, absolute_import, print_function
 
 import os
 import shutil

--- a/test/test_ipfs.py
+++ b/test/test_ipfs.py
@@ -12,7 +12,7 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
-from __future__ import absolute_import, print_function
+from __future__ import division, absolute_import, print_function
 
 from mock import patch
 

--- a/test/test_ipfs.py
+++ b/test/test_ipfs.py
@@ -12,7 +12,7 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 from mock import patch
 

--- a/test/test_ipfs.py
+++ b/test/test_ipfs.py
@@ -12,6 +12,8 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
+from __future__ import print_function
+
 from mock import patch
 
 from beets import library

--- a/test/test_metasync.py
+++ b/test/test_metasync.py
@@ -12,6 +12,9 @@
 #
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
+
+from __future__ import print_function
+
 import os
 import platform
 import time

--- a/test/test_metasync.py
+++ b/test/test_metasync.py
@@ -13,7 +13,7 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
-from __future__ import absolute_import, print_function
+from __future__ import division, absolute_import, print_function
 
 import os
 import platform

--- a/test/test_metasync.py
+++ b/test/test_metasync.py
@@ -13,7 +13,7 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 import os
 import platform

--- a/test/test_ui_commands.py
+++ b/test/test_ui_commands.py
@@ -15,6 +15,9 @@
 
 """Test module for file ui/commands.py
 """
+
+from __future__ import print_function
+
 import os
 import shutil
 

--- a/test/test_ui_commands.py
+++ b/test/test_ui_commands.py
@@ -16,7 +16,7 @@
 """Test module for file ui/commands.py
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import division, absolute_import, print_function
 
 import os
 import shutil

--- a/test/test_ui_commands.py
+++ b/test/test_ui_commands.py
@@ -16,7 +16,7 @@
 """Test module for file ui/commands.py
 """
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 import os
 import shutil

--- a/test/test_ui_init.py
+++ b/test/test_ui_init.py
@@ -15,6 +15,9 @@
 
 """Test module for file ui/__init__.py
 """
+
+from __future__ import print_function
+
 from test import _common
 from test._common import unittest
 

--- a/test/test_ui_init.py
+++ b/test/test_ui_init.py
@@ -16,7 +16,7 @@
 """Test module for file ui/__init__.py
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import division, absolute_import, print_function
 
 from test import _common
 from test._common import unittest

--- a/test/test_ui_init.py
+++ b/test/test_ui_init.py
@@ -16,7 +16,7 @@
 """Test module for file ui/__init__.py
 """
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 from test import _common
 from test._common import unittest

--- a/tox.ini
+++ b/tox.ini
@@ -47,4 +47,5 @@ commands =
 [testenv:flake8]
 deps =
     flake8
+    flake8-future-import
 commands = flake8 beets beetsplug beet test setup.py docs


### PR DESCRIPTION
This adds the [flake8-future-import][f] plugin for flake8, which enforces the standard set of `__future__` imports at the top of all Python files. This revealed a fair number of files that need to be fixed.

To be revisited after #1887 is merged.

[f]: https://github.com/xZise/flake8-future-import