### PR TITLE
add a 'terminal_decoding' option

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -46,7 +46,6 @@ timeout: 5.0
 per_disc_numbering: no
 verbose: 0
 terminal_encoding:
-terminal_decoding:
 original_date: no
 id3v23: no
 va_name: "Various Artists"

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -46,6 +46,7 @@ timeout: 5.0
 per_disc_numbering: no
 verbose: 0
 terminal_encoding:
+terminal_decoding:
 original_date: no
 id3v23: no
 va_name: "Various Artists"

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -71,14 +71,16 @@ class UserError(Exception):
 
 
 # Encoding utilities.
-def _in_encoding():
-    """Get the encoding to use for *inputting* strings to the console.
+
+
+def _in_encoding(default=u'utf-8'):
+    """Get the encoding to use for *inputting* strings from the console.
+
+    :param default: the fallback sys.stdin encoding
     """
-    try:
-        return sys.stdin.encoding or 'utf-8'
-    except LookupError:
-        # TODO: create user config
-        return 'utf-8'
+
+    return config['terminal_decoding'].get() or getattr(sys.stdin, 'encoding',
+                                                        default)
 
 
 def _out_encoding():
@@ -90,7 +92,7 @@ def _out_encoding():
         return encoding
 
     # For testing: When sys.stdout is a StringIO under the test harness,
-    # it doesn't have an `encodiing` attribute. Just use UTF-8.
+    # it doesn't have an `encoding` attribute. Just use UTF-8.
     if not hasattr(sys.stdout, 'encoding'):
         return 'utf8'
 

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -79,7 +79,7 @@ def _in_encoding(default=u'utf-8'):
     :param default: the fallback sys.stdin encoding
     """
 
-    return config['terminal_decoding'].get() or getattr(sys.stdin, 'encoding',
+    return config['terminal_encoding'].get() or getattr(sys.stdin, 'encoding',
                                                         default)
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,9 +23,8 @@ New features:
 * :doc:`/plugins/export`: A new plugin to export the data from queries to a
   json format. Thanks to :user:`GuilhermeHideki`.
 * :doc:`/reference/pathformat`: new functions: %first{} and %ifdef{}
-* :doc:`/reference/config`: new option ``terminal_decoding`` for overriding
-  the encoding from the input. Solves the problem with invalid Python 2 codecs,
-  like ``cp65001`` (fixed on Python 3.3) by setting ``terminal_decoding: utf-8``
+* :doc:`/reference/config`: option ``terminal_encoding`` now works for some
+  inputs
 
 .. _fanart.tv: https://fanart.tv/
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,9 @@ New features:
 * :doc:`/plugins/export`: A new plugin to export the data from queries to a
   json format. Thanks to :user:`GuilhermeHideki`.
 * :doc:`/reference/pathformat`: new functions: %first{} and %ifdef{}
+* :doc:`/reference/config`: new option ``terminal_decoding`` for overriding
+  the encoding from the input. Solves the problem with invalid Python 2 codecs,
+  like ``cp65001`` (fixed on Python 3.3) by setting ``terminal_decoding: utf-8``
 
 .. _fanart.tv: https://fanart.tv/
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -268,7 +268,8 @@ terminal_encoding
 ~~~~~~~~~~~~~~~~~
 
 The text encoding, as `known to Python`_, to use for messages printed to the
-standard output. By default, this is determined automatically from the locale
+standard output. It's also used to read messages from the standard input.
+By default, this is determined automatically from the locale
 environment variables.
 
 .. _known to python: http://docs.python.org/2/library/codecs.html#standard-encodings

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -273,6 +273,14 @@ environment variables.
 
 .. _known to python: http://docs.python.org/2/library/codecs.html#standard-encodings
 
+.. _terminal_decoding:
+
+terminal_decoding
+~~~~~~~~~~~~~~~~~
+
+Like the ``terminal_encoding``, but for inputs
+
+
 .. _clutter:
 
 clutter

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -273,14 +273,6 @@ environment variables.
 
 .. _known to python: http://docs.python.org/2/library/codecs.html#standard-encodings
 
-.. _terminal_decoding:
-
-terminal_decoding
-~~~~~~~~~~~~~~~~~
-
-Like the ``terminal_encoding``, but for inputs
-
-
 .. _clutter:
 
 clutter


### PR DESCRIPTION
The problem with the windows "unicode" code page was that they returned the right code page, but python doesn't know how to "use".

The solutions were:
1. monkey-patch a new encoding which returns 'utf-8'
2. let the user override, that basically the same thing as 1, but more clean.
3. use something like
```py
try:
  myfunc(get_encoding())
except LookupError:
  myfunc('utf-8')
```

One thing to consider, is if `terminal_decoding` should be used to override `_arg_encoding()`