### PR TITLE
play: add --random option

### DIFF
--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -140,7 +140,7 @@ class PlayPlugin(BeetsPlugin):
         # Perform item query and add tracks to playlist.
         else:
             if opts.random:
-                selection = random.random_func(lib, opts, args)
+                selection = random.random_func(lib, opts, args,
                                                print_list=False)
             else:
                 selection = lib.items(ui.decargs(args))

--- a/beetsplug/random.py
+++ b/beetsplug/random.py
@@ -128,6 +128,8 @@ def random_func(lib, opts, args):
     for obj in objs:
         print_(format(obj))
 
+    # Return random subset to be used by other plugins.
+    return objs
 
 random_cmd = Subcommand('random',
                         help=u'choose a random track or album')

--- a/beetsplug/random.py
+++ b/beetsplug/random.py
@@ -112,7 +112,7 @@ def random_objs(objs, album, number=1, time=None, equal_chance=False):
         return _take(perm, number)
 
 
-def random_func(lib, opts, args):
+def random_func(lib, opts, args, print_list=True):
     """Select some random items or albums and print the results.
     """
     # Fetch all the objects matching the query into a list.
@@ -125,11 +125,14 @@ def random_func(lib, opts, args):
     # Print a random subset.
     objs = random_objs(objs, opts.album, opts.number, opts.time,
                        opts.equal_chance)
-    for obj in objs:
-        print_(format(obj))
+
+    if print_list:
+        for obj in objs:
+            print_(format(obj))
 
     # Return random subset to be used by other plugins.
-    return objs
+    else:
+        return objs
 
 random_cmd = Subcommand('random',
                         help=u'choose a random track or album')

--- a/docs/plugins/play.rst
+++ b/docs/plugins/play.rst
@@ -95,6 +95,12 @@ example::
 indicates that you need to insert extra arguments before specifying the
 playlist.
 
+The ``--random`` (or ``-r``) flag will choose a random song (or album, when
+used with ``-a``) from your library and play it. This option uses the
+``random`` plugin, so options available to the ``random`` plugin are also
+available to the ``play`` plugin (``--number`` (``-n``), ``--time`` (``-t``),
+and ``--equal-chance`` (``-e``), see :doc:`random`).
+
 Note on the Leakage of the Generated Playlists
 ----------------------------------------------
 


### PR DESCRIPTION
This adds feature request #795 and part of #2305.

It's the same as #2304, but I closed that one due to updates to the random plugin (and because I didn't branch my master fork to make changes, you live you learn).

As discussed in #2304, #795 and #1948, the best option would be to add a "random" query prefix, but that's too advanced for me (at least for right now) to develop, so I did this instead.