### PR TITLE
Added source option in fetchart to fetch cover art using release group

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -319,7 +319,7 @@ class CoverArtArchiveReleaseGroup(RemoteArtSource):
         URL = 'http://coverartarchive.org/release-group/{mbid}/front'
 
     def get(self, album, plugin, paths):
-        """Return the Cover Art Archive release group URLs using album 
+        """Return the Cover Art Archive release group URLs using album
         MusicBrainz release group ID.
         """
         if album.mb_releasegroupid:
@@ -690,8 +690,8 @@ class FileSystem(LocalArtSource):
 # Try each source in turn.
 
 SOURCES_ALL = [u'filesystem',
-               u'coverart', u'coverartreleasegroup', u'itunes', u'amazon', u'albumart',
-               u'wikipedia', u'google', u'fanarttv']
+               u'coverart', u'coverartreleasegroup', u'itunes', u'amazon',
+               u'albumart', u'wikipedia', u'google', u'fanarttv']
 
 ART_SOURCES = {
     u'filesystem': FileSystem,
@@ -728,7 +728,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             'cautious': False,
             'cover_names': ['cover', 'front', 'art', 'album', 'folder'],
             'sources': ['filesystem', 'coverart', 'itunes', 'amazon',
-                'albumart', 'coverartreleasegroup'],
+                        'albumart', 'coverartreleasegroup'],
             'google_key': None,
             'google_engine': u'001442825323518660753:hrh5ch1gjzm',
             'fanarttv_key': None,

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -310,6 +310,24 @@ class CoverArtArchive(RemoteArtSource):
                 match=Candidate.MATCH_FALLBACK)
 
 
+class CoverArtArchiveReleaseGroup(RemoteArtSource):
+    NAME = u"Cover Art Archive Release Group"
+
+    if util.SNI_SUPPORTED:
+        URL = 'https://coverartarchive.org/release-group/{mbid}/front'
+    else:
+        URL = 'http://coverartarchive.org/release-group/{mbid}/front'
+
+    def get(self, album, plugin, paths):
+        """Return the Cover Art Archive release group URLs using album 
+        MusicBrainz release group ID.
+        """
+        if album.mb_releasegroupid:
+            yield self._candidate(
+                    url=self.URL.format(mbid=album.mb_releasegroupid),
+                    match=Candidate.MATCH_FALLBACK)
+
+
 class Amazon(RemoteArtSource):
     NAME = u"Amazon"
     URL = 'http://images.amazon.com/images/P/%s.%02i.LZZZZZZZ.jpg'
@@ -672,12 +690,13 @@ class FileSystem(LocalArtSource):
 # Try each source in turn.
 
 SOURCES_ALL = [u'filesystem',
-               u'coverart', u'itunes', u'amazon', u'albumart',
+               u'coverart', u'coverartreleasegroup', u'itunes', u'amazon', u'albumart',
                u'wikipedia', u'google', u'fanarttv']
 
 ART_SOURCES = {
     u'filesystem': FileSystem,
     u'coverart': CoverArtArchive,
+    u'coverartreleasegroup': CoverArtArchiveReleaseGroup,
     u'itunes': ITunesStore,
     u'albumart': AlbumArtOrg,
     u'amazon': Amazon,
@@ -708,8 +727,8 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             'enforce_ratio': False,
             'cautious': False,
             'cover_names': ['cover', 'front', 'art', 'album', 'folder'],
-            'sources': ['filesystem',
-                        'coverart', 'itunes', 'amazon', 'albumart'],
+            'sources': ['filesystem', 'coverart', 'itunes', 'amazon',
+                'albumart', 'coverartreleasegroup'],
             'google_key': None,
             'google_engine': u'001442825323518660753:hrh5ch1gjzm',
             'fanarttv_key': None,

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -173,6 +173,14 @@ default engine searches the entire web for cover art.
 Note that the Google custom search API is limited to 100 queries per day.
 After that, the fetchart plugin will fall back on other declared data sources.
 
+Cover art archive
+''''''''''''''''''''
+
+The coverart album art source fetch cover art for a specific release using the
+musicbrainz release id. To fetch cover art for the release group, use
+the coverartreleasegroup source which fetch cover art using the musicbrainz
+release group id.
+
 Fanart.tv
 '''''''''
 

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -65,6 +65,14 @@ file. The available options are:
 - **store_source**: If enabled, fetchart stores the artwork's source in a
   flexible tag named ``art_source``. See below for the rationale behind this.
   Default: ``no``.
+- **use_release_group**: The ``coverart`` source fetches images from the
+  `Cover Art Archive`_. The default source prioritizes the MusicBrainz release
+  ID: i.e., you get release-specific art if it's available. To instead use only
+  *release group* album art, use the source named `coverartreleasegroup`. This
+  will, for example, avoid using the album art for a specific special edition
+  of an album.
+  .. _Cover Art Archive: http://coverartarchive.org
+  Default: ``no``.
 
 Note: ``minwidth`` and ``enforce_ratio`` options require either `ImageMagick`_
 or `Pillow`_.
@@ -172,14 +180,6 @@ default engine searches the entire web for cover art.
 
 Note that the Google custom search API is limited to 100 queries per day.
 After that, the fetchart plugin will fall back on other declared data sources.
-
-Cover art archive
-''''''''''''''''''''
-
-The coverart album art source fetch cover art for a specific release using the
-musicbrainz release id. To fetch cover art for the release group, use
-the coverartreleasegroup source which fetch cover art using the musicbrainz
-release group id.
 
 Fanart.tv
 '''''''''

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -68,11 +68,12 @@ file. The available options are:
 - **use_release_group**: The ``coverart`` source fetches images from the
   `Cover Art Archive`_. The default source prioritizes the MusicBrainz release
   ID: i.e., you get release-specific art if it's available. To instead use only
-  *release group* album art, use the source named `coverartreleasegroup`. This
+  *release group* album art, enable this option. This
   will, for example, avoid using the album art for a specific special edition
   of an album.
-  .. _Cover Art Archive: http://coverartarchive.org
   Default: ``no``.
+
+.. _Cover Art Archive: http://coverartarchive.org
 
 Note: ``minwidth`` and ``enforce_ratio`` options require either `ImageMagick`_
 or `Pillow`_.


### PR DESCRIPTION
Added a coverartreleasegroup source in fetchart to fetch cover art using release group id instead of release id. Some users may prefer release group cover art instead of release specific ones. The possibility that a release group cover art is found is also higher than the possibility that release specific cover arts are found. 