### PR TITLE
Fetchart preview/General thoughts on user interaction by plugins

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -45,6 +45,75 @@ CANDIDATE_BAD = 0
 CANDIDATE_EXACT = 1
 CANDIDATE_DOWNSCALE = 2
 
+MATCH_EXACT = 0
+MATCH_FALLBACK = 1
+
+class Candidate():
+    """ 
+
+    """
+    def __init__(self, path=None, url=None, source=u'', match=None):
+        self.path = path
+        self.source = source
+        self.check = None
+        self.match = match
+        self.size = None
+
+    def _validate(self, extra):
+        """Determine whether the candidate artwork is valid based on
+        its dimensions (width and ratio).
+
+        Return `CANDIDATE_BAD` if the file is unusable.
+        Return `CANDIDATE_EXACT` if the file is usable as-is.
+        Return `CANDIDATE_DOWNSCALE` if the file must be resized.
+        """
+        if not self.path:
+            return CANDIDATE_BAD
+
+        if not (extra.['enforce_ratio'] or 
+                extra.['minwidth'] or 
+                extra.['maxwidth']):
+            return CANDIDATE_EXACT
+
+        # get_size returns None if no local imaging backend is available
+        self.size = ArtResizer.shared.get_size(self.path)
+        self._log.debug(u'image size: {}', self.size)
+
+        if not self.size:
+            self._log.warning(u'Could not get size of image (please see '
+                              u'documentation for dependencies). '
+                              u'The configuration options `minwidth` and '
+                              u'`enforce_ratio` may be violated.')
+            return CANDIDATE_EXACT
+
+        # Check minimum size.
+        if extra.['minwidth'] and self.size[0] < extra.['minwidth']:
+            self._log.debug(u'image too small ({} < {})',
+                            self.size[0], extra.['minwidth'])
+            return CANDIDATE_BAD
+
+        # Check aspect ratio.
+        if extra.['enforce_ratio'] and self.size[0] != self.size[1]:
+            self._log.debug(u'image is not square ({} != {})',
+                            self.size[0], self.size[1])
+            return CANDIDATE_BAD
+
+        # Check maximum size.
+        if extra.['maxwidth'] and self.size[0] > extra.['maxwidth']:
+            self._log.debug(u'image needs resizing ({} > {})',
+                            self.size[0], extra.['maxwidth'])
+            return CANDIDATE_DOWNSCALE
+
+        return CANDIDATE_EXACT
+
+    def validate(self, extra):
+        self.check = self._validate(extra)
+        return self.check
+
+    def resize(self, extra):
+        if extra.['maxwidth'] and self.check == CANDIDATE_DOWNSCALE:
+            self.path = ArtResizer.shared.resize(extra.['maxwidth'], self.path)
+
 
 def _logged_get(log, *args, **kwargs):
     """Like `requests.get`, but logs the effective URL to the specified
@@ -122,9 +191,10 @@ class RemoteArtSource(ArtSource):
         Otherwise, returns None.
         """
         if extra['maxwidth']:
-            url = ArtResizer.shared.proxy_url(extra['maxwidth'], candidate)
+            candidate.url = ArtResizer.shared.proxy_url(extra['maxwidth'], 
+                                                        candidate.url)
         try:
