### PR TITLE
Replaygain backend r128gain

### DIFF
--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -865,7 +865,6 @@ class R128gainBackend(Backend):
         and a optional Gain object (the album gain).
         """
         # scan files
-        print(items)
         paths = [i.path.decode() for i in items]
         self._log.debug(u"scanning {0} with r128gain".format(paths))
         output = self._mod_r128gain.scan(paths, album_gain=is_album)

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -88,6 +88,10 @@ class Backend(object):
         # individual tracks which can be used for any backend.
         raise NotImplementedError()
 
+    def use_ebu_r128(self):
+        """Set this Backend up to use EBU R128."""
+        pass
+
 
 # bsg1770gain backend
 class Bs1770gainBackend(Backend):
@@ -270,6 +274,10 @@ class Bs1770gainBackend(Backend):
         if is_album:
             out.append(album_gain["album"])
         return out
+
+    def use_ebu_r128(self):
+        """Set this Backend up to use EBU R128."""
+        self.method = '--ebu'
 
 
 # mpgain/aacgain CLI tool backend.
@@ -826,6 +834,8 @@ class ReplayGainPlugin(BeetsPlugin):
         "bs1770gain": Bs1770gainBackend,
     }
 
+    r128_backend_names = ["bs1770gain"]
+
     def __init__(self):
         super(ReplayGainPlugin, self).__init__()
 
@@ -1009,7 +1019,9 @@ class ReplayGainPlugin(BeetsPlugin):
                 u"Fatal replay gain error: {0}".format(e))
 
     def init_r128_backend(self):
-        backend_name = 'bs1770gain'
+        backend_name = self.config["backend"].as_str()
+        if backend_name not in self.r128_backend_names:
+            backend_name = "bs1770gain"
 
         try:
             self.r128_backend_instance = self.backends[backend_name](
@@ -1019,7 +1031,7 @@ class ReplayGainPlugin(BeetsPlugin):
             raise ui.UserError(
                 u'replaygain initialization failed: {0}'.format(e))
 
-        self.r128_backend_instance.method = '--ebu'
+        self.r128_backend_instance.use_ebu_r128()
 
     def imported(self, session, task):
         """Add replay gain info to items or albums of ``task``.

--- a/docs/plugins/replaygain.rst
+++ b/docs/plugins/replaygain.rst
@@ -10,10 +10,10 @@ playback levels.
 Installation
 ------------
 
-This plugin can use one of four backends to compute the ReplayGain values:
-GStreamer, mp3gain (and its cousin, aacgain), Python Audio Tools and bs1770gain. mp3gain
-can be easier to install but GStreamer, Audio Tools and bs1770gain support more audio
-formats.
+This plugin can use one of five backends to compute the ReplayGain values:
+GStreamer, mp3gain (and its cousin, aacgain), Python Audio Tools, bs1770gain and
+r128gain. mp3gain can be easier to install but GStreamer, Audio Tools, bs1770gain
+and r128gain support more audio formats.
 
 Once installed, this plugin analyzes all files during the import process. This
 can be a slow process; to instead analyze after the fact, disable automatic
@@ -94,6 +94,18 @@ For Windows users: the tool currently has issues with long and non-ASCII path
 names. You may want to use the :ref:`asciify-paths` configuration option until
 this is resolved.
 
+r128gain
+````````
+
+This backend uses the python module `r128gain`_. It can be installed from PyPI::
+
+    pip3 install r128gain
+
+Also see the `r128gain installation`_ page.
+
+.. _r128gain: https://github.com/desbma/r128gain
+.. _r128gain installation: https://github.com/desbma/r128gain/blob/master/README.md#installation
+
 Configuration
 -------------
 
@@ -110,7 +122,7 @@ configuration file. The available options are:
   Default: 89.
 - **r128**: A space separated list of formats that will use ``R128_`` tags with
   integer values instead of the common ``REPLAYGAIN_`` tags with floating point
-  values. Requires the "bs1770gain" backend.
+  values. Requires the "bs1770gain" or "r128gain" backend.
   Default: ``Opus``.
 
 These options only work with the "command" backend:

--- a/docs/plugins/replaygain.rst
+++ b/docs/plugins/replaygain.rst
@@ -102,6 +102,8 @@ This backend uses the python module `r128gain`_. It can be installed from PyPI::
     pip3 install r128gain
 
 Also see the `r128gain installation`_ page.
+Please note that `r128gain`_ describes itself as "beta software", this backend
+could possibly break.
 
 .. _r128gain: https://github.com/desbma/r128gain
 .. _r128gain installation: https://github.com/desbma/r128gain/blob/master/README.md#installation

--- a/test/test_replaygain.py
+++ b/test/test_replaygain.py
@@ -43,6 +43,12 @@ if has_program('bs1770gain', ['--replaygain']):
 else:
     LOUDNESS_PROG_AVAILABLE = False
 
+try:
+    import r128gain
+    R128GAIN_AVAILABLE = hasattr(r128gain, 'scan')
+except ImportError:
+    R128GAIN_AVAILABLE = False
+
 
 class ReplayGainCliTestBase(TestHelper):
 
@@ -164,6 +170,11 @@ class ReplayGainCmdCliTest(ReplayGainCliTestBase, unittest.TestCase):
 @unittest.skipIf(not LOUDNESS_PROG_AVAILABLE, u'bs1770gain cannot be found')
 class ReplayGainLdnsCliTest(ReplayGainCliTestBase, unittest.TestCase):
     backend = u'bs1770gain'
+
+
+@unittest.skipIf(not R128GAIN_AVAILABLE, u'r128gain cannot be found')
+class ReplayGainR128gainCliTest(ReplayGainCliTestBase, unittest.TestCase):
+    backend = u'r128gain'
 
 
 def suite():


### PR DESCRIPTION
Add a replaygain backend using the [r128gain](https://github.com/desbma/r128gain/) python module. 
It makes for an easier to install (as r128gain is on PyPI) alternative to the bs1770gain backend to create R128_* replaygain tags.