### PR TITLE
importadded: preserve mtime after any write

### DIFF
--- a/beetsplug/importadded.py
+++ b/beetsplug/importadded.py
@@ -19,6 +19,7 @@ class ImportAddedPlugin(BeetsPlugin):
         super(ImportAddedPlugin, self).__init__()
         self.config.add({
             'preserve_mtimes': False,
+            'preserve_write_mtimes': False,
         })
 
         # item.id for new items that were reimported
@@ -37,6 +38,7 @@ class ImportAddedPlugin(BeetsPlugin):
         register('item_linked', self.record_import_mtime)
         register('album_imported', self.update_album_times)
         register('item_imported', self.update_item_times)
+        register('after_write', self.update_after_write_time)
 
     def check_config(self, task, session):
         self.config['preserve_mtimes'].get(bool)
@@ -120,3 +122,13 @@ class ImportAddedPlugin(BeetsPlugin):
             self._log.debug(u"Import of item '{0}', selected item.added={1}",
                             util.displayable_path(item.path), item.added)
             item.store()
+
+    def update_after_write_time(self, item):
+        """Update the mtime of the item's file with the item.added value 
+        after each write of the item if `preserve_write_mtimes` is enabled. 
+        """
+        if item.added:
+            if self.config['preserve_write_mtimes'].get(bool):
+                self.write_item_mtime(item, item.added)
+            self._log.debug(u"Write of item '{0}', selected item.added={1}",
+                            util.displayable_path(item.path), item.added)

--- a/beetsplug/importadded.py
+++ b/beetsplug/importadded.py
@@ -124,8 +124,8 @@ class ImportAddedPlugin(BeetsPlugin):
             item.store()
 
     def update_after_write_time(self, item):
-        """Update the mtime of the item's file with the item.added value 
-        after each write of the item if `preserve_write_mtimes` is enabled. 
+        """Update the mtime of the item's file with the item.added value
+        after each write of the item if `preserve_write_mtimes` is enabled.
         """
         if item.added:
             if self.config['preserve_write_mtimes'].get(bool):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,8 @@ New features:
 
 * :doc:`/plugins/convert`: A new `album_art_maxwidth` lets you resize album
   art while copying it.
+* :doc:`/plugins/importadded`: A new `preserve_write_mtimes` option
+  lets you preserve mtime of files after each write.
 
 Fixes:
 

--- a/docs/plugins/importadded.rst
+++ b/docs/plugins/importadded.rst
@@ -22,8 +22,11 @@ The ``item.added`` field is populated as follows:
   set to the oldest mtime of the files in the album before they were imported.
   The mtime of album directories is ignored.
 
-This plugin can optionally be configured to also preserve mtimes using the
-``preserve_mtimes`` option.
+This plugin can optionally be configured to also preserve mtimes at
+import using the ``preserve_mtimes`` option.
+
+When ``preserve_write_mtimes`` option is set, this plugin preserves
+mtimes after each write to files using the ``item.added`` attribute.
 
 File modification times are preserved as follows:
 
@@ -40,9 +43,13 @@ Configuration
 -------------
 
 To configure the plugin, make an ``importadded:`` section in your
-configuration file. There is one option available:
+configuration file. There are two options available:
 
-- **preserve_mtimes**: After writing files, re-set their mtimes to their
+- **preserve_mtimes**: After importing files, re-set their mtimes to their
+  original value.
+  Default: ``no``.
+
+- **preserve_write_mtimes**: After writing files, re-set their mtimes to their
   original value.
   Default: ``no``.
 


### PR DESCRIPTION
First thanks for beets, it's an incredible tool!

In my setup, I need to preserve mtime at all time, even after import so that my library is still correctly ordered by my streaming software. I added a hook in importadded plugin to do that. There is new option for this module as well to enable this option.

It relies on item.added attribute that should be quite stable if I understand correctly. 