### PR TITLE
Close stdin when performing `command_output()`

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -797,11 +797,16 @@ def command_output(cmd, shell=False):
     """
     cmd = convert_command_args(cmd)
 
+    try:  # python >= 3.3
+        devnull = subprocess.DEVNULL
+    except AttributeError:
+        devnull = open(os.devnull, 'r+b')
+
     proc = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        stdin=subprocess.DEVNULL,
+        stdin=devnull,
         close_fds=platform.system() != 'Windows',
         shell=shell
     )

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -801,6 +801,7 @@ def command_output(cmd, shell=False):
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        stdin=subprocess.DEVNULL,
         close_fds=platform.system() != 'Windows',
         shell=shell
     )

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -52,6 +52,11 @@ New features:
 * :doc:`/plugins/play`: A new ``-y`` or ``--yes`` parameter lets you skip
   the warning message if you enqueue more items than the warning threshold
   usually allows.
+* Fix a bug where commands which forked subprocesses would sometimes prevent
+  further inputs. This bug mainly affected :doc:`/plugins/convert`.
+  Thanks to :user:`jansol`.
+  :bug:`2488`
+  :bug:`2524`
 
 Fixes:
 


### PR DESCRIPTION
This should fix #2488 where some commands, mainly `beet convert` would prevent further inputs.

I've been running with the solution proposed by @sampsyo for some time now and I believe it does indeed suppress this behaviour.
@jansol, could you confirm this fixes problems on your end as well?

I don't know how to test for this however.