### PR TITLE
Add option to hardlink when importing

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -6,6 +6,7 @@ import:
     copy: yes
     move: no
     link: no
+    hardlink: no
     delete: no
     resume: ask
     incremental: no

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -671,8 +671,8 @@ class ImportTask(BaseImportTask):
                 # move in-library files. (Out-of-library files are
                 # copied/moved as usual).
                 old_path = item.path
-                if (copy or link or hardlink) and self.replaced_items[item] and \
-                   session.lib.directory in util.ancestry(old_path):
+                if (copy or link or hardlink) and self.replaced_items[item] \
+                   and session.lib.directory in util.ancestry(old_path):
                     item.move()
                     # We moved the item, so remove the
                     # now-nonexistent file from old_paths.

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -220,13 +220,19 @@ class ImportSession(object):
             iconfig['resume'] = False
             iconfig['incremental'] = False
 
-        # Copy, move, and link are mutually exclusive.
+        # Copy, move, link, and hardlink are mutually exclusive.
         if iconfig['move']:
             iconfig['copy'] = False
             iconfig['link'] = False
+            iconfig['hardlink'] = False
         elif iconfig['link']:
             iconfig['copy'] = False
             iconfig['move'] = False
+            iconfig['hardlink'] = False
+        elif iconfig['hardlink']:
+            iconfig['copy'] = False
+            iconfig['move'] = False
+            iconfig['link'] = False
 
         # Only delete when copying.
         if not iconfig['copy']:
@@ -654,18 +660,18 @@ class ImportTask(BaseImportTask):
             item.update(changes)
 
     def manipulate_files(self, move=False, copy=False, write=False,
-                         link=False, session=None):
+                         link=False, hardlink=False, session=None):
         items = self.imported_items()
         # Save the original paths of all items for deletion and pruning
         # in the next step (finalization).
         self.old_paths = [item.path for item in items]
         for item in items:
-            if move or copy or link:
+            if move or copy or link or hardlink:
                 # In copy and link modes, treat re-imports specially:
                 # move in-library files. (Out-of-library files are
                 # copied/moved as usual).
                 old_path = item.path
-                if (copy or link) and self.replaced_items[item] and \
+                if (copy or link or hardlink) and self.replaced_items[item] and \
                    session.lib.directory in util.ancestry(old_path):
                     item.move()
                     # We moved the item, so remove the
@@ -674,7 +680,7 @@ class ImportTask(BaseImportTask):
                 else:
                     # A normal import. Just copy files and keep track of
                     # old paths.
-                    item.move(copy, link)
+                    item.move(copy, link, hardlink)
 
             if write and (self.apply or self.choice_flag == action.RETAG):
                 item.try_write()
@@ -1412,6 +1418,7 @@ def manipulate_files(session, task):
             copy=session.config['copy'],
             write=session.config['write'],
             link=session.config['link'],
+            hardlink=session.config['hardlink'],
             session=session,
         )
 

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -478,16 +478,15 @@ def move(path, dest, replace=False):
 def link(path, dest, replace=False):
     """Create a symbolic link from path to `dest`. Raises an OSError if
     `dest` already exists, unless `replace` is True. Does nothing if
-    `path` == `dest`."""
-    if (samefile(path, dest)):
+    `path` == `dest`.
+    """
+    if samefile(path, dest):
         return
 
-    path = syspath(path)
-    dest = syspath(dest)
-    if os.path.exists(dest) and not replace:
+    if os.path.exists(syspath(dest)) and not replace:
         raise FilesystemError(u'file exists', 'rename', (path, dest))
     try:
-        os.symlink(path, dest)
+        os.symlink(syspath(path), syspath(dest))
     except NotImplementedError:
         # raised on python >= 3.2 and Windows versions before Vista
         raise FilesystemError(u'OS does not support symbolic links.'
@@ -504,16 +503,15 @@ def link(path, dest, replace=False):
 def hardlink(path, dest, replace=False):
     """Create a hard link from path to `dest`. Raises an OSError if
     `dest` already exists, unless `replace` is True. Does nothing if
-    `path` == `dest`."""
-    if (samefile(path, dest)):
+    `path` == `dest`.
+    """
+    if samefile(path, dest):
         return
 
-    path = syspath(path)
-    dest = syspath(dest)
-    if os.path.exists(dest) and not replace:
+    if os.path.exists(syspath(dest)) and not replace:
         raise FilesystemError(u'file exists', 'rename', (path, dest))
     try:
