### PR TITLE
WIP: Enhance %title

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -23,6 +23,7 @@ import unicodedata
 import time
 import re
 import six
+import string
 
 from beets import logging
 from beets.mediafile import MediaFile, UnreadableFileError
@@ -1456,7 +1457,7 @@ class DefaultTemplateFunctions(object):
     @staticmethod
     def tmpl_title(s):
         """Convert a string to title case."""
-        return s.title()
+        return string.capwords(s)
 
     @staticmethod
     def tmpl_left(s, chars):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -103,7 +103,9 @@ Fixes:
   Thanks to :user:`TaizoSimpson`.
   :bug:`3501`
 * Confusing typo when the convert plugin copies the art covers. :bug:`3063`
-
+* The ``%title`` template function now works correctly with apostrophes.
+  Thanks to :user:`GuilhermeHideki`.
+  :bug:`3033`
 
 .. _python-itunes: https://github.com/ocelma/python-itunes
 

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -589,6 +589,10 @@ class DestinationFunctionTest(_common.TestCase, PathFormattingMixin):
         self._setf(u'%title{$title}')
         self._assert_dest(b'/base/The Title')
 
+    def test_title_case_variable(self):
+        self._setf(u'%title{I can\'t}')
+        self._assert_dest(b'/base/I Can\'t')
+
     def test_asciify_variable(self):
         self._setf(u'%asciify{ab\xa2\xbdd}')
         self._assert_dest(b'/base/abC_ 1_2 d')

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -589,7 +589,7 @@ class DestinationFunctionTest(_common.TestCase, PathFormattingMixin):
         self._setf(u'%title{$title}')
         self._assert_dest(b'/base/The Title')
 
-    def test_title_case_variable(self):
+    def test_title_case_variable_aphostrophe(self):
         self._setf(u'%title{I can\'t}')
         self._assert_dest(b'/base/I Can\'t')
 


### PR DESCRIPTION
Fixes #3033

I would like to know if would be better if we had a "smart mode" which lower-case some prepositions, like [titlecase](https://pypi.org/project/titlecase/) does.

- [x] Tests
- [x] Documentation
- [x] Changelog