### PR TITLE
Add a support for supports_credentials

### DIFF
--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -341,6 +341,7 @@ class WebPlugin(BeetsPlugin):
             'host': u'127.0.0.1',
             'port': 8337,
             'cors': '',
+            'cors_supports_credentials': False,
             'reverse_proxy': False,
             'include_paths': False,
         })
@@ -372,7 +373,12 @@ class WebPlugin(BeetsPlugin):
                 app.config['CORS_RESOURCES'] = {
                     r"/*": {"origins": self.config['cors'].get(str)}
                 }
-                CORS(app)
+                CORS(
+                    app,
+                    supports_credentials=self.config[
+                        'cors_supports_credentials'
+                    ]
+                )
 
             # Allow serving behind a reverse proxy
             if self.config['reverse_proxy']:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,9 @@ New features:
 * :doc:`/plugins/fetchart`: extended syntax for the ``sources`` option to give
   fine-grained control over the search order for backends with several matching
   strategies.
+* :doc:`/plugins/web`: added the boolean ``cors_supports_credentials`` option to
+  allow in-browser clients to login to the beet web server even when it is
+  protected by an authorization mechanism.
 
 
 Fixes:

--- a/docs/plugins/web.rst
+++ b/docs/plugins/web.rst
@@ -63,6 +63,8 @@ configuration file. The available options are:
   Default: 8337.
 - **cors**: The CORS allowed origin (see :ref:`web-cors`, below).
   Default: CORS is disabled.
+- **cors_supports_credentials**: Support credentials when using CORS (see :ref:`web-cors`, below).
+  Default: CORS_SUPPORTS_CREDENTIALS is disabled.
 - **reverse_proxy**: If true, enable reverse proxy support (see
   :ref:`reverse-proxy`, below).
   Default: false.
@@ -100,13 +102,15 @@ default, browsers will only allow access from clients running on the same
 server as the API. (You will get an arcane error about ``XMLHttpRequest``
 otherwise.) A technology called `CORS`_ lets you relax this restriction.
 
-If you want to use an in-browser client hosted elsewhere (or running from
-a different server on your machine), first install the `flask-cors`_ plugin by
-typing ``pip install flask-cors``. Then set the ``cors`` configuration option
-to the "origin" (protocol, host, and optional port number) where the client is
-served. Or set it to ``'*'`` to enable access from all origins. Note that
-there are security implications if you set the origin to ``'*'``, so please
-research this before using it.
+If you want to use an in-browser client hosted elsewhere (or running from a
+different server on your machine), first install the `flask-cors`_ plugin by
+typing ``pip install flask-cors``. Then set the ``cors`` configuration option to
+the "origin" (protocol, host, and optional port number) where the client is
+served. Or set it to ``'*'`` to enable access from all origins. Note that there
+are security implications if you set the origin to ``'*'``, so please research
+this before using it. In addition, if the ``web`` server is hidden via
+credentials, you might want to set the ``cors_supports_credentials``
+configuration option to True for the in-browser client to be able to login.
 
 For example::
 


### PR DESCRIPTION
If the web plugin is behind a credential based http server and is
accessed by another in-browser client in another domain, the
specification of CORS requires the server to indicate it supports
such credentials.