### PR TITLE
Convert plugin skips previously-converted files

### DIFF
--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -24,7 +24,9 @@ To convert a part of your collection, run ``beet convert QUERY``. The
 command will transcode all the files matching the query to the
 destination directory given by the ``-d`` (``--dest``) option or the
 ``dest`` configuration. The path layout mirrors that of your library,
-but it may be customized through the ``paths`` configuration.
+but it may be customized through the ``paths`` configuration. Files
+that have been previously converted — and thus already exist in the
+destination directory — will be skipped.
 
 The plugin uses a command-line program to transcode the audio. With the
 ``-f`` (``--format``) option you can choose the transcoding command


### PR DESCRIPTION
One of the Convert plugin's greatest features is that it skips files that have already been converted. So one can just run `beet convert` willy-nilly without keeping track of which files have already been converted.

This adds one sentence to clarify the documentation, making it clear that one can run `beet convert` without fearing that previously-converted files will be needlessly re-converted.