### PR TITLE
discogs: support simple auth.

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -54,9 +54,11 @@ class DiscogsPlugin(BeetsPlugin):
             'apisecret': 'plxtUTqoCzwxZpqdPysCwGuBSmZNdZVy',
             'tokenfile': 'discogs_token.json',
             'source_weight': 0.5,
+            'user_token': None,
         })
         self.config['apikey'].redact = True
         self.config['apisecret'].redact = True
+        self.config['user_token'].redact = True
         self.discogs_client = None
         self.register_listener('import_begin', self.setup)
 
@@ -65,6 +67,12 @@ class DiscogsPlugin(BeetsPlugin):
         """
         c_key = self.config['apikey'].as_str()
         c_secret = self.config['apisecret'].as_str()
+
+        user_token = self.config['user_token'].as_str()
+
+        if user_token is not None and user_token != '':
+            self.discogs_client = Client(USER_AGENT, user_token=user_token)
+            return
 
         # Get the OAuth token from a file or log in.
         try:

--- a/docs/plugins/discogs.rst
+++ b/docs/plugins/discogs.rst
@@ -14,16 +14,30 @@ To use the ``discogs`` plugin, first enable it in your configuration (see
 
     pip install discogs-client
 
-You will also need to register for a `Discogs`_ account. The first time you
-run the :ref:`import-cmd` command after enabling the plugin, it will ask you
-to authorize with Discogs by visiting the site in a browser. Subsequent runs
-will not require re-authorization.
+You will also need to register for a `Discogs`_ account, and provide
+authentication credentials via a personal access token or an OAuth2
+authorization.
 
 Matches from Discogs will now show up during import alongside matches from
 MusicBrainz.
 
 If you have a Discogs ID for an album you want to tag, you can also enter it
 at the "enter Id" prompt in the importer.
+
+OAuth authorization
+```````````````````
+The first time you run the :ref:`import-cmd` command after enabling the plugin,
+it will ask you to authorize with Discogs by visiting the site in a browser.
+Subsequent runs will not require re-authorization.
+
+Authentication via personal access token
+````````````````````````````````````````
+To get a personal access token (called a user token in the `discogs-client`_
+documentation), login to `Discogs`_, and visit the
+`Developer settings page
+<https://www.discogs.com/settings/developers>`_. Press the ``Generate new
+token`` button, and place the generated token in your configuration, as the
+``user_token`` config option in the ``discogs`` section.
 
 Troubleshooting
 ---------------


### PR DESCRIPTION
The official OAuth authentication seems to have broken, so allow usage
of simple configuration instead.

See-Also: https://github.com/discogs/discogs_client/issues/78
Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>