### PR TITLE
Absubmit improvements

### DIFF
--- a/beetsplug/absubmit.py
+++ b/beetsplug/absubmit.py
@@ -160,7 +160,7 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
                     item=item, error=e
                 )
                 return None
-            with open(filename, 'rb') as tmp_file:
+            with open(filename, 'r') as tmp_file:
                 analysis = json.load(tmp_file)
             # Add the hash to the output.
             analysis['metadata']['version']['essentia_build_sha'] = \

--- a/beetsplug/absubmit.py
+++ b/beetsplug/absubmit.py
@@ -58,8 +58,10 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
         self.config.add({
             'extractor': u'',
             'force': False,
-            'dry': False
+            'pretend': False
         })
+
+        self.PROBE_FIELD = 'mood_acoustic'
 
         self.extractor = self.config['extractor'].as_str()
         if self.extractor:
@@ -108,9 +110,9 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
             help=u're-download data when already present'
         )
         cmd.parser.add_option(
-            u'-d', u'--dry', dest='dry_fetch',
+            u'-p', u'--pretend', dest='pretend_fetch',
             action='store_true', default=False,
-            help=u'dry run, show files which would be processed'
+            help=u'pretend to perform action, but show only files which would be processed'
         )
         cmd.func = self.command
         return [cmd]
@@ -131,7 +133,7 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
 
         # If file has no mbid skip it.
         if not self.opts.force_refetch and not self.config['force']:
-            mood_str = item.get('mood_acoustic', u'')
+            mood_str = item.get(self.PROBE_FIELD, u'')
             if mood_str:
                 return None
 
@@ -140,8 +142,8 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
                            u'musicbrainz track id.', item)
             return None
 
-        if self.opts.dry_fetch or self.config['dry']:
-            self._log.info(u'dry run - extract item: {}', item)
+        if self.opts.pretend_fetch or self.config['pretend']:
+            self._log.info(u'pretend action - extract item: {}', item)
             return None
 
         # Temporary file to save extractor output to, extractor only works

--- a/beetsplug/absubmit.py
+++ b/beetsplug/absubmit.py
@@ -61,6 +61,7 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
             'pretend': False
         })
 
+        # Define a field which shows that acousticbrainz info is present
         self.PROBE_FIELD = 'mood_acoustic'
 
         self.extractor = self.config['extractor'].as_str()

--- a/beetsplug/absubmit.py
+++ b/beetsplug/absubmit.py
@@ -112,8 +112,8 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
         cmd.parser.add_option(
             u'-p', u'--pretend', dest='pretend_fetch',
             action='store_true', default=False,
-            help=u'pretend to perform action, but show ' \
-                'only files which would be processed'
+            help=u'pretend to perform action, but show \
+only files which would be processed'
         )
         cmd.func = self.command
         return [cmd]

--- a/beetsplug/absubmit.py
+++ b/beetsplug/absubmit.py
@@ -111,14 +111,14 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
             u'-d', u'--dry', dest='dry_fetch',
             action='store_true', default=False,
             help=u'dry run, show files which would be processed'
-        )        
+        )
         cmd.func = self.command
         return [cmd]
 
     def command(self, lib, opts, args):
         # Get items from arguments
         items = lib.items(ui.decargs(args))
-        self.opts=opts
+        self.opts = opts
         util.par_map(self.analyze_submit, items)
 
     def analyze_submit(self, item):
@@ -141,7 +141,7 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
             return None
 
         if self.opts.dry_fetch or self.config['dry']:
-            self._log.info(u'dry run - extract item: {}', item)      
+            self._log.info(u'dry run - extract item: {}', item)
             return None
 
         # Temporary file to save extractor output to, extractor only works

--- a/beetsplug/absubmit.py
+++ b/beetsplug/absubmit.py
@@ -112,7 +112,8 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
         cmd.parser.add_option(
             u'-p', u'--pretend', dest='pretend_fetch',
             action='store_true', default=False,
-            help=u'pretend to perform action, but show only files which would be processed'
+            help=u'pretend to perform action, but show ' \
+                'only files which would be processed'
         )
         cmd.func = self.command
         return [cmd]

--- a/docs/plugins/absubmit.rst
+++ b/docs/plugins/absubmit.rst
@@ -43,10 +43,10 @@ To configure the plugin, make a ``absubmit:`` section in your configuration file
   Default: ``no``
 - **extractor**: The absolute path to the `streaming_extractor_music`_ binary.
   Default: search for the program in your ``$PATH``
-- **force**: Analyse AcousticBrainz data even for tracks that already have
+- **force**: Analyze items and submit of AcousticBrainz data even for tracks that already have
   it.
   Default: ``no``.  
-- **dry**: No analyse AcousticBrainz data but print out the files which would be processed
+- **dry**: No analyze and submit of AcousticBrainz data but print out the items which would be processed
   Default: ``no``.    
 
 .. _streaming_extractor_music: https://acousticbrainz.org/download

--- a/docs/plugins/absubmit.rst
+++ b/docs/plugins/absubmit.rst
@@ -55,8 +55,8 @@ file. The available options are:
 - **force**: Analyze items and submit of AcousticBrainz data even for tracks
   that already have it.
   Default: ``no``.
