### PR TITLE
Update tox configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,27 @@
 language: python
 sudo: false
 
+env:
+    global:
+        # Undocumented feature of nose-show-skipped.
+        NOSE_SHOW_SKIPPED: 1
+
 matrix:
     include:
         - python: 2.7
-          env: {TOX_ENV: py27-test, TOX_ARGS: --show-skipped --with-coverage, COVERAGE: 1}
+          env: {TOX_ENV: py27-cov, COVERAGE: 1}
         - python: 3.3
-          env: {TOX_ENV: py33-test, TOX_ARGS: --show-skipped}
+          env: {TOX_ENV: py33-test}
         - python: 3.4
-          env: {TOX_ENV: py34-test, TOX_ARGS: --show-skipped}
+          env: {TOX_ENV: py34-test}
         - python: 3.5
-          env: {TOX_ENV: py35-test, TOX_ARGS: --show-skipped}
+          env: {TOX_ENV: py35-test}
         - python: pypy
-          env: {TOX_ENV: pypy-test, TOX_ARGS: --show-skipped}
+          env: {TOX_ENV: pypy-test}
         - python: 2.7
-          env: {TOX_ENV: py27-flake8, TOX_ARGS: --min-version=2.7}
+          env: {TOX_ENV: py27-flake8}
         - python: 3.3
-          env: {TOX_ENV: py33-flake8, TOX_ARGS: --min-version=3.3}
+          env: {TOX_ENV: py33-flake8}
         - python: 2.7
           env: {TOX_ENV: docs}
     allow_failures:
@@ -37,7 +42,7 @@ install:
     - travis_retry pip install tox sphinx
     - travis_retry tox -e $TOX_ENV --notest
 
-script: tox -e $TOX_ENV -- $TOX_ARGS
+script: tox -e $TOX_ENV
 
 # Report coverage to codecov.io.
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,26 @@ sudo: false
 matrix:
     include:
         - python: 2.7
-          env: {TOX_ENV: py27cov, COVERAGE: 1}
+          env: {TOX_ENV: py27-test, TOX_ARGS: --show-skipped --with-coverage, COVERAGE: 1}
+        - python: 3.3
+          env: {TOX_ENV: py33-test, TOX_ARGS: --show-skipped}
+        - python: 3.4
+          env: {TOX_ENV: py34-test, TOX_ARGS: --show-skipped}
+        - python: 3.5
+          env: {TOX_ENV: py35-test, TOX_ARGS: --show-skipped}
         - python: pypy
-          env: {TOX_ENV: pypy}
+          env: {TOX_ENV: pypy-test, TOX_ARGS: --show-skipped}
         - python: 2.7
-          env: {TOX_ENV: docs, NONTEST: 1}
+          env: {TOX_ENV: py27-flake8, TOX_ARGS: --min-version=2.7}
+        - python: 3.3
+          env: {TOX_ENV: py33-flake8, TOX_ARGS: --min-version=3.3}
         - python: 2.7
-          env: {TOX_ENV: flake8, NONTEST: 1}
+          env: {TOX_ENV: docs}
+    allow_failures:
+        - python: 3.3
+        - python: 3.4
+        - python: 3.5
+        - python: pypy3
 
 # Non-Python dependencies.
 addons:
@@ -25,7 +38,7 @@ install:
     - travis_retry pip install tox sphinx
     - travis_retry tox -e $TOX_ENV --notest
 
-script: tox -e $TOX_ENV
+script: tox -e $TOX_ENV -- $TOX_ARGS
 
 # Report coverage to codecov.io.
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
         - python: 3.3
         - python: 3.4
         - python: 3.5
-        - python: pypy3
 
 # Non-Python dependencies.
 addons:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,17 +4,31 @@ deploy: off
 
 environment:
     matrix:
-        - PYTHON: "C:\\Python27"
-          TOXENV: py27
+        - PYTHON: C:\Python27
+          TOX_ENV: py27-test
+          TOX_ARGS: --show-skipped
+        - PYTHON: C:\Python33
+          TOX_ENV: py33-test
+          TOX_ARGS: --show-skipped
+        - PYTHON: C:\Python34
+          TOX_ENV: py34-test
+          TOX_ARGS: --show-skipped
+        - PYTHON: C:\Python35
+          TOX_ENV: py35-test
+          TOX_ARGS: --show-skipped
 
 # Install Tox for running tests.
 install:
     - "%PYTHON%/Scripts/pip.exe install tox"
+    - "%PYTHON%/Scripts/tox.exe -e %TOX_ENV% --notest"
 
 test_script:
-    - "%PYTHON%/Scripts/tox.exe"
+    - "%PYTHON%/Scripts/tox.exe -e %TOX_ENV% -- %TOX_ARGS%"
 
 # Allow all failures for now: the tests don't yet pass!
 matrix:
     allow_failures:
