### PR TITLE
Support Python 3.8 (fixes #3201)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ matrix:
         - python: 3.7
           env: {TOX_ENV: py37-test}
           dist: xenial
+        - python: 3.8-dev
+          env: {TOX_ENV: py38-test}
+          dist: xenial
         # - python: pypy
         #   - env: {TOX_ENV: pypy-test}
         - python: 3.4

--- a/beets/util/functemplate.py
+++ b/beets/util/functemplate.py
@@ -141,7 +141,13 @@ def compile_func(arg_names, statements, name='_the_func', debug=False):
             decorator_list=[],
         )
 
-    mod = ast.Module([func_def])
+    # The ast.Module signature changed in 3.8 to accept a list of types to
+    # ignore.
+    if sys.version_info >= (3, 8):
+        mod = ast.Module([func_def], [])
+    else:
+        mod = ast.Module([func_def])
+
     ast.fix_missing_locations(mod)
 
     prog = compile(mod, '<generated>', 'exec')

--- a/setup.py
+++ b/setup.py
@@ -154,6 +154,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27-test, py37-test, py27-flake8, docs
+envlist = py27-test, py37-test, py38-test, py27-flake8, docs
 
 # The exhaustive list of environments is:
 # envlist = py{27,34,35}-{test,cov}, py{27,34,35}-flake8, docs
@@ -40,17 +40,18 @@ passenv =
 deps =
     {test,cov}: {[_test]deps}
     py27: pathlib
-    py{27,34,35,36,37}-flake8: {[_flake8]deps}
+    py{27,34,35,36,37,38}-flake8: {[_flake8]deps}
 commands =
     py27-cov: python -m nose --with-coverage {posargs}
     py27-test: python -m nose {posargs}
-    py3{4,5,6,7}-cov: python -bb -m nose --with-coverage {posargs}
-    py3{4,5,6,7}-test: python -bb -m nose {posargs}
+    py3{4,5,6,7,8}-cov: python -bb -m nose --with-coverage {posargs}
+    py3{4,5,6,7,8}-test: python -bb -m nose {posargs}
     py27-flake8: flake8 --min-version 2.7 {posargs} {[_flake8]files}
     py34-flake8: flake8 --min-version 3.4 {posargs} {[_flake8]files}
     py35-flake8: flake8 --min-version 3.5 {posargs} {[_flake8]files}
     py36-flake8: flake8 --min-version 3.6 {posargs} {[_flake8]files}
     py37-flake8: flake8 --min-version 3.7 {posargs} {[_flake8]files}
+    py38-flake8: flake8 --min-version 3.8 {posargs} {[_flake8]files}
 
 [testenv:docs]
 basepython = python2.7


### PR DESCRIPTION
This PR fixes support for Python 3.8 by conditionally providing a new second argument to `ast.Module`.

I have added a `py38-test` tox environment (and associated `-cov` and `-flake8` environments) and enabled this on Travis, however I couldn't even see Python 3.7 being tested on AppVeyor. Should both 3.7 and 3.8 be enabled on there?