### PR TITLE
playlist: Add auto-update functionality and more tests

### DIFF
--- a/beetsplug/playlist.py
+++ b/beetsplug/playlist.py
@@ -99,13 +99,12 @@ class PlaylistPlugin(beets.plugins.BeetsPlugin):
             self.relative_to = beets.util.bytestring_path(
                 beets.config['directory'].as_filename())
         elif self.config['relative_to'].get() != 'playlist':
-            print(repr(self.config['relative_to'].get()))
             self.relative_to = beets.util.bytestring_path(
                 self.config['relative_to'].as_filename())
         else:
             self.relative_to = None
 
-        if self.config['auto'].get(bool):
+        if self.config['auto']:
             self.register_listener('item_moved', self.item_moved)
             self.register_listener('item_removed', self.item_removed)
             self.register_listener('cli_exit', self.cli_exit)

--- a/beetsplug/playlist.py
+++ b/beetsplug/playlist.py
@@ -156,7 +156,7 @@ class PlaylistPlugin(beets.plugins.BeetsPlugin):
                     original_path = line.rstrip(b'\r\n')
 
                     # Ensure that path from playlist is absolute
-                    is_relative = not os.path.isabs(beets.util.syspath(line))
+                    is_relative = not os.path.isabs(line)
                     if is_relative:
                         lookup = os.path.join(base_dir, original_path)
                     else:

--- a/beetsplug/playlist.py
+++ b/beetsplug/playlist.py
@@ -149,7 +149,8 @@ class PlaylistPlugin(beets.plugins.BeetsPlugin):
         changes = 0
         deletions = 0
 
-        with tempfile.NamedTemporaryFile(mode='w+b') as tempfp:
+        with tempfile.NamedTemporaryFile(mode='w+b', delete=False) as tempfp:
+            new_playlist = tempfp.name
             with open(filename, mode='rb') as fp:
                 for line in fp:
                     original_path = line.rstrip(b'\r\n')
@@ -176,9 +177,10 @@ class PlaylistPlugin(beets.plugins.BeetsPlugin):
                             new_path = os.path.relpath(new_path, base_dir)
 
                         tempfp.write(line.replace(original_path, new_path))
-            if changes or deletions:
-                self._log.info(
-                    'Updated playlist {0} ({1} changes, {2} deletions)'.format(
-                        filename, changes, deletions))
-                tempfp.flush()
-                beets.util.copy(tempfp.name, filename, replace=True)
+
+        if changes or deletions:
+            self._log.info(
+                'Updated playlist {0} ({1} changes, {2} deletions)'.format(
+                    filename, changes, deletions))
+            beets.util.copy(new_playlist, filename, replace=True)
+        beets.util.remove(new_playlist)

--- a/beetsplug/playlist.py
+++ b/beetsplug/playlist.py
@@ -162,7 +162,7 @@ class PlaylistPlugin(beets.plugins.BeetsPlugin):
                         lookup = original_path
 
                     try:
-                        new_path = self.changes[lookup]
+                        new_path = self.changes[beets.util.normpath(lookup)]
                     except KeyError:
                         tempfp.write(line)
                     else:

--- a/docs/plugins/playlist.rst
+++ b/docs/plugins/playlist.rst
@@ -8,6 +8,7 @@ To use it, enable the ``playlist`` plugin in your configuration
 Then configure your playlists like this::
 
     playlist:
+        auto: no
         relative_to: ~/Music
         playlist_dir: ~/.mpd/playlists
 
@@ -22,6 +23,10 @@ name::
 
     $ beet ls playlist:anotherplaylist
 
+The plugin can also update playlists in the playlist directory automatically
+every time an item is moved or deleted. This can be controlled by the ``auto``
+configuration option.
+
 Configuration
 -------------
 
@@ -29,6 +34,10 @@ To configure the plugin, make a ``smartplaylist:`` section in your
 configuration file. In addition to the ``playlists`` described above, the
 other configuration options are:
 
