### PR TITLE
[WIP] Add PlaylistQuery plugin

### DIFF
--- a/beetsplug/playlistquery.py
+++ b/beetsplug/playlistquery.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+# This file is part of beets.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+import os
+from beets.plugins import BeetsPlugin
+from beets.dbcore import FieldQuery, types
+from beets.util.confit import NotFoundError
+
+class PlaylistQuery(FieldQuery):
+    """Matches files listed by a playlist file.
+    """
+    relative_path = None
+    playlist_dir = None
+
+    def __init__(self, field, pattern, fast=True):
+        super(PlaylistQuery, self).__init__(field, pattern, fast)
+
+        playlist_file = pattern + '.m3u'
+        playlist_path = os.path.join(self.playlist_dir, playlist_file)
+
+        self.paths = []
+        with open(playlist_path, 'r') as f:
+            for line in f:
+                if line[0] == '#':
+                    # ignore comments, and extm3u extension
+                    continue
+                self.paths.append(os.path.normpath(
+                    os.path.join(self.relative_path, line.decode('utf-8').rstrip())
+                ))
+
+    def match(self, item):
+        return item.path.decode('utf-8') in self.paths
+
+
+class PlaylistType(types.String):
+    """Custom type for playlist query.
+    """
+    query = PlaylistQuery
+
+
+class PlaylistQueryPlugin(BeetsPlugin):
+    item_types = {'playlist': PlaylistType()}
+
+    def __init__(self):
+        super(PlaylistQueryPlugin, self).__init__()
+        self.register_listener('library_opened', self.library_opened)
+
+        PlaylistQuery.playlist_dir = self.config['playlist_dir'].as_filename()
+
+    def library_opened(self, lib):
+        try:
+            relative_to = self.config['relative_to'].as_choice(['base', 'playlist'])
+        except NotFoundError:
+            relative_to = 'base'
+
+        if relative_to == 'playlist':
+            PlaylistQuery.relative_path = PlaylistQuery.playlist_dir
+        else:
+            PlaylistQuery.relative_path = lib.directory


### PR DESCRIPTION
This plugin provides support for queries on M3U playlist files, giving some of the features requested in #123. In my workflow, this allows me to create and manage playlists with a music client (e.g. ncmpcpp) then leverage Beets to transform those tracks, e.g. exporting and converting them into a separate directory for consumption on another device.

It uses a flexible field type definition to add the `playlist:...` query pattern. I considered using prefixes, but that would make for strange behaviour when combined with a field selector. This approach adds a dynamic 'field' to items that allow for matching.

Two configuration parameters are present: `playlist_dir` is required, and defines the location of the playlist directory. `relative_to` defines how relative paths in M3U files are specified, as relative to the base music directory or relative to the playlist. It defaults to paths being relative to the base directory, since that is what ncmpcpp does.

TODO:
- [ ] Add documentation
- [ ] Write tests?

I wanted to get this PR open so people can start commenting on my code