### PR TITLE
bpd: support idle command and with it MPD 0.14

### DIFF
--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -767,7 +767,7 @@ class Command(object):
         # by the client (so we can raise ERROR_ARG instead of ERROR_SYSTEM).
         # Maximum accepted arguments: argspec includes "self" and "conn".
         max_args = len(argspec.args) - 2
-        # Minimum accepted arguments: some arguments might be optional/
+        # Minimum accepted arguments: some arguments might be optional.
         min_args = max_args
         if argspec.defaults:
             min_args -= len(argspec.defaults)

--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -39,7 +39,7 @@ from beets import dbcore
 from beets.mediafile import MediaFile
 import six
 
-PROTOCOL_VERSION = '0.13.0'
+PROTOCOL_VERSION = '0.14.0'
 BUFSIZE = 1024
 
 HELLO = u'OK MPD %s' % PROTOCOL_VERSION

--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -309,7 +309,6 @@ class BaseServer(object):
         playlist, playlistlength, and xfade.
         """
         yield (
-            u'volume: ' + six.text_type(self.volume),
             u'repeat: ' + six.text_type(int(self.repeat)),
             u'random: ' + six.text_type(int(self.random)),
             u'consume: ' + six.text_type(int(self.consume)),
@@ -318,6 +317,9 @@ class BaseServer(object):
             u'playlistlength: ' + six.text_type(len(self.playlist)),
             u'mixrampdb: ' + six.text_type(self.mixrampdb),
         )
+
+        if self.volume > 0:
+            yield u'volume: ' + six.text_type(self.volume)
 
         if not math.isnan(self.mixrampdelay):
             yield u'mixrampdelay: ' + six.text_type(self.mixrampdelay)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -86,6 +86,9 @@ New features:
   new fields for ``status``. The bpd server now understands and ignores some
   additional commands.
   :bug:`3200` :bug:`800`
+* :doc:`/plugins/bpd`: MPD protocol command ``idle`` is now supported, allowing
+  the MPD version to be bumped to 0.14.
+  :bug:`3205` :bug:`800`
 
 Changes:
 

--- a/docs/plugins/bpd.rst
+++ b/docs/plugins/bpd.rst
@@ -75,6 +75,8 @@ The available options are:
   Default: No password.
 - **volume**: Initial volume, as a percentage.
   Default: 100
+- **control_port**: Port for the internal control socket.
+  Default: 6601
 
 Here's an example::
 

--- a/docs/plugins/bpd.rst
+++ b/docs/plugins/bpd.rst
@@ -95,40 +95,42 @@ on-disk directory structure can. (Note that an obvious solution to this is just
 string matching on items' destination, but this requires examining the entire
 library Python-side for every query.)
 
-We don't currently support versioned playlists. Many clients, however, use
-plchanges instead of playlistinfo to get the current playlist, so plchanges
-contains a dummy implementation that just calls playlistinfo.
+BPD plays music using GStreamer's ``playbin`` player, which has a simple API
+but doesn't support many advanced playback features.
 
-The ``stats`` command always send zero for ``playtime``, which is supposed to
-indicate the amount of time the server has spent playing music. BPD doesn't
-currently keep track of this.
+Differences from the real MPD
+-----------------------------
 
-The ``update`` command regenerates the directory tree from the beets database.
-
-Unimplemented Commands
-----------------------
-
-These are the commands from `the MPD protocol`_ that have not yet been
-implemented in BPD.
+BPD currently supports version 0.14 of `the MPD protocol`_, but several of the
+commands and features are "pretend" implementations or have slightly different
+behaviour to their MPD equivalents. BPD aims to look enough like MPD that it
+can interact with the ecosystem of clients, but doesn't try to be
+a fully-fledged MPD replacement in terms of its playback capabilities.
 
 .. _the MPD protocol: http://www.musicpd.org/doc/protocol/
 
-Saved playlists:
+These are some of the known differences between BPD and MPD:
 
-* playlistclear
-* playlistdelete
-* playlistmove
-* playlistadd
-* playlistsearch
-* listplaylist
-* listplaylistinfo
-* playlistfind
-* rm
-* save
-* load
-* rename
-
-Deprecated:
-
-* playlist
-* volume
+* BPD doesn't currently support versioned playlists. Many clients, however, use
+  plchanges instead of playlistinfo to get the current playlist, so plchanges
+  contains a dummy implementation that just calls playlistinfo.
+* Stored playlists aren't supported (BPD understands the commands though).
+* The ``stats`` command always send zero for ``playtime``, which is supposed to
+  indicate the amount of time the server has spent playing music. BPD doesn't
+  currently keep track of this.
+* The ``update`` command regenerates the directory tree from the beets database
+  synchronously, whereas MPD does this in the background.
+* Advanced playback features like cross-fade, ReplayGain and MixRamp are not
+  supported due to BPD's simple audio player backend.
+* Advanced query syntax is not currently supported.
+* Not all tags (fields) are currently exposed to BPD. Clients also can't use
+  the ``tagtypes`` mask to hide fields.
+* BPD's ``random`` mode is not deterministic and doesn't support priorities.
+* Mounts and streams are not supported. BPD can only play files from disk.
+* Stickers are not supported (although this is basically a flexattr in beets
+  nomenclature so this is feasible to add).
+* There is only a single password, and is enabled it grants access to all
+  features rather than having permissions-based granularity.
+* Partitions and alternative outputs are not supported; BPD can only play one
+  song at a time.
+* Client channels are not implemented.

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -354,7 +354,7 @@ class BPDTestHelper(unittest.TestCase, TestHelper):
 class BPDTest(BPDTestHelper):
     def test_server_hello(self):
         with self.run_bpd(do_hello=False) as client:
-            self.assertEqual(client.readline(), b'OK MPD 0.13.0\n')
+            self.assertEqual(client.readline(), b'OK MPD 0.14.0\n')
 
     def test_unknown_cmd(self):
         with self.run_bpd() as client:

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -270,7 +270,7 @@ class BPDTestHelper(unittest.TestCase, TestHelper):
         config = {
                 'pluginpath': [py3_path(self.temp_dir)],
                 'plugins': 'bpd',
-                'bpd': {'host': host, 'port': port},
+                'bpd': {'host': host, 'port': port, 'control_port': port + 1},
         }
         if password:
             config['bpd']['password'] = password

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -23,6 +23,7 @@ from test.helper import TestHelper
 import os
 import sys
 import multiprocessing as mp
+import threading
 import socket
 import time
 import yaml
@@ -37,18 +38,19 @@ from beetsplug import bpd
 import mock
 import imp
 gstplayer = imp.new_module("beetsplug.bpd.gstplayer")
-def _gstplayer_play(_):  # noqa: 42
+def _gstplayer_play(*_):  # noqa: 42
     bpd.gstplayer._GstPlayer.playing = True
     return mock.DEFAULT
 gstplayer._GstPlayer = mock.MagicMock(
     spec_set=[
         "time", "volume", "playing", "run", "play_file", "pause", "stop",
-        "seek"
+        "seek", "play"
     ], **{
         'playing': False,
         'volume': 0,
         'time.return_value': (0, 0),
         'play_file.side_effect': _gstplayer_play,
+        'play.side_effect': _gstplayer_play,
     })
 gstplayer.GstPlayer = lambda _: gstplayer._GstPlayer
 sys.modules["beetsplug.bpd.gstplayer"] = gstplayer
@@ -259,7 +261,7 @@ class BPDTestHelper(unittest.TestCase, TestHelper):
 
     @contextmanager
     def run_bpd(self, host='localhost', port=9876, password=None,
-                do_hello=True):
+                do_hello=True, second_client=False):
         """ Runs BPD in another process, configured with the same library
         database as we created in the setUp method. Exposes a client that is
         connected to the server, and kills the server at the end.
