### PR TITLE
Add flake8 check for quotes

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,5 +48,6 @@ commands =
 deps =
     flake8
     flake8-future-import
+    flake8-quotes
     pep8-naming
 commands = flake8 beets beetsplug beet test setup.py docs


### PR DESCRIPTION
[flake8-quotes]: https://github.com/zheller/flake8-quotes
[PEP 257]: https://www.python.org/dev/peps/pep-0257/

Add flake8 check for quotes using [flake8-quotes][flake8-quotes] \(Q000).

Now I'm honestly not too sure about this one but I thought I'd make a PR just to get some opinions on it.

I'm all for consistency, but seeing the sheer number of places beets uses differing quotes scares me 😨!

This PR enforces docstrings and strings to use single quotes. Here is an example of some code that passes the check:

```python
def hello():
    '''
    Prints "Hello, world!"
    '''
    print('Hello, world!')
```

And some code that does not pass the check:


```python
def hello():
    """
    Prints "Hello, world!"
    """
    print("Hello, world!")
```

One rather big issue I find is that [PEP 257] uses the following style (as does most of beets):

```python
```python
def hello():
    """
    Prints "Hello, world!"
    """
    print('Hello, world!')
```

Which I prefer, as it allows us to distinguish docstrings and normal strings (docstrings use double quotes and normal strings use single quotes). The issue is that [flake8-quotes] doesn't support this, maybe a PR is in order for support?