### PR TITLE
Cover more float types in safe_cast

### DIFF
--- a/beets/mediafile.py
+++ b/beets/mediafile.py
@@ -158,7 +158,8 @@ def _safe_cast(out_type, val):
         else:
             if not isinstance(val, basestring):
                 val = unicode(val)
-            match = re.match(r'[\+-]?[0-9\.]+', val.strip())
+            match = re.match(r'[\+-]?([0-9]+\.?[0-9]*|[0-9]*\.[0-9]+)',
+                             val.strip())
             if match:
                 val = match.group(0)
                 if val:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -59,6 +59,7 @@ Fixes:
 * :doc:`/plugins/web`: A proper 404 error, instead of an internal exception,
   is returned when missing album art is requested. Thanks to
   :user:`sumpfralle`. :bug:`2011`
+* Handle more float edge cases in ``safe_cast``. :bug:`2014`
 
 Other changes:
 

--- a/test/test_mediafile_edge.py
+++ b/test/test_mediafile_edge.py
@@ -132,6 +132,14 @@ class InvalidValueToleranceTest(unittest.TestCase):
         v = _sc(float, u'+')
         self.assertEqual(v, 0.0)
 
+    def test_safe_cast_float_with_dot_only(self):
+        v = _sc(float, u'.')
+        self.assertEqual(v, 0.0)
+
+    def test_safe_cast_float_with_multiple_dots(self):
+        v = _sc(float, u'1.0.0')
+        self.assertEqual(v, 1.0)
+
 
 class SafetyTest(unittest.TestCase, TestHelper):
     def setUp(self):


### PR DESCRIPTION
Now input like `.` and `1.0.0` are handled