### PR TITLE
support for keyfinder-cli, which doesn't want the -f flag for paths

### DIFF
--- a/beetsplug/keyfinder.py
+++ b/beetsplug/keyfinder.py
@@ -18,6 +18,7 @@
 
 from __future__ import division, absolute_import, print_function
 
+import os.path
 import subprocess
 
 from beets import ui
@@ -52,15 +53,19 @@ class KeyFinderPlugin(BeetsPlugin):
 
     def find_key(self, items, write=False):
         overwrite = self.config['overwrite'].get(bool)
-        bin = self.config['bin'].as_str()
+        command = [self.config['bin'].as_str()]
+        # The KeyFinder GUI program needs the -f flag before the path.
+        # keyfinder-cli is similar, but just wants the path with no flag.
+        if 'keyfinder-cli' not in os.path.basename(command[0]).lower():
+            command.append('-f')
 
         for item in items:
             if item['initial_key'] and not overwrite:
                 continue
 
             try:
-                output = util.command_output([bin, '-f',
-                                              util.syspath(item.path)]).stdout
+                output = util.command_output(command + [util.syspath(
+                                                        item.path)]).stdout
             except (subprocess.CalledProcessError, OSError) as exc:
                 self._log.error(u'execution failed: {0}', exc)
                 continue

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 
 New features:
 
+* :doc:`plugins/keyfinder`: Added support for `keyfinder-cli`_
+  Thanks to :user:`BrainDamage`.
 * :doc:`plugins/fetchart`: Added a new ``high_resolution`` config option to
   allow downloading of higher resolution iTunes artwork (at the expense of
   file size).
@@ -204,6 +206,7 @@ For packagers:
 .. _Confuse: https://github.com/beetbox/confuse
 .. _works: https://musicbrainz.org/doc/Work
 .. _Deezer: https://www.deezer.com
+.. _keyfinder-cli: https://github.com/EvanPurkhiser/keyfinder-cli
 
 
 1.4.9 (May 30, 2019)

--- a/docs/plugins/keyfinder.rst
+++ b/docs/plugins/keyfinder.rst
@@ -1,9 +1,9 @@
 Key Finder Plugin
 =================
 
-The `keyfinder` plugin uses the `KeyFinder`_ program to detect the
-musical key of track from its audio data and store it in the
-`initial_key` field of your database.  It does so
+The `keyfinder` plugin uses either the `KeyFinder`_ or `keyfinder-cli`_
+program to  detect the musical key of a track from its audio data and store
+it in the `initial_key` field of your database.  It does so
 automatically when importing music or through the ``beet keyfinder
 [QUERY]`` command.
 
@@ -20,13 +20,16 @@ configuration file. The available options are:
   import. Otherwise, you need to use the ``beet keyfinder`` command
   explicitly.
   Default: ``yes``
-- **bin**: The name of the `KeyFinder`_ program on your system or
-  a path to the binary. If you installed the KeyFinder GUI on a Mac, for
-  example, you want something like
+- **bin**: The name of the program use for key analysis. You can use either
+  `KeyFinder`_ or `keyfinder-cli`_.
+  If you installed the KeyFinder GUI on a Mac, for example, you want
+  something like
   ``/Applications/KeyFinder.app/Contents/MacOS/KeyFinder``.
+  If using `keyfinder-cli`_, the binary must be named ``keyfinder-cli``.
   Default: ``KeyFinder`` (i.e., search for the program in your ``$PATH``)..
 - **overwrite**: Calculate a key even for files that already have an
   `initial_key` value.
   Default: ``no``.
 
 .. _KeyFinder: https://www.ibrahimshaath.co.uk/keyfinder/
+.. _keyfinder-cli: https://github.com/EvanPurkhiser/keyfinder-cli/


### PR DESCRIPTION
Added support for [keyfinder-cli](https://github.com/EvanPurkhiser/keyfinder-cli) to the keyfinder plugin, which doesn't want/rejects the -f flag before a path