### PR TITLE
Lazily fetch album in FormattedItemMapping, it's not needed in most cases

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -24,14 +24,13 @@ import time
 import re
 import six
 import string
-import functools
 
 from beets import logging
 from beets.mediafile import MediaFile, UnreadableFileError
 from beets import plugins
 from beets import util
 from beets.util import bytestring_path, syspath, normpath, samefile, \
-    MoveOperation
+    MoveOperation, lazy_property
 from beets.util.functemplate import Template
 from beets import dbcore
 from beets.dbcore import types
@@ -367,22 +366,6 @@ class LibModel(dbcore.Model):
 
     def __bytes__(self):
         return self.__str__().encode('utf-8')
-
-
-def lazy_property(func):
-    field_name = '_' + func.__name__
-
-    @property
-    @functools.wraps(func)
-    def wrapper(self):
-        if hasattr(self, field_name):
-            return getattr(self, field_name)
-
-        value = func(self)
-        setattr(self, field_name, value)
-        return value
-
-    return wrapper
 
 
 class FormattedItemMapping(dbcore.db.FormattedMapping):

--- a/beets/library.py
+++ b/beets/library.py
@@ -392,7 +392,8 @@ class FormattedItemMapping(dbcore.db.FormattedMapping):
             self.album_keys = []
             if album:
                 for key in album.keys(True):
-                    if key in Album.item_keys or key not in self.item._fields.keys():
+                    if key in Album.item_keys \
+                            or key not in self.item._fields.keys():
                         self.album_keys.append(key)
         return self.album_keys
 

--- a/beets/library.py
+++ b/beets/library.py
@@ -24,6 +24,7 @@ import time
 import re
 import six
 import string
+import functools
 
 from beets import logging
 from beets.mediafile import MediaFile, UnreadableFileError
@@ -368,6 +369,22 @@ class LibModel(dbcore.Model):
         return self.__str__().encode('utf-8')
 
 
+def lazy_property(func):
+    field_name = '_' + func.__name__
+
+    @property
+    @functools.wraps(func)
+    def wrapper(self):
+        if hasattr(self, field_name):
+            return getattr(self, field_name)
+
+        value = func(self)
+        setattr(self, field_name, value)
+        return value
+
+    return wrapper
+
+
 class FormattedItemMapping(dbcore.db.FormattedMapping):
     """Add lookup for album-level fields.
 
@@ -376,42 +393,36 @@ class FormattedItemMapping(dbcore.db.FormattedMapping):
 
     def __init__(self, item, for_path=False):
         super(FormattedItemMapping, self).__init__(item, for_path)
-        self.album = None
-        self.album_keys = None
-        self.all_keys = None
         self.item = item
 
-    def _all_keys(self):
-        if not self.all_keys:
-            self.all_keys = set(self.model_keys).union(self._album_keys())
-        return self.all_keys
+    @lazy_property
+    def all_keys(self):
+        return set(self.model_keys).union(self.album_keys)
 
-    def _album_keys(self):
-        if not self.album_keys:
-            album = self._album()
-            self.album_keys = []
-            if album:
-                for key in album.keys(True):
-                    if key in Album.item_keys \
-                            or key not in self.item._fields.keys():
-                        self.album_keys.append(key)
-        return self.album_keys
+    @lazy_property
+    def album_keys(self):
+        album_keys = []
+        if self.album:
+            for key in self.album.keys(True):
+                if key in Album.item_keys \
+                    or key not in self.item._fields.keys():
+                    album_keys.append(key)
+        return album_keys
 
-    def _album(self):
-        if not self.album:
-            self.album = self.item.get_album()
-        return self.album
+    @lazy_property
+    def album(self):
+        return self.item.get_album()
 
     def _get(self, key):
         """Get the value for a key, either from the album or the item.
         Raise a KeyError for invalid keys.
         """
-        if self.for_path and key in self._album_keys():
-            return self._get_formatted(self._album(), key)
+        if self.for_path and key in self.album_keys:
+            return self._get_formatted(self.album, key)
         elif key in self.model_keys:
             return self._get_formatted(self.model, key)
-        elif key in self._album_keys():
-            return self._get_formatted(self._album(), key)
+        elif key in self.album_keys:
+            return self._get_formatted(self.album, key)
         else:
             raise KeyError(key)
 
@@ -431,10 +442,10 @@ class FormattedItemMapping(dbcore.db.FormattedMapping):
             return value
 
     def __iter__(self):
-        return iter(self._all_keys())
+        return iter(self.all_keys)
 
     def __len__(self):
-        return len(self._all_keys())
+        return len(self.all_keys)
 
 
 class Item(LibModel):

--- a/beets/library.py
+++ b/beets/library.py
@@ -405,7 +405,7 @@ class FormattedItemMapping(dbcore.db.FormattedMapping):
         if self.album:
             for key in self.album.keys(True):
                 if key in Album.item_keys \
-                    or key not in self.item._fields.keys():
+                        or key not in self.item._fields.keys():
                     album_keys.append(key)
         return album_keys
 

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -23,6 +23,7 @@ import locale
 import re
 import shutil
 import fnmatch
+import functools
 from collections import Counter
 from multiprocessing.pool import ThreadPool
 import traceback
@@ -1031,3 +1032,26 @@ def par_map(transform, items):
         pool.map(transform, items)
         pool.close()
         pool.join()
+
+
+def lazy_property(func):
+    """A decorator that creates a lazily evaluated property. On first access,
+    the property is assigned the return value of `func`. This first value is
+    stored, so that future accesses do not have to evaluate `func` again.
+
+    This behaviour is useful when `func` is expensive to evaluate, and it is
+    not certain that the result will be needed.
+    """
+    field_name = '_' + func.__name__
+
+    @property
+    @functools.wraps(func)
+    def wrapper(self):
+        if hasattr(self, field_name):
+            return getattr(self, field_name)
+
+        value = func(self)
+        setattr(self, field_name, value)
+        return value
+
+    return wrapper

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -126,6 +126,10 @@ Some improvements have been focused on improving beets' performance:
   is long.
   Thanks to :user:`ray66`.
   :bug:`3207` :bug:`2752`
+* Querying the library for items is now faster, for all queries that do not need
+  to access album level properties. This was implemented by lazily fetching the
+  album only when needed.
+  Thanks to :user:`SimonPersson`.
 
 Several improvements are related to usability:
 


### PR DESCRIPTION
Broken out from #3258, as it seems orthogonal.

The item formatter is fetching the related album for each item, even when it is not needed. This PR lazily fetches the album if it is really needed, and does not hit the DB in other cases.