### PR TITLE
move_art: Remove missing album art

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -1030,6 +1030,12 @@ class Album(LibModel):
         if not old_art:
             return
 
+        if not os.path.exists(old_art):
+            log.error(u'removing reference to missing album art file {}',
+                      util.displayable_path(old_art))
+            self.artpath = None
+            return
+
         new_art = self.art_destination(old_art)
         if new_art == old_art:
             return

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -86,6 +86,9 @@ Fixes:
 * Fix a problem when resizing images with PIL/Pillow on Python 3.
   Thanks to :user:`architek`.
   :bug:`2504` :bug:`3029`
+* Missing album art file during an update no longer causes a fatal exception
+  (instead, an error is logged and the missing file path is removed from the
+  library). :bug:`3030`
 
 .. _python-itunes: https://github.com/ocelma/python-itunes
 


### PR DESCRIPTION
Prevents a fatal file system error on "beet update" if the album art file has been moved or renamed
and the beets library hasn't been updated with the new path.