### PR TITLE
Extended export plugin support

### DIFF
--- a/beetsplug/export.py
+++ b/beetsplug/export.py
@@ -67,9 +67,9 @@ class ExportPlugin(BeetsPlugin):
                 # XML module formatting options.
                 'formatting': {
                     # The output encoding.
-                    'encoding': 'utf-8',
+                    'encoding': 'unicode',
                     # Controls if XML declaration should be added to the file.
-                    'xml_declaration': True,
+                    # 'xml_declaration': True,
                     # Can be either "xml", "html" or "text" (default is "xml").
                     'method': 'xml'
                 }
@@ -199,20 +199,25 @@ class XMLFormat(ExportFormat):
 
     def export(self, data, **kwargs):
         # Creates the XML file structure.
-        library = ET.Element('library')
-        tracks_key = ET.SubElement(library, 'key')
-        tracks_key.text = "Tracks"
-        tracks_dict = ET.SubElement(library, 'dict')
+        library = ET.Element(u'library')
+        tracks_key = ET.SubElement(library, u'key')
+        tracks_key.text = u'tracks'
+        tracks_dict = ET.SubElement(library, u'dict')
         if data and isinstance(data[0], dict):
             for index, item in enumerate(data):
-                track_key = ET.SubElement(tracks_dict, 'key')
+                track_key = ET.SubElement(tracks_dict, u'key')
                 track_key.text = str(index)
-                track_dict = ET.SubElement(tracks_dict, 'dict')
-                track_details = ET.SubElement(track_dict, 'Track ID')
+                track_dict = ET.SubElement(tracks_dict, u'dict')
+                track_details = ET.SubElement(track_dict, u'Track ID')
                 track_details.text = str(index)
                 for key, value in item.items():
                     track_details = ET.SubElement(track_dict, key)
                     track_details.text = value
 
-        tree = ET.ElementTree(library)
-        tree.write(self.out_stream, **kwargs)
+        # tree = ET.ElementTree(element=library)
+        try:
+            data = ET.tostring(library, **kwargs)
+        except LookupError:
+            data = ET.tostring(library, encoding='utf-8', method='xml')
+
+        self.out_stream.write(data)

--- a/beetsplug/export.py
+++ b/beetsplug/export.py
@@ -67,13 +67,11 @@ class ExportPlugin(BeetsPlugin):
                 # XML module formatting options.
                 'formatting': {
                     # The output encoding.
-                    'encoding': 'unicode',
+                    'encoding': 'utf-8',
                     # Controls if XML declaration should be added to the file.
                     'xml_declaration': True,
                     # Can be either "xml", "html" or "text" (default is "xml").
-                    'method': 'xml',
-                    # Controls formatting of elements that contain no content.
-                    'short_empty_elements': True
+                    'method': 'xml'
                 }
             }
             # TODO: Use something like the edit plugin

--- a/beetsplug/export.py
+++ b/beetsplug/export.py
@@ -18,8 +18,10 @@
 from __future__ import division, absolute_import, print_function
 
 import sys
-import json
 import codecs
+import json
+import csv
+import xml.etree.ElementTree as ET
 
 from datetime import datetime, date
 from beets.plugins import BeetsPlugin
@@ -52,6 +54,24 @@ class ExportPlugin(BeetsPlugin):
                     'sort_keys': True
                 }
             },
+            'csv': {
+                # csv module formatting options
+                'formatting': {
+                    'ensure_ascii': False,
+                    'indent': 0,
+                    'separators': (','),
+                    'sort_keys': True
+                }
+            },
+            'xml': {
+                # xml module formatting options
+                'formatting': {
+                    'ensure_ascii': False,
+                    'indent': 4,
+                    'separators': (','),
+                    'sort_keys': True
+                }
+            }
             # TODO: Use something like the edit plugin
             # 'item_fields': []
         })
@@ -78,17 +98,22 @@ class ExportPlugin(BeetsPlugin):
             u'-o', u'--output',
             help=u'path for the output file. If not given, will print the data'
         )
+        cmd.parser.add_option(
+            u'-f', u'--format', default='json',
+            help=u'specify the format of the exported data. Your options are json (deafult), csv, and xml'
+        )
         return [cmd]
 
     def run(self, lib, opts, args):
 
         file_path = opts.output
-        file_format = self.config['default_format'].get(str)
         file_mode = 'a' if opts.append else 'w'
