### PR TITLE
Add support for user and pass to the Musicbrainz Autotagger

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -86,6 +86,12 @@ def configure():
         config['musicbrainz']['ratelimit_interval'].as_number(),
         config['musicbrainz']['ratelimit'].get(int),
     )
+    config['musicbrainz']['pass'].redact = True
+    if config['musicbrainz']['user'] and config['musicbrainz']['pass']:
+        musicbrainzngs.auth(
+            config['musicbrainz']['user'].as_str(),
+            config['musicbrainz']['pass'].as_str(),
+        )
 
 
 def _preferred_alias(aliases):


### PR DESCRIPTION
I haven't had a chance to test this yet, but it's mostly copied from the mbcollection plugin. There are a few servers which use auth and this would allow their usage when autotagging.