### PR TITLE
Add catalognumber to disambiguation string (when selecting candidates)

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -172,6 +172,8 @@ def disambig_string(info):
             disambig.append(info.country)
         if info.label:
             disambig.append(info.label)
+        if info.catalognum:
+            disambig.append(info.catalognum)
         if info.albumdisambig:
             disambig.append(info.albumdisambig)
 


### PR DESCRIPTION
As per suggestion from: <https://discourse.beets.io/t/created-plugin-find-release-from-barcode/366/8>