### PR TITLE
Allow disabling plugins with $BEETS_DISABLED_PLUGINS.

### DIFF
--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -18,6 +18,7 @@
 from __future__ import division, absolute_import, print_function
 
 import traceback
+import os
 import re
 import inspect
 import abc
@@ -268,7 +269,12 @@ def load_plugins(names=()):
     package in sys.path; the module indicated should contain the
     BeetsPlugin subclasses desired.
     """
+    disabled_plugins = os.environ.get('BEETS_DISABLED_PLUGINS', '').split(',')
     for name in names:
+        if name in disabled_plugins:
+            log.debug(u'Skipping disabled plugin {0}', name)
+            continue
+
         modname = '{0}.{1}'.format(PLUGIN_NAMESPACE, name)
         try:
             try:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -80,6 +80,8 @@ New features:
 * :doc:`/plugins/beatport`: Fix assignment of `genre` and rename `musical_key`
   to `initial_key`.
   :bug:`3387`
+* Plugins can be disabled by setting the `BEETS_DISABLED_PLUGINS`
+  environment variable to a comma seperated list of plugins.
 
 Fixes:
 


### PR DESCRIPTION
My rationale for adding this is somewhat selfish.

I have a handful of custom plugins that perform some CPU or IO heavy tasks (e.g. kick off a full Madsonic rescan/cleanup or a filesystem snapshot). If I don't want these to run then I need to disable these plugins in my config and I'm far too lazy for that!

Originally I just added support for `BEETS_DISABLED_PLUGINS` to each of my plugins but thought this *might* be useful to other people, especially for testing beets itself.