-            with closing(self.request(url, stream=True,
+            with closing(self.request(candidate.url, stream=True,
                                       message=u'downloading image')) as resp:
                 if 'Content-Type' not in resp.headers \
                         or resp.headers['Content-Type'] not in CONTENT_TYPES:
@@ -132,7 +202,8 @@ class RemoteArtSource(ArtSource):
                         u'not a supported image: {}',
                         resp.headers.get('Content-Type') or u'no content type',
                     )
-                    return None
+                    candidate.path = None
+                    return 
 
                 # Generate a temporary file with the correct extension.
                 with NamedTemporaryFile(suffix=DOWNLOAD_EXTENSION,
@@ -141,13 +212,15 @@ class RemoteArtSource(ArtSource):
                         fh.write(chunk)
                 self._log.debug(u'downloaded art to: {0}',
                                 util.displayable_path(fh.name))
-                return fh.name
+                candidate.path = fh.name
+                return
 
         except (IOError, requests.RequestException, TypeError) as exc:
             # Handling TypeError works around a urllib3 bug:
             # https://github.com/shazow/urllib3/issues/556
             self._log.debug(u'error fetching art: {}', exc)
-            return None
+            candidate.path = None
+            return 
 
 
 class CoverArtArchive(RemoteArtSource):
@@ -155,26 +228,32 @@ class CoverArtArchive(RemoteArtSource):
     URL = 'http://coverartarchive.org/release/{mbid}/front'
     GROUP_URL = 'http://coverartarchive.org/release-group/{mbid}/front'
 
-    def get(self, album):
+    def get(self, album, extra):
         """Return the Cover Art Archive and Cover Art Archive release group URLs
         using album MusicBrainz release ID and release group ID.
         """
         if album.mb_albumid:
-            yield self.URL.format(mbid=album.mb_albumid)
+            yield Candidate(url=self.URL.format(mbid=album.mb_albumid),
+                            source=u'coverartarchive.org',
+                            match=MATCH_EXACT)
         if album.mb_releasegroupid:
-            yield self.GROUP_URL.format(mbid=album.mb_releasegroupid)
+            yield Candidate(url=self.GROUP_URL.format(mbid=album.mb_releasegroupid),
+                            source=u'coverartarchive.org',
+                            match=MATCH_FALLBACK)
 
 
 class Amazon(RemoteArtSource):
     URL = 'http://images.amazon.com/images/P/%s.%02i.LZZZZZZZ.jpg'
     INDICES = (1, 2)
 
-    def get(self, album):
+    def get(self, album, extra):
         """Generate URLs using Amazon ID (ASIN) string.
         """
         if album.asin:
             for index in self.INDICES:
-                yield self.URL % (album.asin, index)
+                yield Candidate(url=self.URL % (album.asin, index),
+                                source=u'Amazon',
+                                match=MATCH_EXACT)
 
 
 class AlbumArtOrg(RemoteArtSource):
@@ -182,7 +261,7 @@ class AlbumArtOrg(RemoteArtSource):
     URL = 'http://www.albumart.org/index_detail.php'
     PAT = r'href\s*=\s*"([^>"]*)"[^>]*title\s*=\s*"View larger image"'
 
-    def get(self, album):
+    def get(self, album, extra):
         """Return art URL from AlbumArt.org using album ASIN.
         """
         if not album.asin:
@@ -199,7 +278,9 @@ class AlbumArtOrg(RemoteArtSource):
         m = re.search(self.PAT, resp.text)
         if m:
             image_url = m.group(1)
-            yield image_url
+            yield Candidate(url=image_url,
+                            source=u'AlbumArt.org',
+                            match=MATCH_EXACT)
         else:
             self._log.debug(u'no image found on page')
 
@@ -207,7 +288,7 @@ class AlbumArtOrg(RemoteArtSource):
 class GoogleImages(RemoteArtSource):
     URL = u'https://www.googleapis.com/customsearch/v1'
 
-    def get(self, album):
+    def get(self, album, extra):
         """Return art URL from google custom search engine
         given an album title and interpreter.
         """
@@ -236,12 +317,14 @@ class GoogleImages(RemoteArtSource):
 
         if 'items' in data.keys():
             for item in data['items']:
-                yield item['link']
+                yield Candidate(url=item['link'],
+                                source=u'Google images',
+                                match=MATCH_EXACT)
 
 
 class ITunesStore(RemoteArtSource):
     # Art from the iTunes Store.
-    def get(self, album):
+    def get(self, album, extra):
         """Return art URL from iTunes Store given an album title.
         """
         if not (album.albumartist and album.album):
@@ -266,7 +349,9 @@ class ITunesStore(RemoteArtSource):
             if itunes_album.get_artwork()['100']:
                 small_url = itunes_album.get_artwork()['100']
                 big_url = small_url.replace('100x100', '1200x1200')
-                yield big_url
+                yield Candidate(url=big_url,
+                                source=u'iTunes Store',
+                                match=MATCH_EXACT)
             else:
                 self._log.debug(u'album has no artwork in iTunes Store')
         except IndexError:
@@ -299,7 +384,7 @@ class Wikipedia(RemoteArtSource):
                   }}
                  Limit 1'''
 
-    def get(self, album):
+    def get(self, album, extra):
         if not (album.albumartist and album.album):
             return
 
@@ -391,7 +476,9 @@ class Wikipedia(RemoteArtSource):
             results = data['query']['pages']
             for _, result in results.iteritems():
                 image_url = result['imageinfo'][0]['url']
-                yield image_url
+                yield Candidate(url=image_url,
+                                source=u'Wikipedia',
+                                match=MATCH_EXACT)
         except (ValueError, KeyError, IndexError):
             self._log.debug(u'wikipedia: error scraping imageinfo')
             return
@@ -409,13 +496,11 @@ class FileSystem(LocalArtSource):
         """
         return [idx for (idx, x) in enumerate(cover_names) if x in filename]
 
-    def get(self, extra):
+    def get(self, album, extra):
         """Look for album art files in the specified directories.
         """
         paths = extra['paths']
         cover_names = extra['cover_names']
-        def sortkey():
-            return self.filename_priority(x, cover_names)
         cover_pat = br"(\b|_)({0})(\b|_)".format(b'|'.join(cover_names))
         cautious = extra['cautious']
         
@@ -432,18 +517,23 @@ class FileSystem(LocalArtSource):
                         images.append(fn)
 
             # Look for "preferred" filenames.
-            images = sorted(images, sortkey)
+            images = sorted(images, 
+                            lambda x: self.filename_priority(x, cover_names))
             for fn in images:
                 if re.search(cover_pat, os.path.splitext(fn)[0], re.I):
                     self._log.debug(u'using well-named art file {0}',
                                     util.displayable_path(fn))
-                    yield os.path.join(path, fn)
+                    yield Candidate(path=os.path.join(path, fn),
+                                    source=u'Filesystem',
+                                    match=MATCH_EXACT)
 
             # Fall back to any image in the folder.
             if images and not cautious:
                 self._log.debug(u'using fallback art file {0}',
                                 util.displayable_path(images[0]))
-                yield os.path.join(path, images[0])
+                yield Candidate(path=os.path.join(path, images[0]),
+                                source=u'Filesystem',
+                                match=MATCH_FALLBACK)
 
 
 # Try each source in turn.
@@ -461,6 +551,7 @@ ART_SOURCES = {
     u'wikipedia': Wikipedia,
     u'google': GoogleImages,
 }
+SOURCE_NAMES = {v: k for k, v in ART_SOURCES.items()}
 
 # PLUGIN LOGIC ###############################################################
 
@@ -570,51 +661,6 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
 
     # Utilities converted from functions to methods on logging overhaul
 
-    def _is_valid_image_candidate(self, candidate):
-        """Determine whether the given candidate artwork is valid based on
-        its dimensions (width and ratio).
-
-        Return `CANDIDATE_BAD` if the file is unusable.
-        Return `CANDIDATE_EXACT` if the file is usable as-is.
-        Return `CANDIDATE_DOWNSCALE` if the file must be resized.
-        """
-        if not candidate:
-            return CANDIDATE_BAD
-
-        if not (self.enforce_ratio or self.minwidth or self.maxwidth):
-            return CANDIDATE_EXACT
-
-        # get_size returns None if no local imaging backend is available
-        size = ArtResizer.shared.get_size(candidate)
-        self._log.debug(u'image size: {}', size)
-
-        if not size:
-            self._log.warning(u'Could not get size of image (please see '
-                              u'documentation for dependencies). '
-                              u'The configuration options `minwidth` and '
-                              u'`enforce_ratio` may be violated.')
-            return CANDIDATE_EXACT
-
-        # Check minimum size.
-        if self.minwidth and size[0] < self.minwidth:
-            self._log.debug(u'image too small ({} < {})',
-                            size[0], self.minwidth)
-            return CANDIDATE_BAD
-
-        # Check aspect ratio.
-        if self.enforce_ratio and size[0] != size[1]:
-            self._log.debug(u'image is not square ({} != {})',
-                            size[0], size[1])
-            return CANDIDATE_BAD
-
-        # Check maximum size.
-        if self.maxwidth and size[0] > self.maxwidth:
-            self._log.debug(u'image needs resizing ({} > {})',
-                            size[0], self.maxwidth)
-            return CANDIDATE_DOWNSCALE
-
-        return CANDIDATE_EXACT
-
     def art_for_album(self, album, paths, local_only=False):
         """Given an Album object, returns a path to downloaded art for the
         album (or None if no art is found). If `maxwidth`, then images are
@@ -625,37 +671,38 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         out = None
         check = None
 
+        # all the information any of the sources might need
         cover_names = self.config['cover_names'].as_str_seq()
         cover_names = map(util.bytestring_path, cover_names)
         cautious = self.config['cautious'].get(bool)
         extra = {'paths': paths, 
                  'cover_names': cover_names, 
                  'cautious': cautious,
+                 'enforce_ratio': self.enforce_ratio,
+                 'minwidth': self.minwidth,
                  'maxwidth': self.maxwidth}
-        source_names = {v: k for k, v in ART_SOURCES.items()}
 
         for source in self.sources:
             if source.is_local or not local_only:
                 self._log.debug(
                     u'trying source {0} for album {1.albumartist} - {1.album}',
-                    source_names[type(source)],
+                    SOURCE_NAMES[type(source)],
                     album,
                 )
                 # URLs might be invalid at this point, or the image may not
                 # fulfill the requirements
                 for candidate in source.get(album, extra):
-                    candidate = source.fetch_image(candidate)
-                    check = self._is_valid_image_candidate(candidate)
-                    if check:
+                    source.fetch_image(candidate)
+                    if candidate.validate(extra):
                         out = candidate
                         self._log.debug(u'using {0.LOC_STR()} image {1}'
-                                        .format(source, out))
+                                        .format(source, out.path))
                         break
                 if out:
                     break
 
-        if self.maxwidth and out and check == CANDIDATE_DOWNSCALE:
-            out = ArtResizer.shared.resize(self.maxwidth, out)
+        if out:
+            out.resize(extra)
 
         return out
 

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -70,9 +70,9 @@ class Candidate():
         if not self.path:
             return CANDIDATE_BAD
 
-        if not (extra.['enforce_ratio'] or 
-                extra.['minwidth'] or 
-                extra.['maxwidth']):
+        if not (extra['enforce_ratio'] or 
+                extra['minwidth'] or 
+                extra['maxwidth']):
             return CANDIDATE_EXACT
 
         # get_size returns None if no local imaging backend is available
@@ -87,21 +87,21 @@ class Candidate():
             return CANDIDATE_EXACT
 
         # Check minimum size.
-        if extra.['minwidth'] and self.size[0] < extra.['minwidth']:
+        if extra['minwidth'] and self.size[0] < extra['minwidth']:
             self._log.debug(u'image too small ({} < {})',
-                            self.size[0], extra.['minwidth'])
+                            self.size[0], extra['minwidth'])
             return CANDIDATE_BAD
 
         # Check aspect ratio.
-        if extra.['enforce_ratio'] and self.size[0] != self.size[1]:
+        if extra['enforce_ratio'] and self.size[0] != self.size[1]:
             self._log.debug(u'image is not square ({} != {})',
                             self.size[0], self.size[1])
             return CANDIDATE_BAD
 
         # Check maximum size.
-        if extra.['maxwidth'] and self.size[0] > extra.['maxwidth']:
+        if extra['maxwidth'] and self.size[0] > extra['maxwidth']:
             self._log.debug(u'image needs resizing ({} > {})',
-                            self.size[0], extra.['maxwidth'])
+                            self.size[0], extra['maxwidth'])
             return CANDIDATE_DOWNSCALE
 
         return CANDIDATE_EXACT
@@ -111,8 +111,8 @@ class Candidate():
         return self.check
 
     def resize(self, extra):
-        if extra.['maxwidth'] and self.check == CANDIDATE_DOWNSCALE:
-            self.path = ArtResizer.shared.resize(extra.['maxwidth'], self.path)
+        if extra['maxwidth'] and self.check == CANDIDATE_DOWNSCALE:
+            self.path = ArtResizer.shared.resize(extra['maxwidth'], self.path)
 
 
 def _logged_get(log, *args, **kwargs):
@@ -504,7 +504,7 @@ class FileSystem(LocalArtSource):
         cover_pat = br"(\b|_)({0})(\b|_)".format(b'|'.join(cover_names))
         cautious = extra['cautious']
         
-        for path in paths
+        for path in paths:
             if not os.path.isdir(path):
                 continue
 

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -43,15 +43,14 @@ file. The available options are:
   pixels. The height is recomputed so that the aspect ratio is preserved.
 - **enforce_ratio**: Only images with a width:height ratio of 1:1 are
   considered as valid album art candidates. Default: ``no``.
-- **remote_priority**: Query remote sources every time and use local image only
-  as fallback.
-  Default: ``no``; remote (Web) art sources are only queried if no local art is
-  found in the filesystem.
 - **sources**: List of sources to search for images. An asterisk `*` expands
   to all available sources.
-  Default: ``coverart itunes amazon albumart``, i.e., everything but
+  Default: ``filesystem coverart itunes amazon albumart``, i.e., everything but
   ``wikipedia`` and ``google``. Enable those two sources for more matches at
-  the cost of some speed.
+  the cost of some speed. They are searched in the given order, thus in the
+  default config, no remote (Web) art source are queried if local art is 
+  found in the filesystem. To use a local image as fallback, move it to the end
+  of the list.
 - **google_key**: Your Google API key (to enable the Google Custom Search
   backend).
   Default: None.


### PR DESCRIPTION
As a disclaimer, I'm absolutely new to Beets, and maybe I'm utterly mistaken in some of the following. The main value of this PR might turn out to be for me to write down and clarify some thoughts..

My initial intention was to introduce a new configuration option for `fetchart` to optionally not choose a cover automatically. Instead, it would collect all matches from all sources, display a list with some detail such as origin and size, and prompt the user to select one, optionally previewing it in an image viewer of choice.
For my usage pattern, this would be relevant both during import and on manual execution.
The code attached is some _untested_ refactoring which might lead to less code duplication when actually implementing this.

The problem that comes up however, is that Beets currently is not designed to handle user interaction at more than one stage (i.e. apart from match selection in the `user_query` stage) during import. Due to parallel execution of the pipeline, I see two options to prevent mutiple stages from writing to the commandline simultaneously:

-  Modify `beets/util/pipeline.py` to be able to specify that two distinct pipeline stages are mutually exclusive.
- Add some locking mechanism in `beets/ui/commands.py:TerminalImportSession.choose_match`. This seems more appropriate to me, for example in view of a GUI that might want to collect all pending choices.

Are there any thoughts or hints on how best to solve the issue? Would a change like this have any chance of being merged?
I intend to develop this at least to some working state as I get the time, although that might take a bit.