### PR TITLE
permissions: allow fixing permissions before writing tags

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -737,6 +737,8 @@ class ImportTask(BaseImportTask):
                     # old paths.
                     item.move(operation)
 
+            plugins.send('write_import', lib=session.lib, item=item)
+
             if write and (self.apply or self.choice_flag == action.RETAG):
                 item.try_write()
 

--- a/beetsplug/permissions.py
+++ b/beetsplug/permissions.py
@@ -8,6 +8,7 @@ like the following in your config.yaml to configure:
     permissions:
             file: 644
             dir: 755
+            before_write: yes
 """
 import os
 from beets import config, util
@@ -66,8 +67,12 @@ class Permissions(BeetsPlugin):
         self.config.add({
             u'file': '644',
             u'dir': '755',
+            u'before_write': True,
         })
+        self.before_write = self.config['before_write'].get(bool)
 
+        if self.config['before_write']:
+            self.register_listener('write_import', self.fix)
         self.register_listener('item_imported', self.fix)
         self.register_listener('album_imported', self.fix)
 


### PR DESCRIPTION
Add write_import event before writing to files upon import. Use this event to enhance the permissions plugin to fix permissions before writing data. Closes #3039