### PR TITLE
Add BPM data with acousticbrainz

### DIFF
--- a/beetsplug/acousticbrainz.py
+++ b/beetsplug/acousticbrainz.py
@@ -133,6 +133,9 @@ def fetch_info(log, items, write):
             item.average_loudness = get_value(
                 "lowlevel", "average_loudness"
             )
+            item.bpm = get_value(
+                "rhythm", "bpm"
+            )
             item.chords_changes_rate = get_value(
                 "tonal", "chords_changes_rate"
             )

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,9 @@ The are a couple of small new features:
   filled-out path template for each file. :bug:`2050`
 * :doc:`/plugins/embyupdate`: The plugin can now use an API key instead of a
   password to authenticate with Emby. :bug:`2045` :bug:`2117`
+* :doc:`/plugins/acousticbrainz`: The plugin now also adds a ``bpm``, when a 
+  song can be found on AcousticBrainz, this is faster than using the bpm
+  plugin.
 
 And there are a few bug fixes too:
 

--- a/docs/plugins/acousticbrainz.rst
+++ b/docs/plugins/acousticbrainz.rst
@@ -14,6 +14,7 @@ For all tracks with a MusicBrainz recording ID, the plugin currently sets
 these fields:
 
 * ``average_loudness``
+* ``bpm``
 * ``chords_changes_rate``
 * ``chords_key``
 * ``chords_number_rate``


### PR DESCRIPTION
The bpm plugin is a very slow way to add bpm data to songs, using the acousticbrainz plugin is much faster and can doesn't need a new plugin.