### PR TITLE
On Python 3, use more flexible encoding to send bytes to stdout

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -136,16 +136,22 @@ def print_(*strings, **kwargs):
     txt += kwargs.get('end', u'\n')
 
     # Encode the string and write it to stdout.
-    txt = txt.encode(_out_encoding(), 'replace')
     if six.PY2:
         # On Python 2, sys.stdout expects bytes.
-        sys.stdout.write(txt)
+        out = txt.encode(_out_encoding(), 'replace')
+        sys.stdout.write(out)
     else:
         # On Python 3, sys.stdout expects text strings and uses the
         # exception-throwing encoding error policy. To avoid throwing
         # errors and use our configurable encoding override, we use the
         # underlying bytes buffer instead.
-        sys.stdout.buffer.write(txt)
+        if hasattr(sys.stdout, 'buffer'):
+            out = txt.encode(_out_encoding(), 'replace')
+            sys.stdout.buffer.write(out)
+        else:
+            # In our test harnesses (e.g., DummyOut), sys.stdout.buffer
+            # does not exist. We instead just record the text string.
+            sys.stdout.write(txt)
 
 
 # Configuration wrappers.

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -126,8 +126,7 @@ def print_(*strings, **kwargs):
     Python 3.
 
     The `end` keyword argument behaves similarly to the built-in `print`
-    (it defaults to a newline). The value should have the same string
-    type as the arguments.
+    (it defaults to a newline).
     """
     if not strings:
         strings = [u'']
@@ -136,11 +135,17 @@ def print_(*strings, **kwargs):
     txt = u' '.join(strings)
     txt += kwargs.get('end', u'\n')
 
-    # Send bytes to the stdout stream on Python 2.
+    # Encode the string and write it to stdout.
+    txt = txt.encode(_out_encoding(), 'replace')
     if six.PY2:
-        txt = txt.encode(_out_encoding(), 'replace')
-
-    sys.stdout.write(txt)
+        # On Python 2, sys.stdout expects bytes.
+        sys.stdout.write(txt)
+    else:
+        # On Python 3, sys.stdout expects text strings and uses the
+        # exception-throwing encoding error policy. To avoid throwing
+        # errors and use our configurable encoding override, we use the
+        # underlying bytes buffer instead.
+        sys.stdout.buffer.write(txt)
 
 
 # Configuration wrappers.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,9 @@ Fixes:
 * :doc:`/plugins/replaygain`: Fix Python 3 compatibility in the ``bs1770gain``
   backend. :bug:`2382`
 * :doc:`/plugins/bpd`: Report playback times as integer. :bug:`2394`
+* On Python 3, the :ref:`terminal_encoding` setting is respected again for
+  output and printing will no longer crash on systems configured with a
+  limited encoding.
 
 
 1.4.3 (January 9, 2017)


### PR DESCRIPTION
As explained in #2393, the last big issue in Python 3 is that `print` or `sys.stdout.write` can crash depending on the system's locale configuration. This change restores the Python 2 behavior, which avoids potential crashes by (a) using the `replace` error handler and (b) allowing the user to override the stdout encoding in the configuration.

Unfortunately, this breaks out test harnesses that capture stdout. One way to work around this might be to detect when we're in a test harness and just record the text strings directly.