### PR TITLE
Add Spotify OAuth support and autotagger integration

### DIFF
--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -104,6 +104,20 @@ class SpotifyPlugin(BeetsPlugin):
         return {'Authorization': 'Bearer {}'.format(self.access_token)}
 
     def _handle_response(self, request_type, url, params=None):
+        """
+        Send a request, reauthenticating if necessary.
+
+        :param request_type: Type of :class:`Request` constructor,
+            e.g. ``requests.get``, ``requests.post``, etc.
+        :type request_type: function
+        :param url: URL for the new :class:`Request` object.
+        :type url: str
+        :param params: (optional) list of tuples or bytes to send
+            in the query string for the :class:`Request`.
+        :type params: dict
+        :return: class:`Response <Response>` object
+        :rtype: requests.Response
+        """
         response = request_type(url, headers=self._auth_header, params=params)
         if response.status_code != 200:
             if u'token expired' in response.text:
@@ -122,6 +136,8 @@ class SpotifyPlugin(BeetsPlugin):
 
         :param url_type: Type of Spotify URL, either 'album' or 'track'
         :type url_type: str
+        :param id_: Spotify ID or URL
+        :type id_: str
         :return: Spotify ID
         :rtype: str
         """

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -2,7 +2,6 @@
 
 from __future__ import division, absolute_import, print_function
 
-import os
 import re
 import json
 import base64

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -16,7 +16,7 @@ from beets.autotag.hooks import AlbumInfo, TrackInfo
 
 
 class SpotifyPlugin(BeetsPlugin):
-    # URL for the Web API of Spotify
+    # Endpoints for the Spotify API
     # Documentation here: https://developer.spotify.com/web-api/search-item/
     oauth_token_url = 'https://accounts.spotify.com/api/token'
     base_url = 'https://api.spotify.com/v1/search'
@@ -54,7 +54,9 @@ class SpotifyPlugin(BeetsPlugin):
         self.setup()
 
     def setup(self):
-        """Retrieve previously saved OAuth token or generate a new one"""
+        """
+        Retrieve previously saved OAuth token or generate a new one
+        """
         try:
             with open(self.tokenfile) as f:
                 token_data = json.load(f)
@@ -113,8 +115,8 @@ class SpotifyPlugin(BeetsPlugin):
 
     def album_for_id(self, album_id):
         """
-        Fetches an album by its Spotify album ID or URL and returns an AlbumInfo object
-        or None if the album is not found.
+        Fetches an album by its Spotify album ID or URL and returns an
+        AlbumInfo object or None if the album is not found.
         """
         self._log.debug(u'Searching for album {}', album_id)
         match = re.search(self.id_regex.format('album'), album_id)
@@ -180,8 +182,8 @@ class SpotifyPlugin(BeetsPlugin):
 
     def track_for_id(self, track_id):
         """
-        Fetches a track by its Spotify track ID or URL and returns a TrackInfo object
-        or None if the track is not found.
+        Fetches a track by its Spotify track ID or URL and returns a
+        TrackInfo object or None if the track is not found.
         """
         self._log.debug(u'Searching for track {}', track_id)
         match = re.search(self.id_regex.format('track'), track_id)

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -24,7 +24,6 @@ class SpotifyPlugin(BeetsPlugin):
     album_url = 'https://api.spotify.com/v1/albums/'
     track_url = 'https://api.spotify.com/v1/tracks/'
     playlist_partial = 'spotify:trackset:Playlist:'
-    id_regex = r'(^|open\.spotify\.com/{}/)([0-9A-Za-z]{{22}})'
 
     def __init__(self):
         super(SpotifyPlugin, self).__init__()
@@ -126,8 +125,11 @@ class SpotifyPlugin(BeetsPlugin):
         :return: Spotify ID
         :rtype: str
         """
+        # Spotify IDs consist of 22 alphanumeric characters
+        # (zero-left-padded base62 representation of randomly generated UUID4)
+        id_regex = r'(^|open\.spotify\.com/{}/)([0-9A-Za-z]{{22}})'
         self._log.debug(u'Searching for {} {}', url_type, id_)
-        match = re.search(self.id_regex.format(url_type), id_)
+        match = re.search(id_regex.format(url_type), id_)
         return match.group(2) if match else None
 
     def album_for_id(self, album_id):

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -64,13 +64,16 @@ class SpotifyPlugin(BeetsPlugin):
             self.access_token = token_data['access_token']
 
     def authenticate(self):
