### PR TITLE
discogs: Add `index_tracks` option (closes #3458)

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -57,7 +57,8 @@ class DiscogsPlugin(BeetsPlugin):
             'tokenfile': 'discogs_token.json',
             'source_weight': 0.5,
             'user_token': '',
-            'separator': u', '
+            'separator': u', ',
+            'index_tracks': False
         })
         self.config['apikey'].redact = True
         self.config['apisecret'].redact = True

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -398,14 +398,23 @@ class DiscogsPlugin(BeetsPlugin):
         tracks = []
         index_tracks = {}
         index = 0
+        divisions, next_divisions = [], []
         for track in clean_tracklist:
             # Only real tracks have `position`. Otherwise, it's an index track.
             if track['position']:
                 index += 1
+                if next_divisions:
+                    divisions += next_divisions
+                    next_divisions.clear()
                 track_info = self.get_track_info(track, index)
                 track_info.track_alt = track['position']
                 tracks.append(track_info)
             else:
+                next_divisions.append(track['title'])
+                try:
+                    divisions.pop()
+                except IndexError:
+                    pass
                 index_tracks[index + 1] = track['title']
 
         # Fix up medium and medium_index for each track. Discogs position is

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -398,12 +398,14 @@ class DiscogsPlugin(BeetsPlugin):
         tracks = []
         index_tracks = {}
         index = 0
+        # Distinct works and intra-work divisions, as defined by index tracks.
         divisions, next_divisions = [], []
         for track in clean_tracklist:
             # Only real tracks have `position`. Otherwise, it's an index track.
             if track['position']:
                 index += 1
                 if next_divisions:
+                    # End of a block of index tracks: update the current divisions.
                     divisions += next_divisions
                     next_divisions.clear()
                 track_info = self.get_track_info(track, index, divisions)
@@ -411,6 +413,8 @@ class DiscogsPlugin(BeetsPlugin):
                 tracks.append(track_info)
             else:
                 next_divisions.append(track['title'])
+                # We expect new levels of division at the beginning of the tracklist
+                # (and possibly elsewhere).
                 try:
                     divisions.pop()
                 except IndexError:

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -407,7 +407,7 @@ class DiscogsPlugin(BeetsPlugin):
                 if next_divisions:
                     # End of a block of index tracks: update the current divisions.
                     divisions += next_divisions
-                    next_divisions.clear()
+                    del next_divisions[:]
                 track_info = self.get_track_info(track, index, divisions)
                 track_info.track_alt = track['position']
                 tracks.append(track_info)

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -405,7 +405,8 @@ class DiscogsPlugin(BeetsPlugin):
             if track['position']:
                 index += 1
                 if next_divisions:
-                    # End of a block of index tracks: update the current divisions.
+                    # End of a block of index tracks: update the current
+                    # divisions.
                     divisions += next_divisions
                     del next_divisions[:]
                 track_info = self.get_track_info(track, index, divisions)
@@ -413,8 +414,8 @@ class DiscogsPlugin(BeetsPlugin):
                 tracks.append(track_info)
             else:
                 next_divisions.append(track['title'])
-                # We expect new levels of division at the beginning of the tracklist
-                # (and possibly elsewhere).
+                # We expect new levels of division at the beginning of the
+                # tracklist (and possibly elsewhere).
                 try:
                     divisions.pop()
                 except IndexError:

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -406,7 +406,7 @@ class DiscogsPlugin(BeetsPlugin):
                 if next_divisions:
                     divisions += next_divisions
                     next_divisions.clear()
-                track_info = self.get_track_info(track, index)
+                track_info = self.get_track_info(track, index, divisions)
                 track_info.track_alt = track['position']
                 tracks.append(track_info)
             else:
@@ -549,10 +549,13 @@ class DiscogsPlugin(BeetsPlugin):
 
         return tracklist
 
-    def get_track_info(self, track, index):
+    def get_track_info(self, track, index, divisions):
         """Returns a TrackInfo object for a discogs track.
         """
         title = track['title']
