### PR TITLE
mediafile: prefer latin-1 encoding for ID3 APIC descriptions. Fixes #899

### DIFF
--- a/beets/mediafile.py
+++ b/beets/mediafile.py
@@ -926,9 +926,9 @@ class MP3ImageStorageStyle(ListStorageStyle, MP3StorageStyle):
         try:
             frame.desc.encode("latin-1")
         except UnicodeEncodeError:
-            frame.encoding = 1  # utf-16
+            frame.encoding = mutagen.id3.Encoding.UTF16
         else:
-            frame.encoding = 0  # latin-1 if possible
+            frame.encoding = mutagen.id3.Encoding.LATIN1
 
         frame.type = image.type_index
         return frame

--- a/beets/mediafile.py
+++ b/beets/mediafile.py
@@ -920,7 +920,16 @@ class MP3ImageStorageStyle(ListStorageStyle, MP3StorageStyle):
         frame.data = image.data
         frame.mime = image.mime_type
         frame.desc = image.desc or u''
-        frame.encoding = 3  # UTF-8 encoding of desc
+
+        # For compatibility with OS X/iTunes prefer latin-1 if possible.
+        # See issue #899
+        try:
+            frame.desc.encode("latin-1")
+        except UnicodeEncodeError:
+            frame.encoding = 1  # utf-16
+        else:
+            frame.encoding = 0  # latin-1 if possible
+
         frame.type = image.type_index
         return frame
 

--- a/test/test_mediafile_edge.py
+++ b/test/test_mediafile_edge.py
@@ -19,6 +19,7 @@ from __future__ import division, absolute_import, print_function
 
 import os
 import shutil
+import mutagen.id3
 
 from test import _common
 from test._common import unittest
@@ -392,7 +393,11 @@ class ID3v23Test(unittest.TestCase, TestHelper):
                 mf.save()
                 apic_frames = mf.mgfile.tags.getall('APIC')
                 encodings = dict([(f.desc, f.encoding) for f in apic_frames])
-                self.assertEqual(encodings, {u"": 0, u"foo": 0, u"\u0185": 1})
+                self.assertEqual(encodings, {
+                    u"": mutagen.id3.Encoding.LATIN1,
+                    u"foo": mutagen.id3.Encoding.LATIN1,
+                    u"\u0185": mutagen.id3.Encoding.UTF16,
+                })
             finally:
                 self._delete_test()
 


### PR DESCRIPTION
iTunes has problems with everything but latin-1
Try to use latin-1 if possible and fall back to utf-16.