### PR TITLE
Update Python 3 versions for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ matrix:
         #   dist: xenial
         # - python: pypy
         #   - env: {TOX_ENV: pypy-test}
-        - python: 3.4
-          env: {TOX_ENV: py34-flake8}
+        - python: 3.6
+          env: {TOX_ENV: py36-flake8}
         - python: 2.7.13
           env: {TOX_ENV: docs}
 # Non-Python dependencies.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,8 @@ environment:
           TOX_ENV: py35-test
         - PYTHON: C:\Python36
           TOX_ENV: py36-test
+        - PYTHON: C:\Python37
+          TOX_ENV: py37-test
 
 # Install Tox for running tests.
 install:


### PR DESCRIPTION
I noticed some deprecation messages in the Travis outout when it's running `flake8` using Python 3.4. Let's update that to a more modern version. There's probably more that can be updated in the CI config while we're at it.