### PR TITLE
Made 'beet config -e' more likely to work on windows.

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1637,12 +1637,23 @@ def config_edit():
     """
     path = config.user_config_path()
     editor = util.editor_command()
+
     try:
         if not os.path.isfile(path):
             open(path, 'w+').close()
         util.interactive_open([path], editor)
+
     except OSError as exc:
+        """If it's a windows machine try this first"""
         message = u"Could not edit configuration: {0}".format(exc)
+        if os.name == 'nt':
+            message += u". Detected windows machine, attempting bootleg solution."
+            if(path):
+                confpath = path
+            else:
+                confpath = os.getenv('APPDATA') + "/beets/config.yaml"
+            os.system(u"notepad " + confpath)
+
         if not editor:
             message += u". Please set the EDITOR environment variable"
         raise ui.UserError(message)

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1644,15 +1644,15 @@ def config_edit():
         util.interactive_open([path], editor)
 
         except OSError as exc:
-        message = u"Could not edit configuration: {0}".format(exc)
+            message = u"Could not edit configuration: {0}".format(exc)
 
-        # If it's a windows machine, attempt to open with notepad
-        if os.name == 'nt':
-            util.interactive_open([path], u"notepad")
+            # If it's a windows machine, attempt to open with notepad
+            if os.name == 'nt':
+                util.interactive_open([path], u"notepad")
 
-        if not editor:
-            message += u". Please set the EDITOR environment variable"
-        raise ui.UserError(message)
+            if not editor:
+                message += u". Please set the EDITOR environment variable"
+            raise ui.UserError(message)
 
 config_cmd = ui.Subcommand(u'config',
                            help=u'show or edit the user configuration')

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1643,16 +1643,12 @@ def config_edit():
             open(path, 'w+').close()
         util.interactive_open([path], editor)
 
-    except OSError as exc:
-        """If it's a windows machine try this first"""
+        except OSError as exc:
         message = u"Could not edit configuration: {0}".format(exc)
+
+        # If it's a windows machine, attempt to open with notepad
         if os.name == 'nt':
-            message += u". Detected windows machine, attempting bootleg solution."
-            if(path):
-                confpath = path
-            else:
-                confpath = os.getenv('APPDATA') + "/beets/config.yaml"
-            os.system(u"notepad " + confpath)
+            util.interactive_open([path], u"notepad")
 
         if not editor:
             message += u". Please set the EDITOR environment variable"

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1643,16 +1643,16 @@ def config_edit():
             open(path, 'w+').close()
         util.interactive_open([path], editor)
 
-        except OSError as exc:
-            message = u"Could not edit configuration: {0}".format(exc)
+    except OSError as exc:
+        message = u"Could not edit configuration: {0}".format(exc)
 
-            # If it's a windows machine, attempt to open with notepad
-            if os.name == 'nt':
-                util.interactive_open([path], u"notepad")
+        # If it's a windows machine, attempt to open with notepad
+        if os.name == 'nt':
+            util.interactive_open([path], u"notepad")
 
-            if not editor:
-                message += u". Please set the EDITOR environment variable"
-            raise ui.UserError(message)
+        if not editor:
+            message += u". Please set the EDITOR environment variable"
+        raise ui.UserError(message)
 
 config_cmd = ui.Subcommand(u'config',
                            help=u'show or edit the user configuration')


### PR DESCRIPTION
Addressing the same issue as in #2714 I made the  "beet config -e" command try opening the config file with notepad in addition to the current method of  telling them to add an EDITOR environment variable on windows machines. Reason being I think being met by setbacks first thing when getting into using a new program can be quite discouraging.