### PR TITLE
fetchart: Use Cover Art Archive thumbnails

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -217,6 +217,9 @@ Fixes:
   results or fetched lyrics
   :bug:`2805`
 * Adapt to breaking changes in Python's ``ast`` module in 3.8
+* :doc:`/plugins/fetchart`: Attempt to fetch pre-resized thumbnails from Cover
+  Art Archive if the ``maxwidth`` option matches one of the sizes supported by
+  the Cover Art Archive API.
 
 For plugin developers:
 


### PR DESCRIPTION
The Cover Art Archive API offers pre-resized thumbnails of cover
art. If the `maxwidth` option of `fetchart` matches one of the
supported Cover Art Archive thumbnail sizes, and a thumbnail of
that size exists in the Cover Art Archive, fetch it directly
instead of fetching the full size image then resizing it.