### PR TITLE
Correct documentation of `incremental_skip_later` flag

### DIFF
--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -508,10 +508,10 @@ incremental_skip_later
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Either ``yes`` or ``no``, controlling whether skipped directories are
-recorded in the incremental list. When set to ``yes``, skipped directories
-will be recorded, and skipped later. When set to ``no``, skipped
+recorded in the incremental list. When set to ``yes``, skipped
 directories won't be recorded, and beets will try to import them again
-later. Defaults to ``no``.
+later. When set to ``no``, skipped directories will be recorded, and
+skipped later. Defaults to ``no``.
 
 .. _from_scratch:
 


### PR DESCRIPTION
I just got bitten by the bug described in #3315, and have no recourse besides doing another full import with `incremental` disabled. Here is a fix for the documentation so nobody has to be misled by it anymore.