### PR TITLE
Fix coding style: `Shareable` is a metaclass.

### DIFF
--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -151,15 +151,15 @@ class Shareable(type):
     lazily-created shared instance of ``MyClass`` while calling
     ``MyClass()`` to construct a new object works as usual.
     """
-    def __init__(self, name, bases, dict):
-        super(Shareable, self).__init__(name, bases, dict)
-        self._instance = None
+    def __init__(cls, name, bases, dict):
+        super(Shareable, cls).__init__(name, bases, dict)
+        cls._instance = None
 
     @property
-    def shared(self):
-        if self._instance is None:
-            self._instance = self()
-        return self._instance
+    def shared(cls):
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
 
 
 class ArtResizer(six.with_metaclass(Shareable, object)):


### PR DESCRIPTION
Release v0.6.1 of `pep8-naming` now detects that `Shareable` in `beets/util/artresizer.py` is a metaclass. The first argument of each class method should then named be `cls` instead of `self`.