### PR TITLE
General setup.py improvements: The Sequel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,21 +9,21 @@ env:
 matrix:
     include:
         - python: 2.7
-          env: {TOX_ENV: py27-cov, COVERAGE: 1}
+          env: {TOXENV: py27-cov, COVERAGE: 1}
         - python: 3.3
-          env: {TOX_ENV: py33-test}
+          env: {TOXENV: py33-test}
         - python: 3.4
-          env: {TOX_ENV: py34-test}
+          env: {TOXENV: py34-test}
         - python: 3.5
-          env: {TOX_ENV: py35-test}
+          env: {TOXENV: py35-test}
         - python: pypy
-          env: {TOX_ENV: pypy-test}
+          env: {TOXENV: pypy-test}
         - python: 2.7
-          env: {TOX_ENV: py27-flake8}
+          env: {TOXENV: py27-flake8}
         - python: 3.3
-          env: {TOX_ENV: py33-flake8}
+          env: {TOXENV: py33-flake8}
         - python: 2.7
-          env: {TOX_ENV: docs}
+          env: {TOXENV: docs}
     allow_failures:
         - python: 3.3
         - python: 3.4
@@ -39,9 +39,9 @@ addons:
 # To install dependencies, tell tox to do everything but actually running the
 # test.
 install:
-    - travis_retry python setup.py test -a "-e $TOX_ENV --notest"
+    - travis_retry python setup.py test -a "--notest"
 
-script: python setup.py test -a "-e $TOX_ENV"
+script: python setup.py test
 
 # Report coverage to codecov.io.
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,9 @@ addons:
 # To install dependencies, tell tox to do everything but actually running the
 # test.
 install:
-    - travis_retry pip install tox sphinx
-    - travis_retry tox -e $TOX_ENV --notest
+    - travis_retry python setup.py test -a "-e $TOX_ENV --notest"
 
-script: tox -e $TOX_ENV
+script: python setup.py test -a "-e $TOX_ENV"
 
 # Report coverage to codecov.io.
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,11 +18,10 @@ environment:
 
 # Install Tox for running tests.
 install:
-    - "%PYTHON%/Scripts/pip.exe install tox"
-    - "%PYTHON%/Scripts/tox.exe -e %TOX_ENV% --notest"
+    - python setup.py test -a "-e %TOX_ENV% --notest"
 
 test_script:
-    - "%PYTHON%/Scripts/tox.exe -e %TOX_ENV%"
+    - python setup.py test -a "-e %TOX_ENV%"
 
 # Allow all failures for now: the tests don't yet pass!
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,24 +8,24 @@ environment:
 
     matrix:
         - PYTHON: C:\Python27
-          TOX_ENV: py27-test
+          TOXENV: py27-test
         - PYTHON: C:\Python33
-          TOX_ENV: py33-test
+          TOXENV: py33-test
         - PYTHON: C:\Python34
-          TOX_ENV: py34-test
+          TOXENV: py34-test
         - PYTHON: C:\Python35
-          TOX_ENV: py35-test
+          TOXENV: py35-test
 
 # Install Tox for running tests.
 install:
-    - python setup.py test -a "-e %TOX_ENV% --notest"
+    - python setup.py test -a "--notest"
 
 test_script:
-    - python setup.py test -a "-e %TOX_ENV%"
+    - python setup.py test
 
 # Allow all failures for now: the tests don't yet pass!
 matrix:
     allow_failures:
-        - TOX_ENV: py33-test
-        - TOX_ENV: py34-test
-        - TOX_ENV: py35-test
+        - TOXENV: py33-test
+        - TOXENV: py34-test
+        - TOXENV: py35-test

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,14 +3,9 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
+SPHINXBUILD   = python -m sphinx
 PAPER         =
 BUILDDIR      = _build
-
-# When both are available, use Sphinx 2.x for autodoc compatibility.
-ifeq ($(shell which sphinx-build2 >/dev/null 2>&1 ; echo $$?),0)
-	SPHINXBUILD = sphinx-build2
-endif
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,6 +7,11 @@ SPHINXBUILD   = python -m sphinx
 PAPER         =
 BUILDDIR      = _build
 
