### PR TITLE
Abort quickly on user request

### DIFF
--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -389,7 +389,7 @@ def _add_candidate(items, results, info):
 
 
 def tag_album(items, search_artist=None, search_album=None,
-              search_ids=[]):
+              search_ids=[], cancellable=None):
     """Return a tuple of the current artist name, the current album
     name, and a `Proposal` containing `AlbumMatch` candidates.
 
@@ -459,6 +459,9 @@ def tag_album(items, search_artist=None, search_album=None,
                                                         search_album,
                                                         va_likely):
             _add_candidate(items, candidates, matched_candidate)
+            if cancellable and cancellable.cancelled():
+                log.debug(u'Got cancellation flag. Aborting')
+                break
 
     log.debug(u'Evaluating {0} candidates.', len(candidates))
     # Sort and get the recommendation.
@@ -468,7 +471,7 @@ def tag_album(items, search_artist=None, search_album=None,
 
 
 def tag_item(item, search_artist=None, search_title=None,
-             search_ids=[]):
+             search_ids=[], cancellable=None):
     """Find metadata for a single track. Return a `Proposal` consisting
     of `TrackMatch` objects.
 
@@ -496,6 +499,9 @@ def tag_item(item, search_artist=None, search_title=None,
                         not config['import']['timid']:
                     log.debug(u'Track ID match.')
                     return Proposal(_sort_candidates(candidates.values()), rec)
+                if cancellable and cancellable.cancelled():
+                    log.debug(u'Got cancellation flag.')
+                    break
 
     # If we're searching by ID, don't proceed.
     if search_ids:

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -638,13 +638,14 @@ class ImportTask(BaseImportTask):
             tasks = [t for inner in tasks for t in inner]
         return tasks
 
-    def lookup_candidates(self):
+    def lookup_candidates(self, session):
         """Retrieve and store candidates for this album. User-specified
         candidate IDs are stored in self.search_ids: if present, the
         initial lookup is restricted to only those IDs.
         """
         artist, album, prop = \
-            autotag.tag_album(self.items, search_ids=self.search_ids)
+            autotag.tag_album(self.items, search_ids=self.search_ids,
+                              cancellable=session.cancellable)
         self.cur_artist = artist
         self.cur_album = album
         self.candidates = prop.candidates
@@ -894,8 +895,9 @@ class SingletonImportTask(ImportTask):
         for item in self.imported_items():
             plugins.send('item_imported', lib=lib, item=item)
 
-    def lookup_candidates(self):
-        prop = autotag.tag_item(self.item, search_ids=self.search_ids)
+    def lookup_candidates(self, session):
+        prop = autotag.tag_item(self.item, search_ids=self.search_ids,
+                                cancellable=session.cancellable)
         self.candidates = prop.candidates
         self.rec = prop.recommendation
 
@@ -1354,7 +1356,7 @@ def lookup_candidates(session, task):
     # option. Currently all the IDs are passed onto the tasks directly.
     task.search_ids = session.config['search_ids'].as_str_seq()
 
-    task.lookup_candidates()
+    task.lookup_candidates(session)
 
 
 @pipeline.stage

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -677,7 +677,7 @@ def manual_id(session, task):
 def abort_action(session, task):
     """A prompt choice callback that aborts the importer.
     """
-    raise importer.ImportAbort()
+    session.abort()
 
 
 class TerminalImportSession(importer.ImportSession):

--- a/beets/util/pipeline.py
+++ b/beets/util/pipeline.py
@@ -45,6 +45,23 @@ POISON = '__PIPELINE_POISON__'
 DEFAULT_QUEUE_SIZE = 16
 
 
+class Cancellable(object):
+    """For sharing a 'cancelled' state between objects and threads."""
+    def __init__(self):
+        self.flag = False
+        self.lock = Lock()
+
+    def cancel(self):
+        """Mark as cancelled."""
+        with self.lock:
+            self.flag = True
+
+    def cancelled(self):
+        """Returns False if work should continue, True if work should stop."""
+        with self.lock:
+            return self.flag
+
+
 def _invalidate_queue(q, val=None, sync=True):
     """Breaks a Queue such that it never blocks, always has size 1,
     and has no maximum size. get()ing from the queue returns `val`,

--- a/beets/util/pipeline.py
+++ b/beets/util/pipeline.py
@@ -405,7 +405,7 @@ class Pipeline(object):
         """
         list(self.pull())
 
-    def run_parallel(self, queue_size=DEFAULT_QUEUE_SIZE):
+    def run_parallel(self, queue_size=DEFAULT_QUEUE_SIZE, cancellable=None):
         """Run the pipeline in parallel using one thread per stage. The
         messages between the stages are stored in queues of the given
         size.
@@ -443,6 +443,10 @@ class Pipeline(object):
                 threads[-1].join(1)
 
         except BaseException:
+            # Set flag for running task functions to abort as soon as possible.
+            if cancellable is not None:
+                cancellable.cancel()
+
             # Stop all the threads immediately.
             for thread in threads:
                 thread.abort()

--- a/beetsplug/chroma.py
+++ b/beetsplug/chroma.py
@@ -250,6 +250,10 @@ def fingerprint_task(log, task, session):
     for item in items:
         acoustid_match(log, item.path)
 
+        if session.cancellable.cancelled():
+            log.debug("chroma: import session cancelled, stopping")
+            return
+
 
 def apply_acoustid_metadata(task, session):
     """Apply Acoustid metadata (fingerprint and ID) to the task's items.

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1948,6 +1948,8 @@ class ImportMusicBrainzIdTest(_common.TestCase, ImportHelper):
 
     def test_candidates_album(self):
         """Test directly ImportTask.lookup_candidates()."""
+        self._setup_import_session()
+
         task = importer.ImportTask(paths=self.import_dir,
                                    toppath='top path',
                                    items=[_common.item()])
@@ -1955,19 +1957,21 @@ class ImportMusicBrainzIdTest(_common.TestCase, ImportHelper):
                            self.MB_RELEASE_PREFIX + self.ID_RELEASE_1,
                            'an invalid and discarded id']
 
-        task.lookup_candidates()
+        task.lookup_candidates(self.importer)
         self.assertEqual(set(['VALID_RELEASE_0', 'VALID_RELEASE_1']),
                          set([c.info.album for c in task.candidates]))
 
     def test_candidates_singleton(self):
         """Test directly SingletonImportTask.lookup_candidates()."""
+        self._setup_import_session()
+
         task = importer.SingletonImportTask(toppath='top path',
                                             item=_common.item())
         task.search_ids = [self.MB_RECORDING_PREFIX + self.ID_RECORDING_0,
                            self.MB_RECORDING_PREFIX + self.ID_RECORDING_1,
                            'an invalid and discarded id']
 
-        task.lookup_candidates()
+        task.lookup_candidates(self.importer)
         self.assertEqual(set(['VALID_RECORDING_0', 'VALID_RECORDING_1']),
                          set([c.info.title for c in task.candidates]))
 


### PR DESCRIPTION
First attempt at fixing https://github.com/beetbox/beets/issues/3139

This branch greatly reduces the delay when I tell Beets to abort. It's not perfect, but it's survived my testing so far.

I haven't added any automated tests for this functionality. It's not immediately obvious how best to do that.