### PR TITLE
web plugin: support path queries

### DIFF
--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -177,10 +177,11 @@ class QueryConverter(PathConverter):
     """
 
     def to_python(self, value):
-        return value.split('/')
+        queries = value.split('/')
+        return [query.replace('\\', os.sep) for query in queries]
 
     def to_url(self, value):
-        return ','.join(value)
+        return ','.join([v.replace(os.sep, '\\') for v in value])
 
 
 class EverythingConverter(PathConverter):

--- a/docs/plugins/web.rst
+++ b/docs/plugins/web.rst
@@ -213,7 +213,11 @@ If the server runs UNIX, you'll need to include an extra leading slash:
 Returns a list of tracks matching the query. The *querystring* must be a
 valid query as described in :doc:`/reference/query`. Path elements are
 joined as query keywords. For example, ``/item/query/foo/bar`` will be
-converted to the query ``foo,bar``. ::
+converted to the query ``foo,bar``. As this conflicts with using a slash
+character as a path seperator in path queries, a backlash character
+should be used in these queries instead. This character is converted to
+the path seperator actually used by the operating system before the
+query is performed. ::
 
     {
       "results": [

--- a/docs/plugins/web.rst
+++ b/docs/plugins/web.rst
@@ -210,7 +210,10 @@ If the server runs UNIX, you'll need to include an extra leading slash:
 ``GET /item/query/querystring``
 +++++++++++++++++++++++++++++++
 
-Returns a list of tracks matching the query. The *querystring* must be a valid query as described in :doc:`/reference/query`. ::
+Returns a list of tracks matching the query. The *querystring* must be a
+valid query as described in :doc:`/reference/query`. Path elements are
+joined as query keywords. For example, ``/item/query/foo/bar`` will be
+converted to the query ``foo,bar``. ::
 
     {
       "results": [


### PR DESCRIPTION
The QueryConverter was added without much further explanation in commit
004e9a8144cd120f6f245dd9865db469c243d34d. Unfortunately, the query
converter breaks path queries as flask cannot distinguish between an
URL encoded and a plain '/' character during routing [\[0\]][0]. Additionally,
I don't get why the QueryConverter is needed in the first place as ','
characters can just be used in the URL directly. For example:
`/item/query/foo,bar`. As conversions of slashes into comma characters
wasn't documented anyhow removing this code shouldn't cause much harm.

Fixes #3566

[0]: https://github.com/pallets/flask/issues/900