### PR TITLE
Fix several deprecation warnings

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -23,7 +23,6 @@ from collections import defaultdict
 import threading
 import sqlite3
 import contextlib
-import collections
 
 import beets
 from beets.util.functemplate import Template
@@ -31,6 +30,10 @@ from beets.util import py3_path
 from beets.dbcore import types
 from .query import MatchQuery, NullSort, TrueQuery
 import six
+if six.PY2:
+    from collections import Mapping
+else:
+    from collections.abc import Mapping
 
 
 class DBAccessError(Exception):
@@ -42,7 +45,7 @@ class DBAccessError(Exception):
     """
 
 
-class FormattedMapping(collections.Mapping):
+class FormattedMapping(Mapping):
     """A `dict`-like formatted view of a model.
 
     The accessor `mapping[key]` returns the formatted version of

--- a/beets/util/confit.py
+++ b/beets/util/confit.py
@@ -22,9 +22,13 @@ import os
 import pkgutil
 import sys
 import yaml
-import collections
 import re
+import six
 from collections import OrderedDict
+if six.PY2:
+    from collections import Mapping, Sequence
+else:
+    from collections.abc import Mapping, Sequence
 
 UNIX_DIR_VAR = 'XDG_CONFIG_HOME'
 UNIX_DIR_FALLBACK = '~/.config'
@@ -1165,7 +1169,7 @@ class Choice(Template):
                 view
             )
 
-        if isinstance(self.choices, collections.Mapping):
+        if isinstance(self.choices, Mapping):
             return self.choices[value]
         else:
             return value
@@ -1306,11 +1310,11 @@ class Pairs(StrSeq):
             return (super(Pairs, self)._convert_value(x, view),
                     self.default_value)
         except ConfigTypeError:
-            if isinstance(x, collections.Mapping):
+            if isinstance(x, Mapping):
                 if len(x) != 1:
                     self.fail(u'must be a single-element mapping', view, True)
                 k, v = iter_first(x.items())
-            elif isinstance(x, collections.Sequence):
+            elif isinstance(x, Sequence):
                 if len(x) != 2:
                     self.fail(u'must be a two-element list', view, True)
                 k, v = x
@@ -1367,7 +1371,7 @@ class Filename(Template):
         return 'Filename({0})'.format(', '.join(args))
 
     def resolve_relative_to(self, view, template):
-        if not isinstance(template, (collections.Mapping, MappingTemplate)):
+        if not isinstance(template, (Mapping, MappingTemplate)):
             # disallow config.get(Filename(relative_to='foo'))
             raise ConfigTemplateError(
                 u'relative_to may only be used when getting multiple values.'
@@ -1486,7 +1490,7 @@ def as_template(value):
     if isinstance(value, Template):
         # If it's already a Template, pass it through.
         return value
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, Mapping):
         # Dictionaries work as templates.
         return MappingTemplate(value)
     elif value is int:
@@ -1507,9 +1511,9 @@ def as_template(value):
     elif value is None:
         return Template()
     elif value is dict:
-        return TypeTemplate(collections.Mapping)
+        return TypeTemplate(Mapping)
     elif value is list:
-        return TypeTemplate(collections.Sequence)
+        return TypeTemplate(Sequence)
     elif isinstance(value, type):
         return TypeTemplate(value)
     else:

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -284,7 +284,7 @@ class DiscogsPlugin(BeetsPlugin):
         # https://www.discogs.com/help/doc/submission-guidelines-general-rules
         if not all([result.data.get(k) for k in ['artists', 'title', 'id',
                                                  'tracklist']]):
-            self._log.warn(u"Release does not contain the required fields")
+            self._log.warning(u"Release does not contain the required fields")
             return None
 
         artist, artist_id = self.get_artist([a.data for a in result.artists])

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -446,7 +446,7 @@ def _scrape_strip_cruft(html, plain_text_out=False):
     html = html.replace('\r', '\n')  # Normalize EOL.
     html = re.sub(r' +', ' ', html)  # Whitespaces collapse.
     html = BREAK_RE.sub('\n', html)  # <br> eats up surrounding '\n'.
-    html = re.sub(r'<(script).*?</\1>(?s)', '', html)  # Strip script tags.
+    html = re.sub(r'(?s)<(script).*?</\1>', '', html)  # Strip script tags.
 
     if plain_text_out:  # Strip remaining HTML tags
         html = COMMENT_RE.sub('', html)

--- a/beetsplug/metasync/itunes.py
+++ b/beetsplug/metasync/itunes.py
@@ -24,6 +24,7 @@ import shutil
 import tempfile
 import plistlib
 
+import six
 from six.moves.urllib.parse import urlparse, unquote
 from time import mktime
 
@@ -84,7 +85,11 @@ class Itunes(MetaSource):
             self._log.debug(
                 u'loading iTunes library from {0}'.format(library_path))
             with create_temporary_copy(library_path) as library_copy:
-                raw_library = plistlib.readPlist(library_copy)
+                if six.PY2:
+                    raw_library = plistlib.readPlist(library_copy)
+                else:
+                    with open(library_copy, 'rb') as library_copy_f:
+                        raw_library = plistlib.load(library_copy_f)
         except IOError as e:
             raise ConfigValueError(u'invalid iTunes library: ' + e.strerror)
         except Exception:


### PR DESCRIPTION
While running the test suite with pytest in Python 3.7, it flagged a few distinct deprecation warnings. I see that the YAML one is handled in another PR, but this one addresses:

  * `log.warn()` [should be `log.warning`](https://bugs.python.org/issue13235)
  * Abstract base classes from `collections` were moved to `collections.abc` in Python 3.3 and [will be unavailable](https://docs.python.org/3/library/collections.abc.html) from their original location in Python 3.8.
  * Regex flags that aren't at the start of the pattern [have been deprecated](https://bugs.python.org/issue22493)
  * The `plistlib` module has a [changed interface](https://docs.python.org/3.7/library/plistlib.html#plistlib.readPlist) since Python 3.4