### PR TITLE
Fix item == None issues when writing lyrics ReST (issue #2805)

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -770,7 +770,8 @@ class LyricsPlugin(plugins.BeetsPlugin):
             write = ui.should_write()
             if opts.writerest:
                 self.writerest_indexes(opts.writerest)
-            for item in lib.items(ui.decargs(args)):
+            items = lib.items(ui.decargs(args))
+            for item in items:
                 if not opts.local_only and not self.config['local']:
                     self.fetch_item_lyrics(
                         lib, item, write,
@@ -780,10 +781,10 @@ class LyricsPlugin(plugins.BeetsPlugin):
                     if opts.printlyr:
                         ui.print_(item.lyrics)
                     if opts.writerest:
-                        self.writerest(opts.writerest, item)
-            if opts.writerest:
-                # flush last artist
-                self.writerest(opts.writerest, None)
+                        self.appendrest(opts.writerest, item)
+            if opts.writerest and len(items) > 0:
+                # flush last artist & write to ReST
+                self.writerest(opts.writerest)
                 ui.print_(u'ReST files generated. to build, use one of:')
                 ui.print_(u'  sphinx-build -b html %s _build/html'
                           % opts.writerest)
@@ -795,26 +796,21 @@ class LyricsPlugin(plugins.BeetsPlugin):
         cmd.func = func
         return [cmd]
 
-    def writerest(self, directory, item):
-        """Write the item to an ReST file
+    def appendrest(self, directory, item):
+        """Append the item to an ReST file
 
         This will keep state (in the `rest` variable) in order to avoid
         writing continuously to the same files.
         """
 
-        if item is None or slug(self.artist) != slug(item.albumartist):
-            if self.rest is not None:
-                path = os.path.join(directory, 'artists',
-                                    slug(self.artist) + u'.rst')
-                with open(path, 'wb') as output:
-                    output.write(self.rest.encode('utf-8'))
-                self.rest = None
-                if item is None:
-                    return
+        if slug(self.artist) != slug(item.albumartist):
+            # Write current file and start a new one ~ item.albumartist
+            self.writerest(directory)
             self.artist = item.albumartist.strip()
             self.rest = u"%s\n%s\n\n.. contents::\n   :local:\n\n" \
                         % (self.artist,
                            u'=' * len(self.artist))
+
         if self.album != item.album:
             tmpalbum = self.album = item.album.strip()
             if self.album == '':
@@ -825,6 +821,16 @@ class LyricsPlugin(plugins.BeetsPlugin):
         self.rest += u"%s\n%s\n\n%s\n\n" % (title_str,
                                             u'~' * len(title_str),
                                             block)
+
+    def writerest(self, directory):
+        """Write self.rest to a ReST file
+        """
+        if self.rest is not None and self.artist is not None:
+            path = os.path.join(directory, 'artists',
+                                slug(self.artist) + u'.rst')
+            with open(path, 'wb') as output:
+                output.write(self.rest.encode('utf-8'))
+
 
     def writerest_indexes(self, directory):
         """Write conf.py and index.rst files necessary for Sphinx

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -782,7 +782,7 @@ class LyricsPlugin(plugins.BeetsPlugin):
                         ui.print_(item.lyrics)
                     if opts.writerest:
                         self.appendrest(opts.writerest, item)
-            if opts.writerest and len(items) > 0:
+            if opts.writerest and items:
                 # flush last artist & write to ReST
                 self.writerest(opts.writerest)
                 ui.print_(u'ReST files generated. to build, use one of:')
@@ -830,7 +830,6 @@ class LyricsPlugin(plugins.BeetsPlugin):
                                 slug(self.artist) + u'.rst')
             with open(path, 'wb') as output:
                 output.write(self.rest.encode('utf-8'))
-
 
     def writerest_indexes(self, directory):
         """Write conf.py and index.rst files necessary for Sphinx

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -207,6 +207,9 @@ Fixes:
 * :doc:`/plugins/lyrics`: Adapt the Genius backend to changes in markup to
   reduce the scraping failure rate.
   :bug:`3535` :bug:`3594`
+* :doc:`/plugins/lyrics`: Fix crash when writing ReST files for a query without
+  results or fetched lyrics
+  :bug:`2805`
 
 For plugin developers:
 


### PR DESCRIPTION
Skip ReST writing & sphinx info messages if query doesn't yield anything
* `writerest` into `appendrest` and `writerest`, don't call `writerest(item=None)` to flush state at the end.