### PR TITLE
beatport: Use track numbers from API (#2085)

### DIFF
--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -430,6 +430,7 @@ class BeatportPlugin(BeetsPlugin):
         return TrackInfo(title=title, track_id=track.beatport_id,
                          artist=artist, artist_id=artist_id,
                          length=length, index=track.track_number,
+                         medium_index=track.track_number,
                          data_source=u'Beatport', data_url=track.url)
 
     def _get_artist(self, artists):

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -252,6 +252,7 @@ class BeatportTrack(BeatportObject):
         if 'slug' in data:
             self.url = "http://beatport.com/track/{0}/{1}".format(data['slug'],
                                                                   data['id'])
+        self.track_number = data.get('trackNumber')
 
 
 class BeatportPlugin(BeetsPlugin):
@@ -406,8 +407,7 @@ class BeatportPlugin(BeetsPlugin):
         artist, artist_id = self._get_artist(release.artists)
         if va:
             artist = u"Various Artists"
-        tracks = [self._get_track_info(x, index=idx)
-                  for idx, x in enumerate(release.tracks, 1)]
+        tracks = [self._get_track_info(x) for x in release.tracks]
 
         return AlbumInfo(album=release.name, album_id=release.beatport_id,
                          artist=artist, artist_id=artist_id, tracks=tracks,
@@ -419,7 +419,7 @@ class BeatportPlugin(BeetsPlugin):
                          catalognum=release.catalog_number, media=u'Digital',
                          data_source=u'Beatport', data_url=release.url)
 
-    def _get_track_info(self, track, index=None):
+    def _get_track_info(self, track):
         """Returns a TrackInfo object for a Beatport Track object.
         """
         title = track.name
@@ -427,10 +427,9 @@ class BeatportPlugin(BeetsPlugin):
             title += u" ({0})".format(track.mix_name)
         artist, artist_id = self._get_artist(track.artists)
         length = track.length.total_seconds()
-
         return TrackInfo(title=title, track_id=track.beatport_id,
                          artist=artist, artist_id=artist_id,
-                         length=length, index=index,
+                         length=length, index=track.track_number,
                          data_source=u'Beatport', data_url=track.url)
 
     def _get_artist(self, artists):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,9 @@ Fixes:
 * :doc:`/plugins/permissions`: Fix a regression in the previous release where
   the plugin would always fail to set permissions (and log a warning).
   :bug:`2089`
+* :doc:`/plugins/beatport`: Use track numbers from Beatport (instead of
+  determining them from the order of tracks) and set the `medium_index`
+  value. :bug:`2085`
 
 The last release, 1.3.19, also erroneously reported its version as "1.3.18"
 when you typed ``beet version``. This has been corrected.


### PR DESCRIPTION
Previously the track number was determined by the order of tracks as received from the API (via enumerate). However, the API actually returns a canonical track number in the data for a track, so this PR modifies the code to use this instead.
It also sets the `medium_index` to the same value. As far as I can tell Beatport does not have a concept of multi-"disk" releases, so it's probably safe to do it this way.