### PR TITLE
mbsync no longer queries MusicBrainz when the either the mb_albumid or mb_trackid field is invalid

### DIFF
--- a/beetsplug/mbsync.py
+++ b/beetsplug/mbsync.py
@@ -82,18 +82,24 @@ class MBSyncPlugin(BeetsPlugin):
                                item_formatted)
                 continue
 
-            # Get the MusicBrainz recording info.
-            track_info = hooks.track_for_mbid(item.mb_trackid)
-            if not track_info:
-                self._log.info(u'Recording ID not found: {0} for track {0}',
-                               item.mb_trackid,
+            # Do we have a valid MusicBrainz TrackId
+            if re.match(r"(\d|\w){8}-(\d|\w){4}-(\d|\w){4}-(\d|\w){4}-(\d|\w){12}", item.mb_trackid):
+                # Get the MusicBrainz recording info.
+                track_info = hooks.track_for_mbid(item.mb_trackid)
+                if not track_info:
+                    self._log.info(u'Recording ID not found: {0} for track {0}',
+                                   item.mb_trackid,
+                                   item_formatted)
+                    continue
+
+                # Apply.
+                with lib.transaction():
+                    autotag.apply_item_metadata(item, track_info)
+                    apply_item_changes(lib, item, move, pretend, write)
+            else:
+                self._log.info(u'Skipping singleton with invalid mb_trackid: {0}',
                                item_formatted)
                 continue
-
-            # Apply.
-            with lib.transaction():
-                autotag.apply_item_metadata(item, track_info)
-                apply_item_changes(lib, item, move, pretend, write)
 
     def albums(self, lib, query, move, pretend, write):
         """Retrieve and apply info from the autotagger for albums matched by
@@ -109,69 +115,76 @@ class MBSyncPlugin(BeetsPlugin):
 
             items = list(a.items())
 
-            # Get the MusicBrainz album information.
-            album_info = hooks.album_for_mbid(a.mb_albumid)
-            if not album_info:
-                self._log.info(u'Release ID {0} not found for album {1}',
-                               a.mb_albumid,
-                               album_formatted)
-                continue
-
-            # Map release track and recording MBIDs to their information.
-            # Recordings can appear multiple times on a release, so each MBID
-            # maps to a list of TrackInfo objects.
-            releasetrack_index = dict()
-            track_index = defaultdict(list)
-            for track_info in album_info.tracks:
-                releasetrack_index[track_info.release_track_id] = track_info
-                track_index[track_info.track_id].append(track_info)
-
-            # Construct a track mapping according to MBIDs (release track MBIDs
-            # first, if available, and recording MBIDs otherwise). This should
-            # work for albums that have missing or extra tracks.
-            mapping = {}
-            for item in items:
-                if item.mb_releasetrackid and \
-                        item.mb_releasetrackid in releasetrack_index:
-                    mapping[item] = releasetrack_index[item.mb_releasetrackid]
-                else:
-                    candidates = track_index[item.mb_trackid]
-                    if len(candidates) == 1:
-                        mapping[item] = candidates[0]
-                    else:
-                        # If there are multiple copies of a recording, they are
-                        # disambiguated using their disc and track number.
-                        for c in candidates:
-                            if (c.medium_index == item.track and
-                                    c.medium == item.disc):
-                                mapping[item] = c
-                                break
-
-            # Apply.
-            self._log.debug(u'applying changes to {}', album_formatted)
-            with lib.transaction():
-                autotag.apply_metadata(album_info, mapping)
-                changed = False
-                # Find any changed item to apply MusicBrainz changes to album.
-                any_changed_item = items[0]
-                for item in items:
-                    item_changed = ui.show_model_changes(item)
-                    changed |= item_changed
-                    if item_changed:
-                        any_changed_item = item
-                        apply_item_changes(lib, item, move, pretend, write)
-
-                if not changed:
-                    # No change to any item.
+            # Do we have a valid MusicBrainz AlbumId
+            if re.match(r"(\d|\w){8}-(\d|\w){4}-(\d|\w){4}-(\d|\w){4}-(\d|\w){12}", a.mb_albumid):
+                # Get the MusicBrainz album information.
+                album_info = hooks.album_for_mbid(a.mb_albumid)
+                if not album_info:
+                    self._log.info(u'Release ID {0} not found for album {1}',
+                                   a.mb_albumid,
+                                   album_formatted)
                     continue
 
-                if not pretend:
-                    # Update album structure to reflect an item in it.
-                    for key in library.Album.item_keys:
-                        a[key] = any_changed_item[key]
-                    a.store()
+                # Map release track and recording MBIDs to their information.
+                # Recordings can appear multiple times on a release, so each MBID
+                # maps to a list of TrackInfo objects.
+                releasetrack_index = dict()
+                track_index = defaultdict(list)
+                for track_info in album_info.tracks:
+                    releasetrack_index[track_info.release_track_id] = track_info
+                    track_index[track_info.track_id].append(track_info)
 
-                    # Move album art (and any inconsistent items).
-                    if move and lib.directory in util.ancestry(items[0].path):
-                        self._log.debug(u'moving album {0}', album_formatted)
-                        a.move()
+                # Construct a track mapping according to MBIDs (release track MBIDs
+                # first, if available, and recording MBIDs otherwise). This should
+                # work for albums that have missing or extra tracks.
+                mapping = {}
+                for item in items:
+                    if item.mb_releasetrackid and \
+                            item.mb_releasetrackid in releasetrack_index:
+                        mapping[item] = releasetrack_index[item.mb_releasetrackid]
+                    else:
+                        candidates = track_index[item.mb_trackid]
+                        if len(candidates) == 1:
+                            mapping[item] = candidates[0]
+                        else:
+                            # If there are multiple copies of a recording, they are
+                            # disambiguated using their disc and track number.
+                            for c in candidates:
+                                if (c.medium_index == item.track and
+                                        c.medium == item.disc):
+                                    mapping[item] = c
+                                    break
+
+                # Apply.
+                self._log.debug(u'applying changes to {0}', album_formatted)
+                with lib.transaction():
+                    autotag.apply_metadata(album_info, mapping)
+                    changed = False
+                    # Find any changed item to apply MusicBrainz changes to album.
+                    any_changed_item = items[0]
+                    for item in items:
+                        item_changed = ui.show_model_changes(item)
+                        changed |= item_changed
+                        if item_changed:
+                            any_changed_item = item
+                            apply_item_changes(lib, item, move, pretend, write)
+
+                    if not changed:
+                        # No change to any item.
+                        continue
+
+                    if not pretend:
+                        # Update album structure to reflect an item in it.
+                        for key in library.Album.item_keys:
+                            a[key] = any_changed_item[key]
+                        a.store()
+
+                        # Move album art (and any inconsistent items).
+                        if move and lib.directory in util.ancestry(items[0].path):
+                            self._log.debug(u'moving album {0}', album_formatted)
+                            a.move()
+
+            else:
+                self._log.info(u'Skipping album with invalid mb_albumid: {0}',
+                               album_formatted)
+                continue

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -43,6 +43,13 @@ New features:
   disambiguation comment. A new ``releasegroupdisambig`` field has been added.
   :bug:`3024`
 
+Changes:
+
+* :doc:`/plugins/mbsync` no longer queries MusicBrainz when the either the
+  ``mb_albumid`` or ``mb_trackid`` field is invalid
+  Discussion here https://groups.google.com/forum/#!searchin/beets-users/mbsync|sort:date/beets-users/iwCF6bNdh9A/i1xl4Gx8BQAJ
+  Thanks to :user:`arogl`.
+
 Fixes:
 
 * A new importer option, :ref:`ignore_data_tracks`, lets you skip audio tracks

--- a/test/test_mbsync.py
+++ b/test/test_mbsync.py
@@ -51,7 +51,7 @@ class MbsyncCliTest(unittest.TestCase, TestHelper):
 
         album_item = Item(
             album=u'old title',
-            mb_albumid=u'album id',
+            mb_albumid=u'81ae60d4-5b75-38df-903a-db2cfa51c2c6',
             mb_trackid=u'old track id',
             mb_releasetrackid=u'release track id',
             path=''
@@ -60,13 +60,14 @@ class MbsyncCliTest(unittest.TestCase, TestHelper):
 
         item = Item(
             title=u'old title',
-            mb_trackid=u'singleton track id',
+            mb_trackid=u'b8c2cf90-83f9-3b5f-8ccd-31fb866fcf37',
             path='',
         )
         self.lib.add(item)
 
         with capture_log() as logs:
             self.run_command('mbsync')
+
         self.assertIn('Sending event: albuminfo_received', logs)
         self.assertIn('Sending event: trackinfo_received', logs)
 
@@ -133,6 +134,63 @@ class MbsyncCliTest(unittest.TestCase, TestHelper):
         with capture_log('beets.mbsync') as logs:
             self.run_command('mbsync', '-f', "'$title'")
         e = u"mbsync: Skipping singleton with no mb_trackid: 'old title'"
+        self.assertEqual(e, logs[0])
+
+    def test_message_when_invalid(self):
+        config['format_item'] = u'$artist - $album - $title'
+        config['format_album'] = u'$albumartist - $album'
+
+        # Test album with invalid mb_albumid.
+        # The default format for an album include $albumartist so
+        # set that here, too.
+        album_invalid = Item(
+            albumartist=u'album info',
+            album=u'album info',
+            mb_albumid=u'a1b2c3d4',
+            path=''
+        )
+        self.lib.add_album([album_invalid])
+
+        # default format
+        with capture_log('beets.mbsync') as logs:
+            self.run_command('mbsync')
+        e = u'mbsync: Skipping album with invalid mb_albumid: ' + \
+            u'album info - album info'
+        self.assertEqual(e, logs[0])
+
+        # custom format
+        with capture_log('beets.mbsync') as logs:
+            self.run_command('mbsync', '-f', "'$album'")
+        e = u"mbsync: Skipping album with invalid mb_albumid: 'album info'"
+        self.assertEqual(e, logs[0])
+
+        # restore the config
+        config['format_item'] = u'$artist - $album - $title'
+        config['format_album'] = u'$albumartist - $album'
+
+        # Test singleton with invalid mb_trackid.
+        # The default singleton format includes $artist and $album
+        # so we need to stub them here
+        item_invalid = Item(
+            artist=u'album info',
+            album=u'album info',
+            title=u'old title',
+            mb_trackid=u'a1b2c3d4',
+            path='',
+        )
+        self.lib.add(item_invalid)
+
+        # default format
+        with capture_log('beets.mbsync') as logs:
+            self.run_command('mbsync')
+        e = u'mbsync: Skipping singleton with invalid mb_trackid: ' + \
+            u'album info - album info - old title'
+        self.assertEqual(e, logs[0])
+
+        # custom format
+        with capture_log('beets.mbsync') as logs:
+            self.run_command('mbsync', '-f', "'$title'")
+        e = u"mbsync: Skipping singleton with invalid mb_trackid: 'old title'"
         self.assertEqual(e, logs[0])
 
 


### PR DESCRIPTION
Attempt to stop excess queries to MusicBrainz when an invalid id exist