### PR TITLE
fetchart: clean up tmp, add 'embedded' source

### DIFF
--- a/beets/art.py
+++ b/beets/art.py
@@ -206,7 +206,7 @@ def extract(log, item, outpath=None):
 
     # Append suffix to outpath / create tmp file with suffix
     if outpath is not None:
-        outpath = bytestring_path(outpath + '.' + ext)
+        outpath = bytestring_path(outpath) + bytestring_path('.' + ext)
     else:
         outpath = tmp_path_for('_.' + ext)
 

--- a/beets/art.py
+++ b/beets/art.py
@@ -24,7 +24,7 @@ import platform
 from tempfile import NamedTemporaryFile
 import os
 
-from beets.util import displayable_path, syspath, bytestring_path
+from beets.util import displayable_path, syspath, bytestring_path, tmp_path_for
 from beets.util.artresizer import ArtResizer
 import mediafile
 
@@ -121,7 +121,7 @@ def check_art_similarity(log, item, imagepath, compare_threshold):
     """A boolean indicating if an image is similar to embedded item art.
     """
     with NamedTemporaryFile(delete=True) as f:
-        art = extract(log, f.name, item)
+        art = extract(log, item=item, outpath=f.name)
 
         if art:
             is_windows = platform.system() == "Windows"
@@ -189,20 +189,26 @@ def check_art_similarity(log, item, imagepath, compare_threshold):
     return True
 
 
-def extract(log, outpath, item):
+def extract(log, item, outpath=None):
+    """Extract art from item into outpath, or into a tmp file if unset.
+    """
     art = get_art(log, item)
-    outpath = bytestring_path(outpath)
     if not art:
         log.info(u'No album art present in {0}, skipping.', item)
         return
 
-    # Add an extension to the filename.
+    # Discover image file extension
     ext = mediafile.image_extension(art)
     if not ext:
         log.warning(u'Unknown image type in {0}.',
                     displayable_path(item.path))
         return
-    outpath += bytestring_path('.' + ext)
+
+    # Append suffix to outpath / create tmp file with suffix
+    if outpath is not None:
+        outpath = bytestring_path(outpath + '.' + ext)
+    else:
+        outpath = tmp_path_for('_.' + ext)
 
     log.info(u'Extracting album art from: {0} to: {1}',
              item, displayable_path(outpath))
@@ -213,7 +219,7 @@ def extract(log, outpath, item):
 
 def extract_first(log, outpath, items):
     for item in items:
-        real_path = extract(log, outpath, item)
+        real_path = extract(log, item=item, outpath=outpath)
         if real_path:
             return real_path
 

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -34,6 +34,7 @@ from beets.util import hidden
 import six
 from unidecode import unidecode
 from enum import Enum
+from tempfile import NamedTemporaryFile
 
 
 MAX_FILENAME_LENGTH = 200
@@ -543,6 +544,16 @@ def hardlink(path, dest, replace=False):
         else:
             raise FilesystemError(exc, 'link', (path, dest),
                                   traceback.format_exc())
+
+
+def tmp_path_for(path=None):
+    """Returns a path to a named temporary file with the same file extension as
+    ``path``.  If ``path`` is not provided, a named temporary file with no
+    extension is returned.
+    """
+    ext = os.path.splitext(path or '')[1]
+    with NamedTemporaryFile(suffix=py3_path(ext), delete=False) as f:
+        return bytestring_path(f.name)
 
 
 def unique_path(path):

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -55,20 +55,11 @@ def resize_url(url, maxwidth, quality=0):
     return '{0}?{1}'.format(PROXY_URL, urlencode(params))
 
 
-def temp_file_for(path):
-    """Return an unused filename with the same extension as the
-    specified path.
-    """
-    ext = os.path.splitext(path)[1]
-    with NamedTemporaryFile(suffix=util.py3_path(ext), delete=False) as f:
-        return util.bytestring_path(f.name)
-
-
 def pil_resize(maxwidth, path_in, path_out=None, quality=0):
     """Resize using Python Imaging Library (PIL).  Return the output path
     of resized image.
     """
