### PR TITLE
Update setup.py to install to a directory rather than egg file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
     platforms='ALL',
     long_description=_read('README.rst'),
     test_suite='test.testall.suite',
+    zip_safe=False,
     include_package_data=True,  # Install plugin resources.
 
     packages=[


### PR DESCRIPTION
useful when run as
```
python setup.py install
```
Fixes #3264