### PR TITLE
Handle functions that only accept strings on python 3

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -30,6 +30,7 @@ from beets.mediafile import MediaFile, UnreadableFileError
 from beets import plugins
 from beets import util
 from beets.util import bytestring_path, syspath, normpath, samefile
+from beets.util import py3_path
 from beets.util.functemplate import Template
 from beets import dbcore
 from beets.dbcore import types
@@ -1208,9 +1209,10 @@ class Library(dbcore.Database):
                  path_formats=((PF_KEY_DEFAULT,
                                '$artist/$album/$track $title'),),
                  replacements=None):
-        if path != ':memory:':
-            self.path = bytestring_path(normpath(path))
-        super(Library, self).__init__(path)
+        self.path = path
+        if self.path != ':memory:':
+            self.path = py3_path(bytestring_path(normpath(path)))
+        super(Library, self).__init__(self.path)
 
         self.directory = bytestring_path(normpath(directory))
         self.path_formats = path_formats

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -1106,7 +1106,7 @@ def _load_plugins(config):
     """Load the plugins specified in the configuration.
     """
     paths = config['pluginpath'].get(confit.StrSeq(split=False))
-    paths = list(map(util.normpath, paths))
+    paths = [util.py3_path(util.normpath(p)) for p in paths]
     log.debug(u'plugin paths: {0}', util.displayable_path(paths))
 
     import beetsplug

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -625,6 +625,22 @@ def legalize_path(path, replacements, length, extension, fragment):
     return second_stage_path, retruncated
 
 
+def py3_path(path):
+    """Convert a bytestring path to Unicode on Python 3 only. On Python
+    2, return the bytestring path unchanged.
+
+    This helps deal with APIs on Python 3 that *only* accept Unicode
+    (i.e., `str` objects). I philosophically disagree with this
+    decision, because paths are sadly bytes on Unix, but that's the way
+    it is. So this function helps us "smuggle" the true bytes data
+    through APIs that took Python 3's Unicode mandate too seriously.
+    """
+    assert isinstance(path, bytes)
+    if six.PY2:
+        return path
+    return os.fsdecode(path)
+
+
 def str2bool(value):
     """Returns a boolean reflecting a human-entered string."""
     return value.lower() in (u'yes', u'1', u'true', u't', u'y')

--- a/test/_common.py
+++ b/test/_common.py
@@ -161,15 +161,18 @@ class TestCase(unittest.TestCase, Assertions):
 
         # Direct paths to a temporary directory. Tests can also use this
         # temporary directory.
-        self.temp_dir = tempfile.mkdtemp()
-        beets.config['statefile'] = os.path.join(self.temp_dir, 'state.pickle')
-        beets.config['library'] = os.path.join(self.temp_dir, 'library.db')
-        beets.config['directory'] = os.path.join(self.temp_dir, 'libdir')
+        self.temp_dir = util.bytestring_path(tempfile.mkdtemp())
+        beets.config['statefile'] = \
+            os.path.join(self.temp_dir, b'state.pickle')
+        beets.config['library'] = \
+            util.py3_path(os.path.join(self.temp_dir, b'library.db'))
+        beets.config['directory'] = \
+            util.py3_path(os.path.join(self.temp_dir, b'libdir'))
 
         # Set $HOME, which is used by confit's `config_dir()` to create
         # directories.
         self._old_home = os.environ.get('HOME')
-        os.environ['HOME'] = self.temp_dir
+        os.environ['HOME'] = util.py3_path(self.temp_dir)
 
         # Initialize, but don't install, a DummyIO.
         self.io = DummyIO()

