### PR TITLE
Update artresizer's ImageMagick commands to use the magick binary

### DIFF
--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -93,7 +93,7 @@ def im_resize(maxwidth, path_in, path_out=None):
     # with regards to the height.
     try:
         util.command_output([
-            'convert', util.syspath(path_in, prefix=False),
+            'magick', util.syspath(path_in, prefix=False),
             '-resize', '{0}x>'.format(maxwidth),
             util.syspath(path_out, prefix=False),
         ])
@@ -121,7 +121,7 @@ def pil_getsize(path_in):
 
 
 def im_getsize(path_in):
-    cmd = ['identify', '-format', '%w %h',
+    cmd = ['magick', 'identify', '-format', '%w %h',
            util.syspath(path_in, prefix=False)]
     try:
         out = util.command_output(cmd)
@@ -235,7 +235,7 @@ def get_im_version():
     Try invoking ImageMagick's "convert".
     """
     try:
-        out = util.command_output(['convert', '--version'])
+        out = util.command_output(['magick', '-version'])
 
         if b'imagemagick' in out.lower():
             pattern = br".+ (\d+)\.(\d+)\.(\d+).*"

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -232,9 +232,9 @@ class ArtResizer(six.with_metaclass(Shareable, object)):
     def _check_method():
         """Return a tuple indicating an available method and its version."""
         try:
-            version, im_legacy = get_im_version()
-            if version:
-                return IMAGEMAGICK, version, im_legacy
+            version, legacy = get_im_version()
+            if version > (0, 0, 0):
+                return IMAGEMAGICK, version, legacy
         except TypeError:
             pass
 
@@ -274,7 +274,7 @@ def get_im_version():
         except (subprocess.CalledProcessError, OSError) as exc:
             log.debug(u'ImageMagick version check failed: {}', exc)
 
-        return (0, None)
+        return ((0,), None)
 
 
 def get_pil_version():

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -93,11 +93,11 @@ def im_resize(maxwidth, path_in, path_out=None):
     # than the given width while maintaining the aspect ratio
     # with regards to the height.
     try:
-        cmds = (['magick'],['convert'])
+        cmds = (['magick'], ['convert'])
         cmd = cmds[0] if not im_legacy else cmds[1]
         args = [util.syspath(path_in, prefix=False),
-            '-resize', '{0}x>'.format(maxwidth),
-            util.syspath(path_out, prefix=False)]
+                '-resize', '{0}x>'.format(maxwidth),
+                util.syspath(path_out, prefix=False)]
 
         util.command_output(cmd + args)
     except subprocess.CalledProcessError:
@@ -124,7 +124,7 @@ def pil_getsize(path_in):
 
 
 def im_getsize(path_in):
-    cmds = (['magick', 'identify'],['identify'])
+    cmds = (['magick', 'identify'], ['identify'])
     cmd = cmds[0] if not im_legacy else cmds[1]
     args = ['-format', '%w %h', util.syspath(path_in, prefix=False)]
 
@@ -234,13 +234,16 @@ class ArtResizer(six.with_metaclass(Shareable, object)):
 
         return WEBPROXY, (0)
 
+
 im_legacy = None
+
+
 def get_im_version():
     """Return Image Magick version or None if it is unavailable
-    Try invoking ImageMagick's "magick". If "magick" is unavailable, 
+    Try invoking ImageMagick's "magick". If "magick" is unavailable,
     as with older versions, fall back to "convert"
     """
-    cmds = ('magick','convert')
+    cmds = ('magick', 'convert')
     for isLegacy, cmd in enumerate(cmds):
 
         try:
@@ -250,6 +253,7 @@ def get_im_version():
                 pattern = br".+ (\d+)\.(\d+)\.(\d+).*"
                 match = re.search(pattern, out)
                 if match:
+                    global im_legacy
                     im_legacy = bool(isLegacy)
                     return (int(match.group(1)),
                             int(match.group(2)),
@@ -258,7 +262,7 @@ def get_im_version():
         except (subprocess.CalledProcessError, OSError) as exc:
             log.debug(u'ImageMagick version check failed: {}', exc)
             return None
-        
+
         return (0,)
 
 

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -228,9 +228,9 @@ class ArtResizer(six.with_metaclass(Shareable, object)):
     def _check_method():
         """Return a tuple indicating an available method and its version."""
         try:
-            version, isLegacy = get_im_version()
+            version, im_legacy = get_im_version()
             if version:
-                return IMAGEMAGICK, version, isLegacy
+                return IMAGEMAGICK, version, im_legacy
         except TypeError:
             pass
 
@@ -246,11 +246,11 @@ def get_im_version():
     Try invoking ImageMagick's "magick". If "magick" is unavailable,
     as with older versions, fall back to "convert"
 
-    Our iterator `isLegacy` will be non-zero when the first command
+    Our iterator `im_legacy` will be non-zero when the first command
     fails, and will be returned in a tuple along with the version
     """
     cmds = ('magick', 'convert')
-    for isLegacy, cmd in enumerate(cmds):
+    for im_legacy, cmd in enumerate(cmds):
 
         try:
             out = util.command_output([cmd, '--version'])
@@ -262,7 +262,7 @@ def get_im_version():
                     return ((int(match.group(1)),
                             int(match.group(2)),
                             int(match.group(3))),
-                            bool(isLegacy)
+                            bool(im_legacy)
                             )
 
         except (subprocess.CalledProcessError, OSError) as exc:

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -227,9 +227,12 @@ class ArtResizer(six.with_metaclass(Shareable, object)):
     @staticmethod
     def _check_method():
         """Return a tuple indicating an available method and its version."""
-        version, isLegacy = get_im_version()
-        if version:
-            return IMAGEMAGICK, version, isLegacy
+        try:
+            version, isLegacy = get_im_version()
+            if version:
+                return IMAGEMAGICK, version, isLegacy
+        except TypeError:
+            pass
 
         version = get_pil_version()
         if version:


### PR DESCRIPTION
Updated artresizer's ImageMagick commands to use the magick binary added in ImageMagick 7.x, rather than the legacy utilities ('convert', 'identify', etc.) This resolves an issue where beets is failing to detect or use ImageMagick on Windows even when it is set correctly on the PATH, which in turn restores functionality to the fetchart and embedart plugins on Windows.

Closes #2093