### PR TITLE
Do not warn about a BrokenPipeError we do consider - Fix #2622

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -1276,7 +1276,7 @@ def main(args=None):
     except IOError as exc:
         if exc.errno == errno.EPIPE:
             # "Broken pipe". End silently.
-            pass
+            sys.stderr.close()
         else:
             raise
     except KeyboardInterrupt:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,11 @@ Changelog goes here!
 
 Fixes:
 
+* Prevent Python from warning about a ``BrokenPipeError`` being ignored even
+  though we do take it into account. This was an issue when using beets in
+  simple shell scripts.
+  Thanks to :user:`Azphreal`.
+  :bug:`2622` :bug:`2631`
 * :doc:`/plugins/replaygain`: Fix a regression in the previous release related
   to the new R128 tags. :bug:`2615` :bug:`2623`
 


### PR DESCRIPTION
For some reason Python always warns about a `BrokenPipeError` on
`stderr` even if it is caught.

This should fix #2622 and seems pretty harmless, since `stderr` is systematically flushed by other error messages.
@Azphreal , could we get some feedback from your end before merging?
