### PR TITLE
[WIP] Add SyncMetadataSourcePlugin

### DIFF
--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -863,13 +863,9 @@ class SyncMetadataSourcePlugin(BeetsPlugin):
             self.metadata_source_plugin.id_regex['pattern'].format('track'),
             item.mb_trackid,
         )
-        if match:
-            id_ = match.group(
-                self.metadata_source_plugin.id_regex['match_group']
-            )
-            if id_:
-                return True
-        return False
+        return match and match.group(
+            self.metadata_source_plugin.id_regex['match_group']
+        )
 
     def get_album_tracks(self, album):
         if not album.mb_albumid:

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -764,3 +764,194 @@ class MetadataSourcePlugin(object):
         return get_distance(
             data_source=self.data_source, info=track_info, config=self.config
         )
+
+
+class SyncMetadataSourcePlugin(BeetsPlugin):
+    def __init__(self, command_name, metadata_source_class):
+        super(BeetsPlugin, self).__init__()
+        self.command_name = command_name
+        self.metadata_source_plugin = metadata_source_class()
+        self.metadata_source_plugin.setup()
+
+    def commands(self):
+        from beets import ui
+
+        cmd = ui.Subcommand(
+            self.command_name,
+            help=u'update metadata from {}'.format(
+                self.metadata_source_plugin.data_source
+            ),
+        )
+        cmd.parser.add_option(
+            u'-p',
+            u'--pretend',
+            action='store_true',
+            help=u'show all changes but do nothing',
+        )
+        cmd.parser.add_option(
+            u'-m',
+            u'--move',
+            action='store_true',
+            dest='move',
+            help=u"move files in the library directory",
+        )
+        cmd.parser.add_option(
+            u'-M',
+            u'--nomove',
+            action='store_false',
+            dest='move',
+            help=u"don't move files in library",
+        )
+        cmd.parser.add_option(
+            u'-W',
+            u'--nowrite',
+            action='store_false',
+            default=None,
+            dest='write',
+            help=u"don't write updated metadata to files",
+        )
+        cmd.parser.add_format_option()
+        cmd.func = self.func
+        return [cmd]
+
+    def func(self, lib, opts, args):
+        """Command handler for the bpsync function.
+        """
+        from beets import ui
+
+        move = ui.should_move(opts.move)
+        pretend = opts.pretend
+        write = ui.should_write(opts.write)
+        query = ui.decargs(args)
+
+        self.singletons(lib, query, move, pretend, write)
+        self.albums(lib, query, move, pretend, write)
+
+    def singletons(self, lib, query, move, pretend, write):
+        """Retrieve and apply info from the autotagger for items matched by
+        query.
+        """
+        from beets.autotag import apply_item_metadata
+
+        for item in lib.items(query + [u'singleton:true']):
+            if not item.mb_trackid:
+                self._log.info(
+                    u'Skipping singleton with no mb_trackid: {}', item
+                )
+                continue
+
+            if not self.is_metadata_source_track(item):
+                self._log.info(
+                    u'Skipping non-{} singleton: {}',
+                    self.metadata_source_plugin.data_source,
+                    item,
+                )
+                continue
+
+            # Apply.
+            trackinfo = self.metadata_source_plugin.track_for_id(
+                item.mb_trackid
+            )
+            with lib.transaction():
+                apply_item_metadata(item, trackinfo)
+                apply_item_changes(lib, item, move, pretend, write)
+
+    def is_metadata_source_track(self, item):
+        if item.get('data_source') != self.metadata_source_plugin.data_source:
+            return False
+        match = re.search(
+            self.metadata_source_plugin.id_regex['pattern'].format('track'),
+            item.mb_trackid,
+        )
+        if match:
+            id_ = match.group(
+                self.metadata_source_plugin.id_regex['match_group']
+            )
+            if id_:
+                return True
+        return False
+
+    def get_album_tracks(self, album):
+        if not album.mb_albumid:
+            self._log.info(u'Skipping album with no mb_albumid: {}', album)
+            return False
+        if not album.mb_albumid.isnumeric():
+            self._log.info(
+                u'Skipping album with invalid {} ID: {}',
+                self.metadata_source_plugin.data_source,
+                album,
+            )
+            return False
+        items = list(album.items())
+        if album.get('data_source') == self.metadata_source_plugin.data_source:
+            return items
+        if not all(self.is_metadata_source_track(item) for item in items):
+            self._log.info(
+                u'Skipping non-{} release: {}',
+                self.metadata_source_plugin.data_source,
+                album,
+            )
+            return False
+        return items
+
+    def albums(self, lib, query, move, pretend, write):
+        """Retrieve and apply info from the autotagger for albums matched by
+        query and their items.
+        """
+        from beets import autotag, library, ui, util
+
+        # Process matching albums.
+        for album in lib.albums(query):
+            # Do we have a valid metadata source album?
+            items = self.get_album_tracks(album)
+            if not items:
+                continue
+
+            # Get the metadata source album information.
+            albuminfo = self.metadata_source_plugin.album_for_id(
+                album.mb_albumid
+            )
+            if not albuminfo:
+                self._log.info(
+                    u'Release ID {} not found for album {}',
+                    album.mb_albumid,
+                    album,
+                )
+                continue
+
+            metadata_source_trackid_to_trackinfo = {
+                track.track_id: track for track in albuminfo.tracks
+            }
+            library_trackid_to_item = {
+                int(item.mb_trackid): item for item in items
+            }
+            item_to_trackinfo = {
+                item: metadata_source_trackid_to_trackinfo[track_id]
+                for track_id, item in library_trackid_to_item.items()
+            }
+
+            self._log.info(u'applying changes to {}', album)
+            with lib.transaction():
+                autotag.apply_metadata(albuminfo, item_to_trackinfo)
+                changed = False
+                # Find any changed item to apply Beatport changes to album.
+                any_changed_item = items[0]
+                for item in items:
+                    item_changed = ui.show_model_changes(item)
+                    changed |= item_changed
+                    if item_changed:
+                        any_changed_item = item
+                        apply_item_changes(lib, item, move, pretend, write)
+
+                if pretend or not changed:
+                    continue
+
+                # Update album structure to reflect an item in it.
+                for key in library.Album.item_keys:
+                    album[key] = any_changed_item[key]
+                album.store()
+
+                # Move album art (and any inconsistent items).
+                if move and lib.directory in util.ancestry(items[0].path):
+                    self._log.debug(u'moving album {}', album)
+                    album.move()

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -273,6 +273,11 @@ class BeatportTrack(BeatportObject):
 class BeatportPlugin(BeetsPlugin):
     data_source = 'Beatport'
 
