### PR TITLE
Fetching parentwork if changed, even if not force

### DIFF
--- a/beetsplug/parentwork.py
+++ b/beetsplug/parentwork.py
@@ -174,16 +174,16 @@ add one at https://musicbrainz.org/recording/{}', item, item.mb_trackid)
 
         hasparent = hasattr(item, 'parentwork')
         workfalse = True
-        if hasattr(item, 'mb_workid_current'):
+        if hasattr(item, 'parentwork_workid_current'):
             workfalse = item.mb_workid_current != item.mb_workid
-        if force or (not hasparent) or workfalse:
+        if force or not hasparent or workfalse:
             try:
                 work_info, work_date = find_parentwork_info(item.mb_workid)
             except musicbrainzngs.musicbrainz.WebServiceError as e:
                 self._log.debug("error fetching work: {}", e)
                 return
             parent_info = self.get_info(item, work_info)
-            parent_info['mb_workid_current'] = item.mb_workid
+            parent_info['parentwork_workid_current'] = item.mb_workid
             if 'parent_composer' in parent_info:
                 self._log.debug("Work fetched: {} - {}",
                                 parent_info['parentwork'],
@@ -207,4 +207,4 @@ add one at https://musicbrainz.org/recording/{}', item, item.mb_trackid)
             item, fields=['parentwork', 'parentwork_disambig',
                           'mb_parentworkid', 'parent_composer',
                           'parent_composer_sort', 'work_date',
-                          'mb_workid_current'])
+                          'parentwork_workid_current'])

--- a/beetsplug/parentwork.py
+++ b/beetsplug/parentwork.py
@@ -173,13 +173,17 @@ add one at https://musicbrainz.org/recording/{}', item, item.mb_trackid)
             return
 
         hasparent = hasattr(item, 'parentwork')
-        if force or not hasparent:
+        workfalse = True
+        if hasattr(item, 'mb_workid_current'):
+            workfalse = item.mb_workid_current != item.mb_workid
+        if force or (not hasparent) or workfalse:
             try:
                 work_info, work_date = find_parentwork_info(item.mb_workid)
             except musicbrainzngs.musicbrainz.WebServiceError as e:
                 self._log.debug("error fetching work: {}", e)
                 return
             parent_info = self.get_info(item, work_info)
+            parent_info['mb_workid_current'] = item.mb_workid
             if 'parent_composer' in parent_info:
                 self._log.debug("Work fetched: {} - {}",
                                 parent_info['parentwork'],
@@ -202,4 +206,5 @@ add one at https://musicbrainz.org/recording/{}', item, item.mb_trackid)
         return ui.show_model_changes(
             item, fields=['parentwork', 'parentwork_disambig',
                           'mb_parentworkid', 'parent_composer',
-                          'parent_composer_sort', 'work_date'])
+                          'parent_composer_sort', 'work_date',
+                          'mb_workid_current'])

--- a/beetsplug/parentwork.py
+++ b/beetsplug/parentwork.py
@@ -173,10 +173,10 @@ add one at https://musicbrainz.org/recording/{}', item, item.mb_trackid)
             return
 
         hasparent = hasattr(item, 'parentwork')
-        workfalse = True
+        work_changed = True
         if hasattr(item, 'parentwork_workid_current'):
-            workfalse = item.mb_workid_current != item.mb_workid
-        if force or not hasparent or workfalse:
+            work_changed = item.mb_workid_current != item.mb_workid
+        if force or not hasparent or work_changed:
             try:
                 work_info, work_date = find_parentwork_info(item.mb_workid)
             except musicbrainzngs.musicbrainz.WebServiceError as e:

--- a/docs/plugins/parentwork.rst
+++ b/docs/plugins/parentwork.rst
@@ -18,6 +18,12 @@ example, all the movements of a symphony. This plugin aims to solve this
 problem by also fetching the parent work, which would be the whole symphony in
 this example.
 
+It uses the ``mb_workid`` tag to retrieve the *parent work* and stores the
+``mb_workid`` as ``parentwork_workid_current``. When one executes 
+``beet parentwork`` it checks if ``mb_workid`` has changed by comparing it
+with ``parentwork_workid_current``, if it has changed or if ``force`` is
+enabled it fetches the *parent work* again.
+
 This plugin adds six tags:
 
 - **parentwork**: The title of the parent work.
@@ -27,7 +33,7 @@ This plugin adds six tags:
 - **parent_composer_sort**: The sort name of the parent work composer.
 - **work_date**: The composition date of the work, or the first parent work
   that has a composition date. Format: yyyy-mm-dd.
