### PR TITLE
importer: use tarfile.open to handle compressed archives

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -1034,8 +1034,8 @@ class ArchiveImportTask(SentinelImportTask):
             cls._handlers = []
             from zipfile import is_zipfile, ZipFile
             cls._handlers.append((is_zipfile, ZipFile))
-            from tarfile import is_tarfile, TarFile
-            cls._handlers.append((is_tarfile, TarFile))
+            import tarfile
+            cls._handlers.append((tarfile.is_tarfile, tarfile.open))
             try:
                 from rarfile import is_rarfile, RarFile
             except ImportError:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -124,6 +124,8 @@ New features:
   separators to support path queries.
   Thanks to :user:`nmeum`.
   :bug:`3567`
+* ``beet import`` now handles tar archives with bzip2 or gzip compression.
+  :bug:`3606`
 
 Fixes:
 


### PR DESCRIPTION
Call tarfile.open instead of tarfile.TarFile from the importer so that
we can import compressed tar archives.

Note that tarfile.TarFile does not handle compressed archives:
$ python3
Python 3.8.2 (default, Apr 27 2020, 15:53:34)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import tarfile
>>> tf = tarfile.TarFile("Lagrimas.tar.bz2")
Traceback (most recent call last):
[...]
tarfile.ReadError: invalid header
>>>

But tarfile.open does deal with them:
$ python3
Python 3.8.2 (default, Apr 27 2020, 15:53:34)
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import tarfile
>>> tf = tarfile.open("Lagrimas.tar.bz2")
>>>

Tested:
$ ls Lagrimas/*.mp3 | wc -l
11
$ tar cjf Lagrimas.tar.bz2 Lagrimas/

- Before:
$ beet import Lagrimas.tar.bz2
extraction failed: invalid header
No files imported from /tmp/Lagrimas.tar.bz2

- After:
$ beet import Lagrimas.tar.bz2
[works]

Fixes #3606.