### PR TITLE
replaygain: albumpeak on large collections is calculated as average,not maximum (bug 3008)

### DIFF
--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -181,7 +181,7 @@ class Bs1770gainBackend(Backend):
                 i += 1
                 returnchunk = self.compute_chunk_gain(chunk, is_album)
                 albumgaintot += returnchunk[-1].gain
-                albumpeaktot += returnchunk[-1].peak
+                albumpeaktot = max(albumpeaktot, returnchunk[-1].peak)
                 returnchunks = returnchunks + returnchunk[0:-1]
             returnchunks.append(Gain(albumgaintot / i, albumpeaktot / i))
             return returnchunks

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -183,7 +183,7 @@ class Bs1770gainBackend(Backend):
                 albumgaintot += returnchunk[-1].gain
                 albumpeaktot = max(albumpeaktot, returnchunk[-1].peak)
                 returnchunks = returnchunks + returnchunk[0:-1]
-            returnchunks.append(Gain(albumgaintot / i, albumpeaktot / i))
+            returnchunks.append(Gain(albumgaintot / i, albumpeaktot))
             return returnchunks
         else:
             return self.compute_chunk_gain(items, is_album)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,8 @@ New features:
 * The `absubmit` plugin now works in parallel (on Python 3 only).
   Thanks to :user:`bemeurer`.
   :bug:`2442`
+* replaygain: albumpeak on large collections is calculated as average, not maximum
+  :bug:`3008`
 
 Fixes:
 


### PR DESCRIPTION
this fixes  the first half of #3008 - the peak calculation, 
calculating the albumgain is still wrong