### PR TITLE
Allow to transcode a file on-the-fly and download it from the web ui

### DIFF
--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -279,13 +279,13 @@ def item_converted_file(item_id):
                 u' '.join(ui.decargs(args)), exc
             )
         )
-    attachment_filename = os.path.basename(util.py3_path(item.path))
-    attachment_filename = attachment_filename[:attachment_filename.rfind('.')] + extension
+    attach_filename = os.path.basename(util.py3_path(item.path))
+    attach_filename = attach_filename[:attach_filename.rfind('.')] + extension
 
     response = flask.send_file(
         util.py3_path(dest),
         as_attachment=True,
-        attachment_filename=attachment_filename,
+        attachment_filename=attach_filename,
     )
     response.headers['Content-Length'] = os.path.getsize(dest)
     return response
@@ -430,9 +430,11 @@ class WebPlugin(BeetsPlugin):
 
             app.config['INCLUDE_PATHS'] = self.config['include_paths']
             if 'convert_extension' in self.config:
-                app.config['convert_extension'] = self.config['convert_extension'].as_str()
+                app.config['convert_extension'] = \
+                    self.config['convert_extension'].as_str()
             if 'convert_command' in self.config:
-                app.config['convert_command'] = self.config['convert_command'].as_str()
+                app.config['convert_command'] = \
+                    self.config['convert_command'].as_str()
 
             # Enable CORS if required.
             if self.config['cors']:

--- a/beetsplug/web/static/beets.js
+++ b/beetsplug/web/static/beets.js
@@ -12,6 +12,8 @@ var timeFormat = function(secs) {
     return mins + ':' + secs;
 }
 
+var config = {};
+
 // jQuery extension encapsulating event hookups for audio element controls.
 $.fn.player = function(debug) {
     // Selected element should contain an HTML5 Audio element.
@@ -240,6 +242,11 @@ var AppView = Backbone.View.extend({
             'play': _.bind(this.audioPlay, this),
             'pause': _.bind(this.audioPause, this),
             'ended': _.bind(this.audioEnded, this)
+        });
+        $.getJSON('config', function(data) {
+            config = data;
+        }).fail(function() {
+            config = {};
         });
     },
     showItems: function(items) {

--- a/beetsplug/web/templates/index.html
+++ b/beetsplug/web/templates/index.html
@@ -84,6 +84,11 @@
                 <dd>
                     <a target="_blank" class="download" href="item/<%= id %>/file">download</a>
                 </dd>
+                <% if (config.convert_extension && format != config.convert_extension.toUpperCase() ) { %>
+                <dd>
+                    <a target="_blank" class="download" href="item/<%= id %>/converted_file">convert and download as <%= config.convert_extension %></a>
+                </dd>
+                <% } %>
                 <% if (lyrics) { %>
                     <dt>Lyrics</dt>
                     <dd class="lyrics"><%= lyrics %></dd>


### PR DESCRIPTION
This commit adds two config options to the web plugin:
convert_extension and convert_command.

When convert_extension is defined (for example, as 'mp3'), a new
option "convert and download as mp3" is shown next to the download link
for files that are not already in mp3 format.

This also adds a config global variable to the javascript code, which
is filled with data obtained from the new /config route, which returns
configuration values useful in the UI (so far, only convert_extension).

The code to convert music to another format was mainly copied
from the convert plugin, and put in a new /item/<item_id>/converted_file
route. The convert command used by default is the same as in the convert
plugin too, but can be configured with the convert_command option.

To enable this, just define in the configuration:
```
web:
    convert_extension: mp3
```
And search for any non-mp3 file in the web plugin.