### PR TITLE
Fixes #1210: Skip non-audio tracks from MusicBrainz

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -39,6 +39,8 @@ else:
 NON_AUDIO_FORMATS = ['Data CD', 'DVD', 'DVD-Video', 'Blu-ray', 'HD-DVD', 'VCD',
                      'SVCD', 'UMD', 'VHS']
 
+SKIPPED_TRACKS = ['[data track]']
+
 musicbrainzngs.set_useragent('beets', beets.__version__,
                              'http://beets.io/')
 
@@ -286,6 +288,15 @@ def album_info(release):
             all_tracks.insert(0, medium['pregap'])
 
         for track in all_tracks:
+
+            if ('title' in track['recording'] and
+                    track['recording']['title'] in SKIPPED_TRACKS):
+                continue
+
+            if ('video' in track['recording'] and
+                    track['recording']['video'] == 'true'):
+                continue
+
             # Basic information from the recording.
             index += 1
             ti = track_info(

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -294,7 +294,8 @@ def album_info(release):
                 continue
 
             if ('video' in track['recording'] and
-                    track['recording']['video'] == 'true'):
+                    track['recording']['video'] == 'true' and
+                    config['match']['ignore_video_tracks'].get(bool) is True):
                 continue
 
             # Basic information from the recording.

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -295,7 +295,7 @@ def album_info(release):
 
             if ('video' in track['recording'] and
                     track['recording']['video'] == 'true' and
-                    config['match']['ignore_video_tracks'].get(bool) is True):
+                    config['match']['ignore_video_tracks']):
                 continue
 
             # Basic information from the recording.

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -126,5 +126,6 @@ match:
         original_year: no
     ignored: []
     required: []
+    ignore_video_tracks: yes
     track_length_grace: 10
     track_length_max: 30

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,7 +7,10 @@ Changelog
 Changelog goes here!
 
 Fixes:
+
 * Non-audio media (DVD-Video, etc.) are now skipped by the autotagger. :bug:`2688`
+* Non-audio tracks (data tracks, video tracks, etc.) are now skipped by the
+  autotagger. :bug:`1210`
 
 
 1.4.6 (December 21, 2017)

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -774,6 +774,17 @@ want to enforce to the ``required`` setting::
 
 No tags are required by default.
 
+.. _ignore_video_tracks:
+
+ignore_video_tracks
+~~~~~~~~~~~~~~~~~~~
+
+By default, video tracks within a release will be ignored. If you want them to
+be included (for example if you would like to track the audio-only versions of
+the video tracks), set it to ``no``.
+
+Default: ``yes``.
+
 .. _path-format-config:
 
 Path Format Configuration

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -358,7 +358,7 @@ class MBAlbumInfoTest(_common.TestCase):
         self.assertEqual(d.tracks[0].title, 'TITLE ONE')
         self.assertEqual(d.tracks[1].title, 'TITLE TWO')
 
-    def test_skip_video_track(self):
+    def test_skip_video_tracks_by_default(self):
         tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
                   self._make_track('TITLE VIDEO', 'ID VIDEO', 100.0 * 1000.0,
                                    False, True),
@@ -368,6 +368,19 @@ class MBAlbumInfoTest(_common.TestCase):
         self.assertEqual(len(d.tracks), 2)
         self.assertEqual(d.tracks[0].title, 'TITLE ONE')
         self.assertEqual(d.tracks[1].title, 'TITLE TWO')
+
+    def test_no_skip_video_tracks_if_configured(self):
+        config['match']['ignore_video_tracks'] = False
+        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
+                  self._make_track('TITLE VIDEO', 'ID VIDEO', 100.0 * 1000.0,
+                                   False, True),
+                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
+        release = self._make_release(tracks=tracks)
+        d = mb.album_info(release)
+        self.assertEqual(len(d.tracks), 3)
+        self.assertEqual(d.tracks[0].title, 'TITLE ONE')
+        self.assertEqual(d.tracks[1].title, 'TITLE VIDEO')
+        self.assertEqual(d.tracks[2].title, 'TITLE TWO')
 
 
 class ParseIDTest(_common.TestCase):


### PR DESCRIPTION
This ignores non-audio tracks during import:
- Data tracks, based on their title `[data track]` (which seems to be
the MusicBrainz convention, as there's no specific flag to indicate
that a track is a data one),
- Video tracks, based on the `video=true` attribute.

It's similar to the Picard changes mentioned in #1210, except it doesn't
deal with `[silence]` tracks: These ones will probably require a setting
to let the user control if they should be imported or not.