### PR TITLE
Display the artist credit when matching albums if the user prefers ar…

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -256,6 +256,9 @@ def show_change(cur_artist, cur_album, match):
             # Hide artists for VA releases.
             artist_l, artist_r = u'', u''
 
+        if config['artist_credit']:
+            artist_r = match.info.artist_credit
+
         artist_l, artist_r = ui.colordiff(artist_l, artist_r)
         album_l, album_r = ui.colordiff(album_l, album_r)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,9 @@ Fixes:
   are missing.
   Thanks to :user:`autrimpo`.
   :bug:`2757`
+* Display the artist credit when matching albums if the ref:`artist_credit`
+  configuration option is set.
+  :bug:`2953`
 
 
 1.4.7 (May 29, 2018)


### PR DESCRIPTION
Display the artist credit when matching albums if the user prefers artist credits.

Opened as pull request in case this confuses new users (and so there's an issue number to put in the changelog).