### PR TITLE
Kodi plugin equivalent of Scan-Item-To-Library

### DIFF
--- a/beetsplug/kodiupdate.py
+++ b/beetsplug/kodiupdate.py
@@ -25,19 +25,19 @@ to re-scan your entire library after importing one or more albums:
         pwd: secret
 
 Alternatively, you can choose to only scan each newly imported album directory.
-To do so, add all the config.yaml settings above, but also add 'source' and
-'library' settings that look something like this:
+To do so, add all the config.yaml settings above, but also add `source` and
+`library` settings that look something like this:
 
        source: nfs://myserver.local/music/library/
        library: /home/music/library/
 
-The value for 'source' should be the Kodi Music source found in
+The value for `source` should be the Kodi Music source found in
 .kodi/userdata/sources.xml.
 
-The value for 'library' should be the path to your beets library.
+The value for `library` should be the path to your beets library.
 
-After an album is imported, this plugin strips off the 'library' portion of
-the album path and appends the remaining portion to the 'source', then issues
+After an album is imported, this plugin strips off the `library` portion of
+the album path and appends the remaining portion to the `source`, then issues
 a Kodi update for that path.
 
 """
@@ -52,18 +52,18 @@ import os
 
 def update_kodi(host, port, user, password, path=None):
     """Sends request to the Kodi api to start a library refresh.
-       If 'path' is provided, only refresh that path.
+    If `path` is provided, only refresh that path.
     """
     url = "http://{0}:{1}/jsonrpc".format(host, port)
 
     """Content-Type: application/json is mandatory
-    according to the kodi jsonrpc documentation"""
+    according to the kodi jsonrpc documentation."""
 
     headers = {'Content-Type': 'application/json'}
 
     # Create the payload. Id seems to be mandatory.
     payload = {'jsonrpc': '2.0', 'method': 'AudioLibrary.Scan', 'id': 1}
