### PR TITLE
mpdstats: Re-add fixes from #2707

### DIFF
--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -256,10 +256,6 @@ class MPDStats(object):
         if not path:
             return
 
-        if is_url(path):
-            self._log.info(u'playing stream {0}', displayable_path(path))
-            return
-
         played, duration = map(int, status['time'].split(':', 1))
         remaining = duration - played
 
@@ -275,6 +271,14 @@ class MPDStats(object):
 
                 if diff <= self.time_threshold:
                     return
+
+                if self.now_playing['path'] == path and played == 0:
+                    self.handle_song_change(self.now_playing)
+
+        if is_url(path):
+            self._log.info(u'playing stream {0}', displayable_path(path))
+            self.now_playing = None
+            return
 
         self._log.info(u'playing {0}', displayable_path(path))
 


### PR DESCRIPTION
#3207 seemed to have deleted lines related to #2707 which allowed mpdstats to update songs ratings when playing the same song consecutively as well as when switching from a song to an internet stream.  Re-added the lines and it seems to be working fine with the new currentsong method.