### PR TITLE
Export plugin can now export path from library.

### DIFF
--- a/beetsplug/info.py
+++ b/beetsplug/info.py
@@ -66,7 +66,6 @@ def library_data(lib, args):
 def library_data_emitter(item):
     def emitter():
         data = dict(item.formatted())
-        data.pop('path', None)  # path is fetched from item
 
         return data, item
     return emitter
@@ -184,6 +183,8 @@ class InfoPlugin(BeetsPlugin):
         included_keys = []
         for keys in opts.included_keys:
             included_keys.extend(keys.split(','))
+        # Drop path even if user provides it multiple times
+        included_keys = [k for k in included_keys if k != 'path']
         key_filter = make_key_filter(included_keys)
 
         first = True
@@ -239,4 +240,5 @@ def make_key_filter(include):
 
 
 def identity(val):
+    val.pop('path', None)  # path is fetched from item
     return val

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -53,6 +53,8 @@ Changes:
   ``mb_albumid`` or ``mb_trackid`` field is invalid
   See also the discussion on Google Groups_
   Thanks to :user:`arogl`.
+* :doc:`/plugins/export` now also exports ``path`` field if user explicitly
+  specifies it with ``-i`` parameter. Only works when exporting library fields.
 
 .. _Groups: https://groups.google.com/forum/#!searchin/beets-users/mbsync|sort:date/beets-users/iwCF6bNdh9A/i1xl4Gx8BQAJ
 


### PR DESCRIPTION
Exports path (file path) if specified in fields to export (with -i parameter). Only when exporting library fields, because file tags don't contain path. Info works as before. Path won't be displayed in the list even if user provides it in parameters.