### PR TITLE
Add space-padding to missing tracks dialog

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -379,14 +379,14 @@ def show_change(cur_artist, cur_album, match):
                len(match.extra_tracks) / len(match.info.tracks)
                ))
     for track_info in match.extra_tracks:
-        line = u' ! %s (#%s)' % (track_info.title, format_index(track_info))
+        line = u' ! {0: <48} (#{1: >2})'.format(track_info.title, format_index(track_info))
         if track_info.length:
             line += u' (%s)' % ui.human_seconds_short(track_info.length)
         print_(ui.colorize('text_warning', line))
     if match.extra_items:
         print_(u'Unmatched tracks ({0}):'.format(len(match.extra_items)))
     for item in match.extra_items:
-        line = u' ! %s (#%s)' % (item.title, format_index(item))
+        line = u' ! {0: <48} (#{1: >2})'.format(item.title, format_index(item))
         if item.length:
             line += u' (%s)' % ui.human_seconds_short(item.length)
         print_(ui.colorize('text_warning', line))

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,8 @@ New features:
   and Winamp.
   Thanks to :user:`mz2212`.
   :bug:`2944`
+* Added whitespace padding to missing tracks dialog to improve readability.
+  :user:`jams2`
 
 Fixes:
 


### PR DESCRIPTION
![beet](https://user-images.githubusercontent.com/29293125/41585193-3ff77626-73a1-11e8-9577-36c977d6182b.png)

Hi all,
during a long session organising my library with Beets, I found readability was not great after a while, this might help.
Not sure how to write tests for this, happy to be pointed in the right direction, and happy to look at other dialogs if this is helpful.