### PR TITLE
Fix #2826

### DIFF
--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -127,7 +127,10 @@ class BeetsPlugin(object):
         value after the function returns). Also determines which params may not
         be sent for backwards-compatibility.
         """
-        argspec = inspect.getargspec(func)
+        if six.PY2:
+            argspec = inspect.getargspec(func)
+        else:
+            argspec = inspect.getfullargspec(func)
 
         @wraps(func)
         def wrapper(*args, **kwargs):

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -17,7 +17,6 @@
 
 from __future__ import division, absolute_import, print_function
 
-import inspect
 import traceback
 import re
 from collections import defaultdict
@@ -27,6 +26,7 @@ from functools import wraps
 import beets
 from beets import logging
 from beets import mediafile
+from beets.util import inspect
 import six
 
 PLUGIN_NAMESPACE = 'beetsplug'
@@ -127,10 +127,7 @@ class BeetsPlugin(object):
         value after the function returns). Also determines which params may not
         be sent for backwards-compatibility.
         """
-        if six.PY2:
-            argspec = inspect.getargspec(func)
-        else:
-            argspec = inspect.getfullargspec(func)
+        argspec = inspect.getargspec(func)
 
         @wraps(func)
         def wrapper(*args, **kwargs):

--- a/beets/util/inspect.py
+++ b/beets/util/inspect.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# This file is part of beets.
+# Copyright 2019, Vladimir Zhelezov.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+from __future__ import absolute_import
+
+import inspect
+from collections import namedtuple
+
+from six import PY2
+
+
+def getargspec(func):
+    if PY2:
+        return inspect.getargspec(func)
+
+    ArgSpec = namedtuple('ArgSpec', 'args varargs keywords defaults')
+
+    sig = inspect.signature(func)
+    args = [
+        p.name for p in sig.parameters.values()
+        if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+    ]
+    varargs = [
+        p.name for p in sig.parameters.values()
+        if p.kind == inspect.Parameter.VAR_POSITIONAL
+    ]
+    varargs = varargs[0] if varargs else None
+    varkw = [
+        p.name for p in sig.parameters.values()
+        if p.kind == inspect.Parameter.VAR_KEYWORD
+    ]
+    varkw = varkw[0] if varkw else None
+    defaults = tuple(p.default for p in sig.parameters.values()
+                     if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+                     and p.default is not p.empty) or None
+
+    return ArgSpec(args, varargs, varkw, defaults)

--- a/beets/util/inspect.py
+++ b/beets/util/inspect.py
@@ -21,11 +21,12 @@ from collections import namedtuple
 from six import PY2
 
 
+ArgSpec = namedtuple('ArgSpec', 'args varargs keywords defaults')
+
+
 def getargspec(func):
     if PY2:
         return inspect.getargspec(func)
-
-    ArgSpec = namedtuple('ArgSpec', 'args varargs keywords defaults')
 
     sig = inspect.signature(func)
     args = [


### PR DESCRIPTION
Test for major Python version and use inspect.getargspec() or
inspect.getfullargspec() respectively to silence deprecation warnings in
Python 3 as discussed in #2826 