### PR TITLE
Fetchart respect ignore settings

### DIFF
--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -189,7 +189,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
 
     def remove_artfile(self, album):
         """Possibly delete the album art file for an album (if the
-        appropriate configuration option is enabled.
+        appropriate configuration option is enabled).
         """
         if self.config['remove_art_file'] and album.artpath:
             if os.path.isfile(album.artpath):

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -31,7 +31,7 @@ from beets import util
 from beets import config
 from beets.mediafile import image_mime_type
 from beets.util.artresizer import ArtResizer
-from beets.util import confit
+from beets.util import confit, sorted_walk
 from beets.util import syspath, bytestring_path, py3_path
 import six
 
@@ -666,12 +666,16 @@ class FileSystem(LocalArtSource):
 
             # Find all files that look like images in the directory.
             images = []
-            for fn in os.listdir(syspath(path)):
-                fn = bytestring_path(fn)
-                for ext in IMAGE_EXTENSIONS:
-                    if fn.lower().endswith(b'.' + ext) and \
-                       os.path.isfile(syspath(os.path.join(path, fn))):
-                        images.append(fn)
+            ignore = config['ignore'].as_str_seq()
+            ignore_hidden = config['ignore_hidden'].get(bool)
+            for _, _, files in sorted_walk(path, ignore=ignore,
+                                           ignore_hidden=ignore_hidden):
+                for fn in files:
+                    fn = bytestring_path(fn)
+                    for ext in IMAGE_EXTENSIONS:
+                        if fn.lower().endswith(b'.' + ext) and \
+                           os.path.isfile(syspath(os.path.join(path, fn))):
+                            images.append(fn)
 
             # Look for "preferred" filenames.
             images = sorted(images,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -111,6 +111,7 @@ Fixes:
 * The ``%title`` template function now works correctly with apostrophes.
   Thanks to :user:`GuilhermeHideki`.
   :bug:`3033`
+* Fetchart now respects the ``ignore`` and ``ignore_hidden`` settings. :bug:`1632`
 
 .. _python-itunes: https://github.com/ocelma/python-itunes
 

--- a/test/test_fetchart.py
+++ b/test/test_fetchart.py
@@ -29,21 +29,24 @@ class FetchartCliTest(unittest.TestCase, TestHelper):
         self.config['fetchart']['cover_names'] = 'c\xc3\xb6ver.jpg'
         self.config['art_filename'] = 'mycover'
         self.album = self.add_album()
+        self.cover_path = os.path.join(self.album.path, b'mycover.jpg')
 
     def tearDown(self):
         self.unload_plugins()
         self.teardown_beets()
 
+    def check_cover_is_stored(self):
+        self.assertEqual(self.album['artpath'], self.cover_path)
+        with open(util.syspath(self.cover_path), 'r') as f:
+            self.assertEqual(f.read(), 'IMAGE')
+
     def test_set_art_from_folder(self):
         self.touch(b'c\xc3\xb6ver.jpg', dir=self.album.path, content='IMAGE')
 
         self.run_command('fetchart')
-        cover_path = os.path.join(self.album.path, b'mycover.jpg')
 
         self.album.load()
-        self.assertEqual(self.album['artpath'], cover_path)
-        with open(util.syspath(cover_path), 'r') as f:
-            self.assertEqual(f.read(), 'IMAGE')
+        self.check_cover_is_stored()
 
     def test_filesystem_does_not_pick_up_folder(self):
         os.makedirs(os.path.join(self.album.path, b'mycover.jpg'))

--- a/test/test_fetchart.py
+++ b/test/test_fetchart.py
@@ -54,6 +54,43 @@ class FetchartCliTest(unittest.TestCase, TestHelper):
         self.album.load()
         self.assertEqual(self.album['artpath'], None)
 
+    def test_filesystem_does_not_pick_up_ignored_file(self):
+        self.touch(b'co_ver.jpg', dir=self.album.path, content='IMAGE')
+        self.config['ignore'] = ['*_*']
+        self.run_command('fetchart')
+        self.album.load()
+        self.assertEqual(self.album['artpath'], None)
+
+    def test_filesystem_picks_up_non_ignored_file(self):
+        self.touch(b'cover.jpg', dir=self.album.path, content='IMAGE')
+        self.config['ignore'] = ['*_*']
+        self.run_command('fetchart')
+        self.album.load()
+        self.check_cover_is_stored()
+
+    def test_filesystem_does_not_pick_up_hidden_file(self):
+        self.touch(b'.cover.jpg', dir=self.album.path, content='IMAGE')
+        self.config['ignore'] = []  # By default, ignore includes '.*'.
+        self.config['ignore_hidden'] = True
+        self.run_command('fetchart')
+        self.album.load()
+        self.assertEqual(self.album['artpath'], None)
+
+    def test_filesystem_picks_up_non_hidden_file(self):
+        self.touch(b'cover.jpg', dir=self.album.path, content='IMAGE')
+        self.config['ignore_hidden'] = True
+        self.run_command('fetchart')
+        self.album.load()
+        self.check_cover_is_stored()
+
+    def test_filesystem_picks_up_hidden_file(self):
+        self.touch(b'.cover.jpg', dir=self.album.path, content='IMAGE')
+        self.config['ignore'] = []  # By default, ignore includes '.*'.
+        self.config['ignore_hidden'] = False
+        self.run_command('fetchart')
+        self.album.load()
+        self.check_cover_is_stored()
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)


### PR DESCRIPTION
See #1632.

# The code
Instead of iterating on all files in the directory, `sorted_walk()` is now being used so the files matching an ignore pattern and hidden files are skipped. The [importer](https://github.com/beetbox/beets/blob/master/beets/importer.py#L1611) does the same thing.

# The tests
I wrote a few tests covering both the `ignore` and `ignore_hidden` settings. I have also moved things around a bit in `test_fetchart.py` in order to avoid duplicate code.

# The documentation
No changes.

# The changelog entry
Added an entry under current version in development / fixes.