### PR TITLE
Fix for issue #1693 (Apply `data_source` field to albums)

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -754,6 +754,7 @@ class ImportTask(BaseImportTask):
             self.record_replaced(lib)
             self.remove_replaced(lib)
             self.album = lib.add_album(self.imported_items())
+            self.album.set_parse('data_source', self.imported_items()[0].data_source)
             self.reimport_metadata(lib)
 
     def record_replaced(self, lib):

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -754,7 +754,8 @@ class ImportTask(BaseImportTask):
             self.record_replaced(lib)
             self.remove_replaced(lib)
             self.album = lib.add_album(self.imported_items())
-            self.album.set_parse('data_source', self.imported_items()[0].data_source)
+            if self.imported_items()[0].data_source:
+                self.album.data_source = self.imported_items()[0].data_source
             self.reimport_metadata(lib)
 
     def record_replaced(self, lib):

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -754,7 +754,7 @@ class ImportTask(BaseImportTask):
             self.record_replaced(lib)
             self.remove_replaced(lib)
             self.album = lib.add_album(self.imported_items())
-            if self.imported_items()[0].data_source:
+            if 'data_source' in self.imported_items()[0].keys():
                 self.album.data_source = self.imported_items()[0].data_source
             self.reimport_metadata(lib)
 

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -754,7 +754,7 @@ class ImportTask(BaseImportTask):
             self.record_replaced(lib)
             self.remove_replaced(lib)
             self.album = lib.add_album(self.imported_items())
-            if 'data_source' in self.imported_items()[0].keys():
+            if 'data_source' in self.imported_items()[0]:
                 self.album.data_source = self.imported_items()[0].data_source
             self.reimport_metadata(lib)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -63,6 +63,9 @@ New features:
   Windows.
   Thanks to :user:`MartyLake`.
   :bug:`3331` :bug:`3334`
+* The 'data_source' field is now also applied as an album-level flexible
+  attribute during imports, allowing for more refined album level searches.
+  :bug:`3350` :bug:`1693`
 
 Fixes:
 


### PR DESCRIPTION
This adds the `data_source` field (flex-attribute) to Albums during an import, it copies the value from the  first Item's corresponding field.

Does this need a conditional test to make sure that the Item field exists and actually has a value first?