### PR TITLE
Maintain python 2 compatibility

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -67,6 +67,7 @@ Changes:
 
 Fixes:
 
+* Pin jellyfish requirement to version 0.6.0 to maintain python 2 compatibility.
 * A new importer option, :ref:`ignore_data_tracks`, lets you skip audio tracks
   contained in data files :bug:`3021`
 * Restore iTunes Store album art source, and remove the dependency on

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         'unidecode',
         'musicbrainzngs>=0.4',
         'pyyaml',
-        'jellyfish',
+        'jellyfish==0.6.0',
     ] + (['colorama'] if (sys.platform == 'win32') else []) +
         (['enum34>=1.0.4'] if sys.version_info < (3, 4, 0) else []),
 


### PR DESCRIPTION
Jellyfish is no longer python 2 compatible as of release 0.7.0.

By pinning the previous release, beets is still able to be installed
and run on python 2 systems without issue.

I just found beets today in the comments of a Hacker News post, and ran into the following after installing locally:
```
eric@oudebier:~$ beet -p
Traceback (most recent call last):
  File "/usr/local/bin/beet", line 11, in <module>
    load_entry_point('beets==1.4.7', 'console_scripts', 'beet')()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 480, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2693, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2324, in load
    return self.resolve()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2330, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python2.7/dist-packages/beets/ui/__init__.py", line 42, in <module>
    from beets.autotag import mb
  File "/usr/local/lib/python2.7/dist-packages/beets/autotag/__init__.py", line 25, in <module>
    from .hooks import AlbumInfo, TrackInfo, AlbumMatch, TrackMatch  # noqa
  File "/usr/local/lib/python2.7/dist-packages/beets/autotag/hooks.py", line 28, in <module>
    from jellyfish import levenshtein_distance
  File "/usr/local/lib/python2.7/dist-packages/jellyfish/__init__.py", line 5, in <module>
    from ._jellyfish import *   # noqa
  File "/usr/local/lib/python2.7/dist-packages/jellyfish/_jellyfish.py", line 3, in <module>
    from itertools import zip_longest
ImportError: cannot import name zip_longest
```

`jellyfish` [just put out a new release today that is not py2 compatible](https://github.com/jamesturk/jellyfish/compare/0.6.0...0.7.0#diff-b0508adba031c447ece5a495a136a3d1R6), and I was easily able to resolve the issue by installing the previous version 0.6.0.

Thanks for maintaining this excellent tool!