### PR TITLE
Correctly display track number 0 in show_change

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -241,7 +241,8 @@ def show_change(cur_artist, cur_album, match):
             if mediums and mediums > 1:
                 return u'{0}-{1}'.format(medium, medium_index)
             else:
-                return six.text_type(medium_index or index)
+                return six.text_type(medium_index if medium_index is not None
+                                     else index)
         else:
             return six.text_type(index)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -86,6 +86,9 @@ Fixes:
   returned by Spotify Albums API.
   Thanks to :user:`rhlahuja`.
   :bug:`3343`
+* Fixed a bug that caused the UI to display incorrect track numbers for tracks
+  with index 0 when the ``per_disc_numbering`` option was set.
+  :bug:`3346`
 
 For plugin developers:
 


### PR DESCRIPTION
fixes issue #3346: When the `per_disc_numbering` option was set, the UI would
previously show a `#0 -> #1` change when actually the index would be set
to 0 (a valid index, such as for hidden tracks).  Now, properly
distinguish index 0 and None (i.e. not set)