### PR TITLE
Make `ignore_data_tracks` `yes` by default

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -129,7 +129,7 @@ match:
     ignored: []
     required: []
     ignored_media: []
-    ignore_data_tracks: no
+    ignore_data_tracks: yes
     ignore_video_tracks: yes
     track_length_grace: 10
     track_length_max: 30

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -815,10 +815,9 @@ ignore_data_tracks
 ~~~~~~~~~~~~~~~~~~~
 
 By default, audio files contained in data tracks within a release are included
-in the album's tracklist. If you do not want them to be included, set it to
-``yes``.
+in the album's tracklist. If you want them to be included, set it ``no``.
 
-Default: ``no``.
+Default: ``yes``.
 
 .. _ignore_video_tracks:
 

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -371,7 +371,8 @@ class MBAlbumInfoTest(_common.TestCase):
         self.assertEqual(d.tracks[0].title, 'TITLE ONE')
         self.assertEqual(d.tracks[1].title, 'TITLE TWO')
 
-    def test_no_skip_audio_data_tracks(self):
+    def test_no_skip_audio_data_tracks_if_configured(self):
+        config['match']['ignore_data_tracks'] = False
         tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
                   self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
         data_tracks = [self._make_track('TITLE AUDIO DATA', 'ID DATA TRACK',
@@ -383,8 +384,7 @@ class MBAlbumInfoTest(_common.TestCase):
         self.assertEqual(d.tracks[1].title, 'TITLE TWO')
         self.assertEqual(d.tracks[2].title, 'TITLE AUDIO DATA')
 
-    def test_skip_audio_data_tracks_if_configured(self):
-        config['match']['ignore_data_tracks'] = True
+    def test_skip_audio_data_tracks(self):
         tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
                   self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
         data_tracks = [self._make_track('TITLE AUDIO DATA', 'ID DATA TRACK',

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -371,6 +371,17 @@ class MBAlbumInfoTest(_common.TestCase):
         self.assertEqual(d.tracks[0].title, 'TITLE ONE')
         self.assertEqual(d.tracks[1].title, 'TITLE TWO')
 
+    def test_skip_audio_data_tracks_by_default(self):
+        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
+                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
+        data_tracks = [self._make_track('TITLE AUDIO DATA', 'ID DATA TRACK',
+                                        100.0 * 1000.0)]
+        release = self._make_release(tracks=tracks, data_tracks=data_tracks)
+        d = mb.album_info(release)
+        self.assertEqual(len(d.tracks), 2)
+        self.assertEqual(d.tracks[0].title, 'TITLE ONE')
+        self.assertEqual(d.tracks[1].title, 'TITLE TWO')
+
     def test_no_skip_audio_data_tracks_if_configured(self):
         config['match']['ignore_data_tracks'] = False
         tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
@@ -383,17 +394,6 @@ class MBAlbumInfoTest(_common.TestCase):
         self.assertEqual(d.tracks[0].title, 'TITLE ONE')
         self.assertEqual(d.tracks[1].title, 'TITLE TWO')
         self.assertEqual(d.tracks[2].title, 'TITLE AUDIO DATA')
-
-    def test_skip_audio_data_tracks(self):
-        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
-                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
-        data_tracks = [self._make_track('TITLE AUDIO DATA', 'ID DATA TRACK',
-                                        100.0 * 1000.0)]
-        release = self._make_release(tracks=tracks, data_tracks=data_tracks)
-        d = mb.album_info(release)
-        self.assertEqual(len(d.tracks), 2)
-        self.assertEqual(d.tracks[0].title, 'TITLE ONE')
-        self.assertEqual(d.tracks[1].title, 'TITLE TWO')
 
     def test_skip_video_tracks_by_default(self):
         tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -418,6 +418,7 @@ class MBAlbumInfoTest(_common.TestCase):
         self.assertEqual(d.tracks[1].title, 'TITLE TWO')
 
     def test_no_skip_video_tracks_if_configured(self):
+        config['match']['ignore_data_tracks'] = False
         config['match']['ignore_video_tracks'] = False
         tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
                   self._make_track('TITLE VIDEO', 'ID VIDEO', 100.0 * 1000.0,
@@ -431,6 +432,7 @@ class MBAlbumInfoTest(_common.TestCase):
         self.assertEqual(d.tracks[2].title, 'TITLE TWO')
 
     def test_no_skip_video_data_tracks_if_configured(self):
+        config['match']['ignore_data_tracks'] = False
         config['match']['ignore_video_tracks'] = False
         tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
                   self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]


### PR DESCRIPTION
Follow up for https://github.com/beetbox/beets/pull/3021