### PR TITLE
Emby API Key

### DIFF
--- a/beetsplug/embyupdate.py
+++ b/beetsplug/embyupdate.py
@@ -104,26 +104,26 @@ class EmbyUpdate(BeetsPlugin):
         port = config['emby']['port'].get()
         username = config['emby']['username'].get()
         password = config['emby']['password'].get()
-		token = config['emby']['apikey'].get()
+        token = config['emby']['apikey'].get()
 
         # Get user information from the Emby API.
         user = get_user(host, port, username)
         if not user:
             self._log.warning(u'User {0} could not be found.'.format(username))
             return
-		
-		if not token:
-			# Create Authentication data and headers.
-			auth_data = password_data(username, password)
-			headers = create_headers(user[0]['Id'])
 
-			# Get authentication token.
-			token = get_token(host, port, headers, auth_data)
-			if not token:
-				self._log.warning(
-					u'Could not get token for user {0}', username
-				)
-				return
+        if not token:
+            # Create Authentication data and headers.
+            auth_data = password_data(username, password)
+            headers = create_headers(user[0]['Id'])
+
+            # Get authentication token.
+            token = get_token(host, port, headers, auth_data)
+            if not token:
+                self._log.warning(
+                    u'Could not get token for user {0}', username
+                )
+                return
 
         # Recreate headers with a token.
         headers = create_headers(user[0]['Id'], token=token)

--- a/beetsplug/embyupdate.py
+++ b/beetsplug/embyupdate.py
@@ -104,24 +104,26 @@ class EmbyUpdate(BeetsPlugin):
         port = config['emby']['port'].get()
         username = config['emby']['username'].get()
         password = config['emby']['password'].get()
+		token = config['emby']['apikey'].get()
 
         # Get user information from the Emby API.
         user = get_user(host, port, username)
         if not user:
             self._log.warning(u'User {0} could not be found.'.format(username))
             return
+		
+		if not token:
+			# Create Authentication data and headers.
+			auth_data = password_data(username, password)
+			headers = create_headers(user[0]['Id'])
 
-        # Create Authentication data and headers.
-        auth_data = password_data(username, password)
-        headers = create_headers(user[0]['Id'])
-
-        # Get authentication token.
-        token = get_token(host, port, headers, auth_data)
-        if not token:
-            self._log.warning(
-                u'Could not get token for user {0}', username
-            )
-            return
+			# Get authentication token.
+			token = get_token(host, port, headers, auth_data)
+			if not token:
+				self._log.warning(
+					u'Could not get token for user {0}', username
+				)
+				return
 
         # Recreate headers with a token.
         headers = create_headers(user[0]['Id'], token=token)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+* :doc:`/plugins/embyupdate`: Use the option of Emby's API Key's rather than
+  a password. Add an apikey to your config file for this to work. Does not
+  break the use of password as an authentication method
+
+
 1.4.0 (in development)
 ----------------------
 

--- a/docs/plugins/embyupdate.rst
+++ b/docs/plugins/embyupdate.rst
@@ -9,6 +9,7 @@ To use ``embyupdate`` plugin, enable it in your configuration (see :ref:`using-p
         host: localhost
         port: 8096
         username: user
+        apikey: apikey
         password: password
 
 To use the ``embyupdate`` plugin you need to install the `requests`_ library with::
@@ -30,4 +31,5 @@ The available options under the ``emby:`` section are:
 - **port**: The Emby server port.
   Default: 8096
 - **username**: A username of a Emby user that is allowed to refresh the library.
-- **password**: That user's password.
+- **apikey**: An Emby API key
+- **password**: If no API key is present then enter the user aboves password.


### PR DESCRIPTION
Add the option to read an API Key from the config file and submit that
instead of needing a password. Doesn't remove the use of password so is
backwards compatible with users current config file