### PR TITLE
Use import argument paths as bytestrings on Python 3

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -934,6 +934,13 @@ def import_func(lib, opts, args):
         if not paths:
             raise ui.UserError(u'no path specified')
 
+        # On Python 2, we get filenames as raw bytes, which is what we
+        # need. On Python 3, we need to undo the "helpful" conversion to
+        # Unicode strings to get the real bytestring filename.
+        if not six.PY2:
+            paths = [p.encode(util.arg_encoding(), 'surrogateescape')
+                     for p in paths]
+
     import_files(lib, paths, query)
 
 


### PR DESCRIPTION
This is to address #2793, where, on Python 3 under a limited locale, the path arguments to the `import` command can have surrogate escapes in them. This converts these `str` arguments to the standard beets representation for paths, which is `bytes` values.

I wasn't able to reproduce the problem on my machine, but I'm pretty sure this is the right fix.