### PR TITLE
Allow setting default options for `%unique` in the configuration file.

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -48,6 +48,12 @@ asciify_paths: false
 art_filename: cover
 max_filename_length: 0
 
+aunique:
+    keys: albumartist album
+    disambiguators: albumtype year label catalognum albumdisambig
+    bracket: '[]'
+
+
 plugins: []
 pluginpath: []
 threaded: yes

--- a/beets/library.py
+++ b/beets/library.py
@@ -1510,10 +1510,10 @@ class DefaultTemplateFunctions(object):
         if memoval is not None:
             return memoval
 
-        keys = keys or 'albumartist album'
-        disam = disam or 'albumtype year label catalognum albumdisambig'
+        keys = keys or beets.config['aunique']['keys'].as_str()
+        disam = disam or beets.config['aunique']['disambiguators'].as_str()
         if bracket is None:
-            bracket = '[]'
+            bracket = beets.config['aunique']['bracket'].as_str()
         keys = keys.split()
         disam = disam.split()
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -37,6 +37,8 @@ New features:
   relevant releases according to the :ref:`preferred` configuration options.
   Thanks to :user:`archer4499`.
   :bug:`3017`
+* A new ``aunique`` configuration option allows setting default options
+  for the :ref:`aunique` template function.
 
 Fixes:
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -286,6 +286,23 @@ numbered from one, not zero, so other track numbers may appear to be bumped up
 by one. When it is on, the pregap track for each disc can be numbered zero.
 
 
+.. _config-aunique:
+
+anique
+~~~~~~
+
+These options are used to generate a string that is guaranteed to be unique
+among all albums in the library who share the same set of keys.
+
+The defaults look like this::
+
+    aunique:
+        keys: albumartist album
+        disambiguators: albumtype year label catalognum albumdisambig
+        bracket: '[]'
+
+See :ref:`aunique` for more details.
+
 .. _terminal_encoding:
 
 terminal_encoding


### PR DESCRIPTION
I use the `%aunique` template function in a bunch of places and got tired of copy/pasting the same config over and over again so I made it configurable.

Comments? Questions? Bueller?