### PR TITLE
Fix #3507

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -189,7 +189,7 @@ class LazyConvertDict(object):
 
 class Model(object):
     """An abstract object representing an object in the database. Model
-    objects act like dictionaries (i.e., the allow subscript access like
+    objects act like dictionaries (i.e., they allow subscript access like
     ``obj['field']``). The same field set is available via attribute
     access as a shortcut (i.e., ``obj.field``). Three kinds of attributes are
     available:

--- a/beets/dbcore/types.py
+++ b/beets/dbcore/types.py
@@ -131,6 +131,14 @@ class Integer(Type):
     query = query.NumericQuery
     model_type = int
 
+    def normalize(self, value):
+        try:
+            return self.model_type(round(float(value)))
+        except ValueError:
+            return self.null
+        except TypeError:
+            return self.null
+
 
 class PaddedInt(Integer):
     """An integer field that is formatted with a given number of digits,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -166,6 +166,9 @@ Fixes:
 * Added a warning when configuration files defined in the `include` directive
   of the configuration file fail to be imported.
   :bug:`3498`
+* Added the normalize method to the dbcore.types.INTEGER class which now
+  properly returns integer values.
+  :bug:`762` and :bug:`3507`
 
 For plugin developers:
 

--- a/test/test_autotag.py
+++ b/test/test_autotag.py
@@ -93,7 +93,7 @@ class PluralityTest(_common.TestCase):
                  for i in range(5)]
         likelies, _ = match.current_metadata(items)
         for f in fields:
-            if type(items[0]._fields[f]) in (Integer, PaddedInt):
+            if isinstance(likelies[f], int):
                 self.assertEqual(likelies[f], 0)
             else:
                 self.assertEqual(likelies[f], '%s_1' % f)

--- a/test/test_autotag.py
+++ b/test/test_autotag.py
@@ -21,8 +21,6 @@ import re
 import copy
 import unittest
 
-from beets.dbcore.types import Integer, PaddedInt
-
 from test import _common
 from beets import autotag
 from beets.autotag import match

--- a/test/test_autotag.py
+++ b/test/test_autotag.py
@@ -21,6 +21,8 @@ import re
 import copy
 import unittest
 
+from beets.dbcore.types import Integer, PaddedInt
+
 from test import _common
 from beets import autotag
 from beets.autotag import match
@@ -91,7 +93,10 @@ class PluralityTest(_common.TestCase):
                  for i in range(5)]
         likelies, _ = match.current_metadata(items)
         for f in fields:
-            self.assertEqual(likelies[f], '%s_1' % f)
+            if type(items[0]._fields[f]) in (Integer, PaddedInt):
+                self.assertEqual(likelies[f], 0)
+            else:
+                self.assertEqual(likelies[f], '%s_1' % f)
 
 
 def _make_item(title, track, artist=u'some artist'):

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -53,6 +53,7 @@ class ModelFixture1(dbcore.Model):
     _fields = {
         'id': dbcore.types.PRIMARY_ID,
         'field_one': dbcore.types.INTEGER,
+        'field_two': dbcore.types.STRING,
     }
     _types = {
         'some_float_field': dbcore.types.FLOAT,
@@ -355,7 +356,7 @@ class ModelTest(unittest.TestCase):
     def test_items(self):
         model = ModelFixture1(self.db)
         model.id = 5
-        self.assertEqual({('id', 5), ('field_one', 0)},
+        self.assertEqual({('id', 5), ('field_one', 0), ('field_two', '')},
                          set(model.items()))
 
     def test_delete_internal_field(self):
@@ -370,10 +371,28 @@ class ModelTest(unittest.TestCase):
 
 
 class FormatTest(unittest.TestCase):
-    def test_format_fixed_field(self):
+    def test_format_fixed_field_integer(self):
         model = ModelFixture1()
-        model.field_one = u'caf\xe9'
+        model.field_one = 155
         value = model.formatted().get('field_one')
+        self.assertEqual(value, u'155')
+
+    def test_format_fixed_field_integer_normalized(self):
+        """The normalize method of the Integer class rounds floats
+        """
+        model = ModelFixture1()
+        model.field_one = 142.432
+        value = model.formatted().get('field_one')
+        self.assertEqual(value, u'142')
+
+        model.field_one = 142.863
+        value = model.formatted().get('field_one')
+        self.assertEqual(value, u'143')
+
+    def test_format_fixed_field_string(self):
+        model = ModelFixture1()
+        model.field_two = u'caf\xe9'
+        value = model.formatted().get('field_two')
         self.assertEqual(value, u'caf\xe9')
 
     def test_format_flex_field(self):


### PR DESCRIPTION
Adding normalize method to class `types.INTEGER` overriding the inherited method from the Type class that simply returned the provided value. Also provides Fix #762 and Fix #3507.