### PR TITLE
discogs: fix bytes string literal

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -200,7 +200,7 @@ class DiscogsPlugin(BeetsPlugin):
         query = re.sub(r'(?u)\W+', ' ', query).encode('ascii', "replace")
         # Strip medium information from query, Things like "CD1" and "disk 1"
         # can also negate an otherwise positive result.
-        query = re.sub(br'(?i)\b(CD|disc)\s*\d+', '', query)
+        query = re.sub(b'(?i)\b(CD|disc)\s*\d+', '', query)
         try:
             releases = self.discogs_client.search(query,
                                                   type='release').page(1)


### PR DESCRIPTION
```
beet import /a-dir/
Traceback (most recent call last):
  File "/nix/store/xn255iz8f2k3qj2ihl783cxn3b7s2vks-python3.5-beets-2016-09-09/bin/..beet-wrapped-wrapped", line 12, in <module>
    sys.exit(main())
  File "/nix/store/xn255iz8f2k3qj2ihl783cxn3b7s2vks-python3.5-beets-2016-09-09/lib/python3.5/site-packages/beets/ui/__init__.py", line 1267, in main
    _raw_main(args)
  File "/nix/store/xn255iz8f2k3qj2ihl783cxn3b7s2vks-python3.5-beets-2016-09-09/lib/python3.5/site-packages/beets/ui/__init__.py", line 1254, in _raw_main
    subcommand.func(lib, suboptions, subargs)
  File "/nix/store/xn255iz8f2k3qj2ihl783cxn3b7s2vks-python3.5-beets-2016-09-09/lib/python3.5/site-packages/beets/ui/commands.py", line 969, in import_func
    import_files(lib, paths, query)
  File "/nix/store/xn255iz8f2k3qj2ihl783cxn3b7s2vks-python3.5-beets-2016-09-09/lib/python3.5/site-packages/beets/ui/commands.py", line 946, in import_files
    session.run()
  File "/nix/store/xn255iz8f2k3qj2ihl783cxn3b7s2vks-python3.5-beets-2016-09-09/lib/python3.5/site-packages/beets/importer.py", line 320, in run
    pl.run_parallel(QUEUE_SIZE)
  File "/nix/store/xn255iz8f2k3qj2ihl783cxn3b7s2vks-python3.5-beets-2016-09-09/lib/python3.5/site-packages/beets/util/pipeline.py", line 445, in run_parallel
    six.reraise(exc_info[0], exc_info[1], exc_info[2])
  File "/nix/store/0wggadyd3mrsl1yd1nhvab2xkp6w0yf5-python3.5-six-1.10.0/lib/python3.5/site-packages/six.py", line 686, in reraise
    raise value
  File "/nix/store/xn255iz8f2k3qj2ihl783cxn3b7s2vks-python3.5-beets-2016-09-09/lib/python3.5/site-packages/beets/util/pipeline.py", line 312, in run
    out = self.coro.send(msg)
  File "/nix/store/xn255iz8f2k3qj2ihl783cxn3b7s2vks-python3.5-beets-2016-09-09/lib/python3.5/site-packages/beets/util/pipeline.py", line 194, in coro
    func(*(args + (task,)))
  File "/nix/store/xn255iz8f2k3qj2ihl783cxn3b7s2vks-python3.5-beets-2016-09-09/lib/python3.5/site-packages/beets/importer.py", line 1264, in lookup_candidates
    task.lookup_candidates()
  File "/nix/store/xn255iz8f2k3qj2ihl783cxn3b7s2vks-python3.5-beets-2016-09-09/lib/python3.5/site-packages/beets/importer.py", line 591, in lookup_candidates
    autotag.tag_album(self.items, search_ids=self.search_ids)
  File "/nix/store/xn255iz8f2k3qj2ihl783cxn3b7s2vks-python3.5-beets-2016-09-09/lib/python3.5/site-packages/beets/autotag/match.py", line 445, in tag_album
    search_album, va_likely)
  File "/nix/store/xn255iz8f2k3qj2ihl783cxn3b7s2vks-python3.5-beets-2016-09-09/lib/python3.5/site-packages/beets/autotag/hooks.py", line 593, in album_candidates
    out.extend(plugins.candidates(items, artist, album, va_likely))
  File "/nix/store/xn255iz8f2k3qj2ihl783cxn3b7s2vks-python3.5-beets-2016-09-09/lib/python3.5/site-packages/beets/plugins.py", line 356, in candidates
    out.extend(plugin.candidates(items, artist, album, va_likely))
  File "/nix/store/xn255iz8f2k3qj2ihl783cxn3b7s2vks-python3.5-beets-2016-09-09/lib/python3.5/site-packages/beetsplug/discogs.py", line 146, in candidates
    return self.get_albums(query)
  File "/nix/store/xn255iz8f2k3qj2ihl783cxn3b7s2vks-python3.5-beets-2016-09-09/lib/python3.5/site-packages/beetsplug/discogs.py", line 203, in get_albums
    query = re.sub(br'(?i)\b(CD|disc)\s*\d+', '', query)
  File "/nix/store/sl600bxh7ffih8b54qcirdqn3l078x0g-python-3.5.2/lib/python3.5/re.py", line 182, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: cannot use a string pattern on a bytes-like object
```