### PR TITLE
update bug-report flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -26,7 +26,7 @@ $ beet -vv (... paste here ...)
 ### Actual Result
 (if more explanation needed beyond command output)
 
-## Setup
+### Setup
 
 * OS: 
 * Python version: 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -12,7 +12,7 @@ Hi there, thank you for reporting a bug! Please read our `how to create a good b
 The better the bug report, the quicker we can get to fixing it :rocket:
 
 ## Description
-
+(overview of the issue)
 
 ### Steps to reproduce:
 Running this command in verbose (`-vv`) mode:
@@ -21,7 +21,10 @@ $ beet -vv (... paste here ...)
 ```
 
 ### Expected Result
+(What did you expect to happen?)
 
+### Actual Result
+(if more explanation needed beyond command output)
 
 ## Setup
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -15,12 +15,12 @@ The better the bug report, the quicker we can get to fixing it :rocket:
 
 
 ### Steps to reproduce:
-1. 
+Running this command in verbose (`-vv`) mode:
+```sh
+$ beet -vv (... paste here ...)
+```
 
 ### Expected Result
-
-
-### Actual Result
 
 
 ## Setup
@@ -28,6 +28,7 @@ The better the bug report, the quicker we can get to fixing it :rocket:
 * OS: 
 * Python version: 
 * beets version: 
+* Turning off plugins made problem go away (yes/no):
 
 <details>
   <summary>Minimum reproducible config:</summary>

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -6,37 +6,33 @@ about: Report a problem with beets
 
 <!--
 Describe your problem, feature request, or discussion topic here.
-
-Please fill out this and the "Setup" section below and remember to include
-enough detail so that other people can reproduce the problem.
 -->
 
-### Problem
+Hi there, thank you for reporting a bug! Please read our `how to create a good bug report` wiki page to expedite the process of diagnosing the issue.
+The better the bug report, the quicker we can get to fixing it :rocket:
 
-Running this command in verbose (`-vv`) mode:
-
-```sh
-$ beet -vv (... paste here ...)
-```
-
-Led to this problem:
-
-```
-(paste here)
-```
-
-Here's a link to the music files that trigger the bug (if relevant):
+## Description
 
 
-### Setup
+### Steps to reproduce:
+1. 
+
+### Expected Result
+
+
+### Actual Result
+
+
+## Setup
 
 * OS: 
 * Python version: 
 * beets version: 
-* Turning off plugins made problem go away (yes/no): 
 
-My configuration (output of `beet config`) is:
-
+<details>
+  <summary>Minimum reproducible config:</summary>
+  
 ```yaml
-(paste here)
+(paste config here)
 ```
+</details>


### PR DESCRIPTION
So, I think the bug template could use some attention. My proposal is to create a wiki page that would go through the proper steps of reporting a bug and self-diagnosis, then hopefully have the template as a nice plug and play of the proper info. I made a sample wiki page at my fork [here](https://github.com/jtpavlock/beets/wiki/How-to-create-a-good-bug-report)

I also added a dropdown for the config file that can also be set to be open automatically. I figured this could make some of those issues with painfully long configs easier to read. The template isn't as explicit as before on purpose, to hopefully encourage users to take a look at the wiki page :)