### PR TITLE
Enhance web ui search

### DIFF
--- a/beetsplug/web/static/beets.css
+++ b/beetsplug/web/static/beets.css
@@ -53,6 +53,11 @@ body {
     text-align: center;
     margin: 0.25em 0;
 }
+#selectorButtons {
+  display: block;
+  text-align: center;
+  margin: 0.25em 0;
+}
 #query {
     width: 95%;
     font-size: 1em;
@@ -60,7 +65,7 @@ body {
 #entities ul {
     width: 17em;
 
-    position: fixed;
+    position: relative;
     top: 36px;
     left: 0;
     bottom: 0;

--- a/beetsplug/web/static/beets.js
+++ b/beetsplug/web/static/beets.js
@@ -226,10 +226,21 @@ var AppView = Backbone.View.extend({
     el: $('body'),
     events: {
         'submit #queryForm': 'querySubmit',
+        'click #albumSearch': 'queryAlbum',
+        'click #artistSearch': 'queryArtist',
+        'click #allSearch': 'querySubmit',
     },
     querySubmit: function(ev) {
         ev.preventDefault();
         router.navigate('item/query/' + encodeURIComponent($('#query').val()), true);
+    },
+    queryAlbum: function(ev) {
+        ev.preventDefault();
+        router.navigate('item/query/album:' + encodeURIComponent($('#query').val()), true);
+    },
+    queryArtist: function(ev) {
+        ev.preventDefault();
+        router.navigate('item/query/artist:' + encodeURIComponent($('#query').val()), true);
     },
     initialize: function() {
         this.playingItem = null;

--- a/beetsplug/web/templates/index.html
+++ b/beetsplug/web/templates/index.html
@@ -33,6 +33,11 @@
             <form id="queryForm">
                 <input type="search" id="query" placeholder="Query">
             </form>
+            <form id="selectorButtons">
+              <button id="artistSearch">Artist</button>
+              <button id="albumSearch">Album</button>
+              <button id="allSearch">All</button>
+            </form>
             <ul id="results">
             </ul>
         </div>
@@ -58,7 +63,7 @@
 
             <button class="play">&#9654;</button>
 
-            
+
         </script>
         <script type="text/template" id="item-extra-detail-template">
             <dl>


### PR DESCRIPTION
This is a pretty basic PR which adds three buttons for new search modes.
The basic idea is to prepend `artist:` or `album:` to the query string for the user.
An `all` button is added to avoid confusion around a general search.
While a manual search is possible this makes a qualified search more natural.