### PR TITLE
A new 'beet web' endpoint and configuration option, with docs

### DIFF
--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -223,7 +223,6 @@ def item_query(queries):
 
 @app.route('/item/path/<path:path>')
 def item_at_path(path):
-    g.lib._connection().create_function('bytelower', 1, beets.library._sqlite_bytelower)
     query = beets.library.PathQuery('path', u'/' + path)
     item = g.lib.items(query).get()
     if item:

--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -37,7 +37,7 @@ def _rep(obj, expand=False):
     out = dict(obj)
 
     if isinstance(obj, beets.library.Item):
-        if app.config['exclude_paths_from_items']:
+        if app.config.get('EXCLUDE_PATHS_FROM_ITEMS', True):
             del out['path']
         else:
             out['path'] = out['path'].decode('utf-8')
@@ -339,7 +339,7 @@ class WebPlugin(BeetsPlugin):
             # Normalizes json output
             app.config['JSONIFY_PRETTYPRINT_REGULAR'] = False
 
-            app.config['exclude_paths_from_items'] = (
+            app.config['EXCLUDE_PATHS_FROM_ITEMS'] = (
                 self.config.get('exclude_paths_from_items', True))
 
             # Enable CORS if required.

--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -223,7 +223,7 @@ def item_query(queries):
 
 @app.route('/item/path/<path:path>')
 def item_at_path(path):
-    query = beets.library.PathQuery('path', u'/' + path)
+    query = beets.library.PathQuery('path', b'/' + path.encode('utf-8'))
     item = g.lib.items(query).get()
     if item:
         return flask.jsonify(_rep(item))

--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -37,7 +37,10 @@ def _rep(obj, expand=False):
     out = dict(obj)
 
     if isinstance(obj, beets.library.Item):
-        del out['path']
+        if app.config['exclude_paths_from_items']:
+            del out['path']
+        else:
+            out['path'] = out['path'].decode('utf-8')
 
         # Get the size (in bytes) of the backing file. This is useful
         # for the Tomahawk resolver API.
@@ -309,6 +312,7 @@ class WebPlugin(BeetsPlugin):
             'host': u'127.0.0.1',
             'port': 8337,
             'cors': '',
+            'exclude_paths_from_items': True,
         })
 
     def commands(self):
@@ -326,6 +330,9 @@ class WebPlugin(BeetsPlugin):
             app.config['lib'] = lib
             # Normalizes json output
             app.config['JSONIFY_PRETTYPRINT_REGULAR'] = False
+
+            app.config['exclude_paths_from_items'] = (
+                self.config['exclude_paths_from_items'])
 
             # Enable CORS if required.
             if self.config['cors']:

--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -38,7 +38,7 @@ def _rep(obj, expand=False):
 
     if isinstance(obj, beets.library.Item):
         if app.config.get('INCLUDE_PATHS', False):
-            out['path'] = out['path'].decode('utf-8')
+            out['path'] = util.displayable_path(out['path'])
         else:
             del out['path']
 

--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -37,10 +37,10 @@ def _rep(obj, expand=False):
     out = dict(obj)
 
     if isinstance(obj, beets.library.Item):
-        if app.config.get('EXCLUDE_PATHS_FROM_ITEMS', True):
-            del out['path']
-        else:
+        if app.config.get('INCLUDE_PATHS', False):
             out['path'] = out['path'].decode('utf-8')
+        else:
+            del out['path']
 
         # Get the size (in bytes) of the backing file. This is useful
         # for the Tomahawk resolver API.
@@ -320,7 +320,7 @@ class WebPlugin(BeetsPlugin):
             'host': u'127.0.0.1',
             'port': 8337,
             'cors': '',
-            'exclude_paths_from_items': True,
+            'include_paths': False,
         })
 
     def commands(self):
@@ -339,8 +339,8 @@ class WebPlugin(BeetsPlugin):
             # Normalizes json output
             app.config['JSONIFY_PRETTYPRINT_REGULAR'] = False
 
-            app.config['EXCLUDE_PATHS_FROM_ITEMS'] = (
-                self.config.get('exclude_paths_from_items', True))
+            app.config['INCLUDE_PATHS'] = (
+                self.config.get('include_paths', False))
 
             # Enable CORS if required.
             if self.config['cors']:

--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -340,7 +340,7 @@ class WebPlugin(BeetsPlugin):
             app.config['JSONIFY_PRETTYPRINT_REGULAR'] = False
 
             app.config['exclude_paths_from_items'] = (
-                self.config['exclude_paths_from_items'])
+                self.config.get('exclude_paths_from_items', True))
 
             # Enable CORS if required.
             if self.config['cors']:

--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -221,6 +221,14 @@ def item_query(queries):
     return g.lib.items(queries)
 
 
