### PR TITLE
web: add API functions for retrieving unique values of specific keys

### DIFF
--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -124,6 +124,16 @@ def resource_list(name):
     return make_responder
 
 
+def _get_unique_table_field_values(model, field, sort_field):
+    """ retrieve all unique values belonging to a key from a model """
+    if field not in model.all_keys() or sort_field not in model.all_keys():
+        raise KeyError
+    with g.lib.transaction() as tx:
+        rows = tx.query('SELECT DISTINCT "{0}" FROM "{1}" ORDER BY "{2}"'
+                        .format(field, model._table, sort_field))
+    return [row[0] for row in rows]
+
+
 class IdListConverter(BaseConverter):
     """Converts comma separated lists of ids in urls to integer lists.
     """
@@ -194,6 +204,17 @@ def item_query(queries):
     return g.lib.items(queries)
 
 
+@app.route('/item/values/<string:key>')
+def item_unique_field_values(key):
+    sort_key = flask.request.args.get('sort_key', key)
+    try:
+        values = _get_unique_table_field_values(beets.library.Item, key,
+                                                sort_key)
+    except KeyError:
+        return flask.abort(404)
+    return flask.jsonify(values=values)
+
+
 # Albums.
 
 @app.route('/album/<idlist:ids>')
@@ -219,6 +240,17 @@ def album_query(queries):
 def album_art(album_id):
     album = g.lib.get_album(album_id)
     return flask.send_file(album.artpath)
+
+
+@app.route('/album/values/<string:key>')
+def album_unique_field_values(key):
+    sort_key = flask.request.args.get('sort_key', key)
+    try:
+        values = _get_unique_table_field_values(beets.library.Album, key,
+                                                sort_key)
+    except KeyError:
+        return flask.abort(404)
+    return flask.jsonify(values=values)
 
 
 # Artists.


### PR DESCRIPTION
the following API paths are added:
* /item/unique/FIELD
* /album/unique/FIELD

Both paths will deliver a json dictionary with the key 'values' containing a
list of unique values belonging to the requested table and field.

This feature is useful for categorization by remote clients, e.g. Mopidy-Beets:
* track genres: /item/unique/genre
* track languages: /album/unique/language
* album artists: /album/unique/albumartist
* album years: /album/unique/year


Notes for the reviewer: please take a look at my usage of the half-private attributes "_table" and "_fields". I thought I could use "all_keys()" for the latter, but this attribute was not accessible. I do not know of an alternative for "_table".
Is this attribute access acceptable for you?