### PR TITLE
Add a stale-bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -14,3 +14,13 @@ issues:
     This issue has been automatically marked as stale because it has not had
     recent activity. It will be closed if no further activity occurs. Thank you
     for your contributions.
+    
+pulls:
+  daysUntilStale: 120
+  markComment: >
+    Is this still relevant? If so, what is blocking it? 
+    Is there anything you can do to help move it forward? 
+
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,20 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+daysUntilClose: 7
+staleLabel: stale
+
+issues:
+  daysUntilStale: 60
+  onlyLabels:
+    - needinfo
+  markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+    
+pulls:
+  daysUntilStale: 120
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,6 +8,9 @@ issues:
   onlyLabels:
     - needinfo
   markComment: >
+    Is this still relevant? If so, what is blocking it? 
+    Is there anything you can do to help move it forward? 
+
     This issue has been automatically marked as stale because it has not had
     recent activity. It will be closed if no further activity occurs. Thank you
     for your contributions.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -11,10 +11,3 @@ issues:
     This issue has been automatically marked as stale because it has not had
     recent activity. It will be closed if no further activity occurs. Thank you
     for your contributions.
-    
-pulls:
-  daysUntilStale: 120
-  markComment: >
-    This pull request has been automatically marked as stale because it has not had
-    recent activity. It will be closed if no further activity occurs. Thank you
-    for your contributions.


### PR DESCRIPTION
## Description

Fixes #3656

Adds a [stale-bot](https://github.com/probot/stale) that will comment and mark issues with the `needinfo` label and > 60 days inactivity, and pull requests with > 120 days of inactivity. If no further activity occurs in a week, the bot will close the issue/pull request.

[See usage & config options](https://github.com/probot/stale#usage) 

I also sent a request to install the bot to this repository. Note the bot will not be enabled until a `stale.yml` file is present.