### PR TITLE
inline: expose item in item_field

### DIFF
--- a/beetsplug/inline.py
+++ b/beetsplug/inline.py
@@ -102,6 +102,8 @@ class InlinePlugin(BeetsPlugin):
             out = dict(obj)
             if album:
                 out['items'] = list(obj.items())
+            else:
+                out['item'] = obj
             return out
 
         if is_expr:


### PR DESCRIPTION
In order to be able to load the results of a beets query into a music player we have the `play` plugin. There's a bit of a problem if the music player is bpd however, since `play` gives the real filesystem paths to tracks, whereas bpd expects virtual paths.

There are a couple of ways to go about this, for example just manually recreating the virtual paths using other fields. I wanted a way of getting beets to tell my the paths directly, and it seemed like the `inline` plugin could help. To get the virtual path for an album I was able to do this:
```yaml
album_fields:
    bpd_path: |
      path = items[0].destination(fragment=True)
      return '/'.join(path.split('/')[:-1])
```
This uses `Item.destination` which is exactly what `beets.vfs` uses to construct the virtual path. However when it came to doing the same thing with `item_fields` I got stuck since only the fields are exposed and not the methods. The small change in this PR lets me do:
```yaml
item_fields:
    bpd_path: |
      return item.destination(fragment=True)
```

**Points against**:

- Maybe we don't want this since it's exposing more of the "internal" `Item` API to the configuration file.
- It's also adding a second way to get all of the fields of the item which is potentially confusing ("do I use `artist` or `item.artist`?").
- We could make the vfs structure configurable and/or expose a new field for the virtual path. This could be cleaner and more powerful anyway.
- If we don't do this, is it a problem that real `Item`s are exposed in `album_fields`? Should they be replaced with `namedtuple`s that only expose the fields?