### PR TITLE
Fixed typo in convert when copying cover art

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -399,8 +399,9 @@ class ConvertPlugin(BeetsPlugin):
                                util.displayable_path(album.artpath),
                                util.displayable_path(dest))
             else:
-                self._log.info(u'Copying cover art from {0}',
-                               util.displayable_path(album.artpath))
+                self._log.info(u'Copying cover art from {0} to {1}',
+                               util.displayable_path(album.artpath),
+                               util.displayable_path(dest))
                 util.copy(album.artpath, dest)
 
     def convert_func(self, lib, opts, args):

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -399,9 +399,8 @@ class ConvertPlugin(BeetsPlugin):
                                util.displayable_path(album.artpath),
                                util.displayable_path(dest))
             else:
-                self._log.info(u'Copying cover art to {0}',
-                               util.displayable_path(album.artpath),
-                               util.displayable_path(dest))
+                self._log.info(u'Copying cover art from {0}',
+                               util.displayable_path(album.artpath))
                 util.copy(album.artpath, dest)
 
     def convert_func(self, lib, opts, args):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -102,8 +102,7 @@ Fixes:
   tags
   Thanks to :user:`TaizoSimpson`.
   :bug:`3501`
-* Confusing typo when the convert plugin copies the art covers.
-
+* Confusing typo when the convert plugin copies the art covers. :bug:`3063`
 
 
 .. _python-itunes: https://github.com/ocelma/python-itunes

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -98,6 +98,8 @@ Fixes:
 * Missing album art file during an update no longer causes a fatal exception
   (instead, an error is logged and the missing file path is removed from the
   library). :bug:`3030`
+  
+* Confusing typo when the convert plugin copies the art covers.
 
 .. _python-itunes: https://github.com/ocelma/python-itunes
 


### PR DESCRIPTION
When the convert plugin is copying album arts, it logs
> Copying cover art to MY_SOURCE_FOLDER/cover.png

while it should say `from` (or `to` the source path). I first I thought my original covers were being overwritten. I fixed the <sup>critical</sup> issue.