### PR TITLE
fetchart: add embedded source for #1130

### DIFF
--- a/beets/art.py
+++ b/beets/art.py
@@ -24,7 +24,7 @@ import platform
 from tempfile import NamedTemporaryFile
 import os
 
-from beets.util import displayable_path, syspath, bytestring_path, tmp_path_for
+from beets.util import displayable_path, syspath, bytestring_path, tmp_file_for
 from beets.util.artresizer import ArtResizer
 import mediafile
 
@@ -121,7 +121,7 @@ def check_art_similarity(log, item, imagepath, compare_threshold):
     """A boolean indicating if an image is similar to embedded item art.
     """
     with NamedTemporaryFile(delete=True) as f:
-        art = extract(log, item=item, outpath=f.name)
+        art = extract(log, f.name, item)
 
         if art:
             is_windows = platform.system() == "Windows"
@@ -189,8 +189,9 @@ def check_art_similarity(log, item, imagepath, compare_threshold):
     return True
 
 
-def extract(log, item, outpath=None):
-    """Extract art from item into outpath, or into a tmp file if unset.
+def extract(log, outpath, item):
+    """Extract art from item into outpath with an appropriate file extension,
+    or into a tmp file if outpath is unset.
     """
     art = get_art(log, item)
     if not art:
@@ -208,7 +209,7 @@ def extract(log, item, outpath=None):
     if outpath:
         outpath = bytestring_path(outpath) + bytestring_path('.' + ext)
     else:
-        outpath = tmp_path_for('_.' + ext)
+        outpath = tmp_file_for('_.' + ext)
 
     log.info(u'Extracting album art from: {0} to: {1}',
              item, displayable_path(outpath))
@@ -219,7 +220,7 @@ def extract(log, item, outpath=None):
 
 def extract_first(log, outpath, items):
     for item in items:
-        real_path = extract(log, item=item, outpath=outpath)
+        real_path = extract(log, outpath, item)
         if real_path:
             return real_path
 

--- a/beets/art.py
+++ b/beets/art.py
@@ -198,14 +198,15 @@ def extract(log, outpath, item):
         log.info(u'No album art present in {0}, skipping.', item)
         return
 
-    # Discover image file extension
+    # Discover the image's file extension.
     ext = mediafile.image_extension(art)
     if not ext:
         log.warning(u'Unknown image type in {0}.',
                     displayable_path(item.path))
         return
 
-    # Append extension to outpath / create tmp file with extension
+    # Append the extension to destination path, creating a temporary file
+    # if no destination is specified.
     if outpath:
         outpath = bytestring_path(outpath) + bytestring_path('.' + ext)
     else:

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -547,7 +547,7 @@ def hardlink(path, dest, replace=False):
 
 
 def tmp_file_for(path=''):
-    """Returns a path to a named temporary file with the same file extension as
+    """Return a path to a named temporary file with the same file extension as
     ``path``.  If ``path`` is not provided, a named temporary file with no
     extension is returned.
     """

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -546,7 +546,7 @@ def hardlink(path, dest, replace=False):
                                   traceback.format_exc())
 
 
-def tmp_path_for(path=''):
+def tmp_file_for(path=''):
     """Returns a path to a named temporary file with the same file extension as
     ``path``.  If ``path`` is not provided, a named temporary file with no
     extension is returned.

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -34,6 +34,7 @@ from beets.util import hidden
 import six
 from unidecode import unidecode
 from enum import Enum
+from tempfile import NamedTemporaryFile
 
 
 MAX_FILENAME_LENGTH = 200
@@ -543,6 +544,16 @@ def hardlink(path, dest, replace=False):
         else:
             raise FilesystemError(exc, 'link', (path, dest),
                                   traceback.format_exc())
+
+
+def tmp_path_for(path=''):
+    """Returns a path to a named temporary file with the same file extension as
+    ``path``.  If ``path`` is not provided, a named temporary file with no
+    extension is returned.
+    """
+    ext = os.path.splitext(path)[1]
+    with NamedTemporaryFile(suffix=py3_path(ext), delete=False) as f:
+        return bytestring_path(f.name)
 
 
 def unique_path(path):

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -57,7 +57,7 @@ def pil_resize(maxwidth, path_in, path_out=None, quality=0):
     """Resize using Python Imaging Library (PIL).  Return the output path
     of resized image.
     """
-    path_out = path_out or util.tmp_path_for(path_in)
+    path_out = path_out or util.tmp_file_for(path_in)
     from PIL import Image
     log.debug(u'artresizer: PIL resizing {0} to {1}',
               util.displayable_path(path_in), util.displayable_path(path_out))
@@ -80,7 +80,7 @@ def im_resize(maxwidth, path_in, path_out=None, quality=0):
     Use the ``magick`` program or ``convert`` on older versions. Return
     the output path of resized image.
     """
