### PR TITLE
acousticbrainz plugin: Access acousticbrainz.org over HTTPS.

### DIFF
--- a/beetsplug/acousticbrainz.py
+++ b/beetsplug/acousticbrainz.py
@@ -22,7 +22,7 @@ import operator
 
 from beets import plugins, ui
 
-ACOUSTIC_BASE = "http://acousticbrainz.org/"
+ACOUSTIC_BASE = "https://acousticbrainz.org/"
 LEVELS = ["/low-level", "/high-level"]
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -57,6 +57,11 @@ Fixes:
 * :doc:`/plugins/convert`: The `never_convert_lossy_files` option now
   considers AIFF a lossless format. :bug:`2005`
 
+Other changes:
+
+* :doc:`/plugins/acousticbrainz`: AcousticBrainz lookups are now done over
+  HTTPS. Thanks to :user:`Freso`. :bug:`2007`
+
 
 1.3.17 (February 7, 2016)
 -------------------------


### PR DESCRIPTION
AcousticBrainz is going HTTPS-only soon: https://blog.musicbrainz.org/2016/05/19/were-actually-really-going-to-take-the-https-plunge/

This may cause the plugin to [not work with Python <2.7.9](https://tickets.musicbrainz.org/browse/MBH-363?focusedCommentId=39500&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#action_39500) though, hence the PR instead of just pushing it into the tree. OTOH, I don't think the AcousticBrainz people are going to wait around for Debian/Ubuntu to update their packages to move along.

Also not sure about the changelog entry.

Also also: not actually tested yet.