+        file_format = opts.format
         format_options = self.config[file_format]['formatting'].get(dict)
 
         export_format = ExportFormat.factory(
-            file_format, **{
+            file_type=file_format, 
+            **{
                 'file_path': file_path,
                 'file_mode': file_mode
             }
@@ -108,44 +133,107 @@ class ExportPlugin(BeetsPlugin):
             except (mediafile.UnreadableFileError, IOError) as ex:
                 self._log.error(u'cannot read file: {0}', ex)
                 continue
-
             data = key_filter(data)
             items += [data]
-
         export_format.export(items, **format_options)
 
 
 class ExportFormat(object):
     """The output format type"""
-
-    @classmethod
-    def factory(cls, type, **kwargs):
-        if type == "json":
-            if kwargs['file_path']:
-                return JsonFileFormat(**kwargs)
-            else:
-                return JsonPrintFormat()
-        raise NotImplementedError()
-
-    def export(self, data, **kwargs):
-        raise NotImplementedError()
-
-
-class JsonPrintFormat(ExportFormat):
-    """Outputs to the console"""
-
-    def export(self, data, **kwargs):
-        json.dump(data, sys.stdout, cls=ExportEncoder, **kwargs)
-
-
-class JsonFileFormat(ExportFormat):
-    """Saves in a json file"""
-
     def __init__(self, file_path, file_mode=u'w', encoding=u'utf-8'):
         self.path = file_path
         self.mode = file_mode
         self.encoding = encoding
 
+    @classmethod
+    def factory(cls, file_type, **kwargs):
+        if file_type == "json":
+            return JsonFormat(**kwargs)
+        elif file_type == "csv":
+            return CSVFormat(**kwargs)
+        elif file_type == "xml":
+            return XMLFormat(**kwargs)
+        else:
+            raise NotImplementedError()
+
     def export(self, data, **kwargs):
+        raise NotImplementedError()
+
+
+class JsonFormat(ExportFormat):
+    """Saves in a json file"""
+    def __init__(self, file_path, file_mode=u'w', encoding=u'utf-8'):
+        super(JsonFormat, self).__init__(file_path, file_mode, encoding)
+        self.export = self.export_to_file if self.path else self.export_to_terminal
+
+    def export_to_terminal(self, data, **kwargs):
+        json.dump(data, sys.stdout, cls=ExportEncoder, **kwargs)
+
+    def export_to_file(self, data, **kwargs):
         with codecs.open(self.path, self.mode, self.encoding) as f:
             json.dump(data, f, cls=ExportEncoder, **kwargs)
+
+
+class CSVFormat(ExportFormat):
+    """Saves in a csv file"""
+    def __init__(self, file_path, file_mode=u'w', encoding=u'utf-8'):
+        super(CSVFormat, self).__init__(file_path, file_mode, encoding)
+        self.header = []
+
+    def export(self, data, **kwargs):
+        if data and type(data) is list and len(data) > 0:
+            self.header = list(data[0].keys())
+        if self.path:
+            self.export_to_file(data, **kwargs)
+        else:
+            self.export_to_terminal(data, **kwargs)
+
+    def export_to_terminal(self, data, **kwargs):
+        writer = csv.DictWriter(sys.stdout, fieldnames=self.header)
+        writer.writeheader()
+        writer.writerows(data)
+
+    def export_to_file(self, data, **kwargs):
+        with codecs.open(self.path, self.mode, self.encoding) as f:
+            writer = csv.DictWriter(f, fieldnames=self.header)
+            writer.writeheader()
+            writer.writerows(data)
+
+
+class XMLFormat(ExportFormat):
+    """Saves in a xml file"""
+    def __init__(self, file_path, file_mode=u'w', encoding=u'utf-8'):
+        super(XMLFormat, self).__init__(file_path, file_mode, encoding)
+
+    def export(self, data, **kwargs):
+        # create the file structure
+        library = ET.Element('library')
+        tracks_key = ET.SubElement(library, 'key')
+        tracks_key.text = "Tracks"
+        tracks_dict = ET.SubElement(library, 'dict')
+        if data and type(data) is list \
+        and len(data) > 0 and type(data[0]) is dict:
+            index = 1
+            for item in data:
+                track_key = ET.SubElement(tracks_dict, 'key')
+                track_key.text = str(index)
+                track_dict = ET.SubElement(tracks_dict, 'dict')
+                track_details = ET.SubElement(track_dict, 'Track ID')
+                track_details.text = str(index)
+                index += 1
+                for key, value in item.items():
+                    track_details = ET.SubElement(track_dict, key)
+                    track_details.text = value
+        data = str(ET.tostring(library, encoding=self.encoding))
+        #data = ET.dump(library)
+        if self.path:
+            self.export_to_file(data, **kwargs)
+        else:
+            self.export_to_terminal(data, **kwargs)
+    
+    def export_to_terminal(self, data, **kwargs):
+        print(data)
+
+    def export_to_file(self, data, **kwargs):
+        with codecs.open(self.path, self.mode, self.encoding) as f:
+            f.write(data)

--- a/beetsplug/export.py
+++ b/beetsplug/export.py
@@ -65,10 +65,7 @@ class ExportPlugin(BeetsPlugin):
             },
             'xml': {
                 # XML module formatting options.
-                'formatting': {
-                    # Can be either "xml", "html" or "text" (default is "xml").
-                    'method': 'xml'
-                }
+                'formatting': {}
             }
             # TODO: Use something like the edit plugin
             # 'item_fields': []

--- a/beetsplug/export.py
+++ b/beetsplug/export.py
@@ -68,7 +68,7 @@ class ExportPlugin(BeetsPlugin):
                 'formatting': {
                     'ensure_ascii': False,
                     'indent': 4,
-                    'separators': (','),
+                    'separators': (''),
                     'sort_keys': True
                 }
             }

--- a/beetsplug/export.py
+++ b/beetsplug/export.py
@@ -57,17 +57,23 @@ class ExportPlugin(BeetsPlugin):
             'csv': {
                 # CSV module formatting options.
                 'formatting': {
-                    'delimiter': ',', # The delimiter used to seperate columns.
-                    'dialect': 'excel' # The type of dialect to use when formating the file output.
+                    # The delimiter used to seperate columns.
+                    'delimiter': ',',
+                    # The dialect to use when formating the file output.
+                    'dialect': 'excel'
                 }
             },
             'xml': {
                 # XML module formatting options.
                 'formatting': {
-                    'encoding': 'unicode', # The output encoding.
-                    'xml_declaration':True, # Controls if an XML declaration should be added to the file.
-                    'method': 'xml', # Can be either "xml", "html" or "text" (default is "xml").
-                    'short_empty_elements': True # Controls the formatting of elements that contain no content.
+                    # The output encoding.
+                    'encoding': 'unicode',
+                    # Controls if XML declaration should be added to the file.
+                    'xml_declaration': True,
+                    # Can be either "xml", "html" or "text" (default is "xml").
+                    'method': 'xml',
+                    # Controls formatting of elements that contain no content.
+                    'short_empty_elements': True
                 }
             }
             # TODO: Use something like the edit plugin
@@ -105,11 +111,12 @@ class ExportPlugin(BeetsPlugin):
     def run(self, lib, opts, args):
         file_path = opts.output
         file_mode = 'a' if opts.append else 'w'
