### PR TITLE
Fix error when art_filename contain subdiretories 

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -457,14 +457,14 @@ def copy(path, dest, replace=False):
     """
     if samefile(path, dest):
         return
-    path = syspath(path)
-    original_dest = dest
-    dest = syspath(dest)
-    if not replace and os.path.exists(dest):
+    if not replace and os.path.exists(syspath(dest)):
         raise FilesystemError(u'file exists', 'copy', (path, dest))
-    mkdirall(original_dest)
+    
+    #Create all subdirs in path to destination, if they don't already exist
+    mkdirall(dest)
+    
     try:
-        shutil.copyfile(path, dest)
+        shutil.copyfile(syspath(path), syspath(dest))
     except (OSError, IOError) as exc:
         raise FilesystemError(exc, 'copy', (path, dest),
                               traceback.format_exc())
@@ -480,21 +480,20 @@ def move(path, dest, replace=False):
     """
     if samefile(path, dest):
         return
-    path = syspath(path)
-    original_dest = dest
-    dest = syspath(dest)
-    if os.path.exists(dest) and not replace:
+    if not replace and os.path.exists(syspath(dest)):
         raise FilesystemError(u'file exists', 'rename', (path, dest))
 
+    #Create all subdirs in path to destination, if they don't already exist
+    mkdirall(dest)
+    
     # First, try renaming the file.
-    mkdirall(original_dest)
     try:
-        os.rename(path, dest)
+        os.rename(syspath(path), syspath(dest))
     except OSError:
         # Otherwise, copy and delete the original.
         try:
-            shutil.copyfile(path, dest)
-            os.remove(path)
+            shutil.copyfile(syspath(path), syspath(dest))
+            os.remove(syspath(path))
         except (OSError, IOError) as exc:
             raise FilesystemError(exc, 'move', (path, dest),
                                   traceback.format_exc())

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -458,11 +458,12 @@ def copy(path, dest, replace=False):
     if samefile(path, dest):
         return
     path = syspath(path)
+    original_dest = dest
     dest = syspath(dest)
     if not replace and os.path.exists(dest):
         raise FilesystemError(u'file exists', 'copy', (path, dest))
+    mkdirall(original_dest)
     try:
