### PR TITLE
add --yes argument to play command

### DIFF
--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -82,9 +82,9 @@ class PlayPlugin(BeetsPlugin):
             help=u'add additional arguments to the command',
         )
         play_command.parser.add_option(
-            u'-f', u'--force',
+            u'-y', u'--yes',
             action="store_true",
-            help=u'disable the warning threshold',
+            help=u'skip the warning threshold',
         )
         play_command.func = self._play_command
         return [play_command]
@@ -130,8 +130,8 @@ class PlayPlugin(BeetsPlugin):
 
         # Check if the selection exceeds configured threshold. If True,
         # cancel, otherwise proceed with play command.
-        if opts.force or not self._exceeds_threshold(selection, command_str, open_args,
-                                       item_type):
+        if opts.yes or not self._exceeds_threshold(
+                selection, command_str, open_args, item_type):
             play(command_str, selection, paths, open_args, self._log,
                  item_type)
 

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -81,6 +81,11 @@ class PlayPlugin(BeetsPlugin):
             action='store',
             help=u'add additional arguments to the command',
         )
+        play_command.parser.add_option(
+            u'-f', u'--force',
+            action="store_true",
+            help=u'disable the warning threshold',
+        )
         play_command.func = self._play_command
         return [play_command]
 
@@ -125,7 +130,7 @@ class PlayPlugin(BeetsPlugin):
 
         # Check if the selection exceeds configured threshold. If True,
         # cancel, otherwise proceed with play command.
-        if not self._exceeds_threshold(selection, command_str, open_args,
+        if opts.force or not self._exceeds_threshold(selection, command_str, open_args,
                                        item_type):
             play(command_str, selection, paths, open_args, self._log,
                  item_type)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -49,7 +49,7 @@ New features:
   :bug:`2366` :bug:`2495`
 * Importing a release with multiple release events now selects the
   event based on your :ref:`preferred` countries. :bug:`2501`
-* :doc:`/plugins/play`: A new ``-f`` or ``--force`` parameter lets you skip
+* :doc:`/plugins/play`: A new ``-y`` or ``--yes`` parameter lets you skip
   the warning message if you enqueue more items than the warning threshold
   usually allows.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -49,6 +49,9 @@ New features:
   :bug:`2366` :bug:`2495`
 * Importing a release with multiple release events now selects the
   event based on your :ref:`preferred` countries. :bug:`2501`
+* :doc:`/plugins/play`: A new ``-f`` or ``--force`` parameter lets you skip
+  the warning message if you enqueue more items than the warning threshold
+  usually allows.
 
 Fixes:
 

--- a/docs/plugins/play.rst
+++ b/docs/plugins/play.rst
@@ -95,8 +95,9 @@ example::
 indicates that you need to insert extra arguments before specifying the
 playlist.
 
-The ``--force`` (or ``-f``) flag to the ``play`` command will skip the warning
-message if you choose to play more items than the **warning_threshold** value.
+The ``--yes`` (or ``-y``) flag to the ``play`` command will skip the warning
+message if you choose to play more items than the **warning_threshold** 
+value usually allows.
 
 Note on the Leakage of the Generated Playlists
 ----------------------------------------------

--- a/docs/plugins/play.rst
+++ b/docs/plugins/play.rst
@@ -95,6 +95,9 @@ example::
 indicates that you need to insert extra arguments before specifying the
 playlist.
 
+The ``--force`` (or ``-f``) flag to the ``play`` command will skip the warning
+message if you choose to play more items than the **warning_threshold** value.
+
 Note on the Leakage of the Generated Playlists
 ----------------------------------------------
 

--- a/test/test_play.py
+++ b/test/test_play.py
@@ -115,6 +115,20 @@ class PlayPluginTest(unittest.TestCase, TestHelper):
 
         open_mock.assert_not_called()
 
+    def test_force_warning_threshold_bypass(self, open_mock):
+        self.config['play']['warning_threshold'] = 1
+        self.other_item = self.add_item(title='another NiceTitle')
+
+        expected_playlist = u'{0}\n{1}'.format(
+            self.item.path.decode('utf-8'),
+            self.other_item.path.decode('utf-8'))
+
+        with control_stdin("a"):
+            self.run_and_assert(
+                open_mock,
+                [u'-f', u'NiceTitle'],
+                expected_playlist=expected_playlist)
+
     def test_command_failed(self, open_mock):
         open_mock.side_effect = OSError(u"some reason")
 

--- a/test/test_play.py
+++ b/test/test_play.py
@@ -115,7 +115,7 @@ class PlayPluginTest(unittest.TestCase, TestHelper):
 
         open_mock.assert_not_called()
 
-    def test_force_warning_threshold_bypass(self, open_mock):
+    def test_skip_warning_threshold_bypass(self, open_mock):
         self.config['play']['warning_threshold'] = 1
         self.other_item = self.add_item(title='another NiceTitle')
 
@@ -126,7 +126,7 @@ class PlayPluginTest(unittest.TestCase, TestHelper):
         with control_stdin("a"):
             self.run_and_assert(
                 open_mock,
-                [u'-f', u'NiceTitle'],
+                [u'-y', u'NiceTitle'],
                 expected_playlist=expected_playlist)
 
     def test_command_failed(self, open_mock):


### PR DESCRIPTION
I am Super Lazy and bound a script to auto start shuffling my music when I log into my work machine in the morning and got tired of having to yes 'C' |  to it. So I added -f to beet play so I can bypass the warning_threshold at runtime.

You may disagree that this should be in the plugin; no hard feelings if so.