### PR TITLE
Fix #3358 

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -333,12 +333,7 @@ def arg_encoding():
     """Get the encoding for command-line arguments (and other OS
     locale-sensitive strings).
     """
-    try:
-        return locale.getdefaultlocale()[1] or 'utf-8'
-    except ValueError:
-        # Invalid locale environment variable setting. To avoid
-        # failing entirely for no good reason, assume UTF-8.
-        return 'utf-8'
+    return locale.getpreferredencoding()
 
 
 def _fsencoding():

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -826,7 +826,9 @@ def command_output(cmd, shell=False):
     This replaces `subprocess.check_output` which can have problems if lots of
     output is sent to stderr.
     """
-    cmd = convert_command_args(cmd)
+    # On Python 3, we now pass bytes directly to subprocess
+    if six.PY2:
+        cmd = convert_command_args(cmd)
 
     try:  # python >= 3.3
         devnull = subprocess.DEVNULL
@@ -843,6 +845,9 @@ def command_output(cmd, shell=False):
     )
     stdout, stderr = proc.communicate()
     if proc.returncode:
+        # convert bytes (CalledProcessError doesn't accept bytes)
+        if not six.PY2 and type(cmd[0]) == bytes:
+            cmd = [x.decode(arg_encoding()) for x in cmd]
         raise subprocess.CalledProcessError(
             returncode=proc.returncode,
             cmd=' '.join(cmd),


### PR DESCRIPTION
I'm not 100% sure this solves the problem the correct way, but I wanted you to have a look at it.

Here's what I discovered. Passing `str` types to Python functions for file paths is actually the [recommended](https://docs.python.org/3/howto/unicode.html#unicode-filenames) way to do it. If you pass a string, it's true Python will encode it with the system locale (causing the bug I found), *but* I've discovered that as long as the string has the surrogates properly escaped, the file paths work. So even if my encoding is ASCII, `subprocess` has no complaints with paths that contain bytes that don't decode to ASCII, so long as you pass a string in that's got surrogate escaping for all non-ASCII characters.

Currently the process looks like this.

1. `convert.py` encodes args with the system's encoding (defaulting to UTF-8)
2. `util` takes the args and decodes them (defaulting to UTF-8) into `str` args with surrogate escaping.
3. `subprocess` gets the args and tries to encode them (defaulting to ASCII)

Note that `surrogateescape` is an error handler. When we decode `bytes` as UTF-8 with that handler (as in step 2), a ton of bytes outside of the ASCII range will get decoded without escaping because they don't raise errors. This is what causes the exception in `subprocess` to happen - it can't convert these characters to ASCII!

What I've discovered (this is the main part for you to double check) is that the `str` args handed to us at the beginning of step 1 are *already* escaped with the `arg_encoding()` locale! So the round-trip conversion is not only unnecessary, it's actually what breaks it in the case where there's no set locale.

I've checked that this works on systems with and without the locale defined. Note that if this is merged some other code can be deleted, e.g. in `convert_command_args`. I haven't done that yet until it's clear that this is the right approach, and to make the changes clearer.

If I'm right about how this works, the only change in behavior when a locale *is* defined is actually a slight bug fix. Suppose we're using an unusual encoding, like latin-1. In the case of any non-latin-1 characters in the args, they will be surrogate escaped for us already. Currently, we would then encode them to `bytes` with latin-1. [PEP-383](https://www.python.org/dev/peps/pep-0383/) tells us what will happen next:

> While providing a uniform API to non-decodable bytes, this interface has the limitation that chosen representation only "works" if the data get converted back to bytes with the surrogateescape error handler also. Encoding the data with the locale's encoding and the (default) strict error handler will raise an exception, encoding them with UTF-8 will produce non-sensical data.

So the `.encode()` call was missing a `surrogateescape` error handler! So this pull request probably fixes an unusual crash.