### PR TITLE
Fix LyricsWiki scraping code

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -321,7 +321,8 @@ class LyricsWiki(SymbolsReplaced):
         html = self.fetch_url(url)
         if not html:
             return
-        lyrics = extract_text_in(html, u"<div class='lyricbox'>")
+        lyrics = extract_text_in(unescape(html), u"<div class='lyricbox'>")
+        lyrics = scrape_lyrics_from_html(lyrics)
         if lyrics and 'Unfortunately, we are not licensed' not in lyrics:
             return lyrics
 


### PR DESCRIPTION
LyricsWiki now escapes song lyrics using HTML entities (presumably to prevent scraping), so we now unescape these before parsing.

LyricsWiki has also added a script tag inside the div we are scraping, so we have to remove this using `scrape_lyrics_from_html`.