### PR TITLE
Use different method to remove junk from LyricsWiki output

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -334,7 +334,7 @@ class LyricsWiki(SymbolsReplaced):
 
         # Get the HTML fragment inside the appropriate HTML element and then
         # extract the text from it.
-        html_frag = extract_text_in(unescape(html), u"<div class='lyricbox'>")
+        html_frag = extract_text_in(html, u"<div class='lyricbox'>")
         lyrics = _scrape_strip_cruft(html_frag, True)
 
         if lyrics and 'Unfortunately, we are not licensed' not in lyrics:

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -335,7 +335,7 @@ class LyricsWiki(SymbolsReplaced):
         # Get the HTML fragment inside the appropriate HTML element and then
         # extract the text from it.
         html_frag = extract_text_in(unescape(html), u"<div class='lyricbox'>")
-        lyrics = scrape_lyrics_from_html(html_frag)
+        lyrics = _scrape_strip_cruft(html_frag, True)
 
         if lyrics and 'Unfortunately, we are not licensed' not in lyrics:
             return lyrics


### PR DESCRIPTION
Use `_scrape_strip_cruft` instead of `scrape_lyrics_from_html` so that LyricsWiki does not depend on Beautiful Soup.

Also removes the unneeded call to `unescape`, as `_scrape_strip_cruft` does that for us too.