### PR TITLE
Catch and warn FilesystemError during Album/Item move()

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -52,7 +52,9 @@ class HumanReadableException(Exception):
     associated exception. (Note that this is not necessary in Python 3.x
     and should be removed when we make the transition.)
     """
-    error_kind = 'Error'  # Human-readable description of error type.
+    # Human-readable descriptions of error type.
+    error_kind = 'Error'
+    warn_kind = 'Warning'
 
     def __init__(self, reason, verb, tb=None):
         self.reason = reason
@@ -93,6 +95,14 @@ class HumanReadableException(Exception):
         if self.tb:
             logger.debug(self.tb)
         logger.error(u'{0}: {1}', self.error_kind, self.args[0])
+
+    def log_as_warn(self, logger):
+        """Log to the provided `logger` a human-readable message as a
+        warning and a verbose traceback as a debug message.
+        """
+        if self.tb:
+            logger.debug(self.tb)
+        logger.warn(u'{0}: {1}', self.warn_kind, self.args[0])
 
 
 class FilesystemError(HumanReadableException):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,11 @@ New features:
   recording skipped directories to the incremental list, so you can revisit them
   later. Thanks to :user:`sekjun9878`.
   :bug:`2773`
+* Missing file, album art and other filesystem errors no longer halt batch
+  item moves or updates, leaving your files in a half-completed state.
+  They will now display a warning message and continue moving the rest of files.
+  Thanks to :user:`sekjun9878`.
+  :bug:`1926` :bug:`2419`
 
 
 Fixes:


### PR DESCRIPTION
Hello,

This pull request fixes the old bug where filesystem errors during a batch move or update would halt the entire operation, leaving your files in an inconsistent state.

This patch implements the proposed fix of warning the user of the error, and continuing on with the rest of the files, such as a missing album art which is inconsequential in many cases and does not warrant a fatal halt of the program.

This patch also considers situations where a user may have forgotten to mount a music folder, taking care not to update library path references if a filesystem error has occurred. This prevents surprising behaviour leading to the potential loss of music files.

Issues #1926, #2036, #2768, #2419, #2724, and other duplicates.

Ready for comments and review.