### PR TITLE
Revert "Travis: temporarily pin tox to <=3.8.1"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ addons:
 # To install dependencies, tell tox to do everything but actually running the
 # test.
 install:
-    - travis_retry pip install 'tox<=3.8.1' sphinx
+    - travis_retry pip install tox sphinx
     # upgrade requests to satisfy sphinx linkcheck (for building man pages)
     - if [[ $TRAVIS_PYTHON_VERSION == *_site_packages ]]; then pip install -U requests; fi
     - travis_retry tox -e $TOX_ENV --notest


### PR DESCRIPTION
Looks like tox 3.9.0 fixes the issues we were seeing on Travis.

This reverts commit 777cfbbf610522c0b655659f8f11d519714606b5.

