### PR TITLE
Raising error on missing configuration file inclusion

### DIFF
--- a/beets/__init__.py
+++ b/beets/__init__.py
@@ -35,6 +35,8 @@ class IncludeLazyConfig(confuse.LazyConfig):
                 filename = view.as_filename()
                 if os.path.isfile(filename):
                     self.set_file(filename)
+                else:
+                    raise FileNotFoundError("Warning! Configuration file({0}) does not exist!".format(filename))
         except confuse.NotFoundError:
             pass
 

--- a/beets/__init__.py
+++ b/beets/__init__.py
@@ -36,7 +36,8 @@ class IncludeLazyConfig(confuse.LazyConfig):
                 if os.path.isfile(filename):
                     self.set_file(filename)
                 else:
-                    raise FileNotFoundError("Warning! Configuration file({0}) does not exist!".format(filename))
+                    raise FileNotFoundError(
+                        "Warning! Configuration file({0}) does not exist!".format(filename))
         except confuse.NotFoundError:
             pass
 

--- a/beets/__init__.py
+++ b/beets/__init__.py
@@ -15,8 +15,6 @@
 
 from __future__ import division, absolute_import, print_function
 
-import os
-
 import confuse
 
 __version__ = u'1.5.0'
@@ -32,8 +30,7 @@ class IncludeLazyConfig(confuse.LazyConfig):
 
         try:
             for view in self['include']:
-                filename = view.as_filename()
-                self.set_file(filename)
+                self.set_file(view.as_filename())
         except confuse.NotFoundError:
             pass
         except confuse.ConfigReadError as err:

--- a/beets/__init__.py
+++ b/beets/__init__.py
@@ -16,6 +16,7 @@
 from __future__ import division, absolute_import, print_function
 
 import confuse
+from sys import stderr
 
 __version__ = u'1.5.0'
 __author__ = u'Adrian Sampson <adrian@radbox.org>'
@@ -34,7 +35,8 @@ class IncludeLazyConfig(confuse.LazyConfig):
         except confuse.NotFoundError:
             pass
         except confuse.ConfigReadError as err:
-            print("Warning! Missing configuration file! {}".format(err.reason))
+            stderr.write("Configuration 'import' failed: {}"
+                         .format(err.reason))
             pass
 
 

--- a/beets/__init__.py
+++ b/beets/__init__.py
@@ -33,12 +33,11 @@ class IncludeLazyConfig(confuse.LazyConfig):
         try:
             for view in self['include']:
                 filename = view.as_filename()
-                if os.path.isfile(filename):
-                    self.set_file(filename)
-                else:
-                    raise FileNotFoundError("Warning! Configuration file({0}) "
-                                            "does not exist!".format(filename))
+                self.set_file(filename)
         except confuse.NotFoundError:
+            pass
+        except confuse.ConfigReadError as err:
+            print("Warning! Missing configuration file! {}".format(err.reason))
             pass
 
 

--- a/beets/__init__.py
+++ b/beets/__init__.py
@@ -36,8 +36,8 @@ class IncludeLazyConfig(confuse.LazyConfig):
                 if os.path.isfile(filename):
                     self.set_file(filename)
                 else:
-                    raise FileNotFoundError(
-                        "Warning! Configuration file({0}) does not exist!".format(filename))
+                    raise FileNotFoundError("Warning! Configuration file({0}) "
+                                            "does not exist!".format(filename))
         except confuse.NotFoundError:
             pass
 

--- a/beets/__init__.py
+++ b/beets/__init__.py
@@ -35,9 +35,8 @@ class IncludeLazyConfig(confuse.LazyConfig):
         except confuse.NotFoundError:
             pass
         except confuse.ConfigReadError as err:
-            stderr.write("Configuration 'import' failed: {}"
+            stderr.write("configuration `import` failed: {}"
                          .format(err.reason))
-            pass
 
 
 config = IncludeLazyConfig('beets', __name__)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -160,6 +160,8 @@ Fixes:
   :bug:`3480`
 * :doc:`/plugins/parentwork`: Don't save tracks when nothing has changed.
   :bug:`3492`
+* Added a warning when configuration files defined in the `include` directive
+  of the configuration file fail to be imported.
 
 For plugin developers:
 


### PR DESCRIPTION
I think it is better to know than ignoring it silently. I don't know how you feel about this but I am requesting this PR because I lost a good deal of time convinced that my configuration was read only to discover that I mistyped the path. We could also opt for a 'softer' warning...