### PR TITLE
Added schema variable and added more logging

### DIFF
--- a/beetsplug/subsonicupdate.py
+++ b/beetsplug/subsonicupdate.py
@@ -38,7 +38,7 @@ __author__ = 'https://github.com/maffo999'
 
 
 def create_token():
-    """ Creates salt and token from given password.
+    """Creates salt and token from given password.
 
     :return: The generated salt and hashed token
     """
@@ -55,7 +55,7 @@ def create_token():
 
 
 def format_url():
-    """ Get the Subsonic URL to trigger a scan. Uses either the url
+    """Get the Subsonic URL to trigger a scan. Uses either the url
     config option or the deprecated host, port, and context_path config
     options together.
 
@@ -89,7 +89,7 @@ class SubsonicUpdate(BeetsPlugin):
             'user': 'admin',
             'pass': 'admin',
             'contextpath': '/',
-            'url': 'http://localhost:4040'
+            'url': 'http://localhost:4040',
         })
 
         config['subsonic']['pass'].redact = True

--- a/docs/plugins/subsonicupdate.rst
+++ b/docs/plugins/subsonicupdate.rst
@@ -13,6 +13,12 @@ You can do that using a ``subsonic:`` section in your ``config.yaml``,
 which looks like this::
 
     subsonic:
+        url: https://mydomain.com:443/subsonic
+        user: username
+        pass: password
+
+    # DEPRECATED
+    subsonic:
         host: X.X.X.X
         port: 4040
         user: username
@@ -29,6 +35,14 @@ Configuration
 -------------
 
 The available options under the ``subsonic:`` section are:
+
+- **url**: The Subsonic server resource. Default: ``http://localhost:4040``
+
+Example: ``https://mydomain.com:443/subsonic``
+
+\* Note: context path is optional
+
+DEPRECATED:
 
 - **host**: The Subsonic server name/IP. Default: ``localhost``
 - **port**: The Subsonic server port. Default: ``4040``

--- a/docs/plugins/subsonicupdate.rst
+++ b/docs/plugins/subsonicupdate.rst
@@ -13,17 +13,11 @@ You can do that using a ``subsonic:`` section in your ``config.yaml``,
 which looks like this::
 
     subsonic:
-        url: https://mydomain.com:443/subsonic
+        url: https://example.com:443/subsonic
         user: username
         pass: password
 
-    # DEPRECATED
-    subsonic:
-        host: X.X.X.X
-        port: 4040
-        user: username
-        pass: password
-        contextpath: /subsonic
+\* NOTE: The pass config option can either be clear text or hex-encoded with a "enc:" prefix.
 
 With that all in place, beets will send a Rest API to your Subsonic
 server every time you import new music.
@@ -39,13 +33,3 @@ The available options under the ``subsonic:`` section are:
 - **url**: The Subsonic server resource. Default: ``http://localhost:4040``
 
 Example: ``https://mydomain.com:443/subsonic``
-
-\* Note: context path is optional
-
-DEPRECATED:
-
-- **host**: The Subsonic server name/IP. Default: ``localhost``
-- **port**: The Subsonic server port. Default: ``4040``
-- **user**: The Subsonic user. Default: ``admin``
-- **pass**: The Subsonic user password. Default: ``admin``
-- **contextpath**: The Subsonic context path. Default: ``/``

--- a/docs/plugins/subsonicupdate.rst
+++ b/docs/plugins/subsonicupdate.rst
@@ -17,8 +17,6 @@ which looks like this::
         user: username
         pass: password
 
-\* NOTE: The pass config option can either be clear text or hex-encoded with a "enc:" prefix.
-
 With that all in place, beets will send a Rest API to your Subsonic
 server every time you import new music.
 Due to a current limitation of the API, all libraries visible to that user will be scanned.
@@ -31,3 +29,7 @@ Configuration
 The available options under the ``subsonic:`` section are:
 
 - **url**: The Subsonic server resource. Default: ``http://localhost:4040``
+- **user**: The Subsonic user. Default: ``admin``
+- **pass**: The Subsonic user password. Default: ``admin``
+
+\* NOTE: The pass config option can either be clear text or hex-encoded with a "enc:" prefix.

--- a/docs/plugins/subsonicupdate.rst
+++ b/docs/plugins/subsonicupdate.rst
@@ -31,5 +31,3 @@ Configuration
 The available options under the ``subsonic:`` section are:
 
 - **url**: The Subsonic server resource. Default: ``http://localhost:4040``
-
-Example: ``https://mydomain.com:443/subsonic``


### PR DESCRIPTION
### Description

The plugin does a great job updating, but if I wanted to use the 443 port (https) it fails. Example, going to https://google:80 fails because it doesn't know how to forward this. So in the users' case, they would have to assume that giving port 80 in the config will forward to 443 using https properly. This just makes it more obvious.

I also added some more logs to make it more obvious to the user what's going on if they use the `--verbose` option. And if they don't, then it will send a `log.info` for success cases.

In terms of logging, I think I did this right. Please let me know if I didn't. Also first time contributing something in Python -- sorry if it doesn't look right. Let me know if I need to update anything!