### PR TITLE
Fix MusixMatch issues

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -200,18 +200,27 @@ class Backend(object):
 
 
 class SymbolsReplaced(Backend):
+    REPLACEMENTS = {
+        r'\s+': '_',
+        '<': 'Less_Than',
+        '>': 'Greater_Than',
+        '#': 'Number_',
+        r'[\[\{]': '(',
+        r'[\[\{]': ')'
+    }
+
     @classmethod
     def _encode(cls, s):
-        s = re.sub(r'\s+', '_', s)
-        s = s.replace("<", "Less_Than")
-        s = s.replace(">", "Greater_Than")
-        s = s.replace("#", "Number_")
-        s = re.sub(r'[\[\{]', '(', s)
-        s = re.sub(r'[\]\}]', ')', s)
+        for old, new in cls.REPLACEMENTS.iteritems():
+            s = re.sub(old, new, s)
+
         return super(SymbolsReplaced, cls)._encode(s)
 
-
 class MusiXmatch(SymbolsReplaced):
+    REPLACEMENTS = dict(SymbolsReplaced.REPLACEMENTS, **{
+        r'\s+': '-'
+    })
+
     URL_PATTERN = 'https://www.musixmatch.com/lyrics/%s/%s'
 
     def fetch(self, artist, title):

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -216,6 +216,7 @@ class SymbolsReplaced(Backend):
 
         return super(SymbolsReplaced, cls)._encode(s)
 
+
 class MusiXmatch(SymbolsReplaced):
     REPLACEMENTS = dict(SymbolsReplaced.REPLACEMENTS, **{
         r'\s+': '-'

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -229,7 +229,7 @@ class MusiXmatch(SymbolsReplaced):
         if not html:
             return
         lyrics = extract_text_between(html,
-                                      '"lyrics_body":', '"lyrics_language":')
+                                      '"body":', '"language":')
         return lyrics.strip(',"').replace('\\n', '\n')
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,8 @@ Fixes:
   password in the ``beet config`` output. :bug:`1907`
 * :doc:`/plugins/scrub`: Fix an occasional problem where scrubbing on import
   could undo the ``id3v23`` setting. :bug:`1903`
+* :doc:`/plugins/lyrics`: Fix lyric retrieval for MusixMatch and improve URL
+  generation. :bug:`1880`
 
 
 1.3.17 (February 7, 2016)


### PR DESCRIPTION
This PR fixes #1880, as well as an unreported issue where lyrics can never be retrieved from MusixMatch due to changes in their website.

On a semi-related note, the capitalisation of the `MusiXmatch` class seems to be incorrect (and is incorrect throughout the codebase); I believe it should be `MusixMatch`. Should I open another PR to fix this?