### PR TITLE
Override match.require and match.ignored when searching for explicit IDs

### DIFF
--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -537,7 +537,8 @@ class Distance(object):
 # Structures that compose all the information for a candidate match.
 
 AlbumMatch = namedtuple('AlbumMatch', ['distance', 'info', 'mapping',
-                                       'extra_items', 'extra_tracks'])
+                                       'extra_items', 'extra_tracks',
+                                       'problems'])
 
 TrackMatch = namedtuple('TrackMatch', ['distance', 'info'])
 

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -591,6 +591,11 @@ def choose_candidate(candidates, singleton, rec, cur_artist=None,
                     line.append(ui.colorize('text_highlight_minor',
                                             u'(%s)' % disambig))
 
+                if not singleton:
+                    for problem in match.problems:
+                        line.append(ui.colorize('text_highlight',
+                                                u'(%s)' % problem))
+
                 print_(u' '.join(line))
 
             # Ask the user for a choice.

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -454,7 +454,7 @@ class ArtImporterTest(UseThePlugin):
             artist_id=u'artistid',
             tracks=[],
         )
-        self.task.set_choice(AlbumMatch(0, info, {}, set(), set()))
+        self.task.set_choice(AlbumMatch(0, info, {}, set(), set(), set()))
 
     def tearDown(self):
         self.lib._connection().close()

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1154,7 +1154,7 @@ class InferAlbumDataTest(_common.TestCase):
                          u'some album artist id')
 
     def test_apply_gets_artist_and_id(self):
-        self.task.set_choice(AlbumMatch(0, None, {}, set(), set()))  # APPLY
+        self.task.set_choice(AlbumMatch(0, None, {}, set(), set(), set()))
 
         self.task.align_album_level_fields()
 
@@ -1166,7 +1166,7 @@ class InferAlbumDataTest(_common.TestCase):
         for item in self.items:
             item.albumartist = u'some album artist'
             item.mb_albumartistid = u'some album artist id'
-        self.task.set_choice(AlbumMatch(0, None, {}, set(), set()))  # APPLY
+        self.task.set_choice(AlbumMatch(0, None, {}, set(), set(), set()))
 
         self.task.align_album_level_fields()
 

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -1060,7 +1060,7 @@ class ShowChangeTest(_common.TestCase):
         commands.show_change(
             cur_artist,
             cur_album,
-            autotag.AlbumMatch(album_dist, info, mapping, set(), set()),
+            autotag.AlbumMatch(album_dist, info, mapping, set(), set(), set()),
         )
         # FIXME decoding shouldn't be done here
         return util.text_string(self.io.getoutput().lower())


### PR DESCRIPTION
Quick and dirty fix of the problem described in #1270.