### PR TITLE
doc-play: Fix an error and clarity:

### DIFF
--- a/docs/plugins/play.rst
+++ b/docs/plugins/play.rst
@@ -84,7 +84,7 @@ indicates that you need to insert extra arguments before specifying the
 playlist.
 
 Note on the Leakage of the Generated Playlists
-_______________________________________________
+----------------------------------------------
 
 Because the command that will open the generated ``.m3u`` files can be
 arbitrarily configured by the user, beets won't try to delete those files. For

--- a/docs/plugins/play.rst
+++ b/docs/plugins/play.rst
@@ -2,7 +2,7 @@ Play Plugin
 ===========
 
 The ``play`` plugin allows you to pass the results of a query to a music
-player in the form of an m3u playlist.
+player in the form of an m3u playlist or raw filepaths.
 
 Usage
 -----
@@ -37,7 +37,7 @@ configuration file. The available options are:
 
 - **command**: The command used to open the playlist.
   Default: ``open`` on OS X, ``xdg-open`` on other Unixes and ``start`` on
-  Windows. Insert ``{}`` to make use of the ``--args``-feature.
+  Windows. Insert ``$args`` to make use of the ``--args``-feature.
 - **relative_to**: If set, emit paths relative to this directory.
   Default: None.
 - **use_folders**: When using the ``-a`` option, the m3u will contain the
@@ -90,9 +90,9 @@ Because the command that will open the generated ``.m3u`` files can be
 arbitrarily configured by the user, beets won't try to delete those files. For
 this reason, using this plugin will leave one or several playlist(s) in the
 directory selected to create temporary files (Most likely ``/tmp/`` on Unix-like
-systems. See `tempfile.tempdir`_.). Leaking those playlists until they are
-externally wiped could be an issue for privacy or storage reasons. If this is
-the case for you, you might want to use the ``raw`` config option described
-above.
+systems. See `tempfile.tempdir`_ in python docs.). Leaking those playlists until
+they are externally wiped could be an issue for privacy or storage reasons. If
+this is the case for you, you might want to use the ``raw`` config option
+described above.
 
 .. _tempfile.tempdir: https://docs.python.org/2/library/tempfile.html#tempfile.tempdir


### PR DESCRIPTION
`{}` is not used any more to determine the location of parameters passed with `--args`.
Fix two sentences for clarity/fluidity. Display the plugin's abilities in the intro.

[Just waiting for the checks to complete.]