### PR TITLE
Playlist plugin

### DIFF
--- a/beetsplug/playlist.py
+++ b/beetsplug/playlist.py
@@ -67,8 +67,7 @@ class PlaylistQuery(beets.dbcore.FieldQuery):
         if not self.paths:
             # Playlist is empty
             return '0', ()
-        clause  = 'BYTELOWER(path) IN ({0})'.format(
-            ', '.join('BYTELOWER(?)' for path in self.paths))
+        clause  = 'path IN ({0})'.format(', '.join('?' for path in self.paths))
         return clause, (beets.library.BLOB_TYPE(p) for p in self.paths)
 
     def match(self, item):

--- a/beetsplug/playlist.py
+++ b/beetsplug/playlist.py
@@ -41,7 +41,7 @@ class PlaylistQuery(beets.dbcore.FieldQuery):
 
             try:
                 f = open(beets.util.syspath(playlist_path), mode='rb')
-            except OSError:
+            except (OSError, IOError):
                 continue
 
             if config['relative_to'].get() == 'library':

--- a/beetsplug/playlist.py
+++ b/beetsplug/playlist.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+# This file is part of beets.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+import os
+import beets
+
+
+class PlaylistQuery(beets.dbcore.FieldQuery):
+    """Matches files listed by a playlist file.
+    """
+    def __init__(self, field, pattern, fast=False):
+        super(PlaylistQuery, self).__init__(field, pattern, fast)
+        config = beets.config['playlist']
+
+        # Get the full path to the playlist
+        if os.path.isabs(beets.util.syspath(pattern)):
+            playlist_path = pattern
+        else:
+            playlist_path = os.path.abspath(os.path.join(
+                config['playlist_dir'].as_filename(),
+                '{0}.m3u'.format(pattern),
+            ))
+
+        if config['relative_to'].get() == 'library':
+            relative_to = beets.config['directory'].as_filename()
+        elif config['relative_to'].get() == 'playlist':
+            relative_to = os.path.dirname(playlist_path)
+        else:
+            relative_to = config['relative_to'].as_filename()
+        relative_to = beets.util.bytestring_path(relative_to)
+
+        self.paths = []
+        with open(beets.util.syspath(playlist_path), 'rb') as f:
+            for line in f:
+                if line[0] == '#':
+                    # ignore comments, and extm3u extension
+                    continue
+
+                self.paths.append(beets.util.normpath(
+                    os.path.join(relative_to, line.rstrip())
+                ))
+
+    def match(self, item):
+        return item.path in self.paths
+
+
+class PlaylistType(beets.dbcore.types.String):
+    """Custom type for playlist query.
+    """
+    query = PlaylistQuery
+
+
+class PlaylistPlugin(beets.plugins.BeetsPlugin):
+    item_types = {'playlist': PlaylistType()}
+
+    def __init__(self):
+        super(PlaylistPlugin, self).__init__()
+        self.config.add({
+            'playlist_dir': '.',
+            'relative_to': 'library',
+        })

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,10 @@ New features:
   issues with foobar2000 and Winamp.
   Thanks to :user:`mz2212`.
   :bug:`2944`
+* :doc:`/plugins/playlist`: Add a plugin that can query the beets library using
+  M3U playlists.
+  Thanks to :user:`Holzhaus` and :user:`Xenopathic`.
+  :bug:`123`
 * Added whitespace padding to missing tracks dialog to improve readability.
   Thanks to :user:`jams2`.
   :bug:`2962`

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -81,6 +81,7 @@ like this::
    mpdupdate
    permissions
    play
+   playlist
    plexupdate
    random
    replaygain
@@ -158,6 +159,7 @@ Interoperability
 * :doc:`mpdupdate`: Automatically notifies `MPD`_ whenever the beets library
   changes.
 * :doc:`play`: Play beets queries in your music player.
+* :doc:`playlist`: Use M3U playlists tp query the beets library.
 * :doc:`plexupdate`: Automatically notifies `Plex`_ whenever the beets library
   changes.
 * :doc:`smartplaylist`: Generate smart playlists based on beets queries.

