### PR TITLE
tests: avoid non-test classes named Test*

### DIFF
--- a/test/helper.py
+++ b/test/helper.py
@@ -24,7 +24,7 @@ information or mock the environment.
 - The `generate_album_info` and `generate_track_info` functions return
   fixtures to be used when mocking the autotagger.
 
-- The `TestImportSession` allows one to run importer code while
+- The `ImportSessionFixture` allows one to run importer code while
   controlling the interactions through code.
 
 - The `TestHelper` class encapsulates various fixtures that can be set up.
@@ -251,7 +251,7 @@ class TestHelper(object):
         """Create files to import and return corresponding session.
 
         Copies the specified number of files to a subdirectory of
-        `self.temp_dir` and creates a `TestImportSession` for this path.
+        `self.temp_dir` and creates a `ImportSessionFixture` for this path.
         """
         import_dir = os.path.join(self.temp_dir, b'import')
         if not os.path.isdir(import_dir):
@@ -294,8 +294,8 @@ class TestHelper(object):
         config['import']['autotag'] = False
         config['import']['resume'] = False
 
-        return TestImportSession(self.lib, loghandler=None, query=None,
-                                 paths=[import_dir])
+        return ImportSessionFixture(self.lib, loghandler=None, query=None,
+                                    paths=[import_dir])
 
     # Library fixtures methods
 
@@ -501,11 +501,11 @@ class TestHelper(object):
         return path
 
 
-class TestImportSession(importer.ImportSession):
+class ImportSessionFixture(importer.ImportSession):
     """ImportSession that can be controlled programaticaly.
 
     >>> lib = Library(':memory:')
-    >>> importer = TestImportSession(lib, paths=['/path/to/import'])
+    >>> importer = ImportSessionFixture(lib, paths=['/path/to/import'])
     >>> importer.add_choice(importer.action.SKIP)
     >>> importer.add_choice(importer.action.ASIS)
     >>> importer.default_choice = importer.action.APPLY
@@ -517,7 +517,7 @@ class TestImportSession(importer.ImportSession):
     """
 
     def __init__(self, *args, **kwargs):
-        super(TestImportSession, self).__init__(*args, **kwargs)
+        super(ImportSessionFixture, self).__init__(*args, **kwargs)
         self._choices = []
         self._resolutions = []
 

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -32,11 +32,11 @@ import six
 # Fixture: concrete database and model classes. For migration tests, we
 # have multiple models with different numbers of fields.
 
-class TestSort(dbcore.query.FieldSort):
+class SortFixture(dbcore.query.FieldSort):
     pass
 
 
-class TestQuery(dbcore.query.Query):
+class QueryFixture(dbcore.query.Query):
     def __init__(self, pattern):
         self.pattern = pattern
 
@@ -47,7 +47,7 @@ class TestQuery(dbcore.query.Query):
         return True
 
 
-class TestModel1(dbcore.Model):
+class ModelFixture1(dbcore.Model):
     _table = 'test'
     _flex_table = 'testflex'
     _fields = {
@@ -58,10 +58,10 @@ class TestModel1(dbcore.Model):
         'some_float_field': dbcore.types.FLOAT,
     }
     _sorts = {
-        'some_sort': TestSort,
+        'some_sort': SortFixture,
     }
     _queries = {
-        'some_query': TestQuery,
+        'some_query': QueryFixture,
     }
 
     @classmethod
@@ -72,12 +72,12 @@ class TestModel1(dbcore.Model):
         return {}
 
 
-class TestDatabase1(dbcore.Database):
-    _models = (TestModel1,)
+class DatabaseFixture1(dbcore.Database):
+    _models = (ModelFixture1,)
     pass
 
 
-class TestModel2(TestModel1):
+class ModelFixture2(ModelFixture1):
     _fields = {
         'id': dbcore.types.PRIMARY_ID,
         'field_one': dbcore.types.INTEGER,
@@ -85,12 +85,12 @@ class TestModel2(TestModel1):
     }
 
 
