### PR TITLE
print lyrics as HTML

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -726,7 +726,7 @@ class LyricsPlugin(plugins.BeetsPlugin):
             if self.rst is not None:
                 slug = re.sub(r'\W+', '-', unidecode(self.artist).lower())
                 path = os.path.join(directory, 'artists', slug + u'.rst')
-                with open(path, 'w') as output:
+                with open(path, 'wb') as output:
                     output.write(self.rst.encode('utf-8'))
                 self.rst = None
                 if item is None:
@@ -761,7 +761,7 @@ class LyricsPlugin(plugins.BeetsPlugin):
                 raise
         indexfile = os.path.join(directory, 'index.rst')
         if not os.path.exists(indexfile):
-            with open(indexfile, 'w') as output:
+            with open(indexfile, 'wb') as output:
                 output.write(u'''Lyrics
 ======
 
@@ -778,7 +778,7 @@ Artist index:
 ''')
         conffile = os.path.join(directory, 'conf.py')
         if not os.path.exists(conffile):
-            with open(conffile, 'w') as output:
+            with open(conffile, 'wb') as output:
                 output.write(u'''# -*- coding: utf-8 -*-
 master_doc = 'index'
 project = u'Lyrics'

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -598,7 +598,7 @@ class LyricsPlugin(plugins.BeetsPlugin):
                 "76V-uFL5jks5dNvcGCdarqFjDhP9c",
             'fallback': None,
             'force': False,
-            'skip': False,
+            'local': False,
             'sources': self.SOURCES,
         })
         self.config['bing_client_secret'].redact = True
@@ -673,9 +673,9 @@ class LyricsPlugin(plugins.BeetsPlugin):
             help=u'always re-download lyrics',
         )
         cmd.parser.add_option(
-            u'-s', u'--skip', dest='skip_fetched',
+            u'-l', u'--local', dest='local_only',
             action='store_true', default=False,
-            help=u'skip already fetched lyrics',
+            help=u'do not fetch missing lyrics',
         )
 
         def func(lib, opts, args):
@@ -686,7 +686,7 @@ class LyricsPlugin(plugins.BeetsPlugin):
             album = False
             output = sys.stdout
             for item in lib.items(ui.decargs(args)):
-                if not opts.skip_fetched and not self.config['skip']:
+                if not opts.local_only and not self.config['local']:
                     self.fetch_item_lyrics(
                         lib, item, write,
                         opts.force_refetch or self.config['force'],

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -797,11 +797,11 @@ class LyricsPlugin(plugins.BeetsPlugin):
                 raise
         indexfile = os.path.join(directory, 'index.rst')
         if not os.path.exists(indexfile):
-            with open(indexfile, 'wb') as output:
+            with open(indexfile, 'w') as output:
                 output.write(REST_INDEX_TEMPLATE)
         conffile = os.path.join(directory, 'conf.py')
         if not os.path.exists(conffile):
-            with open(conffile, 'wb') as output:
+            with open(conffile, 'w') as output:
                 output.write(REST_CONF_TEMPLATE)
 
     def imported(self, session, task):

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -760,7 +760,8 @@ class LyricsPlugin(plugins.BeetsPlugin):
         """
         if item is None or self.artist != item.artist:
             if self.rest is not None:
-                slug = re.sub(r'\W+', '-', unidecode(self.artist).lower())
+                slug = re.sub(r'\W+', '-',
+                              unidecode(self.artist.strip()).lower())
                 path = os.path.join(directory, 'artists', slug + u'.rst')
                 with open(path, 'wb') as output:
                     output.write(self.rest.encode('utf-8'))
@@ -769,14 +770,15 @@ class LyricsPlugin(plugins.BeetsPlugin):
                     return
             self.artist = item.artist
             self.rest = u"%s\n%s\n\n.. contents::\n   :local:\n\n" \
-                        % (self.artist, u'=' * len(self.artist))
+                        % (self.artist.strip(),
+                           u'=' * len(self.artist.strip()))
         if self.album != item.album:
             tmpalbum = self.album = item.album
             if self.album == '':
                 tmpalbum = u'Unknown album'
-            self.rest += u"%s\n%s\n\n" % (tmpalbum,
-                                          u'-' * len(tmpalbum))
-        title_str = u":index:`%s`" % item.title
+            self.rest += u"%s\n%s\n\n" % (tmpalbum.strip(),
+                                          u'-' * len(tmpalbum.strip()))
+        title_str = u":index:`%s`" % item.title.strip()
         block = u'| ' + item.lyrics.replace(u'\n', u'\n| ')
         self.rest += u"%s\n%s\n\n%s\n" % (title_str,
                                           u'~' * len(title_str),

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -595,6 +595,7 @@ class LyricsPlugin(plugins.BeetsPlugin):
                 "76V-uFL5jks5dNvcGCdarqFjDhP9c",
             'fallback': None,
             'force': False,
+            'skip': False,
             'sources': self.SOURCES,
         })
         self.config['bing_client_secret'].redact = True
@@ -663,18 +664,33 @@ class LyricsPlugin(plugins.BeetsPlugin):
             action='store_true', default=False,
             help=u'always re-download lyrics',
         )
+        cmd.parser.add_option(
+            u'-s', u'--skip', dest='skip_fetched',
+            action='store_true', default=False,
+            help=u'skip already fetched lyrics',
+        )
 
         def func(lib, opts, args):
             # The "write to files" option corresponds to the
             # import_write config value.
             write = ui.should_write()
+            artist = ''
+            album = ''
             for item in lib.items(ui.decargs(args)):
-                self.fetch_item_lyrics(
-                    lib, item, write,
-                    opts.force_refetch or self.config['force'],
-                )
+                if not opts.skip_fetched and not self.config['skip']:
+                    self.fetch_item_lyrics(
+                        lib, item, write,
+                        opts.force_refetch or self.config['force'],
+                    )
                 if opts.printlyr and item.lyrics:
-                    ui.print_(item.lyrics)
+                    if artist != item.artist:
+                        artist = item.artist
+                        ui.print_('<h1>' + artist + '</h1>')
+                    if album != item.album:
+                        album = item.album
+                        ui.print_('<h2>' + artist + '</h2>')
+                    ui.print_('<h3>' + item.title + '</h3>')
+                    ui.print_('<pre>' + item.lyrics + '</pre>')
 
         cmd.func = func
         return [cmd]

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -672,7 +672,7 @@ class LyricsPlugin(plugins.BeetsPlugin):
         )
         cmd.parser.add_option(
             u'-r', u'--write-rst', dest='writerst',
-            action='store', default='.',
+            action='store', default='.', metavar='directory',
             help=u'write lyrics to given directory as RST files',
         )
         cmd.parser.add_option(

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -605,14 +605,14 @@ class LyricsPlugin(plugins.BeetsPlugin):
         self.config['google_API_key'].redact = True
         self.config['google_engine_ID'].redact = True
         self.config['genius_api_key'].redact = True
-        # state information for the RST writer
+        # state information for the ReST writer
         # the current artist
         self.artist = u'Unknown artist'
         # the current album, False means no album yet
         self.album = False
-        # the current rst file content. None means the file is not
+        # the current rest file content. None means the file is not
         # open yet.
-        self.rst = None
+        self.rest = None
 
         available_sources = list(self.SOURCES)
         sources = plugins.sanitize_choices(
@@ -671,9 +671,9 @@ class LyricsPlugin(plugins.BeetsPlugin):
             help=u'print lyrics to console',
         )
         cmd.parser.add_option(
-            u'-r', u'--write-rst', dest='writerst',
+            u'-r', u'--write-rest', dest='writerest',
             action='store', default='.', metavar='dir',
-            help=u'write lyrics to given directory as RST files',
+            help=u'write lyrics to given directory as ReST files',
         )
         cmd.parser.add_option(
             u'-f', u'--force', dest='force_refetch',
@@ -690,8 +690,8 @@ class LyricsPlugin(plugins.BeetsPlugin):
             # The "write to files" option corresponds to the
             # import_write config value.
             write = ui.should_write()
-            if opts.writerst:
-                self.writerst_indexes(opts.writerst)
+            if opts.writerest:
+                self.writerest_indexes(opts.writerest)
             for item in lib.items(ui.decargs(args)):
                 if not opts.local_only and not self.config['local']:
                     self.fetch_item_lyrics(
@@ -701,53 +701,53 @@ class LyricsPlugin(plugins.BeetsPlugin):
                 if item.lyrics:
                     if opts.printlyr:
                         ui.print_(item.lyrics)
-                    if opts.writerst:
-                        self.writerst(opts.writerst, item)
-            if opts.writerst:
+                    if opts.writerest:
+                        self.writerest(opts.writerest, item)
+            if opts.writerest:
                 # flush last artist
-                self.writerst(opts.writerst, None)
-                ui.print_(u'RST files generated. to build, use one of:')
+                self.writerest(opts.writerest, None)
+                ui.print_(u'ReST files generated. to build, use one of:')
                 ui.print_(u'  sphinx-build -b html %s _build/html'
-                          % opts.writerst)
+                          % opts.writerest)
                 ui.print_(u'  sphinx-build -b epub %s _build/epub'
-                          % opts.writerst)
+                          % opts.writerest)
                 ui.print_((u'  sphinx-build -b latex %s _build/latex '
                            u'&& make -C _build/latex all-pdf')
-                          % opts.writerst)
+                          % opts.writerest)
         cmd.func = func
         return [cmd]
 
-    def writerst(self, directory, item):
-        """Write the item to an RST file
+    def writerest(self, directory, item):
+        """Write the item to an ReST file
 
-        this will keep state (in the `rst` variable) in order to avoid
-        writing continuously to the same files
+        This will keep state (in the `rest` variable) in order to avoid
+        writing continuously to the same files.
         """
         if item is None or self.artist != item.artist:
-            if self.rst is not None:
+            if self.rest is not None:
                 slug = re.sub(r'\W+', '-', unidecode(self.artist).lower())
                 path = os.path.join(directory, 'artists', slug + u'.rst')
                 with open(path, 'wb') as output:
-                    output.write(self.rst.encode('utf-8'))
-                self.rst = None
+                    output.write(self.rest.encode('utf-8'))
+                self.rest = None
                 if item is None:
                     return
             self.artist = item.artist
-            self.rst = u"%s\n%s\n\n.. contents::\n   :local:\n\n" \
-                       % (self.artist, u'=' * len(self.artist))
+            self.rest = u"%s\n%s\n\n.. contents::\n   :local:\n\n" \
+                        % (self.artist, u'=' * len(self.artist))
         if self.album != item.album:
             tmpalbum = self.album = item.album
             if self.album == '':
                 tmpalbum = u'Unknown album'
-            self.rst += u"%s\n%s\n\n" % (tmpalbum,
-                                         u'-' * len(tmpalbum))
+            self.rest += u"%s\n%s\n\n" % (tmpalbum,
+                                          u'-' * len(tmpalbum))
         title_str = u":index:`%s`" % item.title
         block = u'| ' + item.lyrics.replace(u'\n', u'\n| ')
-        self.rst += u"%s\n%s\n\n%s\n" % (title_str,
-                                         u'~' * len(title_str),
-                                         block)
+        self.rest += u"%s\n%s\n\n%s\n" % (title_str,
+                                          u'~' * len(title_str),
+                                          block)
 
-    def writerst_indexes(self, directory):
+    def writerest_indexes(self, directory):
         """Write conf.py and index.rst files necessary for Sphinx
 
         We write minimal configurations that are necessary for Sphinx

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -660,6 +660,11 @@ class LyricsPlugin(plugins.BeetsPlugin):
             help=u'print lyrics to console',
         )
         cmd.parser.add_option(
+            u'-r', u'--print-rst', dest='printrst',
+            action='store_true', default=False,
+            help=u'print lyrics to console as RST text',
+        )
+        cmd.parser.add_option(
             u'-f', u'--force', dest='force_refetch',
             action='store_true', default=False,
             help=u'always re-download lyrics',
@@ -682,15 +687,27 @@ class LyricsPlugin(plugins.BeetsPlugin):
                         lib, item, write,
                         opts.force_refetch or self.config['force'],
                     )
-                if opts.printlyr and item.lyrics:
-                    if artist != item.artist:
-                        artist = item.artist
-                        ui.print_('<h1>' + artist + '</h1>')
-                    if album != item.album:
-                        album = item.album
-                        ui.print_('<h2>' + artist + '</h2>')
-                    ui.print_('<h3>' + item.title + '</h3>')
-                    ui.print_('<pre>' + item.lyrics + '</pre>')
+                if item.lyrics:
+                    if opts.printlyr:
+                        ui.print_(item.lyrics)
+                    if opts.printrst:
+                        if artist != item.artist:
+                            artist = item.artist
+                            ui.print_(artist)
+                            ui.print_(u'=' * len(artist))
+                            ui.print_()
+                        if album != item.album:
+                            album = item.album
+                            ui.print_(album)
+                            ui.print_(u'-' * len(album))
+                            ui.print_()
+                        title_str = u':index:`' + item.title + u'`'
+                        ui.print_(title_str)
+                        ui.print_(u'~' * len(title_str))
+                        ui.print_()
+                        # turn lyrics into a line block
+                        ui.print_(u'| ' + item.lyrics.replace(u'\n', u'\n| '))
+                        ui.print_()
 
         cmd.func = func
         return [cmd]

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -672,7 +672,7 @@ class LyricsPlugin(plugins.BeetsPlugin):
         )
         cmd.parser.add_option(
             u'-r', u'--write-rst', dest='writerst',
-            action='store', default='.', metavar='directory',
+            action='store', default='.', metavar='dir',
             help=u'write lyrics to given directory as RST files',
         )
         cmd.parser.add_option(

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -711,7 +711,8 @@ class LyricsPlugin(plugins.BeetsPlugin):
                           % opts.writerst)
                 ui.print_(u'  sphinx-build -b epub %s _build/epub'
                           % opts.writerst)
-                ui.print_(u'  sphinx-build -b latex %s _build/latex && make -C _build/latex all-pdf'
+                ui.print_((u'  sphinx-build -b latex %s _build/latex '
+                           u'&& make -C _build/latex all-pdf')
                           % opts.writerst)
         cmd.func = func
         return [cmd]

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -77,6 +77,41 @@ URL_CHARACTERS = {
 }
 USER_AGENT = 'beets/{}'.format(beets.__version__)
 
+# the content for the base index.rst generated
+REST_INDEX_TEMPLATE = u'''Lyrics
+======
+
+* :ref:`Song index <genindex>`
+* :ref:`search`
+
+Artist index:
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   artists/*
+'''
+
+# the content for the base conf.py generated
+REST_CONF_TEMPLATE = u'''# -*- coding: utf-8 -*-
+master_doc = 'index'
+project = u'Lyrics'
+copyright = u'none'
+author = u'Various Authors'
+latex_documents = [
+    (master_doc, 'Lyrics.tex', project,
+     author, 'manual'),
+]
+epub_title = project
+epub_author = author
+epub_publisher = author
+epub_copyright = copyright
+epub_exclude_files = ['search.html']
+epub_tocdepth = 1
+epub_tocdup = False
+'''
+
 
 # Utilities.
 
@@ -763,40 +798,11 @@ class LyricsPlugin(plugins.BeetsPlugin):
         indexfile = os.path.join(directory, 'index.rst')
         if not os.path.exists(indexfile):
             with open(indexfile, 'wb') as output:
-                output.write(u'''Lyrics
-======
-
-* :ref:`Song index <genindex>`
-* :ref:`search`
-
-Artist index:
-
-.. toctree::
-   :maxdepth: 1
-   :glob:
-
-   artists/*
-''')
+                output.write(REST_INDEX_TEMPLATE)
         conffile = os.path.join(directory, 'conf.py')
         if not os.path.exists(conffile):
             with open(conffile, 'wb') as output:
-                output.write(u'''# -*- coding: utf-8 -*-
-master_doc = 'index'
-project = u'Lyrics'
-copyright = u'none'
-author = u'Various Authors'
-latex_documents = [
-    (master_doc, 'Lyrics.tex', project,
-     author, 'manual'),
-]
-epub_title = project
-epub_author = author
-epub_publisher = author
-epub_copyright = copyright
-epub_exclude_files = ['search.html']
-epub_tocdepth = 1
-epub_tocdup = False
-''')
+                output.write(REST_CONF_TEMPLATE)
 
     def imported(self, session, task):
         """Import hook for fetching lyrics automatically.

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -713,10 +713,12 @@ class LyricsPlugin(plugins.BeetsPlugin):
 ''')
                             output.write(u'\n')
                         if album != item.album:
-                            album = item.album
-                            output.write(album.encode('utf-8'))
+                            tmpalbum = album = item.album
+                            if album == '':
+                                tmpalbum = 'Unknown album'
+                            output.write(tmpalbum.encode('utf-8'))
                             output.write(u'\n')
-                            output.write(u'-' * len(album))
+                            output.write(u'-' * len(tmpalbum))
                             output.write(u'\n')
                             output.write(u'\n')
                         title_str = u':index:`' + item.title + u'`'

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -703,35 +703,27 @@ class LyricsPlugin(plugins.BeetsPlugin):
                                           unidecode(artist).lower())
                             path = os.path.join(opts.writerst, slug + u'.rst')
                             output = open(path, 'w')
-                            output.write(artist.encode('utf-8'))
-                            output.write(u'\n')
-                            output.write(u'=' * len(artist))
-                            output.write(u'\n')
-                            output.write(u'''
+                            rst = u'''%s
+%s
+
 .. contents::
    :local:
-''')
-                            output.write(u'\n')
+
+''' % (artist, u'=' * len(artist))
+                            output.write(rst.encode('utf-8'))
                         if album != item.album:
                             tmpalbum = album = item.album
                             if album == '':
-                                tmpalbum = 'Unknown album'
-                            output.write(tmpalbum.encode('utf-8'))
-                            output.write(u'\n')
-                            output.write(u'-' * len(tmpalbum))
-                            output.write(u'\n')
-                            output.write(u'\n')
-                        title_str = u':index:`' + item.title + u'`'
-                        output.write(title_str.encode('utf-8'))
-                        output.write(u'\n')
-                        output.write(u'~' * len(title_str))
-                        output.write(u'\n')
-                        output.write(u'\n')
-                        # turn lyrics into a line block
+                                tmpalbum = u'Unknown album'
+                            rst = u"%s\n%s\n\n" % (tmpalbum,
+                                                   u'-' * len(tmpalbum))
+                            output.write(rst.encode('utf-8'))
+                        title_str = u":index:`%s`" % item.title
                         block = u'| ' + item.lyrics.replace(u'\n', u'\n| ')
-                        output.write(block.encode('utf-8'))
-                        output.write(u'\n')
-                        output.write(u'\n')
+                        rst = u"%s\n%s\n\n%s\n" % (title_str,
+                                                   u'~' * len(title_str),
+                                                   block)
+                        output.write(rst.encode('utf-8'))
             if opts.writerst:
                 output.close()
 

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -723,13 +723,8 @@ class LyricsPlugin(plugins.BeetsPlugin):
                 if item is None:
                     return
             self.artist = item.artist
-            self.rst = u'''%s
-%s
-
-.. contents::
-   :local:
-
-''' % (self.artist, u'=' * len(self.artist))
+            self.rst = u"%s\n%s\n\n.. contents::\n   :local:\n\n" \
+                       % (self.artist, u'=' * len(self.artist))
         if self.album != item.album:
             tmpalbum = self.album = item.album
             if self.album == '':

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,11 @@ Changelog
 1.4.6 (in development)
 ----------------------
 
-Changelog goes here!
+New features:
+
+* :doc:`/plugins/lyrics`: The plugin can now produce reStructuredText files
+  for beautiful, readable books of lyrics. Thanks to :user:`anarcat`.
+  :bug:`2628`
 
 Fixes:
 

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -84,58 +84,39 @@ lyrics will be added to the beets database and, if ``import.write`` is on,
 embedded into files' metadata.
 
 The ``-p`` option to the ``lyrics`` command makes it print lyrics out to the
-console so you can view the fetched (or previously-stored) lyrics. The
-``-r directory`` option similarly shows all lyrics as an RST (ReStructuredText)
-document structure located in ``directory`` (which defaults to the
-current directory). That document, in turn, can be parsed by tools like Sphinx
-to generate HTML, ePUB or PDF formatted documents. Use, for example,
-the following ``conf.py``::
-
-  # -*- coding: utf-8 -*-
-  master_doc = 'index'
-  project = u'Lyrics'
-  copyright = u'none'
-  author = u'Various Authors'
-  latex_documents = [
-      (master_doc, 'Lyrics.tex', project,
-       author, 'manual'),
-  ]
-  epub_title = project
-  epub_author = author
-  epub_publisher = author
-  epub_copyright = copyright
-  epub_exclude_files = ['search.html']
-  epub_tocdepth = 1
-  epub_tocdup = False
-
-Then the output can be written to ``index.rst``. An alternative is to
-use the following ``index.rst`` file, which will also generate an
-index of song titles::
-
-  Lyrics
-  ======
-  
-  * :ref:`Song index <genindex>`
-  * :ref:`search`
-  
-  Artist index:
-  
-  .. toctree::
-     :maxdepth: 1
-     :glob:
-  
-     artists/*
-
-Then the correct format can be generated with one of::
-
-  sphinx-build -b epub3 . _build/epub
-  sphinx-build -b latex . _build/latex
-  sphinx-build -b html . _build/html
+console so you can view the fetched (or previously-stored) lyrics.
 
 The ``-f`` option forces the command to fetch lyrics, even for tracks that
 already have lyrics. Inversely, the ``-l`` option restricts operations
 to lyrics that are locally available, to show lyrics faster without
 retrying them over the network all the time.
+
+Rendering lyrics into other formats
+-----------------------------------
+
+The ``-r directory`` option similarly renders all lyrics as an RST
+(ReStructuredText) document structure located in ``directory`` (which
+defaults to the current directory). That directory, in turn, can be
+parsed by tools like Sphinx to generate HTML, ePUB or PDF formatted
+documents. A minimal ``conf.py`` and ``index.rst`` files are created
+the first time the command is ran, to provide templates that can be
+modified. They are not overwritten on subsequent runs.
+
+Sphinx supports various `builders
+<http://www.sphinx-doc.org/en/stable/builders.html>`_, but here are a
+few suggestions.
+
+ * build a HTML version::
+
+    sphinx-build -b html . _build/html
+
+ * build an ePUB3 formatted file, usable on ebook-readers::
+
+     sphinx-build -b epub3 . _build/epub
+
+ * build a PDF file, which incidentally also builds a LaTeX file::
+
+    sphinx-build -b latex %s _build/latex && make -C _build/latex all-pdf
 
 .. _activate-google-custom-search:
 

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -133,8 +133,9 @@ Then the correct format can be generated with one of::
   sphinx-build -b html . _build/html
 
 The ``-f`` option forces the command to fetch lyrics, even for tracks that
-already have lyrics. Inversely, the ``-s`` option skips lyrics that
-are not locally available, to dump lyrics faster.
+already have lyrics. Inversely, the ``-l`` option restricts operations
+to lyrics that are locally available, to show lyrics faster without
+retrying them over the network all the time.
 
 .. _activate-google-custom-search:
 

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -84,10 +84,55 @@ lyrics will be added to the beets database and, if ``import.write`` is on,
 embedded into files' metadata.
 
 The ``-p`` option to the ``lyrics`` command makes it print lyrics out to the
-console so you can view the fetched (or previously-stored) lyrics.
+console so you can view the fetched (or previously-stored) lyrics. The
+``-r`` option similarly shows all lyrics as an RST (ReStructuredText)
+document. That document, in turn, can be parsed by tools like Sphinx
+to generate HTML, ePUB or PDF formatted documents. Use, for example,
+the following ``conf.py``::
+
+  # -*- coding: utf-8 -*-
+  master_doc = 'index'
+  project = u'Lyrics'
+  copyright = u'none'
+  author = u'Various Authors'
+  latex_documents = [
+      (master_doc, 'Lyrics.tex', project,
+       author, 'manual'),
+  ]
+  epub_title = project
+  epub_author = author
+  epub_publisher = author
+  epub_copyright = copyright
+  epub_exclude_files = ['search.html']
+  epub_tocdepth = 1
+  epub_tocdup = False
+
+Then the output can be written to ``index.rst``. An alternative is to
+use the following ``index.rst`` file, which will also generate an
+index of song titles::
+
+  Lyrics
+  ======
+  
+  * :ref:`Song index <genindex>`
+  * :ref:`search`
+  
+  Artist index:
+  
+  .. toctree::
+     :maxdepth: 1
+  
+     artists
+
+Then the correct format can be generated with one of::
+
+  sphinx-build -b epub3 . _build/epub
+  sphinx-build -b latex . _build/latex
+  sphinx-build -b html . _build/html
 
 The ``-f`` option forces the command to fetch lyrics, even for tracks that
-already have lyrics.
+already have lyrics. Inversely, the ``-s`` option skips lyrics that
+are not locally available, to dump lyrics faster.
 
 .. _activate-google-custom-search:
 

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -88,33 +88,37 @@ console so you can view the fetched (or previously-stored) lyrics.
 
 The ``-f`` option forces the command to fetch lyrics, even for tracks that
 already have lyrics. Inversely, the ``-l`` option restricts operations
-to lyrics that are locally available, to show lyrics faster without
-retrying them over the network all the time.
+to lyrics that are locally available, which show lyrics faster without using
+the network at all.
 
 Rendering Lyrics into Other Formats
 -----------------------------------
 
-The ``-r directory`` option similarly renders all lyrics as an RST
-(ReStructuredText) document structure located in ``directory`` (which
-defaults to the current directory). That directory, in turn, can be
-parsed by tools like Sphinx to generate HTML, ePUB or PDF formatted
-documents. A minimal ``conf.py`` and ``index.rst`` files are created
-the first time the command is ran, to provide templates that can be
-modified. They are not overwritten on subsequent runs.
+The ``-r directory`` option renders all lyrics as `reStructuredText`_ (ReST)
+documents in ``directory`` (by default, the current directory). That
+directory, in turn, can be parsed by tools like `Sphinx`_ to generate HTML,
+ePUB, or PDF documents.
+
+A minimal ``conf.py`` and ``index.rst`` files are created the first time the
+command is run. They are not overwritten on subsequent runs, so you can safely
+modify these files to customize the output.
+
+.. _Sphinx: http://www.sphinx-doc.org/
+.. _reStructuredText: http://docutils.sourceforge.net/rst.html
 
 Sphinx supports various `builders
 <http://www.sphinx-doc.org/en/stable/builders.html>`_, but here are a
 few suggestions.
 
- * build a HTML version::
+ * Build an HTML version::
 
     sphinx-build -b html . _build/html
 
- * build an ePUB3 formatted file, usable on ebook-readers::
+ * Build an ePUB3 formatted file, usable on ebook readers::
 
-     sphinx-build -b epub3 . _build/epub
+    sphinx-build -b epub3 . _build/epub
 
- * build a PDF file, which incidentally also builds a LaTeX file::
+ * Build a PDF file, which incidentally also builds a LaTeX file::
 
     sphinx-build -b latex %s _build/latex && make -C _build/latex all-pdf
 

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -91,7 +91,7 @@ already have lyrics. Inversely, the ``-l`` option restricts operations
 to lyrics that are locally available, to show lyrics faster without
 retrying them over the network all the time.
 
-Rendering lyrics into other formats
+Rendering Lyrics into Other Formats
 -----------------------------------
 
 The ``-r directory`` option similarly renders all lyrics as an RST
@@ -120,7 +120,7 @@ few suggestions.
 
 .. _activate-google-custom-search:
 
-Activate Google custom search
+Activate Google Custom Search
 ------------------------------
 
 Using the Google backend requires `BeautifulSoup`_, which you can install

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -122,8 +122,9 @@ index of song titles::
   
   .. toctree::
      :maxdepth: 1
+     :glob:
   
-     artists
+     artists/*
 
 Then the correct format can be generated with one of::
 

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -85,8 +85,9 @@ embedded into files' metadata.
 
 The ``-p`` option to the ``lyrics`` command makes it print lyrics out to the
 console so you can view the fetched (or previously-stored) lyrics. The
-``-r`` option similarly shows all lyrics as an RST (ReStructuredText)
-document. That document, in turn, can be parsed by tools like Sphinx
+``-r directory`` option similarly shows all lyrics as an RST (ReStructuredText)
+document structure located in ``directory`` (which defaults to the
+current directory). That document, in turn, can be parsed by tools like Sphinx
 to generate HTML, ePUB or PDF formatted documents. Use, for example,
 the following ``conf.py``::
 


### PR DESCRIPTION
Here's another crazy idea: how about printing lyrics in a usable
format? Here, `lyrics -p` on the whole library just dumps a
concatenation of all lyrics, which is not very useful.

I was thinking of improving the output a little, maybe by adding HTML
tags or some form of markup. this pull request does exactly that,
although rather crudely: the resulting output is probably not valid
HTML (it's just snippets) and embeds the lyrics in `<pre>` tags (as
opposed to trying to format them correctly).

the output is, of course, not an ebook in any way, although it could
be used to construct an ebook or other things.

comments? other ideas? suggestions?

i figured it was better to implement this directly in beets instead of
hacking at the sqlite database on the side...