### PR TITLE
add flake8-coding to our tox config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ logging-clear-handlers=1
 
 [flake8]
 min-version=2.7
+accept-encodings=utf-8
 # Default pyflakes errors we ignore:
 # - E241: missing whitespace after ',' (used to align visually)
 # - E221: multiple spaces before operator (used to align visually)

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ deps =
 [_flake8]
 deps =
     flake8
+    flake8-coding
     flake8-future-import
     pep8-naming
 files = beets beetsplug beet test setup.py docs


### PR DESCRIPTION
Now we can enforce that all py files have the coding magic comment with
utf-8.

https://pypi.python.org/pypi/flake8-coding