### PR TITLE
[beatport] Exclude invalid musical keys

### DIFF
--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -257,8 +257,7 @@ class BeatportTrack(BeatportObject):
             self.url = "https://beatport.com/track/{0}/{1}" \
                 .format(data['slug'], data['id'])
         self.track_number = data.get('trackNumber')
-        if 'bpm' in data:
-            self.bpm = data['bpm']
+        self.bpm = data.get('bpm')
         self.musical_key = six.text_type(
             (data.get('key') or {}).get('shortName')
         )

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -259,8 +259,7 @@ class BeatportTrack(BeatportObject):
         self.track_number = data.get('trackNumber')
         if 'bpm' in data:
             self.bpm = data['bpm']
-        if data.get('key'):
-            self.musical_key = six.text_type(data['key'].get('shortName'))
+        self.musical_key = six.text_type(data.get('key', {}).get('shortName'))
 
         # Use 'subgenre' and if not present, 'genre' as a fallback.
         if data.get('subGenres'):

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -259,7 +259,7 @@ class BeatportTrack(BeatportObject):
         self.track_number = data.get('trackNumber')
         if 'bpm' in data:
             self.bpm = data['bpm']
-        if 'key' in data:
+        if data.get('key'):
             self.musical_key = six.text_type(data['key'].get('shortName'))
 
         # Use 'subgenre' and if not present, 'genre' as a fallback.

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -259,7 +259,9 @@ class BeatportTrack(BeatportObject):
         self.track_number = data.get('trackNumber')
         if 'bpm' in data:
             self.bpm = data['bpm']
-        self.musical_key = six.text_type(data.get('key', {}).get('shortName'))
+        self.musical_key = six.text_type(
+            (data.get('key') or {}).get('shortName')
+        )
 
         # Use 'subgenre' and if not present, 'genre' as a fallback.
         if data.get('subGenres'):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -73,6 +73,8 @@ New features:
 * :doc:`/plugins/beatport`: The plugin now gets the musical key, BPM and the
   genre for each track.
   :bug:`2080`
+* :doc:`/plugins/beatport`: Fix default assignment of the musical key.
+  :bug:`3377`
 
 Fixes:
 


### PR DESCRIPTION
Fix a bug introduced in https://github.com/beetbox/beets/pull/3372 by defaulting the `musical_key` to None for Beatport releases, avoiding the following:
```
Traceback (most recent call last):
  File "/Users/rahulahuja/Dropbox/.virtualenvs/beetbox/beets/bin/beet", line 11, in <module>
    load_entry_point('beets', 'console_scripts', 'beet')()
  File "/Users/rahulahuja/git/beetbox/beets/beets/ui/__init__.py", line 1267, in main
    _raw_main(args)
  File "/Users/rahulahuja/git/beetbox/beets/beets/ui/__init__.py", line 1254, in _raw_main
    subcommand.func(lib, suboptions, subargs)
  File "/Users/rahulahuja/git/beetbox/beets/beets/ui/commands.py", line 956, in import_func
    import_files(lib, paths, query)
  File "/Users/rahulahuja/git/beetbox/beets/beets/ui/commands.py", line 926, in import_files
    session.run()
  File "/Users/rahulahuja/git/beetbox/beets/beets/importer.py", line 329, in run
    pl.run_parallel(QUEUE_SIZE)
  File "/Users/rahulahuja/git/beetbox/beets/beets/util/pipeline.py", line 445, in run_parallel
    six.reraise(exc_info[0], exc_info[1], exc_info[2])
  File "/Users/rahulahuja/rahuja Dropbox/Rahul Ahuja/.virtualenvs/beetbox/beets/lib/python3.7/site-packages/six.py", line 693, in reraise
    raise value
  File "/Users/rahulahuja/git/beetbox/beets/beets/util/pipeline.py", line 312, in run
    out = self.coro.send(msg)
  File "/Users/rahulahuja/git/beetbox/beets/beets/util/pipeline.py", line 194, in coro
    func(*(args + (task,)))
  File "/Users/rahulahuja/git/beetbox/beets/beets/importer.py", line 1353, in lookup_candidates
    task.lookup_candidates()
  File "/Users/rahulahuja/git/beetbox/beets/beets/importer.py", line 641, in lookup_candidates
    autotag.tag_album(self.items, search_ids=self.search_ids)
  File "/Users/rahulahuja/git/beetbox/beets/beets/autotag/match.py", line 460, in tag_album
    va_likely):
  File "/Users/rahulahuja/git/beetbox/beets/beets/plugins.py", line 576, in decorated
    for v in generator(*args, **kwargs):
  File "/Users/rahulahuja/git/beetbox/beets/beets/autotag/hooks.py", line 637, in album_candidates
    for candidate in plugins.candidates(items, artist, album, va_likely):
  File "/Users/rahulahuja/git/beetbox/beets/beets/plugins.py", line 386, in candidates
    for candidate in plugin.candidates(items, artist, album, va_likely):
  File "/Users/rahulahuja/git/beetbox/beets/beetsplug/beatport.py", line 362, in candidates
    return self._get_releases(query)
  File "/Users/rahulahuja/git/beetbox/beets/beetsplug/beatport.py", line 418, in _get_releases
    for x in self.client.search(query)]
  File "/Users/rahulahuja/git/beetbox/beets/beetsplug/beatport.py", line 417, in <listcomp>
    albums = [self._get_album_info(x)
  File "/Users/rahulahuja/git/beetbox/beets/beetsplug/beatport.py", line 138, in search
    release = self.get_release(item['id'])
  File "/Users/rahulahuja/git/beetbox/beets/beetsplug/beatport.py", line 155, in get_release
    release.tracks = self.get_release_tracks(beatport_id)
  File "/Users/rahulahuja/git/beetbox/beets/beetsplug/beatport.py", line 168, in get_release_tracks
    return [BeatportTrack(t) for t in response]
  File "/Users/rahulahuja/git/beetbox/beets/beetsplug/beatport.py", line 168, in <listcomp>
    return [BeatportTrack(t) for t in response]
  File "/Users/rahulahuja/git/beetbox/beets/beetsplug/beatport.py", line 263, in __init__
    self.musical_key = six.text_type(data['key'].get('shortName'))
AttributeError: 'NoneType' object has no attribute 'get'
```