-        file_format = opts.format if opts.format else self.config['default_format'].get(str)
+        file_format = opts.format if opts.format else \
+            self.config['default_format'].get(str)
         format_options = self.config[file_format]['formatting'].get(dict)
 
         export_format = ExportFormat.factory(
-            file_type=file_format, 
+            file_type=file_format,
             **{
                 'file_path': file_path,
                 'file_mode': file_mode
@@ -144,8 +151,12 @@ class ExportFormat(object):
         self.path = file_path
         self.mode = file_mode
         self.encoding = encoding
-        # Assigned sys.stdout (terminal output) or the file stream for the path specified.
-        self.out_stream = codecs.open(self.path, self.mode, self.encoding) if self.path else sys.stdout
+        """ self.out_stream =
+                sys.stdout if path doesn't exit
+                codecs.open(..) else
+        """
+        self.out_stream = codecs.open(self.path, self.mode, self.encoding) \
+            if self.path else sys.stdout
 
     @classmethod
     def factory(cls, file_type, **kwargs):
@@ -178,7 +189,7 @@ class CSVFormat(ExportFormat):
 
     def export(self, data, **kwargs):
         header = list(data[0].keys()) if data else []
-        writer = csv.DictWriter(self.out_stream, fieldnames=self.header, **kwargs)
+        writer = csv.DictWriter(self.out_stream, fieldnames=header, **kwargs)
         writer.writeheader()
         writer.writerows(data)
 

--- a/beetsplug/export.py
+++ b/beetsplug/export.py
@@ -46,7 +46,7 @@ class ExportPlugin(BeetsPlugin):
         self.config.add({
             'default_format': 'json',
             'json': {
-                # json module formatting options
+                # JSON module formatting options.
                 'formatting': {
                     'ensure_ascii': False,
                     'indent': 4,
@@ -55,20 +55,19 @@ class ExportPlugin(BeetsPlugin):
                 }
             },
             'csv': {
-                # csv module formatting options
+                # CSV module formatting options.
                 'formatting': {
-                    'delimiter': ',', # column seperator
-                    'dialect': 'excel', # the name of the dialect to use
-                    'quotechar': '|'
+                    'delimiter': ',', # The delimiter used to seperate columns.
+                    'dialect': 'excel' # The type of dialect to use when formating the file output.
                 }
             },
             'xml': {
-                # xml module formatting options
+                # XML module formatting options.
                 'formatting': {
-                    'encoding': 'unicode', # the output encoding
-                    'xml_declaration':'True', # controls if an XML declaration should be added to the file
-                    'method': 'xml', # either "xml", "html" or "text" (default is "xml")
-                    'short_empty_elements': 'True' # controls the formatting of elements that contain no content.
+                    'encoding': 'unicode', # The output encoding.
+                    'xml_declaration':True, # Controls if an XML declaration should be added to the file.
+                    'method': 'xml', # Can be either "xml", "html" or "text" (default is "xml").
+                    'short_empty_elements': True # Controls the formatting of elements that contain no content.
                 }
             }
             # TODO: Use something like the edit plugin
@@ -123,6 +122,7 @@ class ExportPlugin(BeetsPlugin):
         included_keys = []
         for keys in opts.included_keys:
             included_keys.extend(keys.split(','))
+
         key_filter = make_key_filter(included_keys)
 
         for data_emitter in data_collector(lib, ui.decargs(args)):
@@ -144,7 +144,7 @@ class ExportFormat(object):
         self.path = file_path
         self.mode = file_mode
         self.encoding = encoding
-        # out_stream is assigned sys.stdout (terminal output) or the file stream for the path specified
+        # Assigned sys.stdout (terminal output) or the file stream for the path specified.
         self.out_stream = codecs.open(self.path, self.mode, self.encoding) if self.path else sys.stdout
 
     @classmethod
@@ -175,11 +175,9 @@ class CSVFormat(ExportFormat):
     """Saves in a csv file"""
     def __init__(self, file_path, file_mode=u'w', encoding=u'utf-8'):
         super(CSVFormat, self).__init__(file_path, file_mode, encoding)
-        self.header = []
 
     def export(self, data, **kwargs):
-        if data and len(data) > 0:
-            self.header = list(data[0].keys())
+        header = list(data[0].keys()) if data else []
         writer = csv.DictWriter(self.out_stream, fieldnames=self.header, **kwargs)
         writer.writeheader()
         writer.writerows(data)
@@ -191,23 +189,21 @@ class XMLFormat(ExportFormat):
         super(XMLFormat, self).__init__(file_path, file_mode, encoding)
 
     def export(self, data, **kwargs):
-        # create the file structure
+        # Creates the XML file structure.
         library = ET.Element('library')
         tracks_key = ET.SubElement(library, 'key')
         tracks_key.text = "Tracks"
         tracks_dict = ET.SubElement(library, 'dict')
-        if data and type(data) is list \
-        and len(data) > 0 and type(data[0]) is dict:
-            index = 1
-            for item in data:
+        if data and isinstance(data[0], dict):
+            for index, item in enumerate(data):
                 track_key = ET.SubElement(tracks_dict, 'key')
                 track_key.text = str(index)
                 track_dict = ET.SubElement(tracks_dict, 'dict')
                 track_details = ET.SubElement(track_dict, 'Track ID')
                 track_details.text = str(index)
-                index += 1
                 for key, value in item.items():
                     track_details = ET.SubElement(track_dict, key)
                     track_details.text = value
+
         tree = ET.ElementTree(library)
         tree.write(self.out_stream, **kwargs)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,7 @@ New features:
   which allows for the ability to export in json, csv and xml.
   Thanks to :user:`austinmm`.
   :bug:`3402`
+* :doc:`/plugins/unimported`: lets you find untracked files in your library directory.
 * We now fetch information about `works`_ from MusicBrainz.
   MusicBrainz matches provide the fields ``work`` (the title), ``mb_workid``
   (the MBID), and ``work_disambig`` (the disambiguation string).
@@ -74,6 +75,16 @@ New features:
   you can now match tracks and albums using the `Deezer`_ database.
   Thanks to :user:`rhlahuja`.
   :bug:`3355`
+* :doc:`/plugins/beatport`: The plugin now gets the musical key, BPM and the
+  genre for each track.
+  :bug:`2080`
+* :doc:`/plugins/beatport`: Fix default assignment of the musical key.
+  :bug:`3377`
+* :doc:`/plugins/bpsync`: Add `bpsync` plugin to sync metadata changes
+  from the Beatport database.
+* :doc:`/plugins/beatport`: Fix assignment of `genre` and rename `musical_key`
+  to `initial_key`.
+  :bug:`3387`
 
 Fixes:
 
@@ -108,6 +119,13 @@ Fixes:
 * ``none_rec_action`` does not import automatically when ``timid`` is enabled.
   Thanks to :user:`RollingStar`.
   :bug:`3242`
+* Fix a bug that caused a crash when tagging items with the beatport plugin.
+  :bug:`3374`
+* ``beet update`` will now confirm that the user still wants to update if
+  their library folder cannot be found, preventing the user from accidentally
+  wiping out their beets database.
+  Thanks to :user:`logan-arens`.
+  :bug:`1934`
 
 For plugin developers:
 
@@ -140,6 +158,8 @@ For plugin developers:
   APIs to provide metadata matches for the importer. Refer to the Spotify and
   Deezer plugins for examples of using this template class.
   :bug:`3355`
+* The autotag hooks have been modified such that they now take 'bpm',
+  'musical_key' and a per-track based 'genre' as attributes.
 
 For packagers:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,10 @@ Changelog
 
 New features:
 
+* :doc:`/plugins/export`: Added new ``-f`` (``--format``) flag; 
+  which allows for the ability to export in json, csv and xml.
+  Thanks to :user:`austinmm`.
+  :bug:`3402`
 * We now fetch information about `works`_ from MusicBrainz.
   MusicBrainz matches provide the fields ``work`` (the title), ``mb_workid``
   (the MBID), and ``work_disambig`` (the disambiguation string).

--- a/docs/plugins/export.rst
+++ b/docs/plugins/export.rst
@@ -45,28 +45,24 @@ Configuration
 -------------
 
 To configure the plugin, make a ``export:`` section in your configuration
-file. Under the ``json``, ``csv``, and ``xml`` keys, these options are available:
+file.
+For JSON export, these options are available under the ``json`` key:
 
-- **JSON Formatting**
-    - **ensure_ascii**: Escape non-ASCII characters with ``\uXXXX`` entities.
+- **ensure_ascii**: Escape non-ASCII characters with ``\uXXXX`` entities.
+- **indent**: The number of spaces for indentation.
+- **separators**: A ``[item_separator, dict_separator]`` tuple.
+- **sort_keys**: Sorts the keys in JSON dictionaries.
 
-    - **indent**: The number of spaces for indentation.
+Those options match the options from the `Python json module`_.
+Similarly, these options are available for the CSV format under the ``csv``
+key:
 
-    - **separators**: A ``[item_separator, dict_separator]`` tuple.
-
-    - **sort_keys**: Sorts the keys in JSON dictionaries.
-
-These options match the options from the `Python json module`_.
-
-.. _Python json module: https://docs.python.org/2/library/json.html#basic-usage
-
-- **CSV Formatting**
-    - **delimiter**: Used as the separating character between fields. The default value is a comma (,).
-
-    - **dialect**: The kind of CSV file to produce. The default is `excel`.
+- **delimiter**: Used as the separating character between fields. The default value is a comma (,).
+- **dialect**: The kind of CSV file to produce. The default is `excel`.
 
 These options match the options from the `Python csv module`_.
 
+.. _Python json module: https://docs.python.org/2/library/json.html#basic-usage
 .. _Python csv module: https://docs.python.org/3/library/csv.html#csv-fmt-params
 
 The default options look like this::
@@ -74,7 +70,7 @@ The default options look like this::
     export:
         json:
             formatting:
-                ensure_ascii: False
+                ensure_ascii: false
                 indent: 4
                 separators: [',' , ': ']
                 sort_keys: true

--- a/docs/plugins/export.rst
+++ b/docs/plugins/export.rst
@@ -39,8 +39,7 @@ The ``export`` command has these command-line options:
 
 * ``--append``: Appends the data to the file instead of writing.
 
-* ``--format`` or ``-f``: Specifies the format the data will be exported as. If not informed, JSON will be used by default.
-The format options include csv, json and xml.
+* ``--format`` or ``-f``: Specifies the format the data will be exported as. If not informed, JSON will be used by default. The format options include csv, json and xml.
 
 Configuration
 -------------

--- a/docs/plugins/export.rst
+++ b/docs/plugins/export.rst
@@ -2,9 +2,11 @@ Export Plugin
 =============
 
 The ``export`` plugin lets you get data from the items and export the content
-as `JSON`_.
+as `JSON`_, `CSV`_, or `XML`_.
 
 .. _JSON: https://www.json.org
+.. _CSV: https://fileinfo.com/extension/csv
+.. _XML: https://fileinfo.com/extension/xml
 
 Enable the ``export`` plugin (see :ref:`using-plugins` for help). Then, type ``beet export`` followed by a :doc:`query </reference/query>` to get the data from
 your library. For example, run this::
@@ -36,11 +38,13 @@ The ``export`` command has these command-line options:
 
 * ``--append``: Appends the data to the file instead of writing.
 
+* ``--format`` or ``-f``: Specifies the format of the exported data. If not informed, JSON will be used.
+
 Configuration
 -------------
 
 To configure the plugin, make a ``export:`` section in your configuration
-file. Under the ``json`` key, these options are available:
+file. Under the ``json``, ``csv``, and ``xml`` keys, these options are available:
 
 - **ensure_ascii**: Escape non-ASCII characters with ``\uXXXX`` entities.
 
@@ -62,4 +66,16 @@ The default options look like this::
                 ensure_ascii: False
                 indent: 4
                 separators: [',' , ': ']
+                sort_keys: true
+        csv:
+            formatting:
+                ensure_ascii: False
+                indent: 0
+                separators: [',']
+                sort_keys: true
+        xml:
+            formatting:
+                ensure_ascii: False
+                indent: 4
+                separators: ['>']
                 sort_keys: true

--- a/docs/plugins/export.rst
+++ b/docs/plugins/export.rst
@@ -63,7 +63,7 @@ These options match the options from the `Python json module`_.
 - **CSV Formatting**
     - **delimiter**: Used as the separating character between fields. The default value is a comma (,).
 
-    - **dialect**: A dialect is a construct that allows you to create, store, and re-use various formatting parameters for your data.
+    - **dialect**: The kind of CSV file to produce. The default is `excel`.
 
 These options match the options from the `Python csv module`_.
 
@@ -77,8 +77,8 @@ The default options look like this::
                 ensure_ascii: False
                 indent: 4
                 separators: [',' , ': ']
-                sort_keys: True
+                sort_keys: true
         csv:
             formatting:
                 delimiter: ','
-                dialect: 'excel'
+                dialect: excel

--- a/docs/plugins/export.rst
+++ b/docs/plugins/export.rst
@@ -40,11 +40,7 @@ The ``export`` command has these command-line options:
 * ``--append``: Appends the data to the file instead of writing.
 
 * ``--format`` or ``-f``: Specifies the format the data will be exported as. If not informed, JSON will be used by default.
-  For example::
-
-      $ beet export -f csv beatles
-      $ beet export -f json beatles
-      $ beet export -f xml beatles
+The format options include csv, json and xml.
 
 Configuration
 -------------

--- a/docs/plugins/export.rst
+++ b/docs/plugins/export.rst
@@ -56,21 +56,25 @@ file. Under the ``json``, ``csv``, and ``xml`` keys, these options are available
 
     - **sort_keys**: Sorts the keys in JSON dictionaries.
 
-- **CSV Formatting**
-    - **delimiter**: Used as the separating character between fields. The default value is a comma (,).
-
-    - **dialect**: A dialect, in the context of reading and writing CSVs, is a construct that allows you to create, store, and re-use various formatting parameters for your data.
-
-- **XML Formatting**
-    - **encoding**: Use encoding="unicode" to generate a Unicode string (otherwise, a bytestring is generated).
-
-    - **xml_declaration**: Controls if an XML declaration should be added to the file. Use False for never, True for always, None for only if not US-ASCII or UTF-8 or Unicode (default is None).
-
-    - **method**: Can be either "xml", "html" or "text" (default is "xml")
-
 These options match the options from the `Python json module`_.
 
 .. _Python json module: https://docs.python.org/2/library/json.html#basic-usage
+
+- **CSV Formatting**
+    - **delimiter**: Used as the separating character between fields. The default value is a comma (,).
+
+    - **dialect**: A dialect is a construct that allows you to create, store, and re-use various formatting parameters for your data.
+
+These options match the options from the `Python csv module`_.
+
+.. _Python csv module: https://docs.python.org/3/library/csv.html#csv-fmt-params
+
+- **XML Formatting**
+    - **method**: Can be either "xml", "html" or "text" (default is "xml")
+
+These options match the options from the `Python xml module`_.
+
+.. _Python xml module: https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.tostring
 
 The default options look like this::
 
@@ -87,6 +91,4 @@ The default options look like this::
                 dialect: 'excel' 
         xml:
             formatting:
-                encoding: 'unicode'
-                xml_declaration: True
                 method: 'xml'

--- a/docs/plugins/export.rst
+++ b/docs/plugins/export.rst
@@ -69,13 +69,6 @@ These options match the options from the `Python csv module`_.
 
 .. _Python csv module: https://docs.python.org/3/library/csv.html#csv-fmt-params
 
-- **XML Formatting**
-    - **method**: Can be either "xml", "html" or "text" (default is "xml")
-
-These options match the options from the `Python xml module`_.
-
-.. _Python xml module: https://docs.python.org/3/library/xml.etree.elementtree.html#xml.etree.ElementTree.tostring
-
 The default options look like this::
 
     export:
@@ -88,7 +81,4 @@ The default options look like this::
         csv:
             formatting:
                 delimiter: ','
-                dialect: 'excel' 
-        xml:
-            formatting:
-                method: 'xml'
+                dialect: 'excel'

--- a/docs/plugins/export.rst
+++ b/docs/plugins/export.rst
@@ -56,6 +56,18 @@ file. Under the ``json``, ``csv``, and ``xml`` keys, these options are available
 
 - **sort_keys**: Sorts the keys in JSON dictionaries.
 
+- **delimiter**: Used as the separating character between fields. The default value is a comma (,).
+
+- **dialect**: A dialect, in the context of reading and writing CSVs, is a construct that allows you to create, store, and re-use various formatting parameters for your data.
+
+- **encoding**: Use encoding="unicode" to generate a Unicode string (otherwise, a bytestring is generated).
+
+- **xml_declaration**: Controls if an XML declaration should be added to the file. Use False for never, True for always, None for only if not US-ASCII or UTF-8 or Unicode (default is None).
+
+- **method**: Can be either "xml", "html" or "text" (default is "xml")
+
+- **short_empty_elements**: Controls the formatting of elements that contain no content. If True (the default), they are emitted as a single self-closed tag, otherwise they are emitted as a pair of start/end tags.
+
 These options match the options from the `Python json module`_.
 
 .. _Python json module: https://docs.python.org/2/library/json.html#basic-usage
@@ -71,34 +83,11 @@ The default options look like this::
                 sort_keys: True
         csv:
             formatting:
-                /*
-                    Used as the separating character between fields. The default value is a comma (,).
-                */
                 delimiter: ','
-                /* 
-                    A dialect, in the context of reading and writing CSVs, 
-                    is a construct that allows you to create, store, 
-                    and re-use various formatting parameters for your data.
-                */
                 dialect: 'excel' 
         xml:
             formatting:
-                /*
-                     Use encoding="unicode" to generate a Unicode string (otherwise, a bytestring is generated).
-                */
-                encoding: 'unicode',
-                /*
-                    Controls if an XML declaration should be added to the file. 
-                    Use False for never, True for always, None for only if not US-ASCII or UTF-8 or Unicode (default is None).
-                */
-                xml_declaration: True,
-                /*
-                    Can be either "xml", "html" or "text" (default is "xml")
-                */
+                encoding: 'unicode'
+                xml_declaration: True
                 method: 'xml'
-                /*
-                    Controls the formatting of elements that contain no content. 
-                    If True (the default), they are emitted as a single self-closed tag, 
-                    otherwise they are emitted as a pair of start/end tags.
-                */
                 short_empty_elements: True

--- a/docs/plugins/export.rst
+++ b/docs/plugins/export.rst
@@ -48,25 +48,28 @@ Configuration
 To configure the plugin, make a ``export:`` section in your configuration
 file. Under the ``json``, ``csv``, and ``xml`` keys, these options are available:
 
-- **ensure_ascii**: Escape non-ASCII characters with ``\uXXXX`` entities.
+- **JSON Formatting**
+    - **ensure_ascii**: Escape non-ASCII characters with ``\uXXXX`` entities.
 
-- **indent**: The number of spaces for indentation.
+    - **indent**: The number of spaces for indentation.
 
-- **separators**: A ``[item_separator, dict_separator]`` tuple.
+    - **separators**: A ``[item_separator, dict_separator]`` tuple.
 
-- **sort_keys**: Sorts the keys in JSON dictionaries.
+    - **sort_keys**: Sorts the keys in JSON dictionaries.
 
-- **delimiter**: Used as the separating character between fields. The default value is a comma (,).
+- **CSV Formatting**
+    - **delimiter**: Used as the separating character between fields. The default value is a comma (,).
 
-- **dialect**: A dialect, in the context of reading and writing CSVs, is a construct that allows you to create, store, and re-use various formatting parameters for your data.
+    - **dialect**: A dialect, in the context of reading and writing CSVs, is a construct that allows you to create, store, and re-use various formatting parameters for your data.
 
-- **encoding**: Use encoding="unicode" to generate a Unicode string (otherwise, a bytestring is generated).
+- **XML Formatting**
+    - **encoding**: Use encoding="unicode" to generate a Unicode string (otherwise, a bytestring is generated).
 
-- **xml_declaration**: Controls if an XML declaration should be added to the file. Use False for never, True for always, None for only if not US-ASCII or UTF-8 or Unicode (default is None).
+    - **xml_declaration**: Controls if an XML declaration should be added to the file. Use False for never, True for always, None for only if not US-ASCII or UTF-8 or Unicode (default is None).
 
-- **method**: Can be either "xml", "html" or "text" (default is "xml")
+    - **method**: Can be either "xml", "html" or "text" (default is "xml")
 
-- **short_empty_elements**: Controls the formatting of elements that contain no content. If True (the default), they are emitted as a single self-closed tag, otherwise they are emitted as a pair of start/end tags.
+    - **short_empty_elements**: Controls the formatting of elements that contain no content. If True (the default), they are emitted as a single self-closed tag, otherwise they are emitted as a pair of start/end tags.
 
 These options match the options from the `Python json module`_.
 

--- a/docs/plugins/export.rst
+++ b/docs/plugins/export.rst
@@ -68,16 +68,14 @@ The default options look like this::
                 ensure_ascii: False
                 indent: 4
                 separators: [',' , ': ']
-                sort_keys: true
+                sort_keys: True
         csv:
             formatting:
-                ensure_ascii: False
-                indent: 0
-                separators: [',']
-                sort_keys: true
+                delimiter: ','
+                dialect: 'excel'
         xml:
             formatting:
-                ensure_ascii: False
-                indent: 4
-                separators: ['>']
-                sort_keys: true
+                encoding: 'unicode',
+                xml_declaration: True,
+                method: 'xml'
+                short_empty_elements: True

--- a/docs/plugins/export.rst
+++ b/docs/plugins/export.rst
@@ -69,8 +69,6 @@ file. Under the ``json``, ``csv``, and ``xml`` keys, these options are available
 
     - **method**: Can be either "xml", "html" or "text" (default is "xml")
 
-    - **short_empty_elements**: Controls the formatting of elements that contain no content. If True (the default), they are emitted as a single self-closed tag, otherwise they are emitted as a pair of start/end tags.
-
 These options match the options from the `Python json module`_.
 
 .. _Python json module: https://docs.python.org/2/library/json.html#basic-usage
@@ -93,4 +91,3 @@ The default options look like this::
                 encoding: 'unicode'
                 xml_declaration: True
                 method: 'xml'
-                short_empty_elements: True

--- a/docs/plugins/export.rst
+++ b/docs/plugins/export.rst
@@ -15,6 +15,7 @@ your library. For example, run this::
 
 to print a JSON file containing information about your Beatles tracks.
 
+
 Command-Line Options
 --------------------
 
@@ -38,7 +39,12 @@ The ``export`` command has these command-line options:
 
 * ``--append``: Appends the data to the file instead of writing.
 
-* ``--format`` or ``-f``: Specifies the format of the exported data. If not informed, JSON will be used.
+* ``--format`` or ``-f``: Specifies the format the data will be exported as. If not informed, JSON will be used by default.
+  For example::
+
+      $ beet export -f csv beatles
+      $ beet export -f json beatles
+      $ beet export -f xml beatles
 
 Configuration
 -------------

--- a/test/test_export.py
+++ b/test/test_export.py
@@ -21,12 +21,16 @@ from __future__ import division, absolute_import, print_function
 import unittest
 from test.helper import TestHelper
 import re
+import beets
+import beets.plugins
 
 
 class ExportPluginTest(unittest.TestCase, TestHelper):
+    
     def setUp(self):
         self.setup_beets()
         self.load_plugins('export')
+        self.test_values = {'title': 'xtitle', 'album': 'xalbum'}
 
     def tearDown(self):
         self.unload_plugins()
@@ -44,8 +48,8 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
     def create_item(self):
         item, = self.add_item_fixtures()
         item.artist = 'xartist'
-        item.title = 'xtitle'
-        item.album = 'xalbum'
+        item.title = self.test_values['title']
+        item.album = self.test_values['album']
         item.write()
         item.store()
         return item
@@ -56,12 +60,13 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
             format_type='json',
             artist=item1.artist
         )
-        expected = u'[{"album":"%s","title":"%s"}]'\
-            % (item1.album, item1.title)
-        self.assertIn(
-            expected,
-            actual
-        )
+        for key, val in self.test_values.items():
+            self.check_assertIn(
+                actual=actual,
+                str_format='"{0}":"{1}"',
+                key=key,
+                val=val
+            )
 
     def test_csv_output(self):
         item1 = self.create_item()
@@ -69,12 +74,13 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
             format_type='csv',
             artist=item1.artist
         )
-        expected = u'album,title%s,%s'\
-            % (item1.album, item1.title)
-        self.assertIn(
-            expected,
-            actual
-        )
+        for key, val in self.test_values.items():
+            self.check_assertIn(
+                actual=actual,
+                str_format='{0}{1}',
+                key='',
+                val=val
+            )
 
     def test_xml_output(self):
         item1 = self.create_item()
@@ -82,8 +88,16 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
             format_type='xml',
             artist=item1.artist
         )
-        expected = u'<album>%s</album><title>%s</title>'\
-            % (item1.album, item1.title)
+        for key, val in self.test_values.items():
+            self.check_assertIn(
+                actual=actual,
+                str_format='<{0}>{1}</{0}>',
+                key=key,
+                val=val
+            )
+
+    def check_assertIn(self, actual, str_format, key, val):
+        expected = str_format.format(key, val)
         self.assertIn(
             expected,
             actual

--- a/test/test_export.py
+++ b/test/test_export.py
@@ -20,7 +20,10 @@ from __future__ import division, absolute_import, print_function
 
 import unittest
 from test.helper import TestHelper
-import re
+import re  # used to test csv format
+import json
+from xml.etree.ElementTree import Element
+import xml.etree.ElementTree as ET
 
 
 class ExportPluginTest(unittest.TestCase, TestHelper):
@@ -34,10 +37,11 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
         self.teardown_beets()
 
     def execute_command(self, format_type, artist):
+        query = ','.format(list(self.test_values.keys()))
         actual = self.run_with_output(
             'export',
             '-f', format_type,
-            '-i', 'album,title',
+            '-i', query,
             artist
         )
         return re.sub("\\s+", '', actual)
@@ -53,18 +57,64 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
 
     def test_json_output(self):
         item1 = self.create_item()
-        actual = self.execute_command(
-            format_type='json',
-            artist=item1.artist
+        out = self.run_with_output(
+            'export',
+            '-f', 'json',
+            '-i', 'album,title',
+            item1.artist
         )
+        json_data = json.loads(out)[0]
         for key, val in self.test_values.items():
-            self.check_assertin(
-                actual=actual,
-                str_format='"{0}":"{1}"',
-                key=key,
-                val=val
-            )
+            self.assertTrue(key in json_data)
+            self.assertEqual(val, json_data[key])
 
+    def test_csv_output(self):
+        item1 = self.create_item()
+        out = self.run_with_output(
+            'export',
+            '-f', 'csv',
+            '-i', 'album,title',
+            item1.artist
+        )
+        csv_list = re.split('\r', re.sub('\n', '', out))
+        head = re.split(',', csv_list[0])
+        vals = re.split(',|\r', csv_list[1])
+        for index, column in enumerate(head):
+            self.assertTrue(self.test_values.get(column, None) is not None)
+            self.assertEqual(vals[index], self.test_values[column])
+
+    def test_xml_output(self):
+        item1 = self.create_item()
+        out = self.run_with_output(
+            'export',
+            '-f', 'xml',
+            '-i', 'album,title',
+            item1.artist
+        )
+        library = ET.fromstring(out)
+        self.assertIsInstance(library, Element)
+        for track in library[0]:
+            for details in track:
+                tag = details.tag
+                txt = details.text
+                self.assertTrue(tag in self.test_values, msg=tag)
+                self.assertEqual(self.test_values[tag], txt, msg=txt)
+
+    def check_assertin(self, actual, str_format, key, val):
+        expected = str_format.format(key, val)
+        self.assertIn(
+            expected,
+            actual
+        )
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromName(__name__)
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')
+
+"""
     def test_csv_output(self):
         item1 = self.create_item()
         actual = self.execute_command(
@@ -93,16 +143,17 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
                 val=val
             )
 
-    def check_assertin(self, actual, str_format, key, val):
-        expected = str_format.format(key, val)
-        self.assertIn(
-            expected,
-            actual
+    def test_json_output(self):
+        item1 = self.create_item()
+        actual = self.execute_command(
+            format_type='json',
+            artist=item1.artist
         )
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+        for key, val in self.test_values.items():
+            self.check_assertin(
+                actual=actual,
+                str_format='"{0}":"{1}"',
+                key=key,
+                val=val
+            )
+"""

--- a/test/test_export.py
+++ b/test/test_export.py
@@ -19,10 +19,7 @@
 from __future__ import division, absolute_import, print_function
 
 import unittest
-from test import helper
 from test.helper import TestHelper
-#from beetsplug.export import ExportPlugin, ExportFormat, JSONFormat, CSVFormat, XMLFormat
-#from collections import namedtuple
 
 
 class ExportPluginTest(unittest.TestCase, TestHelper):
@@ -41,11 +38,11 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
         item1.track = "ttrack"
         item1.write()
         item1.store()
-
-        out = self.run_with_output('export', '-f json -i "track,album" tartist')
+        options = '-f json -i "track,album" ' + item1.artist
+        out = self.run_with_output('export', options)
         self.assertIn('"track": "' + item1.track + '"', out)
         self.assertIn('"album": "' + item1.album + '"', out)
-    
+
     def test_csv_output(self):
         item1, item2 = self.add_item_fixtures(count=2)
         item1.album = 'talbum'
@@ -53,10 +50,10 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
         item1.track = "ttrack"
         item1.write()
         item1.store()
-
-        out = self.run_with_output('export', '-f json -i "track,album" tartist')
+        options = '-f csv -i "track,album" ' + item1.artist
+        out = self.run_with_output('export', options)
         self.assertIn(item1.track + ',' + item1.album,  out)
-    
+
     def test_xml_output(self):
         item1, item2 = self.add_item_fixtures(count=2)
         item1.album = 'talbum'
@@ -64,31 +61,10 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
         item1.track = "ttrack"
         item1.write()
         item1.store()
-
-        out = self.run_with_output('export', '-f json -i "track,album" tartist')
+        options = '-f xml -i "track,album" ' + item1.artist
+        out = self.run_with_output('export', options)
         self.assertIn("<title>" + item1.track + "</title>", out)
         self.assertIn("<album>" + item1.album + "</album>", out)
-
-    """
-    def setUp(self):
-        Opts = namedtuple('Opts', 'output append included_keys library format')
-        self.args = None
-        self._export = ExportPlugin()
-        included_keys = ['title,artist,album']
-        self.opts = Opts(None, False, included_keys, True, "json")
-        self.export_format_classes = {"json": ExportFormat, "csv": CSVFormat, "xml": XMLFormat}
-
-    def test_run(self, _format="json"):
-        self.opts.format = _format
-        self._export.run(lib=self.lib, opts=self.opts, args=self.args)
-        # 1.) Test that the ExportFormat Factory class method invoked the correct class 
-        self.assertEqual(type(self._export.export_format), self.export_format_classes[_format])
-        # 2.) Test that the cmd parser options specified were processed in correctly
-        self.assertEqual(self._export.export_format.path, self.opts.output)
-        mode = 'a' if self.opts.append else 'w'
-        self.assertEqual(self._export.export_format.mode, mode)
-    """
-
 
 
 def suite():

--- a/test/test_export.py
+++ b/test/test_export.py
@@ -21,7 +21,6 @@ from __future__ import division, absolute_import, print_function
 import unittest
 from test.helper import TestHelper
 
-
 class ExportPluginTest(unittest.TestCase, TestHelper):
     def setUp(self):
         self.setup_beets()
@@ -31,40 +30,37 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
         self.unload_plugins()
         self.teardown_beets()
 
-    def test_json_output(self):
-        item1, item2 = self.add_item_fixtures(count=2)
-        item1.album = 'talbum'
-        item1.artist = "tartist"
-        item1.track = "ttrack"
+    def execute_command(self, format_type, artist):
+        options = ' -f %s -i "track,album" s'.format(format_type, artist)
+        actual = self.run_with_output('export', options)
+        return actual.replace(" ", "")
+    
+    def create_item(self, album='talbum', artist='tartist', track='ttrack'):
+        item1, = self.add_item_fixtures()
+        item1.album = album
+        item1.artist = artist
+        item1.track = track
         item1.write()
         item1.store()
-        options = '-f json -i "track,album" ' + item1.artist
-        out = self.run_with_output('export', options)
-        self.assertIn('"track": "' + item1.track + '"', out)
-        self.assertIn('"album": "' + item1.album + '"', out)
+        return item1
+
+    def test_json_output(self):
+        item1 = self.create_item()
+        actual = self.execute_command(format_type='json',artist=item1.artist)
+        expected = '[{"track":%s,"album":%s}]'.format(item1.track,item1.album)
+        self.assertIn(first=expected,second=actual,msg="export in JSON format failed")
 
     def test_csv_output(self):
-        item1, item2 = self.add_item_fixtures(count=2)
-        item1.album = 'talbum'
-        item1.artist = "tartist"
-        item1.track = "ttrack"
-        item1.write()
-        item1.store()
-        options = '-f csv -i "track,album" ' + item1.artist
-        out = self.run_with_output('export', options)
-        self.assertIn(item1.track + ',' + item1.album,  out)
+        item1 = self.create_item()
+        actual = self.execute_command(format_type='json',artist=item1.artist)
+        expected = 'track,album\n%s,%s'.format(item1.track,item1.album)
+        self.assertIn(first=expected,second=actual,msg="export in CSV format failed")
 
     def test_xml_output(self):
-        item1, item2 = self.add_item_fixtures(count=2)
-        item1.album = 'talbum'
-        item1.artist = "tartist"
-        item1.track = "ttrack"
-        item1.write()
-        item1.store()
-        options = '-f xml -i "track,album" ' + item1.artist
-        out = self.run_with_output('export', options)
-        self.assertIn("<title>" + item1.track + "</title>", out)
-        self.assertIn("<album>" + item1.album + "</album>", out)
+        item1 = self.create_item()
+        actual = self.execute_command(format_type='json',artist=item1.artist)
+        expected = '<title>%s</title><album>%s</album>'.format(item1.track,item1.album)
+        self.assertIn(first=expected,second=actual,msg="export in XML format failed")
 
 
 def suite():

--- a/test/test_export.py
+++ b/test/test_export.py
@@ -21,12 +21,9 @@ from __future__ import division, absolute_import, print_function
 import unittest
 from test.helper import TestHelper
 import re
-import beets
-import beets.plugins
 
 
 class ExportPluginTest(unittest.TestCase, TestHelper):
-    
     def setUp(self):
         self.setup_beets()
         self.load_plugins('export')
@@ -61,7 +58,7 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
             artist=item1.artist
         )
         for key, val in self.test_values.items():
-            self.check_assertIn(
+            self.check_assertin(
                 actual=actual,
                 str_format='"{0}":"{1}"',
                 key=key,
@@ -75,7 +72,7 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
             artist=item1.artist
         )
         for key, val in self.test_values.items():
-            self.check_assertIn(
+            self.check_assertin(
                 actual=actual,
                 str_format='{0}{1}',
                 key='',
@@ -89,14 +86,14 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
             artist=item1.artist
         )
         for key, val in self.test_values.items():
-            self.check_assertIn(
+            self.check_assertin(
                 actual=actual,
                 str_format='<{0}>{1}</{0}>',
                 key=key,
                 val=val
             )
 
-    def check_assertIn(self, actual, str_format, key, val):
+    def check_assertin(self, actual, str_format, key, val):
         expected = str_format.format(key, val)
         self.assertIn(
             expected,

--- a/test/test_export.py
+++ b/test/test_export.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+# This file is part of beets.
+# Copyright 2019, Carl Suster
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""Test the beets.export utilities associated with the export plugin.
+"""
+
+from __future__ import division, absolute_import, print_function
+
+import unittest
+from test import helper
+from test.helper import TestHelper
+#from beetsplug.export import ExportPlugin, ExportFormat, JSONFormat, CSVFormat, XMLFormat
+#from collections import namedtuple
+
+
+class ExportPluginTest(unittest.TestCase, TestHelper):
+    def setUp(self):
+        self.setup_beets()
+        self.load_plugins('export')
+
+    def tearDown(self):
+        self.unload_plugins()
+        self.teardown_beets()
+
+    def test_json_output(self):
+        item1, item2 = self.add_item_fixtures(count=2)
+        item1.album = 'talbum'
+        item1.artist = "tartist"
+        item1.track = "ttrack"
+        item1.write()
+        item1.store()
+
+        out = self.run_with_output('export', '-f json -i "track,album" tartist')
+        self.assertIn('"track": "' + item1.track + '"', out)
+        self.assertIn('"album": "' + item1.album + '"', out)
+    
+    def test_csv_output(self):
+        item1, item2 = self.add_item_fixtures(count=2)
+        item1.album = 'talbum'
+        item1.artist = "tartist"
+        item1.track = "ttrack"
+        item1.write()
+        item1.store()
+
+        out = self.run_with_output('export', '-f json -i "track,album" tartist')
+        self.assertIn(item1.track + ',' + item1.album,  out)
+    
+    def test_xml_output(self):
+        item1, item2 = self.add_item_fixtures(count=2)
+        item1.album = 'talbum'
+        item1.artist = "tartist"
+        item1.track = "ttrack"
+        item1.write()
+        item1.store()
+
+        out = self.run_with_output('export', '-f json -i "track,album" tartist')
+        self.assertIn("<title>" + item1.track + "</title>", out)
+        self.assertIn("<album>" + item1.album + "</album>", out)
+
+    """
+    def setUp(self):
+        Opts = namedtuple('Opts', 'output append included_keys library format')
+        self.args = None
+        self._export = ExportPlugin()
+        included_keys = ['title,artist,album']
+        self.opts = Opts(None, False, included_keys, True, "json")
+        self.export_format_classes = {"json": ExportFormat, "csv": CSVFormat, "xml": XMLFormat}
+
+    def test_run(self, _format="json"):
+        self.opts.format = _format
+        self._export.run(lib=self.lib, opts=self.opts, args=self.args)
+        # 1.) Test that the ExportFormat Factory class method invoked the correct class 
+        self.assertEqual(type(self._export.export_format), self.export_format_classes[_format])
+        # 2.) Test that the cmd parser options specified were processed in correctly
+        self.assertEqual(self._export.export_format.path, self.opts.output)
+        mode = 'a' if self.opts.append else 'w'
+        self.assertEqual(self._export.export_format.mode, mode)
+    """
+
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromName(__name__)
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/test/test_export.py
+++ b/test/test_export.py
@@ -37,14 +37,14 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
         self.teardown_beets()
 
     def execute_command(self, format_type, artist):
-        query = ','.format(list(self.test_values.keys()))
-        actual = self.run_with_output(
+        query = ','.join(self.test_values.keys())
+        out = self.run_with_output(
             'export',
             '-f', format_type,
             '-i', query,
             artist
         )
-        return re.sub("\\s+", '', actual)
+        return out
 
     def create_item(self):
         item, = self.add_item_fixtures()
@@ -57,11 +57,9 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
 
     def test_json_output(self):
         item1 = self.create_item()
-        out = self.run_with_output(
-            'export',
-            '-f', 'json',
-            '-i', 'album,title',
-            item1.artist
+        out = self.execute_command(
+            format_type='json',
+            artist=item1.artist
         )
         json_data = json.loads(out)[0]
         for key, val in self.test_values.items():
@@ -70,11 +68,9 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
 
     def test_csv_output(self):
         item1 = self.create_item()
-        out = self.run_with_output(
-            'export',
-            '-f', 'csv',
-            '-i', 'album,title',
-            item1.artist
+        out = self.execute_command(
+            format_type='csv',
+            artist=item1.artist
         )
         csv_list = re.split('\r', re.sub('\n', '', out))
         head = re.split(',', csv_list[0])
@@ -85,11 +81,9 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
 
     def test_xml_output(self):
         item1 = self.create_item()
-        out = self.run_with_output(
-            'export',
-            '-f', 'xml',
-            '-i', 'album,title',
-            item1.artist
+        out = self.execute_command(
+            format_type='xml',
+            artist=item1.artist
         )
         library = ET.fromstring(out)
         self.assertIsInstance(library, Element)
@@ -100,60 +94,9 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
                 self.assertTrue(tag in self.test_values, msg=tag)
                 self.assertEqual(self.test_values[tag], txt, msg=txt)
 
-    def check_assertin(self, actual, str_format, key, val):
-        expected = str_format.format(key, val)
-        self.assertIn(
-            expected,
-            actual
-        )
-
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 if __name__ == '__main__':
     unittest.main(defaultTest='suite')
-
-"""
-    def test_csv_output(self):
-        item1 = self.create_item()
-        actual = self.execute_command(
-            format_type='csv',
-            artist=item1.artist
-        )
-        for key, val in self.test_values.items():
-            self.check_assertin(
-                actual=actual,
-                str_format='{0}{1}',
-                key='',
-                val=val
-            )
-
-    def test_xml_output(self):
-        item1 = self.create_item()
-        actual = self.execute_command(
-            format_type='xml',
-            artist=item1.artist
-        )
-        for key, val in self.test_values.items():
-            self.check_assertin(
-                actual=actual,
-                str_format='<{0}>{1}</{0}>',
-                key=key,
-                val=val
-            )
-
-    def test_json_output(self):
-        item1 = self.create_item()
-        actual = self.execute_command(
-            format_type='json',
-            artist=item1.artist
-        )
-        for key, val in self.test_values.items():
-            self.check_assertin(
-                actual=actual,
-                str_format='"{0}":"{1}"',
-                key=key,
-                val=val
-            )
-"""

--- a/test/test_export.py
+++ b/test/test_export.py
@@ -20,6 +20,8 @@ from __future__ import division, absolute_import, print_function
 
 import unittest
 from test.helper import TestHelper
+import re
+
 
 class ExportPluginTest(unittest.TestCase, TestHelper):
     def setUp(self):
@@ -31,36 +33,61 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
         self.teardown_beets()
 
     def execute_command(self, format_type, artist):
-        options = ' -f %s -i "track,album" s'.format(format_type, artist)
-        actual = self.run_with_output('export', options)
-        return actual.replace(" ", "")
-    
-    def create_item(self, album='talbum', artist='tartist', track='ttrack'):
-        item1, = self.add_item_fixtures()
-        item1.album = album
-        item1.artist = artist
-        item1.track = track
-        item1.write()
-        item1.store()
-        return item1
+        actual = self.run_with_output(
+            'export',
+            '-f', format_type,
+            '-i', 'album,title',
+            artist
+        )
+        return re.sub("\\s+", '', actual)
+
+    def create_item(self):
+        item, = self.add_item_fixtures()
+        item.artist = 'xartist'
+        item.title = 'xtitle'
+        item.album = 'xalbum'
+        item.write()
+        item.store()
+        return item
 
     def test_json_output(self):
         item1 = self.create_item()
-        actual = self.execute_command(format_type='json',artist=item1.artist)
-        expected = '[{"track":%s,"album":%s}]'.format(item1.track,item1.album)
-        self.assertIn(first=expected,second=actual,msg="export in JSON format failed")
+        actual = self.execute_command(
+            format_type='json',
+            artist=item1.artist
+        )
+        expected = u'[{"album":"%s","title":"%s"}]'\
+            % (item1.album, item1.title)
+        self.assertIn(
+            expected,
+            actual
+        )
 
     def test_csv_output(self):
         item1 = self.create_item()
-        actual = self.execute_command(format_type='json',artist=item1.artist)
-        expected = 'track,album\n%s,%s'.format(item1.track,item1.album)
-        self.assertIn(first=expected,second=actual,msg="export in CSV format failed")
+        actual = self.execute_command(
+            format_type='csv',
+            artist=item1.artist
+        )
+        expected = u'album,title%s,%s'\
+            % (item1.album, item1.title)
+        self.assertIn(
+            expected,
+            actual
+        )
 
     def test_xml_output(self):
         item1 = self.create_item()
-        actual = self.execute_command(format_type='json',artist=item1.artist)
-        expected = '<title>%s</title><album>%s</album>'.format(item1.track,item1.album)
-        self.assertIn(first=expected,second=actual,msg="export in XML format failed")
+        actual = self.execute_command(
+            format_type='xml',
+            artist=item1.artist
+        )
+        expected = u'<album>%s</album><title>%s</title>'\
+            % (item1.album, item1.title)
+        self.assertIn(
+            expected,
+            actual
+        )
 
 
 def suite():


### PR DESCRIPTION
The original export plugin only exported as JSON so I added the ability to export in CSV or XML format. To do this I created a new option `-f` or `--format` which specifies the export format, the default is still JSON. For example...
`$ beet export -f csv -i "title,album" ACDC`
I also updated the plugin documentation to reflect the changes I've made to the plugin. Lastly, I also created a unit test for the export plugin; since one hadn't been created yet.