### PR TITLE
Rectify artwork extension via imghdr

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -259,7 +259,6 @@ class RemoteArtSource(ArtSource):
                 if real_ct not in CONTENT_TYPES:
                     self._log.debug(u'not a supported image: {}',
                                     real_ct or u'unknown content type')
-                    candidate.path = None
                     return
 
                 ext = b'.' + CONTENT_TYPES[real_ct][0]
@@ -285,7 +284,6 @@ class RemoteArtSource(ArtSource):
             # Handling TypeError works around a urllib3 bug:
             # https://github.com/shazow/urllib3/issues/556
             self._log.debug(u'error fetching art: {}', exc)
-            candidate.path = None
             return
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -40,9 +40,9 @@ Fixes:
 * Fix a crash when specifying non-ASCII format strings on the command line
   with the ``-f`` option to many commands. :bug:`2063`
 * :doc:`/plugins/fetchart`: Determine the file extension for downloaded images
-  based on the ``Content-Type`` header instead of hardcoding it to .jpg.
-  Reported in :bug:`2053`, which for now it does not fix due to
-  server-side issues, though.
+  based on the image's magic bytes and warn if result is not consistent with
+  the server-supplied ``Content-Type`` header instead of
+  hardcoding it to .jpg. :bug:`2053`
 
 1.3.18 (May 31, 2016)
 ---------------------

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -60,7 +60,8 @@ class FetchImageHelper(_common.TestCase):
             file_type = content_type
         responses.add(responses.GET, url,
                       content_type=content_type,
-                      body=IMAGEHEADER.get(file_type, b'\x00' * 32))
+                      # imghdr reads 32 bytes
+                      body=IMAGEHEADER.get(file_type, b'').ljust(32, b'\x00'))
 
 
 class FetchImageTest(FetchImageHelper, UseThePlugin):

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -46,22 +46,24 @@ class UseThePlugin(_common.TestCase):
 
 
 class FetchImageHelper(_common.TestCase):
-    """Helper mixin for mocking requests when fetching images 
+    """Helper mixin for mocking requests when fetching images
     with remote art sources.
     """
     @responses.activate
     def run(self, *args, **kwargs):
         super(FetchImageHelper, self).run(*args, **kwargs)
 
+    IMAGEHEADER = {'image/jpeg': b'\x00' * 6 + b'JFIF',
+                   'image/png': b'\211PNG\r\n\032\n', }
+
     def mock_response(self, url, content_type='image/jpeg', file_type=None):
-        IMAGEHEADER = {'image/jpeg': b'\x00' * 6 + b'JFIF',
-                       'image/png': b'\211PNG\r\n\032\n', }
         if file_type is None:
             file_type = content_type
         responses.add(responses.GET, url,
                       content_type=content_type,
                       # imghdr reads 32 bytes
-                      body=IMAGEHEADER.get(file_type, b'').ljust(32, b'\x00'))
+                      body=self.IMAGEHEADER.get(
+                          file_type, b'').ljust(32, b'\x00'))
 
 
 class FetchImageTest(FetchImageHelper, UseThePlugin):


### PR DESCRIPTION
Work-around for #2053, see also #2068. I reported the server-side issue (incorrect `Content-Type` and incorrect file extension) upstream (https://forum.fanart.tv/viewtopic.php?f=4&t=6011), if it gets fixed there, this PR may probably be dropped.
As of now, it not only applies to the problematic fanart.tv source, but unconditionally checks every image (also those found in the filesystem) that is moved/copied into the library, and it is not clear whether this might be overkill (https://github.com/beetbox/beets/pull/2068#issuecomment-227492147).
On the other hand, `imghdr` will only read the first 32 bytes of a file, so this may be pretty irrelevant compared to the amount of filesystem-iteraction for metadata etc.

Uses [imghdr](https://docs.python.org/2/library/imghdr.html) for type detection.