### PR TITLE
the: log a debug only when text is changed

### DIFF
--- a/beetsplug/the.py
+++ b/beetsplug/the.py
@@ -93,8 +93,8 @@ class ThePlugin(BeetsPlugin):
             for p in self.patterns:
                 r = self.unthe(text, p)
                 if r != text:
+                    self._log.debug(u'\"{0}\" -> \"{1}\"', text, r)
                     break
-            self._log.debug(u'\"{0}\" -> \"{1}\"', text, r)
             return r
         else:
             return u''


### PR DESCRIPTION
Previously the `the` plugin would log a debug message when the text _didn't_ get changed by the plugin, whereas I think what was intended was the opposite. With this change the logged messages show the actual transformations made by the plugin.