### PR TITLE
Convert Plugin: Added dont_convert Option

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -31,6 +31,8 @@ from beets.plugins import BeetsPlugin
 from beets.util.confit import ConfigTypeError
 from beets import art
 from beets.util.artresizer import ArtResizer
+from beets.library import parse_query_string
+from beets.library import Item
 
 _fs_lock = threading.Lock()
 _temp_files = []  # Keep track of temporary transcoded files for deletion.
@@ -92,6 +94,12 @@ def should_transcode(item, fmt):
     """Determine whether the item should be transcoded as part of
     conversion (i.e., its bitrate is high or it has the wrong format).
     """
+    dont_convert_queries = config['convert']['dont_convert'].as_str_seq()
+    if dont_convert_queries:
+        for query_string in dont_convert_queries:
+            query, _ = parse_query_string(query_string, Item)
+            if query.match(item):
+                return False
     if config['convert']['never_convert_lossy_files'] and \
             not (item.format.lower() in LOSSLESS_FORMATS):
         return False

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -141,6 +141,7 @@ class ConvertPlugin(BeetsPlugin):
             u'quiet': False,
             u'embed': True,
             u'paths': {},
+            u'dont_convert': u'',
             u'never_convert_lossy_files': False,
             u'copy_album_art': False,
             u'album_art_maxwidth': 0,

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -94,9 +94,9 @@ def should_transcode(item, fmt):
     """Determine whether the item should be transcoded as part of
     conversion (i.e., its bitrate is high or it has the wrong format).
     """
-    dont_convert_queries = config['convert']['dont_convert'].as_str_seq()
-    if dont_convert_queries:
-        for query_string in dont_convert_queries:
+    no_convert_queries = config['convert']['no_convert'].as_str_seq()
+    if no_convert_queries:
+        for query_string in no_convert_queries:
             query, _ = parse_query_string(query_string, Item)
             if query.match(item):
                 return False
@@ -141,7 +141,7 @@ class ConvertPlugin(BeetsPlugin):
             u'quiet': False,
             u'embed': True,
             u'paths': {},
-            u'dont_convert': u'',
+            u'no_convert': u'',
             u'never_convert_lossy_files': False,
             u'copy_album_art': False,
             u'album_art_maxwidth': 0,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,9 @@ New features:
 * :doc:`/plugins/lyrics`: The plugin can now produce reStructuredText files
   for beautiful, readable books of lyrics. Thanks to :user:`anarcat`.
   :bug:`2628`
+* :doc:`/plugins/convert`: Adds ``no_convert`` option which ignores transcoding
+  items matching provided query string. Thanks to :user:`Stunner`.
+  :bug:`2732` :bug:`2751`
 * :doc:`/plugins/fetchart`: The plugin has now a quiet switch that will only
   display missing album arts. Thanks to :user:`euri10`.
   :bug:`2683`

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -73,7 +73,7 @@ file. The available options are:
   this does not guarantee that all converted files will have a lower
   bitrate---that depends on the encoder and its configuration.
   Default: none.
-- **dont_convert**: Does not transcode items matching provided query string
+- **no_convert**: Does not transcode items matching provided query string
   (see :doc:`/reference/query`). (i.e. ``format:AAC, format:WMA`` or
   ``path::\.(m4a|wma)$``)
 - **never_convert_lossy_files**: Cross-conversions between lossy codecs---such

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -73,6 +73,9 @@ file. The available options are:
   this does not guarantee that all converted files will have a lower
   bitrate---that depends on the encoder and its configuration.
   Default: none.
+- **dont_convert**: Does not transcode items matching provided query string
+  (see :doc:`/reference/query`). (i.e. ``format:AAC, format:WMA`` or
+  ``path::\.(m4a|wma)$``)
 - **never_convert_lossy_files**: Cross-conversions between lossy codecs---such
   as mp3, ogg vorbis, etc.---makes little sense as they will decrease quality
   even further. If set to ``yes``, lossy files are always copied.


### PR DESCRIPTION
Addresses #2732. I changed the name from `noconvert` to a more intuitive `dont_convert` which I think falls better in-line with the other options of the convert plugin (i.e. `never_convert_lossy_files`).