### PR TITLE
Drop `reduce` imports

### DIFF
--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -29,7 +29,6 @@ from beets import config
 from beets.util import plurality
 from beets.autotag import hooks
 from beets.util.enumeration import OrderedEnum
-from functools import reduce
 
 # Artist signals that indicate "various artists". These are used at the
 # album level to determine whether a given release is likely a VA
@@ -261,19 +260,21 @@ def match_by_id(items):
     AlbumInfo object for the corresponding album. Otherwise, returns
     None.
     """
-    # Is there a consensus on the MB album ID?
-    albumids = [item.mb_albumid for item in items if item.mb_albumid]
-    if not albumids:
-        log.debug(u'No album IDs found.')
+    albumids = (item.mb_albumid for item in items if item.mb_albumid)
+    try:
+        # Did any of the items have an MB album ID?
+        first = albumids.next()
+    except StopIteration:
+        log.debug(u'No album ID found.')
         return None
-
-    # If all album IDs are equal, look up the album.
-    if bool(reduce(lambda x, y: x if x == y else (), albumids)):
-        albumid = albumids[0]
-        log.debug(u'Searching for discovered album ID: {0}', albumid)
-        return hooks.album_for_mbid(albumid)
     else:
-        log.debug(u'No album ID consensus.')
+        # Is there a consensus on the MB album ID?
+        if all(first == other for other in albumids):
+            # If all album IDs are equal, look up the album.
+            log.debug(u'Searching for discovered album ID: {0}', first)
+            return hooks.album_for_mbid(first)
+        else:
+            log.debug(u'No album ID consensus.')
 
 
 def _recommendation(results):

--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -261,20 +261,22 @@ def match_by_id(items):
     None.
     """
     albumids = (item.mb_albumid for item in items if item.mb_albumid)
+
+    # Did any of the items have an MB album ID?
     try:
-        # Did any of the items have an MB album ID?
-        first = albumids.next()
+        first = next(albumids)
     except StopIteration:
         log.debug(u'No album ID found.')
         return None
-    else:
-        # Is there a consensus on the MB album ID?
-        if all(first == other for other in albumids):
-            # If all album IDs are equal, look up the album.
-            log.debug(u'Searching for discovered album ID: {0}', first)
-            return hooks.album_for_mbid(first)
-        else:
+
+    # Is there a consensus on the MB album ID?
+    for other in albumids:
+        if other != first:
             log.debug(u'No album ID consensus.')
+            return None
+    # If all album IDs are equal, look up the album.
+    log.debug(u'Searching for discovered album ID: {0}', first)
+    return hooks.album_for_mbid(first)
 
 
 def _recommendation(results):


### PR DESCRIPTION
Avoid using `reduce` when it can be elegantly avoided.

`ag '[^\.]reduce\(' -C 5`

````
  beets/autotag/match.py
  267-        log.debug(u'No album IDs found.')
  268-        return None
  269-
  270-    # If all album IDs are equal, look up the album.
  271:    if bool(reduce(lambda x, y: x if x == y else (), albumids)):
  272-        albumid = albumids[0]
  273-        log.debug(u'Searching for discovered album ID: {0}', albumid)
  274-        return hooks.album_for_mbid(albumid)
  275-    else:

  beets/dbcore/query.py
  380-    def __hash__(self):
  381-        """Since subqueries are mutable, this object should not be hashable.
  382-        However and for conveniences purposes, it can be hashed.
  383-        """
  384:        return reduce(mul, map(hash, self.subqueries), 1)
  385-
  386-
  387-class AnyFieldQuery(CollectionQuery):
  388-    """A query that matches if a given FieldQuery subclass matches in

  beetsplug/acousticbrainz.py
  60-    """
  61-
  62-    def get_value(*map_path):
  63-        try:
  64:            return reduce(operator.getitem, map_path, data)
  65-        except KeyError:
  66-            log.debug(u'Invalid Path: {}', map_path)
  67-
  68-    for item in items:
````

I don't think there is better way to do the hashing in `beets/dbcore/query.py`, and I did not take a look at `get_value` in `beetsplug/acousticbrainz.py` yet.

So far, I refactored the one in `beets/autotag/match.py`. I went in to get rid of `reduce`, but I think the rewrite is actually useful in terms or readability. Moreover, it explicitly uses lazy evaluation, while I don't think the old way did, even though I didn't benchmark. It also accommodates generators better for future improvements. 