### PR TITLE
Windows links and hardlinks

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -505,7 +505,12 @@ def link(path, dest, replace=False):
         raise FilesystemError(u'file exists', 'rename', (path, dest))
 
     try:
-	symlink(syspath(path), syspath(dest))
+        if sys.platform == 'win32':
+            if ctypes.windll.kernel32.CreateSymbolicLinkW(syspath(dest),syspath(path),0) != 1:
+                raise ctypes.WinError()
+        else:
+            os.symlink(syspath(path), syspath(dest))
+
     except NotImplementedError:
         # raised on python >= 3.2 and Windows versions before Vista
         raise FilesystemError(u'OS does not support symbolic links.'
@@ -530,8 +535,12 @@ def hardlink(path, dest, replace=False):
     if os.path.exists(syspath(dest)) and not replace:
         raise FilesystemError(u'file exists', 'rename', (path, dest))
 
-    try: 
-	hrdlink(syspath(path), syspath(dest))
+    try:
+        if sys.platform == 'win32':
+            if ctypes.windll.kernel32.CreateHardLinkW(syspath(dest), syspath(path), 0) != 1:
+                raise ctypes.WinError()
+        else:
+            os.link(syspath(path), syspath(dest))
 	
     except NotImplementedError:
         raise FilesystemError(u'OS does not support hard links.'

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -32,6 +32,7 @@ from beets.util import hidden
 import six
 from unidecode import unidecode
 from enum import Enum
+import win32file
 
 
 MAX_FILENAME_LENGTH = 200
@@ -133,6 +134,11 @@ class MoveOperation(Enum):
     LINK = 2
     HARDLINK = 3
 
+def symlink(source, link_name):
+    win32file.CreateSymbolicLink(link_name,source)
+
+def hrdlink(source, link_name):
+    win32file.CreateHardLink(link_name,source)
 
 def normpath(path):
     """Provide the canonical form of the path suitable for storing in
@@ -497,8 +503,9 @@ def link(path, dest, replace=False):
 
     if os.path.exists(syspath(dest)) and not replace:
         raise FilesystemError(u'file exists', 'rename', (path, dest))
+
     try:
-        os.symlink(syspath(path), syspath(dest))
+	symlink(syspath(path), syspath(dest))
     except NotImplementedError:
         # raised on python >= 3.2 and Windows versions before Vista
         raise FilesystemError(u'OS does not support symbolic links.'
@@ -522,8 +529,10 @@ def hardlink(path, dest, replace=False):
 
     if os.path.exists(syspath(dest)) and not replace:
         raise FilesystemError(u'file exists', 'rename', (path, dest))
-    try:
-        os.link(syspath(path), syspath(dest))
+
+    try: 
+	hrdlink(syspath(path), syspath(dest))
+	
     except NotImplementedError:
         raise FilesystemError(u'OS does not support hard links.'
                               'link', (path, dest), traceback.format_exc())

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -32,7 +32,7 @@ from beets.util import hidden
 import six
 from unidecode import unidecode
 from enum import Enum
-import win32file
+import ctypes
 
 
 MAX_FILENAME_LENGTH = 200
@@ -135,10 +135,10 @@ class MoveOperation(Enum):
     HARDLINK = 3
 
 def symlink(source, link_name):
-    win32file.CreateSymbolicLink(link_name,source)
+    ctypes.windll.kernel32.CreateSymbolicLinkW(link_name,source,0)
 
 def hrdlink(source, link_name):
-    win32file.CreateHardLink(link_name,source)
+    ctypes.windll.kernel32.CreateHardLinkW(link_name,source,0)
 
 def normpath(path):
     """Provide the canonical form of the path suitable for storing in

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setup(
         'munkres',
         'unidecode',
         'musicbrainzngs>=0.4',
+		'pywin32',
         'pyyaml',
         'jellyfish',
     ] + (['colorama'] if (sys.platform == 'win32') else []) +

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,6 @@ setup(
         'munkres',
         'unidecode',
         'musicbrainzngs>=0.4',
-		'pywin32',
         'pyyaml',
         'jellyfish',
     ] + (['colorama'] if (sys.platform == 'win32') else []) +


### PR DESCRIPTION
This adds python module `pywin32` to requirements and uses it in a couple of functions to create links. 
However, a few issues that need editing and testing:

- I deleted the Unix os.symlink code entirely - which means this only works in Windows. I'd like to just append the code so linking can work with Unix _and_ Windows.

- The pywin32 module may be unnecessary. I've read that a built-in module, [`cytypes`, could be used](https://stackoverflow.com/a/1447651/2664985), but I had trouble getting that to work.

- I think Windows only started using this type of linking and hardlinking in Vista. Notice the [requirements in MSDN](https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-createsymboliclinka)