-class TestDatabase2(dbcore.Database):
-    _models = (TestModel2,)
+class DatabaseFixture2(dbcore.Database):
+    _models = (ModelFixture2,)
     pass
 
 
-class TestModel3(TestModel1):
+class ModelFixture3(ModelFixture1):
     _fields = {
         'id': dbcore.types.PRIMARY_ID,
         'field_one': dbcore.types.INTEGER,
@@ -99,12 +99,12 @@ class TestModel3(TestModel1):
     }
 
 
-class TestDatabase3(dbcore.Database):
-    _models = (TestModel3,)
+class DatabaseFixture3(dbcore.Database):
+    _models = (ModelFixture3,)
     pass
 
 
-class TestModel4(TestModel1):
+class ModelFixture4(ModelFixture1):
     _fields = {
         'id': dbcore.types.PRIMARY_ID,
         'field_one': dbcore.types.INTEGER,
@@ -114,12 +114,12 @@ class TestModel4(TestModel1):
     }
 
 
-class TestDatabase4(dbcore.Database):
-    _models = (TestModel4,)
+class DatabaseFixture4(dbcore.Database):
+    _models = (ModelFixture4,)
     pass
 
 
-class AnotherTestModel(TestModel1):
+class AnotherModelFixture(ModelFixture1):
     _table = 'another'
     _flex_table = 'anotherflex'
     _fields = {
@@ -128,7 +128,7 @@ class AnotherTestModel(TestModel1):
     }
 
 
-class TestModel5(TestModel1):
+class ModelFixture5(ModelFixture1):
     _fields = {
         'some_string_field': dbcore.types.STRING,
         'some_float_field': dbcore.types.FLOAT,
@@ -136,17 +136,17 @@ class TestModel5(TestModel1):
     }
 
 
-class TestDatabase5(dbcore.Database):
-    _models = (TestModel5,)
+class DatabaseFixture5(dbcore.Database):
+    _models = (ModelFixture5,)
     pass
 
 
-class TestDatabaseTwoModels(dbcore.Database):
-    _models = (TestModel2, AnotherTestModel)
+class DatabaseFixtureTwoModels(dbcore.Database):
+    _models = (ModelFixture2, AnotherModelFixture)
     pass
 
 
-class TestModelWithGetters(dbcore.Model):
+class ModelFixtureWithGetters(dbcore.Model):
 
     @classmethod
     def _getters(cls):
@@ -167,7 +167,7 @@ class MigrationTest(unittest.TestCase):
         handle, cls.orig_libfile = mkstemp('orig_db')
         os.close(handle)
         # Set up a database with the two-field schema.
