### PR TITLE
Allow FetchArt to work with single files

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -683,10 +683,9 @@ class FileSystem(LocalArtSource):
         cover_names_str = b'|'.join(cover_names)
         cover_pat = br''.join([br"(\b|_)(", cover_names_str, br")(\b|_)"])
 
-        for _path in paths:
-            path = _path
+        for path in paths:
             if not os.path.isdir(syspath(path)):
-                path = os.path.dirname(_path)
+                path = os.path.dirname(path)
 
             # Find all files that look like images in the directory.
             images = []

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -683,9 +683,10 @@ class FileSystem(LocalArtSource):
         cover_names_str = b'|'.join(cover_names)
         cover_pat = br''.join([br"(\b|_)(", cover_names_str, br")(\b|_)"])
 
-        for path in paths:
+        for _path in paths:
+            path = _path
             if not os.path.isdir(syspath(path)):
-                continue
+                path = os.path.dirname(_path)
 
             # Find all files that look like images in the directory.
             images = []


### PR DESCRIPTION
In its current state, the FetchArt plugin doesn't work with tracks that aren't in their album folders. This pull request enables an image to be recognised if it's in the same directory as the track, while not necessarily being in its own album folder.