-- **dry**: No analyze and submit of AcousticBrainz data but print out the
-  items which would be processed
+- **pretend**: Do not analyze and submit of AcousticBrainz data but print out
+  the items which would be processed.
   Default: ``no``.
 
 .. _streaming_extractor_music: https://acousticbrainz.org/download

--- a/docs/plugins/absubmit.rst
+++ b/docs/plugins/absubmit.rst
@@ -20,9 +20,12 @@ Submitting Data
 
 Type::
 
-    beet absubmit [QUERY]
+    beet absubmit [-f] [-d] [QUERY]
 
-to run the analysis program and upload its results.
+to run the analysis program and upload its results. By default, the command will only look for AcousticBrainz data when the tracks
+doesn't already have it; the ``-f`` or ``--force`` switch makes it refetch data even 
+when it already exists. You can use the ``-d`` or ``--dry``swtich to check which files will be 
+analyzed, before you start a longer period of processing.
 
 The plugin works on music with a MusicBrainz track ID attached. The plugin
 will also skip music that the analysis tool doesn't support.
@@ -40,6 +43,11 @@ To configure the plugin, make a ``absubmit:`` section in your configuration file
   Default: ``no``
 - **extractor**: The absolute path to the `streaming_extractor_music`_ binary.
   Default: search for the program in your ``$PATH``
+- **force**: Analyse AcousticBrainz data even for tracks that already have
+  it.
+  Default: ``no``.  
+- **dry**: No analyse AcousticBrainz data but print out the files which would be processed
+  Default: ``no``.    
 
 .. _streaming_extractor_music: https://acousticbrainz.org/download
 .. _FAQ: https://acousticbrainz.org/faq

--- a/docs/plugins/absubmit.rst
+++ b/docs/plugins/absubmit.rst
@@ -7,13 +7,18 @@ The ``absubmit`` plugin lets you submit acoustic analysis results to the
 Installation
 ------------
 
-The ``absubmit`` plugin requires the `streaming_extractor_music`_ program to run. Its source can be found on `GitHub`_, and while it is possible to compile the extractor from source, AcousticBrainz would prefer if you used their binary (see the AcousticBrainz `FAQ`_).
+The ``absubmit`` plugin requires the `streaming_extractor_music`_ program
+to run. Its source can be found on `GitHub`_, and while it is possible to
+compile the extractor from source, AcousticBrainz would prefer if you used
+their binary (see the AcousticBrainz `FAQ`_).
 
-The ``absubmit`` plugin also requires `requests`_, which you can install using `pip`_ by typing::
+The ``absubmit`` plugin also requires `requests`_, which you can install
+using `pip`_ by typing::
 
     pip install requests
 
-After installing both the extractor binary and requests you can enable the plugin ``absubmit`` in your configuration (see :ref:`using-plugins`).
+After installing both the extractor binary and requests you can enable
+the plugin ``absubmit`` in your configuration (see :ref:`using-plugins`).
 
 Submitting Data
 ---------------
@@ -22,10 +27,12 @@ Type::
 
     beet absubmit [-f] [-d] [QUERY]
 
-to run the analysis program and upload its results. By default, the command will only look for AcousticBrainz data when the tracks
-doesn't already have it; the ``-f`` or ``--force`` switch makes it refetch data even 
-when it already exists. You can use the ``-d`` or ``--dry``swtich to check which files will be 
-analyzed, before you start a longer period of processing.
+To run the analysis program and upload its results. By default, the
+command will only look for AcousticBrainz data when the tracks
+doesn't already have it; the ``-f`` or ``--force`` switch makes it refetch
+data even when it already exists. You can use the ``-d`` or ``--dry`` swtich
+to check which files will be analyzed, before you start a longer period
+of processing.
 
 The plugin works on music with a MusicBrainz track ID attached. The plugin
 will also skip music that the analysis tool doesn't support.
@@ -37,17 +44,20 @@ will also skip music that the analysis tool doesn't support.
 Configuration
 -------------
 
-To configure the plugin, make a ``absubmit:`` section in your configuration file. The available options are:
+To configure the plugin, make a ``absubmit:`` section in your configuration
+file. The available options are:
 
-- **auto**: Analyze every file on import. Otherwise, you need to use the ``beet absubmit`` command explicitly.
+- **auto**: Analyze every file on import. Otherwise, you need to use the
+  ``beet absubmit`` command explicitly.
   Default: ``no``
 - **extractor**: The absolute path to the `streaming_extractor_music`_ binary.
   Default: search for the program in your ``$PATH``
-- **force**: Analyze items and submit of AcousticBrainz data even for tracks that already have
-  it.
-  Default: ``no``.  
-- **dry**: No analyze and submit of AcousticBrainz data but print out the items which would be processed
-  Default: ``no``.    
+- **force**: Analyze items and submit of AcousticBrainz data even for tracks
+  that already have it.
+  Default: ``no``.
+- **dry**: No analyze and submit of AcousticBrainz data but print out the
+  items which would be processed
+  Default: ``no``.
 
 .. _streaming_extractor_music: https://acousticbrainz.org/download
 .. _FAQ: https://acousticbrainz.org/faq


### PR DESCRIPTION
just wanted to have the possibility to skip items which have already Acousticbrainz data (which is now default). 
-force will go back to the old behavior
-dry will show only the items which would be processed

see
https://discourse.beets.io/t/acousticbrainz-for-big-libraries/378