-        os.link(path, dest)
+        os.link(syspath(path), syspath(dest))
     except NotImplementedError:
         raise FilesystemError(u'OS does not support hard links.'
                               'link', (path, dest), traceback.format_exc())

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -514,14 +514,9 @@ def hardlink(path, dest, replace=False):
     try:
         os.link(path, dest)
     except NotImplementedError:
-        # raised on python >= 3.2 and Windows versions before Vista
         raise FilesystemError(u'OS does not support hard links.'
                               'link', (path, dest), traceback.format_exc())
     except OSError as exc:
-        # TODO: Windows version checks can be removed for python 3
-        if hasattr('sys', 'getwindowsversion'):
-            if sys.getwindowsversion()[0] < 6:  # is before Vista
-                exc = u'OS does not support hard links.'
         raise FilesystemError(exc, 'link', (path, dest),
                               traceback.format_exc())
 

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -18,6 +18,7 @@
 from __future__ import division, absolute_import, print_function
 import os
 import sys
+import errno
 import locale
 import re
 import shutil
@@ -517,8 +518,12 @@ def hardlink(path, dest, replace=False):
         raise FilesystemError(u'OS does not support hard links.'
                               'link', (path, dest), traceback.format_exc())
     except OSError as exc:
-        raise FilesystemError(exc, 'link', (path, dest),
-                              traceback.format_exc())
+        if exc.errno == errno.EXDEV:
+            raise FilesystemError(u'Cannot hard link across devices.'
+                                  'link', (path, dest), traceback.format_exc())
+        else:
+            raise FilesystemError(exc, 'link', (path, dest),
+                                  traceback.format_exc())
 
 
 def unique_path(path):

--- a/beetsplug/importadded.py
+++ b/beetsplug/importadded.py
@@ -36,6 +36,7 @@ class ImportAddedPlugin(BeetsPlugin):
         register('before_item_moved', self.record_import_mtime)
         register('item_copied', self.record_import_mtime)
         register('item_linked', self.record_import_mtime)
+        register('item_hardlinked', self.record_import_mtime)
         register('album_imported', self.update_album_times)
         register('item_imported', self.update_item_times)
         register('after_write', self.update_after_write_time)
@@ -51,7 +52,7 @@ class ImportAddedPlugin(BeetsPlugin):
 
     def record_if_inplace(self, task, session):
         if not (session.config['copy'] or session.config['move'] or
-                session.config['link']):
+                session.config['link'] or session.config['hardlink']):
             self._log.debug(u"In place import detected, recording mtimes from "
                             u"source paths")
             items = [task.item] \

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -161,6 +161,10 @@ The events currently available are:
   for a file.
   Parameters: ``item``, ``source`` path, ``destination`` path
 
+* `item_hardlinked`: called with an ``Item`` object whenever a hardlink is
+  created for a file.
+  Parameters: ``item``, ``source`` path, ``destination`` path
+
 * `item_removed`: called with an ``Item`` object every time an item (singleton
   or album's part) is removed from the library (even when its file is not
   deleted from disk).

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -433,10 +433,25 @@ link
 ~~~~
 
 Either ``yes`` or ``no``, indicating whether to use symbolic links instead of
-moving or copying files. (It conflicts with the ``move`` and ``copy``
-options.) Defaults to ``no``.
+moving or copying files. (It conflicts with the ``move``, ``copy`` and
+``hardlink`` options.) Defaults to ``no``.
 
 This option only works on platforms that support symbolic links: i.e., Unixes.
+It will fail on Windows.
+
+It's likely that you'll also want to set ``write`` to ``no`` if you use this
+option to preserve the metadata on the linked files.
+
+.. _hardlink:
+
+hardlink
+~~~~
+
+Either ``yes`` or ``no``, indicating whether to use hard links instead of
+moving or copying or symlinking files. (It conflicts with the ``move``,
+``copy``, and ``link`` options.) Defaults to ``no``.
+
+This option only works on platforms that support hardlinks: i.e., Unixes.
 It will fail on Windows.
 
 It's likely that you'll also want to set ``write`` to ``no`` if you use this

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -445,7 +445,7 @@ option to preserve the metadata on the linked files.
 .. _hardlink:
 
 hardlink
