### PR TITLE
Flush the stdout buffer after printing a line

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -148,6 +148,7 @@ def print_(*strings, **kwargs):
         if hasattr(sys.stdout, 'buffer'):
             out = txt.encode(_out_encoding(), 'replace')
             sys.stdout.buffer.write(out)
+            sys.stdout.buffer.flush()
         else:
             # In our test harnesses (e.g., DummyOut), sys.stdout.buffer
             # does not exist. We instead just record the text string.


### PR DESCRIPTION
Pointed out in #2490, this is a regression introduced by #2398. We need to flush the buffer to faithfully emulate the "real" print() function.