### PR TITLE
Use multiprocessing to do parallel uploads of music to google-music

### DIFF
--- a/beetsplug/gmusic.py
+++ b/beetsplug/gmusic.py
@@ -36,6 +36,9 @@ class Gmusic(BeetsPlugin):
         super(Gmusic, self).__init__()
 
         self.m = self.create_music_manager()
+        self.config.add({
+            'processes': multiprocessing.cpu_count()
+        })
 
     def commands(self):
         gupload = Subcommand('gmusic-upload',
@@ -58,7 +61,7 @@ class Gmusic(BeetsPlugin):
         items = lib.items(ui.decargs(args))
         files = [x.path.decode('utf-8') for x in items]
         ui.print_(u'Uploading your files...')
-        pool = multiprocessing.Pool(initializer=self._pool_init)
+        pool = multiprocessing.Pool(initializer=self._pool_init, processes=self.config['processes'])
         chunks = [tuple(files[i:i + 25]) for i in range(0, len(files), 25)]
         pool.map(self._upload_file, chunks)
         ui.print_(u'Your files were successfully added to library')

--- a/docs/plugins/gmusic.rst
+++ b/docs/plugins/gmusic.rst
@@ -26,6 +26,11 @@ To upload tracks to Google Play Music, use the ``gmusic-upload`` command::
     beet gmusic-upload [QUERY]
 
 If you don't include a query, the plugin will upload your entire collection.
+By default beets will use one process per cpu to upload in parallel. You
+can customize the number of processes by using the ``processes`` config option::
+
+    gmusic:
+        processes: 8
 
 To query the songs in your collection, you will need to add your Google
 credentials to your beets configuration file. Put your Google username and


### PR DESCRIPTION
This improves the speed of uploads to google music. Currently it uploads sequentially, with this it will upload in parallel (depending on the number of cores).

We batch the files together because the google-music library can batch-detect songs that have already been uploaded, so it makes sense to do sequential uploads of 25 files.