### PR TITLE
Edit plugin logic: Regression from previous PR; incorrect diffs

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -218,9 +218,12 @@ class Model(object):
             raise ValueError(u'{0} has no id'.format(type(self).__name__))
 
     def copy(self):
-        """Create a semi-deep copy of the item. In particular, the _db object
-        is not duplicated. A simple copy.deepcopy wouldn't work due to the
-        sqlite objects in _db.
+        """Create a copy of the model object.
+
+        The field values and other state is duplicated, but the new copy
+        remains associated with the same database as the old object.
+        (A simple `copy.deepcopy` will not work because it would try to
+        duplicate the SQLite connection.)
         """
         new = self.__class__()
         new._db = self._db

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -217,6 +217,18 @@ class Model(object):
         if need_id and not self.id:
             raise ValueError(u'{0} has no id'.format(type(self).__name__))
 
+    def copy(self):
+        """Create a semi-deep copy of the item. In particular, the _db object
+        is not duplicated. A simple copy.deepcopy wouldn't work due to the
+        sqlite objects in _db.
+        """
+        new = self.__class__()
+        new._db = self._db
+        new._values_fixed = self._values_fixed.copy()
+        new._values_flex = self._values_flex.copy()
+        new._dirty = self._dirty.copy()
+        return new
+
     # Essential field accessors.
 
     @classmethod

--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -302,8 +302,7 @@ class EditPlugin(plugins.BeetsPlugin):
                     return False
                 elif choice == u'e':  # Keep editing.
                     # Reset the temporary changes to the objects. I we have a
-                    # deepcopy from above, use that, else reload from the
-                    # database.
+                    # copy from above, use that, else reload from the database.
                     objs = [(old_obj or obj)
                             for old_obj, obj in zip(objs_old, objs)]
                     for obj in objs:

--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -23,7 +23,6 @@ from beets import ui
 from beets.dbcore import types
 from beets.importer import action
 from beets.ui.commands import _do_query, PromptChoice
-from copy import deepcopy
 import codecs
 import subprocess
 import yaml
@@ -283,7 +282,7 @@ class EditPlugin(plugins.BeetsPlugin):
                 # Show the changes.
                 # If the objects are not on the DB yet, we need a copy of their
                 # original state for show_model_changes.
-                objs_old = [deepcopy(obj) if obj.id < 0 else None
+                objs_old = [obj.copy() if obj.id < 0 else None
                             for obj in objs]
                 self.apply_data(objs, old_data, new_data)
                 changed = False

--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -302,9 +302,14 @@ class EditPlugin(plugins.BeetsPlugin):
                 elif choice == u'c':  # Cancel.
                     return False
                 elif choice == u'e':  # Keep editing.
-                    # Reset the temporary changes to the objects.
+                    # Reset the temporary changes to the objects. I we have a
+                    # deepcopy from above, use that, else reload from the
+                    # database.
+                    objs = [(old_obj or obj)
+                            for old_obj, obj in zip(objs_old, objs)]
                     for obj in objs:
-                        obj.read()
+                        if obj._db:
+                            obj.load()
                     continue
 
         # Remove the temporary file before returning.

--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -283,7 +283,7 @@ class EditPlugin(plugins.BeetsPlugin):
                 # Show the changes.
                 # If the objects are not on the DB yet, we need a copy of their
                 # original state for show_model_changes.
-                objs_old = [deepcopy(obj) if not obj._db else None
+                objs_old = [deepcopy(obj) if obj.id < 0 else None
                             for obj in objs]
                 self.apply_data(objs, old_data, new_data)
                 changed = False
@@ -308,7 +308,7 @@ class EditPlugin(plugins.BeetsPlugin):
                     objs = [(old_obj or obj)
                             for old_obj, obj in zip(objs_old, objs)]
                     for obj in objs:
-                        if obj._db:
+                        if not obj.id < 0:
                             obj.load()
                     continue
 
@@ -374,7 +374,8 @@ class EditPlugin(plugins.BeetsPlugin):
         # yet. By using negative values, no clash with items in the database
         # can occur.
         for i, obj in enumerate(task.items, start=1):
-            if not obj._db:
+            # The importer may set the id to None when re-importing albums.
+            if not obj._db or obj.id is None:
                 obj.id = -i
 
         # Present the YAML to the user and let her change it.
@@ -383,7 +384,7 @@ class EditPlugin(plugins.BeetsPlugin):
 
         # Remove temporary ids.
         for obj in task.items:
-            if not obj._db:
+            if obj.id < 0:
                 obj.id = None
 
         # Save the new data.


### PR DESCRIPTION
Contains two fixes:

- Turns out I introduced a regression in #2659 due to incorrectly assuming objects to have a valid `id` when `object._db` is set. Crashed beets when re-tagging albums (since the yaml file would contain `id: ''` which can obviously not be coerced to an integer)
- The plugin shows diffs against different initial states in first and subsequent edits, see the commit message for more detail.

