### PR TITLE
Add Spotify `candidates` and `item_candidates`

### DIFF
--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -106,7 +106,7 @@ class SpotifyPlugin(BeetsPlugin):
         :param params: (optional) list of tuples or bytes to send
             in the query string for the :class:`Request`.
         :type params: dict
-        :return: JSON data for the class:`Response <Response>` object
+        :return: JSON data for the class:`Response <Response>` object.
         :rtype: dict
         """
         response = request_type(
@@ -128,11 +128,11 @@ class SpotifyPlugin(BeetsPlugin):
     def _get_spotify_id(self, url_type, id_):
         """Parse a Spotify ID from its URL if necessary.
 
-        :param url_type: Type of Spotify URL, either 'album' or 'track'
+        :param url_type: Type of Spotify URL, either 'album' or 'track'.
         :type url_type: str
-        :param id_: Spotify ID or URL
+        :param id_: Spotify ID or URL.
         :type id_: str
-        :return: Spotify ID
+        :return: Spotify ID.
         :rtype: str
         """
         # Spotify IDs consist of 22 alphanumeric characters
@@ -314,16 +314,16 @@ class SpotifyPlugin(BeetsPlugin):
         """Returns a list of AlbumInfo objects for Spotify Search API results
         matching an ``album`` and ``artist`` (if not various).
 
-        :param items: List of items comprised by an album to be matched
+        :param items: List of items comprised by an album to be matched.
         :type items: list[beets.library.Item]
-        :param artist: The artist of the album to be matched
+        :param artist: The artist of the album to be matched.
         :type artist: str
-        :param album: The name of the album to be matched
+        :param album: The name of the album to be matched.
         :type album: str
         :param va_likely: True if the album to be matched likely has
-            Various Artists
+            Various Artists.
         :type va_likely: bool
-        :return: Candidate AlbumInfo objects
+        :return: Candidate AlbumInfo objects.
         :rtype: list[beets.autotag.hooks.AlbumInfo]
         """
         query_filters = {'album': album}
@@ -343,13 +343,13 @@ class SpotifyPlugin(BeetsPlugin):
         """Returns a list of TrackInfo objects for Spotify Search API results
         matching ``title`` and ``artist``.
 
-        :param item: Singleton item to be matched
+        :param item: Singleton item to be matched.
         :type item: beets.library.Item
-        :param artist: The artist of the track to be matched
+        :param artist: The artist of the track to be matched.
         :type artist: str
-        :param title: The title of the track to be matched
+        :param title: The title of the track to be matched.
         :type title: str
-        :return: Candidate TrackInfo objects
+        :return: Candidate TrackInfo objects.
         :rtype: list[beets.autotag.hooks.TrackInfo]
         """
         response_data = self._search_spotify(
@@ -366,14 +366,13 @@ class SpotifyPlugin(BeetsPlugin):
     def _construct_search_query(filters=None, keywords=''):
         """Construct a query string with the specified filters and keywords to
         be provided to the Spotify Search API
