### PR TITLE
 from_scratch option: keep immutable fields (#2972)

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -564,7 +564,7 @@ class Item(LibModel):
 
     def clear(self):
         """Set all key/value pairs to None."""
-        for key in self._media_fields:
+        for key in self._media_tag_fields:
             setattr(self, key, None)
 
     def get_album(self):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,9 @@ Fixes:
 * Display the artist credit when matching albums if the ref:`artist_credit`
   configuration option is set.
   :bug:`2953`
+* With the :ref:`from_scratch` configuration option set, only writable fields
+  are cleared. Beets now no longer ignores the format your music is saved in. 
+  :bug:`2972`
 
 
 1.4.7 (May 29, 2018)

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -644,6 +644,21 @@ class ImportTest(_common.TestCase, ImportHelper):
         self.importer.run()
         self.assertEqual(self.lib.items().get().genre, u'')
 
+    def test_apply_from_scratch_keeps_format(self):
+        config['import']['from_scratch'] = True
+
+        self.importer.add_choice(importer.action.APPLY)
+        self.importer.run()
+        self.assertEqual(self.lib.items().get().format, u'MP3')
+
+    def test_apply_from_scratch_keeps_bitrate(self):
+        config['import']['from_scratch'] = True
+        bitrate = 80000
+
+        self.importer.add_choice(importer.action.APPLY)
+        self.importer.run()
+        self.assertEqual(self.lib.items().get().bitrate, bitrate)
+
     def test_apply_with_move_deletes_import(self):
         config['import']['move'] = True
 


### PR DESCRIPTION
This should fix #2972. 
I just implemented @tummychow's solution, tested it and added tests. 

In the second test (test_apply_from_scratch_keeps_bitrate) the expected bitrate is hardcoded. As I did not find the test-file's bitrate documented anywhere this feels like depending on some implementation detail (of the test setup). Would extracting that value from the file before importing it be a better option? 
