### PR TITLE
Allow force-quitting the pipeline

### DIFF
--- a/beets/mediafile.py
+++ b/beets/mediafile.py
@@ -1210,7 +1210,7 @@ class DateField(MediaField):
         for item in items:
             try:
                 items_.append(int(item))
-            except:
+            except (TypeError, ValueError):
                 items_.append(None)
         return items_
 

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -264,7 +264,7 @@ def load_plugins(names=()):
                             and obj != BeetsPlugin and obj not in _classes:
                         _classes.add(obj)
 
-        except:
+        except Exception:
             log.warn(
                 u'** error loading plugin {}:\n{}',
                 name,

--- a/beets/util/bluelet.py
+++ b/beets/util/bluelet.py
@@ -282,7 +282,7 @@ def run(root_coro):
         except StopIteration:
             # Thread is done.
             complete_thread(coro, None)
-        except:
+        except BaseException:
             # Thread raised some other exception.
             del threads[coro]
             raise ThreadException(coro, sys.exc_info())
@@ -379,7 +379,7 @@ def run(root_coro):
                 exit_te = te
                 break
 
-        except:
+        except BaseException:
             # For instance, KeyboardInterrupt during select(). Raise
             # into root thread and terminate others.
             threads = {root_coro: ExceptionEvent(sys.exc_info())}

--- a/beets/util/functemplate.py
+++ b/beets/util/functemplate.py
@@ -524,7 +524,7 @@ class Template(object):
         """
         try:
             res = self.compiled(values, functions)
-        except:  # Handle any exceptions thrown by compiled version.
+        except Exception:  # Handle any exceptions thrown by compiled version.
             res = self.interpret(values, functions)
         return res
 

--- a/beets/util/pipeline.py
+++ b/beets/util/pipeline.py
@@ -259,7 +259,7 @@ class FirstPipelineThread(PipelineThread):
                             return
                     self.out_queue.put(msg)
 
-        except:
+        except BaseException:
             self.abort_all(sys.exc_info())
             return
 
@@ -307,7 +307,7 @@ class MiddlePipelineThread(PipelineThread):
                             return
                     self.out_queue.put(msg)
 
-        except:
+        except BaseException:
             self.abort_all(sys.exc_info())
             return
 
@@ -346,7 +346,7 @@ class LastPipelineThread(PipelineThread):
                 # Send to consumer.
                 self.coro.send(msg)
 
-        except:
+        except BaseException:
             self.abort_all(sys.exc_info())
             return
 
@@ -414,7 +414,7 @@ class Pipeline(object):
             while threads[-1].isAlive():
                 threads[-1].join(1)
 
-        except:
+        except BaseException:
             # Stop all the threads immediately.
             for thread in threads:
                 thread.abort()

--- a/beetsplug/duplicates.py
+++ b/beetsplug/duplicates.py
@@ -184,7 +184,7 @@ class DuplicatesPlugin(BeetsPlugin):
         if tag:
             try:
                 k, v = tag.split('=')
-            except:
+            except Exception:
                 raise UserError(
                     u"{}: can't parse k=v tag: {}".format(PLUGIN, tag)
                 )

--- a/beetsplug/thumbnails.py
+++ b/beetsplug/thumbnails.py
@@ -271,8 +271,6 @@ class GioURI(URIGetter):
 
         try:
             uri_ptr = self.libgio.g_file_get_uri(g_file_ptr)
-        except:
-            raise
         finally:
             self.libgio.g_object_unref(g_file_ptr)
         if not uri_ptr:
@@ -282,8 +280,6 @@ class GioURI(URIGetter):
 
         try:
             uri = copy_c_string(uri_ptr)
-        except:
-            raise
         finally:
             self.libgio.g_free(uri_ptr)
         return uri


### PR DESCRIPTION
The situation: I was running an import task, that apparently locked up, i.e. it didn't advance for hours, even though not all user queries were run. Replaygain was enabled, but for 20-ish albums, even that should not take as long. Worse, I couldn't quit beets per `KeyboardInterrupt` and as a result didn't end up with a traceback when I eventually `kill`-ed beets. Not very satisfying, because I couldn't find out where it actually got stuck.

(The actual culprit may have been related to a flaky USB connection to the external drive with the music.)

Therefore, this is my attempt at allowing to quit at any time, safeguarded by having to press `Ctrl-C` rapidly several times (and a warning about data loss). What do you think? Worth merging, or better off as a developer tool in a separate branch?

I think at least the first commit should go in, as it fixes a few catch-all `except:`s. According to `grep`, the only remaining catch-alls are now in `beets/util/bluelet.py`, which I dared not touch. Also, it is only used by the `bpd` plugin (again, says `grep`), and might already be properly handled (I did not read the `bluelet` code).

This tackles https://github.com/beetbox/beets/issues/803 , but does not actually solve the problem (Maybe I'll revive that issue). 
