### PR TITLE
Add loadext plugin

### DIFF
--- a/beetsplug/loadext.py
+++ b/beetsplug/loadext.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# This file is part of beets.
+# Copyright 2019, Jack Wilsdon <jack.wilsdon@gmail.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""Load SQLite extensions.
+"""
+
+from __future__ import division, absolute_import, print_function
+
+from beets.dbcore import Database
+from beets.plugins import BeetsPlugin
+import sqlite3
+
+
+class LoadExtPlugin(BeetsPlugin):
+    def __init__(self):
+        super(LoadExtPlugin, self).__init__()
+
+        if not Database.supports_extensions:
+            self._log.warn('loadext is enabled but the current SQLite '
+                           'installation does not support extensions')
+            return
+
+        self.register_listener('library_opened', self.library_opened)
+
+    def library_opened(self, lib):
+        for v in self.config:
+            ext = v.as_filename()
+
+            self._log.debug(u'loading extension {}', ext)
+
+            try:
+                lib.load_extension(ext)
+            except sqlite3.OperationalError as e:
+                self._log.error(u'failed to load extension {}: {}', ext, e)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -94,6 +94,9 @@ New features:
   :bug:`3205` :bug:`800`
 * :doc:`/plugins/bpd`: MPD protocol command ``decoders`` is now supported.
   :bug:`3222`
+* The new :doc:`/plugins/loadext` allows loading of SQLite extensions, primarily
+  for use with the ICU SQLite extension for internationalization.
+  :bug:`3160` :bug:`3226`
 
 Changes:
 

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -71,6 +71,7 @@ like this::
    kodiupdate
    lastgenre
    lastimport
+   loadext
    lyrics
    mbcollection
    mbsubmit
@@ -189,6 +190,7 @@ Miscellaneous
 * :doc:`hook`: Run a command when an event is emitted by beets.
 * :doc:`ihate`: Automatically skip albums and tracks during the import process.
 * :doc:`info`: Print music files' tags to the console.
+* :doc:`loadext`: Load SQLite extensions.
 * :doc:`mbcollection`: Maintain your MusicBrainz collection list.
 * :doc:`mbsubmit`: Print an album's tracks in a MusicBrainz-friendly format.
 * :doc:`missing`: List missing tracks.

--- a/docs/plugins/loadext.rst
+++ b/docs/plugins/loadext.rst
@@ -1,0 +1,53 @@
+Load Extension Plugin
+=====================
+
+Beets uses an SQLite database to store and query library information, which
+has support for extensions to extend its functionality. The ``loadext`` plugin
+lets you enable these SQLite extensions within beets.
+
+One of the primary uses of this within beets is with the `"ICU" extension`_,
+which adds support for case insensitive querying of non-ASCII characters.
+
+.. _"ICU" extension: https://www.sqlite.org/src/dir?ci=7461d2e120f21493&name=ext/icu
+
+Configuration
+-------------
+
+To configure the plugin, make a ``loadext`` section in your configuration
+file. The section must consist of a list of paths to extensions to load, which
+looks like this:
+
+.. code-block:: yaml
+
+    loadext:
+      - libicu
+
+If a relative path is specified, it is resolved relative to the beets
+configuration directory.
+
+If no file extension is specified, the default dynamic library extension for
+the current platform will be used.
+
+Building the ICU extension
+--------------------------
+This section is for **advanced** users only, and is not an in-depth guide on
+building the extension.
+
+To compile the ICU extension, you will need a few dependencies:
+
+ - gcc
+ - icu-devtools
+ - libicu
+ - libicu-dev
+ - libsqlite3-dev
+
+Here's roughly how to download, build and install the extension (although the
+specifics may vary from system to system):
+
+.. code-block:: shell
+
+    $ wget https://sqlite.org/2019/sqlite-src-3280000.zip
+    $ unzip sqlite-src-3280000.zip
+    $ cd sqlite-src-3280000/ext/icu
+    $ gcc -shared -fPIC icu.c `icu-config --ldflags` -o libicu.so
+    $ cp libicu.so ~/.config/beets


### PR DESCRIPTION
This is a rough draft at the moment of what a `loadext` plugin could look like for loading SQLite extensions. This plugin can be used to fix #3160 by allowing users to load the ICU plugin like so;

```
loadext:
  - libicu
```

Note that this will require the user to compile their own copy of `ext/icu` from SQLite sources.

## Points of Discussion
I've got a few points of discussion I'd like to bring up regarding this PR;

1. The elephant in the room;
 
    ```Python
    # TODO: Find a way of getting a connection without calling a private method.
    conn = lib._connection()
    ```

    This is certainly less than ideal, as we're reaching into beets internals from this plugin. There ~are two~ is one possible solution~s~ I can think of to this;

    * ~Use `SELECT load_extension(...)`~ This doesn't work properly, see [this thread](http://sqlite.1065341.n5.nabble.com/Error-on-loading-ICU-extension-td41219.html) regarding the issues.
    * Add a `load_extension` method to `dbcore.Database`.

2. Where should these extension paths be relative to? In this initial draft the paths are relative to wherever `beets` is running, and as such running beets in different folders breaks this unless you use an absolute path for the extension. I think using the beets config directory for relative paths is probably the best idea, but I'll leave this open to others to decide.

3. How in depth do we want to go into the documentation with this? This plugin seems like a somewhat advanced feature, as it requires the user to compile their own `ext/icu` extension from the SQLite sources.

4. How do we test this? Do we mock out the `load_extension` method and make sure it's called? Or do we compile the ICU extension on Travis and attempt to call one of the methods provided by it?

## Compiling the ICU extension
To compile the ICU extension, you need the following;

 * gcc
 * icu-devtools
 * libicu-dev
 * libicu60 (or any other version I guess?)
 * libsqlite3-dev

```Shell
$ wget https://sqlite.org/2019/sqlite-src-3280000.zip
$ unzip sqlite-src-3280000.zip
$ cd sqlite-src-3280000/ext/icu
$ gcc -shared -fPIC icu.c `icu-config --ldflags` -o libicu.so
$ cp libicu.so [wherever you want]
```