### PR TITLE
New importer option incremental_skip_later, fixes #2773

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -10,6 +10,7 @@ import:
     delete: no
     resume: ask
     incremental: no
+    incremental_skip_later: no
     from_scratch: no
     quiet_fallback: skip
     none_rec_action: ask

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -577,7 +577,8 @@ class ImportTask(BaseImportTask):
         # Update progress.
         if session.want_resume:
             self.save_progress()
-        if session.config['incremental']:
+        if (session.config['incremental'] and
+                not session.config['incremental_skip_later']):
             self.save_history()
 
         self.cleanup(copy=session.config['copy'],

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,10 @@ New features:
 
 * :doc:`/plugins/replaygain`: add ``--force``, ``--write`` and ``--nowrite``
   options to ``beet replaygain``. :bug:`2778`
+* A new importer configuration ``incremental_skip_later`` allows you to avoid
+  recording skipped directories to the incremental list, so you can revisit them
+  later. Thanks to :user:`sekjun9878`.
+  :bug:`2773`
 
 
 Fixes:

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -475,6 +475,16 @@ Either ``yes`` or ``no``, controlling whether imported directories are
 recorded and whether these recorded directories are skipped.  This
 corresponds to the ``-i`` flag to ``beet import``.
 
+.. _incremental_skip_later:
+
+incremental_skip_later
+~~~~~~~~~~~~~~~~~~~~~~
+
+Either ``yes`` or ``no``, controlling whether skipped directories are
+recorded in the incremental list. Set this option to ``yes`` if you would
+like to revisit skipped directories later whilst using incremental
+mode. Defaults to ``no``.
+
 .. _from_scratch:
 
 from_scratch


### PR DESCRIPTION
This pull request implements the configuration option `incremental_skip_later`, which changes the skip behaviour to bypass recording skipped items to the incremental list, allowing them to be revisited later on.

The configuration option defaults to current behaviour.

Issue #2773 
  