### PR TITLE
Fix handling of Spotify year-only release dates

### DIFF
--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -173,7 +173,7 @@ class SpotifyPlugin(BeetsPlugin):
             year, month = date_parts
             day = None
         elif release_date_precision == 'year':
-            year = date_parts
+            year = date_parts[0]
             month = None
             day = None
         else:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -80,8 +80,10 @@ Fixes:
 * :doc:`plugins/replaygain`: Fix the storage format in R128 gain tags.
   :bug:`3311` :bug:`3314`
 * :doc:`/plugins/discogs`: Fixed a crash that occurred when the Master URI
-  isn't set
+  isn't set.
   :bug:`2965` :bug:`3239`
+* :doc:`/plugins/spotify`: Fix handling of year-only release dates 
+  returned by Spotify Albums API.
 
 For plugin developers:
 


### PR DESCRIPTION
I've had this fix in place locally for a while but forgot to submit a PR! This properly assigns the `AlbumInfo.year` attribute with year-only release dates returned by the Spotify Albums API and prevents a downstream `sqlite3.InterfaceError` when trying to insert e.g. `[2019]` in an INTEGER field.