### PR TITLE
Add artist_sort as the last entry in the artists to search

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -206,7 +206,10 @@ def search_pairs(item):
         # Remove any featuring artists from the artists name
         r"(.*?) {0}".format(plugins.feat_tokens())]
     artists = generate_alternatives(artist, patterns)
-    artists.append(artist_sort)
+    # Use the artist_sort as fallback only if it differs from artist to avoid
+    # repeated remote requests with the same search terms
+    if artist != artist_sort:
+        artists.append(artist_sort)
 
     patterns = [
         # Remove a parenthesized suffix from a title string. Common

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -200,12 +200,13 @@ def search_pairs(item):
                 alternatives.append(match.group(1))
         return alternatives
 
-    title, artist = item.title, item.artist
+    title, artist, artist_sort = item.title, item.artist, item.artist_sort
 
     patterns = [
         # Remove any featuring artists from the artists name
         r"(.*?) {0}".format(plugins.feat_tokens())]
     artists = generate_alternatives(artist, patterns)
+    artists.append(artist_sort)
 
     patterns = [
         # Remove a parenthesized suffix from a title string. Common

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -187,6 +187,9 @@ def search_pairs(item):
     In addition to the artist and title obtained from the `item` the
     method tries to strip extra information like paranthesized suffixes
     and featured artists from the strings and add them as candidates.
+    The artist sort name is added as a fallback candidate to help in
+    cases where artist name includes special characters or is in a
+    non-latin script.
     The method also tries to split multiple titles separated with `/`.
     """
     def generate_alternatives(string, patterns):

--- a/test/test_lyrics.py
+++ b/test/test_lyrics.py
@@ -95,6 +95,27 @@ class LyricsPluginTest(unittest.TestCase):
         self.assertEqual(('Alice and Bob', ['song']),
                          list(lyrics.search_pairs(item))[0])
 
+    def test_search_artist_sort(self):
+        item = Item(artist='CHVRCHΞS', title='song', artist_sort='CHVRCHES')
+        self.assertIn(('CHVRCHΞS', ['song']),
+                      lyrics.search_pairs(item))
+        self.assertIn(('CHVRCHES', ['song']),
+                      lyrics.search_pairs(item))
+
+        # Make sure that the original artist name is still the first entry
+        self.assertEqual(('CHVRCHΞS', ['song']),
+                         list(lyrics.search_pairs(item))[0])
+
+        item = Item(artist='横山克', title='song', artist_sort='Masaru Yokoyama')
+        self.assertIn(('横山克', ['song']),
+                      lyrics.search_pairs(item))
+        self.assertIn(('Masaru Yokoyama', ['song']),
+                      lyrics.search_pairs(item))
+
+        # Make sure that the original artist name is still the first entry
+        self.assertEqual(('横山克', ['song']),
+                         list(lyrics.search_pairs(item))[0])
+
     def test_search_pairs_multi_titles(self):
         item = Item(title='1 / 2', artist='A')
         self.assertIn(('A', ['1 / 2']), lyrics.search_pairs(item))


### PR DESCRIPTION
This will handle cases where the artist name includes some
characters which can cause a search failure for some
websites - mainly unicode.

Fixes https://github.com/beetbox/beets/issues/3340.