+    id_regex = {
+        'pattern': r'(^|beatport\.com/release/.+/)(\d+)$',
+        'match_group': 2,
+    }
+
     def __init__(self):
         super(BeatportPlugin, self).__init__()
         self.config.add({
@@ -385,11 +390,11 @@ class BeatportPlugin(BeetsPlugin):
         or None if the query is not a valid ID or release is not found.
         """
         self._log.debug(u'Searching for release {0}', release_id)
-        match = re.search(r'(^|beatport\.com/release/.+/)(\d+)$', release_id)
+        match = re.search(self.id_regex['pattern'], release_id)
         if not match:
             self._log.debug(u'Not a valid Beatport release ID.')
             return None
-        release = self.client.get_release(match.group(2))
+        release = self.client.get_release(match.group(self.id_regex['match_group']))
         if release:
             return self._get_album_info(release)
         return None

--- a/beetsplug/bpsync.py
+++ b/beetsplug/bpsync.py
@@ -17,13 +17,11 @@
 """
 from __future__ import division, absolute_import, print_function
 
-from beets.plugins import SyncMetadataSourcePlugin
+from beets.plugins import SyncMetadataSourcePlugin, BeetsPlugin
 
 from .beatport import BeatportPlugin
 
 
-class BPSyncPlugin(SyncMetadataSourcePlugin):
+class BPSyncPlugin(SyncMetadataSourcePlugin, BeetsPlugin):
     def __init__(self):
-        super(BPSyncPlugin, self).__init__(
-            command_name='bpsync', metadata_source_class=BeatportPlugin
-        )
+        super(BPSyncPlugin, self).__init__('bpsync', BeatportPlugin)

--- a/beetsplug/bpsync.py
+++ b/beetsplug/bpsync.py
@@ -25,5 +25,5 @@ from .beatport import BeatportPlugin
 class BPSyncPlugin(SyncMetadataSourcePlugin):
     def __init__(self):
         super(BPSyncPlugin, self).__init__(
-            command_name='bpsync', metadata_source_plugin=BeatportPlugin
+            command_name='bpsync', metadata_source_class=BeatportPlugin
         )

--- a/beetsplug/dcsync.py
+++ b/beetsplug/dcsync.py
@@ -13,17 +13,17 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
-"""Update library's tags using Beatport.
+"""Update library's tags using Discogs.
 """
 from __future__ import division, absolute_import, print_function
 
 from beets.plugins import SyncMetadataSourcePlugin
 
-from .beatport import BeatportPlugin
+from .discogs import DiscogsPlugin
 
 
-class BPSyncPlugin(SyncMetadataSourcePlugin):
+class DCSyncPlugin(SyncMetadataSourcePlugin):
     def __init__(self):
-        super(BPSyncPlugin, self).__init__(
-            command_name='bpsync', metadata_source_plugin=BeatportPlugin
+        super(DCSyncPlugin, self).__init__(
+            command_name='dcsync', metadata_source_plugin=DiscogsPlugin
         )

--- a/beetsplug/dcsync.py
+++ b/beetsplug/dcsync.py
@@ -17,13 +17,11 @@
 """
 from __future__ import division, absolute_import, print_function
 
-from beets.plugins import SyncMetadataSourcePlugin
+from beets.plugins import SyncMetadataSourcePlugin, BeetsPlugin
 
 from .discogs import DiscogsPlugin
 
 
-class DCSyncPlugin(SyncMetadataSourcePlugin):
+class DCSyncPlugin(SyncMetadataSourcePlugin, BeetsPlugin):
     def __init__(self):
-        super(DCSyncPlugin, self).__init__(
-            command_name='dcsync', metadata_source_class=DiscogsPlugin
-        )
+        super(DCSyncPlugin, self).__init__('dcsync', DiscogsPlugin)

--- a/beetsplug/dcsync.py
+++ b/beetsplug/dcsync.py
@@ -25,5 +25,5 @@ from .discogs import DiscogsPlugin
 class DCSyncPlugin(SyncMetadataSourcePlugin):
     def __init__(self):
         super(DCSyncPlugin, self).__init__(
-            command_name='dcsync', metadata_source_plugin=DiscogsPlugin
+            command_name='dcsync', metadata_source_class=DiscogsPlugin
         )

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -48,6 +48,8 @@ CONNECTION_ERRORS = (ConnectionError, socket.error, http_client.HTTPException,
 
 
 class DiscogsPlugin(BeetsPlugin):
+    data_source = 'Discogs'
+
     id_regex = {
         'pattern': r'(^|\[*r|discogs\.com/.+/release/)(\d+)($|\])',
         'match_group': 2,
@@ -164,7 +166,7 @@ class DiscogsPlugin(BeetsPlugin):
         """Returns the album distance.
         """
         return get_distance(
-            data_source='Discogs',
+            data_source=self.data_source,
             info=album_info,
             config=self.config
         )
@@ -173,7 +175,7 @@ class DiscogsPlugin(BeetsPlugin):
         """Returns the track distance.
         """
         return get_distance(
-            data_source='Discogs',
+            data_source=self.data_source,
             info=track_info,
             config=self.config
         )
@@ -368,7 +370,7 @@ class DiscogsPlugin(BeetsPlugin):
                          albumstatus=None, media=media,
                          albumdisambig=None, artist_credit=None,
                          original_year=original_year, original_month=None,
-                         original_day=None, data_source='Discogs',
+                         original_day=None, data_source=self.data_source,
                          data_url=data_url,
                          discogs_albumid=discogs_albumid)
 

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -48,6 +48,10 @@ CONNECTION_ERRORS = (ConnectionError, socket.error, http_client.HTTPException,
 
 
 class DiscogsPlugin(BeetsPlugin):
+    id_regex = {
+        'pattern': r'(^|\[*r|discogs\.com/.+/release/)(\d+)($|\])',
+        'match_group': 2,
+    }
 
     def __init__(self):
         super(DiscogsPlugin, self).__init__()
@@ -210,11 +214,12 @@ class DiscogsPlugin(BeetsPlugin):
         # of an input string as to avoid confusion with other metadata plugins.
         # An optional bracket can follow the integer, as this is how discogs
         # displays the release ID on its webpage.
-        match = re.search(r'(^|\[*r|discogs\.com/.+/release/)(\d+)($|\])',
-                          album_id)
+        match = re.search(self.id_regex['pattern'], album_id)
         if not match:
             return None
-        result = Release(self.discogs_client, {'id': int(match.group(2))})
+        result = Release(
+            self.discogs_client, {'id': int(self.id_regex['match_group'])}
+        )
         # Try to obtain title to verify that we indeed have a valid Release
         try:
             getattr(result, 'title')

--- a/beetsplug/dzsync.py
+++ b/beetsplug/dzsync.py
@@ -17,13 +17,11 @@
 """
 from __future__ import division, absolute_import, print_function
 
-from beets.plugins import SyncMetadataSourcePlugin
+from beets.plugins import SyncMetadataSourcePlugin, BeetsPlugin
 
 from .deezer import DeezerPlugin
 
 
-class DZSyncPlugin(SyncMetadataSourcePlugin):
+class DZSyncPlugin(SyncMetadataSourcePlugin, BeetsPlugin):
     def __init__(self):
-        super(DZSyncPlugin, self).__init__(
-            command_name='bpsync', metadata_source_class=DeezerPlugin
-        )
+        super(DZSyncPlugin, self).__init__('dzsync', DeezerPlugin)

--- a/beetsplug/dzsync.py
+++ b/beetsplug/dzsync.py
@@ -13,17 +13,17 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
-"""Update library's tags using Beatport.
+"""Update library's tags using Deezer.
 """
 from __future__ import division, absolute_import, print_function
 
 from beets.plugins import SyncMetadataSourcePlugin
 
-from .beatport import BeatportPlugin
+from .deezer import DeezerPlugin
 
 
-class BPSyncPlugin(SyncMetadataSourcePlugin):
+class DZSyncPlugin(SyncMetadataSourcePlugin):
     def __init__(self):
-        super(BPSyncPlugin, self).__init__(
-            command_name='bpsync', metadata_source_plugin=BeatportPlugin
+        super(DZSyncPlugin, self).__init__(
+            command_name='bpsync', metadata_source_plugin=DeezerPlugin
         )

--- a/beetsplug/dzsync.py
+++ b/beetsplug/dzsync.py
@@ -25,5 +25,5 @@ from .deezer import DeezerPlugin
 class DZSyncPlugin(SyncMetadataSourcePlugin):
     def __init__(self):
         super(DZSyncPlugin, self).__init__(
-            command_name='bpsync', metadata_source_plugin=DeezerPlugin
+            command_name='bpsync', metadata_source_class=DeezerPlugin
         )

--- a/beetsplug/spsync.py
+++ b/beetsplug/spsync.py
@@ -25,5 +25,5 @@ from .spotify import SpotifyPlugin
 class SPSyncPlugin(SyncMetadataSourcePlugin):
     def __init__(self):
         super(SPSyncPlugin, self).__init__(
-            command_name='bpsync', metadata_source_plugin=SpotifyPlugin
+            command_name='bpsync', metadata_source_class=SpotifyPlugin
         )

--- a/beetsplug/spsync.py
+++ b/beetsplug/spsync.py
@@ -17,13 +17,11 @@
 """
 from __future__ import division, absolute_import, print_function
 
-from beets.plugins import SyncMetadataSourcePlugin
+from beets.plugins import SyncMetadataSourcePlugin, BeetsPlugin
 
 from .spotify import SpotifyPlugin
 
 
-class SPSyncPlugin(SyncMetadataSourcePlugin):
+class SPSyncPlugin(SyncMetadataSourcePlugin, BeetsPlugin):
     def __init__(self):
-        super(SPSyncPlugin, self).__init__(
-            command_name='bpsync', metadata_source_class=SpotifyPlugin
-        )
+        super(SPSyncPlugin, self).__init__('spsync', SpotifyPlugin)

--- a/beetsplug/spsync.py
+++ b/beetsplug/spsync.py
@@ -13,17 +13,17 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
-"""Update library's tags using Beatport.
+"""Update library's tags using Spotify.
 """
 from __future__ import division, absolute_import, print_function
 
 from beets.plugins import SyncMetadataSourcePlugin
 
-from .beatport import BeatportPlugin
+from .spotify import SpotifyPlugin
 
 
-class BPSyncPlugin(SyncMetadataSourcePlugin):
+class SPSyncPlugin(SyncMetadataSourcePlugin):
     def __init__(self):
-        super(BPSyncPlugin, self).__init__(
-            command_name='bpsync', metadata_source_plugin=BeatportPlugin
+        super(SPSyncPlugin, self).__init__(
+            command_name='bpsync', metadata_source_plugin=SpotifyPlugin
         )


### PR DESCRIPTION
This code isn't working yet, but gets across the idea of what I'm going after -- simplify the creation of "sync classes" to sync API metadata from plugins that need not be `MetadataSourcePlugin` subclasses, but which must implement:
- `data_source: str` and `id_regex: dict` attributes
- `track_for_id` and `album_for_id` functions

This class can then be leveraged to easily create plugins for syncing metadata from Discogs, Spotify, Deezer, and Beatport.

Right now, I'm running into the following stacktrace because `plugins.find_plugins()` is trying to instantiate `SyncMetadataSourcePlugin()` on its own, when it's only intended to be instantiated in subclasses with arguments (see subclass implementations). I haven't dug into this much, but suspect there's a better way to implement this, perhaps using metaclasses.

I plan to dig into this more later, but wanted to throw it out there in case @sampsyo or others have suggestions of better ways to structure this.

```
Traceback (most recent call last):
  File "/Users/rahulahuja/Dropbox/.virtualenvs/rhlahuja/beets/bin/beet", line 11, in <module>
    load_entry_point('beets', 'console_scripts', 'beet')()
  File "/Users/rahulahuja/git/rhlahuja/beets/beets/ui/__init__.py", line 1267, in main
    _raw_main(args)
  File "/Users/rahulahuja/git/rhlahuja/beets/beets/ui/__init__.py", line 1250, in _raw_main
    subcommands, plugins, lib = _setup(options, lib)
  File "/Users/rahulahuja/git/rhlahuja/beets/beets/ui/__init__.py", line 1136, in _setup
    plugins = _load_plugins(config)
  File "/Users/rahulahuja/git/rhlahuja/beets/beets/ui/__init__.py", line 1122, in _load_plugins
    plugins.send("pluginload")
  File "/Users/rahulahuja/git/rhlahuja/beets/beets/plugins.py", line 490, in send
    for handler in event_handlers()[event]:
  File "/Users/rahulahuja/git/rhlahuja/beets/beets/plugins.py", line 473, in event_handlers
    for plugin in find_plugins():
  File "/Users/rahulahuja/git/rhlahuja/beets/beets/plugins.py", line 309, in find_plugins
    _instances[cls] = cls()
TypeError: __init__() missing 2 required positional arguments: 'command_name' and 'metadata_source_class'
```