### PR TITLE
/fix keyfinder => put paths in quotationmarks

### DIFF
--- a/beetsplug/keyfinder.py
+++ b/beetsplug/keyfinder.py
@@ -50,6 +50,9 @@ class KeyFinderPlugin(BeetsPlugin):
     def imported(self, session, task):
         self.find_key(task.items)
 
+    def set_quotation(s):
+        return '\'' + s + '\''
+
     def find_key(self, items, write=False):
         overwrite = self.config['overwrite'].get(bool)
         bin = self.config['bin'].as_str()
@@ -59,8 +62,8 @@ class KeyFinderPlugin(BeetsPlugin):
                 continue
 
             try:
-                output = util.command_output([bin, '-f',
-                                              util.syspath(item.path)])
+                output = util.command_output([set_quotation(bin), '-f',
+                                              set_quotation(util.syspath(item.path))])
             except (subprocess.CalledProcessError, OSError) as exc:
                 self._log.error(u'execution failed: {0}', exc)
                 continue


### PR DESCRIPTION
To avoid errors like this:

`keyfinder: execution failed: Command '/Applications/KeyFinder.app/Contents/MacOS/KeyFinder -f /Volumes/MUSIC/Music/Some Title With Spaces.mp3' returned non-zero exit status 1.`

You should put the paths in quotation marks.