--- a/docs/plugins/playlist.rst
+++ b/docs/plugins/playlist.rst
@@ -32,6 +32,7 @@ other configuration options are:
 - **playlist_dir**: Where to read playlist files from.
   Default: The current working directory (i.e., ``'.'``).
 - **relative_to**: Interpret paths in the playlist files relative to a base
-  directory. It is also possible to set it to ``playlist`` to use the
-  playlist's parent directory as base directory.
+  directory. Instead of setting it to a fixed path, it is also possible to
+  set it to ``playlist`` to use the playlist's parent directory or to
+  ``library`` to use the library directory.
   Default: ``library``

--- a/docs/plugins/playlist.rst
+++ b/docs/plugins/playlist.rst
@@ -1,0 +1,37 @@
+Smart Playlist Plugin
+=====================
+
+``playlist`` is a plugin to use playlists in m3u format.
+
+To use it, enable the ``playlist`` plugin in your configuration
+(see :ref:`using-plugins`).
+Then configure your playlists like this::
+
+    playlist:
+        relative_to: ~/Music
+        playlist_dir: ~/.mpd/playlists
+
+It is possible to query the library based on a playlist by speicifying its
+absolute path::
+
+    $ beet ls playlist:/path/to/someplaylist.m3u
+
+The plugin also supports referencing playlists by name. The playlist is then
+seached in the playlist_dir and the ".m3u" extension is appended to the
+name::
+
+    $ beet ls playlist:anotherplaylist
+
+Configuration
+-------------
+
+To configure the plugin, make a ``smartplaylist:`` section in your
+configuration file. In addition to the ``playlists`` described above, the
+other configuration options are:
+
+- **playlist_dir**: Where to read playlist files from.
+  Default: The current working directory (i.e., ``'.'``).
+- **relative_to**: Interpret paths in the playlist files relative to a base
+  directory. It is also possible to set it to ``playlist`` to use the
+  playlist's parent directory as base directory.
+  Default: ``library``

--- a/test/test_playlist.py
+++ b/test/test_playlist.py
@@ -14,6 +14,7 @@
 # included in all copies or substantial portions of the Software.
 
 from __future__ import division, absolute_import, print_function
+from six.moves import shlex_quote
 
 import os
 import shutil
@@ -87,10 +88,10 @@ class PlaylistTest(unittest.TestCase, helper.TestHelper):
         ]))
 
     def test_query_path(self):
-        q = u'playlist:{0}'.format(os.path.join(
+        q = u'playlist:{0}'.format(shlex_quote(os.path.join(
             self.playlist_dir,
             'test.m3u',
-        ))
+        )))
         results = self.lib.items(q)
         self.assertEqual(set([i.title for i in results]), set([
             u'some item',
@@ -103,10 +104,11 @@ class PlaylistTest(unittest.TestCase, helper.TestHelper):
         self.assertEqual(set(results), set())
 
     def test_query_path_nonexisting(self):
-        q = u'playlist:{0}'.format(os.path.join(
+        q = u'playlist:{0}'.format(shlex_quote(os.path.join(
+            self.playlist_dir,
             self.playlist_dir,
             'nonexisting.m3u',
-        ))
+        )))
         results = self.lib.items(q)
         self.assertEqual(set(results), set())
 

--- a/test/test_playlist.py
+++ b/test/test_playlist.py
@@ -87,7 +87,10 @@ class PlaylistTest(unittest.TestCase, helper.TestHelper):
         ]))
 
     def test_query_path(self):
