### PR TITLE
mbsync: fix updating album with invalid first track MBID

### DIFF
--- a/beetsplug/mbsync.py
+++ b/beetsplug/mbsync.py
@@ -152,10 +152,13 @@ class MBSyncPlugin(BeetsPlugin):
             with lib.transaction():
                 autotag.apply_metadata(album_info, mapping)
                 changed = False
+                # Find any changed item to apply MusicBrainz changes to album.
+                any_changed_item = items[0]
                 for item in items:
                     item_changed = ui.show_model_changes(item)
                     changed |= item_changed
                     if item_changed:
+                        any_changed_item = item
                         apply_item_changes(lib, item, move, pretend, write)
 
                 if not changed:
@@ -165,7 +168,7 @@ class MBSyncPlugin(BeetsPlugin):
                 if not pretend:
                     # Update album structure to reflect an item in it.
                     for key in library.Album.item_keys:
-                        a[key] = items[0][key]
+                        a[key] = any_changed_item[key]
                     a.store()
 
                     # Move album art (and any inconsistent items).

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -115,6 +115,8 @@ Fixes:
   tracks. :bug:`2537`
 * In the ``mbsync`` plugin, support MusicBrainz recording ID changes, relying
   on release track IDs instead. Thanks to :user:`jdetrey`. :bug:`1234`
+* In the ``mbsync`` plugin, allow beets to update album if the first track
+  has a missing MusicBrainz recording ID.
 
 
 For developers:


### PR DESCRIPTION
MBID of recording could become invalid after merging. The existing
code always copies metadata from first track after updating. But for
albums with invalid track MBID that happens to be the first track,
MusicBrainz changes won't be applied to whole album, only whose
tracks with valid MBID. This is particularly annoying since those
changes are actually displayed for every `beet mbsync` run, but never
get applied.

Fix this issue by finding any track that get MusicBrainz updates, and
apply it to whole album.

Some additional comments:

1. While #2917 seems being able to solve `beet mbsync` issues in long term. It still can't handle existing collection with invalid track MBID. Since those tracks won't receive any updates (including `mb_release_trackid`), and becomes "zombie". This pull request won't solve the whole "track MBID missing" issue, just the most annoying part of it.
2. This issue actually caused #2914 (partially) for me. It stops merged album MBID from being updated during `beet mbsync` run. The issue of #2914 still exists, but with this pull request at least `beet mbsync` could become a work around.