### PR TITLE
add file check to move command

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -976,6 +976,13 @@ class Album(LibModel):
         if not old_art:
             return
 
+        if not os.path.isfile(syspath(self.artpath)):
+            log.warn(u'album art gone missing: {0} - {1}',
+                     self.albumartist, self.album)
+            self.artpath = None
+            plugins.send('art_set', album=self)
+            return
+
         new_art = self.art_destination(old_art)
         if new_art == old_art:
             return

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1467,6 +1467,19 @@ def move_items(lib, dest, query, copy, album, pretend, confirm=False):
     isalbummoved = lambda album: any(isitemmoved(i) for i in album.items())
     objs = [o for o in objs if (isalbummoved if album else isitemmoved)(o)]
 
+    # Check if all files actually exist
+    log.debug(u'testing if files exist')
+    if album:
+        missing = []
+        for a in objs:
+            missing.extend([o for o in a.items() if not os.path.isfile(syspath(o.path))])
+    else:
+        missing = [o for o in objs if not os.path.isfile(syspath(o.path))]
+    if missing:
+        for o in missing:
+            log.error(u'file missing: {0}', o.path)
+        raise ui.UserError(u'missing files, replace them or update the library')
+
     action = u'Copying' if copy else u'Moving'
     act = u'copy' if copy else u'move'
     entity = u'album' if album else u'item'


### PR DESCRIPTION
Currently missing files, including album art, cause move operations to error out midway, leaving things in a dirty state with half moved albums.

This patch adds a pre-check to the move command and aborts if any audio file to be moved is missing. Missing album art triggers a warning and is dereferenced in the library.
