### PR TITLE
docs: update the pip install instructions

### DIFF
--- a/docs/guides/main.rst
+++ b/docs/guides/main.rst
@@ -58,8 +58,8 @@ Beets works on `Python 2.7`_ and Python 3.4 or later.
 .. _Ubuntu details: https://launchpad.net/ubuntu/+source/beets
 .. _beets is in [community]: https://www.archlinux.org/packages/community/any/beets/
 
-If you have `pip`_, just say ``pip install beets`` (you might need ``sudo`` in
-front of that).
+If you have `pip`_, just say ``pip install beets`` (or ``pip install --user
+beets`` if you run into permissions problems).
 
 To install without pip, download beets from `its PyPI page`_ and run ``python
 setup.py install`` in the directory therein.
@@ -79,12 +79,12 @@ Installing on macOS 10.11 and Higher
 Starting with version 10.11 (El Capitan), macOS has a new security feature
 called `System Integrity Protection`_ (SIP) that prevents you from modifying
 some parts of the system. This means that some ``pip`` commands may fail with
-a permissions error, even when you use ``sudo``. (You probably *won't* run
-into this if you've installed Python yourself with `Homebrew`_ or otherwise.)
+a permissions error. (You probably *won't* run into this if you've installed
+Python yourself with `Homebrew`_ or otherwise.)
 
-If this happens, you can install beets for the current user only (sans
-``sudo``) by typing ``pip install --user beets``. If you do that, you might want
-to add ``~/Library/Python/3.6/bin`` to your ``$PATH``.
+If this happens, you can install beets for the current user only by typing
+``pip install --user beets``. If you do that, you might want to add
+``~/Library/Python/3.6/bin`` to your ``$PATH``.
 
 .. _System Integrity Protection: https://support.apple.com/en-us/HT204899
 .. _Homebrew: http://brew.sh


### PR DESCRIPTION
Hello! I was reading Beets' install guide when I saw that it suggested using ``sudo`` if ``pip install beets`` didn't work.

Using ``sudo`` to install Python packages using pip is [not a good practice security-wise](https://askubuntu.com/questions/802544/is-sudo-pip-install-still-a-broken-practice). The proposed PR will suggest an alternative way using ``--user`` to make sure the package is installed locally.

Cheers!