### PR TITLE
bpd: support MPD 0.16 protocol and more clients

### DIFF
--- a/beets/util/bluelet.py
+++ b/beets/util/bluelet.py
@@ -346,6 +346,10 @@ def run(root_coro):
                             exc.args[0] == errno.EPIPE:
                         # Broken pipe. Remote host disconnected.
                         pass
+                    elif isinstance(exc.args, tuple) and \
+                            exc.args[0] == errno.ECONNRESET:
+                        # Connection was reset by peer.
+                        pass
                     else:
                         traceback.print_exc()
                     # Abort the coroutine.

--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -77,8 +77,8 @@ SAFE_COMMANDS = (
 SUBSYSTEMS = [
     u'update', u'player', u'mixer', u'options', u'playlist', u'database',
     # Related to unsupported commands:
-    # u'stored_playlist', u'output', u'subscription', u'sticker', u'message',
-    # u'partition',
+    u'stored_playlist', u'output', u'subscription', u'sticker', u'message',
+    u'partition',
 ]
 
 ITEM_KEYS_WRITABLE = set(MediaFile.fields()).intersection(Item._fields.keys())

--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -627,7 +627,6 @@ class BaseServer(object):
         """Advance to the next song in the playlist."""
         old_index = self.current_index
         self.current_index = self._succ_idx()
-        self._send_event('playlist')
         if self.consume:
             # TODO how does consume interact with single+repeat?
             self.playlist.pop(old_index)
@@ -648,7 +647,6 @@ class BaseServer(object):
         """Step back to the last song."""
         old_index = self.current_index
         self.current_index = self._prev_idx()
-        self._send_event('playlist')
         if self.consume:
             self.playlist.pop(old_index)
         if self.current_index < 0:

--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -1094,6 +1094,8 @@ class Server(BaseServer):
         self.cmd_update(None)
         log.info(u'Server ready and listening on {}:{}'.format(
             host, port))
+        log.debug(u'Listening for control signals on {}:{}'.format(
+            host, ctrl_port))
 
     def run(self):
         self.player.run()

--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -454,7 +454,8 @@ class BaseServer(object):
 
     def cmd_volume(self, conn, vol_delta):
         """Deprecated command to change the volume by a relative amount."""
-        raise BPDError(ERROR_SYSTEM, u'No mixer')
+        vol_delta = cast_arg(int, vol_delta)
+        return self.cmd_setvol(conn, self.volume + vol_delta)
 
     def cmd_crossfade(self, conn, crossfade):
         """Set the number of seconds of crossfading."""

--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -593,7 +593,9 @@ class BaseServer(object):
             yield self._item_info(track)
 
     def cmd_playlistid(self, conn, track_id=-1):
-        return self.cmd_playlistinfo(conn, self._id_to_index(track_id))
+        if track_id != -1:
+            track_id = self._id_to_index(track_id)
+        return self.cmd_playlistinfo(conn, track_id)
 
     def cmd_plchanges(self, conn, version):
         """Sends playlist changes since the given version.

--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -1548,7 +1548,7 @@ class Server(BaseServer):
     def cmd_seek(self, conn, index, pos):
         """Seeks to the specified position in the specified song."""
         index = cast_arg(int, index)
-        pos = cast_arg(int, pos)
+        pos = cast_arg(float, pos)
         super(Server, self).cmd_seek(conn, index, pos)
         self.player.seek(pos)
 

--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -39,7 +39,7 @@ from beets import dbcore
 from mediafile import MediaFile
 import six
 
-PROTOCOL_VERSION = '0.14.0'
+PROTOCOL_VERSION = '0.16.0'
 BUFSIZE = 1024
 
 HELLO = u'OK MPD %s' % PROTOCOL_VERSION

--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -847,6 +847,9 @@ class MPDConnection(Connection):
                     yield self.send(err.response())
                     break
                 continue
+            if line == u'noidle':
+                # When not in idle, this command sends no response.
+                continue
 
             if clist is not None:
                 # Command list already opened.

--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -412,6 +412,11 @@ class BaseServer(object):
             current_id = self._item_id(self.playlist[self.current_index])
             yield u'song: ' + six.text_type(self.current_index)
             yield u'songid: ' + six.text_type(current_id)
+            if len(self.playlist) > self.current_index + 1:
+                # If there's a next song, report its index too.
+                next_id = self._item_id(self.playlist[self.current_index + 1])
+                yield u'nextsong: ' + six.text_type(self.current_index + 1)
+                yield u'nextsongid: ' + six.text_type(next_id)
 
         if self.error:
             yield u'error: ' + self.error

--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -1117,18 +1117,9 @@ class Server(BaseServer):
         info_lines = [
             u'file: ' + item.destination(fragment=True),
             u'Time: ' + six.text_type(int(item.length)),
-            u'Title: ' + item.title,
-            u'Artist: ' + item.artist,
-            u'Album: ' + item.album,
-            u'Genre: ' + item.genre,
+            u'duration: ' + u'{:.3f}'.format(item.length),
+            u'Id: ' + six.text_type(item.id),
         ]
-
-        track = six.text_type(item.track)
-        if item.tracktotal:
-            track += u'/' + six.text_type(item.tracktotal)
-        info_lines.append(u'Track: ' + track)
-
-        info_lines.append(u'Date: ' + six.text_type(item.year))
 
         try:
             pos = self._id_to_index(item.id)
@@ -1137,7 +1128,9 @@ class Server(BaseServer):
             # Don't include position if not in playlist.
             pass
 
-        info_lines.append(u'Id: ' + six.text_type(item.id))
+        for tagtype, field in self.tagtype_map.items():
+            info_lines.append(u'{}: {}'.format(
+                tagtype, six.text_type(getattr(item, field))))
 
         return info_lines
 
@@ -1341,18 +1334,24 @@ class Server(BaseServer):
 
     tagtype_map = {
         u'Artist':          u'artist',
+        u'ArtistSort':      u'artist_sort',
         u'Album':           u'album',
         u'Title':           u'title',
         u'Track':           u'track',
         u'AlbumArtist':     u'albumartist',
         u'AlbumArtistSort': u'albumartist_sort',
-        # Name?
+        u'Label':           u'label',
         u'Genre':           u'genre',
         u'Date':            u'year',
+        u'OriginalDate':    u'original_year',
         u'Composer':        u'composer',
-        # Performer?
         u'Disc':            u'disc',
-        u'filename':        u'path',  # Suspect.
+        u'Comment':         u'comments',
+        u'MUSICBRAINZ_TRACKID':        u'mb_trackid',
+        u'MUSICBRAINZ_ALBUMID':        u'mb_albumid',
+        u'MUSICBRAINZ_ARTISTID':       u'mb_artistid',
+        u'MUSICBRAINZ_ALBUMARTISTID':  u'mb_albumartistid',
+        u'MUSICBRAINZ_RELEASETRACKID': u'mb_releasetrackid',
     }
 
     def cmd_tagtypes(self, conn):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,12 @@ New features:
   (the MBID), and ``work_disambig`` (the disambiguation string).
   Thanks to :user:`dosoe`.
   :bug:`2580` :bug:`3272`
+* :doc:`/plugins/bpd`: BPD now supports most of the features of version 0.16
+  of the MPD protocol. This is enough to get it talking to more complicated
+  clients like ncmpcpp, but there are still some incompatibilities, largely due
+  to MPD commands we don't support yet. Let us know if you find an MPD client
+  that doesn't get along with BPD!
+  :bug:`3214` :bug:`800`
 
 Fixes:
 
@@ -20,6 +26,10 @@ Fixes:
   objects could seem to reuse values from earlier objects when they were
   missing a value for a given field. These values are now properly undefined.
   :bug:`2406`
+* :doc:`/plugins/bpd`: Seeking by fractions of a second now works as intended,
+  fixing crashes in MPD clients like mpDris2 on seek.
+  The ``playlistid`` command now works properly in its zero-argument form.
+  :bug:`3214`
 
 For plugin developers:
 

--- a/docs/plugins/bpd.rst
+++ b/docs/plugins/bpd.rst
@@ -125,8 +125,7 @@ These are some of the known differences between BPD and MPD:
 * Advanced playback features like cross-fade, ReplayGain and MixRamp are not
   supported due to BPD's simple audio player backend.
 * Advanced query syntax is not currently supported.
-* Not all tags (fields) are currently exposed to BPD. Clients also can't use
-  the ``tagtypes`` mask to hide fields.
+* Clients can't use the ``tagtypes`` mask to hide fields.
 * BPD's ``random`` mode is not deterministic and doesn't support priorities.
 * Mounts and streams are not supported. BPD can only play files from disk.
 * Stickers are not supported (although this is basically a flexattr in beets

--- a/docs/plugins/bpd.rst
+++ b/docs/plugins/bpd.rst
@@ -103,7 +103,7 @@ but doesn't support many advanced playback features.
 Differences from the real MPD
 -----------------------------
 
-BPD currently supports version 0.14 of `the MPD protocol`_, but several of the
+BPD currently supports version 0.16 of `the MPD protocol`_, but several of the
 commands and features are "pretend" implementations or have slightly different
 behaviour to their MPD equivalents. BPD aims to look enough like MPD that it
 can interact with the ecosystem of clients, but doesn't try to be

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -623,8 +623,13 @@ class BPDPlaybackTest(BPDTestHelper):
 
     def test_cmd_volume(self):
         with self.run_bpd() as client:
-            response = client.send_command('volume', '10')
-        self._assert_failed(response, bpd.ERROR_SYSTEM)
+            responses = client.send_commands(
+                    ('setvol', '10'),
+                    ('volume', '5'),
+                    ('volume', '-2'),
+                    ('status',))
+        self._assert_ok(*responses)
+        self.assertEqual('13', responses[3].data['volume'])
 
     def test_cmd_replay_gain(self):
         with self.run_bpd() as client:

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -684,7 +684,7 @@ class BPDControlTest(BPDTestHelper):
 class BPDQueueTest(BPDTestHelper):
     test_implements_queue = implements({
             'addid', 'clear', 'delete', 'deleteid', 'move',
-            'moveid', 'playlist', 'playlistfind', 'playlistid',
+            'moveid', 'playlist', 'playlistfind',
             'playlistsearch', 'plchanges',
             'plchangesposid', 'prio', 'prioid', 'rangeid', 'shuffle',
             'swap', 'swapid', 'addtagid', 'cleartagid',
@@ -702,6 +702,16 @@ class BPDQueueTest(BPDTestHelper):
                     ('playlistinfo', '0'),
                     ('playlistinfo', '200'))
         self._assert_failed(responses, bpd.ERROR_ARG, pos=2)
+
+    def test_cmd_playlistid(self):
+        with self.run_bpd() as client:
+            self._bpd_add(client, self.item1, self.item2)
+            responses = client.send_commands(
+                    ('playlistid', '2'),
+                    ('playlistid',))
+        self._assert_ok(*responses)
+        self.assertEqual('Track Two Title', responses[0].data['Title'])
+        self.assertEqual(['1', '2'], responses[1].data['Track'])
 
 
 class BPDPlaylistsTest(BPDTestHelper):

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -339,8 +339,9 @@ class BPDTestHelper(unittest.TestCase, TestHelper):
             previous_commands = response[0:pos]
             self._assert_ok(*previous_commands)
             response = response[pos]
-            self.assertEqual(pos, response.err_data[1])
         self.assertFalse(response.ok)
+        if pos is not None:
+            self.assertEqual(pos, response.err_data[1])
         if code is not None:
             self.assertEqual(code, response.err_data[0])
 
@@ -781,12 +782,15 @@ class BPDQueueTest(BPDTestHelper):
 
     def test_cmd_playlistinfo(self):
         with self.run_bpd() as client:
-            self._bpd_add(client, self.item1)
+            self._bpd_add(client, self.item1, self.item2)
             responses = client.send_commands(
                     ('playlistinfo',),
                     ('playlistinfo', '0'),
+                    ('playlistinfo', '0:2'),
                     ('playlistinfo', '200'))
-        self._assert_failed(responses, bpd.ERROR_ARG, pos=2)
+        self._assert_failed(responses, bpd.ERROR_ARG, pos=3)
+        self.assertEqual('1', responses[1].data['Id'])
+        self.assertEqual(['1', '2'], responses[2].data['Id'])
 
     def test_cmd_playlistinfo_tagtypes(self):
         with self.run_bpd() as client:

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -433,7 +433,8 @@ class BPDQueryTest(BPDTestHelper):
         }
         self.assertEqual(fields_not_playing, set(responses[0].data.keys()))
         fields_playing = fields_not_playing | {
-            'song', 'songid', 'time', 'elapsed', 'bitrate', 'duration', 'audio'
+            'song', 'songid', 'time', 'elapsed', 'bitrate', 'duration',
+            'audio', 'nextsong', 'nextsongid'
         }
         self.assertEqual(fields_playing, set(responses[2].data.keys()))
 

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -457,6 +457,14 @@ class BPDQueryTest(BPDTestHelper):
             response = client.send_command('noidle')
         self._assert_ok(response)
 
+    def test_cmd_noidle_when_not_idle(self):
+        with self.run_bpd() as client:
+            # Manually send a command without reading a response.
+            request = client.serialise_command('noidle')
+            client.sock.sendall(request)
+            response = client.send_command('notacommand')
+        self._assert_failed(response, bpd.ERROR_UNKNOWN)
+
 
 class BPDPlaybackTest(BPDTestHelper):
     test_implements_playback = implements({

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -363,7 +363,7 @@ class BPDTestHelper(unittest.TestCase, TestHelper):
 class BPDTest(BPDTestHelper):
     def test_server_hello(self):
         with self.run_bpd(do_hello=False) as client:
-            self.assertEqual(client.readline(), b'OK MPD 0.14.0\n')
+            self.assertEqual(client.readline(), b'OK MPD 0.16.0\n')
 
     def test_unknown_cmd(self):
         with self.run_bpd() as client:


### PR DESCRIPTION
Now that `idle` has been implemented, we're almost all the way to MPD 0.16 support. There are a couple of small commands that need adding, but most of what we need is already in place. More importantly, claiming to support the newer protocol version means that more clients will talk to us; fixes #800.

- [x] `nextsong` and `nextsongid` fields in `status` output.
- [x] playlist range support in `playlistinfo`.
- [ ] playlist range support in `move`.
- [x] ~~stickers (which are basically flexible attrs).~~ Moved to #3290

I've expanded my local tests to include ncmpcpp and two Android clients (MPDroid and MALP). So far bpd breaks all three of these clients. Known compatibility issues are listed below.

#### ncmpcpp (Linux, libmpdclient)
- [x] ncmpcpp sends `noidle` when bpd doesn't expect it to be in the idle state.
- [x] ncmpcpp uses the deprecated `volume` command to change the volume and we ignore it.
- [x] ncmpcpp sometimes causes an error with errno 104 `ECONNRESET` when quitting.
- [x] ncmpcpp issues the unimplemented command `decoders` (fixed in #3222).
- [x] ~~It notices when playback is paused, but doesn't notice when it's resumed again, even if it was resumed using ncmpcpp itself! Issuing a different command (e.g. changing the volume) will prompt it to refresh the status and update the playback state.~~ This doesn't seem to happen any more. I'm not sure what fixed it.
- [x] ~~ncmpcpp expects stored playlists to be supported and when bpd sends an error it gets stuck in an infinite loop and the UI freezes.~~ Moved to #176.
- [ ] When it receives a `playlist` event and tries to update its playlist using `plchanges` it doesn't like the response returned by bpd and ncmpcpp's playlist becomes blank.

#### M.A.L.P. (Android)
- [x] I'm seeing the issue in #3007 when using MALP (fixed in #3215).
- [x] MALP would like to have extra tags, especially the MusicBrainz ones.

#### MPDroid (Android)
- [x] MPDroid uses extra idle events that we don't support yet (`idle "database" "mixer" "options" "output" "player" "playlist" "sticker" "update"`).
- [ ] MPDroid crashes at startup although there is no MPD error sent over the protocol. We must be giving it wrong output in the successful commands somehow.

#### mpDris2 (Linux)
- [x] mpDris2 seeks using fractional seconds and crashes when bpd doesn't accept that.
- [ ] mpDris2 (and another client but I've forgotten which) crash sometimes with an error that implies that bpd forgot the `state` field in a response to the `status` command. This doesn't seem to be possible though. Its backtrace starts with `KeyError: 'state'`

#### mpdscribble (Linux, libmpdclient)
- [x] ~~mpdscribble tries to register a client channel. It doesn't mind that it fails, but it would be nice to support it.~~ Moved to #3291
- [ ] I noticed it stopped scrobbling and there was an error in the log: `mpd error (7): expected more list_OK's`. I didn't manage to correlate it to the protocol log in bpd though so I'm not sure what happened.

#### Other clients
- [x] ~~beets' own mpdupdate plugin doesn't work with bpd since it expects output from the `update` command, but we never send any.~~ Moved to #3292