### PR TITLE
mpdstats: update stats when switching from song to stream and when playing a song consecutively 

### DIFF
--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -271,6 +271,9 @@ class MPDStats(object):
 
                 if diff <= self.time_threshold:
                     return
+                
+                if self.now_playing['path'] == path and played == 0:
+                    self.handle_song_change(self.now_playing)
 
         if is_url(path):
             self._log.info(u'playing stream {0}', displayable_path(path))

--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -256,10 +256,6 @@ class MPDStats(object):
         if not path:
             return
 
-        if is_url(path):
-            self._log.info(u'playing stream {0}', displayable_path(path))
-            return
-
         played, duration = map(int, status['time'].split(':', 1))
         remaining = duration - played
 
@@ -275,6 +271,11 @@ class MPDStats(object):
 
                 if diff <= self.time_threshold:
                     return
+
+        if is_url(path):
+            self._log.info(u'playing stream {0}', displayable_path(path))
+            self.now_playing = None
+            return
 
         self._log.info(u'playing {0}', displayable_path(path))
 

--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -271,7 +271,7 @@ class MPDStats(object):
 
                 if diff <= self.time_threshold:
                     return
-                
+
                 if self.now_playing['path'] == path and played == 0:
                     self.handle_song_change(self.now_playing)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,8 @@ New features:
   :bug:`2685`
 * :doc:`/plugins/mbcollection`: The plugin now supports removing albums
   from collections that are longer in the beets library.
+* :doc:`/plugins/mpdstats`: The plugin now updates song stats when MPD switches 
+  from a song to a stream and when it plays the same song consecutively.
 
 Fixes:
 


### PR DESCRIPTION
Fixes an issue where mpdstats won't update play/skip counts of a song when MPD switches from the song to an internet stream. Also updates play counts for a song being played consecutively. 