### PR TITLE
changed flask cors import

### DIFF
--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -383,7 +383,7 @@ class WebPlugin(BeetsPlugin):
             if self.config['cors']:
                 self._log.info(u'Enabling CORS with origin: {0}',
                                self.config['cors'])
-                from flask.ext.cors import CORS
+                from flask_cors import CORS
                 app.config['CORS_ALLOW_HEADERS'] = "Content-Type"
                 app.config['CORS_RESOURCES'] = {
                     r"/*": {"origins": self.config['cors'].get(str)}


### PR DESCRIPTION
Per the [Flask Documentation](http://flask.pocoo.org/docs/1.0/upgrading/#extension-imports):

> ## Extension imports
> 
> Extension imports of the form flask.ext.foo are deprecated, you should use flask_foo.
> 
> The old form still works, but Flask will issue a flask.exthook.ExtDeprecationWarning for each extension you import the old way. We also provide a migration utility called flask-ext-migrate that is supposed to automatically rewrite your imports for this.

This changes the CORS import from the deprecated form to the preferred form.

Issue #2979 
