### PR TITLE
replaygain: fix #3311

### DIFF
--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -901,27 +901,27 @@ class ReplayGainPlugin(BeetsPlugin):
         item.rg_track_gain = track_gain.gain
         item.rg_track_peak = track_gain.peak
         item.store()
-
-        self._log.debug(u'applied track gain {0}, peak {1}',
+        self._log.debug(u'applied track gain {0} LU, peak {1} of FS',
                         item.rg_track_gain, item.rg_track_peak)
-
-    def store_track_r128_gain(self, item, track_gain):
-        item.r128_track_gain = int(round(track_gain.gain * pow(2, 8)))
-        item.store()
-
-        self._log.debug(u'applied r128 track gain {0}', item.r128_track_gain)
 
     def store_album_gain(self, item, album_gain):
         item.rg_album_gain = album_gain.gain
         item.rg_album_peak = album_gain.peak
         item.store()
-        self._log.debug(u'applied album gain {0}, peak {1}',
+        self._log.debug(u'applied album gain {0} LU, peak {1} of FS',
                         item.rg_album_gain, item.rg_album_peak)
+
+    def store_track_r128_gain(self, item, track_gain):
+        item.r128_track_gain = track_gain.gain
+        item.store()
+
+        self._log.debug(u'applied r128 track gain {0} LU',
+                        item.r128_track_gain)
 
     def store_album_r128_gain(self, item, album_gain):
         item.r128_album_gain = album_gain.gain
         item.store()
-        self._log.debug(u'applied r128 album gain {0}',
+        self._log.debug(u'applied r128 album gain {0} LU',
                         item.r128_album_gain)
 
     def handle_album(self, album, write, force=False):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -48,6 +48,7 @@ Fixes:
 * :doc:`/plugins/importadded`: Fixed a crash that occurred when the
   ``after_write`` signal was emitted.
   :bug:`3301`
+* doc:`plugins/replaygain`: Fix storage format in R128_ALBUM_GAIN tags.
 
 For plugin developers:
 

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
         'unidecode',
         'musicbrainzngs>=0.4',
         'pyyaml',
-        'mediafile>=0.1.0',
+        'mediafile>=0.2.0',
         'confuse>=1.0.0',
     ] + [
         # Avoid a version of munkres incompatible with Python 3.


### PR DESCRIPTION
Fix #3311.

As suggested in the discussion there, the Q7.8 conversion has been moved into mediafile. Thus this depends upon [mediafile #16](https://github.com/beetbox/mediafile/pull/16).