### PR TITLE
Move wiki cookbook to the docs

### DIFF
--- a/docs/guides/advanced.rst
+++ b/docs/guides/advanced.rst
@@ -158,27 +158,27 @@ Automatically add new music to your library
 
 As a command-line tool, beets is perfect for automated operation via a cron job
 or the like. To use it this way, you might want to use these options in your
-`config file`_::
+:doc:`config file </reference/config>`:
 
-    [beets]
-    import_incremental: yes
-    import_quiet: yes
-    import_log: /path/to/log.txt
+.. code-block:: yaml
 
-The ``import_incremental`` option will skip importing any directories that have
+    import:
+        incremental: yes
+        quiet: yes
+        log: /path/to/log.txt
+
+The :ref:`incremental` option will skip importing any directories that have
 been imported in the past.
-``import_quiet`` avoids asking you any questions (since this will be run
+:ref:`quiet` avoids asking you any questions (since this will be run
 automatically, no input is possible).
-You might also want to use the ``import_quiet_fallback`` options to configure
+You might also want to use the :ref:`quiet_fallback` options to configure
 what should happen when no near-perfect match is found -- this option depends
 on your level of paranoia.
-Finally, ``import_log`` will make beets record its decisions so you can come
+Finally, :ref:`import_log` will make beets record its decisions so you can come
 back later and see what you need to handle manually.
 
 The last step is to set up cron or some other automation system to run
 ``beet import /path/to/incoming/music``.
-
-.. _config file: http://beets.readthedocs.org/page/reference/config.html
 
 
 Useful reports
@@ -193,17 +193,13 @@ powerful queries to run on your library.
 
 * See a list of all albums with the tracks listed in order of bit rate::
 
-      beet ls -f '$bitrate $artist - $title' | sort -n
-
-* See a list of all albums with the tracks listed in order of sample rate::
-
-      beet ls -f '$samplerate $artist - $title' | sort -n
+      beet ls -f '$bitrate $artist - $title' bitrate+
 
 * See a list of albums and their formats::
 
       beet ls -f '$albumartist $album $format' | sort | uniq
 
   Note that ``beet ls --album -f '... $format'`` doesn't do what you want,
-  because there is no notion of an album format.
+  because ``format`` is an item-level field, not an album-level one.
   If an album's tracks exist in multiple formats, the album will appear in the
   list once for each format.

--- a/docs/guides/advanced.rst
+++ b/docs/guides/advanced.rst
@@ -179,3 +179,31 @@ The last step is to set up cron or some other automation system to run
 ``beet import /path/to/incoming/music``.
 
 .. _config file: http://beets.readthedocs.org/page/reference/config.html
+
+
+Useful reports
+--------------
+
+Since beets has a quite powerful query tool, this list contains some useful and
+powerful queries to run on your library.
+
+* See a list of all albums which have files which are 128 bit rate::
+
+      beet list bitrate:128000
+
+* See a list of all albums with the tracks listed in order of bit rate::
+
+      beet ls -f '$bitrate $artist - $title' | sort -n
+
+* See a list of all albums with the tracks listed in order of sample rate::
+
+      beet ls -f '$samplerate $artist - $title' | sort -n
+
+* See a list of albums and their formats::
+
+      beet ls -f '$albumartist $album $format' | sort | uniq
+
+  Note that ``beet ls --album -f '... $format'`` doesn't do what you want,
+  because there is no notion of an album format.
+  If an album's tracks exist in multiple formats, the album will appear in the
+  list once for each format.

--- a/docs/guides/advanced.rst
+++ b/docs/guides/advanced.rst
@@ -151,3 +151,31 @@ differently. Put something like this in your configuration file::
 
 Used together, flexible attributes and path format conditions let you sort
 your music by any criteria you can imagine.
+
+
+Automatically add new music to your library
+-------------------------------------------
+
+As a command-line tool, beets is perfect for automated operation via a cron job
+or the like. To use it this way, you might want to use these options in your
+`config file`_::
+
+    [beets]
+    import_incremental: yes
+    import_quiet: yes
+    import_log: /path/to/log.txt
+
+The ``import_incremental`` option will skip importing any directories that have
+been imported in the past.
+``import_quiet`` avoids asking you any questions (since this will be run
+automatically, no input is possible).
+You might also want to use the ``import_quiet_fallback`` options to configure
+what should happen when no near-perfect match is found -- this option depends
+on your level of paranoia.
+Finally, ``import_log`` will make beets record its decisions so you can come
+back later and see what you need to handle manually.
+
+The last step is to set up cron or some other automation system to run
+``beet import /path/to/incoming/music``.
+
+.. _config file: http://beets.readthedocs.org/page/reference/config.html

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -522,6 +522,17 @@ Either ``yes`` or ``no`` (default), controlling whether existing metadata is
 discarded when a match is applied. This corresponds to the ``--from_scratch``
 flag to ``beet import``.
 
+.. _quiet:
+
+quiet
+~~~~~
+
+Either ``yes`` or ``no`` (default), controlling whether to ask for a manual
+decision from the user when the importer is unsure how to proceed. This
+corresponds to the ``--quiet`` flag to ``beet import``.
+
+.. _quiet_fallback:
+
 quiet_fallback
 ~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This adds two of the recipes from the Cookbook page to the "Advanced awesomeness" guide in the docs, changing markup syntax but otherwise leaving the text alone. The other two recipes already existed in the docs with different text. After this we can delete the Cookbook page (#3283).