### PR TITLE
Artist credit config

### DIFF
--- a/beets/autotag/__init__.py
+++ b/beets/autotag/__init__.py
@@ -63,12 +63,19 @@ def apply_metadata(album_info, mapping):
     mapping from Items to TrackInfo objects.
     """
     for item, track_info in mapping.items():
-        # Album, artist, track count.
-        if track_info.artist:
-            item.artist = track_info.artist
+        # Artist or artist credit.
+        if config['artist_credit']:
+            item.artist = (track_info.artist_credit or
+                           track_info.artist or
+                           album_info.artist_credit or
+                           album_info.artist)
+            item.albumartist = (album_info.artist_credit or
+                                album_info.artist)
         else:
-            item.artist = album_info.artist
-        item.albumartist = album_info.artist
+            item.artist = (track_info.artist or album_info.artist)
+            item.albumartist = album_info.artist
+
+        # Album.
         item.album = album_info.album
 
         # Artist sort and credit names.

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -56,6 +56,7 @@ per_disc_numbering: no
 verbose: 0
 terminal_encoding:
 original_date: no
+artist_credit: no
 id3v23: no
 va_name: "Various Artists"
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,9 @@ New features:
 * :doc:`/plugins/web`: added the boolean ``cors_supports_credentials`` option to
   allow in-browser clients to login to the beet web server even when it is
   protected by an authorization mechanism.
+* A new importer configuration ``artist_credit`` will tell beets to prefer the
+  artist credit over the artist when autotagging.
+  :bug:`1249`
 
 
 Fixes:
@@ -75,9 +78,9 @@ Fixes:
   album art would not work and throw an exception. It now works as expected.
   Additionally, the server will now return a 404 response when the album id
   is unknown, instead of a 500 response and a thrown exception. :bug:`2823`
-* :doc:`/plugins/web`: In a python 3 enviroment, the server would throw an 
+* :doc:`/plugins/web`: In a python 3 enviroment, the server would throw an
   exception if non latin-1 characters where in the File name.
-  It now checks if non latin-1 characters are in the filename and changes 
+  It now checks if non latin-1 characters are in the filename and changes
   them to ascii-characters in that case :bug:`2815`
 * Partially fix bash completion for subcommand names that contain hyphens.
   :bug:`2836` :bug:`2837`

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -253,6 +253,15 @@ Either ``yes`` or ``no``, indicating whether matched albums should have their
 That is, if this option is turned on, then ``year`` will always equal
 ``original_year`` and so on. Default: ``no``.
 
+.. _artist_credit:
+
+artist_credit
+~~~~~~~~~~~~~
+
+Either ``yes`` or ``no``, indicating whether matched tracks and albums should
+use the artist credit, rather than the artist. That is, if this option is turned
+on, then ``artist`` will contain the artist as credited on the release.
+
 .. _per_disc_numbering:
 
 per_disc_numbering


### PR DESCRIPTION
Fixes #1249.

* [x] Write test cases that cover all the scenarios (but how?)

I based myself off the existing `original_date` and `per_disc_numbering` options.

**Questions:**

* What should we pick if there is an `artist`, no `artist_credit`, an `albumartist` and an `albumartist_credit`? I assume that `artist` is the best choice here; correct?

* How do I write a test that verifies all combinations of `artist`, `artist_credit`, `albumartist` and `albumartist_credit`?