### PR TITLE
Fix the --key option in the `duplicates` plugin.

### DIFF
--- a/beetsplug/duplicates.py
+++ b/beetsplug/duplicates.py
@@ -81,7 +81,7 @@ class DuplicatesPlugin(BeetsPlugin):
             help=u'report duplicates only if all attributes are set',
         )
         self._command.parser.add_option(
-            u'-k', u'--key',
+            u'-k', u'--key', dest='keys',
             action='append', metavar='KEY',
             help=u'report duplicates based on keys (use multiple times)',
         )

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -45,6 +45,8 @@ Fixes:
   Python 3 on Windows with non-ASCII filenames. :bug:`2671`
 * :doc:`/plugins/absubmit`: Fix an occasional crash on Python 3 when the AB
   analysis tool produced non-ASCII metadata. :bug:`2673`
+* :doc:`/plugins/duplicates`: Fix the `--key` command line option, which was
+  ignored.
 
 For developers:
 


### PR DESCRIPTION
During a refactoring, the "dest='keys'" parameter was lost. This caused
the option to not have any effect.