### PR TITLE
Fetchart: unify source handling, split out of #1917

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -42,7 +42,7 @@ CONTENT_TYPES = ('image/jpeg', 'image/png')
 DOWNLOAD_EXTENSION = '.jpg'
 
 
-class Candidate():
+class Candidate(object):
     """Holds information about a matching artwork, deals with validation of
     dimension restrictions and resizing.
     """

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -698,7 +698,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                     source.fetch_image(candidate, extra)
                     if candidate.validate(extra):
                         out = candidate
-                        self._log.debug(u'using {0.LOC_STR()} image {1}'
+                        self._log.debug(u'using {0.LOC_STR} image {1}'
                                         .format(source, out.path))
                         break
                 if out:

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -179,7 +179,7 @@ class LocalArtSource(ArtSource):
     LOC_STR = u'local'
 
     def fetch_image(self, candidate, extra):
-        return candidate
+        pass 
 
 class RemoteArtSource(ArtSource):
     IS_LOCAL = False

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -626,10 +626,10 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                 # For any other choices (e.g., TRACKS), do nothing.
                 return
 
-            path = self.art_for_album(task.album, task.paths, local)
+            candidate = self.art_for_album(task.album, task.paths, local)
 
-            if path:
-                self.art_paths[task] = path
+            if candidate:
+                self.art_paths[task] = candidate.path
 
     # Synchronous; after music files are put in place.
     def assign_art(self, session, task):
@@ -719,9 +719,9 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                 # sources.
                 local_paths = None if force else [album.path]
 
-                path = self.art_for_album(album, local_paths)
-                if path:
-                    album.set_art(path, False)
+                candidate = self.art_for_album(album, local_paths)
+                if candidate:
+                    album.set_art(candidate.path, False)
                     album.store()
                     message = ui.colorize('text_success', u'found album art')
                 else:

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -297,8 +297,8 @@ class GoogleImages(RemoteArtSource):
 
     def __init__(self, *args, **kwargs):
         super(RemoteArtSource, self).__init__(*args, **kwargs)
-            self.key: self._config['google_key'].get(),
-            self.cx: self._config['google_engine'].get(),
+        self.key = self._config['google_key'].get(),
+        self.cx = self._config['google_engine'].get(),
 
     def get(self, album, extra):
         """Return art URL from google custom search engine

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -45,6 +45,75 @@ CANDIDATE_BAD = 0
 CANDIDATE_EXACT = 1
 CANDIDATE_DOWNSCALE = 2
 
+MATCH_EXACT = 0
+MATCH_FALLBACK = 1
+
+class Candidate():
+    """ 
+
+    """
+    def __init__(self, path=None, url=None, source=u'', match=None):
+        self.path = path
+        self.source = source
+        self.check = None
+        self.match = match
+        self.size = None
+
+    def _validate(self, extra):
+        """Determine whether the candidate artwork is valid based on
+        its dimensions (width and ratio).
+
+        Return `CANDIDATE_BAD` if the file is unusable.
+        Return `CANDIDATE_EXACT` if the file is usable as-is.
+        Return `CANDIDATE_DOWNSCALE` if the file must be resized.
+        """
+        if not self.path:
+            return CANDIDATE_BAD
+
+        if not (extra.['enforce_ratio'] or 
+                extra.['minwidth'] or 
+                extra.['maxwidth']):
+            return CANDIDATE_EXACT
+
+        # get_size returns None if no local imaging backend is available
+        self.size = ArtResizer.shared.get_size(self.path)
+        self._log.debug(u'image size: {}', self.size)
+
+        if not self.size:
+            self._log.warning(u'Could not get size of image (please see '
+                              u'documentation for dependencies). '
+                              u'The configuration options `minwidth` and '
+                              u'`enforce_ratio` may be violated.')
+            return CANDIDATE_EXACT
+
+        # Check minimum size.
+        if extra.['minwidth'] and self.size[0] < extra.['minwidth']:
+            self._log.debug(u'image too small ({} < {})',
+                            self.size[0], extra.['minwidth'])
+            return CANDIDATE_BAD
+
+        # Check aspect ratio.
+        if extra.['enforce_ratio'] and self.size[0] != self.size[1]:
+            self._log.debug(u'image is not square ({} != {})',
+                            self.size[0], self.size[1])
+            return CANDIDATE_BAD
+
+        # Check maximum size.
+        if extra.['maxwidth'] and self.size[0] > extra.['maxwidth']:
+            self._log.debug(u'image needs resizing ({} > {})',
+                            self.size[0], extra.['maxwidth'])
+            return CANDIDATE_DOWNSCALE
+
+        return CANDIDATE_EXACT
+
+    def validate(self, extra):
+        self.check = self._validate(extra)
+        return self.check
+
+    def resize(self, extra):
+        if extra.['maxwidth'] and self.check == CANDIDATE_DOWNSCALE:
+            self.path = ArtResizer.shared.resize(extra.['maxwidth'], self.path)
+
 
 def _logged_get(log, *args, **kwargs):
     """Like `requests.get`, but logs the effective URL to the specified
@@ -122,9 +191,10 @@ class RemoteArtSource(ArtSource):
         Otherwise, returns None.
         """
         if extra['maxwidth']:
-            url = ArtResizer.shared.proxy_url(extra['maxwidth'], candidate)
+            candidate.url = ArtResizer.shared.proxy_url(extra['maxwidth'], 
+                                                        candidate.url)
         try:
-            with closing(self.request(url, stream=True,
+            with closing(self.request(candidate.url, stream=True,
                                       message=u'downloading image')) as resp:
                 if 'Content-Type' not in resp.headers \
                         or resp.headers['Content-Type'] not in CONTENT_TYPES:
@@ -132,7 +202,8 @@ class RemoteArtSource(ArtSource):
                         u'not a supported image: {}',
                         resp.headers.get('Content-Type') or u'no content type',
                     )
-                    return None
+                    candidate.path = None
+                    return 
 
                 # Generate a temporary file with the correct extension.
                 with NamedTemporaryFile(suffix=DOWNLOAD_EXTENSION,
@@ -141,13 +212,15 @@ class RemoteArtSource(ArtSource):
                         fh.write(chunk)
                 self._log.debug(u'downloaded art to: {0}',
                                 util.displayable_path(fh.name))
-                return fh.name
+                candidate.path = fh.name
+                return
 
         except (IOError, requests.RequestException, TypeError) as exc:
             # Handling TypeError works around a urllib3 bug:
             # https://github.com/shazow/urllib3/issues/556
             self._log.debug(u'error fetching art: {}', exc)
-            return None
+            candidate.path = None
+            return 
 
 
 class CoverArtArchive(RemoteArtSource):
@@ -155,26 +228,32 @@ class CoverArtArchive(RemoteArtSource):
     URL = 'http://coverartarchive.org/release/{mbid}/front'
     GROUP_URL = 'http://coverartarchive.org/release-group/{mbid}/front'
 
-    def get(self, album):
+    def get(self, album, extra):
         """Return the Cover Art Archive and Cover Art Archive release group URLs
         using album MusicBrainz release ID and release group ID.
         """
         if album.mb_albumid:
-            yield self.URL.format(mbid=album.mb_albumid)
+            yield Candidate(url=self.URL.format(mbid=album.mb_albumid),
+                            source=u'coverartarchive.org',
+                            match=MATCH_EXACT)
         if album.mb_releasegroupid:
-            yield self.GROUP_URL.format(mbid=album.mb_releasegroupid)
+            yield Candidate(url=self.GROUP_URL.format(mbid=album.mb_releasegroupid),
+                            source=u'coverartarchive.org',
+                            match=MATCH_FALLBACK)
 
 
 class Amazon(RemoteArtSource):
     URL = 'http://images.amazon.com/images/P/%s.%02i.LZZZZZZZ.jpg'
     INDICES = (1, 2)
 
-    def get(self, album):
+    def get(self, album, extra):
         """Generate URLs using Amazon ID (ASIN) string.
         """
         if album.asin:
             for index in self.INDICES:
-                yield self.URL % (album.asin, index)
+                yield Candidate(url=self.URL % (album.asin, index),
+                                source=u'Amazon',
+                                match=MATCH_EXACT)
 
 
 class AlbumArtOrg(RemoteArtSource):
@@ -182,7 +261,7 @@ class AlbumArtOrg(RemoteArtSource):
     URL = 'http://www.albumart.org/index_detail.php'
     PAT = r'href\s*=\s*"([^>"]*)"[^>]*title\s*=\s*"View larger image"'
 
-    def get(self, album):
+    def get(self, album, extra):
         """Return art URL from AlbumArt.org using album ASIN.
         """
         if not album.asin:
@@ -199,7 +278,9 @@ class AlbumArtOrg(RemoteArtSource):
         m = re.search(self.PAT, resp.text)
         if m:
             image_url = m.group(1)
-            yield image_url
+            yield Candidate(url=image_url,
+                            source=u'AlbumArt.org',
+                            match=MATCH_EXACT)
         else:
             self._log.debug(u'no image found on page')
 
@@ -207,7 +288,7 @@ class AlbumArtOrg(RemoteArtSource):
 class GoogleImages(RemoteArtSource):
     URL = u'https://www.googleapis.com/customsearch/v1'
 
-    def get(self, album):
+    def get(self, album, extra):
         """Return art URL from google custom search engine
         given an album title and interpreter.
         """
@@ -236,12 +317,14 @@ class GoogleImages(RemoteArtSource):
 
         if 'items' in data.keys():
             for item in data['items']:
-                yield item['link']
+                yield Candidate(url=item['link'],
+                                source=u'Google images',
+                                match=MATCH_EXACT)
 
 
 class ITunesStore(RemoteArtSource):
     # Art from the iTunes Store.
-    def get(self, album):
+    def get(self, album, extra):
         """Return art URL from iTunes Store given an album title.
         """
         if not (album.albumartist and album.album):
@@ -266,7 +349,9 @@ class ITunesStore(RemoteArtSource):
             if itunes_album.get_artwork()['100']:
                 small_url = itunes_album.get_artwork()['100']
                 big_url = small_url.replace('100x100', '1200x1200')
-                yield big_url
+                yield Candidate(url=big_url,
+                                source=u'iTunes Store',
+                                match=MATCH_EXACT)
             else:
                 self._log.debug(u'album has no artwork in iTunes Store')
         except IndexError:
@@ -299,7 +384,7 @@ class Wikipedia(RemoteArtSource):
                   }}
                  Limit 1'''
 
-    def get(self, album):
+    def get(self, album, extra):
         if not (album.albumartist and album.album):
             return
 
@@ -391,7 +476,9 @@ class Wikipedia(RemoteArtSource):
             results = data['query']['pages']
             for _, result in results.iteritems():
                 image_url = result['imageinfo'][0]['url']
-                yield image_url
+                yield Candidate(url=image_url,
+                                source=u'Wikipedia',
+                                match=MATCH_EXACT)
         except (ValueError, KeyError, IndexError):
             self._log.debug(u'wikipedia: error scraping imageinfo')
             return
@@ -409,13 +496,11 @@ class FileSystem(LocalArtSource):
         """
         return [idx for (idx, x) in enumerate(cover_names) if x in filename]
 
-    def get(self, extra):
+    def get(self, album, extra):
         """Look for album art files in the specified directories.
         """
         paths = extra['paths']
         cover_names = extra['cover_names']
-        def sortkey():
-            return self.filename_priority(x, cover_names)
         cover_pat = br"(\b|_)({0})(\b|_)".format(b'|'.join(cover_names))
         cautious = extra['cautious']
         
@@ -432,18 +517,23 @@ class FileSystem(LocalArtSource):
                         images.append(fn)
 
             # Look for "preferred" filenames.
-            images = sorted(images, sortkey)
+            images = sorted(images, 
+                            lambda x: self.filename_priority(x, cover_names))
             for fn in images:
                 if re.search(cover_pat, os.path.splitext(fn)[0], re.I):
                     self._log.debug(u'using well-named art file {0}',
                                     util.displayable_path(fn))
-                    yield os.path.join(path, fn)
+                    yield Candidate(path=os.path.join(path, fn),
+                                    source=u'Filesystem',
+                                    match=MATCH_EXACT)
 
             # Fall back to any image in the folder.
             if images and not cautious:
                 self._log.debug(u'using fallback art file {0}',
                                 util.displayable_path(images[0]))
-                yield os.path.join(path, images[0])
+                yield Candidate(path=os.path.join(path, images[0]),
+                                source=u'Filesystem',
+                                match=MATCH_FALLBACK)
 
 
 # Try each source in turn.
@@ -461,6 +551,7 @@ ART_SOURCES = {
     u'wikipedia': Wikipedia,
     u'google': GoogleImages,
 }
+SOURCE_NAMES = {v: k for k, v in ART_SOURCES.items()}
 
 # PLUGIN LOGIC ###############################################################
 
@@ -570,51 +661,6 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
 
     # Utilities converted from functions to methods on logging overhaul
 
-    def _is_valid_image_candidate(self, candidate):
-        """Determine whether the given candidate artwork is valid based on
-        its dimensions (width and ratio).
-
-        Return `CANDIDATE_BAD` if the file is unusable.
-        Return `CANDIDATE_EXACT` if the file is usable as-is.
-        Return `CANDIDATE_DOWNSCALE` if the file must be resized.
-        """
-        if not candidate:
-            return CANDIDATE_BAD
-
-        if not (self.enforce_ratio or self.minwidth or self.maxwidth):
-            return CANDIDATE_EXACT
-
-        # get_size returns None if no local imaging backend is available
-        size = ArtResizer.shared.get_size(candidate)
-        self._log.debug(u'image size: {}', size)
-
-        if not size:
-            self._log.warning(u'Could not get size of image (please see '
-                              u'documentation for dependencies). '
-                              u'The configuration options `minwidth` and '
-                              u'`enforce_ratio` may be violated.')
-            return CANDIDATE_EXACT
-
-        # Check minimum size.
-        if self.minwidth and size[0] < self.minwidth:
-            self._log.debug(u'image too small ({} < {})',
-                            size[0], self.minwidth)
-            return CANDIDATE_BAD
-
-        # Check aspect ratio.
-        if self.enforce_ratio and size[0] != size[1]:
-            self._log.debug(u'image is not square ({} != {})',
-                            size[0], size[1])
-            return CANDIDATE_BAD
-
-        # Check maximum size.
-        if self.maxwidth and size[0] > self.maxwidth:
-            self._log.debug(u'image needs resizing ({} > {})',
-                            size[0], self.maxwidth)
-            return CANDIDATE_DOWNSCALE
-
-        return CANDIDATE_EXACT
-
     def art_for_album(self, album, paths, local_only=False):
         """Given an Album object, returns a path to downloaded art for the
         album (or None if no art is found). If `maxwidth`, then images are
@@ -625,37 +671,38 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         out = None
         check = None
 
+        # all the information any of the sources might need
         cover_names = self.config['cover_names'].as_str_seq()
         cover_names = map(util.bytestring_path, cover_names)
         cautious = self.config['cautious'].get(bool)
         extra = {'paths': paths, 
                  'cover_names': cover_names, 
                  'cautious': cautious,
+                 'enforce_ratio': self.enforce_ratio,
+                 'minwidth': self.minwidth,
                  'maxwidth': self.maxwidth}
-        source_names = {v: k for k, v in ART_SOURCES.items()}
 
         for source in self.sources:
             if source.is_local or not local_only:
                 self._log.debug(
                     u'trying source {0} for album {1.albumartist} - {1.album}',
-                    source_names[type(source)],
+                    SOURCE_NAMES[type(source)],
                     album,
                 )
                 # URLs might be invalid at this point, or the image may not
                 # fulfill the requirements
                 for candidate in source.get(album, extra):
-                    candidate = source.fetch_image(candidate)
-                    check = self._is_valid_image_candidate(candidate)
-                    if check:
+                    source.fetch_image(candidate)
+                    if candidate.validate(extra):
                         out = candidate
                         self._log.debug(u'using {0.LOC_STR()} image {1}'
-                                        .format(source, out))
+                                        .format(source, out.path))
                         break
                 if out:
                     break
 
-        if self.maxwidth and out and check == CANDIDATE_DOWNSCALE:
-            out = ArtResizer.shared.resize(self.maxwidth, out)
+        if out:
+            out.resize(extra)
 
         return out
 

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -70,9 +70,9 @@ class Candidate():
         if not self.path:
             return CANDIDATE_BAD
 
-        if not (extra.['enforce_ratio'] or 
-                extra.['minwidth'] or 
-                extra.['maxwidth']):
+        if not (extra['enforce_ratio'] or 
+                extra['minwidth'] or 
+                extra['maxwidth']):
             return CANDIDATE_EXACT
 
         # get_size returns None if no local imaging backend is available
@@ -87,21 +87,21 @@ class Candidate():
             return CANDIDATE_EXACT
 
         # Check minimum size.
-        if extra.['minwidth'] and self.size[0] < extra.['minwidth']:
+        if extra['minwidth'] and self.size[0] < extra['minwidth']:
             self._log.debug(u'image too small ({} < {})',
-                            self.size[0], extra.['minwidth'])
+                            self.size[0], extra['minwidth'])
             return CANDIDATE_BAD
 
         # Check aspect ratio.
-        if extra.['enforce_ratio'] and self.size[0] != self.size[1]:
+        if extra['enforce_ratio'] and self.size[0] != self.size[1]:
             self._log.debug(u'image is not square ({} != {})',
                             self.size[0], self.size[1])
             return CANDIDATE_BAD
 
         # Check maximum size.
-        if extra.['maxwidth'] and self.size[0] > extra.['maxwidth']:
+        if extra['maxwidth'] and self.size[0] > extra['maxwidth']:
             self._log.debug(u'image needs resizing ({} > {})',
-                            self.size[0], extra.['maxwidth'])
+                            self.size[0], extra['maxwidth'])
             return CANDIDATE_DOWNSCALE
 
         return CANDIDATE_EXACT
@@ -111,8 +111,8 @@ class Candidate():
         return self.check
 
     def resize(self, extra):
-        if extra.['maxwidth'] and self.check == CANDIDATE_DOWNSCALE:
-            self.path = ArtResizer.shared.resize(extra.['maxwidth'], self.path)
+        if extra['maxwidth'] and self.check == CANDIDATE_DOWNSCALE:
+            self.path = ArtResizer.shared.resize(extra['maxwidth'], self.path)
 
 
 def _logged_get(log, *args, **kwargs):
@@ -504,7 +504,7 @@ class FileSystem(LocalArtSource):
         cover_pat = br"(\b|_)({0})(\b|_)".format(b'|'.join(cover_names))
         cautious = extra['cautious']
         
-        for path in paths
+        for path in paths:
             if not os.path.isdir(path):
                 continue
 

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -335,7 +335,7 @@ class GoogleImages(RemoteArtSource):
                                       match=Candidate.MATCH_EXACT)
 
 
-class FanartTV(ArtSource):
+class FanartTV(RemoteArtSource):
     """Art from fanart.tv requested using their API"""
     NAME = u"fanart.tv"
 

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -43,15 +43,14 @@ file. The available options are:
   pixels. The height is recomputed so that the aspect ratio is preserved.
 - **enforce_ratio**: Only images with a width:height ratio of 1:1 are
   considered as valid album art candidates. Default: ``no``.
-- **remote_priority**: Query remote sources every time and use local image only
-  as fallback.
-  Default: ``no``; remote (Web) art sources are only queried if no local art is
-  found in the filesystem.
 - **sources**: List of sources to search for images. An asterisk `*` expands
   to all available sources.
-  Default: ``coverart itunes amazon albumart``, i.e., everything but
+  Default: ``filesystem coverart itunes amazon albumart``, i.e., everything but
   ``wikipedia`` and ``google``. Enable those two sources for more matches at
-  the cost of some speed.
+  the cost of some speed. They are searched in the given order, thus in the
+  default config, no remote (Web) art source are queried if local art is 
+  found in the filesystem. To use a local image as fallback, move it to the end
+  of the list.
 - **google_key**: Your Google API key (to enable the Google Custom Search
   backend).
   Default: None.

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -415,6 +415,8 @@ class ArtForAlbumTest(UseThePlugin):
 
         fetchart.FileSystem.get = fs_source_get
 
+        self.album = _common.Bag()
+
     def tearDown(self):
         fetchart.FileSystem.get = self.old_fs_source_get
         super(ArtForAlbumTest, self).tearDown()
@@ -423,7 +425,7 @@ class ArtForAlbumTest(UseThePlugin):
         self.assertExists(image_file)
         self.image_file = image_file
 
-        candidate = self.plugin.art_for_album(None, [''], True)
+        candidate = self.plugin.art_for_album(self.album, [''], True)
 
         if should_exist:
             self.assertNotEqual(candidate, None)
@@ -435,7 +437,7 @@ class ArtForAlbumTest(UseThePlugin):
     def _assertImageResized(self, image_file, should_resize):
         self.image_file = image_file
         with patch.object(ArtResizer.shared, 'resize') as mock_resize:
-            self.plugin.art_for_album(None, [''], True)
+            self.plugin.art_for_album(self.album, [''], True)
             self.assertEqual(mock_resize.called, should_resize)
 
     def _require_backend(self):

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -367,12 +367,7 @@ class ArtImporterTest(UseThePlugin):
         self.assertExists(self.art_file)
 
     def test_delete_original_file(self):
-        config['import']['delete'] = True
-        self._fetch_art(True)
-        self.assertNotExists(self.art_file)
-
-    def test_move_original_file(self):
-        config['import']['move'] = True
+        self.plugin.src_removed = True
         self._fetch_art(True)
         self.assertNotExists(self.art_file)
 

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -405,44 +405,30 @@ class ArtForAlbumTest(UseThePlugin):
     def setUp(self):
         super(ArtForAlbumTest, self).setUp()
 
-        self.old_fs_source_get = self.plugin.fs_source.get
-        self.old_fetch_img = self.plugin._fetch_image
-        self.old_source_urls = self.plugin._source_urls
+        self.old_fs_source_get = fetchart.FileSystem.get
 
-        def fs_source_get(*_):
-            return self.image_file
+        def fs_source_get(album, paths, *_):
+            if paths:
+                yield fetchart.Candidate(path=self.image_file)
 
-        def source_urls(_):
-            return ['']
-
-        def fetch_img(_):
-            return self.image_file
-
-        self.plugin.fs_source.get = fs_source_get
-        self.plugin._source_urls = source_urls
-        self.plugin._fetch_image = fetch_img
+        fetchart.FileSystem.get = fs_source_get
 
     def tearDown(self):
-        self.plugin.fs_source.get = self.old_fs_source_get
-        self.plugin._source_urls = self.old_source_urls
-        self.plugin._fetch_image = self.old_fetch_img
+        fetchart.FileSystem.get = self.old_fs_source_get
         super(ArtForAlbumTest, self).tearDown()
 
     def _assertImageIsValidArt(self, image_file, should_exist):
         self.assertExists(image_file)
         self.image_file = image_file
 
-        local_artpath = self.plugin.art_for_album(None, [''], True)
-        remote_artpath = self.plugin.art_for_album(None, [], False)
-
-        self.assertEqual(local_artpath, remote_artpath)
+        artpath = self.plugin.art_for_album(None, [''], True).path
 
         if should_exist:
-            self.assertEqual(local_artpath, self.image_file)
-            self.assertExists(local_artpath)
-            return local_artpath
+            self.assertEqual(artpath, self.image_file)
+            self.assertExists(artpath)
+            return artpath
         else:
-            self.assertIsNone(local_artpath)
+            self.assertIsNone(artpath)
 
     def _assertImageResized(self, image_file, should_resize):
         self.image_file = image_file

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -29,7 +29,6 @@ from beetsplug import fetchart
 from beets.autotag import AlbumInfo, AlbumMatch
 from beets import library
 from beets import importer
-from beets import config
 from beets import logging
 from beets import util
 from beets.util.artresizer import ArtResizer, WEBPROXY

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -286,7 +286,7 @@ class ArtImporterTest(UseThePlugin):
         self.art_file = os.path.join(self.temp_dir, 'tmpcover.jpg')
         _common.touch(self.art_file)
         self.old_afa = self.plugin.art_for_album
-        self.afa_response = self.art_file
+        self.afa_response = fetchart.Candidate(path=self.art_file)
 
         def art_for_album(i, p, local_only=False):
             return self.afa_response
@@ -377,7 +377,7 @@ class ArtImporterTest(UseThePlugin):
     def test_do_not_delete_original_if_already_in_place(self):
         artdest = os.path.join(os.path.dirname(self.i.path), 'cover.jpg')
         shutil.copyfile(self.art_file, artdest)
-        self.afa_response = artdest
+        self.afa_response = fetchart.Candidate(path=artdest)
         self._fetch_art(True)
 
     def test_fetch_art_if_imported_file_deleted(self):


### PR DESCRIPTION
As suggested by @sampsyo in #1917, this is my Fetchart refactoring in a separate PR. It adds no functionality, but may come in handy if I actually get around implementing said PR.

Opened for now to run the tests.