### PR TITLE
Support ipfs add --nocopy in ipfs plugin

### DIFF
--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -32,6 +32,7 @@ class IPFSPlugin(BeetsPlugin):
         super(IPFSPlugin, self).__init__()
         self.config.add({
             'auto': True,
+            'nocopy': False,
         })
 
         if self.config['auto']:
@@ -116,7 +117,10 @@ class IPFSPlugin(BeetsPlugin):
 
         self._log.info('Adding {0} to ipfs', album_dir)
 
-        cmd = "ipfs add -q -r".split()
+        if self.config['nocopy']:
+            cmd = "ipfs add --nocopy -q -r".split()
+        else:
+            cmd = "ipfs add -q -r".split()
         cmd.append(album_dir)
         try:
             output = util.command_output(cmd).split()
@@ -174,7 +178,10 @@ class IPFSPlugin(BeetsPlugin):
         with tempfile.NamedTemporaryFile() as tmp:
             self.ipfs_added_albums(lib, tmp.name)
             try:
-                cmd = "ipfs add -q ".split()
+                if self.config['nocopy']:
+                    cmd = "ipfs add --nocopy -q ".split()
+                else:
+                    cmd = "ipfs add -q ".split()
                 cmd.append(tmp.name)
                 output = util.command_output(cmd)
             except (OSError, subprocess.CalledProcessError) as err:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -64,7 +64,7 @@ New features:
   Thanks to :user:`rhlahuja`.
   :bug:`3123`
 * :doc:`/plugins/ipfs`: The plugin now supports a ``nocopy`` option which passes that flag to ipfs.
-  THanks to :user:`wildthyme`.
+  Thanks to :user:`wildthyme`.
 
 
 Changes:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -63,6 +63,8 @@ New features:
   provider: you can match tracks and albums using the Spotify database.
   Thanks to :user:`rhlahuja`.
   :bug:`3123`
+* :doc:`/plugins/ipfs`: The plugin now supports a ``nocopy`` option which passes that flag to ipfs.
+  THanks to :user:`wildthyme`.
 
 
 Changes:

--- a/docs/plugins/ipfs.rst
+++ b/docs/plugins/ipfs.rst
@@ -70,3 +70,5 @@ Configuration
 The ipfs plugin will automatically add imported albums to ipfs and add those
 hashes to the database. This can be turned off by setting the ``auto`` option
 in the ``ipfs:`` section of the config to ``no``.
+
+If the setting ``nocopy`` is true (defaults false) then the plugin will pass the ``--nocopy`` option when adding things to ipfs. If the filestore option of ipfs is enabled this will mean files are neither removed from beets nor copied somewhere else.


### PR DESCRIPTION
This is a very minor change, but previously the ipfs plugin was making a separate copy of every file added. I left the default behaviour the same because using this requires setting an additional option in ipfs proper.