### PR TITLE
convert plugin: Change the default ogg quality

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -120,7 +120,7 @@ class ConvertPlugin(BeetsPlugin):
                 u'opus':
                     u'ffmpeg -i $source -y -vn -acodec libopus -ab 96k $dest',
                 u'ogg':
-                    u'ffmpeg -i $source -y -vn -acodec libvorbis -aq 2 $dest',
+                    u'ffmpeg -i $source -y -vn -acodec libvorbis -aq 3 $dest',
                 u'wma':
                     u'ffmpeg -i $source -y -vn -acodec wmav2 -vn $dest',
             },


### PR DESCRIPTION
According to the `oggenc(1)` man page (in vorbis-tools), the default quality is 3, not 2. So we should use that.