-        mkdirall(dest)
         shutil.copyfile(path, dest)
     except (OSError, IOError) as exc:
         raise FilesystemError(exc, 'copy', (path, dest),
@@ -480,13 +481,14 @@ def move(path, dest, replace=False):
     if samefile(path, dest):
         return
     path = syspath(path)
+    original_dest = dest
     dest = syspath(dest)
     if os.path.exists(dest) and not replace:
         raise FilesystemError(u'file exists', 'rename', (path, dest))
 
     # First, try renaming the file.
+    mkdirall(original_dest)
     try:
-        mkdirall(dest)
         os.rename(path, dest)
     except OSError:
         # Otherwise, copy and delete the original.

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -462,6 +462,7 @@ def copy(path, dest, replace=False):
     if not replace and os.path.exists(dest):
         raise FilesystemError(u'file exists', 'copy', (path, dest))
     try:
+        os.makedirs(os.path.dirname(dest), mode=0o777, exist_ok=True)
         shutil.copyfile(path, dest)
     except (OSError, IOError) as exc:
         raise FilesystemError(exc, 'copy', (path, dest),
@@ -485,6 +486,7 @@ def move(path, dest, replace=False):
 
     # First, try renaming the file.
     try:
+        os.makedirs(os.path.dirname(dest), mode=0o777, exist_ok=True)
         os.rename(path, dest)
     except OSError:
         # Otherwise, copy and delete the original.

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -459,10 +459,10 @@ def copy(path, dest, replace=False):
         return
     if not replace and os.path.exists(syspath(dest)):
         raise FilesystemError(u'file exists', 'copy', (path, dest))
-    
-    #Create all subdirs in path to destination, if they don't already exist
+
+    # Create all subdirs in path to destination, if they don't already exist
     mkdirall(dest)
-    
+
     try:
         shutil.copyfile(syspath(path), syspath(dest))
     except (OSError, IOError) as exc:
@@ -483,9 +483,9 @@ def move(path, dest, replace=False):
     if not replace and os.path.exists(syspath(dest)):
         raise FilesystemError(u'file exists', 'rename', (path, dest))
 
-    #Create all subdirs in path to destination, if they don't already exist
+    # Create all subdirs in path to destination, if they don't already exist
     mkdirall(dest)
-    
+
     # First, try renaming the file.
     try:
         os.rename(syspath(path), syspath(dest))

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -459,10 +459,6 @@ def copy(path, dest, replace=False):
         return
     if not replace and os.path.exists(syspath(dest)):
         raise FilesystemError(u'file exists', 'copy', (path, dest))
-
-    # Create all subdirs in path to destination, if they don't already exist
-    mkdirall(dest)
-
     try:
         shutil.copyfile(syspath(path), syspath(dest))
     except (OSError, IOError) as exc:
@@ -482,10 +478,7 @@ def move(path, dest, replace=False):
         return
     if not replace and os.path.exists(syspath(dest)):
         raise FilesystemError(u'file exists', 'rename', (path, dest))
-
-    # Create all subdirs in path to destination, if they don't already exist
-    mkdirall(dest)
-
+        
     # First, try renaming the file.
     try:
         os.rename(syspath(path), syspath(dest))

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -462,7 +462,7 @@ def copy(path, dest, replace=False):
     if not replace and os.path.exists(dest):
         raise FilesystemError(u'file exists', 'copy', (path, dest))
     try:
-        os.makedirs(os.path.dirname(dest), mode=0o777, exist_ok=True)
+        mkdirall(dest);
         shutil.copyfile(path, dest)
     except (OSError, IOError) as exc:
         raise FilesystemError(exc, 'copy', (path, dest),
@@ -486,7 +486,7 @@ def move(path, dest, replace=False):
 
     # First, try renaming the file.
     try:
-        os.makedirs(os.path.dirname(dest), mode=0o777, exist_ok=True)
+        mkdirall(dest)
         os.rename(path, dest)
     except OSError:
         # Otherwise, copy and delete the original.

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -462,7 +462,7 @@ def copy(path, dest, replace=False):
     if not replace and os.path.exists(dest):
         raise FilesystemError(u'file exists', 'copy', (path, dest))
     try:
-        mkdirall(dest);
+        mkdirall(dest)
         shutil.copyfile(path, dest)
     except (OSError, IOError) as exc:
         raise FilesystemError(exc, 'copy', (path, dest),

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -167,8 +167,7 @@ Fixes:
 * Added a warning when configuration files defined in the `include` directive
   of the configuration file fail to be imported.
   :bug:`3498`
-* Automatically creates destination directories as needed when copying/moving files,   
-  so including directories as part of eg art_filename no longer lead to errors.
+* Enhanced code legibility/consistency in `beets/__init__.py`
   Thanks to :user:`DurvalMenezes`.
   :bug:`3514`
 * Added the normalize method to the dbcore.types.INTEGER class which now

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -169,7 +169,8 @@ Fixes:
   :bug:`3498`
 * Automatically creates destination directories as needed when copying/moving files,   
   so including directories as part of eg art_filename no longer lead to errors.
-  Thanks to :user:`DurvalMenezes`
+  Thanks to :user:`DurvalMenezes`.
+  :bug:`3514`
 * Added the normalize method to the dbcore.types.INTEGER class which now
   properly returns integer values, which should avoid problems where fields
   like ``bpm`` would sometimes store non-integer values.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -167,7 +167,7 @@ Fixes:
 * Added a warning when configuration files defined in the `include` directive
   of the configuration file fail to be imported.
   :bug:`3498`
-* Enhanced code legibility/consistency in `beets/__init__.py`
+* Enhanced code legibility/consistency in `util/__init__.py`
   Thanks to :user:`DurvalMenezes`.
   :bug:`3514`
 * Added the normalize method to the dbcore.types.INTEGER class which now

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -167,6 +167,9 @@ Fixes:
 * Added a warning when configuration files defined in the `include` directive
   of the configuration file fail to be imported.
   :bug:`3498`
+* Automatically creates destination directories as needed when copying/moving files,   
+  so including directories as part of eg art_filename no longer lead to errors.
+  Thanks to :user:`DurvalMenezes`
 
 For plugin developers:
 


### PR DESCRIPTION
This is a fix for the error that will happen when you have, in config.yam, something like this: 
    art_filename: art/front

(note the "scan" subdirectory -- I do it this way because I segregate all art files in a subdir). 

Without this fix, the `beet import` command fails with:  

    Error: No such file or directory while copying /tmp/tmp5aczqcob.jpg to MY_DIR/ARTIST/ALBUM/art/front.jpg

as generally (at least the way I'm using beets) the subdir 'art' would not exist . 

With these modifications `beet import` will then create the missing subdir as needed, ditto `beet move` when moving. 

Please note that I'm no Python nor beets expert, so other/better fixes for this may exist. Please feel free to change or discard this PR if it is somehow innappropriate.