### PR TITLE
Add support for "named queries" and use them in the playlist plugin

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -143,6 +143,11 @@ class Model(object):
     are subclasses of `Sort`.
     """
 
+    _queries = {}
+    """Named queries that use a field-like `name:value` syntax but which
+    do not relate to any specific field.
+    """
+
     _always_dirty = False
     """By default, fields only become "dirty" when their value actually
     changes. Enabling this flag marks fields as dirty even when the new

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -344,6 +344,16 @@ def types(model_cls):
     return types
 
 
+def named_queries(model_cls):
+    # Gather `item_queries` and `album_queries` from the plugins.
+    attr_name = '{0}_queries'.format(model_cls.__name__.lower())
+    queries = {}
+    for plugin in find_plugins():
+        plugin_queries = getattr(plugin, attr_name, {})
+        queries.update(plugin_queries)
+    return queries
+
+
 def track_distance(item, info):
     """Gets the track distance calculated by all loaded plugins.
     Returns a Distance object.

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -1143,8 +1143,12 @@ def _setup(options, lib=None):
     if lib is None:
         lib = _open_library(config)
         plugins.send("library_opened", lib=lib)
+
+    # Add types and queries defined by plugins.
     library.Item._types.update(plugins.types(library.Item))
     library.Album._types.update(plugins.types(library.Album))
+    library.Item._queries.update(plugins.named_queries(library.Item))
+    library.Album._queries.update(plugins.named_queries(library.Album))
 
     return subcommands, plugins, lib
 

--- a/beetsplug/playlist.py
+++ b/beetsplug/playlist.py
@@ -17,11 +17,11 @@ import fnmatch
 import beets
 
 
-class PlaylistQuery(beets.dbcore.FieldQuery):
+class PlaylistQuery(beets.dbcore.Query):
     """Matches files listed by a playlist file.
     """
-    def __init__(self, field, pattern, fast=True):
-        super(PlaylistQuery, self).__init__(field, pattern, fast)
+    def __init__(self, pattern):
+        self.pattern = pattern
         config = beets.config['playlist']
 
         # Get the full path to the playlist
@@ -74,14 +74,8 @@ class PlaylistQuery(beets.dbcore.FieldQuery):
         return item.path in self.paths
 
 
-class PlaylistType(beets.dbcore.types.String):
-    """Custom type for playlist query.
-    """
-    query = PlaylistQuery
-
-
 class PlaylistPlugin(beets.plugins.BeetsPlugin):
-    item_types = {'playlist': PlaylistType()}
+    item_queries = {'playlist': PlaylistQuery}
 
     def __init__(self):
         super(PlaylistPlugin, self).__init__()

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -144,6 +144,14 @@ Fixes:
 
 .. _python-itunes: https://github.com/ocelma/python-itunes
 
+For developers:
+
+* In addition to prefix-based field queries, plugins can now define *named
+  queries* that are not associated with any specific field.
+  For example, the new :doc:`/plugins/playlist` supports queries like
+  ``playlist:name`` although there is no field named ``playlist``.
+  See :ref:`extend-query` for details.
+
 
 1.4.7 (May 29, 2018)
 --------------------

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -443,15 +443,24 @@ Extend the Query Syntax
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 You can add new kinds of queries to beets' :doc:`query syntax
-</reference/query>` indicated by a prefix. As an example, beets already
+</reference/query>`. There are two ways to add custom queries: using a prefix
+and using a name. Prefix-based query extension can apply to *any* field, while
+named queries are not associated with any field. For example, beets already
 supports regular expression queries, which are indicated by a colon
 prefix---plugins can do the same.
 
-To do so, define a subclass of the ``Query`` type from the
-``beets.dbcore.query`` module. Then, in the ``queries`` method of your plugin
-class, return a dictionary mapping prefix strings to query classes.
+For either kind of query extension, define a subclass of the ``Query`` type
+from the ``beets.dbcore.query`` module. Then:
 
-One simple kind of query you can extend is the ``FieldQuery``, which
+- To define a prefix-based query, define a ``queries`` method in your plugin
+  class. Return from this method a dictionary mapping prefix strings to query
+  classes.
+- To define a named query, defined dictionaries named either ``item_queries``
+  or ``album_queries``. These should map names to query types. So if you
+  use ``{ "foo": FooQuery }``, then the query ``foo:bar`` will construct a
+  query like ``FooQuery("bar")``.
+
+For prefix-based queries, you will want to extend ``FieldQuery``, which
 implements string comparisons on fields. To use it, create a subclass
 inheriting from that class and override the ``value_match`` class method.
 (Remember the ``@classmethod`` decorator!) The following example plugin

--- a/test/helper.py
+++ b/test/helper.py
@@ -222,11 +222,18 @@ class TestHelper(object):
         beets.config['plugins'] = plugins
         beets.plugins.load_plugins(plugins)
         beets.plugins.find_plugins()
-        # Take a backup of the original _types to restore when unloading
+
+        # Take a backup of the original _types and _queries to restore
+        # when unloading.
         Item._original_types = dict(Item._types)
         Album._original_types = dict(Album._types)
         Item._types.update(beets.plugins.types(Item))
         Album._types.update(beets.plugins.types(Album))
+
+        Item._original_queries = dict(Item._queries)
+        Album._original_queries = dict(Album._queries)
+        Item._queries.update(beets.plugins.named_queries(Item))
+        Album._queries.update(beets.plugins.named_queries(Album))
 
     def unload_plugins(self):
         """Unload all plugins and remove the from the configuration.
@@ -237,6 +244,8 @@ class TestHelper(object):
         beets.plugins._instances = {}
         Item._types = Item._original_types
         Album._types = Album._original_types
+        Item._queries = Item._original_queries
+        Album._queries = Album._original_queries
 
     def create_importer(self, item_count=1, album_count=1):
         """Create files to import and return corresponding session.

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -36,6 +36,17 @@ class TestSort(dbcore.query.FieldSort):
     pass
 
 
+class TestQuery(dbcore.query.Query):
+    def __init__(self, pattern):
+        self.pattern = pattern
+
+    def clause(self):
+        return None, ()
+
+    def match(self):
+        return True
+
+
 class TestModel1(dbcore.Model):
     _table = 'test'
     _flex_table = 'testflex'
@@ -48,6 +59,9 @@ class TestModel1(dbcore.Model):
     }
     _sorts = {
         'some_sort': TestSort,
+    }
+    _queries = {
+        'some_query': TestQuery,
     }
 
     @classmethod
@@ -518,6 +532,10 @@ class QueryFromStringsTest(unittest.TestCase):
     def test_empty_query_part(self):
         q = self.qfs([''])
         self.assertIsInstance(q.subqueries[0], dbcore.query.TrueQuery)
+
+    def test_parse_named_query(self):
+        q = self.qfs(['some_query:foo'])
+        self.assertIsInstance(q.subqueries[0], TestQuery)
 
 
 class SortFromStringsTest(unittest.TestCase):


### PR DESCRIPTION
As discussed in https://github.com/beetbox/beets/pull/3145#pullrequestreview-204523870, this adds a generic facility for defining "named" queries that are *not* field queries. This way, a query part like `playlist:foo` need not rely on a declaration of a field called `playlist` despite the fact that no one is ever supposed to put data in the `playlist` field. Instead, the query parser can recognize these non-field queries and use them directly.

This also should obviate the need for #3149, which was another way to "force" field queries to be fast, even when the underlying field did not exist. @Holzhaus, can you please take a look and let me know if this suffices to get the behavior you want?

This should also make it possible to support random queries like `rand:5`, as discussed in https://github.com/beetbox/beets/pull/2350.