### PR TITLE
Clarify description of incremental_skip_later

### DIFF
--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -508,9 +508,10 @@ incremental_skip_later
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Either ``yes`` or ``no``, controlling whether skipped directories are
-recorded in the incremental list. Set this option to ``yes`` if you would
-like to ignore skipped directories later whilst using incremental
-mode. Defaults to ``no``.
+recorded in the incremental list. When set to ``yes``, skipped directories
+will be recorded, and skipped later. When set to ``no``, skipped
+directories won't be recorded, and beets will try to import them again
+later. Defaults to ``no``.
 
 .. _from_scratch:
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -509,7 +509,7 @@ incremental_skip_later
 
 Either ``yes`` or ``no``, controlling whether skipped directories are
 recorded in the incremental list. Set this option to ``yes`` if you would
-like to revisit skipped directories later whilst using incremental
+like to ignore skipped directories later whilst using incremental
 mode. Defaults to ``no``.
 
 .. _from_scratch:


### PR DESCRIPTION
Contrary to what the current docs say, `incremental_skip_later` should be set to `no` for beets  to revisit skipped directories: https://github.com/beetbox/beets/blob/3b78d933cf46d5cad8f90ea6cdf38ada9e10846f/beets/importer.py#L582-L586