### PR TITLE
Add kodinfo plugin

### DIFF
--- a/beetsplug/kodinfo.py
+++ b/beetsplug/kodinfo.py
@@ -30,7 +30,7 @@ class KodiNfo(BeetsPlugin):
         self.register_listener('album_imported', self.makeAlbumNfo)
         self.register_listener('item_imported', self.makeItemNfo)
 
-        def makeAlbumNfo(self, lib, album):
+    def makeAlbumNfo(self, lib, album):
         linkAlbum = 'https://musicbrainz.org/release/{0}'
         linkArtist = 'https://musicbrainz.org/artist/{0}'
         with open(album.path + '/album.nfo', 'w') as f:

--- a/beetsplug/kodinfo.py
+++ b/beetsplug/kodinfo.py
@@ -25,20 +25,20 @@ from beets import library
 
 
 class KodiNfo(BeetsPlugin):
-  def __init__(self):
-    super(KodiNfo, self).__init__()
-    self.register_listener('album_imported', self.makeAlbumNfo)
-    self.register_listener('item_imported', self.makeItemNfo)
+    def __init__(self):
+        super(KodiNfo, self).__init__()
+        self.register_listener('album_imported', self.makeAlbumNfo)
+        self.register_listener('item_imported', self.makeItemNfo)
 
-  def makeAlbumNfo(self, lib, album):
-    linkAlbum = 'https://musicbrainz.org/release/{0}'
-    linkArtist = 'https://musicbrainz.org/artist/{0}'
-    with open(album.path + '/album.nfo', 'w') as f:
-		f.write(linkAlbum.format(album.mb_albumid))
-    with open(album.path + '/../artist.nfo', 'w') as f:
-        f.write(linkArtist.format(album.mb_albumartistid))
+        def makeAlbumNfo(self, lib, album):
+        linkAlbum = 'https://musicbrainz.org/release/{0}'
+        linkArtist = 'https://musicbrainz.org/artist/{0}'
+        with open(album.path + '/album.nfo', 'w') as f:
+            f.write(linkAlbum.format(album.mb_albumid))
+        with open(album.path + '/../artist.nfo', 'w') as f:
+            f.write(linkArtist.format(album.mb_albumartistid))
 
-  def makeItemNfo(self, lib, item):
-    link = 'https://musicbrainz.org/recording/{0}'
-    with open(item.path + '/' + item.title + '.nfo/', 'w') as f:
-		f.write(link.format(item.mb_trackid))
+    def makeItemNfo(self, lib, item):
+        link = 'https://musicbrainz.org/recording/{0}'
+        with open(item.path + '/' + item.title + '.nfo/', 'w') as f:
+            f.write(link.format(item.mb_trackid))

--- a/beetsplug/kodinfo.py
+++ b/beetsplug/kodinfo.py
@@ -20,7 +20,8 @@ and other details.
 For singletons, it generates one .nfo for each track.
 """
 
-from beets.plugins import BeetsPlugin
+from beets.plugins import BeetsPlugin 
+
 
 class KodiNfo(BeetsPlugin):
     def __init__(self):

--- a/beetsplug/kodinfo.py
+++ b/beetsplug/kodinfo.py
@@ -1,4 +1,3 @@
-
 # -*- coding: utf-8 -*-
 # This file is part of beets.
 # Copyright 2017, Sergio Soto.
@@ -20,7 +19,14 @@ and other details.
 For singletons, it generates one .nfo for each track.
 """
 
+from __future__ import absolute_import, division, print_function
+
+import os
 from beets.plugins import BeetsPlugin
+
+LINK_ALBUM = 'https://musicbrainz.org/release/{0}'
+LINK_ARTIST = 'https://musicbrainz.org/artist/{0}'
+LINK_TRACK = 'https://musicbrainz.org/recording/{0}'
 
 
 class KodiNfo(BeetsPlugin):
@@ -30,14 +36,17 @@ class KodiNfo(BeetsPlugin):
         self.register_listener('item_imported', self.make_item_nfo)
 
     def make_album_nfo(self, lib, album):
-        linkalbum = 'https://musicbrainz.org/release/{0}'
-        linkartist = 'https://musicbrainz.org/artist/{0}'
-        with open(album.path + '/album.nfo', 'w') as f:
-            f.write(linkalbum.format(album.mb_albumid))
-        with open(album.path + '/../artist.nfo', 'w') as f:
-            f.write(linkartist.format(album.mb_albumartistid))
+        album_path = os.path.join(album.path, 'album.nfo')
+        artist_path = os.path.join(album.path, os.pardir, 'artist.nfo')
+        if not os.path.isfile(album_path):
+            with open(album_path, 'w') as f:
+                f.write(LINK_ALBUM.format(album.mb_albumid))
+        if not os.path.isfile(artist_path):
+            with open(artist_path, 'w') as f:
+                f.write(LINK_ARTIST.format(album.mb_albumartistid))
 
     def make_item_nfo(self, lib, item):
