### PR TITLE
Remove TypeError from string + int concat

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -420,7 +420,7 @@ class FanartTV(RemoteArtSource):
 
         try:
             response = self.request(
-                self.API_ALBUMS + album.mb_releasegroupid,
+                self.API_ALBUMS + str(album.mb_releasegroupid),
                 headers={'api-key': self.PROJECT_KEY,
                          'client-key': self.client_key})
         except requests.RequestException:


### PR DESCRIPTION
This removes the problem of concatenating string and int (#3303) but not the real problem (Discogs ids on mb* fields, I guess)