### PR TITLE
pre-resolve package path for lazy-load configuration

### DIFF
--- a/beets/util/confit.py
+++ b/beets/util/confit.py
@@ -794,6 +794,8 @@ class Configuration(RootView):
         super(Configuration, self).__init__([])
         self.appname = appname
         self.modname = modname
+        # Pre-resolve default source location
+        self._package_path = _package_path(appname)
 
         self._env_var = '{0}DIR'.format(self.appname.upper())
 
@@ -822,9 +824,8 @@ class Configuration(RootView):
         `modname` if it was given.
         """
         if self.modname:
-            pkg_path = _package_path(self.modname)
-            if pkg_path:
-                filename = os.path.join(pkg_path, DEFAULT_FILENAME)
+            if self._package_path:
+                filename = os.path.join(self._package_path, DEFAULT_FILENAME)
                 if os.path.isfile(filename):
                     self.add(ConfigSource(load_yaml(filename), filename, True))
 


### PR DESCRIPTION
The test `test_ui.ConfigTest.test_command_line_option_relative_to_working_dir` was failing on my system but, for some odd reason, not on Travis nor AppVeyor. The test fails because it changes working directories before the relative lazy-loaded default configuration path is resolved, later causing a `beets.util.confit.NotFoundError: musicbrainz.host not found` error. Unfortunately, the pkgutil loader returns `../beets/__init__.py` as the path to the default configuration source and 99% of the time this resolves because the working directory doesn't change.
I made a small change to the `LazyConfig` class to pre-resolve this path so that it can be lazy-loaded after a working directory change.