### PR TITLE
add lost+found directory to default ignore list

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -25,8 +25,9 @@ import:
     search_ids: []
 
 clutter: ["Thumbs.DB", ".DS_Store"]
-ignore: [".*", "*~", "System Volume Information"]
+ignore: [".*", "*~", "System Volume Information", "lost+found"]
 ignore_hidden: yes
+
 replace:
     '[\\/]': _
     '^\.': _

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,8 @@ New features:
   emitted by beets. :bug:`1561` :bug:`1603`
 * :doc:`/reference/config`: New ``ignore_hidden`` configuration option allowing
   platform-specific hidden files to be ignored on import.
+* :doc:`/reference/config`: option ``ignore`` now includes ``lost+found``
+  directory by default
 
 .. _fanart.tv: https://fanart.tv/
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -87,9 +87,10 @@ ignore
 ~~~~~~
 
 A list of glob patterns specifying file and directory names to be ignored when
-importing. By default, this consists of ``.*``,  ``*~``, and ``System Volume
-Information`` (i.e., beets ignores Unix-style hidden files, backup files, and
-a directory that appears at the root of some Windows filesystems).
+importing. By default, this consists of ``.*``,  ``*~``,  ``System Volume
+Information``, ``lost+found`` (i.e., beets ignores Unix-style hidden files,
+backup files, and directories that appears at the root of some Linux and Windows
+filesystems).
 
 ignore_hidden
 ~~~~~~~~~~~~~


### PR DESCRIPTION
This directory is often found at the root of various Linux filesystems