### PR TITLE
Fix import of multidisc releases with subdirectories

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -1473,10 +1473,8 @@ def is_subdir_of_any_in_list(path, dirs):
     """Returns True if path os a subdirectory of any directory in dirs
     (a list). In other case, returns False.
     """
-    for d in dirs:
-        if path.startswith(d + b'/'):
-            return True
-    return False
+    ancestors = ancestry(path)
+    return any(d in ancestors for d in dirs)
 
 
 def albums_in_dir(path):
@@ -1498,10 +1496,9 @@ def albums_in_dir(path):
         # and add the current directory. If so, just add the directory
         # and move on to the next directory. If not, stop collapsing.
         if collapse_paths:
-            if (not collapse_pat and collapse_paths[0] in ancestry(root)) or \
+            if (is_subdir_of_any_in_list(root, collapse_paths)) or \
                     (collapse_pat and
-                     collapse_pat.match(os.path.basename(root))) or \
-                    is_subdir_of_any_in_list(root, collapse_paths):
+                     collapse_pat.match(os.path.basename(root))):
                 # Still collapsing.
                 collapse_paths.append(root)
                 collapse_items += items

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -1469,6 +1469,16 @@ MULTIDISC_MARKERS = (br'dis[ck]', br'cd')
 MULTIDISC_PAT_FMT = br'^(.*%s[\W_]*)\d'
 
 
+def is_subdir_of_any_in_list(path, dirs):
+    """Returns True if path os a subdirectory of any directory in dirs
+    (a list). In other case, returns False.
+    """
+    for d in dirs:
+        if path.startswith(d + b'/'):
+            return True
+    return False
+
+
 def albums_in_dir(path):
     """Recursively searches the given directory and returns an iterable
     of (paths, items) where paths is a list of directories and items is
@@ -1490,7 +1500,8 @@ def albums_in_dir(path):
         if collapse_paths:
             if (not collapse_pat and collapse_paths[0] in ancestry(root)) or \
                     (collapse_pat and
-                     collapse_pat.match(os.path.basename(root))):
+                     collapse_pat.match(os.path.basename(root))) or \
+                    is_subdir_of_any_in_list(root, collapse_paths):
                 # Still collapsing.
                 collapse_paths.append(root)
                 collapse_items += items

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -79,6 +79,8 @@ Fixes:
   limited encoding.
 * :doc:`/plugins/convert`: The default configuration uses FFmpeg's built-in
   AAC codec instead of faac. Thanks to :user:`jansol`. :bug:`2484`
+* Fix import of multidisc releases with subdirectories, which previously
+  made each disc be imported separately in different releases. :bug:`2493`
 
 
 1.4.3 (January 9, 2017)


### PR DESCRIPTION
Don't stop collapsing paths when iterating over subdirectories of
already collapsed paths.

Fixes #2493