### PR TITLE
Add ability for 'missing' plugin to show missing albums by library artists

### DIFF
--- a/beetsplug/missing.py
+++ b/beetsplug/missing.py
@@ -159,12 +159,16 @@ class MissingPlugin(BeetsPlugin):
         """Print a listing of albums missing from each artist in the library
         matching query.
         """
+        total = self.config['total'].get()
+
         albums = lib.albums(query)
         # build dict mapping artist to list of their albums in library
         albums_by_artist = defaultdict(list)
         for alb in albums:
             artist = (alb['albumartist'], alb['mb_albumartistid'])
             albums_by_artist[artist].append(alb)
+
+        total_missing = 0
 
         # build dict mapping artist to list of all albums
         for artist, albums in albums_by_artist.items():
@@ -196,10 +200,17 @@ class MissingPlugin(BeetsPlugin):
                         present.append(rg)
                         break
 
+            total_missing += len(missing)
+            if total:
+                continue
+
             missing_titles = {rg['title'] for rg in missing}
 
             for release_title in missing_titles:
                 print_(u"{} - {}".format(artist[0], release_title))
+
+        if total:
+            print(total_missing)
 
     def _missing(self, album):
         """Query MusicBrainz to determine items missing from `album`.

--- a/docs/plugins/missing.rst
+++ b/docs/plugins/missing.rst
@@ -11,7 +11,8 @@ Usage
 
 Add the ``missing`` plugin to your configuration (see :ref:`using-plugins`).
 By default, the ``beet missing`` command lists the names of tracks that your
-library is missing from each album.
+library is missing from each album. It can also list the names of albums that
+your library is missing from each artist.
 You can customize the output format, count
 the number of missing tracks per album, or total up the number of missing
 tracks over your whole library, using command-line switches::
@@ -20,8 +21,11 @@ tracks over your whole library, using command-line switches::
                             print with custom FORMAT
       -c, --count           count missing tracks per album
       -t, --total           count total of missing tracks
+      -a, --album           show missing albums for artist instead of tracks
 
 …or by editing corresponding options.
+
+Note that ``-c`` is ignored when used with ``-a``.
 
 Configuration
 -------------
@@ -59,6 +63,10 @@ Examples
 List all missing tracks in your collection::
 
   beet missing
+
+List all missing albums in your collection::
+
+  beet missing -a
 
 List all missing tracks from 2008::
 

--- a/docs/plugins/missing.rst
+++ b/docs/plugins/missing.rst
@@ -20,7 +20,7 @@ tracks over your whole library, using command-line switches::
       -f FORMAT, --format=FORMAT
                             print with custom FORMAT
       -c, --count           count missing tracks per album
-      -t, --total           count total of missing tracks
+      -t, --total           count total of missing tracks or albums
       -a, --album           show missing albums for artist instead of tracks
 
 …or by editing corresponding options.


### PR DESCRIPTION
Passing the `-a` flag shows, for each artist in the library, the albums by that artist which are not in the library.

Also includes a minor enhancement to allow `beets.ui.print_` to print to `stderr`.

Example output (truncated):

```
(venv) user@host ~/d/p/beets> beet missing -a
Theorem - Fallout
Theorem - Shift
Theorem - Day From Hell
Theorem - Mantra One
Theorem - Embed
Theorem - Cinder
Theorem - [untitled]
Theorem - Nano
Theorem - Recoil
Theorem - Break in at Apartment 205
Theorem - Intervals
Theorem - THX: Experiments in Synchronicity
Tinariwen - Amassakoul
Tinariwen - Aman Iman : L'eau c'est la vie
Tinariwen - Aman Iman: Water Is Life
Tinariwen - The Radio Tisdas Sessions
Tinariwen - Imidiwan: Companions
Tinariwen - Tassili
[!] No musicbrainz ID for artist she, skipping.
Carbon Based Lifeforms - Irdial
Carbon Based Lifeforms - The Path
Carbon Based Lifeforms - ALT:01
Carbon Based Lifeforms - Photosynthesis Remixes
Carbon Based Lifeforms - Twentythree
Carbon Based Lifeforms - Refuge: Original Motion Picture Soundtrack
Carbon Based Lifeforms - MOS 6581 Remixes
Carbon Based Lifeforms - Hydroponic Garden
Carbon Based Lifeforms - VLA
Carbon Based Lifeforms - Interloper
...
```