### PR TITLE
Web attachment filenames must be passed as a string for Python 3

### DIFF
--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -206,7 +206,7 @@ def item_file(item_id):
     response = flask.send_file(
         util.py3_path(item.path),
         as_attachment=True,
-        attachment_filename=os.path.basename(item.path),
+        attachment_filename=os.path.basename(util.py3_path(item.path)),
     )
     response.headers['Content-Length'] = os.path.getsize(item.path)
     return response


### PR DESCRIPTION
This PR fixes the following bug in the web interface

When downloading a file the the following error occurs:
```
[2016-12-29 11:11:07,039] ERROR in app: Exception on /item/10652/file [GET]
Traceback (most recent call last):
  File "/home/mrl/projects/beets/lib/python3.5/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/mrl/projects/beets/lib/python3.5/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/mrl/projects/beets/lib/python3.5/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/mrl/projects/beets/lib/python3.5/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/home/mrl/projects/beets/lib/python3.5/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/mrl/projects/beets/lib/python3.5/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/mrl/projects/beets/lib/python3.5/site-packages/beets-1.4.3-py3.5.egg/beetsplug/web/__init__.py", line 209, in item_file
    attachment_filename=os.path.basename(item.path),
  File "/home/mrl/projects/beets/lib/python3.5/site-packages/flask/helpers.py", line 522, in send_file
    mimetype = mimetypes.guess_type(attachment_filename)[0] \
  File "/usr/lib/python3.5/mimetypes.py", line 289, in guess_type
    return _db.guess_type(url, strict)
  File "/usr/lib/python3.5/mimetypes.py", line 114, in guess_type
    scheme, url = urllib.parse.splittype(url)
  File "/usr/lib/python3.5/urllib/parse.py", line 862, in splittype
    match = _typeprog.match(url)
TypeError: cannot use a string pattern on a bytes-like object
```