### PR TITLE
functemplate: Adapt ast syntax to PEP570 changes on python3.8

### DIFF
--- a/beets/util/functemplate.py
+++ b/beets/util/functemplate.py
@@ -118,29 +118,35 @@ def compile_func(arg_names, statements, name='_the_func', debug=False):
     bytecode of the compiled function.
     """
     if six.PY2:
-        func_def = ast.FunctionDef(
-            name=name.encode('utf-8'),
-            args=ast.arguments(
-                args=[ast.Name(n, ast.Param()) for n in arg_names],
-                vararg=None,
-                kwarg=None,
-                defaults=[ex_literal(None) for _ in arg_names],
-            ),
-            body=statements,
-            decorator_list=[],
+        name = name.encode('utf-8')
+        args = ast.arguments(
+            args=[ast.Name(n, ast.Param()) for n in arg_names],
+            vararg=None,
+            kwarg=None,
+            defaults=[ex_literal(None) for _ in arg_names],
+        )
+    elif sys.version_info >= (3, 8):
+        args = ast.arguments(
+            args=[ast.arg(arg=n, annotation=None) for n in arg_names],
+            posonlyargs=[],
+            kwonlyargs=[],
+            kw_defaults=[],
+            defaults=[ex_literal(None) for _ in arg_names],
         )
     else:
-        func_def = ast.FunctionDef(
-            name=name,
-            args=ast.arguments(
-                args=[ast.arg(arg=n, annotation=None) for n in arg_names],
-                kwonlyargs=[],
-                kw_defaults=[],
-                defaults=[ex_literal(None) for _ in arg_names],
-            ),
-            body=statements,
-            decorator_list=[],
+        args = ast.arguments(
+            args=[ast.arg(arg=n, annotation=None) for n in arg_names],
+            kwonlyargs=[],
+            kw_defaults=[],
+            defaults=[ex_literal(None) for _ in arg_names],
         )
+
+    func_def = ast.FunctionDef(
+        name=name,
+        args=args,
+        body=statements,
+        decorator_list=[],
+    )
 
     # The ast.Module signature changed in 3.8 to accept a list of types to
     # ignore.

--- a/beets/util/functemplate.py
+++ b/beets/util/functemplate.py
@@ -125,21 +125,16 @@ def compile_func(arg_names, statements, name='_the_func', debug=False):
             kwarg=None,
             defaults=[ex_literal(None) for _ in arg_names],
         )
-    elif sys.version_info >= (3, 8):
-        args = ast.arguments(
-            args=[ast.arg(arg=n, annotation=None) for n in arg_names],
-            posonlyargs=[],
-            kwonlyargs=[],
-            kw_defaults=[],
-            defaults=[ex_literal(None) for _ in arg_names],
-        )
     else:
-        args = ast.arguments(
-            args=[ast.arg(arg=n, annotation=None) for n in arg_names],
-            kwonlyargs=[],
-            kw_defaults=[],
-            defaults=[ex_literal(None) for _ in arg_names],
-        )
+        args_fields = {
+            'args': [ast.arg(arg=n, annotation=None) for n in arg_names],
+            'kwonlyargs': [],
+            'kw_defaults': [],
+            'defaults': [ex_literal(None) for _ in arg_names],
+        }
+        if 'posonlyargs' in ast.arguments._fields:  # Added in Python 3.8.
+            args_fields['posonlyargs'] = []
+        args = ast.arguments(**args_fields)
 
     func_def = ast.FunctionDef(
         name=name,


### PR DESCRIPTION
Python 3.8 adds the required `posonlyargs` to `ast.arguments` (see the [Grammar](https://docs.python.org/3.8/library/ast.html?highlight=posonlyargs#abstract-grammar)), resulting in failures such as these: https://travis-ci.org/geigerzaehler/beets-alternatives/jobs/538912903.

There's some discussion about similar breaking API changes (namely in the inspect module) [here](https://github.com/python/cpython/pull/12701/files) and [here](https://bugs.python.org/issue36751),  which however does not mention the lower level ast syntax changes, so I'm assuming that the ast module is supposed to always reflect the grammer such that this is not to be considered a regression.

Does this warrant a changelog entry? Due to the werkzeug incompatibility, Python 3.8 still is not fully supported.