@@ -290,7 +292,7 @@ class BPDTestHelper(unittest.TestCase, TestHelper):
         server.start()
 
         # Wait until the socket is connected:
-        sock = None
+        sock, sock2 = None, None
         for _ in range(20):
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             if sock.connect_ex((host, port)) == 0:
@@ -302,9 +304,16 @@ class BPDTestHelper(unittest.TestCase, TestHelper):
             raise RuntimeError('Timed out waiting for the BPD server')
 
         try:
-            yield MPCClient(sock, do_hello)
+            if second_client:
+                sock2 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock2.connect((host, port))
+                yield MPCClient(sock, do_hello), MPCClient(sock2, do_hello)
+            else:
+                yield MPCClient(sock, do_hello)
         finally:
             sock.close()
+            if sock2:
+                sock2.close()
             server.terminate()
             server.join(timeout=0.2)
 
@@ -375,8 +384,8 @@ class BPDTest(BPDTestHelper):
 
 class BPDQueryTest(BPDTestHelper):
     test_implements_query = implements({
-            'clearerror', 'currentsong', 'idle', 'stats',
-            }, expectedFailure=True)
+            'clearerror', 'currentsong', 'stats',
+            })
 
     def test_cmd_status(self):
         with self.run_bpd() as client:
@@ -396,6 +405,41 @@ class BPDQueryTest(BPDTestHelper):
             'song', 'songid', 'time', 'elapsed', 'bitrate', 'duration', 'audio'
         }
         self.assertEqual(fields_playing, set(responses[2].data.keys()))
