### PR TITLE
Install imagemagick in travis so the embedart compare tests can run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ addons:
         packages:
             - bash-completion
             - mp3gain
+            - imagemagick
 
 # To install dependencies, tell tox to do everything but actually running the
 # test.


### PR DESCRIPTION
Unfortunately, this fails because travis is still on an ancient (ca. 2011) version of ImageMagick. I don't really know anything about travis; is there a simple way to install a newer version?