### PR TITLE
Add ability for play plugin to emit utf8 BOM

### DIFF
--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -65,6 +65,7 @@ class PlayPlugin(BeetsPlugin):
             'relative_to': None,
             'raw': False,
             'warning_threshold': 100,
+            'bom': False,
         })
 
         self.register_listener('before_choose_candidate',
@@ -185,7 +186,12 @@ class PlayPlugin(BeetsPlugin):
     def _create_tmp_playlist(self, paths_list):
         """Create a temporary .m3u file. Return the filename.
         """
+        utf8_bom = config['play']['bom'].get(bool)
         m3u = NamedTemporaryFile('wb', suffix='.m3u', delete=False)
+
+        if utf8_bom:
+            m3u.write(b'\xEF\xBB\xBF')
+
         for item in paths_list:
             m3u.write(item + b'\n')
         m3u.close()

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,10 @@ New features:
   the catalog number.
   Thanks to :user:`8h2a`.
   :bug:`2951`
+* The play plugin can now emit a UTF-8 BOM, fixing some issues with foobar2000
+  and Winamp.
+  Thanks to :user:`mz2212`.
+  :bug:`2944`
 
 Fixes:
 

--- a/docs/plugins/play.rst
+++ b/docs/plugins/play.rst
@@ -62,6 +62,9 @@ configuration file. The available options are:
 - **warning_threshold**: Set the minimum number of files to play which will
   trigger a warning to be emitted. If set to ``no``, warning are never issued.
   Default: 100.
+- **bom**: Set whether or not a UTF-8 Byte Order Mark should be emitted into
+  the m3u file. If you're using foobar2000 or Winamp, this is needed.
+  Default: ``no``.
 
 Optional Arguments
 ------------------


### PR DESCRIPTION
Closes #2944 
I've never written tests before, and I didn't want to break anything too bad.  
I'm now using the modified `play.py` on my local machine and it works well.

This is my first time contributing code as well, please tell me if I did anything wrong.