### PR TITLE
Fix #3533 - crash when calculating RG/R128 mix

### DIFF
--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -1326,10 +1326,10 @@ class ReplayGainPlugin(BeetsPlugin):
 
         if (any([self.should_use_r128(item) for item in album.items()]) and not
                 all(([self.should_use_r128(item) for item in album.items()]))):
-            raise ReplayGainError(
-                u"Mix of ReplayGain and EBU R128 detected"
-                u" for some tracks in album {0}".format(album)
-            )
+            self._log.info(
+                u"Cannot calculate gain for album {0} (incompatible formats)",
+                album)
+            return
 
         tag_vals = self.tag_specific_values(album.items())
         store_track_gain, store_album_gain, target_level, peak = tag_vals

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -185,6 +185,12 @@ Fixes:
   can help find matches when the artist name has special characters.
   Thanks to :user:`hashhar`.
   :bug:`3340` :bug:`3558`
+* :doc:`/plugins/replaygain`: Trying to calculate volume gain for an album
+  consisting of some formats using ``ReplayGain`` and some using ``R128``
+  will no longer crash; instead it is skipped and and a message is logged.
+  The log message has also been rewritten for to improve clarity.
+  Thanks to :user:`autrimpo`.
+  :bug:`3533`
 
 For plugin developers:
 


### PR DESCRIPTION
I've moved the check into the `try` block as per the discussion in #3533.
I've also rewritten the message, hopefully it is clearer now.