### PR TITLE
Scrape new Genius song page html

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -373,13 +373,34 @@ class Genius(Backend):
         # Remove script tags that they put in the middle of the lyrics.
         [h.extract() for h in html('script')]
 
-        # At least Genius is nice and has a tag called 'lyrics'!
-        # Updated css where the lyrics are based in HTML.
+        # Most of the time, the page contains a div with class="lyrics" where
+        # all of the lyrics can be found already correctly formatted
+        # Sometimes, though, it packages the lyrics into separate divs, most
+        # likely for easier ad placement
         lyrics_div = html.find("div", class_="lyrics")
-        if lyrics_div is None:
-            self._log.debug(u'Genius lyrics for {0} not found',
-                            page_url)
-            return None
+        if not lyrics_div:
+            self._log.debug(u'Received unusual song page html')
+            verse_div = html.find("div",
+                                  class_=re.compile("Lyrics__Container"))
+            if not verse_div:
+                with open('instrumental.html', 'w') as text_file:
+                        text_file.write(str(html))
+                if html.find("div",
+                             class_=re.compile("LyricsPlaceholder__Message"),
+                             string="This song is an instrumental"):
+                    self._log.debug('Detected instrumental')
+                    return "[Instrumental]"
+                else:
+                    self._log.debug("Couldn't scrape page using known layouts")
+                    return None
+
+            lyrics_div = verse_div.parent
+            for br in lyrics_div.find_all("br"):
+                br.replace_with("\n")
+            ads = lyrics_div.find_all("div",
+                                      class_=re.compile("InreadAd__Container"))
+            for ad in ads:
+                ad.replace_with("\n")
 
         return lyrics_div.get_text()
 

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -383,8 +383,6 @@ class Genius(Backend):
             verse_div = html.find("div",
                                   class_=re.compile("Lyrics__Container"))
             if not verse_div:
-                with open('instrumental.html', 'w') as text_file:
-                        text_file.write(str(html))
                 if html.find("div",
                              class_=re.compile("LyricsPlaceholder__Message"),
                              string="This song is an instrumental"):

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -390,7 +390,7 @@ class Genius(Backend):
 
     def fetch(self, artist, title):
         search_url = self.base_url + "/search"
-        data = {'q': title}
+        data = {'q': title + " " + artist.lower()}
         try:
             response = requests.get(search_url, data=data,
                                     headers=self.headers)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -202,6 +202,7 @@ Fixes:
   The log message has also been rewritten for to improve clarity.
   Thanks to :user:`autrimpo`.
   :bug:`3533`
+* :doc:`/plugins/lyrics`: Reduce the failure rate of the Genius backend.
 
 For plugin developers:
 

--- a/test/test_lyrics.py
+++ b/test/test_lyrics.py
@@ -474,7 +474,8 @@ class LyricsGeniusScrapeTest(LyricsGeniusBaseTest):
         """
         # https://github.com/beetbox/beets/issues/3535
         # expected return value None
-        self.assertEqual(genius.lyrics_from_song_page('https://genius.com/sample'),
+        song_url = 'https://genius.com/sample'
+        self.assertEqual(genius.lyrics_from_song_page(song_url),
                          None)
 
 

--- a/test/test_lyrics.py
+++ b/test/test_lyrics.py
@@ -456,7 +456,7 @@ class LyricsGeniusBaseTest(unittest.TestCase):
             self.skipTest("Python's built-in HTML parser is not good enough")
 
 
-class LyricsGeniusScrapTest(LyricsGeniusBaseTest):
+class LyricsGeniusScrapeTest(LyricsGeniusBaseTest):
 
     """Checks that Genius backend works as intended.
     """
@@ -469,12 +469,12 @@ class LyricsGeniusScrapTest(LyricsGeniusBaseTest):
 
     @patch.object(requests, 'get', GeniusMockGet())
     def test_no_lyrics_div(self):
-        """Ensure that `lyrics_from_song_api_path` doesn't crash when the html
-        for a Genius page contain <div class="lyrics"></div>
+        """Ensure that `lyrics_from_song_page` doesn't crash when the html
+        for a Genius page doesn't contain <div class="lyrics"></div>
         """
         # https://github.com/beetbox/beets/issues/3535
         # expected return value None
-        self.assertEqual(genius.lyrics_from_song_api_path('/nolyric'),
+        self.assertEqual(genius.lyrics_from_song_page('https://genius.com/sample'),
                          None)
 
 


### PR DESCRIPTION
As noted in #3535, Genius now doesn't always produce html pages that the existing code can scrape. While the fix in #3554 stops the lyrics plugin from completely crashing, it now simply ignores these pages, even though they do contain the desired lyrics. I added a few lines to the algorithm to deal with this new layout.

While I was at it, I also removed the indirection over the /song api, so we only need to query Genius twice per song instead of thrice.

Another change was to include the artist in the search query sent to Genius. This produces much better search results for songs with very common names but less known arists.