### PR TITLE
mpdstats: use currentsong instead of playlist

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -188,6 +188,11 @@ Fixes:
   :bug:`3201` :bug:`3202`
 * :doc:`/plugins/bpd`: Fix crashes in the bpd server during exception handling.
   :bug:`3200`
+* :doc:`/plugins/mpdstats`: Use the ``currentsong`` MPD command instead of
+  ``playlist`` to get the current song, improving performance when the playlist
+  is long.
+  Thanks to :user:`ray66`.
+  :bug:`3207` :bug:`2752`
 
 .. _python-itunes: https://github.com/ocelma/python-itunes
 

--- a/test/test_mpdstats.py
+++ b/test/test_mpdstats.py
@@ -65,7 +65,7 @@ class MPDStatsTest(unittest.TestCase, TestHelper):
 
     @patch("beetsplug.mpdstats.MPDClientWrapper", return_value=Mock(**{
         "events.side_effect": EVENTS, "status.side_effect": STATUSES,
-        "playlist.return_value": {1: item_path}}))
+        "currentsong.return_value": item_path}))
     def test_run_mpdstats(self, mpd_mock):
         item = Item(title=u'title', path=self.item_path, id=1)
         item.add(self.lib)


### PR DESCRIPTION
This is a copy of #2754, rebased and with the additional small change required to the test. Ive also tested it using bpd (with the changes from my `bpd-idle` branch) and it appears to be working well.

Closes #2754, closes #2752