### PR TITLE
Increment playlist_version when a track is consumed.

### DIFF
--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -639,6 +639,8 @@ class BaseServer(object):
             self.playlist.pop(old_index)
             if self.current_index > old_index:
                 self.current_index -= 1
+            self.playlist_version += 1
+            self._send_event("playlist")
         if self.current_index >= len(self.playlist):
             # Fallen off the end. Move to stopped state or loop.
             if self.repeat:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -131,6 +131,7 @@ Fixes:
   wiping out their beets database.
   Thanks to :user:`logan-arens`.
   :bug:`1934`
+* :doc:`/plugins/bpd`: Fix the transition to next track when in consume mode.
 
 For plugin developers:
 


### PR DESCRIPTION
This fixes the playlist not updating when in consume mode, at least in
ncmpcpp.

Someone who knows the mpd protocol better might want to make sure I'm doing this right, though,