### PR TITLE
Performance improvement: Type cast properties on demand

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -785,14 +785,14 @@ class ImportTask(BaseImportTask):
             replaced_album = self.replaced_albums.get(self.album.path)
             if replaced_album:
                 self.album.added = replaced_album.added
-                self.album.update(replaced_album._raw_values_flex)
+                self.album.update(replaced_album._values_flex)
                 self.album.artpath = replaced_album.artpath
                 self.album.store()
                 log.debug(
                     u'Reimported album: added {0}, flexible '
                     u'attributes {1} from album {2} for {3}',
                     self.album.added,
-                    replaced_album._raw_values_flex.keys(),
+                    replaced_album._values_flex.keys(),
                     replaced_album.id,
                     displayable_path(self.album.path)
                 )
@@ -809,11 +809,11 @@ class ImportTask(BaseImportTask):
                         dup_item.id,
                         displayable_path(item.path)
                     )
-                item.update(dup_item._raw_values_flex)
+                item.update(dup_item._values_flex)
                 log.debug(
                     u'Reimported item flexible attributes {0} '
                     u'from item {1} for {2}',
-                    dup_item._raw_values_flex.keys(),
+                    dup_item._values_flex.keys(),
                     dup_item.id,
                     displayable_path(item.path)
                 )

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -785,14 +785,14 @@ class ImportTask(BaseImportTask):
             replaced_album = self.replaced_albums.get(self.album.path)
             if replaced_album:
                 self.album.added = replaced_album.added
-                self.album.update(replaced_album._values_flex)
+                self.album.update(replaced_album._raw_values_flex)
                 self.album.artpath = replaced_album.artpath
                 self.album.store()
                 log.debug(
                     u'Reimported album: added {0}, flexible '
                     u'attributes {1} from album {2} for {3}',
                     self.album.added,
-                    replaced_album._values_flex.keys(),
+                    replaced_album._raw_values_flex.keys(),
                     replaced_album.id,
                     displayable_path(self.album.path)
                 )
@@ -809,11 +809,11 @@ class ImportTask(BaseImportTask):
                         dup_item.id,
                         displayable_path(item.path)
                     )
-                item.update(dup_item._values_flex)
+                item.update(dup_item._raw_values_flex)
                 log.debug(
                     u'Reimported item flexible attributes {0} '
                     u'from item {1} for {2}',
-                    dup_item._values_flex.keys(),
+                    dup_item._raw_values_flex.keys(),
                     dup_item.id,
                     displayable_path(item.path)
                 )


### PR DESCRIPTION
I analyzed where time is spent when querying the library and found that most of it is actually type casting properties after retrieving them from the database. However, this isn't really necessary. We hardly ever need access to all properties, so it makes much more sense to delay the actual casting until a property is accessed.

Taking my previous baseline of `3.66s` for master, doing the delayed type casting reduces this to `1.96s`, or down to `1.45s` when #2798 is also applied (a bit slower now than my first number with it now no longer being a poc).
Our of those remaining ~1.5s, about 0.5s is spent on the actual database queries, and the rest is object creation.

I'm open to ideas for further performance improvements here, but we get firmly into area of micro-optimizations (creating 11000 objects in 1s, we'd need to make every object creation 1/22000s faster to save another 0.5s). At least I didn't find any obvious candidates.