### PR TITLE
smartplaylist: Support overlapping playlist defs

### DIFF
--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -172,6 +172,9 @@ class SmartPlaylistPlugin(BeetsPlugin):
         if relative_to:
             relative_to = normpath(relative_to)
 
+        # Maps playlist filenames to lists of track filenames.
+        m3us = {}
+
         for playlist in self._matched_playlists:
             name, (query, q_sort), (album_query, a_q_sort) = playlist
             self._log.debug(u"Creating playlist {0}", name)
@@ -183,7 +186,6 @@ class SmartPlaylistPlugin(BeetsPlugin):
                 for album in lib.albums(album_query, a_q_sort):
                     items.extend(album.items())
 
-            m3us = {}
             # As we allow tags in the m3u names, we'll need to iterate through
             # the items and generate the correct m3u file names.
             for item in items:
@@ -196,13 +198,14 @@ class SmartPlaylistPlugin(BeetsPlugin):
                     item_path = os.path.relpath(item.path, relative_to)
                 if item_path not in m3us[m3u_name]:
                     m3us[m3u_name].append(item_path)
-            # Now iterate through the m3us that we need to generate
-            for m3u in m3us:
-                m3u_path = normpath(os.path.join(playlist_dir,
-                                    bytestring_path(m3u)))
-                mkdirall(m3u_path)
-                with open(syspath(m3u_path), 'wb') as f:
-                    for path in m3us[m3u]:
-                        f.write(path + b'\n')
+
+        # Write all of the accumulated track lists to files.
+        for m3u in m3us:
+            m3u_path = normpath(os.path.join(playlist_dir,
+                                bytestring_path(m3u)))
+            mkdirall(m3u_path)
+            with open(syspath(m3u_path), 'wb') as f:
+                for path in m3us[m3u]:
+                    f.write(path + b'\n')
 
         self._log.info(u"{0} playlists updated", len(self._matched_playlists))


### PR DESCRIPTION
The idea is to let different smart playlist definitions add songs to the same concrete playlist. See http://discourse.beets.io/t/beets-path-handling-for-delimited-fields/44 for discussion.