### PR TITLE
fix bug with pathlib

### DIFF
--- a/beetsplug/thumbnails.py
+++ b/beetsplug/thumbnails.py
@@ -224,7 +224,7 @@ class PathlibURI(URIGetter):
     name = "Python Pathlib"
 
     def uri(self, path):
-        return PurePosixPath(path).as_uri()
+        return PurePosixPath(util.py3_path(path)).as_uri()
 
 
 def copy_c_string(c_string):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -139,6 +139,9 @@ New features:
 * :doc:`/plugins/lyrics`: Fix a bug in the heuristic for detecting valid
   lyrics in the Google source of the lyrics plugin
   :bug:`2969`
+* :doc:`/plugins/thumbnails`: Fix a bug where pathlib expected a string instead
+  of bytes for a path.
+  :bug:`3360`
 
 Fixes:
 

--- a/test/test_thumbnails.py
+++ b/test/test_thumbnails.py
@@ -284,6 +284,15 @@ class ThumbnailsTest(unittest.TestCase, TestHelper):
             u'file:///music/%EC%8B%B8%EC%9D%B4')
 
 
+class TestPathlibURI():
+    """Test PathlibURI class"""
+    def test_uri(self):
+        test_uri = PathlibURI()
+
+        # test it won't break if we pass it bytes for a path
+        test_uri.uri(b'/')
+
+
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 


### PR DESCRIPTION
Hi,

The `thumbnails` plugin was failing for me. The following patch fixed it.

```
$ python --version
Python 3.5.7
jojo at jojo-mini in ~/code/beets (master●)
$ beet thumbnails
Traceback (most recent call last):
  File "/Users/jojo/.asdf/installs/python/3.5.7/bin/beet", line 11, in <module>
    load_entry_point('beets==1.4.9', 'console_scripts', 'beet')()
  File "/Users/jojo/.asdf/installs/python/3.5.7/lib/python3.5/site-packages/beets/ui/__init__.py", line 1266, in main
    _raw_main(args)
  File "/Users/jojo/.asdf/installs/python/3.5.7/lib/python3.5/site-packages/beets/ui/__init__.py", line 1253, in _raw_main
    subcommand.func(lib, suboptions, subargs)
  File "/Users/jojo/.asdf/installs/python/3.5.7/lib/python3.5/site-packages/beetsplug/thumbnails.py", line 78, in process_query
    self.process_album(album)
  File "/Users/jojo/.asdf/installs/python/3.5.7/lib/python3.5/site-packages/beetsplug/thumbnails.py", line 133, in process_album
    wrote &= self.make_cover_thumbnail(album, 128, NORMAL_DIR)
  File "/Users/jojo/.asdf/installs/python/3.5.7/lib/python3.5/site-packages/beetsplug/thumbnails.py", line 144, in make_cover_thumbnail
    target = os.path.join(target_dir, self.thumbnail_file_name(album.path))
  File "/Users/jojo/.asdf/installs/python/3.5.7/lib/python3.5/site-packages/beetsplug/thumbnails.py", line 165, in thumbnail_file_name
    uri = self.get_uri(path)
  File "/Users/jojo/.asdf/installs/python/3.5.7/lib/python3.5/site-packages/beetsplug/thumbnails.py", line 227, in uri
    return PurePosixPath(path).as_uri()
  File "/Users/jojo/.asdf/installs/python/3.5.7/lib/python3.5/pathlib.py", line 622, in __new__
    return cls._from_parts(args)
  File "/Users/jojo/.asdf/installs/python/3.5.7/lib/python3.5/pathlib.py", line 651, in _from_parts
    drv, root, parts = self._parse_args(args)
  File "/Users/jojo/.asdf/installs/python/3.5.7/lib/python3.5/pathlib.py", line 643, in _parse_args
    % type(a))
TypeError: argument should be a path or str object, not <class 'bytes'>
```