-        (https://developer.spotify.com/documentation/web-api/reference/search/search/).
+        (https://developer.spotify.com/documentation/web-api/reference/search/search/#writing-a-query---guidelines).
 
         :param filters: (Optional) Field filters to apply.
         :type filters: dict
         :param keywords: (Optional) Query keywords to use.
         :type keywords: str
-        :return: Search query string to be provided to the Search API
-            (https://developer.spotify.com/documentation/web-api/reference/search/search/#writing-a-query---guidelines)
+        :return: Query string to be provided to the Search API.
         :rtype: str
         """
         query_string = keywords
@@ -385,7 +384,7 @@ class SpotifyPlugin(BeetsPlugin):
 
     def _search_spotify(self, query_type, filters=None, keywords=''):
         """Query the Spotify Search API for the specified ``keywords``, applying
-        the provided filters.
+        the provided ``filters``.
 
         :param query_type: A comma-separated list of item types to search
             across. Valid types are: 'album', 'artist', 'playlist', and
@@ -397,7 +396,7 @@ class SpotifyPlugin(BeetsPlugin):
         :param keywords: (Optional) Query keywords to use.
         :type keywords: str
         :return: JSON data for the class:`Response <Response>` object or None
-            if no search results are returned
+            if no search results are returned.
         :rtype: dict or None
         """
         query = self._construct_search_query(

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -8,8 +8,9 @@ import base64
 import webbrowser
 import collections
 
-import requests
 import six
+import unidecode
+import requests
 
 from beets import ui
 from beets.plugins import BeetsPlugin
@@ -383,7 +384,7 @@ class SpotifyPlugin(BeetsPlugin):
         query = ' '.join([q for q in query_components if q])
         if not isinstance(query, six.text_type):
             query = query.decode('utf8')
-        return query
+        return unidecode.unidecode(query)
 
     def _search_spotify(self, query_type, filters=None, keywords=''):
         """Query the Spotify Search API for the specified ``keywords``, applying

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -120,7 +120,7 @@ class SpotifyPlugin(BeetsPlugin):
                     'Spotify access token has expired. Reauthenticating.'
                 )
                 self._authenticate()
-                self._handle_response(request_type, url, params=params)
+                return self._handle_response(request_type, url, params=params)
             else:
                 raise ui.UserError(u'Spotify API error:\n{}', response.text)
         return response.json()
@@ -374,12 +374,11 @@ class SpotifyPlugin(BeetsPlugin):
         :return: Query string to be provided to the Search API.
         :rtype: str
         """
-        query_string = keywords
-        if filters is not None:
-            query_string += ' ' + ' '.join(
-                ':'.join((k, v)) for k, v in filters.items()
-            )
-        return query_string
+        query_components = [
+            keywords,
+            ' '.join(':'.join((k, v)) for k, v in filters.items()),
+        ]
+        return ' '.join([s for s in query_components if s])
 
     def _search_spotify(self, query_type, filters=None, keywords=''):
         """Query the Spotify Search API for the specified ``keywords``, applying

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -151,7 +151,7 @@ class SpotifyPlugin(BeetsPlugin):
         :param album_id: Spotify ID or URL for the album
         :type album_id: str
         :return: AlbumInfo object for album
-        :rtype: beets.autotag.hooks.AlbumInfo
+        :rtype: beets.autotag.hooks.AlbumInfo or None
         """
         spotify_id = self._get_spotify_id('album', album_id)
         if spotify_id is None:
@@ -243,7 +243,7 @@ class SpotifyPlugin(BeetsPlugin):
             provided instead of ``track_id`` to avoid unnecessary API calls.
         :type track_data: dict
         :return: TrackInfo object for track
-        :rtype: beets.autotag.hooks.TrackInfo
+        :rtype: beets.autotag.hooks.TrackInfo or None
         """
         if track_data is None:
             spotify_id = self._get_spotify_id('track', track_id)

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -143,7 +143,7 @@ class SpotifyPlugin(BeetsPlugin):
         return match.group(2) if match else None
 
     def album_for_id(self, album_id):
-        """Fetches an album by its Spotify ID or URL and returns an
+        """Fetch an album by its Spotify ID or URL and return an
         AlbumInfo object or None if the album is not found.
 
         :param album_id: Spotify ID or URL for the album
@@ -177,7 +177,7 @@ class SpotifyPlugin(BeetsPlugin):
         else:
             raise ui.UserError(
                 u"Invalid `release_date_precision` returned "
-                u"from Spotify API: '{}'".format(release_date_precision)
+                u"by Spotify API: '{}'".format(release_date_precision)
             )
 
         tracks = []
@@ -231,7 +231,7 @@ class SpotifyPlugin(BeetsPlugin):
         )
 
     def track_for_id(self, track_id=None, track_data=None):
-        """Fetches a track by its Spotify ID or URL and returns a
+        """Fetch a track by its Spotify ID or URL and return a
         TrackInfo object or None if the track is not found.
 
         :param track_id: (Optional) Spotify ID or URL for the track. Either
@@ -252,8 +252,9 @@ class SpotifyPlugin(BeetsPlugin):
             )
         track = self._get_track(track_data)
 
