### PR TITLE
Add support for NO_COLOR.

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -529,21 +529,21 @@ def colorize(color_name, text):
     """Colorize text if colored output is enabled. (Like _colorize but
     conditional.)
     """
-    if config['ui']['color']:
-        global COLORS
-        if not COLORS:
-            COLORS = dict((name,
-                           config['ui']['colors'][name].as_str())
-                          for name in COLOR_NAMES)
-        # In case a 3rd party plugin is still passing the actual color ('red')
-        # instead of the abstract color name ('text_error')
-        color = COLORS.get(color_name)
-        if not color:
-            log.debug(u'Invalid color_name: {0}', color_name)
-            color = color_name
-        return _colorize(color, text)
-    else:
+    if not config['ui']['color'] or 'NO_COLOR' in os.environ.keys():
         return text
+
+    global COLORS
+    if not COLORS:
+        COLORS = dict((name,
+                       config['ui']['colors'][name].as_str())
+                      for name in COLOR_NAMES)
+    # In case a 3rd party plugin is still passing the actual color ('red')
+    # instead of the abstract color name ('text_error')
+    color = COLORS.get(color_name)
+    if not color:
+        log.debug(u'Invalid color_name: {0}', color_name)
+        color = color_name
+    return _colorize(color, text)
 
 
 def _colordiff(a, b, highlight='text_highlight',

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,13 @@ Fixes:
   the ``gmusicapi`` module.
   :bug:`3270`
 
+New features:
+
+* Support for the `NO_COLOR`_ environment variable.
+  :bug:`3273`
+
+.. _NO_COLOR: https://no-color.org
+
 
 1.4.8 (May 16, 2019)
 --------------------


### PR DESCRIPTION
This commit adds support for the [`NO_COLOR` environment variable](https://no-color.org/).

I was looking for a way to temporarily disable colors while piping the output of `beet mbsync -p` to a file. Rather than implement this as a top-level `--no-color` option, it was much easier to just add support for `NO_COLOR`.