### PR TITLE
Added a setting to control which formats are ignored

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -277,7 +277,7 @@ def album_info(release):
         disctitle = medium.get('title')
         format = medium.get('format')
 
-        if format in config['match']['ignored_formats'].as_str_seq():
+        if format in config['match']['ignored_media'].as_str_seq():
             continue
 
         all_tracks = medium['track-list']

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -36,9 +36,6 @@ if util.SNI_SUPPORTED:
 else:
     BASE_URL = 'http://musicbrainz.org/'
 
-NON_AUDIO_FORMATS = ['Data CD', 'DVD', 'DVD-Video', 'Blu-ray', 'HD-DVD', 'VCD',
-                     'SVCD', 'UMD', 'VHS']
-
 SKIPPED_TRACKS = ['[data track]']
 
 musicbrainzngs.set_useragent('beets', beets.__version__,
@@ -280,7 +277,7 @@ def album_info(release):
         disctitle = medium.get('title')
         format = medium.get('format')
 
-        if format in NON_AUDIO_FORMATS:
+        if format in config['match']['ignored_formats'].as_str_seq():
             continue
 
         all_tracks = medium['track-list']

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -126,7 +126,7 @@ match:
         original_year: no
     ignored: []
     required: []
-    ignored_formats: ['Data CD', 'DVD', 'DVD-Video', 'Blu-ray', 'HD-DVD', 'VCD', 'SVCD', 'UMD', 'VHS']
+    ignored_media: ['Data CD', 'DVD', 'DVD-Video', 'Blu-ray', 'HD-DVD', 'VCD', 'SVCD', 'UMD', 'VHS']
     ignore_video_tracks: yes
     track_length_grace: 10
     track_length_max: 30

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -126,6 +126,7 @@ match:
         original_year: no
     ignored: []
     required: []
+    ignored_formats: ['Data CD', 'DVD', 'DVD-Video', 'Blu-ray', 'HD-DVD', 'VCD', 'SVCD', 'UMD', 'VHS']
     ignore_video_tracks: yes
     track_length_grace: 10
     track_length_max: 30

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,7 +9,7 @@ Changelog goes here!
 Fixes:
 
 * Non-audio media (DVD-Video, etc.) are now skipped by default by the
-  autotagger. A new option ``ignored_formats`` controls which formats to
+  autotagger. A new option ``ignored_media`` controls which media formats to
   ignore. :bug:`2688`
 * Non-audio tracks (data tracks, video tracks) are now skipped by the
   autotagger. Data tracks will always be ignored, but a new option

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,9 +8,13 @@ Changelog goes here!
 
 Fixes:
 
-* Non-audio media (DVD-Video, etc.) are now skipped by the autotagger. :bug:`2688`
-* Non-audio tracks (data tracks, video tracks, etc.) are now skipped by the
-  autotagger. :bug:`1210`
+* Non-audio media (DVD-Video, etc.) are now skipped by default by the
+  autotagger. A new option ``ignored_formats`` controls which formats to
+  ignore. :bug:`2688`
+* Non-audio tracks (data tracks, video tracks) are now skipped by the
+  autotagger. Data tracks will always be ignored, but a new option
+  ``ignore_video_tracks`` has been added to control if video tracks should be
+  ignored or not. :bug:`1210`
 * :doc:`/plugins/replaygain`: Fix a corner-case with the ``bs1770gain`` backend where ReplayGain values were assigned to the wrong files. Now ``bs1770gain`` version 0.4.6 or later is required. :bug:`2777`
 
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -774,13 +774,13 @@ want to enforce to the ``required`` setting::
 
 No tags are required by default.
 
-.. _ignored_formats:
+.. _ignored_media:
 
-ignored_formats
-~~~~~~~~~~~~~~~
+ignored_media
+~~~~~~~~~~~~~
 
-By default a list of release formats considered not containing audio will be
-ignored. If you want them to be included (for example if you would like to
+By default a list of release media formats considered not containing audio will
+be ignored. If you want them to be included (for example if you would like to
 consider the audio portion of DVD-Video tracks) you can alter the list
 accordingly.
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -774,6 +774,19 @@ want to enforce to the ``required`` setting::
 
 No tags are required by default.
 
+.. _ignored_formats:
+
+ignored_formats
+~~~~~~~~~~~~~~~
+
+By default a list of release formats considered not containing audio will be
+ignored. If you want them to be included (for example if you would like to
+consider the audio portion of DVD-Video tracks) you can alter the list
+accordingly.
+
+Default: ``['Data CD', 'DVD', 'DVD-Video', 'Blu-ray', 'HD-DVD', 'VCD', 'SVCD',
+'UMD', 'VHS']``.
+
 .. _ignore_video_tracks:
 
 ignore_video_tracks

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -326,24 +326,20 @@ class MBAlbumInfoTest(_common.TestCase):
         d = mb.album_info(release)
         self.assertEqual(d.data_source, 'MusicBrainz')
 
-    def test_skip_non_audio_dvd(self):
+    def test_ignored_formats(self):
+        config['match']['ignored_formats'] = ['IGNORED1', 'IGNORED2']
         tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
                   self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
-        release = self._make_release(tracks=tracks, medium_format="DVD")
+        release = self._make_release(tracks=tracks, medium_format="IGNORED1")
         d = mb.album_info(release)
         self.assertEqual(len(d.tracks), 0)
 
-    def test_skip_non_audio_dvd_video(self):
+    def test_no_ignored_formats(self):
+        config['match']['ignored_formats'] = ['IGNORED1', 'IGNORED2']
         tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
                   self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
-        release = self._make_release(tracks=tracks, medium_format="DVD-Video")
-        d = mb.album_info(release)
-        self.assertEqual(len(d.tracks), 0)
-
-    def test_no_skip_dvd_audio(self):
-        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
-                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
-        release = self._make_release(tracks=tracks, medium_format="DVD-Audio")
+        release = self._make_release(tracks=tracks,
+                                     medium_format="NON-IGNORED")
         d = mb.album_info(release)
         self.assertEqual(len(d.tracks), 2)
 

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -326,16 +326,16 @@ class MBAlbumInfoTest(_common.TestCase):
         d = mb.album_info(release)
         self.assertEqual(d.data_source, 'MusicBrainz')
 
-    def test_ignored_formats(self):
-        config['match']['ignored_formats'] = ['IGNORED1', 'IGNORED2']
+    def test_ignored_media(self):
+        config['match']['ignored_media'] = ['IGNORED1', 'IGNORED2']
         tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
                   self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
         release = self._make_release(tracks=tracks, medium_format="IGNORED1")
         d = mb.album_info(release)
         self.assertEqual(len(d.tracks), 0)
 
-    def test_no_ignored_formats(self):
-        config['match']['ignored_formats'] = ['IGNORED1', 'IGNORED2']
+    def test_no_ignored_media(self):
+        config['match']['ignored_media'] = ['IGNORED1', 'IGNORED2']
         tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
                   self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
         release = self._make_release(tracks=tracks,


### PR DESCRIPTION
This is related to #2688 where a list of hard-coded non-audio formats to
ignore has been added. Some users may want to rip the audio portion of
video tracks (e.g. DVD-Video) so it would be beneficial to let them
control exactly which formats to ignore.

I added a `ignored_formats` setting for that purpose and moved the
hard-coded list into the config. Test and documentation have been
updated accordingly.

Aside: I also clarified the changelog a bit regarding this change and
the related one for #1210.