### PR TITLE
Switch from pathlib to pathlib2

### DIFF
--- a/beetsplug/thumbnails.py
+++ b/beetsplug/thumbnails.py
@@ -25,7 +25,7 @@ from hashlib import md5
 import os
 import shutil
 from itertools import chain
-from pathlib import PurePosixPath
+from pathlib2 import PurePosixPath
 import ctypes
 import ctypes.util
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -41,7 +41,12 @@ And there are a few bug fixes too:
 The last release, 1.3.19, also erroneously reported its version as "1.3.18"
 when you typed ``beet version``. This has been corrected.
 
+????
+
+* The pathlib module dependency was replaced by `pathlib2`_
+
 .. _six: https://pythonhosted.org/six/
+.. _pathlib2: https://pypi.python.org/pypi/pathlib2/
 
 
 1.3.19 (June 25, 2016)

--- a/docs/plugins/thumbnails.rst
+++ b/docs/plugins/thumbnails.rst
@@ -7,7 +7,7 @@ Nautilus or Thunar, and is therefore POSIX-only.
 
 To use the ``thumbnails`` plugin, enable it (see :doc:`/plugins/index`) as well
 as the :doc:`/plugins/fetchart`.  You'll need 2 additional python packages:
-`pyxdg` and `pathlib`.
+`pyxdg` and `pathlib2`.
 
 ``thumbnails`` needs to resize the covers, and therefore requires either
 `ImageMagick`_ or `Pillow`_.

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ setup(
         'rarfile',
         'responses',
         'pyxdg',
-        'pathlib',
+        'pathlib2',
         'python-mpd2',
     ],
 
@@ -119,7 +119,7 @@ setup(
         'web': ['flask', 'flask-cors'],
         'import': ['rarfile'],
         'thumbnails': ['pyxdg'] +
-        (['pathlib'] if (sys.version_info < (3, 4, 0)) else []),
+        (['pathlib2'] if (sys.version_info < (3, 4, 0)) else []),
         'metasync': ['dbus-python'],
     },
     # Non-Python/non-PyPI plugin dependencies:

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ passenv =
     NOSE_SHOW_SKIPPED # Undocumented feature of nose-show-skipped.
 deps =
     {test,cov}: {[_test]deps}
-    py27: pathlib
+    py27: pathlib2
     py{27,34}-flake8: {[_flake8]deps}
 commands =
     py27-cov: python -m nose --with-coverage {posargs}


### PR DESCRIPTION
Quoting the pathlib2 documentation:

> The old pathlib module on bitbucket is in bugfix-only mode. The goal of pathlib2 is to provide a backport of standard pathlib module which tracks the standard library module, so all the newest features of the standard pathlib can be used also on older Python versions.