### PR TITLE
Fixes import problem when a leading slash is used in path names

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -888,6 +888,9 @@ class Item(LibModel):
                 beets.config['path_sep_replace'].as_str()
             )
 
+        # If present, remove the leading slash to ensure this isn't an absolute path
+        subpath = subpath.lstrip(os.path.sep)
+
         maxlen = beets.config['max_filename_length'].get(int)
         if not maxlen:
             # When zero, try to determine from filesystem.


### PR DESCRIPTION
### Summary and resolution

This PR fixes a bug where path names that start with a leading slash will lead beets to try to copy/move files to the root directory on import.

This PR strips the leading path separator if it exists at the start of the subpath.

### Problem

If you use a path format like the following:
```
paths:
  default: $grouping/$artist - $title
  ...
```
...and the tag `$grouping` isn't present in the file, the subpath the importer sees will be just `/$artist - $title`. The subpath in this case starts with a leading slash.

When beets determines where to move the file (in the [`destination` function](https://github.com/beetbox/beets/blob/master/beets/library.py#L913), `os.path.join` uses two arguments: the library directory and the subpath for the specific file.

The second argument can't start with a leading slash, or `os.path.join()` will simply ignore the first argument, [as it's an absolute path](https://docs.python.org/3/library/os.path.html#os.path.join):
```
os.path.join('/library', '/Radiohead - Everything in Its Right Place.flac')`
# will return '/Radiohead - Everything in Its Right Place.flac`
```
This means the importer tries to place it in the root directory (`/`).