-        link = 'https://musicbrainz.org/recording/{0}'
-        with open(item.path + '/' + item.title + '.nfo/', 'w') as f:
-            f.write(link.format(item.mb_trackid))
+        track_file = item.title + '.nfo'
+        track_path = os.path.join(item.path, track_file)
+        with open(track_path, 'w') as f:
+            f.write(LINK_TRACK.format(item.mb_trackid))

--- a/beetsplug/kodinfo.py
+++ b/beetsplug/kodinfo.py
@@ -1,15 +1,44 @@
-from beets.plugins import BeetsPlugin
 
-from beets.autotag import mb
+# -*- coding: utf-8 -*-
+# This file is part of beets.
+# Copyright 2017, Sergio Soto.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""Genertes artist.nfo and album.nfo after the import process
+These are used by Kodi and other platforms to save the MBID
+and other details.
+For singletons, it generates one .nfo for each track.
+"""
+
+from beets.plugins import BeetsPlugin
+from beets import library
+
 
 class KodiNfo(BeetsPlugin):
   def __init__(self):
     super(KodiNfo, self).__init__()
     self.register_listener('album_imported', self.makeAlbumNfo)
+    self.register_listener('item_imported', self.makeItemNfo)
 
   def makeAlbumNfo(self, lib, album):
-    d = mb.match_album(album.albumartist, album.album, None)
-    b = (x for x in d ).next().album_id
-    file = open(album.path + "/album.nfo","w+")
-    file.write("https://musicbrainz.org/release/%s" % b)
-    file.close()
+    linkAlbum = 'https://musicbrainz.org/release/{0}'
+    linkArtist = 'https://musicbrainz.org/artist/{0}'
+    with open(album.path + '/album.nfo', 'w') as f:
+		f.write(linkAlbum.format(album.mb_albumid))
+    with open(album.path + '/../artist.nfo', 'w') as f:
+        f.write(linkArtist.format(album.mb_albumartistid))
+
+  def makeItemNfo(self, lib, item):
+    link = 'https://musicbrainz.org/recording/{0}'
+    with open(item.path + '/' + item.title + '.nfo/', 'w') as f:
+		f.write(link.format(item.mb_trackid))

--- a/beetsplug/kodinfo.py
+++ b/beetsplug/kodinfo.py
@@ -21,24 +21,22 @@ For singletons, it generates one .nfo for each track.
 """
 
 from beets.plugins import BeetsPlugin
-from beets import library
-
 
 class KodiNfo(BeetsPlugin):
     def __init__(self):
         super(KodiNfo, self).__init__()
-        self.register_listener('album_imported', self.makeAlbumNfo)
-        self.register_listener('item_imported', self.makeItemNfo)
+        self.register_listener('album_imported', self.make_album_nfo)
+        self.register_listener('item_imported', self.make_item_nfo)
 
-    def makeAlbumNfo(self, lib, album):
-        linkAlbum = 'https://musicbrainz.org/release/{0}'
-        linkArtist = 'https://musicbrainz.org/artist/{0}'
+    def make_album_nfo(self, lib, album):
+        linkalbum = 'https://musicbrainz.org/release/{0}'
+        linkartist = 'https://musicbrainz.org/artist/{0}'
         with open(album.path + '/album.nfo', 'w') as f:
-            f.write(linkAlbum.format(album.mb_albumid))
+            f.write(linkalbum.format(album.mb_albumid))
         with open(album.path + '/../artist.nfo', 'w') as f:
-            f.write(linkArtist.format(album.mb_albumartistid))
+            f.write(linkartist.format(album.mb_albumartistid))
 
-    def makeItemNfo(self, lib, item):
+    def make_item_nfo(self, lib, item):
         link = 'https://musicbrainz.org/recording/{0}'
         with open(item.path + '/' + item.title + '.nfo/', 'w') as f:
             f.write(link.format(item.mb_trackid))

