### PR TITLE
Fix #3374 beatport

### DIFF
--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -263,9 +263,9 @@ class BeatportTrack(BeatportObject):
             self.musical_key = six.text_type(data['key'].get('shortName'))
 
         # Use 'subgenre' and if not present, 'genre' as a fallback.
-        if 'subGenres' in data and data['subGenres']:
+        if data.get('subGenres'):
             self.genre = six.text_type(data['subGenres'][0].get('name'))
-        elif 'genres' in data and data['genres']:
+        elif data.get('genres'):
             self.genre = six.text_type(data['genres'][0].get('name'))
 
 

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -385,9 +385,8 @@ class BeatportPlugin(BeetsPlugin):
             self._log.debug(u'Not a valid Beatport release ID.')
             return None
         release = self.client.get_release(match.group(2))
-        if release is not None:
-            album = self._get_album_info(release)
-            return album
+        if release:
+            return self._get_album_info(release)
         return None
 
     def track_for_id(self, track_id):
@@ -401,8 +400,7 @@ class BeatportPlugin(BeetsPlugin):
             return None
         bp_track = self.client.get_track(match.group(2))
         if bp_track is not None:
-            track = self._get_track_info(bp_track)
-            return track
+            return self._get_track_info(bp_track)
         return None
 
     def _get_releases(self, query):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -107,6 +107,8 @@ Fixes:
 * ``none_rec_action`` does not import automatically when ``timid`` is enabled.
   Thanks to :user:`RollingStar`.
   :bug:`3242`
+* Fix a bug that caused a crash when tagging items with the beatport plugin.
+  :bug:`3374`
 
 For plugin developers:
 

--- a/test/test_beatport.py
+++ b/test/test_beatport.py
@@ -558,6 +558,70 @@ class BeatportTest(_common.TestCase, TestHelper):
             self.assertEqual(track.genre, test_track.genre)
 
 
+class BeatportResponseEmptyTest(_common.TestCase, TestHelper):
+    def _make_tracks_response(self):
+        results = [{
+            "id": 7817567,
+            "name": "Mirage a Trois",
+            "genres": [{
+              "id": 9,
+              "name": "Breaks",
+              "slug": "breaks",
+              "type": "genre"
+            }],
+            "subGenres": [{
+              "id": 209,
+              "name": "Glitch Hop",
+              "slug": "glitch-hop",
+              "type": "subgenre"
+            }],
+        }]
+        return results
+
+    def setUp(self):
+        self.setup_beets()
+        self.load_plugins('beatport')
+        self.lib = library.Library(':memory:')
+
+        # Set up 'tracks'.
+        self.response_tracks = self._make_tracks_response()
+        self.tracks = [beatport.BeatportTrack(t) for t in self.response_tracks]
+
+        # Make alias to be congruent with class `BeatportTest`.
+        self.test_tracks = self.response_tracks
+
+    def tearDown(self):
+        self.unload_plugins()
+        self.teardown_beets()
+
+    def test_response_tracks_empty(self):
+        response_tracks = []
+        tracks = [beatport.BeatportTrack(t) for t in response_tracks]
+        self.assertEqual(tracks, [])
+
+    def test_sub_genre_empty_fallback(self):
+        """No 'sub_genre' is provided. Test if fallback to 'genre' works.
+        """
+        self.response_tracks[0]['subGenres'] = []
+        tracks = [beatport.BeatportTrack(t) for t in self.response_tracks]
+
+        self.test_tracks[0]['subGenres'] = []
+
+        self.assertEqual(tracks[0].genre,
+                         self.test_tracks[0]['genres'][0]['name'])
+
+    def test_genre_empty(self):
+        """No 'genre' is provided. Test if 'sub_genre' is applied.
+        """
+        self.response_tracks[0]['genres'] = []
+        tracks = [beatport.BeatportTrack(t) for t in self.response_tracks]
+
+        self.test_tracks[0]['genres'] = []
+
+        self.assertEqual(tracks[0].genre,
+                         self.test_tracks[0]['subGenres'][0]['name'])
+
+
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 

--- a/test/test_beatport.py
+++ b/test/test_beatport.py
@@ -425,7 +425,6 @@ class BeatportTest(_common.TestCase, TestHelper):
 
         # Set up 'test_album'.
         self.test_album = self.mk_test_album()
-        # print(self.test_album.keys())
 
         # Set up 'test_tracks'
         self.test_tracks = self.test_album.items()

--- a/test/test_beatport.py
+++ b/test/test_beatport.py
@@ -31,7 +31,7 @@ class BeatportTest(_common.TestCase, TestHelper):
     def _make_release_response(self):
         """Returns a dict that mimics a response from the beatport API.
 
-        The results were retrived from:
+        The results were retrieved from:
         https://oauth-api.beatport.com/catalog/3/releases?id=1742984
         The list of elements on the returned dict is incomplete, including just
         those required for the tests on this class.
@@ -72,7 +72,7 @@ class BeatportTest(_common.TestCase, TestHelper):
     def _make_tracks_response(self):
         """Return a list that mimics a response from the beatport API.
 
-        The results were retrived from:
+        The results were retrieved from:
         https://oauth-api.beatport.com/catalog/3/tracks?releaseId=1742984
         The list of elements on the returned list is incomplete, including just
         those required for the tests on this class.


### PR DESCRIPTION
This fixes bug #3374 .

I have added checks to see if the response actually exists in the method `get_release`.

The reported bug should be fixed by looking first if the attribute in the dictionary is there and then checking if the list contained therein is truthy which means it has items in it that can then be accessed.

Two typos were in docstrings and one forgotton print statement.