### PR TITLE
Fix #3527

### DIFF
--- a/beetsplug/absubmit.py
+++ b/beetsplug/absubmit.py
@@ -164,8 +164,13 @@ only files which would be processed'
                     item=item, error=e
                 )
                 return None
+            decoded = bytearray()
             with open(filename, 'r') as tmp_file:
-                analysis = json.load(tmp_file)
+                byte = tmp_file.read(1)
+                while byte:
+                    decoded.extend(bytes(byte, 'utf-8'))
+                    byte = tmp_file.read(1)
+                analysis = json.loads(decoded)
             # Add the hash to the output.
             analysis['metadata']['version']['essentia_build_sha'] = \
                 self.extractor_sha

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -118,6 +118,9 @@ New features:
 
 Fixes:
 
+* :doc:`/plugins/absubmit`: Strings with characters that make a json
+  object invalid will no longer affect json.loads because they are parsed and
+  decoded to UTF-8.
 * :doc:`/plugins/fetchart`: Fixed a bug that caused fetchart to not take 
   environment variables such as proxy servers into account when making requests
   :bug:`3450`

--- a/test/test_acousticbrainz.py
+++ b/test/test_acousticbrainz.py
@@ -101,6 +101,14 @@ class MapDataToSchemeTest(unittest.TestCase):
         }
         self.assertEqual(mapping, expected)
 
+    def test_invalid_characters(self):
+        ab = AcousticPlugin()
+        data = {'key 1': "['?\x32\x96 233474']", 'key 2': '\xb9\x42'}
+        scheme = {'key 1': 'attribute 1', 'key 2': 'attribute 2'}
+        mapping = set(ab._map_data_to_scheme(data, scheme))
+        self.assertEqual(mapping, {('attribute 1', "['?\x32\x96 233474']"),
+                                   ('attribute 2', '\xb9\x42')})
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)


### PR DESCRIPTION
Fixes the absubmit plugin bug from #3527 where certain metadata tags in the json output can potentially contain characters that make the json invalid.

Solves this potential issue by reading in the file containing the JSON into a bytestring where each byte is read in using UTF-8 encoding, and creating the resulting JSON object from that bytestring rather than the file itself.

Closes: #3527