### PR TITLE
gmusic plugin fixes and additions

### DIFF
--- a/beetsplug/gmusic.py
+++ b/beetsplug/gmusic.py
@@ -36,7 +36,7 @@ class Gmusic(BeetsPlugin):
             u'uploader_id': '',
             u'uploader_name': '',
             u'device_id': '',
-            u'oauth_filepath': '',
+            u'oauth_file': gmusicapi.clients.OAUTH_FILEPATH,
         })
         if self.config['auto']:
             self.import_stages = [self.autoupload]
@@ -62,16 +62,15 @@ class Gmusic(BeetsPlugin):
             return
         # Checks for OAuth2 credentials,
         # if they don't exist - performs authorization
-        oauth_filepath = (self.config['oauth_filepath'].as_str()
-                          or gmusicapi.clients.OAUTH_FILEPATH)
-        if os.path.isfile(oauth_filepath):
+        oauth_file = self.config['oauth_file'].as_str()
+        if os.path.isfile(oauth_file):
             uploader_id = self.config['uploader_id']
             uploader_name = self.config['uploader_name']
-            self.m.login(oauth_credentials=oauth_filepath,
+            self.m.login(oauth_credentials=oauth_file,
                          uploader_id=uploader_id.as_str().upper() or None,
                          uploader_name=uploader_name.as_str() or None)
         else:
-            self.m.perform_oauth(oauth_filepath)
+            self.m.perform_oauth(oauth_file)
 
     def upload(self, lib, opts, args):
         items = lib.items(ui.decargs(args))

--- a/docs/plugins/gmusic.rst
+++ b/docs/plugins/gmusic.rst
@@ -27,7 +27,8 @@ Configuration is required before use. Below is an example configuration::
         password: seekrit
         auto: yes
         uploader_id: 00:11:22:33:AA:BB
-        device_id: F96AE4C643A5
+        device_id: 00112233AABB
+        oauth_filepath: ~/.config/beets/oauth.cred
 
 
 To upload tracks to Google Play Music, use the ``gmusic-upload`` command::
@@ -67,15 +68,18 @@ The available options are:
 - **auto**: Set to ``yes`` to automatically upload new imports to Google Play
   Music.  
   Default: ``no``
-- **uploader_id**: Unique id as a MAC address, eg ``'00:11:22:33:AA:BB'``.
+- **uploader_id**: Unique id as a MAC address, eg ``00:11:22:33:AA:BB``.
   This option should be set before the maximum number of authorized devices is
   reached.  
   If provided, use the same id for all future runs on this, and other, beets
   installations as to not reach the maximum number of authorized devices.  
   Default: device's MAC address.
-- **device_id**: Unique device ID for authorized devices.
+- **device_id**: Unique device ID for authorized devices. It is usually
+  the same as your MAC address with the colons removed, eg ``00112233AABB``.  
   This option only needs to be set if you receive an `InvalidDeviceId`
   exception. Below the exception will be a list of valid device IDs.  
+  Default: none.
+- **oauth_filepath**: Filepath for oauth credentials file.  
   Default: none.
 
 Refer to the `Google Play Music Help

--- a/docs/plugins/gmusic.rst
+++ b/docs/plugins/gmusic.rst
@@ -28,7 +28,7 @@ Configuration is required before use. Below is an example configuration::
         auto: yes
         uploader_id: 00:11:22:33:AA:BB
         device_id: 00112233AABB
-        oauth_filepath: ~/.config/beets/oauth.cred
+        oauth_file: ~/.config/beets/oauth.cred
 
 
 To upload tracks to Google Play Music, use the ``gmusic-upload`` command::
@@ -79,8 +79,8 @@ The available options are:
   This option only needs to be set if you receive an `InvalidDeviceId`
   exception. Below the exception will be a list of valid device IDs.  
   Default: none.
-- **oauth_filepath**: Filepath for oauth credentials file.  
-  Default: none.
+- **oauth_file**: Filepath for oauth credentials file.  
+  Default: `{user_data_dir} <https://pypi.org/project/appdirs/>`__/gmusicapi/oauth.cred
 
 Refer to the `Google Play Music Help
 <https://support.google.com/googleplaymusic/answer/3139562?hl=en>`__


### PR DESCRIPTION
Currently, if the `gmusic` plugin is used, any command ran with beets will run the `gmusicapi` oauth authentication even if it has nothing related to `gmusic`.

**Example**, using command "ls" triggers the auth (every command does, including "web"):
![bad gmusic](https://i.imgur.com/gJmaUh7.png)

**Fixed example**, "ls" command does not trigger auth, but using one of the gmusic commands does:
![bad gmusic](https://i.imgur.com/DthrRP3.png)