### PR TITLE
 Fixes #2847

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -877,7 +877,9 @@ def open_anything():
     if sys_name == 'Darwin':
         base_cmd = 'open'
     elif sys_name == 'Windows':
-        base_cmd = 'start'
+        # python is not aware of cmd commands
+        # Start cmd.exe with start as argument
+        base_cmd = 'cmd /c \"start {}\"'
     else:  # Assume Unix
         base_cmd = 'xdg-open'
     return base_cmd
@@ -916,10 +918,11 @@ def shlex_split(s):
 
 
 def interactive_open(targets, command):
-    """Open the files in `targets` by `exec`ing a new `command`, given
-    as a Unicode string. (The new program takes over, and Python
-    execution ends: this does not fork a subprocess.)
-
+    """On Unix like OS's open the files in `targets`
+    by `exec`ing a new `command` given as a Unicode string.
+    The new program takes over and Python execution ends.
+    This does not fork a subprocess.
+    On Windows each file in targets is invoked via `start file`.
     Can raise `OSError`.
     """
     assert command
@@ -929,6 +932,11 @@ def interactive_open(targets, command):
         args = shlex_split(command)
     except ValueError:  # Malformed shell tokens.
         args = [command]
+
+    if platform.system() == 'Windows':
+        for f in targets:
+            subprocess.call(' '.join(args).format(f))
+        return
 
     args.insert(0, args[0])  # for argv[0]
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -226,6 +226,8 @@ Fixes:
   the Cover Art Archive API.
   Thanks to :user:`trolley`.
   :bug:`3637`
+* :doc: Fix opening config on Windows produces Errno 22
+  :bug: `2847`
 
 For plugin developers:
 

--- a/test/test_config_command.py
+++ b/test/test_config_command.py
@@ -3,6 +3,7 @@
 from __future__ import division, absolute_import, print_function
 
 import os
+import platform
 import yaml
 from mock import patch
 from tempfile import mkdtemp
@@ -97,23 +98,44 @@ class ConfigCommandTest(unittest.TestCase, TestHelper):
 
     def test_edit_config_with_editor_env(self):
         os.environ['EDITOR'] = 'myeditor'
-        with patch('os.execlp') as execlp:
+        if platform.system() == 'Windows':
+            func = 'subprocess.call'
+        else:
+            func = 'os.execlp'
+
+        with patch(func) as process:
             self.run_command('config', '-e')
-        execlp.assert_called_once_with(
-            'myeditor', 'myeditor', self.config_path)
+        if platform.system() == 'Windows':
+            process.assert_called_once_with('myeditor')
+        else:
+            process.assert_called_once_with(
+                'myeditor', 'myeditor', self.config_path)
 
     def test_edit_config_with_automatic_open(self):
         with patch('beets.util.open_anything') as open:
             open.return_value = 'please_open'
-            with patch('os.execlp') as execlp:
+            if platform.system() == 'Windows':
+                func = 'subprocess.call'
+            else:
+                func = 'os.execlp'
+
+            with patch(func) as process:
                 self.run_command('config', '-e')
-        execlp.assert_called_once_with(
-            'please_open', 'please_open', self.config_path)
+        if platform.system() == 'Windows':
+            process.assert_called_once_with('please_open')
+        else:
+            process.assert_called_once_with(
+                'please_open', 'please_open', self.config_path)
 
     def test_config_editor_not_found(self):
         with self.assertRaises(ui.UserError) as user_error:
-            with patch('os.execlp') as execlp:
-                execlp.side_effect = OSError('here is problem')
+            if platform.system() == 'Windows':
+                func = 'subprocess.call'
+            else:
+                func = 'os.execlp'
+
+            with patch(func) as process:
+                process.side_effect = OSError('here is problem')
                 self.run_command('config', '-e')
         self.assertIn('Could not edit configuration',
                       six.text_type(user_error.exception))
@@ -126,10 +148,18 @@ class ConfigCommandTest(unittest.TestCase, TestHelper):
         config._materialized = False
 
         os.environ['EDITOR'] = 'myeditor'
-        with patch('os.execlp') as execlp:
+        if platform.system() == 'Windows':
+            func = 'subprocess.call'
+        else:
+            func = 'os.execlp'
+
+        with patch(func) as process:
             self.run_command('config', '-e')
-        execlp.assert_called_once_with(
-            'myeditor', 'myeditor', self.config_path)
+        if platform.system() == 'Windows':
+            process.assert_called_once_with('myeditor')
+        else:
+            process.assert_called_once_with(
+                'myeditor', 'myeditor', self.config_path)
 
 
 def suite():

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -51,7 +51,10 @@ class UtilTest(unittest.TestCase):
     def test_interactive_open(self, mock_open, mock_execlp):
         mock_open.return_value = u'tagada'
         util.interactive_open(['foo'], util.open_anything())
-        mock_execlp.assert_called_once_with(u'tagada', u'tagada', u'foo')
+        if platform.system() == 'Windows':
+            mock_execlp.assert_called_once_with(u'tagada')
+        else:
+            mock_execlp.assert_called_once_with(u'tagada', u'tagada', u'foo')
         mock_execlp.reset_mock()
 
         util.interactive_open(['foo'], u'bar')

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -19,6 +19,7 @@ from __future__ import division, absolute_import, print_function
 import sys
 import re
 import os
+import platform
 import subprocess
 import unittest
 
@@ -32,7 +33,7 @@ import six
 class UtilTest(unittest.TestCase):
     def test_open_anything(self):
         with _common.system_mock('Windows'):
-            self.assertEqual(util.open_anything(), 'start')
+            self.assertEqual(util.open_anything(), 'cmd /c \"start {}\"')
 
         with _common.system_mock('Darwin'):
             self.assertEqual(util.open_anything(), 'open')
@@ -40,7 +41,12 @@ class UtilTest(unittest.TestCase):
         with _common.system_mock('Tagada'):
             self.assertEqual(util.open_anything(), 'xdg-open')
 
-    @patch('os.execlp')
+    if platform.system() == 'Windows':
+        process = 'subprocess.call'
+    else:
+        process = 'os.execlp'
+
+    @patch(process)
     @patch('beets.util.open_anything')
     def test_interactive_open(self, mock_open, mock_execlp):
         mock_open.return_value = u'tagada'


### PR DESCRIPTION
## Description

Fixes #2847

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
