### PR TITLE
Removed call to  .decode('utf-8') when printing flexible attributes

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -87,7 +87,7 @@ def _print_keys(query):
     returned row, with identation of 2 spaces.
     """
     for row in query:
-        print_(u' ' * 2 + row['key'].decode('utf-8'))
+        print_(u' ' * 2 + row['key'])
 
 
 def fields_func(lib, opts, args):


### PR DESCRIPTION
I think this is because of the switch to python3. Fixes printing of flexible attributes, which threw an exception previously.