### PR TITLE
Set Spotify AlbumInfo.mediums

### DIFF
--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -72,8 +72,8 @@ class AlbumInfo(object):
     - ``data_source``: The original data source (MusicBrainz, Discogs, etc.)
     - ``data_url``: The data source release URL.
 
-    The fields up through ``tracks`` are required. The others are
-    optional and may be None.
+    ``mediums`` along with the fields up through ``tracks`` are required.
+    The others are optional and may be None.
     """
     def __init__(self, album, album_id, artist, artist_id, tracks, asin=None,
                  albumtype=None, va=False, year=None, month=None, day=None,

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -205,6 +205,7 @@ class SpotifyPlugin(BeetsPlugin):
             month=month,
             day=day,
             label=response_data['label'],
+            mediums=max(medium_totals.keys()),
             data_source='Spotify',
             data_url=response_data['external_urls']['spotify'],
         )
@@ -286,8 +287,6 @@ class SpotifyPlugin(BeetsPlugin):
             if not artist_id:
                 artist_id = artist['id']
             name = artist['name']
-            # Strip disambiguation number.
-            name = re.sub(r' \(\d+\)$', '', name)
             # Move articles to the front.
             name = re.sub(r'^(.*?), (a|an|the)$', r'\2 \1', name, flags=re.I)
             artist_names.append(name)


### PR DESCRIPTION
Set `AlbumInfo.mediums` in the Spotify plugin's `candidates` function to address:
```
Correcting tags from:
    Progressive Collection, Vol. 8
To:
    Progressive Collection, Vol. 8
URL:
    https://open.spotify.com/album/6IJPzMcrOsZfKGncwTKIKB
(Similarity: 83.4%) (tracks, source) (Spotify, 2016, Forward Music)
Traceback (most recent call last):
  File "/usr/local/bin/beet", line 11, in <module>
    load_entry_point('beets', 'console_scripts', 'beet')()
  File "/Users/rahulahuja/git/beetbox/beets/beets/ui/__init__.py", line 1262, in main
    _raw_main(args)
  File "/Users/rahulahuja/git/beetbox/beets/beets/ui/__init__.py", line 1249, in _raw_main
    subcommand.func(lib, suboptions, subargs)
  File "/Users/rahulahuja/git/beetbox/beets/beets/ui/commands.py", line 955, in import_func
    import_files(lib, paths, query)
  File "/Users/rahulahuja/git/beetbox/beets/beets/ui/commands.py", line 925, in import_files
    session.run()
  File "/Users/rahulahuja/git/beetbox/beets/beets/importer.py", line 329, in run
    pl.run_parallel(QUEUE_SIZE)
  File "/Users/rahulahuja/git/beetbox/beets/beets/util/pipeline.py", line 445, in run_parallel
    six.reraise(exc_info[0], exc_info[1], exc_info[2])
  File "/usr/local/lib/python3.7/site-packages/six.py", line 693, in reraise
    raise value
  File "/Users/rahulahuja/git/beetbox/beets/beets/util/pipeline.py", line 312, in run
    out = self.coro.send(msg)
  File "/Users/rahulahuja/git/beetbox/beets/beets/util/pipeline.py", line 171, in coro
    task = func(*(args + (task,)))
  File "/Users/rahulahuja/git/beetbox/beets/beets/importer.py", line 1375, in user_query
    task.choose_match(session)
  File "/Users/rahulahuja/git/beetbox/beets/beets/importer.py", line 838, in choose_match
    choice = session.choose_match(self)
  File "/Users/rahulahuja/git/beetbox/beets/beets/ui/commands.py", line 714, in choose_match
    task.cur_album, itemcount=len(task.items), choices=choices
  File "/Users/rahulahuja/git/beetbox/beets/beets/ui/commands.py", line 615, in choose_candidate
    show_change(cur_artist, cur_album, match)
  File "/Users/rahulahuja/git/beetbox/beets/beets/ui/commands.py", line 304, in show_change
    if match.info.mediums > 1 and track_info.disctitle:
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```
I've also adjusted the `AlbumInfo` docstring to reflect that `mediums` is a required field, which is what that error seems to imply. Is this accurate? I probably should've caught this during testing my last PR btw :sweat_smile:. But the good news is that with this bugfix, `beet import` / Spotify Search API has been autotagging my music flawlessly!