+
+    def test_cmd_idle(self):
+        def _toggle(c):
+            for _ in range(3):
+                rs = c.send_commands(('play',), ('pause',))
+                # time.sleep(0.05)  # uncomment if test is flaky
+                if any(not r.ok for r in rs):
+                    raise RuntimeError('Toggler failed')
+        with self.run_bpd(second_client=True) as (client, client2):
+            self._bpd_add(client, self.item1, self.item2)
+            toggler = threading.Thread(target=_toggle, args=(client2,))
+            toggler.start()
+            # Idling will hang until the toggler thread changes the play state.
+            # Since the client sockets have a 1s timeout set at worst this will
+            # raise a socket.timeout and fail the test if the toggler thread
+            # manages to finish before the idle command is sent here.
+            response = client.send_command('idle', 'player')
+            toggler.join()
+        self._assert_ok(response)
+
+    def test_cmd_idle_with_pending(self):
+        with self.run_bpd(second_client=True) as (client, client2):
+            response1 = client.send_command('random', '1')
+            response2 = client2.send_command('idle')
+        self._assert_ok(response1, response2)
+        self.assertEqual('options', response2.data['changed'])
+
+    def test_cmd_noidle(self):
+        with self.run_bpd() as client:
+            # Manually send a command without reading a response.
+            request = client.serialise_command('idle')
+            client.sock.sendall(request)
+            time.sleep(0.01)
+            response = client.send_command('noidle')
+        self._assert_ok(response)
 
 
 class BPDPlaybackTest(BPDTestHelper):

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -367,6 +367,11 @@ class BPDTest(BPDTestHelper):
             response = client.send_command('crash_TypeError')
         self._assert_failed(response, bpd.ERROR_SYSTEM)
 
+    def test_empty_request(self):
+        with self.run_bpd() as client:
+            response = client.send_command('')
+        self._assert_failed(response, bpd.ERROR_UNKNOWN)
+
 
 class BPDQueryTest(BPDTestHelper):
     test_implements_query = implements({

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -384,7 +384,7 @@ class BPDQueryTest(BPDTestHelper):
         fields_not_playing = {
             'repeat', 'random', 'single', 'consume', 'playlist',
             'playlistlength', 'mixrampdb', 'state',
-            'volume'  # not (always?) returned by MPD
+            'volume'
         }
         self.assertEqual(fields_not_playing, set(responses[0].data.keys()))
         fields_playing = fields_not_playing | {


### PR DESCRIPTION
The `idle` command from a client signals that the connection should remain idle until an event occurs in the player, at which point the client should be notified. This PR adds support for the command by making the client's thread poll a list of events. The server can asynchronously populate the event list in response to requests from other clients.

This is the next step for #800 and gets us to MPD 0.14.

Details from the MPD protocol specification:
>Waits until there is a noteworthy change in one or more of MPD’s subsystems. As soon as there is one, it lists all changed systems in a line in the format `changed: SUBSYSTEM`.
>
>Change events accumulate, even while the connection is not in “idle” mode; no events gets lost while the client is doing something else with the connection. If an event had already occurred since the last call, the new idle command will return immediately.
>
>While a client is waiting for idle results, the server disables timeouts, allowing a client to wait for events as long as mpd runs. The idle command can be canceled by sending the command noidle (no other commands are allowed). MPD will then leave idle mode and print results immediately; might be empty at this time. If the optional SUBSYSTEMS argument is used, MPD will only send notifications when something changed in one of the specified subsytems.

Example excerpt of the log (in the new format introduced in this PR) from an mpDris session:
```
bpd: <[127.0.0.1:60926]: idle
bpd: <[127.0.0.1:60926]: noidle
bpd: >[127.0.0.1:60926]: OK
bpd: <[127.0.0.1:60926]: currentsong
bpd: >[127.0.0.1:60926]: OK
bpd: <[127.0.0.1:60926]: status
bpd: >[127.0.0.1:60926]: repeat: 0
bpd: >[127.0.0.1:60926]: random: 0
bpd: >[127.0.0.1:60926]: consume: 0
bpd: >[127.0.0.1:60926]: single: 0
bpd: >[127.0.0.1:60926]: playlist: 0
bpd: >[127.0.0.1:60926]: playlistlength: 0
bpd: >[127.0.0.1:60926]: mixrampdb: 0.0
bpd: >[127.0.0.1:60926]: volume: 10
bpd: >[127.0.0.1:60926]: state: stop
bpd: >[127.0.0.1:60926]: OK
bpd: <[127.0.0.1:60926]: idle
bpd: >[127.0.0.1:60926]: ACK [5@0] {} Got command while idle: close
bpd: *[127.0.0.1:60926]: disconnected
```
(NB: this shows that mpDris sends `close` when it's quit while in idle mode. Here bpd is replying with an error since it's not expecting that. It didn't matter since the client anyway quit, and the protocol says a client should just disconnect without using `close`, which is now deprecated.)

Remaining work:
- [x] ~~See if there's a way to use bluelet here without polling. The only alternative I can think of is to open a new socket we can `select` and use that to wait for the MPD events.~~
- [x] Support the full list of events specified by MPD.
- [x] Work out when events should be fired (the specification is a bit vague here so this will mean checking the MPD source).
- [x] Avoid sending duplicate events (use a `set` for the queued events).
- [x] Cleanup when clients disconnect while `idle`ing (currently the coroutine stays alive in that case).
- [x] Add tests.
- [x] Bump MPD protocol version.
- [x] Test on real clients besides `mpc`.