### PR TITLE
lastgenre prefer specific without canonical (#2973)

### DIFF
--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -138,9 +138,18 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         # Read the genres tree for canonicalization if enabled.
         self.c14n_branches = []
         c14n_filename = self.config['canonical'].get()
-        if c14n_filename in (True, ''):  # Default tree.
+        self.canonicalize = c14n_filename is not False
+
+        # Default tree
+        if c14n_filename in (True, ''):
             c14n_filename = C14N_TREE
+        elif not self.canonicalize and self.config['prefer_specific'].get():
+            # prefer_specific requires a tree, load default tree
+            c14n_filename = C14N_TREE
+
+        # Read the tree
         if c14n_filename:
+            self._log.debug('Loading canonicalization tree {0}', c14n_filename)
             c14n_filename = normpath(c14n_filename)
             with codecs.open(c14n_filename, 'r', encoding='utf-8') as f:
                 genres_tree = yaml.load(f)
@@ -186,7 +195,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
             return None
 
         count = self.config['count'].get(int)
-        if self.c14n_branches:
+        if self.c14n_branches and self.canonicalize:
             # Extend the list to consider tags parents in the c14n tree
             tags_all = []
             for tag in tags:

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -195,7 +195,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
             return None
 
         count = self.config['count'].get(int)
-        if self.c14n_branches and self.canonicalize:
+        if self.canonicalize:
             # Extend the list to consider tags parents in the c14n tree
             tags_all = []
             for tag in tags:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,7 +23,7 @@ Fixes:
   are missing.
   Thanks to :user:`autrimpo`.
   :bug:`2757`
-* Display the artist credit when matching albums if the ref:`artist_credit`
+* Display the artist credit when matching albums if the :ref:`artist_credit`
   configuration option is set.
   :bug:`2953`
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,9 @@ Fixes:
 * Display the artist credit when matching albums if the :ref:`artist_credit`
   configuration option is set.
   :bug:`2953`
+* LastGenre: Allow to set the configuration option ``prefer_specific``
+  without setting ``canonical``.
+  :bug:`2973`
 
 
 1.4.7 (May 29, 2018)

--- a/test/test_lastgenre.py
+++ b/test/test_lastgenre.py
@@ -36,9 +36,11 @@ class LastGenrePluginTest(unittest.TestCase, TestHelper):
     def tearDown(self):
         self.teardown_beets()
 
-    def _setup_config(self, whitelist=False, canonical=False, count=1):
+    def _setup_config(self, whitelist=False, canonical=False, count=1,
+                      prefer_specific=False):
         config['lastgenre']['canonical'] = canonical
         config['lastgenre']['count'] = count
+        config['lastgenre']['prefer_specific'] = prefer_specific
         if isinstance(whitelist, (bool, six.string_types)):
             # Filename, default, or disabled.
             config['lastgenre']['whitelist'] = whitelist

--- a/test/test_lastgenre.py
+++ b/test/test_lastgenre.py
@@ -138,6 +138,21 @@ class LastGenrePluginTest(unittest.TestCase, TestHelper):
         self.assertEqual(self.plugin._resolve_genres(['iota blues']),
                          u'')
 
+    def test_prefer_specific_loads_tree(self):
+        """When prefer_specific is enabled but canonical is not the
+        tree still has to be loaded.
+        """
+        self._setup_config(prefer_specific=True, canonical=False)
+        self.assertNotEqual(self.plugin.c14n_branches, [])
+
+    def test_prefer_specific_without_canonical(self):
+        """When prefer_specific is enabled but canonical is not the
+        tree still has to be loaded.
+        """
+        self._setup_config(prefer_specific=True, canonical=False)
+        self.assertEqual(self.plugin._resolve_genres(['delta blues']),
+                         u'Delta Blues')
+
     def test_no_duplicate(self):
         """Remove duplicated genres.
         """

--- a/test/test_lastgenre.py
+++ b/test/test_lastgenre.py
@@ -146,12 +146,12 @@ class LastGenrePluginTest(unittest.TestCase, TestHelper):
         self.assertNotEqual(self.plugin.c14n_branches, [])
 
     def test_prefer_specific_without_canonical(self):
-        """When prefer_specific is enabled but canonical is not the
-        tree still has to be loaded.
+        """Prefer_specific works without canonical.
         """
-        self._setup_config(prefer_specific=True, canonical=False)
-        self.assertEqual(self.plugin._resolve_genres(['delta blues']),
-                         u'Delta Blues')
+        self._setup_config(prefer_specific=True, canonical=False, count=4)
+        self.assertEqual(self.plugin._resolve_genres(
+                         ['math rock', 'post-rock']),
+                         u'Post-Rock, Math Rock')
 
     def test_no_duplicate(self):
         """Remove duplicated genres.


### PR DESCRIPTION
## Allow to use LastGenre's `prefer_specific` without `canonical`. 

#### Old behaviour:
```sh
$ beet lastgenre LITE Cubic
lastgenre: genre for album LITE - Cubic (None):
```

#### New behaviour:
```sh
$ # without lastgenre.canonical
$ beet lastgenre LITE Cubic
lastgenre: genre for album LITE - Cubic (artist): Post-Rock, Math Rock
$ # compare: with lastgenre.canonical
$ beet lastgenre LITE Cubic
lastgenre: genre for album LITE - Cubic (artist): Post-Rock, Math Rock, Alternative Rock, Rock
```

I.e. it prefers the more specific genres using the canonicalization tree without actually canonicalizing the genres. That seems to fit what `prefer_specific: yes` `canonical: no` implies.

This should fix #2973 (with the alternative solution described there).

I have possibly violated every coding convention on earth, so please tell me what I should change.
