### PR TITLE
Catch OSError in prune_dirs helper

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -283,13 +283,13 @@ def prune_dirs(path, root=None, clutter=('.DS_Store', 'Thumbs.db')):
             continue
         clutter = [bytestring_path(c) for c in clutter]
         match_paths = [bytestring_path(d) for d in os.listdir(directory)]
-        if fnmatch_all(match_paths, clutter):
-            # Directory contains only clutter (or nothing).
-            try:
+        try:
+            if fnmatch_all(match_paths, clutter):
+                # Directory contains only clutter (or nothing).
                 shutil.rmtree(directory)
-            except OSError:
+            else:
                 break
-        else:
+        except OSError:
             break
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -195,6 +195,8 @@ Fixes:
   is long.
   Thanks to :user:`ray66`.
   :bug:`3207` :bug:`2752`
+* Fix an unhandled exception when pruning empty directories.
+  :bug:`1996` :bug:`3209`
 
 .. _python-itunes: https://github.com/ocelma/python-itunes
 


### PR DESCRIPTION
Since `fnmatch_all` can raise `OSError`s, and we were already silently giving up in `prune_dirs` on some of these exception, just do more of the same. Closes #1996.

It seems that this solution was agreed on in the issue but nobody went ahead and implemented it. I haven't made any attempt to test this but it looks sensible.

/cc @jackwilsdon 