### PR TITLE
Make pathlib dependency in tests conditional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,10 +115,12 @@ setup(
         'rarfile',
         'responses',
         'pyxdg',
-        'pathlib',
         'python-mpd2',
         'discogs-client'
-    ],
+    ] + (
+        # Tests for the thumbnails plugin need pathlib on Python 2 too.
+        ['pathlib'] if (sys.version_info < (3, 4, 0)) else []
+    ),
 
     # Plugin (optional) dependencies:
     extras_require={


### PR DESCRIPTION
We already do this in the optional dependency section so this shouldn't cause any problems. It's only used by the `thumbnails` plugin.

I noticed that Debian was carrying a patch to remove this line since they install beets with Python 3 only and don't have a Py3 package for pathlib.