### PR TITLE
support reverse proxy

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -123,3 +123,5 @@ match:
     required: []
     track_length_grace: 10
     track_length_max: 30
+
+reverse_proxy: no

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -124,4 +124,5 @@ match:
     track_length_grace: 10
     track_length_max: 30
 
-reverse_proxy: no
+web:
+    reverse_proxy: no

--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -29,6 +29,47 @@ import json
 
 # Utilities.
 
+class ReverseProxied(object):
+    """Wrap the application in this middleware and configure the
+    front-end server to add these headers, to let you quietly bind
+    this to a URL other than / and to an HTTP scheme that is
+    different than what is used locally.
+
+    In nginx:
+    location /beets {
+        proxy_pass http://192.168.0.1:5001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Scheme $scheme;
+        proxy_set_header X-Script-Name /beets;
+    }
+
+    From: http://flask.pocoo.org/snippets/35/
+
+    :param app: the WSGI application
+    """
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        script_name = environ.get('HTTP_X_SCRIPT_NAME', '')
+        if script_name:
+            environ['SCRIPT_NAME'] = script_name
+            path_info = environ['PATH_INFO']
+            if path_info.startswith(script_name):
+                environ['PATH_INFO'] = path_info[len(script_name):]
+
+        scheme = environ.get('HTTP_X_SCHEME', '')
+        if scheme:
+            environ['wsgi.url_scheme'] = scheme
+
+        server = environ.get('HTTP_X_FORWARDED_SERVER', '')
+        if server:
+            environ['HTTP_HOST'] = server
+
+        return self.app(environ, start_response)
+
+
 def _rep(obj, expand=False):
     """Get a flat -- i.e., JSON-ish -- representation of a beets Item or
     Album object. For Albums, `expand` dictates whether tracks are
@@ -337,6 +378,11 @@ class WebPlugin(BeetsPlugin):
                     r"/*": {"origins": self.config['cors'].get(str)}
                 }
                 CORS(app)
+
+            # allow serving behind nginx
+            if self.config['reverse_proxy']:
+                app.wsgi_app = ReverseProxied(app.wsgi_app)
+
             # Start the web application.
             app.run(host=self.config['host'].as_str(),
                     port=self.config['port'].get(int),


### PR DESCRIPTION
I'm trying to get nginx serving beets at example.com/beets instead of localhost:port.

I came across https://github.com/beetbox/beets/pull/755 and a few other issues.

This is my attempt to solve it. I am in the process of testing.

I wasn't sure the best way to do the config.  It seems like this new key should be under the "web" section, but I'm not sure exactly how the config object works since I haven't dug into the code much yet.