### PR TITLE
Make sure release events are selected in preferred order.

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -118,8 +118,8 @@ def _preferred_release_event(release):
     """
     countries = config['match']['preferred']['countries'].as_str_seq()
 
-    for event in release.get('release-event-list', {}):
-        for country in countries:
+    for country in countries:
+        for event in release.get('release-event-list', {}):
             try:
                 if country in event['area']['iso-3166-1-code-list']:
                     return country, event['date']

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -56,6 +56,9 @@ Fixes:
   incompatible between the source and target file formats.
   :bug:`2814`
   Thanks to :user:`autrimpo`.
+* Importing a release with multiple release events now selects the
+  event based on the order of your :ref:`preferred` countries rather than
+  the order of release events in MusicBrainz. :bug:`2816`
 
 For developers:
 


### PR DESCRIPTION
Previously, release events were selected based on the order that MusicBrainz listed them rather than the order defined in config.yaml.

Opening this as a pull request instead of pushing directly because this _may_* cause large metadata changes the next time someone runs `beet mbsync`. But it should _improve_ the metadata, making it align better with a user's preferred countries.

\* I ran this over my entire collection of around 4000 albums and it changed only eight.