### PR TITLE
Add pydocstyle checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
           env: {TOX_ENV: docs, NONTEST: 1}
         - python: 2.7
           env: {TOX_ENV: flake8, NONTEST: 1}
+        - python: 2.7
+          env: {TOX_ENV: pydocstyle, NONTEST: 1}
 
 # Non-Python dependencies.
 addons:

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,5 @@ deps =
 commands = flake8 beets beetsplug beet test setup.py docs
 
 [testenv:pydocstyle]
-deps =
-    pydocstyle
-commands =
-    -pydocstyle beets beetsplug beet test setup.py docs
+deps = pydocstyle
+commands = -pydocstyle beets beetsplug beet test setup.py docs

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, pypy, docs, flake8
+envlist = py27, pypy, docs, flake8, pydocstyle
 
 [testenv]
 deps =
@@ -50,3 +50,8 @@ deps =
     flake8-future-import
     pep8-naming
 commands = flake8 beets beetsplug beet test setup.py docs
+
+[testenv:pydocstyle]
+deps =
+    pydocstyle
+commands = pydocstyle beets beetsplug beet test setup.py docs

--- a/tox.ini
+++ b/tox.ini
@@ -54,4 +54,5 @@ commands = flake8 beets beetsplug beet test setup.py docs
 [testenv:pydocstyle]
 deps =
     pydocstyle
-commands = pydocstyle beets beetsplug beet test setup.py docs
+commands =
+    -pydocstyle beets beetsplug beet test setup.py docs


### PR DESCRIPTION
Sadly we have to add a new tox environment and test to the travis matrix for this, as we can't easily integrate this with flake8.

As we currently stand (using the default configuration), there are a large number of errors output by [`pydocstyle`](https://github.com/PyCQA/pydocstyle), although I'm sure we can fine tune it to suit our needs.
