### PR TITLE
lyrics: detect MusixMatch blocking

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -301,9 +301,19 @@ class MusiXmatch(SymbolsReplaced):
         html = self.fetch_url(url)
         if not html:
             return
+        if "We detected that your IP is blocked" in html:
+            self._log.warning(u'we are blocked at MusixMatch: url %s failed'
+                              % url)
+            return
         html_part = html.split('<p class="mxm-lyrics__content')[-1]
         lyrics = extract_text_between(html_part, '>', '</p>')
-        return lyrics.strip(',"').replace('\\n', '\n')
+        lyrics = lyrics.strip(',"').replace('\\n', '\n')
+        # another odd case: sometimes only that string remains, for
+        # missing songs. this seems to happen after being blocked
+        # above, when filling in the CAPTCHA.
+        if "Instant lyrics for all your music." in lyrics:
+            return
+        return lyrics
 
 
 class Genius(Backend):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,9 @@ Fixes:
 
 * :doc:`/plugins/replaygain`: Fix a regression in the previous release related
   to the new R128 tags. :bug:`2615` :bug:`2623`
+* :doc:`/plugins/lyrics`: The MusixMatch backend now detect and warns
+  the user when blocked on the server. Thanks to
+  :user:`anarcat`. :bug:`2634` :bug:`2632`
 
 For developers:
 


### PR DESCRIPTION
we just look for the bad string in the HTML. this has the downside
that we may consider songs that have those exact lyrics (you never
know, really) may trigger this warning as well and we would fail to
fetch those songs.

we also fail if lyrics contain another magic string that seems to come
up when you do fill in the CAPTCHA after being blocked.

for an example of error messages in songs, I suggest listening to the
excellent "Retry? Abort? Ignore?" from the band called "Martyr".

this is to fix #2632, obviously.