### PR TITLE
Rename error

### DIFF
--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -47,7 +47,7 @@ class InvalidQueryError(ParsingError):
         super(InvalidQueryError, self).__init__(message)
 
 
-class InvalidQueryArgumentTypeError(ParsingError):
+class InvalidQueryArgumentValueError(ParsingError):
     """Represent a query argument that could not be converted as expected.
 
     It exists to be caught in upper stack levels so a meaningful (i.e. with the
@@ -57,7 +57,7 @@ class InvalidQueryArgumentTypeError(ParsingError):
         message = u"'{0}' is not {1}".format(what, expected)
         if detail:
             message = u"{0}: {1}".format(message, detail)
-        super(InvalidQueryArgumentTypeError, self).__init__(message)
+        super(InvalidQueryArgumentValueError, self).__init__(message)
 
 
 class Query(object):
@@ -211,9 +211,9 @@ class RegexpQuery(StringFieldQuery):
             self.pattern = re.compile(self.pattern)
         except re.error as exc:
             # Invalid regular expression.
-            raise InvalidQueryArgumentTypeError(pattern,
-                                                u"a regular expression",
-                                                format(exc))
+            raise InvalidQueryArgumentValueError(pattern,
+                                                 u"a regular expression",
+                                                 format(exc))
 
     @staticmethod
     def _normalize(s):
@@ -285,7 +285,7 @@ class NumericQuery(FieldQuery):
             try:
                 return float(s)
             except ValueError:
-                raise InvalidQueryArgumentTypeError(s, u"an int or a float")
+                raise InvalidQueryArgumentValueError(s, u"an int or a float")
 
     def __init__(self, field, pattern, fast=True):
         super(NumericQuery, self).__init__(field, pattern, fast)
@@ -548,7 +548,7 @@ class Period(object):
     @classmethod
     def parse(cls, string):
         """Parse a date and return a `Period` object, or `None` if the
-        string is empty, or raise an InvalidQueryArgumentTypeError if
+        string is empty, or raise an InvalidQueryArgumentValueError if
         the string could not be parsed to a date.
         """
         if not string:
@@ -556,15 +556,15 @@ class Period(object):
         ordinal = string.count('-')
         if ordinal >= len(cls.date_formats):
             # Too many components.
-            raise InvalidQueryArgumentTypeError(string,
-                                                'a valid datetime string')
+            raise InvalidQueryArgumentValueError(string,
+                                                 'a valid datetime string')
         date_format = cls.date_formats[ordinal]
         try:
             date = datetime.strptime(string, date_format)
         except ValueError:
             # Parsing failed.
-            raise InvalidQueryArgumentTypeError(string,
-                                                'a valid datetime string')
+            raise InvalidQueryArgumentValueError(string,
+                                                 'a valid datetime string')
         precision = cls.precisions[ordinal]
         return cls(date, precision)
 
@@ -686,7 +686,7 @@ class DurationQuery(NumericQuery):
             try:
                 return float(s)
             except ValueError:
-                raise InvalidQueryArgumentTypeError(
+                raise InvalidQueryArgumentValueError(
                     s,
                     u"a M:SS string or a float")
 

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -563,7 +563,7 @@ class Period(object):
                 pass
         if date is None:
             raise InvalidQueryArgumentValueError(string,
-                                                'a valid datetime string')
+                                                 'a valid datetime string')
         precision = cls.precisions[ordinal]
         return cls(date, precision)
 

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -562,7 +562,7 @@ class Period(object):
                 # Parsing failed.
                 pass
         if date is None:
-            raise InvalidQueryArgumentTypeError(string,
+            raise InvalidQueryArgumentValueError(string,
                                                 'a valid datetime string')
         precision = cls.precisions[ordinal]
         return cls(date, precision)

--- a/beets/library.py
+++ b/beets/library.py
@@ -1306,7 +1306,7 @@ class Library(dbcore.Database):
                 query, parsed_sort = parse_query_string(query, model_cls)
             elif isinstance(query, (list, tuple)):
                 query, parsed_sort = parse_query_parts(query, model_cls)
-        except dbcore.query.InvalidQueryArgumentTypeError as exc:
+        except dbcore.query.InvalidQueryArgumentValueError as exc:
             raise dbcore.InvalidQueryError(query, exc)
 
         # Any non-null sort specified by the parsed query overrides the

--- a/test/test_datequery.py
+++ b/test/test_datequery.py
@@ -22,7 +22,7 @@ from datetime import datetime
 import unittest
 import time
 from beets.dbcore.query import _parse_periods, DateInterval, DateQuery,\
-    InvalidQueryArgumentTypeError
+    InvalidQueryArgumentValueError
 
 
 def _date(string):
@@ -118,11 +118,11 @@ class DateQueryTest(_common.LibTestCase):
 
 class DateQueryConstructTest(unittest.TestCase):
     def test_long_numbers(self):
-        with self.assertRaises(InvalidQueryArgumentTypeError):
+        with self.assertRaises(InvalidQueryArgumentValueError):
             DateQuery('added', '1409830085..1412422089')
 
     def test_too_many_components(self):
-        with self.assertRaises(InvalidQueryArgumentTypeError):
+        with self.assertRaises(InvalidQueryArgumentValueError):
             DateQuery('added', '12-34-56-78')
 
     def test_invalid_date_query(self):
@@ -137,7 +137,7 @@ class DateQueryConstructTest(unittest.TestCase):
             '..2aa'
         ]
         for q in q_list:
-            with self.assertRaises(InvalidQueryArgumentTypeError):
+            with self.assertRaises(InvalidQueryArgumentValueError):
                 DateQuery('added', q)
 
 

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -30,7 +30,7 @@ import beets.library
 from beets import dbcore
 from beets.dbcore import types
 from beets.dbcore.query import (NoneQuery, ParsingError,
-                                InvalidQueryArgumentTypeError)
+                                InvalidQueryArgumentValueError)
 from beets.library import Library, Item
 from beets import util
 import platform
@@ -301,11 +301,11 @@ class GetTest(DummyDataTestCase):
         self.assertFalse(results)
 
     def test_invalid_query(self):
-        with self.assertRaises(InvalidQueryArgumentTypeError) as raised:
+        with self.assertRaises(InvalidQueryArgumentValueError) as raised:
             dbcore.query.NumericQuery('year', u'199a')
         self.assertIn(u'not an int', six.text_type(raised.exception))
 
-        with self.assertRaises(InvalidQueryArgumentTypeError) as raised:
+        with self.assertRaises(InvalidQueryArgumentValueError) as raised:
             dbcore.query.RegexpQuery('year', u'199(')
         exception_text = six.text_type(raised.exception)
         self.assertIn(u'not a regular expression', exception_text)


### PR DESCRIPTION
As discussed at https://github.com/beetbox/beets/pull/2517#issuecomment-294300430, the way we use `InvalidQueryArgumentTypeError` is more akin to a `ValueError` than a `TypeError`. For example, we try to parse a string as an int, float, or date, but the parsing fails - there was nothing wrong with the Type of the variable (string), but its contents were not parseable into the type we wanted - there was a problem with the value of the string.

Thus `InvalidQueryArgumentTypeError` is renamed to `InvalidQueryArgumentValueError` in this pull request.