### PR TITLE
Run python2 or python3 depending on what's being used

### DIFF
--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -28,6 +28,15 @@ from beets.mediafile import MediaFile
 from beets import util
 
 
+def shell_quote(text):
+    if sys.version_info[0] < 3:
+        import pipes
+        return pipes.quote(text)
+    else:
+        import shlex
+        return shlex.quote(text)
+
+
 class TestHelper(helper.TestHelper):
 
     def tagged_copy_cmd(self, tag):
@@ -40,7 +49,7 @@ class TestHelper(helper.TestHelper):
 
         # A Python script that copies the file and appends a tag.
         stub = os.path.join(_common.RSRC, b'convert_stub.py').decode('utf-8')
-        return u"'{}' '{}' $source $dest {}".format(sys.executable, stub, tag)
+        return u"{} {} $source $dest {}".format(shell_quote(sys.executable), shell_quote(stub), tag)
 
     def assertFileTag(self, path, tag):  # noqa
         """Assert that the path is a file and the files content ends with `tag`.

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -49,7 +49,8 @@ class TestHelper(helper.TestHelper):
 
         # A Python script that copies the file and appends a tag.
         stub = os.path.join(_common.RSRC, b'convert_stub.py').decode('utf-8')
-        return u"{} {} $source $dest {}".format(shell_quote(sys.executable), shell_quote(stub), tag)
+        return u"{} {} $source $dest {}".format(shell_quote(sys.executable),
+                                                shell_quote(stub), tag)
 
     def assertFileTag(self, path, tag):  # noqa
         """Assert that the path is a file and the files content ends with `tag`.
@@ -282,6 +283,7 @@ class NeverConvertLossyFilesTest(unittest.TestCase, TestHelper,
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
+
 
 if __name__ == '__main__':
     unittest.main(defaultTest='suite')

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -40,7 +40,7 @@ class TestHelper(helper.TestHelper):
 
         # A Python script that copies the file and appends a tag.
         stub = os.path.join(_common.RSRC, b'convert_stub.py').decode('utf-8')
-        return u"{} '{}' $source $dest {}".format(sys.executable, stub, tag)
+        return u"'{}' '{}' $source $dest {}".format(sys.executable, stub, tag)
 
     def assertFileTag(self, path, tag):  # noqa
         """Assert that the path is a file and the files content ends with `tag`.

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -15,6 +15,7 @@
 
 from __future__ import division, absolute_import, print_function
 
+import sys
 import re
 import os.path
 import unittest
@@ -39,7 +40,7 @@ class TestHelper(helper.TestHelper):
 
         # A Python script that copies the file and appends a tag.
         stub = os.path.join(_common.RSRC, b'convert_stub.py').decode('utf-8')
-        return u"python '{}' $source $dest {}".format(stub, tag)
+        return u"python{} '{}' $source $dest {}".format(sys.version_info.major, stub, tag)
 
     def assertFileTag(self, path, tag):  # noqa
         """Assert that the path is a file and the files content ends with `tag`.

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -40,7 +40,7 @@ class TestHelper(helper.TestHelper):
 
         # A Python script that copies the file and appends a tag.
         stub = os.path.join(_common.RSRC, b'convert_stub.py').decode('utf-8')
-        return u"python{} '{}' $source $dest {}".format(sys.version_info.major, stub, tag)
+        return u"{} '{}' $source $dest {}".format(sys.executable, stub, tag)
 
     def assertFileTag(self, path, tag):  # noqa
         """Assert that the path is a file and the files content ends with `tag`.


### PR DESCRIPTION
On a system with dependencies installed for python3 but not for python2,
we have to make sure python3 is used everywhere since 'python' might be running
the python2 interpreter.

This helps with some problems in #2400, but doesn't fix the issue completely.