### PR TITLE
Fix album_art() in __init__.py

### DIFF
--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -285,8 +285,8 @@ def album_query(queries):
 @app.route('/album/<int:album_id>/art')
 def album_art(album_id):
     album = g.lib.get_album(album_id)
-    if album.artpath:
-        return flask.send_file(album.artpath)
+    if album and album.artpath:
+        return flask.send_file(album.artpath.decode())
     else:
         return flask.abort(404)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -71,6 +71,10 @@ Fixes:
 * :doc:`/plugins/web`: The time display in the web interface would incorrectly jump
   at the 30-second mark of every minute. Now, it correctly changes over at zero
   seconds. :bug:`2822`
+* :doc:`/plugins/web`: In a python 3 enviroment, the function to fetch the
+  album art would not work and throw an exception. It now works as expected.
+  Additionally, the server will now return a 404 response when the album id
+  is unknown, instead of a 500 response and a thrown exception. :bug:`2823`
 
 For developers:
 


### PR DESCRIPTION
flask.send_file() expects a string, g.lib.get_album() returns bytes. Added decode() to album_art(). 

If g.lib.get_album() gets a non-existing id, it returns None. Python would throw an error in this case. Added check to prevent this.