### PR TITLE
Add write option to bpm plugin

### DIFF
--- a/beetsplug/bpm.py
+++ b/beetsplug/bpm.py
@@ -54,6 +54,7 @@ class BPMPlugin(BeetsPlugin):
         self.config.add({
             u'max_strokes': 3,
             u'overwrite': True,
+            u'write': False
         })
 
     def commands(self):
@@ -64,7 +65,9 @@ class BPMPlugin(BeetsPlugin):
         return [cmd]
 
     def command(self, lib, opts, args):
-        self.get_bpm(lib.items(ui.decargs(args)))
+        items = lib.items(ui.decargs(args))
+        write = self.config['write'].get(bool)
+        self.get_bpm(items, write)
 
     def get_bpm(self, items, write=False):
         overwrite = self.config['overwrite'].get(bool)

--- a/beetsplug/bpm.py
+++ b/beetsplug/bpm.py
@@ -53,7 +53,7 @@ class BPMPlugin(BeetsPlugin):
         super(BPMPlugin, self).__init__()
         self.config.add({
             u'max_strokes': 3,
-            u'overwrite': True
+            u'overwrite': True,
         })
 
     def commands(self):

--- a/beetsplug/bpm.py
+++ b/beetsplug/bpm.py
@@ -53,8 +53,7 @@ class BPMPlugin(BeetsPlugin):
         super(BPMPlugin, self).__init__()
         self.config.add({
             u'max_strokes': 3,
-            u'overwrite': True,
-            u'write': False
+            u'overwrite': True
         })
 
     def commands(self):
@@ -66,7 +65,7 @@ class BPMPlugin(BeetsPlugin):
 
     def command(self, lib, opts, args):
         items = lib.items(ui.decargs(args))
-        write = self.config['write'].get(bool)
+        write = ui.should_write()
         self.get_bpm(items, write)
 
     def get_bpm(self, items, write=False):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,8 +22,8 @@ New features:
   source in a flexible field; for a usecase see the documentation.
 * :doc:`/plugins/export`: A new plugin to export the data from queries to a
   json format. Thanks to :user:`GuilhermeHideki`.
-* :doc:`/plugins/bpm`: Add ``write`` option to write tracks after updating
-  their BPM.
+* :doc:`/plugins/bpm`: Now uses ``import.write`` option to write tracks after
+  updating their BPM.
 * :doc:`/reference/pathformat`: new functions: %first{} and %ifdef{}
 * :doc:`/reference/config`: option ``terminal_encoding`` now works for some
   inputs

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,8 @@ New features:
   source in a flexible field; for a usecase see the documentation.
 * :doc:`/plugins/export`: A new plugin to export the data from queries to a
   json format. Thanks to :user:`GuilhermeHideki`.
+* :doc:`/plugins/bpm`: Add ``write`` option to write tracks after updating
+  their BPM.
 * :doc:`/reference/pathformat`: new functions: %first{} and %ifdef{}
 * :doc:`/reference/config`: option ``terminal_encoding`` now works for some
   inputs

--- a/docs/plugins/bpm.rst
+++ b/docs/plugins/bpm.rst
@@ -22,6 +22,20 @@ for instance, with ``mpc`` you can do something like::
 
      beet bpm $(mpc |head -1|tr -d "-")
 
+Configuration
+-------------
+
+To configure the plugin, make a ``bpm:`` section in your configuration file.
+The available options are:
+
+- **max_strokes**: The maximum number of strokes to accept when tapping out the
+  BPM.
+  Default: 3.
+- **overwrite**: Overwrite the track's existing BPM.
+  Default: ``yes``.
+- **write**: Write the song's tags to file when the BPM is updated.
+  Default: ``no``.
+
 Credit
 ------
 

--- a/docs/plugins/bpm.rst
+++ b/docs/plugins/bpm.rst
@@ -22,6 +22,9 @@ for instance, with ``mpc`` you can do something like::
 
      beet bpm $(mpc |head -1|tr -d "-")
 
+If :ref:`import.write <config-import-write>` is ``yes``, the song's tags are
+written to disk.
+
 Configuration
 -------------
 
@@ -33,8 +36,6 @@ The available options are:
   Default: 3.
 - **overwrite**: Overwrite the track's existing BPM.
   Default: ``yes``.
-- **write**: Write the song's tags to file when the BPM is updated.
-  Default: ``no``.
 
 Credit
 ------

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -373,6 +373,8 @@ file that looks like this::
 
 These options are available in this section:
 
+.. _config-import-write:
+
 write
 ~~~~~
 


### PR DESCRIPTION
Add write option to `bpm` plugin and tidy up command function.

It looks like a write option was going to be implemented but never ended up being added? The reason I think this is that there's an unused `write` argument for `get_bpm` that writes the item after the BPM is updated.

See #1991 and [#1991 (comment)](https://github.com/beetbox/beets/issues/1991#issuecomment-217119879) for more information.
