### PR TITLE
altered `super` call in `CountedQueue` init method (see #3073)

### DIFF
--- a/beets/util/pipeline.py
+++ b/beets/util/pipeline.py
@@ -92,7 +92,7 @@ class CountedQueue(queue.Queue):
     finished with the queue.
     """
     def __init__(self, maxsize=0):
-        queue.Queue.__init__(self, maxsize)
+        super(CountedQueue, self).__init__(maxsize)
         self.nthreads = 0
         self.poisoned = False
 


### PR DESCRIPTION
The way how the `CountedQueue.__init__` called its parent class's init method gave problems when trying to green the `threading` library using Eventlet.

See #3073 for the original discussion and purpose.