### PR TITLE
convert plugin: fix braces in filenames causing tracebacks in "pretend" mode

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -202,7 +202,7 @@ class ConvertPlugin(BeetsPlugin):
                 encode_cmd.append(args[i].encode(util.arg_encoding()))
 
         if pretend:
-            self._log.info(u' '.join(ui.decargs(args)))
+            self._log.info(u'{0}', u' '.join(ui.decargs(args)))
             return
 
         try:


### PR DESCRIPTION
Previously "pretend" mode (a.k.a. dry run mode) passed the command to be
printed directly to `_log.info`, whose first argument is technically a
format string. Thus the command string was parsed for replacement fields, such
as `{foo}`, which could cause the format evaluation to fail if the filenames
contained in the command contained valid (or partially valid) replacement fields.

This fix simply inserts an argument `'{0}'` to the call to `_log.info`, which is a
format string that simply evaluates to the second argument to `_log.info` (the
command string). By doing this, the command string is not parsed for replacement
fields.