### PR TITLE
Correct beet/autotag/__init__.py to adapt to flexible tags

### DIFF
--- a/beets/autotag/__init__.py
+++ b/beets/autotag/__init__.py
@@ -35,6 +35,41 @@ from .match import Recommendation  # noqa
 # Global logger.
 log = logging.getLogger('beets')
 
+# metadata that is already hardcoded
+MISC_FIELDS = {
+    'album': (
+        'va',
+        'releasegroup_id',
+        'artist_id',
+        'album_id',
+        'mediums',
+        'tracks',
+        'year',
+        'month',
+        'day',
+        'artist',
+        'artist_credit',
+        'artist_sort',
+        'data_url'
+    ),
+    'track': (
+        'track_alt',
+        'artist_id',
+        'release_track_id',
+        'medium',
+        'index',
+        'medium_index',
+        'title',
+        'artist_credit',
+        'artist_sort',
+        'artist',
+        'track_id',
+        'medium_total',
+        'data_url',
+        'length'
+    )
+}
+
 
 # Additional utilities for the main interface.
 
@@ -52,23 +87,11 @@ def apply_item_metadata(item, track_info):
     if track_info.data_source:
         item.data_source = track_info.data_source
 
-    misc_fields = ['artist_id',
-                   'release_track_id',
-                   'title',
-                   'artist_credit',
-                   'artist_sort',
-                   'artist',
-                   'track_id',
-                   'data_url',
-                   'length'
-                   ]
-
-    for field in track_info.keys():
-        if field in misc_fields:
+    for field, value in track_info.items():
+        # only overwrite fields that are not already hardcoded
+        if field in MISC_FIELDS['track']:
             continue
-        clobber = field in config['overwrite_null']['track'].as_str_seq()
-        value = getattr(track_info, field)
-        if value is None and not clobber:
+        if value is None:
             continue
         item[field] = value
 
@@ -162,54 +185,20 @@ def apply_metadata(album_info, mapping):
         # Track alt.
         item.track_alt = track_info.track_alt
 
-        # Metadata that has already been set
-        misc_fields = {
-            'album': (
-                'va',
-                'releasegroup_id',
-                'artist_id',
-                'album_id',
-                'mediums',
-                'tracks',
-                'year',
-                'month',
-                'day',
-                'artist',
-                'artist_credit',
-                'artist_sort',
-                'data_url'
-            ),
-            'track': (
-                'track_alt',
-                'artist_id',
-                'release_track_id',
-                'medium',
-                'index',
-                'medium_index',
-                'title',
-                'artist_credit',
-                'artist_sort',
-                'artist',
-                'track_id',
-                'medium_total',
-                'data_url',
-                'length'
-            )
-        }
-
         # Don't overwrite fields with empty values unless the
         # field is explicitly allowed to be overwritten
-        for field in album_info.keys():
-            if field in misc_fields['album']:
+        for field, value in album_info.items():
+            # only overwrite fields that are not already hardcoded
+            if field in MISC_FIELDS['album']:
                 continue
             clobber = field in config['overwrite_null']['album'].as_str_seq()
-            value = getattr(album_info, field)
             if value is None and not clobber:
                 continue
             item[field] = value
 
-        for field in track_info.keys():
-            if field in misc_fields['track']:
+        for field, value in track_info.items():
+            # only overwrite fields that are not already hardcoded
+            if field in MISC_FIELDS['track']:
                 continue
             clobber = field in config['overwrite_null']['track'].as_str_seq()
             value = getattr(track_info, field)

--- a/beets/autotag/__init__.py
+++ b/beets/autotag/__init__.py
@@ -171,7 +171,8 @@ def apply_metadata(album_info, mapping):
                 'day',
                 'artist',
                 'artist_credit',
