### PR TITLE
mbcollection: Add support from removing albums.

### DIFF
--- a/beetsplug/mbcollection.py
+++ b/beetsplug/mbcollection.py
@@ -112,8 +112,9 @@ class MusicBrainzCollectionPlugin(BeetsPlugin):
         mbupdate = Subcommand('mbupdate',
                               help=u'Update MusicBrainz collection')
         mbupdate.parser.add_option('-r', '--remove',
-                                   action='store_true', default=None,
-                                   dest='remove_missing',
+                                   action='store_true',
+                                   default=False,
+                                   dest='remove',
                                    help='Remove albums not in beets library')
         mbupdate.func = self.update_collection
         return [mbupdate]
@@ -130,13 +131,8 @@ class MusicBrainzCollectionPlugin(BeetsPlugin):
             )
 
     def update_collection(self, lib, opts, args):
-        # If the ``-r`` option is not given then fall back to the
-        # config defaults.
-        if opts.remove_missing is None:
-            remove_missing = self.config['remove'].get(bool)
-        else:
-            remove_missing = opts.remove_missing
-
+        self.config.set_args(opts)
+        remove_missing = self.config['remove'].get(bool)
         self.update_album_list(lib, lib.albums(), remove_missing)
 
     def imported(self, session, task):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,8 @@ New features:
 * :doc:`/plugins/mbcollection`: The plugin now supports a custom MusicBrainz
   collection via the ``collection`` configuration option.
   :bug:`2685`
+* :doc:`/plugins/mbcollection`: The plugin now supports removing albums
+  from collections that are longer in the beets library.
 
 Fixes:
 

--- a/docs/plugins/mbcollection.rst
+++ b/docs/plugins/mbcollection.rst
@@ -20,6 +20,12 @@ command automatically adds all of your albums to the first collection it finds.
 If you don't have a MusicBrainz collection yet, you may need to add one to your
 profile first.
 
+The command has one command-line option:
+
+* To remove albums from the collection which are no longer present in
+  the beets database, use the ``-r`` (``--remove``) flag.
+
+
 Configuration
 -------------
 
@@ -30,4 +36,7 @@ configuration file. There is one option available:
   import a new album.
   Default: ``no``.
 - **collection**: Which MusicBrainz collection to update.
+  Default: ``None``.
+- **remove**: Remove albums from collections which are no longer
+  present in the beets database.
   Default: ``None``.


### PR DESCRIPTION
Add a new ``mbcollection.remove`` configuration option (default: None) and a new ``-r`` (``--remove``) flag which removes albums from collections that are no longer present in the beets database.

The ``-r`` flag takes precedence over the ``remove`` configuration option.