### PR TITLE
Allow overriding "fast" detection in FieldQuery subclasses

### DIFF
--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -115,6 +115,10 @@ class FieldQuery(Query):
             return None, ()
 
     @classmethod
+    def check_fast(cls, key, model_cls):
+        return key in model_cls._fields
+
+    @classmethod
     def value_match(cls, pattern, value):
         """Determine whether the value matches the pattern. Both
         arguments are strings.

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -153,7 +153,8 @@ def construct_query_part(model_cls, prefixes, query_part):
     # Otherwise, this must be a `FieldQuery`. Use the field name to
     # construct the query object.
     key = key.lower()
-    q = query_class(key.lower(), pattern, key in model_cls._fields)
+    fast = query_class.check_fast(key, model_cls)
+    q = query_class(key, pattern, fast)
     if negate:
         return query.NotQuery(q)
     return q


### PR DESCRIPTION
This is small fix that allows to override the `fast` detection for `FieldQuery` subclasses. This can potentially speed up the `playlist` query in #3145.

This also removes a duplicate `key.lower()` invocation.