### PR TITLE
Correct a typo

### DIFF
--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -557,7 +557,7 @@ duplicate_action
 
 Either ``skip``, ``keep``, ``remove``, or ``ask``. Controls how duplicates
 are treated in import task. "skip" means that new item(album or track) will be
-skiped; "keep" means keep both old and new items; "remove" means remove old
+skipped; "keep" means keep both old and new items; "remove" means remove old
 item; "ask" means the user should be prompted for the action each time.
 The default is ``ask``.
 


### PR DESCRIPTION
Spotted by [lintian](https://lintian.debian.org/full/python-apps-team@lists.alioth.debian.org.html#beets_1.3.19-1) which runs spellchecks on man pages.