-    if path is not None:
+    if path:
         payload['params'] = {'directory': path}
     r = requests.post(
         url,
@@ -89,17 +89,17 @@ class KodiUpdate(BeetsPlugin):
 
         config['kodi']['pwd'].redact = True
         if config['source'] == '':
-            # rescan entire library
+            # Re-scan the entire library.
             self.register_listener('database_change',
                                    self.listen_for_db_change)
         else:
-            # only rescan the path to this album
+            # Scan only the path to this album.
             self.register_listener('album_imported',
                                    self.album_imported)
 
     def listen_for_db_change(self, lib, model):
         """Listens for beets db change, waits for cli exit,
-        then registers the update"""
+        then registers the update."""
         self.register_listener('cli_exit', self.cli_exit)
 
     def album_imported(self, lib, album):

--- a/beetsplug/kodiupdate.py
+++ b/beetsplug/kodiupdate.py
@@ -25,17 +25,20 @@ to re-scan your entire library after importing one or more albums:
         pwd: secret
 
 Alternatively, you can choose to only scan each newly imported album directory.
-To do so, add all the config.yaml settings above, but also add 'source' and 'library'
-settings that look something like this:
+To do so, add all the config.yaml settings above, but also add 'source' and
+'library' settings that look something like this:
 
        source: nfs://myserver.local/music/library/
        library: /home/music/library/
 
-The value for 'source' should be the Kodi Music source found in .kodi/userdata/sources.xml
+The value for 'source' should be the Kodi Music source found in
+.kodi/userdata/sources.xml.
+
 The value for 'library' should be the path to your beets library.
 
-After an album is imported, this plugin strips off the 'library' portion of the album path
-and appends the remaining portion to the 'source', then issues a Kodi update for that path.
+After an album is imported, this plugin strips off the 'library' portion of
+the album path and appends the remaining portion to the 'source', then issues
+a Kodi update for that path.
 
 """
 from __future__ import division, absolute_import, print_function
@@ -60,7 +63,7 @@ def update_kodi(host, port, user, password, path=None):
 
     # Create the payload. Id seems to be mandatory.
     payload = {'jsonrpc': '2.0', 'method': 'AudioLibrary.Scan', 'id': 1}
-    if not path is None:
+    if path is not None:
         payload['params'] = {'directory': path}
     r = requests.post(
         url,
@@ -86,22 +89,27 @@ class KodiUpdate(BeetsPlugin):
 
         config['kodi']['pwd'].redact = True
         if config['source'] == '':
-            self.register_listener('database_change', self.listen_for_db_change) # rescan entire library
+            # rescan entire library
+            self.register_listener('database_change',
+                                   self.listen_for_db_change)
         else:
-            self.register_listener('album_imported', self.album_imported) # onyl rescan the path to this album
+            # only rescan the path to this album
+            self.register_listener('album_imported',
+                                   self.album_imported)
 
     def listen_for_db_change(self, lib, model):
-        """Listens for beets db change, waits for cli exit, then registers the update"""
+        """Listens for beets db change, waits for cli exit,
+        then registers the update"""
         self.register_listener('cli_exit', self.cli_exit)
 
     def album_imported(self, lib, album):
         source = config['kodi']['source'].get()
         library = config['kodi']['library'].get()
         apath = album.item_dir()
-        suffix = os.path.relpath (apath,library)
-        self.update (path=os.path.join (source,suffix.decode('utf-8')))
+        suffix = os.path.relpath(apath, library)
+        self.update(path=os.path.join(source, suffix.decode('utf-8')))
 
-    def cli_exit(self,lib):
+    def cli_exit(self, lib):
         """When the client exits try to send refresh request to Kodi server.
         """
         self.update()
@@ -110,7 +118,7 @@ class KodiUpdate(BeetsPlugin):
         if path is None:
             self._log.info(u'Requesting a Kodi library update...')
         else:
-            self._log.info(u'Requesting a Kodi update for {0}',path)
+            self._log.info(u'Requesting a Kodi update for {0}', path)
 
         # Try to send update request.
         try:

--- a/beetsplug/kodiupdate.py
+++ b/beetsplug/kodiupdate.py
@@ -25,19 +25,19 @@ to re-scan your entire library after importing one or more albums:
         pwd: secret
 
 Alternatively, you can choose to only scan each newly imported album directory.
-To do so, add all the config.yaml settings above, but also add `source` and
+To do so, add all the config.yaml settings above, but also add `kodi_dir` and
 `library` settings that look something like this:
 
-       source: nfs://myserver.local/music/library/
+       kodi_dir: nfs://myserver.local/music/library/
        library: /home/music/library/
 
-The value for `source` should be the Kodi Music source found in
+The value for `kodi_dir` should be the Kodi Music path found in
 .kodi/userdata/sources.xml.
 
 The value for `library` should be the path to your beets library.
 
 After an album is imported, this plugin strips off the `library` portion of
-the album path and appends the remaining portion to the `source`, then issues
+the album path and appends the remaining portion to the `kodi_dir`, then issues
 a Kodi update for that path.
 
 """
@@ -84,11 +84,11 @@ class KodiUpdate(BeetsPlugin):
             u'port': 8080,
             u'user': u'kodi',
             u'pwd': u'kodi',
-            u'source': u'',
+            u'kodi_dir': u'',
             u'library': u''})
 
         config['kodi']['pwd'].redact = True
-        if config['source'] == '':
+        if config['kodi']['kodi_dir'] == '':
             # Re-scan the entire library.
             self.register_listener('database_change',
                                    self.listen_for_db_change)
@@ -103,11 +103,11 @@ class KodiUpdate(BeetsPlugin):
         self.register_listener('cli_exit', self.cli_exit)
 
     def album_imported(self, lib, album):
-        source = config['kodi']['source'].get()
+        kodi_dir = config['kodi']['kodi_dir'].get()
         library = config['kodi']['library'].get()
         apath = album.item_dir()
         suffix = os.path.relpath(apath, library)
-        self.update(path=os.path.join(source, suffix.decode('utf-8')))
+        self.update(path=os.path.join(kodi_dir, suffix.decode('utf-8')))
 
     def cli_exit(self, lib):
         """When the client exits try to send refresh request to Kodi server.

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -154,7 +154,7 @@ Interoperability
 * :doc:`importfeeds`: Keep track of imported files via ``.m3u`` playlist file(s) or symlinks.
 * :doc:`ipfs`: Import libraries from friends and get albums from them via ipfs.
 * :doc:`kodiupdate`: Automatically notifies `Kodi`_ whenever the beets library
-  changes.
+  changes or when a new album is added.
 * :doc:`mpdupdate`: Automatically notifies `MPD`_ whenever the beets library
   changes.
 * :doc:`play`: Play beets queries in your music player.
@@ -190,7 +190,7 @@ Miscellaneous
 * :doc:`mbcollection`: Maintain your MusicBrainz collection list.
 * :doc:`mbsubmit`: Print an album's tracks in a MusicBrainz-friendly format.
 * :doc:`missing`: List missing tracks.
-* `mstream`_: A music streaming server + webapp that can be used alongside beets. 
+* `mstream`_: A music streaming server + webapp that can be used alongside beets.
 * :doc:`random`: Randomly choose albums and tracks from your library.
 * :doc:`spotify`: Create Spotify playlists from the Beets library.
 * :doc:`types`: Declare types for flexible attributes.

--- a/docs/plugins/kodiupdate.rst
+++ b/docs/plugins/kodiupdate.rst
@@ -2,7 +2,8 @@ KodiUpdate Plugin
 =================
 
 The ``kodiupdate`` plugin lets you automatically update `Kodi`_'s music
-library whenever you change your beets library.
+library whenever you change your beets library or, alternatively, every
+time a new album is imported.
 
 To use ``kodiupdate`` plugin, enable it in your configuration
 (see :ref:`using-plugins`).
@@ -15,6 +16,27 @@ which looks like this::
         port: 8080
         user: kodi
         pwd: kodi
+
+With the basic configuration settings above, the ``kodiupdate`` plugin
+will notify Kodi to scan your entire music library after the import
+operation has completed. For large music libraries you may prefer to have
+Kodi only scan the directory where each album was imported. To enable
+this behavior, add `source` and `library` settings, like this:
+
+    kodi:
+        host: localhost
+        port: 8080
+        user: kodi
+        pwd: kodi
+        source: nfs://myserver.local/music/library/
+        library: /home/music/library/
+
+`source` should be the Kodi Music source found in .kodi/userdata/sources.xml.
+`library` should be the path to your beets library.
+
+With this configuration, after every album import, the `library` path is stripped
+from the imported album's path and the remaining part is added to the `source`.
+Kodi is then asked to scan the resulting directory.
 
 To use the ``kodiupdate`` plugin you need to install the `requests`_ library with::
 
@@ -42,3 +64,7 @@ The available options under the ``kodi:`` section are:
   Default: ``kodi``
 - **pwd**: The Kodi host password.
   Default: ``kodi``
+- **source**: The Kodi Music source.
+  Default: ````
+- **library**: The beets library directory.
+  Default: ````

--- a/docs/plugins/kodiupdate.rst
+++ b/docs/plugins/kodiupdate.rst
@@ -18,10 +18,14 @@ which looks like this::
         pwd: kodi
 
 With the basic configuration settings above, the ``kodiupdate`` plugin
-will notify Kodi to scan your entire music library after the import
-operation has completed. For large music libraries you may prefer to have
-Kodi only scan the directory where each album was imported. To enable
-this behavior, add `source` and `library` settings, like this:
+will notify Kodi to scan your entire music library after any changes to
+the beets database. For importing albums into large music libraries you
+may prefer to have Kodi only scan the directory where each album was
+imported. To enable this behavior, add a `source` setting, which reflects
+the Kodi `Music` source found in Kodi's sources.xml file, and a `library`
+setting, which indicates exactly how much of the beets library album
+path should be removed before appending the remaining portion to
+the `source`:
 
     kodi:
         host: localhost

--- a/docs/plugins/kodiupdate.rst
+++ b/docs/plugins/kodiupdate.rst
@@ -21,25 +21,25 @@ With the basic configuration settings above, the ``kodiupdate`` plugin
 will notify Kodi to scan your entire music library after any changes to
 the beets database. For importing albums into large music libraries you
 may prefer to have Kodi only scan the directory where each album was
-imported. To enable this behavior, add a `source` setting, which reflects
-the Kodi `Music` source found in Kodi's sources.xml file, and a `library`
+imported. To enable this behavior, add a `kodi_dir` setting, which reflects
+the Kodi `Music` directory found in Kodi's sources.xml file, and a `library`
 setting, which indicates exactly how much of the beets library album
 path should be removed before appending the remaining portion to
-the `source`:
+the `kodi_dir`:
 
     kodi:
         host: localhost
         port: 8080
         user: kodi
         pwd: kodi
-        source: nfs://myserver.local/music/library/
+        kodi_dir: nfs://myserver.local/music/library/
         library: /home/music/library/
 
-`source` should be the Kodi Music source found in .kodi/userdata/sources.xml.
+`kodi_dir` should be the Kodi Music path found in .kodi/userdata/sources.xml.
 `library` should be the path to your beets library.
 
 With this configuration, after every album import, the `library` path is stripped
-from the imported album's path and the remaining part is added to the `source`.
+from the imported album's path and the remaining part is added to the `kodi_dir`.
 Kodi is then asked to scan the resulting directory.
 
 To use the ``kodiupdate`` plugin you need to install the `requests`_ library with::
@@ -68,7 +68,7 @@ The available options under the ``kodi:`` section are:
   Default: ``kodi``
 - **pwd**: The Kodi host password.
   Default: ``kodi``
-- **source**: The Kodi Music source.
+- **kodi_dir**: The Kodi Music path.
   Default: none
 - **library**: The beets library directory.
   Default: none

--- a/docs/plugins/kodiupdate.rst
+++ b/docs/plugins/kodiupdate.rst
@@ -65,6 +65,6 @@ The available options under the ``kodi:`` section are:
 - **pwd**: The Kodi host password.
   Default: ``kodi``
 - **source**: The Kodi Music source.
-  Default: ````
+  Default: none
 - **library**: The beets library directory.
-  Default: ````
+  Default: none


### PR DESCRIPTION
I've modified kodiupdate.py to allow adding two new configuration settings that support only scanning the album that was imported. Without the new configuration settings, the original behavior is retained (re-scan entire music library at exit).

I'm unsure about the decode('utf-8') when stripping off the last part of the path to the imported album. It works with my system when I encounter funky characters (Linux), but I'm not sure iit would work on Windows since the file system encoding there is not utf-8. Any ideas on how to process non-ascii characters in a cross-platform manner would be appreciated.