### PR TITLE
Load YAML as binary data

### DIFF
--- a/beets/util/confit.py
+++ b/beets/util/confit.py
@@ -668,7 +668,7 @@ def load_yaml(filename):
     parsed, a ConfigReadError is raised.
     """
     try:
-        with open(filename, 'r') as f:
+        with open(filename, 'rb') as f:
             return yaml.load(f, Loader=Loader)
     except (IOError, yaml.error.YAMLError) as exc:
         raise ConfigReadError(filename, exc)
@@ -908,9 +908,10 @@ class Configuration(RootView):
                 default_source = source
                 break
         if default_source and default_source.filename:
-            with open(default_source.filename, 'r') as fp:
+            with open(default_source.filename, 'rb') as fp:
                 default_data = fp.read()
-            yaml_out = restore_yaml_comments(yaml_out, default_data)
+            yaml_out = restore_yaml_comments(yaml_out,
+                                             default_data.decode('utf8'))
 
         return yaml_out
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -107,6 +107,8 @@ Fixes:
 * :doc:`/plugins/web`: Avoid a crash when sending binary data, such as
   Chromaprint fingerprints, in music attributes. :bug:`2542` :bug:`2532`
 * Fix a hang when parsing templates that end in newlines. :bug:`2562`
+* Fix a crash when reading non-ASCII characters in configuration files on
+  Windows under Python 3. :bug:`2456` :bug:`2565` :bug:`2566`
 
 Two plugins had backends removed due to bitrot:
 


### PR DESCRIPTION
This lets the YAML library itself deal with the encoding (mostly), which should address issues having to do with `open` giving us a system-specific encoding by default on Python 3 on Windows when the files should have been written using UTF-8 per the YAML standard.

Fixes #2456; fixes #2565.