-        old_lib = TestDatabase2(cls.orig_libfile)
+        old_lib = DatabaseFixture2(cls.orig_libfile)
 
         # Add an item to the old library.
         old_lib._connection().execute(
@@ -189,35 +189,35 @@ class MigrationTest(unittest.TestCase):
         os.remove(self.libfile)
 
     def test_open_with_same_fields_leaves_untouched(self):
-        new_lib = TestDatabase2(self.libfile)
+        new_lib = DatabaseFixture2(self.libfile)
         c = new_lib._connection().cursor()
         c.execute("select * from test")
         row = c.fetchone()
-        self.assertEqual(len(row.keys()), len(TestModel2._fields))
+        self.assertEqual(len(row.keys()), len(ModelFixture2._fields))
 
     def test_open_with_new_field_adds_column(self):
-        new_lib = TestDatabase3(self.libfile)
+        new_lib = DatabaseFixture3(self.libfile)
         c = new_lib._connection().cursor()
         c.execute("select * from test")
         row = c.fetchone()
-        self.assertEqual(len(row.keys()), len(TestModel3._fields))
+        self.assertEqual(len(row.keys()), len(ModelFixture3._fields))
 
     def test_open_with_fewer_fields_leaves_untouched(self):
-        new_lib = TestDatabase1(self.libfile)
+        new_lib = DatabaseFixture1(self.libfile)
         c = new_lib._connection().cursor()
         c.execute("select * from test")
         row = c.fetchone()
-        self.assertEqual(len(row.keys()), len(TestModel2._fields))
+        self.assertEqual(len(row.keys()), len(ModelFixture2._fields))
 
     def test_open_with_multiple_new_fields(self):
-        new_lib = TestDatabase4(self.libfile)
+        new_lib = DatabaseFixture4(self.libfile)
         c = new_lib._connection().cursor()
         c.execute("select * from test")
         row = c.fetchone()
-        self.assertEqual(len(row.keys()), len(TestModel4._fields))
+        self.assertEqual(len(row.keys()), len(ModelFixture4._fields))
 
     def test_extra_model_adds_table(self):
-        new_lib = TestDatabaseTwoModels(self.libfile)
+        new_lib = DatabaseFixtureTwoModels(self.libfile)
         try:
             new_lib._connection().execute("select * from another")
         except sqlite3.OperationalError:
@@ -226,19 +226,19 @@ class MigrationTest(unittest.TestCase):
 
 class ModelTest(unittest.TestCase):
     def setUp(self):
-        self.db = TestDatabase1(':memory:')
+        self.db = DatabaseFixture1(':memory:')
 
     def tearDown(self):
         self.db._connection().close()
 
     def test_add_model(self):
-        model = TestModel1()
+        model = ModelFixture1()
         model.add(self.db)
         rows = self.db._connection().execute('select * from test').fetchall()
         self.assertEqual(len(rows), 1)
 
     def test_store_fixed_field(self):
-        model = TestModel1()
+        model = ModelFixture1()
         model.add(self.db)
         model.field_one = 123
         model.store()
@@ -246,54 +246,54 @@ class ModelTest(unittest.TestCase):
         self.assertEqual(row['field_one'], 123)
 
     def test_retrieve_by_id(self):
-        model = TestModel1()
+        model = ModelFixture1()
         model.add(self.db)
-        other_model = self.db._get(TestModel1, model.id)
+        other_model = self.db._get(ModelFixture1, model.id)
         self.assertEqual(model.id, other_model.id)
 
     def test_store_and_retrieve_flexattr(self):
-        model = TestModel1()
+        model = ModelFixture1()
         model.add(self.db)
         model.foo = 'bar'
         model.store()
 
-        other_model = self.db._get(TestModel1, model.id)
+        other_model = self.db._get(ModelFixture1, model.id)
         self.assertEqual(other_model.foo, 'bar')
 
     def test_delete_flexattr(self):
-        model = TestModel1()
+        model = ModelFixture1()
         model['foo'] = 'bar'
         self.assertTrue('foo' in model)
         del model['foo']
         self.assertFalse('foo' in model)
 
     def test_delete_flexattr_via_dot(self):
-        model = TestModel1()
+        model = ModelFixture1()
         model['foo'] = 'bar'
         self.assertTrue('foo' in model)
         del model.foo
         self.assertFalse('foo' in model)
 
     def test_delete_flexattr_persists(self):
-        model = TestModel1()
+        model = ModelFixture1()
         model.add(self.db)
         model.foo = 'bar'
         model.store()
 
-        model = self.db._get(TestModel1, model.id)
+        model = self.db._get(ModelFixture1, model.id)
         del model['foo']
         model.store()
 
-        model = self.db._get(TestModel1, model.id)
+        model = self.db._get(ModelFixture1, model.id)
         self.assertFalse('foo' in model)
 
     def test_delete_non_existent_attribute(self):
-        model = TestModel1()
+        model = ModelFixture1()
         with self.assertRaises(KeyError):
             del model['foo']
 
     def test_delete_fixed_attribute(self):
-        model = TestModel5()
+        model = ModelFixture5()
         model.some_string_field = 'foo'
         model.some_float_field = 1.23
         model.some_boolean_field = True
@@ -306,26 +306,26 @@ class ModelTest(unittest.TestCase):
             self.assertEqual(model[field], type_.null)
 
     def test_null_value_normalization_by_type(self):
-        model = TestModel1()
+        model = ModelFixture1()
         model.field_one = None
         self.assertEqual(model.field_one, 0)
 
     def test_null_value_stays_none_for_untyped_field(self):
-        model = TestModel1()
+        model = ModelFixture1()
         model.foo = None
         self.assertEqual(model.foo, None)
 
     def test_normalization_for_typed_flex_fields(self):
-        model = TestModel1()
+        model = ModelFixture1()
         model.some_float_field = None
         self.assertEqual(model.some_float_field, 0.0)
 
     def test_load_deleted_flex_field(self):
-        model1 = TestModel1()
+        model1 = ModelFixture1()
         model1['flex_field'] = True
         model1.add(self.db)
 
-        model2 = self.db._get(TestModel1, model1.id)
+        model2 = self.db._get(ModelFixture1, model1.id)
         self.assertIn('flex_field', model2)
 
         del model1['flex_field']
@@ -338,22 +338,22 @@ class ModelTest(unittest.TestCase):
         with assertRaisesRegex(self, ValueError, 'no database'):
             dbcore.Model()._check_db()
         with assertRaisesRegex(self, ValueError, 'no id'):
-            TestModel1(self.db)._check_db()
+            ModelFixture1(self.db)._check_db()
 
         dbcore.Model(self.db)._check_db(need_id=False)
 
     def test_missing_field(self):
         with self.assertRaises(AttributeError):
-            TestModel1(self.db).nonExistingKey
+            ModelFixture1(self.db).nonExistingKey
 
     def test_computed_field(self):
-        model = TestModelWithGetters()
+        model = ModelFixtureWithGetters()
         self.assertEqual(model.aComputedField, 'thing')
         with assertRaisesRegex(self, KeyError, u'computed field .+ deleted'):
             del model.aComputedField
 
     def test_items(self):
-        model = TestModel1(self.db)
+        model = ModelFixture1(self.db)
         model.id = 5
         self.assertEqual({('id', 5), ('field_one', 0)},
                          set(model.items()))
@@ -371,31 +371,31 @@ class ModelTest(unittest.TestCase):
 
 class FormatTest(unittest.TestCase):
     def test_format_fixed_field(self):
-        model = TestModel1()
+        model = ModelFixture1()
         model.field_one = u'caf\xe9'
         value = model.formatted().get('field_one')
         self.assertEqual(value, u'caf\xe9')
 
     def test_format_flex_field(self):
-        model = TestModel1()
+        model = ModelFixture1()
         model.other_field = u'caf\xe9'
         value = model.formatted().get('other_field')
         self.assertEqual(value, u'caf\xe9')
 
     def test_format_flex_field_bytes(self):
-        model = TestModel1()
+        model = ModelFixture1()
         model.other_field = u'caf\xe9'.encode('utf-8')
         value = model.formatted().get('other_field')
         self.assertTrue(isinstance(value, six.text_type))
         self.assertEqual(value, u'caf\xe9')
 
     def test_format_unset_field(self):
-        model = TestModel1()
+        model = ModelFixture1()
         value = model.formatted().get('other_field')
         self.assertEqual(value, u'')
 
     def test_format_typed_flex_field(self):
-        model = TestModel1()
+        model = ModelFixture1()
         model.some_float_field = 3.14159265358979
         value = model.formatted().get('some_float_field')
         self.assertEqual(value, u'3.1')
@@ -403,40 +403,40 @@ class FormatTest(unittest.TestCase):
 
 class FormattedMappingTest(unittest.TestCase):
     def test_keys_equal_model_keys(self):
-        model = TestModel1()
+        model = ModelFixture1()
         formatted = model.formatted()
         self.assertEqual(set(model.keys(True)), set(formatted.keys()))
 
     def test_get_unset_field(self):
-        model = TestModel1()
+        model = ModelFixture1()
         formatted = model.formatted()
         with self.assertRaises(KeyError):
             formatted['other_field']
 
     def test_get_method_with_default(self):
-        model = TestModel1()
+        model = ModelFixture1()
         formatted = model.formatted()
         self.assertEqual(formatted.get('other_field'), u'')
 
     def test_get_method_with_specified_default(self):
-        model = TestModel1()
+        model = ModelFixture1()
         formatted = model.formatted()
         self.assertEqual(formatted.get('other_field', 'default'), 'default')
 
 
 class ParseTest(unittest.TestCase):
     def test_parse_fixed_field(self):
-        value = TestModel1._parse('field_one', u'2')
+        value = ModelFixture1._parse('field_one', u'2')
         self.assertIsInstance(value, int)
         self.assertEqual(value, 2)
 
     def test_parse_flex_field(self):
-        value = TestModel1._parse('some_float_field', u'2')
+        value = ModelFixture1._parse('some_float_field', u'2')
         self.assertIsInstance(value, float)
         self.assertEqual(value, 2.0)
 
     def test_parse_untyped_field(self):
-        value = TestModel1._parse('field_nine', u'2')
+        value = ModelFixture1._parse('field_nine', u'2')
         self.assertEqual(value, u'2')
 
 
@@ -503,7 +503,7 @@ class QueryFromStringsTest(unittest.TestCase):
     def qfs(self, strings):
         return dbcore.queryparse.query_from_strings(
             dbcore.query.AndQuery,
-            TestModel1,
+            ModelFixture1,
             {':': dbcore.query.RegexpQuery},
             strings,
         )
@@ -535,13 +535,13 @@ class QueryFromStringsTest(unittest.TestCase):
 
     def test_parse_named_query(self):
         q = self.qfs(['some_query:foo'])
-        self.assertIsInstance(q.subqueries[0], TestQuery)
+        self.assertIsInstance(q.subqueries[0], QueryFixture)
 
 
 class SortFromStringsTest(unittest.TestCase):
     def sfs(self, strings):
         return dbcore.queryparse.sort_from_strings(
-            TestModel1,
+            ModelFixture1,
             strings,
         )
 
@@ -571,13 +571,13 @@ class SortFromStringsTest(unittest.TestCase):
 
     def test_special_sort(self):
         s = self.sfs(['some_sort+'])
-        self.assertIsInstance(s, TestSort)
+        self.assertIsInstance(s, SortFixture)
 
 
 class ParseSortedQueryTest(unittest.TestCase):
     def psq(self, parts):
         return dbcore.parse_sorted_query(
-            TestModel1,
+            ModelFixture1,
             parts.split(),
         )
 
@@ -626,11 +626,11 @@ class ParseSortedQueryTest(unittest.TestCase):
 
 class ResultsIteratorTest(unittest.TestCase):
     def setUp(self):
-        self.db = TestDatabase1(':memory:')
-        model = TestModel1()
+        self.db = DatabaseFixture1(':memory:')
+        model = ModelFixture1()
         model['foo'] = 'baz'
         model.add(self.db)
-        model = TestModel1()
+        model = ModelFixture1()
         model['foo'] = 'bar'
         model.add(self.db)
 
@@ -638,16 +638,16 @@ class ResultsIteratorTest(unittest.TestCase):
         self.db._connection().close()
 
     def test_iterate_once(self):
-        objs = self.db._fetch(TestModel1)
+        objs = self.db._fetch(ModelFixture1)
         self.assertEqual(len(list(objs)), 2)
 
     def test_iterate_twice(self):
-        objs = self.db._fetch(TestModel1)
+        objs = self.db._fetch(ModelFixture1)
         list(objs)
         self.assertEqual(len(list(objs)), 2)
 
     def test_concurrent_iterators(self):
-        results = self.db._fetch(TestModel1)
+        results = self.db._fetch(ModelFixture1)
         it1 = iter(results)
         it2 = iter(results)
         next(it1)
@@ -656,44 +656,44 @@ class ResultsIteratorTest(unittest.TestCase):
 
     def test_slow_query(self):
         q = dbcore.query.SubstringQuery('foo', 'ba', False)
-        objs = self.db._fetch(TestModel1, q)
+        objs = self.db._fetch(ModelFixture1, q)
         self.assertEqual(len(list(objs)), 2)
 
     def test_slow_query_negative(self):
         q = dbcore.query.SubstringQuery('foo', 'qux', False)
-        objs = self.db._fetch(TestModel1, q)
+        objs = self.db._fetch(ModelFixture1, q)
         self.assertEqual(len(list(objs)), 0)
 
     def test_iterate_slow_sort(self):
         s = dbcore.query.SlowFieldSort('foo')
-        res = self.db._fetch(TestModel1, sort=s)
+        res = self.db._fetch(ModelFixture1, sort=s)
         objs = list(res)
         self.assertEqual(objs[0].foo, 'bar')
         self.assertEqual(objs[1].foo, 'baz')
 
     def test_unsorted_subscript(self):
-        objs = self.db._fetch(TestModel1)
+        objs = self.db._fetch(ModelFixture1)
         self.assertEqual(objs[0].foo, 'baz')
         self.assertEqual(objs[1].foo, 'bar')
 
     def test_slow_sort_subscript(self):
         s = dbcore.query.SlowFieldSort('foo')
-        objs = self.db._fetch(TestModel1, sort=s)
+        objs = self.db._fetch(ModelFixture1, sort=s)
         self.assertEqual(objs[0].foo, 'bar')
         self.assertEqual(objs[1].foo, 'baz')
 
     def test_length(self):
-        objs = self.db._fetch(TestModel1)
+        objs = self.db._fetch(ModelFixture1)
         self.assertEqual(len(objs), 2)
 
     def test_out_of_range(self):
-        objs = self.db._fetch(TestModel1)
+        objs = self.db._fetch(ModelFixture1)
         with self.assertRaises(IndexError):
             objs[100]
 
     def test_no_results(self):
         self.assertIsNone(self.db._fetch(
-            TestModel1, dbcore.query.FalseQuery()).get())
+            ModelFixture1, dbcore.query.FalseQuery()).get())
 
 
 def suite():

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -32,7 +32,8 @@ import unittest
 
 from test import _common
 from beets.util import displayable_path, bytestring_path, py3_path