-        q = u'playlist:{0}/test.m3u'.format(self.playlist_dir)
+        q = u'playlist:{0}'.format(os.path.join(
+            self.playlist_dir,
+            'test.m3u',
+        ))
         results = self.lib.items(q)
         self.assertEqual(set([i.title for i in results]), set([
             u'some item',
@@ -100,7 +103,10 @@ class PlaylistTest(unittest.TestCase, helper.TestHelper):
         self.assertEqual(set(results), set())
 
     def test_query_path_nonexisting(self):
-        q = u'playlist:{0}/nonexisting.m3u'.format(self.playlist_dir)
+        q = u'playlist:{0}'.format(os.path.join(
+            self.playlist_dir,
+            'nonexisting.m3u',
+        ))
         results = self.lib.items(q)
         self.assertEqual(set(results), set())
 

--- a/test/test_playlist.py
+++ b/test/test_playlist.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+# This file is part of beets.
+# Copyright 2016, Thomas Scholtes.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+from __future__ import division, absolute_import, print_function
+
+import os
+import tempfile
+import unittest
+
+from test import _common
+from test import helper
+
+import beets
+
+
+class PlaylistTest(unittest.TestCase, helper.TestHelper):
+    def setUp(self):
+        self.setup_beets()
+        self.lib = beets.library.Library(':memory:')
+
+        i1 = _common.item()
+        i1.path = beets.util.normpath('/a/b/c.mp3')
+        i1.title = u'some item'
+        i1.album = u'some album'
+        self.lib.add(i1)
+        self.lib.add_album([i1])
+
+        i2 = _common.item()
+        i2.path = beets.util.normpath('/d/e/f.mp3')
+        i2.title = 'another item'
+        i2.album = 'another album'
+        self.lib.add(i2)
+        self.lib.add_album([i2])
+
+        i3 = _common.item()
+        i3.path = beets.util.normpath('/x/y/z.mp3')
+        i3.title = 'yet another item'
+        i3.album = 'yet another album'
+        self.lib.add(i3)
+        self.lib.add_album([i3])
+
+        self.playlist_dir = tempfile.TemporaryDirectory()
+        with open(os.path.join(self.playlist_dir.name, 'test.m3u'), 'w') as f:
+            f.write('{0}\n'.format(beets.util.displayable_path(i1.path)))
+            f.write('{0}\n'.format(beets.util.displayable_path(i2.path)))
+
+        self.config['directory'] = '/'
+        self.config['playlist']['relative_to'] = 'library'
+        self.config['playlist']['playlist_dir'] = self.playlist_dir.name
+        self.load_plugins('playlist')
+
+    def tearDown(self):
+        self.unload_plugins()
+        self.playlist_dir.cleanup()
+        self.teardown_beets()
+
+    def test_query_name(self):
+        q = u'playlist:test'
+        results = self.lib.items(q)
+        self.assertEqual(set([i.title for i in results]), set([
+            u'some item',
+            u'another item',
+        ]))
+
+    def test_query_path(self):
+        q = u'playlist:{0}/test.m3u'.format(self.playlist_dir.name)
+        results = self.lib.items(q)
+        self.assertEqual(set([i.title for i in results]), set([
+            u'some item',
+            u'another item',
+        ]))
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromName(__name__)
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/test/test_playlist.py
+++ b/test/test_playlist.py
@@ -82,6 +82,16 @@ class PlaylistTest(unittest.TestCase, helper.TestHelper):
             u'another item',
         ]))
 
+    def test_query_name_nonexisting(self):
+        q = u'playlist:nonexisting'.format(self.playlist_dir.name)
+        results = self.lib.items(q)
+        self.assertEqual(set(results), set())
+
+    def test_query_path_nonexisting(self):
+        q = u'playlist:{0}/nonexisting.m3u'.format(self.playlist_dir.name)
+        results = self.lib.items(q)
+        self.assertEqual(set(results), set())
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)

--- a/test/test_playlist.py
+++ b/test/test_playlist.py
@@ -31,22 +31,33 @@ class PlaylistTest(unittest.TestCase, helper.TestHelper):
         self.setup_beets()
         self.lib = beets.library.Library(':memory:')
 
+        self.music_dir = os.path.expanduser('~/Music')
+
         i1 = _common.item()
-        i1.path = beets.util.normpath('/a/b/c.mp3')
+        i1.path = beets.util.normpath(os.path.join(
+            self.music_dir,
+            'a/b/c.mp3',
+        ))
         i1.title = u'some item'
         i1.album = u'some album'
         self.lib.add(i1)
         self.lib.add_album([i1])
 
         i2 = _common.item()
-        i2.path = beets.util.normpath('/d/e/f.mp3')
+        i2.path = beets.util.normpath(os.path.join(
+            self.music_dir,
+            'd/e/f.mp3',
+        ))
         i2.title = 'another item'
         i2.album = 'another album'
         self.lib.add(i2)
         self.lib.add_album([i2])
 
         i3 = _common.item()
