### PR TITLE
beets update: dont move album art twice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ ENV/
 /.project
 /.pydevproject
 /.settings
+.vscode

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1177,7 +1177,7 @@ def update_items(lib, query, album, move, pretend, fields):
                 # Manually moving and storing the album.
                 items = list(album.items())
                 for item in items:
-                    item.move(store=False)
+                    item.move(store=False, with_album=False)
                     item.store(fields=fields)
                 album.move(store=False)
                 album.store(fields=fields)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -142,6 +142,7 @@ Fixes:
 * The ``%title`` template function now works correctly with apostrophes.
   Thanks to :user:`GuilhermeHideki`.
   :bug:`3033`
+* When updating the database, beets no longer tries to move album art twice.
 * :doc:`/plugins/fetchart`: Added network connection error handling to backends
   so that beets won't crash if a request fails.
   Thanks to :user:`Holzhaus`.

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -507,10 +507,14 @@ class UpdateTest(_common.TestCase):
         # Copy a file into the library.
         self.lib = library.Library(':memory:', self.libdir)
         item_path = os.path.join(_common.RSRC, b'full.mp3')
+        item_path_two = os.path.join(_common.RSRC, b'full.flac')
         self.i = library.Item.from_path(item_path)
+        self.i2 = library.Item.from_path(item_path_two)
         self.lib.add(self.i)
+        self.lib.add(self.i2)
         self.i.move(operation=MoveOperation.COPY)
-        self.album = self.lib.add_album([self.i])
+        self.i2.move(operation=MoveOperation.COPY)
+        self.album = self.lib.add_album([self.i, self.i2])
 
         # Album art.
         artfile = os.path.join(self.temp_dir, b'testart.jpg')
@@ -531,12 +535,14 @@ class UpdateTest(_common.TestCase):
     def test_delete_removes_item(self):
         self.assertTrue(list(self.lib.items()))
         os.remove(self.i.path)
+        os.remove(self.i2.path)
         self._update()
         self.assertFalse(list(self.lib.items()))
 
     def test_delete_removes_album(self):
         self.assertTrue(self.lib.albums())
         os.remove(self.i.path)
+        os.remove(self.i2.path)
         self._update()
         self.assertFalse(self.lib.albums())
 
@@ -544,6 +550,7 @@ class UpdateTest(_common.TestCase):
         artpath = self.album.artpath
         self.assertExists(artpath)
         os.remove(self.i.path)
+        os.remove(self.i2.path)
         self._update()
         self.assertNotExists(artpath)
 
@@ -607,6 +614,7 @@ class UpdateTest(_common.TestCase):
         self._update(move=True)
         album = self.lib.albums()[0]
         self.assertNotEqual(artpath, album.artpath)
+        self.assertIsNotNone(album.artpath)
 
     def test_selective_modified_album_metadata_moved(self):
         mf = MediaFile(syspath(self.i.path))


### PR DESCRIPTION
In many cases https://github.com/beetbox/beets/issues/2419 was being hit not because users had moved the album art, but because:
* beets moves items in an album
* this moves the covert art since `with_album=True`, but doesn't update album.artpath in the DB because `store=False`
* beets moves the album itself
* this moves the cover art again from the old path, which no longer exists

https://github.com/beetbox/beets/pull/3030 hides this error in most cases, but without this fix beets will still lose track of your album art, even if it doesn't throw, as evidenced by the test.

note: to fail without the fix, the test needs to add a second item to the album. this is because only the *second* item move actually moves the album cover, because the album's path is guessed from its first item's path, and the first item is stored *after* being moved.