### PR TITLE
Fetchart: add fanart.tv source

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -204,7 +204,7 @@ class FanartTV(ArtSource):
         response = self.request(
             self.API_ALBUMS + album.mb_releasegroupid,
             headers={
-                'api-key': self._config['fanarttv_api_key'].get(),
+                'api-key': self._config['fanarttv_project_key'].get(),
                 'client-key': self._config['fanarttv_personal_key'].get()
             })
 
@@ -488,7 +488,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             'sources': ['coverart', 'itunes', 'amazon', 'albumart'],
             'google_key': None,
             'google_engine': u'001442825323518660753:hrh5ch1gjzm',
-            'fanarttv_api_key': None,
+            'fanarttv_project_key': None,
             'fanarttv_personal_key': None
         })
         self.config['google_key'].redact = True

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -216,12 +216,6 @@ class FanartTV(ArtSource):
                             response.text)
             return
 
-        def escape_for_log(s):
-            # the logger will eventually try to .format() the message, and
-            # interpret the dict as format spec...
-            return ''.join((2 * c if c in '{}' else c for c in s))
-        self._log.debug(escape_for_log(str(data)))
-
         if u'status' in data and data[u'status'] == u'error':
             if u'not found' in data[u'error message'].lower():
                 self._log.debug(u'fanart.tv: no image found')

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -196,7 +196,7 @@ class FanartTV(ArtSource):
     """Art from fanart.tv requested using their API"""
     API_URL = 'http://webservice.fanart.tv/v3/'
     API_ALBUMS = API_URL + 'music/albums/'
-    PROJECT_KEY = ''
+    PROJECT_KEY = '61a7d0ab4e67162b7a0c7c35915cd48e'
 
     def get(self, album):
         if not album.mb_releasegroupid:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,10 @@ New features:
   art while copying it.
 * :doc:`/plugins/importadded`: A new `preserve_write_mtimes` option
   lets you preserve mtime of files after each write.
+* :doc:`/plugins/fetchart`: Album art can now be fetched from `fanart.tv`_.
+  Albums are matched using the ``mb_releasegroupid`` tag.
+
+.. _fanart.tv: https://fanart.tv/
 
 Fixes:
 

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -165,7 +165,7 @@ Note that the Google custom search API is limited to 100 queries per day.
 After that, the fetchart plugin will fall back on other declared data sources.
 
 Fanart.tv
-.........
+'''''''''
 
 Although not strictly necesarry right now, you might think about
 `registering a personal fanart.tv API key`_. Set the ``fanarttv_personal_key``

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -50,13 +50,15 @@ file. The available options are:
 - **sources**: List of sources to search for images. An asterisk `*` expands
   to all available sources.
   Default: ``coverart itunes amazon albumart``, i.e., everything but
-  ``wikipedia`` and ``google``. Enable those two sources for more matches at
-  the cost of some speed.
+  ``wikipedia``, ``google`` and ``fanarttv``. Enable those sources for more
+  matches at the cost of some speed.
 - **google_key**: Your Google API key (to enable the Google Custom Search
   backend).
   Default: None.
 - **google_engine**: The custom search engine to use.
   Default: The `beets custom search engine`_, which searches the entire web.
+  **fanarttv_personal_key**: The personal API key for requesting art from
+  fanart.tv. See below.
 
 Note: ``minwidth`` and ``enforce_ratio`` options require either `ImageMagick`_
 or `Pillow`_.
@@ -161,6 +163,21 @@ default engine searches the entire web for cover art.
 
 Note that the Google custom search API is limited to 100 queries per day.
 After that, the fetchart plugin will fall back on other declared data sources.
+
+Fanart.tv
+.........
+
+Although not strictly necesarry right now, you might think about
+`registering a personal fanart.tv API key`_. Set the ``fanarttv_personal_key``
+configurati option to your key, then add ``fanarttv`` to the list of sources in
+your configuration.
+
+.. _registering a personal fanart.tv API key: https://fanart.tv/get-an-api-key/
+
+More detailed information can be found `on their blog`_. Specifically, the
+personal key will give you earlier access to new art.
+
+.. _on their blog: https://fanart.tv/2015/01/personal-api-keys/
 
 Embedding Album Art
 -------------------

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -57,7 +57,7 @@ file. The available options are:
   Default: None.
 - **google_engine**: The custom search engine to use.
   Default: The `beets custom search engine`_, which searches the entire web.
-  **fanarttv_personal_key**: The personal API key for requesting art from
+  **fanarttv_key**: The personal API key for requesting art from
   fanart.tv. See below.
 
 Note: ``minwidth`` and ``enforce_ratio`` options require either `ImageMagick`_
@@ -167,8 +167,8 @@ After that, the fetchart plugin will fall back on other declared data sources.
 Fanart.tv
 '''''''''
 