-                'artist_sort'
+                'artist_sort',
+                'data_url'
             ),
             'track': (
                 'track_alt',

--- a/beets/autotag/__init__.py
+++ b/beets/autotag/__init__.py
@@ -171,6 +171,7 @@ def apply_metadata(album_info, mapping):
                 'day',
                 'artist',
                 'artist_credit',
+                'artist_sort'
             ),
             'track': (
                 'track_alt',

--- a/beets/autotag/__init__.py
+++ b/beets/autotag/__init__.py
@@ -35,7 +35,7 @@ from .match import Recommendation  # noqa
 # Global logger.
 log = logging.getLogger('beets')
 
-# Metadata that is already hardcoded.
+# Metadata fields that are already hardcoded, or where the tag name changes.
 SPECIAL_FIELDS = {
     'album': (
         'va',

--- a/beets/autotag/__init__.py
+++ b/beets/autotag/__init__.py
@@ -35,7 +35,7 @@ from .match import Recommendation  # noqa
 # Global logger.
 log = logging.getLogger('beets')
 
-# metadata that is already hardcoded
+# Metadata that is already hardcoded.
 SPECIAL_FIELDS = {
     'album': (
         'va',
@@ -86,7 +86,7 @@ def apply_item_metadata(item, track_info):
         item.mb_artistid = track_info.artist_id
 
     for field, value in track_info.items():
-        # only overwrite fields that are not already hardcoded
+        # We only overwrite fields that are not already hardcoded.
         if field in SPECIAL_FIELDS['track']:
             continue
         if value is None:

--- a/beets/autotag/__init__.py
+++ b/beets/autotag/__init__.py
@@ -59,7 +59,8 @@ def apply_item_metadata(item, track_info):
                    'artist_sort',
                    'artist',
                    'track_id',
-                   'data_url'
+                   'data_url',
+                   'length'
                    ]
 
     for field in track_info.keys():
@@ -191,7 +192,8 @@ def apply_metadata(album_info, mapping):
                 'artist',
                 'track_id',
                 'medium_total',
-                'data_url'
+                'data_url',
+                'length'
             )
         }
 

--- a/beets/autotag/__init__.py
+++ b/beets/autotag/__init__.py
@@ -36,7 +36,7 @@ from .match import Recommendation  # noqa
 log = logging.getLogger('beets')
 
 # metadata that is already hardcoded
-MISC_FIELDS = {
+SPECIAL_FIELDS = {
     'album': (
         'va',
         'releasegroup_id',
@@ -84,12 +84,10 @@ def apply_item_metadata(item, track_info):
     item.mb_releasetrackid = track_info.release_track_id
     if track_info.artist_id:
         item.mb_artistid = track_info.artist_id
-    if track_info.data_source:
-        item.data_source = track_info.data_source
 
     for field, value in track_info.items():
         # only overwrite fields that are not already hardcoded
-        if field in MISC_FIELDS['track']:
+        if field in SPECIAL_FIELDS['track']:
             continue
         if value is None:
             continue
@@ -188,8 +186,7 @@ def apply_metadata(album_info, mapping):
         # Don't overwrite fields with empty values unless the
         # field is explicitly allowed to be overwritten
         for field, value in album_info.items():
-            # only overwrite fields that are not already hardcoded
-            if field in MISC_FIELDS['album']:
+            if field in SPECIAL_FIELDS['album']:
                 continue
             clobber = field in config['overwrite_null']['album'].as_str_seq()
             if value is None and not clobber:
@@ -197,8 +194,7 @@ def apply_metadata(album_info, mapping):
             item[field] = value
 
         for field, value in track_info.items():
-            # only overwrite fields that are not already hardcoded
-            if field in MISC_FIELDS['track']:
+            if field in SPECIAL_FIELDS['track']:
                 continue
             clobber = field in config['overwrite_null']['track'].as_str_seq()
             value = getattr(track_info, field)

--- a/beets/autotag/__init__.py
+++ b/beets/autotag/__init__.py
@@ -157,52 +157,52 @@ def apply_metadata(album_info, mapping):
         # Track alt.
         item.track_alt = track_info.track_alt
 
-        # Miscellaneous/nullable metadata.
+        # Metadata that has already been set
         misc_fields = {
             'album': (
-                'albumtype',
-                'label',
-                'asin',
-                'catalognum',
-                'script',
-                'language',
-                'country',
-                'style',
-                'genre',
-                'discogs_albumid',
-                'discogs_artistid',
-                'discogs_labelid',
-                'albumstatus',
-                'albumdisambig',
-                'releasegroupdisambig',
-                'data_source',
+                'va',
+                'releasegroup_id',
+                'artist_id',
+                'album_id',
+                'mediums',
+                'tracks',
+                'year',
+                'month',
+                'day',
+                'artist',
+                'artist_credit',
             ),
             'track': (
-                'disctitle',
-                'lyricist',
-                'media',
-                'composer',
-                'composer_sort',
-                'arranger',
-                'work',
-                'mb_workid',
-                'work_disambig',
-                'bpm',
-                'initial_key',
-                'genre'
+                'track_alt',
+                'artist_id',
+                'release_track_id',
+                'medium',
+                'index',
+                'medium_index',
+                'title',
+                'artist_credit',
+                'artist_sort',
+                'artist',
+                'track_id',
+                'medium_total',
+                'data_url'
             )
         }
 
         # Don't overwrite fields with empty values unless the
         # field is explicitly allowed to be overwritten
-        for field in misc_fields['album']:
+        for field in album_info.keys():
+            if field in misc_fields['album']:
+                continue
             clobber = field in config['overwrite_null']['album'].as_str_seq()
             value = getattr(album_info, field)
             if value is None and not clobber:
                 continue
             item[field] = value
 
-        for field in misc_fields['track']:
+        for field in track_info.keys():
+            if field in misc_fields['track']:
+                continue
             clobber = field in config['overwrite_null']['track'].as_str_seq()
             value = getattr(track_info, field)
             if value is None and not clobber:

--- a/beets/autotag/__init__.py
+++ b/beets/autotag/__init__.py
@@ -52,20 +52,24 @@ def apply_item_metadata(item, track_info):
     if track_info.data_source:
         item.data_source = track_info.data_source
 
-    if track_info.lyricist is not None:
-        item.lyricist = track_info.lyricist
-    if track_info.composer is not None:
-        item.composer = track_info.composer
-    if track_info.composer_sort is not None:
-        item.composer_sort = track_info.composer_sort
-    if track_info.arranger is not None:
-        item.arranger = track_info.arranger
-    if track_info.work is not None:
-        item.work = track_info.work
-    if track_info.mb_workid is not None:
-        item.mb_workid = track_info.mb_workid
-    if track_info.work_disambig is not None:
-        item.work_disambig = track_info.work_disambig
+    misc_fields = ['artist_id',
+                   'release_track_id',
+                   'title',
+                   'artist_credit',
+                   'artist_sort',
+                   'artist',
+                   'track_id',
+                   'data_url'
+                   ]
+
+    for field in track_info.keys():
+        if field in misc_fields:
+            continue
+        clobber = field in config['overwrite_null']['track'].as_str_seq()
+        value = getattr(track_info, field)
+        if value is None and not clobber:
+            continue
+        item[field] = value
 
     # At the moment, the other metadata is left intact (including album
     # and track number). Perhaps these should be emptied?


### PR DESCRIPTION
Hi! 
Coming back to https://github.com/beetbox/beets/pull/3568, I tried to add a new tag (as should be much easier now) but I noticed that any changes wouldn't get applied. I eventually found out that the problem was in ```beet/autotag/__init__.py``` in ```apply_metadata```, which gets the metadata it has to apply from a list. As the tags are flexible now, this doesn't work. In this PR, I change it to: 
Do your stuff with special tags (```track_id``` becomes ```mb_trackid``` and similar adaptations)
Take all the remaining tags and apply the changes to those. 

I wonder by the way how the ```scrub``` plugin reacts to tags being flexible, I didn't look into it. 