+        if self.config['index_tracks']:
+            prefix = ', '.join(divisions)
+            title = ': '.join(prefix, title)
         track_id = None
         medium, medium_index, _ = self.get_track_index(track['position'])
         artist, artist_id = MetadataSourcePlugin.get_artist(

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -559,7 +559,7 @@ class DiscogsPlugin(BeetsPlugin):
         title = track['title']
         if self.config['index_tracks']:
             prefix = ', '.join(divisions)
-            title = ': '.join(prefix, title)
+            title = ': '.join([prefix, title])
         track_id = None
         medium, medium_index, _ = self.get_track_index(track['position'])
         artist, artist_id = MetadataSourcePlugin.get_artist(

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -96,6 +96,11 @@ New features:
   HTTPS.
   Thanks to :user:`jef`.
   :bug:`3449`
+* :doc:`/plugins/discogs`: The new ``index_tracks`` option enables
+  incorporation of work names and intra-work divisions into imported track
+  titles.
+  Thanks to :user:`cole-miller`.
+  :bug:`3459`
 
 Fixes:
 

--- a/docs/plugins/discogs.rst
+++ b/docs/plugins/discogs.rst
@@ -52,7 +52,7 @@ There is one additional option in the ``discogs:`` section, ``index_tracks``.
 Index tracks (see the `Discogs guidelines
 <https://support.discogs.com/hc/en-us/articles/360005055373-Database-Guidelines-12-Tracklisting#12.13>`_),
 along with headers, mark divisions between distinct works on the same release
-or within works. When ``index_tracks`` is enabled,::
+or within works. When ``index_tracks`` is enabled::
 
     discogs:
         index_tracks: yes

--- a/docs/plugins/discogs.rst
+++ b/docs/plugins/discogs.rst
@@ -48,6 +48,33 @@ Configuration
 
 This plugin can be configured like other metadata source plugins as described in :ref:`metadata-source-plugin-configuration`.
 
+There is one additional option in the ``discogs:`` section, ``index_tracks``.
+Index tracks (see the `Discogs guidelines
+<https://support.discogs.com/hc/en-us/articles/360005055373-Database-Guidelines-12-Tracklisting#12.13>`_),
+along with headers, mark divisions between distinct works on the same release
+or within works. When ``index_tracks`` is enabled,::
+
+    discogs:
+        index_tracks: yes
+
+beets will incorporate the names of the divisions containing each track into
+the imported track's title. For example, importing
+`this album
+<https://www.discogs.com/Handel-Sutherland-Kirkby-Kwella-Nelson-Watkinson-Bowman-Rolfe-Johnson-Elliott-Partridge-Thomas-The-A/release/2026070>`_
+would result in track names like::
+
+    Messiah, Part I: No.1: Sinfony
+    Messiah, Part II: No.22: Chorus- Behold The Lamb Of God
+    Athalia, Act I, Scene I: Sinfonia
+
+whereas with ``index_track`` disabled you'd get::
+
+    No.1: Sinfony
+    No.22: Chorus- Behold The Lamb Of God
+    Sinfonia
+
+This option is useful when importing classical music.
+
 Troubleshooting
 ---------------
 

--- a/docs/plugins/discogs.rst
+++ b/docs/plugins/discogs.rst
@@ -67,7 +67,7 @@ would result in track names like::
     Messiah, Part II: No.22: Chorus- Behold The Lamb Of God
     Athalia, Act I, Scene I: Sinfonia
 
-whereas with ``index_track`` disabled you'd get::
+whereas with ``index_tracks`` disabled you'd get::
 
     No.1: Sinfony
     No.22: Chorus- Behold The Lamb Of God


### PR DESCRIPTION
This PR implements the feature described in #3458, enabled with the `index_tracks` option in the `discogs:` section.

Since `DiscogsPlugin.coalesce_tracks` discards index tracks that are used to title subtrack mergers, I don't *think* it interacts badly with this feature. But I might be missing something, in which case please correct me.