### PR TITLE
Support extra tags for MusicBrainz queries

### DIFF
--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -614,17 +614,21 @@ def tracks_for_id(track_id):
 
 
 @plugins.notify_info_yielded(u'albuminfo_received')
-def album_candidates(items, artist, album, va_likely):
+def album_candidates(items, artist, album, va_likely, extra_tags):
     """Search for album matches. ``items`` is a list of Item objects
     that make up the album. ``artist`` and ``album`` are the respective
     names (strings), which may be derived from the item list or may be
     entered by the user. ``va_likely`` is a boolean indicating whether
-    the album is likely to be a "various artists" release.
+    the album is likely to be a "various artists" release. ``extra_tags``
+    is an optional dictionary of additional tags used to further
+    constrain the search.
     """
+
     # Base candidates if we have album and artist to match.
     if artist and album:
         try:
-            for candidate in mb.match_album(artist, album, len(items)):
+            for candidate in mb.match_album(artist, album, len(items),
+                                            extra_tags):
                 yield candidate
         except mb.MusicBrainzAPIError as exc:
             exc.log(log)
@@ -632,13 +636,15 @@ def album_candidates(items, artist, album, va_likely):
     # Also add VA matches from MusicBrainz where appropriate.
     if va_likely and album:
         try:
-            for candidate in mb.match_album(None, album, len(items)):
+            for candidate in mb.match_album(None, album, len(items),
+                                            extra_tags):
                 yield candidate
         except mb.MusicBrainzAPIError as exc:
             exc.log(log)
 
     # Candidates from plugins.
-    for candidate in plugins.candidates(items, artist, album, va_likely):
+    for candidate in plugins.candidates(items, artist, album, va_likely,
+                                        extra_tags):
         yield candidate
 
 

--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -447,6 +447,12 @@ def tag_album(items, search_artist=None, search_album=None,
             search_artist, search_album = cur_artist, cur_album
         log.debug(u'Search terms: {0} - {1}', search_artist, search_album)
 
+        extra_tags = None
+        if config['musicbrainz']['extra_tags']:
+            tag_list = config['musicbrainz']['extra_tags'].get()
+            extra_tags = {k: v for (k, v) in likelies.items() if k in tag_list}
+            log.debug(u'Additional search terms: {0}', extra_tags)
+
         # Is this album likely to be a "various artist" release?
         va_likely = ((not consensus['artist']) or
                      (search_artist.lower() in VA_ARTISTS) or
@@ -457,7 +463,8 @@ def tag_album(items, search_artist=None, search_album=None,
         for matched_candidate in hooks.album_candidates(items,
                                                         search_artist,
                                                         search_album,
-                                                        va_likely):
+                                                        va_likely,
+                                                        extra_tags):
             _add_candidate(items, candidates, matched_candidate)
 
     log.debug(u'Evaluating {0} candidates.', len(candidates))

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -103,6 +103,7 @@ musicbrainz:
     ratelimit: 1
     ratelimit_interval: 1.0
     searchlimit: 5
+    extra_tags: []
 
 match:
     strong_rec_thresh: 0.04

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -172,7 +172,7 @@ class BeetsPlugin(object):
         """
         return beets.autotag.hooks.Distance()
 
-    def candidates(self, items, artist, album, va_likely):
+    def candidates(self, items, artist, album, va_likely, extra_tags=None):
         """Should return a sequence of AlbumInfo objects that match the
         album whose items are provided.
         """
@@ -379,11 +379,12 @@ def album_distance(items, album_info, mapping):
     return dist
 
 
-def candidates(items, artist, album, va_likely):
+def candidates(items, artist, album, va_likely, extra_tags=None):
     """Gets MusicBrainz candidates for an album from each plugin.
     """
     for plugin in find_plugins():
-        for candidate in plugin.candidates(items, artist, album, va_likely):
+        for candidate in plugin.candidates(items, artist, album, va_likely,
+                                           extra_tags):
             yield candidate
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 
 New features:
 
+* A new :ref:`extra_tags` configuration option allows more tagged metadata
+  to be included in MusicBrainz queries.
 * A new :doc:`/plugins/fish` adds `Fish shell`_ tab autocompletion to beets
 * :doc:`plugins/fetchart` and :doc:`plugins/embedart`: Added a new ``quality``
   option that controls the quality of the image output when the image is

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -701,6 +701,26 @@ MusicBrainz server.
 
 Default: ``5``.
 
+.. _extra_tags:
+
+extra_tags
+~~~~~~~~~~
+
+By default, beets will use only the artist, album, and track count to query
+MusicBrainz. Additional tags to be queried can be supplied with the
+``extra_tags`` setting. For example::
+
+    musicbrainz:
+        extra_tags: [year, catalognum, country, media, label]
+
+This setting should improve the autotagger results if the metadata with the
+given tags match the metadata returned by MusicBrainz.
+
+Note that the only tags supported by this setting are the ones listed in the
+above example.
+
+Default: ``[]``
+
 .. _match-config:
 
 Autotagger Matching Options

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -79,7 +79,7 @@ class AutotagStub(object):
         autotag.mb.album_for_id = self.mb_album_for_id
         autotag.mb.track_for_id = self.mb_track_for_id
 
-    def match_album(self, albumartist, album, tracks):
+    def match_album(self, albumartist, album, tracks, extra_tags):
         if self.matching == self.IDENT:
             yield self._make_album_match(albumartist, album, tracks)
 


### PR DESCRIPTION
Here's a first go at the "hints" behavior discussed in https://discourse.beets.io/t/providing-hints-to-autotagger/1072/10.

This adds a single `extra_tags` config parameter that, when enabled, includes the following tags in the MusicBrainz query:  `media`, `year`, `country`, `label`, `catalognum`. The selection of tags to include is somewhat arbitrary, but based on a combination of the tags I needed in my particular use case and the tags already used by `likelies` in `current_metadata`.