-        - TOXENV: py27
+        - TOX_ENV: py27-test
+        - TOX_ENV: py33-test
+        - TOX_ENV: py34-test
+        - TOX_ENV: py35-test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,19 +3,18 @@ build: off
 deploy: off
 
 environment:
+    # Undocumented feature of nose-show-skipped.
+    NOSE_SHOW_SKIPPED: 1
+
     matrix:
         - PYTHON: C:\Python27
           TOX_ENV: py27-test
-          TOX_ARGS: --show-skipped
         - PYTHON: C:\Python33
           TOX_ENV: py33-test
-          TOX_ARGS: --show-skipped
         - PYTHON: C:\Python34
           TOX_ENV: py34-test
-          TOX_ARGS: --show-skipped
         - PYTHON: C:\Python35
           TOX_ENV: py35-test
-          TOX_ARGS: --show-skipped
 
 # Install Tox for running tests.
 install:
@@ -23,7 +22,7 @@ install:
     - "%PYTHON%/Scripts/tox.exe -e %TOX_ENV% --notest"
 
 test_script:
-    - "%PYTHON%/Scripts/tox.exe -e %TOX_ENV% -- %TOX_ARGS%"
+    - "%PYTHON%/Scripts/tox.exe -e %TOX_ENV%"
 
 # Allow all failures for now: the tests don't yet pass!
 matrix:

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ logging-clear-handlers=1
 eval-attr="!=slow"
 
 [flake8]
+min-version=2.7
 # Default pyflakes errors we ignore:
 # - E241: missing whitespace after ',' (used to align visually)
 # - E221: multiple spaces before operator (used to align visually)

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,6 @@ logging-clear-handlers=1
 eval-attr="!=slow"
 
 [flake8]
-min-version = 2.7
 # Default pyflakes errors we ignore:
 # - E241: missing whitespace after ',' (used to align visually)
 # - E221: multiple spaces before operator (used to align visually)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = test, flake8, docs
+envlist = py{27,33,34,35}-{test,cov}, py{27,33}-flake8, docs
 
 [_test]
 deps =
@@ -31,12 +31,21 @@ deps =
 files = beets beetsplug beet test setup.py docs
 
 [testenv]
+basepython =
+    py27: python2.7
+    py33: python3.3
+    py34: python3.4
+    py35: python3.5
+passenv =
+    NOSE_SHOW_SKIPPED # Undocumented feature of nose-show-skipped.
 deps =
-    test: {[_test]deps}
-    flake8: {[_flake8]deps}
+    {test,cov}: {[_test]deps}
+    py{27,33}-flake8: {[_flake8]deps}
 commands =
+    cov: nosetests --with-coverage {posargs}
     test: nosetests {posargs}
-    flake8: flake8 {posargs:--min-version=2.7} {[_flake8]files}
+    py27-flake8: flake8 --min-version 2.7 {posargs} {[_flake8]files}
+    py33-flake8: flake8 --min-version 3.3 {posargs} {[_flake8]files}
 
 [testenv:docs]
 basepython = python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -31,11 +31,6 @@ deps =
 files = beets beetsplug beet test setup.py docs
 
 [testenv]
-basepython =
-    py27: python2.7
-    py33: python3.3
-    py34: python3.4
-    py35: python3.5
 passenv =
     NOSE_SHOW_SKIPPED # Undocumented feature of nose-show-skipped.
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,9 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, pypy, docs, flake8
+envlist = test, flake8, docs
 
-[testenv]
+[_test]
 deps =
     beautifulsoup4
     flask
@@ -21,27 +21,24 @@ deps =
     pyxdg
     jellyfish
     python-mpd2
-commands = nosetests {posargs}
-
-[testenv:py27cov]
-basepython = python2.7
-deps =
-    {[testenv]deps}
     coverage
-commands = nosetests --show-skipped --with-coverage {posargs}
 
-[testenv:py27setup]
-basepython = python2.7
-commands = python ./setup.py test {posargs}
-
-[testenv:docs]
-changedir = docs
-deps = sphinx
-commands = sphinx-build -W -q -b html . {envtmpdir}/html
-
-[testenv:flake8]
+[_flake8]
 deps =
     flake8
     flake8-future-import
     pep8-naming
-commands = flake8 beets beetsplug beet test setup.py docs
+files = beets beetsplug beet test setup.py docs
+
+[testenv]
+deps =
+    test: {[_test]deps}
+    flake8: {[_flake8]deps}
+commands =
+    test: nosetests {posargs}
+    flake8: flake8 {posargs:--min-version=2.7} {[_flake8]files}
+
+[testenv:docs]
+basepython = python2.7
+deps = sphinx
+commands = sphinx-build -W -q -b html docs {envtmpdir}/html {posargs}


### PR DESCRIPTION
 - Add support for Python 3 testing.
 - Add Python 3.3, 3.4 and 3.5 tests to Travis and AppVeyor.
 - Allow arguments to be passed to tox from test matrix.
 - Simplify tox configuration so that we now only have `test`, `flake8` and `docs` tasks.

This is a squashed version of #2029.