-~~~~
+~~~~~~~~
 
 Either ``yes`` or ``no``, indicating whether to use hard links instead of
 moving or copying or symlinking files. (It conflicts with the ``move``,

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -451,11 +451,9 @@ Either ``yes`` or ``no``, indicating whether to use hard links instead of
 moving or copying or symlinking files. (It conflicts with the ``move``,
 ``copy``, and ``link`` options.) Defaults to ``no``.
 
-This option only works on platforms that support hardlinks: i.e., Unixes.
-It will fail on Windows.
-
-It's likely that you'll also want to set ``write`` to ``no`` if you use this
-option to preserve the metadata on the linked files.
+As with symbolic links (see :ref:`link`, above), this will not work on Windows
+and you will want to set ``write`` to ``no``.  Otherwise meatadata on the
+original file will be modified.
 
 resume
 ~~~~~~

--- a/test/_common.py
+++ b/test/_common.py
@@ -54,6 +54,7 @@ _item_ident = 0
 
 # OS feature test.
 HAVE_SYMLINK = sys.platform != 'win32'
+HAVE_HARDLINK = sys.platform != 'win32'
 
 
 def item(lib=None):

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -148,8 +148,8 @@ class MoveTest(_common.TestCase):
         s1 = os.stat(self.path)
         s2 = os.stat(self.dest)
         self.assertTrue(
-            (s1[stat.ST_INO], s1[stat.ST_DEV]) == \
-                (s2[stat.ST_INO], s2[stat.ST_DEV])
+            (s1[stat.ST_INO], s1[stat.ST_DEV]) ==
+            (s2[stat.ST_INO], s2[stat.ST_DEV])
         )
 
     @unittest.skipUnless(_common.HAVE_HARDLINK, "need hardlinks")

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -145,8 +145,12 @@ class MoveTest(_common.TestCase):
     def test_hardlink_arrives(self):
         self.i.move(hardlink=True)
         self.assertExists(self.dest)
-        self.assertTrue(os.path.islink(self.dest))
-        self.assertEqual(os.readlink(self.dest), self.path)
+        s1 = os.stat(self.path)
+        s2 = os.stat(self.dest)
+        self.assertTrue(
+            (s1[stat.ST_INO], s1[stat.ST_DEV]) == \
+                (s2[stat.ST_INO], s2[stat.ST_DEV])
+        )
 
     @unittest.skipUnless(_common.HAVE_HARDLINK, "need hardlinks")
     def test_hardlink_does_not_depart(self):

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -141,6 +141,23 @@ class MoveTest(_common.TestCase):
         self.i.move(link=True)
         self.assertEqual(self.i.path, util.normpath(self.dest))
 
+    @unittest.skipUnless(_common.HAVE_HARDLINK, "need hardlinks")
+    def test_hardlink_arrives(self):
+        self.i.move(hardlink=True)
+        self.assertExists(self.dest)
+        self.assertTrue(os.path.islink(self.dest))
+        self.assertEqual(os.readlink(self.dest), self.path)
+
+    @unittest.skipUnless(_common.HAVE_HARDLINK, "need hardlinks")
+    def test_hardlink_does_not_depart(self):
+        self.i.move(hardlink=True)
+        self.assertExists(self.path)
+
+    @unittest.skipUnless(_common.HAVE_HARDLINK, "need hardlinks")
+    def test_hardlink_changes_path(self):
+        self.i.move(hardlink=True)
+        self.assertEqual(self.i.path, util.normpath(self.dest))
+
 
 class HelperTest(_common.TestCase):
     def test_ancestry_works_on_file(self):

--- a/test/test_importadded.py
+++ b/test/test_importadded.py
@@ -93,6 +93,7 @@ class ImportAddedTest(unittest.TestCase, ImportHelper):
         self.config['import']['copy'] = False
         self.config['import']['move'] = False
         self.config['import']['link'] = False
+        self.config['import']['hardlink'] = False
         self.assertAlbumImport()
 
     def test_import_album_with_preserved_mtimes(self):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -22,6 +22,7 @@ import re
 import shutil
 import unicodedata
 import sys
+import stat
 from six import StringIO
 from tempfile import mkstemp
 from zipfile import ZipFile
@@ -209,7 +210,8 @@ class ImportHelper(TestHelper):
 
     def _setup_import_session(self, import_dir=None, delete=False,
                               threaded=False, copy=True, singletons=False,
-                              move=False, autotag=True, link=False):
+                              move=False, autotag=True, link=False,
+                              hardlink=False):
         config['import']['copy'] = copy
         config['import']['delete'] = delete
         config['import']['timid'] = True
