### PR TITLE
Partial fix for cmd names with dashes (ref #2836)

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1758,7 +1758,7 @@ def completion_script(commands):
     # Command aliases
     yield u"  local aliases='%s'\n" % ' '.join(aliases.keys())
     for alias, cmd in aliases.items():
-        yield u"  local alias__%s=%s\n" % (alias, cmd)
+        yield u"  local alias__%s=%s\n" % (alias.replace('-', '_'), cmd)
     yield u'\n'
 
     # Fields
@@ -1775,7 +1775,7 @@ def completion_script(commands):
             if option_list:
                 option_list = u' '.join(option_list)
                 yield u"  local %s__%s='%s'\n" % (
-                    option_type, cmd, option_list)
+                    option_type, cmd.replace('-', '_'), option_list)
 
     yield u'  _beet_dispatch\n'
     yield u'}\n'

--- a/beets/ui/completion_base.sh
+++ b/beets/ui/completion_base.sh
@@ -70,7 +70,7 @@ _beet_dispatch() {
 
   # Replace command shortcuts
   if [[ -n $cmd ]] && _list_include_item "$aliases" "$cmd"; then
-    eval "cmd=\$alias__$cmd"
+    eval "cmd=\$alias__${cmd//-/_}"
   fi
 
   case $cmd in
@@ -94,8 +94,8 @@ _beet_dispatch() {
 _beet_complete() {
   if [[ $cur == -* ]]; then
     local opts flags completions
-    eval "opts=\$opts__$cmd"
-    eval "flags=\$flags__$cmd"
+    eval "opts=\$opts__${cmd//-/_}"
+    eval "flags=\$flags__${cmd//-/_}"
     completions="${flags___common} ${opts} ${flags}"
     COMPREPLY+=( $(compgen -W "$completions"  -- $cur) )
   else
@@ -129,7 +129,7 @@ _beet_complete_global() {
     COMPREPLY+=( $(compgen -W "$completions" -- $cur) )
   elif [[ -n $cur ]] && _list_include_item "$aliases" "$cur"; then
     local cmd
-    eval "cmd=\$alias__$cur"
+    eval "cmd=\$alias__${cur//-/_}"
     COMPREPLY+=( "$cmd" )
   else
     COMPREPLY+=( $(compgen -W "$commands" -- $cur) )
@@ -138,7 +138,7 @@ _beet_complete_global() {
 
 _beet_complete_query() {
   local opts
-  eval "opts=\$opts__$cmd"
+  eval "opts=\$opts__${cmd//-/_}"
 
   if [[ $cur == -* ]] || _list_include_item "$opts" "$prev"; then
     _beet_complete


### PR DESCRIPTION
This patch avoids errors during completion when a plugin
uses names like "sub-command". It does not make completion
fully working for such commands though, thus no close.