### PR TITLE
mbsubmit plugin : numeric sort in print_tracks (for >=10 track releases)

### DIFF
--- a/beetsplug/mbsubmit.py
+++ b/beetsplug/mbsubmit.py
@@ -56,5 +56,5 @@ class MBSubmitPlugin(BeetsPlugin):
             return [PromptChoice(u'p', u'Print tracks', self.print_tracks)]
 
     def print_tracks(self, session, task):
-        for i in task.items:
+        for i in sorted(task.items, key=lambda i: i.track):
             print_data(None, i, self.config['format'].as_str())


### PR DESCRIPTION
As it says on the tin, single line change to mbsync so that tracklists end up sorted. This is important because track order is different from track number in musicbrainz, so an incorrectly sorted list is semantically meaningful to the musicbrainz track parser.

Before, running on https://musicbrainz.org/release/3b4a35f9-6a8d-4715-a8bf-f30e8e2b0f0a :

```
16. True to Yourself - John Barera (6:44)
02. Triple Treat - Brame & Hamo (5:33)
10. Inch of Light - Downtown Party Network (7:05)
05. That Same Thing - Loz Goddard (6:02)
01. The Schrew - Laurence Guy & Harry Wolfman (7:56)
06. Pleister - Homework (5:07)
09. Dizzy Talks - Kito Jempere (5:52)
11. Tieflicht - Kyodai (8:16)
14. Maybe One Day We Can Be Friends - Edit Murphy (5:00)
08. Let Me Show You the City - Ponty Mython (5:46)
03. Catch Up - Nachtbraker (5:05)
12. Truth - Rhythm Operator (5:56)
15. Lies - Schmutz (7:14)
04. Mirror Makers - Soul of Hex (6:14)
07. The Long Way Home - Voyeur (6:44)
13. See Me Now - Waifs & Strays vs. PBR Streetgang (6:58)
```

After : 

```
01. The Schrew - Laurence Guy & Harry Wolfman (7:56)
02. Triple Treat - Brame & Hamo (5:33)
03. Catch Up - Nachtbraker (5:05)
04. Mirror Makers - Soul of Hex (6:14)
05. That Same Thing - Loz Goddard (6:02)
06. Pleister - Homework (5:07)
07. The Long Way Home - Voyeur (6:44)
08. Let Me Show You the City - Ponty Mython (5:46)
09. Dizzy Talks - Kito Jempere (5:52)
10. Inch of Light - Downtown Party Network (7:05)
11. Tieflicht - Kyodai (8:16)
12. Truth - Rhythm Operator (5:56)
13. See Me Now - Waifs & Strays vs. PBR Streetgang (6:58)
14. Maybe One Day We Can Be Friends - Edit Murphy (5:00)
15. Lies - Schmutz (7:14)
16. True to Yourself - John Barera (6:44)
```