### PR TITLE
mbcollection: Support specifiying collection ID.

### DIFF
--- a/beetsplug/mbcollection.py
+++ b/beetsplug/mbcollection.py
@@ -81,7 +81,8 @@ class MusicBrainzCollectionPlugin(BeetsPlugin):
         collection = self.config['collection'].as_str()
         if collection:
             if collection not in collection_ids:
-                raise ui.UserError(u'invalid collection ID: {0}'.format(collection))
+                raise ui.UserError(u'invalid collection ID: {}'
+                                   .format(collection))
             return collection
 
         # No specified collection. Just return the first collection ID

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,9 @@ New features:
 * :doc:`/plugins/fetchart`: The plugin has now a quiet switch that will only
   display missing album arts. Thanks to :user:`euri10`.
   :bug:`2683`
+* :doc:`/plugins/mbcollection`: The plugin now supports a custom MusicBrainz
+  collection via the ``collection`` configuration option.
+  :bug:`2685`
 
 Fixes:
 

--- a/docs/plugins/mbcollection.rst
+++ b/docs/plugins/mbcollection.rst
@@ -29,3 +29,5 @@ configuration file. There is one option available:
 - **auto**: Automatically amend your MusicBrainz collection whenever you
   import a new album.
   Default: ``no``.
+- **collection**: Which MusicBrainz collection to update.
+  Default: ``None``.


### PR DESCRIPTION
For those of us who have multiple MusicBrainz collections I've added support for specifying which collection you'd like to use.

In the future I'd like to add support for multiple collections updated via queries (in the vein of the smartplaylist plugin).