### PR TITLE
Fix ImageMagick Detection

### DIFF
--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -278,7 +278,7 @@ def get_im_version():
                                int(match.group(3)))
                     return version, legacy
 
-        return None
+    return None
 
 
 def get_pil_version():


### PR DESCRIPTION
The `return` statement was at the wrong indent level, so we never checked for the legacy `convert` executable. I ran into this with the 1.4.8 upgrade, getting warnings since `convert` no longer gets detected.

@ababyduck looks like you were last in this code, this look OK to you?