### PR TITLE
Fix `list -af` example in documentation

### DIFF
--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -212,7 +212,7 @@ The ``-p`` option makes beets print out filenames of matched items, which might
 be useful for piping into other Unix commands (such as `xargs`_). Similarly, the
 ``-f`` option lets you specify a specific format with which to print every album
 or track. This uses the same template syntax as beets' :doc:`path formats
-<pathformat>`. For example, the command ``beet ls -af '$album: $tracktotal'
+<pathformat>`. For example, the command ``beet ls -af '$album: $albumtotal'
 beatles`` prints out the number of tracks on each Beatles album. In Unix shells,
 remember to enclose the template argument in single quotes to avoid environment
 variable expansion.


### PR DESCRIPTION
Didn't work since $tracktotal is not an Album field

![image](https://user-images.githubusercontent.com/31547038/83255424-adc66d80-a1b0-11ea-8c9d-088d969d7c3a.png)
