### PR TITLE
Fetchart store artwork origin in a flexible field

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -676,7 +676,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             'google_key': None,
             'google_engine': u'001442825323518660753:hrh5ch1gjzm',
             'fanarttv_key': None,
-            'store_origin': False
+            'store_source': False,
         })
         self.config['google_key'].redact = True
         self.config['fanarttv_key'].redact = True
@@ -704,7 +704,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         cover_names = self.config['cover_names'].as_str_seq()
         self.cover_names = map(util.bytestring_path, cover_names)
         self.cautious = self.config['cautious'].get(bool)
-        self.store_origin = self.config['store_origin'].get(bool)
+        self.store_source = self.config['store_source'].get(bool)
 
         self.src_removed = (config['import']['delete'].get(bool) or
                             config['import']['move'].get(bool))
@@ -759,12 +759,12 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
 
     def _set_art(self, album, candidate, delete=False):
         album.set_art(candidate.path, delete)
-        if self.store_origin:
-            # store the origin of the chosen artwork in a flexible field
+        if self.store_source:
+            # store the source of the chosen artwork in a flexible field
             self._log.debug(
-                u"Storing artorigin for {0.albumartist} - {0.album}",
+                u"Storing art_source for {0.albumartist} - {0.album}",
                 album)
-            album.artorigin = candidate.source
+            album.art_source = candidate.source
         album.store()
 
     # Synchronous; after music files are put in place.

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -197,7 +197,7 @@ class ArtSource(RequestMixin):
         raise NotImplementedError()
 
     def _candidate(self, **kwargs):
-        return Candidate(source=self.NAME, log=self._log, **kwargs)
+        return Candidate(source=self, log=self._log, **kwargs)
 
     def fetch_image(self, candidate, extra):
         raise NotImplementedError()
@@ -764,7 +764,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             self._log.debug(
                 u"Storing art_source for {0.albumartist} - {0.album}",
                 album)
-            album.art_source = candidate.source
+            album.art_source = SOURCE_NAMES[type(candidate.source)]
         album.store()
 
     # Synchronous; after music files are put in place.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,8 @@ New features:
 * :doc:`/plugins/fetchart`: The ``enforce_ratio`` option was enhanced and now
   allows specifying a certain deviation that a valid image may have from being
   exactly square.
+* :doc:`/plugins/fetchart`: The plugin can now optionally save the artwork's
+  source in a flexible field; for a usecase see the documentation.
 * :doc:`/plugins/export`: A new plugin to export the data from queries to a
   json format. Thanks to :user:`GuilhermeHideki`.
 

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -62,6 +62,9 @@ file. The available options are:
   Default: The `beets custom search engine`_, which searches the entire web.
   **fanarttv_key**: The personal API key for requesting art from
   fanart.tv. See below.
+  **store_origin**: If enabled, fetchart store the artwork's source in a
+  flexible tag. See below for the rationale behind this.
+  Default: ``no``.
 
 Note: ``minwidth`` and ``enforce_ratio`` options require either `ImageMagick`_
 or `Pillow`_.
@@ -181,6 +184,16 @@ More detailed information can be found `on their blog`_. Specifically, the
 personal key will give you earlier access to new art.
 
 .. _on their blog: https://fanart.tv/2015/01/personal-api-keys/
+
+Storing the artwork's origin
+----------------------------
+
+Storing the current artwork's source gives the opportunity to selectively
+search for new art. For example, if some albums have artwork placed manually in
+their directories that should not be replaced by a forced album art fetch, you
+could do
+
+``beet fetchart -f ^artorigin:filesystem``
 
 Embedding Album Art
 -------------------

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -62,8 +62,8 @@ file. The available options are:
   Default: The `beets custom search engine`_, which searches the entire web.
   **fanarttv_key**: The personal API key for requesting art from
   fanart.tv. See below.
-  **store_origin**: If enabled, fetchart store the artwork's source in a
-  flexible tag. See below for the rationale behind this.
+- **store_source**: If enabled, fetchart store the artwork's source in a
+  flexible tag named ``art_source``. See below for the rationale behind this.
   Default: ``no``.
 
 Note: ``minwidth`` and ``enforce_ratio`` options require either `ImageMagick`_
@@ -185,7 +185,7 @@ personal key will give you earlier access to new art.
 
 .. _on their blog: https://fanart.tv/2015/01/personal-api-keys/
 
-Storing the artwork's origin
+Storing the Artwork's Source
 ----------------------------
 
 Storing the current artwork's source gives the opportunity to selectively
@@ -193,7 +193,7 @@ search for new art. For example, if some albums have artwork placed manually in
 their directories that should not be replaced by a forced album art fetch, you
 could do
 
-``beet fetchart -f ^artorigin:filesystem``
+``beet fetchart -f ^art_source:filesystem``
 
 Embedding Album Art
 -------------------

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -195,6 +195,12 @@ could do
 
 ``beet fetchart -f ^art_source:filesystem``
 
+The values written to ``art_source`` are:
+
+``'Cover Art Archive'``, ``'Amazon'``, ``'AlbumArt.org scraper'``, ``'Google Images'``,
+``'fanart.tv'``, ``'iTunes Store'``, ``'Wikipedia (queried through DBpedia)'``,
+``'Filesystem'``
+
 Embedding Album Art
 -------------------
 

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -62,7 +62,7 @@ file. The available options are:
   Default: The `beets custom search engine`_, which searches the entire web.
   **fanarttv_key**: The personal API key for requesting art from
   fanart.tv. See below.
-- **store_source**: If enabled, fetchart store the artwork's source in a
+- **store_source**: If enabled, fetchart stores the artwork's source in a
   flexible tag named ``art_source``. See below for the rationale behind this.
   Default: ``no``.
 
@@ -188,18 +188,15 @@ personal key will give you earlier access to new art.
 Storing the Artwork's Source
 ----------------------------
 
-Storing the current artwork's source gives the opportunity to selectively
-search for new art. For example, if some albums have artwork placed manually in
-their directories that should not be replaced by a forced album art fetch, you
-could do
+Storing the current artwork's source might be used to narrow down
+``fetchart`` commands. For example, if some albums have artwork placed
+manually in their directories that should not be replaced by a forced
+album art fetch, you could do
 
 ``beet fetchart -f ^art_source:filesystem``
 
-The values written to ``art_source`` are:
-
-``'Cover Art Archive'``, ``'Amazon'``, ``'AlbumArt.org scraper'``, ``'Google Images'``,
-``'fanart.tv'``, ``'iTunes Store'``, ``'Wikipedia (queried through DBpedia)'``,
-``'Filesystem'``
+The values written to ``art_source`` are the same names used in the ``sources``
+configuration value.
 
 Embedding Album Art
 -------------------


### PR DESCRIPTION
This is probably rather niche. I care about high-quality artwork, so occasionally, I might download some images manually in difficult cases and place them in the filesystem to import. Consequently, I don't want them to be replaced by a `beet fetchart -f` which will not consider local art. Even if it did, I don't see a way for it to decide whether the local image is to be kept. This PR would enable me to prevent this by a query like so:

`beet fetchart -f ^artorigin:filesystem`

and even speed it up if I consider a remote source to always provide sufficient quality:

`beet fetchart -f ^artorigin:filesystem ^artorigin:fanart`

Now this does add a config option that I'm not sure of anybody but me would use, therefore I'd like to hear some opinions on whether this should go into master, or rather be kept as a local patch for me. This is based on the unmerged #1930 because it provided me a straightforward way to pass the source's name around in `fetchart.py`. **Only the last commit** here is actually specific to this PR, all the rest is from #1930.