### PR TITLE
introduce snapcraft.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ var/
 *.manifest
 *.spec
 
+# Snapcraft output
+*.snap
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt

--- a/docs/guides/main.rst
+++ b/docs/guides/main.rst
@@ -22,9 +22,7 @@ Beets works on `Python 2.7`_ and Python 3.4 or later.
   official package (`Debian details`_, `Ubuntu details`_), so try typing:
   ``apt-get install beets``. But the version in the repositories might lag
   behind, so make sure you read the right version of these docs. If you want
-  the latest version, you can get everything you need to install with pip
-  as described below by running:
-  ``apt-get install python-dev python-pip``
+  the latest version, you can use the `snap <snap_>`_.
 
 * On **Arch Linux**, `beets is in [community] <Arch community_>`_, so just run ``pacman -S
   beets``. (There's also a bleeding-edge `dev package <AUR_>`_ in the AUR, which will
@@ -48,6 +46,8 @@ Beets works on `Python 2.7`_ and Python 3.4 or later.
 
 * On **NixOS**, there's a `package <NixOS_>`_ you can install with ``nix-env -i beets``.
 
+* On **snap** enabled systems, there's a `snap <snap>_`_.
+
 .. _DNF package: https://apps.fedoraproject.org/packages/beets
 .. _SlackBuild: https://slackbuilds.org/repository/14.2/multimedia/beets/
 .. _FreeBSD: http://portsmon.freebsd.org/portoverview.py?category=audio&portname=beets
@@ -57,6 +57,7 @@ Beets works on `Python 2.7`_ and Python 3.4 or later.
 .. _OpenBSD: http://openports.se/audio/beets
 .. _Arch community: https://www.archlinux.org/packages/community/any/beets/
 .. _NixOS: https://github.com/NixOS/nixpkgs/tree/master/pkgs/tools/audio/beets
+.. _snap: https://snapcraft.io/beets
 
 If you have `pip`_, just say ``pip install beets`` (or ``pip install --user
 beets`` if you run into permissions problems).

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,35 @@
+name: beets
+base: core20
+summary: Beets is the media library management system for obsessive music geeks.
+description: |
+  The purpose of beets is to get your music collection right once and for all.
+  It catalogs your collection, automatically improving its metadata as it goes.
+  It then provides a bouquet of tools for manipulating and accessing your music.
+confinement: strict
+adopt-info: beets
+
+apps:
+  beet:
+    command: bin/beet
+    plugs:
+      - home
+      - removable-media
+      - network
+      - network-bind
+
+parts:
+  beets:
+    source: .
+    override-pull: |
+      snapcraftctl pull
+      version="$(git describe --always --tags| sed -e 's/^v//;s/-/+git/;y/-/./')"
+      [ -n "$(echo $version | grep "+git")" ] && grade=devel || grade=stable
+      snapcraftctl set-version "$version"
+      snapcraftctl set-grade "$grade"
+    plugin: python
+    python-packages:
+      - requests
+      - Pillow
+      - pylast
+      - pyxdg
+      - wheel


### PR DESCRIPTION
## Description

This change introduces a snapcraft.yaml that would be handy for publishing to the Snap Store for Linux users. I am currently the publisher of the snap but if you want, I wouldn't mind transferring the ownership to you and from a _snap_ maintenance point of view I could remain as a collaborator of this snap if desired or warranted.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
