### PR TITLE
replaygain: Handle invalid XML output from bs1770gain

### DIFF
--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -251,7 +251,14 @@ class Bs1770gainBackend(Backend):
                 state['gain'] = state['peak'] = None
         parser.StartElementHandler = start_element_handler
         parser.EndElementHandler = end_element_handler
-        parser.Parse(text, True)
+
+        try:
+            parser.Parse(text, True)
+        except xml.parsers.expat.ExpatError:
+            raise ReplayGainError(
+                u'The bs1770gain tool produced malformed XML. '
+                'Using version >=0.4.10 may solve this problem.'
+            )
 
         if len(per_file_gain) != len(path_list):
             raise ReplayGainError(


### PR DESCRIPTION
I've opened this as a draft as I'm not 100% happy with my test implementation (and also the wording of the error itself). I implemented the test in the way I did as I didn't want us to actually require bs1770gain to run the test, as we are mocking the tool's output anyway. This meant that we couldn't use the existing `ReplayGainLdnsCliTest` class as it extends `ReplayGainCliTestBase`, which tries to run a whole suite of tests on the backend.

I'm not a fan of patching `beetsplug.replaygain.call`, as it's a somewhat "internal" feature of the plugin, but I couldn't see another way to mock the output from bs1770gain.

---

Fixes #2983 