### PR TITLE
feat: support secure Plex connections

### DIFF
--- a/beetsplug/plexupdate.py
+++ b/beetsplug/plexupdate.py
@@ -18,12 +18,12 @@ from beets import config
 from beets.plugins import BeetsPlugin
 
 
-def get_music_section(host, port, token, library_name, use_secure,
+def get_music_section(host, port, token, library_name, secure,
                       ignore_cert_errors):
     """Getting the section key for the music library in Plex.
     """
     api_endpoint = append_token('library/sections', token)
-    url = urljoin('{0}://{1}:{2}'.format(get_protocol(use_secure), host,
+    url = urljoin('{0}://{1}:{2}'.format(get_protocol(secure), host,
                   port), api_endpoint)
 
     # Sends request.
@@ -36,7 +36,7 @@ def get_music_section(host, port, token, library_name, use_secure,
             return child.get('key')
 
 
-def update_plex(host, port, token, library_name, use_secure,
+def update_plex(host, port, token, library_name, secure,
                 ignore_cert_errors):
     """Ignore certificate errors if configured to.
     """
@@ -47,10 +47,10 @@ def update_plex(host, port, token, library_name, use_secure,
     """
     # Getting section key and build url.
     section_key = get_music_section(host, port, token, library_name,
-                                    use_secure, ignore_cert_errors)
+                                    secure, ignore_cert_errors)
     api_endpoint = 'library/sections/{0}/refresh'.format(section_key)
     api_endpoint = append_token(api_endpoint, token)
-    url = urljoin('{0}://{1}:{2}'.format(get_protocol(use_secure), host,
+    url = urljoin('{0}://{1}:{2}'.format(get_protocol(secure), host,
                   port), api_endpoint)
 
     # Sends request and returns requests object.
@@ -66,8 +66,8 @@ def append_token(url, token):
     return url
 
 
-def get_protocol(use_secure):
-    if use_secure:
+def get_protocol(secure):
+    if secure:
         return 'https'
     else:
         return 'http'
@@ -83,7 +83,7 @@ class PlexUpdate(BeetsPlugin):
             u'port': 32400,
             u'token': u'',
             u'library_name': u'Music',
-            u'use_secure': False,
+            u'secure': False,
             u'ignore_cert_errors': False})
 
         config['plex']['token'].redact = True
@@ -105,7 +105,7 @@ class PlexUpdate(BeetsPlugin):
                 config['plex']['port'].get(),
                 config['plex']['token'].get(),
                 config['plex']['library_name'].get(),
-                config['plex']['use_secure'].get(bool),
+                config['plex']['secure'].get(bool),
                 config['plex']['ignore_cert_errors'].get(bool))
             self._log.info(u'... started.')
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -126,6 +126,9 @@ New features:
   :bug:`3567`
 * ``beet import`` now handles tar archives with bzip2 or gzip compression.
   :bug:`3606`
+* :doc:`/plugins/plexupdate`: Add option to use secure connection to Plex
+  server, and to ignore certificate validation errors if necessary.
+  :bug:`2871`
 
 Fixes:
 

--- a/docs/plugins/plexupdate.rst
+++ b/docs/plugins/plexupdate.rst
@@ -41,7 +41,7 @@ The available options under the ``plex:`` section are:
   Default: Empty.
 - **library_name**: The name of the Plex library to update.
   Default: ``Music``
-- **use_secure**: Use secure connections to the Plex server.
+- **secure**: Use secure connections to the Plex server.
   Default: ``False``
 - **ignore_cert_errors**: Ignore TLS certificate errors when using secure connections.
   Default: ``False``

--- a/docs/plugins/plexupdate.rst
+++ b/docs/plugins/plexupdate.rst
@@ -41,3 +41,7 @@ The available options under the ``plex:`` section are:
   Default: Empty.
 - **library_name**: The name of the Plex library to update.
   Default: ``Music``
+- **use_secure**: Use secure connections to the Plex server.
+  Default: ``False``
+- **ignore_cert_errors**: Ignore TLS certificate errors when using secure connections.
+  Default: ``False``

--- a/test/test_plexupdate.py
+++ b/test/test_plexupdate.py
@@ -93,7 +93,9 @@ class PlexUpdateTest(unittest.TestCase, TestHelper):
             self.config['plex']['host'],
             self.config['plex']['port'],
             self.config['plex']['token'],
-            self.config['plex']['library_name'].get()), '2')
+            self.config['plex']['library_name'].get(),
+            self.config['plex']['use_secure'],
+            self.config['plex']['ignore_cert_errors']), '2')
 
     @responses.activate
     def test_get_named_music_section(self):
@@ -104,7 +106,9 @@ class PlexUpdateTest(unittest.TestCase, TestHelper):
             self.config['plex']['host'],
             self.config['plex']['port'],
             self.config['plex']['token'],
-            'My Music Library'), '2')
+            'My Music Library',
+            self.config['plex']['use_secure'],
+            self.config['plex']['ignore_cert_errors']), '2')
 
     @responses.activate
     def test_update_plex(self):
@@ -117,7 +121,9 @@ class PlexUpdateTest(unittest.TestCase, TestHelper):
             self.config['plex']['host'],
             self.config['plex']['port'],
             self.config['plex']['token'],
-            self.config['plex']['library_name'].get()).status_code, 200)
+            self.config['plex']['library_name'].get(),
+            self.config['plex']['use_secure'],
+            self.config['plex']['ignore_cert_errors']).status_code, 200)
 
 
 def suite():

--- a/test/test_plexupdate.py
+++ b/test/test_plexupdate.py
@@ -94,7 +94,7 @@ class PlexUpdateTest(unittest.TestCase, TestHelper):
             self.config['plex']['port'],
             self.config['plex']['token'],
             self.config['plex']['library_name'].get(),
-            self.config['plex']['use_secure'],
+            self.config['plex']['secure'],
             self.config['plex']['ignore_cert_errors']), '2')
 
     @responses.activate
@@ -107,7 +107,7 @@ class PlexUpdateTest(unittest.TestCase, TestHelper):
             self.config['plex']['port'],
             self.config['plex']['token'],
             'My Music Library',
-            self.config['plex']['use_secure'],
+            self.config['plex']['secure'],
             self.config['plex']['ignore_cert_errors']), '2')
 
     @responses.activate
@@ -122,7 +122,7 @@ class PlexUpdateTest(unittest.TestCase, TestHelper):
             self.config['plex']['port'],
             self.config['plex']['token'],
             self.config['plex']['library_name'].get(),
-            self.config['plex']['use_secure'],
+            self.config['plex']['secure'],
             self.config['plex']['ignore_cert_errors']).status_code, 200)
 
 


### PR DESCRIPTION
Attempt to fix issue #2871.

Adds two new options to the `plexupdate` config:
* `secure` - boolean of whether to use secure connections or not
* `ignore_cert_errors` - boolean of whether to ignore certificate errors