+@app.route('/item/at_path/<path:path>')
+def item_at_path(path):
+    try:
+        return flask.jsonify(_rep(beets.library.Item.from_path('/' + path)))
+    except beets.library.ReadError:
+        return flask.abort(404)
+
+
 @app.route('/item/values/<string:key>')
 def item_unique_field_values(key):
     sort_key = flask.request.args.get('sort_key', key)

--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -176,11 +176,16 @@ class QueryConverter(PathConverter):
         return ','.join(value)
 
 
+class EverythingConverter(PathConverter):
+    regex = '.*?'
+
+
 # Flask setup.
 
 app = flask.Flask(__name__)
 app.url_map.converters['idlist'] = IdListConverter
 app.url_map.converters['query'] = QueryConverter
+app.url_map.converters['everything'] = EverythingConverter
 
 
 @app.before_request
@@ -221,9 +226,9 @@ def item_query(queries):
     return g.lib.items(queries)
 
 
-@app.route('/item/path/<path:path>')
+@app.route('/item/path/<everything:path>')
 def item_at_path(path):
-    query = beets.library.PathQuery('path', b'/' + path.encode('utf-8'))
+    query = beets.library.PathQuery('path', path.encode('utf-8'))
     item = g.lib.items(query).get()
     if item:
         return flask.jsonify(_rep(item))

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,10 @@ New features:
   non-numeric track index data. For example, some vinyl or tape media will
   report the side of the record using a letter instead of a number in that
   field. :bug:`1831` :bug:`2363`
+* The :doc:`/plugins/web` has a new endpoint, ``/item/path/foo``, which will
+  return the item info for the file at the given path, or 404.
+* The :doc:`/plugins/web` also has a new config option, ``include_paths``,
+  which will cause paths to be included in item API responses if set to true.
 
 Fixes:
 

--- a/docs/plugins/web.rst
+++ b/docs/plugins/web.rst
@@ -162,6 +162,13 @@ response includes all the items requested. If a track is not found it is silentl
 dropped from the response.
 
 
