### PR TITLE
use a Click style Result object for run_with_output

### DIFF
--- a/test/helper.py
+++ b/test/helper.py
@@ -40,6 +40,7 @@ import shutil
 import subprocess
 from tempfile import mkdtemp, mkstemp
 from contextlib import contextmanager
+from collections import namedtuple
 from six import StringIO
 from enum import Enum
 
@@ -447,7 +448,10 @@ class TestHelper(object):
     def run_with_output(self, *args):
         with capture_stdout() as out:
             self.run_command(*args)
-        return util.text_string(out.getvalue())
+
+        result = namedtuple('Result', ['output'])
+        result.output = util.text_string(out.getvalue())
+        return result
 
     # Safe file operations
 

--- a/test/test_info.py
+++ b/test/test_info.py
@@ -45,7 +45,8 @@ class InfoTest(unittest.TestCase, TestHelper):
         mediafile.composer = None
         mediafile.save()
 
-        out = self.run_with_output(path)
+        result = self.run_with_output(path)
+        out = result.output
         self.assertIn(path, out)
         self.assertIn('albumartist: AAA', out)
         self.assertIn('disctitle: DDD', out)
@@ -60,7 +61,8 @@ class InfoTest(unittest.TestCase, TestHelper):
         item1.album = 'yyyy'
         item1.store()
 
-        out = self.run_with_output('album:yyyy')
+        result = self.run_with_output('album:yyyy')
+        out = result.output
         self.assertIn(displayable_path(item1.path), out)
         self.assertIn(u'album: xxxx', out)
 
@@ -71,7 +73,8 @@ class InfoTest(unittest.TestCase, TestHelper):
         item.album = 'xxxx'
         item.store()
 
-        out = self.run_with_output('--library', 'album:xxxx')
+        result = self.run_with_output('--library', 'album:xxxx')
+        out = result.output
         self.assertIn(displayable_path(item.path), out)
         self.assertIn(u'album: xxxx', out)
 
@@ -89,7 +92,8 @@ class InfoTest(unittest.TestCase, TestHelper):
         item.store()
         mediafile.save()
 
-        out = self.run_with_output('--summarize', 'album:AAA', path)
+        result = self.run_with_output('--summarize', 'album:AAA', path)
+        out = result.output
         self.assertIn(u'album: AAA', out)
         self.assertIn(u'tracktotal: 5', out)
         self.assertIn(u'title: [various]', out)
@@ -100,16 +104,18 @@ class InfoTest(unittest.TestCase, TestHelper):
         item.album = 'xxxx'
         item.store()
 
-        out = self.run_with_output('--library', 'album:xxxx',
-                                   '--include-keys', '*lbu*')
+        result = self.run_with_output('--library', 'album:xxxx',
+                                      '--include-keys', '*lbu*')
+        out = result.output
         self.assertIn(displayable_path(item.path), out)
         self.assertNotIn(u'title:', out)
         self.assertIn(u'album: xxxx', out)
 
     def test_custom_format(self):
         self.add_item_fixtures()
-        out = self.run_with_output('--library', '--format',
-                                   '$track. $title - $artist ($length)')
+        result = self.run_with_output('--library', '--format',
+                                      '$track. $title - $artist ($length)')
+        out = result.output
         self.assertEqual(u'02. tïtle 0 - the artist (0:01)\n', out)
 
 

--- a/test/test_metasync.py
+++ b/test/test_metasync.py
@@ -92,8 +92,9 @@ class MetaSyncTest(_common.TestCase, TestHelper):
         self.assertIn('itunes_rating', Item._types)
 
     def test_pretend_sync_from_itunes(self):
-        out = self.run_with_output('metasync', '-p')
+        result = self.run_with_output('metasync', '-p')
 
+        out = result.output
         self.assertIn('itunes_rating: 60 -> 80', out)
         self.assertIn('itunes_rating: 100', out)
         self.assertIn('itunes_playcount: 31', out)

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -77,18 +77,18 @@ class ItemTypesTest(unittest.TestCase, TestHelper):
         item.add(self.lib)
 
         # Do not match unset values
-        out = self.run_with_output(u'ls', u'rating:1..3')
-        self.assertNotIn(u'aaa', out)
+        result = self.run_with_output(u'ls', u'rating:1..3')
+        self.assertNotIn(u'aaa', result.output)
 
         self.run_command(u'modify', u'rating=2', u'--yes')
 
         # Match in range
-        out = self.run_with_output(u'ls', u'rating:1..3')
-        self.assertIn(u'aaa', out)
+        result = self.run_with_output(u'ls', u'rating:1..3')
+        self.assertIn(u'aaa', result.output)
 
         # Don't match out of range
-        out = self.run_with_output(u'ls', u'rating:3..5')
-        self.assertNotIn(u'aaa', out)
+        result = self.run_with_output(u'ls', u'rating:3..5')
+        self.assertNotIn(u'aaa', result.output)
 
 
 class ItemWriteTest(unittest.TestCase, TestHelper):

--- a/test/test_types_plugin.py
+++ b/test/test_types_plugin.py
@@ -134,14 +134,17 @@ class TypesPluginTest(unittest.TestCase, TestHelper):
             self.run_command(u'ls')
 
     def modify(self, *args):
-        return self.run_with_output(u'modify', u'--yes', u'--nowrite',
-                                    u'--nomove', *args)
+        result = self.run_with_output(u'modify', u'--yes', u'--nowrite',
+                                      u'--nomove', *args)
+        return result.output
 
     def list(self, query, fmt=u'$artist - $album - $title'):