-- **parentwork_workid_current**: The musicbrainz id of the work as it was when
+- **parentwork_workid_current**: The Musicbrainz id of the work as it was when
   the parentwork was retrieved. This tag exists only for internal bookkeeping,
   to keep track of recordings whose work have changed. 
 
@@ -41,7 +47,8 @@ To configure the plugin, make a ``parentwork:`` section in your
 configuration file. The available options are:
 
 - **force**: As a default, ``parentwork`` only fetches work info for
-  recordings that do not already have a ``parentwork`` tag. If ``force``
+  recordings that do not already have a ``parentwork`` tag or where 
+  ``mb_workid`` differs from ``parentwork_workid_current``. If ``force``
   is enabled, it fetches it for all recordings.
   Default: ``no``
 

--- a/docs/plugins/parentwork.rst
+++ b/docs/plugins/parentwork.rst
@@ -18,7 +18,7 @@ example, all the movements of a symphony. This plugin aims to solve this
 problem by also fetching the parent work, which would be the whole symphony in
 this example.
 
-This plugin adds five tags:
+This plugin adds six tags:
 
 - **parentwork**: The title of the parent work.
 - **mb_parentworkid**: The musicbrainz id of the parent work.
@@ -27,6 +27,9 @@ This plugin adds five tags:
 - **parent_composer_sort**: The sort name of the parent work composer.
 - **work_date**: The composition date of the work, or the first parent work
   that has a composition date. Format: yyyy-mm-dd.
+- **parentwork_workid_current**: The musicbrainz id of the work as it was when
+  the parentwork was retrieved. This tag exists only for internal bookkeeping,
+  to keep track of recordings whose work have changed. 
 
 To use the ``parentwork`` plugin, enable it in your configuration (see
 :ref:`using-plugins`).

--- a/docs/plugins/parentwork.rst
+++ b/docs/plugins/parentwork.rst
@@ -35,7 +35,7 @@ This plugin adds six tags:
   that has a composition date. Format: yyyy-mm-dd.
 - **parentwork_workid_current**: The Musicbrainz id of the work as it was when
   the parentwork was retrieved. This tag exists only for internal bookkeeping,
-  to keep track of recordings whose work have changed. 
+  to keep track of recordings whose works have changed. 
 
 To use the ``parentwork`` plugin, enable it in your configuration (see
 :ref:`using-plugins`).

--- a/docs/plugins/parentwork.rst
+++ b/docs/plugins/parentwork.rst
@@ -18,22 +18,24 @@ example, all the movements of a symphony. This plugin aims to solve this
 problem by also fetching the parent work, which would be the whole symphony in
 this example.
 
-It uses the ``mb_workid`` tag to retrieve the *parent work* and stores the
-``mb_workid`` as ``parentwork_workid_current``. When one executes 
-``beet parentwork`` it checks if ``mb_workid`` has changed by comparing it
-with ``parentwork_workid_current``, if it has changed or if ``force`` is
-enabled it fetches the *parent work* again.
+The plugin can detect changes in ``mb_workid`` so it knows when to re-fetch
+other metadata, such as ``parentwork``. To do this, when it runs, it stores a
+copy of ``mb_workid`` in the bookkeeping field ``parentwork_workid_current``.
+At any later run of ``beet parentwork`` it will check if the tags
+``mb_workid`` and ``parentwork_workid_current`` are still identical. If it is
+not the case, it means the work has changed and all the tags need to be
+fetched again.
 
 This plugin adds six tags:
 
 - **parentwork**: The title of the parent work.
-- **mb_parentworkid**: The musicbrainz id of the parent work.
+- **mb_parentworkid**: The MusicBrainz id of the parent work.
 - **parentwork_disambig**: The disambiguation of the parent work title.
 - **parent_composer**: The composer of the parent work.
 - **parent_composer_sort**: The sort name of the parent work composer.
 - **work_date**: The composition date of the work, or the first parent work
   that has a composition date. Format: yyyy-mm-dd.
-- **parentwork_workid_current**: The Musicbrainz id of the work as it was when
+- **parentwork_workid_current**: The MusicBrainz id of the work as it was when
   the parentwork was retrieved. This tag exists only for internal bookkeeping,
   to keep track of recordings whose works have changed. 
 
@@ -53,5 +55,5 @@ configuration file. The available options are:
   Default: ``no``
 
 - **auto**: If enabled, automatically fetches works at import. It takes quite
-  some time, because beets is restricted to one musicbrainz query per second.
+  some time, because beets is restricted to one MusicBrainz query per second.
   Default: ``no``


### PR DESCRIPTION
Add a new tag, ```mb_workid_current``` that is checked when performing ```beet parentwork``` to check if some works changed and update the parentworks, updating changed works without having to check all parentworks. 