### PR TITLE
Add beets-originquery plugin

### DIFF
--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -314,6 +314,9 @@ Here are a few of the plugins written by the beets community:
 
 * `beets-bpmanalyser`_ analyses songs and calculates their tempo (BPM).
 
+* `beets-originquery`_ augments MusicBrainz queries with locally-sourced data
+  to improve autotagger results.
+
 .. _beets-barcode: https://github.com/8h2a/beets-barcode
 .. _beets-check: https://github.com/geigerzaehler/beets-check
 .. _copyartifacts: https://github.com/sbarakat/beets-copyartifacts
@@ -342,3 +345,4 @@ Here are a few of the plugins written by the beets community:
 .. _beets-autofix: https://github.com/adamjakab/BeetsPluginAutofix
 .. _beets-describe: https://github.com/adamjakab/BeetsPluginDescribe
 .. _beets-bpmanalyser: https://github.com/adamjakab/BeetsPluginBpmAnalyser
+.. _beets-originquery: https://github.com/x1ppy/beets-originquery


### PR DESCRIPTION
I'm not familiar with the process for adding new plugins on the plugins page, but here's a PR in case you'd like to include it.

[`beets-originquery`](https://github.com/x1ppy/beets-originquery) integrates with the new beets [`extra_tags`](https://github.com/beetbox/beets/blob/master/docs/reference/config.rst#id70) config setting to improve autotagger results by augmenting the MusicBrainz query with locally-sourced data. This allows you to more easily enable the `extra_tags` functionality since you don't have to update the tags first; tags can simply be specified in an _origin file_. The origin file format is extremely flexible and configurable, allowing for compatibility with the wide variety of supplemental metadata files people often include with their music.