### PR TITLE
docs/plugins/discogs.rst: Update plugin documentation

### DIFF
--- a/docs/plugins/beatport.rst
+++ b/docs/plugins/beatport.rst
@@ -36,6 +36,11 @@ also search for an id like so:
 
     beet import path/to/music/library --search-id id
 
+Configuration
+-------------
+
+This plugin can be configured like other metadata source plugins as described in :ref:`metadata-source-plugin-configuration`.
+
 .. _requests: https://docs.python-requests.org/en/latest/
 .. _requests_oauthlib: https://github.com/requests/requests-oauthlib
 .. _Beatport: https://beetport.com

--- a/docs/plugins/deezer.rst
+++ b/docs/plugins/deezer.rst
@@ -22,13 +22,4 @@ prompt during import::
 Configuration
 -------------
 
-Put these options in config.yaml under the ``deezer:`` section:
-
-- **source_weight**: Penalty applied to Deezer matches during import. Set to
-  0.0 to disable.
-  Default: ``0.5``.
-
-Here's an example::
-
-    deezer:
-        source_weight: 0.7
+This plugin can be configured like other metadata source plugins as described in :ref:`metadata-source-plugin-configuration`.

--- a/docs/plugins/discogs.rst
+++ b/docs/plugins/discogs.rst
@@ -46,9 +46,7 @@ token`` button, and place the generated token in your configuration, as the
 Configuration
 -------------
 
-- **source_weight**: Penalty applied to Discogs matches during import. Set to
-  0.0 to disable.
-  Default: ``0.5``.
+This plugin can be configured like other metadata source plugins as described in :ref:`metadata-source-plugin-configuration`.
 
 Troubleshooting
 ---------------

--- a/docs/plugins/discogs.rst
+++ b/docs/plugins/discogs.rst
@@ -43,6 +43,13 @@ documentation), login to `Discogs`_, and visit the
 token`` button, and place the generated token in your configuration, as the
 ``user_token`` config option in the ``discogs`` section.
 
+Configuration
+-------------
+
+- **source_weight**: Penalty applied to Discogs matches during import. Set to
+  0.0 to disable.
+  Default: ``0.5``.
+
 Troubleshooting
 ---------------
 

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -35,6 +35,27 @@ like this::
 
     pip install beets[fetchart,lyrics,lastgenre]
 
+.. _metadata-source-plugin-configuration:
+
+Using Metadata Source Plugins
+-----------------------------
+
+Some plugins provide sources for metadata in addition to MusicBrainz. These
+plugins share the following configuration option:
+
+- **source_weight**: Penalty applied to matches during import. Set to 0.0 to
+  disable.
+  Default: ``0.5``.
+
+For example, to equally consider matches from Discogs and MusicBrainz add the
+following to your configuration::
+
+    plugins: discogs
+
+    discogs:
+       source_weight: 0.0
+
+
 .. toctree::
    :hidden:
 

--- a/docs/plugins/spotify.rst
+++ b/docs/plugins/spotify.rst
@@ -52,6 +52,9 @@ prompt during import::
 Configuration
 -------------
 
+This plugin can be configured like other metadata source plugins as described in :ref:`metadata-source-plugin-configuration`. In addition, the following
+configuration options are provided.
+
 The default options should work as-is, but there are some options you can put
 in config.yaml under the ``spotify:`` section:
 
@@ -79,9 +82,6 @@ in config.yaml under the ``spotify:`` section:
   track/album/artist fields before sending them to Spotify.  Can be useful for
   changing certain abbreviations, like ft. -> feat.  See the examples below.
   Default: None.
-- **source_weight**: Penalty applied to Spotify matches during import. Set to
-  0.0 to disable.
-  Default: ``0.5``.
 
 Here's an example::
 


### PR DESCRIPTION
I have found that the documentation of DiscogsPlugin does not mention the 'source_weight' option. This PR adds that information:

Add Configuration section and describe the 'source_weight' option.