### PR TITLE
Implement album merging for duplicates

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -358,7 +358,7 @@ class ImportSession(object):
         """
         for path in paths:
             if path not in self._merged_items \
-                and path not in self._merged_dirs:
+               and path not in self._merged_dirs:
                 return False
         return True
 
@@ -367,7 +367,7 @@ class ImportSession(object):
         """
         self._merged_items.update(paths)
         dirs = set([os.path.dirname(path) if os.path.isfile(path) else path
-                        for path in paths])
+                    for path in paths])
         self._merged_dirs.update(dirs)
 
     def is_resuming(self, toppath):

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -1365,8 +1365,13 @@ def user_query(session, task):
                                 user_query(session))
 
     resolve_duplicates(session, task)
+
     if task.should_merge_duplicates:
+        # Create a new task for tagging the current items
+        # and duplicates together
         duplicate_items = task.duplicate_items(session.lib)
+
+        # duplicates would be reimported so make them look "fresh"
         _freshen_items(duplicate_items)
         duplicate_paths = [item.path for item in duplicate_items]
 

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -1038,6 +1038,7 @@ class ArchiveImportTask(SentinelImportTask):
         self.extracted = True
         self.toppath = extract_to
 
+
 class MergedImportTask(ImportTask):
     def __init__(self, toppath, paths, items):
         super(MergedImportTask, self).__init__(toppath, paths, items)
@@ -1367,9 +1368,8 @@ def user_query(session, task):
 
             duplicate_paths = [item.path for item in duplicate_items]
 
-            merged_task = MergedImportTask(None,
-                            task.paths + duplicate_paths,
-                            task.items + duplicate_items)
+            merged_task = MergedImportTask(None, task.paths + duplicate_paths,
+                                           task.items + duplicate_items)
 
             ipl = pipeline.Pipeline([
                 iter([merged_task]),

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -791,7 +791,7 @@ class TerminalImportSession(importer.ImportSession):
             ))
 
             sel = ui.input_options(
-                (u'Skip new', u'Keep both', u'Remove old')
+                (u'Skip new', u'Keep both', u'Remove old', u'Merge all')
             )
 
         if sel == u's':
@@ -803,6 +803,8 @@ class TerminalImportSession(importer.ImportSession):
         elif sel == u'r':
             # Remove old.
             task.should_remove_duplicates = True
+        elif sel == u'm':
+            task.should_merge_duplicates = True
         else:
             assert False
 

--- a/docs/guides/tagger.rst
+++ b/docs/guides/tagger.rst
@@ -234,16 +234,24 @@ If beets finds an album or item in your library that seems to be the same as the
 one you're importing, you may see a prompt like this::
 
     This album is already in the library!
-    [S]kip new, Keep both, Remove old?
+    [S]kip new, Keep both, Remove old, Merge all?
 
 Beets wants to keep you safe from duplicates, which can be a real pain, so you
-have three choices in this situation. You can skip importing the new music,
+have four choices in this situation. You can skip importing the new music,
 choosing to keep the stuff you already have in your library; you can keep both
-the old and the new music; or you can remove the existing music and choose the
-new stuff. If you choose that last "trump" option, any duplicates will be
+the old and the new music; you can remove the existing music and choose the
+new stuff; or you can merge the newly imported album and existing duplicate
+into one single album. 
+If you choose that "remove" option, any duplicates will be
 removed from your library database---and, if the corresponding files are located
 inside of your beets library directory, the files themselves will be deleted as
 well.
+
+If you choose "merge", beets will try re-importing the existing and new tracks
+as one bundle so they will get tagged together appropriately.
+This is particularly helpful when you are importing extra tracks
+of an album in your library with missing tracks, so beets will ask you the same
+questions as it would if you were importing all tracks at once.
 
 If you choose to keep two identically-named albums, beets can avoid storing both
 in the same directory. See :ref:`aunique` for details.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -571,11 +571,12 @@ Default: ``yes``.
 duplicate_action
 ~~~~~~~~~~~~~~~~
 
-Either ``skip``, ``keep``, ``remove``, or ``ask``. Controls how duplicates
-are treated in import task. "skip" means that new item(album or track) will be
-skipped; "keep" means keep both old and new items; "remove" means remove old
-item; "ask" means the user should be prompted for the action each time.
-The default is ``ask``.
+Either ``skip``, ``keep``, ``remove``, ``merge`` or ``ask``. 
+Controls how duplicates are treated in import task. 
+"skip" means that new item(album or track) will be skipped; 
+"keep" means keep both old and new items; "remove" means remove old
+item; "merge" means merge into one album; "ask" means the user 
+should be prompted for the action each time. The default is ``ask``.
 
 .. _bell:
 

--- a/test/helper.py
+++ b/test/helper.py
@@ -535,7 +535,7 @@ class TestImportSession(importer.ImportSession):
 
     choose_item = choose_match
 
-    Resolution = Enum('Resolution', 'REMOVE SKIP KEEPBOTH')
+    Resolution = Enum('Resolution', 'REMOVE SKIP KEEPBOTH MERGE')
 
     default_resolution = 'REMOVE'
 
@@ -553,6 +553,8 @@ class TestImportSession(importer.ImportSession):
             task.set_choice(importer.action.SKIP)
         elif res == self.Resolution.REMOVE:
             task.should_remove_duplicates = True
+        elif res == self.Resolution.MERGE:
+            task.should_merge_duplicates = True
 
 
 def generate_album_info(album_id, track_ids):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1248,6 +1248,12 @@ class ImportDuplicateAlbumTest(unittest.TestCase, TestHelper,
         item = self.lib.items().get()
         self.assertEqual(item.title, u't\xeftle 0')
 
+    def test_merge_duplicate_album(self):
+        self.importer.default_resolution = self.importer.Resolution.MERGE
+        self.importer.run()
+
+        self.assertEqual(len(self.lib.albums()), 1)
+
     def test_twice_in_import_dir(self):
         self.skipTest('write me')
 


### PR DESCRIPTION
Fixes #112

Would removing the album before running the merge task make sense? This code seems to work now
but I think it gives problems when reimporting library with existing duplicate albums. The tests don't fail though.