### PR TITLE
Get performer names and roles

### DIFF
--- a/beets/autotag/__init__.py
+++ b/beets/autotag/__init__.py
@@ -186,6 +186,7 @@ def apply_metadata(album_info, mapping):
                 'composer',
                 'composer_sort',
                 'arranger',
+                'performer',
                 'work',
                 'mb_workid',
                 'work_disambig',

--- a/beets/autotag/__init__.py
+++ b/beets/autotag/__init__.py
@@ -60,6 +60,8 @@ def apply_item_metadata(item, track_info):
         item.composer_sort = track_info.composer_sort
     if track_info.arranger is not None:
         item.arranger = track_info.arranger
+    if track_info.performer is not None:
+        item.performer = track_info.performer
     if track_info.work is not None:
         item.work = track_info.work
     if track_info.mb_workid is not None:

--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -168,6 +168,7 @@ class TrackInfo(object):
     - ``composer``: individual track composer name
     - ``composer_sort``: individual track composer sort name
     - ``arranger`: individual track arranger name
+    - ``performer`: individual track performers and instruments
     - ``track_alt``: alternative track number (tape, vinyl, etc.)
     - ``work`: individual track work title
     - ``mb_workid`: individual track work id
@@ -182,9 +183,9 @@ class TrackInfo(object):
                  medium_index=None, medium_total=None, artist_sort=None,
                  disctitle=None, artist_credit=None, data_source=None,
                  data_url=None, media=None, lyricist=None, composer=None,
-                 composer_sort=None, arranger=None, track_alt=None,
-                 work=None, mb_workid=None, work_disambig=None, bpm=None,
-                 initial_key=None, genre=None):
+                 composer_sort=None, arranger=None, performer=None,
+                 track_alt=None, work=None, mb_workid=None, work_disambig=None,
+                 bpm=None, initial_key=None, genre=None):
         self.title = title
         self.track_id = track_id
         self.release_track_id = release_track_id
@@ -205,6 +206,7 @@ class TrackInfo(object):
         self.composer = composer
         self.composer_sort = composer_sort
         self.arranger = arranger
+        self.performer = performer
         self.track_alt = track_alt
         self.work = work
         self.mb_workid = mb_workid

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -257,7 +257,7 @@ def track_info(recording, index=None, medium=None, medium_index=None,
                     attr = u', '.join(artist_relation['attribute-list'])
                 else:
                     attr = type
-                performer.append(artist_relation['artist']['name'] + '(' +
+                performer.append(artist_relation['artist']['name'] + ' (' +
                                  attr + ')')
     if arranger:
         info.arranger = u', '.join(arranger)

--- a/beets/library.py
+++ b/beets/library.py
@@ -459,6 +459,7 @@ class Item(LibModel):
         'mb_workid':            types.STRING,
         'work_disambig':        types.STRING,
         'arranger':             types.STRING,
+        'performer':            types.STRING,
         'grouping':             types.STRING,
         'year':                 types.PaddedInt(4),
         'month':                types.PaddedInt(2),

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -115,6 +115,8 @@ New features:
   :bug:`3459`
 * :doc:`/plugins/fetchart`: Album art can now be fetched from `last.fm`_.
   :bug:`3530`
+* A new tag ``performer`` has been added. 
+  Thanks to :user:`dosoe`.
 
 Fixes:
 

--- a/test/_common.py
+++ b/test/_common.py
@@ -69,6 +69,7 @@ def item(lib=None):
         lyricist=u'the lyricist',
         composer=u'the composer',
         arranger=u'the arranger',
+        performer=u'the performer',
         grouping=u'the grouping',
         work=u'the work title',
         mb_workid=u'the work musicbrainz id',


### PR DESCRIPTION
Gets the performer names and instruments/roles, puts them into a long list in the form ```performer1 (instrument1), performer2 (instrument2)``` . It has a few shortcomings:

-   it uses the names of the performers, which can be tricky (think of artists that use another alphabet)
-   if a performer has several roles, he appears several times
-   I don't look at the precise roles: if someone sings Carmen in an opera, she will appear as ```performer (soprano vocals)```
-   it creates one tag ```performer```, not one tag for each instrument/role

However, as discussed in https://github.com/beetbox/beets/pull/2563#issuecomment-554990758 this could be a start to tackle this issue. 