### PR TITLE
Date value field validation

### DIFF
--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -561,7 +561,7 @@ class Period(object):
             date = datetime.strptime(string, date_format)
         except ValueError:
             # Parsing failed.
-            raise InvalidQueryArgumentTypeError(string, datetime)
+            raise InvalidQueryArgumentTypeError(string, 'a valid datetime string')
         precision = cls.precisions[ordinal]
         return cls(date, precision)
 

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -561,7 +561,7 @@ class Period(object):
             date = datetime.strptime(string, date_format)
         except ValueError:
             # Parsing failed.
-            return None
+            raise InvalidQueryArgumentTypeError(string, datetime)
         precision = cls.precisions[ordinal]
         return cls(date, precision)
 

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -555,7 +555,7 @@ class Period(object):
         ordinal = string.count('-')
         if ordinal >= len(cls.date_formats):
             # Too many components.
-            return None
+            raise InvalidQueryArgumentTypeError(string, 'a valid datetime string')
         date_format = cls.date_formats[ordinal]
         try:
             date = datetime.strptime(string, date_format)

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -547,8 +547,9 @@ class Period(object):
 
     @classmethod
     def parse(cls, string):
-        """Parse a date and return a `Period` object or `None` if the
-        string is empty.
+        """Parse a date and return a `Period` object, or `None` if the
+        string is empty, or raise an InvalidQueryArgumentTypeError if
+        the string could not be parsed to a date.
         """
         if not string:
             return None

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -556,13 +556,15 @@ class Period(object):
         ordinal = string.count('-')
         if ordinal >= len(cls.date_formats):
             # Too many components.
-            raise InvalidQueryArgumentTypeError(string, 'a valid datetime string')
+            raise InvalidQueryArgumentTypeError(string,
+                                                'a valid datetime string')
         date_format = cls.date_formats[ordinal]
         try:
             date = datetime.strptime(string, date_format)
         except ValueError:
             # Parsing failed.
-            raise InvalidQueryArgumentTypeError(string, 'a valid datetime string')
+            raise InvalidQueryArgumentTypeError(string,
+                                                'a valid datetime string')
         precision = cls.precisions[ordinal]
         return cls(date, precision)
 

--- a/test/test_datequery.py
+++ b/test/test_datequery.py
@@ -124,6 +124,21 @@ class DateQueryConstructTest(unittest.TestCase):
         with self.assertRaises(InvalidQueryArgumentTypeError):
             DateQuery('added', '12-34-56-78')
 
+    def test_invalid_date_query(self):
+        q_list = [
+            '2001-01-0a',
+            '2001-0a',
+            '200a',
+            '2001-01-01..2001-01-0a',
+            '2001-0a..2001-01',
+            '200a..2002',
+            '20aa..',
+            '..2aa'
+        ]
+        for q in q_list:
+            with self.assertRaises(InvalidQueryArgumentTypeError):
+                DateQuery('added', q)
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)

--- a/test/test_datequery.py
+++ b/test/test_datequery.py
@@ -21,7 +21,8 @@ from test import _common
 from datetime import datetime
 import unittest
 import time
-from beets.dbcore.query import _parse_periods, DateInterval, DateQuery, InvalidQueryArgumentTypeError
+from beets.dbcore.query import _parse_periods, DateInterval, DateQuery,\
+    InvalidQueryArgumentTypeError
 
 
 def _date(string):

--- a/test/test_datequery.py
+++ b/test/test_datequery.py
@@ -121,7 +121,8 @@ class DateQueryConstructTest(unittest.TestCase):
             DateQuery('added', '1409830085..1412422089')
 
     def test_too_many_components(self):
-        DateQuery('added', '12-34-56-78')
+        with self.assertRaises(InvalidQueryArgumentTypeError):
+            DateQuery('added', '12-34-56-78')
 
 
 def suite():

--- a/test/test_datequery.py
+++ b/test/test_datequery.py
@@ -21,7 +21,7 @@ from test import _common
 from datetime import datetime
 import unittest
 import time
-from beets.dbcore.query import _parse_periods, DateInterval, DateQuery
+from beets.dbcore.query import _parse_periods, DateInterval, DateQuery, InvalidQueryArgumentTypeError
 
 
 def _date(string):
@@ -117,7 +117,8 @@ class DateQueryTest(_common.LibTestCase):
 
 class DateQueryConstructTest(unittest.TestCase):
     def test_long_numbers(self):
-        DateQuery('added', '1409830085..1412422089')
+        with self.assertRaises(InvalidQueryArgumentTypeError):
+            DateQuery('added', '1409830085..1412422089')
 
     def test_too_many_components(self):
         DateQuery('added', '12-34-56-78')

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -890,6 +890,7 @@ class NotQueryTest(DummyDataTestCase):
         self.assert_items_matched(not_results, [u'beets 4 eva'])
         self.assertNegationProperties(q)
 
+    @unittest.skip # skip until I can figure out what this test is doing
     def test_type_date(self):
         q = dbcore.query.DateQuery(u'mtime', u'0.0')
         not_results = self.lib.items(dbcore.query.NotQuery(q))
@@ -992,7 +993,8 @@ class NotQueryTest(DummyDataTestCase):
         AttributeError: type object 'NoneQuery' has no attribute 'field'
         at NoneQuery.match() (due to being @classmethod, and no self?)
         """
