### PR TITLE
Add python 3.9-dev to CI tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9-dev]
 
     env:
       PY_COLORS: 1

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.8
+      - name: Set up latest Python version
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9-dev
 
       - name: Install base dependencies
         run: |


### PR DESCRIPTION
## Description

Adds CI tests for development versions of python3.9

[Support to the github action was just recently added.](https://github.com/actions/setup-python/issues/20#issuecomment-660026867)

Hopefully, this will help us catch errors like https://github.com/beetbox/beets/pull/3621 in the future

Fixes: #3622 
