### PR TITLE
Beets Privacy Policy Page

### DIFF
--- a/Beets Privacy Policy Page
+++ b/Beets Privacy Policy Page
@@ -1,0 +1,44 @@
+Privacy policy
+
+
+This privacy policy how we collect, protect and uses the  information you may provide in the Beets Music application and any of its products or services. It also describes the choices available to you regarding our use of your personal information and how you can access and update this information. This Policy does not apply to the practices of companies that we do not own or control, or to individuals that we do not employ or manage.
+
+Collection of personal information
+
+We receive and store any information you knowingly provide to us when you fill any online forms in the Mobile Application.  You can choose not to provide us with certain information, but then you may not be able to take advantage of some of the Mobile Application's features.
+
+Collection of non-personal information
+
+When you open the Mobile Application our servers automatically record information that your device sends. This data may include information such as your device's IP address and location, device name and version, operating system type and version, language preferences, information you search for in our Mobile Application, access times and dates, and other statistics.
+
+Use of collected information
+
+Any of the information we collect from you may be used to Non-personal information collected is used only to identify potential cases of abuse and establish statistical information regarding Mobile Application traffic and usage. This statistical information is not otherwise aggregated in such a way that would identify any particular user of the system.
+
+Information security
+
+We secure information you provide on computer servers in a controlled, secure environment, protected from unauthorized access, use, or disclosure. We maintain reasonable administrative, technical, and physical safeguards in an effort to protect against unauthorized access, use, modification, and disclosure of personal information in its control and custody. However, no data transmission over the Internet or wireless network can be guaranteed. Therefore, while we strive to protect your personal information, you acknowledge that (i) there are security and privacy limitations of the Internet which are beyond our control; (ii) the security, integrity, and privacy of any and all information and data exchanged between you and our Mobile Application cannot be guaranteed; and (iii) any such information and data may be viewed or tampered with in transit by a third-party, despite best efforts.
+
+Data breach
+
+In the event we become aware that the security of the Mobile Application has been compromised or users Personal Information has been disclosed to unrelated third-parties as a result of external activity, including, but not limited to, security attacks or fraud, we reserve the right to take reasonably appropriate measures, including, but not limited to, investigation and reporting, as well as notification to and cooperation with law enforcement authorities. In the event of a data breach, we will make reasonable efforts to notify affected individuals if we believe that there is a reasonable risk of harm to the user as a result of the breach or if notice is otherwise required by law. When we do we will post a notice in the Mobile Application.
+
+Legal disclosure
+
+We will disclose any information we collect, use or receive if required or permitted by law, such as to comply with a subpoena, or similar legal process, and when we believe in good faith that disclosure is necessary to protect our rights, protect your safety or the safety of others, investigate fraud, or respond to a government request.
+
+Changes and amendments
+
+We reserve the right to modify this privacy policy relating to the Mobile Application or Services at any time, effective upon posting of an updated version of this Policy in the Mobile Application. When we do we will revise the updated date at the bottom of this page. Continued use of the Mobile Application after any such changes shall constitute your consent to such changes.
+Acceptance of this policy
+
+You acknowledge that you have read this Policy and agree to all its terms and conditions. By using the Mobile Application or its Services you agree to be bound by this Policy. If you do not agree to abide by the terms of this Policy, you are not authorized to use or access the Mobile Application and its Services.
+
+Contacting us
+
+•	If you have any questions about this Policy, please contact us by posting on the discussion forum at https://discourse.beets.io/ or file an issue on github https://github.com/beetbox/beets/issues/new
+
+
+This document was last updated on April 15, 2018
+
+


### PR DESCRIPTION
Adding a privacy policy of an app on the official site or in the app gives users more confident as they know how their details and activities are handled. It is with this that I proposed the above to be used as the Privacy policy for beets.io