### PR TITLE
Subsonicupdate plugin: Added context path and fixed bug in port configuration

### DIFF
--- a/beetsplug/subsonicupdate.py
+++ b/beetsplug/subsonicupdate.py
@@ -21,6 +21,7 @@ a "subsonic" section like the following:
         port: 4040 (default)
         user: <your username>
         pass: <your password>
+        contextpath: /subsonic
 """
 from __future__ import division, absolute_import, print_function
 
@@ -44,15 +45,17 @@ class SubsonicUpdate(BeetsPlugin):
             'port': '4040',
             'user': 'admin',
             'pass': 'admin',
+            'contextpath': '/',
         })
         config['subsonic']['pass'].redact = True
         self.register_listener('import', self.loaded)
 
     def loaded(self):
         host = config['subsonic']['host'].as_str()
-        port = config['subsonic']['port'].as_str()
+        port = config['subsonic']['port'].get(int)
         user = config['subsonic']['user'].as_str()
         passw = config['subsonic']['pass'].as_str()
+        contextpath = config['subsonic']['contextpath'].as_str()
 
         # To avoid sending plaintext passwords, authentication will be
         # performed via username, a token, and a 6 random
@@ -75,7 +78,9 @@ class SubsonicUpdate(BeetsPlugin):
             'v': '1.15.0',  # Subsonic 6.1 and newer.
             'c': 'beets'
         }
-        url = "http://{}:{}/rest/startScan".format(host, port)
+        if contextpath is '/':
+            contextpath = ''
+        url = "http://{}:{}{}/rest/startScan".format(host, port, contextpath)
         response = requests.post(url, params=payload)
 
         if response.status_code != 200:

--- a/docs/plugins/subsonicupdate.rst
+++ b/docs/plugins/subsonicupdate.rst
@@ -17,6 +17,7 @@ which looks like this::
         port: 4040
         user: username
         pass: password
+        contextpath: /subsonic
 
 With that all in place, beets will send a Rest API to your Subsonic
 server every time you import new music.
@@ -33,3 +34,4 @@ The available options under the ``subsonic:`` section are:
 - **port**: The Subsonic server port. Default: ``4040``
 - **user**: The Subsonic user. Default: ``admin``
 - **pass**: The Subsonic user password. Default: ``admin``
+- **contextpath**: The Subsonic context path. Default: ``/``


### PR DESCRIPTION
This pull request suggests that solves the two following problems:

1. When specifying a port, the following error occurred:

`configuration error: subsonic.port: must be a string`

2. The subsonic configuration allows the user to specify a context path to append to the url, which is currently not supported by the plugin. This pull request contains a fix which suggests that an optional configuration `contextpath` is added.

