### PR TITLE
Fix acoustid_fingerprint type confusion

### DIFF
--- a/beetsplug/chroma.py
+++ b/beetsplug/chroma.py
@@ -93,6 +93,7 @@ def acoustid_match(log, path):
         log.error(u'fingerprinting of {0} failed: {1}',
                   util.displayable_path(repr(path)), exc)
         return None
+    fp = fp.decode()
     _fingerprints[path] = fp
     try:
         res = acoustid.lookup(API_KEY, fp, duration,
@@ -334,7 +335,7 @@ def fingerprint_item(log, item, write=False):
                  util.displayable_path(item.path))
         try:
             _, fp = acoustid.fingerprint_file(util.syspath(item.path))
-            item.acoustid_fingerprint = fp
+            item.acoustid_fingerprint = fp.decode()
             if write:
                 log.info(u'{0}: writing fingerprint',
                          util.displayable_path(item.path))


### PR DESCRIPTION
Since pyacoustid returns the fingerprint as bytes (and thus causes the
database to store a bytes/BLOB object), but the tag value is a string,
the acoustid_fingerprint tag always causes file change when using beet's
"write" command, even if the actual value didn't change.

Issue #2942 describes the problem.

This commit fixes that issue for newly imported/fingerprinted files. However,
you still need to change the type of all acoustid_fingerprint fields
that are already present in the database:

    $ sqlite3 beets.db
    SQLite version 3.26.0 2018-12-01 12:34:55
    Enter ".help" for usage hints.
    sqlite> UPDATE items SET acoustid_fingerprint = CAST(acoustid_fingerprint AS TEXT);