### PR TITLE
Cleanup zero plugin

### DIFF
--- a/test/test_zero.py
+++ b/test/test_zero.py
@@ -8,7 +8,6 @@ import unittest
 from test.helper import TestHelper
 
 from beets.library import Item
-from beets import config
 from beetsplug.zero import ZeroPlugin
 from beets.mediafile import MediaFile
 from beets.util import syspath
@@ -17,108 +16,96 @@ from beets.util import syspath
 class ZeroPluginTest(unittest.TestCase, TestHelper):
     def setUp(self):
         self.setup_beets()
+        self.config['zero'] = {
+            'fields': [],
+            'keep_fields': [],
+            'update_database': False,
+        }
 
     def tearDown(self):
+        ZeroPlugin.listeners = None
         self.teardown_beets()
         self.unload_plugins()
 
     def test_no_patterns(self):
-        tags = {
-            'comments': u'test comment',
-            'day': 13,
-            'month': 3,
-            'year': 2012,
-        }
-        z = ZeroPlugin()
-        z.debug = False
-        z.fields = ['comments', 'month', 'day']
-        z.patterns = {'comments': [u'.'],
-                      'month': [u'.'],
-                      'day': [u'.']}
-        z.write_event(None, None, tags)
-        self.assertEqual(tags['comments'], None)
-        self.assertEqual(tags['day'], None)
-        self.assertEqual(tags['month'], None)
-        self.assertEqual(tags['year'], 2012)
+        self.config['zero']['fields'] = ['comments', 'month']
 
-    def test_patterns(self):
-        z = ZeroPlugin()
-        z.debug = False
-        z.fields = ['comments', 'year']
-        z.patterns = {'comments': u'eac lame'.split(),
-                      'year': u'2098 2099'.split()}
-
-        tags = {
-            'comments': u'from lame collection, ripped by eac',
-            'year': 2012,
-        }
-        z.write_event(None, None, tags)
-        self.assertEqual(tags['comments'], None)
-        self.assertEqual(tags['year'], 2012)
-
-    def test_delete_replaygain_tag(self):
-        path = self.create_mediafile_fixture()
-        item = Item.from_path(path)
-        item.rg_track_peak = 0.0
+        item = self.add_item_fixture(
+            comments=u'test comment',
+            title=u'Title',
+            month=1,
+            year=2000,
+        )
         item.write()
 
-        mediafile = MediaFile(syspath(item.path))
-        self.assertIsNotNone(mediafile.rg_track_peak)
-        self.assertIsNotNone(mediafile.rg_track_gain)
-
-        config['zero'] = {
-            'fields': ['rg_track_peak', 'rg_track_gain'],
-        }
         self.load_plugins('zero')
-
         item.write()
-        mediafile = MediaFile(syspath(item.path))
-        self.assertIsNone(mediafile.rg_track_peak)
-        self.assertIsNone(mediafile.rg_track_gain)
+
+        mf = MediaFile(syspath(item.path))
+        self.assertIsNone(mf.comments)
+        self.assertIsNone(mf.month)
+        self.assertEqual(mf.title, u'Title')
+        self.assertEqual(mf.year, 2000)
+
+    def test_pattern_match(self):
+        self.config['zero']['fields'] = ['comments']
+        self.config['zero']['comments'] = [u'encoded by']
+
+        item = self.add_item_fixture(comments=u'encoded by encoder')
+        item.write()
+
+        self.load_plugins('zero')
+        item.write()
+
+        mf = MediaFile(syspath(item.path))
+        self.assertIsNone(mf.comments)
+
+    def test_pattern_nomatch(self):
+        self.config['zero']['fields'] = ['comments']
+        self.config['zero']['comments'] = [u'encoded by']
+
+        item = self.add_item_fixture(comments=u'recorded at place')
+        item.write()
+
+        self.load_plugins('zero')
+        item.write()
+
+        mf = MediaFile(syspath(item.path))
+        self.assertEqual(mf.comments, u'recorded at place')
 
     def test_do_not_change_database(self):
+        self.config['zero']['fields'] = ['year']
+
         item = self.add_item_fixture(year=2000)
         item.write()
-        mediafile = MediaFile(syspath(item.path))
-        self.assertEqual(2000, mediafile.year)
 
-        config['zero'] = {'fields': ['year']}
         self.load_plugins('zero')
-
         item.write()
-        mediafile = MediaFile(syspath(item.path))
+
         self.assertEqual(item['year'], 2000)
-        self.assertIsNone(mediafile.year)
 
     def test_change_database(self):
+        self.config['zero']['fields'] = ['year']
+        self.config['zero']['update_database'] = True
+
         item = self.add_item_fixture(year=2000)
         item.write()
-        mediafile = MediaFile(syspath(item.path))
-        self.assertEqual(2000, mediafile.year)
 
-        config['zero'] = {
-            'fields': [u'year'],
-            'update_database': True,
-        }
         self.load_plugins('zero')
-
         item.write()
-        mediafile = MediaFile(syspath(item.path))
+
         self.assertEqual(item['year'], 0)
-        self.assertIsNone(mediafile.year)
 
     def test_album_art(self):
+        self.config['zero']['fields'] = ['images']
+
         path = self.create_mediafile_fixture(images=['jpg'])
         item = Item.from_path(path)
 
-        mediafile = MediaFile(syspath(item.path))
-        self.assertNotEqual(0, len(mediafile.images))
-
-        config['zero'] = {'fields': [u'images']}
         self.load_plugins('zero')
-
         item.write()
-        mediafile = MediaFile(syspath(item.path))
+
+        mediafile = MediaFile(syspath(path))
         self.assertEqual(0, len(mediafile.images))
 
 


### PR DESCRIPTION
The testing is proving to be a real PITA.

I expected to have to rewrite it since it was originally written based on the internals rather than the interface so the cleanup would have consequences. However, what I did not expect is that for some reason there seem to be some state carried from test to test despite `setUp` and `tearDown`. Here are my current thoughts:

* Minor gripe, but `add_item_fixture()` is not *that* practical, because you have to call `item.write()` immediately after if you want the tags to be written to the mediafile fixture. This is a bit annoying, especially when you are trying to test a plugin which is triggered by a write event.

* It seems to me that despite `unload_plugins()`, plugins which did register a listener do not get nuked because they remain registered. This is my best guess at why several instances of `ZeroPlugin` try to take care of a single write event.

For those reasons, the tests do not pass for now. I only rewrote the three or four first tests because it was kinda frustrating...