### PR TITLE
Temporarily allow empty checksum for unrar on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,8 @@ environment:
 # Install Tox for running tests.
 install:
     - cinst imagemagick -y
-    - cinst unrar -y
+    # TODO: remove --allow-empty-checksums when unrar offers a proper checksum
+    - cinst unrar -y --allow-empty-checksums
     - "%PYTHON%/Scripts/pip.exe install tox"
     - "%PYTHON%/Scripts/tox.exe -e %TOX_ENV% --notest"
 


### PR DESCRIPTION
Obviously it'd be best if we didn't have to do it, but I doubt we can
wait forever for the packagers to add it.