### PR TITLE
Send albuminfo_received / trackinfo_received when running mbsync

### DIFF
--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -539,7 +539,10 @@ def album_for_mbid(release_id):
     if the ID is not found.
     """
     try:
-        return mb.album_for_id(release_id)
+        album = mb.album_for_id(release_id)
+        if album:
+            plugins.send(u'albuminfo_received', info=album)
+        return album
     except mb.MusicBrainzAPIError as exc:
         exc.log(log)
 
@@ -549,12 +552,14 @@ def track_for_mbid(recording_id):
     if the ID is not found.
     """
     try:
-        return mb.track_for_id(recording_id)
+        track = mb.track_for_id(recording_id)
+        if track:
+            plugins.send(u'trackinfo_received', info=track)
+        return track
     except mb.MusicBrainzAPIError as exc:
         exc.log(log)
 
 
-@plugins.notify_info_yielded(u'albuminfo_received')
 def albums_for_id(album_id):
     """Get a list of albums for an ID."""
     a = album_for_mbid(album_id)
@@ -562,10 +567,10 @@ def albums_for_id(album_id):
         yield a
     for a in plugins.album_for_id(album_id):
         if a:
+            plugins.send(u'albuminfo_received', info=a)
             yield a
 
 
-@plugins.notify_info_yielded(u'trackinfo_received')
 def tracks_for_id(track_id):
     """Get a list of tracks for an ID."""
     t = track_for_mbid(track_id)
@@ -573,6 +578,7 @@ def tracks_for_id(track_id):
         yield t
     for t in plugins.track_for_id(track_id):
         if t:
+            plugins.send(u'trackinfo_received', info=t)
             yield t
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -115,6 +115,9 @@ Fixes:
   tracks. :bug:`2537`
 * In the ``mbsync`` plugin, support MusicBrainz recording ID changes, relying
   on release track IDs instead. Thanks to :user:`jdetrey`. :bug:`1234`
+* Properly send ``albuminfo_received`` and ``trackinfo_received`` in all cases,
+  most notably when using the ``mbsync`` plugin. This was a regression since
+  version 1.4.1. :bug:`2921`
 
 
 For developers:

--- a/test/test_mbsync.py
+++ b/test/test_mbsync.py
@@ -37,15 +37,15 @@ class MbsyncCliTest(unittest.TestCase, TestHelper):
         self.unload_plugins()
         self.teardown_beets()
 
-    @patch('beets.autotag.hooks.album_for_mbid')
-    @patch('beets.autotag.hooks.track_for_mbid')
-    def test_update_library(self, track_for_mbid, album_for_mbid):
-        album_for_mbid.return_value = \
+    @patch('beets.autotag.mb.album_for_id')
+    @patch('beets.autotag.mb.track_for_id')
+    def test_update_library(self, track_for_id, album_for_id):
+        album_for_id.return_value = \
             generate_album_info(
                 'album id',
                 [('track id', {'release_track_id': u'release track id'})]
             )
-        track_for_mbid.return_value = \
+        track_for_id.return_value = \
             generate_track_info(u'singleton track id',
                                 {'title': u'singleton info'})
 
@@ -65,7 +65,10 @@ class MbsyncCliTest(unittest.TestCase, TestHelper):
         )
         self.lib.add(item)
 
-        self.run_command('mbsync')
+        with capture_log() as logs:
+            self.run_command('mbsync')
+        self.assertIn('Sending event: albuminfo_received', logs)
+        self.assertIn('Sending event: trackinfo_received', logs)
 
         item.load()
         self.assertEqual(item.title, u'singleton info')


### PR DESCRIPTION
Fixes #2921, and adds a test case to hopefully help future refactors of autotag.hooks not break mbsync events.

I don't think completely removing `@plugins.notify_info_yielded` is the right thing here, it works really well for `album_candidates`/`item_candidates`.