### PR TITLE
Unignore flake8 E221, E226, E242, E704

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -38,7 +38,7 @@ from string import ascii_lowercase
 
 
 USER_AGENT = u'beets/{0} +https://beets.io/'.format(beets.__version__)
-API_KEY    = 'rAzVUQYRaoFjeBjyWuWZ'
+API_KEY = 'rAzVUQYRaoFjeBjyWuWZ'
 API_SECRET = 'plxtUTqoCzwxZpqdPysCwGuBSmZNdZVy'
 
 # Exceptions that discogs_client should really handle but does not.

--- a/beetsplug/playlist.py
+++ b/beetsplug/playlist.py
@@ -71,7 +71,7 @@ class PlaylistQuery(beets.dbcore.Query):
         if not self.paths:
             # Playlist is empty
             return '0', ()
-        clause  = 'path IN ({0})'.format(', '.join('?' for path in self.paths))
+        clause = 'path IN ({0})'.format(', '.join('?' for path in self.paths))
         return clause, (beets.library.BLOB_TYPE(p) for p in self.paths)
 
     def match(self, item):

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,11 +9,8 @@ ignore =
     E123,  # closing bracket does not match indentation of opening bracket's line
     E126,  # continuation line over-indented for hangin indent
     E221,  # multiple spaces before operator (for vertical alignment)
-    E226,  # missing whitespace around arithmetic operator
     E241,  # multiple spaces after non-arithmetic operators (for vertical alignment)
-    E242,  # tabs after ','
     E305,  # expected 2 blank lines after end of function or class
-    E704,  # multiple statements on one line
     E731,  # do not assign a lamba expression, use a def
     E741,  # do not use variables name 'I', 'O', or 'l'
     # pycodestyle warnings

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,19 +1,32 @@
 [flake8]
-min-version=2.7
-accept-encodings=utf-8
-# Errors we ignore:
-# - E121,E123,E126,E24,E704,W503,W504 flake8 default ignores, excluding E226 (have to be listed here to not be overridden)
-# - E221: multiple spaces before operator (used to align visually)
-# - E731: do not assign a lambda expression, use a def
-# - F405 object may be undefined, or defined from star imports
-# - C901: function/method complexity
-# - E305: spacing after a declaration (might be nice to change eventually)
-# `flake8-future-import` errors we ignore:
-# - FI50: `__future__` import "division" present
-# - FI51: `__future__` import "absolute_import" present
-# - FI12: `__future__` import "with_statement" missing
-# - FI53: `__future__` import "print_function" present
-# - FI14: `__future__` import "unicode_literals" missing
-# - FI15: `__future__` import "generator_stop" missing
-# - E741: ambiguous variable name
-ignore=E121,E123,E126,E24,E704,W503,W504,E305,C901,E221,E731,F405,FI50,FI51,FI12,FI53,FI14,FI15,E741
+min-version = 2.7
+accept-encodings = utf-8
+docstring-convention = numpy
+# flake8 errors we ignore. See https://www.flake8rules.com/
+ignore =
+    # pycodestyle errors
+    E121,  # continuation line under-indented for hanging indent
+    E123,  # closing bracket does not match indentation of opening bracket's line
+    E126,  # continuation line over-indented for hangin indent
+    E221,  # multiple spaces before operator (for vertical alignment)
+    E226,  # missing whitespace around arithmetic operator
+    E241,  # multiple spaces after non-arithmetic operators (for vertical alignment)
+    E242,  # tabs after ','
+    E305,  # expected 2 blank lines after end of function or class
+    E704,  # multiple statements on one line
+    E731,  # do not assign a lamba expression, use a def
+    E741,  # do not use variables name 'I', 'O', or 'l'
+    # pycodestyle warnings
+    W503,  # line break occurred before a binary operator
+    W504,  # line break occurred after a binary operator
+    # pyflakes errors
+    F405,  # name be undefined, or defined from star imports: module
+    # mccabe error
+    C901,  # function is too complex
+    # future-import errors
+    FI12,  # `__future__` import "with_statement" missing
+    FI14,  # `__future__` import "unicode_literals" missing
+    FI15,  # `__future__` import "generator_stop" missing
+    FI50,  # `__future__` import "division" present
+    FI51,  # `__future__` import "absolute_import" present
+    FI53,  # `__future__` import "print_function" present

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,7 @@
 [flake8]
 min-version = 2.7
 accept-encodings = utf-8
-docstring-convention = numpy
-# flake8 errors we ignore. See https://www.flake8rules.com/
+# errors we ignore; see https://www.flake8rules.com/ for more info
 ignore =
     # pycodestyle errors
     E121,  # continuation line under-indented for hanging indent

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,6 @@ ignore =
     E121,  # continuation line under-indented for hanging indent
     E123,  # closing bracket does not match indentation of opening bracket's line
     E126,  # continuation line over-indented for hangin indent
-    E221,  # multiple spaces before operator (for vertical alignment)
     E241,  # multiple spaces after non-arithmetic operators (for vertical alignment)
     E305,  # expected 2 blank lines after end of function or class
     E731,  # do not assign a lamba expression, use a def


### PR DESCRIPTION
## Description

Un-ignore flake8 errors that required zero or minimal change to the codebase.

See [the discourse discussion ](https://discourse.beets.io/t/updating-the-errors-we-ignore-with-flake8/1393)
