### PR TITLE
Added a missing switch to the fetchart command

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -824,9 +824,15 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             action='store_true', default=False,
             help=u're-download art when already present'
         )
+        cmd.parser.add_option(
+            u'-m', u'--missing', dest='missing',
+            action='store_true', default=False,
+            help=u'shows only missing art'
+        )
 
         def func(lib, opts, args):
-            self.batch_fetch_art(lib, lib.albums(ui.decargs(args)), opts.force)
+            self.batch_fetch_art(lib, lib.albums(ui.decargs(args)), opts.force,
+                                 opts.missing)
         cmd.func = func
         return [cmd]
 
@@ -866,13 +872,16 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
 
         return out
 
-    def batch_fetch_art(self, lib, albums, force):
+    def batch_fetch_art(self, lib, albums, force, missing):
         """Fetch album art for each of the albums. This implements the manual
         fetchart CLI command.
         """
         for album in albums:
             if album.artpath and not force and os.path.isfile(album.artpath):
-                message = ui.colorize('text_highlight_minor', u'has album art')
+                if not missing:
+                    message = ui.colorize('text_highlight_minor',
+                                          u'has album art')
+                    self._log.info(u'{0}: {1}', album, message)
             else:
                 # In ordinary invocations, look for images on the
                 # filesystem. When forcing, however, always go to the Web
@@ -885,5 +894,4 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                     message = ui.colorize('text_success', u'found album art')
                 else:
                     message = ui.colorize('text_error', u'no art found')
-
-            self._log.info(u'{0}: {1}', album, message)
+                self._log.info(u'{0}: {1}', album, message)

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -825,14 +825,14 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             help=u're-download art when already present'
         )
         cmd.parser.add_option(
-            u'-m', u'--missing', dest='missing',
+            u'-q', u'--quiet', dest='quiet',
             action='store_true', default=False,
-            help=u'shows only missing art'
+            help=u'shows only quiet art'
         )
 
         def func(lib, opts, args):
             self.batch_fetch_art(lib, lib.albums(ui.decargs(args)), opts.force,
-                                 opts.missing)
+                                 opts.quiet)
         cmd.func = func
         return [cmd]
 
@@ -872,13 +872,13 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
 
         return out
 
-    def batch_fetch_art(self, lib, albums, force, missing):
+    def batch_fetch_art(self, lib, albums, force, quiet):
         """Fetch album art for each of the albums. This implements the manual
         fetchart CLI command.
         """
         for album in albums:
             if album.artpath and not force and os.path.isfile(album.artpath):
-                if not missing:
+                if not quiet:
                     message = ui.colorize('text_highlight_minor',
                                           u'has album art')
                     self._log.info(u'{0}: {1}', album, message)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,9 @@ New features:
 * :doc:`/plugins/lyrics`: The plugin can now produce reStructuredText files
   for beautiful, readable books of lyrics. Thanks to :user:`anarcat`.
   :bug:`2628`
+* :doc:`/plugins/fetchart`: The plugin has now a quiet switch that will only
+  display missing album arts. Thanks to :user:`euri10`.
+  :bug:`2683`
 
 Fixes:
 

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -109,13 +109,13 @@ be processed; otherwise, the command processes every album in your library.
 Display Only Missing Album Art
 ------------------------------
 
-Use the ``fetchart`` command with the ``-m`` switch in order to display only missing
+Use the ``fetchart`` command with the ``-q`` switch in order to display only missing
 art::
 
-    $ beet fetchart [-m] [query]
+    $ beet fetchart [-q] [query]
 
-By default the command will display all results, the ``-m`` or ``--missing``
-switch will only display results for those album arts that still miss.
+By default the command will display all results, the ``-q`` or ``--quiet``
+switch will only display results for album arts that are still missing.
 
 Image Resizing
 --------------

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -106,6 +106,17 @@ be processed; otherwise, the command processes every album in your library.
 
 .. _image-resizing:
 
+Display Only Missing Album Art
+------------------------------
+
+Use the ``fetchart`` command with the ``-m`` switch in order to display only missing
+art::
+
+    $ beet fetchart [-m] [query]
+
+By default the command will display all results, the ``-m`` or ``--missing``
+switch will only display results for those album arts that still miss.
+
 Image Resizing
 --------------
 

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -519,7 +519,7 @@ class ArtImporterTest(UseThePlugin):
         self._fetch_art(True)
         util.remove(self.album.artpath)
         self.plugin.batch_fetch_art(self.lib, self.lib.albums(), force=False,
-                                    missing=False)
+                                    quiet=False)
         self.assertExists(self.album.artpath)
 
 

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -518,7 +518,8 @@ class ArtImporterTest(UseThePlugin):
         # message "<album> has album art".
         self._fetch_art(True)
         util.remove(self.album.artpath)
-        self.plugin.batch_fetch_art(self.lib, self.lib.albums(), force=False)
+        self.plugin.batch_fetch_art(self.lib, self.lib.albums(), force=False,
+                                    missing=False)
         self.assertExists(self.album.artpath)
 
 


### PR DESCRIPTION
I was trying to complete my album art collection today and found it not very friendly: maybe I'm using it the wrong way, there's always that possibility!

In the current state, issuing a beet fetchart command yields a gigantic list of already found stuff I really don't care about when your goal is just to fill the gaps in your collection,

that PR may solve the "issue"