### PR TITLE
Fix misuse of flags in re.sub() calls

### DIFF
--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -394,10 +394,10 @@ class BeatportPlugin(BeetsPlugin):
         # cause a query to return no results, even if they match the artist or
         # album title. Use `re.UNICODE` flag to avoid stripping non-english
         # word characters.
-        query = re.sub(r'\W+', ' ', query, re.UNICODE)
+        query = re.sub(r'\W+', ' ', query, flags=re.UNICODE)
         # Strip medium information from query, Things like "CD1" and "disk 1"
         # can also negate an otherwise positive result.
-        query = re.sub(r'\b(CD|disc)\s*\d+', '', query, re.I)
+        query = re.sub(r'\b(CD|disc)\s*\d+', '', query, flags=re.I)
         albums = [self._get_album_info(x)
                   for x in self.client.search(query)]
         return albums


### PR DESCRIPTION
The 4th argument of `re.sub()` is maximum number of substitutions, not flags.

Found using [pydiatra](https://github.com/jwilk/pydiatra).