### PR TITLE
Revert "Expose the relative path to the library instead of omitting t…

### DIFF
--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -37,7 +37,7 @@ def _rep(obj, expand=False):
     out = dict(obj)
 
     if isinstance(obj, beets.library.Item):
-        out['path'] = obj.destination(fragment=True)
+        del out['path']
 
         # Get the size (in bytes) of the backing file. This is useful
         # for the Tomahawk resolver API.


### PR DESCRIPTION
…he 'path' variable"

This reverts commit 5e8ac9e4a5d06de791fe051a419ba070bbdd5bec, because of
a slowdown. Resolves #2182.

Sorry for the delay. Looked into it and I think it's easier to modify music-cyclon.