### PR TITLE
Add uploader_id, uploader_name, and device_id for gmusicapi auth in gmusic plugin

### DIFF
--- a/beetsplug/gmusic.py
+++ b/beetsplug/gmusic.py
@@ -30,17 +30,23 @@ import gmusicapi.clients
 class Gmusic(BeetsPlugin):
     def __init__(self):
         super(Gmusic, self).__init__()
+        self.config.add({
+            u'auto': False,
+            u'uploader_id': '',
+            u'uploader_name': '',
+            u'device_id': '',
+        })
         # Checks for OAuth2 credentials,
         # if they don't exist - performs authorization
         self.m = Musicmanager()
         if os.path.isfile(gmusicapi.clients.OAUTH_FILEPATH):
-            self.m.login()
+            uploader_id = self.config['uploader_id']
+            uploader_name = self.config['uploader_name']
+            self.m.login(uploader_id=uploader_id.as_str().upper() or None,
+                         uploader_name=uploader_name.as_str() or None)
         else:
             self.m.perform_oauth()
 
-        self.config.add({
-            u'auto': False,
-        })
         if self.config['auto']:
             self.import_stages = [self.autoupload]
 
@@ -82,6 +88,7 @@ class Gmusic(BeetsPlugin):
     def search(self, lib, opts, args):
         password = config['gmusic']['password']
         email = config['gmusic']['email']
+        device_id = config['gmusic']['device_id']
         password.redact = True
         email.redact = True
         # Since Musicmanager doesn't support library management