--- a/test/helper.py
+++ b/test/helper.py
@@ -169,7 +169,7 @@ class TestHelper(object):
         Make sure you call ``teardown_beets()`` afterwards.
         """
         self.create_temp_dir()
-        os.environ['BEETSDIR'] = self.temp_dir
+        os.environ['BEETSDIR'] = util.py3_path(self.temp_dir)
 
         self.config = beets.config
         self.config.clear()
@@ -182,10 +182,11 @@ class TestHelper(object):
 
         self.libdir = os.path.join(self.temp_dir, b'libdir')
         os.mkdir(self.libdir)
-        self.config['directory'] = self.libdir
+        self.config['directory'] = util.py3_path(self.libdir)
 
         if disk:
-            dbpath = self.config['library'].as_filename()
+            dbpath = util.bytestring_path(
+                self.config['library'].as_filename())
         else:
             dbpath = ':memory:'
         self.lib = Library(dbpath, self.libdir)

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -415,7 +415,7 @@ class ArtImporterTest(UseThePlugin):
         self.plugin.art_for_album = art_for_album
 
         # Test library.
-        self.libpath = os.path.join(self.temp_dir, 'tmplib.blb')
+        self.libpath = os.path.join(self.temp_dir, b'tmplib.blb')
         self.libdir = os.path.join(self.temp_dir, b'tmplib')
         os.mkdir(self.libdir)
         os.mkdir(os.path.join(self.libdir, b'album'))

--- a/test/test_metasync.py
+++ b/test/test_metasync.py
@@ -20,6 +20,7 @@ import platform
 import time
 from datetime import datetime
 from beets.library import Item
+from beets.util import py3_path
 
 from test import _common
 from test._common import unittest
@@ -48,10 +49,10 @@ class MetaSyncTest(_common.TestCase, TestHelper):
 
         if _is_windows():
             self.config['metasync']['itunes']['library'] = \
-                self.itunes_library_windows
+                py3_path(self.itunes_library_windows)
         else:
             self.config['metasync']['itunes']['library'] = \
-                self.itunes_library_unix
+                py3_path(self.itunes_library_unix)
 
         self._set_up_data()
 

--- a/test/test_smartplaylist.py
+++ b/test/test_smartplaylist.py
@@ -25,7 +25,7 @@ from beetsplug.smartplaylist import SmartPlaylistPlugin
 from beets.library import Item, Album, parse_query_string
 from beets.dbcore import OrQuery
 from beets.dbcore.query import NullSort, MultipleSort, FixedFieldSort
-from beets.util import syspath, bytestring_path
+from beets.util import syspath, bytestring_path, py3_path
 from beets.ui import UserError
 from beets import config
 
@@ -161,7 +161,7 @@ class SmartPlaylistTest(unittest.TestCase):
 
         dir = bytestring_path(mkdtemp())
         config['smartplaylist']['relative_to'] = False
-        config['smartplaylist']['playlist_dir'] = dir
+        config['smartplaylist']['playlist_dir'] = py3_path(dir)
         try:
             spl.update_playlists(lib)
         except Exception:
@@ -191,7 +191,7 @@ class SmartPlaylistCLITest(unittest.TestCase, TestHelper):
             {'name': 'all.m3u',
              'query': u''}
         ])
-        config['smartplaylist']['playlist_dir'].set(self.temp_dir)
+        config['smartplaylist']['playlist_dir'].set(py3_path(self.temp_dir))
         self.load_plugins('smartplaylist')
 
     def tearDown(self):

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -657,12 +657,12 @@ class ConfigTest(unittest.TestCase, TestHelper, _common.Assertions):
         # directory there. Some tests will set `BEETSDIR` themselves.
         del os.environ['BEETSDIR']
         self._old_home = os.environ.get('HOME')
-        os.environ['HOME'] = self.temp_dir
+        os.environ['HOME'] = util.py3_path(self.temp_dir)
 
         # Also set APPDATA, the Windows equivalent of setting $HOME.
         self._old_appdata = os.environ.get('APPDATA')
         os.environ['APPDATA'] = \
-            os.path.join(self.temp_dir, 'AppData', 'Roaming')
+            util.py3_path(os.path.join(self.temp_dir, b'AppData', b'Roaming'))
 
         self._orig_cwd = os.getcwd()
         self.test_cmd = self._make_test_cmd()
@@ -671,18 +671,18 @@ class ConfigTest(unittest.TestCase, TestHelper, _common.Assertions):
         # Default user configuration
         if platform.system() == 'Windows':
             self.user_config_dir = os.path.join(
-                self.temp_dir, 'AppData', 'Roaming', 'beets'
+                self.temp_dir, b'AppData', b'Roaming', b'beets'
             )
         else:
             self.user_config_dir = os.path.join(
-                self.temp_dir, '.config', 'beets'
+                self.temp_dir, b'.config', b'beets'
             )
         os.makedirs(self.user_config_dir)
         self.user_config_path = os.path.join(self.user_config_dir,
-                                             'config.yaml')
+                                             b'config.yaml')
 
         # Custom BEETSDIR
-        self.beetsdir = os.path.join(self.temp_dir, 'beetsdir')
+        self.beetsdir = os.path.join(self.temp_dir, b'beetsdir')
         os.makedirs(self.beetsdir)
 
         self._reset_config()
@@ -793,8 +793,8 @@ class ConfigTest(unittest.TestCase, TestHelper, _common.Assertions):
         self.assertEqual(config['anoption'].get(), 'cli overwrite')
 
     def test_cli_config_file_overwrites_beetsdir_defaults(self):
-        os.environ['BEETSDIR'] = self.beetsdir
-        env_config_path = os.path.join(self.beetsdir, 'config.yaml')
+        os.environ['BEETSDIR'] = util.py3_path(self.beetsdir)
+        env_config_path = os.path.join(self.beetsdir, b'config.yaml')
         with open(env_config_path, 'w') as file:
             file.write('anoption: value')
 
@@ -846,15 +846,15 @@ class ConfigTest(unittest.TestCase, TestHelper, _common.Assertions):
         ui._raw_main(['--config', cli_config_path, 'test'])
         self.assert_equal_path(
             config['library'].as_filename(),
-            os.path.join(self.user_config_dir, 'beets.db')
+            os.path.join(self.user_config_dir, b'beets.db')
         )
         self.assert_equal_path(
             config['statefile'].as_filename(),
-            os.path.join(self.user_config_dir, 'state')
+            os.path.join(self.user_config_dir, b'state')
         )
 
     def test_cli_config_paths_resolve_relative_to_beetsdir(self):
-        os.environ['BEETSDIR'] = self.beetsdir
+        os.environ['BEETSDIR'] = util.py3_path(self.beetsdir)
 
         cli_config_path = os.path.join(self.temp_dir, 'config.yaml')
         with open(cli_config_path, 'w') as file:
@@ -863,9 +863,9 @@ class ConfigTest(unittest.TestCase, TestHelper, _common.Assertions):
 
         ui._raw_main(['--config', cli_config_path, 'test'])
         self.assert_equal_path(config['library'].as_filename(),
-                               os.path.join(self.beetsdir, 'beets.db'))
+                               os.path.join(self.beetsdir, b'beets.db'))
         self.assert_equal_path(config['statefile'].as_filename(),
-                               os.path.join(self.beetsdir, 'state'))
+                               os.path.join(self.beetsdir, b'state'))
 
     def test_command_line_option_relative_to_working_dir(self):
         os.chdir(self.temp_dir)
@@ -883,9 +883,9 @@ class ConfigTest(unittest.TestCase, TestHelper, _common.Assertions):
         self.assertTrue(plugins.find_plugins()[0].is_test_plugin)
 
     def test_beetsdir_config(self):
-        os.environ['BEETSDIR'] = self.beetsdir
+        os.environ['BEETSDIR'] = util.py3_path(self.beetsdir)
 
-        env_config_path = os.path.join(self.beetsdir, 'config.yaml')
+        env_config_path = os.path.join(self.beetsdir, b'config.yaml')
         with open(env_config_path, 'w') as file:
             file.write('anoption: overwrite')
 
@@ -893,13 +893,13 @@ class ConfigTest(unittest.TestCase, TestHelper, _common.Assertions):
         self.assertEqual(config['anoption'].get(), 'overwrite')
 
     def test_beetsdir_points_to_file_error(self):
-        beetsdir = os.path.join(self.temp_dir, 'beetsfile')
+        beetsdir = os.path.join(self.temp_dir, b'beetsfile')
         open(beetsdir, 'a').close()
-        os.environ['BEETSDIR'] = beetsdir
+        os.environ['BEETSDIR'] = util.py3_path(beetsdir)
         self.assertRaises(ConfigError, ui._raw_main, ['test'])
 
     def test_beetsdir_config_does_not_load_default_user_config(self):
-        os.environ['BEETSDIR'] = self.beetsdir
+        os.environ['BEETSDIR'] = util.py3_path(self.beetsdir)
 
         with open(self.user_config_path, 'w') as file:
             file.write('anoption: value')
@@ -908,27 +908,27 @@ class ConfigTest(unittest.TestCase, TestHelper, _common.Assertions):
         self.assertFalse(config['anoption'].exists())
 
     def test_default_config_paths_resolve_relative_to_beetsdir(self):
-        os.environ['BEETSDIR'] = self.beetsdir
+        os.environ['BEETSDIR'] = util.py3_path(self.beetsdir)
 
         config.read()
-        self.assertEqual(config['library'].as_filename(),
-                         os.path.join(self.beetsdir, 'library.db'))
-        self.assertEqual(config['statefile'].as_filename(),
-                         os.path.join(self.beetsdir, 'state.pickle'))
+        self.assert_equal_path(config['library'].as_filename(),
+                               os.path.join(self.beetsdir, b'library.db'))
+        self.assert_equal_path(config['statefile'].as_filename(),
+                               os.path.join(self.beetsdir, b'state.pickle'))
 
     def test_beetsdir_config_paths_resolve_relative_to_beetsdir(self):
-        os.environ['BEETSDIR'] = self.beetsdir
+        os.environ['BEETSDIR'] = util.py3_path(self.beetsdir)
 
-        env_config_path = os.path.join(self.beetsdir, 'config.yaml')
+        env_config_path = os.path.join(self.beetsdir, b'config.yaml')
         with open(env_config_path, 'w') as file:
             file.write('library: beets.db\n')
             file.write('statefile: state')
 
         config.read()
-        self.assertEqual(config['library'].as_filename(),
-                         os.path.join(self.beetsdir, 'beets.db'))
-        self.assertEqual(config['statefile'].as_filename(),
-                         os.path.join(self.beetsdir, 'state'))
+        self.assert_equal_path(config['library'].as_filename(),
+                               os.path.join(self.beetsdir, b'beets.db'))
+        self.assert_equal_path(config['statefile'].as_filename(),
+                               os.path.join(self.beetsdir, b'state'))
 
 
 class ShowModelChangeTest(_common.TestCase):


### PR DESCRIPTION
This introduces a new function called `py3_path` (name subject to change)

We must use this function (or an equivalent one) to deal with functions/methods that only accept strings on Python 3.

This includes:

  * `os.environ`
  * confit/confuse filename storage (where we use `config['option'].as_filename()`
  * `sqlite3_connect`
  * plugin paths

It doesn't yet include (or maybe not at all in this PR):

  * archive import handling
  * proving that it does anything more than pass the testsuite on py3