### PR TITLE
Fix album replaygain calculation with gstreamer backend

### DIFF
--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -606,6 +606,10 @@ class GStreamerBackend(Backend):
         self._decbin.sync_state_with_parent()
         self._decbin.get_state(self.Gst.CLOCK_TIME_NONE)
 
+        self._decbin.link(self._conv)
+        self._pipe.set_state(self.Gst.State.READY)
+        self._pipe.set_state(self.Gst.State.PLAYING)
+
         return True
 
     def _set_next_file(self):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -51,6 +51,8 @@ Fixes:
   analysis tool produced non-ASCII metadata. :bug:`2673`
 * :doc:`/plugins/duplicates`: Fix the `--key` command line option, which was
   ignored.
+* :doc:`/plugins/replaygain`: Fix album replaygain calculation with the
+  gstreamer backend. :bug:`2636`
 
 For developers:
 


### PR DESCRIPTION
Calling this WIP, as I'm not exactly sure what I'm doing.

We have an unlink here, so it makes sense that after we are done changing the location we link it back up.
The set_state I assume tell gstreamer that we are ready to continue. Setting PLAYING directly locks up the pipeline, so I assume it's not in READY state already at that point. So we set it to READY first, and then continue with PLAYING.

Modeled the solution after a stackoverflow post I found here https://stackoverflow.com/questions/4712266/gstreamer-pausing-resuming-video-in-rtp-streams/7771723#7771723

Fixes #2636 
