### PR TITLE
Fix fetchart hardcoding the image extension

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,10 @@ Fixes:
   installations. Thanks to :user:`bismark`. :bug:`2038`
 * Fix a crash introduced in the previous version when the standard input was
   connected to a Unix pipe. :bug:`2041`
+* :doc:`/plugins/fetchart`: Determine the file extension for downloaded images
+  based on the ``Content-Type`` header instead of hardcoding it to .jpg.
+  Reported in :bug:`2053`, which for now it does not fix due to
+  server-side issues, though.
 
 1.3.18 (May 31, 2016)
 ---------------------

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -46,7 +46,7 @@ class UseThePlugin(_common.TestCase):
 
 
 class FetchImageTest(UseThePlugin):
-    URL = 'http://example.com'
+    URL = 'http://example.com/test.jpg'
 
     @responses.activate
     def run(self, *args, **kwargs):
@@ -61,18 +61,23 @@ class FetchImageTest(UseThePlugin):
         self.dpath = os.path.join(self.temp_dir, b'arttest')
         self.source = fetchart.RemoteArtSource(logger, self.plugin.config)
         self.extra = {'maxwidth': 0}
+        self.candidate = fetchart.Candidate(logger, url=self.URL)
 
     def test_invalid_type_returns_none(self):
         self.mock_response('image/watercolour')
-        candidate = fetchart.Candidate(logger, url=self.URL)
-        self.source.fetch_image(candidate, self.extra)
-        self.assertEqual(candidate.path, None)
+        self.source.fetch_image(self.candidate, self.extra)
+        self.assertEqual(self.candidate.path, None)
 
     def test_jpeg_type_returns_path(self):
         self.mock_response('image/jpeg')
-        candidate = fetchart.Candidate(logger, url=self.URL)
-        self.source.fetch_image(candidate, self.extra)
-        self.assertNotEqual(candidate.path, None)
+        self.source.fetch_image(self.candidate, self.extra)
+        self.assertNotEqual(self.candidate.path, None)
+
+    def test_extension_set_by_content_type(self):
+        self.mock_response('image/png')
+        self.source.fetch_image(self.candidate, self.extra)
+        self.assertEqual(os.path.splitext(self.candidate.path)[1], b'.png')
+        self.assertExists(self.candidate.path)
 
 
 class FSArtTest(UseThePlugin):


### PR DESCRIPTION
When downloading files from any source, fetchart used to hardcode the extension to `jpg` but also support `png` images. As there are misnamed (i.e. with a `jpg` extension) files in the wild with a correct `Content-Type` set, use that to determine the extension.

Missing
- [x] Changelog
- [ ] Test on real-world data
- [x] https://github.com/beetbox/beets/commit/d9974081a77573c9045dbf5e7abc48bf1e276686 -> check whether the proxy returns correct `Content-Type`s -> It does.

EDIT: doesn't fix #2053, see there. This PR fixes our part of the issue, the image header based correction to work around the server-side problem is split out into a new PR as its fate is not as clear: #2072.