### PR TITLE
Fix kodiupdate URL and add better error reporting

### DIFF
--- a/beetsplug/kodiupdate.py
+++ b/beetsplug/kodiupdate.py
@@ -33,7 +33,7 @@ from beets.plugins import BeetsPlugin
 def update_kodi(host, port, user, password):
     """Sends request to the Kodi api to start a library refresh.
     """
-    url = "http://{0}:{1}/jsonrpc/".format(host, port)
+    url = "http://{0}:{1}/jsonrpc".format(host, port)
 
     """Content-Type: application/json is mandatory
     according to the kodi jsonrpc documentation"""

--- a/beetsplug/kodiupdate.py
+++ b/beetsplug/kodiupdate.py
@@ -28,6 +28,7 @@ from __future__ import division, absolute_import, print_function
 import requests
 from beets import config
 from beets.plugins import BeetsPlugin
+import six
 
 
 def update_kodi(host, port, user, password):
@@ -72,16 +73,26 @@ class KodiUpdate(BeetsPlugin):
     def update(self, lib):
         """When the client exists try to send refresh request to Kodi server.
         """
-        self._log.info(u'Updating Kodi library...')
+        self._log.info(u'Requesting a Kodi library update...')
 
         # Try to send update request.
         try:
-            update_kodi(
+            r = update_kodi(
                 config['kodi']['host'].get(),
                 config['kodi']['port'].get(),
                 config['kodi']['user'].get(),
                 config['kodi']['pwd'].get())
-            self._log.info(u'... started.')
+            r.raise_for_status()
 
-        except requests.exceptions.RequestException:
-            self._log.warning(u'Update failed.')
+        except requests.exceptions.RequestException as e:
+            self._log.warning(u'Kodi update failed: {0}',
+                              six.text_type(e))
+            return
+
+        json = r.json()
+        if json.get('result') != 'OK':
+            self._log.warning(u'Kodi update failed: JSON response was {0!r}',
+                              json)
+            return
+
+        self._log.info(u'Kodi update triggered')

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,8 @@ Fixes:
   :user:`anarcat`. :bug:`2634` :bug:`2632`
 * :doc:`/plugins/importfeeds`: Fix an error on Python 3 in certain
   configurations. Thanks to :user:`djl`. :bug:`2467` :bug:`2658`
+* :doc:`/plugins/kodiupdate`: Fix server URL and add better error reporting.
+  :bug:`2662`
 
 For developers:
 


### PR DESCRIPTION
The most important aspect of this change is to correct the Kodi URL. The current URL, which has a trailing slash, produces a 404 error on my system (Kodi v17.1 on ArchLinux).

The existing error handling/logging missed this, so I added checks of the HTTP status code and the JSON response data for more detailed information.