### PR TITLE
improvements and fixes to the lyrics RST rendering

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -236,6 +236,10 @@ def slug(text):
     2. shift everything to lowercase
     3. strip whitespace
     4. replace other non-word characters with dashes
+
+    This somewhat duplicates the :func:`Google.slugify` function but
+    slugify is not as generic as this one, which can be reused
+    elsewhere.
     """
     return re.sub(r'\W+', '-', unidecode(text).lower().strip())
 

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -774,11 +774,10 @@ class LyricsPlugin(plugins.BeetsPlugin):
                         % (self.artist,
                            u'=' * len(self.artist))
         if self.album != item.album:
-            tmpalbum = self.album = item.album
+            tmpalbum = self.album = item.album.strip()
             if self.album == '':
                 tmpalbum = u'Unknown album'
-            self.rest += u"%s\n%s\n\n" % (tmpalbum.strip(),
-                                          u'-' * len(tmpalbum.strip()))
+            self.rest += u"%s\n%s\n\n" % (tmpalbum, u'-' * len(tmpalbum))
         title_str = u":index:`%s`" % item.title.strip()
         block = u'| ' + item.lyrics.replace(u'\n', u'\n| ')
         self.rest += u"%s\n%s\n\n%s\n\n" % (title_str,

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -781,9 +781,9 @@ class LyricsPlugin(plugins.BeetsPlugin):
                                           u'-' * len(tmpalbum.strip()))
         title_str = u":index:`%s`" % item.title.strip()
         block = u'| ' + item.lyrics.replace(u'\n', u'\n| ')
-        self.rest += u"%s\n%s\n\n%s\n" % (title_str,
-                                          u'~' * len(title_str),
-                                          block)
+        self.rest += u"%s\n%s\n\n%s\n\n" % (title_str,
+                                            u'~' * len(title_str),
+                                            block)
 
     def writerest_indexes(self, directory):
         """Write conf.py and index.rst files necessary for Sphinx

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -759,7 +759,7 @@ class LyricsPlugin(plugins.BeetsPlugin):
         This will keep state (in the `rest` variable) in order to avoid
         writing continuously to the same files.
         """
-        if item is None or self.artist != item.artist:
+        if item is None or self.artist != item.artist.strip():
             if self.rest is not None:
                 slug = re.sub(r'\W+', '-',
                               unidecode(self.artist.strip()).lower())
@@ -769,10 +769,10 @@ class LyricsPlugin(plugins.BeetsPlugin):
                 self.rest = None
                 if item is None:
                     return
-            self.artist = item.artist
+            self.artist = item.artist.strip()
             self.rest = u"%s\n%s\n\n.. contents::\n   :local:\n\n" \
-                        % (self.artist.strip(),
-                           u'=' * len(self.artist.strip()))
+                        % (self.artist,
+                           u'=' * len(self.artist))
         if self.album != item.album:
             tmpalbum = self.album = item.album
             if self.album == '':

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -227,6 +227,19 @@ def search_pairs(item):
     return itertools.product(artists, multi_titles)
 
 
+def slug(text):
+    """Make a URL-safe, human-readable version of the given text
+
+    This will do the following:
+
+    1. decode unicode characters into ASCII
+    2. shift everything to lowercase
+    3. strip whitespace
+    4. replace other non-word characters with dashes
+    """
+    return re.sub(r'\W+', '-', unidecode(text).lower().strip())
+
+
 class Backend(object):
     def __init__(self, config, log):
         self._log = log
@@ -759,17 +772,6 @@ class LyricsPlugin(plugins.BeetsPlugin):
         This will keep state (in the `rest` variable) in order to avoid
         writing continuously to the same files.
         """