-        # get album's tracks to set the track's index/position on
-        # the entire release
+        # Get album's tracks to set `track.index` (position on the entire
+        # release) and `track.medium_total` (total number of tracks on
+        # the track's disc).
         album_data = self._handle_response(
             requests.get, self.album_url + track_data['album']['id']
         )
@@ -378,7 +379,7 @@ class SpotifyPlugin(BeetsPlugin):
             keywords,
             ' '.join(':'.join((k, v)) for k, v in filters.items()),
         ]
-        return ' '.join([s for s in query_components if s])
+        return ' '.join([q for q in query_components if q])
 
     def _search_spotify(self, query_type, filters=None, keywords=''):
         """Query the Spotify Search API for the specified ``keywords``, applying
@@ -402,7 +403,9 @@ class SpotifyPlugin(BeetsPlugin):
         )
         if not query:
             return None
-        self._log.debug(u'Searching Spotify for "{}"'.format(query))
+        self._log.debug(
+            u'Searching Spotify for "{}"'.format(query.decode('utf8'))
+        )
         response_data = self._handle_response(
             requests.get,
             self.search_url,
@@ -458,8 +461,7 @@ class SpotifyPlugin(BeetsPlugin):
         return True
 
     def _match_library_tracks(self, library, keywords):
-        """
-        Get a list of simplified track objects dicts for library tracks
+        """Get a list of simplified track object dicts for library tracks
         matching the specified ``keywords``.
 
         :param library: beets library object to query.
@@ -564,8 +566,7 @@ class SpotifyPlugin(BeetsPlugin):
         return results
 
     def _output_match_results(self, results):
-        """
-        Open a playlist or print Spotify URLs for the provided track
+        """Open a playlist or print Spotify URLs for the provided track
         object dicts.
 
         :param results: List of simplified track object dicts

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -370,8 +370,9 @@ class SpotifyPlugin(BeetsPlugin):
         :param filters: (Optional) Field filters to apply.
         :type filters: dict
         :param keywords: (Optional) Query keywords to use.
-        :return: JSON data for the class:`Response <Response>` object
-        :rtype: dict
+        :return: JSON data for the class:`Response <Response>` object or None
+            if no search results are returned
+        :rtype: dict or None
         """
         query = self._construct_search_query(
             keywords=keywords, filters=filters

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -320,6 +320,8 @@ class SpotifyPlugin(BeetsPlugin):
         response_data = self._search_spotify(
             query_type='album', filters=query_filters
         )
+        if response_data is None:
+            return []
         return [
             self.album_for_id(album_id=album_data['id'])
             for album_data in response_data['albums']['items']
@@ -332,6 +334,8 @@ class SpotifyPlugin(BeetsPlugin):
         response_data = self._search_spotify(
             query_type='track', keywords=title, filters={'artist': artist}
         )
+        if response_data is None:
+            return []
         return [
             self.track_for_id(track_data=track_data)
             for track_data in response_data['tracks']['items']
@@ -469,7 +473,7 @@ class SpotifyPlugin(BeetsPlugin):
             keywords = item[self.config['track_field'].get()]
 
             # Query the Web API for each track, look for the items' JSON data
-            query_filters = {'artist': artist, 'album': album}
+            query_filters = {'album': album, 'artist': artist}
             response_data = self._search_spotify(
                 query_type='track', keywords=keywords, filters=query_filters
             )

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -311,7 +311,7 @@ class SpotifyPlugin(BeetsPlugin):
         return dist
 
     def candidates(self, items, artist, album, va_likely):
-        """Returns a list of AlbumInfo objects for Spotify Search results
+        """Returns a list of AlbumInfo objects for Spotify Search API results
         matching an ``album`` and ``artist`` (if not various).
         """
         query_filters = {'album': album}
@@ -326,7 +326,7 @@ class SpotifyPlugin(BeetsPlugin):
         ]
 
     def item_candidates(self, item, artist, title):
-        """Returns a list of TrackInfo objects for Spotify Search results
+        """Returns a list of TrackInfo objects for Spotify Search API results
         matching ``title`` and ``artist``.
         """
         response_data = self._search_spotify(

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -313,14 +313,15 @@ class SpotifyPlugin(BeetsPlugin):
     def candidates(self, items, artist, album, va_likely):
         """Returns a list of AlbumInfo objects for Spotify Search API results
         matching an ``album`` and ``artist`` (if not various).
-        
-        :param items: List of tracks on the candidate album
+
+        :param items: List of items comprised by an album to be matched
         :type items: list[beets.library.Item]
-        :param artist: The of the candidate album
+        :param artist: The artist of the album to be matched
         :type artist: str
-        :param album: The name of the candidate album
+        :param album: The name of the album to be matched
         :type album: str
-        :param va_likely: True if the candidate album likely has Various Artists
+        :param va_likely: True if the album to be matched likely has
+            Various Artists
         :type va_likely: bool
         :return: Candidate AlbumInfo objects
         :rtype: list[beets.autotag.hooks.AlbumInfo]
@@ -342,11 +343,11 @@ class SpotifyPlugin(BeetsPlugin):
         """Returns a list of TrackInfo objects for Spotify Search API results
         matching ``title`` and ``artist``.
 
-        :param item: Candidate track
+        :param item: Singleton item to be matched
         :type item: beets.library.Item
-        :param artist: The artist of the candidate track
+        :param artist: The artist of the track to be matched
         :type artist: str
-        :param title: The title of the candidate track
+        :param title: The title of the track to be matched
         :type title: str
         :return: Candidate TrackInfo objects
         :rtype: list[beets.autotag.hooks.TrackInfo]

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -255,11 +255,11 @@ class SpotifyPlugin(BeetsPlugin):
 
         # get album's tracks to set the track's index/position on
         # the entire release
-        response_data_album = self._handle_response(
+        album_data = self._handle_response(
             requests.get, self.album_url + track_data['album']['id']
         )
         medium_total = 0
-        for i, track_data in enumerate(response_data_album['tracks']['items']):
+        for i, track_data in enumerate(album_data['tracks']['items']):
             if track_data['disc_number'] == track.medium:
                 medium_total += 1
                 if track_data['id'] == spotify_id:
@@ -473,7 +473,7 @@ class SpotifyPlugin(BeetsPlugin):
             keywords = item[self.config['track_field'].get()]
 
             # Query the Web API for each track, look for the items' JSON data
-            query_filters = {'album': album, 'artist': artist}
+            query_filters = {'artist': artist, 'album': album}
             response_data = self._search_spotify(
                 query_type='track', keywords=keywords, filters=query_filters
             )

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -243,11 +243,10 @@ class SpotifyPlugin(BeetsPlugin):
         :return: TrackInfo object for track
         :rtype: beets.autotag.hooks.TrackInfo
         """
-        spotify_id = self._get_spotify_id('track', track_id)
-        if spotify_id is None:
-            return None
-
         if track_data is None:
+            spotify_id = self._get_spotify_id('track', track_id)
+            if spotify_id is None:
+                return None
             track_data = self._handle_response(
                 requests.get, self.track_url + spotify_id
             )

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -462,7 +462,7 @@ class SpotifyPlugin(BeetsPlugin):
         """
         Get a list of simplified track objects dicts for library tracks
         matching the specified ``keywords``.
-        
+
         :param library: beets library object to query.
         :type library: beets.library.Library
         :param keywords: Query to match library items against.
@@ -566,7 +566,8 @@ class SpotifyPlugin(BeetsPlugin):
 
     def _output_match_results(self, results):
         """
-        Open a playlist or print Spotify URLs for the provided track object dicts.
+        Open a playlist or print Spotify URLs for the provided track
+        object dicts.
 
         :param results: List of simplified track object dicts
             (https://developer.spotify.com/documentation/web-api/reference/object-model/#track-object-simplified)

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -313,6 +313,17 @@ class SpotifyPlugin(BeetsPlugin):
     def candidates(self, items, artist, album, va_likely):
         """Returns a list of AlbumInfo objects for Spotify Search API results
         matching an ``album`` and ``artist`` (if not various).
+        
+        :param items: List of tracks on the candidate album
+        :type items: list[beets.library.Item]
+        :param artist: The of the candidate album
+        :type artist: str
+        :param album: The name of the candidate album
+        :type album: str
+        :param va_likely: True if the candidate album likely has Various Artists
+        :type va_likely: bool
+        :return: Candidate AlbumInfo objects
+        :rtype: list[beets.autotag.hooks.AlbumInfo]
         """
         query_filters = {'album': album}
         if not va_likely:
@@ -330,6 +341,15 @@ class SpotifyPlugin(BeetsPlugin):
     def item_candidates(self, item, artist, title):
         """Returns a list of TrackInfo objects for Spotify Search API results
         matching ``title`` and ``artist``.
+
+        :param item: Candidate track
+        :type item: beets.library.Item
+        :param artist: The artist of the candidate track
+        :type artist: str
+        :param title: The title of the candidate track
+        :type title: str
+        :return: Candidate TrackInfo objects
+        :rtype: list[beets.autotag.hooks.TrackInfo]
         """
         response_data = self._search_spotify(
             query_type='track', keywords=title, filters={'artist': artist}
@@ -374,6 +394,7 @@ class SpotifyPlugin(BeetsPlugin):
         :param filters: (Optional) Field filters to apply.
         :type filters: dict
         :param keywords: (Optional) Query keywords to use.
+        :type keywords: str
         :return: JSON data for the class:`Response <Response>` object or None
             if no search results are returned
         :rtype: dict or None

--- a/test/test_spotify.py
+++ b/test/test_spotify.py
@@ -47,19 +47,19 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
         )
         self.spotify = spotify.SpotifyPlugin()
         opts = ArgumentsMock("list", False)
-        self.spotify.parse_opts(opts)
+        self.spotify._parse_opts(opts)
 
     def tearDown(self):
         self.teardown_beets()
 
     def test_args(self):
         opts = ArgumentsMock("fail", True)
-        self.assertEqual(False, self.spotify.parse_opts(opts))
+        self.assertEqual(False, self.spotify._parse_opts(opts))
         opts = ArgumentsMock("list", False)
-        self.assertEqual(True, self.spotify.parse_opts(opts))
+        self.assertEqual(True, self.spotify._parse_opts(opts))
 
     def test_empty_query(self):
-        self.assertEqual(None, self.spotify.query_spotify(self.lib, u"1=2"))
+        self.assertEqual(None, self.spotify._query_spotify(self.lib, u"1=2"))
 
     @responses.activate
     def test_missing_request(self):
@@ -84,7 +84,7 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
             length=10,
         )
         item.add(self.lib)
-        self.assertEqual([], self.spotify.query_spotify(self.lib, u""))
+        self.assertEqual([], self.spotify._query_spotify(self.lib, u""))
 
         params = _params(responses.calls[0].request.url)
         self.assertEqual(
@@ -116,10 +116,10 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
             length=10,
         )
         item.add(self.lib)
-        results = self.spotify.query_spotify(self.lib, u"Happy")
+        results = self.spotify._query_spotify(self.lib, u"Happy")
         self.assertEqual(1, len(results))
         self.assertEqual(u"6NPVjNh8Jhru9xOmyQigds", results[0]['id'])
-        self.spotify.output_results(results)
+        self.spotify._output_results(results)
 
         params = _params(responses.calls[0].request.url)
         self.assertEqual(

--- a/test/test_spotify.py
+++ b/test/test_spotify.py
@@ -59,7 +59,9 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
         self.assertEqual(True, self.spotify._parse_opts(opts))
 
     def test_empty_query(self):
-        self.assertEqual(None, self.spotify._match_library_tracks(self.lib, u"1=2"))
+        self.assertEqual(
+            None, self.spotify._match_library_tracks(self.lib, u"1=2")
+        )
 
     @responses.activate
     def test_missing_request(self):

--- a/test/test_spotify.py
+++ b/test/test_spotify.py
@@ -59,7 +59,7 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
         self.assertEqual(True, self.spotify._parse_opts(opts))
 
     def test_empty_query(self):
-        self.assertEqual(None, self.spotify._query_spotify(self.lib, u"1=2"))
+        self.assertEqual(None, self.spotify._match_library_tracks(self.lib, u"1=2"))
 
     @responses.activate
     def test_missing_request(self):
@@ -84,7 +84,7 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
             length=10,
         )
         item.add(self.lib)
-        self.assertEqual([], self.spotify._query_spotify(self.lib, u""))
+        self.assertEqual([], self.spotify._match_library_tracks(self.lib, u""))
 
         params = _params(responses.calls[0].request.url)
         query = params['q'][0]
@@ -116,10 +116,10 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
             length=10,
         )
         item.add(self.lib)
-        results = self.spotify._query_spotify(self.lib, u"Happy")
+        results = self.spotify._match_library_tracks(self.lib, u"Happy")
         self.assertEqual(1, len(results))
         self.assertEqual(u"6NPVjNh8Jhru9xOmyQigds", results[0]['id'])
-        self.spotify._output_results(results)
+        self.spotify._output_match_results(results)
 
         params = _params(responses.calls[0].request.url)
         query = params['q'][0]

--- a/test/test_spotify.py
+++ b/test/test_spotify.py
@@ -122,10 +122,10 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
         self.spotify._output_results(results)
 
         params = _params(responses.calls[0].request.url)
-        self.assertEqual(
-            params['q'],
-            [u'Happy artist:Pharrell Williams album:Despicable Me 2'],
-        )
+        query = params['q']
+        self.assertIn(u'Happy', query)
+        self.assertIn(u'artist:Pharrell Williams', query)
+        self.assertIn(u'album:Despicable Me 2', query)
         self.assertEqual(params['type'], [u'track'])
 
 

--- a/test/test_spotify.py
+++ b/test/test_spotify.py
@@ -87,10 +87,10 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
         self.assertEqual([], self.spotify._query_spotify(self.lib, u""))
 
         params = _params(responses.calls[0].request.url)
-        self.assertEqual(
-            params['q'],
-            [u'duifhjslkef artist:ujydfsuihse album:lkajsdflakjsd'],
-        )
+        query = params['q'][0]
+        self.assertIn(u'duifhjslkef', query)
+        self.assertIn(u'artist:ujydfsuihse', query)
+        self.assertIn(u'album:lkajsdflakjsd', query)
         self.assertEqual(params['type'], [u'track'])
 
     @responses.activate

--- a/test/test_spotify.py
+++ b/test/test_spotify.py
@@ -122,7 +122,7 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
         self.spotify._output_results(results)
 
         params = _params(responses.calls[0].request.url)
-        query = params['q']
+        query = params['q'][0]
         self.assertIn(u'Happy', query)
         self.assertIn(u'artist:Pharrell Williams', query)
         self.assertIn(u'album:Despicable Me 2', query)

--- a/test/test_spotify.py
+++ b/test/test_spotify.py
@@ -89,7 +89,7 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
         params = _params(responses.calls[0].request.url)
         self.assertEqual(
             params['q'],
-            [u'duifhjslkef album:lkajsdflakjsd artist:ujydfsuihse'],
+            [u'duifhjslkef artist:ujydfsuihse album:lkajsdflakjsd'],
         )
         self.assertEqual(params['type'], [u'track'])
 

--- a/test/test_spotify.py
+++ b/test/test_spotify.py
@@ -124,7 +124,7 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
         params = _params(responses.calls[0].request.url)
         self.assertEqual(
             params['q'],
-            [u'Happy album:Despicable Me 2 artist:Pharrell Williams'],
+            [u'Happy artist:Pharrell Williams album:Despicable Me 2'],
         )
         self.assertEqual(params['type'], [u'track'])
 


### PR DESCRIPTION
I realized I'd forgotten to implement the `candidates` and `item_candidates` functions in https://github.com/beetbox/beets/pull/3123 for the Spotify plugin, which I assume are used by the importer to identify potential matches when not provided manually. I'm using the Spotify Search API to retrieve these candidates, and have modularized that logic to make this easier to implement.

I noticed that the Beatport and Discogs plugins don't use any of the passed `Item` attributes when determining potential matches. Is this recommended behavior if that data can't be meaningfully used to refine the API queries?