### PR TITLE
feat: uses new subsonic format as default

### DIFF
--- a/beetsplug/subsonicupdate.py
+++ b/beetsplug/subsonicupdate.py
@@ -17,11 +17,9 @@
 Your Beets configuration file should contain
 a "subsonic" section like the following:
     subsonic:
-        host: 192.168.x.y (Subsonic server IP)
-        port: 4040 (default)
-        user: <your username>
-        pass: <your password>
-        contextpath: /subsonic
+        url: https://mydomain.com:443/subsonic
+        user: username
+        pass: password
 """
 from __future__ import division, absolute_import, print_function
 
@@ -84,11 +82,8 @@ class SubsonicUpdate(BeetsPlugin):
 
         # Set default configuration values
         config['subsonic'].add({
-            'host': 'localhost',
-            'port': '4040',
             'user': 'admin',
             'pass': 'admin',
-            'contextpath': '/',
             'url': 'http://localhost:4040',
         })
 


### PR DESCRIPTION
### Description

Also gets rid of warning that `port` must be `int` when it's default was a `string`.

Left over from https://github.com/beetbox/beets/pull/3449.