### PR TITLE
Allow ignoring of audio data tracks on import

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -281,7 +281,8 @@ def album_info(release):
             continue
 
         all_tracks = medium['track-list']
-        if 'data-track-list' in medium:
+        if ('data-track-list' in medium
+                and not config['match']['ignore_data_tracks']):
             all_tracks += medium['data-track-list']
         track_count = len(all_tracks)
 

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -129,6 +129,7 @@ match:
     ignored: []
     required: []
     ignored_media: []
+    ignore_data_tracks: no
     ignore_video_tracks: yes
     track_length_grace: 10
     track_length_max: 30

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -40,6 +40,8 @@ New features:
 
 Fixes:
 
+* A new importer option, :ref:`ignore_data_tracks`, lets you skip audio tracks
+  contained in data files :bug:`xxxx`
 * Restore iTunes Store album art source, and remove the dependency on
   python-itunes_, which had gone unmaintained and was not py3 compatible.
   Thanks to :user:`ocelma` for creating python-itunes_ in the first place.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -41,7 +41,7 @@ New features:
 Fixes:
 
 * A new importer option, :ref:`ignore_data_tracks`, lets you skip audio tracks
-  contained in data files :bug:`xxxx`
+  contained in data files :bug:`3021`
 * Restore iTunes Store album art source, and remove the dependency on
   python-itunes_, which had gone unmaintained and was not py3 compatible.
   Thanks to :user:`ocelma` for creating python-itunes_ in the first place.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -811,6 +811,15 @@ No formats are ignored by default.
 
 .. _ignore_video_tracks:
 
+ignore_data_tracks
+~~~~~~~~~~~~~~~~~~~
+
+By default, audio files contained in data tracks within a release are included
+in the album's tracklist. If you do not want them to be included, set it to
+``yes``.
+
+Default: ``no``.
+
 ignore_video_tracks
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -809,7 +809,7 @@ of audio, for example::
 No formats are ignored by default.
 
 
-.. _ignore_video_tracks:
+.. _ignore_data_tracks:
 
 ignore_data_tracks
 ~~~~~~~~~~~~~~~~~~~
@@ -819,6 +819,8 @@ in the album's tracklist. If you do not want them to be included, set it to
 ``yes``.
 
 Default: ``no``.
+
+.. _ignore_video_tracks:
 
 ignore_video_tracks
 ~~~~~~~~~~~~~~~~~~~

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -383,6 +383,18 @@ class MBAlbumInfoTest(_common.TestCase):
         self.assertEqual(d.tracks[1].title, 'TITLE TWO')
         self.assertEqual(d.tracks[2].title, 'TITLE AUDIO DATA')
 
+    def test_skip_audio_data_tracks_if_configured(self):
+        config['match']['ignore_data_tracks'] = True
+        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
+                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
+        data_tracks = [self._make_track('TITLE AUDIO DATA', 'ID DATA TRACK',
+                                        100.0 * 1000.0)]
+        release = self._make_release(tracks=tracks, data_tracks=data_tracks)
+        d = mb.album_info(release)
+        self.assertEqual(len(d.tracks), 2)
+        self.assertEqual(d.tracks[0].title, 'TITLE ONE')
+        self.assertEqual(d.tracks[1].title, 'TITLE TWO')
+
     def test_skip_video_tracks_by_default(self):
         tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
                   self._make_track('TITLE VIDEO', 'ID VIDEO', 100.0 * 1000.0,


### PR DESCRIPTION
https://github.com/beetbox/beets/pull/1638 by @jdetrey changed the importer to take data tracks into imports. This adds a configuration option to disable that feature.

I'm proposing adding this since it seems like video tracks still get included sometimes in `data-track-list`, such as in this release where there is a multimedia track: http://musicbrainz.org/ws/2/release/cbc97377-05f3-4011-a8fa-0aaa1ca9ffd1?inc=artists+artist-credits+recordings+aliases