### PR TITLE
Allow equals within import --set value

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -799,8 +799,11 @@ def _store_dict(option, opt_str, value, parser):
         setattr(parser.values, dest, {})
         option_values = getattr(parser.values, dest)
 
+    # Decode the argument using the platform's argument encoding.
+    value = util.text_string(value, util.arg_encoding())
+
     try:
-        key, value = map(lambda s: util.text_string(s), value.split('='))
+        key, value = value.split('=', 1)
         if not (key and value):
             raise ValueError
     except ValueError:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -343,6 +343,8 @@ Fixes:
 * :doc:`/plugins/web`: DELETE and PATCH methods are disallowed by default.
   Set ``readonly: no`` web config option to enable them.
   :bug:`3870`
+* Allow equals within ``--set`` value when importing.
+  :bug:`2984`
 
 For plugin developers:
 


### PR DESCRIPTION
This seems like the simplest fix we can do to achieve this.

I think there may be something else wrong here though - should we be using `util.text_string()` to decode arguments without specifying an encoding (defaulting to `utf-8`)? It looks like `beets modify` uses `decargs` instead, which actually uses `util.arg_encoding()` as the encoding.

I'm not sure if it's worth merging this functionality between `modify` and `import`, as it seems to work slightly differently and it is just a `x.split('=', 1)` anyway.

Fixes #2984.
