### PR TITLE
Don't evaluate bucket template argument as year if there's no year buckets

### DIFF
--- a/beetsplug/bucket.py
+++ b/beetsplug/bucket.py
@@ -235,7 +235,7 @@ class BucketPlugin(plugins.BeetsPlugin):
         return s[0].upper()
 
     def _tmpl_bucket(self, text, field=None):
-        if not field and len(text) == 4 and text.isdigit():
+        if not field and len(text) == 4 and text.isdigit() and len(self.year_spans):
             field = 'year'
 
         if field == 'year':


### PR DESCRIPTION
The bucket template_func makes the decision whether its argument is an
artist/album or a year bucket definition by doing a simple check on the
argument. If the argument is 4 letters long and it's all digits it is
assumed that the argument relates to a year span bucket. This condition
is way too simplistic and leads to incorrect behaviour. One example is
artists and bands which are actually named as a year i.e. band: "1349".
In order to disable incorrect argument evaluation, this change adds a
check if there are any year span definitions at all. In case there's
none, the template_func should default to an alpha evaluation.

Signed-off-by: Tomasz Wisniewski <tomasz.wisni3wski@gmail.com>