### PR TITLE
Replace confit with confuse

### DIFF
--- a/beets/__init__.py
+++ b/beets/__init__.py
@@ -17,14 +17,14 @@ from __future__ import division, absolute_import, print_function
 
 import os
 
-from beets.util import confit
+import confuse
 
 __version__ = u'1.3.18'
 __author__ = u'Adrian Sampson <adrian@radbox.org>'
 
 
-class IncludeLazyConfig(confit.LazyConfig):
-    """A version of Confit's LazyConfig that also merges in data from
+class IncludeLazyConfig(confuse.LazyConfig):
+    """A version of Confuse's LazyConfig that also merges in data from
     YAML files specified in an `include` setting.
     """
     def read(self, user=True, defaults=True):
@@ -35,7 +35,7 @@ class IncludeLazyConfig(confit.LazyConfig):
                 filename = view.as_filename()
                 if os.path.isfile(filename):
                     self.set_file(filename)
-        except confit.NotFoundError:
+        except confuse.NotFoundError:
             pass
 
 

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -38,7 +38,7 @@ from beets import plugins
 from beets import util
 from beets.util.functemplate import Template
 from beets import config
-from beets.util import confit
+import confuse
 from beets.autotag import mb
 from beets.dbcore import query as db_query
 
@@ -608,7 +608,7 @@ def get_path_formats(subview=None):
 
 
 def get_replacements():
-    """Confit validation function that reads regex/string pairs.
+    """Confuse validation function that reads regex/string pairs.
     """
     replacements = []
     for pattern, repl in config['replace'].get(dict).items():
@@ -1090,7 +1090,7 @@ def vararg_callback(option, opt_str, value, parser):
 def _load_plugins(config):
     """Load the plugins specified in the configuration.
     """
-    paths = config['pluginpath'].get(confit.StrSeq(split=False))
+    paths = config['pluginpath'].get(confuse.StrSeq(split=False))
     paths = list(map(util.normpath, paths))
     log.debug(u'plugin paths: {0}', util.displayable_path(paths))
 
@@ -1270,7 +1270,7 @@ def main(args=None):
         log.debug('{}', traceback.format_exc())
         log.error('{}', exc)
         sys.exit(1)
-    except confit.ConfigError as exc:
+    except confuse.ConfigError as exc:
         log.error(u'configuration error: {0}', exc)
         sys.exit(1)
     except db_query.InvalidQueryError as exc:

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -37,7 +37,7 @@ from beets.util import syspath, normpath, ancestry, displayable_path
 from beets import library
 from beets import config
 from beets import logging
-from beets.util.confit import _package_path
+from confuse import _package_path
 
 VARIOUS_ARTISTS = u'Various Artists'
 PromptChoice = namedtuple('ExtraChoice', ['short', 'long', 'callback'])

--- a/beets/util/functemplate.py
+++ b/beets/util/functemplate.py
@@ -34,7 +34,7 @@ import ast
 import dis
 import types
 
-from .confit import NUMERIC_TYPES
+from confuse import NUMERIC_TYPES
 
 SYMBOL_DELIM = u'$'
 FUNC_DELIM = u'%'

--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -20,9 +20,10 @@ from __future__ import division, absolute_import, print_function
 
 from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand
-from beets.util import displayable_path, confit
+from beets.util import displayable_path
 from beets import ui
 from subprocess import check_output, CalledProcessError, list2cmdline, STDOUT
+import confuse
 import shlex
 import os
 import errno
@@ -71,7 +72,7 @@ class BadFiles(BeetsPlugin):
         ext = ext.lower()
         try:
             command = self.config['commands'].get(dict).get(ext)
-        except confit.NotFoundError:
+        except confuse.NotFoundError:
             command = None
         if command:
             return self.check_custom(command)

--- a/beetsplug/chroma.py
+++ b/beetsplug/chroma.py
@@ -22,7 +22,7 @@ from beets import plugins
 from beets import ui
 from beets import util
 from beets import config
-from beets.util import confit
+import confuse
 from beets.autotag import hooks
 import acoustid
 from collections import defaultdict
