### PR TITLE
parentwork: Only call store when the metadata has changed.

### DIFF
--- a/beetsplug/parentwork.py
+++ b/beetsplug/parentwork.py
@@ -89,10 +89,11 @@ class ParentWorkPlugin(BeetsPlugin):
             write = ui.should_write()
 
             for item in lib.items(ui.decargs(args)):
-                self.find_work(item, force_parent)
-                item.store()
-                if write:
-                    item.try_write()
+                changed = self.find_work(item, force_parent)
+                if changed:
+                    item.store()
+                    if write:
+                        item.try_write()
         command = ui.Subcommand(
             'parentwork',
             help=u'fetche parent works, composers and dates')
@@ -198,7 +199,7 @@ add one at https://musicbrainz.org/recording/{}', item, item.mb_trackid)
 
         if work_date:
             item['work_date'] = work_date
-        ui.show_model_changes(
+        return ui.show_model_changes(
             item, fields=['parentwork', 'parentwork_disambig',
                           'mb_parentworkid', 'parent_composer',
                           'parent_composer_sort', 'work_date'])

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -158,6 +158,8 @@ Fixes:
   :bug:`3446`
 * :doc:`/plugins/replaygain`: Support ``bs1770gain`` v0.6.0 and up
   :bug:`3480`
+* :doc:`/plugins/parentwork`: Don't save tracks when nothing has changed.
+  :bug:`3492`
 
 For plugin developers:
 


### PR DESCRIPTION
Otherwise, this rewrites all your files every time.