### PR TITLE
Do not attempt matching unset fields on DateQuery

### DIFF
--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -628,6 +628,8 @@ class DateQuery(FieldQuery):
         self.interval = DateInterval.from_periods(start, end)
 
     def match(self, item):
+        if self.field not in item:
+            return False
         timestamp = float(item[self.field])
         date = datetime.utcfromtimestamp(timestamp)
         return self.interval.contains(date)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -68,6 +68,8 @@ And there are a few bug fixes too:
   a problem that it was not possible to get tokens from the Emby API.
 * :doc:`/plugins/lyrics`: Search for lyrics using the title part preceding the 
   colon character. :bug:`2206`
+* Fix a crash when a query contains a date field that is not set for all
+  the items. :bug:`1938` 
 
 The last release, 1.3.19, also erroneously reported its version as "1.3.18"
 when you typed ``beet version``. This has been corrected.

--- a/test/test_types_plugin.py
+++ b/test/test_types_plugin.py
@@ -70,6 +70,10 @@ class TypesPluginTest(unittest.TestCase, TestHelper):
         self.config['types'] = {'myfloat': u'float'}
         item = self.add_item(artist=u'aaa')
 
+        # Do not match unset values
+        out = self.list(u'myfloat:10..0')
+        self.assertEqual(u'', out)
+
         self.modify(u'myfloat=-9.1')
         item.load()
         self.assertEqual(item['myfloat'], -9.1)
@@ -83,6 +87,10 @@ class TypesPluginTest(unittest.TestCase, TestHelper):
         true = self.add_item(artist=u'true')
         false = self.add_item(artist=u'false')
         self.add_item(artist=u'unset')
+
+        # Do not match unset values
+        out = self.list(u'mybool:true, mybool:false')
+        self.assertEqual(u'', out)
 
         # Set true
         self.modify(u'mybool=1', u'artist:true')
@@ -111,6 +119,10 @@ class TypesPluginTest(unittest.TestCase, TestHelper):
         self.config['time_format'] = '%Y-%m-%d'
         old = self.add_item(artist=u'prince')
         new = self.add_item(artist=u'britney')
+
+        # Do not match unset values
+        out = self.list(u'mydate:..2000')
+        self.assertEqual(u'', out)
 
         self.modify(u'mydate=1999-01-01', u'artist:prince')
         old.load()


### PR DESCRIPTION
On a attempt to fix #1938, it seems that the problem is actually caused by `DateQuery.match` being reached for an item that does not have a value set for the `field` to be compared? I could reproduced it by using just the `types` plugin:
```
...
types:
  foo=date
```
and simply:
```
$ beet ls foo:2000
```

I have added a check that returns `False` (basically copying the one in `NumericQuery.match`), and adjusted some unit tests to catch the situation. I still have not tested specifically with `mpdstats`, as I'm not really an user of that particular plugin, but it seems it would fix the problem?