### PR TITLE
Change default aac encoder to FFmpeg's native one

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -109,8 +109,8 @@ class ConvertPlugin(BeetsPlugin):
             u'format': u'mp3',
             u'formats': {
                 u'aac': {
-                    u'command': u'ffmpeg -i $source -y -vn -acodec libfaac '
-                                u'-aq 100 $dest',
+                    u'command': u'ffmpeg -i $source -y -vn -acodec aac '
+                                u'-aq 1 $dest',
                     u'extension': u'm4a',
                 },
                 u'alac': {


### PR DESCRIPTION
FFmpeg's native aac encoder was declared stable in 3.0 (Feb 15. 2016).
Support for libfaac was removed some time later:
http://git.videolan.org/?p=ffmpeg.git;a=commit;h=dc0f711459e0c682bf9f94ba38d26736e90cff45