### PR TITLE
Add unicode support to IPFS plugin

### DIFF
--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -25,6 +25,10 @@ import shutil
 import os
 import tempfile
 
+import sys
+
+reload(sys)
+sys.setdefaultencoding('UTF8')
 
 class IPFSPlugin(BeetsPlugin):
 


### PR DESCRIPTION
I was having an issue with the IPFS plugin not being set to encode to UTF-8 (using the default ASCII encoding in Python) and totally failing to publish if I had any albums in my library that used Unicode characters (e.g. Japanese characters). I added a small workaround to set the default encoding for this plugin to UTF-8.

This is a hacky fix, but I don't think it should really make a difference for a plugin this small. But this is my first pull request ever and I'm a total programming noob so I may have overlooked something.