### PR TITLE
Absubmit add section in the documentation on skipped file by the plugin

### DIFF
--- a/docs/plugins/absubmit.rst
+++ b/docs/plugins/absubmit.rst
@@ -25,6 +25,8 @@ Type::
 to run the analysis program and upload its results. This will work on any
 music with a MusicBrainz track ID attached.
 
+The plugin skips any file missing a MusicBrainz ID (MBID). This should rarely happen as Beets tags all files with their MBID on import. Files of in an unsupported encoding format are also skipped. `streaming_extractor_music`_ currently supports files with the following extensions: ``mp3``, ``ogg``, ``oga``, ``flac``, ``mp4``, ``m4a``, ``m4r``, ``m4b``, ``m4p``, ``aac``, ``wma``, ``asf``, ``mpc``, ``wv``, ``spx``, ``tta``, ``3g2``, ``aif``, ``aiff`` and ``ape``.
+
 Configuration
 -------------
 


### PR DESCRIPTION
Add a section to the absubmit plugin documentation about files that are skipped by this plugin. As mentioned by @tux-00 in pull request #2342. 