-    path_out = path_out or util.tmp_path_for(path_in)
+    path_out = path_out or util.tmp_file_for(path_in)
     log.debug(u'artresizer: ImageMagick resizing {0} to {1}',
               util.displayable_path(path_in), util.displayable_path(path_out))
 

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -19,9 +19,7 @@ public resizing proxy if neither is available.
 from __future__ import division, absolute_import, print_function
 
 import subprocess
-import os
 import re
-from tempfile import NamedTemporaryFile
 from six.moves.urllib.parse import urlencode
 from beets import logging
 from beets import util
@@ -55,20 +53,11 @@ def resize_url(url, maxwidth, quality=0):
     return '{0}?{1}'.format(PROXY_URL, urlencode(params))
 
 
-def temp_file_for(path):
-    """Return an unused filename with the same extension as the
-    specified path.
-    """
-    ext = os.path.splitext(path)[1]
-    with NamedTemporaryFile(suffix=util.py3_path(ext), delete=False) as f:
-        return util.bytestring_path(f.name)
-
-
 def pil_resize(maxwidth, path_in, path_out=None, quality=0):
     """Resize using Python Imaging Library (PIL).  Return the output path
     of resized image.
     """
-    path_out = path_out or temp_file_for(path_in)
+    path_out = path_out or util.tmp_path_for(path_in)
     from PIL import Image
     log.debug(u'artresizer: PIL resizing {0} to {1}',
               util.displayable_path(path_in), util.displayable_path(path_out))
@@ -91,7 +80,7 @@ def im_resize(maxwidth, path_in, path_out=None, quality=0):
     Use the ``magick`` program or ``convert`` on older versions. Return
     the output path of resized image.
     """
-    path_out = path_out or temp_file_for(path_in)
+    path_out = path_out or util.tmp_path_for(path_in)
     log.debug(u'artresizer: ImageMagick resizing {0} to {1}',
               util.displayable_path(path_in), util.displayable_path(path_out))
 


### PR DESCRIPTION
I wanted the inverse of the EmbedArt plugin; i.e. extract album art from tags, and save it as a local file.  This plugin introduces the "embedded" source type, which calls `art.extract()` on each member of `album.items()` until a validating image is found.

A new `EmbeddedArtSource`class is introduced, whose `fetch_image` simply calls `art.extract(item=candidate.item)`.  This meant I needed to keep track of each `item`, so I added that optional argument to the `Candidate` constructor.

I also found it easiest to let `art.extract()` create its own tempfile if the `outpath` argument is set to None.  This is mainly because that function internally adds a file extension to the provided `outpath`, and I don't know if there is a 100% safe way of generating a tmpfile prefix and guaranteeing that prefix + ".jpg" doesn't already exist (for example).  Maybe I'm just being too paranoid...

As part of that work, I added `util.temp_path_for` and moved that method out of artresizer, and renamed it slightly (was formerly `temp_file_for`).

Importantly, this also required me to change the signature of `art.extract()` to move the now-optional `outpath` argument to the end.  I think I updated all invocations of this function in the beets repo, but I'm not sure what the policy is on changing method signatures like that... as 3rd party plugins that call the function with positional arguments are probably out there.  I could easily update the PR to keep `art.extract()` and `artresizer.temp_file_for` unchanged if need be!