### PR TITLE
update link to current homepage

### DIFF
--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -11,7 +11,7 @@ To use the ``fetchart`` plugin, first enable it in your configuration (see
 
 The plugin uses `requests`_ to fetch album art from the Web.
 
-.. _requests: https://docs.python-requests.org/en/latest/
+.. _requests: https://requests.readthedocs.io/en/master/
 
 Fetching Album Art During Import
 --------------------------------


### PR DESCRIPTION
update link from defunt page the plugin's current homepage

## Description

Fixes #X.  <!-- Insert issue number here if applicable. -->

(...)

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
