### PR TITLE
fix "Sporadic test failures in BPD tests #3309"

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -80,6 +80,9 @@ For plugin developers:
   value.
   Thanks to :user:`zsinskri`.
   :bug:`3329`
+* There were sporadic failures in ``test.test_player``. Hopefully these are
+  fixed. If they resurface, please reopen the relevant issue.
+  :bug:`3309` :bug:`3330`
 
 For packagers:
 

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -310,21 +310,23 @@ class BPDTestHelper(unittest.TestCase, TestHelper):
         ], assigned_port))
         server.start()
 
-        # Wait until the socket is connected:
-        for _ in range(20):
-            if assigned_port.value != 0:
-                # read which port has been assigned by the OS
-                port = assigned_port.value
-                break
-            time.sleep(0.01)
-        else:
-            raise RuntimeError('Timed out waiting for the BPD server')
-
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.connect((host, port))
-
-        sock2 = None
         try:
+            # Wait until the socket is connected:
+            for _ in range(20):
+                if assigned_port.value != 0:
+                    # read which port has been assigned by the OS
+                    port = assigned_port.value
+                    break
+                time.sleep(0.01)
+            else:
+                raise RuntimeError(
+                    'Timed out waiting for the BPD server to start'
+                )
+
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.connect((host, port))
+
+            sock2 = None
             if second_client:
                 sock2 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 sock2.connect((host, port))

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -324,19 +324,25 @@ class BPDTestHelper(unittest.TestCase, TestHelper):
                 )
 
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.connect((host, port))
+            try:
+                sock.connect((host, port))
 
-            sock2 = None
-            if second_client:
-                sock2 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                sock2.connect((host, port))
-                yield MPCClient(sock, do_hello), MPCClient(sock2, do_hello)
-            else:
-                yield MPCClient(sock, do_hello)
+                if second_client:
+                    sock2 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    try:
+                        sock2.connect((host, port))
+                        yield (
+                            MPCClient(sock, do_hello),
+                            MPCClient(sock2, do_hello),
+                        )
+                    finally:
+                        sock2.close()
+
+                else:
+                    yield MPCClient(sock, do_hello)
+            finally:
+                sock.close()
         finally:
-            sock.close()
-            if sock2:
-                sock2.close()
             server.terminate()
             server.join(timeout=0.2)
 

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -247,13 +247,14 @@ def start_server(args, assigned_port, listener_patch):
     """
     def listener_wrap(host, port):
         """Wrap `bluelet.Listener`, writing the port to `assigend_port`.
-
-        `bluelet.Listener` has previously been saved to
-        `bluelet_listener` as this function will replace it at its
-        original location.
         """
+        # `bluelet.Listener` has previously been saved to
+        # `bluelet_listener` as this function will replace it at its
+        # original location.
         listener = bluelet_listener(host, port)
-        assigned_port.value = listener.sock.getsockname()[1]
+        # read which port has been assigned by the OS
+        # TODO: change to put_nowait. There should always be a free slot.
+        assigned_port.put(listener.sock.getsockname()[1])
         return listener
     listener_patch.side_effect = listener_wrap
 
@@ -301,7 +302,7 @@ class BPDTestHelper(unittest.TestCase, TestHelper):
         config_file.close()
 
         # Fork and launch BPD in the new process:
-        assigned_port = mp.Value("I", 0)
+        assigned_port = mp.Queue(1)
         server = mp.Process(target=start_server, args=([
             '--library', self.config['library'].as_filename(),
             '--directory', py3_path(self.libdir),
@@ -311,17 +312,12 @@ class BPDTestHelper(unittest.TestCase, TestHelper):
         server.start()
 
         try:
-            # Wait until the socket is connected:
-            for _ in range(20):
-                if assigned_port.value != 0:
-                    # read which port has been assigned by the OS
-                    port = assigned_port.value
-                    break
-                time.sleep(0.01)
-            else:
-                raise RuntimeError(
-                    'Timed out waiting for the BPD server to start'
-                )
+            # TODO: ugly hack. remove
+            print("ignoring port in queue:", assigned_port.get(timeout=2))
+            # Wait until the socket is connected
+            port = assigned_port.get(timeout=2)
+            print("test bpd server on port", port)
+            time.sleep(0.1)
 
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             try:


### PR DESCRIPTION
The bpd test bind a socket in order to test the protocol implementation. When
running concurrently this often resulted in an attempt to bind an already
occupied port.

By using the port number `0` we instead let the OS choose a free port. We then
have to extract it from the socket (which is handled by `bluelet`) via
`mock.patch`ing.

Please note that I'm not really familiar with any of the relevant technologies (the `bpd` plugin, python's `multiprocessing`, `bluelet`, sockets and `unittest.mock.patch`). Please review thoroughly.