### PR TITLE
Replace Python 3.4 with 3.6 on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,10 @@ environment:
     matrix:
         - PYTHON: C:\Python27
           TOX_ENV: py27-test
-        - PYTHON: C:\Python34
-          TOX_ENV: py34-test
         - PYTHON: C:\Python35
           TOX_ENV: py35-test
+        - PYTHON: C:\Python36
+          TOX_ENV: py36-test
 
 # Install Tox for running tests.
 install:


### PR DESCRIPTION
Python 3.4 is quite old and offers little value on Windows.

Closes #2344