### PR TITLE
Add tests for BPD

### DIFF
--- a/test/_common.py
+++ b/test/_common.py
@@ -284,6 +284,9 @@ class DummyIn(object):
         else:
             self.buf.append(s + '\n')
 
+    def close(self):
+        pass
+
     def readline(self):
         if not self.buf:
             if self.out:

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -216,7 +216,7 @@ class BPDTest(unittest.TestCase, TestHelper):
         self.lib.add_album([self.item1, self.item2])
 
         with open(os.path.join(self.temp_dir, b'bpd_mock.py'), 'wb') as f:
-            f.write(b'from unittest import mock\n')
+            f.write(b'import mock\n')
             f.write(b'import sys, imp\n')
             f.write(b'gstplayer = imp.new_module("beetsplug.bpg.gstplayer")\n')
             f.write(b'gstplayer._GstPlayer = mock.MagicMock(spec_set=["time",')
@@ -260,7 +260,7 @@ class BPDTest(unittest.TestCase, TestHelper):
         # Launch BPD in a new process:
         env = dict(os.environ.items())
         env['PYTHONPATH'] = ':'.join(
-                [self.temp_dir.decode('utf-8')] + sys.path[1:])
+                [self.temp_dir.decode('utf-8')] + sys.path[1:]).encode('utf-8')
         beet = os.path.join(os.path.dirname(__file__), '..', 'beet')
         server = subprocess.Popen([
             beet,

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -20,6 +20,12 @@ from __future__ import division, absolute_import, print_function
 import unittest
 from beetsplug import bpd
 
+import multiprocessing as mp
+import socket
+import time
+
+from test.helper import TestHelper
+
 
 class CommandParseTest(unittest.TestCase):
     def test_no_args(self):
@@ -61,6 +67,102 @@ class CommandParseTest(unittest.TestCase):
         s = r'command "hello \\ there"'
         c = bpd.Command(s)
         self.assertEqual(c.args, [u'hello \\ there'])
+
+
+class MPCResponse(object):
+    def __init__(self, raw_response):
+        self.body = b'\n'.join(raw_response.split(b'\n')[:-2])
+        self.status = raw_response.split(b'\n')[-2]
+        self.ok = self.status.startswith(b'OK')
+        self.err = self.status.startswith(b'ACK')
+        if self.err:
+            print(self.status)
+
+
+class MPCClient(object):
+    def __init__(self, host, port, do_hello=True):
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.connect((host, port))
+        self.buf = b''
+        if do_hello:
+            hello = self.get_response()
+            if not hello.ok:
+                raise RuntimeError('Bad hello: {}'.format(hello.status))
+
+    def __del__(self):
+        self.sock.close()
+
+    def get_response(self):
+        response = b''
+        while True:
+            line = self.readline()
+            response += line
+            if line.startswith(b'OK') or line.startswith(b'ACK'):
+                return MPCResponse(response)
+
+    def send_command(self, command, *args):
+        cmd = [command]
+        for arg in args:
+            if b' ' in arg:
+                cmd.append(b'"{}"'.format(arg))
+            else:
+                cmd.append(arg)
+        self.sock.sendall(b' '.join(cmd) + b'\n')
+        return self.get_response()
+
+    def readline(self, terminator=b'\n', bufsize=1024):
+        ''' Reads a line of data from the socket. '''
+
+        while True:
+            if terminator in self.buf:
+                line, self.buf = self.buf.split(terminator, 1)
+                line += terminator
+                return line
+            data = self.sock.recv(bufsize)
+            if data:
+                self.buf += data
+            else:
+                line = self.buf
+                self.buf = b''
+                return line
+
+
+class BPDTest(unittest.TestCase, TestHelper):
+    def setUp(self):
+        self.setup_beets()
+        self.load_plugins('bpd')
+        self.item = self.add_item()
+        self.lib.add_album([self.item])
+
+        self.server_proc, self.client = self.make_server_client()
+
+    def tearDown(self):
+        self.server_proc.terminate()
+        self.teardown_beets()
+        self.unload_plugins()
+
+    def make_server(self, host, port, password=None):
+        bpd_server = bpd.BaseServer(host, port, password)
+        server_proc = mp.Process(target=bpd_server.run)
+        server_proc.start()
+        return server_proc
+
+    def make_client(self, host='localhost', port=9876, do_hello=True):
+        return MPCClient(host, port, do_hello)
+
+    def make_server_client(self, host='localhost', port=9876, password=None):
+        server_proc = self.make_server(host, port, password)
+        time.sleep(1)
+        client = self.make_client(host, port)
+        return server_proc, client
+
+    def test_server_hello(self):
+        alt_client = self.make_client(do_hello=False)
+        self.assertEqual(alt_client.readline(), b'OK MPD 0.13.0\n')
+
+    def test_cmd_ping(self):
+        response = self.client.send_command(b'ping')
+        self.assertTrue(response.ok)
 
 
 def suite():

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -260,8 +260,7 @@ class BPDTest(unittest.TestCase, TestHelper):
             '--library', self.config['library'].as_filename(),
             '--directory', py3_path(self.libdir),
             '--config', py3_path(config_file.name),
-            '--verbose', '--verbose',
-            'bpd', '--debug'
+            'bpd'
         )
         server = mp.Process(target=start_beets, args=args)
         server.start()
@@ -281,8 +280,7 @@ class BPDTest(unittest.TestCase, TestHelper):
             yield MPCClient(host, port, do_hello)
         finally:
             server.terminate()
-            server.join(timeout=0.1)
-            server.kill()
+            server.join(timeout=0.2)
 
     def test_server_hello(self):
         with self.run_bpd(do_hello=False) as client:

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -164,6 +164,26 @@ class BPDTest(unittest.TestCase, TestHelper):
         response = self.client.send_command(b'ping')
         self.assertTrue(response.ok)
 
+    def test_cmd_password(self):
+        self.server_proc.terminate()
+        self.server_proc, self.client = self.make_server_client(
+                password='abc123')
+
+        response = self.client.send_command(b'status')
+        self.assertTrue(response.err)
+        self.assertEqual(response.status,
+                         b'ACK [4@0] {} insufficient privileges')
+
+        response = self.client.send_command(b'password', b'wrong')
+        self.assertTrue(response.err)
+        self.assertEqual(response.status,
+                         b'ACK [3@0] {password} incorrect password')
+
+        response = self.client.send_command(b'password', b'abc123')
+        self.assertTrue(response.ok)
+        response = self.client.send_command(b'status')
+        self.assertTrue(response.ok)
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -247,14 +247,14 @@ class BPDTest(unittest.TestCase, TestHelper):
         """
         # Create a config file:
         config = {
-                'pluginpath': [os.fsdecode(self.temp_dir)],
+                'pluginpath': [py3_path(self.temp_dir)],
                 'plugins': 'bpd',
                 'bpd': {'host': host, 'port': port},
         }
         if password:
             config['bpd']['password'] = password
         config_file = tempfile.NamedTemporaryFile(
-                mode='wb', dir=os.fsdecode(self.temp_dir), suffix='.yaml',
+                mode='wb', dir=py3_path(self.temp_dir), suffix='.yaml',
                 delete=False)
         config_file.write(
                 yaml.dump(config, Dumper=confit.Dumper, encoding='utf-8'))

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -36,12 +36,20 @@ from beetsplug import bpd
 # Mock GstPlayer so that the forked process doesn't attempt to import gi:
 import mock
 import imp
-gstplayer = imp.new_module("beetsplug.bpg.gstplayer")
-gstplayer._GstPlayer = mock.MagicMock(spec_set=[
-    "time", "volume", "playing", "run", "play_file", "pause", "stop", "seek"])
-gstplayer._GstPlayer.time.return_value = (0, 0)
-gstplayer._GstPlayer.volume = 0.0
-gstplayer._GstPlayer.playing = False
+gstplayer = imp.new_module("beetsplug.bpd.gstplayer")
+def _gstplayer_play(_):  # noqa: 42
+    bpd.gstplayer._GstPlayer.playing = True
+    return mock.DEFAULT
+gstplayer._GstPlayer = mock.MagicMock(
+    spec_set=[
+        "time", "volume", "playing", "run", "play_file", "pause", "stop",
+        "seek"
+    ], **{
+        'playing': False,
+        'volume': 0.0,
+        'time.return_value': (0, 0),
+        'play_file.side_effect': _gstplayer_play,
+    })
 gstplayer.GstPlayer = lambda _: gstplayer._GstPlayer
 sys.modules["beetsplug.bpd.gstplayer"] = gstplayer
 bpd.gstplayer = gstplayer

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -429,15 +429,14 @@ class BPDTest(unittest.TestCase, TestHelper):
     def test_cmd_tagtypes(self):
         with self.run_bpd() as client:
             response = client.send_command('tagtypes')
-        types = {tag.lower() for tag in response.data['tag']}
         self.assertEqual({
-            'artist', 'artistsort', 'album', 'albumsort', 'albumartist',
-            'albumartistsort', 'title', 'track', 'name', 'genre', 'date',
-            'composer', 'performer', 'comment', 'disc', 'label',
-            'musicbrainz_artistid', 'musicbrainz_albumid',
-            'musicbrainz_albumartistid', 'musicbrainz_trackid',
-            'musicbrainz_releasetrackid', 'musicbrainz_workid',
-            }, types)
+            'Artist', 'ArtistSort', 'Album', 'AlbumSort', 'AlbumArtist',
+            'AlbumArtistSort', 'Title', 'Track', 'Name', 'Genre', 'Date',
+            'Composer', 'Performer', 'Comment', 'Disc', 'Label',
+            'OriginalDate', 'MUSICBRAINZ_ARTISTID', 'MUSICBRAINZ_ALBUMID',
+            'MUSICBRAINZ_ALBUMARTISTID', 'MUSICBRAINZ_TRACKID',
+            'MUSICBRAINZ_RELEASETRACKID', 'MUSICBRAINZ_WORKID',
+            }, set(response.data['tag']))
 
     @unittest.expectedFailure
     def test_tagtypes_mask(self):

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -469,7 +469,7 @@ class BPDTest(unittest.TestCase, TestHelper):
             response = client.send_command('ping')
         self._assert_ok(response)
 
-    @unittest.expectedFailure
+    @unittest.skip
     def test_cmd_tagtypes(self):
         with self.run_bpd() as client:
             response = client.send_command('tagtypes')
@@ -483,7 +483,7 @@ class BPDTest(unittest.TestCase, TestHelper):
             'MUSICBRAINZ_RELEASETRACKID', 'MUSICBRAINZ_WORKID',
             }, set(response.data['tag']))
 
-    @unittest.expectedFailure
+    @unittest.skip
     def test_tagtypes_mask(self):
         with self.run_bpd() as client:
             response = client.send_command('tagtypes', 'clear')

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -31,7 +31,7 @@ from beetsplug import bpd
 
 # Intercept and mock the GstPlayer player:
 gstplayer = imp.new_module('beetsplug.bpg.gstplayer')
-gstplayer.GstPlayer = type('fake.GstPlayer', (), {
+gstplayer.GstPlayer = type('GstPlayer', (), {
     '__init__': lambda self, callback: None,
     'playing': False,
     'volume': 0.0,
@@ -97,7 +97,7 @@ class MPCResponse(object):
                    self.status.startswith(b'list_OK'))
         self.err = self.status.startswith(b'ACK')
         if not self.ok:
-            print(self.status)
+            print(self.status.decode('utf-8'))
 
 
 class MPCClient(object):
@@ -187,7 +187,7 @@ class MPCClient(object):
                 return line
 
 
-def implements(commands, expectedFailure=False):
+def implements(commands, expectedFailure=False):  # noqa: N803
     def _test(self):
         response = self.client.send_command(b'commands')
         implemented = {line[9:] for line in response.body.split(b'\n')}

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -224,12 +224,12 @@ class BPDTest(unittest.TestCase, TestHelper):
     def setUp(self):
         self.setup_beets(disk=True)
         self.load_plugins('bpd')
-        self.item1 = self.add_item(title='Track One Title',
-                                   album='Album Title', artist='Artist Name',
-                                   track=1)
-        self.item2 = self.add_item(title='Track Two Title',
-                                   album='Album Title', artist='Artist Name',
-                                   track=2)
+        self.item1 = self.add_item(
+                title='Track One Title', track=1,
+                album='Album Title', artist='Artist Name')
+        self.item2 = self.add_item(
+                title='Track Two Title', track=2,
+                album='Album Title', artist='Artist Name')
         self.lib.add_album([self.item1, self.item2])
 
     def tearDown(self):
@@ -238,7 +238,7 @@ class BPDTest(unittest.TestCase, TestHelper):
 
     @contextmanager
     def run_bpd(self, host='localhost', port=9876, password=None,
-                           do_hello=True):
+                do_hello=True):
         """ Runs BPD in another process, configured with the same library
         database as we created in the setUp method. Exposes a client that is
         connected to the server, and kills the server at the end.
@@ -404,7 +404,6 @@ class BPDTest(unittest.TestCase, TestHelper):
 
     def test_cmd_password(self):
         with self.run_bpd(password='abc123') as client:
-
             response = client.send_command('status')
             self.assertTrue(response.err)
             self.assertEqual(response.status,


### PR DESCRIPTION
I'd like to work on updating the MPD server version supported by BPD (#800) so as a first step I'm adding some tests that exercise BPD. I found an existing file that was testing parts of the BPD plugin, though the name is a bit unexpected (`test_player.py` rather than, say, `test_bpd.py`) so perhaps this should be renamed.

The test code adds a simple TCP client that can speak to an MPD server. It provides a small number of convenience functions for building requests and interpreting responses but it intended to be pretty dumb. This way we can treat BPD as a black box and test how it responds over the protocol rather than unit testing the functions in the plugin's module. The real BPD server is started in a separate thread, and we have to wait a small amount of time for it to spin up before attempting to connect to it. ~~Since starting the BPD server requires executing `import gi` this means the tests have to grow a dependency on the relevant GObject modules. Since I start the BPD server in the `setUp` method, we incur the wait-to-connect delay for each test. I set this to 0.1s and it's sufficient on my laptop but it might need to be longer on other hardware.~~ (The client now polls the server until the socket is bound so there's not much wasted delay, and the overall timeout is longer.)

I've written tests based on the current MPD protocol specification, which is several versions ahead of where BPD is at. For this reason I've marked several of them as expected failures for now. The various `test_implements_*` tests are just checking that BPD claims to support all of the commands in each category of the full MPD list. They can perhaps be removed after we support all the commands, but I'm just using them as a progress meter for now to highlight what's missing from the implementation.

My plan is to add more tests and update BPD in subsequent PRs. As well as new commands there are new behaviours like a new more powerful filter syntax and additional flags for old commands. For now I just want to get this stub for the test framework merged.