### PR TITLE
Fixes #2688: Skip non-audio media from MusicBrainz

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -36,6 +36,9 @@ if util.SNI_SUPPORTED:
 else:
     BASE_URL = 'http://musicbrainz.org/'
 
+NON_AUDIO_FORMATS = ['Data CD', 'DVD', 'DVD-Video', 'Blu-ray', 'HD-DVD', 'VCD',
+                     'SVCD', 'UMD', 'VHS']
+
 musicbrainzngs.set_useragent('beets', beets.__version__,
                              'http://beets.io/')
 
@@ -274,6 +277,9 @@ def album_info(release):
     for medium in release['medium-list']:
         disctitle = medium.get('title')
         format = medium.get('format')
+
+        if format in NON_AUDIO_FORMATS:
+            continue
 
         all_tracks = medium['track-list']
         if 'pregap' in medium:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,9 @@ Changelog
 
 Changelog goes here!
 
+Fixes:
+* Non-audio media (DVD-Video, etc.) are now skipped by the autotagger. :bug:`2688`
+
 
 1.4.6 (December 21, 2017)
 -------------------------

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -27,7 +27,7 @@ import mock
 
 class MBAlbumInfoTest(_common.TestCase):
     def _make_release(self, date_str='2009', tracks=None, track_length=None,
-                      track_artist=False):
+                      track_artist=False, medium_format='FORMAT'):
         release = {
             'title': 'ALBUM TITLE',
             'id': 'ALBUM ID',
@@ -90,7 +90,7 @@ class MBAlbumInfoTest(_common.TestCase):
             release['medium-list'].append({
                 'position': '1',
                 'track-list': track_list,
-                'format': 'FORMAT',
+                'format': medium_format,
                 'title': 'MEDIUM TITLE',
             })
         return release
@@ -323,6 +323,27 @@ class MBAlbumInfoTest(_common.TestCase):
         release = self._make_release()
         d = mb.album_info(release)
         self.assertEqual(d.data_source, 'MusicBrainz')
+
+    def test_skip_non_audio_dvd(self):
+        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
+                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
+        release = self._make_release(tracks=tracks, medium_format="DVD")
+        d = mb.album_info(release)
+        self.assertEqual(len(d.tracks), 0)
+
+    def test_skip_non_audio_dvd_video(self):
+        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
+                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
+        release = self._make_release(tracks=tracks, medium_format="DVD-Video")
+        d = mb.album_info(release)
+        self.assertEqual(len(d.tracks), 0)
+
+    def test_no_skip_dvd_audio(self):
+        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
+                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
+        release = self._make_release(tracks=tracks, medium_format="DVD-Audio")
+        d = mb.album_info(release)
+        self.assertEqual(len(d.tracks), 2)
 
 
 class ParseIDTest(_common.TestCase):


### PR DESCRIPTION
Some releases have non-audio media, such as CD+DVD or CD+DVD-Video. Skip
these media when fetching album info as they will never match audio
tracks and will always report missing tracks.

I took the naive approach of cherry-picking a list of media suspected to
not contain audio from the MusicBrainz formats list:

https://musicbrainz.org/doc/Release/Format