@@ -89,7 +96,7 @@ class Gmusic(BeetsPlugin):
         mobile = Mobileclient()
         try:
             mobile.login(email.as_str(), password.as_str(),
-                         Mobileclient.FROM_MAC_ADDRESS)
+                         device_id.as_str() or Mobileclient.FROM_MAC_ADDRESS)
             files = mobile.get_all_songs()
         except NotLoggedIn:
             ui.print_(

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,8 @@ New features:
   :user:`jams2`
 * Automatically upload to Google Play Music library on track import.
   :user:`shuaiscott`
+* New options for Google Play Music authentication in gmusic plugin.
+  :user:`thetarkus`
 
 Fixes:
 

--- a/docs/plugins/gmusic.rst
+++ b/docs/plugins/gmusic.rst
@@ -20,14 +20,7 @@ Then, you can enable the ``gmusic`` plugin in your configuration (see
 
 Usage
 -----
-
-To automatically upload all tracks to Google Play Music, add the ``auto: yes``
-parameter to your configuration file like the example below::
-
-    gmusic:
-        auto: yes
-        email: user@example.com
-        password: seekrit
+**Configuration required before use.**
 
 To upload tracks to Google Play Music, use the ``gmusic-upload`` command::
 
@@ -35,19 +28,7 @@ To upload tracks to Google Play Music, use the ``gmusic-upload`` command::
 
 If you don't include a query, the plugin will upload your entire collection.
 
-To query the songs in your collection, you will need to add your Google
-credentials to your beets configuration file. Put your Google username and
-password under a section called ``gmusic``, like so::
-
-    gmusic:
-        email: user@example.com
-        password: seekrit
-
-If you have enabled two-factor authentication in your Google account, you will
-need to set up and use an *application-specific password*. You can obtain one
-from your Google security settings page.
-
-Then, use the ``gmusic-songs`` command to list music::
+To list your music collection, use the ``gmusic-songs`` command::
 
     beet gmusic-songs [-at] [ARGS]
 
@@ -59,3 +40,45 @@ example::
 
 For a list of all songs in your library, run ``beet gmusic-songs`` without any
 arguments.
+
+
+Configuration
+-------------
+To configure the plugin, make a ``gmusic:`` section in your configuration file.
+The available options are:
+
+- **email**: Your Google account email address.  
+  Default: none.
+- **password**: Password to your Google account. Required to query songs in
+  your collection.  
+  For accounts with 2-step-verification, an
+  `app password <https://support.google.com/accounts/answer/185833?hl=en>`__
+  will need to be generated. An app password for an account without
+  2-step-verification is not required but is recommended.  
+  Default: none.
+- **auto**: Set to ``yes`` to automatically upload new imports to Google Play
+  Music.  
+  Default: ``no``
+- **uploader_id**: Unique id as a MAC address, eg ``'00:11:22:33:AA:BB'``.
+  This option should be set before the maximum number of authorized devices is
+  reached.  
+  If provided, use the same id for all future runs on this, and other, beets
+  installations as to not reach the maximum number of authorized devices.  
+  Default: device's MAC address.
+- **device_id**: Unique device ID for authorized devices.
+  This option only needs to be set if you receive an `InvalidDeviceId`
+  exception. Below the exception will be a list of valid device IDs.  
+  Default: none.
+
+Refer to the `Google Play Music Help
+<https://support.google.com/googleplaymusic/answer/3139562?hl=en>`__
+page for more details on authorized devices.
+
+Below is an example configuration::
+
+    gmusic:
+        email: user@example.com
+        password: seekrit
+        auto: yes
+        uploader_id: 00:11:22:33:AA:BB
+        device_id: F96AE4C643A5

--- a/docs/plugins/gmusic.rst
+++ b/docs/plugins/gmusic.rst
@@ -20,7 +20,15 @@ Then, you can enable the ``gmusic`` plugin in your configuration (see
 
 Usage
 -----
-**Configuration required before use.**
+Configuration is required before use. Below is an example configuration::
+
+    gmusic:
+        email: user@example.com
+        password: seekrit
+        auto: yes
+        uploader_id: 00:11:22:33:AA:BB
+        device_id: F96AE4C643A5
+
 
 To upload tracks to Google Play Music, use the ``gmusic-upload`` command::
 
@@ -73,12 +81,3 @@ The available options are:
 Refer to the `Google Play Music Help
 <https://support.google.com/googleplaymusic/answer/3139562?hl=en>`__
 page for more details on authorized devices.
-
-Below is an example configuration::
-
-    gmusic:
-        email: user@example.com
-        password: seekrit
-        auto: yes
-        uploader_id: 00:11:22:33:AA:BB
-        device_id: F96AE4C643A5


### PR DESCRIPTION
`gmusicapi` auth uses the MAC address to "register" in Google's service. Running `beet gmusic-upload` will fail if you use beets on multiple machines because too many MAC addresses will be registered. The fix it to be able to use the same MAC address (and `device_id` for searching) for all of the machines.

## uploader_id (optional)
Allow custom `uploader_id` to not reach maximum amount of registered devices. This field should be in the format of a MAC address.
From `gmusicapi` method docstring: [Link](https://github.com/simon-weber/gmusicapi/blob/1be1e0b461ae78ac5f1c504ab3387472e82e813e/gmusicapi/clients/musicmanager.py#L163)
```
There are hard limits on how many upload devices can be registered; refer to `Google's
docs <http://support.google.com/googleplay/bin/answer.py?hl=en&answer=1230356>`__. There
have been limits on deauthorizing devices in the past, so it's smart not to register
more devices than necessary.
```


## uploader_name (optional)
May not be necessary, but perhaps in the future.
From `gmusicapi` method docstring: [Link](https://github.com/simon-weber/gmusicapi/blob/1be1e0b461ae78ac5f1c504ab3387472e82e813e/gmusicapi/clients/musicmanager.py#L155)
```
This doesn't appear to be a part of authentication at all.
Registering with (id, name = X, Y) and logging in with
(id, name = X, Z) works, and does not change the server-stored
uploader_name.
```

## device_id (optional)
When running `beet gmusic-songs` from a different machine (with a different MAC address) sometimes you may get this error. The `device_id` is generated from the MAC address.
```
gmusicapi.exceptions.InvalidDeviceId: Invalid device_id XXXXXXXXA351.Your valid device IDs are:
* XXXXXXXXF92F
* XXXXXXXX43A5
```
You can then change `device_id` in your config to one of the valid device IDs that `gmusicapi` lists for you.

## config example
```yaml
plugins: gmusic

gmusic:
  email: musicgoogleaccount@gmail.com
  password: seekrit
  uploader_id: XX:XX:XX:XX:f7:97
  device_id: XXXXXXXX43A5
```

---

Let me know if this is acceptable and I will write something up for the gmusic docs.