### PR TITLE
Add tags configuration to acousticbrainz plugin

### DIFF
--- a/beetsplug/acousticbrainz.py
+++ b/beetsplug/acousticbrainz.py
@@ -110,6 +110,7 @@ class AcousticPlugin(plugins.BeetsPlugin):
         self.config.add({
             'auto': True,
             'force': False,
+            'tags': []
         })
 
         if self.config['auto']:
@@ -164,6 +165,7 @@ class AcousticPlugin(plugins.BeetsPlugin):
     def _fetch_info(self, items, write, force):
         """Fetch additional information from AcousticBrainz for the `item`s.
         """
+        tags = self.config['tags'].get()
         for item in items:
             # If we're not forcing re-downloading for all tracks, check
             # whether the data is already present. We use one
@@ -183,11 +185,17 @@ class AcousticPlugin(plugins.BeetsPlugin):
             data = self._get_data(item.mb_trackid)
             if data:
                 for attr, val in self._map_data_to_scheme(data, ABSCHEME):
-                    self._log.debug(u'attribute {} of {} set to {}',
-                                    attr,
-                                    item,
-                                    val)
-                    setattr(item, attr, val)
+                    if not tags or attr in tags:
+                        self._log.debug(u'attribute {} of {} set to {}',
+                                        attr,
+                                        item,
+                                        val)
+                        setattr(item, attr, val)
+                    else:
+                        self._log.debug(u'skipping attribute {} of {} (value {}) due to config',
+                                        attr,
+                                        item,
+                                        val)
                 item.store()
                 if write:
                     item.try_write()

--- a/beetsplug/acousticbrainz.py
+++ b/beetsplug/acousticbrainz.py
@@ -165,7 +165,7 @@ class AcousticPlugin(plugins.BeetsPlugin):
     def _fetch_info(self, items, write, force):
         """Fetch additional information from AcousticBrainz for the `item`s.
         """
-        tags = self.config['tags'].get()
+        tags = self.config['tags'].as_str_seq()
         for item in items:
             # If we're not forcing re-downloading for all tracks, check
             # whether the data is already present. We use one
@@ -192,8 +192,8 @@ class AcousticPlugin(plugins.BeetsPlugin):
                                         val)
                         setattr(item, attr, val)
                     else:
-                        self._log.debug(u'skipping attribute {} of {} (value {})'
-                                        u' due to config',
+                        self._log.debug(u'skipping attribute {} of {}'
+                                        u' (value {}) due to config',
                                         attr,
                                         item,
                                         val)

--- a/beetsplug/acousticbrainz.py
+++ b/beetsplug/acousticbrainz.py
@@ -192,7 +192,8 @@ class AcousticPlugin(plugins.BeetsPlugin):
                                         val)
                         setattr(item, attr, val)
                     else:
-                        self._log.debug(u'skipping attribute {} of {} (value {}) due to config',
+                        self._log.debug(u'skipping attribute {} of {} (value {})'
+                                        u' due to config',
                                         attr,
                                         item,
                                         val)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,9 +28,9 @@ New features:
   before touching your files.
   Thanks to :user:`konman2`.
   :bug:`2708` :bug:`2427`
-* :doc:`/plugins/lyrics`: The Genius backend should work again.
-  Thanks to :user:`lmagno`.
-  :bug:`2709`
+* :doc:`/plugins/acousticbrainz`: The plugin can now be configured to write only
+  a specific list of tags.
+  Thanks to :user:`woparry`.
 
 Fixes:
 

--- a/docs/plugins/acousticbrainz.rst
+++ b/docs/plugins/acousticbrainz.rst
@@ -54,10 +54,12 @@ Configuration
 -------------
 
 To configure the plugin, make a ``acousticbrainz:`` section in your
-configuration file. There is one option:
+configuration file. There are three options:
 
 - **auto**: Enable AcousticBrainz during ``beet import``.
   Default: ``yes``.
 - **force**: Download AcousticBrainz data even for tracks that already have
   it.
   Default: ``no``.
+- **tags**: Which tags from the list above to set on your files.
+  Default: [] (all)


### PR DESCRIPTION
The acousticbrainz plugin pulls a lot of information from the database.

However, some people (me) might want to only apply some of the tags from acousticbrainz to our files, either because we want to avoid conflicts with tags from other sources, or because we know we won't use them and like to keep things neat and tidy.

Add a new tags configuration option to the plugin, which allows you to specify a list of tags to write to your files. The default is still to apply all available tags.