### PR TITLE
Addresses hook.py ability to handle non-string item properties

### DIFF
--- a/beetsplug/hook.py
+++ b/beetsplug/hook.py
@@ -68,6 +68,8 @@ class CodingFormatter(string.Formatter):
             converted = converted.decode(self._coding)
         except UnicodeEncodeError:
             pass
+        except AttributeError:
+            converted = value    
 
         return converted
 

--- a/beetsplug/hook.py
+++ b/beetsplug/hook.py
@@ -64,13 +64,9 @@ class CodingFormatter(string.Formatter):
         converted = super(CodingFormatter, self).convert_field(value,
                                                                conversion)
 
-        try:
-            converted = converted.decode(self._coding)
-        except UnicodeEncodeError:
-            pass
-        except AttributeError:
-            converted = value    
-
+        if isinstance(converted, bytes):
+            return converted.decode(self._coding)
+        
         return converted
 
 

--- a/beetsplug/hook.py
+++ b/beetsplug/hook.py
@@ -66,7 +66,7 @@ class CodingFormatter(string.Formatter):
 
         if isinstance(converted, bytes):
             return converted.decode(self._coding)
-        
+
         return converted
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,10 @@ New features:
 
 Fixes:
 
+* :doc:`/plugins/hook`: Fixed a problem whereby accessing non-string properties of
+  objects such as item or album (e.g. item.track) would cause a crash.
+  Thanks to :user:`broddo`.
+  :bug:`2740`
 * :doc:`/plugins/play`: When ``relative_to`` is set, correctly emit relative paths
   even when querying for albums rather than tracks.
   Thanks to :user:`j000`.


### PR DESCRIPTION
This is a simple fix for #2740 that catches an AttributeError if the value returned by convert_field() doesn't have a decode() method. 