### PR TITLE
Testing cleanup & nose -> pytest

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,6 @@
 omit =
     */pyshared/*
     */python?.?/*
-    */site-packages/nose/*
     */test/*
 exclude_lines =
     assert False

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,6 @@ jobs:
       matrix:
         platform: [ ubuntu-latest ]
     env:
-      NOSE_SHOW_SKIPPED: 1
       PY_COLOR: 1
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,93 +1,78 @@
 name: ci
 on: [push, pull_request]
 jobs:
-  test-27:
+  test:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ ubuntu-latest ]
+        platform: [ubuntu-latest]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
     env:
-      PY_COLOR: 1
+      PY_COLORS: 1
+
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 2.7
+
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: 2.7
-      - uses: actions/cache@v1
-        if: startsWith(runner.os, 'Linux')
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - uses: actions/cache@v1
-        if: startsWith(runner.os, 'Windows')
-        with:
-          path: ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Install base dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install tox sphinx
-      - name: Test with tox
-        run: tox -e py27-test
-  test-3x:
-    runs-on: ${{ matrix.platform }}
-    strategy:
-      matrix:
-        platform: [ ubuntu-latest ]
-        python-version: [ 5, 6, 7, 8 ]
-    env:
-      PY_COLOR: 1
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.${{ matrix.python-version }}
-      - uses: actions/cache@v1
-        if: startsWith(runner.os, 'Linux')
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - uses: actions/cache@v1
-        if: startsWith(runner.os, 'Windows')
-        with:
-          path: ~\AppData\Local\pip\Cache
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Install base dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install tox sphinx
-      - name: Test, coverage, and flake8 with tox
-        if: matrix.python-version == '8'
-        run: |
-          tox -e py3${{ matrix.python-version }}-test
-          tox -e py3${{ matrix.python-version }}-cov
-          tox -e py3${{ matrix.python-version }}-lint
-          pip install codecov || true
-          codecov || true
-      - name: Test with tox
-        if: matrix.python-version != '8'
-        run: tox -e py3${{ matrix.python-version }}-test
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python to build docs with Sphinx
-        uses: actions/setup-python@v2
-        with:
-          python-version: 2.7
+          python-version: ${{ matrix.python-version }}
+
       - name: Install base dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install tox sphinx
+
+      - name: Test with tox
+        if: matrix.python-version != '3.8'
+        run: |
+          tox -e py-test
+
+      - name: Test with tox and get coverage
+        if: matrix.python-version == '3.8'
+        run: |
+          tox -vv -e py-cov
+        
+      - name: Upload code coverage
+        if: matrix.python-version == '3.8'
+        run: |
+          pip install codecov || true
+          codecov || true
+
+  test-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 2.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 2.7
+
+      - name: Install base dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox sphinx
+
       - name: Build and check docs using tox
         run: tox -e docs
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install base dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox sphinx
+
+      - name: Lint with flake8
+        run: tox -e py-lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         platform: [ ubuntu-latest ]
-        python-version: [ 4, 5, 6, 7, 8 ]
+        python-version: [ 5, 6, 7, 8 ]
     env:
       PY_COLOR: 1
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,9 +40,8 @@ jobs:
     strategy:
       matrix:
         platform: [ ubuntu-latest ]
-        python-version: [ 5, 6, 7, 8 ]
+        python-version: [ 4, 5, 6, 7, 8 ]
     env:
-      NOSE_SHOW_SKIPPED: 1
       PY_COLOR: 1
     steps:
       - uses: actions/checkout@v2
@@ -73,7 +72,7 @@ jobs:
         run: |
           tox -e py3${{ matrix.python-version }}-test
           tox -e py3${{ matrix.python-version }}-cov
-          tox -e py3${{ matrix.python-version }}-flake8
+          tox -e py3${{ matrix.python-version }}-lint
           pip install codecov || true
           codecov || true
       - name: Test with tox

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest]
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+
     env:
       PY_COLORS: 1
 
@@ -42,6 +43,9 @@ jobs:
   test-docs:
     runs-on: ubuntu-latest
 
+    env:
+      PY_COLORS: 1
+
     steps:
       - uses: actions/checkout@v2
 
@@ -60,6 +64,9 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+
+    env:
+      PY_COLORS: 1
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -8,7 +8,6 @@ jobs:
     strategy:
       python-version: 3.8
     env:
-      NOSE_SHOW_SKIPPED: 1
       PY_COLOR: 1
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -5,26 +5,20 @@ on:
 jobs:
   test integration:
     runs-on: ubuntu-latest
-    strategy:
-      python-version: 3.8
-    env:
-      PY_COLOR: 1
+
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+
       - name: Install base dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox
+          python -m pip install tox sphinx
+
       - name: Test with tox
         run: |
           tox -e int

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -10,7 +10,6 @@ jobs:
     env:
       NOSE_SHOW_SKIPPED: 1
       PY_COLOR: 1
-      INTEGRATION_TEST: 1
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.8
@@ -29,4 +28,4 @@ jobs:
           pip install tox
       - name: Test with tox
         run: |
-          tox -e py38-test
+          tox -e int

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -6,6 +6,9 @@ jobs:
   test integration:
     runs-on: ubuntu-latest
 
+    env:
+      PY_COLORS: 1
+
     steps:
       - uses: actions/checkout@v2
 

--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,6 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
-nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,6 @@ skip_commits:
     message: /\[appveyor skip\]/
 
 environment:
-    # Undocumented feature of nose-show-skipped.
-    NOSE_SHOW_SKIPPED: 1
-
     matrix:
         - PYTHON: C:\Python27
           TOX_ENV: py27-test

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[nosetests]
-verbosity=1
-logging-clear-handlers=1
-
 [flake8]
 min-version=2.7
 accept-encodings=utf-8

--- a/setup.py
+++ b/setup.py
@@ -109,24 +109,33 @@ setup(
         ['colorama'] if (sys.platform == 'win32') else []
     ),
 
-    tests_require=[
-        'beautifulsoup4',
-        'flask',
-        'mock',
-        'pylast',
-        'rarfile',
-        'responses',
-        'pyxdg',
-        'python-mpd2',
-        'discogs-client',
-        'requests_oauthlib'
-    ] + (
-        # Tests for the thumbnails plugin need pathlib on Python 2 too.
-        ['pathlib'] if (sys.version_info < (3, 4, 0)) else []
-    ),
-
-    # Plugin (optional) dependencies:
     extras_require={
+        'test': [
+            'beautifulsoup4',
+            'coverage',
+            'discogs-client',
+            'flask',
+            'mock',
+            'pylast',
+            'pytest',
+            'python-mpd2',
+            'pyxdg',
+            'rarfile',
+            'responses>=0.3.0',
+            'requests_oauthlib',
+        ] + (
+            # Tests for the thumbnails plugin need pathlib on Python 2 too.
+            ['pathlib'] if (sys.version_info < (3, 4, 0)) else []
+            ),
+        'lint': [
+            'flake8',
+            'flake8-blind-except',
+            'flake8-coding',
+            'flake8-future-import',
+            'pep8-naming',
+        ],
+
+        # Plugin (optional) dependencies:
         'absubmit': ['requests'],
         'fetchart': ['requests', 'Pillow'],
         'embedart': ['Pillow'],

--- a/test/_common.py
+++ b/test/_common.py
@@ -44,7 +44,7 @@ beetsplug.__path__ = [os.path.abspath(
 RSRC = util.bytestring_path(os.path.join(os.path.dirname(__file__), 'rsrc'))
 PLUGINPATH = os.path.join(os.path.dirname(__file__), 'rsrc', 'beetsplug')
 
-# Propagate to root logger so nosetest can capture it
+# Propagate to root logger so the test runner can capture it
 log = logging.getLogger('beets')
 log.propagate = True
 log.setLevel(logging.DEBUG)

--- a/test/test_parentwork.py
+++ b/test/test_parentwork.py
@@ -17,6 +17,7 @@
 
 from __future__ import division, absolute_import, print_function
 
+import os
 import unittest
 from test.helper import TestHelper
 
@@ -34,6 +35,9 @@ class ParentWorkTest(unittest.TestCase, TestHelper):
         self.unload_plugins()
         self.teardown_beets()
 
+    @unittest.skipUnless(
+        os.environ.get('INTEGRATION_TEST', '0') == '1',
+        'integration testing not enabled')
     def test_normal_case(self):
         item = Item(path='/file',
                     mb_workid=u'e27bda6e-531e-36d3-9cd7-b8ebc18e8c53')
@@ -45,6 +49,9 @@ class ParentWorkTest(unittest.TestCase, TestHelper):
         self.assertEqual(item['mb_parentworkid'],
                          u'32c8943f-1b27-3a23-8660-4567f4847c94')
 
+    @unittest.skipUnless(
+        os.environ.get('INTEGRATION_TEST', '0') == '1',
+        'integration testing not enabled')
     def test_force(self):
         self.config['parentwork']['force'] = True
         item = Item(path='/file',
@@ -58,6 +65,9 @@ class ParentWorkTest(unittest.TestCase, TestHelper):
         self.assertEqual(item['mb_parentworkid'],
                          u'32c8943f-1b27-3a23-8660-4567f4847c94')
 
+    @unittest.skipUnless(
+        os.environ.get('INTEGRATION_TEST', '0') == '1',
+        'integration testing not enabled')
     def test_no_force(self):
         self.config['parentwork']['force'] = True
         item = Item(path='/file', mb_workid=u'e27bda6e-531e-36d3-9cd7-\
@@ -72,6 +82,9 @@ class ParentWorkTest(unittest.TestCase, TestHelper):
     # test different cases, still with Matthew Passion Ouverture or Mozart
     # requiem
 
+    @unittest.skipUnless(
+        os.environ.get('INTEGRATION_TEST', '0') == '1',
+        'integration testing not enabled')
     def test_direct_parent_work(self):
         mb_workid = u'2e4a3668-458d-3b2a-8be2-0b08e0d8243a'
         self.assertEqual(u'f04b42df-7251-4d86-a5ee-67cfa49580d1',

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,10 @@
 envlist = py27-test, py38-{cov,lint}, docs
 
 [_test]
-deps = .[test]  # defined in setup.py
+deps = .[test]
 
 [_lint]
-deps = .[lint]  # defined in setup.py
+deps = .[lint]
 files = beets beetsplug beet test setup.py docs
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -4,57 +4,33 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27-test, py37-test, py27-flake8, docs
-
-# The exhaustive list of environments is:
-# envlist = py{27,34,35}-{test,cov}, py{27,34,35}-flake8, docs
+envlist = py27-test, py38-{cov,lint}, docs
 
 [_test]
-deps =
-    beautifulsoup4
-    flask
-    mock
-    nose
-    nose-show-skipped
-    pylast
-    rarfile
-    responses>=0.3.0
-    pyxdg
-    python-mpd2
-    coverage
-    discogs-client
-    requests_oauthlib
+deps = .[test]  # defined in setup.py
 
-[_flake8]
-deps =
-    flake8
-    flake8-coding
-    flake8-future-import
-    flake8-blind-except
-    pep8-naming
+[_lint]
+deps = .[lint]  # defined in setup.py
 files = beets beetsplug beet test setup.py docs
 
 [testenv]
-passenv =
-    NOSE_SHOW_SKIPPED # Undocumented feature of nose-show-skipped.
-    INTEGRATION_TEST  # set to 1 for integration tests
 deps =
     {test,cov}: {[_test]deps}
+    lint: {[_lint]deps}
     py27: pathlib
-    py{27,34,35,36,37,38}-flake8: {[_flake8]deps}
 commands =
-    py27-cov: python -m nose --with-coverage {posargs}
-    py27-test: python -m nose {posargs}
-    py3{4,5,6,7,8}-cov: python -bb -m nose --with-coverage {posargs}
-    py3{4,5,6,7,8}-test: python -bb -m nose {posargs}
-    py27-flake8: flake8 {posargs} {[_flake8]files}
-    py34-flake8: flake8 {posargs} {[_flake8]files}
-    py35-flake8: flake8 {posargs} {[_flake8]files}
-    py36-flake8: flake8 {posargs} {[_flake8]files}
-    py37-flake8: flake8 {posargs} {[_flake8]files}
-    py38-flake8: flake8 {posargs} {[_flake8]files}
+    py27-test: python -m pytest {posargs}
+    py3{4,5,6,7,8}-test: python -bb -m pytest {posargs}
+    cov: coverage run -m pytest {posargs}
+    lint: python -m flake8 {posargs} {[_lint]files}
 
 [testenv:docs]
 basepython = python2.7
 deps = sphinx
 commands = sphinx-build -W -q -b html docs {envtmpdir}/html {posargs}
+
+[testenv:int]
+basepython = python3.8
+deps = {[_test]deps}
+setenv = INTEGRATION_TEST = 1
+commands = python -m pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -17,10 +17,8 @@ files = beets beetsplug beet test setup.py docs
 deps =
     {test,cov}: {[_test]deps}
     lint: {[_lint]deps}
-    py27: pathlib
 commands =
-    py27-test: python -m pytest {posargs}
-    py3{4,5,6,7,8}-test: python -bb -m pytest {posargs}
+    test: python -bb -m pytest {posargs}
     cov: coverage run -m pytest {posargs}
     lint: python -m flake8 {posargs} {[_lint]files}
 
@@ -30,7 +28,6 @@ deps = sphinx
 commands = sphinx-build -W -q -b html docs {envtmpdir}/html {posargs}
 
 [testenv:int]
-basepython = python3.8
 deps = {[_test]deps}
 setenv = INTEGRATION_TEST = 1
-commands = python -m pytest {posargs}
+commands = python -bb -m pytest {posargs}


### PR DESCRIPTION
## Description

Fixes #2202

So this covers a few things:
1. [Since setup.py test is deprecated](https://github.com/pypa/setuptools/pull/1878), I removed the `test_requires` section of `setup.py` in favor of putting it under `extras`. This allows us to reference the dependencies in multiple locations e.g. `tox.ini`
2. Cleans `tox.ini` a bit removing unneeded or unused code
3. Since `nose` is deprecated, I transitioned to using `pytest`

## To Do

- [x] Documentation - replace instances of nose with pytest
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)

Editing the Testing wiki is on my list of to-dos and I'm just waiting until I am finished going through all the testing stuff
