### PR TITLE
Allow "deleting" fixed attributes via `beet modify`.

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -290,10 +290,11 @@ class Model(object):
         if key in self._values_flex:  # Flexible.
             del self._values_flex[key]
             self._dirty.add(key)  # Mark for dropping on store.
+        elif key in self._fields:  # Fixed
+            setattr(self, key, self._type(key).null)
+            self._dirty.add(key)  # Mark for dropping on store.
         elif key in self._getters():  # Computed.
             raise KeyError(u'computed field {0} cannot be deleted'.format(key))
-        elif key in self._fields:  # Fixed.
-            raise KeyError(u'fixed field {0} cannot be deleted'.format(key))
         else:
             raise KeyError(u'no such field {0}'.format(key))
 

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -292,7 +292,6 @@ class Model(object):
             self._dirty.add(key)  # Mark for dropping on store.
         elif key in self._fields:  # Fixed
             setattr(self, key, self._type(key).null)
-            self._dirty.add(key)  # Mark for dropping on store.
         elif key in self._getters():  # Computed.
             raise KeyError(u'computed field {0} cannot be deleted'.format(key))
         else:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -42,6 +42,10 @@ New features:
 * The ``albumdisambig`` field no longer includes the MusicBrainz release group
   disambiguation comment. A new ``releasegroupdisambig`` field has been added.
   :bug:`3024`
+* The :ref:`modify-cmd` command now allows resetting fixed attributes. For
+  example, ``beet modify -a artist:beatles artpath!`` resets ``artpath``
+  attribute from matching albums back to the default value.
+  :bug:`2497`
 
 Changes:
 

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -114,6 +114,19 @@ class AnotherTestModel(TestModel1):
     }
 
 
+class TestModel5(TestModel1):
+    _fields = {
+        'some_string_field': dbcore.types.STRING,
+        'some_float_field': dbcore.types.FLOAT,
+        'some_boolean_field': dbcore.types.BOOLEAN,
+    }
+
+
+class TestDatabase5(dbcore.Database):
+    _models = (TestModel5,)
+    pass
+
+
 class TestDatabaseTwoModels(dbcore.Database):
     _models = (TestModel2, AnotherTestModel)
     pass
@@ -266,9 +279,18 @@ class ModelTest(unittest.TestCase):
             del model['foo']
 
     def test_delete_fixed_attribute(self):
-        model = TestModel1()
-        with self.assertRaises(KeyError):
-            del model['field_one']
+        model = TestModel5()
+        model.some_string_field = 'foo'
+        model.some_float_field = 1.23
+        model.some_boolean_field = True
+
+        for field, type_ in model._fields.items():
+            print("%s - %s" % (model[field], field))
+            self.assertNotEqual(model[field], type_.null)
+
+        for field, type_ in model._fields.items():
+            del model[field]
+            self.assertEqual(model[field], type_.null)
 
     def test_null_value_normalization_by_type(self):
         model = TestModel1()


### PR DESCRIPTION
Deleting a fixed field isn't possible so we just reset the field back to it's "null" value.

Fixes #2497.

I spent a while trying to figure out why `beet modify -a foo artpath!` didn't work before discovering #2497. This *should* fix the problem.