### PR TITLE
Fix test_ui:test_version under pytest

### DIFF
--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -1223,13 +1223,14 @@ class CommonOptionsParserCliTest(unittest.TestCase, TestHelper):
     """
     def setUp(self):
         self.setup_beets()
-        self.lib = library.Library(':memory:')
         self.item = _common.item()
         self.item.path = b'xxx/yyy'
         self.lib.add(self.item)
         self.lib.add_album([self.item])
+        self.load_plugins()
 
     def tearDown(self):
+        self.unload_plugins()
         self.teardown_beets()
 
     def test_base(self):


### PR DESCRIPTION
The test `CommonOptionsParserCliTest.test_version` was passing with nose but failing with pytest (see output below). The reason for the failure seemed to be that the `test` plugin was loaded when it wasn't expected to be loaded, changing the output of the `version` command. I'm not sure exactly why that was happening, but since that test already inherited from `TestHelper`, just invoking the plugin load/unload helper was enough to fix it. I also removed the line setting the `self.lib` variable since that's already done in the helper.

```
self = <test.test_ui.CommonOptionsParserCliTest testMethod=test_version>

    def test_version(self):
        l = self.run_with_output(u'version')
        self.assertIn(u'Python version', l)
>       self.assertIn(u'no plugins loaded', l)
E       AssertionError: 'no plugins loaded' not found in 'beets version 1.4.8\nPython version 3.7.3rc1\nplugins: test\n'

test/test_ui.py:1292: AssertionError
```