-        b64_encoded = base64.b64encode(
-            ':'.join(
-                self.config[k].as_str() for k in ('client_id', 'client_secret')
-            ).encode()
-        ).decode()
-        headers = {'Authorization': 'Basic {}'.format(b64_encoded)}
-
+        headers = {
+            'Authorization': 'Basic {}'.format(
+                base64.b64encode(
+                    ':'.join(
+                        self.config[k].as_str()
+                        for k in ('client_id', 'client_secret')
+                    ).encode()
+                ).decode()
+            )
+        }
         response = requests.post(
             self.oauth_token_url,
             data={'grant_type': 'client_credentials'},

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -145,6 +145,11 @@ class SpotifyPlugin(BeetsPlugin):
     def album_for_id(self, album_id):
         """Fetches an album by its Spotify ID or URL and returns an
         AlbumInfo object or None if the album is not found.
+
+        :param album_id: Spotify ID or URL for the album
+        :type album_id: str
+        :return: AlbumInfo object for album
+        :rtype: beets.autotag.hooks.AlbumInfo
         """
         spotify_id = self._get_spotify_id('album', album_id)
         if spotify_id is None:
@@ -247,9 +252,8 @@ class SpotifyPlugin(BeetsPlugin):
 
         # get album's tracks to set the track's index/position on
         # the entire release
-        spotify_id_album = response_track['album']['id']
         response_album = self._handle_response(
-            requests.get, self.album_url + spotify_id_album
+            requests.get, self.album_url + response_data_track['album']['id']
         )
         response_data_album = response_album.json()
         medium_total = 0
@@ -261,7 +265,8 @@ class SpotifyPlugin(BeetsPlugin):
         track.medium_total = medium_total
         return track
 
-    def _get_artist(self, artists):
+    @staticmethod
+    def _get_artist(artists):
         """Returns an artist string (all artists) and an artist_id (the main
         artist) for a list of Spotify artist object dicts.
 

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -38,8 +38,8 @@ class SpotifyPlugin(BeetsPlugin):
                 'track_field': 'title',
                 'region_filter': None,
                 'regex': [],
-                'client_id': 'N3dliiOOTBEEFqCH5NDDUmF5Eo8bl7AN',
-                'client_secret': '6DRS7k66h4643yQEbepPxOuxeVW0yZpk',
+                'client_id': '4e414367a1d14c75a5c5129a627fcab8',
+                'client_secret': 'f82bdc09b2254f1a8286815d02fd46dc',
                 'tokenfile': 'spotify_token.json',
                 'source_weight': 0.5,
             }

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -68,10 +68,10 @@ class SpotifyPlugin(BeetsPlugin):
             'Authorization': 'Basic {}'.format(
                 base64.b64encode(
                     '{}:{}'.format(
-                        bytes(self.config['client_id'].as_str()),
-                        bytes(self.config['client_secret'].as_str()),
+                        self.config['client_id'].as_str().encode(),
+                        self.config['client_secret'].as_str().encode(),
                     )
-                )
+                ).decode()
             )
         }
         response = requests.post(

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -215,6 +215,7 @@ class SpotifyPlugin(BeetsPlugin):
             artist_id=artist_id,
             length=track_data['duration_ms'] / 1000,
             index=track_data['track_number'],
+            medium=track_data['disc_number'],
             medium_index=track_data['track_number'],
             data_source='Spotify',
             data_url=track_data['external_urls']['spotify'],

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -49,7 +49,9 @@ class SpotifyPlugin(BeetsPlugin):
         self.config['client_secret'].redact = True
 
         """Path to the JSON file for storing the OAuth access token."""
-        self.tokenfile = self.config['tokenfile'].get(confit.Filename(in_app_dir=True))
+        self.tokenfile = self.config['tokenfile'].get(
+            confit.Filename(in_app_dir=True)
+        )
         self.register_listener('import_begin', self.setup)
 
     def setup(self):
@@ -82,7 +84,9 @@ class SpotifyPlugin(BeetsPlugin):
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
             raise ui.UserError(
-                u'Spotify authorization failed: {}\n{}'.format(e, response.content)
+                u'Spotify authorization failed: {}\n{}'.format(
+                    e, response.content
+                )
             )
         self.access_token = response.json()['access_token']
 
@@ -101,7 +105,9 @@ class SpotifyPlugin(BeetsPlugin):
         response = request_type(url, headers=self.auth_header, params=params)
         if response.status_code != 200:
             if u'token expired' in response.text:
-                self._log.debug('Spotify access token has expired. Reauthenticating.')
+                self._log.debug(
+                    'Spotify access token has expired. Reauthenticating.'
+                )
                 self.authenticate()
                 self._handle_response(request_type, url, params=params)
             else:
@@ -240,12 +246,15 @@ class SpotifyPlugin(BeetsPlugin):
                 results = self.query_spotify(lib, ui.decargs(args))
                 self.output_results(results)
 
-        spotify_cmd = ui.Subcommand('spotify', help=u'build a Spotify playlist')
+        spotify_cmd = ui.Subcommand(
+            'spotify', help=u'build a Spotify playlist'
+        )
         spotify_cmd.parser.add_option(
             u'-m',
             u'--mode',
             action='store',
-            help=u'"open" to open Spotify with playlist, ' u'"list" to print (default)',
+            help=u'"open" to open Spotify with playlist, '
+            u'"list" to print (default)',
         )
         spotify_cmd.parser.add_option(
             u'-f',
@@ -265,7 +274,9 @@ class SpotifyPlugin(BeetsPlugin):
             self.config['show_failures'].set(True)
 
         if self.config['mode'].get() not in ['list', 'open']:
-            self._log.warning(u'{0} is not a valid mode', self.config['mode'].get())
+            self._log.warning(
+                u'{0} is not a valid mode', self.config['mode'].get()
+            )
             return False
 
         self.opts = opts
@@ -278,7 +289,9 @@ class SpotifyPlugin(BeetsPlugin):
         items = lib.items(query)
 
         if not items:
-            self._log.debug(u'Your beets query returned no items, ' u'skipping spotify')
+            self._log.debug(
+                u'Your beets query returned no items, ' u'skipping spotify'
+            )
             return
 
         self._log.info(u'Processing {0} tracks...', len(items))
@@ -287,11 +300,17 @@ class SpotifyPlugin(BeetsPlugin):
 
             # Apply regex transformations if provided
             for regex in self.config['regex'].get():
-                if not regex['field'] or not regex['search'] or not regex['replace']:
+                if (
+                    not regex['field']
+                    or not regex['search']
+                    or not regex['replace']
+                ):
                     continue
 
                 value = item[regex['field']]
-                item[regex['field']] = re.sub(regex['search'], regex['replace'], value)
+                item[regex['field']] = re.sub(
+                    regex['search'], regex['replace'], value
+                )
 
             # Custom values can be passed in the config (just in case)
             artist = item[self.config['artist_field'].get()]
@@ -301,13 +320,17 @@ class SpotifyPlugin(BeetsPlugin):
 
             # Query the Web API for each track, look for the items' JSON data
             r = self._handle_response(
-                requests.get, self.base_url, params={"q": search_url, "type": "track"}
+                requests.get,
+                self.base_url,
+                params={"q": search_url, "type": "track"},
             )
             self._log.debug('{}', r.url)
             try:
                 r.raise_for_status()
             except requests.exceptions.HTTPError as e:
-                self._log.debug(u'URL returned a {0} error', e.response.status_code)
+                self._log.debug(
+                    u'URL returned a {0} error', e.response.status_code
+                )
                 failures.append(search_url)
                 continue
 
@@ -316,16 +339,24 @@ class SpotifyPlugin(BeetsPlugin):
             # Apply market filter if requested
             region_filter = self.config['region_filter'].get()
             if region_filter:
-                r_data = [x for x in r_data if region_filter in x['available_markets']]
+                r_data = [
+                    x
+                    for x in r_data
+                    if region_filter in x['available_markets']
+                ]
 
             # Simplest, take the first result
             chosen_result = None
             if len(r_data) == 1 or self.config['tiebreak'].get() == "first":
-                self._log.debug(u'Spotify track(s) found, count: {0}', len(r_data))
+                self._log.debug(
+                    u'Spotify track(s) found, count: {0}', len(r_data)
+                )
                 chosen_result = r_data[0]
             elif len(r_data) > 1:
                 # Use the popularity filter
-                self._log.debug(u'Most popular track chosen, count: {0}', len(r_data))
+                self._log.debug(
+                    u'Most popular track chosen, count: {0}', len(r_data)
+                )
                 chosen_result = max(r_data, key=lambda x: x['popularity'])
 
             if chosen_result:

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -68,10 +68,10 @@ class SpotifyPlugin(BeetsPlugin):
             'Authorization': 'Basic {}'.format(
                 base64.b64encode(
                     '{}:{}'.format(
-                        self.config['client_id'].as_str().encode(),
-                        self.config['client_secret'].as_str().encode(),
+                        self.config['client_id'].as_str(),
+                        self.config['client_secret'].as_str(),
                     )
-                ).decode()
+                )
             )
         }
         response = requests.post(

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -41,7 +41,6 @@ class SpotifyPlugin(BeetsPlugin):
                 'client_secret': '6DRS7k66h4643yQEbepPxOuxeVW0yZpk',
                 'tokenfile': 'spotify_token.json',
                 'source_weight': 0.5,
-                'user_token': '',
             }
         )
         self.config['client_secret'].redact = True
@@ -184,7 +183,7 @@ class SpotifyPlugin(BeetsPlugin):
 
         return AlbumInfo(
             album=response_data['name'],
-            album_id=album_id,
+            album_id=spotify_id,
             artist=artist,
             artist_id=artist_id,
             tracks=tracks,

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -46,16 +46,13 @@ class SpotifyPlugin(BeetsPlugin):
         )
         self.config['client_secret'].redact = True
 
-        """Path to the JSON file for storing the OAuth access token."""
         self.tokenfile = self.config['tokenfile'].get(
             confit.Filename(in_app_dir=True)
-        )
+        )  # Path to the JSON file for storing the OAuth access token.
         self.setup()
 
     def setup(self):
-        """
-        Retrieve previously saved OAuth token or generate a new one.
-        """
+        """Retrieve previously saved OAuth token or generate a new one."""
         try:
             with open(self.tokenfile) as f:
                 token_data = json.load(f)
@@ -65,8 +62,7 @@ class SpotifyPlugin(BeetsPlugin):
             self.access_token = token_data['access_token']
 
     def _authenticate(self):
-        """
-        Request an access token via the Client Credentials Flow:
+        """Request an access token via the Client Credentials Flow:
         https://developer.spotify.com/documentation/general/guides/authorization-guide/#client-credentials-flow
         """
         headers = {
@@ -104,8 +100,7 @@ class SpotifyPlugin(BeetsPlugin):
         return {'Authorization': 'Bearer {}'.format(self.access_token)}
 
     def _handle_response(self, request_type, url, params=None):
-        """
-        Send a request, reauthenticating if necessary.
+        """Send a request, reauthenticating if necessary.
 
         :param request_type: Type of :class:`Request` constructor,
             e.g. ``requests.get``, ``requests.post``, etc.
@@ -131,8 +126,7 @@ class SpotifyPlugin(BeetsPlugin):
         return response
 
     def _get_spotify_id(self, url_type, id_):
-        """
-        Parse a Spotify ID from its URL if necessary.
+        """Parse a Spotify ID from its URL if necessary.
 
         :param url_type: Type of Spotify URL, either 'album' or 'track'
         :type url_type: str
@@ -149,8 +143,7 @@ class SpotifyPlugin(BeetsPlugin):
         return match.group(2) if match else None
 
     def album_for_id(self, album_id):
-        """
-        Fetches an album by its Spotify ID or URL and returns an
+        """Fetches an album by its Spotify ID or URL and returns an
         AlbumInfo object or None if the album is not found.
         """
         spotify_id = self._get_spotify_id('album', album_id)
@@ -207,8 +200,7 @@ class SpotifyPlugin(BeetsPlugin):
         )
 
     def _get_track(self, track_data):
-        """
-        Convert a Spotify track object dict to a TrackInfo object.
+        """Convert a Spotify track object dict to a TrackInfo object.
 
         :param track_data: Simplified track object
             (https://developer.spotify.com/documentation/web-api/reference/object-model/#track-object-simplified)
@@ -230,8 +222,7 @@ class SpotifyPlugin(BeetsPlugin):
         )
 
     def track_for_id(self, track_id):
-        """
-        Fetches a track by its Spotify ID or URL and returns a
+        """Fetches a track by its Spotify ID or URL and returns a
         TrackInfo object or None if the track is not found.
 
         :param track_id: Spotify ID or URL for the track
@@ -249,8 +240,7 @@ class SpotifyPlugin(BeetsPlugin):
         return self._get_track(response.json())
 
     def _get_artist(self, artists):
-        """
-        Returns an artist string (all artists) and an artist_id (the main
+        """Returns an artist string (all artists) and an artist_id (the main
         artist) for a list of Spotify artist object dicts.
 
         :param artists: Iterable of simplified Spotify artist objects
@@ -274,8 +264,7 @@ class SpotifyPlugin(BeetsPlugin):
         return artist, artist_id
 
     def album_distance(self, items, album_info, mapping):
-        """
-        Returns the Spotify source weight and the maximum source weight
+        """Returns the Spotify source weight and the maximum source weight
         for albums.
         """
         dist = Distance()
@@ -284,8 +273,7 @@ class SpotifyPlugin(BeetsPlugin):
         return dist
 
     def track_distance(self, item, track_info):
-        """
-        Returns the Spotify source weight and the maximum source weight
+        """Returns the Spotify source weight and the maximum source weight
         for individual tracks.
         """
         dist = Distance()
@@ -344,7 +332,7 @@ class SpotifyPlugin(BeetsPlugin):
 
         if not items:
             self._log.debug(
-                u'Your beets query returned no items, ' u'skipping spotify'
+                u'Your beets query returned no items, skipping Spotify'
             )
             return
 

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -12,7 +12,7 @@ import requests
 from beets import ui
 from beets.plugins import BeetsPlugin
 from beets.util import confit
-from beets.autotag.hooks import AlbumInfo, TrackInfo
+from beets.autotag.hooks import AlbumInfo, TrackInfo, Distance
 
 
 class SpotifyPlugin(BeetsPlugin):
@@ -272,6 +272,26 @@ class SpotifyPlugin(BeetsPlugin):
             artist_names.append(name)
         artist = ', '.join(artist_names).replace(' ,', ',') or None
         return artist, artist_id
+
+    def album_distance(self, items, album_info, mapping):
+        """
+        Returns the Spotify source weight and the maximum source weight
+        for albums.
+        """
+        dist = Distance()
+        if album_info.data_source == 'Spotify':
+            dist.add('source', self.config['source_weight'].as_number())
+        return dist
+
+    def track_distance(self, item, track_info):
+        """
+        Returns the Spotify source weight and the maximum source weight
+        for individual tracks.
+        """
+        dist = Distance()
+        if track_info.data_source == 'Spotify':
+            dist.add('source', self.config['source_weight'].as_number())
+        return dist
 
     def commands(self):
         def queries(lib, opts, args):

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -239,7 +239,7 @@ class SpotifyPlugin(BeetsPlugin):
         response_data_track = response_track.json()
         track = self._get_track(response_data_track)
 
-        # get album tracks set index/position on entire release
+        # get album's tracks to set the track's index/position on entire release
         spotify_id_album = response_track['album']['id']
         response_album = self._handle_response(
             requests.get, self.album_url + spotify_id_album

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -68,8 +68,8 @@ class SpotifyPlugin(BeetsPlugin):
             'Authorization': 'Basic {}'.format(
                 base64.b64encode(
                     '{}:{}'.format(
-                        self.config['client_id'].as_str(),
-                        self.config['client_secret'].as_str(),
+                        bytes(self.config['client_id'].as_str()),
+                        bytes(self.config['client_secret'].as_str()),
                     )
                 )
             )

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -388,9 +388,9 @@ class SpotifyPlugin(BeetsPlugin):
     def output_results(self, results):
         if results:
             ids = [x['id'] for x in results]
-            if self.config['mode'].get() == 'open':
+            if self.config['mode'].get() == "open":
                 self._log.info(u'Attempting to open Spotify with playlist')
-                spotify_url = self.playlist_partial + ','.join(ids)
+                spotify_url = self.playlist_partial + ",".join(ids)
                 webbrowser.open(spotify_url)
 
             else:

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -240,12 +240,12 @@ class SpotifyPlugin(BeetsPlugin):
         :return: TrackInfo object for track
         :rtype: beets.autotag.hooks.TrackInfo
         """
-        spotify_id_track = self._get_spotify_id('track', track_id)
-        if spotify_id_track is None:
+        spotify_id = self._get_spotify_id('track', track_id)
+        if spotify_id is None:
             return None
 
         response_track = self._handle_response(
-            requests.get, self.track_url + spotify_id_track
+            requests.get, self.track_url + spotify_id
         )
         response_data_track = response_track.json()
         track = self._get_track(response_data_track)
@@ -260,7 +260,7 @@ class SpotifyPlugin(BeetsPlugin):
         for i, track_data in enumerate(response_data_album['tracks']['items']):
             if track_data['disc_number'] == track.medium:
                 medium_total += 1
-                if track_data['id'] == spotify_id_track:
+                if track_data['id'] == spotify_id:
                     track.index = i + 1
         track.medium_total = medium_total
         return track

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -52,7 +52,7 @@ class SpotifyPlugin(BeetsPlugin):
         self.tokenfile = self.config['tokenfile'].get(
             confit.Filename(in_app_dir=True)
         )
-        self.register_listener('import_begin', self.setup)
+        # self.register_listener('import_begin', self.setup)
 
     def setup(self):
         """Retrieve previously saved OAuth token or generate a new one"""

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -2,55 +2,257 @@
 
 from __future__ import division, absolute_import, print_function
 
+import os
 import re
+import json
+import base64
 import webbrowser
+
 import requests
-from beets.plugins import BeetsPlugin
-from beets.ui import decargs
+
 from beets import ui
-from requests.exceptions import HTTPError
+from beets.plugins import BeetsPlugin
+from beets.util import confit
+from beets.autotag.hooks import AlbumInfo, TrackInfo
 
 
 class SpotifyPlugin(BeetsPlugin):
-
     # URL for the Web API of Spotify
     # Documentation here: https://developer.spotify.com/web-api/search-item/
-    base_url = "https://api.spotify.com/v1/search"
-    open_url = "http://open.spotify.com/track/"
-    playlist_partial = "spotify:trackset:Playlist:"
+    oauth_token_url = 'https://accounts.spotify.com/api/token'
+    base_url = 'https://api.spotify.com/v1/search'
+    open_url = 'http://open.spotify.com/track/'
+    album_url = 'https://api.spotify.com/v1/albums/'
+    track_url = 'https://api.spotify.com/v1/tracks/'
+    playlist_partial = 'spotify:trackset:Playlist:'
+    id_regex = r'(^|open\.spotify\.com/{}/)([0-9A-Za-z]{{22}})'
 
     def __init__(self):
         super(SpotifyPlugin, self).__init__()
-        self.config.add({
-            'mode': 'list',
-            'tiebreak': 'popularity',
-            'show_failures': False,
-            'artist_field': 'albumartist',
-            'album_field': 'album',
-            'track_field': 'title',
-            'region_filter': None,
-            'regex': []
-        })
+        self.config.add(
+            {
+                'mode': 'list',
+                'tiebreak': 'popularity',
+                'show_failures': False,
+                'artist_field': 'albumartist',
+                'album_field': 'album',
+                'track_field': 'title',
+                'region_filter': None,
+                'regex': [],
+                'client_id': 'N3dliiOOTBEEFqCH5NDDUmF5Eo8bl7AN',
+                'client_secret': '6DRS7k66h4643yQEbepPxOuxeVW0yZpk',
+                'tokenfile': 'spotify_token.json',
+                'source_weight': 0.5,
+                'user_token': '',
+            }
+        )
+        self.config['client_secret'].redact = True
+
+        """Path to the JSON file for storing the OAuth access token."""
+        self.tokenfile = self.config['tokenfile'].get(confit.Filename(in_app_dir=True))
+        self.register_listener('import_begin', self.setup)
+
+    def setup(self):
+        """Retrieve previously saved OAuth token or generate a new one"""
+        try:
+            with open(self.tokenfile) as f:
+                token_data = json.load(f)
+        except IOError:
+            self.authenticate()
+        else:
+            self.access_token = token_data['access_token']
+
+    def authenticate(self):
+        headers = {
+            'Authorization': 'Basic {}'.format(
+                base64.b64encode(
+                    '{}:{}'.format(
+                        self.config['client_id'].as_str(),
+                        self.config['client_secret'].as_str(),
+                    )
+                )
+            )
+        }
+        response = requests.post(
+            self.oauth_token_url,
+            data={'grant_type': 'client_credentials'},
+            headers=headers,
+        )
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            raise ui.UserError(
+                u'Spotify authorization failed: {}\n{}'.format(e, response.content)
+            )
+        self.access_token = response.json()['access_token']
+
+        # Save the token for later use.
+        self._log.debug(u'Spotify access token: {}', self.access_token)
+        with open(self.tokenfile, 'w') as f:
+            json.dump({'access_token': self.access_token}, f)
+
+    @property
+    def auth_header(self):
+        if not hasattr(self, 'access_token'):
+            self.setup()
+        return {'Authorization': 'Bearer {}'.format(self.access_token)}
+
+    def _handle_response(self, request_type, url, params=None):
+        response = request_type(url, headers=self.auth_header, params=params)
+        if response.status_code != 200:
+            if u'token expired' in response.text:
+                self._log.debug('Spotify access token has expired. Reauthenticating.')
+                self.authenticate()
+                self._handle_response(request_type, url, params=params)
+            else:
+                raise ui.UserError(u'Spotify API error:\n{}', response.text)
+        return response
+
+    def album_for_id(self, album_id):
+        """
+        Fetches an album by its Spotify album ID or URL and returns an AlbumInfo object
+        or None if the album is not found.
+        """
+        self._log.debug(u'Searching for album {}', album_id)
+        match = re.search(self.id_regex.format('album'), album_id)
+        if not match:
+            return None
+        spotify_album_id = match.group(2)
+
+        response = self._handle_response(
+            requests.get, self.album_url + spotify_album_id
+        )
+
+        data = response.json()
+
+        artist, artist_id = self._get_artist(data['artists'])
+
+        date_parts = [int(part) for part in data['release_date'].split('-')]
+
+        if data['release_date_precision'] == 'day':
+            year, month, day = date_parts
+        elif data['release_date_precision'] == 'month':
+            year, month = date_parts
+            day = None
+        elif data['release_date_precision'] == 'year':
+            year = date_parts
+            month = None
+            day = None
+
+        album = AlbumInfo(
+            album=data['name'],
+            album_id=album_id,
+            artist=artist,
+            artist_id=artist_id,
+            tracks=None,
+            asin=None,
+            albumtype=data['album_type'],
+            va=False,
+            year=year,
+            month=month,
+            day=day,
+            label=None,
+            mediums=None,
+            artist_sort=None,
+            releasegroup_id=None,
+            catalognum=None,
+            script=None,
+            language=None,
+            country=None,
+            albumstatus=None,
+            media=None,
+            albumdisambig=None,
+            releasegroupdisambig=None,
+            artist_credit=None,
+            original_year=None,
+            original_month=None,
+            original_day=None,
+            data_source='Spotify',
+            data_url=None,
+        )
+
+        return album
+
+    def track_for_id(self, track_id):
+        """
+        Fetches a track by its Spotify track ID or URL and returns a TrackInfo object
+        or None if the track is not found.
+        """
+        self._log.debug(u'Searching for track {}', track_id)
+        match = re.search(self.id_regex.format('track'), track_id)
+        if not match:
+            return None
+        spotify_track_id = match.group(2)
+
+        response = self._handle_response(
+            requests.get, self.track_url + spotify_track_id
+        )
+        data = response.json()
+        artist, artist_id = self._get_artist(data['artists'])
+        track = TrackInfo(
+            title=data['title'],
+            track_id=spotify_track_id,
+            release_track_id=data.get('album').get('id'),
+            artist=artist,
+            artist_id=artist_id,
+            length=data['duration_ms'] / 1000,
+            index=None,
+            medium=None,
+            medium_index=data['track_number'],
+            medium_total=None,
+            artist_sort=None,
+            disctitle=None,
+            artist_credit=None,
+            data_source=None,
+            data_url=None,
+            media=None,
+            lyricist=None,
+            composer=None,
+            composer_sort=None,
+            arranger=None,
+            track_alt=None,
+        )
+        return track
+
+    def _get_artist(self, artists):
+        """
+        Returns an artist string (all artists) and an artist_id (the main
+        artist) for a list of Beatport release or track artists.
+        """
+        artist_id = None
+        artist_names = []
+        for artist in artists:
+            if not artist_id:
+                artist_id = artist['id']
+            name = artist['name']
+            # Strip disambiguation number.
+            name = re.sub(r' \(\d+\)$', '', name)
+            # Move articles to the front.
+            name = re.sub(r'^(.*?), (a|an|the)$', r'\2 \1', name, flags=re.I)
+            artist_names.append(name)
+        artist = ', '.join(artist_names).replace(' ,', ',') or None
+        return artist, artist_id
 
     def commands(self):
         def queries(lib, opts, args):
             success = self.parse_opts(opts)
             if success:
-                results = self.query_spotify(lib, decargs(args))
+                results = self.query_spotify(lib, ui.decargs(args))
                 self.output_results(results)
-        spotify_cmd = ui.Subcommand(
-            'spotify',
-            help=u'build a Spotify playlist'
+
+        spotify_cmd = ui.Subcommand('spotify', help=u'build a Spotify playlist')
+        spotify_cmd.parser.add_option(
+            u'-m',
+            u'--mode',
+            action='store',
+            help=u'"open" to open Spotify with playlist, ' u'"list" to print (default)',
         )
         spotify_cmd.parser.add_option(
-            u'-m', u'--mode', action='store',
-            help=u'"open" to open Spotify with playlist, '
-                 u'"list" to print (default)'
-        )
-        spotify_cmd.parser.add_option(
-            u'-f', u'--show-failures',
-            action='store_true', dest='show_failures',
-            help=u'list tracks that did not match a Spotify ID'
+            u'-f',
+            u'--show-failures',
+            action='store_true',
+            dest='show_failures',
+            help=u'list tracks that did not match a Spotify ID',
         )
         spotify_cmd.func = queries
         return [spotify_cmd]
@@ -63,23 +265,20 @@ class SpotifyPlugin(BeetsPlugin):
             self.config['show_failures'].set(True)
 
         if self.config['mode'].get() not in ['list', 'open']:
-            self._log.warning(u'{0} is not a valid mode',
-                              self.config['mode'].get())
+            self._log.warning(u'{0} is not a valid mode', self.config['mode'].get())
             return False
 
         self.opts = opts
         return True
 
     def query_spotify(self, lib, query):
-
         results = []
         failures = []
 
         items = lib.items(query)
 
         if not items:
-            self._log.debug(u'Your beets query returned no items, '
-                            u'skipping spotify')
+            self._log.debug(u'Your beets query returned no items, ' u'skipping spotify')
             return
 
         self._log.info(u'Processing {0} tracks...', len(items))
@@ -88,17 +287,11 @@ class SpotifyPlugin(BeetsPlugin):
 
             # Apply regex transformations if provided
             for regex in self.config['regex'].get():
-                if (
-                    not regex['field'] or
-                    not regex['search'] or
-                    not regex['replace']
-                ):
+                if not regex['field'] or not regex['search'] or not regex['replace']:
                     continue
 
                 value = item[regex['field']]
-                item[regex['field']] = re.sub(
-                    regex['search'], regex['replace'], value
-                )
+                item[regex['field']] = re.sub(regex['search'], regex['replace'], value)
 
             # Custom values can be passed in the config (just in case)
             artist = item[self.config['artist_field'].get()]
@@ -107,15 +300,14 @@ class SpotifyPlugin(BeetsPlugin):
             search_url = query + " album:" + album + " artist:" + artist
 
             # Query the Web API for each track, look for the items' JSON data
-            r = requests.get(self.base_url, params={
-                "q": search_url, "type": "track"
-            })
+            r = self._handle_response(
+                requests.get, self.base_url, params={"q": search_url, "type": "track"}
+            )
             self._log.debug('{}', r.url)
             try:
                 r.raise_for_status()
-            except HTTPError as e:
-                self._log.debug(u'URL returned a {0} error',
-                                e.response.status_code)
+            except requests.exceptions.HTTPError as e:
+                self._log.debug(u'URL returned a {0} error', e.response.status_code)
                 failures.append(search_url)
                 continue
 
@@ -124,19 +316,16 @@ class SpotifyPlugin(BeetsPlugin):
             # Apply market filter if requested
             region_filter = self.config['region_filter'].get()
             if region_filter:
-                r_data = [x for x in r_data if region_filter
-                          in x['available_markets']]
+                r_data = [x for x in r_data if region_filter in x['available_markets']]
 
             # Simplest, take the first result
             chosen_result = None
             if len(r_data) == 1 or self.config['tiebreak'].get() == "first":
-                self._log.debug(u'Spotify track(s) found, count: {0}',
-                                len(r_data))
+                self._log.debug(u'Spotify track(s) found, count: {0}', len(r_data))
                 chosen_result = r_data[0]
             elif len(r_data) > 1:
                 # Use the popularity filter
-                self._log.debug(u'Most popular track chosen, count: {0}',
-                                len(r_data))
+                self._log.debug(u'Most popular track chosen, count: {0}', len(r_data))
                 chosen_result = max(r_data, key=lambda x: x['popularity'])
 
             if chosen_result:
@@ -148,15 +337,18 @@ class SpotifyPlugin(BeetsPlugin):
         failure_count = len(failures)
         if failure_count > 0:
             if self.config['show_failures'].get():
-                self._log.info(u'{0} track(s) did not match a Spotify ID:',
-                               failure_count)
+                self._log.info(
+                    u'{0} track(s) did not match a Spotify ID:', failure_count
+                )
                 for track in failures:
                     self._log.info(u'track: {0}', track)
                 self._log.info(u'')
             else:
-                self._log.warning(u'{0} track(s) did not match a Spotify ID;\n'
-                                  u'use --show-failures to display',
-                                  failure_count)
+                self._log.warning(
+                    u'{0} track(s) did not match a Spotify ID;\n'
+                    u'use --show-failures to display',
+                    failure_count,
+                )
 
         return results
 

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -203,7 +203,7 @@ class SpotifyPlugin(BeetsPlugin):
             day=day,
             label=response_data['label'],
             data_source='Spotify',
-            data_url=response_data['uri'],
+            data_url=response_data['external_urls']['spotify'],
         )
 
     def _get_track(self, track_data):
@@ -226,7 +226,7 @@ class SpotifyPlugin(BeetsPlugin):
             index=track_data['track_number'],
             medium_index=track_data['track_number'],
             data_source='Spotify',
-            data_url=track_data['uri'],
+            data_url=track_data['external_urls']['spotify'],
         )
 
     def track_for_id(self, track_id):

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -95,10 +95,6 @@ class SpotifyPlugin(BeetsPlugin):
         with open(self.tokenfile, 'w') as f:
             json.dump({'access_token': self.access_token}, f)
 
-    @property
-    def _auth_header(self):
-        return {'Authorization': 'Bearer {}'.format(self.access_token)}
-
     def _handle_response(self, request_type, url, params=None):
         """Send a request, reauthenticating if necessary.
 
@@ -113,7 +109,11 @@ class SpotifyPlugin(BeetsPlugin):
         :return: class:`Response <Response>` object
         :rtype: requests.Response
         """
-        response = request_type(url, headers=self._auth_header, params=params)
+        response = request_type(
+            url,
+            headers={'Authorization': 'Bearer {}'.format(self.access_token)},
+            params=params,
+        )
         if response.status_code != 200:
             if u'token expired' in response.text:
                 self._log.debug(

--- a/docs/plugins/spotify.rst
+++ b/docs/plugins/spotify.rst
@@ -2,14 +2,10 @@ Spotify Plugin
 ==============
 
 The ``spotify`` plugin generates `Spotify`_ playlists from tracks in your
-library with the ``beet spotify`` command. Using the `Spotify Search API`_,
-any tracks that can be matched with a Spotify ID are returned, and the
-results can be either pasted in to a playlist or opened directly in the
-Spotify app.
+library with the ``beet spotify`` command using the `Spotify Search API`_.
 
-Spotify URLs and IDs may also be provided to the ``Enter release ID:`` prompt
-during ``beet import`` to autotag music with data from the Spotify
-`Album`_ and `Track`_ APIs.
+Also, the plugin can use the Spotify `Album`_ and `Track`_ APIs to provide
+metadata matches for the importer.
 
 .. _Spotify: https://www.spotify.com/
 .. _Spotify Search API: https://developer.spotify.com/documentation/web-api/reference/search/search/
@@ -58,23 +54,11 @@ Command-line options include:
 * ``--show-failures`` or ``-f``: List the tracks that did not match a Spotify
   ID.
 
-A Spotify ID or URL may also be provided to the ``Enter release ID:``
+You can enter the URL for an album or song on Spotify at the ``enter Id``
 prompt during import::
 
     Enter search, enter Id, aBort, eDit, edit Candidates, plaY? i
     Enter release ID: https://open.spotify.com/album/2rFYTHFBLQN3AYlrymBPPA
-    Tagging:
-        Bear Hands - Blue Lips / Ignoring the Truth / Back Seat Driver (Spirit Guide) / 2AM
-    URL:
-        https://open.spotify.com/album/2rFYTHFBLQN3AYlrymBPPA
-    (Similarity: 88.2%) (source, tracks) (Spotify, 2019, Spensive Sounds)
-     * Blue Lips (feat. Ursula Rose)   -> Blue Lips (feat. Ursula Rose) (source)
-     * Ignoring the Truth              -> Ignoring the Truth (source)
-     * Back Seat Driver (Spirit Guide) -> Back Seat Driver (Spirit Guide) (source)
-     * 2AM                             -> 2AM (source)
-    [A]pply, More candidates, Skip, Use as-is, as Tracks, Group albums,
-    Enter search, enter Id, aBort, eDit, edit Candidates, plaY?
-
 
 Configuration
 -------------
@@ -106,9 +90,6 @@ in config.yaml under the ``spotify:`` section:
   track/album/artist fields before sending them to Spotify.  Can be useful for
   changing certain abbreviations, like ft. -> feat.  See the examples below.
   Default: None.
-- **tokenfile**: Filename of the JSON file stored in the beets configuration
-  directory to use for caching the OAuth access token.
-  Default: ``spotify_token.json``.
 - **source_weight**: Penalty applied to Spotify matches during import. Set to
   0.0 to disable.
   Default: ``0.5``.
@@ -119,7 +100,6 @@ Here's an example::
         client_id: N3dliiOOTBEEFqCH5NDDUmF5Eo8bl7AN
         client_secret: 6DRS7k66h4643yQEbepPxOuxeVW0yZpk
         source_weight: 0.7
-        tokenfile: my_spotify_token.json
         mode: open
         region_filter: US
         show_failures: on

--- a/docs/plugins/spotify.rst
+++ b/docs/plugins/spotify.rst
@@ -108,13 +108,10 @@ in config.yaml under the ``spotify:`` section:
   Default: None.
 - **tokenfile**: Filename of the JSON file stored in the beets configuration
   directory to use for caching the OAuth access token.
-  access token.
   Default: ``spotify_token.json``.
 - **source_weight**: Penalty applied to Spotify matches during import. Set to
   0.0 to disable.
   Default: ``0.5``.
-
-.. _beets configuration directory: https://beets.readthedocs.io/en/stable/reference/config.html#default-location
 
 Here's an example::
 

--- a/docs/plugins/spotify.rst
+++ b/docs/plugins/spotify.rst
@@ -22,7 +22,7 @@ Why Use This Plugin?
 * You're a Beets user and Spotify user already.
 * You have playlists or albums you'd like to make available in Spotify from Beets without having to search for each artist/album/track.
 * You want to check which tracks in your library are available on Spotify.
-* You want to autotag music with Spotify metadata
+* You want to autotag music with metadata from the Spotify API.
 
 Basic Usage
 -----------
@@ -58,7 +58,7 @@ Command-line options include:
 * ``--show-failures`` or ``-f``: List the tracks that did not match a Spotify
   ID.
 
-A Spotify ID or URL may also be provided to the ``Enter release ID``
+A Spotify ID or URL may also be provided to the ``Enter release ID:``
 prompt during import::
 
     Enter search, enter Id, aBort, eDit, edit Candidates, plaY? i

--- a/docs/plugins/spotify.rst
+++ b/docs/plugins/spotify.rst
@@ -1,10 +1,20 @@
 Spotify Plugin
 ==============
 
-The ``spotify`` plugin generates `Spotify`_ playlists from tracks in your library. Using the `Spotify Web API`_, any tracks that can be matched with a Spotify ID are returned, and the results can be either pasted in to a playlist or opened directly in the Spotify app.
+The ``spotify`` plugin generates `Spotify`_ playlists from tracks in your
+library with the ``beet spotify`` command. Using the `Spotify Search API`_,
+any tracks that can be matched with a Spotify ID are returned, and the
+results can be either pasted in to a playlist or opened directly in the
+Spotify app.
+
+Spotify URLs and IDs may also be provided in the ``Enter release ID:`` prompt
+during ``beet import`` to autotag music with data from the Spotify
+`Album`_ and `Track`_ APIs.
 
 .. _Spotify: https://www.spotify.com/
-.. _Spotify Web API: https://developer.spotify.com/web-api/search-item/
+.. _Spotify Search API: https://developer.spotify.com/documentation/web-api/reference/search/search/
+.. _Album: https://developer.spotify.com/documentation/web-api/reference/albums/get-album/
+.. _Track: https://developer.spotify.com/documentation/web-api/reference/tracks/get-track/
 
 Why Use This Plugin?
 --------------------
@@ -12,12 +22,23 @@ Why Use This Plugin?
 * You're a Beets user and Spotify user already.
 * You have playlists or albums you'd like to make available in Spotify from Beets without having to search for each artist/album/track.
 * You want to check which tracks in your library are available on Spotify.
+* You want to autotag music with Spotify metadata
 
 Basic Usage
 -----------
 
-First, enable the ``spotify`` plugin (see :ref:`using-plugins`).
-Then, use the ``spotify`` command with a beets query::
+First, register a `Spotify application`_ to use with beets and add your Client ID
+and Client Secret to your :doc:`configuration file </reference/config>` under a
+``spotify`` section::
+
+    spotify:
+        client_id: N3dliiOOTBEEFqCH5NDDUmF5Eo8bl7AN
+        client_secret: 6DRS7k66h4643yQEbepPxOuxeVW0yZpk
+
+.. _Spotify application: https://developer.spotify.com/documentation/general/guides/app-settings/
+
+Then, enable the ``spotify`` plugin (see :ref:`using-plugins`) and use the ``spotify``
+command with a beets query::
 
     beet spotify [OPTIONS...] QUERY
 
@@ -36,6 +57,24 @@ Command-line options include:
   open it in the Spotify app. (See below.)
 * ``--show-failures`` or ``-f``: List the tracks that did not match a Spotify
   ID.
+
+A Spotify ID or URL may also be provided to the ``Enter release ID``
+prompt during import::
+
+    Enter search, enter Id, aBort, eDit, edit Candidates, plaY? i
+    Enter release ID: https://open.spotify.com/album/2rFYTHFBLQN3AYlrymBPPA
+    Tagging:
+        Bear Hands - Blue Lips / Ignoring the Truth / Back Seat Driver (Spirit Guide) / 2AM
+    URL:
+        https://open.spotify.com/album/2rFYTHFBLQN3AYlrymBPPA
+    (Similarity: 88.2%) (source, tracks) (Spotify, 2019, Spensive Sounds)
+     * Blue Lips (feat. Ursula Rose)   -> Blue Lips (feat. Ursula Rose) (source)
+     * Ignoring the Truth              -> Ignoring the Truth (source)
+     * Back Seat Driver (Spirit Guide) -> Back Seat Driver (Spirit Guide) (source)
+     * 2AM                             -> 2AM (source)
+    [A]pply, More candidates, Skip, Use as-is, as Tracks, Group albums,
+    Enter search, enter Id, aBort, eDit, edit Candidates, plaY?
+
 
 Configuration
 -------------
@@ -67,10 +106,23 @@ in config.yaml under the ``spotify:`` section:
   track/album/artist fields before sending them to Spotify.  Can be useful for
   changing certain abbreviations, like ft. -> feat.  See the examples below.
   Default: None.
+- **tokenfile**: Filename of the JSON file stored in the beets configuration
+  directory to use for caching the OAuth access token.
+  access token.
+  Default: ``spotify_token.json``.
+- **source_weight**: Penalty applied to Spotify matches during import. Set to
+  0.0 to disable.
+  Default: ``0.5``.
+
+.. _beets configuration directory: https://beets.readthedocs.io/en/stable/reference/config.html#default-location
 
 Here's an example::
 
     spotify:
+        client_id: N3dliiOOTBEEFqCH5NDDUmF5Eo8bl7AN
+        client_secret: 6DRS7k66h4643yQEbepPxOuxeVW0yZpk
+        source_weight: 0.7
+        tokenfile: my_spotify_token.json
         mode: open
         region_filter: US
         show_failures: on

--- a/docs/plugins/spotify.rst
+++ b/docs/plugins/spotify.rst
@@ -22,19 +22,8 @@ Why Use This Plugin?
 
 Basic Usage
 -----------
-
-First, register a `Spotify application`_ to use with beets and add your Client ID
-and Client Secret to your :doc:`configuration file </reference/config>` under a
-``spotify`` section::
-
-    spotify:
-        client_id: N3dliiOOTBEEFqCH5NDDUmF5Eo8bl7AN
-        client_secret: 6DRS7k66h4643yQEbepPxOuxeVW0yZpk
-
-.. _Spotify application: https://developer.spotify.com/documentation/general/guides/app-settings/
-
-Then, enable the ``spotify`` plugin (see :ref:`using-plugins`) and use the ``spotify``
-command with a beets query::
+First, enable the ``spotify`` plugin (see :ref:`using-plugins`).
+Then, use the ``spotify`` command with a beets query::
 
     beet spotify [OPTIONS...] QUERY
 
@@ -97,8 +86,6 @@ in config.yaml under the ``spotify:`` section:
 Here's an example::
 
     spotify:
-        client_id: N3dliiOOTBEEFqCH5NDDUmF5Eo8bl7AN
-        client_secret: 6DRS7k66h4643yQEbepPxOuxeVW0yZpk
         source_weight: 0.7
         mode: open
         region_filter: US

--- a/docs/plugins/spotify.rst
+++ b/docs/plugins/spotify.rst
@@ -7,7 +7,7 @@ any tracks that can be matched with a Spotify ID are returned, and the
 results can be either pasted in to a playlist or opened directly in the
 Spotify app.
 
-Spotify URLs and IDs may also be provided in the ``Enter release ID:`` prompt
+Spotify URLs and IDs may also be provided to the ``Enter release ID:`` prompt
 during ``beet import`` to autotag music with data from the Spotify
 `Album`_ and `Track`_ APIs.
 

--- a/test/test_spotify.py
+++ b/test/test_spotify.py
@@ -116,7 +116,7 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
             length=10,
         )
         item.add(self.lib)
-        results = self.spotify.query_spotify(self.lib, u'Happy')
+        results = self.spotify.query_spotify(self.lib, u"Happy")
         self.assertEqual(1, len(results))
         self.assertEqual(u"6NPVjNh8Jhru9xOmyQigds", results[0]['id'])
         self.spotify.output_results(results)

--- a/test/test_spotify.py
+++ b/test/test_spotify.py
@@ -29,10 +29,21 @@ def _params(url):
 
 
 class SpotifyPluginTest(_common.TestCase, TestHelper):
-
+    @responses.activate
     def setUp(self):
         config.clear()
         self.setup_beets()
+        responses.add(
+            responses.POST,
+            spotify.SpotifyPlugin.oauth_token_url,
+            status=200,
+            json={
+                'access_token': '3XyiC3raJySbIAV5LVYj1DaWbcocNi3LAJTNXRnYYGVUl6mbbqXNhW3YcZnQgYXNWHFkVGSMlc0tMuvq8CF',
+                'token_type': 'Bearer',
+                'expires_in': 3600,
+                'scope': '',
+            },
+        )
         self.spotify = spotify.SpotifyPlugin()
         opts = ArgumentsMock("list", False)
         self.spotify.parse_opts(opts)
@@ -51,20 +62,25 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
 
     @responses.activate
     def test_missing_request(self):
-        json_file = os.path.join(_common.RSRC, b'spotify',
-                                 b'missing_request.json')
+        json_file = os.path.join(
+            _common.RSRC, b'spotify', b'missing_request.json'
+        )
         with open(json_file, 'rb') as f:
             response_body = f.read()
 
-        responses.add(responses.GET, 'https://api.spotify.com/v1/search',
-                      body=response_body, status=200,
-                      content_type='application/json')
+        responses.add(
+            responses.GET,
+            spotify.SpotifyPlugin.base_url,
+            body=response_body,
+            status=200,
+            content_type='application/json',
+        )
         item = Item(
             mb_trackid=u'01234',
             album=u'lkajsdflakjsd',
             albumartist=u'ujydfsuihse',
             title=u'duifhjslkef',
-            length=10
+            length=10,
         )
         item.add(self.lib)
         self.assertEqual([], self.spotify.query_spotify(self.lib, u""))
@@ -78,21 +94,25 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
 
     @responses.activate
     def test_track_request(self):
-
-        json_file = os.path.join(_common.RSRC, b'spotify',
-                                 b'track_request.json')
+        json_file = os.path.join(
+            _common.RSRC, b'spotify', b'track_request.json'
+        )
         with open(json_file, 'rb') as f:
             response_body = f.read()
 
-        responses.add(responses.GET, 'https://api.spotify.com/v1/search',
-                      body=response_body, status=200,
-                      content_type='application/json')
+        responses.add(
+            responses.GET,
+            'https://api.spotify.com/v1/search',
+            body=response_body,
+            status=200,
+            content_type='application/json',
+        )
         item = Item(
             mb_trackid=u'01234',
             album=u'Despicable Me 2',
             albumartist=u'Pharrell Williams',
             title=u'Happy',
-            length=10
+            length=10,
         )
         item.add(self.lib)
         results = self.spotify.query_spotify(self.lib, u"Happy")
@@ -110,6 +130,7 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
+
 
 if __name__ == '__main__':
     unittest.main(defaultTest='suite')

--- a/test/test_spotify.py
+++ b/test/test_spotify.py
@@ -71,7 +71,7 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
 
         responses.add(
             responses.GET,
-            spotify.SpotifyPlugin.base_url,
+            spotify.SpotifyPlugin.search_url,
             body=response_body,
             status=200,
             content_type='application/json',
@@ -103,7 +103,7 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
 
         responses.add(
             responses.GET,
-            spotify.SpotifyPlugin.base_url,
+            spotify.SpotifyPlugin.search_url,
             body=response_body,
             status=200,
             content_type='application/json',

--- a/test/test_spotify.py
+++ b/test/test_spotify.py
@@ -38,27 +38,28 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
             spotify.SpotifyPlugin.oauth_token_url,
             status=200,
             json={
-                'access_token': '3XyiC3raJySbIAV5LVYj1DaWbcocNi3LAJTNXRnYYGVUl6mbbqXNhW3YcZnQgYXNWHFkVGSMlc0tMuvq8CF',
+                'access_token': '3XyiC3raJySbIAV5LVYj1DaWbcocNi3LAJTNXRnYY'
+                'GVUl6mbbqXNhW3YcZnQgYXNWHFkVGSMlc0tMuvq8CF',
                 'token_type': 'Bearer',
                 'expires_in': 3600,
                 'scope': '',
             },
         )
         self.spotify = spotify.SpotifyPlugin()
-        opts = ArgumentsMock("list", False)
+        opts = ArgumentsMock('list', False)
         self.spotify.parse_opts(opts)
 
     def tearDown(self):
         self.teardown_beets()
 
     def test_args(self):
-        opts = ArgumentsMock("fail", True)
+        opts = ArgumentsMock('fail', True)
         self.assertEqual(False, self.spotify.parse_opts(opts))
-        opts = ArgumentsMock("list", False)
+        opts = ArgumentsMock('list', False)
         self.assertEqual(True, self.spotify.parse_opts(opts))
 
     def test_empty_query(self):
-        self.assertEqual(None, self.spotify.query_spotify(self.lib, u"1=2"))
+        self.assertEqual(None, self.spotify.query_spotify(self.lib, u'1=2'))
 
     @responses.activate
     def test_missing_request(self):
@@ -102,7 +103,7 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
 
         responses.add(
             responses.GET,
-            'https://api.spotify.com/v1/search',
+            spotify.SpotifyPlugin.base_url,
             body=response_body,
             status=200,
             content_type='application/json',
@@ -115,9 +116,9 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
             length=10,
         )
         item.add(self.lib)
-        results = self.spotify.query_spotify(self.lib, u"Happy")
+        results = self.spotify.query_spotify(self.lib, u'Happy')
         self.assertEqual(1, len(results))
-        self.assertEqual(u"6NPVjNh8Jhru9xOmyQigds", results[0]['id'])
+        self.assertEqual(u'6NPVjNh8Jhru9xOmyQigds', results[0]['id'])
         self.spotify.output_results(results)
 
         params = _params(responses.calls[0].request.url)

--- a/test/test_spotify.py
+++ b/test/test_spotify.py
@@ -46,20 +46,20 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
             },
         )
         self.spotify = spotify.SpotifyPlugin()
-        opts = ArgumentsMock('list', False)
+        opts = ArgumentsMock("list", False)
         self.spotify.parse_opts(opts)
 
     def tearDown(self):
         self.teardown_beets()
 
     def test_args(self):
-        opts = ArgumentsMock('fail', True)
+        opts = ArgumentsMock("fail", True)
         self.assertEqual(False, self.spotify.parse_opts(opts))
-        opts = ArgumentsMock('list', False)
+        opts = ArgumentsMock("list", False)
         self.assertEqual(True, self.spotify.parse_opts(opts))
 
     def test_empty_query(self):
-        self.assertEqual(None, self.spotify.query_spotify(self.lib, u'1=2'))
+        self.assertEqual(None, self.spotify.query_spotify(self.lib, u"1=2"))
 
     @responses.activate
     def test_missing_request(self):
@@ -118,7 +118,7 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
         item.add(self.lib)
         results = self.spotify.query_spotify(self.lib, u'Happy')
         self.assertEqual(1, len(results))
-        self.assertEqual(u'6NPVjNh8Jhru9xOmyQigds', results[0]['id'])
+        self.assertEqual(u"6NPVjNh8Jhru9xOmyQigds", results[0]['id'])
         self.spotify.output_results(results)
 
         params = _params(responses.calls[0].request.url)


### PR DESCRIPTION
Addressing https://github.com/beetbox/beets/issues/2694, I've added OAuth support for the Spotify plugin using Client Credentials Flow. This requires a [registered application](https://developer.spotify.com/documentation/general/guides/app-settings/) and Client ID/Secret to be provided via `client_id` and `client_secret` under the `spotify` options in config.yaml.

I've also started working on adding Spotify support for the importer (incomplete `album_for_id` and `track_for_id` funcs included in this PR with some logic copied from the Discogs plugin), since I've come across more than a few releases that don't exist in MusicBrainz/Discogs/Beatport/Bandcamp but do in Spotify. However, I realize that the Spotify API doesn't provide certain fields like album `media`, `catalognum`, etc. like these other beets sources do. So, @sampsyo, do you think it's still worth extending the autotagger with Spotify matches, despite offering incomplete metadata?