+- **auto**: If this is set to ``yes``, then anytime an item in the library is
+  moved or removed, the plugin will update all playlists in the
+  ``playlist_dir`` directory that contain that item to reflect the change.
+  Default: ``no``
 - **playlist_dir**: Where to read playlist files from.
   Default: The current working directory (i.e., ``'.'``).
 - **relative_to**: Interpret paths in the playlist files relative to a base

--- a/test/test_playlist.py
+++ b/test/test_playlist.py
@@ -79,6 +79,8 @@ class PlaylistTestHelper(helper.TestHelper):
         shutil.rmtree(self.playlist_dir)
         self.teardown_beets()
 
+
+class PlaylistQueryTestHelper(PlaylistTestHelper):
     def test_name_query_with_absolute_paths_in_playlist(self):
         q = u'playlist:absolute'
         results = self.lib.items(q)
@@ -132,7 +134,7 @@ class PlaylistTestHelper(helper.TestHelper):
         self.assertEqual(set(results), set())
 
 
-class PlaylistTestRelativeToLib(PlaylistTestHelper, unittest.TestCase):
+class PlaylistTestRelativeToLib(PlaylistQueryTestHelper, unittest.TestCase):
     def setup_test(self):
         with open(os.path.join(self.playlist_dir, 'absolute.m3u'), 'w') as f:
             f.write('{0}\n'.format(os.path.join(
@@ -150,7 +152,7 @@ class PlaylistTestRelativeToLib(PlaylistTestHelper, unittest.TestCase):
         self.config['playlist']['relative_to'] = 'library'
 
 
-class PlaylistTestRelativeToDir(PlaylistTestHelper, unittest.TestCase):
+class PlaylistTestRelativeToDir(PlaylistQueryTestHelper, unittest.TestCase):
     def setup_test(self):
         with open(os.path.join(self.playlist_dir, 'absolute.m3u'), 'w') as f:
             f.write('{0}\n'.format(os.path.join(
@@ -168,7 +170,7 @@ class PlaylistTestRelativeToDir(PlaylistTestHelper, unittest.TestCase):
         self.config['playlist']['relative_to'] = self.music_dir
 
 
-class PlaylistTestRelativeToPls(PlaylistTestHelper, unittest.TestCase):
+class PlaylistTestRelativeToPls(PlaylistQueryTestHelper, unittest.TestCase):
     def setup_test(self):
         with open(os.path.join(self.playlist_dir, 'absolute.m3u'), 'w') as f:
             f.write('{0}\n'.format(os.path.join(

--- a/test/test_playlist.py
+++ b/test/test_playlist.py
@@ -27,7 +27,7 @@ from test import helper
 import beets
 
 
-class PlaylistTest(unittest.TestCase, helper.TestHelper):
+class PlaylistTestHelper(helper.TestHelper):
     def setUp(self):
         self.setup_beets()
         self.lib = beets.library.Library(':memory:')
@@ -65,20 +65,14 @@ class PlaylistTest(unittest.TestCase, helper.TestHelper):
         self.lib.add_album([i3])
 
         self.playlist_dir = tempfile.mkdtemp()
-        with open(os.path.join(self.playlist_dir, 'absolute.m3u'), 'w') as f:
-            f.write('{0}\n'.format(beets.util.displayable_path(i1.path)))
-            f.write('{0}\n'.format(beets.util.displayable_path(i2.path)))
-            f.write('{0}\n'.format(os.path.join(
-                self.music_dir, 'nonexisting.mp3')))
-        with open(os.path.join(self.playlist_dir, 'relative.m3u'), 'w') as f:
-            f.write('{0}\n'.format(os.path.join('a', 'b', 'c.mp3')))
-            f.write('{0}\n'.format(os.path.join('d', 'e', 'f.mp3')))
-            f.write('{0}\n'.format('nonexisting.mp3'))
-
         self.config['directory'] = self.music_dir
-        self.config['playlist']['relative_to'] = 'library'
         self.config['playlist']['playlist_dir'] = self.playlist_dir
+
+        self.setup_test()
         self.load_plugins('playlist')
+
+    def setup_test(self):
+        raise NotImplementedError
 
     def tearDown(self):
         self.unload_plugins()
@@ -136,6 +130,70 @@ class PlaylistTest(unittest.TestCase, helper.TestHelper):
         )))
         results = self.lib.items(q)
         self.assertEqual(set(results), set())
+
+
+class PlaylistTestRelativeToLib(PlaylistTestHelper, unittest.TestCase):
+    def setup_test(self):
+        with open(os.path.join(self.playlist_dir, 'absolute.m3u'), 'w') as f:
+            f.write('{0}\n'.format(os.path.join(
+                self.music_dir, 'a', 'b', 'c.mp3')))
+            f.write('{0}\n'.format(os.path.join(
+                self.music_dir, 'd', 'e', 'f.mp3')))
+            f.write('{0}\n'.format(os.path.join(
+                self.music_dir, 'nonexisting.mp3')))
+
+        with open(os.path.join(self.playlist_dir, 'relative.m3u'), 'w') as f:
+            f.write('{0}\n'.format(os.path.join('a', 'b', 'c.mp3')))
+            f.write('{0}\n'.format(os.path.join('d', 'e', 'f.mp3')))
+            f.write('{0}\n'.format('nonexisting.mp3'))
+
+        self.config['playlist']['relative_to'] = 'library'
+
+
+class PlaylistTestRelativeToDir(PlaylistTestHelper, unittest.TestCase):
+    def setup_test(self):
+        with open(os.path.join(self.playlist_dir, 'absolute.m3u'), 'w') as f:
+            f.write('{0}\n'.format(os.path.join(
+                self.music_dir, 'a', 'b', 'c.mp3')))
+            f.write('{0}\n'.format(os.path.join(
+                self.music_dir, 'd', 'e', 'f.mp3')))
+            f.write('{0}\n'.format(os.path.join(
+                self.music_dir, 'nonexisting.mp3')))
+
+        with open(os.path.join(self.playlist_dir, 'relative.m3u'), 'w') as f:
+            f.write('{0}\n'.format(os.path.join('a', 'b', 'c.mp3')))
+            f.write('{0}\n'.format(os.path.join('d', 'e', 'f.mp3')))
+            f.write('{0}\n'.format('nonexisting.mp3'))
+
+        self.config['playlist']['relative_to'] = self.music_dir
+
+
+class PlaylistTestRelativeToPls(PlaylistTestHelper, unittest.TestCase):
+    def setup_test(self):
+        with open(os.path.join(self.playlist_dir, 'absolute.m3u'), 'w') as f:
+            f.write('{0}\n'.format(os.path.join(
+                self.music_dir, 'a', 'b', 'c.mp3')))
+            f.write('{0}\n'.format(os.path.join(
+                self.music_dir, 'd', 'e', 'f.mp3')))
+            f.write('{0}\n'.format(os.path.join(
+                self.music_dir, 'nonexisting.mp3')))
+
+        with open(os.path.join(self.playlist_dir, 'relative.m3u'), 'w') as f:
+            f.write('{0}\n'.format(os.path.relpath(
+                os.path.join(self.music_dir, 'a', 'b', 'c.mp3'),
+                start=self.playlist_dir,
+            )))
+            f.write('{0}\n'.format(os.path.relpath(
+                os.path.join(self.music_dir, 'd', 'e', 'f.mp3'),
+                start=self.playlist_dir,
+            )))
+            f.write('{0}\n'.format(os.path.relpath(
+                os.path.join(self.music_dir, 'nonexisting.mp3'),
+                start=self.playlist_dir,
+            )))
+
+        self.config['playlist']['relative_to'] = 'playlist'
+        self.config['playlist']['playlist_dir'] = self.playlist_dir
 
 
 def suite():

--- a/test/test_playlist.py
+++ b/test/test_playlist.py
@@ -220,7 +220,7 @@ class PlaylistUpdateTestHelper(PlaylistTestHelper):
 class PlaylistTestItemMoved(PlaylistUpdateTestHelper, unittest.TestCase):
     def test_item_moved(self):
         # Emit item_moved event for an item that is in a playlist
-        results = self.lib.items('path:{0}'.format(shlex_quote(
+        results = self.lib.items(u'path:{0}'.format(shlex_quote(
             os.path.join(self.music_dir, 'd', 'e', 'f.mp3'))))
         item = results[0]
         beets.plugins.send(
@@ -229,7 +229,7 @@ class PlaylistTestItemMoved(PlaylistUpdateTestHelper, unittest.TestCase):
                 os.path.join(self.music_dir, 'g', 'h', 'i.mp3')))
 
         # Emit item_moved event for an item that is not in a playlist
-        results = self.lib.items('path:{0}'.format(shlex_quote(
+        results = self.lib.items(u'path:{0}'.format(shlex_quote(
             os.path.join(self.music_dir, 'x', 'y', 'z.mp3'))))
         item = results[0]
         beets.plugins.send(
@@ -266,13 +266,13 @@ class PlaylistTestItemMoved(PlaylistUpdateTestHelper, unittest.TestCase):
 class PlaylistTestItemRemoved(PlaylistUpdateTestHelper, unittest.TestCase):
     def test_item_removed(self):
         # Emit item_removed event for an item that is in a playlist
-        results = self.lib.items('path:{0}'.format(shlex_quote(
+        results = self.lib.items(u'path:{0}'.format(shlex_quote(
             os.path.join(self.music_dir, 'd', 'e', 'f.mp3'))))
         item = results[0]
         beets.plugins.send('item_removed', item=item)
 
         # Emit item_removed event for an item that is not in a playlist
-        results = self.lib.items('path:{0}'.format(shlex_quote(
+        results = self.lib.items(u'path:{0}'.format(shlex_quote(
             os.path.join(self.music_dir, 'x', 'y', 'z.mp3'))))
         item = results[0]
         beets.plugins.send('item_removed', item=item)

--- a/test/test_playlist.py
+++ b/test/test_playlist.py
@@ -32,7 +32,7 @@ class PlaylistTestHelper(helper.TestHelper):
         self.setup_beets()
         self.lib = beets.library.Library(':memory:')
 
-        self.music_dir = os.path.expanduser('~/Music')
+        self.music_dir = os.path.expanduser(os.path.join('~', 'Music'))
 
         i1 = _common.item()
         i1.path = beets.util.normpath(os.path.join(

--- a/test/test_playlist.py
+++ b/test/test_playlist.py
@@ -68,9 +68,12 @@ class PlaylistTest(unittest.TestCase, helper.TestHelper):
         with open(os.path.join(self.playlist_dir, 'absolute.m3u'), 'w') as f:
             f.write('{0}\n'.format(beets.util.displayable_path(i1.path)))
             f.write('{0}\n'.format(beets.util.displayable_path(i2.path)))
+            f.write('{0}\n'.format(os.path.join(
+                self.music_dir, 'nonexisting.mp3')))
         with open(os.path.join(self.playlist_dir, 'relative.m3u'), 'w') as f:
             f.write('{0}\n'.format(os.path.join('a', 'b', 'c.mp3')))
             f.write('{0}\n'.format(os.path.join('d', 'e', 'f.mp3')))
+            f.write('{0}\n'.format('nonexisting.mp3'))
 
         self.config['directory'] = self.music_dir
         self.config['playlist']['relative_to'] = 'library'

--- a/test/test_playlist.py
+++ b/test/test_playlist.py
@@ -37,7 +37,7 @@ class PlaylistTest(unittest.TestCase, helper.TestHelper):
         i1 = _common.item()
         i1.path = beets.util.normpath(os.path.join(
             self.music_dir,
-            'a/b/c.mp3',
+            'a', 'b', 'c.mp3',
         ))
         i1.title = u'some item'
         i1.album = u'some album'
@@ -47,7 +47,7 @@ class PlaylistTest(unittest.TestCase, helper.TestHelper):
         i2 = _common.item()
         i2.path = beets.util.normpath(os.path.join(
             self.music_dir,
-            'd/e/f.mp3',
+            'd', 'e', 'f.mp3',
         ))
         i2.title = 'another item'
         i2.album = 'another album'
@@ -57,7 +57,7 @@ class PlaylistTest(unittest.TestCase, helper.TestHelper):
         i3 = _common.item()
         i3.path = beets.util.normpath(os.path.join(
             self.music_dir,
-            'x/y/z.mp3',
+            'x', 'y', 'z.mp3',
         ))
         i3.title = 'yet another item'
         i3.album = 'yet another album'

--- a/test/test_playlist.py
+++ b/test/test_playlist.py
@@ -65,9 +65,12 @@ class PlaylistTest(unittest.TestCase, helper.TestHelper):
         self.lib.add_album([i3])
 
         self.playlist_dir = tempfile.mkdtemp()
-        with open(os.path.join(self.playlist_dir, 'test.m3u'), 'w') as f:
+        with open(os.path.join(self.playlist_dir, 'absolute.m3u'), 'w') as f:
             f.write('{0}\n'.format(beets.util.displayable_path(i1.path)))
             f.write('{0}\n'.format(beets.util.displayable_path(i2.path)))
+        with open(os.path.join(self.playlist_dir, 'relative.m3u'), 'w') as f:
+            f.write('{0}\n'.format(os.path.join('a', 'b', 'c.mp3')))
+            f.write('{0}\n'.format(os.path.join('d', 'e', 'f.mp3')))
 
         self.config['directory'] = self.music_dir
         self.config['playlist']['relative_to'] = 'library'
@@ -79,18 +82,18 @@ class PlaylistTest(unittest.TestCase, helper.TestHelper):
         shutil.rmtree(self.playlist_dir)
         self.teardown_beets()
 
-    def test_query_name(self):
-        q = u'playlist:test'
+    def test_name_query_with_absolute_paths_in_playlist(self):
+        q = u'playlist:absolute'
         results = self.lib.items(q)
         self.assertEqual(set([i.title for i in results]), set([
             u'some item',
             u'another item',
         ]))
 
-    def test_query_path(self):
+    def test_path_query_with_absolute_paths_in_playlist(self):
         q = u'playlist:{0}'.format(shlex_quote(os.path.join(
             self.playlist_dir,
-            'test.m3u',
+            'absolute.m3u',
         )))
         results = self.lib.items(q)
         self.assertEqual(set([i.title for i in results]), set([
@@ -98,12 +101,31 @@ class PlaylistTest(unittest.TestCase, helper.TestHelper):
             u'another item',
         ]))
 
-    def test_query_name_nonexisting(self):
+    def test_name_query_with_relative_paths_in_playlist(self):
+        q = u'playlist:relative'
+        results = self.lib.items(q)
+        self.assertEqual(set([i.title for i in results]), set([
+            u'some item',
+            u'another item',
+        ]))
+
+    def test_path_query_with_relative_paths_in_playlist(self):
+        q = u'playlist:{0}'.format(shlex_quote(os.path.join(
+            self.playlist_dir,
+            'relative.m3u',
+        )))
+        results = self.lib.items(q)
+        self.assertEqual(set([i.title for i in results]), set([
+            u'some item',
+            u'another item',
+        ]))
+
+    def test_name_query_with_nonexisting_playlist(self):
         q = u'playlist:nonexisting'.format(self.playlist_dir)
         results = self.lib.items(q)
         self.assertEqual(set(results), set())
 
-    def test_query_path_nonexisting(self):
+    def test_path_query_with_nonexisting_playlist(self):
         q = u'playlist:{0}'.format(shlex_quote(os.path.join(
             self.playlist_dir,
             self.playlist_dir,


### PR DESCRIPTION
This is round two for the `playlist` plugin:

This improves the existing tests (and adds some more to ensure nothing breaks), and also adds the auto-update functionality that I described in issue #123:

If the `auto` is set, then whenever a database item is moved or removed, the playlists inside the `playlist_dir` are updated to reflect that change.