### PR TITLE
discogs: set `track.medium` correctly for single medium albums

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -335,6 +335,7 @@ class DiscogsPlugin(BeetsPlugin):
                     index_count = 0
                     side_count = 0
             index_count += 1
+            medium_count = 1 if medium_count == 0 else medium_count
             track.medium, track.medium_index = medium_count, index_count
 
         # Get `disctitle` from Discogs index tracks. Assume that an index track

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -74,7 +74,8 @@ And there are a few bug fixes too:
   the items. :bug:`1938`
 * :doc:`/plugins/discogs`: Subtracks are now detected and combined into a
   single track, two-sided mediums are treated as single discs, and tracks
-  have ``media`` and ``medium_total`` set correctly. :bug:`2222`
+  have ``media``, ``medium_total`` and ``medium`` set correctly. :bug:`2222`
+  :bug:`2228`.
 
 The last release, 1.3.19, also erroneously reported its version as "1.3.18"
 when you typed ``beet version``. This has been corrected.

--- a/test/test_discogs.py
+++ b/test/test_discogs.py
@@ -92,6 +92,44 @@ class DGAlbumInfoTest(_common.TestCase):
         self.assertEqual(t[0].media, d.media)
         self.assertEqual(t[1].media, d.media)
 
+    def test_parse_medium_numbers_single_medium(self):
+        release = self._make_release_from_positions(['1', '2'])
+        d = DiscogsPlugin().get_album_info(release)
+        t = d.tracks
+
+        self.assertEqual(d.mediums, 1)
+        self.assertEqual(t[0].medium, 1)
+        self.assertEqual(t[0].medium_total, 1)
+        self.assertEqual(t[1].medium, 1)
+        self.assertEqual(t[0].medium_total, 1)
+
+    def test_parse_medium_numbers_two_mediums(self):
+        release = self._make_release_from_positions(['1-1', '2-1'])
+        d = DiscogsPlugin().get_album_info(release)
+        t = d.tracks
+
+        self.assertEqual(d.mediums, 2)
+        self.assertEqual(t[0].medium, 1)
+        self.assertEqual(t[0].medium_total, 2)
+        self.assertEqual(t[1].medium, 2)
+        self.assertEqual(t[1].medium_total, 2)
+
+    def test_parse_medium_numbers_two_mediums_two_sided(self):
+        release = self._make_release_from_positions(['A1', 'B1', 'C1'])
+        d = DiscogsPlugin().get_album_info(release)
+        t = d.tracks
+
+        self.assertEqual(d.mediums, 2)
+        self.assertEqual(t[0].medium, 1)
+        self.assertEqual(t[0].medium_total, 2)
+        self.assertEqual(t[0].medium_index, 1)
+        self.assertEqual(t[1].medium, 1)
+        self.assertEqual(t[1].medium_total, 2)
+        self.assertEqual(t[1].medium_index, 2)
+        self.assertEqual(t[2].medium, 2)
+        self.assertEqual(t[2].medium_total, 2)
+        self.assertEqual(t[2].medium_index, 1)
+
     def test_parse_track_indices(self):
         release = self._make_release_from_positions(['1', '2'])
         d = DiscogsPlugin().get_album_info(release)


### PR DESCRIPTION
This pull requests mean to carry on the job by @kooimens at the open pull request #1691, adding some tests and an updated changelog. I cherry-picked the commit from kooimens in order to preserve credit.

As hinted on #2222, the problem was that `medium_count` was correctly increased whenever a new medium was detected on the main loop, but for albums with only one medium that increase did not take place, ending up with a `track.medium = 0`.