-        def slug(text):
-            """Make a URL-safe, human-readable version of the given text
-
-            This will do the following:
-
-            1. decode unicode characters into ASCII
-            2. shift everything to lowercase
-            3. strip whitespace
-            4. replace other non-word characters with dashes
-            """
-            return re.sub(r'\W+', '-', unidecode(text).lower().strip())
 
         if item is None or slug(self.artist) != slug(item.artist):
             if self.rest is not None:

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -759,11 +759,22 @@ class LyricsPlugin(plugins.BeetsPlugin):
         This will keep state (in the `rest` variable) in order to avoid
         writing continuously to the same files.
         """
-        if item is None or self.artist != item.artist.strip():
+        def slug(text):
+            """Make a URL-safe, human-readable version of the given text
+
+            This will do the following:
+
+            1. decode unicode characters into ASCII
+            2. shift everything to lowercase
+            3. strip whitespace
+            4. replace other non-word characters with dashes
+            """
+            return re.sub(r'\W+', '-', unidecode(text).lower().strip())
+
+        if item is None or slug(self.artist) != slug(item.artist):
             if self.rest is not None:
-                slug = re.sub(r'\W+', '-',
-                              unidecode(self.artist.strip()).lower())
-                path = os.path.join(directory, 'artists', slug + u'.rst')
+                path = os.path.join(directory, 'artists',
+                                    slug(self.artist) + u'.rst')
                 with open(path, 'wb') as output:
                     output.write(self.rest.encode('utf-8'))
                 self.rest = None

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -236,12 +236,13 @@ def slug(text):
     2. shift everything to lowercase
     3. strip whitespace
     4. replace other non-word characters with dashes
+    5. strip extra dashes
 
     This somewhat duplicates the :func:`Google.slugify` function but
     slugify is not as generic as this one, which can be reused
     elsewhere.
     """
-    return re.sub(r'\W+', '-', unidecode(text).lower().strip())
+    return re.sub(r'\W+', '-', unidecode(text).lower().strip()).strip('-')
 
 
 class Backend(object):

--- a/test/test_lyrics.py
+++ b/test/test_lyrics.py
@@ -393,6 +393,26 @@ class LyricsGooglePluginMachineryTest(LyricsGoogleBaseTest):
         google.is_page_candidate(url, url_title, s['title'], u'Sunn O)))')
 
 
+class SlugTests(unittest.TestCase):
+
+    def test_slug(self):
+        # plain ascii passthrough
+        text = u"test"
+        self.assertEqual(lyrics.slug(text), 'test')
+        # german unicode and capitals
+        text = u"Mørdag"
+        self.assertEqual(lyrics.slug(text), 'mordag')
+        # more accents and quotes
+        text = u"l'été c'est fait pour jouer"
+        self.assertEqual(lyrics.slug(text), 'l-ete-c-est-fait-pour-jouer')
+        # accents, parens and spaces
+        text = u"\xe7afe au lait (boisson)"
+        self.assertEqual(lyrics.slug(text), 'cafe-au-lait-boisson')
+        text = u"Multiple  spaces -- and symbols! -- merged"
+        self.assertEqual(lyrics.slug(text),
+                         'multiple-spaces-and-symbols-merged')
+
+
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 


### PR DESCRIPTION
a few issues were discovered in https://github.com/beetbox/beets/pull/2628#issuecomment-315792892:

 1. a newline is missing after the lyrics block, which generates a warning for every song (!!) when the resulting rst is built
 2. the last commit, which aimed at fixing some :index: directive that were not rendered correctly, doesn't seem to be working here, and may introduce overwrite between differently named artists that end up with the same "slug"

this introduces a new local function named `slug` which overlaps with the already existing `slugify` function. the code was taken in part from [this stack overflow discussion](https://stackoverflow.com/a/8366771/1174784) which explains how the `NKFD` approach used by the `slugify` function is actually incorrect. For example, `NKFD` will do this:

```
Mørdag -> mrdag
Æther -> ther
```

while unidecode will do that:

```
Mørdag -> mordag
Æther -> aether
```

we already depend on unidecode, so this is not an additional dependency. i'm hesitant in replacing the `slugify` function, however: it behaves very differently than my implementation and seems more complicated. it strips stuff in parens, for example, but also uses underscores instead of dashes to replace non-word characters.

i also wonder if we want to have unit tests for the lyrics stuff - is it mandatory for new things to get into beets?