### PR TITLE
Proposal: Add specificity option to lastgenre plugin

### DIFF
--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -200,8 +200,8 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 tags_all += parents
                 # Stop if we have enough tags already, unless we need to find
                 # the most specific tag (instead of the most popular).
-                if (not self.config['prefer_specific']
-                        and len(tags_all) >= count):
+                if (not self.config['prefer_specific'] and
+                        len(tags_all) >= count):
                     break
             tags = tags_all
 

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -173,12 +173,9 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         """Given a list of tags, sort the tags by their depths in the
         genre tree.
         """
-        tags_by_depth = []
-        for key, value in enumerate(tags):
-            depth = self._get_depth(value)
-            tags_by_depth.append({'tag': value, 'depth': depth})
-        tags_by_depth = sorted(tags_by_depth, key=lambda k: k['depth'], reverse=True)
-        return [i['tag'] for i in tags_by_depth]
+        depth_tag_pairs = [(self._get_depth(t), t) for t in tags]
+        depth_tag_pairs.sort(reverse=True)
+        return [p[1] for p in depth_tag_pairs]
 
     def _resolve_genres(self, tags):
         """Given a list of strings, return a genre by joining them into a
@@ -201,15 +198,15 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                     parents = [find_parents(tag, self.c14n_branches)[-1]]
 
                 tags_all += parents
-                # Don't break here if we need to sort by specificity, which happens with
-                # the full tag list below
+                # Stop if we have enough tags already, unless we need to find
+                # the most specific tag (instead of the most popular).
                 if not self.config['specificity'] and len(tags_all) >= count:
                     break
             tags = tags_all
 
         tags = deduplicate(tags)
 
-        # sort the tags by specificity
+        # Sort the tags by specificity.
         if self.config['specificity']:
             tags = self._sort_by_depth(tags)
 

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -109,7 +109,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
             'force': True,
             'auto': True,
             'separator': u', ',
-            'specificity': False,
+            'prefer_specific': False,
         })
 
         self.setup()
@@ -200,14 +200,15 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 tags_all += parents
                 # Stop if we have enough tags already, unless we need to find
                 # the most specific tag (instead of the most popular).
-                if not self.config['specificity'] and len(tags_all) >= count:
+                if (not self.config['prefer_specific'] and
+                    len(tags_all) >= count):
                     break
             tags = tags_all
 
         tags = deduplicate(tags)
 
         # Sort the tags by specificity.
-        if self.config['specificity']:
+        if self.config['prefer_specific']:
             tags = self._sort_by_depth(tags)
 
         # c14n only adds allowed genres but we may have had forbidden genres in

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -200,8 +200,8 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 tags_all += parents
                 # Stop if we have enough tags already, unless we need to find
                 # the most specific tag (instead of the most popular).
-                if (not self.config['prefer_specific'] and
-                    len(tags_all) >= count):
+                if (not self.config['prefer_specific']
+                        and len(tags_all) >= count):
                     break
             tags = tags_all
 

--- a/docs/plugins/lastgenre.rst
+++ b/docs/plugins/lastgenre.rst
@@ -103,6 +103,19 @@ The plugin uses this weight to discard unpopular tags.  The default is to
 ignore tags with a weight less then 10. You can change this by setting
 the ``min_weight`` config option.
 
+Specific vs. Popular Genres
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, the plugin sorts genres by popularity. However, you can use the
+``prefer_specific`` option to override this behavior and instead sort genres
+by specificity, as determined by your whitelist and canonicalization tree.
+
+For instance, say you have both ``folk`` and ``americana`` in your whitelist
+and canonicalization tree and ``americana`` is a leaf within ``folk``. If
+Last.fm returns both of those tags, lastgenre is going to use the most
+popular, which is often the most generic (in this case ``folk``). By setting
+``prefer_specific`` to true, lastgenre would use ``americana`` instead.
+
 Configuration
 -------------
 
@@ -126,6 +139,8 @@ configuration file. The available options are:
   Default: ``yes``.
 - **min_weight**: Minimum popularity factor below which genres are discarded.
   Default: 10.
+- **prefer_specific**: Sort genres by the most to least specific, rather than
+  most to least popular. Default: ``no``.
 - **source**: Which entity to look up in Last.fm. Can be
   either ``artist``, ``album`` or ``track``.
   Default: ``album``.


### PR DESCRIPTION
(Apologies in advance for my terrible, terrible python. I really wanted this feature, so I hacked my way through it. Please provide guidance on the better ways to do things!)

### What Is This?
I love the lastgenre plugin, but after running it on my library, I found myself wishing that it would prefer the _most specific_ tag available instead of simply defaulting to the _most popular_ tag, which is often the most generic. 

Here's an example. I have both "folk" and "americana" on my whitelist and in my canonicalization tree, where "americana" is a leaf within "folk." 

If I run lastgenre for the artist "The Be Good Tanyas", the genres that last.fm returns are: 
```
[u'folk', u'albums i own', u'female vocalists', u'alt-country', u'country', u'singer-songwriter', u'americana', u'canadian', u'2003', u'00s']
```

You see that both `folk` and `americana` are present. Now, the default behavior of lastgenre is to just use `folk`, as it's the most popular. However, since `americana` is present in my whitelist, I'd rather use that as the genre as it's more specific and thus more useful for categorization. 

Note, I **do not** want to remove `folk` from my whitelist because there are cases where a more specific tag is not available. `Folk` is still a useful genre to me; I just want to be able to use more specific genres _when_ they're available. 

Does all that make sense? 

### What I Changed
So to achieve this, I added a `specificity` option (defaults to `False`, and I'm definitely open to suggestions on the name) which, when set to `True` will sort genres by their depth in the genre tree from most to least deep before determining which genre(s) to use. That's pretty much it. 

Like I said at the top, I don't really know any python so I'm positive there are much more elegant ways to do what I did. Please school me! 

Also, I'm new to contributing to the project, so please let me know if there's anything else I need to do. Cheers! 