-    path_out = path_out or temp_file_for(path_in)
+    path_out = path_out or util.tmp_path_for(path_in)
     from PIL import Image
     log.debug(u'artresizer: PIL resizing {0} to {1}',
               util.displayable_path(path_in), util.displayable_path(path_out))
@@ -91,7 +82,7 @@ def im_resize(maxwidth, path_in, path_out=None, quality=0):
     Use the ``magick`` program or ``convert`` on older versions. Return
     the output path of resized image.
     """
-    path_out = path_out or temp_file_for(path_in)
+    path_out = path_out or util.tmp_path_for(path_in)
     log.debug(u'artresizer: ImageMagick resizing {0} to {1}',
               util.displayable_path(path_in), util.displayable_path(path_out))
 

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -19,9 +19,7 @@ public resizing proxy if neither is available.
 from __future__ import division, absolute_import, print_function
 
 import subprocess
-import os
 import re
-from tempfile import NamedTemporaryFile
 from six.moves.urllib.parse import urlencode
 from beets import logging
 from beets import util

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -30,6 +30,7 @@ from beets import importer
 from beets import ui
 from beets import util
 from beets import config
+from beets import art
 from mediafile import image_mime_type
 from beets.util.artresizer import ArtResizer
 from beets.util import sorted_walk
@@ -55,9 +56,10 @@ class Candidate(object):
     MATCH_EXACT = 0
     MATCH_FALLBACK = 1
 
-    def __init__(self, log, path=None, url=None, source=u'',
+    def __init__(self, log, item=None, path=None, url=None, source=u'',
                  match=None, size=None):
         self._log = log
+        self.item = item
         self.path = path
         self.url = url
         self.source = source
@@ -211,7 +213,11 @@ class ArtSource(RequestMixin):
         raise NotImplementedError()
 
     def cleanup_tmp(self, candidate):
-        raise NotImplementedError()
+        if candidate.path:
+            try:
+                util.remove(path=candidate.path)
+            except util.FilesystemError as exc:
+                self._log.warning(u'error cleaning up tmp art: {}', exc)
 
 
 class LocalArtSource(ArtSource):
@@ -224,6 +230,17 @@ class LocalArtSource(ArtSource):
     def cleanup_tmp(self, candidate):
         # local art source does not create tmp files
         pass
+
+
+class EmbeddedArtSource(ArtSource):
+  IS_LOCAL = True
+  LOC_STR = u'embedded'
+
+  def fetch_image(self, candidate, plugin):
+      # extract best album art from candidate.item
+      tmp_path = art.extract(self._log, item=candidate.item)
+      if tmp_path:
+          candidate.path = tmp_path
 
 
 class RemoteArtSource(ArtSource):
@@ -297,13 +314,6 @@ class RemoteArtSource(ArtSource):
             # https://github.com/shazow/urllib3/issues/556
             self._log.debug(u'error fetching art: {}', exc)
             return
-
-    def cleanup_tmp(self, candidate):
-        if candidate.path:
-            try:
-                util.remove(path=candidate.path)
-            except util.FilesystemError as exc:
-                self._log.warning(u'error cleaning up tmp art: {}', exc)
 
 
 class CoverArtArchive(RemoteArtSource):
@@ -757,6 +767,14 @@ class FileSystem(LocalArtSource):
                                       match=Candidate.MATCH_FALLBACK)
 
 
+class Embedded(EmbeddedArtSource):
+    NAME = u"Embedded"
+
+    def get(self, album, plugin, paths):
+        for item in album.items():
+            yield self._candidate(item=item, match=Candidate.MATCH_EXACT)
+
+
 class LastFM(RemoteArtSource):
     NAME = u"Last.fm"
 
@@ -820,12 +838,13 @@ class LastFM(RemoteArtSource):
 
 # Try each source in turn.
 
-SOURCES_ALL = [u'filesystem',
+SOURCES_ALL = [u'filesystem', u'embedded',
                u'coverart', u'itunes', u'amazon', u'albumart',
                u'wikipedia', u'google', u'fanarttv', u'lastfm']
 
 ART_SOURCES = {
     u'filesystem': FileSystem,
+    u'embedded': Embedded,
     u'coverart': CoverArtArchive,
     u'itunes': ITunesStore,
     u'albumart': AlbumArtOrg,

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -233,14 +233,14 @@ class LocalArtSource(ArtSource):
 
 
 class EmbeddedArtSource(ArtSource):
-  IS_LOCAL = True
-  LOC_STR = u'embedded'
+    IS_LOCAL = True
+    LOC_STR = u'embedded'
 
-  def fetch_image(self, candidate, plugin):
-      # extract best album art from candidate.item
-      tmp_path = art.extract(self._log, item=candidate.item)
-      if tmp_path:
-          candidate.path = tmp_path
+    def fetch_image(self, candidate, plugin):
+        # extract best album art from candidate.item
+        tmp_path = art.extract(self._log, item=candidate.item)
+        if tmp_path:
+            candidate.path = tmp_path
 
 
 class RemoteArtSource(ArtSource):
@@ -478,11 +478,11 @@ class FanartTV(RemoteArtSource):
 
         matches = []
         # can there be more than one releasegroupid per response?
-        for mbid, art in data.get(u'albums', dict()).items():
+        for mbid, art_ in data.get(u'albums', dict()).items():
             # there might be more art referenced, e.g. cdart, and an albumcover
             # might not be present, even if the request was successful
-            if album.mb_releasegroupid == mbid and u'albumcover' in art:
-                matches.extend(art[u'albumcover'])
+            if album.mb_releasegroupid == mbid and u'albumcover' in art_:
+                matches.extend(art_[u'albumcover'])
             # can this actually occur?
             else:
                 self._log.debug(u'fanart.tv: unexpected mb_releasegroupid in '


### PR DESCRIPTION
 **de83ffe fetchart: clean up invalid tmp files** 

The remote album art sources write into `NamedTemporaryFile`s in order to check image type and dimensions.  However, when an image fails validation, it doesn't seem to get removed from /tmp.  I was fetching art for a large library with aggressive size filters, and found a bunch of temp album art crud piling up there, so I wanted fetchart to clean up after itself a bit.

This commit introduces a `cleanup_tmp(candidate)` method on sources, which is only called on candidates that fail validation.  The `LocalArtSource` has a no-op implementation, but `RemoteArtSource` simply calls `util.remove(candidate.path)`.

There is probably some more tmp cleanup work that could be done in the future.  If you're importing with `copy` or `link`, for example, any fetched art that passes validation seems to remain in /tmp.  I also noticed that the `ArtResizer` class also seems to leave tmp files lying about.  But this solves at least one problem so I wanted to get some feedback.


**a8c8ae7 fetchart: add embedded source**

I wanted the inverse of the EmbedArt plugin; i.e. extract album art from tags, and save it as a local file.  This plugin introduces the "embedded" source type, which calls `art.extract()` on each member of `album.items()` until a validating image is found.

A new `EmbeddedArtSource`class is introduced, whose `fetch_image` simply calls `art.extract(item=candidate.item)`.  This meant I needed to keep track of each `item`, so I added that optional argument to the `Candidate` constructor.

I also found it easiest to let `art.extract()` create its own tempfile if the `outpath` argument is set to None.  This is mainly because that function internally adds a file extension to the provided `outpath`, and I don't know if there is a 100% safe way of generating a tmpfile prefix and guaranteeing that prefix + ".jpg" doesn't already exist (for example).  Maybe I'm just being too paranoid...

As part of that work, I added `util.temp_path_for` and moved that method out of artresizer, and renamed it slightly (was formerly `temp_file_for`).

Importantly, this also required me to change the signature of `art.extract()` to move the now-optional `outpath` argument to the end.  I think I updated all invocations of this function in the beets repo, but I'm not sure what the policy is on changing method signatures like that... as 3rd party plugins that call the function with positional arguments are probably out there.  I could easily update the PR to keep `art.extract()` and `artresizer.temp_file_for` unchanged if need be!