+# When both are available, use Sphinx 2.x for autodoc compatibility.
+ifeq ($(shell python2 -c "import sphinx" >/dev/null 2>&1; echo $$?), 0)
+	SPHINXBUILD = python2 -m sphinx
+endif
+
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ class BeetsDistribution(Distribution):
         Distribution.__init__(self, *args, **kwargs)
 
     def get_eggs(self):
+        """Returns the paths of all egg files in the egg cache directory."""
         cache_dir = self.get_egg_cache_dir()
         cache_glob = path.join(cache_dir, '*.egg')
         files = glob.glob(cache_glob)
@@ -46,6 +47,8 @@ class BeetsDistribution(Distribution):
 
 
 class sdist(default_sdist):  # noqa: ignore=N801
+    """Custom sdist that builds the man pages before the normal sdist build."""
+
     def __init__(self, *args, **kwargs):
         default_sdist.__init__(self, *args, **kwargs)
         self._setup_directory = path.dirname(__file__)
@@ -55,6 +58,7 @@ class sdist(default_sdist):  # noqa: ignore=N801
                                               'man')
 
     def _copy_man_pages(self):
+        """Copy the built man pages to the output directory."""
         if path.exists(self._man_directory):
             shutil.rmtree(self._man_directory)
 
@@ -62,6 +66,7 @@ class sdist(default_sdist):  # noqa: ignore=N801
         shutil.copytree(self._built_man_directory, self._man_directory)
 
     def _build_man_pages(self):
+        """Build the man pages using make."""
         # Add eggs to PYTHONPATH. We need to do this to ensure our eggs are
         # seen by the new python instance.
         self.distribution.update_path_with_eggs()

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,12 @@ class BeetsDistribution(Distribution):
         return map(path.abspath, files)
 
     def update_path_with_eggs(self):
-        os.environ['PYTHONPATH'] = ':'.join(self.get_eggs())
+        """Adds all of the eggs returned by get_eggs to PYTHONPATH."""
+        original_path = filter(len, os.environ['PYTHONPATH'].split(':'))
+        full_path = original_path + self.get_eggs()
+        unique_path = set(full_path)
+
+        os.environ['PYTHONPATH'] = ':'.join(unique_path)
 
 
 class sdist(default_sdist):  # noqa: ignore=N801

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ class BeetsDistribution(Distribution):
         return map(path.abspath, files)
 
     def update_path_with_eggs(self):
-        os.environ['PYTHONPATH'] = ':'.join(self.distribution.get_eggs())
+        os.environ['PYTHONPATH'] = ':'.join(self.get_eggs())
 
 
 class sdist(default_sdist):  # noqa: ignore=N801

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ class BeetsDistribution(Distribution):
         cache_glob = path.join(cache_dir, '*.egg')
         files = glob.glob(cache_glob)
 