-        return self.run_with_output(u'ls', u'-f', fmt, query).strip()
+        result = self.run_with_output(u'ls', u'-f', fmt, query)
+        return result.output.strip()
 
     def list_album(self, query, fmt=u'$albumartist - $album - $title'):
-        return self.run_with_output(u'ls', u'-a', u'-f', fmt, query).strip()
+        result = self.run_with_output(u'ls', u'-a', u'-f', fmt, query)
+        return result.output.strip()
 
 
 def mktime(*args):

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -1187,67 +1187,82 @@ class CommonOptionsParserCliTest(unittest.TestCase, TestHelper):
         self.teardown_beets()
 
     def test_base(self):
-        l = self.run_with_output(u'ls')
-        self.assertEqual(l, u'the artist - the album - the title\n')
+        result = self.run_with_output(u'ls')
+        out = result.output
+        self.assertEqual(out, u'the artist - the album - the title\n')
 
-        l = self.run_with_output(u'ls', u'-a')
-        self.assertEqual(l, u'the album artist - the album\n')
+        result = self.run_with_output(u'ls', u'-a')
+        out = result.output
+        self.assertEqual(out, u'the album artist - the album\n')
 
     def test_path_option(self):
-        l = self.run_with_output(u'ls', u'-p')
-        self.assertEqual(l, u'xxx/yyy\n')
+        result = self.run_with_output(u'ls', u'-p')
+        out = result.output
+        self.assertEqual(out, u'xxx/yyy\n')
 
-        l = self.run_with_output(u'ls', u'-a', u'-p')
-        self.assertEqual(l, u'xxx\n')
+        result = self.run_with_output(u'ls', u'-a', u'-p')
+        out = result.output
+        self.assertEqual(out, u'xxx\n')
 
     def test_format_option(self):
-        l = self.run_with_output(u'ls', u'-f', u'$artist')
-        self.assertEqual(l, u'the artist\n')
+        result = self.run_with_output(u'ls', u'-f', u'$artist')
+        out = result.output
+        self.assertEqual(out, u'the artist\n')
 
-        l = self.run_with_output(u'ls', u'-a', u'-f', u'$albumartist')
-        self.assertEqual(l, u'the album artist\n')
+        result = self.run_with_output(u'ls', u'-a', u'-f', u'$albumartist')
+        out = result.output
+        self.assertEqual(out, u'the album artist\n')
 
     def test_format_option_unicode(self):
-        l = self.run_with_output(b'ls', b'-f',
-                                 u'caf\xe9'.encode(util.arg_encoding()))
-        self.assertEqual(l, u'caf\xe9\n')
+        result = self.run_with_output(b'ls', b'-f',
+                                      u'caf\xe9'.encode(util.arg_encoding()))
+        out = result.output
+        self.assertEqual(out, u'caf\xe9\n')
 
     def test_root_format_option(self):
-        l = self.run_with_output(u'--format-item', u'$artist',
-                                 u'--format-album', u'foo', u'ls')
-        self.assertEqual(l, u'the artist\n')
+        result = self.run_with_output(u'--format-item', u'$artist',
+                                      u'--format-album', u'foo', u'ls')
+        out = result.output
+        self.assertEqual(out, u'the artist\n')
 
-        l = self.run_with_output(u'--format-item', u'foo',
-                                 u'--format-album', u'$albumartist',
-                                 u'ls', u'-a')
-        self.assertEqual(l, u'the album artist\n')
+        result = self.run_with_output(u'--format-item', u'foo',
+                                      u'--format-album', u'$albumartist',
+                                      u'ls', u'-a')
+        out = result.output
+        self.assertEqual(out, u'the album artist\n')
 
     def test_help(self):
-        l = self.run_with_output(u'help')
-        self.assertIn(u'Usage:', l)
+        result = self.run_with_output(u'help')
+        out = result.output
+        self.assertIn(u'Usage:', out)
 
-        l = self.run_with_output(u'help', u'list')
-        self.assertIn(u'Usage:', l)
+        result = self.run_with_output(u'help', u'list')
+        out = result.output
+        self.assertIn(u'Usage:', out)
 
         with self.assertRaises(ui.UserError):
             self.run_command(u'help', u'this.is.not.a.real.command')
 
     def test_stats(self):
-        l = self.run_with_output(u'stats')
-        self.assertIn(u'Approximate total size:', l)
+        result = self.run_with_output(u'stats')
+        out = result.output
+        self.assertIn(u'Approximate total size:', out)
 
         # # Need to have more realistic library setup for this to work
-        # l = self.run_with_output('stats', '-e')
-        # self.assertIn('Total size:', l)
+        # result = self.run_with_output('stats', '-e')
+        # out = result.output
+        # self.assertIn('Total size:', out)
 
     def test_version(self):
-        l = self.run_with_output(u'version')
-        self.assertIn(u'python version', l)
-        self.assertIn(u'no plugins loaded', l)
+        result = self.run_with_output(u'version')
+        out = result.output
+        self.assertIn(u'python version', out)
+        self.assertIn(u'no plugins loaded', out)
 
         # # Need to have plugin loaded
-        # l = self.run_with_output('version')
-        # self.assertIn('plugins: ', l)
+        # result = self.run_with_output('version')
+        # out = result.output
+        # self.assertIn('plugins: ', out)
 
 
 class CommonOptionsParserTest(unittest.TestCase, TestHelper):


### PR DESCRIPTION
This is like http://click.pocoo.org/6/testing/#basic-testing

Currently only `output` is implemented. Others can be added as needed.

This should make a ton of our tests align with click's `invoke` method output
