### PR TITLE
library: show album id in empty album error

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -1119,7 +1119,7 @@ class Album(LibModel):
         """
         item = self.items().get()
         if not item:
-            raise ValueError(u'empty album')
+            raise ValueError(u'empty album for album id %d' % self.id)
         return os.path.dirname(item.path)
 
     def _albumtotal(self):


### PR DESCRIPTION
This makes it possible to recover from this case, as you can correct
whatever caused it, by either fixing album ids on tracks or removing the
empty album id.

I ran into this with joining albums and manual manipulation of the ids, which I expect most won't run into, but it's better to not get into a state that we can't easily recover from, so I think it's worthwhile to include the info needed to recover.