### PR TITLE
Fix miscellaneous typos

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -433,7 +433,7 @@ class FanartTV(RemoteArtSource):
         # can there be more than one releasegroupid per response?
         for mbid, art in data.get(u'albums', dict()).items():
             # there might be more art referenced, e.g. cdart, and an albumcover
-            # might not be present, even if the request was succesful
+            # might not be present, even if the request was successful
             if album.mb_releasegroupid == mbid and u'albumcover' in art:
                 matches.extend(art[u'albumcover'])
             # can this actually occur?
@@ -597,7 +597,7 @@ class Wikipedia(RemoteArtSource):
             )
 
             # Try to see if one of the images on the pages matches our
-            # imcomplete cover_filename
+            # incomplete cover_filename
             try:
                 data = wikipedia_response.json()
                 results = data['query']['pages'][page_id]['images']

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -81,7 +81,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
 
     def build_queries(self):
         """
-        Instanciate queries for the playlists.
+        Instantiate queries for the playlists.
 
         Each playlist has 2 queries: one or items one for albums, each with a
         sort. We must also remember its name. _unmatched_playlists is a set of

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1463,7 +1463,7 @@ And many little fixes and improvements:
 * The error message when MusicBrainz is not reachable on the network is now
   much clearer. Thanks to Tom Jaspers. :bug:`1190` :bug:`1272`
 * Improve error messages when parsing query strings with shlex. :bug:`1290`
-* :doc:`/plugins/embedart`: Fix a crash that occured when used together
+* :doc:`/plugins/embedart`: Fix a crash that occurred when used together
   with the *check* plugin. :bug:`1241`
 * :doc:`/plugins/scrub`: Log an error instead of stopping when the ``beet
   scrub`` command cannot write a file. Also, avoid problems on Windows with

--- a/docs/plugins/replaygain.rst
+++ b/docs/plugins/replaygain.rst
@@ -130,7 +130,7 @@ These options only works with the "bs1770gain" backend:
   the reference level: -18, -23, or -24 LUFS respectively. Default:
   `replaygain`
 - **chunk_at**: Splits an album in groups of tracks of this amount.
-  Usefull when running into memory problems when analysing albums with
+  Useful when running into memory problems when analysing albums with
   an exceptionally large amount of tracks. Default:5000
 
 Manual Analysis

--- a/test/test_autotag.py
+++ b/test/test_autotag.py
@@ -751,7 +751,7 @@ class ApplyTest(_common.TestCase, ApplyTestUtil):
         self.assertEqual(self.items[0].artist, 'artistNew')
         self.assertEqual(self.items[1].artist, 'artistNew')
 
-    def test_album_artist_overriden_by_nonempty_track_artist(self):
+    def test_album_artist_overridden_by_nonempty_track_artist(self):
         my_info = copy.deepcopy(self.info)
         my_info.tracks[0].artist = 'artist1!'
         my_info.tracks[1].artist = 'artist2!'

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -158,7 +158,7 @@ class DestinationTest(_common.TestCase):
         self.lib.path_formats = [(u'default', u'two')]
         self.assertEqual(self.i.destination(), np('one/two'))
 
-    def test_destination_substitues_metadata_values(self):
+    def test_destination_substitutes_metadata_values(self):
         self.lib.directory = b'base'
         self.lib.path_formats = [(u'default', u'$album/$artist $title')]
         self.i.title = 'three'


### PR DESCRIPTION
I'll admit this is pretty nit-picky, but there seems to be a couple of typos across the codebase and documentation :grin: this PR fixes them up :+1:

I used [client9/misspell](https://github.com/client9/misspell) to find these.