-        classes = [(dbcore.query.DateQuery, [u'mtime', u'0.0']),
+        classes = [#(dbcore.query.DateQuery, [u'mtime', u'0.0']), # skip until I can figure out what this test is doing
+                    # replacing '0.0' with a proper date e.g. '2001-01-01' passes the test
                    (dbcore.query.MatchQuery, [u'artist', u'one']),
                    # (dbcore.query.NoneQuery, ['rg_track_gain']),
                    (dbcore.query.NumericQuery, [u'year', u'2002']),

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -893,8 +893,10 @@ class NotQueryTest(DummyDataTestCase):
     def test_type_date(self):
         q = dbcore.query.DateQuery(u'added', u'2000-01-01')
         not_results = self.lib.items(dbcore.query.NotQuery(q))
-        # query date is in the past, thus the 'not' results should contain all items
-        self.assert_items_matched(not_results, [u'foo bar', u'baz qux', u'beets 4 eva'])
+        # query date is in the past, thus the 'not' results should contain all
+        # items
+        self.assert_items_matched(not_results, [u'foo bar', u'baz qux',
+                                                u'beets 4 eva'])
         self.assertNegationProperties(q)
 
     def test_type_false(self):

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -890,11 +890,11 @@ class NotQueryTest(DummyDataTestCase):
         self.assert_items_matched(not_results, [u'beets 4 eva'])
         self.assertNegationProperties(q)
 
-    @unittest.skip # skip until I can figure out what this test is doing
     def test_type_date(self):
-        q = dbcore.query.DateQuery(u'mtime', u'0.0')
+        q = dbcore.query.DateQuery(u'added', u'2000-01-01')
         not_results = self.lib.items(dbcore.query.NotQuery(q))
-        self.assert_items_matched(not_results, [])
+        # query date is in the past, thus the 'not' results should contain all items
+        self.assert_items_matched(not_results, [u'foo bar', u'baz qux', u'beets 4 eva'])
         self.assertNegationProperties(q)
 
     def test_type_false(self):
@@ -993,8 +993,7 @@ class NotQueryTest(DummyDataTestCase):
         AttributeError: type object 'NoneQuery' has no attribute 'field'
         at NoneQuery.match() (due to being @classmethod, and no self?)
         """
-        classes = [#(dbcore.query.DateQuery, [u'mtime', u'0.0']), # skip until I can figure out what this test is doing
-                    # replacing '0.0' with a proper date e.g. '2001-01-01' passes the test
+        classes = [(dbcore.query.DateQuery, [u'added', u'2001-01-01']),
                    (dbcore.query.MatchQuery, [u'artist', u'one']),
                    # (dbcore.query.NoneQuery, ['rg_track_gain']),
                    (dbcore.query.NumericQuery, [u'year', u'2002']),


### PR DESCRIPTION
This pull request is for issue #2513 (Date-valued field queries allow non-date values).
 
`Period.parse()` now raises a `InvalidQueryArgumentTypeError` when the string does not parse to a date - although I do wonder whether this is the correct error to raise, as I'm not comparing types here. I wonder whether a `ValueError`, or perhaps creating a new `InvalidQueryArgumentValueError` is more appropriate?

I have changed the way `Period.parse()` works - it used to first count the number of hyphens in the date to determine the precision (day, month, or year) and then try to parse the string against the appropriate date format. This did work fine. However, in anticipation of new feature #2506 (Extend the query date parser with (optional) times), where we will have '-', ':', and possibly ' ' or 'T' characters to count, I have opted for a different approach. I now test the string against each of the formats supported, from most precise to least precise, until a match is found (or not).

Tests have been updated to assert that the new errors are raised.

The output of a bad date query now reads quite nicely in the output:
```
$ beet list added:2017-01..2017-aa
invalid query: 'added:2017-01..2017-aa': '2017-aa' is not a valid datetime string
```

Finally, I have fixed a couple of older tests which were attempting to test `mtime` queries with an odd looking value of `0.0` and updated them to correct values.

`tox` passes all tests.