### PR TITLE
Added beets-bpmanalyser to the list of 'other plugins'

### DIFF
--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -299,6 +299,8 @@ Here are a few of the plugins written by the beets community:
 
 * `beets-mosaic`_ generates a montage of a mosiac from cover art.
 
+* `beets-bpmanalyser`_ analyses songs and calculates tempo(bpm).
+
 .. _beets-barcode: https://github.com/8h2a/beets-barcode
 .. _beets-check: https://github.com/geigerzaehler/beets-check
 .. _copyartifacts: https://github.com/sbarakat/beets-copyartifacts
@@ -321,3 +323,4 @@ Here are a few of the plugins written by the beets community:
 .. _beets-ydl: https://github.com/vmassuchetto/beets-ydl
 .. _beet-summarize: https://github.com/steven-murray/beet-summarize
 .. _beets-mosaic: https://github.com/SusannaMaria/beets-mosaic
+.. _beets-bpmanalyser: https://github.com/adamjakab/BeetsPluginBpmAnalyser


### PR DESCRIPTION
I could not find a logical explanation to the order of the plugins so I assumed that they are in a chronological order and therefore I put mine to the bottom. (Maybe alphabetical would be better. What do you think?)
