### PR TITLE
Rebase our .gitignore on top of gitignore.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,39 +1,86 @@
-
 # general hidden files/directories
-
 .DS_Store
-.sconsign*
-.svn
-.tox
-.coverage
 .idea
-.ackrc
 
 # file patterns
-
-*.dylib
-*.la
-*.lo
-*.o
-*.pyc
-*.pyo
-*.so
-*.tar.gz
-*.tar.bz2
 *~
-*.project
-*.pydevproject
-*.ropeproject
-*.orig
 
 # Project Specific patterns
-
-dist/*
-beets.egg-info/*
-build/*
-docs/_build/*
 man
-htmlcov/*
-.noseids
-*.egg
 test/rsrc/lyrics/*
+
+# The rest is from https://www.gitignore.io/api/python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# pyenv
+.python-version
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject


### PR DESCRIPTION
The gitignore is located here: https://www.gitignore.io/api/python

I kept our settings at the top