-from test.helper import TestImportSession, TestHelper, has_program, capture_log
+from test.helper import TestHelper, has_program, capture_log
+from test.helper import ImportSessionFixture
 from beets import importer
 from beets.importer import albums_in_dir
 from mediafile import MediaFile
@@ -223,7 +224,7 @@ class ImportHelper(TestHelper):
         config['import']['link'] = link
         config['import']['hardlink'] = hardlink
 
-        self.importer = TestImportSession(
+        self.importer = ImportSessionFixture(
             self.lib, loghandler=None, query=None,
             paths=[import_dir or self.import_dir]
         )

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -43,7 +43,7 @@ def _consume(l):
 
 
 # A worker that raises an exception.
-class TestException(Exception):
+class ExceptionFixture(Exception):
     pass
 
 
@@ -52,7 +52,7 @@ def _exc_work(num=3):
     while True:
         i = yield i
         if i == num:
-            raise TestException()
+            raise ExceptionFixture()
         i *= 2
 
 
@@ -126,10 +126,10 @@ class ExceptionTest(unittest.TestCase):
                                      _consume(self.l)))
 
     def test_run_sequential(self):
-        self.assertRaises(TestException, self.pl.run_sequential)
+        self.assertRaises(ExceptionFixture, self.pl.run_sequential)
 
     def test_run_parallel(self):
