### PR TITLE
(Mostly) remove patch dot start

### DIFF
--- a/test/test_edit.py
+++ b/test/test_edit.py
@@ -106,6 +106,7 @@ class EditMixin(object):
 
 
 @_common.slow_test()
+@patch('beets.library.Item.write')
 class EditCommandTest(unittest.TestCase, TestHelper, EditMixin):
     """Black box tests for `beetsplug.edit`. Command line interaction is
     simulated using `test.helper.control_stdin()`, and yaml editing via an
@@ -123,26 +124,21 @@ class EditCommandTest(unittest.TestCase, TestHelper, EditMixin):
         self.items_orig = [{f: item[f] for f in item._fields} for
                            item in self.album.items()]
 
-        # Keep track of write()s.
-        self.write_patcher = patch('beets.library.Item.write')
-        self.mock_write = self.write_patcher.start()
-
     def tearDown(self):
         EditPlugin.listeners = None
-        self.write_patcher.stop()
         self.teardown_beets()
         self.unload_plugins()
 
-    def assertCounts(self, album_count=ALBUM_COUNT, track_count=TRACK_COUNT,  # noqa
+    def assertCounts(self, mock_write, album_count=ALBUM_COUNT, track_count=TRACK_COUNT,  # noqa
                      write_call_count=TRACK_COUNT, title_starts_with=''):
         """Several common assertions on Album, Track and call counts."""
         self.assertEqual(len(self.lib.albums()), album_count)
         self.assertEqual(len(self.lib.items()), track_count)
-        self.assertEqual(self.mock_write.call_count, write_call_count)
+        self.assertEqual(mock_write.call_count, write_call_count)
         self.assertTrue(all(i.title.startswith(title_starts_with)
                             for i in self.lib.items()))
 
-    def test_title_edit_discard(self):
+    def test_title_edit_discard(self, m):
         """Edit title for all items in the library, then discard changes."""
         # Edit track titles.
         self.run_mocked_command({'replacements': {u't\u00eftle':
@@ -150,11 +146,11 @@ class EditCommandTest(unittest.TestCase, TestHelper, EditMixin):
                                 # Cancel.
                                 ['c'])
 
-        self.assertCounts(write_call_count=0,
+        self.assertCounts(m, write_call_count=0,
                           title_starts_with=u't\u00eftle')
         self.assertItemFieldsModified(self.album.items(), self.items_orig, [])
 
-    def test_title_edit_apply(self):
+    def test_title_edit_apply(self, m):
         """Edit title for all items in the library, then apply changes."""
         # Edit track titles.
         self.run_mocked_command({'replacements': {u't\u00eftle':
@@ -162,12 +158,12 @@ class EditCommandTest(unittest.TestCase, TestHelper, EditMixin):
                                 # Apply changes.
                                 ['a'])
 
-        self.assertCounts(write_call_count=self.TRACK_COUNT,
+        self.assertCounts(m, write_call_count=self.TRACK_COUNT,
                           title_starts_with=u'modified t\u00eftle')
         self.assertItemFieldsModified(self.album.items(), self.items_orig,
                                       ['title'])
 
-    def test_single_title_edit_apply(self):
+    def test_single_title_edit_apply(self, m):
         """Edit title for one item in the library, then apply changes."""
         # Edit one track title.
         self.run_mocked_command({'replacements': {u't\u00eftle 9':
@@ -175,25 +171,25 @@ class EditCommandTest(unittest.TestCase, TestHelper, EditMixin):
                                 # Apply changes.
                                 ['a'])
 
-        self.assertCounts(write_call_count=1,)
+        self.assertCounts(m, write_call_count=1,)
         # No changes except on last item.
         self.assertItemFieldsModified(list(self.album.items())[:-1],
                                       self.items_orig[:-1], [])
         self.assertEqual(list(self.album.items())[-1].title,
                          u'modified t\u00eftle 9')
 
-    def test_noedit(self):
+    def test_noedit(self, m):
         """Do not edit anything."""
         # Do not edit anything.
         self.run_mocked_command({'contents': None},
                                 # No stdin.
                                 [])
 
-        self.assertCounts(write_call_count=0,
+        self.assertCounts(m, write_call_count=0,
                           title_starts_with=u't\u00eftle')
         self.assertItemFieldsModified(self.album.items(), self.items_orig, [])
 
-    def test_album_edit_apply(self):
+    def test_album_edit_apply(self, m):
         """Edit the album field for all items in the library, apply changes.
         By design, the album should not be updated.""
         """
@@ -203,14 +199,14 @@ class EditCommandTest(unittest.TestCase, TestHelper, EditMixin):
                                 # Apply changes.
                                 ['a'])
 
-        self.assertCounts(write_call_count=self.TRACK_COUNT)
+        self.assertCounts(m, write_call_count=self.TRACK_COUNT)
         self.assertItemFieldsModified(self.album.items(), self.items_orig,
                                       ['album'])
         # Ensure album is *not* modified.
         self.album.load()
         self.assertEqual(self.album.album, u'\u00e4lbum')
 
-    def test_single_edit_add_field(self):
+    def test_single_edit_add_field(self, m):
         """Edit the yaml file appending an extra field to the first item, then
         apply changes."""
         # Append "foo: bar" to item with id == 1.
@@ -220,10 +216,10 @@ class EditCommandTest(unittest.TestCase, TestHelper, EditMixin):
                                 ['a'])
 
         self.assertEqual(self.lib.items(u'id:1')[0].foo, 'bar')
-        self.assertCounts(write_call_count=1,
+        self.assertCounts(m, write_call_count=1,
                           title_starts_with=u't\u00eftle')
 
-    def test_a_album_edit_apply(self):
+    def test_a_album_edit_apply(self, m):
         """Album query (-a), edit album field, apply changes."""
         self.run_mocked_command({'replacements': {u'\u00e4lbum':
                                                   u'modified \u00e4lbum'}},
@@ -232,12 +228,12 @@ class EditCommandTest(unittest.TestCase, TestHelper, EditMixin):
                                 args=['-a'])
 
         self.album.load()
-        self.assertCounts(write_call_count=self.TRACK_COUNT)
+        self.assertCounts(m, write_call_count=self.TRACK_COUNT)
         self.assertEqual(self.album.album, u'modified \u00e4lbum')
         self.assertItemFieldsModified(self.album.items(), self.items_orig,
                                       ['album'])
 
-    def test_a_albumartist_edit_apply(self):
+    def test_a_albumartist_edit_apply(self, m):
         """Album query (-a), edit albumartist field, apply changes."""
         self.run_mocked_command({'replacements': {u'album artist':
                                                   u'modified album artist'}},
@@ -246,12 +242,12 @@ class EditCommandTest(unittest.TestCase, TestHelper, EditMixin):
                                 args=['-a'])
 
         self.album.load()
-        self.assertCounts(write_call_count=self.TRACK_COUNT)
+        self.assertCounts(m, write_call_count=self.TRACK_COUNT)
         self.assertEqual(self.album.albumartist, u'the modified album artist')
         self.assertItemFieldsModified(self.album.items(), self.items_orig,
                                       ['albumartist'])
 
-    def test_malformed_yaml(self):
+    def test_malformed_yaml(self, m):
         """Edit the yaml file incorrectly (resulting in a malformed yaml
         document)."""
         # Edit the yaml file to an invalid file.
@@ -259,10 +255,10 @@ class EditCommandTest(unittest.TestCase, TestHelper, EditMixin):
                                 # Edit again to fix? No.
                                 ['n'])
 
-        self.assertCounts(write_call_count=0,
+        self.assertCounts(m, write_call_count=0,
                           title_starts_with=u't\u00eftle')
 
-    def test_invalid_yaml(self):
+    def test_invalid_yaml(self, m):
         """Edit the yaml file incorrectly (resulting in a well-formed but
         invalid yaml document)."""
         # Edit the yaml file to an invalid but parseable file.
@@ -270,7 +266,7 @@ class EditCommandTest(unittest.TestCase, TestHelper, EditMixin):
                                 # No stdin.
                                 [])
 
-        self.assertCounts(write_call_count=0,
+        self.assertCounts(m, write_call_count=0,
                           title_starts_with=u't\u00eftle')
 
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1766,8 +1766,10 @@ def mocked_get_recording_by_id(id_, includes=[], release_status=[],
     }
 
 
-@patch('musicbrainzngs.get_recording_by_id', Mock(side_effect=mocked_get_recording_by_id))
-@patch('musicbrainzngs.get_release_by_id', Mock(side_effect=mocked_get_release_by_id))
+@patch('musicbrainzngs.get_recording_by_id',
+       Mock(side_effect=mocked_get_recording_by_id))
+@patch('musicbrainzngs.get_release_by_id',
+       Mock(side_effect=mocked_get_release_by_id))
 class ImportMusicBrainzIdTest(_common.TestCase, ImportHelper):
     """Test the --musicbrainzid argument."""
 
@@ -1849,6 +1851,7 @@ class ImportMusicBrainzIdTest(_common.TestCase, ImportHelper):
         task.lookup_candidates()
         self.assertEqual(set(['VALID_RECORDING_0', 'VALID_RECORDING_1']),
                          set([c.info.title for c in task.candidates]))
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -26,7 +26,7 @@ from six import StringIO
 from tempfile import mkstemp
 from zipfile import ZipFile
 from tarfile import TarFile
-from mock import patch
+from mock import patch, Mock
 
 from test import _common
 from test._common import unittest
@@ -1072,7 +1072,7 @@ class InferAlbumDataTest(_common.TestCase):
         self.assertFalse(self.items[0].comp)
 
 
-def test_album_info():
+def test_album_info(*args, **kwargs):
     """Create an AlbumInfo object for testing.
     """
     track_info = TrackInfo(
@@ -1087,9 +1087,10 @@ def test_album_info():
         album_id=u'albumid',
         artist_id=u'artistid',
     )
-    return album_info
+    return iter([album_info])
 
 
+@patch('beets.autotag.mb.match_album', Mock(side_effect=test_album_info))
 class ImportDuplicateAlbumTest(unittest.TestCase, TestHelper,
                                _common.Assertions):
 
@@ -1099,17 +1100,11 @@ class ImportDuplicateAlbumTest(unittest.TestCase, TestHelper,
         # Original album
         self.add_album_fixture(albumartist=u'artist', album=u'album')
 
-        # Create duplicate through autotagger
-        self.match_album_patcher = patch('beets.autotag.mb.match_album')
-        self.match_album = self.match_album_patcher.start()
-        self.match_album.return_value = iter([test_album_info()])
-
         # Create import session
         self.importer = self.create_importer()
         config['import']['autotag'] = True
 
     def tearDown(self):
-        self.match_album_patcher.stop()
         self.teardown_beets()
 
     def test_remove_duplicate_album(self):
@@ -1179,6 +1174,13 @@ class ImportDuplicateAlbumTest(unittest.TestCase, TestHelper,
         return album
 
 
+def test_track_info(*args, **kwargs):
+    return iter([TrackInfo(
+        artist=u'artist', title=u'title',
+        track_id=u'new trackid', index=0,)])
+
+
+@patch('beets.autotag.mb.match_track', Mock(side_effect=test_track_info))
 class ImportDuplicateSingletonTest(unittest.TestCase, TestHelper,
                                    _common.Assertions):
 
@@ -1189,24 +1191,12 @@ class ImportDuplicateSingletonTest(unittest.TestCase, TestHelper,
         self.add_item_fixture(artist=u'artist', title=u'title',
                               mb_trackid='old trackid')
 
-        # Create duplicate through autotagger
-        self.match_track_patcher = patch('beets.autotag.mb.match_track')
-        self.match_track = self.match_track_patcher.start()
-        track_info = TrackInfo(
-            artist=u'artist',
-            title=u'title',
-            track_id=u'new trackid',
-            index=0,
-        )
-        self.match_track.return_value = iter([track_info])
-
         # Import session
         self.importer = self.create_importer()
         config['import']['autotag'] = True
         config['import']['singletons'] = True
 
     def tearDown(self):
-        self.match_track_patcher.stop()
         self.teardown_beets()
 
     def test_remove_duplicate(self):
@@ -1706,100 +1696,6 @@ class ImportPretendTest(_common.TestCase, ImportHelper):
         self.assertEqual(logs, [u'No files imported from {0}'
                          .format(displayable_path(self.empty_path))])
 
-
-class ImportMusicBrainzIdTest(_common.TestCase, ImportHelper):
-    """Test the --musicbrainzid argument."""
-
-    MB_RELEASE_PREFIX = 'https://musicbrainz.org/release/'
-    MB_RECORDING_PREFIX = 'https://musicbrainz.org/recording/'
-    ID_RELEASE_0 = '00000000-0000-0000-0000-000000000000'
-    ID_RELEASE_1 = '11111111-1111-1111-1111-111111111111'
-    ID_RECORDING_0 = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
-    ID_RECORDING_1 = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
-
-    def setUp(self):
-        self.setup_beets()
-        self._create_import_dir(1)
-
-        # Patch calls to musicbrainzngs.
-        self.release_patcher = patch('musicbrainzngs.get_release_by_id',
-                                     side_effect=mocked_get_release_by_id)
-        self.recording_patcher = patch('musicbrainzngs.get_recording_by_id',
-                                       side_effect=mocked_get_recording_by_id)
-        self.release_patcher.start()
-        self.recording_patcher.start()
-
-    def tearDown(self):
-        self.recording_patcher.stop()
-        self.release_patcher.stop()
-        self.teardown_beets()
-
-    def test_one_mbid_one_album(self):
-        self.config['import']['search_ids'] = \
-            [self.MB_RELEASE_PREFIX + self.ID_RELEASE_0]
-        self._setup_import_session()
-
-        self.importer.add_choice(importer.action.APPLY)
-        self.importer.run()
-        self.assertEqual(self.lib.albums().get().album, 'VALID_RELEASE_0')
-
-    def test_several_mbid_one_album(self):
-        self.config['import']['search_ids'] = \
-            [self.MB_RELEASE_PREFIX + self.ID_RELEASE_0,
-             self.MB_RELEASE_PREFIX + self.ID_RELEASE_1]
-        self._setup_import_session()
-
-        self.importer.add_choice(2)  # Pick the 2nd best match (release 1).
-        self.importer.add_choice(importer.action.APPLY)
-        self.importer.run()
-        self.assertEqual(self.lib.albums().get().album, 'VALID_RELEASE_1')
-
-    def test_one_mbid_one_singleton(self):
-        self.config['import']['search_ids'] = \
-            [self.MB_RECORDING_PREFIX + self.ID_RECORDING_0]
-        self._setup_import_session(singletons=True)
-
-        self.importer.add_choice(importer.action.APPLY)
-        self.importer.run()
-        self.assertEqual(self.lib.items().get().title, 'VALID_RECORDING_0')
-
-    def test_several_mbid_one_singleton(self):
-        self.config['import']['search_ids'] = \
-            [self.MB_RECORDING_PREFIX + self.ID_RECORDING_0,
-             self.MB_RECORDING_PREFIX + self.ID_RECORDING_1]
-        self._setup_import_session(singletons=True)
-
-        self.importer.add_choice(2)  # Pick the 2nd best match (recording 1).
-        self.importer.add_choice(importer.action.APPLY)
-        self.importer.run()
-        self.assertEqual(self.lib.items().get().title, 'VALID_RECORDING_1')
-
-    def test_candidates_album(self):
-        """Test directly ImportTask.lookup_candidates()."""
-        task = importer.ImportTask(paths=self.import_dir,
-                                   toppath='top path',
-                                   items=[_common.item()])
-        task.search_ids = [self.MB_RELEASE_PREFIX + self.ID_RELEASE_0,
-                           self.MB_RELEASE_PREFIX + self.ID_RELEASE_1,
-                           'an invalid and discarded id']
-
-        task.lookup_candidates()
-        self.assertEqual(set(['VALID_RELEASE_0', 'VALID_RELEASE_1']),
-                         set([c.info.album for c in task.candidates]))
-
-    def test_candidates_singleton(self):
-        """Test directly SingletonImportTask.lookup_candidates()."""
-        task = importer.SingletonImportTask(toppath='top path',
-                                            item=_common.item())
-        task.search_ids = [self.MB_RECORDING_PREFIX + self.ID_RECORDING_0,
-                           self.MB_RECORDING_PREFIX + self.ID_RECORDING_1,
-                           'an invalid and discarded id']
-
-        task.lookup_candidates()
-        self.assertEqual(set(['VALID_RECORDING_0', 'VALID_RECORDING_1']),
-                         set([c.info.title for c in task.candidates]))
-
-
 # Helpers for ImportMusicBrainzIdTest.
 
 
@@ -1869,6 +1765,90 @@ def mocked_get_recording_by_id(id_, includes=[], release_status=[],
         }
     }
 
+
+@patch('musicbrainzngs.get_recording_by_id', Mock(side_effect=mocked_get_recording_by_id))
+@patch('musicbrainzngs.get_release_by_id', Mock(side_effect=mocked_get_release_by_id))
+class ImportMusicBrainzIdTest(_common.TestCase, ImportHelper):
+    """Test the --musicbrainzid argument."""
+
+    MB_RELEASE_PREFIX = 'https://musicbrainz.org/release/'
+    MB_RECORDING_PREFIX = 'https://musicbrainz.org/recording/'
+    ID_RELEASE_0 = '00000000-0000-0000-0000-000000000000'
+    ID_RELEASE_1 = '11111111-1111-1111-1111-111111111111'
+    ID_RECORDING_0 = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+    ID_RECORDING_1 = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+
+    def setUp(self):
+        self.setup_beets()
+        self._create_import_dir(1)
+
+    def tearDown(self):
+        self.teardown_beets()
+
+    def test_one_mbid_one_album(self):
+        self.config['import']['search_ids'] = \
+            [self.MB_RELEASE_PREFIX + self.ID_RELEASE_0]
+        self._setup_import_session()
+
+        self.importer.add_choice(importer.action.APPLY)
+        self.importer.run()
+        self.assertEqual(self.lib.albums().get().album, 'VALID_RELEASE_0')
+
+    def test_several_mbid_one_album(self):
+        self.config['import']['search_ids'] = \
+            [self.MB_RELEASE_PREFIX + self.ID_RELEASE_0,
+             self.MB_RELEASE_PREFIX + self.ID_RELEASE_1]
+        self._setup_import_session()
+
+        self.importer.add_choice(2)  # Pick the 2nd best match (release 1).
+        self.importer.add_choice(importer.action.APPLY)
+        self.importer.run()
+        self.assertEqual(self.lib.albums().get().album, 'VALID_RELEASE_1')
+
+    def test_one_mbid_one_singleton(self):
+        self.config['import']['search_ids'] = \
+            [self.MB_RECORDING_PREFIX + self.ID_RECORDING_0]
+        self._setup_import_session(singletons=True)
+
+        self.importer.add_choice(importer.action.APPLY)
+        self.importer.run()
+        self.assertEqual(self.lib.items().get().title, 'VALID_RECORDING_0')
+
+    def test_several_mbid_one_singleton(self):
+        self.config['import']['search_ids'] = \
+            [self.MB_RECORDING_PREFIX + self.ID_RECORDING_0,
+             self.MB_RECORDING_PREFIX + self.ID_RECORDING_1]
+        self._setup_import_session(singletons=True)
+
+        self.importer.add_choice(2)  # Pick the 2nd best match (recording 1).
+        self.importer.add_choice(importer.action.APPLY)
+        self.importer.run()
+        self.assertEqual(self.lib.items().get().title, 'VALID_RECORDING_1')
+
+    def test_candidates_album(self):
+        """Test directly ImportTask.lookup_candidates()."""
+        task = importer.ImportTask(paths=self.import_dir,
+                                   toppath='top path',
+                                   items=[_common.item()])
+        task.search_ids = [self.MB_RELEASE_PREFIX + self.ID_RELEASE_0,
+                           self.MB_RELEASE_PREFIX + self.ID_RELEASE_1,
+                           'an invalid and discarded id']
+
+        task.lookup_candidates()
+        self.assertEqual(set(['VALID_RELEASE_0', 'VALID_RELEASE_1']),
+                         set([c.info.album for c in task.candidates]))
+
+    def test_candidates_singleton(self):
+        """Test directly SingletonImportTask.lookup_candidates()."""
+        task = importer.SingletonImportTask(toppath='top path',
+                                            item=_common.item())
+        task.search_ids = [self.MB_RECORDING_PREFIX + self.ID_RECORDING_0,
+                           self.MB_RECORDING_PREFIX + self.ID_RECORDING_1,
+                           'an invalid and discarded id']
+
+        task.lookup_candidates()
+        self.assertEqual(set(['VALID_RECORDING_0', 'VALID_RECORDING_1']),
+                         set([c.info.title for c in task.candidates]))
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)

--- a/test/test_ipfs.py
+++ b/test/test_ipfs.py
@@ -14,7 +14,7 @@
 
 from __future__ import division, absolute_import, print_function
 
-from mock import patch
+from mock import patch, Mock
 
 from beets import library
 from beets.util import bytestring_path, _fsencoding
@@ -26,19 +26,17 @@ from test.helper import TestHelper
 import os
 
 
+@patch('beets.util.command_output', Mock())
 class IPFSPluginTest(unittest.TestCase, TestHelper):
 
     def setUp(self):
         self.setup_beets()
         self.load_plugins('ipfs')
-        self.patcher = patch('beets.util.command_output')
-        self.command_output = self.patcher.start()
         self.lib = library.Library(":memory:")
 
     def tearDown(self):
         self.unload_plugins()
         self.teardown_beets()
-        self.patcher.stop()
 
     def test_stored_hashes(self):
         test_album = self.mk_test_album()

--- a/test/test_keyfinder.py
+++ b/test/test_keyfinder.py
@@ -23,56 +23,54 @@ from beets.library import Item
 from beets import util
 
 
+@patch('beets.util.command_output')
 class KeyFinderTest(unittest.TestCase, TestHelper):
 
     def setUp(self):
         self.setup_beets()
         self.load_plugins('keyfinder')
-        self.patcher = patch('beets.util.command_output')
-        self.command_output = self.patcher.start()
 
     def tearDown(self):
         self.teardown_beets()
         self.unload_plugins()
-        self.patcher.stop()
 
-    def test_add_key(self):
+    def test_add_key(self, command_output):
         item = Item(path='/file')
         item.add(self.lib)
 
-        self.command_output.return_value = 'dbm'
+        command_output.return_value = 'dbm'
         self.run_command('keyfinder')
 
         item.load()
         self.assertEqual(item['initial_key'], 'C#m')
-        self.command_output.assert_called_with(
+        command_output.assert_called_with(
             [b'KeyFinder', b'-f', util.syspath(item.path)])
 
-    def test_add_key_on_import(self):
-        self.command_output.return_value = 'dbm'
+    def test_add_key_on_import(self, command_output):
+        command_output.return_value = 'dbm'
         importer = self.create_importer()
         importer.run()
 
         item = self.lib.items().get()
         self.assertEqual(item['initial_key'], 'C#m')
 
-    def test_force_overwrite(self):
+    def test_force_overwrite(self, command_output):
         self.config['keyfinder']['overwrite'] = True
 
         item = Item(path='/file', initial_key='F')
         item.add(self.lib)
 
-        self.command_output.return_value = 'C#m'
+        command_output.return_value = 'C#m'
         self.run_command('keyfinder')
 
         item.load()
         self.assertEqual(item['initial_key'], 'C#m')
 
-    def test_do_not_overwrite(self):
+    def test_do_not_overwrite(self, command_output):
         item = Item(path='/file', initial_key='F')
         item.add(self.lib)
 
-        self.command_output.return_value = 'dbm'
+        command_output.return_value = 'dbm'
         self.run_command('keyfinder')
 
         item.load()

--- a/test/test_play.py
+++ b/test/test_play.py
@@ -41,8 +41,8 @@ class PlayPluginTest(unittest.TestCase, TestHelper):
         self.teardown_beets()
         self.unload_plugins()
 
-    def do_test(self, open_mock, args=('title:aNiceTitle',), expected_cmd='echo',
-                expected_playlist=None):
+    def do_test(self, open_mock, args=('title:aNiceTitle',),
+                expected_cmd='echo', expected_playlist=None):
         self.run_command('play', *args)
 
         open_mock.assert_called_once_with(ANY, expected_cmd)
@@ -58,12 +58,14 @@ class PlayPluginTest(unittest.TestCase, TestHelper):
         self.do_test(open_mock, [u'-a', u'nice'])
 
     def test_args_option(self, open_mock):
-        self.do_test(open_mock, [u'-A', u'foo', u'title:aNiceTitle'], u'echo foo')
+        self.do_test(open_mock,
+                     [u'-A', u'foo', u'title:aNiceTitle'], u'echo foo')
 
     def test_args_option_in_middle(self, open_mock):
         self.config['play']['command'] = 'echo $args other'
 
-        self.do_test(open_mock, [u'-A', u'foo', u'title:aNiceTitle'], u'echo foo other')
+        self.do_test(open_mock,
+                     [u'-A', u'foo', u'title:aNiceTitle'], u'echo foo other')
 
     def test_relative_to(self, open_mock):
         self.config['play']['command'] = 'echo'
@@ -71,7 +73,8 @@ class PlayPluginTest(unittest.TestCase, TestHelper):
 
         path = os.path.relpath(self.item.path, b'/something')
         playlist = path.decode('utf8')
-        self.do_test(open_mock, expected_cmd='echo', expected_playlist=playlist)
+        self.do_test(open_mock,
+                     expected_cmd='echo', expected_playlist=playlist)
 
     def test_use_folders(self, open_mock):
         self.config['play']['command'] = None

--- a/test/test_play.py
+++ b/test/test_play.py
@@ -41,8 +41,8 @@ class PlayPluginTest(unittest.TestCase, TestHelper):
         self.teardown_beets()
         self.unload_plugins()
 
-    def do_test(self, open_mock, args=('title:aNiceTitle',),
-                expected_cmd='echo', expected_playlist=None):
+    def run_and_assert(self, open_mock, args=('title:aNiceTitle',),
+                       expected_cmd='echo', expected_playlist=None):
         self.run_command('play', *args)
 
         open_mock.assert_called_once_with(ANY, expected_cmd)
@@ -52,20 +52,20 @@ class PlayPluginTest(unittest.TestCase, TestHelper):
             self.assertEqual(exp_playlist, playlist.read().decode('utf-8'))
 
     def test_basic(self, open_mock):
-        self.do_test(open_mock)
+        self.run_and_assert(open_mock)
 
     def test_album_option(self, open_mock):
-        self.do_test(open_mock, [u'-a', u'nice'])
+        self.run_and_assert(open_mock, [u'-a', u'nice'])
 
     def test_args_option(self, open_mock):
-        self.do_test(open_mock,
-                     [u'-A', u'foo', u'title:aNiceTitle'], u'echo foo')
+        self.run_and_assert(
+            open_mock, [u'-A', u'foo', u'title:aNiceTitle'], u'echo foo')
 
     def test_args_option_in_middle(self, open_mock):
         self.config['play']['command'] = 'echo $args other'
 
-        self.do_test(open_mock,
-                     [u'-A', u'foo', u'title:aNiceTitle'], u'echo foo other')
+        self.run_and_assert(
+            open_mock, [u'-A', u'foo', u'title:aNiceTitle'], u'echo foo other')
 
     def test_relative_to(self, open_mock):
         self.config['play']['command'] = 'echo'
@@ -73,8 +73,8 @@ class PlayPluginTest(unittest.TestCase, TestHelper):
 
         path = os.path.relpath(self.item.path, b'/something')
         playlist = path.decode('utf8')
-        self.do_test(open_mock,
-                     expected_cmd='echo', expected_playlist=playlist)
+        self.run_and_assert(
+            open_mock, expected_cmd='echo', expected_playlist=playlist)
 
     def test_use_folders(self, open_mock):
         self.config['play']['command'] = None

--- a/test/test_play.py
+++ b/test/test_play.py
@@ -28,96 +28,94 @@ from beets.ui import UserError
 from beets.util import open_anything
 
 
+@patch('beetsplug.play.util.interactive_open')
 class PlayPluginTest(unittest.TestCase, TestHelper):
     def setUp(self):
         self.setup_beets()
         self.load_plugins('play')
         self.item = self.add_item(album=u'a nice älbum', title=u'aNiceTitle')
         self.lib.add_album([self.item])
-        self.open_patcher = patch('beetsplug.play.util.interactive_open')
-        self.open_mock = self.open_patcher.start()
         self.config['play']['command'] = 'echo'
 
     def tearDown(self):
-        self.open_patcher.stop()
         self.teardown_beets()
         self.unload_plugins()
 
-    def do_test(self, args=('title:aNiceTitle',), expected_cmd='echo',
+    def do_test(self, open_mock, args=('title:aNiceTitle',), expected_cmd='echo',
                 expected_playlist=None):
         self.run_command('play', *args)
 
-        self.open_mock.assert_called_once_with(ANY, expected_cmd)
+        open_mock.assert_called_once_with(ANY, expected_cmd)
         expected_playlist = expected_playlist or self.item.path.decode('utf-8')
         exp_playlist = expected_playlist + u'\n'
-        with open(self.open_mock.call_args[0][0][0], 'rb') as playlist:
+        with open(open_mock.call_args[0][0][0], 'rb') as playlist:
             self.assertEqual(exp_playlist, playlist.read().decode('utf-8'))
 
-    def test_basic(self):
-        self.do_test()
+    def test_basic(self, open_mock):
+        self.do_test(open_mock)
 
-    def test_album_option(self):
-        self.do_test([u'-a', u'nice'])
+    def test_album_option(self, open_mock):
+        self.do_test(open_mock, [u'-a', u'nice'])
 
-    def test_args_option(self):
-        self.do_test([u'-A', u'foo', u'title:aNiceTitle'], u'echo foo')
+    def test_args_option(self, open_mock):
+        self.do_test(open_mock, [u'-A', u'foo', u'title:aNiceTitle'], u'echo foo')
 
-    def test_args_option_in_middle(self):
+    def test_args_option_in_middle(self, open_mock):
         self.config['play']['command'] = 'echo $args other'
 
-        self.do_test([u'-A', u'foo', u'title:aNiceTitle'], u'echo foo other')
+        self.do_test(open_mock, [u'-A', u'foo', u'title:aNiceTitle'], u'echo foo other')
 
-    def test_relative_to(self):
+    def test_relative_to(self, open_mock):
         self.config['play']['command'] = 'echo'
         self.config['play']['relative_to'] = '/something'
 
         path = os.path.relpath(self.item.path, b'/something')
         playlist = path.decode('utf8')
-        self.do_test(expected_cmd='echo', expected_playlist=playlist)
+        self.do_test(open_mock, expected_cmd='echo', expected_playlist=playlist)
 
-    def test_use_folders(self):
+    def test_use_folders(self, open_mock):
         self.config['play']['command'] = None
         self.config['play']['use_folders'] = True
         self.run_command('play', '-a', 'nice')
 
-        self.open_mock.assert_called_once_with(ANY, open_anything())
-        playlist = open(self.open_mock.call_args[0][0][0], 'rb')
+        open_mock.assert_called_once_with(ANY, open_anything())
+        playlist = open(open_mock.call_args[0][0][0], 'rb')
         self.assertEqual(u'{}\n'.format(
             os.path.dirname(self.item.path.decode('utf-8'))),
             playlist.read().decode('utf-8'))
 
-    def test_raw(self):
+    def test_raw(self, open_mock):
         self.config['play']['raw'] = True
 
         self.run_command(u'play', u'nice')
 
-        self.open_mock.assert_called_once_with([self.item.path], 'echo')
+        open_mock.assert_called_once_with([self.item.path], 'echo')
 
-    def test_not_found(self):
+    def test_not_found(self, open_mock):
         self.run_command(u'play', u'not found')
 
-        self.open_mock.assert_not_called()
+        open_mock.assert_not_called()
 
-    def test_warning_threshold(self):
+    def test_warning_threshold(self, open_mock):
         self.config['play']['warning_threshold'] = 1
         self.add_item(title='another NiceTitle')
 
         with control_stdin("a"):
             self.run_command(u'play', u'nice')
 
-        self.open_mock.assert_not_called()
+        open_mock.assert_not_called()
 
-    def test_warning_threshold_backwards_compat(self):
+    def test_warning_threshold_backwards_compat(self, open_mock):
         self.config['play']['warning_treshold'] = 1
         self.add_item(title=u'another NiceTitle')
 
         with control_stdin("a"):
             self.run_command(u'play', u'nice')
 
-        self.open_mock.assert_not_called()
+        open_mock.assert_not_called()
 
-    def test_command_failed(self):
-        self.open_mock.side_effect = OSError(u"some reason")
+    def test_command_failed(self, open_mock):
+        open_mock.side_effect = OSError(u"some reason")
 
         with self.assertRaises(UserError):
             self.run_command(u'play', u'title:aNiceTitle')


### PR DESCRIPTION
This removes most of the uses of `mock.patch.start()` from the tests. It is good to remove these, because unlike the other two forms of `mock.patch` (annotation and context manager) the `start()` method requires explicit cleanup.

It is probably possible to remove it from the two remaining files (`test_plugins.py` and `test_query.py`) but it's trickier, and I thought it worth applying these changes in the meantime.

Even though this only touches test code, I'd appreciate someone else hitting the Merge button.