### PR TITLE
bpd: support short form of list command for albums

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -200,6 +200,9 @@ Fixes:
   :bug:`3207` :bug:`2752`
 * Fix an unhandled exception when pruning empty directories.
   :bug:`1996` :bug:`3209`
+* :doc:`/plugins/bpd`: Fix a crash triggered when certain clients tried to list
+  the albums belonging to a particular artist.
+  :bug:`3007` :bug:`3215`
 
 .. _python-itunes: https://github.com/ocelma/python-itunes
 

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -774,10 +774,20 @@ class BPDDatabaseTest(BPDTestHelper):
         with self.run_bpd() as client:
             responses = client.send_commands(
                     ('list', 'album'),
-                    ('list', 'track'))
-        self._assert_ok(*responses)
+                    ('list', 'track'),
+                    ('list', 'album', 'artist', 'Artist Name', 'track'))
+        self._assert_failed(responses, bpd.ERROR_ARG, pos=2)
         self.assertEqual('Album Title', responses[0].data['Album'])
         self.assertEqual(['1', '2'], responses[1].data['Track'])
+
+    def test_cmd_list_three_arg_form(self):
+        with self.run_bpd() as client:
+            responses = client.send_commands(
+                    ('list', 'album', 'artist', 'Artist Name'),
+                    ('list', 'album', 'Artist Name'),
+                    ('list', 'track', 'Artist Name'))
+        self._assert_failed(responses, bpd.ERROR_ARG, pos=2)
+        self.assertEqual(responses[0].data, responses[1].data)
 
     def test_cmd_lsinfo(self):
         with self.run_bpd() as client:


### PR DESCRIPTION
Some clients list the albums belonging to an artist by issuing the command `list album <ARTIST NAME>`. This change inserts the tag `artist` before the artist name so that this succeeds. Fixes #3007.

I confirmed the behaviour with the current MPD. It gave a rather helpful error message `ACK [2@0] {list} should be "Album" for 3 arguments` that shows that the shorter version is only for getting the albums of an artist.

A small unrelated change is to address a minor issue where if clients listed all album artists the first result would be blank (due to not all items in beets' database having album artist tags). We just skip any blank responses for the specific case of listing all unique values of a tag.