### PR TITLE
Stop using beets.config['sort_case_insensitive'] in beets.dbcore

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -1239,8 +1239,10 @@ def parse_query_parts(parts, model_cls):
         else:
             non_path_parts.append(s)
 
+    case_insensitive = beets.config['sort_case_insensitive'].get(bool)
+
     query, sort = dbcore.parse_sorted_query(
-        model_cls, non_path_parts, prefixes
+        model_cls, non_path_parts, prefixes, case_insensitive
     )
 
     # Add path queries to aggregate query.


### PR DESCRIPTION
This PR removes the use of `beets.config['sort_case_insensitive']` from `beets.dbcore`, instead moving the configuration access into `library.py`.

There is still one more use of `beets.config` within `beets.dbcore`, which I am hoping to address separately.

Related: #1531