@@ -182,7 +182,7 @@ class AcoustidPlugin(plugins.BeetsPlugin):
         def submit_cmd_func(lib, opts, args):
             try:
                 apikey = config['acoustid']['apikey'].get(unicode)
-            except confit.NotFoundError:
+            except confuse.NotFoundError:
                 raise ui.UserError(u'no Acoustid user API key provided')
             submit_items(self._log, apikey, lib.items(ui.decargs(args)))
         submit_cmd.func = submit_cmd_func

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -26,7 +26,7 @@ from string import Template
 
 from beets import ui, util, plugins, config
 from beets.plugins import BeetsPlugin
-from beets.util.confit import ConfigTypeError
+from confuse import ConfigTypeError
 from beets import art
 from beets.util.artresizer import ArtResizer
 

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -23,7 +23,7 @@ from beets import logging
 from beets import config
 from beets.autotag.hooks import AlbumInfo, TrackInfo, Distance
 from beets.plugins import BeetsPlugin
-from beets.util import confit
+import confuse
 from discogs_client import Release, Client
 from discogs_client.exceptions import DiscogsAPIError
 from requests.exceptions import ConnectionError
@@ -92,7 +92,7 @@ class DiscogsPlugin(BeetsPlugin):
     def _tokenfile(self):
         """Get the path to the JSON file for storing the OAuth token.
         """
-        return self.config['tokenfile'].get(confit.Filename(in_app_dir=True))
+        return self.config['tokenfile'].get(confuse.Filename(in_app_dir=True))
 
     def authenticate(self, c_key, c_secret):
         # Get the link for the OAuth page.

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -30,8 +30,8 @@ from beets import ui
 from beets import util
 from beets import config
 from beets.util.artresizer import ArtResizer
-from beets.util import confit
 from beets.util import syspath, bytestring_path
+import confuse
 
 try:
     import itunes
@@ -689,9 +689,9 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
 
         # allow both pixel and percentage-based margin specifications
         self.enforce_ratio = self.config['enforce_ratio'].get(
-            confit.OneOf([bool,
-                          confit.String(pattern=self.PAT_PX),
-                          confit.String(pattern=self.PAT_PERCENT)]))
+            confuse.OneOf([bool,
+                           confuse.String(pattern=self.PAT_PX),
+                           confuse.String(pattern=self.PAT_PERCENT)]))
         self.margin_px = None
         self.margin_percent = None
         if type(self.enforce_ratio) is unicode:
@@ -701,7 +701,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                 self.margin_px = int(self.enforce_ratio[:-2])
             else:
                 # shouldn't happen
-                raise confit.ConfigValueError()
+                raise confuse.ConfigValueError()
             self.enforce_ratio = True
 
         cover_names = self.config['cover_names'].as_str_seq()

--- a/beetsplug/metasync/__init__.py
+++ b/beetsplug/metasync/__init__.py
@@ -21,7 +21,7 @@ from __future__ import division, absolute_import, print_function
 from abc import abstractmethod, ABCMeta
 from importlib import import_module
 
-from beets.util.confit import ConfigValueError
+from confuse import ConfigValueError
 from beets import ui
 from beets.plugins import BeetsPlugin
 

--- a/beetsplug/metasync/itunes.py
+++ b/beetsplug/metasync/itunes.py
@@ -30,7 +30,7 @@ from time import mktime
 from beets import util
 from beets.dbcore import types
 from beets.library import DateType
-from beets.util.confit import ConfigValueError
+from confuse import ConfigValueError
 from beetsplug.metasync import MetaSource
 
 

--- a/beetsplug/types.py
+++ b/beetsplug/types.py
@@ -17,7 +17,7 @@ from __future__ import division, absolute_import, print_function
 
 from beets.plugins import BeetsPlugin
 from beets.dbcore import types
-from beets.util.confit import ConfigValueError
+from confuse import ConfigValueError
 from beets import library
 
 

