### PR TITLE
Fix jumping time in beets.js

### DIFF
--- a/beetsplug/web/static/beets.js
+++ b/beetsplug/web/static/beets.js
@@ -4,7 +4,7 @@ var timeFormat = function(secs) {
         return '0:00';
     }
     secs = Math.round(secs);
-    var mins = '' + Math.round(secs / 60);
+    var mins = '' + Math.floor(secs / 60);
     secs = '' + (secs % 60);
     if (secs.length < 2) {
         secs = '0' + secs;

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -65,6 +65,9 @@ Fixes:
 * Importing a release with multiple release events now selects the
   event based on the order of your :ref:`preferred` countries rather than
   the order of release events in MusicBrainz. :bug:`2816`
+* :doc:`/plugins/web`: The time display in the web interface would incorrectly jump
+  at the 30-second mark of every minute. Now, it correctly changes over at zero
+  seconds. :bug:`2822`
 
 For developers:
 


### PR DESCRIPTION
Round was used instead of floor, so the minute counter jumped after each 30 seconds