-        i3.path = beets.util.normpath('/x/y/z.mp3')
+        i3.path = beets.util.normpath(os.path.join(
+            self.music_dir,
+            'x/y/z.mp3',
+        ))
         i3.title = 'yet another item'
         i3.album = 'yet another album'
         self.lib.add(i3)
@@ -57,7 +68,7 @@ class PlaylistTest(unittest.TestCase, helper.TestHelper):
             f.write('{0}\n'.format(beets.util.displayable_path(i1.path)))
             f.write('{0}\n'.format(beets.util.displayable_path(i2.path)))
 
-        self.config['directory'] = '/'
+        self.config['directory'] = self.music_dir
         self.config['playlist']['relative_to'] = 'library'
         self.config['playlist']['playlist_dir'] = self.playlist_dir
         self.load_plugins('playlist')

--- a/test/test_playlist.py
+++ b/test/test_playlist.py
@@ -16,6 +16,7 @@
 from __future__ import division, absolute_import, print_function
 
 import os
+import shutil
 import tempfile
 import unittest
 
@@ -51,19 +52,19 @@ class PlaylistTest(unittest.TestCase, helper.TestHelper):
         self.lib.add(i3)
         self.lib.add_album([i3])
 
-        self.playlist_dir = tempfile.TemporaryDirectory()
-        with open(os.path.join(self.playlist_dir.name, 'test.m3u'), 'w') as f:
+        self.playlist_dir = tempfile.mkdtemp()
+        with open(os.path.join(self.playlist_dir, 'test.m3u'), 'w') as f:
             f.write('{0}\n'.format(beets.util.displayable_path(i1.path)))
             f.write('{0}\n'.format(beets.util.displayable_path(i2.path)))
 
         self.config['directory'] = '/'
         self.config['playlist']['relative_to'] = 'library'
-        self.config['playlist']['playlist_dir'] = self.playlist_dir.name
+        self.config['playlist']['playlist_dir'] = self.playlist_dir
         self.load_plugins('playlist')
 
     def tearDown(self):
         self.unload_plugins()
-        self.playlist_dir.cleanup()
+        shutil.rmtree(self.playlist_dir)
         self.teardown_beets()
 
     def test_query_name(self):
@@ -75,7 +76,7 @@ class PlaylistTest(unittest.TestCase, helper.TestHelper):
         ]))
 
     def test_query_path(self):
-        q = u'playlist:{0}/test.m3u'.format(self.playlist_dir.name)
+        q = u'playlist:{0}/test.m3u'.format(self.playlist_dir)
         results = self.lib.items(q)
         self.assertEqual(set([i.title for i in results]), set([
             u'some item',
@@ -83,12 +84,12 @@ class PlaylistTest(unittest.TestCase, helper.TestHelper):
         ]))
 
     def test_query_name_nonexisting(self):
-        q = u'playlist:nonexisting'.format(self.playlist_dir.name)
+        q = u'playlist:nonexisting'.format(self.playlist_dir)
         results = self.lib.items(q)
         self.assertEqual(set(results), set())
 
     def test_query_path_nonexisting(self):
-        q = u'playlist:{0}/nonexisting.m3u'.format(self.playlist_dir.name)
+        q = u'playlist:{0}/nonexisting.m3u'.format(self.playlist_dir)
         results = self.lib.items(q)
         self.assertEqual(set(results), set())
 


### PR DESCRIPTION
Adds M3U playlist support as a query to beets and thus partially
resolves issue #123. The implementation is heavily based on #2380 by
Robin McCorkell.

It supports referencing playlists by absolute path:

    $ beet ls playlist:/path/to/someplaylist.m3u

It also supports referencing playlists by name. The playlist is then
seached in the `playlist_dir` and the `.m3u` extension is appended to the
name:

    $ beet ls playlist:anotherplaylist

The configuration for the plugin looks like this:

    playlist:
        relative_to: library
        playlist_dir: /path/to/playlists

The `relative_to` option specifies how relative paths in playlists are
handled. By default, paths are relative to the `library` directory. It
also possible to make them relative to the `playlist` or set the option
or set it to a fixed path.