-Although not strictly necesarry right now, you might think about
-`registering a personal fanart.tv API key`_. Set the ``fanarttv_personal_key``
+Although not strictly necessary right now, you might think about
+`registering a personal fanart.tv API key`_. Set the ``fanarttv_key``
 configuration option to your key, then add ``fanarttv`` to the list of sources
 in your configuration.
 

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -169,8 +169,8 @@ Fanart.tv
 
 Although not strictly necesarry right now, you might think about
 `registering a personal fanart.tv API key`_. Set the ``fanarttv_personal_key``
-configurati option to your key, then add ``fanarttv`` to the list of sources in
-your configuration.
+configuration option to your key, then add ``fanarttv`` to the list of sources
+in your configuration.
 
 .. _registering a personal fanart.tv API key: https://fanart.tv/get-an-api-key/
 

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -260,6 +260,81 @@ class GoogleImageTest(UseThePlugin):
         self.assertEqual(list(result_url), [])
 
 
+class FanartTVTest(UseThePlugin):
+    RESPONSE_MULTIPLE = u"""{
+        "name": "artistname",
+        "mbid_id": "artistid",
+        "albums": {
+            "thereleasegroupid": {
+                "albumcover": [
+                    {
+                        "id": "24",
+                        "url": "http://example.com/1.jpg",
+                        "likes": "0"
+                    },
+                    {
+                        "id": "42",
+                        "url": "http://example.com/2.jpg",
+                        "likes": "0"
+                    },
+                    {
+                        "id": "23",
+                        "url": "http://example.com/3.jpg",
+                        "likes": "0"
+                    }
+                ],
+                "cdart": [
+                    {
+                        "id": "123",
+                        "url": "http://example.com/4.jpg",
+                        "likes": "0",
+                        "disc": "1",
+                        "size": "1000"
+                    }
+                ]
+            }
+        }
+    }"""
+    RESPONSE_ERROR = u"""{
+        "status": "error",
+        "error message": "the error message"
+    }"""
+    RESPONSE_MALFORMED = u"bla blup"
+
+    def setUp(self):
+        super(FanartTVTest, self).setUp()
+        self.source = fetchart.FanartTV(logger, self.plugin.config)
+
+    @responses.activate
+    def run(self, *args, **kwargs):
+        super(FanartTVTest, self).run(*args, **kwargs)
+
+    def mock_response(self, url, json):
+        responses.add(responses.GET, url, body=json,
+                      content_type='application/json')
+
+    def test_fanarttv_finds_image(self):
+        album = _common.Bag(mb_releasegroupid=u'thereleasegroupid')
+        self.mock_response(fetchart.FanartTV.API_ALBUMS + u'thereleasegroupid',
+                           self.RESPONSE_MULTIPLE)
+        result_url = self.source.get(album)
+        self.assertEqual(list(result_url)[0], 'http://example.com/1.jpg')
+
+    def test_fanarttv_returns_no_result_when_error_received(self):
+        album = _common.Bag(mb_releasegroupid=u'thereleasegroupid')
+        self.mock_response(fetchart.FanartTV.API_ALBUMS + u'thereleasegroupid',
+                           self.RESPONSE_ERROR)
+        result_url = self.source.get(album)
+        self.assertEqual(list(result_url), [])
+
+    def test_fanarttv_returns_no_result_with_malformed_response(self):
+        album = _common.Bag(mb_releasegroupid=u'thereleasegroupid')
+        self.mock_response(fetchart.FanartTV.API_ALBUMS + u'thereleasegroupid',
+                           self.RESPONSE_MALFORMED)
+        result_url = self.source.get(album)
+        self.assertEqual(list(result_url), [])
+
+
 @_common.slow_test()
 class ArtImporterTest(UseThePlugin):
     def setUp(self):


### PR DESCRIPTION
This has evolved to be my favourite art source due to high quality, hence the PR. There is a nice API, it requires a project API key though.
How has this been handled for other webservices; is there some project(beets.io/beetbox?) mailbox that is usually used for registering keys? This is done on the same website as for personal keys:
[Get an API key](https://fanart.tv/get-an-api-key/)
Using a key registered with a private mail, the code works just fine (for existing as for non-existing art).

Missing:
- [x] API key
- [x] tests
- [x] review the amount of debug prints; compare to other sources