### PR TITLE
Improve error messages in case of sqlite errors

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -1195,7 +1195,7 @@ def _open_library(config):
         lib.get_item(0)  # Test database connection.
     except (sqlite3.OperationalError, sqlite3.DatabaseError) as db_error:
         log.debug(u'{}', traceback.format_exc())
-        raise UserError(u"database file {0} could not be opened, reason: {1}".format(
+        raise UserError(u"database file {0} cannot not be opened: {1}".format(
             util.displayable_path(dbpath),
             db_error
         ))

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -1193,10 +1193,11 @@ def _open_library(config):
             get_replacements(),
         )
         lib.get_item(0)  # Test database connection.
-    except (sqlite3.OperationalError, sqlite3.DatabaseError):
+    except (sqlite3.OperationalError, sqlite3.DatabaseError) as db_error:
         log.debug(u'{}', traceback.format_exc())
-        raise UserError(u"database file {0} could not be opened".format(
-            util.displayable_path(dbpath)
+        raise UserError(u"database file {0} could not be opened, reason: {1}".format(
+            util.displayable_path(dbpath),
+            db_error
         ))
     log.debug(u'library database: {0}\n'
               u'library directory: {1}',

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -50,6 +50,8 @@ Fixes:
   with CORS enabled.
   Thanks to :user:`rveachkc`.
   :bug:`2979`: :bug:`2980`
+* Improve error reporting: during startup if sqlite returns an error the
+  sqlite error message is attached to the beets message
 
 .. _python-itunes: https://github.com/ocelma/python-itunes
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -51,7 +51,8 @@ Fixes:
   Thanks to :user:`rveachkc`.
   :bug:`2979`: :bug:`2980`
 * Improve error reporting: during startup if sqlite returns an error the
-  sqlite error message is attached to the beets message
+  sqlite error message is attached to the beets message.
+  :bug:`3005`
 
 .. _python-itunes: https://github.com/ocelma/python-itunes
 


### PR DESCRIPTION
when beets is started and the database file is on e.g. a volume that is full beets quits with the message "database file could not be opened {path to file}". The original error message coming from sqlite is lost. the proposed patch attaches the original error as 'reason'. in the case of disk full it reads now "database file {path to file} could not be opened, reason: database or disk is full"

I have no idea how to create a test for it, because the test case either depends on a not-writeable database file or on a mock of sqlite