### PR TITLE
Mention backups in the main guide

### DIFF
--- a/docs/guides/main.rst
+++ b/docs/guides/main.rst
@@ -182,6 +182,11 @@ here, including the directory and file naming scheme. See
 Importing Your Library
 ----------------------
 
+The next step is to import your music files into the beets library database.
+Because this can involve moving files around, data loss is always a
+possibility, so now would be a good time to make sure you have a recent backup
+of all your music. We'll wait.
+
 There are two good ways to bring your existing library into beets. You can
 either: (a) quickly bring all your files with all their current metadata into
 beets' database, or (b) use beets' highly-refined autotagger to find canonical


### PR DESCRIPTION
As an alternative to #2728, this mentions the need to back up your music before importing stuff. This wording fits better with the style of the rest of the guide. I'd be interested to hear feedback on how to word this.