@@ -219,6 +221,7 @@ class ImportHelper(TestHelper):
         config['import']['autotag'] = autotag
         config['import']['resume'] = False
         config['import']['link'] = link
+        config['import']['hardlink'] = hardlink
 
         self.importer = TestImportSession(
             self.lib, loghandler=None, query=None,
@@ -351,6 +354,24 @@ class NonAutotaggedImportTest(_common.TestCase, ImportHelper):
             self.assert_equal_path(
                 util.bytestring_path(os.readlink(filename)),
                 mediafile.path
+            )
+
+    @unittest.skipUnless(_common.HAVE_HARDLINK, "need hardlinks")
+    def test_import_hardlink_arrives(self):
+        config['import']['hardlink'] = True
+        self.importer.run()
+        for mediafile in self.import_media:
+            filename = os.path.join(
+                self.libdir,
+                b'Tag Artist', b'Tag Album',
+                util.bytestring_path('{0}.mp3'.format(mediafile.title))
+            )
+            self.assertExists(filename)
+            s1 = os.stat(mediafile.path)
+            s2 = os.stat(filename)
+            self.assertTrue(
+                (s1[stat.ST_INO], s1[stat.ST_DEV]) == \
+                    (s2[stat.ST_INO], s2[stat.ST_DEV])
             )
 
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -370,8 +370,8 @@ class NonAutotaggedImportTest(_common.TestCase, ImportHelper):
             s1 = os.stat(mediafile.path)
             s2 = os.stat(filename)
             self.assertTrue(
-                (s1[stat.ST_INO], s1[stat.ST_DEV]) == \
-                    (s2[stat.ST_INO], s2[stat.ST_DEV])
+                (s1[stat.ST_INO], s1[stat.ST_DEV]) ==
+                (s2[stat.ST_INO], s2[stat.ST_DEV])
             )
 
 

--- a/test/test_mediafile_edge.py
+++ b/test/test_mediafile_edge.py
@@ -197,6 +197,15 @@ class SafetyTest(unittest.TestCase, _common.TempDirMixin):
         finally:
             os.unlink(fn)
 
+    @unittest.skipUnless(_common.HAVE_HARDLINK, u'platform lacks hardlink')
+    def test_broken_hardlink(self):
+        fn = os.path.join(_common.RSRC, b'brokenlink')
+        os.link('does_not_exist', fn)
+        try:
+            self.assertRaises(mediafile.UnreadableFileError,
+                              mediafile.MediaFile, fn)
+        finally:
+            os.unlink(fn)
 
 class SideEffectsTest(unittest.TestCase):
     def setUp(self):

--- a/test/test_mediafile_edge.py
+++ b/test/test_mediafile_edge.py
@@ -197,16 +197,6 @@ class SafetyTest(unittest.TestCase, _common.TempDirMixin):
         finally:
             os.unlink(fn)
 
-    @unittest.skipUnless(_common.HAVE_HARDLINK, u'platform lacks hardlink')
-    def test_broken_hardlink(self):
-        fn = os.path.join(_common.RSRC, b'brokenlink')
-        os.link('does_not_exist', fn)
-        try:
-            self.assertRaises(mediafile.UnreadableFileError,
-                              mediafile.MediaFile, fn)
-        finally:
-            os.unlink(fn)
-
 class SideEffectsTest(unittest.TestCase):
     def setUp(self):
         self.empty = os.path.join(_common.RSRC, b'empty.mp3')

--- a/test/test_mediafile_edge.py
+++ b/test/test_mediafile_edge.py
@@ -197,6 +197,7 @@ class SafetyTest(unittest.TestCase, _common.TempDirMixin):
         finally:
             os.unlink(fn)
 
+
 class SideEffectsTest(unittest.TestCase):
     def setUp(self):
         self.empty = os.path.join(_common.RSRC, b'empty.mp3')


### PR DESCRIPTION
This PR adds an option to hardlink files when importing, similar to the existing `link` option that enables symlinks.  Tests in the same style as the symlink tests are included.

```yaml
import:
    write: no
    hardlink: yes
```