### PR TITLE
bpd: support decoders command

### DIFF
--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -1321,6 +1321,16 @@ class Server(BaseServer):
             u'db_update: ' + six.text_type(int(self.updated_time)),
         )
 
+    def cmd_decoders(self, conn):
+        """Send list of supported decoders and formats."""
+        decoders = self.player.get_decoders()
+        for name, (mimes, exts) in decoders.items():
+            yield u'plugin: {}'.format(name)
+            for ext in exts:
+                yield u'suffix: {}'.format(ext)
+            for mime in mimes:
+                yield u'mime_type: {}'.format(mime)
+
     # Searching.
 
     tagtype_map = {

--- a/beetsplug/bpd/gstplayer.py
+++ b/beetsplug/bpd/gstplayer.py
@@ -215,6 +215,59 @@ class GstPlayer(object):
         while self.playing:
             time.sleep(1)
 
+    def get_decoders(self):
+        return get_decoders()
+
+
+def get_decoders():
+    """Get supported audio decoders from GStreamer.
+    Returns a dict mapping decoder element names to the associated media types
+    and file extensions.
+    """
+    # We only care about audio decoder elements.
+    filt = (Gst.ELEMENT_FACTORY_TYPE_DEPAYLOADER |
+            Gst.ELEMENT_FACTORY_TYPE_DEMUXER |
+            Gst.ELEMENT_FACTORY_TYPE_PARSER |
+            Gst.ELEMENT_FACTORY_TYPE_DECODER |
+            Gst.ELEMENT_FACTORY_TYPE_MEDIA_AUDIO)
+
+    decoders = {}
+    mime_types = set()
+    for f in Gst.ElementFactory.list_get_elements(filt, Gst.Rank.NONE):
+        for pad in f.get_static_pad_templates():
+            if pad.direction == Gst.PadDirection.SINK:
+                caps = pad.static_caps.get()
+                mimes = set()
+                for i in range(caps.get_size()):
+                    struct = caps.get_structure(i)
+                    mime = struct.get_name()
+                    if mime == 'unknown/unknown':
+                        continue
+                    mimes.add(mime)
+                    mime_types.add(mime)
+                if mimes:
+                    decoders[f.get_name()] = (mimes, set())
+
+    # Check all the TypeFindFactory plugin features form the registry. If they
+    # are associated with an audio media type that we found above, get the list
+    # of corresponding file extensions.
+    mime_extensions = {mime: set() for mime in mime_types}
+    for feat in Gst.Registry.get().get_feature_list(Gst.TypeFindFactory):
+        caps = feat.get_caps()
+        if caps:
+            for i in range(caps.get_size()):
+                struct = caps.get_structure(i)
+                mime = struct.get_name()
+                if mime in mime_types:
+                    mime_extensions[mime].update(feat.get_extensions())
+
+    # Fill in the slot we left for file extensions.
+    for name, (mimes, exts) in decoders.items():
+        for mime in mimes:
+            exts.update(mime_extensions[mime])
+
+    return decoders
+
 
 def play_simple(paths):
     """Play the files in paths in a straightforward way, without

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -89,6 +89,8 @@ New features:
 * :doc:`/plugins/bpd`: MPD protocol command ``idle`` is now supported, allowing
   the MPD version to be bumped to 0.14.
   :bug:`3205` :bug:`800`
+* :doc:`/plugins/bpd`: MPD protocol command ``decoders`` is now supported.
+  :bug:`3222`
 
 Changes:
 


### PR DESCRIPTION
This uses GStreamer APIs to extract a list of audio decoders and the relevant MIME types and file extensions. Some clients like ncmpcpp use this command to fetch a list of supported file extensions.

I'm by no means familiar with GStreamer, and I got some pointers about the relevant APIs from a similar effort in Mopidy: mopidy/mopidy#812. At least ncmpcpp uses this command to fetch the list of supported file extensions (it ignores the rest of the information) and then uses that to tune its interface when browsing local files.

The full output on my system uses this information (format is `<plugin> <mime types> <file exts>`):
```
mpegaudioparse {'audio/mpeg'} {'mp2', 'mp1', 'adif', 'mpga', 'aac', 'adts', 'loas', 'mp3'}
openmptdec {'audio/x-mod'} {'stm', 'mod', 'stx', 'dmf', 'dbm', 'dsm', 'ams', 'digi', 'gdm', 'xm', 'umx', 'far', 'j2b', 'imf', 's3m', 'psm', 'sam', '669', 'amf', 'mdl', 'okt', 'it', 'med', 'ult', 'ptm', 'mt2', 'mtm'}
aacparse {'audio/mpeg'} {'mp2', 'mp1', 'adif', 'mpga', 'aac', 'adts', 'loas', 'mp3'}
ac3parse {'audio/x-eac3', 'audio/ac3', 'audio/x-private1-ac3', 'audio/x-ac3'} {'ac3', 'eac3'}
amrparse {'audio/x-amr-nb-sh', 'audio/x-amr-wb-sh'} {'amr'}
dcaparse {'audio/x-private1-dts', 'audio/x-dts'} {'dts'}
flacparse {'audio/x-flac'} {'flac'}
sbcparse {'audio/x-sbc'} {'sbc'}
wavpackparse {'audio/x-wavpack'} {'wvp', 'wv'}
adpcmdec {'audio/x-adpcm'} set()
aiffparse {'audio/x-aiff'} {'aifc', 'aif', 'aiff'}
alawdec {'audio/x-alaw'} set()
amrnbdec {'audio/AMR'} set()
amrwbdec {'audio/AMR-WB'} set()
avdec_aac {'audio/mpeg'} {'mp2', 'mp1', 'adif', 'mpga', 'aac', 'adts', 'loas', 'mp3'}
avdec_aac_fixed {'audio/mpeg'} {'mp2', 'mp1', 'adif', 'mpga', 'aac', 'adts', 'loas', 'mp3'}
avdec_cook {'audio/x-pn-realaudio'} set()
avdec_real_144 {'audio/x-pn-realaudio'} set()
avdec_real_288 {'audio/x-pn-realaudio'} set()
dtsdec {'audio/x-private1-dts', 'audio/x-dts'} {'dts'}
dvdlpcmdec {'audio/x-private1-lpcm', 'audio/x-lpcm', 'audio/x-private-ts-lpcm', 'audio/x-private2-lpcm'} set()
flacdec {'audio/x-flac'} {'flac'}
gmedec {'audio/x-hes', 'audio/x-vgm', 'audio/x-sap', 'audio/x-spc', 'audio/x-nsf', 'audio/x-gym', 'audio/x-gbs', 'audio/x-kss', 'audio/x-ay'} {'spc', 'vgm', 'gbs', 'kss', 'nsf', 'sap', 'gym', 'ay'}
gsmdec {'audio/x-gsm', 'audio/ms-gsm'} {'gsm'}
midiparse {'audio/riff-midi', 'audio/midi'} {'mid', 'midi'}
modplug {'audio/x-xm', 'audio/x-mod', 'audio/x-stm', 'audio/x-it', 'audio/x-s3m'} {'stm', 'mod', 'stx', 'dmf', 'dbm', 'dsm', 'ams', 'digi', 'gdm', 'xm', 'umx', 'far', 'j2b', 'imf', 's3m', 'psm', 'sam', '669', 'amf', 'mdl', 'okt', 'it', 'med', 'ult', 'ptm', 'mt2', 'mtm'}
mulawdec {'audio/x-mulaw'} set()
musepackdec {'audio/x-musepack'} {'mpp', 'mp+', 'mpc'}
ogmaudioparse {'application/x-ogm-audio'} set()
opusdec {'audio/x-opus'} set()
sbcdec {'audio/x-sbc'} {'sbc'}
siddec {'audio/x-sid'} {'sid'}
speexdec {'audio/x-speex'} set()
vorbisdec {'audio/x-vorbis'} set()
wavpackdec {'audio/x-wavpack'} {'wvp', 'wv'}
wavparse {'audio/x-wav'} {'wav'}
a52dec {'audio/ac3', 'audio/x-private1-ac3', 'audio/x-ac3'} {'ac3', 'eac3'}
auparse {'audio/x-au'} {'au', 'snd'}
avdec_sipr {'audio/x-sipro'} set()
faad {'audio/mpeg'} {'mp2', 'mp1', 'adif', 'mpga', 'aac', 'adts', 'loas', 'mp3'}
fluiddec {'audio/x-midi-event'} set()
avdec_aac_latm {'audio/mpeg'} {'mp2', 'mp1', 'adif', 'mpga', 'aac', 'adts', 'loas', 'mp3'}
avdec_ac3 {'audio/x-ac3'} {'ac3', 'eac3'}
avdec_ac3_fixed {'audio/x-ac3'} {'ac3', 'eac3'}
avdec_adpcm_4xm {'audio/x-adpcm'} set()
avdec_adpcm_adx {'audio/x-adpcm'} set()
avdec_adpcm_ct {'audio/x-adpcm'} set()
avdec_adpcm_ea {'audio/x-adpcm'} set()
avdec_adpcm_ea_maxis_xa {'audio/x-adpcm'} set()
avdec_adpcm_ea_r1 {'audio/x-adpcm'} set()
avdec_adpcm_ea_r2 {'audio/x-adpcm'} set()
avdec_adpcm_ea_r3 {'audio/x-adpcm'} set()
avdec_adpcm_ea_xas {'audio/x-adpcm'} set()
avdec_adpcm_ima_amv {'audio/x-adpcm'} set()
avdec_adpcm_ima_dk3 {'audio/x-adpcm'} set()
avdec_adpcm_ima_dk4 {'audio/x-adpcm'} set()
avdec_adpcm_ima_ea_eacs {'audio/x-adpcm'} set()
avdec_adpcm_ima_ea_sead {'audio/x-adpcm'} set()
avdec_adpcm_ima_iss {'audio/x-adpcm'} set()
avdec_adpcm_ima_qt {'audio/x-adpcm'} set()
avdec_adpcm_ima_smjpeg {'audio/x-adpcm'} set()
avdec_adpcm_ima_wav {'audio/x-adpcm'} set()
avdec_adpcm_ima_ws {'audio/x-adpcm'} set()
avdec_adpcm_ms {'audio/x-adpcm'} set()
avdec_adpcm_sbpro_2 {'audio/x-adpcm'} set()
avdec_adpcm_sbpro_3 {'audio/x-adpcm'} set()
avdec_adpcm_sbpro_4 {'audio/x-adpcm'} set()
avdec_adpcm_swf {'audio/x-adpcm'} set()
avdec_adpcm_thp {'audio/x-adpcm'} set()
avdec_adpcm_xa {'audio/x-adpcm'} set()
avdec_adpcm_yamaha {'audio/x-adpcm'} set()
avdec_alac {'audio/x-alac'} set()
avdec_amrnb {'audio/AMR'} set()
avdec_amrwb {'audio/AMR-WB'} set()
avdec_ape {'audio/x-ffmpeg-parsed-ape'} set()
avdec_atrac1 {'audio/x-vnd.sony.atrac1'} set()
avdec_atrac3 {'audio/x-vnd.sony.atrac3'} set()
avdec_dca {'audio/x-dts'} {'dts'}
avdec_dsd_lsbf {'audio/x-dsd'} set()
avdec_dsd_lsbf_planar {'audio/x-dsd'} set()
avdec_dsd_msbf {'audio/x-dsd'} set()
avdec_dsd_msbf_planar {'audio/x-dsd'} set()
avdec_dvaudio {'audio/x-dv'} set()
avdec_eac3 {'audio/x-eac3'} set()
avdec_flac {'audio/x-flac'} {'flac'}
avdec_g722 {'audio/G722'} set()
avdec_g726 {'audio/x-adpcm'} set()
avdec_g729 {'audio/G729'} set()
avdec_gsm {'audio/x-gsm'} {'gsm'}
avdec_gsm_ms {'audio/ms-gsm'} set()
avdec_imc {'audio/x-imc'} set()
avdec_interplay_dpcm {'audio/x-dpcm'} set()
avdec_mace3 {'audio/x-mace'} set()
avdec_mace6 {'audio/x-mace'} set()
avdec_mlp {'audio/x-mlp'} set()
avdec_mp1float {'audio/mpeg'} {'mp2', 'mp1', 'adif', 'mpga', 'aac', 'adts', 'loas', 'mp3'}
avdec_mp2float {'audio/mpeg'} {'mp2', 'mp1', 'adif', 'mpga', 'aac', 'adts', 'loas', 'mp3'}
avdec_mp3 {'audio/mpeg'} {'mp2', 'mp1', 'adif', 'mpga', 'aac', 'adts', 'loas', 'mp3'}
avdec_mp3adu {'audio/x-gst-av-mp3adufloat'} set()
avdec_mp3adufloat {'audio/x-gst-av-mp3adufloat'} set()
avdec_mp3float {'audio/mpeg'} {'mp2', 'mp1', 'adif', 'mpga', 'aac', 'adts', 'loas', 'mp3'}
avdec_mp3on4 {'audio/x-gst-av-mp3on4float'} set()
avdec_mp3on4float {'audio/x-gst-av-mp3on4float'} set()
avdec_mpc7 {'audio/x-ffmpeg-parsed-musepack'} set()
avdec_mpc8 {'audio/x-ffmpeg-parsed-musepack'} set()
avdec_nellymoser {'audio/x-nellymoser'} set()
avdec_opus {'audio/x-opus'} set()
avdec_qcelp {'audio/qcelp'} {'qcp'}
avdec_qdm2 {'audio/x-qdm2'} set()
avdec_roq_dpcm {'audio/x-dpcm'} set()
avdec_s302m {'audio/x-smpte-302m'} set()
avdec_shorten {'audio/x-shorten'} {'shn'}
avdec_sol_dpcm {'audio/x-dpcm'} set()
avdec_truehd {'audio/x-true-hd'} set()
avdec_truespeech {'audio/x-truespeech'} set()
avdec_tta {'audio/x-tta'} set()
avdec_twinvq {'audio/x-twin-vq'} set()
avdec_vmdaudio {'audio/x-gst-av-vmdaudio'} set()
avdec_wmalossless {'audio/x-wma'} set()
avdec_wmapro {'audio/x-wma'} set()
avdec_wmav1 {'audio/x-wma'} set()
avdec_wmav2 {'audio/x-wma'} set()
avdec_wmavoice {'audio/x-wms'} set()
avdec_ws_snd1 {'audio/x-gst-av-ws_snd1'} set()
avdec_xan_dpcm {'audio/x-dpcm'} set()
mpg123audiodec {'audio/mpeg'} {'mp2', 'mp1', 'adif', 'mpga', 'aac', 'adts', 'loas', 'mp3'}
sfdec {'audio/x-nist', 'audio/x-svx', 'audio/x-w64', 'audio/x-paris', 'audio/x-sds', 'audio/x-rf64', 'audio/x-voc', 'audio/x-xi', 'audio/x-ircam'} {'sds', 'sf', 'iff', 'w64', 'nist', 'xi', 'svx', 'paf', 'voc', 'rf64'}
sirendec {'audio/x-siren'} set()
unalignedaudioparse {'audio/x-unaligned-raw'} set()
wildmididec {'audio/riff-midi', 'audio/midi'} {'mid', 'midi'}
opusparse {'audio/x-opus'} set()
rawaudioparse {'audio/x-unaligned-raw', 'audio/x-mulaw', 'audio/x-alaw', 'audio/x-raw'} set()
vorbisparse {'audio/x-vorbis'} set()
```

I'm not sure if it's necessary to break this down by GStreamer element like this, or whether we should just show a single `plugin: gstreamer` and dump all the supported types and extensions under that section. I haven't yet seen an MPD client that uses anything other than the the file extension fields.