### PR TITLE
badfiles: Fix #3158 by calling superclass __init__ method

### DIFF
--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -50,6 +50,7 @@ class CheckerCommandException(Exception):
 
 class BadFiles(BeetsPlugin):
     def __init__(self):
+        super(BadFiles, self).__init__()
         self.verbose = False
 
     def run_command(self, cmd):


### PR DESCRIPTION
Without this patch, the superclass `__init__` method is never called, thus the `early_import_stages` attribute does not exist and causes an `AttributeError`.