-        self.assertRaises(TestException, self.pl.run_parallel)
+        self.assertRaises(ExceptionFixture, self.pl.run_parallel)
 
     def test_pull(self):
         pl = pipeline.Pipeline((_produce(), _exc_work()))
@@ -137,9 +137,9 @@ class ExceptionTest(unittest.TestCase):
         for i in range(3):
             next(pull)
         if six.PY2:
-            self.assertRaises(TestException, pull.next)
+            self.assertRaises(ExceptionFixture, pull.next)
         else:
-            self.assertRaises(TestException, pull.__next__)
+            self.assertRaises(ExceptionFixture, pull.__next__)
 
 
 class ParallelExceptionTest(unittest.TestCase):
@@ -150,7 +150,7 @@ class ParallelExceptionTest(unittest.TestCase):
         ))
 
     def test_run_parallel(self):
-        self.assertRaises(TestException, self.pl.run_parallel)
+        self.assertRaises(ExceptionFixture, self.pl.run_parallel)
 
 
 class ConstrainedThreadedPipelineTest(unittest.TestCase):
@@ -166,7 +166,7 @@ class ConstrainedThreadedPipelineTest(unittest.TestCase):
         # Raise an exception in a constrained pipeline.
         l = []
         pl = pipeline.Pipeline((_produce(1000), _exc_work(), _consume(l)))
