### PR TITLE
badfiles: displaying results only for corrupted files by default

### DIFF
--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -113,11 +113,16 @@ class BadFiles(BeetsPlugin):
                           .format(ui.colorize('text_warning', dpath), errors))
                 for line in output:
                     ui.print_(u"  {}".format(displayable_path(line)))
-            else:
+            elif opts.verbose:
                 ui.print_(u"{}: ok".format(ui.colorize('text_success', dpath)))
 
     def commands(self):
         bad_command = Subcommand('bad',
                                  help=u'check for corrupt or missing files')
+        bad_command.parser.add_option(
+            u'-v', u'--verbose',
+            action='store_true', default=False, dest='verbose',
+            help=u'view results for both the bad and uncorrupted files'
+        )
         bad_command.func = self.check_bad
         return [bad_command]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,9 @@ New features:
 * Added a ``--move`` or ``-m`` option to the importer so that the files can be
   moved to the library instead of being copied or added "in place".
   :bug:`2252` :bug:`2429` 
+* Added a ``--verbose`` or ``-v`` option to the badfiles plugin. Results are 
+  now displayed only for corrupted files by default and for all the files when
+  the verbose option is set. :bug:`1654` :bug:`2434`
 
 Fixes:
 

--- a/docs/plugins/badfiles.rst
+++ b/docs/plugins/badfiles.rst
@@ -52,3 +52,7 @@ Note that the default `mp3val` checker is a bit verbose and can output a lot
 of "stream error" messages, even for files that play perfectly well.
 Generally, if more than one stream error happens, or if a stream error happens
 in the middle of a file, this is a bad sign.
+
+By default, only errors for the bad files will be shown. In order for the
+results for all of the checked files to be seen, including the uncorrupted 
+ones, use the ``-v`` or ``--verbose`` option.


### PR DESCRIPTION
Per request from #1654.

As a continuation to the discussion on the change: I think it would make sense to have a separate option for displaying all checker results (including the positive ones) with only bad files being displayed by default. The reason for having that, instead of logging the results for the uncorrupted files at the debug level, is that using this option the user would be able to see the results for all of the files without seeing a bunch of other debug messages, making the output less messy. The option could be named --all or --show-all, in order to be distinguished from the global --verbose.

This is just a suggestion, though. Let me know if you'd rather have the positive checker results be logged on the debug level, instead of introducing this new option.