### PR TITLE
Improvements to query performance

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -25,7 +25,7 @@ import sqlite3
 import contextlib
 
 import beets
-from beets.util.functemplate import Template
+from beets.util import functemplate
 from beets.util import py3_path
 from beets.dbcore import types
 from .query import MatchQuery, NullSort, TrueQuery
@@ -597,7 +597,7 @@ class Model(object):
         """
         # Perform substitution.
         if isinstance(template, six.string_types):
-            template = Template(template)
+            template = functemplate.template(template)
         return template.substitute(self.formatted(for_path),
                                    self._template_funcs())
 

--- a/beets/library.py
+++ b/beets/library.py
@@ -31,7 +31,7 @@ from beets import plugins
 from beets import util
 from beets.util import bytestring_path, syspath, normpath, samefile, \
     MoveOperation
-from beets.util.functemplate import Template
+from beets.util.functemplate import template, Template
 from beets import dbcore
 from beets.dbcore import types
 import beets
@@ -855,7 +855,7 @@ class Item(LibModel):
         if isinstance(path_format, Template):
             subpath_tmpl = path_format
         else:
-            subpath_tmpl = Template(path_format)
+            subpath_tmpl = template(path_format)
 
         # Evaluate the selected template.
         subpath = self.evaluate_template(subpath_tmpl, True)
@@ -1134,7 +1134,7 @@ class Album(LibModel):
         image = bytestring_path(image)
         item_dir = item_dir or self.item_dir()
 
-        filename_tmpl = Template(
+        filename_tmpl = template(
             beets.config['art_filename'].as_str())
         subpath = self.evaluate_template(filename_tmpl, True)
         if beets.config['asciify_paths']:

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -36,7 +36,7 @@ from beets import logging
 from beets import library
 from beets import plugins
 from beets import util
-from beets.util.functemplate import Template
+from beets.util.functemplate import template
 from beets import config
 from beets.util import confit, as_string
 from beets.autotag import mb
@@ -616,7 +616,7 @@ def get_path_formats(subview=None):
     subview = subview or config['paths']
     for query, view in subview.items():
         query = PF_KEY_QUERIES.get(query, query)  # Expand common queries.
-        path_formats.append((query, Template(view.as_str())))
+        path_formats.append((query, template(view.as_str())))
     return path_formats
 
 

--- a/beets/util/functemplate.py
+++ b/beets/util/functemplate.py
@@ -553,12 +553,21 @@ def _parse(template):
         parts.append(remainder)
     return Expression(parts)
 
-@functools.lru_cache(maxsize=128)
+
+# Decorator that enables lru_cache on py3, and no caching on py2.
+def cached(func):
+    if six.PY2:
+        # Sorry python2 users, no caching for you :(
+        return func
+    return functools.lru_cache(maxsize=128)(func)
+
+
+@cached
 def template(fmt):
     return Template(fmt)
 
-# External interface.
 
+# External interface.
 class Template(object):
     """A string template, including text, Symbols, and Calls.
     """

--- a/beets/util/functemplate.py
+++ b/beets/util/functemplate.py
@@ -35,6 +35,7 @@ import dis
 import types
 import sys
 import six
+import functools
 
 SYMBOL_DELIM = u'$'
 FUNC_DELIM = u'%'
@@ -552,6 +553,9 @@ def _parse(template):
         parts.append(remainder)
     return Expression(parts)
 
+@functools.lru_cache(maxsize=128)
+def template(fmt):
+    return Template(fmt)
 
 # External interface.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -117,6 +117,9 @@ Some improvements have been focused on improving beets' performance:
   to be displayed.
   Thanks to :user:`pprkut`.
   :bug:`3089`
+* Querying the library was further improved by reusing compiled teamplates
+  instead of compiling them over and over again.
+  Thanks to :user:`SimonPersson`.
 * :doc:`/plugins/absubmit`, :doc:`/plugins/badfiles`: Analysis now works in
   parallel (on Python 3 only).
   Thanks to :user:`bemeurer`.


### PR DESCRIPTION
As discussed in PR #2388, this PR makes gives some performance improvements for querying. On my database of around 14k songs, these commits make `beet ls > /dev/null` run in 6.4 seconds, down from 15.5.

The second commit confuses me. For some reason, inlining the call to `formatted()` makes the difference between 11 seconds and 6.4 seconds. I was confused for quite some time, thinking that `FormattedMapping` itself was doing something slow, but it turns out that the function call overhead was causing it?!

In this PR I have used `lru_cache` to cache the formatting templates. I would have preferred to explicitly create the template at the call site, but I can't seem to figure it out. The function `list_items`, in `ui/commands.py`, receives an argument `fmt`. I figured that this argument would contain the formatting string, but it appears to be empty. Whether I specify a formatting string on the command line or not does not seem to matter. Any pointers here would be great. In it's current state, I imagine that this PR would break Python2 support. I don't know if you intend to support Python 2, given that it will be deprecated in half a year now.

Finally, I'm not sure how to run the tests? I run the `tox` command, but it complains about some interpreters missing. Am I expected to have every version of Python installed on my computer for this to work? Sorry, I'm not really a pythonista :)