### PR TITLE
Make test_random work with setup.py test

### DIFF
--- a/test/test_random.py
+++ b/test/test_random.py
@@ -80,3 +80,10 @@ class RandomTest(unittest.TestCase, TestHelper):
         self.assertAlmostEqual(0, median1, delta=1)
         self.assertAlmostEqual(len(self.items) // 2, median2, delta=1)
         self.assertGreater(stdev2, stdev1)
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromName(__name__)
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')


### PR DESCRIPTION
Without this change `python setup.py test` fails to run, since this test was missing a `suite`.