### PR TITLE
Always use specific null values for fixed fields

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -236,7 +236,7 @@ class Model(object):
         if key in getters:  # Computed.
             return getters[key](self)
         elif key in self._fields:  # Fixed.
-            return self._values_fixed.get(key)
+            return self._values_fixed.get(key, self._type(key).null)
         elif key in self._values_flex:  # Flexible.
             return self._values_flex[key]
         else:

--- a/beets/library.py
+++ b/beets/library.py
@@ -144,9 +144,26 @@ class DateType(types.Float):
 
 
 class PathType(types.Type):
+    """A dbcore type for filesystem paths. These are represented as
+    `bytes` objects, in keeping with the Unix filesystem abstraction.
+    """
+
     sql = u'BLOB'
     query = PathQuery
     model_type = bytes
+
+    def __init__(self, nullable=False):
+        """Create a path type object. `nullable` controls whether the
+        type may be missing, i.e., None.
+        """
+        self.nullable = nullable
+
+    @property
+    def null(self):
+        if self.nullable:
+            return None
+        else:
+            return b''
 
     def format(self, value):
         return util.displayable_path(value)
@@ -873,7 +890,7 @@ class Album(LibModel):
     _always_dirty = True
     _fields = {
         'id':      types.PRIMARY_ID,
-        'artpath': PathType(),
+        'artpath': PathType(True),
         'added':   DateType(),
 
         'albumartist':        types.STRING,

--- a/beets/library.py
+++ b/beets/library.py
@@ -205,6 +205,8 @@ class MusicalKey(types.String):
         r'bb': 'a#',
     }
 
+    null = None
+
     def parse(self, key):
         key = key.lower()
         for flat, sharp in self.ENHARMONIC.items():

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -320,7 +320,7 @@ class ModelTest(unittest.TestCase):
     def test_items(self):
         model = TestModel1(self.db)
         model.id = 5
-        self.assertEqual({('id', 5), ('field_one', None)},
+        self.assertEqual({('id', 5), ('field_one', 0)},
                          set(model.items()))
 
     def test_delete_internal_field(self):

--- a/test/test_ipfs.py
+++ b/test/test_ipfs.py
@@ -67,17 +67,17 @@ class IPFSPluginTest(unittest.TestCase, TestHelper):
     def mk_test_album(self):
         items = [_common.item() for _ in range(3)]
         items[0].title = 'foo bar'
-        items[0].artist = 'one'
+        items[0].artist = '1one'
         items[0].album = 'baz'
         items[0].year = 2001
         items[0].comp = True
         items[1].title = 'baz qux'
-        items[1].artist = 'two'
+        items[1].artist = '2two'
         items[1].album = 'baz'
         items[1].year = 2002
         items[1].comp = True
         items[2].title = 'beets 4 eva'
-        items[2].artist = 'three'
+        items[2].artist = '3three'
         items[2].album = 'foo'
         items[2].year = 2003
         items[2].comp = False

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -79,10 +79,10 @@ class AnyFieldQueryTest(_common.LibTestCase):
 
 class AssertsMixin(object):
     def assert_items_matched(self, results, titles):
-        self.assertEqual([i.title for i in results], titles)
+        self.assertEqual(set([i.title for i in results]), set(titles))
 
     def assert_albums_matched(self, results, albums):
-        self.assertEqual([a.album for a in results], albums)
+        self.assertEqual(set([a.album for a in results]), set(albums))
 
 
 # A test case class providing a library with some dummy data and some


### PR DESCRIPTION
This came out of an attempt to address the mysterious testing problems from #2563 and turned into a big old debacle. As it turns out, the problem came from calling Item.from_path and getting None for fields that weren't filled out by the MediaFile data. Everywhere else, we fill out these fixed attributes with the special null value for the field's type, so it's actually pretty confusing that these could mysteriously become None. I think it will be saner all around if we enforce this universally.

There were two possible fixes: one in `__getitem__` to check for missing values and one that set all the missing values in the constructor. I opted for the former because it has a smaller footprint, but the latter might have slightly better performance (depending on the ratio of constructions to lookups).

There were a few tests that implicitly depended on the old behavior, which I've fixed. I've also fixed a couple of fields that were relying implicitly on the old sometimes-None, sometimes-not behavior to explicitly allow the fields to be None. (Namely, `artpath` and `initial_key`.)