### PR TITLE
Include extra bits in the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -31,3 +31,6 @@ include beets/config_default.yaml
 
 # Shell completion template
 include beets/ui/completion_base.sh
+
+# Include extra bits
+recursive-include extra *


### PR DESCRIPTION
We got [a request](https://bugs.debian.org/775811) to include the zsh completion, in our Debian beets package. To do this, it needs to be shipped in the source tarball.