### PR TITLE
Duplicates plugin: tiebreak album vs items fix

### DIFF
--- a/beetsplug/duplicates.py
+++ b/beetsplug/duplicates.py
@@ -253,13 +253,12 @@ class DuplicatesPlugin(BeetsPlugin):
         "completeness" (objects with more non-null fields come first)
         and Albums are ordered by their track count.
         """
-        if tiebreak:
-            kind = 'items' if all(isinstance(o, Item)
-                                  for o in objs) else 'albums'
+        kind = 'items' if all(isinstance(o, Item) for o in objs) else 'albums'
+
+        if tiebreak and kind in tiebreak.keys():
             key = lambda x: tuple(getattr(x, k) for k in tiebreak[kind])
         else:
-            kind = Item if all(isinstance(o, Item) for o in objs) else Album
-            if kind is Item:
+            if kind is 'items':
                 def truthy(v):
                     # Avoid a Unicode warning by avoiding comparison
                     # between a bytes object and the empty Unicode

--- a/beetsplug/duplicates.py
+++ b/beetsplug/duplicates.py
@@ -258,14 +258,14 @@ class DuplicatesPlugin(BeetsPlugin):
         if tiebreak and kind in tiebreak.keys():
             key = lambda x: tuple(getattr(x, k) for k in tiebreak[kind])
         else:
-            if kind is 'items':
+            if kind == 'items':
                 def truthy(v):
                     # Avoid a Unicode warning by avoiding comparison
                     # between a bytes object and the empty Unicode
                     # string ''.
                     return v is not None and \
                         (v != '' if isinstance(v, six.text_type) else True)
-                fields = kind.all_keys()
+                fields = Item.all_keys()
                 key = lambda x: sum(1 for f in fields if truthy(getattr(x, f)))
             else:
                 key = lambda x: len(x.items())

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -70,6 +70,8 @@ Fixes:
   Python 3 on Windows with non-ASCII filenames. :bug:`2671`
 * :doc:`/plugins/absubmit`: Fix an occasional crash on Python 3 when the AB
   analysis tool produced non-ASCII metadata. :bug:`2673`
+* :doc:`/plugins/duplicates`: Use default tiebreak for any kind (item/album) that
+  does not have a tiebreak specified in the configuration.
 * :doc:`/plugins/duplicates`: Fix the `--key` command line option, which was
   ignored.
 * :doc:`/plugins/replaygain`: Fix album replaygain calculation with the


### PR DESCRIPTION
At present, if tiebreak is specified to give keys for the order of priority in determining duplicates, it must be specified for both items and albums, or an error will be raised when the unspecified one is used.  This is particularly bad because the default order of priority appears to be impossible to specify in tiebreak, so if the user wants (as in my case) a tiebreak specification for items, and the default order for albums, this is impossible.

This small change makes it so that tiebreak is only used if it specifies keys for ordering the kind (track/album) being considered; otherwise, the default is used.