### PR TITLE
Remove support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
     include:
         - python: 2.7
           env: {TOX_ENV: py27-cov, COVERAGE: 1}
-        - python: 3.3
-          env: {TOX_ENV: py33-test}
         - python: 3.4
           env: {TOX_ENV: py34-test}
         - python: 3.5
@@ -20,12 +18,11 @@ matrix:
         #   - env: {TOX_ENV: pypy-test}
         - python: 2.7
           env: {TOX_ENV: py27-flake8}
-        - python: 3.3
-          env: {TOX_ENV: py33-flake8}
+        - python: 3.4
+          env: {TOX_ENV: py34-flake8}
         - python: 2.7
           env: {TOX_ENV: docs}
     allow_failures:
-        - python: 3.3
         - python: 3.4
         - python: 3.5
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,6 @@ environment:
     matrix:
         - PYTHON: C:\Python27
           TOX_ENV: py27-test
-        - PYTHON: C:\Python33
-          TOX_ENV: py33-test
         - PYTHON: C:\Python34
           TOX_ENV: py34-test
         - PYTHON: C:\Python35
@@ -27,6 +25,5 @@ test_script:
 # Allow all failures for now: the tests don't yet pass!
 matrix:
     allow_failures:
-        - TOX_ENV: py33-test
         - TOX_ENV: py34-test
         - TOX_ENV: py35-test

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 envlist = py27-test, py27-flake8, docs
 
 # The exhaustive list of environments is:
-# envlist = py{27,33,34,35}-{test,cov}, py{27,33}-flake8, docs
+# envlist = py{27,34,35}-{test,cov}, py{27,34}-flake8, docs
 
 [_test]
 deps =
@@ -37,12 +37,12 @@ passenv =
     NOSE_SHOW_SKIPPED # Undocumented feature of nose-show-skipped.
 deps =
     {test,cov}: {[_test]deps}
-    py{27,33}-flake8: {[_flake8]deps}
+    py{27,34}-flake8: {[_flake8]deps}
 commands =
     cov: nosetests --with-coverage {posargs}
     test: nosetests {posargs}
     py27-flake8: flake8 --min-version 2.7 {posargs} {[_flake8]files}
-    py33-flake8: flake8 --min-version 3.3 {posargs} {[_flake8]files}
+    py34-flake8: flake8 --min-version 3.4 {posargs} {[_flake8]files}
 
 [testenv:docs]
 basepython = python2.7


### PR DESCRIPTION
It doesn't seem like Python 3.3 is worth supporting anymore. I'm not
sure if any popular(ish) distro supports Python 3.3, only 3.2 or >=3.4