### PR TITLE
mediafile._safe_cast: be safer when converting to int

### DIFF
--- a/beets/mediafile.py
+++ b/beets/mediafile.py
@@ -159,11 +159,8 @@ def _safe_cast(out_type, val):
             elif not isinstance(val, six.string_types):
                 val = six.text_type(val)
             # Get a number from the front of the string.
-            val = re.match(r'[\+-]?[0-9]*', val.strip()).group(0)
-            if not val:
-                return 0
-            else:
-                return int(val)
+            match = re.match(r'[\+-]?[0-9]+', val.strip())
+            return int(match.group(0)) if match else 0
 
     elif out_type == bool:
         try:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -71,6 +71,8 @@ Fixes:
   versions of Mutagen. :bug:`2716`
 * :doc:`/plugins/fetchart`: Fix: don't skip running the fetchart plugin during import, when the
   "Edit Candidates" option is used. :bug:`2734`
+* Fix a crash when numeric metadata fields contain just a minus or plus sign
+  with no following numbers.
 
 For developers:
 

--- a/test/test_mediafile_edge.py
+++ b/test/test_mediafile_edge.py
@@ -105,6 +105,9 @@ class InvalidValueToleranceTest(unittest.TestCase):
     def test_safe_cast_string_to_int(self):
         self.assertEqual(_sc(int, u'something'), 0)
 
+    def test_safe_cast_string_to_int_with_no_numbers(self):
+        self.assertEqual(_sc(int, u'-'), 0)
+
     def test_safe_cast_int_string_to_int(self):
         self.assertEqual(_sc(int, u'20'), 20)
 


### PR DESCRIPTION
The regex «[\+-]?[0-9]*» possibly matches a single minus/plus, which was then
passed on to int, raising a ValueError from within _safe_cast. The test suite
covered this for float, but not for int.

We now make sure we actually have a number after the sign by using a Kleene
plus.