### PR TITLE
chg: dev: add main module.

### DIFF
--- a/beets/__main__.py
+++ b/beets/__main__.py
@@ -1,4 +1,5 @@
 """main module."""
+# -*- coding: utf-8 -*-
 import sys
 from .ui import main
 

--- a/beets/__main__.py
+++ b/beets/__main__.py
@@ -1,0 +1,6 @@
+"""main module."""
+import sys
+from .ui import main
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/beets/__main__.py
+++ b/beets/__main__.py
@@ -1,5 +1,31 @@
-"""main module."""
 # -*- coding: utf-8 -*-
+"""main module.
+
+This module will be executed when beets module is run with `-m`.
+
+Example : `python -m beets`
+
+Related links about __main__.py:
+
+* python3 docs entry: https://docs.python.org/3/library/__main__.html
+* related SO: http://stackoverflow.com/q/4042905
+"""
+# This file is part of beets.
+# Copyright 2017, Adrian Sampson.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+from __future__ import division, absolute_import, print_function
+
 import sys
 from .ui import main
 

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -946,16 +946,6 @@ class SubcommandsOptionParser(CommonOptionsParser):
 
         self.subcommands = []
 
-    def get_prog_name(self):
-        """Get program name.
-
-        Returns:
-            Program name.
-        """
-        prog_name = super(SubcommandsOptionParser, self).get_prog_name()
-        prog_name = 'beets' if prog_name == '__main__.py' else prog_name
-        return prog_name
-
     def add_subcommand(self, *cmds):
         """Adds a Subcommand object to the parser's list of commands.
         """

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -946,6 +946,16 @@ class SubcommandsOptionParser(CommonOptionsParser):
 
         self.subcommands = []
 
+    def get_prog_name(self):
+        """Get program name.
+
+        Returns:
+            Program name.
+        """
+        prog_name = super(SubcommandsOptionParser, self).get_prog_name()
+        prog_name = 'beets' if prog_name == '__main__.py' else prog_name
+        return prog_name
+
     def add_subcommand(self, *cmds):
         """Adds a Subcommand object to the parser's list of commands.
         """

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,7 @@ New features:
 * A new :ref:`hardlink` config option instructs the importer to create hard
   links on filesystems that support them. Thanks to :user:`jacobwgillespie`.
   :bug:`2445`
+* Added support to run program from module, e.g. `python -m beets`.
 
 Fixes:
 


### PR DESCRIPTION
add main file for module. with this program can be run from module. e.g. `python -m beets`. but this require fix on `SubcommandOption`, because it will print `__main__.py` instead of program name. so i add another method to inherit parent class and add exception for that word.

i don't know how to test this with unittest, but if threre is introduction for testing this program, that would be helpful and i will add another commit for test.

python version: Python 3.5.2+ 

Distributor ID: Ubuntu
Description:    Ubuntu 16.10
Release:        16.10
Codename:       yakkety
