### PR TITLE
mpdupdate: Use `$MPD_HOST` environment variable.

### DIFF
--- a/beetsplug/mpdupdate.py
+++ b/beetsplug/mpdupdate.py
@@ -68,7 +68,7 @@ class MPDUpdatePlugin(BeetsPlugin):
     def __init__(self):
         super(MPDUpdatePlugin, self).__init__()
         config['mpd'].add({
-            'host':     u'localhost',
+            'host':     os.environ.get('MPD_HOST', u'localhost'),
             'port':     6600,
             'password': u'',
         })

--- a/docs/plugins/mpdupdate.rst
+++ b/docs/plugins/mpdupdate.rst
@@ -31,7 +31,7 @@ Configuration
 The available options under the ``mpd:`` section are:
 
 - **host**: The MPD server name.
-  Default: ``localhost``.
+  Default: The ``$MPD_HOST`` environment variable if set, falling back to ``localhost`` otherwise.
 - **port**: The MPD server port.
   Default: 6600.
 - **password**: The MPD server password.


### PR DESCRIPTION
This variable is not standardized, but is already used by the mpc which is the official command-line client. It would be nice if beets read it too, to avoid duplicate configuration for mpc users.