### PR TITLE
Add parallel map utility

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -24,6 +24,7 @@ import re
 import shutil
 import fnmatch
 from collections import Counter
+from multiprocessing.pool import ThreadPool
 import traceback
 import subprocess
 import platform
@@ -1009,3 +1010,22 @@ def asciify_path(path, sep_replace):
                 sep_replace
             )
     return os.sep.join(path_components)
+
+
+def par_map(transform, items):
+    """
+    This module implements a simple utility to either:
+        a) Perform a parallel map when running under Python >=3
+        b) Perform a sequential map otherwise
+
+    This is useful whenever there is some operation `do_something()` which we
+    want to efficiently apply to our music library.
+    """
+    if sys.version_info[0] < 3:
+        for item in items:
+            transform(item)
+    else:
+        pool = ThreadPool()
+        pool.map(transform, items)
+        pool.close()
+        pool.join()

--- a/beetsplug/absubmit.py
+++ b/beetsplug/absubmit.py
@@ -24,9 +24,7 @@ import json
 import os
 import subprocess
 import tempfile
-import sys
 
-from multiprocessing.pool import ThreadPool
 from distutils.spawn import find_executable
 import requests
 
@@ -106,15 +104,7 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
     def command(self, lib, opts, args):
         # Get items from arguments
         items = lib.items(ui.decargs(args))
-        if sys.version_info[0] < 3:
-            for item in items:
-                self.analyze_submit(item)
-        else:
-            # Analyze in parallel using a thread pool.
-            pool = ThreadPool()
-            pool.map(self.analyze_submit, items)
-            pool.close()
-            pool.join()
+        util.par_map(self.analyze_submit, items)
 
     def analyze_submit(self, item):
         analysis = self._get_analysis(item)


### PR DESCRIPTION
Following #3003 and #3006, and the now long-forgotten promises I made, here is the parallel_map function making it into utils! This way we can now very easily apply transforms to the library in a parallel way (in Py3) while remaining compatible with Py2.

This also converts `absubmit` to use the new util. Expect updates to #3006 as well!