### PR TITLE
A few changes to the badfiles plugin

### DIFF
--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -113,11 +113,16 @@ class BadFiles(BeetsPlugin):
                           .format(ui.colorize('text_warning', dpath), errors))
                 for line in output:
                     ui.print_(u"  {}".format(displayable_path(line)))
-            else:
+            elif opts.verbose:
                 ui.print_(u"{}: ok".format(ui.colorize('text_success', dpath)))
 
     def commands(self):
         bad_command = Subcommand('bad',
                                  help=u'check for corrupt or missing files')
+        bad_command.parser.add_option(
+            u'-v', u'--verbose', 
+            action='store_true', default=False, dest='verbose',
+            help=u'view results for both the bad and uncorrupted files'
+        )
         bad_command.func = self.check_bad
         return [bad_command]

--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -105,7 +105,7 @@ class BadFiles(BeetsPlugin):
             if not checker:
                 missing_checkers[ext] = None
                 if opts.verbose:
-                    self._log.debug(u"no checker specified for {}", ext)
+                    self._log.error(u"no checker specified for {}", ext)
                 continue
             path = item.path
             if not isinstance(path, six.text_type):

--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -120,7 +120,7 @@ class BadFiles(BeetsPlugin):
                     self._log.error(u"error invoking {}: {}", e.checker, e.msg)
                 continue
             if status > 0:
-                ui.print_(u"{}: checker exited withs status {}"
+                ui.print_(u"{}: checker exited with status {}"
                           .format(ui.colorize('text_error', dpath), status))
                 for line in output:
                     ui.print_(u"  {}".format(displayable_path(line)))

--- a/docs/plugins/badfiles.rst
+++ b/docs/plugins/badfiles.rst
@@ -52,3 +52,7 @@ Note that the default `mp3val` checker is a bit verbose and can output a lot
 of "stream error" messages, even for files that play perfectly well.
 Generally, if more than one stream error happens, or if a stream error happens
 in the middle of a file, this is a bad sign.
+
+By default, only errors for the bad files will be shown. In order for the
+results for all of the checked files to be seen, including the uncorrupted 
+ones, use the ``-v`` or ``--verbose`` option.


### PR DESCRIPTION
Adding a verbosity option per request from #1654.

Process now continues to other files instead of stopping after a checker error (#2430).

The checker errors are logged only once for each file extension by default and for each file separately in the verbose mode. Let me know if this is fine or if you'd rather have just one of those.