--- a/beetsplug/zero.py
+++ b/beetsplug/zero.py
@@ -21,7 +21,7 @@ import re
 from beets.plugins import BeetsPlugin
 from beets.mediafile import MediaFile
 from beets.importer import action
-from beets.util import confit
+import confuse
 
 __author__ = 'baobab@heresiarch.info'
 __version__ = '0.10'
@@ -94,7 +94,7 @@ class ZeroPlugin(BeetsPlugin):
         """
         try:
             self.patterns[field] = self.config[field].as_str_seq()
-        except confit.NotFoundError:
+        except confuse.NotFoundError:
             # Matches everything
             self.patterns[field] = True
 

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
         'musicbrainzngs>=0.4',
         'pyyaml',
         'jellyfish',
+        'confuse>=0.4.0',
     ] + (['colorama'] if (sys.platform == 'win32') else []),
 
     tests_require=[

--- a/test/_common.py
+++ b/test/_common.py
@@ -166,7 +166,7 @@ class TestCase(unittest.TestCase, Assertions):
         beets.config['library'] = os.path.join(self.temp_dir, 'library.db')
         beets.config['directory'] = os.path.join(self.temp_dir, 'libdir')
 
-        # Set $HOME, which is used by confit's `config_dir()` to create
+        # Set $HOME, which is used by confuse's `config_dir()` to create
         # directories.
         self._old_home = os.environ.get('HOME')
         os.environ['HOME'] = self.temp_dir

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -33,7 +33,7 @@ from beets import importer
 from beets import logging
 from beets import util
 from beets.util.artresizer import ArtResizer, WEBPROXY
-from beets.util import confit
+import confuse
 
 
 logger = logging.getLogger('beets.test_art')
@@ -616,7 +616,7 @@ class EnforceRatioConfigTest(_common.TestCase):
         if should_raise:
             for v in values:
                 config['fetchart']['enforce_ratio'] = v
-                with self.assertRaises(confit.ConfigValueError):
+                with self.assertRaises(confuse.ConfigValueError):
                     fetchart.FetchArtPlugin()
         else:
             for v in values:

--- a/test/test_lyrics.py
+++ b/test/test_lyrics.py
@@ -27,7 +27,8 @@ from mock import MagicMock
 from test._common import unittest
 from beetsplug import lyrics
 from beets.library import Item
-from beets.util import confit, bytestring_path
+from beets.util import bytestring_path
+import confuse
 from beets import logging
 
 log = logging.getLogger('beets.test_lyrics')
@@ -214,7 +215,8 @@ def is_lyrics_content_ok(title, text):
     return all(x in text.lower() for x in keywords)
 
 LYRICS_ROOT_DIR = os.path.join(_common.RSRC, b'lyrics')
-LYRICS_TEXTS = confit.load_yaml(os.path.join(_common.RSRC, b'lyricstext.yaml'))
+LYRICS_TEXTS = confuse.load_yaml(os.path.join(_common.RSRC,
+                                              b'lyricstext.yaml'))
 DEFAULT_SONG = dict(artist=u'The Beatles', title=u'Lady Madonna')
 
 DEFAULT_SOURCES = [

--- a/test/test_types_plugin.py
+++ b/test/test_types_plugin.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from test._common import unittest
 from test.helper import TestHelper
 
-from beets.util.confit import ConfigValueError
+from confuse import ConfigValueError
 
 
 class TypesPluginTest(unittest.TestCase, TestHelper):

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -37,7 +37,7 @@ from beets.autotag.match import distance
 from beets.mediafile import MediaFile
 from beets import config
 from beets import plugins
-from beets.util.confit import ConfigError
+from confuse import ConfigError
 from beets import util
 
 


### PR DESCRIPTION
Use [sampsyo/confuse](https://github.com/sampsyo/confuse) (previously named confit) throughout beets instead of having our own copy of it.

This is part of #1966 that has been separated at the request of @jrobeson. Go there if you would like to see our discussion so far.

**Note**: [This PR should not be merged until we've notified packagers of the new dependency](https://github.com/beetbox/beets/pull/1966#issuecomment-225643360) (i.e. the 1st of August and 1.4.0).
