### PR TITLE
Small performance optimization when fetching items from library.

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -32,6 +32,7 @@ from beets.dbcore import types
 from .query import MatchQuery, NullSort, TrueQuery
 import six
 
+
 class DBAccessError(Exception):
     """The SQLite database became inaccessible.
 
@@ -567,9 +568,7 @@ class Results(object):
         first.
         """
 
-        # First fetch all flexible attributes for all items in the result.
-        # Doing the per-item filtering in python is faster than issuing
-        # one query per item to sqlite.
+        # Index flexible attributes by the item ID, so we have easier access
         flex_attrs = self._get_indexed_flex_attrs()
 
         index = 0  # Position in the materialized objects.
@@ -913,7 +912,9 @@ class Database(object):
             "ORDER BY {0}".format(order_by) if order_by else '',
         )
 
-        # Fetch flexible attributes for items matching the main query
+        # Fetch flexible attributes for items matching the main query.
+        # Doing the per-item filtering in python is faster than issuing
+        # one query per item to sqlite.
         flex_sql = ("""
             SELECT * FROM {0} WHERE entity_id IN
                 (SELECT id FROM {1} WHERE {2});

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -583,10 +583,7 @@ class Results(object):
             else:
                 while self._rows:
                     row = self._rows.pop(0)
-                    if flex_attrs:
-                        obj = self._make_model(row, flex_attrs[row['id']])
-                    else:
-                        obj = self._make_model(row)
+                    obj = self._make_model(row, flex_attrs.get(row['id'], {}))
                     # If there is a slow-query predicate, ensurer that the
                     # object passes it.
                     if not self.query or self.query.match(obj):


### PR DESCRIPTION
Fetch flexible attributes once for all relevant items instead of once per item.
For queries with larger result sets this drastically cuts down the number of issued sqlite queries.

In the end, this didn't quite give the performance boost I'd hoped it would, but it feels still slightly faster for larger queries.
Unfortunately the hot spot seems to be somewhere else though :-/

One thing to note, since the list of IDs used in the WHERE..IN clause can be quite large (and reach sqlite's query parameter limit), I resorted to not passing them as parameters.
This should be fine, since these are not values originating from input but coming from the database from a previous query. Not sure how big of an issue this is nonetheless.