### PR TITLE
mpdupdate, mpdstats: use MPD_PORT env variable

### DIFF
--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -326,7 +326,7 @@ class MPDStatsPlugin(plugins.BeetsPlugin):
             'rating':          True,
             'rating_mix':      0.75,
             'host':            os.environ.get('MPD_HOST', u'localhost'),
-            'port':            6600,
+            'port':            int(os.environ.get('MPD_PORT', 6600)),
             'password':        u'',
         })
         mpd_config['password'].redact = True

--- a/beetsplug/mpdupdate.py
+++ b/beetsplug/mpdupdate.py
@@ -69,7 +69,7 @@ class MPDUpdatePlugin(BeetsPlugin):
         super(MPDUpdatePlugin, self).__init__()
         config['mpd'].add({
             'host':     os.environ.get('MPD_HOST', u'localhost'),
-            'port':     6600,
+            'port':     int(os.environ.get('MPD_PORT', 6600)),
             'password': u'',
         })
         config['mpd']['password'].redact = True

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -81,6 +81,9 @@ New features:
   to be displayed.
   Thanks to :user:`pprkut`.
   :bug:`3089`
+* :doc:`/plugins/mpdstats`, :doc:`/plugins/mpdupdate`: Use the ``MPD_PORT``
+  environment variable if no port is specified in the configuration file.
+  :bug:`3223`
 * :doc:`/plugins/bpd`: MPD protocol commands ``consume`` and ``single`` are now
   supported along with updated semantics for ``repeat`` and ``previous`` and
   new fields for ``status``. The bpd server now understands and ignores some

--- a/docs/plugins/mpdstats.rst
+++ b/docs/plugins/mpdstats.rst
@@ -42,7 +42,8 @@ configuration file. The available options are:
   Default: The ``$MPD_HOST`` environment variable if set,
   falling back to ``localhost`` otherwise.
 - **port**: The MPD server port.
-  Default: 6600.
+  Default: The ``$MPD_PORT`` environment variable if set,
+  falling back to 6600 otherwise.
 - **password**: The MPD server password.
   Default: None.
 - **music_directory**: If your MPD library is at a different location from the

--- a/docs/plugins/mpdupdate.rst
+++ b/docs/plugins/mpdupdate.rst
@@ -33,6 +33,7 @@ The available options under the ``mpd:`` section are:
 - **host**: The MPD server name.
   Default: The ``$MPD_HOST`` environment variable if set, falling back to ``localhost`` otherwise.
 - **port**: The MPD server port.
-  Default: 6600.
+  Default: The ``$MPD_PORT`` environment variable if set, falling back to 6600
+  otherwise.
 - **password**: The MPD server password.
   Default: None.


### PR DESCRIPTION
Most MPD clients support the environment variables `MPD_HOST` and `MPD_PORT`. The two MPD client plugins in beets supported the former but not the latter. This change will allow the correct setting to be picked up automatically in more cases, while still allowing the port to be overridden in the config file.