### PR TITLE
Fix linter issues

### DIFF
--- a/beets/art.py
+++ b/beets/art.py
@@ -60,8 +60,8 @@ def embed_item(log, item, imagepath, maxwidth=None, itempath=None,
             log.info(u'Image not similar; skipping.')
             return
     if ifempty and get_art(log, item):
-            log.info(u'media file already contained art')
-            return
+        log.info(u'media file already contained art')
+        return
     if maxwidth and not as_album:
         imagepath = resize_image(log, imagepath, maxwidth)
 

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -286,7 +286,7 @@ class DiscogsPlugin(BeetsPlugin):
         if va:
             artist = config['va_name'].as_str()
         if catalogno == 'none':
-                catalogno = None
+            catalogno = None
         # Explicitly set the `media` for the tracks, since it is expected by
         # `autotag.apply_metadata`, and set `medium_total`.
         for track in tracks:

--- a/beetsplug/filefilter.py
+++ b/beetsplug/filefilter.py
@@ -43,8 +43,8 @@ class FileFilterPlugin(BeetsPlugin):
                 bytestring_path(self.config['album_path'].get()))
 
         if 'singleton_path' in self.config:
-                self.path_singleton_regex = re.compile(
-                    bytestring_path(self.config['singleton_path'].get()))
+            self.path_singleton_regex = re.compile(
+                bytestring_path(self.config['singleton_path'].get()))
 
     def import_task_created_event(self, session, task):
         if task.items and len(task.items) > 0:

--- a/beetsplug/hook.py
+++ b/beetsplug/hook.py
@@ -91,28 +91,28 @@ class HookPlugin(BeetsPlugin):
 
     def create_and_register_hook(self, event, command):
         def hook_function(**kwargs):
-                if command is None or len(command) == 0:
-                    self._log.error('invalid command "{0}"', command)
-                    return
+            if command is None or len(command) == 0:
+                self._log.error('invalid command "{0}"', command)
+                return
 
-                # Use a string formatter that works on Unicode strings.
-                if six.PY2:
-                    formatter = CodingFormatter(arg_encoding())
-                else:
-                    formatter = string.Formatter()
+            # Use a string formatter that works on Unicode strings.
+            if six.PY2:
+                formatter = CodingFormatter(arg_encoding())
+            else:
+                formatter = string.Formatter()
 
-                command_pieces = shlex_split(command)
+            command_pieces = shlex_split(command)
 
-                for i, piece in enumerate(command_pieces):
-                    command_pieces[i] = formatter.format(piece, event=event,
-                                                         **kwargs)
+            for i, piece in enumerate(command_pieces):
+                command_pieces[i] = formatter.format(piece, event=event,
+                                                     **kwargs)
 
-                self._log.debug(u'running command "{0}" for event {1}',
-                                u' '.join(command_pieces), event)
+            self._log.debug(u'running command "{0}" for event {1}',
+                            u' '.join(command_pieces), event)
 
-                try:
-                    subprocess.Popen(command_pieces).wait()
-                except OSError as exc:
-                    self._log.error(u'hook for {0} failed: {1}', event, exc)
+            try:
+                subprocess.Popen(command_pieces).wait()
+            except OSError as exc:
+                self._log.error(u'hook for {0} failed: {1}', event, exc)
 
         self.register_listener(event, hook_function)

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -935,10 +935,10 @@ class ReplayGainPlugin(BeetsPlugin):
 
         if (any([self.should_use_r128(item) for item in album.items()]) and not
                 all(([self.should_use_r128(item) for item in album.items()]))):
-                raise ReplayGainError(
-                    u"Mix of ReplayGain and EBU R128 detected"
-                    u" for some tracks in album {0}".format(album)
-                )
+            raise ReplayGainError(
+                u"Mix of ReplayGain and EBU R128 detected"
+                u" for some tracks in album {0}".format(album)
+            )
 
         if any([self.should_use_r128(item) for item in album.items()]):
             if self.r128_backend_instance == '':

--- a/beetsplug/subsonicupdate.py
+++ b/beetsplug/subsonicupdate.py
@@ -78,7 +78,7 @@ class SubsonicUpdate(BeetsPlugin):
             'v': '1.15.0',  # Subsonic 6.1 and newer.
             'c': 'beets'
         }
-        if contextpath is '/':
+        if contextpath == '/':
             contextpath = ''
         url = "http://{}:{}{}/rest/startScan".format(host, port, contextpath)
         response = requests.post(url, params=payload)

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps =
     flake8-coding
     flake8-future-import
     flake8-blind-except
-    pep8-naming
+    pep8-naming~=0.7.0
 files = beets beetsplug beet test setup.py docs
 
 [testenv]


### PR DESCRIPTION
As it turns out, there _is_ a whole bunch of crazy indentation in our code! No idea how it got there and how it wasn't caught before, but I've fixed the few places where the indentation was wrong.

I also changed the `is` comparison to be a `==` check, as we shouldn't be using `is` to compare strings.

And finally, I've locked `pep8-naming` to `0.7.x` so we can avoid the weird bugs that are in that version.