### PR TITLE
Add possibility to select individual items to the remove CLI command

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -389,17 +389,19 @@ def input_yn(prompt, require=False):
     return sel == u'y'
 
 
-def input_select_objects(prompt, objs, rep):
+def input_select_objects(prompt, objs, rep, prompt_all=None):
     """Prompt to user to choose all, none, or some of the given objects.
     Return the list of selected objects.
 
     `prompt` is the prompt string to use for each question (it should be
-    phrased as an imperative verb). `rep` is a function to call on each
-    object to print it out when confirming objects individually.
+    phrased as an imperative verb). If `prompt_all` is given, it is used
+    instead of `prompt` for the first (yes(/no/select) question.
+    `rep` is a function to call on each object to print it out when confirming
+    objects individually.
     """
     choice = input_options(
         (u'y', u'n', u's'), False,
-        u'%s? (Yes/no/select)' % prompt)
+        u'%s? (Yes/no/select)' % (prompt_all or prompt))
     print()  # Blank line.
 
     if choice == u'y':  # Yes.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -148,6 +148,8 @@ New features:
   Thanks to :user:`logan-arens`.
   :bug:`2947`
 * Added flac-specific reporting of samplerate and bitrate when importing duplicates.
+* ``beet remove`` now also allows interactive selection of items from the query
+  similar to ``beet modify``
 
 Fixes:
 

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -230,10 +230,21 @@ remove
 Remove music from your library.
 
 This command uses the same :doc:`query <query>` syntax as the ``list`` command.
-You'll be shown a list of the files that will be removed and asked to confirm.
-By default, this just removes entries from the library database; it doesn't
-touch the files on disk. To actually delete the files, use ``beet remove -d``.
-If you do not want to be prompted to remove the files, use ``beet remove -f``.
+By default, it just removes entries from the library database; it doesn't
+touch the files on disk. To actually delete the files, use the ``-d`` flag.
+When the ``-a`` flag is given, the command operates on albums instead of
+individual tracks.
+
+When you run the ``remove`` command, it prints a list of all
+affected items in the library and asks for your permission before removing
+them. You can then choose to abort (type `n`), confirm (`y`), or interactively
+choose some of the items (`s`). In the latter case, the command will prompt you
+for every matching item or album and invite you to type `y` to remove the
+item/album, `n` to keep it or `q` to exit and only remove the items/albums
+selected up to this point.
+This option lets you choose precisely which tracks/albums to remove without
+spending too much time to carefully craft a query.
+If you do not want to be prompted at all, use the ``-f`` option.
 
 .. _modify-cmd:
 

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -163,10 +163,14 @@ class RemoveTest(_common.TestCase, TestHelper):
         commands.remove_items(self.lib, u'', False, True, False)
         items = self.lib.items()
         self.assertEqual(len(list(items)), 1)
-        # FIXME: is the order of the items as queried by the remove command
-        # really deterministic?
-        self.assertFalse(os.path.exists(syspath(self.i.path)))
-        self.assertTrue(os.path.exists(syspath(i2.path)))
+        # There is probably no guarantee that the items are queried in any
+        # spcecific order, thus just ensure that exactly one was removed.
+        # To improve upon this, self.io would need to have the capability to
+        # generate input that depends on previous output.
+        num_existing = 0
+        num_existing += 1 if os.path.exists(syspath(self.i.path)) else 0
+        num_existing += 1 if os.path.exists(syspath(i2.path)) else 0
+        self.assertEqual(num_existing, 1)
 
     def test_remove_albums_select_with_delete(self):
         a1 = self.add_album_fixture()
@@ -181,10 +185,11 @@ class RemoveTest(_common.TestCase, TestHelper):
         commands.remove_items(self.lib, u'', True, True, False)
         items = self.lib.items()
         self.assertEqual(len(list(items)), 2)  # incl. the item from setUp()
-        # FIXME: is the order of the items as queried by the remove command
-        # really deterministic?
-        self.assertFalse(os.path.exists(syspath(path1)))
-        self.assertTrue(os.path.exists(syspath(path2)))
+        # See test_remove_items_select_with_delete()
+        num_existing = 0
+        num_existing += 1 if os.path.exists(syspath(path1)) else 0
+        num_existing += 1 if os.path.exists(syspath(path2)) else 0
+        self.assertEqual(num_existing, 1)
 
 
 class ModifyTest(unittest.TestCase, TestHelper):

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -111,7 +111,7 @@ class ListTest(unittest.TestCase):
         self.assertNotIn(u'the album', stdout.getvalue())
 
 
-class RemoveTest(_common.TestCase):
+class RemoveTest(_common.TestCase, TestHelper):
     def setUp(self):
         super(RemoveTest, self).setUp()
 
@@ -122,8 +122,8 @@ class RemoveTest(_common.TestCase):
 
         # Copy a file into the library.
         self.lib = library.Library(':memory:', self.libdir)
-        item_path = os.path.join(_common.RSRC, b'full.mp3')
-        self.i = library.Item.from_path(item_path)
+        self.item_path = os.path.join(_common.RSRC, b'full.mp3')
+        self.i = library.Item.from_path(self.item_path)
         self.lib.add(self.i)
         self.i.move(operation=MoveOperation.COPY)
 
@@ -152,6 +152,39 @@ class RemoveTest(_common.TestCase):
         items = self.lib.items()
         self.assertEqual(len(list(items)), 0)
         self.assertFalse(os.path.exists(self.i.path))
+
+    def test_remove_items_select_with_delete(self):
+        i2 = library.Item.from_path(self.item_path)
+        self.lib.add(i2)
+        i2.move(operation=MoveOperation.COPY)
+
+        for s in ('s', 'y', 'n'):
+            self.io.addinput(s)
+        commands.remove_items(self.lib, u'', False, True, False)
+        items = self.lib.items()
+        self.assertEqual(len(list(items)), 1)
+        # FIXME: is the order of the items as queried by the remove command
+        # really deterministic?
+        self.assertFalse(os.path.exists(syspath(self.i.path)))
+        self.assertTrue(os.path.exists(syspath(i2.path)))
+
+    def test_remove_albums_select_with_delete(self):
+        a1 = self.add_album_fixture()
+        a2 = self.add_album_fixture()
+        path1 = a1.items()[0].path
+        path2 = a2.items()[0].path
+        items = self.lib.items()
+        self.assertEqual(len(list(items)), 3)
+
+        for s in ('s', 'y', 'n'):
+            self.io.addinput(s)
+        commands.remove_items(self.lib, u'', True, True, False)
+        items = self.lib.items()
+        self.assertEqual(len(list(items)), 2)  # incl. the item from setUp()
+        # FIXME: is the order of the items as queried by the remove command
+        # really deterministic?
+        self.assertFalse(os.path.exists(syspath(path1)))
+        self.assertTrue(os.path.exists(syspath(path2)))
 
 
 class ModifyTest(unittest.TestCase, TestHelper):


### PR DESCRIPTION
I just wanted to remove a few individual tracks from my library, for which a query was not simple to construct. As it turns out, the `remove` command wasn't very helpful in this case. Hence, this adds interactive selection of items to the `remove` command, analogously to item selection in the `modify` command. The `yes/no` answers to the prompt work as before, and the `select` answer is added. Thus, there's no change of previous behaviour.

I also changed the output when `-a` is given to group albums more clearly.