### PR TITLE
fetchart: Restore iTunes Store source

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -479,11 +479,13 @@ class ITunesStore(RemoteArtSource):
             self._log.debug(u'Could not decode json response: {0}', e)
             return
         except KeyError as e:
-            self._log.debug(u'No results lists in response: {0}', e)
+            self._log.debug(u'{} not found in json. Fields are {} ',
+                            e,
+                            list(r.json().keys()))
             return
 
         if not candidates:
-            self._log.debug(u'iTunes search for {:r} got no results',
+            self._log.debug(u'iTunes search for {!r} got no results',
                             payload['term'])
             return
 
@@ -496,7 +498,9 @@ class ITunesStore(RemoteArtSource):
                     yield self._candidate(url=art_url,
                                           match=Candidate.MATCH_EXACT)
             except KeyError as e:
-                self._log.debug(u'Malformed itunes candidate {0}', e)
+                self._log.debug(u'Malformed itunes candidate: {} not found in {}',  # NOQA E501
+                                e,
+                                list(c.keys()))
 
         try:
             fallback_art_url = candidates[0]['artworkUrl100']
@@ -504,7 +508,9 @@ class ITunesStore(RemoteArtSource):
             yield self._candidate(url=fallback_art_url,
                                   match=Candidate.MATCH_FALLBACK)
         except KeyError as e:
-            self._log.debug(u'Malformed itunes candidate {0}', e)
+            self._log.debug(u'Malformed itunes candidate: {} not found in {}',
+                            e,
+                            list(c.keys()))
 
 
 class Wikipedia(RemoteArtSource):

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -35,12 +35,6 @@ from beets.util import confit
 from beets.util import syspath, bytestring_path, py3_path
 import six
 
-try:
-    import itunes
-    HAVE_ITUNES = True
-except ImportError:
-    HAVE_ITUNES = False
-
 CONTENT_TYPES = {
     'image/jpeg': [b'jpg', b'jpeg'],
     'image/png': [b'png']
@@ -458,37 +452,59 @@ class FanartTV(RemoteArtSource):
 
 class ITunesStore(RemoteArtSource):
     NAME = u"iTunes Store"
+    API_URL = u'https://itunes.apple.com/search'
 
     def get(self, album, plugin, paths):
         """Return art URL from iTunes Store given an album title.
         """
         if not (album.albumartist and album.album):
             return
-        search_string = (album.albumartist + ' ' + album.album).encode('utf-8')
+
+        payload = {
+            'term': album.albumartist + u' ' + album.album,
+            'entity': u'album',
+            'media': u'music',
+            'limit': 200
+        }
         try:
-            # Isolate bugs in the iTunes library while searching.
+            r = self.request(self.API_URL, params=payload)
+            r.raise_for_status()
+        except requests.RequestException as e:
+            self._log.debug(u'iTunes search failed: {0}', e)
+            return
+
+        try:
+            candidates = r.json()['results']
+        except ValueError as e:
+            self._log.debug(u'Could not decode json response: {0}', e)
+            return
+        except KeyError as e:
+            self._log.debug(u'No results lists in response: {0}', e)
+            return
+
+        if not candidates:
+            self._log.debug(u'iTunes search for {:r} got no results',
+                            payload['term'])
+            return
+
+        for c in candidates:
             try:
-                results = itunes.search_album(search_string)
-            except Exception as exc:
-                self._log.debug(u'iTunes search failed: {0}', exc)
-                return
+                if (c['artistName'] == album.albumartist
+                        and c['collectionName'] == album.album):
+                    art_url = c['artworkUrl100']
+                    art_url = art_url.replace('100x100', '1200x1200')
+                    yield self._candidate(url=art_url,
+                                          match=Candidate.MATCH_EXACT)
+            except KeyError as e:
+                self._log.debug(u'Malformed itunes candidate {0}', e)
 
-            # Get the first match.
-            if results:
-                itunes_album = results[0]
-            else:
-                self._log.debug(u'iTunes search for {:r} got no results',
-                                search_string)
-                return
-
-            if itunes_album.get_artwork()['100']:
-                small_url = itunes_album.get_artwork()['100']
-                big_url = small_url.replace('100x100', '1200x1200')
-                yield self._candidate(url=big_url, match=Candidate.MATCH_EXACT)
-            else:
-                self._log.debug(u'album has no artwork in iTunes Store')
-        except IndexError:
-            self._log.debug(u'album not found in iTunes Store')
+        try:
+            fallback_art_url = candidates[0]['artworkUrl100']
+            fallback_art_url = fallback_art_url.replace('100x100', '1200x1200')
+            yield self._candidate(url=fallback_art_url,
+                                  match=Candidate.MATCH_FALLBACK)
+        except KeyError as e:
+            self._log.debug(u'Malformed itunes candidate {0}', e)
 
 
 class Wikipedia(RemoteArtSource):
@@ -756,8 +772,6 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             self.register_listener('import_task_files', self.assign_art)
 
         available_sources = list(SOURCES_ALL)
-        if not HAVE_ITUNES and u'itunes' in available_sources:
-            available_sources.remove(u'itunes')
         if not self.config['google_key'].get() and \
                 u'google' in available_sources:
             available_sources.remove(u'google')

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,11 @@ New features:
 
 Fixes:
 
+* Restore iTunes Store album art source, and remove the dependency on
+  python-itunes_, which had gone unmaintained and was not py3 compatible.
+  Thanks to :user:`ocelma` for creating python-itunes_ in the first place.
+  Thanks to :user:`nathdwek`.
+  :bug:`2371` :bug:`2551` :bug:`2718`
 * Fix compatibility Python 3.7 and its change to a name in the ``re`` module.
   :bug:`2978`
 * R128 normalization tags are now properly deleted from files when the values
@@ -40,6 +45,8 @@ Fixes:
   with CORS enabled.
   Thanks to :user:`rveachkc`.
   :bug:`2979`: :bug:`2980`
+
+.. _python-itunes: https://github.com/ocelma/python-itunes
 
 
 1.4.7 (May 29, 2018)

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -16,12 +16,13 @@ The plugin uses `requests`_ to fetch album art from the Web.
 Fetching Album Art During Import
 --------------------------------
 
-When the plugin is enabled, it automatically gets album art for every album
-you import.
+When the plugin is enabled, it automatically tries to get album art for every
+album you import.
 
 By default, beets stores album art image files alongside the music files for an
 album in a file called ``cover.jpg``. To customize the name of this file, use
-the :ref:`art-filename` config option.
+the :ref:`art-filename` config option. To embed the art into the files'tag,
+use the :doc:`/plugins/embedart`. (You'll want to have both plugins enabled.)
 
 Configuration
 -------------
@@ -49,7 +50,7 @@ file. The available options are:
   (``enforce_ratio: 0.5%``). Default: ``no``.
 - **sources**: List of sources to search for images. An asterisk `*` expands
   to all available sources.
-  Default: ``filesystem coverart amazon albumart``, i.e., everything but
+  Default: ``filesystem coverart itunes amazon albumart``, i.e., everything but
   ``wikipedia``, ``google`` and ``fanarttv``. Enable those sources for more
   matches at the cost of some speed. They are searched in the given order,
   thus in the default config, no remote (Web) art source are queried if
@@ -83,13 +84,13 @@ or `Pillow`_.
 .. _ImageMagick: http://www.imagemagick.org/
 
 Here's an example that makes plugin select only images that contain *front* or
-*back* keywords in their filenames and prioritizes the Amazon source over
+*back* keywords in their filenames and prioritizes the iTunes source over
 others::
 
     fetchart:
         cautious: true
         cover_names: front back
-        sources: amazon *
+        sources: itunes *
 
 
 Manually Fetching Album Art
@@ -142,7 +143,7 @@ Album Art Sources
 -----------------
 
 By default, this plugin searches for art in the local filesystem as well as on
-the Cover Art Archive, Amazon, and AlbumArt.org, in that
+the Cover Art Archive, the iTunes Store, Amazon, and AlbumArt.org, in that
 order.
 You can reorder the sources or remove
 some to speed up the process using the ``sources`` configuration option.
@@ -222,10 +223,3 @@ album art fetch, you could do
 
 The values written to ``art_source`` are the same names used in the ``sources``
 configuration value.
-
-Embedding Album Art
--------------------
-
-This plugin fetches album art but does not embed images into files' tags. To do
-that, use the :doc:`/plugins/embedart`. (You'll want to have both plugins
-enabled.)

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -21,7 +21,7 @@ album you import.
 
 By default, beets stores album art image files alongside the music files for an
 album in a file called ``cover.jpg``. To customize the name of this file, use
-the :ref:`art-filename` config option. To embed the art into the files'tag,
+the :ref:`art-filename` config option. To embed the art into the files' tags,
 use the :doc:`/plugins/embedart`. (You'll want to have both plugins enabled.)
 
 Configuration


### PR DESCRIPTION
This is a tentative at addressing #2551 . For the moment this is very much a work in progress, but I would like to discuss some points.

For the moment I took python-itunes from @ocelma, stripped it of some unnecessary stuff and fixed some stuff to make python3 compatible.

Open questions are:
* Place in the beetbox universe: I do not really see us maintaining this for anyone's else purpose than ours. I would like to strip the code down even more so that it is as as simple and minimalistic as required to fetch the images, nothing else. Keeping it inside beets gives us some more freedom in terms of interface.
* Licensing/recognition: python-itunes is GPL. I removed all the comments at the top of the file for the moment, but only to be able to remove clutter, for my own sanity when reading the code. I think even outside of licensing issues we should give some recognition to the original author(s).

To fix:
* Some pep8 and long lines
* Python2-3 compat: I think key issues will be urllib and strings when dealing with requests/responses
* Remove a ton of unnecessary getters and unneeded complexity

