### PR TITLE
beet version: include platform info

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -19,10 +19,12 @@ Here's a link to the music files that trigger the bug (if relevant):
 
 ### Setup
 
-* OS: 
-* Python version: 
-* beets version: 
-* Turning off plugins made problem go away (yes/no): 
+Note that calling `beet version` shows this information (platform only in newer versions).
+
+* beets version:
+* Python version:
+* Platform:
+* Turning off plugins made problem go away (yes/no):
 
 My configuration (output of `beet config`) is:
 

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1324,8 +1324,21 @@ default_commands.append(stats_cmd)
 # version: Show current beets version.
 
 def show_version(lib, opts, args):
+    # Use the improved 'distro' package for platform info, if available
+    # (the stdlib platform module has simplistic logic, and 3.7 will drop it)
+    from platform import platform
+    os_id = platform()
+    if os.name == 'posix':
+        try:
+            import distro
+        except ImportError:
+            pass
+        else:
+            os_id = distro.name(pretty=True) or platform()
+
     print_(u'beets version %s' % beets.__version__)
     print_(u'Python version {}'.format(python_version()))
+    print_(u'Platform: {}'.format(os_id))
     # Show plugins.
     names = sorted(p.name for p in plugins.find_plugins())
     if names:


### PR DESCRIPTION
This supports issue reporting, showing **all** the information that is asked for (thus the issue template got a hint, too).