### PR TITLE
Remove unnecessary escape caret in ImageMagick convert argument

### DIFF
--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -88,14 +88,13 @@ def im_resize(maxwidth, path_in, path_out=None):
     log.debug(u'artresizer: ImageMagick resizing {0} to {1}',
               util.displayable_path(path_in), util.displayable_path(path_out))
 
-    # "-resize widthxheight>" shrinks images with dimension(s) larger
-    # than the corresponding width and/or height dimension(s). The >
-    # "only shrink" flag is prefixed by ^ escape char for Windows
-    # compatibility.
+    # "-resize WIDTHx>" shrinks images with the width larger
+    # than the given width while maintaining the aspect ratio
+    # with regards to the height.
     try:
         util.command_output([
             'convert', util.syspath(path_in, prefix=False),
-            '-resize', '{0}x^>'.format(maxwidth),
+            '-resize', '{0}x>'.format(maxwidth),
             util.syspath(path_out, prefix=False),
         ])
     except subprocess.CalledProcessError:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -88,6 +88,8 @@ Fixes:
   "Edit Candidates" option is used. :bug:`2734`
 * Fix a crash when numeric metadata fields contain just a minus or plus sign
   with no following numbers. Thanks to :user:`eigengrau`. :bug:`2741`
+* Fixed an issue where images would be resized according to their longest edge,
+  instead of their width. Thanks to :user:`sekjun9878`. :bug:`2729`
 
 For developers:
 


### PR DESCRIPTION
Hello,

I'm looking to get started contributing to beets with this simple pull request :)

Regarding the Windows caret (`^`) escaping issue, it seems that this is only an issue if we launch ImageMagick by cmd.exe. We instead launch using `CreateProcess()` on Windows.

In calling `CreateProcess()`, Python takes no special actions for neither `^` nor `>`, as referenced [here](https://docs.python.org/2/library/subprocess.html#converting-argument-sequence)

Because Windows uses strings, not arrays, to pass argv to processes, further command line parsing still happens inside the called process (i.e. escapes are still parsed even when called using CreateProcess()) and this behaviour seems dependent entirely on the compiler used. However, it seems that the caret (`^`) is not one of those escapes handled by the compiler, as referenced [here](http://daviddeley.com/autohotkey/parameters/parameters.htm#WINCRULESCHANGE). Specifically,

> **The caret character (^) is not recognized as an escape character or delimiter. The character is handled completely by the command-line parser in the operating system before being passed to the argv array in the program.**
> They are referring to the scenario discussed in sec. 6.2 below, where first the command line parser (cmd.exe) parses your command, handling such things as the escape character ^ , the redirection characters > & < , the pipe character | , the %  character which may identify environment variables that need to be expanded (e.g. %PROGRAMFILES%), etc. **The rules here describe how your C/C++ executable will parse the lpCommandLine that was passed to CreateProcess() by cmd.exe or whoever calls CreateProcess().**

Issue #2729