### PR TITLE
Ugly workaround for comparison problems with id3v23 tags

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1595,9 +1595,21 @@ def write_items(lib, query, pretend, force):
                       displayable_path(item.path), exc)
             continue
 
+        fields = library.Item._media_tag_fields
+        if beets.config['id3v23'].get(bool):
+            # Filter unsupported fields (ugly hack, affects ALL file types)
+            # https://github.com/quodlibet/mutagen/blob/a1db79ece62c4e86259f15825e360d1ce0986a22/mutagen/id3/_tags.py#L465-L469
+            fields = fields.difference([
+                'original_date',  # TDOR
+                'original_month',  # TDOR
+                'original_day',  # TDOR
+                'arranger',  # TIPL
+                'artist_sort',  # TSOP
+                'disctitle',  # TSST
+            ])
+
         # Check for and display changes.
-        changed = ui.show_model_changes(item, clean_item,
-                                        library.Item._media_tag_fields, force)
+        changed = ui.show_model_changes(item, clean_item, fields, force)
         if (changed or force) and not pretend:
             # We use `try_sync` here to keep the mtime up to date in the
             # database.


### PR DESCRIPTION
If you use the `write` command, some tags will be discarded by mutagen's
`update_to_id3v23()` method. These will then show up as changed fields
and cause a tag sync.

This is a small workaround, but there needs a to be a better way to do
this. Problems with this approach are:

1. It's ugly
2. This unecessarily affects ALL filetypes (e.g. FLAC/Ogg/etc. files) if
   the id3v23 option is set.
3. This still causes problems, e.g. if `month` is set but `day` is not,
   which will cause `update_to_id3v23()` to discard them both.