### PR TITLE
Early stage pipeline plugin functions

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -313,6 +313,8 @@ class ImportSession(object):
                 stages += [import_asis(self)]
 
             # Plugin stages.
+            for stage_func in plugins.early_import_stages():
+                stages.append(plugin_stage(self, stage_func))
             for stage_func in plugins.import_stages():
                 stages.append(plugin_stage(self, stage_func))
 

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -81,6 +81,7 @@ class BeetsPlugin(object):
             self.template_fields = {}
         if not self.album_template_fields:
             self.album_template_fields = {}
+        self.early_import_stages = []
         self.import_stages = []
 
         self._log = log.getChild(self.name)
@@ -93,6 +94,17 @@ class BeetsPlugin(object):
         commands that should be added to beets' CLI.
         """
         return ()
+
+    def get_early_import_stages(self):
+        """Return a list of functions that should be called as importer
+        pipelines stages early in the pipeline.
+
+        The callables are wrapped versions of the functions in
+        `self.early_import_stages`. Wrapping provides some bookkeeping for the
+        plugin: specifically, the logging level is adjusted to WARNING.
+        """
+        return [self._set_log_level_and_params(logging.WARNING, import_stage)
+                for import_stage in self.early_import_stages]
 
     def get_import_stages(self):
         """Return a list of functions that should be called as importer
@@ -391,6 +403,14 @@ def template_funcs():
         if plugin.template_funcs:
             funcs.update(plugin.template_funcs)
     return funcs
+
+
+def early_import_stages():
+    """Get a list of early import stage functions defined by plugins."""
+    stages = []
+    for plugin in find_plugins():
+        stages += plugin.get_early_import_stages()
+    return stages
 
 
 def import_stages():

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -95,6 +95,12 @@ class BeetsPlugin(object):
         """
         return ()
 
+    def _set_stage_log_level(self, stages):
+        """Adjust all the stages in `stages` to WARNING logging level.
+        """
+        return [self._set_log_level_and_params(logging.WARNING, stage)
+                for stage in stages]
+
     def get_early_import_stages(self):
         """Return a list of functions that should be called as importer
         pipelines stages early in the pipeline.
@@ -103,8 +109,7 @@ class BeetsPlugin(object):
         `self.early_import_stages`. Wrapping provides some bookkeeping for the
         plugin: specifically, the logging level is adjusted to WARNING.
         """
-        return [self._set_log_level_and_params(logging.WARNING, import_stage)
-                for import_stage in self.early_import_stages]
+        return self._set_stage_log_level(self.early_import_stages)
 
     def get_import_stages(self):
         """Return a list of functions that should be called as importer
@@ -114,8 +119,7 @@ class BeetsPlugin(object):
         `self.import_stages`. Wrapping provides some bookkeeping for the
         plugin: specifically, the logging level is adjusted to WARNING.
         """
-        return [self._set_log_level_and_params(logging.WARNING, import_stage)
-                for import_stage in self.import_stages]
+        return self._set_stage_log_level(self.import_stages)
 
     def _set_log_level_and_params(self, base_log_level, func):
         """Wrap `func` to temporarily set this plugin's logger level to

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -146,7 +146,7 @@ class ConvertPlugin(BeetsPlugin):
             u'copy_album_art': False,
             u'album_art_maxwidth': 0,
         })
-        self.import_stages = [self.auto_convert]
+        self.early_import_stages = [self.auto_convert]
 
         self.register_listener('import_task_files', self._cleanup)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -46,6 +46,11 @@ Fixes:
 * Avoid a crash when importing a non-ASCII filename when using an ASCII locale
   on Unix under Python 3.
   :bug:`2793` :bug:`2803`
+* Convert plugin now runs before all others in the pipeline to solve an issue
+  with generating ReplayGain data incompatible between the source and target
+  file formats. This option to request (part of) your plugin to run early in the
+  pipeline has been exposed in the plugin API as well (```early_import_stages```).
+  Thanks to :user:`autrimpo`.
 
 
 1.4.6 (December 21, 2017)

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -432,6 +432,11 @@ to register it::
         def stage(self, session, task):
             print('Importing something!')
 
+It is also possible to request your function to run early in the pipeline by
+adding the function to the plugin's ``early_import_stages`` field instead.::
+
+  self.early_import_stages = [self.stage]
+
 .. _extend-query:
 
 Extend the Query Syntax


### PR DESCRIPTION
This is a bug report together with a PR because I like to scratch my own itch :)
Something has been bugging me for quite some time after switching to Opus - some of the albums I've imported didn't have replaygain calculated, even though the replaygain plugin did definitely run. After lots of debugging the issue seems to be as follows:
1. User tries to import a FLAC album
2. Since the plugins don't run in a deterministic order (as far as I've noticed), ReplayGain is sometimes calculated on the FLAC files
3. Files get converted to Opus
4. There are ReplayGain values calculated from FLAC but Opus only takes R128
5. The imported files need to have `replaygain` calculated again, manually

I've added a (quite ugly) hack to always convert the file first, which from my testing seems to reliably solve the issue. If you have better idea how to solve this (I've considered dividing the plugins into groups by 'priority' but that felt like an overkill), I'll happily implement it.