### PR TITLE
mpdstats: More general approach to multiple on_play calls for the same song

### DIFF
--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -266,8 +266,11 @@ class MPDStats(object):
         if self.now_playing:
             if self.now_playing['path'] != path:
                 self.handle_song_change(self.now_playing)
-            else:  # in case we got mpd play event with same song playing multiple times
-                # assume low diff means redundant second play event after natural song start
+            else:
+                # In case we got mpd play event with same song playing
+                # multiple times,
+                # assume low diff means redundant second play event
+                # after natural song start.
                 diff = abs(time.time() - self.now_playing['started'])
 
                 if diff <= self.time_threshold:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,7 @@ Fixes:
 * :doc:`/plugins/bpd`: Report playback times as integer. :bug:`2394`
 * :doc:`/plugins/mpdstats`: Fix Python 3 compatibility. The plugin also now
   requires version 0.4.2 or later of the ``python-mpd2`` library. :bug:`2405`
+* :doc:`/plugins/mpdstats`: Improve handling of mpd status queries.
 
 
 1.4.3 (January 9, 2017)


### PR DESCRIPTION
This change is related to #773. On my machine, with mpd 20.2 and beets 1.4.4, redundant second on_play call with same song playing, happens only on start of playing queue. Afterwards, this event is triggering only once per song change, no matter if previous song was skipped or naturally finished. And current version of on_play in my case resulted in broken state transition and ruined rating and play counts 
So, I've made minor changes, which in my believe respects both cases. 