### PR TITLE
Support Homebrew's bash-completion2

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1666,6 +1666,7 @@ BASH_COMPLETION_PATHS = map(syspath, [
     u'/usr/share/local/bash-completion/bash_completion',
     u'/opt/local/share/bash-completion/bash_completion',  # SmartOS
     u'/usr/local/etc/bash_completion',  # Homebrew
+    u'/usr/local/share/bash-completion/bash_completion',  # Homebrew bash-completion2
 ])
 
 

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1664,9 +1664,12 @@ BASH_COMPLETION_PATHS = map(syspath, [
     u'/etc/bash_completion',
     u'/usr/share/bash-completion/bash_completion',
     u'/usr/share/local/bash-completion/bash_completion',
-    u'/opt/local/share/bash-completion/bash_completion',  # SmartOS
-    u'/usr/local/etc/bash_completion',  # Homebrew
-    u'/usr/local/share/bash-completion/bash_completion',  # Homebrew bash-completion2
+    # SmartOS
+    u'/opt/local/share/bash-completion/bash_completion',
+    # Homebrew
+    u'/usr/local/etc/bash_completion',
+    # Homebrew bash-completion2
+    u'/usr/local/share/bash-completion/bash_completion',
 ])
 
 


### PR DESCRIPTION
[bash-completion2][1] is installed at a different path. This will stop the warning about being unable to find bash-completion.

[1]: https://github.com/Homebrew/homebrew-versions/blob/master/bash-completion2.rb