### PR TITLE
Fix bugs in beatport plugin

### DIFF
--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -262,7 +262,7 @@ class BeatportPlugin(BeetsPlugin):
         })
         self.config['apikey'].redact = True
         self.config['apisecret'].redact = True
-        self.discogs_client = None
+        self.client = None
         self.register_listener('import_begin', self.setup)
 
     def setup(self, session=None):
@@ -280,7 +280,7 @@ class BeatportPlugin(BeetsPlugin):
             token = tokendata['token']
             secret = tokendata['secret']
 
-        self.beatport_api = BeatportClient(c_key, c_secret, token, secret)
+        self.client = BeatportClient(c_key, c_secret, token, secret)
 
     def authenticate(self, c_key, c_secret):
         # Get the link for the OAuth page.

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -266,7 +266,6 @@ class BeatportPlugin(BeetsPlugin):
         self.register_listener('import_begin', self.setup)
 
     def setup(self, session=None):
-        import pdb; pdb.set_trace()
         c_key = self.config['apikey'].get(unicode)
         c_secret = self.config['apisecret'].get(unicode)
 

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -266,6 +266,7 @@ class BeatportPlugin(BeetsPlugin):
         self.register_listener('import_begin', self.setup)
 
     def setup(self, session=None):
+        import pdb; pdb.set_trace()
         c_key = self.config['apikey'].get(unicode)
         c_secret = self.config['apisecret'].get(unicode)
 
@@ -393,7 +394,7 @@ class BeatportPlugin(BeetsPlugin):
         # can also negate an otherwise positive result.
         query = re.sub(r'\b(CD|disc)\s*\d+', '', query, re.I)
         albums = [self._get_album_info(x)
-                  for x in self.client.search(query).results]
+                  for x in self.client.search(query)]
         return albums
 
     def _get_album_info(self, release):

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -187,7 +187,7 @@ class BeatportClient(object):
         try:
             response = self.api.get(self._make_url(endpoint), params=kwargs)
         except Exception as e:
-            raise BeatportAPIError("Error connection to Beatport API: {}"
+            raise BeatportAPIError("Error connecting to Beatport API: {}"
                                    .format(e.message))
         if not response:
             raise BeatportAPIError(

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -451,6 +451,6 @@ class BeatportPlugin(BeetsPlugin):
     def _get_tracks(self, query):
         """Returns a list of TrackInfo objects for a Beatport query.
         """
-        bp_tracks = self.client.search(query, release_type='track').results
+        bp_tracks = self.client.search(query, release_type='track')
         tracks = [self._get_track_info(x) for x in bp_tracks]
         return tracks


### PR DESCRIPTION
As mentioned in the last PR, I had not tested the integration with beets.
Turns out there were two bugs lurking, one due to a naming confusion and another due to incompatibility with the API of the previous plugin version.
Both are fixed and according to my superficial test the plugin should now work as expected.