### PR TITLE
Drop lyrics.com backend

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -381,39 +381,6 @@ class LyricsWiki(SymbolsReplaced):
                 return lyrics
 
 
-class LyricsCom(Backend):
-    """Fetch lyrics from Lyrics.com."""
-
-    URL_PATTERN = 'http://www.lyrics.com/%s-lyrics-%s.html'
-    NOT_FOUND = (
-        'Sorry, we do not have the lyric',
-        'Submit Lyrics',
-    )
-
-    @classmethod
-    def _encode(cls, s):
-        s = re.sub(r'[^\w\s-]', '', s)
-        s = re.sub(r'\s+', '-', s)
-        return super(LyricsCom, cls)._encode(s).lower()
-
-    def fetch(self, artist, title):
-        url = self.build_url(artist, title)
-        html = self.fetch_url(url)
-        if not html:
-            return
-        lyrics = extract_text_between(html, '<div id="lyrics" class="SCREENO'
-                                      'NLY" itemprop="description">', '</div>')
-        if not lyrics:
-            return
-        for not_found_str in self.NOT_FOUND:
-            if not_found_str in lyrics:
-                return
-
-        parts = lyrics.split('\n---\nLyrics powered by', 1)
-        if parts:
-            return parts[0]
-
-
 def remove_credits(text):
     """Remove first/last line of text if it contains the word 'lyrics'
     eg 'Lyrics by songsdatabase.com'
@@ -605,11 +572,10 @@ class Google(Backend):
 
 
 class LyricsPlugin(plugins.BeetsPlugin):
-    SOURCES = ['google', 'lyricwiki', 'lyrics.com', 'musixmatch']
+    SOURCES = ['google', 'lyricwiki', 'musixmatch']
     SOURCE_BACKENDS = {
         'google': Google,
         'lyricwiki': LyricsWiki,
-        'lyrics.com': LyricsCom,
         'musixmatch': MusiXmatch,
         'genius': Genius,
     }

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -103,6 +103,7 @@ Fixes:
 * :doc:`plugins/fetchart`'s iTunes Store artwork lookup no longer recommended
   in documentation, as the unmaintained `python-itunes`_ is broken. Want
   to adopt it? :bug:`2371` :bug:`1610`
+* :doc:`/plugins/lyrics`: drop Lyrics.com backend (don't work anymore)
 
 .. _python-itunes: https://github.com/ocelma/python-itunes
 

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -2,11 +2,10 @@ Lyrics Plugin
 =============
 
 The ``lyrics`` plugin fetches and stores song lyrics from databases on the Web.
-Namely, the current version of the plugin uses `Lyric Wiki`_, `Lyrics.com`_,
+Namely, the current version of the plugin uses `Lyric Wiki`_, 
 `Musixmatch`_, `Genius.com`_, and, optionally, the Google custom search API.
 
 .. _Lyric Wiki: http://lyrics.wikia.com/
-.. _Lyrics.com: http://www.lyrics.com/
 .. _Musixmatch: https://www.musixmatch.com/
 .. _Genius.com: http://genius.com/
 
@@ -60,7 +59,7 @@ configuration file. The available options are:
   sources known to be scrapeable.
 - **sources**: List of sources to search for lyrics. An asterisk ``*`` expands
   to all available sources.
-  Default: ``google lyricwiki lyrics.com musixmatch``, i.e., all the
+  Default: ``google lyricwiki musixmatch``, i.e., all the
   sources except for `genius`. The `google` source will be automatically
   deactivated if no ``google_API_key`` is setup.
 

--- a/test/test_lyrics.py
+++ b/test/test_lyrics.py
@@ -246,7 +246,6 @@ class LyricsPluginSourcesTest(LyricsGoogleBaseTest):
 
     DEFAULT_SOURCES = [
         dict(DEFAULT_SONG, backend=lyrics.LyricsWiki),
-        dict(DEFAULT_SONG, backend=lyrics.LyricsCom),
         dict(artist=u'Santana', title=u'Black magic woman',
              backend=lyrics.MusiXmatch),
         dict(DEFAULT_SONG, backend=lyrics.Genius),


### PR DESCRIPTION
Address #2548 by dropping the backend as I see no solution to get from (artist, title) to the magic number used in the url.