### PR TITLE
Workaround for a race condition on queue invalidation

### DIFF
--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -162,7 +162,6 @@ class ConstrainedThreadedPipelineTest(unittest.TestCase):
         pl.run_parallel(1)
         self.assertEqual(l, [i * 2 for i in range(1000)])
 
-    @unittest.skipIf(six.PY3, u'freezes the test suite in py3')
     def test_constrained_exception(self):
         # Raise an exception in a constrained pipeline.
         l = []


### PR DESCRIPTION
See Issue #2078. 

**EDIT**: Seems to run fine on all py3 versions in Travis.