### PR TITLE
Use the 'resource_url' from discogs_client to not throw exception

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -208,7 +208,8 @@ class DiscogsPlugin(BeetsPlugin):
             getattr(result, 'title')
         except DiscogsAPIError as e:
             if e.status_code != 404:
-                self._log.debug(u'API Error: {0} (query: {1})', e, result._uri)
+                self._log.debug(u'API Error: {0} (query: {1})', e,
+                                result.data['resource_url'])
                 if e.status_code == 401:
                     self.reset_auth()
                     return self.album_for_id(album_id)
@@ -260,7 +261,8 @@ class DiscogsPlugin(BeetsPlugin):
             return year
         except DiscogsAPIError as e:
             if e.status_code != 404:
-                self._log.debug(u'API Error: {0} (query: {1})', e, result._uri)
+                self._log.debug(u'API Error: {0} (query: {1})', e,
+                                result.data['resource_url'])
                 if e.status_code == 401:
                     self.reset_auth()
                     return self.get_master_year(master_id)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -79,6 +79,9 @@ Fixes:
   :bug:`3301`
 * :doc:`plugins/replaygain`: Fix the storage format in R128 gain tags.
   :bug:`3311` :bug:`3314`
+* :doc:`/plugins/discogs`: Fixed a crash that occurred when the Master URI
+  isn't set
+  :bug:`2965` :bug:`3239`
 
 For plugin developers:
 


### PR DESCRIPTION
Redoing #3337 with the style fixes and a changelog.

From what I understand, the Discogs Master isn't required like the MB Release Group, so sometimes the url is undefined


fixes #2965, fixes #3239