### PR TITLE
Capitalize letters after punctuations

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -23,7 +23,6 @@ import unicodedata
 import time
 import re
 import six
-import string
 
 from beets import logging
 from mediafile import MediaFile, UnreadableFileError
@@ -130,17 +129,17 @@ class DateType(types.Float):
         return time.strftime(beets.config['time_format'].as_str(),
                              time.localtime(value or 0))
 
-    def parse(self, string):
+    def parse(self, s):
         try:
             # Try a formatted date string.
             return time.mktime(
-                time.strptime(string,
+                time.strptime(s,
                               beets.config['time_format'].as_str())
             )
         except ValueError:
             # Fall back to a plain timestamp number.
             try:
-                return float(string)
+                return float(s)
             except ValueError:
                 return self.null
 
@@ -1483,7 +1482,8 @@ class DefaultTemplateFunctions(object):
         return s.upper()
 
     # Regular expressions used by tmpl_title
-    SMALL = 'a|an|and|as|at|but|by|en|for|if|in|of|on|or|the|to|v\\.?|via|vs\\.?'  # noqa: E501
+    SMALL = 'a|an|and|as|at|but|by|en|for|' \
+        'if|in|of|on|or|the|to|v\\.?|via|vs\\.?'
     PUNCT = r"""!"“#$%&'‘()*+,\-–‒—―./:;?@[\\\]_`{|}~"""
     SMALL_WORDS = re.compile(r'^(%s)$' % SMALL, re.I)
     INLINE_PERIOD = re.compile(r'[a-z][.][a-z]', re.I)

--- a/beets/library.py
+++ b/beets/library.py
@@ -24,6 +24,7 @@ import time
 import re
 import six
 
+from titlecase import titlecase
 from beets import logging
 from mediafile import MediaFile, UnreadableFileError
 from beets import plugins
@@ -1481,92 +1482,10 @@ class DefaultTemplateFunctions(object):
         """Covert a string to upper case."""
         return s.upper()
 
-    # Regular expressions used by tmpl_title
-    SMALL = 'a|an|and|as|at|but|by|en|for|' \
-        'if|in|of|on|or|the|to|v\\.?|via|vs\\.?'
-    PUNCT = r"""!"“#$%&'‘()*+,\-–‒—―./:;?@[\\\]_`{|}~"""
-    SMALL_WORDS = re.compile(r'^(%s)$' % SMALL, re.I)
-    INLINE_PERIOD = re.compile(r'[a-z][.][a-z]', re.I)
-    UC_ELSEWHERE = re.compile(r'[%s]*?[a-zA-Z]+[A-Z]+?' % PUNCT)
-    UC_INITIALS = re.compile(r'^(?:[A-Z]{1}\.{1}|[A-Z]{1}\.{1}[A-Z]{1})+$')
-    CAPFIRST = re.compile(r"^[%s]*?[A-Za-z]" % PUNCT)
-    SMALL_FIRST = re.compile(r'^([%s]*)(%s)\b' % (PUNCT, SMALL), re.I)
-    SMALL_LAST = re.compile(r'\b(%s)[%s]?$' % (SMALL, PUNCT), re.I)
-    SUBPHRASE = re.compile(r'([:.;?!\-–‒—―][ ])(%s)' % SMALL)
-    APOS_SECOND = re.compile(r"^[dol]{1}['‘]{1}[a-z]+(?:['s]{2})?$", re.I)
-
     @staticmethod
     def tmpl_title(s):
         """Convert a string to title case."""
-        all_caps = s.upper() == s
-        words = re.split('[\t ]', s)
-        processed = []
-        for word in words:
-            # Preserve initials
-            if all_caps and DefaultTemplateFunctions.UC_INITIALS.match(word):
-                processed.append(word)
-                continue
-
-            # Properly capitalize the first letter in contractions like "don't"
-            if DefaultTemplateFunctions.APOS_SECOND.match(word):
-                if len(word[0]) == 1 and word[0] not in 'aeiouAEIOU':
-                    word = "%s%s%s%s" % (
-                        word[0].lower(), word[1],
-                        word[2].upper(), word[3:])
-                else:
-                    word = "%s%s%s%s" % (
-                        word[0].upper(), word[1],
-                        word[2].upper(), word[3:])
-                processed.append(word)
-                continue
-
-            # Preserve initials
-            inline_period = DefaultTemplateFunctions.INLINE_PERIOD.search(word)
-            uc_elsewhere = DefaultTemplateFunctions.UC_ELSEWHERE.match(word)
-            if inline_period or (not all_caps and uc_elsewhere):
-                processed.append(word)
-                continue
-
-            # Make all small words are lowercase
-            if DefaultTemplateFunctions.SMALL_WORDS.match(word):
-                processed.append(word.lower())
-                continue
-
-            # Split the word further by a slash and process each word
-            if '/' in word and '//' not in word:
-                slashed = map(
-                    lambda w: DefaultTemplateFunctions.tmpl_title(w),
-                    word.split('/'))
-                processed.append('/'.join(slashed))
-                continue
-
-            # Split the word further by a hyphen and process each word
-            if '-' in word:
-                slashed = map(
-                    lambda w: DefaultTemplateFunctions.tmpl_title(w),
-                    word.split('-'))
-                processed.append('-'.join(slashed))
-                continue
-
-            if all_caps:
-                word = word.lower()
-
-            # Capitalize the first letter
-            processed.append(DefaultTemplateFunctions.CAPFIRST.sub(
-                lambda m: m.group(0).upper(), word))
-
-        if len(processed) > 0:
-            processed[0] = DefaultTemplateFunctions.SMALL_FIRST.sub(
-                lambda m: '%s%s' % (m.group(1), m.group(2).capitalize()),
-                processed[0])
-            processed[-1] = DefaultTemplateFunctions.SMALL_LAST.sub(
-                lambda m: m.group(0).capitalize(),
-                processed[-1])
-
-        result = ' '.join(processed)
-        result = DefaultTemplateFunctions.SUBPHRASE.sub(
-            lambda m: '%s%s' % (m.group(1), m.group(2).capitalize()), result)
-        return result
+        return titlecase(s)
 
     @staticmethod
     def tmpl_left(s, chars):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -73,6 +73,9 @@ New features:
 
 Fixes:
 
+* Fixed a bug where letters were not being capitalized after punctuation
+  characters when using the %title title case function.
+  :bug:`3298`
 * :doc:`/plugins/inline`: In function-style field definitions that refer to
   flexible attributes, values could stick around from one function invocation
   to the next. This meant that, when displaying a list of objects, later

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
         'pyyaml',
         'mediafile>=0.2.0',
         'confuse>=1.0.0',
+        'titlecase',
     ] + [
         # Avoid a version of munkres incompatible with Python 3.
         'munkres~=1.0.0' if sys.version_info < (3, 5, 0) else
@@ -118,7 +119,8 @@ setup(
         'responses',
         'pyxdg',
         'python-mpd2',
-        'discogs-client'
+        'discogs-client',
+        'titlecase',
     ] + (
         # Tests for the thumbnails plugin need pathlib on Python 2 too.
         ['pathlib'] if (sys.version_info < (3, 4, 0)) else []

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -585,36 +585,36 @@ class DestinationFunctionTest(_common.TestCase, PathFormattingMixin):
         self._assert_dest(b'/base/THE TITLE')
 
     def test_title_case_variable(self):
-        self._setf(u'%title{$title}')
-        self._assert_dest(b'/base/The Title')
+        self._setf(u'%title{title}')
+        self._assert_dest(b'/base/Title')
 
     def test_title_case_variable_aphostrophe(self):
         self._setf(u'%title{I can\'t}')
         self._assert_dest(b'/base/I Can\'t')
 
     def test_title_case_variable_after_single_quote(self):
-        self._setf(u"%title{'$title'}")
-        self._assert_dest(b"/base/'The Title'")
+        self._setf(u"%title{'title'}")
+        self._assert_dest(b"/base/'Title'")
 
     def test_title_case_variable_after_slash(self):
-        self._setf(u'%title{$title/$artist}')
-        self._assert_dest(b'/base/The Title/The Artist')
+        self._setf(u'%title{first/second}')
+        self._assert_dest(b'/base/First/Second')
 
     def test_title_case_variable_after_parenthesis(self):
-        self._setf(u'%title{($title)}')
-        self._assert_dest(b'/base/(The Title)')
+        self._setf(u'%title{(title)}')
+        self._assert_dest(b'/base/(Title)')
 
     def test_title_case_variable_after_bracket(self):
-        self._setf(u'%title{[$title]}')
-        self._assert_dest(b'/base/[The Title]')
+        self._setf(u'%title{[title]}')
+        self._assert_dest(b'/base/[Title]')
 
     def test_title_case_variable_hythen_separator(self):
-        self._setf(u'%title{$title-$artist}')
-        self._assert_dest(b'/base/The Title-The Artist')
+        self._setf(u'%title{first-second}')
+        self._assert_dest(b'/base/First-Second')
 
     def test_title_case_variable_single_slash_separator(self):
-        self._setf(u'%title{$title/$artist}')
-        self._assert_dest(b'/base/The Title/The Artist')
+        self._setf(u'%title{first/second}')
+        self._assert_dest(b'/base/First/Second')
 
     def test_title_case_variable_small_words(self):
         self._setf(u'%title{first and second}')
@@ -623,6 +623,10 @@ class DestinationFunctionTest(_common.TestCase, PathFormattingMixin):
     def test_title_case_variable_all_caps(self):
         self._setf(u'%title{THE TITLE}')
         self._assert_dest(b'/base/The Title')
+
+    def test_title_case_variable_multi_words(self):
+        self._setf(u'%title{a longer title}')
+        self._assert_dest(b'/base/A Longer Title')
 
     def test_asciify_variable(self):
         self._setf(u'%asciify{ab\xa2\xbdd}')

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -592,6 +592,38 @@ class DestinationFunctionTest(_common.TestCase, PathFormattingMixin):
         self._setf(u'%title{I can\'t}')
         self._assert_dest(b'/base/I Can\'t')
 
+    def test_title_case_variable_after_single_quote(self):
+        self._setf(u"%title{'$title'}")
+        self._assert_dest(b"/base/'The Title'")
+
+    def test_title_case_variable_after_slash(self):
+        self._setf(u'%title{$title/$artist}')
+        self._assert_dest(b'/base/The Title/The Artist')
+
+    def test_title_case_variable_after_parenthesis(self):
+        self._setf(u'%title{($title)}')
+        self._assert_dest(b'/base/(The Title)')
+
+    def test_title_case_variable_after_bracket(self):
+        self._setf(u'%title{[$title]}')
+        self._assert_dest(b'/base/[The Title]')
+
+    def test_title_case_variable_hythen_separator(self):
+        self._setf(u'%title{$title-$artist}')
+        self._assert_dest(b'/base/The Title-The Artist')
+
+    def test_title_case_variable_single_slash_separator(self):
+        self._setf(u'%title{$title/$artist}')
+        self._assert_dest(b'/base/The Title/The Artist')
+
+    def test_title_case_variable_small_words(self):
+        self._setf(u'%title{first and second}')
+        self._assert_dest(b'/base/First and Second')
+
+    def test_title_case_variable_all_caps(self):
+        self._setf(u'%title{THE TITLE}')
+        self._assert_dest(b'/base/The Title')
+
     def test_asciify_variable(self):
         self._setf(u'%asciify{ab\xa2\xbdd}')
         self._assert_dest(b'/base/abC_ 1_2 d')

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ envlist = py27-test, py37-test, py27-flake8, docs
 [_test]
 deps =
     beautifulsoup4
+    titlecase
     flask
     mock
     nose


### PR DESCRIPTION
Addresses the issues noted in https://github.com/beetbox/beets/issues/3298

Revamps the current %title functionality, moving from Python's string.capwords() to using the [python-titlecase](https://github.com/ppannuto/python-titlecase) package. Supports the original functionality while also capitalizing the first letter of words that follow a punctuation (such as ', ", /, etc).