### PR TITLE
ffmpeg replaygain backend: Only calculate replaygain for audio stream

### DIFF
--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -456,6 +456,7 @@ class FfmpegBackend(Backend):
             "-hide_banner",
             "-i",
             item.path,
+            "-map a:0",
             "-filter",
             "ebur128=peak={0}".format(peak_method),
             "-f",

--- a/docs/plugins/replaygain.rst
+++ b/docs/plugins/replaygain.rst
@@ -92,7 +92,8 @@ configuration file. The available options are:
 
 - **auto**: Enable ReplayGain analysis during import.
   Default: ``yes``.
-- **backend**: The analysis backend; either ``gstreamer``, ``command``, or ``audiotools``.
+- **backend**: The analysis backend; either ``gstreamer``, ``command``, ``audiotools``
+  or ``ffmpeg``.
   Default: ``command``.
 - **overwrite**: Re-analyze files that already have ReplayGain tags.
   Default: ``no``.


### PR DESCRIPTION
# Problem
When I tried to use the ffmpeg backend for the replaygain plugin it threw the following error:
```
replaygain: ReplayGain error: ffmpeg exited with status 1
```

When running the ffmpeg command manually the following error occurred:
```
Stream mapping:
  Stream #0:1 -> #0:0 (mjpeg (native) -> wrapped_avframe (native))
  Stream #0:0 -> #0:1 (flac (native) -> pcm_s16le (native))
Press [q] to stop, [?] for help
Cannot connect audio filter to non audio input
```

# Solution
I figured out that the issue occurred when the file contains embedded album art. When the file has embedded album art ffmpeg also tries to calculate the replaygain values for the album art, which obviously doesn't work.

Therefore i added '-map a:0' to the command in order to inform ffmpeg to only apply the filter to the audio stream.

(While at it I also made a minor fix in the replaygain documentation)

