### PR TITLE
fix bug where $args would be included in the command output

### DIFF
--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -91,8 +91,7 @@ class PlayPlugin(BeetsPlugin):
             else:
                 command_str = u"{} {}".format(command_str, opts.args)
         else:
-            if ARGS_MARKER in command_str:
-                command_str = command_str.replace(" " + ARGS_MARKER, "")
+            command_str = command_str.replace(" " + ARGS_MARKER, "")
 
         # Perform search by album and add folders rather than tracks to
         # playlist.

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -92,7 +92,7 @@ class PlayPlugin(BeetsPlugin):
                 command_str = u"{} {}".format(command_str, opts.args)
         else:
             if ARGS_MARKER in command_str:
-                command_str = command_str.replace(" "+ARGS_MARKER, "")
+                command_str = command_str.replace(" " + ARGS_MARKER, "")
 
         # Perform search by album and add folders rather than tracks to
         # playlist.

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -90,6 +90,9 @@ class PlayPlugin(BeetsPlugin):
                 command_str = command_str.replace(ARGS_MARKER, opts.args)
             else:
                 command_str = u"{} {}".format(command_str, opts.args)
+        else:
+            if ARGS_MARKER in command_str:
+                command_str = command_str.replace(" "+ARGS_MARKER, "")
 
         # Perform search by album and add folders rather than tracks to
         # playlist.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -39,6 +39,8 @@ And there are a few bug fixes too:
 * With :ref:`per_disc_numbering` enabled, some metadata sources (notably, the
   :doc:`/plugins/beatport`) would not set the track number at all. This is
   fixed. :bug:`2085`
+* :doc:`/plugins/play`: Fix $args getting passed verbatim to the play command
+  if it was set in the configuration but -A or --args was ommitted.
 
 The last release, 1.3.19, also erroneously reported its version as "1.3.18"
 when you typed ``beet version``. This has been corrected.

--- a/test/test_play.py
+++ b/test/test_play.py
@@ -67,6 +67,12 @@ class PlayPluginTest(unittest.TestCase, TestHelper):
         self.run_and_assert(
             open_mock, [u'-A', u'foo', u'title:aNiceTitle'], u'echo foo other')
 
+    def test_unset_args_option_in_middle(self, open_mock):
+        self.config['play']['command'] = 'echo $args other'
+
+        self.run_and_assert(
+            open_mock, [u'title:aNiceTitle'], u'echo other')
+
     def test_relative_to(self, open_mock):
         self.config['play']['command'] = 'echo'
         self.config['play']['relative_to'] = '/something'


### PR DESCRIPTION
if $args was set in config but -A or --args was left off the beet play command, $args would appear in the command. Fixed and test included thanks to Wise Tutelage of jrobeson