### PR TITLE
replace py27-flake8 with py34-flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,13 @@ matrix:
           env: {TOX_ENV: py35-test}
         # - python: pypy
         #   - env: {TOX_ENV: pypy-test}
-        - python: 2.7
-          env: {TOX_ENV: py27-flake8}
         - python: 3.4
           env: {TOX_ENV: py34-flake8}
         - python: 2.7
           env: {TOX_ENV: docs}
     allow_failures:
         - python: 3.4
+          env: {TOX_ENV: py34-test}
         - python: 3.5
 
 # Non-Python dependencies.


### PR DESCRIPTION
We definitely want py34-flake8 to succeed, so we don't end up with
`unicode` and other py27 specific stuff. With that in mind, we don't need
py27-flake8 anymore either.