### PR TITLE
Remove --replaygain flag when checking bs1770gain availability

### DIFF
--- a/test/test_replaygain.py
+++ b/test/test_replaygain.py
@@ -40,7 +40,7 @@ if any(has_program(cmd, ['-v']) for cmd in ['mp3gain', 'aacgain']):
 else:
     GAIN_PROG_AVAILABLE = False
 
-if has_program('bs1770gain', ['--replaygain']):
+if has_program('bs1770gain'):
     LOUDNESS_PROG_AVAILABLE = True
 else:
     LOUDNESS_PROG_AVAILABLE = False
@@ -58,7 +58,6 @@ def reset_replaygain(item):
 
 
 class ReplayGainCliTestBase(TestHelper):
-
     def setUp(self):
         self.setup_beets()
         self.config['replaygain']['backend'] = self.backend


### PR DESCRIPTION
`bs1770gain` is marked as unavailable when it shouldn't be because `bs1770gain --replaygain` returns an error.