### PR TITLE
Revert Cover Art Archive thumbnails

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -317,26 +317,12 @@ class CoverArtArchive(RemoteArtSource):
         """Return the Cover Art Archive and Cover Art Archive release group URLs
         using album MusicBrainz release ID and release group ID.
         """
-
-        # Cover Art Archive API offers pre-resized thumbnails at several sizes.
-        # If the maxwidth config matches one of the already available sizes
-        # fetch it directly intead of fetching the full sized image and
-        # resizing it.
-        release_url = self.URL
-        group_url = self.GROUP_URL
-        valid_thumbnail_sizes = [250, 500, 1200]
-        if plugin.maxwidth in valid_thumbnail_sizes:
-            size_suffix = "-" + str(plugin.maxwidth)
-            release_url += size_suffix
-            group_url += size_suffix
-
         if 'release' in self.match_by and album.mb_albumid:
-            yield self._candidate(
-                url=release_url.format(mbid=album.mb_albumid),
-                                       match=Candidate.MATCH_EXACT)
+            yield self._candidate(url=self.URL.format(mbid=album.mb_albumid),
+                                  match=Candidate.MATCH_EXACT)
         if 'releasegroup' in self.match_by and album.mb_releasegroupid:
             yield self._candidate(
-                url=group_url.format(mbid=album.mb_releasegroupid),
+                url=self.GROUP_URL.format(mbid=album.mb_releasegroupid),
                 match=Candidate.MATCH_FALLBACK)
 
 

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -333,8 +333,7 @@ class CoverArtArchive(RemoteArtSource):
         if 'release' in self.match_by and album.mb_albumid:
             yield self._candidate(
                 url=release_url.format(mbid=album.mb_albumid),
-                match=Candidate.MATCH_EXACT,
-            )
+                                       match=Candidate.MATCH_EXACT)
         if 'releasegroup' in self.match_by and album.mb_releasegroupid:
             yield self._candidate(
                 url=group_url.format(mbid=album.mb_releasegroupid),

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -217,8 +217,6 @@ Fixes:
 * :doc:`/plugins/fetchart`: Fetch pre-resized thumbnails from Cover Art Archive
   if the ``maxwidth`` option matches one of the sizes supported by the Cover
   Art Archive API.
-  Thanks to :user:`trolley`.
-  :bug:`3637`
 
 For plugin developers:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -214,9 +214,6 @@ Fixes:
   results or fetched lyrics
   :bug:`2805`
 * Adapt to breaking changes in Python's ``ast`` module in 3.8
-* :doc:`/plugins/fetchart`: Fetch pre-resized thumbnails from Cover Art Archive
-  if the ``maxwidth`` option matches one of the sizes supported by the Cover
-  Art Archive API.
 
 For plugin developers:
 


### PR DESCRIPTION
Revert PR #3637 and related changes due to issue #3638.

I will reworks this to make sure it falls back gracefully if the thumbnail image doesn't exist.