### PR TITLE
feat: support secure Plex connections

### DIFF
--- a/beetsplug/plexupdate.py
+++ b/beetsplug/plexupdate.py
@@ -18,14 +18,14 @@ from beets import config
 from beets.plugins import BeetsPlugin
 
 
-def get_music_section(host, port, token, library_name):
+def get_music_section(host, port, token, library_name, use_secure, ignore_cert_errors):
     """Getting the section key for the music library in Plex.
     """
     api_endpoint = append_token('library/sections', token)
-    url = urljoin('http://{0}:{1}'.format(host, port), api_endpoint)
+    url = urljoin('{0}://{1}:{2}'.format(get_protocol(use_secure), host, port), api_endpoint)
 
     # Sends request.
-    r = requests.get(url)
+    r = requests.get(url, verify=use_secure)
 
     # Parse xml tree and extract music section key.
     tree = ElementTree.fromstring(r.content)
@@ -34,17 +34,22 @@ def get_music_section(host, port, token, library_name):
             return child.get('key')
 
 
-def update_plex(host, port, token, library_name):
+def update_plex(host, port, token, library_name, use_secure, ignore_cert_errors):
+    """Ignore certificate errors if configured to.
+    """
+    if ignore_cert_errors:
+        import urllib3
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
     """Sends request to the Plex api to start a library refresh.
     """
     # Getting section key and build url.
-    section_key = get_music_section(host, port, token, library_name)
+    section_key = get_music_section(host, port, token, library_name, use_secure, ignore_cert_errors)
     api_endpoint = 'library/sections/{0}/refresh'.format(section_key)
     api_endpoint = append_token(api_endpoint, token)
-    url = urljoin('http://{0}:{1}'.format(host, port), api_endpoint)
+    url = urljoin('{0}://{1}:{2}'.format(get_protocol(use_secure), host, port), api_endpoint)
 
     # Sends request and returns requests object.
-    r = requests.get(url)
+    r = requests.get(url, verify=use_secure)
     return r
 
 
@@ -56,6 +61,13 @@ def append_token(url, token):
     return url
 
 
+def get_protocol(use_secure):
+    if use_secure:
+        return 'https'
+    else:
+        return 'http'
+
+
 class PlexUpdate(BeetsPlugin):
     def __init__(self):
         super(PlexUpdate, self).__init__()
@@ -65,7 +77,9 @@ class PlexUpdate(BeetsPlugin):
             u'host': u'localhost',
             u'port': 32400,
             u'token': u'',
-            u'library_name': u'Music'})
+            u'library_name': u'Music',
+            u'use_secure': False,
+            u'ignore_cert_errors': False})
 
         config['plex']['token'].redact = True
         self.register_listener('database_change', self.listen_for_db_change)
@@ -85,7 +99,9 @@ class PlexUpdate(BeetsPlugin):
                 config['plex']['host'].get(),
                 config['plex']['port'].get(),
                 config['plex']['token'].get(),
-                config['plex']['library_name'].get())
+                config['plex']['library_name'].get(),
+                config['plex']['use_secure'].get(bool),
+                config['plex']['ignore_cert_errors'].get(bool))
             self._log.info(u'... started.')
 
         except requests.exceptions.RequestException:

--- a/docs/plugins/plexupdate.rst
+++ b/docs/plugins/plexupdate.rst
@@ -41,3 +41,7 @@ The available options under the ``plex:`` section are:
   Default: Empty.
 - **library_name**: The name of the Plex library to update.
   Default: ``Music``
+- **use_secure**: Use secure connections to the Plex server.
+  Default: ``False``
+- **ignore_cert_errors**: Ignore TLS certificate errors when using secure connections.
+  Default: ``False``

--- a/test/test_plexupdate.py
+++ b/test/test_plexupdate.py
@@ -93,7 +93,9 @@ class PlexUpdateTest(unittest.TestCase, TestHelper):
             self.config['plex']['host'],
             self.config['plex']['port'],
             self.config['plex']['token'],
-            self.config['plex']['library_name'].get()), '2')
+            self.config['plex']['library_name'].get(),
+            self.config['plex']['use_secure'],
+            self.config['plex']['ignore_cert_errors']), '2')
 
     @responses.activate
     def test_get_named_music_section(self):
@@ -104,7 +106,9 @@ class PlexUpdateTest(unittest.TestCase, TestHelper):
             self.config['plex']['host'],
             self.config['plex']['port'],
             self.config['plex']['token'],
-            'My Music Library'), '2')
+            'My Music Library',
+            self.config['plex']['use_secure'],
+            self.config['plex']['ignore_cert_errors']), '2')
 
     @responses.activate
     def test_update_plex(self):
@@ -117,7 +121,9 @@ class PlexUpdateTest(unittest.TestCase, TestHelper):
             self.config['plex']['host'],
             self.config['plex']['port'],
             self.config['plex']['token'],
-            self.config['plex']['library_name'].get()).status_code, 200)
+            self.config['plex']['library_name'].get(),
+            self.config['plex']['use_secure'],
+            self.config['plex']['ignore_cert_errors']).status_code, 200)
 
 
 def suite():


### PR DESCRIPTION
Attempt to fix issue #2871.

Adds two new options to the `plexupdate` config:
* `use_secure` - boolean of whether to use secure connections or not
* `ignore_cert_errors` - boolean of whether to ignore certificate errors