### PR TITLE
fetchart: clean up invalid tmp files

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -210,12 +210,19 @@ class ArtSource(RequestMixin):
     def fetch_image(self, candidate, plugin):
         raise NotImplementedError()
 
+    def cleanup_tmp(self, candidate):
+        raise NotImplementedError()
+
 
 class LocalArtSource(ArtSource):
     IS_LOCAL = True
     LOC_STR = u'local'
 
     def fetch_image(self, candidate, plugin):
+        pass
+
+    def cleanup_tmp(self, candidate):
+        # local art source does not create tmp files
         pass
 
 
@@ -290,6 +297,13 @@ class RemoteArtSource(ArtSource):
             # https://github.com/shazow/urllib3/issues/556
             self._log.debug(u'error fetching art: {}', exc)
             return
+
+    def cleanup_tmp(self, candidate):
+        if candidate.path:
+            try:
+                util.remove(path=candidate.path)
+            except util.FilesystemError as exc:
+                self._log.debug(u'error cleaning up tmp art: {}', exc)
 
 
 class CoverArtArchive(RemoteArtSource):
@@ -1017,6 +1031,8 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                             u'using {0.LOC_STR} image {1}'.format(
                                 source, util.displayable_path(out.path)))
                         break
+                    # else: remove tmp images created by this invalid candidate
+                    source.cleanup_tmp(candidate)
                 if out:
                     break
 

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -210,8 +210,8 @@ class ArtSource(RequestMixin):
     def fetch_image(self, candidate, plugin):
         raise NotImplementedError()
 
-    def cleanup_tmp(self, candidate):
-        raise NotImplementedError()
+    def cleanup(self, candidate):
+        pass
 
 
 class LocalArtSource(ArtSource):
@@ -219,10 +219,6 @@ class LocalArtSource(ArtSource):
     LOC_STR = u'local'
 
     def fetch_image(self, candidate, plugin):
-        pass
-
-    def cleanup_tmp(self, candidate):
-        # local art source does not create tmp files
         pass
 
 
@@ -298,7 +294,7 @@ class RemoteArtSource(ArtSource):
             self._log.debug(u'error fetching art: {}', exc)
             return
 
-    def cleanup_tmp(self, candidate):
+    def cleanup(self, candidate):
         if candidate.path:
             try:
                 util.remove(path=candidate.path)
@@ -1031,8 +1027,8 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                             u'using {0.LOC_STR} image {1}'.format(
                                 source, util.displayable_path(out.path)))
                         break
-                    # else: remove tmp images created by this invalid candidate
-                    source.cleanup_tmp(candidate)
+                    # Remove temporary files for invalid candidates.
+                    source.cleanup(candidate)
                 if out:
                     break
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -122,9 +122,11 @@ New features:
 
 Fixes:
 
-* :doc:`/plugins/fetchart`: Fixed a bug that caused fetchart to not take 
+* :doc:`/plugins/fetchart`: Fixed a bug that caused fetchart to not take
   environment variables such as proxy servers into account when making requests
   :bug:`3450`
+* :doc:`/plugins/fetchart`: Temporary files for fetched album art that fail
+  validation are now removed
 * :doc:`/plugins/inline`: In function-style field definitions that refer to
   flexible attributes, values could stick around from one function invocation
   to the next. This meant that, when displaying a list of objects, later


### PR DESCRIPTION
The remote album art sources write into `NamedTemporaryFile`s in order to check image type and dimensions.  However, when an image fails validation, it doesn't seem to get removed from /tmp.  I was fetching art for a large library with aggressive size filters, and found a bunch of temp album art crud piling up there, so I wanted fetchart to clean up after itself a bit.

This commit introduces a `cleanup_tmp(candidate)` method on sources, which is only called on candidates that fail validation.  The `LocalArtSource` has a no-op implementation, but `RemoteArtSource` simply calls `util.remove(candidate.path)`.

There is probably some more tmp cleanup work that could be done in the future.  If you're importing with `copy` or `link`, for example, any fetched art that passes validation seems to remain in /tmp.  I also noticed that the `ArtResizer` class also seems to leave tmp files lying about.  But this solves at least one problem so I wanted to get some feedback.