### PR TITLE
Use a new stdlib method for dbcore.query._to_epoch_time on Python 3

### DIFF
--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -503,9 +503,13 @@ def _to_epoch_time(date):
     """Convert a `datetime` object to an integer number of seconds since
     the (local) Unix epoch.
     """
-    epoch = datetime.fromtimestamp(0)
-    delta = date - epoch
-    return int(delta.total_seconds())
+    if hasattr(date, 'timestamp'):
+        # The `timestamp` method exists on Python 3.3+.
+        return int(date.timestamp())
+    else:
+        epoch = datetime.fromtimestamp(0)
+        delta = date - epoch
+        return int(delta.total_seconds())
 
 
 def _parse_periods(pattern):


### PR DESCRIPTION
This also works around a bug in Python 3.6.0 on Windows: see #2358.