--- a/beetsplug/kodinfo.py
+++ b/beetsplug/kodinfo.py
@@ -20,7 +20,7 @@ and other details.
 For singletons, it generates one .nfo for each track.
 """
 
-from beets.plugins import BeetsPlugin 
+from beets.plugins import BeetsPlugin
 
 
 class KodiNfo(BeetsPlugin):

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -564,11 +564,17 @@ class Google(Backend):
                  urllib.parse.quote(query.encode('utf-8')))
 
         data = self.fetch_url(url)
-        data = json.loads(data)
+        if not data:
+            self._log.debug(u'google backend returned no data')
+            return None
+        try:
+            data = json.loads(data)
+        except ValueError as exc:
+            self._log.debug(u'google backend returned malformed JSON: {}', exc)
         if 'error' in data:
             reason = data['error']['errors'][0]['reason']
-            self._log.debug(u'google lyrics backend error: {0}', reason)
-            return
+            self._log.debug(u'google backend error: {0}', reason)
+            return None
 
         if 'items' in data.keys():
             for item in data['items']:

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -150,6 +150,8 @@ Interoperability
 * :doc:`embyupdate`: Automatically notifies `Emby`_ whenever the beets library changes.
 * :doc:`importfeeds`: Keep track of imported files via ``.m3u`` playlist file(s) or symlinks.
 * :doc:`ipfs`: Import libraries from friends and get albums from them via ipfs.
+* :doc:`kodinfo`: Automatically generates .nfo files for albums and artists that `Kodi`_ can 
+  read whenever beets imports albums and tracks.
 * :doc:`kodiupdate`: Automatically notifies `Kodi`_ whenever the beets library
   changes.
 * :doc:`mpdupdate`: Automatically notifies `MPD`_ whenever the beets library

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -66,6 +66,7 @@ like this::
    inline
    ipfs
    keyfinder
+   kodinfo
    kodiupdate
    lastgenre
    lastimport

--- a/docs/plugins/kodinfo.rst
+++ b/docs/plugins/kodinfo.rst
@@ -1,0 +1,31 @@
+KodiUpdate Plugin
+=================
+
+The ``kodinfo`` plugin lets you automatically generate .nfo `files`_ used by `KODI`_ 
+and other similar media servers like `Plex`_ whenever you import albums and tracks your beets library.
+
+To use the ``kodinfo`` plugin, enable it in your configuration
+(see :ref:`using-plugins`).
+
+Once enabled, the plugin will generate the artist.nfo file under the album artist's 
+folder, and one album.nfo for each imported album inside its corresponding folder. These 
+files will then be loaded by Kodi automatically when it attempts to get metadata for these tracks. 
+For singletons, ``kodinfo`` will generate an individual .nfo file with the name of the track for each 
+file. 
+
+.. _files: http://kodi.wiki/view/NFO_files/music
+.. _KODI: http://kodi.tv/
+.. _Plex: https://www.plex.tv
+.. _requests: http://docs.python-requests.org/en/latest/
+
+Configuration
+-------------
+
+The ``kodi:`` section has no configurable options.
+
+
+A note on folder structure configuration
+----------------------------------------
+
+``kodinfo`` will only work for configurations where the artist path is the direct parent of the album 
+paths. 

--- a/docs/plugins/kodinfo.rst
+++ b/docs/plugins/kodinfo.rst
@@ -1,4 +1,4 @@
-KodiUpdate Plugin
+KodiNfo Plugin
 =================
 
 The ``kodinfo`` plugin lets you automatically generate .nfo `files`_ used by `KODI`_ 

--- a/docs/plugins/kodinfo.rst
+++ b/docs/plugins/kodinfo.rst
@@ -13,19 +13,11 @@ files will then be loaded by Kodi automatically when it attempts to get metadata
 For singletons, ``kodinfo`` will generate an individual .nfo file with the name of the track for each 
 file. 
 
+``kodinfo`` will only work for configurations where the artist path is the direct parent of the 
+folder where the albums are located. This is because beets doesn't keep track of where the artist folders 
+are, so the plugin assumes they are located a level above from the albums. 
+
 .. _files: http://kodi.wiki/view/NFO_files/music
 .. _KODI: http://kodi.tv/
 .. _Plex: https://www.plex.tv
 .. _requests: http://docs.python-requests.org/en/latest/
-
-Configuration
--------------
-
-The ``kodi:`` section has no configurable options.
-
-
-A note on folder structure configuration
-----------------------------------------
-
-``kodinfo`` will only work for configurations where the artist path is the direct parent of the album 
-paths. 


### PR DESCRIPTION
Here's the plugin to generate the .nfo files for kodi. It generates one per album imported and one for the artist. It generates one for each singleton as well, although I didn't find support for this anywhere in the Kodi wiki, but perhaps for Plex and other systems.
Is there anything else I need to add like documentation, style guide, add test cases or anything similar to it?
@sampsyo, please let me know your comments! :squirrel: 