### PR TITLE
Get the date of the parentwork, which may be different from the date of the child work.

### DIFF
--- a/beetsplug/parentwork.py
+++ b/beetsplug/parentwork.py
@@ -131,6 +131,8 @@ class ParentWorkPlugin(BeetsPlugin):
                 if artist['type'] == 'composer':
                     parent_composer.append(artist['artist']['name'])
                     parent_composer_sort.append(artist['artist']['sort-name'])
+                    if 'end' in artist.keys():
+                        parentwork_info["parentwork_date"] = artist['end']
 
             parentwork_info['parent_composer'] = u', '.join(parent_composer)
             parentwork_info['parent_composer_sort'] = u', '.join(
@@ -207,4 +209,4 @@ add one at https://musicbrainz.org/recording/{}', item, item.mb_trackid)
             item, fields=['parentwork', 'parentwork_disambig',
                           'mb_parentworkid', 'parent_composer',
                           'parent_composer_sort', 'work_date',
-                          'parentwork_workid_current'])
+                          'parentwork_workid_current', 'parentwork_date'])

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -132,6 +132,10 @@ New features:
 * :doc:`/plugins/lyrics`: Improved searching Genius backend when artist
   contained special characters.
   :bug:`3634`
+* :doc:`/plugins/parentwork`: Also get the composition date of the parent work,
+  instead of just the child work.
+  Thanks to :user:`aereaux`.
+  :bug:`3650`
 
 Fixes:
 

--- a/docs/plugins/parentwork.rst
+++ b/docs/plugins/parentwork.rst
@@ -26,7 +26,7 @@ At any later run of ``beet parentwork`` it will check if the tags
 not the case, it means the work has changed and all the tags need to be
 fetched again.
 
-This plugin adds six tags:
+This plugin adds seven tags:
 
 - **parentwork**: The title of the parent work.
 - **mb_parentworkid**: The MusicBrainz id of the parent work.
@@ -38,6 +38,7 @@ This plugin adds six tags:
 - **parentwork_workid_current**: The MusicBrainz id of the work as it was when
   the parentwork was retrieved. This tag exists only for internal bookkeeping,
   to keep track of recordings whose works have changed. 
+- **parentwork_date**: The composition date of the parent work.
 
 To use the ``parentwork`` plugin, enable it in your configuration (see
 :ref:`using-plugins`).


### PR DESCRIPTION
##  Description

Fixes #3650.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
