### PR TITLE
Remove deprecated top level colors config option

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -1121,14 +1121,6 @@ def _configure(options):
     else:
         log.set_global_level(logging.INFO)
 
-    # Ensure compatibility with old (top-level) color configuration.
-    # Deprecation msg to motivate user to switch to config['ui']['color].
-    if config['color'].exists():
-        log.warning(u'Warning: top-level configuration of `color` '
-                    u'is deprecated. Configure color use under `ui`. '
-                    u'See documentation for more info.')
-        config['ui']['color'].set(config['color'].get(bool))
-
     # Compatibility from list_format_{item,album} to format_{item,album}
     for elem in ('item', 'album'):
         old_key = 'list_format_{0}'.format(elem)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,10 @@ UI Change:
   of ``-k title albumartist album``. Each argument must be prefixed with
   ``-k``. Example: ``-k title -k albumartist -k album``
 
+Deprecated configuration optional removals:
+
+* Remove top level ``colors`` configuration option.
+
 The are a couple of small new features:
 
 * :doc:`/plugins/mpdupdate`, :doc:`/plugins/mpdstats`: When the ``host`` option


### PR DESCRIPTION
It was deprecated in https://github.com/beetbox/beets/commit/d3fce35481f09f28561dc2438baa7ec5245b7870 on 2015-01-26.