### PR TITLE
PY3 compatibility for the functemplate AST compiler

### DIFF
--- a/beets/util/functemplate.py
+++ b/beets/util/functemplate.py
@@ -534,8 +534,7 @@ class Template(object):
     def __init__(self, template):
         self.expr = _parse(template)
         self.original = template
-        if six.PY2:  # FIXME Compiler is broken on Python 3.
-            self.compiled = self.translate()
+        self.compiled = self.translate()
 
     def __eq__(self, other):
         return self.original == other.original
@@ -551,13 +550,11 @@ class Template(object):
     def substitute(self, values={}, functions={}):
         """Evaluate the template given the values and functions.
         """
-        if six.PY2:  # FIXME As above.
-            try:
-                res = self.compiled(values, functions)
-            except:  # Handle any exceptions thrown by compiled version.
-                res = self.interpret(values, functions)
-        else:
+        try:
+            res = self.compiled(values, functions)
+        except:  # Handle any exceptions thrown by compiled version.
             res = self.interpret(values, functions)
+
         return res
 
     def translate(self):

--- a/beets/util/functemplate.py
+++ b/beets/util/functemplate.py
@@ -113,8 +113,10 @@ def compile_func(arg_names, statements, name='_the_func', debug=False):
     the resulting Python function. If `debug`, then print out the
     bytecode of the compiled function.
     """
+    if six.PY2:
+        name = name.encode('utf-8')
     func_def = ast.FunctionDef(
-        name=name.encode('utf8'),
+        name=name,
         args=ast.arguments(
             args=[ast.Name(n, ast.Param()) for n in arg_names],
             vararg=None,
@@ -165,8 +167,12 @@ class Symbol(object):
 
     def translate(self):
         """Compile the variable lookup."""
-        expr = ex_rvalue(VARIABLE_PREFIX + self.ident.encode('utf8'))
-        return [expr], set([self.ident.encode('utf8')]), set()
+        if six.PY2:
+            ident = self.ident.encode('utf-8')
+        else:
+            ident = self.ident
+        expr = ex_rvalue(VARIABLE_PREFIX + ident)
+        return [expr], set([ident]), set()
 
 
 class Call(object):
@@ -199,7 +205,11 @@ class Call(object):
     def translate(self):
         """Compile the function call."""
         varnames = set()
-        funcnames = set([self.ident.encode('utf8')])
+        if six.PY2:
+            ident = self.ident.encode('utf-8')
+        else:
+            ident = self.ident
+        funcnames = set([ident])
 
         arg_exprs = []
         for arg in self.args:
@@ -221,7 +231,7 @@ class Call(object):
             ))
 
         subexpr_call = ex_call(
-            FUNCTION_PREFIX + self.ident.encode('utf8'),
+            FUNCTION_PREFIX + ident,
             arg_exprs
         )
         return [subexpr_call], varnames, funcnames

--- a/beets/util/functemplate.py
+++ b/beets/util/functemplate.py
@@ -214,7 +214,7 @@ class Call(object):
                 [ex_call(
                     'map',
                     [
-                        ex_rvalue('unicode'),
+                        ex_rvalue(six.text_type.__name__),
                         ast.List(subexprs, ast.Load()),
                     ]
                 )],


### PR DESCRIPTION
Highlights:
  * Conditional Python 3 compatble `ast.FunctionDef` and `ast.Call` calls
  * Python 2 and 3 compatible string types for `ex_rvalue`
  * Only encode strings to `utf-8` on Python2, as they are `unicode` type there. 
  * Enable template compilation on Python 3