### PR TITLE
Add appveyor skip as an alias for skip appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,9 @@
 version: "{build}"
 build: off
 deploy: off
+skip_commits:
+    # add [appveyor skip] as an alias for [skip appveyor] (like [ci skip])
+    message: /\[appveyor skip\]/
 
 environment:
     # Undocumented feature of nose-show-skipped.


### PR DESCRIPTION
Strangely while both "ci skip" and "skip ci" are supported (with brackets)
only "skip appveyor" is supported by default