### PR TITLE
beatport: Use track numbers from API (#2085)

### DIFF
--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -262,7 +262,7 @@ class BeatportPlugin(BeetsPlugin):
         })
         self.config['apikey'].redact = True
         self.config['apisecret'].redact = True
-        self.discogs_client = None
+        self.client = None
         self.register_listener('import_begin', self.setup)
 
     def setup(self, session=None):
@@ -280,7 +280,7 @@ class BeatportPlugin(BeetsPlugin):
             token = tokendata['token']
             secret = tokendata['secret']
 
-        self.beatport_api = BeatportClient(c_key, c_secret, token, secret)
+        self.client = BeatportClient(c_key, c_secret, token, secret)
 
     def authenticate(self, c_key, c_secret):
         # Get the link for the OAuth page.

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -266,7 +266,6 @@ class BeatportPlugin(BeetsPlugin):
         self.register_listener('import_begin', self.setup)
 
     def setup(self, session=None):
-        import pdb; pdb.set_trace()
         c_key = self.config['apikey'].get(unicode)
         c_secret = self.config['apisecret'].get(unicode)
 

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -266,6 +266,7 @@ class BeatportPlugin(BeetsPlugin):
         self.register_listener('import_begin', self.setup)
 
     def setup(self, session=None):
+        import pdb; pdb.set_trace()
         c_key = self.config['apikey'].get(unicode)
         c_secret = self.config['apisecret'].get(unicode)
 
@@ -393,7 +394,7 @@ class BeatportPlugin(BeetsPlugin):
         # can also negate an otherwise positive result.
         query = re.sub(r'\b(CD|disc)\s*\d+', '', query, re.I)
         albums = [self._get_album_info(x)
-                  for x in self.client.search(query).results]
+                  for x in self.client.search(query)]
         return albums
 
     def _get_album_info(self, release):

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -249,6 +249,7 @@ class BeatportTrack(BeatportObject):
         if 'slug' in data:
             self.url = "http://beatport.com/track/{0}/{1}".format(data['slug'],
                                                                   data['id'])
+        self.track_number = data.get('trackNumber')
 
 
 class BeatportPlugin(BeetsPlugin):
@@ -403,8 +404,7 @@ class BeatportPlugin(BeetsPlugin):
         artist, artist_id = self._get_artist(release.artists)
         if va:
             artist = u"Various Artists"
-        tracks = [self._get_track_info(x, index=idx)
-                  for idx, x in enumerate(release.tracks, 1)]
+        tracks = [self._get_track_info(x) for x in release.tracks]
 
         return AlbumInfo(album=release.name, album_id=release.beatport_id,
                          artist=artist, artist_id=artist_id, tracks=tracks,
@@ -416,7 +416,7 @@ class BeatportPlugin(BeetsPlugin):
                          catalognum=release.catalog_number, media=u'Digital',
                          data_source=u'Beatport', data_url=release.url)
 
-    def _get_track_info(self, track, index=None):
+    def _get_track_info(self, track):
         """Returns a TrackInfo object for a Beatport Track object.
         """
         title = track.name
@@ -424,10 +424,9 @@ class BeatportPlugin(BeetsPlugin):
             title += u" ({0})".format(track.mix_name)
         artist, artist_id = self._get_artist(track.artists)
         length = track.length.total_seconds()
-
         return TrackInfo(title=title, track_id=track.beatport_id,
                          artist=artist, artist_id=artist_id,
-                         length=length, index=index,
+                         length=length, index=track.track_number,
                          data_source=u'Beatport', data_url=track.url)
 
     def _get_artist(self, artists):

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -187,7 +187,7 @@ class BeatportClient(object):
         try:
             response = self.api.get(self._make_url(endpoint), params=kwargs)
         except Exception as e:
-            raise BeatportAPIError("Error connection to Beatport API: {}"
+            raise BeatportAPIError("Error connecting to Beatport API: {}"
                                    .format(e.message))
         if not response:
             raise BeatportAPIError(

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -451,6 +451,6 @@ class BeatportPlugin(BeetsPlugin):
     def _get_tracks(self, query):
         """Returns a list of TrackInfo objects for a Beatport query.
         """
-        bp_tracks = self.client.search(query, release_type='track').results
+        bp_tracks = self.client.search(query, release_type='track')
         tracks = [self._get_track_info(x) for x in bp_tracks]
         return tracks


### PR DESCRIPTION
Previously the track number was determined by the order of tracks as received from the API (via `enumerate`). However, the API actually returns a canonical track number in the data for a track, so this PR modifies the code to use this instead.