### PR TITLE
Avoid using an internal confuse function

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -39,7 +39,6 @@ from beets.util import syspath, normpath, ancestry, displayable_path, \
 from beets import library
 from beets import config
 from beets import logging
-from confuse import _package_path
 import six
 from . import _store_dict
 
@@ -1726,7 +1725,7 @@ def completion_script(commands):
     ``commands`` is alist of ``ui.Subcommand`` instances to generate
     completion data for.
     """
-    base_script = os.path.join(_package_path('beets.ui'), 'completion_base.sh')
+    base_script = os.path.join(os.path.dirname(__file__), 'completion_base.sh')
     with open(base_script, 'r') as base_script:
         yield util.text_string(base_script.read())
 


### PR DESCRIPTION
Just taking care of the loose thread from #3224. This function from confuse wasn't necessary here in the one place that was using it. The old version was possibly a little clearer in intent, but the new version has less indirection.