+``GET /item/by_path/...``
++++++++++++++++++++++
+
+Look for an item at the given path on the server. If it corresponds to a track,
+return the track in the same format as /item/*.
+
+
 ``GET /item/query/querystring``
 +++++++++++++++++++++++++++++++
 

--- a/docs/plugins/web.rst
+++ b/docs/plugins/web.rst
@@ -162,8 +162,8 @@ response includes all the items requested. If a track is not found it is silentl
 dropped from the response.
 
 
-``GET /item/by_path/...``
-+++++++++++++++++++++++++
+``GET /item/path/...``
+++++++++++++++++++++++
 
 Look for an item at the given path on the server. If it corresponds to a track,
 return the track in the same format as ``/item/*``.

--- a/docs/plugins/web.rst
+++ b/docs/plugins/web.rst
@@ -165,8 +165,11 @@ dropped from the response.
 ``GET /item/path/...``
 ++++++++++++++++++++++
 
-Look for an item at the given path on the server. If it corresponds to a track,
-return the track in the same format as ``/item/*``.
+Look for an item at the given absolute path on the server. If it corresponds to
+a track, return the track in the same format as ``/item/*``.
+
+If the server runs UNIX, you'll need to include an extra leading slash:
+``http://localhost:8337/item/path//Users/beets/Music/Foo/Bar/Baz.mp3``
 
 
 ``GET /item/query/querystring``

--- a/docs/plugins/web.rst
+++ b/docs/plugins/web.rst
@@ -163,7 +163,7 @@ dropped from the response.
 
 
 ``GET /item/by_path/...``
-+++++++++++++++++++++
++++++++++++++++++++++++++
 
 Look for an item at the given path on the server. If it corresponds to a track,
 return the track in the same format as /item/*.

--- a/docs/plugins/web.rst
+++ b/docs/plugins/web.rst
@@ -166,7 +166,7 @@ dropped from the response.
 +++++++++++++++++++++++++
 
 Look for an item at the given path on the server. If it corresponds to a track,
-return the track in the same format as /item/*.
+return the track in the same format as ``/item/*``.
 
 
 ``GET /item/query/querystring``

--- a/docs/plugins/web.rst
+++ b/docs/plugins/web.rst
@@ -63,6 +63,8 @@ configuration file. The available options are:
   Default: 8337.
 - **cors**: The CORS allowed origin (see :ref:`web-cors`, below).
   Default: CORS is disabled.
+- **exclude_paths_from_items**: The 'path' key of items is filtered out of JSON
+  responses for security reasons. Default: true.
 
 Implementation
 --------------

--- a/docs/plugins/web.rst
+++ b/docs/plugins/web.rst
@@ -63,8 +63,8 @@ configuration file. The available options are:
   Default: 8337.
 - **cors**: The CORS allowed origin (see :ref:`web-cors`, below).
   Default: CORS is disabled.
-- **exclude_paths_from_items**: The 'path' key of items is filtered out of JSON
-  responses for security reasons. Default: true.
+- **include_paths**: If true, includes paths in item objects.
+  Default: false.
 
 Implementation
 --------------

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -79,7 +79,7 @@ class WebPluginTest(_common.LibTestCase):
     def test_get_single_item_by_path(self):
         data_path = os.path.join(_common.RSRC, b'full.mp3')
         self.lib.add(Item.from_path(data_path))
-        response = self.client.get('/item/path' + data_path.decode('utf-8'))
+        response = self.client.get('/item/path/' + data_path.decode('utf-8'))
         response.json = json.loads(response.data.decode('utf-8'))
 
         self.assertEqual(response.status_code, 200)
@@ -89,7 +89,7 @@ class WebPluginTest(_common.LibTestCase):
         data_path = os.path.join(_common.RSRC, b'full.mp3')
         # data_path points to a valid file, but we have not added the file
         # to the library.
-        response = self.client.get('/item/path' + data_path.decode('utf-8'))
+        response = self.client.get('/item/path/' + data_path.decode('utf-8'))
 
         self.assertEqual(response.status_code, 404)
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -28,16 +28,24 @@ class WebPluginTest(_common.LibTestCase):
 
         web.app.config['TESTING'] = True
         web.app.config['lib'] = self.lib
-        web.app.config['EXCLUDE_PATHS_FROM_ITEMS'] = True
+        web.app.config['INCLUDE_PATHS'] = False
         self.client = web.app.test_client()
 
-    def test_config_exclude_paths_from_items(self):
-        web.app.config['EXCLUDE_PATHS_FROM_ITEMS'] = False
+    def test_config_include_paths_true(self):
+        web.app.config['INCLUDE_PATHS'] = True
         response = self.client.get('/item/1')
         response.json = json.loads(response.data.decode('utf-8'))
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json['path'], u'/path_1')
+
+    def test_config_include_paths_false(self):
+        web.app.config['INCLUDE_PATHS'] = False
+        response = self.client.get('/item/1')
+        response.json = json.loads(response.data.decode('utf-8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('path', response.json)
 
     def test_get_all_items(self):
         response = self.client.get('/item/')

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -21,14 +21,23 @@ class WebPluginTest(_common.LibTestCase):
         # Add fixtures
         for track in self.lib.items():
             track.remove()
-        self.lib.add(Item(title=u'title', path='', id=1))
-        self.lib.add(Item(title=u'another title', path='', id=2))
+        self.lib.add(Item(title=u'title', path='/path_1', id=1))
+        self.lib.add(Item(title=u'another title', path='/path_2', id=2))
         self.lib.add(Album(album=u'album', id=3))
         self.lib.add(Album(album=u'another album', id=4))
 
         web.app.config['TESTING'] = True
         web.app.config['lib'] = self.lib
+        web.app.config['EXCLUDE_PATHS_FROM_ITEMS'] = True
         self.client = web.app.test_client()
+
+    def test_config_exclude_paths_from_items(self):
+        web.app.config['EXCLUDE_PATHS_FROM_ITEMS'] = False
+        response = self.client.get('/item/1')
+        response.json = json.loads(response.data.decode('utf-8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json['path'], u'/path_1')
 
     def test_get_all_items(self):
         response = self.client.get('/item/')


### PR DESCRIPTION
I am working on a web app which combines a beets library with the mpv player. Since mpv doesn't know about beets, but I am using mpv as the source of truth for the playback queue, I need to be able to turn a file path into a beets track for the purpose of showing the "now playing" info. Additionally, I need the API responses for tracks to contain their paths so I can enqueue the tracks in mpv.

To that end, I have added a new configuration option `exclude_paths_from_items`, which defaults to `true` (the current behavior) but which can be set to `false` to allow paths to make it into API responses. I figured you had a good reason for excluding paths in most cases.

I also added a new endpoint `/item/at_path/<path:path>`, which can be called like `/item/at_path/Users/irskep/Music/The Beatles/Abbey Road/01 Come Together.mp3` to get the beets track info for the file at that path. While you might think it's possible to just do a "path:" query at /item/query/, in practice it doesn't work for a couple reasons that are annoying to work around. I can elaborate on that if you like. There are about 3 layers of breakage.

I will add tests tomorrow. (It is after midnight for me!)

[You can see my project here.](https://github.com/irskep/summertunes) It is quite far along. I already wrote my own HTTP server to interface with beets in exactly the way I want, but I would rather just use the project's existing server and not maintain a separate codebase.

I am eager to know if you support this approach so I can make some decisions about my own project's implementation.