### PR TITLE
list skipped tests when running nosetests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
     flask
     mock
     nose
+    nose-show-skipped
     pyechonest
     pylast
     rarfile
@@ -29,7 +30,7 @@ deps =
     {[testenv]deps}
     coverage
 commands =
-    nosetests --with-coverage {posargs}
+    nosetests --show-skipped --with-coverage {posargs}
 
 [testenv:py27setup]
 basepython = python2.7


### PR DESCRIPTION
I found this useful to check whether all tests related to the code I changed were actually run. At least to me this was non-obvious as there are unimplemented tests on master (so there's always a number of skipped tests, which may even differ from system to system, depending for example on image-resize backends installed on my box but not on travis).
The travis output of `py27cov` should show what this looks like in a few minutes.