### PR TITLE
Convert is multihreaded now

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -25,6 +25,8 @@ import shlex
 import six
 from string import Template
 import platform
+from multiprocessing.pool import ThreadPool
+from itertools import repeat
 
 from beets import ui, util, plugins, config
 from beets.plugins import BeetsPlugin
@@ -172,8 +174,10 @@ class ConvertPlugin(BeetsPlugin):
 
     def auto_convert(self, config, task):
         if self.config['auto']:
-            for item in task.imported_items():
-                self.convert_on_import(config.lib, item)
+            pool = ThreadPool()
+            pool.starmap(self.convert_on_import, zip(repeat(config.lib),list(task.imported_items())))
+            pool.close()
+            pool.join()
 
     # Utilities converted from functions to methods on logging overhaul
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,7 @@ New features:
 * The `absubmit` plugin now works in parallel (on Python 3 only).
   Thanks to :user:`bemeurer`.
   :bug:`2442`
+* The `convert` plugin now works in parallel (on Python 3 only).
 
 Fixes:
 


### PR DESCRIPTION
similar to #3006 this patch parallelizes the convert step. Before the encoder used 1 of the 4 available cores with this patch all available cpu cores are used