### PR TITLE
Setup path correctly in testall.py

### DIFF
--- a/test/testall.py
+++ b/test/testall.py
@@ -22,16 +22,15 @@ import re
 import sys
 import unittest
 
-pkgpath = os.path.dirname(__file__) or '.'
-sys.path.append(pkgpath)
-os.chdir(pkgpath)
+pkgpath = os.path.dirname(os.path.dirname(os.path.realpath(__file__))) or '..'
+sys.path.insert(0, pkgpath)
 
 
 def suite():
     s = unittest.TestSuite()
     # Get the suite() of every module in this directory beginning with
     # "test_".
-    for fname in os.listdir(pkgpath):
+    for fname in os.listdir(os.path.join(pkgpath, 'test')):
         match = re.match(r'(test_\S+)\.py$', fname)
         if match:
             modname = match.group(1)


### PR DESCRIPTION
I was unable to run the test suite using `testall.py` without removing this line. After this change it works when invoked from the top-level directory.

Our [Testing](https://github.com/beetbox/beets/wiki/Testing) wiki says one way to invoke tests is `cd test ; python testall.py`. I was unable to get this working:
  * From the `test` directory, calling `python testall.py` results in:
 ```
Traceback (most recent call last):
  File "testall.py", line 43, in <module>
    unittest.main(defaultTest='suite')
  File "/usr/lib/python3.7/unittest/main.py", line 100, in __init__
    self.parseArgs(argv)
  File "/usr/lib/python3.7/unittest/main.py", line 147, in parseArgs
    self.createTests()
  File "/usr/lib/python3.7/unittest/main.py", line 159, in createTests
    self.module)
  File "/usr/lib/python3.7/unittest/loader.py", line 220, in loadTestsFromNames
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/usr/lib/python3.7/unittest/loader.py", line 220, in <listcomp>
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/usr/lib/python3.7/unittest/loader.py", line 205, in loadTestsFromName
    test = obj()
  File "testall.py", line 38, in suite
    s.addTest(__import__(modname).suite())
  File "<...>/beets/test/test_config_command.py", line 15, in <module>
    from test.helper import TestHelper
ModuleNotFoundError: No module named 'test.helper'
```
* From the top-level directory, `python test/testall.py` results in:
```
Traceback (most recent call last):
  File "test/testall.py", line 43, in <module>
    unittest.main(defaultTest='suite')
  File "/usr/lib/python3.7/unittest/main.py", line 100, in __init__
    self.parseArgs(argv)
  File "/usr/lib/python3.7/unittest/main.py", line 147, in parseArgs
    self.createTests()
  File "/usr/lib/python3.7/unittest/main.py", line 159, in createTests
    self.module)
  File "/usr/lib/python3.7/unittest/loader.py", line 220, in loadTestsFromNames
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/usr/lib/python3.7/unittest/loader.py", line 220, in <listcomp>
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/usr/lib/python3.7/unittest/loader.py", line 205, in loadTestsFromName
    test = obj()
  File "test/testall.py", line 34, in suite
    for fname in os.listdir(pkgpath):
FileNotFoundError: [Errno 2] No such file or directory: 'test'
```

If I prevent it from changing directory from within `testall.py` then the second option works. If we accept this then we should also update that line on the wiki.