### PR TITLE
Fixes #2504 in artresizer

### DIFF
--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -72,7 +72,7 @@ def pil_resize(maxwidth, path_in, path_out=None):
         im = Image.open(util.syspath(path_in))
         size = maxwidth, maxwidth
         im.thumbnail(size, Image.ANTIALIAS)
-        im.save(path_out)
+        im.save(util.displayable_path(path_out))
         return path_out
     except IOError:
         log.error(u"PIL cannot create thumbnail for '{0}'",

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -72,7 +72,7 @@ def pil_resize(maxwidth, path_in, path_out=None):
         im = Image.open(util.syspath(path_in))
         size = maxwidth, maxwidth
         im.thumbnail(size, Image.ANTIALIAS)
-        im.save(util.displayable_path(path_out))
+        im.save(util.py3_path(path_out))
         return path_out
     except IOError:
         log.error(u"PIL cannot create thumbnail for '{0}'",


### PR DESCRIPTION
This PR fixes #2504

PIL Image.save() requires a string parameter [1] while with python3 we call it with bytes.
This leads to wrong format detection (b'.png' isn't a key in supported formats list whereas '.png' is).


I haven't found a better existing function to do this (feel free to change patch) nor a unit test using PIL Image.save.

[1] https://pillow.readthedocs.io/en/latest/reference/Image.html#PIL.Image.Image.save