-        return map(path.abspath, files)
+        return [path.abspath(f) for f in files]
 
     def update_path_with_eggs(self):
         """Adds all of the eggs returned by get_eggs to PYTHONPATH."""

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,7 @@ setup(
     ] + (['colorama'] if (sys.platform == 'win32') else []),
 
     tests_require=[
+        'sphinx',
         'tox',
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,9 @@ class BeetsDistribution(Distribution):
 
     def update_path_with_eggs(self):
         """Adds all of the eggs returned by get_eggs to PYTHONPATH."""
-        original_path = filter(len, os.environ['PYTHONPATH'].split(':'))
+        original_path = os.environ.get('PYTHONPATH', '').split(':')
         full_path = original_path + self.get_eggs()
-        unique_path = set(full_path)
+        unique_path = set(filter(len, full_path))
 
         os.environ['PYTHONPATH'] = ':'.join(unique_path)
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ class BeetsDistribution(Distribution):
         Distribution.__init__(self, *args, **kwargs)
 
 
-class sdist(default_sdist):
+class sdist(default_sdist):  # noqa: ignore=N801
     def __init__(self, *args, **kwargs):
         default_sdist.__init__(self, *args, **kwargs)
 
@@ -70,7 +70,7 @@ class sdist(default_sdist):
         default_sdist.run(self, *args, **kwargs)
 
 
-class test(Command):
+class test(Command):  # noqa: ignore=N801
     """Command to run tox."""
 
     description = "run tox tests"

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ class sdist(default_sdist):  # noqa: ignore=N801
 
         self._build_man_pages()
 
-        # Run the default sdist task
+        # Run the default sdist task.
         default_sdist.run(self, *args, **kwargs)
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,29 @@ import sys
 import subprocess
 import shutil
 from setuptools import setup
+from setuptools.command.test import test as default_test
+
+
+class test(default_test):
+    user_options = [('tox-args=', 'a', "Arguments to pass to tox")]
+
+    def initialize_options(self):
+        default_test.initialize_options(self)
+        self.tox_args = None
+
+    def finalize_options(self):
+        default_test.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        import shlex
+        import tox
+        args = self.tox_args
+        if args:
+            args = shlex.split(self.tox_args)
+        errno = tox.cmdline(args=args)
+        sys.exit(errno)
 
 
 def _read(fn):
@@ -96,16 +119,12 @@ setup(
     ] + (['colorama'] if (sys.platform == 'win32') else []),
 
     tests_require=[
-        'beautifulsoup4',
-        'flask',
-        'mock',
-        'pylast',
-        'rarfile',
-        'responses',
-        'pyxdg',
-        'pathlib',
-        'python-mpd2',
+        'tox',
     ],
+
+    cmdclass = {
+        'test': test
+    },
 
     # Plugin (optional) dependencies:
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,12 @@ class sdist(default_sdist):  # noqa: ignore=N801
         return True
 
     def run(self, *args, **kwargs):
+        install_requires = self.distribution.install_requires
         sdist_requires = self.distribution.sdist_requires
+
+        # Install install dependencies if needed.
+        if install_requires:
+            self.distribution.fetch_build_eggs(install_requires)
 
         # Install sdist dependencies if needed.
         if sdist_requires:

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,9 @@ class BeetsDistribution(Distribution):
 
         return map(path.abspath, files)
 
+    def update_path_with_eggs(self):
+        os.environ['PYTHONPATH'] = ':'.join(self.distribution.get_eggs())
+
 
 class sdist(default_sdist):  # noqa: ignore=N801
     def __init__(self, *args, **kwargs):
@@ -61,7 +64,7 @@ class sdist(default_sdist):  # noqa: ignore=N801
     def _build_man_pages(self):
         # Add eggs to PYTHONPATH. We need to do this to ensure our eggs are
         # seen by the new python instance.
-        os.environ['PYTHONPATH'] = ':'.join(self.distribution.get_eggs())
+        self.distribution.update_path_with_eggs()
 
         try:
             # Build man pages using make.
@@ -112,7 +115,7 @@ class test(Command):  # noqa: ignore=N801
 
         # Add eggs to PYTHONPATH. We need to do this to ensure our eggs are
         # seen by Tox.
-        os.environ['PYTHONPATH'] = ':'.join(self.distribution.get_eggs())
+        self.distribution.update_path_with_eggs()
 
         import shlex
         import tox

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@
 
 from __future__ import division, absolute_import, print_function
 
-import os.path as path
+from os import path
 import sys
 import subprocess
 import shutil


### PR DESCRIPTION
From #2040:

> This started off as a custom test command that ran Tox but quickly built up into a rather large change.
> 
> I'm not sure whether I should move the classes outside of `setup.py` itself, possibly putting them in `extra` alongside an `__init__.py`?
> 
> So some reasoning behind the changes;
> 1. I've created a custom `Distribution` subclass and added an `sdist_requires` option which allows us to define dependencies specifically for `sdist`. The reason I've done this is that `sdist` would fail if you didn't have `sphinx` installed, causing the overall build to fail. This is also the reasoning behind the custom `sdist` class.
> 2. The class names are lowercase as that's the name the help pages use oddly enough (e.g. if the class was named `Foo` but set as `test`, `setup.py test --help` would show `Foo` as the name).
> 3. I've created a custom `test` class (not a subclass of the default test) as it means we can run Tox without worrying about `unittest` being installed (it seems the default class has some unittest specific code in it). Take a look at message for 2b39a18 for a bit more information on this.
> 
> One note on this; should we catch `CalledProcessError` as well as `OSError` inside `_build_man_pages`? We end up with an `OSError` if `make` isn't installed and a `CalledProcessError` if sphinx isn't installed.

Things to do:
- Fix `sdist` building man pages on Python 3. The issue here is mainly down to us doing some weird stuff when it comes to egg versions.
- Consider removing `sdist_requires` if we can't get it working as desired.
- Generally tidy up code.
