### PR TITLE
decode yaml dumped data as utf-8 in edit plugin for PY2

### DIFF
--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -252,6 +252,8 @@ class EditPlugin(plugins.BeetsPlugin):
                                      encoding='utf-8')
         old_str = dump(old_data)
         new.write(old_str)
+        if six.PY2:
+            old_str = old_str.decode('utf-8')
         new.close()
 
         # Loop until we have parseable data and the user confirms.


### PR DESCRIPTION
Yaml doesn't return a true unicode string even with `allow_unicode`
passed to `safe_dump_all`.