### PR TITLE
[Play plugin]Respect relative paths when using albums

### DIFF
--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -116,9 +116,10 @@ class PlayPlugin(BeetsPlugin):
         else:
             selection = lib.items(ui.decargs(args))
             paths = [item.path for item in selection]
-            if relative_to:
-                paths = [relpath(path, relative_to) for path in paths]
             item_type = 'track'
+         
+        if relative_to:
+            paths = [relpath(path, relative_to) for path in paths]
 
         if not selection:
             ui.print_(ui.colorize('text_warning',

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -117,7 +117,7 @@ class PlayPlugin(BeetsPlugin):
             selection = lib.items(ui.decargs(args))
             paths = [item.path for item in selection]
             item_type = 'track'
-         
+
         if relative_to:
             paths = [relpath(path, relative_to) for path in paths]
 


### PR DESCRIPTION
Now relative_to setting in play plugin is respected when searching by albums.

Small tweak, but my mpd likes it a lot :)