### PR TITLE
web: handle missing art gracefully

### DIFF
--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -218,7 +218,10 @@ def album_query(queries):
 @app.route('/album/<int:album_id>/art')
 def album_art(album_id):
     album = g.lib.get_album(album_id)
-    return flask.send_file(album.artpath)
+    if album.artpath:
+        return flask.send_file(album.artpath)
+    else:
+        return flask.abort(404)
 
 
 # Artists.


### PR DESCRIPTION
This patch ensures to return a 404 if the requested album art is not available.
Right now an exception is thrown instead.