### PR TITLE
Lock munkres to 1.0.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     install_requires=[
         'six>=1.9',
         'mutagen>=1.33',
-        'munkres',
+        'munkres~=1.0.0',
         'unidecode',
         'musicbrainzngs>=0.4',
         'pyyaml',


### PR DESCRIPTION
Even though munkres 1.1.2 fixed the issue with Python 3.5 (#3143), it had already dropped support for Python <3.5.x in [1.1.0](https://github.com/bmc/munkres/blob/5badef0ae62ed5a8d4164fd358dda96163295c8f/CHANGELOG.md) (which beets still supports).

We are going to have to lock our version of munkres to 1.0.x until we drop support for 3.5 ourselves.