-        self.assertRaises(TestException, pl.run_parallel, 1)
+        self.assertRaises(ExceptionFixture, pl.run_parallel, 1)
 
     def test_constrained_parallel(self):
         l = []

--- a/test/test_ui_importer.py
+++ b/test/test_ui_importer.py
@@ -30,11 +30,11 @@ from beets import config
 import six
 
 
-class TestTerminalImportSession(TerminalImportSession):
+class TerminalImportSessionFixture(TerminalImportSession):
 
     def __init__(self, *args, **kwargs):
         self.io = kwargs.pop('io')
-        super(TestTerminalImportSession, self).__init__(*args, **kwargs)
+        super(TerminalImportSessionFixture, self).__init__(*args, **kwargs)
         self._choices = []
 
     default_choice = importer.action.APPLY
@@ -47,11 +47,11 @@ class TestTerminalImportSession(TerminalImportSession):
 
     def choose_match(self, task):
         self._add_choice_input()
-        return super(TestTerminalImportSession, self).choose_match(task)
+        return super(TerminalImportSessionFixture, self).choose_match(task)
 
     def choose_item(self, task):
         self._add_choice_input()
-        return super(TestTerminalImportSession, self).choose_item(task)
+        return super(TerminalImportSessionFixture, self).choose_item(task)
 
     def _add_choice_input(self):
         try:
@@ -96,7 +96,7 @@ class TerminalImportSessionSetup(object):
         if not hasattr(self, 'io'):
             self.io = DummyIO()
         self.io.install()
-        self.importer = TestTerminalImportSession(
+        self.importer = TerminalImportSessionFixture(
             self.lib, loghandler=None, query=None, io=self.io,
             paths=[import_dir or self.import_dir],
         )


### PR DESCRIPTION
When using pytest's test collector, any class with a name starting with `Test` is collected. If it notices that the class has an `__init__` member then it skips it with a warning since it's probably a false positive. This isn't a big deal, but we can avoid warnings like this:

    test/test_ui_importer.py:33
      beets/test/test_ui_importer.py:33: PytestCollectionWarning: cannot collect test class 'TestTerminalImportSession' because it has a __init__ constructor
        class TestTerminalImportSession(TerminalImportSession):

simply by renaming `TestX` to `XFixture`.