### PR TITLE
add site-packages tests to the travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,11 @@ matrix:
     include:
         - python: 2.7
           env: {TOX_ENV: py27-cov, COVERAGE: 1}
+        - python: 2.7_with_system_site_packages
+          env: {TOX_ENV: py27-test}
         - python: 3.4
+          env: {TOX_ENV: py34-test}
+        - python: 3.4_with_system_site_packages
           env: {TOX_ENV: py34-test}
         - python: 3.5
           env: {TOX_ENV: py35-test}
@@ -51,7 +55,13 @@ install:
     - travis_retry pip install tox sphinx
     - travis_retry tox -e $TOX_ENV --notest
 
-script: tox -e $TOX_ENV
+script:
+    # prevents "libdc1394 error: Failed to initialize libdc1394" errors
+    - sudo ln -s /dev/null /dev/raw1394
+    - if [[ $TRAVIS_PYTHON_VERSION == *_site_packages ]]; then SITE_PACKAGES=--sitepackages; fi
+    # pip in trusty breaks on packages prefixed with "_". See https://github.com/pypa/pip/issues/3681
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.4_with_system_site_packages ]]; then sudo rm -rf /usr/lib/python3/dist-packages/_lxc-0.1.egg-info; fi
+    - tox -e $TOX_ENV $SITE_PACKAGES
 
 # Report coverage to codecov.io.
 before_install:


### PR DESCRIPTION
Now we can test any plugin that depends on Gstreamer. It was previously impossible to do so, since `pygobject` (a gstreamer dep) is not installable via pip. 

I discovered (after totally missing it it in the quodlibet `.travis.yml` for months)  that travis offers `with_site_package` variants of the 2 pythons (one 2.7, one 3.x) that come with the distribution. 