### PR TITLE
Add black as an auto formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+default_stages: [commit]
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: stable
+    hooks:
+      - id: black
+        language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,13 @@ repos:
     hooks:
       - id: black
         language_version: python3
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: master
+    hooks:
+      - id: flake8
+        additional_dependencies: [
+        flake8-blind-except,
+        flake8-coding,
+        flake8-future-import,
+        ]

--- a/beet
+++ b/beet
@@ -19,5 +19,5 @@ from __future__ import division, absolute_import, print_function
 
 import beets.ui
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     beets.ui.main()

--- a/beets/__init__.py
+++ b/beets/__init__.py
@@ -18,25 +18,27 @@ from __future__ import division, absolute_import, print_function
 import confuse
 from sys import stderr
 
-__version__ = u'1.5.0'
-__author__ = u'Adrian Sampson <adrian@radbox.org>'
+__version__ = u"1.5.0"
+__author__ = u"Adrian Sampson <adrian@radbox.org>"
 
 
 class IncludeLazyConfig(confuse.LazyConfig):
     """A version of Confuse's LazyConfig that also merges in data from
     YAML files specified in an `include` setting.
     """
+
     def read(self, user=True, defaults=True):
         super(IncludeLazyConfig, self).read(user, defaults)
 
         try:
-            for view in self['include']:
+            for view in self["include"]:
                 self.set_file(view.as_filename())
         except confuse.NotFoundError:
             pass
         except confuse.ConfigReadError as err:
-            stderr.write("configuration `import` failed: {}"
-                         .format(err.reason))
+            stderr.write(
+                "configuration `import` failed: {}".format(err.reason)
+            )
 
 
-config = IncludeLazyConfig('beets', __name__)
+config = IncludeLazyConfig("beets", __name__)

--- a/beets/art.py
+++ b/beets/art.py
@@ -33,7 +33,7 @@ def mediafile_image(image_path, maxwidth=None):
     """Return a `mediafile.Image` object for the path.
     """
 
-    with open(syspath(image_path), 'rb') as f:
+    with open(syspath(image_path), "rb") as f:
         data = f.read()
     return mediafile.Image(data, type=mediafile.ImageType.front)
 
@@ -43,77 +43,114 @@ def get_art(log, item):
     try:
         mf = mediafile.MediaFile(syspath(item.path))
     except mediafile.UnreadableFileError as exc:
-        log.warning(u'Could not extract art from {0}: {1}',
-                    displayable_path(item.path), exc)
+        log.warning(
+            u"Could not extract art from {0}: {1}",
+            displayable_path(item.path),
+            exc,
+        )
         return
 
     return mf.art
 
 
-def embed_item(log, item, imagepath, maxwidth=None, itempath=None,
-               compare_threshold=0, ifempty=False, as_album=False, id3v23=None,
-               quality=0):
+def embed_item(
+    log,
+    item,
+    imagepath,
+    maxwidth=None,
+    itempath=None,
+    compare_threshold=0,
+    ifempty=False,
+    as_album=False,
+    id3v23=None,
+    quality=0,
+):
     """Embed an image into the item's media file.
     """
     # Conditions and filters.
     if compare_threshold:
         if not check_art_similarity(log, item, imagepath, compare_threshold):
-            log.info(u'Image not similar; skipping.')
+            log.info(u"Image not similar; skipping.")
             return
     if ifempty and get_art(log, item):
-        log.info(u'media file already contained art')
+        log.info(u"media file already contained art")
         return
     if maxwidth and not as_album:
         imagepath = resize_image(log, imagepath, maxwidth, quality)
 
     # Get the `Image` object from the file.
     try:
-        log.debug(u'embedding {0}', displayable_path(imagepath))
+        log.debug(u"embedding {0}", displayable_path(imagepath))
         image = mediafile_image(imagepath, maxwidth)
     except IOError as exc:
-        log.warning(u'could not read image file: {0}', exc)
+        log.warning(u"could not read image file: {0}", exc)
         return
 
     # Make sure the image kind is safe (some formats only support PNG
     # and JPEG).
-    if image.mime_type not in ('image/jpeg', 'image/png'):
-        log.info('not embedding image of unsupported type: {}',
-                 image.mime_type)
+    if image.mime_type not in ("image/jpeg", "image/png"):
+        log.info(
+            "not embedding image of unsupported type: {}", image.mime_type
+        )
         return
 
-    item.try_write(path=itempath, tags={'images': [image]}, id3v23=id3v23)
+    item.try_write(path=itempath, tags={"images": [image]}, id3v23=id3v23)
 
 
-def embed_album(log, album, maxwidth=None, quiet=False, compare_threshold=0,
-                ifempty=False, quality=0):
+def embed_album(
+    log,
+    album,
+    maxwidth=None,
+    quiet=False,
+    compare_threshold=0,
+    ifempty=False,
+    quality=0,
+):
     """Embed album art into all of the album's items.
     """
     imagepath = album.artpath
     if not imagepath:
-        log.info(u'No album art present for {0}', album)
+        log.info(u"No album art present for {0}", album)
         return
     if not os.path.isfile(syspath(imagepath)):
-        log.info(u'Album art not found at {0} for {1}',
-                 displayable_path(imagepath), album)
+        log.info(
+            u"Album art not found at {0} for {1}",
+            displayable_path(imagepath),
+            album,
+        )
         return
     if maxwidth:
         imagepath = resize_image(log, imagepath, maxwidth, quality)
 
-    log.info(u'Embedding album art into {0}', album)
+    log.info(u"Embedding album art into {0}", album)
 
     for item in album.items():
-        embed_item(log, item, imagepath, maxwidth, None, compare_threshold,
-                   ifempty, as_album=True, quality=quality)
+        embed_item(
+            log,
+            item,
+            imagepath,
+            maxwidth,
+            None,
+            compare_threshold,
+            ifempty,
+            as_album=True,
+            quality=quality,
+        )
 
 
 def resize_image(log, imagepath, maxwidth, quality):
     """Returns path to an image resized to maxwidth and encoded with the
     specified quality level.
     """
-    log.debug(u'Resizing album art to {0} pixels wide and encoding at quality \
-              level {1}', maxwidth, quality)
-    imagepath = ArtResizer.shared.resize(maxwidth, syspath(imagepath),
-                                         quality=quality)
+    log.debug(
+        u"Resizing album art to {0} pixels wide and encoding at quality \
+              level {1}",
+        maxwidth,
+        quality,
+    )
+    imagepath = ArtResizer.shared.resize(
+        maxwidth, syspath(imagepath), quality=quality
+    )
     return imagepath
 
 
@@ -131,12 +168,20 @@ def check_art_similarity(log, item, imagepath, compare_threshold):
             # to grayscale and then pipe them into the `compare` command.
             # On Windows, ImageMagick doesn't support the magic \\?\ prefix
             # on paths, so we pass `prefix=False` to `syspath`.
-            convert_cmd = ['convert', syspath(imagepath, prefix=False),
-                           syspath(art, prefix=False),
-                           '-colorspace', 'gray', 'MIFF:-']
-            compare_cmd = ['compare', '-metric', 'PHASH', '-', 'null:']
-            log.debug(u'comparing images with pipeline {} | {}',
-                      convert_cmd, compare_cmd)
+            convert_cmd = [
+                "convert",
+                syspath(imagepath, prefix=False),
+                syspath(art, prefix=False),
+                "-colorspace",
+                "gray",
+                "MIFF:-",
+            ]
+            compare_cmd = ["compare", "-metric", "PHASH", "-", "null:"]
+            log.debug(
+                u"comparing images with pipeline {} | {}",
+                convert_cmd,
+                compare_cmd,
+            )
             convert_proc = subprocess.Popen(
                 convert_cmd,
                 stdout=subprocess.PIPE,
@@ -159,7 +204,7 @@ def check_art_similarity(log, item, imagepath, compare_threshold):
             convert_proc.wait()
             if convert_proc.returncode:
                 log.debug(
-                    u'ImageMagick convert failed with status {}: {!r}',
+                    u"ImageMagick convert failed with status {}: {!r}",
                     convert_proc.returncode,
                     convert_stderr,
                 )
@@ -169,9 +214,11 @@ def check_art_similarity(log, item, imagepath, compare_threshold):
             stdout, stderr = compare_proc.communicate()
             if compare_proc.returncode:
                 if compare_proc.returncode != 1:
-                    log.debug(u'ImageMagick compare failed: {0}, {1}',
-                              displayable_path(imagepath),
-                              displayable_path(art))
+                    log.debug(
+                        u"ImageMagick compare failed: {0}, {1}",
+                        displayable_path(imagepath),
+                        displayable_path(art),
+                    )
                     return
                 out_str = stderr
             else:
@@ -180,10 +227,10 @@ def check_art_similarity(log, item, imagepath, compare_threshold):
             try:
                 phash_diff = float(out_str)
             except ValueError:
-                log.debug(u'IM output is not a number: {0!r}', out_str)
+                log.debug(u"IM output is not a number: {0!r}", out_str)
                 return
 
-            log.debug(u'ImageMagick compare score: {0}', phash_diff)
+            log.debug(u"ImageMagick compare score: {0}", phash_diff)
             return phash_diff <= compare_threshold
 
     return True
@@ -193,20 +240,22 @@ def extract(log, outpath, item):
     art = get_art(log, item)
     outpath = bytestring_path(outpath)
     if not art:
-        log.info(u'No album art present in {0}, skipping.', item)
+        log.info(u"No album art present in {0}, skipping.", item)
         return
 
     # Add an extension to the filename.
     ext = mediafile.image_extension(art)
     if not ext:
-        log.warning(u'Unknown image type in {0}.',
-                    displayable_path(item.path))
+        log.warning(u"Unknown image type in {0}.", displayable_path(item.path))
         return
-    outpath += bytestring_path('.' + ext)
+    outpath += bytestring_path("." + ext)
 
-    log.info(u'Extracting album art from: {0} to: {1}',
-             item, displayable_path(outpath))
-    with open(syspath(outpath), 'wb') as f:
+    log.info(
+        u"Extracting album art from: {0} to: {1}",
+        item,
+        displayable_path(outpath),
+    )
+    with open(syspath(outpath), "wb") as f:
         f.write(art)
     return outpath
 
@@ -220,7 +269,7 @@ def extract_first(log, outpath, items):
 
 def clear(log, lib, query):
     items = lib.items(query)
-    log.info(u'Clearing album art from {0} items', len(items))
+    log.info(u"Clearing album art from {0} items", len(items))
     for item in items:
-        log.debug(u'Clearing art for {0}', item)
-        item.try_write(tags={'images': None})
+        log.debug(u"Clearing art for {0}", item)
+        item.try_write(tags={"images": None})

--- a/beets/autotag/__init__.py
+++ b/beets/autotag/__init__.py
@@ -33,45 +33,46 @@ from .match import tag_item, tag_album, Proposal  # noqa
 from .match import Recommendation  # noqa
 
 # Global logger.
-log = logging.getLogger('beets')
+log = logging.getLogger("beets")
 
 # Metadata fields that are already hardcoded, or where the tag name changes.
 SPECIAL_FIELDS = {
-    'album': (
-        'va',
-        'releasegroup_id',
-        'artist_id',
-        'album_id',
-        'mediums',
-        'tracks',
-        'year',
-        'month',
-        'day',
-        'artist',
-        'artist_credit',
-        'artist_sort',
-        'data_url'
+    "album": (
+        "va",
+        "releasegroup_id",
+        "artist_id",
+        "album_id",
+        "mediums",
+        "tracks",
+        "year",
+        "month",
+        "day",
+        "artist",
+        "artist_credit",
+        "artist_sort",
+        "data_url",
     ),
-    'track': (
-        'track_alt',
-        'artist_id',
-        'release_track_id',
-        'medium',
-        'index',
-        'medium_index',
-        'title',
-        'artist_credit',
-        'artist_sort',
-        'artist',
-        'track_id',
-        'medium_total',
-        'data_url',
-        'length'
-    )
+    "track": (
+        "track_alt",
+        "artist_id",
+        "release_track_id",
+        "medium",
+        "index",
+        "medium_index",
+        "title",
+        "artist_credit",
+        "artist_sort",
+        "artist",
+        "track_id",
+        "medium_total",
+        "data_url",
+        "length",
+    ),
 }
 
 
 # Additional utilities for the main interface.
+
 
 def apply_item_metadata(item, track_info):
     """Set an item's metadata from its matched TrackInfo object.
@@ -87,7 +88,7 @@ def apply_item_metadata(item, track_info):
 
     for field, value in track_info.items():
         # We only overwrite fields that are not already hardcoded.
-        if field in SPECIAL_FIELDS['track']:
+        if field in SPECIAL_FIELDS["track"]:
             continue
         if value is None:
             continue
@@ -103,15 +104,16 @@ def apply_metadata(album_info, mapping):
     """
     for item, track_info in mapping.items():
         # Artist or artist credit.
-        if config['artist_credit']:
-            item.artist = (track_info.artist_credit or
-                           track_info.artist or
-                           album_info.artist_credit or
-                           album_info.artist)
-            item.albumartist = (album_info.artist_credit or
-                                album_info.artist)
+        if config["artist_credit"]:
+            item.artist = (
+                track_info.artist_credit
+                or track_info.artist
+                or album_info.artist_credit
+                or album_info.artist
+            )
+            item.albumartist = album_info.artist_credit or album_info.artist
         else:
-            item.artist = (track_info.artist or album_info.artist)
+            item.artist = track_info.artist or album_info.artist
             item.albumartist = album_info.artist
 
         # Album.
@@ -119,23 +121,24 @@ def apply_metadata(album_info, mapping):
 
         # Artist sort and credit names.
         item.artist_sort = track_info.artist_sort or album_info.artist_sort
-        item.artist_credit = (track_info.artist_credit or
-                              album_info.artist_credit)
+        item.artist_credit = (
+            track_info.artist_credit or album_info.artist_credit
+        )
         item.albumartist_sort = album_info.artist_sort
         item.albumartist_credit = album_info.artist_credit
 
         # Release date.
-        for prefix in '', 'original_':
-            if config['original_date'] and not prefix:
+        for prefix in "", "original_":
+            if config["original_date"] and not prefix:
                 # Ignore specific release date.
                 continue
 
-            for suffix in 'year', 'month', 'day':
+            for suffix in "year", "month", "day":
                 key = prefix + suffix
                 value = getattr(album_info, key) or 0
 
                 # If we don't even have a year, apply nothing.
-                if suffix == 'year' and not value:
+                if suffix == "year" and not value:
                     break
 
                 # Otherwise, set the fetched value (or 0 for the month
@@ -144,13 +147,13 @@ def apply_metadata(album_info, mapping):
 
                 # If we're using original release date for both fields,
                 # also set item.year = info.original_year, etc.
-                if config['original_date']:
+                if config["original_date"]:
                     item[suffix] = value
 
         # Title.
         item.title = track_info.title
 
-        if config['per_disc_numbering']:
+        if config["per_disc_numbering"]:
             # We want to let the track number be zero, but if the medium index
             # is not provided we need to fall back to the overall index.
             if track_info.medium_index is not None:
@@ -186,17 +189,17 @@ def apply_metadata(album_info, mapping):
         # Don't overwrite fields with empty values unless the
         # field is explicitly allowed to be overwritten
         for field, value in album_info.items():
-            if field in SPECIAL_FIELDS['album']:
+            if field in SPECIAL_FIELDS["album"]:
                 continue
-            clobber = field in config['overwrite_null']['album'].as_str_seq()
+            clobber = field in config["overwrite_null"]["album"].as_str_seq()
             if value is None and not clobber:
                 continue
             item[field] = value
 
         for field, value in track_info.items():
-            if field in SPECIAL_FIELDS['track']:
+            if field in SPECIAL_FIELDS["track"]:
                 continue
-            clobber = field in config['overwrite_null']['track'].as_str_seq()
+            clobber = field in config["overwrite_null"]["track"].as_str_seq()
             value = getattr(track_info, field)
             if value is None and not clobber:
                 continue

--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -29,7 +29,7 @@ from jellyfish import levenshtein_distance
 from unidecode import unidecode
 import six
 
-log = logging.getLogger('beets')
+log = logging.getLogger("beets")
 
 # The name of the type for patterns in re changed in Python 3.7.
 try:
@@ -70,17 +70,45 @@ class AlbumInfo(AttrDict):
     ``mediums`` along with the fields up through ``tracks`` are required.
     The others are optional and may be None.
     """
-    def __init__(self, tracks, album=None, album_id=None, artist=None,
-                 artist_id=None, asin=None, albumtype=None, va=False,
-                 year=None, month=None, day=None, label=None, mediums=None,
-                 artist_sort=None, releasegroup_id=None, catalognum=None,
-                 script=None, language=None, country=None, style=None,
-                 genre=None, albumstatus=None, media=None, albumdisambig=None,
-                 releasegroupdisambig=None, artist_credit=None,
-                 original_year=None, original_month=None,
-                 original_day=None, data_source=None, data_url=None,
-                 discogs_albumid=None, discogs_labelid=None,
-                 discogs_artistid=None, **kwargs):
+
+    def __init__(
+        self,
+        tracks,
+        album=None,
+        album_id=None,
+        artist=None,
+        artist_id=None,
+        asin=None,
+        albumtype=None,
+        va=False,
+        year=None,
+        month=None,
+        day=None,
+        label=None,
+        mediums=None,
+        artist_sort=None,
+        releasegroup_id=None,
+        catalognum=None,
+        script=None,
+        language=None,
+        country=None,
+        style=None,
+        genre=None,
+        albumstatus=None,
+        media=None,
+        albumdisambig=None,
+        releasegroupdisambig=None,
+        artist_credit=None,
+        original_year=None,
+        original_month=None,
+        original_day=None,
+        data_source=None,
+        data_url=None,
+        discogs_albumid=None,
+        discogs_labelid=None,
+        discogs_artistid=None,
+        **kwargs
+    ):
         self.album = album
         self.album_id = album_id
         self.artist = artist
@@ -120,19 +148,34 @@ class AlbumInfo(AttrDict):
     # Work around a bug in python-musicbrainz-ngs that causes some
     # strings to be bytes rather than Unicode.
     # https://github.com/alastair/python-musicbrainz-ngs/issues/85
-    def decode(self, codec='utf-8'):
+    def decode(self, codec="utf-8"):
         """Ensure that all string attributes on this object, and the
         constituent `TrackInfo` objects, are decoded to Unicode.
         """
-        for fld in ['album', 'artist', 'albumtype', 'label', 'artist_sort',
-                    'catalognum', 'script', 'language', 'country', 'style',
-                    'genre', 'albumstatus', 'albumdisambig',
-                    'releasegroupdisambig', 'artist_credit',
-                    'media', 'discogs_albumid', 'discogs_labelid',
-                    'discogs_artistid']:
+        for fld in [
+            "album",
+            "artist",
+            "albumtype",
+            "label",
+            "artist_sort",
+            "catalognum",
+            "script",
+            "language",
+            "country",
+            "style",
+            "genre",
+            "albumstatus",
+            "albumdisambig",
+            "releasegroupdisambig",
+            "artist_credit",
+            "media",
+            "discogs_albumid",
+            "discogs_labelid",
+            "discogs_artistid",
+        ]:
             value = getattr(self, fld)
             if isinstance(value, bytes):
-                setattr(self, fld, value.decode(codec, 'ignore'))
+                setattr(self, fld, value.decode(codec, "ignore"))
 
         for track in self.tracks:
             track.decode(codec)
@@ -155,15 +198,38 @@ class TrackInfo(AttrDict):
     may be None. The indices ``index``, ``medium``, and ``medium_index``
     are all 1-based.
     """
-    def __init__(self, title=None, track_id=None, release_track_id=None,
-                 artist=None, artist_id=None, length=None, index=None,
-                 medium=None, medium_index=None, medium_total=None,
-                 artist_sort=None, disctitle=None, artist_credit=None,
-                 data_source=None, data_url=None, media=None, lyricist=None,
-                 composer=None, composer_sort=None, arranger=None,
-                 track_alt=None, work=None, mb_workid=None,
-                 work_disambig=None, bpm=None, initial_key=None, genre=None,
-                 **kwargs):
+
+    def __init__(
+        self,
+        title=None,
+        track_id=None,
+        release_track_id=None,
+        artist=None,
+        artist_id=None,
+        length=None,
+        index=None,
+        medium=None,
+        medium_index=None,
+        medium_total=None,
+        artist_sort=None,
+        disctitle=None,
+        artist_credit=None,
+        data_source=None,
+        data_url=None,
+        media=None,
+        lyricist=None,
+        composer=None,
+        composer_sort=None,
+        arranger=None,
+        track_alt=None,
+        work=None,
+        mb_workid=None,
+        work_disambig=None,
+        bpm=None,
+        initial_key=None,
+        genre=None,
+        **kwargs
+    ):
         self.title = title
         self.track_id = track_id
         self.release_track_id = release_track_id
@@ -194,15 +260,22 @@ class TrackInfo(AttrDict):
         self.update(kwargs)
 
     # As above, work around a bug in python-musicbrainz-ngs.
-    def decode(self, codec='utf-8'):
+    def decode(self, codec="utf-8"):
         """Ensure that all string attributes on this object are decoded
         to Unicode.
         """
-        for fld in ['title', 'artist', 'medium', 'artist_sort', 'disctitle',
-                    'artist_credit', 'media']:
+        for fld in [
+            "title",
+            "artist",
+            "medium",
+            "artist_sort",
+            "disctitle",
+            "artist_credit",
+            "media",
+        ]:
             value = getattr(self, fld)
             if isinstance(value, bytes):
-                setattr(self, fld, value.decode(codec, 'ignore'))
+                setattr(self, fld, value.decode(codec, "ignore"))
 
     def copy(self):
         dupe = TrackInfo()
@@ -214,19 +287,19 @@ class TrackInfo(AttrDict):
 
 # Parameters for string distance function.
 # Words that can be moved to the end of a string using a comma.
-SD_END_WORDS = ['the', 'a', 'an']
+SD_END_WORDS = ["the", "a", "an"]
 # Reduced weights for certain portions of the string.
 SD_PATTERNS = [
-    (r'^the ', 0.1),
-    (r'[\[\(]?(ep|single)[\]\)]?', 0.0),
-    (r'[\[\(]?(featuring|feat|ft)[\. :].+', 0.1),
-    (r'\(.*?\)', 0.3),
-    (r'\[.*?\]', 0.3),
-    (r'(, )?(pt\.|part) .+', 0.2),
+    (r"^the ", 0.1),
+    (r"[\[\(]?(ep|single)[\]\)]?", 0.0),
+    (r"[\[\(]?(featuring|feat|ft)[\. :].+", 0.1),
+    (r"\(.*?\)", 0.3),
+    (r"\[.*?\]", 0.3),
+    (r"(, )?(pt\.|part) .+", 0.2),
 ]
 # Replacements to use before testing distance.
 SD_REPLACE = [
-    (r'&', 'and'),
+    (r"&", "and"),
 ]
 
 
@@ -240,8 +313,8 @@ def _string_dist_basic(str1, str2):
     assert isinstance(str2, six.text_type)
     str1 = as_string(unidecode(str1))
     str2 = as_string(unidecode(str2))
-    str1 = re.sub(r'[^a-z0-9]', '', str1.lower())
-    str2 = re.sub(r'[^a-z0-9]', '', str2.lower())
+    str1 = re.sub(r"[^a-z0-9]", "", str1.lower())
+    str2 = re.sub(r"[^a-z0-9]", "", str2.lower())
     if not str1 and not str2:
         return 0.0
     return levenshtein_distance(str1, str2) / float(max(len(str1), len(str2)))
@@ -264,10 +337,10 @@ def string_dist(str1, str2):
     # example, "the something" should be considered equal to
     # "something, the".
     for word in SD_END_WORDS:
-        if str1.endswith(', %s' % word):
-            str1 = '%s %s' % (word, str1[:-len(word) - 2])
-        if str2.endswith(', %s' % word):
-            str2 = '%s %s' % (word, str2[:-len(word) - 2])
+        if str1.endswith(", %s" % word):
+            str1 = "%s %s" % (word, str1[: -len(word) - 2])
+        if str2.endswith(", %s" % word):
+            str2 = "%s %s" % (word, str2[: -len(word) - 2])
 
     # Perform a couple of basic normalizing substitutions.
     for pat, repl in SD_REPLACE:
@@ -282,8 +355,8 @@ def string_dist(str1, str2):
     penalty = 0.0
     for pat, weight in SD_PATTERNS:
         # Get strings that drop the pattern.
-        case_str1 = re.sub(pat, '', str1)
-        case_str2 = re.sub(pat, '', str2)
+        case_str1 = re.sub(pat, "", str1)
+        case_str2 = re.sub(pat, "", str2)
 
         if case_str1 != str1 or case_str2 != str2:
             # If the pattern was present (i.e., it is deleted in the
@@ -310,6 +383,7 @@ class LazyClassProperty(object):
     the sense that the getter is only invoked once. Subsequent accesses
     through *any* instance use the cached result.
     """
+
     def __init__(self, getter):
         self.getter = getter
         self.computed = False
@@ -328,6 +402,7 @@ class Distance(object):
     weighted distance for all penalties as well as a weighted distance
     for each individual penalty.
     """
+
     def __init__(self):
         self._penalties = {}
 
@@ -335,7 +410,7 @@ class Distance(object):
     def _weights(cls):  # noqa: N805
         """A dictionary from keys to floating-point weights.
         """
-        weights_view = config['match']['distance_weights']
+        weights_view = config["match"]["distance_weights"]
         weights = {}
         for key in weights_view.keys():
             weights[key] = weights_view[key].as_number()
@@ -385,8 +460,7 @@ class Distance(object):
         # ascending order (for keys, when the penalty is equal) and
         # still get the items with the biggest distance first.
         return sorted(
-            list_,
-            key=lambda key_and_dist: (-key_and_dist[1], key_and_dist[0])
+            list_, key=lambda key_and_dist: (-key_and_dist[1], key_and_dist[0])
         )
 
     def __hash__(self):
@@ -437,7 +511,7 @@ class Distance(object):
         """
         if not isinstance(dist, Distance):
             raise ValueError(
-                u'`dist` must be a Distance object, not {0}'.format(type(dist))
+                u"`dist` must be a Distance object, not {0}".format(type(dist))
             )
         for key, penalties in dist._penalties.items():
             self._penalties.setdefault(key, []).extend(penalties)
@@ -461,7 +535,7 @@ class Distance(object):
         """
         if not 0.0 <= dist <= 1.0:
             raise ValueError(
-                u'`dist` must be between 0.0 and 1.0, not {0}'.format(dist)
+                u"`dist` must be between 0.0 and 1.0, not {0}".format(dist)
             )
         self._penalties.setdefault(key, []).append(dist)
 
@@ -542,13 +616,16 @@ class Distance(object):
 
 # Structures that compose all the information for a candidate match.
 
-AlbumMatch = namedtuple('AlbumMatch', ['distance', 'info', 'mapping',
-                                       'extra_items', 'extra_tracks'])
+AlbumMatch = namedtuple(
+    "AlbumMatch",
+    ["distance", "info", "mapping", "extra_items", "extra_tracks"],
+)
 
-TrackMatch = namedtuple('TrackMatch', ['distance', 'info'])
+TrackMatch = namedtuple("TrackMatch", ["distance", "info"])
 
 
 # Aggregation of sources.
+
 
 def album_for_mbid(release_id):
     """Get an AlbumInfo object for a MusicBrainz release ID. Return None
@@ -557,7 +634,7 @@ def album_for_mbid(release_id):
     try:
         album = mb.album_for_id(release_id)
         if album:
-            plugins.send(u'albuminfo_received', info=album)
+            plugins.send(u"albuminfo_received", info=album)
         return album
     except mb.MusicBrainzAPIError as exc:
         exc.log(log)
@@ -570,7 +647,7 @@ def track_for_mbid(recording_id):
     try:
         track = mb.track_for_id(recording_id)
         if track:
-            plugins.send(u'trackinfo_received', info=track)
+            plugins.send(u"trackinfo_received", info=track)
         return track
     except mb.MusicBrainzAPIError as exc:
         exc.log(log)
@@ -583,7 +660,7 @@ def albums_for_id(album_id):
         yield a
     for a in plugins.album_for_id(album_id):
         if a:
-            plugins.send(u'albuminfo_received', info=a)
+            plugins.send(u"albuminfo_received", info=a)
             yield a
 
 
@@ -594,11 +671,11 @@ def tracks_for_id(track_id):
         yield t
     for t in plugins.track_for_id(track_id):
         if t:
-            plugins.send(u'trackinfo_received', info=t)
+            plugins.send(u"trackinfo_received", info=t)
             yield t
 
 
-@plugins.notify_info_yielded(u'albuminfo_received')
+@plugins.notify_info_yielded(u"albuminfo_received")
 def album_candidates(items, artist, album, va_likely, extra_tags):
     """Search for album matches. ``items`` is a list of Item objects
     that make up the album. ``artist`` and ``album`` are the respective
@@ -612,8 +689,9 @@ def album_candidates(items, artist, album, va_likely, extra_tags):
     # Base candidates if we have album and artist to match.
     if artist and album:
         try:
-            for candidate in mb.match_album(artist, album, len(items),
-                                            extra_tags):
+            for candidate in mb.match_album(
+                artist, album, len(items), extra_tags
+            ):
                 yield candidate
         except mb.MusicBrainzAPIError as exc:
             exc.log(log)
@@ -621,19 +699,21 @@ def album_candidates(items, artist, album, va_likely, extra_tags):
     # Also add VA matches from MusicBrainz where appropriate.
     if va_likely and album:
         try:
-            for candidate in mb.match_album(None, album, len(items),
-                                            extra_tags):
+            for candidate in mb.match_album(
+                None, album, len(items), extra_tags
+            ):
                 yield candidate
         except mb.MusicBrainzAPIError as exc:
             exc.log(log)
 
     # Candidates from plugins.
-    for candidate in plugins.candidates(items, artist, album, va_likely,
-                                        extra_tags):
+    for candidate in plugins.candidates(
+        items, artist, album, va_likely, extra_tags
+    ):
         yield candidate
 
 
-@plugins.notify_info_yielded(u'trackinfo_received')
+@plugins.notify_info_yielded(u"trackinfo_received")
 def item_candidates(item, artist, title):
     """Search for item matches. ``item`` is the Item to be matched.
     ``artist`` and ``title`` are strings and either reflect the item or

--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -35,18 +35,20 @@ from beets.util.enumeration import OrderedEnum
 # album level to determine whether a given release is likely a VA
 # release and also on the track level to to remove the penalty for
 # differing artists.
-VA_ARTISTS = (u'', u'various artists', u'various', u'va', u'unknown')
+VA_ARTISTS = (u"", u"various artists", u"various", u"va", u"unknown")
 
 # Global logger.
-log = logging.getLogger('beets')
+log = logging.getLogger("beets")
 
 
 # Recommendation enumeration.
+
 
 class Recommendation(OrderedEnum):
     """Indicates a qualitative suggestion to the user about what should
     be done with a given match.
     """
+
     none = 0
     low = 1
     medium = 2
@@ -57,10 +59,11 @@ class Recommendation(OrderedEnum):
 # consists of a list of possible candidates (i.e., AlbumInfo or TrackInfo
 # objects) and a recommendation value.
 
-Proposal = namedtuple('Proposal', ('candidates', 'recommendation'))
+Proposal = namedtuple("Proposal", ("candidates", "recommendation"))
 
 
 # Primary matching functionality.
+
 
 def current_metadata(items):
     """Extract the likely current metadata for an album given a list of its
@@ -72,17 +75,27 @@ def current_metadata(items):
 
     likelies = {}
     consensus = {}
-    fields = ['artist', 'album', 'albumartist', 'year', 'disctotal',
-              'mb_albumid', 'label', 'catalognum', 'country', 'media',
-              'albumdisambig']
+    fields = [
+        "artist",
+        "album",
+        "albumartist",
+        "year",
+        "disctotal",
+        "mb_albumid",
+        "label",
+        "catalognum",
+        "country",
+        "media",
+        "albumdisambig",
+    ]
     for field in fields:
         values = [item[field] for item in items if item]
         likelies[field], freq = plurality(values)
-        consensus[field] = (freq == len(values))
+        consensus[field] = freq == len(values)
 
     # If there's an album artist consensus, use this for the artist.
-    if consensus['albumartist'] and likelies['albumartist']:
-        likelies['artist'] = likelies['albumartist']
+    if consensus["albumartist"] and likelies["albumartist"]:
+        likelies["artist"] = likelies["albumartist"]
 
     return likelies, consensus
 
@@ -103,9 +116,9 @@ def assign_items(items, tracks):
         costs.append(row)
 
     # Find a minimum-cost bipartite matching.
-    log.debug('Computing track assignment...')
+    log.debug("Computing track assignment...")
     matching = Munkres().compute(costs)
-    log.debug('...done.')
+    log.debug("...done.")
 
     # Produce the output matching.
     mapping = dict((items[i], tracks[j]) for (i, j) in matching)
@@ -132,26 +145,34 @@ def track_distance(item, track_info, incl_artist=False):
 
     # Length.
     if track_info.length:
-        diff = abs(item.length - track_info.length) - \
-            config['match']['track_length_grace'].as_number()
-        dist.add_ratio('track_length', diff,
-                       config['match']['track_length_max'].as_number())
+        diff = (
+            abs(item.length - track_info.length)
+            - config["match"]["track_length_grace"].as_number()
+        )
+        dist.add_ratio(
+            "track_length",
+            diff,
+            config["match"]["track_length_max"].as_number(),
+        )
 
     # Title.
-    dist.add_string('track_title', item.title, track_info.title)
+    dist.add_string("track_title", item.title, track_info.title)
 
     # Artist. Only check if there is actually an artist in the track data.
-    if incl_artist and track_info.artist and \
-            item.artist.lower() not in VA_ARTISTS:
-        dist.add_string('track_artist', item.artist, track_info.artist)
+    if (
+        incl_artist
+        and track_info.artist
+        and item.artist.lower() not in VA_ARTISTS
+    ):
+        dist.add_string("track_artist", item.artist, track_info.artist)
 
     # Track index.
     if track_info.index and item.track:
-        dist.add_expr('track_index', track_index_changed(item, track_info))
+        dist.add_expr("track_index", track_index_changed(item, track_info))
 
     # Track ID.
     if item.mb_trackid:
-        dist.add_expr('track_id', item.mb_trackid != track_info.track_id)
+        dist.add_expr("track_id", item.mb_trackid != track_info.track_id)
 
     # Plugins.
     dist.update(plugins.track_distance(item, track_info))
@@ -174,90 +195,96 @@ def distance(items, album_info, mapping):
 
     # Artist, if not various.
     if not album_info.va:
-        dist.add_string('artist', likelies['artist'], album_info.artist)
+        dist.add_string("artist", likelies["artist"], album_info.artist)
 
     # Album.
-    dist.add_string('album', likelies['album'], album_info.album)
+    dist.add_string("album", likelies["album"], album_info.album)
 
     # Current or preferred media.
     if album_info.media:
         # Preferred media options.
-        patterns = config['match']['preferred']['media'].as_str_seq()
-        options = [re.compile(r'(\d+x)?(%s)' % pat, re.I) for pat in patterns]
+        patterns = config["match"]["preferred"]["media"].as_str_seq()
+        options = [re.compile(r"(\d+x)?(%s)" % pat, re.I) for pat in patterns]
         if options:
-            dist.add_priority('media', album_info.media, options)
+            dist.add_priority("media", album_info.media, options)
         # Current media.
-        elif likelies['media']:
-            dist.add_equality('media', album_info.media, likelies['media'])
+        elif likelies["media"]:
+            dist.add_equality("media", album_info.media, likelies["media"])
 
     # Mediums.
-    if likelies['disctotal'] and album_info.mediums:
-        dist.add_number('mediums', likelies['disctotal'], album_info.mediums)
+    if likelies["disctotal"] and album_info.mediums:
+        dist.add_number("mediums", likelies["disctotal"], album_info.mediums)
 
     # Prefer earliest release.
-    if album_info.year and config['match']['preferred']['original_year']:
+    if album_info.year and config["match"]["preferred"]["original_year"]:
         # Assume 1889 (earliest first gramophone discs) if we don't know the
         # original year.
         original = album_info.original_year or 1889
         diff = abs(album_info.year - original)
         diff_max = abs(datetime.date.today().year - original)
-        dist.add_ratio('year', diff, diff_max)
+        dist.add_ratio("year", diff, diff_max)
     # Year.
-    elif likelies['year'] and album_info.year:
-        if likelies['year'] in (album_info.year, album_info.original_year):
+    elif likelies["year"] and album_info.year:
+        if likelies["year"] in (album_info.year, album_info.original_year):
             # No penalty for matching release or original year.
-            dist.add('year', 0.0)
+            dist.add("year", 0.0)
         elif album_info.original_year:
             # Prefer matchest closest to the release year.
-            diff = abs(likelies['year'] - album_info.year)
-            diff_max = abs(datetime.date.today().year -
-                           album_info.original_year)
-            dist.add_ratio('year', diff, diff_max)
+            diff = abs(likelies["year"] - album_info.year)
+            diff_max = abs(
+                datetime.date.today().year - album_info.original_year
+            )
+            dist.add_ratio("year", diff, diff_max)
         else:
             # Full penalty when there is no original year.
-            dist.add('year', 1.0)
+            dist.add("year", 1.0)
 
     # Preferred countries.
-    patterns = config['match']['preferred']['countries'].as_str_seq()
+    patterns = config["match"]["preferred"]["countries"].as_str_seq()
     options = [re.compile(pat, re.I) for pat in patterns]
     if album_info.country and options:
-        dist.add_priority('country', album_info.country, options)
+        dist.add_priority("country", album_info.country, options)
     # Country.
-    elif likelies['country'] and album_info.country:
-        dist.add_string('country', likelies['country'], album_info.country)
+    elif likelies["country"] and album_info.country:
+        dist.add_string("country", likelies["country"], album_info.country)
 
     # Label.
-    if likelies['label'] and album_info.label:
-        dist.add_string('label', likelies['label'], album_info.label)
+    if likelies["label"] and album_info.label:
+        dist.add_string("label", likelies["label"], album_info.label)
 
     # Catalog number.
-    if likelies['catalognum'] and album_info.catalognum:
-        dist.add_string('catalognum', likelies['catalognum'],
-                        album_info.catalognum)
+    if likelies["catalognum"] and album_info.catalognum:
+        dist.add_string(
+            "catalognum", likelies["catalognum"], album_info.catalognum
+        )
 
     # Disambiguation.
-    if likelies['albumdisambig'] and album_info.albumdisambig:
-        dist.add_string('albumdisambig', likelies['albumdisambig'],
-                        album_info.albumdisambig)
+    if likelies["albumdisambig"] and album_info.albumdisambig:
+        dist.add_string(
+            "albumdisambig",
+            likelies["albumdisambig"],
+            album_info.albumdisambig,
+        )
 
     # Album ID.
-    if likelies['mb_albumid']:
-        dist.add_equality('album_id', likelies['mb_albumid'],
-                          album_info.album_id)
+    if likelies["mb_albumid"]:
+        dist.add_equality(
+            "album_id", likelies["mb_albumid"], album_info.album_id
+        )
 
     # Tracks.
     dist.tracks = {}
     for item, track in mapping.items():
         dist.tracks[track] = track_distance(item, track, album_info.va)
-        dist.add('tracks', dist.tracks[track].distance)
+        dist.add("tracks", dist.tracks[track].distance)
 
     # Missing tracks.
     for i in range(len(album_info.tracks) - len(mapping)):
-        dist.add('missing_tracks', 1.0)
+        dist.add("missing_tracks", 1.0)
 
     # Unmatched tracks.
     for i in range(len(items) - len(mapping)):
-        dist.add('unmatched_tracks', 1.0)
+        dist.add("unmatched_tracks", 1.0)
 
     # Plugins.
     dist.update(plugins.album_distance(items, album_info, mapping))
@@ -276,16 +303,16 @@ def match_by_id(items):
     try:
         first = next(albumids)
     except StopIteration:
-        log.debug(u'No album ID found.')
+        log.debug(u"No album ID found.")
         return None
 
     # Is there a consensus on the MB album ID?
     for other in albumids:
         if other != first:
-            log.debug(u'No album ID consensus.')
+            log.debug(u"No album ID consensus.")
             return None
     # If all album IDs are equal, look up the album.
-    log.debug(u'Searching for discovered album ID: {0}', first)
+    log.debug(u"Searching for discovered album ID: {0}", first)
     return hooks.album_for_mbid(first)
 
 
@@ -303,17 +330,19 @@ def _recommendation(results):
 
     # Basic distance thresholding.
     min_dist = results[0].distance
-    if min_dist < config['match']['strong_rec_thresh'].as_number():
+    if min_dist < config["match"]["strong_rec_thresh"].as_number():
         # Strong recommendation level.
         rec = Recommendation.strong
-    elif min_dist <= config['match']['medium_rec_thresh'].as_number():
+    elif min_dist <= config["match"]["medium_rec_thresh"].as_number():
         # Medium recommendation level.
         rec = Recommendation.medium
     elif len(results) == 1:
         # Only a single candidate.
         rec = Recommendation.low
-    elif results[1].distance - min_dist >= \
-            config['match']['rec_gap_thresh'].as_number():
+    elif (
+        results[1].distance - min_dist
+        >= config["match"]["rec_gap_thresh"].as_number()
+    ):
         # Gap between first two candidates is large.
         rec = Recommendation.low
     else:
@@ -326,15 +355,17 @@ def _recommendation(results):
     if isinstance(results[0], hooks.AlbumMatch):
         for track_dist in min_dist.tracks.values():
             keys.update(list(track_dist.keys()))
-    max_rec_view = config['match']['max_rec']
+    max_rec_view = config["match"]["max_rec"]
     for key in keys:
         if key in list(max_rec_view.keys()):
-            max_rec = max_rec_view[key].as_choice({
-                'strong': Recommendation.strong,
-                'medium': Recommendation.medium,
-                'low': Recommendation.low,
-                'none': Recommendation.none,
-            })
+            max_rec = max_rec_view[key].as_choice(
+                {
+                    "strong": Recommendation.strong,
+                    "medium": Recommendation.medium,
+                    "low": Recommendation.low,
+                    "none": Recommendation.none,
+                }
+            )
             rec = min(rec, max_rec)
 
     return rec
@@ -351,23 +382,24 @@ def _add_candidate(items, results, info):
     checking the track count, ordering the items, checking for
     duplicates, and calculating the distance.
     """
-    log.debug(u'Candidate: {0} - {1} ({2})',
-              info.artist, info.album, info.album_id)
+    log.debug(
+        u"Candidate: {0} - {1} ({2})", info.artist, info.album, info.album_id
+    )
 
     # Discard albums with zero tracks.
     if not info.tracks:
-        log.debug(u'No tracks.')
+        log.debug(u"No tracks.")
         return
 
     # Don't duplicate.
     if info.album_id in results:
-        log.debug(u'Duplicate.')
+        log.debug(u"Duplicate.")
         return
 
     # Discard matches without required tags.
-    for req_tag in config['match']['required'].as_str_seq():
+    for req_tag in config["match"]["required"].as_str_seq():
         if getattr(info, req_tag) is None:
-            log.debug(u'Ignored. Missing required tag: {0}', req_tag)
+            log.debug(u"Ignored. Missing required tag: {0}", req_tag)
             return
 
     # Find mapping between the items and the track info.
@@ -378,18 +410,18 @@ def _add_candidate(items, results, info):
 
     # Skip matches with ignored penalties.
     penalties = [key for key, _ in dist]
-    for penalty in config['match']['ignored'].as_str_seq():
+    for penalty in config["match"]["ignored"].as_str_seq():
         if penalty in penalties:
-            log.debug(u'Ignored. Penalty: {0}', penalty)
+            log.debug(u"Ignored. Penalty: {0}", penalty)
             return
 
-    log.debug(u'Success. Distance: {0}', dist)
-    results[info.album_id] = hooks.AlbumMatch(dist, info, mapping,
-                                              extra_items, extra_tracks)
+    log.debug(u"Success. Distance: {0}", dist)
+    results[info.album_id] = hooks.AlbumMatch(
+        dist, info, mapping, extra_items, extra_tracks
+    )
 
 
-def tag_album(items, search_artist=None, search_album=None,
-              search_ids=[]):
+def tag_album(items, search_artist=None, search_album=None, search_ids=[]):
     """Return a tuple of the current artist name, the current album
     name, and a `Proposal` containing `AlbumMatch` candidates.
 
@@ -409,9 +441,9 @@ def tag_album(items, search_artist=None, search_album=None,
     """
     # Get current metadata.
     likelies, consensus = current_metadata(items)
-    cur_artist = likelies['artist']
-    cur_album = likelies['album']
-    log.debug(u'Tagging {0} - {1}', cur_artist, cur_album)
+    cur_artist = likelies["artist"]
+    cur_album = likelies["album"]
+    log.debug(u"Tagging {0} - {1}", cur_artist, cur_album)
 
     # The output result (distance, AlbumInfo) tuples (keyed by MB album
     # ID).
@@ -420,7 +452,7 @@ def tag_album(items, search_artist=None, search_album=None,
     # Search by explicit ID.
     if search_ids:
         for search_id in search_ids:
-            log.debug(u'Searching for album ID: {0}', search_id)
+            log.debug(u"Searching for album ID: {0}", search_id)
             for id_candidate in hooks.albums_for_id(search_id):
                 _add_candidate(items, candidates, id_candidate)
 
@@ -431,51 +463,53 @@ def tag_album(items, search_artist=None, search_album=None,
         if id_info:
             _add_candidate(items, candidates, id_info)
             rec = _recommendation(list(candidates.values()))
-            log.debug(u'Album ID match recommendation is {0}', rec)
-            if candidates and not config['import']['timid']:
+            log.debug(u"Album ID match recommendation is {0}", rec)
+            if candidates and not config["import"]["timid"]:
                 # If we have a very good MBID match, return immediately.
                 # Otherwise, this match will compete against metadata-based
                 # matches.
                 if rec == Recommendation.strong:
-                    log.debug(u'ID match.')
-                    return cur_artist, cur_album, \
-                        Proposal(list(candidates.values()), rec)
+                    log.debug(u"ID match.")
+                    return (
+                        cur_artist,
+                        cur_album,
+                        Proposal(list(candidates.values()), rec),
+                    )
 
         # Search terms.
         if not (search_artist and search_album):
             # No explicit search terms -- use current metadata.
             search_artist, search_album = cur_artist, cur_album
-        log.debug(u'Search terms: {0} - {1}', search_artist, search_album)
+        log.debug(u"Search terms: {0} - {1}", search_artist, search_album)
 
         extra_tags = None
-        if config['musicbrainz']['extra_tags']:
-            tag_list = config['musicbrainz']['extra_tags'].get()
+        if config["musicbrainz"]["extra_tags"]:
+            tag_list = config["musicbrainz"]["extra_tags"].get()
             extra_tags = {k: v for (k, v) in likelies.items() if k in tag_list}
-            log.debug(u'Additional search terms: {0}', extra_tags)
+            log.debug(u"Additional search terms: {0}", extra_tags)
 
         # Is this album likely to be a "various artist" release?
-        va_likely = ((not consensus['artist']) or
-                     (search_artist.lower() in VA_ARTISTS) or
-                     any(item.comp for item in items))
-        log.debug(u'Album might be VA: {0}', va_likely)
+        va_likely = (
+            (not consensus["artist"])
+            or (search_artist.lower() in VA_ARTISTS)
+            or any(item.comp for item in items)
+        )
+        log.debug(u"Album might be VA: {0}", va_likely)
 
         # Get the results from the data sources.
-        for matched_candidate in hooks.album_candidates(items,
-                                                        search_artist,
-                                                        search_album,
-                                                        va_likely,
-                                                        extra_tags):
+        for matched_candidate in hooks.album_candidates(
+            items, search_artist, search_album, va_likely, extra_tags
+        ):
             _add_candidate(items, candidates, matched_candidate)
 
-    log.debug(u'Evaluating {0} candidates.', len(candidates))
+    log.debug(u"Evaluating {0} candidates.", len(candidates))
     # Sort and get the recommendation.
     candidates = _sort_candidates(candidates.values())
     rec = _recommendation(candidates)
     return cur_artist, cur_album, Proposal(candidates, rec)
 
 
-def tag_item(item, search_artist=None, search_title=None,
-             search_ids=[]):
+def tag_item(item, search_artist=None, search_title=None, search_ids=[]):
     """Find metadata for a single track. Return a `Proposal` consisting
     of `TrackMatch` objects.
 
@@ -492,16 +526,19 @@ def tag_item(item, search_artist=None, search_title=None,
     trackids = search_ids or [t for t in [item.mb_trackid] if t]
     if trackids:
         for trackid in trackids:
-            log.debug(u'Searching for track ID: {0}', trackid)
+            log.debug(u"Searching for track ID: {0}", trackid)
             for track_info in hooks.tracks_for_id(trackid):
                 dist = track_distance(item, track_info, incl_artist=True)
-                candidates[track_info.track_id] = \
-                    hooks.TrackMatch(dist, track_info)
+                candidates[track_info.track_id] = hooks.TrackMatch(
+                    dist, track_info
+                )
                 # If this is a good match, then don't keep searching.
                 rec = _recommendation(_sort_candidates(candidates.values()))
-                if rec == Recommendation.strong and \
-                        not config['import']['timid']:
-                    log.debug(u'Track ID match.')
+                if (
+                    rec == Recommendation.strong
+                    and not config["import"]["timid"]
+                ):
+                    log.debug(u"Track ID match.")
                     return Proposal(_sort_candidates(candidates.values()), rec)
 
     # If we're searching by ID, don't proceed.
@@ -514,7 +551,7 @@ def tag_item(item, search_artist=None, search_title=None,
     # Search terms.
     if not (search_artist and search_title):
         search_artist, search_title = item.artist, item.title
-    log.debug(u'Item search terms: {0} - {1}', search_artist, search_title)
+    log.debug(u"Item search terms: {0} - {1}", search_artist, search_title)
 
     # Get and evaluate candidate metadata.
     for track_info in hooks.item_candidates(item, search_artist, search_title):
@@ -522,7 +559,7 @@ def tag_item(item, search_artist=None, search_title=None,
         candidates[track_info.track_id] = hooks.TrackMatch(dist, track_info)
 
     # Sort by distance and return with recommendation.
-    log.debug(u'Found {0} candidates.', len(candidates))
+    log.debug(u"Found {0} candidates.", len(candidates))
     candidates = _sort_candidates(candidates.values())
     rec = _recommendation(candidates)
     return Proposal(candidates, rec)

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -29,70 +29,80 @@ from beets import util
 from beets import config
 import six
 
-VARIOUS_ARTISTS_ID = '89ad4ac3-39f7-470e-963a-56509c546377'
+VARIOUS_ARTISTS_ID = "89ad4ac3-39f7-470e-963a-56509c546377"
 
 if util.SNI_SUPPORTED:
-    BASE_URL = 'https://musicbrainz.org/'
+    BASE_URL = "https://musicbrainz.org/"
 else:
-    BASE_URL = 'http://musicbrainz.org/'
+    BASE_URL = "http://musicbrainz.org/"
 
-SKIPPED_TRACKS = ['[data track]']
+SKIPPED_TRACKS = ["[data track]"]
 
 FIELDS_TO_MB_KEYS = {
-    'catalognum': 'catno',
-    'country': 'country',
-    'label': 'label',
-    'media': 'format',
-    'year': 'date',
+    "catalognum": "catno",
+    "country": "country",
+    "label": "label",
+    "media": "format",
+    "year": "date",
 }
 
-musicbrainzngs.set_useragent('beets', beets.__version__,
-                             'https://beets.io/')
+musicbrainzngs.set_useragent("beets", beets.__version__, "https://beets.io/")
 
 
 class MusicBrainzAPIError(util.HumanReadableException):
     """An error while talking to MusicBrainz. The `query` field is the
     parameter to the action and may have any type.
     """
+
     def __init__(self, reason, verb, query, tb=None):
         self.query = query
         if isinstance(reason, musicbrainzngs.WebServiceError):
-            reason = u'MusicBrainz not reachable'
+            reason = u"MusicBrainz not reachable"
         super(MusicBrainzAPIError, self).__init__(reason, verb, tb)
 
     def get_message(self):
-        return u'{0} in {1} with query {2}'.format(
+        return u"{0} in {1} with query {2}".format(
             self._reasonstr(), self.verb, repr(self.query)
         )
 
-log = logging.getLogger('beets')
 
-RELEASE_INCLUDES = ['artists', 'media', 'recordings', 'release-groups',
-                    'labels', 'artist-credits', 'aliases',
-                    'recording-level-rels', 'work-rels',
-                    'work-level-rels', 'artist-rels']
-TRACK_INCLUDES = ['artists', 'aliases']
-if 'work-level-rels' in musicbrainzngs.VALID_INCLUDES['recording']:
-    TRACK_INCLUDES += ['work-level-rels', 'artist-rels']
+log = logging.getLogger("beets")
+
+RELEASE_INCLUDES = [
+    "artists",
+    "media",
+    "recordings",
+    "release-groups",
+    "labels",
+    "artist-credits",
+    "aliases",
+    "recording-level-rels",
+    "work-rels",
+    "work-level-rels",
+    "artist-rels",
+]
+TRACK_INCLUDES = ["artists", "aliases"]
+if "work-level-rels" in musicbrainzngs.VALID_INCLUDES["recording"]:
+    TRACK_INCLUDES += ["work-level-rels", "artist-rels"]
 
 
 def track_url(trackid):
-    return urljoin(BASE_URL, 'recording/' + trackid)
+    return urljoin(BASE_URL, "recording/" + trackid)
 
 
 def album_url(albumid):
-    return urljoin(BASE_URL, 'release/' + albumid)
+    return urljoin(BASE_URL, "release/" + albumid)
 
 
 def configure():
     """Set up the python-musicbrainz-ngs module according to settings
     from the beets configuration. This should be called at startup.
     """
-    hostname = config['musicbrainz']['host'].as_str()
+    hostname = config["musicbrainz"]["host"].as_str()
     musicbrainzngs.set_hostname(hostname)
     musicbrainzngs.set_rate_limit(
-        config['musicbrainz']['ratelimit_interval'].as_number(),
-        config['musicbrainz']['ratelimit'].get(int),
+        config["musicbrainz"]["ratelimit_interval"].as_number(),
+        config["musicbrainz"]["ratelimit"].get(int),
     )
 
 
@@ -105,13 +115,14 @@ def _preferred_alias(aliases):
         return
 
     # Only consider aliases that have locales set.
-    aliases = [a for a in aliases if 'locale' in a]
+    aliases = [a for a in aliases if "locale" in a]
 
     # Search configured locales in order.
-    for locale in config['import']['languages'].as_str_seq():
+    for locale in config["import"]["languages"].as_str_seq():
         # Find matching primary aliases for this locale.
-        matches = [a for a in aliases
-                   if a['locale'] == locale and 'primary' in a]
+        matches = [
+            a for a in aliases if a["locale"] == locale and "primary" in a
+        ]
         # Skip to the next locale if we have no matches
         if not matches:
             continue
@@ -124,17 +135,17 @@ def _preferred_release_event(release):
     event as a tuple of (country, release_date). Fall back to the
     default release event if a preferred event is not found.
     """
-    countries = config['match']['preferred']['countries'].as_str_seq()
+    countries = config["match"]["preferred"]["countries"].as_str_seq()
 
     for country in countries:
-        for event in release.get('release-event-list', {}):
+        for event in release.get("release-event-list", {}):
             try:
-                if country in event['area']['iso-3166-1-code-list']:
-                    return country, event['date']
+                if country in event["area"]["iso-3166-1-code-list"]:
+                    return country, event["date"]
             except KeyError:
                 pass
 
-    return release.get('country'), release.get('date')
+    return release.get("country"), release.get("date")
 
 
 def _flatten_artist_credit(credit):
@@ -153,38 +164,39 @@ def _flatten_artist_credit(credit):
             artist_sort_parts.append(el)
 
         else:
-            alias = _preferred_alias(el['artist'].get('alias-list', ()))
+            alias = _preferred_alias(el["artist"].get("alias-list", ()))
 
             # An artist.
             if alias:
-                cur_artist_name = alias['alias']
+                cur_artist_name = alias["alias"]
             else:
-                cur_artist_name = el['artist']['name']
+                cur_artist_name = el["artist"]["name"]
             artist_parts.append(cur_artist_name)
 
             # Artist sort name.
             if alias:
-                artist_sort_parts.append(alias['sort-name'])
-            elif 'sort-name' in el['artist']:
-                artist_sort_parts.append(el['artist']['sort-name'])
+                artist_sort_parts.append(alias["sort-name"])
+            elif "sort-name" in el["artist"]:
+                artist_sort_parts.append(el["artist"]["sort-name"])
             else:
                 artist_sort_parts.append(cur_artist_name)
 
             # Artist credit.
-            if 'name' in el:
-                artist_credit_parts.append(el['name'])
+            if "name" in el:
+                artist_credit_parts.append(el["name"])
             else:
                 artist_credit_parts.append(cur_artist_name)
 
     return (
-        ''.join(artist_parts),
-        ''.join(artist_sort_parts),
-        ''.join(artist_credit_parts),
+        "".join(artist_parts),
+        "".join(artist_sort_parts),
+        "".join(artist_credit_parts),
     )
 
 
-def track_info(recording, index=None, medium=None, medium_index=None,
-               medium_total=None):
+def track_info(
+    recording, index=None, medium=None, medium_index=None, medium_total=None
+):
     """Translates a MusicBrainz recording result dictionary into a beets
     ``TrackInfo`` object. Three parameters are optional and are used
     only for tracks that appear on releases (non-singletons): ``index``,
@@ -193,63 +205,68 @@ def track_info(recording, index=None, medium=None, medium_index=None,
     the number of tracks on the medium. Each number is a 1-based index.
     """
     info = beets.autotag.hooks.TrackInfo(
-        title=recording['title'],
-        track_id=recording['id'],
+        title=recording["title"],
+        track_id=recording["id"],
         index=index,
         medium=medium,
         medium_index=medium_index,
         medium_total=medium_total,
-        data_source=u'MusicBrainz',
-        data_url=track_url(recording['id']),
+        data_source=u"MusicBrainz",
+        data_url=track_url(recording["id"]),
     )
 
-    if recording.get('artist-credit'):
+    if recording.get("artist-credit"):
         # Get the artist names.
-        info.artist, info.artist_sort, info.artist_credit = \
-            _flatten_artist_credit(recording['artist-credit'])
+        (
+            info.artist,
+            info.artist_sort,
+            info.artist_credit,
+        ) = _flatten_artist_credit(recording["artist-credit"])
 
         # Get the ID and sort name of the first artist.
-        artist = recording['artist-credit'][0]['artist']
-        info.artist_id = artist['id']
+        artist = recording["artist-credit"][0]["artist"]
+        info.artist_id = artist["id"]
 
-    if recording.get('length'):
-        info.length = int(recording['length']) / (1000.0)
+    if recording.get("length"):
+        info.length = int(recording["length"]) / (1000.0)
 
     lyricist = []
     composer = []
     composer_sort = []
-    for work_relation in recording.get('work-relation-list', ()):
-        if work_relation['type'] != 'performance':
+    for work_relation in recording.get("work-relation-list", ()):
+        if work_relation["type"] != "performance":
             continue
-        info.work = work_relation['work']['title']
-        info.mb_workid = work_relation['work']['id']
-        if 'disambiguation' in work_relation['work']:
-            info.work_disambig = work_relation['work']['disambiguation']
+        info.work = work_relation["work"]["title"]
+        info.mb_workid = work_relation["work"]["id"]
+        if "disambiguation" in work_relation["work"]:
+            info.work_disambig = work_relation["work"]["disambiguation"]
 
-        for artist_relation in work_relation['work'].get(
-                'artist-relation-list', ()):
-            if 'type' in artist_relation:
-                type = artist_relation['type']
-                if type == 'lyricist':
-                    lyricist.append(artist_relation['artist']['name'])
-                elif type == 'composer':
-                    composer.append(artist_relation['artist']['name'])
+        for artist_relation in work_relation["work"].get(
+            "artist-relation-list", ()
+        ):
+            if "type" in artist_relation:
+                type = artist_relation["type"]
+                if type == "lyricist":
+                    lyricist.append(artist_relation["artist"]["name"])
+                elif type == "composer":
+                    composer.append(artist_relation["artist"]["name"])
                     composer_sort.append(
-                        artist_relation['artist']['sort-name'])
+                        artist_relation["artist"]["sort-name"]
+                    )
     if lyricist:
-        info.lyricist = u', '.join(lyricist)
+        info.lyricist = u", ".join(lyricist)
     if composer:
-        info.composer = u', '.join(composer)
-        info.composer_sort = u', '.join(composer_sort)
+        info.composer = u", ".join(composer)
+        info.composer_sort = u", ".join(composer_sort)
 
     arranger = []
-    for artist_relation in recording.get('artist-relation-list', ()):
-        if 'type' in artist_relation:
-            type = artist_relation['type']
-            if type == 'arranger':
-                arranger.append(artist_relation['artist']['name'])
+    for artist_relation in recording.get("artist-relation-list", ()):
+        if "type" in artist_relation:
+            type = artist_relation["type"]
+            if type == "arranger":
+                arranger.append(artist_relation["artist"]["name"])
     if arranger:
-        info.arranger = u', '.join(arranger)
+        info.arranger = u", ".join(arranger)
 
     info.decode()
     return info
@@ -261,8 +278,8 @@ def _set_date_str(info, date_str, original=False):
     `original`, then set the original_year, etc., fields.
     """
     if date_str:
-        date_parts = date_str.split('-')
-        for key in ('year', 'month', 'day'):
+        date_parts = date_str.split("-")
+        for key in ("year", "month", "day"):
             if date_parts:
                 date_part = date_parts.pop(0)
                 try:
@@ -271,7 +288,7 @@ def _set_date_str(info, date_str, original=False):
                     continue
 
                 if original:
-                    key = 'original_' + key
+                    key = "original_" + key
                 setattr(info, key, date_num)
 
 
@@ -280,115 +297,134 @@ def album_info(release):
     AlbumInfo object containing the interesting data about that release.
     """
     # Get artist name using join phrases.
-    artist_name, artist_sort_name, artist_credit_name = \
-        _flatten_artist_credit(release['artist-credit'])
+    artist_name, artist_sort_name, artist_credit_name = _flatten_artist_credit(
+        release["artist-credit"]
+    )
 
     # Basic info.
     track_infos = []
     index = 0
-    for medium in release['medium-list']:
-        disctitle = medium.get('title')
-        format = medium.get('format')
+    for medium in release["medium-list"]:
+        disctitle = medium.get("title")
+        format = medium.get("format")
 
-        if format in config['match']['ignored_media'].as_str_seq():
+        if format in config["match"]["ignored_media"].as_str_seq():
             continue
 
-        all_tracks = medium['track-list']
-        if ('data-track-list' in medium
-                and not config['match']['ignore_data_tracks']):
-            all_tracks += medium['data-track-list']
+        all_tracks = medium["track-list"]
+        if (
+            "data-track-list" in medium
+            and not config["match"]["ignore_data_tracks"]
+        ):
+            all_tracks += medium["data-track-list"]
         track_count = len(all_tracks)
 
-        if 'pregap' in medium:
-            all_tracks.insert(0, medium['pregap'])
+        if "pregap" in medium:
+            all_tracks.insert(0, medium["pregap"])
 
         for track in all_tracks:
 
-            if ('title' in track['recording'] and
-                    track['recording']['title'] in SKIPPED_TRACKS):
+            if (
+                "title" in track["recording"]
+                and track["recording"]["title"] in SKIPPED_TRACKS
+            ):
                 continue
 
-            if ('video' in track['recording'] and
-                    track['recording']['video'] == 'true' and
-                    config['match']['ignore_video_tracks']):
+            if (
+                "video" in track["recording"]
+                and track["recording"]["video"] == "true"
+                and config["match"]["ignore_video_tracks"]
+            ):
                 continue
 
             # Basic information from the recording.
             index += 1
             ti = track_info(
-                track['recording'],
+                track["recording"],
                 index,
-                int(medium['position']),
-                int(track['position']),
+                int(medium["position"]),
+                int(track["position"]),
                 track_count,
             )
-            ti.release_track_id = track['id']
+            ti.release_track_id = track["id"]
             ti.disctitle = disctitle
             ti.media = format
-            ti.track_alt = track['number']
+            ti.track_alt = track["number"]
 
             # Prefer track data, where present, over recording data.
-            if track.get('title'):
-                ti.title = track['title']
-            if track.get('artist-credit'):
+            if track.get("title"):
+                ti.title = track["title"]
+            if track.get("artist-credit"):
                 # Get the artist names.
-                ti.artist, ti.artist_sort, ti.artist_credit = \
-                    _flatten_artist_credit(track['artist-credit'])
-                ti.artist_id = track['artist-credit'][0]['artist']['id']
-            if track.get('length'):
-                ti.length = int(track['length']) / (1000.0)
+                (
+                    ti.artist,
+                    ti.artist_sort,
+                    ti.artist_credit,
+                ) = _flatten_artist_credit(track["artist-credit"])
+                ti.artist_id = track["artist-credit"][0]["artist"]["id"]
+            if track.get("length"):
+                ti.length = int(track["length"]) / (1000.0)
 
             track_infos.append(ti)
 
     info = beets.autotag.hooks.AlbumInfo(
-        album=release['title'],
-        album_id=release['id'],
+        album=release["title"],
+        album_id=release["id"],
         artist=artist_name,
-        artist_id=release['artist-credit'][0]['artist']['id'],
+        artist_id=release["artist-credit"][0]["artist"]["id"],
         tracks=track_infos,
-        mediums=len(release['medium-list']),
+        mediums=len(release["medium-list"]),
         artist_sort=artist_sort_name,
         artist_credit=artist_credit_name,
-        data_source=u'MusicBrainz',
-        data_url=album_url(release['id']),
+        data_source=u"MusicBrainz",
+        data_url=album_url(release["id"]),
     )
     info.va = info.artist_id == VARIOUS_ARTISTS_ID
     if info.va:
-        info.artist = config['va_name'].as_str()
-    info.asin = release.get('asin')
-    info.releasegroup_id = release['release-group']['id']
-    info.albumstatus = release.get('status')
+        info.artist = config["va_name"].as_str()
+    info.asin = release.get("asin")
+    info.releasegroup_id = release["release-group"]["id"]
+    info.albumstatus = release.get("status")
 
     # Get the disambiguation strings at the release and release group level.
-    if release['release-group'].get('disambiguation'):
-        info.releasegroupdisambig = \
-            release['release-group'].get('disambiguation')
-    if release.get('disambiguation'):
-        info.albumdisambig = release.get('disambiguation')
+    if release["release-group"].get("disambiguation"):
+        info.releasegroupdisambig = release["release-group"].get(
+            "disambiguation"
+        )
+    if release.get("disambiguation"):
+        info.albumdisambig = release.get("disambiguation")
 
     # Get the "classic" Release type. This data comes from a legacy API
     # feature before MusicBrainz supported multiple release types.
-    if 'type' in release['release-group']:
-        reltype = release['release-group']['type']
+    if "type" in release["release-group"]:
+        reltype = release["release-group"]["type"]
         if reltype:
             info.albumtype = reltype.lower()
 
     # Log the new-style "primary" and "secondary" release types.
     # Eventually, we'd like to actually store this data, but we just log
     # it for now to help understand the differences.
-    if 'primary-type' in release['release-group']:
-        rel_primarytype = release['release-group']['primary-type']
+    if "primary-type" in release["release-group"]:
+        rel_primarytype = release["release-group"]["primary-type"]
         if rel_primarytype:
-            log.debug('primary MB release type: ' + rel_primarytype.lower())
-    if 'secondary-type-list' in release['release-group']:
-        if release['release-group']['secondary-type-list']:
-            log.debug('secondary MB release type(s): ' + ', '.join(
-                [secondarytype.lower() for secondarytype in
-                    release['release-group']['secondary-type-list']]))
+            log.debug("primary MB release type: " + rel_primarytype.lower())
+    if "secondary-type-list" in release["release-group"]:
+        if release["release-group"]["secondary-type-list"]:
+            log.debug(
+                "secondary MB release type(s): "
+                + ", ".join(
+                    [
+                        secondarytype.lower()
+                        for secondarytype in release["release-group"][
+                            "secondary-type-list"
+                        ]
+                    ]
+                )
+            )
 
     # Release events.
     info.country, release_date = _preferred_release_event(release)
-    release_group_date = release['release-group'].get('first-release-date')
+    release_group_date = release["release-group"].get("first-release-date")
     if not release_date:
         # Fall back if release-specific date is not available.
         release_date = release_group_date
@@ -396,24 +432,24 @@ def album_info(release):
     _set_date_str(info, release_group_date, True)
 
     # Label name.
-    if release.get('label-info-list'):
-        label_info = release['label-info-list'][0]
-        if label_info.get('label'):
-            label = label_info['label']['name']
-            if label != '[no label]':
+    if release.get("label-info-list"):
+        label_info = release["label-info-list"][0]
+        if label_info.get("label"):
+            label = label_info["label"]["name"]
+            if label != "[no label]":
                 info.label = label
-        info.catalognum = label_info.get('catalog-number')
+        info.catalognum = label_info.get("catalog-number")
 
     # Text representation data.
-    if release.get('text-representation'):
-        rep = release['text-representation']
-        info.script = rep.get('script')
-        info.language = rep.get('language')
+    if release.get("text-representation"):
+        rep = release["text-representation"]
+        info.script = rep.get("script")
+        info.language = rep.get("language")
 
     # Media (format).
-    if release['medium-list']:
-        first_medium = release['medium-list'][0]
-        info.media = first_medium.get('format')
+    if release["medium-list"]:
+        first_medium = release["medium-list"][0]
+        info.media = first_medium.get("format")
 
     info.decode()
     return info
@@ -428,22 +464,22 @@ def match_album(artist, album, tracks=None, extra_tags=None):
     optionally, a number of tracks on the album and any other extra tags.
     """
     # Build search criteria.
-    criteria = {'release': album.lower().strip()}
+    criteria = {"release": album.lower().strip()}
     if artist is not None:
-        criteria['artist'] = artist.lower().strip()
+        criteria["artist"] = artist.lower().strip()
     else:
         # Various Artists search.
-        criteria['arid'] = VARIOUS_ARTISTS_ID
+        criteria["arid"] = VARIOUS_ARTISTS_ID
     if tracks is not None:
-        criteria['tracks'] = six.text_type(tracks)
+        criteria["tracks"] = six.text_type(tracks)
 
     # Additional search cues from existing metadata.
     if extra_tags:
         for tag in extra_tags:
             key = FIELDS_TO_MB_KEYS[tag]
-            value = six.text_type(extra_tags.get(tag, '')).lower().strip()
-            if key == 'catno':
-                value = value.replace(u' ', '')
+            value = six.text_type(extra_tags.get(tag, "")).lower().strip()
+            if key == "catno":
+                value = value.replace(u" ", "")
             if value:
                 criteria[key] = value
 
@@ -452,16 +488,18 @@ def match_album(artist, album, tracks=None, extra_tags=None):
         return
 
     try:
-        log.debug(u'Searching for MusicBrainz releases with: {!r}', criteria)
+        log.debug(u"Searching for MusicBrainz releases with: {!r}", criteria)
         res = musicbrainzngs.search_releases(
-            limit=config['musicbrainz']['searchlimit'].get(int), **criteria)
+            limit=config["musicbrainz"]["searchlimit"].get(int), **criteria
+        )
     except musicbrainzngs.MusicBrainzError as exc:
-        raise MusicBrainzAPIError(exc, 'release search', criteria,
-                                  traceback.format_exc())
-    for release in res['release-list']:
+        raise MusicBrainzAPIError(
+            exc, "release search", criteria, traceback.format_exc()
+        )
+    for release in res["release-list"]:
         # The search result is missing some data (namely, the tracks),
         # so we just use the ID and fetch the rest of the information.
-        albuminfo = album_for_id(release['id'])
+        albuminfo = album_for_id(release["id"])
         if albuminfo is not None:
             yield albuminfo
 
@@ -471,8 +509,8 @@ def match_track(artist, title):
     objects. May raise a MusicBrainzAPIError.
     """
     criteria = {
-        'artist': artist.lower().strip(),
-        'recording': title.lower().strip(),
+        "artist": artist.lower().strip(),
+        "recording": title.lower().strip(),
     }
 
     if not any(criteria.values()):
@@ -480,11 +518,13 @@ def match_track(artist, title):
 
     try:
         res = musicbrainzngs.search_recordings(
-            limit=config['musicbrainz']['searchlimit'].get(int), **criteria)
+            limit=config["musicbrainz"]["searchlimit"].get(int), **criteria
+        )
     except musicbrainzngs.MusicBrainzError as exc:
-        raise MusicBrainzAPIError(exc, 'recording search', criteria,
-                                  traceback.format_exc())
-    for recording in res['recording-list']:
+        raise MusicBrainzAPIError(
+            exc, "recording search", criteria, traceback.format_exc()
+        )
+    for recording in res["recording-list"]:
         yield track_info(recording)
 
 
@@ -493,7 +533,7 @@ def _parse_id(s):
     no ID can be found, return None.
     """
     # Find the first thing that looks like a UUID/MBID.
-    match = re.search(u'[a-f0-9]{8}(-[a-f0-9]{4}){3}-[a-f0-9]{12}', s)
+    match = re.search(u"[a-f0-9]{8}(-[a-f0-9]{4}){3}-[a-f0-9]{12}", s)
     if match:
         return match.group()
 
@@ -503,21 +543,21 @@ def album_for_id(releaseid):
     object or None if the album is not found. May raise a
     MusicBrainzAPIError.
     """
-    log.debug(u'Requesting MusicBrainz release {}', releaseid)
+    log.debug(u"Requesting MusicBrainz release {}", releaseid)
     albumid = _parse_id(releaseid)
     if not albumid:
-        log.debug(u'Invalid MBID ({0}).', releaseid)
+        log.debug(u"Invalid MBID ({0}).", releaseid)
         return
     try:
-        res = musicbrainzngs.get_release_by_id(albumid,
-                                               RELEASE_INCLUDES)
+        res = musicbrainzngs.get_release_by_id(albumid, RELEASE_INCLUDES)
     except musicbrainzngs.ResponseError:
-        log.debug(u'Album ID match failed.')
+        log.debug(u"Album ID match failed.")
         return None
     except musicbrainzngs.MusicBrainzError as exc:
-        raise MusicBrainzAPIError(exc, u'get release by ID', albumid,
-                                  traceback.format_exc())
-    return album_info(res['release'])
+        raise MusicBrainzAPIError(
+            exc, u"get release by ID", albumid, traceback.format_exc()
+        )
+    return album_info(res["release"])
 
 
 def track_for_id(releaseid):
@@ -526,14 +566,15 @@ def track_for_id(releaseid):
     """
     trackid = _parse_id(releaseid)
     if not trackid:
-        log.debug(u'Invalid MBID ({0}).', releaseid)
+        log.debug(u"Invalid MBID ({0}).", releaseid)
         return
     try:
         res = musicbrainzngs.get_recording_by_id(trackid, TRACK_INCLUDES)
     except musicbrainzngs.ResponseError:
-        log.debug(u'Track ID match failed.')
+        log.debug(u"Track ID match failed.")
         return None
     except musicbrainzngs.MusicBrainzError as exc:
-        raise MusicBrainzAPIError(exc, u'get recording by ID', trackid,
-                                  traceback.format_exc())
-    return track_info(res['recording'])
+        raise MusicBrainzAPIError(
+            exc, u"get recording by ID", trackid, traceback.format_exc()
+        )
+    return track_info(res["recording"])

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -31,6 +31,7 @@ from beets.util import py3_path
 from beets.dbcore import types
 from .query import MatchQuery, NullSort, TrueQuery
 import six
+
 if six.PY2:
     from collections import Mapping
 else:
@@ -81,14 +82,14 @@ class FormattedMapping(Mapping):
     def _get_formatted(self, model, key):
         value = model._type(key).format(model.get(key))
         if isinstance(value, bytes):
-            value = value.decode('utf-8', 'ignore')
+            value = value.decode("utf-8", "ignore")
 
         if self.for_path:
-            sep_repl = beets.config['path_sep_replace'].as_str()
-            sep_drive = beets.config['drive_sep_replace'].as_str()
+            sep_repl = beets.config["path_sep_replace"].as_str()
+            sep_drive = beets.config["drive_sep_replace"].as_str()
 
-            if re.match(r'^\w:', value):
-                value = re.sub(r'(?<=^\w):', sep_drive, value)
+            if re.match(r"^\w:", value):
+                value = re.sub(r"(?<=^\w):", sep_drive, value)
 
             for sep in (os.path.sep, os.path.altsep):
                 if sep:
@@ -192,6 +193,7 @@ class LazyConvertDict(object):
 
 
 # Abstract base for model classes.
+
 
 class Model(object):
     """An abstract object representing an object in the database. Model
@@ -302,9 +304,9 @@ class Model(object):
         return obj
 
     def __repr__(self):
-        return '{0}({1})'.format(
+        return "{0}({1})".format(
             type(self).__name__,
-            ', '.join('{0}={1!r}'.format(k, v) for k, v in dict(self).items()),
+            ", ".join("{0}={1!r}".format(k, v) for k, v in dict(self).items()),
         )
 
     def clear_dirty(self):
@@ -320,10 +322,10 @@ class Model(object):
         """
         if not self._db:
             raise ValueError(
-                u'{0} has no database'.format(type(self).__name__)
+                u"{0} has no database".format(type(self).__name__)
             )
         if need_id and not self.id:
-            raise ValueError(u'{0} has no id'.format(type(self).__name__))
+            raise ValueError(u"{0} has no id".format(type(self).__name__))
 
     def copy(self):
         """Create a copy of the model object.
@@ -404,9 +406,9 @@ class Model(object):
         elif key in self._fields:  # Fixed
             setattr(self, key, self._type(key).null)
         elif key in self._getters():  # Computed.
-            raise KeyError(u'computed field {0} cannot be deleted'.format(key))
+            raise KeyError(u"computed field {0} cannot be deleted".format(key))
         else:
-            raise KeyError(u'no such field {0}'.format(key))
+            raise KeyError(u"no such field {0}".format(key))
 
     def keys(self, computed=False):
         """Get a list of available field names for this object. The
@@ -464,22 +466,22 @@ class Model(object):
     # Convenient attribute access.
 
     def __getattr__(self, key):
-        if key.startswith('_'):
-            raise AttributeError(u'model has no attribute {0!r}'.format(key))
+        if key.startswith("_"):
+            raise AttributeError(u"model has no attribute {0!r}".format(key))
         else:
             try:
                 return self[key]
             except KeyError:
-                raise AttributeError(u'no such field {0!r}'.format(key))
+                raise AttributeError(u"no such field {0!r}".format(key))
 
     def __setattr__(self, key, value):
-        if key.startswith('_'):
+        if key.startswith("_"):
             super(Model, self).__setattr__(key, value)
         else:
             self[key] = value
 
     def __delattr__(self, key):
-        if key.startswith('_'):
+        if key.startswith("_"):
             super(Model, self).__delattr__(key)
         else:
             del self[key]
@@ -499,17 +501,17 @@ class Model(object):
         assignments = []
         subvars = []
         for key in fields:
-            if key != 'id' and key in self._dirty:
+            if key != "id" and key in self._dirty:
                 self._dirty.remove(key)
-                assignments.append(key + '=?')
+                assignments.append(key + "=?")
                 value = self._type(key).to_sql(self[key])
                 subvars.append(value)
-        assignments = ','.join(assignments)
+        assignments = ",".join(assignments)
 
         with self._db.transaction() as tx:
             # Main table update.
             if assignments:
-                query = 'UPDATE {0} SET {1} WHERE id=?'.format(
+                query = "UPDATE {0} SET {1} WHERE id=?".format(
                     self._table, assignments
                 )
                 subvars.append(self.id)
@@ -520,18 +522,18 @@ class Model(object):
                 if key in self._dirty:
                     self._dirty.remove(key)
                     tx.mutate(
-                        'INSERT INTO {0} '
-                        '(entity_id, key, value) '
-                        'VALUES (?, ?, ?);'.format(self._flex_table),
+                        "INSERT INTO {0} "
+                        "(entity_id, key, value) "
+                        "VALUES (?, ?, ?);".format(self._flex_table),
                         (self.id, key, value),
                     )
 
             # Deleted flexible attributes.
             for key in self._dirty:
                 tx.mutate(
-                    'DELETE FROM {0} '
-                    'WHERE entity_id=? AND key=?'.format(self._flex_table),
-                    (self.id, key)
+                    "DELETE FROM {0} "
+                    "WHERE entity_id=? AND key=?".format(self._flex_table),
+                    (self.id, key),
                 )
 
         self.clear_dirty()
@@ -553,12 +555,11 @@ class Model(object):
         self._check_db()
         with self._db.transaction() as tx:
             tx.mutate(
-                'DELETE FROM {0} WHERE id=?'.format(self._table),
-                (self.id,)
+                "DELETE FROM {0} WHERE id=?".format(self._table), (self.id,)
             )
             tx.mutate(
-                'DELETE FROM {0} WHERE entity_id=?'.format(self._flex_table),
-                (self.id,)
+                "DELETE FROM {0} WHERE entity_id=?".format(self._flex_table),
+                (self.id,),
             )
 
     def add(self, db=None):
@@ -575,7 +576,7 @@ class Model(object):
 
         with self._db.transaction() as tx:
             new_id = tx.mutate(
-                'INSERT INTO {0} DEFAULT VALUES'.format(self._table)
+                "INSERT INTO {0} DEFAULT VALUES".format(self._table)
             )
             self.id = new_id
             self.added = time.time()
@@ -604,8 +605,9 @@ class Model(object):
         # Perform substitution.
         if isinstance(template, six.string_types):
             template = functemplate.template(template)
-        return template.substitute(self.formatted(for_path),
-                                   self._template_funcs())
+        return template.substitute(
+            self.formatted(for_path), self._template_funcs()
+        )
 
     # Parsing.
 
@@ -626,12 +628,15 @@ class Model(object):
 
 # Database controller and supporting interfaces.
 
+
 class Results(object):
     """An item query result set. Iterating over the collection lazily
     constructs LibModel objects that reflect database rows.
     """
-    def __init__(self, model_class, rows, db, flex_rows,
-                 query=None, sort=None):
+
+    def __init__(
+        self, model_class, rows, db, flex_rows, query=None, sort=None
+    ):
         """Create a result set that will construct objects of type
         `model_class`.
 
@@ -689,7 +694,7 @@ class Results(object):
             else:
                 while self._rows:
                     row = self._rows.pop(0)
-                    obj = self._make_model(row, flex_attrs.get(row['id'], {}))
+                    obj = self._make_model(row, flex_attrs.get(row["id"], {}))
                     # If there is a slow-query predicate, ensurer that the
                     # object passes it.
                     if not self.query or self.query.match(obj):
@@ -716,10 +721,10 @@ class Results(object):
         """
         flex_values = dict()
         for row in self.flex_rows:
-            if row['entity_id'] not in flex_values:
-                flex_values[row['entity_id']] = dict()
+            if row["entity_id"] not in flex_values:
+                flex_values[row["entity_id"]] = dict()
 
-            flex_values[row['entity_id']][row['key']] = row['value']
+            flex_values[row["entity_id"]][row["key"]] = row["value"]
 
         return flex_values
 
@@ -727,8 +732,7 @@ class Results(object):
         """ Create a Model object for the given row
         """
         cols = dict(row)
-        values = dict((k, v) for (k, v) in cols.items()
-                      if not k[:4] == 'flex')
+        values = dict((k, v) for (k, v) in cols.items() if not k[:4] == "flex")
 
         # Construct the Python object
         obj = self.model_class._awaken(self.db, values, flex_values)
@@ -777,7 +781,7 @@ class Results(object):
                 next(it)
             return next(it)
         except StopIteration:
-            raise IndexError(u'result index {0} out of range'.format(n))
+            raise IndexError(u"result index {0} out of range".format(n))
 
     def get(self):
         """Return the first matching object, or None if no objects
@@ -794,6 +798,7 @@ class Transaction(object):
     """A context manager for safe, concurrent access to the database.
     All SQL commands should be executed through a transaction.
     """
+
     def __init__(self, db):
         self.db = db
 
@@ -841,8 +846,10 @@ class Transaction(object):
             # In two specific cases, SQLite reports an error while accessing
             # the underlying database file. We surface these exceptions as
             # DBAccessError so the application can abort.
-            if e.args[0] in ("attempt to write a readonly database",
-                             "unable to open database file"):
+            if e.args[0] in (
+                "attempt to write a readonly database",
+                "unable to open database file",
+            ):
                 raise DBAccessError(e.args[0])
             else:
                 raise
@@ -861,7 +868,7 @@ class Database(object):
     """The Model subclasses representing tables in this database.
     """
 
-    supports_extensions = hasattr(sqlite3.Connection, 'enable_load_extension')
+    supports_extensions = hasattr(sqlite3.Connection, "enable_load_extension")
     """Whether or not the current version of SQLite supports extensions"""
 
     def __init__(self, path, timeout=5.0):
@@ -916,9 +923,7 @@ class Database(object):
         # Make a new connection. The `sqlite3` module can't use
         # bytestring paths here on Python 3, so we need to
         # provide a `str` using `py3_path`.
-        conn = sqlite3.connect(
-            py3_path(self.path), timeout=self.timeout
-        )
+        conn = sqlite3.connect(py3_path(self.path), timeout=self.timeout)
 
         if self.supports_extensions:
             conn.enable_load_extension(True)
@@ -959,7 +964,8 @@ class Database(object):
         """Load an SQLite extension into all open connections."""
         if not self.supports_extensions:
             raise ValueError(
-                    'this sqlite3 installation does not support extensions')
+                "this sqlite3 installation does not support extensions"
+            )
 
         self._extensions.append(path)
 
@@ -975,7 +981,7 @@ class Database(object):
         """
         # Get current schema.
         with self.transaction() as tx:
-            rows = tx.query('PRAGMA table_info(%s)' % table)
+            rows = tx.query("PRAGMA table_info(%s)" % table)
         current_fields = set([row[1] for row in rows])
 
         field_names = set(fields.keys())
@@ -987,17 +993,18 @@ class Database(object):
             # No table exists.
             columns = []
             for name, typ in fields.items():
-                columns.append('{0} {1}'.format(name, typ.sql))
-            setup_sql = 'CREATE TABLE {0} ({1});\n'.format(table,
-                                                           ', '.join(columns))
+                columns.append("{0} {1}".format(name, typ.sql))
+            setup_sql = "CREATE TABLE {0} ({1});\n".format(
+                table, ", ".join(columns)
+            )
 
         else:
             # Table exists does not match the field set.
-            setup_sql = ''
+            setup_sql = ""
             for name, typ in fields.items():
                 if name in current_fields:
                     continue
-                setup_sql += 'ALTER TABLE {0} ADD COLUMN {1} {2};\n'.format(
+                setup_sql += "ALTER TABLE {0} ADD COLUMN {1} {2};\n".format(
                     table, name, typ.sql
                 )
 
@@ -1009,7 +1016,8 @@ class Database(object):
         for the given entity (if they don't exist).
         """
         with self.transaction() as tx:
-            tx.script("""
+            tx.script(
+                """
                 CREATE TABLE IF NOT EXISTS {0} (
                     id INTEGER PRIMARY KEY,
                     entity_id INTEGER,
@@ -1018,7 +1026,10 @@ class Database(object):
                     UNIQUE(entity_id, key) ON CONFLICT REPLACE);
                 CREATE INDEX IF NOT EXISTS {0}_by_entity
                     ON {0} (entity_id);
-                """.format(flex_table))
+                """.format(
+                    flex_table
+                )
+            )
 
     # Querying.
 
@@ -1035,21 +1046,18 @@ class Database(object):
 
         sql = ("SELECT * FROM {0} WHERE {1} {2}").format(
             model_cls._table,
-            where or '1',
-            "ORDER BY {0}".format(order_by) if order_by else '',
+            where or "1",
+            "ORDER BY {0}".format(order_by) if order_by else "",
         )
 
         # Fetch flexible attributes for items matching the main query.
         # Doing the per-item filtering in python is faster than issuing
         # one query per item to sqlite.
-        flex_sql = ("""
+        flex_sql = """
             SELECT * FROM {0} WHERE entity_id IN
                 (SELECT id FROM {1} WHERE {2});
             """.format(
-                model_cls._flex_table,
-                model_cls._table,
-                where or '1',
-            )
+            model_cls._flex_table, model_cls._table, where or "1",
         )
 
         with self.transaction() as tx:
@@ -1057,7 +1065,10 @@ class Database(object):
             flex_rows = tx.query(flex_sql, subvals)
 
         return Results(
-            model_cls, rows, self, flex_rows,
+            model_cls,
+            rows,
+            self,
+            flex_rows,
             None if where else query,  # Slow query component.
             sort if sort.is_slow() else None,  # Slow sort component.
         )
@@ -1066,4 +1077,4 @@ class Database(object):
         """Get a Model object by its id or None if the id does not
         exist.
         """
-        return self._fetch(model_cls, MatchQuery('id', id)).get()
+        return self._fetch(model_cls, MatchQuery("id", id)).get()

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -125,12 +125,17 @@ class FieldQuery(Query):
         return self.value_match(self.pattern, item.get(self.field))
 
     def __repr__(self):
-        return ("{0.__class__.__name__}({0.field!r}, {0.pattern!r}, "
-                "{0.fast})".format(self))
+        return (
+            "{0.__class__.__name__}({0.field!r}, {0.pattern!r}, "
+            "{0.fast})".format(self)
+        )
 
     def __eq__(self, other):
-        return super(FieldQuery, self).__eq__(other) and \
-            self.field == other.field and self.pattern == other.pattern
+        return (
+            super(FieldQuery, self).__eq__(other)
+            and self.field == other.field
+            and self.pattern == other.pattern
+        )
 
     def __hash__(self):
         return hash((self.field, hash(self.pattern)))
@@ -187,11 +192,12 @@ class SubstringQuery(StringFieldQuery):
     """A query that matches a substring in a specific item field."""
 
     def col_clause(self):
-        pattern = (self.pattern
-                   .replace('\\', '\\\\')
-                   .replace('%', '\\%')
-                   .replace('_', '\\_'))
-        search = '%' + pattern + '%'
+        pattern = (
+            self.pattern.replace("\\", "\\\\")
+            .replace("%", "\\%")
+            .replace("_", "\\_")
+        )
+        search = "%" + pattern + "%"
         clause = self.field + " like ? escape '\\'"
         subvals = [search]
         return clause, subvals
@@ -216,16 +222,16 @@ class RegexpQuery(StringFieldQuery):
             self.pattern = re.compile(self.pattern)
         except re.error as exc:
             # Invalid regular expression.
-            raise InvalidQueryArgumentValueError(pattern,
-                                                 u"a regular expression",
-                                                 format(exc))
+            raise InvalidQueryArgumentValueError(
+                pattern, u"a regular expression", format(exc)
+            )
 
     @staticmethod
     def _normalize(s):
         """Normalize a Unicode string's representation (used on both
         patterns and matched values).
         """
-        return unicodedata.normalize('NFC', s)
+        return unicodedata.normalize("NFC", s)
 
     @classmethod
     def string_match(cls, pattern, value):
@@ -259,7 +265,7 @@ class BytesQuery(MatchQuery):
         # rather than encoded Unicode.
         if isinstance(self.pattern, (six.text_type, bytes)):
             if isinstance(self.pattern, six.text_type):
-                self.pattern = self.pattern.encode('utf-8')
+                self.pattern = self.pattern.encode("utf-8")
             self.buf_pattern = buffer(self.pattern)
         elif isinstance(self.pattern, buffer):
             self.buf_pattern = self.pattern
@@ -298,7 +304,7 @@ class NumericQuery(FieldQuery):
     def __init__(self, field, pattern, fast=True):
         super(NumericQuery, self).__init__(field, pattern, fast)
 
-        parts = pattern.split('..', 1)
+        parts = pattern.split("..", 1)
         if len(parts) == 1:
             # No range.
             self.point = self._convert(parts[0])
@@ -328,17 +334,19 @@ class NumericQuery(FieldQuery):
 
     def col_clause(self):
         if self.point is not None:
-            return self.field + '=?', (self.point,)
+            return self.field + "=?", (self.point,)
         else:
             if self.rangemin is not None and self.rangemax is not None:
-                return (u'{0} >= ? AND {0} <= ?'.format(self.field),
-                        (self.rangemin, self.rangemax))
+                return (
+                    u"{0} >= ? AND {0} <= ?".format(self.field),
+                    (self.rangemin, self.rangemax),
+                )
             elif self.rangemin is not None:
-                return u'{0} >= ?'.format(self.field), (self.rangemin,)
+                return u"{0} >= ?".format(self.field), (self.rangemin,)
             elif self.rangemax is not None:
-                return u'{0} <= ?'.format(self.field), (self.rangemax,)
+                return u"{0} <= ?".format(self.field), (self.rangemax,)
             else:
-                return u'1', ()
+                return u"1", ()
 
 
 class CollectionQuery(Query):
@@ -374,17 +382,19 @@ class CollectionQuery(Query):
             if not subq_clause:
                 # Fall back to slow query.
                 return None, ()
-            clause_parts.append('(' + subq_clause + ')')
+            clause_parts.append("(" + subq_clause + ")")
             subvals += subq_subvals
-        clause = (' ' + joiner + ' ').join(clause_parts)
+        clause = (" " + joiner + " ").join(clause_parts)
         return clause, subvals
 
     def __repr__(self):
         return "{0.__class__.__name__}({0.subqueries!r})".format(self)
 
     def __eq__(self, other):
-        return super(CollectionQuery, self).__eq__(other) and \
-            self.subqueries == other.subqueries
+        return (
+            super(CollectionQuery, self).__eq__(other)
+            and self.subqueries == other.subqueries
+        )
 
     def __hash__(self):
         """Since subqueries are mutable, this object should not be hashable.
@@ -410,7 +420,7 @@ class AnyFieldQuery(CollectionQuery):
         super(AnyFieldQuery, self).__init__(subqueries)
 
     def clause(self):
-        return self.clause_with_joiner('or')
+        return self.clause_with_joiner("or")
 
     def match(self, item):
         for subq in self.subqueries:
@@ -419,12 +429,16 @@ class AnyFieldQuery(CollectionQuery):
         return False
 
     def __repr__(self):
-        return ("{0.__class__.__name__}({0.pattern!r}, {0.fields!r}, "
-                "{0.query_class.__name__})".format(self))
+        return (
+            "{0.__class__.__name__}({0.pattern!r}, {0.fields!r}, "
+            "{0.query_class.__name__})".format(self)
+        )
 
     def __eq__(self, other):
-        return super(AnyFieldQuery, self).__eq__(other) and \
-            self.query_class == other.query_class
+        return (
+            super(AnyFieldQuery, self).__eq__(other)
+            and self.query_class == other.query_class
+        )
 
     def __hash__(self):
         return hash((self.pattern, tuple(self.fields), self.query_class))
@@ -446,7 +460,7 @@ class AndQuery(MutableCollectionQuery):
     """A conjunction of a list of other queries."""
 
     def clause(self):
-        return self.clause_with_joiner('and')
+        return self.clause_with_joiner("and")
 
     def match(self, item):
         return all([q.match(item) for q in self.subqueries])
@@ -456,7 +470,7 @@ class OrQuery(MutableCollectionQuery):
     """A conjunction of a list of other queries."""
 
     def clause(self):
-        return self.clause_with_joiner('or')
+        return self.clause_with_joiner("or")
 
     def match(self, item):
         return any([q.match(item) for q in self.subqueries])
@@ -473,7 +487,7 @@ class NotQuery(Query):
     def clause(self):
         clause, subvals = self.subquery.clause()
         if clause:
-            return 'not ({0})'.format(clause), subvals
+            return "not ({0})".format(clause), subvals
         else:
             # If there is no clause, there is nothing to negate. All the logic
             # is handled by match() for slow queries.
@@ -486,18 +500,20 @@ class NotQuery(Query):
         return "{0.__class__.__name__}({0.subquery!r})".format(self)
 
     def __eq__(self, other):
-        return super(NotQuery, self).__eq__(other) and \
-            self.subquery == other.subquery
+        return (
+            super(NotQuery, self).__eq__(other)
+            and self.subquery == other.subquery
+        )
 
     def __hash__(self):
-        return hash(('not', hash(self.subquery)))
+        return hash(("not", hash(self.subquery)))
 
 
 class TrueQuery(Query):
     """A query that always matches."""
 
     def clause(self):
-        return '1', ()
+        return "1", ()
 
     def match(self, item):
         return True
@@ -507,7 +523,7 @@ class FalseQuery(Query):
     """A query that never matches."""
 
     def clause(self):
-        return '0', ()
+        return "0", ()
 
     def match(self, item):
         return False
@@ -515,11 +531,12 @@ class FalseQuery(Query):
 
 # Time/date queries.
 
+
 def _to_epoch_time(date):
     """Convert a `datetime` object to an integer number of seconds since
     the (local) Unix epoch.
     """
-    if hasattr(date, 'timestamp'):
+    if hasattr(date, "timestamp"):
         # The `timestamp` method exists on Python 3.3+.
         return int(date.timestamp())
     else:
@@ -532,7 +549,7 @@ def _parse_periods(pattern):
     """Parse a string containing two dates separated by two dots (..).
     Return a pair of `Period` objects.
     """
-    parts = pattern.split('..', 1)
+    parts = pattern.split("..", 1)
     if len(parts) == 1:
         instant = Period.parse(parts[0])
         return (instant, instant)
@@ -549,18 +566,19 @@ class Period(object):
     instants of time during January 2014.
     """
 
-    precisions = ('year', 'month', 'day', 'hour', 'minute', 'second')
+    precisions = ("year", "month", "day", "hour", "minute", "second")
     date_formats = (
-        ('%Y',),  # year
-        ('%Y-%m',),  # month
-        ('%Y-%m-%d',),  # day
-        ('%Y-%m-%dT%H', '%Y-%m-%d %H'),  # hour
-        ('%Y-%m-%dT%H:%M', '%Y-%m-%d %H:%M'),  # minute
-        ('%Y-%m-%dT%H:%M:%S', '%Y-%m-%d %H:%M:%S')  # second
+        ("%Y",),  # year
+        ("%Y-%m",),  # month
+        ("%Y-%m-%d",),  # day
+        ("%Y-%m-%dT%H", "%Y-%m-%d %H"),  # hour
+        ("%Y-%m-%dT%H:%M", "%Y-%m-%d %H:%M"),  # minute
+        ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S"),  # second
     )
-    relative_units = {'y': 365, 'm': 30, 'w': 7, 'd': 1}
-    relative_re = '(?P<sign>[+|-]?)(?P<quantity>[0-9]+)' + \
-        '(?P<timespan>[y|m|w|d])'
+    relative_units = {"y": 365, "m": 30, "w": 7, "d": 1}
+    relative_re = (
+        "(?P<sign>[+|-]?)(?P<quantity>[0-9]+)" + "(?P<timespan>[y|m|w|d])"
+    )
 
     def __init__(self, date, precision):
         """Create a period with the given date (a `datetime` object) and
@@ -568,7 +586,7 @@ class Period(object):
         or "second").
         """
         if precision not in Period.precisions:
-            raise ValueError(u'Invalid precision {0}'.format(precision))
+            raise ValueError(u"Invalid precision {0}".format(precision))
         self.date = date
         self.precision = precision
 
@@ -607,23 +625,26 @@ class Period(object):
         # Check for a relative date.
         match_dq = re.match(cls.relative_re, string)
         if match_dq:
-            sign = match_dq.group('sign')
-            quantity = match_dq.group('quantity')
-            timespan = match_dq.group('timespan')
+            sign = match_dq.group("sign")
+            quantity = match_dq.group("quantity")
+            timespan = match_dq.group("timespan")
 
             # Add or subtract the given amount of time from the current
             # date.
-            multiplier = -1 if sign == '-' else 1
+            multiplier = -1 if sign == "-" else 1
             days = cls.relative_units[timespan]
-            date = datetime.now() + \
-                timedelta(days=int(quantity) * days) * multiplier
+            date = (
+                datetime.now()
+                + timedelta(days=int(quantity) * days) * multiplier
+            )
             return cls(date, cls.precisions[5])
 
         # Check for an absolute date.
         date, ordinal = find_date_and_format(string)
         if date is None:
-            raise InvalidQueryArgumentValueError(string,
-                                                 'a valid date/time string')
+            raise InvalidQueryArgumentValueError(
+                string, "a valid date/time string"
+            )
         precision = cls.precisions[ordinal]
         return cls(date, precision)
 
@@ -633,23 +654,23 @@ class Period(object):
         """
         precision = self.precision
         date = self.date
-        if 'year' == self.precision:
+        if "year" == self.precision:
             return date.replace(year=date.year + 1, month=1)
-        elif 'month' == precision:
-            if (date.month < 12):
+        elif "month" == precision:
+            if date.month < 12:
                 return date.replace(month=date.month + 1)
             else:
                 return date.replace(year=date.year + 1, month=1)
-        elif 'day' == precision:
+        elif "day" == precision:
             return date + timedelta(days=1)
-        elif 'hour' == precision:
+        elif "hour" == precision:
             return date + timedelta(hours=1)
-        elif 'minute' == precision:
+        elif "minute" == precision:
             return date + timedelta(minutes=1)
-        elif 'second' == precision:
+        elif "second" == precision:
             return date + timedelta(seconds=1)
         else:
-            raise ValueError(u'unhandled precision {0}'.format(precision))
+            raise ValueError(u"unhandled precision {0}".format(precision))
 
 
 class DateInterval(object):
@@ -661,8 +682,9 @@ class DateInterval(object):
 
     def __init__(self, start, end):
         if start is not None and end is not None and not start < end:
-            raise ValueError(u"start date {0} is not before end date {1}"
-                             .format(start, end))
+            raise ValueError(
+                u"start date {0} is not before end date {1}".format(start, end)
+            )
         self.start = start
         self.end = end
 
@@ -682,7 +704,7 @@ class DateInterval(object):
         return True
 
     def __str__(self):
-        return '[{0}, {1})'.format(self.start, self.end)
+        return "[{0}, {1})".format(self.start, self.end)
 
 
 class DateQuery(FieldQuery):
@@ -723,10 +745,10 @@ class DateQuery(FieldQuery):
 
         if clause_parts:
             # One- or two-sided interval.
-            clause = ' AND '.join(clause_parts)
+            clause = " AND ".join(clause_parts)
         else:
             # Match any date.
-            clause = '1'
+            clause = "1"
         return clause, subvals
 
 
@@ -754,11 +776,12 @@ class DurationQuery(NumericQuery):
                 return float(s)
             except ValueError:
                 raise InvalidQueryArgumentValueError(
-                    s,
-                    u"a M:SS string or a float")
+                    s, u"a M:SS string or a float"
+                )
 
 
 # Sorting.
+
 
 class Sort(object):
     """An abstract class representing a sort operation for a query into
@@ -847,14 +870,16 @@ class MultipleSort(Sort):
         return items
 
     def __repr__(self):
-        return 'MultipleSort({!r})'.format(self.sorts)
+        return "MultipleSort({!r})".format(self.sorts)
 
     def __hash__(self):
         return hash(tuple(self.sorts))
 
     def __eq__(self, other):
-        return super(MultipleSort, self).__eq__(other) and \
-            self.sorts == other.sorts
+        return (
+            super(MultipleSort, self).__eq__(other)
+            and self.sorts == other.sorts
+        )
 
 
 class FieldSort(Sort):
@@ -873,7 +898,7 @@ class FieldSort(Sort):
         # attributes with different types without falling over.
 
         def key(item):
-            field_val = item.get(self.field, '')
+            field_val = item.get(self.field, "")
             if self.case_insensitive and isinstance(field_val, six.text_type):
                 field_val = field_val.lower()
             return field_val
@@ -881,19 +906,19 @@ class FieldSort(Sort):
         return sorted(objs, key=key, reverse=not self.ascending)
 
     def __repr__(self):
-        return '<{0}: {1}{2}>'.format(
-            type(self).__name__,
-            self.field,
-            '+' if self.ascending else '-',
+        return "<{0}: {1}{2}>".format(
+            type(self).__name__, self.field, "+" if self.ascending else "-",
         )
 
     def __hash__(self):
         return hash((self.field, self.ascending))
 
     def __eq__(self, other):
-        return super(FieldSort, self).__eq__(other) and \
-            self.field == other.field and \
-            self.ascending == other.ascending
+        return (
+            super(FieldSort, self).__eq__(other)
+            and self.field == other.field
+            and self.ascending == other.ascending
+        )
 
 
 class FixedFieldSort(FieldSort):
@@ -903,10 +928,12 @@ class FixedFieldSort(FieldSort):
     def order_clause(self):
         order = "ASC" if self.ascending else "DESC"
         if self.case_insensitive:
-            field = '(CASE ' \
-                    'WHEN TYPEOF({0})="text" THEN LOWER({0}) ' \
-                    'WHEN TYPEOF({0})="blob" THEN LOWER({0}) ' \
-                    'ELSE {0} END)'.format(self.field)
+            field = (
+                "(CASE "
+                'WHEN TYPEOF({0})="text" THEN LOWER({0}) '
+                'WHEN TYPEOF({0})="blob" THEN LOWER({0}) '
+                "ELSE {0} END)".format(self.field)
+            )
         else:
             field = self.field
         return "{0} {1}".format(field, order)

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -23,21 +23,19 @@ from . import query
 
 PARSE_QUERY_PART_REGEX = re.compile(
     # Non-capturing optional segment for the keyword.
-    r'(-|\^)?'   # Negation prefixes.
-
-    r'(?:'
-    r'(\S+?)'    # The field key.
-    r'(?<!\\):'  # Unescaped :
-    r')?'
-
-    r'(.*)',         # The term itself.
-
-    re.I  # Case-insensitive.
+    r"(-|\^)?"  # Negation prefixes.
+    r"(?:"
+    r"(\S+?)"  # The field key.
+    r"(?<!\\):"  # Unescaped :
+    r")?"
+    r"(.*)",  # The term itself.
+    re.I,  # Case-insensitive.
 )
 
 
-def parse_query_part(part, query_classes={}, prefixes={},
-                     default_class=query.SubstringQuery):
+def parse_query_part(
+    part, query_classes={}, prefixes={}, default_class=query.SubstringQuery
+):
     """Parse a single *query part*, which is a chunk of a complete query
     string representing a single criterion.
 
@@ -88,13 +86,13 @@ def parse_query_part(part, query_classes={}, prefixes={},
     assert match  # Regex should always match
     negate = bool(match.group(1))
     key = match.group(2)
-    term = match.group(3).replace('\\:', ':')
+    term = match.group(3).replace("\\:", ":")
 
     # Check whether there's a prefix in the query and use the
     # corresponding query type.
     for pre, query_class in prefixes.items():
         if term.startswith(pre):
-            return key, term[len(pre):], query_class, negate
+            return key, term[len(pre) :], query_class, negate
 
     # No matching prefix, so use either the query class determined by
     # the field or the default as a fallback.
@@ -121,14 +119,16 @@ def construct_query_part(model_cls, prefixes, query_part):
     # Use `model_cls` to build up a map from field (or query) names to
     # `Query` classes.
     query_classes = {}
-    for k, t in itertools.chain(model_cls._fields.items(),
-                                model_cls._types.items()):
+    for k, t in itertools.chain(
+        model_cls._fields.items(), model_cls._types.items()
+    ):
         query_classes[k] = t.query
     query_classes.update(model_cls._queries)  # Non-field queries.
 
     # Parse the string.
-    key, pattern, query_class, negate = \
-        parse_query_part(query_part, query_classes, prefixes)
+    key, pattern, query_class, negate = parse_query_part(
+        query_part, query_classes, prefixes
+    )
 
     # If there's no key (field name) specified, this is a "match
     # anything" query.
@@ -137,8 +137,9 @@ def construct_query_part(model_cls, prefixes, query_part):
             # The query type matches a specific field, but none was
             # specified. So we use a version of the query that matches
             # any field.
-            out_query = query.AnyFieldQuery(pattern, model_cls._search_fields,
-                                            query_class)
+            out_query = query.AnyFieldQuery(
+                pattern, model_cls._search_fields, query_class
+            )
         else:
             # Non-field query type.
             out_query = query_class(pattern)
@@ -185,12 +186,13 @@ def construct_sort_part(model_cls, part, case_insensitive=True):
     field = part[:-1]
     assert field, "field is missing"
     direction = part[-1]
-    assert direction in ('+', '-'), "part must end with + or -"
-    is_ascending = direction == '+'
+    assert direction in ("+", "-"), "part must end with + or -"
+    is_ascending = direction == "+"
 
     if field in model_cls._sorts:
-        sort = model_cls._sorts[field](model_cls, is_ascending,
-                                       case_insensitive)
+        sort = model_cls._sorts[field](
+            model_cls, is_ascending, case_insensitive
+        )
     elif field in model_cls._fields:
         sort = query.FixedFieldSort(field, is_ascending, case_insensitive)
     else:
@@ -209,13 +211,13 @@ def sort_from_strings(model_cls, sort_parts, case_insensitive=True):
     else:
         sort = query.MultipleSort()
         for part in sort_parts:
-            sort.add_sort(construct_sort_part(model_cls, part,
-                                              case_insensitive))
+            sort.add_sort(
+                construct_sort_part(model_cls, part, case_insensitive)
+            )
     return sort
 
 
-def parse_sorted_query(model_cls, parts, prefixes={},
-                       case_insensitive=True):
+def parse_sorted_query(model_cls, parts, prefixes={}, case_insensitive=True):
     """Given a list of strings, create the `Query` and `Sort` that they
     represent.
     """
@@ -226,24 +228,28 @@ def parse_sorted_query(model_cls, parts, prefixes={},
     # Split up query in to comma-separated subqueries, each representing
     # an AndQuery, which need to be joined together in one OrQuery
     subquery_parts = []
-    for part in parts + [u',']:
-        if part.endswith(u','):
+    for part in parts + [u","]:
+        if part.endswith(u","):
             # Ensure we can catch "foo, bar" as well as "foo , bar"
             last_subquery_part = part[:-1]
             if last_subquery_part:
                 subquery_parts.append(last_subquery_part)
             # Parse the subquery in to a single AndQuery
             # TODO: Avoid needlessly wrapping AndQueries containing 1 subquery?
-            query_parts.append(query_from_strings(
-                query.AndQuery, model_cls, prefixes, subquery_parts
-            ))
+            query_parts.append(
+                query_from_strings(
+                    query.AndQuery, model_cls, prefixes, subquery_parts
+                )
+            )
             del subquery_parts[:]
         else:
             # Sort parts (1) end in + or -, (2) don't have a field, and
             # (3) consist of more than just the + or -.
-            if part.endswith((u'+', u'-')) \
-                    and u':' not in part \
-                    and len(part) > 1:
+            if (
+                part.endswith((u"+", u"-"))
+                and u":" not in part
+                and len(part) > 1
+            ):
                 sort_parts.append(part)
             else:
                 subquery_parts.append(part)

--- a/beets/dbcore/types.py
+++ b/beets/dbcore/types.py
@@ -27,13 +27,14 @@ if not six.PY2:
 
 # Abstract base.
 
+
 class Type(object):
     """An object encapsulating the type of a model field. Includes
     information about how to store, query, format, and parse a given
     field.
     """
 
-    sql = u'TEXT'
+    sql = u"TEXT"
     """The SQLite column type for the value.
     """
 
@@ -63,9 +64,9 @@ class Type(object):
             value = self.null
         # `self.null` might be `None`
         if value is None:
-            value = u''
+            value = u""
         if isinstance(value, bytes):
-            value = value.decode('utf-8', 'ignore')
+            value = value.decode("utf-8", "ignore")
 
         return six.text_type(value)
 
@@ -105,7 +106,7 @@ class Type(object):
         and the method must handle these in addition.
         """
         if isinstance(sql_value, buffer):
-            sql_value = bytes(sql_value).decode('utf-8', 'ignore')
+            sql_value = bytes(sql_value).decode("utf-8", "ignore")
         if isinstance(sql_value, six.text_type):
             return self.parse(sql_value)
         else:
@@ -120,6 +121,7 @@ class Type(object):
 
 # Reusable types.
 
+
 class Default(Type):
     null = None
 
@@ -127,7 +129,8 @@ class Default(Type):
 class Integer(Type):
     """A basic integer type.
     """
-    sql = u'INTEGER'
+
+    sql = u"INTEGER"
     query = query.NumericQuery
     model_type = int
 
@@ -144,16 +147,18 @@ class PaddedInt(Integer):
     """An integer field that is formatted with a given number of digits,
     padded with zeroes.
     """
+
     def __init__(self, digits):
         self.digits = digits
 
     def format(self, value):
-        return u'{0:0{1}d}'.format(value or 0, self.digits)
+        return u"{0:0{1}d}".format(value or 0, self.digits)
 
 
 class NullPaddedInt(PaddedInt):
     """Same as `PaddedInt`, but does not normalize `None` to `0.0`.
     """
+
     null = None
 
 
@@ -161,30 +166,33 @@ class ScaledInt(Integer):
     """An integer whose formatting operation scales the number by a
     constant and adds a suffix. Good for units with large magnitudes.
     """
-    def __init__(self, unit, suffix=u''):
+
+    def __init__(self, unit, suffix=u""):
         self.unit = unit
         self.suffix = suffix
 
     def format(self, value):
-        return u'{0}{1}'.format((value or 0) // self.unit, self.suffix)
+        return u"{0}{1}".format((value or 0) // self.unit, self.suffix)
 
 
 class Id(Integer):
     """An integer used as the row id or a foreign key in a SQLite table.
     This type is nullable: None values are not translated to zero.
     """
+
     null = None
 
     def __init__(self, primary=True):
         if primary:
-            self.sql = u'INTEGER PRIMARY KEY'
+            self.sql = u"INTEGER PRIMARY KEY"
 
 
 class Float(Type):
     """A basic floating-point type. The `digits` parameter specifies how
     many decimal places to use in the human-readable representation.
     """
-    sql = u'REAL'
+
+    sql = u"REAL"
     query = query.NumericQuery
     model_type = float
 
@@ -192,26 +200,29 @@ class Float(Type):
         self.digits = digits
 
     def format(self, value):
-        return u'{0:.{1}f}'.format(value or 0, self.digits)
+        return u"{0:.{1}f}".format(value or 0, self.digits)
 
 
 class NullFloat(Float):
     """Same as `Float`, but does not normalize `None` to `0.0`.
     """
+
     null = None
 
 
 class String(Type):
     """A Unicode string type.
     """
-    sql = u'TEXT'
+
+    sql = u"TEXT"
     query = query.SubstringQuery
 
 
 class Boolean(Type):
     """A boolean type.
     """
-    sql = u'INTEGER'
+
+    sql = u"INTEGER"
     query = query.BooleanQuery
     model_type = bool
 

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -42,54 +42,56 @@ from beets.util import syspath, normpath, displayable_path
 from enum import Enum
 import mediafile
 
-action = Enum('action',
-              ['SKIP', 'ASIS', 'TRACKS', 'APPLY', 'ALBUMS', 'RETAG'])
+action = Enum("action", ["SKIP", "ASIS", "TRACKS", "APPLY", "ALBUMS", "RETAG"])
 # The RETAG action represents "don't apply any match, but do record
 # new metadata". It's not reachable via the standard command prompt but
 # can be used by plugins.
 
 QUEUE_SIZE = 128
 SINGLE_ARTIST_THRESH = 0.25
-PROGRESS_KEY = 'tagprogress'
-HISTORY_KEY = 'taghistory'
+PROGRESS_KEY = "tagprogress"
+HISTORY_KEY = "taghistory"
 
 # Global logger.
-log = logging.getLogger('beets')
+log = logging.getLogger("beets")
 
 
 class ImportAbort(Exception):
     """Raised when the user aborts the tagging operation.
     """
+
     pass
 
 
 # Utilities.
 
+
 def _open_state():
     """Reads the state file, returning a dictionary."""
     try:
-        with open(config['statefile'].as_filename(), 'rb') as f:
+        with open(config["statefile"].as_filename(), "rb") as f:
             return pickle.load(f)
     except Exception as exc:
         # The `pickle` module can emit all sorts of exceptions during
         # unpickling, including ImportError. We use a catch-all
         # exception to avoid enumerating them all (the docs don't even have a
         # full list!).
-        log.debug(u'state file could not be read: {0}', exc)
+        log.debug(u"state file could not be read: {0}", exc)
         return {}
 
 
 def _save_state(state):
     """Writes the state dictionary out to disk."""
     try:
-        with open(config['statefile'].as_filename(), 'wb') as f:
+        with open(config["statefile"].as_filename(), "wb") as f:
             pickle.dump(state, f)
     except IOError as exc:
-        log.error(u'state file could not be written: {0}', exc)
+        log.error(u"state file could not be written: {0}", exc)
 
 
 # Utilities for reading and writing the beets progress file, which
 # allows long tagging tasks to be resumed when they pause (or crash).
+
 
 def progress_read():
     state = _open_state()
@@ -150,6 +152,7 @@ def progress_reset(toppath):
 # This keeps track of all directories that were ever imported, which
 # allows the importer to only import new stuff.
 
+
 def history_add(paths):
     """Indicate that the import of the album in `paths` is completed and
     should not be repeated in incremental imports.
@@ -174,10 +177,12 @@ def history_get():
 
 # Abstract session class.
 
+
 class ImportSession(object):
     """Controls an import action. Subclasses should implement methods to
     communicate with the user or otherwise make decisions.
     """
+
     def __init__(self, lib, loghandler, paths, query):
         """Create a session. `lib` is a Library object. `loghandler` is a
         logging.Handler. Either `paths` or `query` is non-null and indicates
@@ -213,40 +218,40 @@ class ImportSession(object):
         self.config = iconfig
 
         # Incremental and progress are mutually exclusive.
-        if iconfig['incremental']:
-            iconfig['resume'] = False
+        if iconfig["incremental"]:
+            iconfig["resume"] = False
 
         # When based on a query instead of directories, never
         # save progress or try to resume.
         if self.query is not None:
-            iconfig['resume'] = False
-            iconfig['incremental'] = False
+            iconfig["resume"] = False
+            iconfig["incremental"] = False
 
         # Copy, move, link, and hardlink are mutually exclusive.
-        if iconfig['move']:
-            iconfig['copy'] = False
-            iconfig['link'] = False
-            iconfig['hardlink'] = False
-        elif iconfig['link']:
-            iconfig['copy'] = False
-            iconfig['move'] = False
-            iconfig['hardlink'] = False
-        elif iconfig['hardlink']:
-            iconfig['copy'] = False
-            iconfig['move'] = False
-            iconfig['link'] = False
+        if iconfig["move"]:
+            iconfig["copy"] = False
+            iconfig["link"] = False
+            iconfig["hardlink"] = False
+        elif iconfig["link"]:
+            iconfig["copy"] = False
+            iconfig["move"] = False
+            iconfig["hardlink"] = False
+        elif iconfig["hardlink"]:
+            iconfig["copy"] = False
+            iconfig["move"] = False
+            iconfig["link"] = False
 
         # Only delete when copying.
-        if not iconfig['copy']:
-            iconfig['delete'] = False
+        if not iconfig["copy"]:
+            iconfig["delete"] = False
 
-        self.want_resume = config['resume'].as_choice([True, False, 'ask'])
+        self.want_resume = config["resume"].as_choice([True, False, "ask"])
 
     def tag_log(self, status, paths):
         """Log a message about a given album to the importer log. The status
         should reflect the reason the album couldn't be tagged.
         """
-        self.logger.info(u'{0} {1}', status, displayable_path(paths))
+        self.logger.info(u"{0} {1}", status, displayable_path(paths))
 
     def log_choice(self, task, duplicate=False):
         """Logs the task's current choice if it should be logged. If
@@ -257,17 +262,17 @@ class ImportSession(object):
         if duplicate:
             # Duplicate: log all three choices (skip, keep both, and trump).
             if task.should_remove_duplicates:
-                self.tag_log(u'duplicate-replace', paths)
+                self.tag_log(u"duplicate-replace", paths)
             elif task.choice_flag in (action.ASIS, action.APPLY):
-                self.tag_log(u'duplicate-keep', paths)
+                self.tag_log(u"duplicate-keep", paths)
             elif task.choice_flag is (action.SKIP):
-                self.tag_log(u'duplicate-skip', paths)
+                self.tag_log(u"duplicate-skip", paths)
         else:
             # Non-duplicate: log "skip" and "asis" choices.
             if task.choice_flag is action.ASIS:
-                self.tag_log(u'asis', paths)
+                self.tag_log(u"asis", paths)
             elif task.choice_flag is action.SKIP:
-                self.tag_log(u'skip', paths)
+                self.tag_log(u"skip", paths)
 
     def should_resume(self, path):
         raise NotImplementedError
@@ -284,8 +289,8 @@ class ImportSession(object):
     def run(self):
         """Run the import task.
         """
-        self.logger.info(u'import started {0}', time.asctime())
-        self.set_config(config['import'])
+        self.logger.info(u"import started {0}", time.asctime())
+        self.set_config(config["import"])
 
         # Set up the pipeline.
         if self.query is None:
@@ -294,11 +299,10 @@ class ImportSession(object):
             stages = [query_tasks(self)]
 
         # In pretend mode, just log what would otherwise be imported.
-        if self.config['pretend']:
+        if self.config["pretend"]:
             stages += [log_files(self)]
         else:
-            if self.config['group_albums'] and \
-               not self.config['singletons']:
+            if self.config["group_albums"] and not self.config["singletons"]:
                 # Split directory tasks into one task for each album.
                 stages += [group_albums(self)]
 
@@ -307,7 +311,7 @@ class ImportSession(object):
             # import everything as-is. In *both* cases, these stages
             # also add the music to the library database, so later
             # stages need to read and write data from there.
-            if self.config['autotag']:
+            if self.config["autotag"]:
                 stages += [lookup_candidates(self), user_query(self)]
             else:
                 stages += [import_asis(self)]
@@ -323,9 +327,9 @@ class ImportSession(object):
         pl = pipeline.Pipeline(stages)
 
         # Run the pipeline.
-        plugins.send('import_begin', session=self)
+        plugins.send("import_begin", session=self)
         try:
-            if config['threaded']:
+            if config["threaded"]:
                 pl.run_parallel(QUEUE_SIZE)
             else:
                 pl.run_sequential()
@@ -339,18 +343,18 @@ class ImportSession(object):
         """Returns true if the files belonging to this task have already
         been imported in a previous session.
         """
-        if self.is_resuming(toppath) \
-           and all([progress_element(toppath, p) for p in paths]):
+        if self.is_resuming(toppath) and all(
+            [progress_element(toppath, p) for p in paths]
+        ):
             return True
-        if self.config['incremental'] \
-           and tuple(paths) in self.history_dirs:
+        if self.config["incremental"] and tuple(paths) in self.history_dirs:
             return True
 
         return False
 
     @property
     def history_dirs(self):
-        if not hasattr(self, '_history_dirs'):
+        if not hasattr(self, "_history_dirs"):
             self._history_dirs = history_get()
         return self._history_dirs
 
@@ -359,8 +363,10 @@ class ImportSession(object):
         during previous tasks.
         """
         for path in paths:
-            if path not in self._merged_items \
-               and path not in self._merged_dirs:
+            if (
+                path not in self._merged_items
+                and path not in self._merged_dirs
+            ):
                 return False
         return True
 
@@ -368,8 +374,12 @@ class ImportSession(object):
         """Mark paths and directories as merged for future reimport tasks.
         """
         self._merged_items.update(paths)
-        dirs = set([os.path.dirname(path) if os.path.isfile(path) else path
-                    for path in paths])
+        dirs = set(
+            [
+                os.path.dirname(path) if os.path.isfile(path) else path
+                for path in paths
+            ]
+        )
         self._merged_dirs.update(dirs)
 
     def is_resuming(self, toppath):
@@ -387,10 +397,11 @@ class ImportSession(object):
         """
         if self.want_resume and has_progress(toppath):
             # Either accept immediately or prompt for input to decide.
-            if self.want_resume is True or \
-               self.should_resume(toppath):
-                log.warning(u'Resuming interrupted import of {0}',
-                            util.displayable_path(toppath))
+            if self.want_resume is True or self.should_resume(toppath):
+                log.warning(
+                    u"Resuming interrupted import of {0}",
+                    util.displayable_path(toppath),
+                )
                 self._is_resuming[toppath] = True
             else:
                 # Clear progress; we're starting from the top.
@@ -399,11 +410,13 @@ class ImportSession(object):
 
 # The importer task class.
 
+
 class BaseImportTask(object):
     """An abstract base class for importer tasks.
 
     Tasks flow through the importer pipeline. Each stage can update
     them.     """
+
     def __init__(self, toppath, paths, items):
         """Create a task. The primary fields that define a task are:
 
@@ -457,6 +470,7 @@ class ImportTask(BaseImportTask):
     * `finalize()` Update the import progress and cleanup the file
       system.
     """
+
     def __init__(self, toppath, paths, items):
         super(ImportTask, self).__init__(toppath, paths, items)
         self.choice_flag = None
@@ -475,8 +489,13 @@ class ImportTask(BaseImportTask):
         """
         # Not part of the task structure:
         assert choice != action.APPLY  # Only used internally.
-        if choice in (action.SKIP, action.ASIS, action.TRACKS, action.ALBUMS,
-                      action.RETAG):
+        if choice in (
+            action.SKIP,
+            action.ASIS,
+            action.TRACKS,
+            action.ALBUMS,
+            action.RETAG,
+        ):
             self.choice_flag = choice
             self.match = None
         else:
@@ -536,7 +555,7 @@ class ImportTask(BaseImportTask):
     def apply_metadata(self):
         """Copy metadata from match info to the items.
         """
-        if config['import']['from_scratch']:
+        if config["import"]["from_scratch"]:
             for item in self.match.mapping:
                 item.clear()
 
@@ -550,26 +569,28 @@ class ImportTask(BaseImportTask):
 
     def remove_duplicates(self, lib):
         duplicate_items = self.duplicate_items(lib)
-        log.debug(u'removing {0} old duplicated items', len(duplicate_items))
+        log.debug(u"removing {0} old duplicated items", len(duplicate_items))
         for item in duplicate_items:
             item.remove()
             if lib.directory in util.ancestry(item.path):
-                log.debug(u'deleting duplicate {0}',
-                          util.displayable_path(item.path))
+                log.debug(
+                    u"deleting duplicate {0}", util.displayable_path(item.path)
+                )
                 util.remove(item.path)
-                util.prune_dirs(os.path.dirname(item.path),
-                                lib.directory)
+                util.prune_dirs(os.path.dirname(item.path), lib.directory)
 
     def set_fields(self):
         """Sets the fields given at CLI or configuration to the specified
         values.
         """
-        for field, view in config['import']['set_fields'].items():
+        for field, view in config["import"]["set_fields"].items():
             value = view.get()
-            log.debug(u'Set field {1}={2} for {0}',
-                      displayable_path(self.paths),
-                      field,
-                      value)
+            log.debug(
+                u"Set field {1}={2} for {0}",
+                displayable_path(self.paths),
+                field,
+                value,
+            )
             self.album[field] = value
         self.album.store()
 
@@ -579,15 +600,18 @@ class ImportTask(BaseImportTask):
         # Update progress.
         if session.want_resume:
             self.save_progress()
-        if session.config['incremental'] and not (
+        if session.config["incremental"] and not (
             # Should we skip recording to incremental list?
-            self.skip and session.config['incremental_skip_later']
+            self.skip
+            and session.config["incremental_skip_later"]
         ):
             self.save_history()
 
-        self.cleanup(copy=session.config['copy'],
-                     delete=session.config['delete'],
-                     move=session.config['move'])
+        self.cleanup(
+            copy=session.config["copy"],
+            delete=session.config["delete"],
+            move=session.config["move"],
+        )
 
         if not self.skip:
             self._emit_imported(session.lib)
@@ -616,7 +640,7 @@ class ImportTask(BaseImportTask):
                 self.prune(old_path)
 
     def _emit_imported(self, lib):
-        plugins.send('album_imported', lib=lib, album=self.album)
+        plugins.send("album_imported", lib=lib, album=self.album)
 
     def handle_created(self, session):
         """Send the `import_task_created` event for this task. Return a list of
@@ -624,7 +648,7 @@ class ImportTask(BaseImportTask):
         list containing only the task itself, but plugins can replace the task
         with new ones.
         """
-        tasks = plugins.send('import_task_created', session=session, task=self)
+        tasks = plugins.send("import_task_created", session=session, task=self)
         if not tasks:
             tasks = [self]
         else:
@@ -637,8 +661,9 @@ class ImportTask(BaseImportTask):
         candidate IDs are stored in self.search_ids: if present, the
         initial lookup is restricted to only those IDs.
         """
-        artist, album, prop = \
-            autotag.tag_album(self.items, search_ids=self.search_ids)
+        artist, album, prop = autotag.tag_album(
+            self.items, search_ids=self.search_ids
+        )
         self.cur_artist = artist
         self.cur_album = album
         self.candidates = prop.candidates
@@ -656,10 +681,12 @@ class ImportTask(BaseImportTask):
 
         duplicates = []
         task_paths = set(i.path for i in self.items if i)
-        duplicate_query = dbcore.AndQuery((
-            dbcore.MatchQuery('albumartist', artist),
-            dbcore.MatchQuery('album', album),
-        ))
+        duplicate_query = dbcore.AndQuery(
+            (
+                dbcore.MatchQuery("albumartist", artist),
+                dbcore.MatchQuery("album", album),
+            )
+        )
 
         for album in lib.albums(duplicate_query):
             # Check whether the album paths are all present in the task
@@ -683,24 +710,25 @@ class ImportTask(BaseImportTask):
             plur_albumartist, freq = util.plurality(
                 [i.albumartist or i.artist for i in self.items]
             )
-            if freq == len(self.items) or \
-                (freq > 1 and
-                    float(freq) / len(self.items) >= SINGLE_ARTIST_THRESH):
+            if freq == len(self.items) or (
+                freq > 1
+                and float(freq) / len(self.items) >= SINGLE_ARTIST_THRESH
+            ):
                 # Single-artist album.
-                changes['albumartist'] = plur_albumartist
-                changes['comp'] = False
+                changes["albumartist"] = plur_albumartist
+                changes["comp"] = False
             else:
                 # VA.
-                changes['albumartist'] = config['va_name'].as_str()
-                changes['comp'] = True
+                changes["albumartist"] = config["va_name"].as_str()
+                changes["comp"] = True
 
         elif self.choice_flag in (action.APPLY, action.RETAG):
             # Applying autotagged metadata. Just get AA from the first
             # item.
             if not self.items[0].albumartist:
-                changes['albumartist'] = self.items[0].artist
+                changes["albumartist"] = self.items[0].artist
             if not self.items[0].mb_albumartistid:
-                changes['mb_albumartistid'] = self.items[0].mb_artistid
+                changes["mb_albumartistid"] = self.items[0].mb_artistid
 
         # Apply new metadata.
         for item in self.items:
@@ -725,9 +753,11 @@ class ImportTask(BaseImportTask):
                 # move in-library files. (Out-of-library files are
                 # copied/moved as usual).
                 old_path = item.path
-                if (operation != MoveOperation.MOVE
-                        and self.replaced_items[item]
-                        and session.lib.directory in util.ancestry(old_path)):
+                if (
+                    operation != MoveOperation.MOVE
+                    and self.replaced_items[item]
+                    and session.lib.directory in util.ancestry(old_path)
+                ):
                     item.move()
                     # We moved the item, so remove the
                     # now-nonexistent file from old_paths.
@@ -744,7 +774,7 @@ class ImportTask(BaseImportTask):
             for item in self.imported_items():
                 item.store()
 
-        plugins.send('import_task_files', session=session, task=self)
+        plugins.send("import_task_files", session=session, task=self)
 
     def add(self, lib):
         """Add the items as an album to the library and remove replaced items.
@@ -754,7 +784,7 @@ class ImportTask(BaseImportTask):
             self.record_replaced(lib)
             self.remove_replaced(lib)
             self.album = lib.add_album(self.imported_items())
-            if 'data_source' in self.imported_items()[0]:
+            if "data_source" in self.imported_items()[0]:
                 self.album.data_source = self.imported_items()[0].data_source
             self.reimport_metadata(lib)
 
@@ -766,13 +796,15 @@ class ImportTask(BaseImportTask):
         self.replaced_albums = defaultdict(list)
         replaced_album_ids = set()
         for item in self.imported_items():
-            dup_items = list(lib.items(
-                dbcore.query.BytesQuery('path', item.path)
-            ))
+            dup_items = list(
+                lib.items(dbcore.query.BytesQuery("path", item.path))
+            )
             self.replaced_items[item] = dup_items
             for dup_item in dup_items:
-                if (not dup_item.album_id or
-                        dup_item.album_id in replaced_album_ids):
+                if (
+                    not dup_item.album_id
+                    or dup_item.album_id in replaced_album_ids
+                ):
                     continue
                 replaced_album = dup_item.get_album()
                 if replaced_album:
@@ -791,12 +823,12 @@ class ImportTask(BaseImportTask):
                 self.album.artpath = replaced_album.artpath
                 self.album.store()
                 log.debug(
-                    u'Reimported album: added {0}, flexible '
-                    u'attributes {1} from album {2} for {3}',
+                    u"Reimported album: added {0}, flexible "
+                    u"attributes {1} from album {2} for {3}",
                     self.album.added,
                     replaced_album._values_flex.keys(),
                     replaced_album.id,
-                    displayable_path(self.album.path)
+                    displayable_path(self.album.path),
                 )
 
         for item in self.imported_items():
@@ -805,19 +837,18 @@ class ImportTask(BaseImportTask):
                 if dup_item.added and dup_item.added != item.added:
                     item.added = dup_item.added
                     log.debug(
-                        u'Reimported item added {0} '
-                        u'from item {1} for {2}',
+                        u"Reimported item added {0} " u"from item {1} for {2}",
                         item.added,
                         dup_item.id,
-                        displayable_path(item.path)
+                        displayable_path(item.path),
                     )
                 item.update(dup_item._values_flex)
                 log.debug(
-                    u'Reimported item flexible attributes {0} '
-                    u'from item {1} for {2}',
+                    u"Reimported item flexible attributes {0} "
+                    u"from item {1} for {2}",
                     dup_item._values_flex.keys(),
                     dup_item.id,
-                    displayable_path(item.path)
+                    displayable_path(item.path),
                 )
                 item.store()
 
@@ -827,12 +858,17 @@ class ImportTask(BaseImportTask):
         """
         for item in self.imported_items():
             for dup_item in self.replaced_items[item]:
-                log.debug(u'Replacing item {0}: {1}',
-                          dup_item.id, displayable_path(item.path))
+                log.debug(
+                    u"Replacing item {0}: {1}",
+                    dup_item.id,
+                    displayable_path(item.path),
+                )
                 dup_item.remove()
-        log.debug(u'{0} of {1} items replaced',
-                  sum(bool(l) for l in self.replaced_items.values()),
-                  len(self.imported_items()))
+        log.debug(
+            u"{0} of {1} items replaced",
+            sum(bool(l) for l in self.replaced_items.values()),
+            len(self.imported_items()),
+        )
 
     def choose_match(self, session):
         """Ask the session which match should apply and apply it.
@@ -858,9 +894,11 @@ class ImportTask(BaseImportTask):
         call when the file in question may not have been removed.
         """
         if self.toppath and not os.path.exists(filename):
-            util.prune_dirs(os.path.dirname(filename),
-                            self.toppath,
-                            clutter=config['clutter'].as_str_seq())
+            util.prune_dirs(
+                os.path.dirname(filename),
+                self.toppath,
+                clutter=config["clutter"].as_str_seq(),
+            )
 
 
 class SingletonImportTask(ImportTask):
@@ -888,7 +926,7 @@ class SingletonImportTask(ImportTask):
 
     def _emit_imported(self, lib):
         for item in self.imported_items():
-            plugins.send('item_imported', lib=lib, item=item)
+            plugins.send("item_imported", lib=lib, item=item)
 
     def lookup_candidates(self):
         prop = autotag.tag_item(self.item, search_ids=self.search_ids)
@@ -902,10 +940,12 @@ class SingletonImportTask(ImportTask):
         artist, title = self.chosen_ident()
 
         found_items = []
-        query = dbcore.AndQuery((
-            dbcore.MatchQuery('artist', artist),
-            dbcore.MatchQuery('title', title),
-        ))
+        query = dbcore.AndQuery(
+            (
+                dbcore.MatchQuery("artist", artist),
+                dbcore.MatchQuery("title", title),
+            )
+        )
         for other_item in lib.items(query):
             # Existing items not considered duplicates.
             if other_item.path != self.item.path:
@@ -938,12 +978,14 @@ class SingletonImportTask(ImportTask):
         """Sets the fields given at CLI or configuration to the specified
         values.
         """
-        for field, view in config['import']['set_fields'].items():
+        for field, view in config["import"]["set_fields"].items():
             value = view.get()
-            log.debug(u'Set field {1}={2} for {0}',
-                      displayable_path(self.paths),
-                      field,
-                      value)
+            log.debug(
+                u"Set field {1}={2} for {0}",
+                displayable_path(self.paths),
+                field,
+                value,
+            )
             self.item[field] = value
         self.item.store()
 
@@ -1030,11 +1072,13 @@ class ArchiveImportTask(SentinelImportTask):
         handled by `ArchiveClass`. `ArchiveClass` is a class that
         implements the same interface as `tarfile.TarFile`.
         """
-        if not hasattr(cls, '_handlers'):
+        if not hasattr(cls, "_handlers"):
             cls._handlers = []
             from zipfile import is_zipfile, ZipFile
+
             cls._handlers.append((is_zipfile, ZipFile))
             import tarfile
+
             cls._handlers.append((tarfile.is_tarfile, tarfile.open))
             try:
                 from rarfile import is_rarfile, RarFile
@@ -1049,8 +1093,10 @@ class ArchiveImportTask(SentinelImportTask):
         """Removes the temporary directory the archive was extracted to.
         """
         if self.extracted:
-            log.debug(u'Removing extracted directory: {0}',
-                      displayable_path(self.toppath))
+            log.debug(
+                u"Removing extracted directory: {0}",
+                displayable_path(self.toppath),
+            )
             shutil.rmtree(self.toppath)
 
     def extract(self):
@@ -1062,7 +1108,7 @@ class ArchiveImportTask(SentinelImportTask):
                 break
 
         extract_to = mkdtemp()
-        archive = handler_class(util.py3_path(self.toppath), mode='r')
+        archive = handler_class(util.py3_path(self.toppath), mode="r")
         try:
             archive.extractall(extract_to)
         finally:
@@ -1075,6 +1121,7 @@ class ImportTaskFactory(object):
     """Generate album and singleton import tasks for all media files
     indicated by a path.
     """
+
     def __init__(self, toppath, session):
         """Create a new task factory.
 
@@ -1109,7 +1156,7 @@ class ImportTaskFactory(object):
 
         # Search for music in the directory.
         for dirs, paths in self.paths():
-            if self.session.config['singletons']:
+            if self.session.config["singletons"]:
                 for path in paths:
                     tasks = self._create(self.singleton(path))
                     for task in tasks:
@@ -1154,7 +1201,7 @@ class ImportTaskFactory(object):
         """
         if not os.path.isdir(syspath(self.toppath)):
             yield [self.toppath], [self.toppath]
-        elif self.session.config['flat']:
+        elif self.session.config["flat"]:
             paths = []
             for dirs, paths_in_dir in albums_in_dir(self.toppath):
                 paths += paths_in_dir
@@ -1167,8 +1214,10 @@ class ImportTaskFactory(object):
         """Return a `SingletonImportTask` for the music file.
         """
         if self.session.already_imported(self.toppath, [path]):
-            log.debug(u'Skipping previously-imported path: {0}',
-                      displayable_path(path))
+            log.debug(
+                u"Skipping previously-imported path: {0}",
+                displayable_path(path),
+            )
             self.skipped += 1
             return None
 
@@ -1191,8 +1240,10 @@ class ImportTaskFactory(object):
             dirs = list(set(os.path.dirname(p) for p in paths))
 
         if self.session.already_imported(self.toppath, dirs):
-            log.debug(u'Skipping previously-imported path: {0}',
-                      displayable_path(dirs))
+            log.debug(
+                u"Skipping previously-imported path: {0}",
+                displayable_path(dirs),
+            )
             self.skipped += 1
             return None
 
@@ -1219,24 +1270,24 @@ class ImportTaskFactory(object):
         """
         assert self.is_archive
 
-        if not (self.session.config['move'] or
-                self.session.config['copy']):
-            log.warning(u"Archive importing requires either "
-                        u"'copy' or 'move' to be enabled.")
+        if not (self.session.config["move"] or self.session.config["copy"]):
+            log.warning(
+                u"Archive importing requires either "
+                u"'copy' or 'move' to be enabled."
+            )
             return
 
-        log.debug(u'Extracting archive: {0}',
-                  displayable_path(self.toppath))
+        log.debug(u"Extracting archive: {0}", displayable_path(self.toppath))
         archive_task = ArchiveImportTask(self.toppath)
         try:
             archive_task.extract()
         except Exception as exc:
-            log.error(u'extraction failed: {0}', exc)
+            log.error(u"extraction failed: {0}", exc)
             return
 
         # Now read albums from the extracted directory.
         self.toppath = archive_task.toppath
-        log.debug(u'Archive extracted to: {0}', self.toppath)
+        log.debug(u"Archive extracted to: {0}", self.toppath)
         return archive_task
 
     def read_item(self, path):
@@ -1252,13 +1303,15 @@ class ImportTaskFactory(object):
                 # Silently ignore non-music files.
                 pass
             elif isinstance(exc.reason, mediafile.UnreadableFileError):
-                log.warning(u'unreadable file: {0}', displayable_path(path))
+                log.warning(u"unreadable file: {0}", displayable_path(path))
             else:
-                log.error(u'error reading {0}: {1}',
-                          displayable_path(path), exc)
+                log.error(
+                    u"error reading {0}: {1}", displayable_path(path), exc
+                )
 
 
 # Pipeline utilities
+
 
 def _freshen_items(items):
     # Clear IDs from re-tagged items so they appear "fresh" when
@@ -1281,6 +1334,7 @@ def _extend_pipeline(tasks, *stages):
 
 # Full-album pipeline stages.
 
+
 def read_tasks(session):
     """A generator yielding all the albums (as ImportTask objects) found
     in the user-specified list of paths. In the case of a singleton
@@ -1298,12 +1352,13 @@ def read_tasks(session):
         skipped += task_factory.skipped
 
         if not task_factory.imported:
-            log.warning(u'No files imported from {0}',
-                        displayable_path(toppath))
+            log.warning(
+                u"No files imported from {0}", displayable_path(toppath)
+            )
 
     # Show skipped directories (due to incremental/resume).
     if skipped:
-        log.info(u'Skipped {0} paths.', skipped)
+        log.info(u"Skipped {0} paths.", skipped)
 
 
 def query_tasks(session):
@@ -1311,7 +1366,7 @@ def query_tasks(session):
     Instead of finding files from the filesystem, a query is used to
     match items from the library.
     """
-    if session.config['singletons']:
+    if session.config["singletons"]:
         # Search for items.
         for item in session.lib.items(session.query):
             task = SingletonImportTask(None, item)
@@ -1321,8 +1376,12 @@ def query_tasks(session):
     else:
         # Search for albums.
         for album in session.lib.albums(session.query):
-            log.debug(u'yielding album {0}: {1} - {2}',
-                      album.id, album.albumartist, album.album)
+            log.debug(
+                u"yielding album {0}: {1} - {2}",
+                album.id,
+                album.albumartist,
+                album.album,
+            )
             items = list(album.items())
             _freshen_items(items)
 
@@ -1343,12 +1402,12 @@ def lookup_candidates(session, task):
         # abstraction.
         return
 
-    plugins.send('import_task_start', session=session, task=task)
-    log.debug(u'Looking up: {0}', displayable_path(task.paths))
+    plugins.send("import_task_start", session=session, task=task)
+    log.debug(u"Looking up: {0}", displayable_path(task.paths))
 
     # Restrict the initial lookup to IDs specified by the user via the -m
     # option. Currently all the IDs are passed onto the tasks directly.
-    task.search_ids = session.config['search_ids'].as_str_seq()
+    task.search_ids = session.config["search_ids"].as_str_seq()
 
     task.lookup_candidates()
 
@@ -1375,7 +1434,7 @@ def user_query(session, task):
 
     # Ask the user for a choice.
     task.choose_match(session)
-    plugins.send('import_task_choice', session=session, task=task)
+    plugins.send("import_task_choice", session=session, task=task)
 
     # As-tracks: transition to singleton workflow.
     if task.choice_flag is action.TRACKS:
@@ -1387,16 +1446,18 @@ def user_query(session, task):
                     yield new_task
             yield SentinelImportTask(task.toppath, task.paths)
 
-        return _extend_pipeline(emitter(task),
-                                lookup_candidates(session),
-                                user_query(session))
+        return _extend_pipeline(
+            emitter(task), lookup_candidates(session), user_query(session)
+        )
 
     # As albums: group items by albums and create task for each album
     if task.choice_flag is action.ALBUMS:
-        return _extend_pipeline([task],
-                                group_albums(session),
-                                lookup_candidates(session),
-                                user_query(session))
+        return _extend_pipeline(
+            [task],
+            group_albums(session),
+            lookup_candidates(session),
+            user_query(session),
+        )
 
     resolve_duplicates(session, task)
 
@@ -1412,12 +1473,13 @@ def user_query(session, task):
         # Record merged paths in the session so they are not reimported
         session.mark_merged(duplicate_paths)
 
-        merged_task = ImportTask(None, task.paths + duplicate_paths,
-                                 task.items + duplicate_items)
+        merged_task = ImportTask(
+            None, task.paths + duplicate_paths, task.items + duplicate_items
+        )
 
-        return _extend_pipeline([merged_task],
-                                lookup_candidates(session),
-                                user_query(session))
+        return _extend_pipeline(
+            [merged_task], lookup_candidates(session), user_query(session)
+        )
 
     apply_choice(session, task)
     return task
@@ -1430,30 +1492,34 @@ def resolve_duplicates(session, task):
     if task.choice_flag in (action.ASIS, action.APPLY, action.RETAG):
         found_duplicates = task.find_duplicates(session.lib)
         if found_duplicates:
-            log.debug(u'found duplicates: {}'.format(
-                [o.id for o in found_duplicates]
-            ))
+            log.debug(
+                u"found duplicates: {}".format(
+                    [o.id for o in found_duplicates]
+                )
+            )
 
             # Get the default action to follow from config.
-            duplicate_action = config['import']['duplicate_action'].as_choice({
-                u'skip': u's',
-                u'keep': u'k',
-                u'remove': u'r',
-                u'merge': u'm',
-                u'ask': u'a',
-            })
-            log.debug(u'default action for duplicates: {0}', duplicate_action)
+            duplicate_action = config["import"]["duplicate_action"].as_choice(
+                {
+                    u"skip": u"s",
+                    u"keep": u"k",
+                    u"remove": u"r",
+                    u"merge": u"m",
+                    u"ask": u"a",
+                }
+            )
+            log.debug(u"default action for duplicates: {0}", duplicate_action)
 
-            if duplicate_action == u's':
+            if duplicate_action == u"s":
                 # Skip new.
                 task.set_choice(action.SKIP)
-            elif duplicate_action == u'k':
+            elif duplicate_action == u"k":
                 # Keep both. Do nothing; leave the choice intact.
                 pass
-            elif duplicate_action == u'r':
+            elif duplicate_action == u"r":
                 # Remove old.
                 task.should_remove_duplicates = True
-            elif duplicate_action == u'm':
+            elif duplicate_action == u"m":
                 # Merge duplicates together
                 task.should_merge_duplicates = True
             else:
@@ -1473,7 +1539,7 @@ def import_asis(session, task):
     if task.skip:
         return
 
-    log.info(u'{}', displayable_path(task.paths))
+    log.info(u"{}", displayable_path(task.paths))
     task.set_choice(action.ASIS)
     apply_choice(session, task)
 
@@ -1488,7 +1554,7 @@ def apply_choice(session, task):
     # Change metadata.
     if task.apply:
         task.apply_metadata()
-        plugins.send('import_task_apply', session=session, task=task)
+        plugins.send("import_task_apply", session=session, task=task)
 
     task.add(session.lib)
 
@@ -1497,7 +1563,7 @@ def apply_choice(session, task):
     # NOTE: This cannot be done before the ``task.add()`` call above,
     # because then the ``ImportTask`` won't have an `album` for which
     # it can set the fields.
-    if config['import']['set_fields']:
+    if config["import"]["set_fields"]:
         task.set_fields()
 
 
@@ -1528,21 +1594,19 @@ def manipulate_files(session, task):
         if task.should_remove_duplicates:
             task.remove_duplicates(session.lib)
 
-        if session.config['move']:
+        if session.config["move"]:
             operation = MoveOperation.MOVE
-        elif session.config['copy']:
+        elif session.config["copy"]:
             operation = MoveOperation.COPY
-        elif session.config['link']:
+        elif session.config["link"]:
             operation = MoveOperation.LINK
-        elif session.config['hardlink']:
+        elif session.config["hardlink"]:
             operation = MoveOperation.HARDLINK
         else:
             operation = None
 
         task.manipulate_files(
-            operation,
-            write=session.config['write'],
-            session=session,
+            operation, write=session.config["write"], session=session,
         )
 
     # Progress, cleanup, and event.
@@ -1554,11 +1618,11 @@ def log_files(session, task):
     """A coroutine (pipeline stage) to log each file to be imported.
     """
     if isinstance(task, SingletonImportTask):
-        log.info(u'Singleton: {0}', displayable_path(task.item['path']))
+        log.info(u"Singleton: {0}", displayable_path(task.item["path"]))
     elif task.items:
-        log.info(u'Album: {0}', displayable_path(task.paths[0]))
+        log.info(u"Album: {0}", displayable_path(task.paths[0]))
         for item in task.items:
-            log.info(u'  {0}', displayable_path(item['path']))
+            log.info(u"  {0}", displayable_path(item["path"]))
 
 
 def group_albums(session):
@@ -1568,6 +1632,7 @@ def group_albums(session):
     Groups are identified using their artist and album fields. The
     pipeline stage emits new album tasks for each discovered group.
     """
+
     def group(item):
         return (item.albumartist or item.artist, item.album)
 
@@ -1580,16 +1645,15 @@ def group_albums(session):
         sorted_items = sorted(task.items, key=group)
         for _, items in itertools.groupby(sorted_items, group):
             items = list(items)
-            task = ImportTask(task.toppath, [i.path for i in items],
-                              items)
+            task = ImportTask(task.toppath, [i.path for i in items], items)
             tasks += task.handle_created(session)
         tasks.append(SentinelImportTask(task.toppath, task.paths))
 
         task = pipeline.multiple(tasks)
 
 
-MULTIDISC_MARKERS = (br'dis[ck]', br'cd')
-MULTIDISC_PAT_FMT = br'^(.*%s[\W_]*)\d'
+MULTIDISC_MARKERS = (br"dis[ck]", br"cd")
+MULTIDISC_PAT_FMT = br"^(.*%s[\W_]*)\d"
 
 
 def is_subdir_of_any_in_list(path, dirs):
@@ -1607,21 +1671,21 @@ def albums_in_dir(path):
     containing any media files is an album.
     """
     collapse_pat = collapse_paths = collapse_items = None
-    ignore = config['ignore'].as_str_seq()
-    ignore_hidden = config['ignore_hidden'].get(bool)
+    ignore = config["ignore"].as_str_seq()
+    ignore_hidden = config["ignore_hidden"].get(bool)
 
-    for root, dirs, files in sorted_walk(path, ignore=ignore,
-                                         ignore_hidden=ignore_hidden,
-                                         logger=log):
+    for root, dirs, files in sorted_walk(
+        path, ignore=ignore, ignore_hidden=ignore_hidden, logger=log
+    ):
         items = [os.path.join(root, f) for f in files]
         # If we're currently collapsing the constituent directories in a
         # multi-disc album, check whether we should continue collapsing
         # and add the current directory. If so, just add the directory
         # and move on to the next directory. If not, stop collapsing.
         if collapse_paths:
-            if (is_subdir_of_any_in_list(root, collapse_paths)) or \
-                    (collapse_pat and
-                     collapse_pat.match(os.path.basename(root))):
+            if (is_subdir_of_any_in_list(root, collapse_paths)) or (
+                collapse_pat and collapse_pat.match(os.path.basename(root))
+            ):
                 # Still collapsing.
                 collapse_paths.append(root)
                 collapse_items += items
@@ -1641,7 +1705,7 @@ def albums_in_dir(path):
         start_collapsing = False
         for marker in MULTIDISC_MARKERS:
             # We're using replace on %s due to lack of .format() on bytestrings
-            p = MULTIDISC_PAT_FMT.replace(b'%s', marker)
+            p = MULTIDISC_PAT_FMT.replace(b"%s", marker)
             marker_pat = re.compile(p, re.I)
             match = marker_pat.match(os.path.basename(root))
 
@@ -1659,8 +1723,7 @@ def albums_in_dir(path):
                         if match:
                             match_group = re.escape(match.group(1))
                             subdir_pat = re.compile(
-                                b''.join([b'^', match_group, br'\d']),
-                                re.I
+                                b"".join([b"^", match_group, br"\d"]), re.I
                             )
                         else:
                             start_collapsing = False
@@ -1682,8 +1745,7 @@ def albums_in_dir(path):
                 # Set the current pattern to match directories with the same
                 # prefix as this one, followed by a digit.
                 collapse_pat = re.compile(
-                    b''.join([b'^', re.escape(match.group(1)), br'\d']),
-                    re.I
+                    b"".join([b"^", re.escape(match.group(1)), br"\d"]), re.I
                 )
                 break
 

--- a/beets/logging.py
+++ b/beets/logging.py
@@ -52,7 +52,7 @@ def logsafe(val):
         # (a) only do this for paths, if they can be given a distinct
         # type, and (b) warn the developer if they do this for other
         # bytestrings.
-        return val.decode('utf-8', 'replace')
+        return val.decode("utf-8", "replace")
 
     # A "problem" object: needs a workaround.
     elif isinstance(val, subprocess.CalledProcessError):
@@ -61,7 +61,7 @@ def logsafe(val):
         except UnicodeDecodeError:
             # An object with a broken __unicode__ formatter. Use __str__
             # instead.
-            return str(val).decode('utf-8', 'replace')
+            return str(val).decode("utf-8", "replace")
 
     # Other objects are used as-is so field access, etc., still works in
     # the format string.
@@ -94,6 +94,7 @@ class StrFormatLogger(Logger):
 class ThreadLocalLevelLogger(Logger):
     """A version of `Logger` whose level is thread-local instead of shared.
     """
+
     def __init__(self, name, level=NOTSET):
         self._thread_level = threading.local()
         self.default_level = NOTSET

--- a/beets/mediafile.py
+++ b/beets/mediafile.py
@@ -18,11 +18,12 @@ from __future__ import division, absolute_import, print_function
 import mediafile
 
 import warnings
+
 warnings.warn("beets.mediafile is deprecated; use mediafile instead")
 
 # Import everything from the mediafile module into this module.
 for key, value in mediafile.__dict__.items():
-    if key not in ['__name__']:
+    if key not in ["__name__"]:
         globals()[key] = value
 
 del key, value, warnings, mediafile

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -31,13 +31,13 @@ import mediafile
 import six
 
 
-PLUGIN_NAMESPACE = 'beetsplug'
+PLUGIN_NAMESPACE = "beetsplug"
 
 # Plugins using the Last.fm API can share the same API key.
-LASTFM_KEY = '2dc3914abf35f0d9c92d97d8f8e42b43'
+LASTFM_KEY = "2dc3914abf35f0d9c92d97d8f8e42b43"
 
 # Global logger.
-log = logging.getLogger('beets')
+log = logging.getLogger("beets")
 
 
 class PluginConflictException(Exception):
@@ -52,12 +52,14 @@ class PluginLogFilter(logging.Filter):
     """A logging filter that identifies the plugin that emitted a log
     message.
     """
+
     def __init__(self, plugin):
-        self.prefix = u'{0}: '.format(plugin.name)
+        self.prefix = u"{0}: ".format(plugin.name)
 
     def filter(self, record):
-        if hasattr(record.msg, 'msg') and isinstance(record.msg.msg,
-                                                     six.string_types):
+        if hasattr(record.msg, "msg") and isinstance(
+            record.msg.msg, six.string_types
+        ):
             # A _LogMessage from our hacked-up Logging replacement.
             record.msg.msg = self.prefix + record.msg.msg
         elif isinstance(record.msg, six.string_types):
@@ -67,15 +69,17 @@ class PluginLogFilter(logging.Filter):
 
 # Managing the plugins themselves.
 
+
 class BeetsPlugin(object):
     """The base class for all beets plugins. Plugins provide
     functionality by defining a subclass of BeetsPlugin and overriding
     the abstract methods defined here.
     """
+
     def __init__(self, name=None):
         """Perform one-time plugin setup.
         """
-        self.name = name or self.__module__.split('.')[-1]
+        self.name = name or self.__module__.split(".")[-1]
         self.config = beets.config[self.name]
         if not self.template_funcs:
             self.template_funcs = {}
@@ -100,8 +104,10 @@ class BeetsPlugin(object):
     def _set_stage_log_level(self, stages):
         """Adjust all the stages in `stages` to WARNING logging level.
         """
-        return [self._set_log_level_and_params(logging.WARNING, stage)
-                for stage in stages]
+        return [
+            self._set_log_level_and_params(logging.WARNING, stage)
+            for stage in stages
+        ]
 
     def get_early_import_stages(self):
         """Return a list of functions that should be called as importer
@@ -137,7 +143,7 @@ class BeetsPlugin(object):
         @wraps(func)
         def wrapper(*args, **kwargs):
             assert self._log.level == logging.NOTSET
-            verbosity = beets.config['verbose'].get(int)
+            verbosity = beets.config["verbose"].get(int)
             log_level = max(logging.DEBUG, base_log_level - 10 * verbosity)
             self._log.setLevel(log_level)
             try:
@@ -146,13 +152,17 @@ class BeetsPlugin(object):
                 except TypeError as exc:
                     if exc.args[0].startswith(func.__name__):
                         # caused by 'func' and not stuff internal to 'func'
-                        kwargs = dict((arg, val) for arg, val in kwargs.items()
-                                      if arg in func_args)
+                        kwargs = dict(
+                            (arg, val)
+                            for arg, val in kwargs.items()
+                            if arg in func_args
+                        )
                         return func(*args, **kwargs)
                     else:
                         raise
             finally:
                 self._log.setLevel(logging.NOTSET)
+
         return wrapper
 
     def queries(self):
@@ -208,6 +218,7 @@ class BeetsPlugin(object):
         """
         # Defer import to prevent circular dependency
         from beets import library
+
         mediafile.MediaFile.add_field(name, descriptor)
         library.Item._media_fields.add(name)
 
@@ -237,11 +248,13 @@ class BeetsPlugin(object):
         function will be invoked as ``%name{}`` from path format
         strings.
         """
+
         def helper(func):
             if cls.template_funcs is None:
                 cls.template_funcs = {}
             cls.template_funcs[name] = func
             return func
+
         return helper
 
     @classmethod
@@ -251,11 +264,13 @@ class BeetsPlugin(object):
         strings. The function must accept a single parameter, the Item
         being formatted.
         """
+
         def helper(func):
             if cls.template_fields is None:
                 cls.template_fields = {}
             cls.template_fields[name] = func
             return func
+
         return helper
 
 
@@ -269,25 +284,29 @@ def load_plugins(names=()):
     BeetsPlugin subclasses desired.
     """
     for name in names:
-        modname = '{0}.{1}'.format(PLUGIN_NAMESPACE, name)
+        modname = "{0}.{1}".format(PLUGIN_NAMESPACE, name)
         try:
             try:
                 namespace = __import__(modname, None, None)
             except ImportError as exc:
                 # Again, this is hacky:
-                if exc.args[0].endswith(' ' + name):
-                    log.warning(u'** plugin {0} not found', name)
+                if exc.args[0].endswith(" " + name):
+                    log.warning(u"** plugin {0} not found", name)
                 else:
                     raise
             else:
                 for obj in getattr(namespace, name).__dict__.values():
-                    if isinstance(obj, type) and issubclass(obj, BeetsPlugin) \
-                            and obj != BeetsPlugin and obj not in _classes:
+                    if (
+                        isinstance(obj, type)
+                        and issubclass(obj, BeetsPlugin)
+                        and obj != BeetsPlugin
+                        and obj not in _classes
+                    ):
                         _classes.add(obj)
 
         except Exception:
             log.warning(
-                u'** error loading plugin {}:\n{}',
+                u"** error loading plugin {}:\n{}",
                 name,
                 traceback.format_exc(),
             )
@@ -313,6 +332,7 @@ def find_plugins():
 
 # Communication with plugins.
 
+
 def commands():
     """Returns a list of Subcommand objects from all loaded plugins.
     """
@@ -334,16 +354,16 @@ def queries():
 
 def types(model_cls):
     # Gives us `item_types` and `album_types`
-    attr_name = '{0}_types'.format(model_cls.__name__.lower())
+    attr_name = "{0}_types".format(model_cls.__name__.lower())
     types = {}
     for plugin in find_plugins():
         plugin_types = getattr(plugin, attr_name, {})
         for field in plugin_types:
             if field in types and plugin_types[field] != types[field]:
                 raise PluginConflictException(
-                    u'Plugin {0} defines flexible field {1} '
-                    u'which has already been defined with '
-                    u'another type.'.format(plugin.name, field)
+                    u"Plugin {0} defines flexible field {1} "
+                    u"which has already been defined with "
+                    u"another type.".format(plugin.name, field)
                 )
         types.update(plugin_types)
     return types
@@ -351,7 +371,7 @@ def types(model_cls):
 
 def named_queries(model_cls):
     # Gather `item_queries` and `album_queries` from the plugins.
-    attr_name = '{0}_queries'.format(model_cls.__name__.lower())
+    attr_name = "{0}_queries".format(model_cls.__name__.lower())
     queries = {}
     for plugin in find_plugins():
         plugin_queries = getattr(plugin, attr_name, {})
@@ -364,6 +384,7 @@ def track_distance(item, info):
     Returns a Distance object.
     """
     from beets.autotag.hooks import Distance
+
     dist = Distance()
     for plugin in find_plugins():
         dist.update(plugin.track_distance(item, info))
@@ -373,6 +394,7 @@ def track_distance(item, info):
 def album_distance(items, album_info, mapping):
     """Returns the album distance calculated by plugins."""
     from beets.autotag.hooks import Distance
+
     dist = Distance()
     for plugin in find_plugins():
         dist.update(plugin.album_distance(items, album_info, mapping))
@@ -383,8 +405,9 @@ def candidates(items, artist, album, va_likely, extra_tags=None):
     """Gets MusicBrainz candidates for an album from each plugin.
     """
     for plugin in find_plugins():
-        for candidate in plugin.candidates(items, artist, album, va_likely,
-                                           extra_tags):
+        for candidate in plugin.candidates(
+            items, artist, album, va_likely, extra_tags
+        ):
             yield candidate
 
 
@@ -443,6 +466,7 @@ def import_stages():
 
 # New-style (lazy) plugin-provided fields.
 
+
 def item_field_getters():
     """Get a dictionary mapping field names to unary functions that
     compute the field's value.
@@ -466,6 +490,7 @@ def album_field_getters():
 
 # Event dispatch.
 
+
 def event_handlers():
     """Find all event handlers from plugins as a dictionary mapping
     event names to sequences of callables.
@@ -486,7 +511,7 @@ def send(event, **arguments):
 
     Return a list of non-None values returned from the handlers.
     """
-    log.debug(u'Sending event: {0}', event)
+    log.debug(u"Sending event: {0}", event)
     results = []
     for handler in event_handlers()[event]:
         result = handler(**arguments)
@@ -501,11 +526,11 @@ def feat_tokens(for_artist=True):
     The `for_artist` option determines whether the regex should be
     suitable for matching artist fields (the default) or title fields.
     """
-    feat_words = ['ft', 'featuring', 'feat', 'feat.', 'ft.']
+    feat_words = ["ft", "featuring", "feat", "feat.", "ft."]
     if for_artist:
-        feat_words += ['with', 'vs', 'and', 'con', '&']
-    return r'(?<=\s)(?:{0})(?=\s)'.format(
-        '|'.join(re.escape(x) for x in feat_words)
+        feat_words += ["with", "vs", "and", "con", "&"]
+    return r"(?<=\s)(?:{0})(?=\s)".format(
+        "|".join(re.escape(x) for x in feat_words)
     )
 
 
@@ -521,7 +546,7 @@ def sanitize_choices(choices, choices_all):
         if s not in seen:
             if s in list(choices_all):
                 res.append(s)
-            elif s == '*':
+            elif s == "*":
                 res.extend(others)
         seen.add(s)
     return res
@@ -554,11 +579,11 @@ def sanitize_pairs(pairs, pairs_all):
                 if x not in seen:
                     seen.add(x)
                     res.append(x)
-            elif k == '*':
+            elif k == "*":
                 new = [o for o in others if o not in seen]
                 seen.update(new)
                 res.extend(new)
-            elif v == '*':
+            elif v == "*":
                 new = [o for o in others if o not in seen and o[0] == k]
                 seen.update(new)
                 res.extend(new)
@@ -572,12 +597,15 @@ def notify_info_yielded(event):
     Each yielded value is passed to plugins using the 'info' parameter of
     'send'.
     """
+
     def decorator(generator):
         def decorated(*args, **kwargs):
             for v in generator(*args, **kwargs):
                 send(event, info=v)
                 yield v
+
         return decorated
+
     return decorator
 
 
@@ -587,7 +615,7 @@ def get_distance(config, data_source, info):
     """
     dist = beets.autotag.Distance()
     if info.data_source == data_source:
-        dist.add('source', config['source_weight'].as_number())
+        dist.add("source", config["source_weight"].as_number())
     return dist
 
 
@@ -625,7 +653,7 @@ def apply_item_changes(lib, item, move, pretend, write):
 class MetadataSourcePlugin(object):
     def __init__(self):
         super(MetadataSourcePlugin, self).__init__()
-        self.config.add({'source_weight': 0.5})
+        self.config.add({"source_weight": 0.5})
 
     @abc.abstractproperty
     def id_regex(self):
@@ -648,7 +676,7 @@ class MetadataSourcePlugin(object):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def _search_api(self, query_type, filters, keywords=''):
+    def _search_api(self, query_type, filters, keywords=""):
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -660,7 +688,7 @@ class MetadataSourcePlugin(object):
         raise NotImplementedError
 
     @staticmethod
-    def get_artist(artists, id_key='id', name_key='name'):
+    def get_artist(artists, id_key="id", name_key="name"):
         """Returns an artist string (all artists) and an artist_id (the main
         artist) for a list of artist object dicts.
 
@@ -688,11 +716,11 @@ class MetadataSourcePlugin(object):
                 artist_id = artist[id_key]
             name = artist[name_key]
             # Strip disambiguation number.
-            name = re.sub(r' \(\d+\)$', '', name)
+            name = re.sub(r" \(\d+\)$", "", name)
             # Move articles to the front.
-            name = re.sub(r'^(.*?), (a|an|the)$', r'\2 \1', name, flags=re.I)
+            name = re.sub(r"^(.*?), (a|an|the)$", r"\2 \1", name, flags=re.I)
             artist_names.append(name)
-        artist = ', '.join(artist_names).replace(' ,', ',') or None
+        artist = ", ".join(artist_names).replace(" ,", ",") or None
         return artist, artist_id
 
     def _get_id(self, url_type, id_):
@@ -708,9 +736,9 @@ class MetadataSourcePlugin(object):
         self._log.debug(
             u"Searching {} for {} '{}'", self.data_source, url_type, id_
         )
-        match = re.search(self.id_regex['pattern'].format(url_type), str(id_))
+        match = re.search(self.id_regex["pattern"].format(url_type), str(id_))
         if match:
-            id_ = match.group(self.id_regex['match_group'])
+            id_ = match.group(self.id_regex["match_group"])
             if id_:
                 return id_
         return None
@@ -731,11 +759,11 @@ class MetadataSourcePlugin(object):
         :return: Candidate AlbumInfo objects.
         :rtype: list[beets.autotag.hooks.AlbumInfo]
         """
-        query_filters = {'album': album}
+        query_filters = {"album": album}
         if not va_likely:
-            query_filters['artist'] = artist
-        results = self._search_api(query_type='album', filters=query_filters)
-        albums = [self.album_for_id(album_id=r['id']) for r in results]
+            query_filters["artist"] = artist
+        results = self._search_api(query_type="album", filters=query_filters)
+        albums = [self.album_for_id(album_id=r["id"]) for r in results]
         return [a for a in albums if a is not None]
 
     def item_candidates(self, item, artist, title):
@@ -752,7 +780,7 @@ class MetadataSourcePlugin(object):
         :rtype: list[beets.autotag.hooks.TrackInfo]
         """
         tracks = self._search_api(
-            query_type='track', keywords=title, filters={'artist': artist}
+            query_type="track", keywords=title, filters={"artist": artist}
         )
         return [self.track_for_id(track_data=track) for track in tracks]
 

--- a/beets/random.py
+++ b/beets/random.py
@@ -31,7 +31,7 @@ def _length(obj, album):
         return obj.length
 
 
-def _equal_chance_permutation(objs, field='albumartist', random_gen=None):
+def _equal_chance_permutation(objs, field="albumartist", random_gen=None):
     """Generate (lazily) a permutation of the objects where every group
     with equal values for `field` have an equal chance of appearing in
     any given position.
@@ -88,8 +88,9 @@ def _take_time(iter, secs, album):
     return out
 
 
-def random_objs(objs, album, number=1, time=None, equal_chance=False,
-                random_gen=None):
+def random_objs(
+    objs, album, number=1, time=None, equal_chance=False, random_gen=None
+):
     """Get a random subset of the provided `objs`.
 
     If `number` is provided, produce that many matches. Otherwise, if

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -46,7 +46,7 @@ import confuse
 import six
 
 # On Windows platforms, use colorama to support "ANSI" terminal colors.
-if sys.platform == 'win32':
+if sys.platform == "win32":
     try:
         import colorama
     except ImportError:
@@ -55,15 +55,15 @@ if sys.platform == 'win32':
         colorama.init()
 
 
-log = logging.getLogger('beets')
+log = logging.getLogger("beets")
 if not log.handlers:
     log.addHandler(logging.StreamHandler())
 log.propagate = False  # Don't propagate to root handler.
 
 
 PF_KEY_QUERIES = {
-    'comp': u'comp:true',
-    'singleton': u'singleton:true',
+    "comp": u"comp:true",
+    "singleton": u"singleton:true",
 }
 
 
@@ -88,20 +88,20 @@ def _out_encoding():
     return _stream_encoding(sys.stdout)
 
 
-def _stream_encoding(stream, default='utf-8'):
+def _stream_encoding(stream, default="utf-8"):
     """A helper for `_in_encoding` and `_out_encoding`: get the stream's
     preferred encoding, using a configured override or a default
     fallback if neither is not specified.
     """
     # Configured override?
-    encoding = config['terminal_encoding'].get()
+    encoding = config["terminal_encoding"].get()
     if encoding:
         return encoding
 
     # For testing: When sys.stdout or sys.stdin is a StringIO under the
     # test harness, it doesn't have an `encoding` attribute. Just use
     # UTF-8.
-    if not hasattr(stream, 'encoding'):
+    if not hasattr(stream, "encoding"):
         return default
 
     # Python's guessed output stream encoding, or UTF-8 as a fallback
@@ -131,24 +131,24 @@ def print_(*strings, **kwargs):
     (it defaults to a newline).
     """
     if not strings:
-        strings = [u'']
+        strings = [u""]
     assert isinstance(strings[0], six.text_type)
 
-    txt = u' '.join(strings)
-    txt += kwargs.get('end', u'\n')
+    txt = u" ".join(strings)
+    txt += kwargs.get("end", u"\n")
 
     # Encode the string and write it to stdout.
     if six.PY2:
         # On Python 2, sys.stdout expects bytes.
-        out = txt.encode(_out_encoding(), 'replace')
+        out = txt.encode(_out_encoding(), "replace")
         sys.stdout.write(out)
     else:
         # On Python 3, sys.stdout expects text strings and uses the
         # exception-throwing encoding error policy. To avoid throwing
         # errors and use our configurable encoding override, we use the
         # underlying bytes buffer instead.
-        if hasattr(sys.stdout, 'buffer'):
-            out = txt.encode(_out_encoding(), 'replace')
+        if hasattr(sys.stdout, "buffer"):
+            out = txt.encode(_out_encoding(), "replace")
             sys.stdout.buffer.write(out)
             sys.stdout.buffer.flush()
         else:
@@ -158,6 +158,7 @@ def print_(*strings, **kwargs):
 
 
 # Configuration wrappers.
+
 
 def _bool_fallback(a, b):
     """Given a boolean or None, return the original value or a fallback.
@@ -174,7 +175,7 @@ def should_write(write_opt=None):
     """Decide whether a command that updates metadata should also write
     tags, using the importer configuration as the default.
     """
-    return _bool_fallback(write_opt, config['import']['write'].get(bool))
+    return _bool_fallback(write_opt, config["import"]["write"].get(bool))
 
 
 def should_move(move_opt=None):
@@ -189,12 +190,13 @@ def should_move(move_opt=None):
     """
     return _bool_fallback(
         move_opt,
-        config['import']['move'].get(bool) or
-        config['import']['copy'].get(bool)
+        config["import"]["move"].get(bool)
+        or config["import"]["copy"].get(bool),
     )
 
 
 # Input prompts.
+
 
 def input_(prompt=None):
     """Like `input`, but decodes the result to a Unicode string.
@@ -206,21 +208,28 @@ def input_(prompt=None):
     # use print_() explicitly to display prompts.
     # https://bugs.python.org/issue1927
     if prompt:
-        print_(prompt, end=u' ')
+        print_(prompt, end=u" ")
 
     try:
         resp = input()
     except EOFError:
-        raise UserError(u'stdin stream ended while input required')
+        raise UserError(u"stdin stream ended while input required")
 
     if six.PY2:
-        return resp.decode(_in_encoding(), 'ignore')
+        return resp.decode(_in_encoding(), "ignore")
     else:
         return resp
 
 
-def input_options(options, require=False, prompt=None, fallback_prompt=None,
-                  numrange=None, default=None, max_width=72):
+def input_options(
+    options,
+    require=False,
+    prompt=None,
+    fallback_prompt=None,
+    numrange=None,
+    default=None,
+    max_width=72,
+):
     """Prompts a user for input. The sequence of `options` defines the
     choices the user has. A single-letter shortcut is inferred for each
     option; the user's choice is returned as that single, lower-case
@@ -260,31 +269,33 @@ def input_options(options, require=False, prompt=None, fallback_prompt=None,
                     found_letter = letter
                     break
             else:
-                raise ValueError(u'no unambiguous lettering found')
+                raise ValueError(u"no unambiguous lettering found")
 
         letters[found_letter.lower()] = option
         index = option.index(found_letter)
 
         # Mark the option's shortcut letter for display.
         if not require and (
-            (default is None and not numrange and first) or
-            (isinstance(default, six.string_types) and
-             found_letter.lower() == default.lower())):
+            (default is None and not numrange and first)
+            or (
+                isinstance(default, six.string_types)
+                and found_letter.lower() == default.lower()
+            )
+        ):
             # The first option is the default; mark it.
-            show_letter = '[%s]' % found_letter.upper()
+            show_letter = "[%s]" % found_letter.upper()
             is_default = True
         else:
             show_letter = found_letter.upper()
             is_default = False
 
         # Colorize the letter shortcut.
-        show_letter = colorize('action_default' if is_default else 'action',
-                               show_letter)
+        show_letter = colorize(
+            "action_default" if is_default else "action", show_letter
+        )
 
         # Insert the highlighted letter back into the word.
-        capitalized.append(
-            option[:index] + show_letter + option[index + 1:]
-        )
+        capitalized.append(option[:index] + show_letter + option[index + 1 :])
         display_letters.append(found_letter.upper())
 
         first = False
@@ -305,36 +316,37 @@ def input_options(options, require=False, prompt=None, fallback_prompt=None,
         if numrange:
             if isinstance(default, int):
                 default_name = six.text_type(default)
-                default_name = colorize('action_default', default_name)
-                tmpl = '# selection (default %s)'
+                default_name = colorize("action_default", default_name)
+                tmpl = "# selection (default %s)"
                 prompt_parts.append(tmpl % default_name)
                 prompt_part_lengths.append(len(tmpl % six.text_type(default)))
             else:
-                prompt_parts.append('# selection')
+                prompt_parts.append("# selection")
                 prompt_part_lengths.append(len(prompt_parts[-1]))
         prompt_parts += capitalized
         prompt_part_lengths += [len(s) for s in options]
 
         # Wrap the query text.
-        prompt = ''
+        prompt = ""
         line_length = 0
-        for i, (part, length) in enumerate(zip(prompt_parts,
-                                               prompt_part_lengths)):
+        for i, (part, length) in enumerate(
+            zip(prompt_parts, prompt_part_lengths)
+        ):
             # Add punctuation.
             if i == len(prompt_parts) - 1:
-                part += '?'
+                part += "?"
             else:
-                part += ','
+                part += ","
             length += 1
 
             # Choose either the current line or the beginning of the next.
             if line_length + length + 1 > max_width:
-                prompt += '\n'
+                prompt += "\n"
                 line_length = 0
 
             if line_length != 0:
                 # Not the beginning of the line; need a space.
-                part = ' ' + part
+                part = " " + part
                 length += 1
 
             prompt += part
@@ -343,10 +355,10 @@ def input_options(options, require=False, prompt=None, fallback_prompt=None,
     # Make a fallback prompt too. This is displayed if the user enters
     # something that is not recognized.
     if not fallback_prompt:
-        fallback_prompt = u'Enter one of '
+        fallback_prompt = u"Enter one of "
         if numrange:
-            fallback_prompt += u'%i-%i, ' % numrange
-        fallback_prompt += ', '.join(display_letters) + ':'
+            fallback_prompt += u"%i-%i, " % numrange
+        fallback_prompt += ", ".join(display_letters) + ":"
 
     resp = input_(prompt)
     while True:
@@ -383,10 +395,8 @@ def input_yn(prompt, require=False):
     """Prompts the user for a "yes" or "no" response. The default is
     "yes" unless `require` is `True`, in which case there is no default.
     """
-    sel = input_options(
-        ('y', 'n'), require, prompt, u'Enter Y or N:'
-    )
-    return sel == u'y'
+    sel = input_options(("y", "n"), require, prompt, u"Enter Y or N:")
+    return sel == u"y"
 
 
 def input_select_objects(prompt, objs, rep):
@@ -398,24 +408,26 @@ def input_select_objects(prompt, objs, rep):
     object to print it out when confirming objects individually.
     """
     choice = input_options(
-        (u'y', u'n', u's'), False,
-        u'%s? (Yes/no/select)' % prompt)
+        (u"y", u"n", u"s"), False, u"%s? (Yes/no/select)" % prompt
+    )
     print()  # Blank line.
 
-    if choice == u'y':  # Yes.
+    if choice == u"y":  # Yes.
         return objs
 
-    elif choice == u's':  # Select.
+    elif choice == u"s":  # Select.
         out = []
         for obj in objs:
             rep(obj)
             answer = input_options(
-                ('y', 'n', 'q'), True, u'%s? (yes/no/quit)' % prompt,
-                u'Enter Y or N:'
+                ("y", "n", "q"),
+                True,
+                u"%s? (yes/no/quit)" % prompt,
+                u"Enter Y or N:",
             )
-            if answer == u'y':
+            if answer == u"y":
                 out.append(obj)
-            elif answer == u'q':
+            elif answer == u"q":
                 return out
         return out
 
@@ -425,15 +437,16 @@ def input_select_objects(prompt, objs, rep):
 
 # Human output formatting.
 
+
 def human_bytes(size):
     """Formats size, a number of bytes, in a human-readable way."""
-    powers = [u'', u'K', u'M', u'G', u'T', u'P', u'E', u'Z', u'Y', u'H']
-    unit = 'B'
+    powers = [u"", u"K", u"M", u"G", u"T", u"P", u"E", u"Z", u"Y", u"H"]
+    unit = "B"
     for power in powers:
         if size < 1024:
             return u"%3.1f %s%s" % (size, power, unit)
         size /= 1024.0
-        unit = u'iB'
+        unit = u"iB"
     return u"big"
 
 
@@ -442,13 +455,13 @@ def human_seconds(interval):
     interval using English words.
     """
     units = [
-        (1, u'second'),
-        (60, u'minute'),
-        (60, u'hour'),
-        (24, u'day'),
-        (7, u'week'),
-        (52, u'year'),
-        (10, u'decade'),
+        (1, u"second"),
+        (60, u"minute"),
+        (60, u"hour"),
+        (24, u"day"),
+        (7, u"week"),
+        (52, u"year"),
+        (10, u"decade"),
     ]
     for i in range(len(units) - 1):
         increment, suffix = units[i]
@@ -469,7 +482,7 @@ def human_seconds_short(interval):
     string.
     """
     interval = int(interval)
-    return u'%i:%02i' % (interval // 60, interval % 60)
+    return u"%i:%02i" % (interval // 60, interval % 60)
 
 
 # Colorization.
@@ -489,7 +502,7 @@ DARK_COLORS = {
     "darkmagenta": 5,
     "teal": 6,
     "darkcyan": 6,
-    "lightgray": 7
+    "lightgray": 7,
 }
 LIGHT_COLORS = {
     "darkgray": 0,
@@ -501,14 +514,21 @@ LIGHT_COLORS = {
     "magenta": 5,
     "turquoise": 6,
     "cyan": 6,
-    "white": 7
+    "white": 7,
 }
 RESET_COLOR = COLOR_ESCAPE + "39;49;00m"
 
 # These abstract COLOR_NAMES are lazily mapped on to the actual color in COLORS
 # as they are defined in the configuration files, see function: colorize
-COLOR_NAMES = ['text_success', 'text_warning', 'text_error', 'text_highlight',
-               'text_highlight_minor', 'action_default', 'action']
+COLOR_NAMES = [
+    "text_success",
+    "text_warning",
+    "text_error",
+    "text_highlight",
+    "text_highlight_minor",
+    "action_default",
+    "action",
+]
 COLORS = None
 
 
@@ -522,7 +542,7 @@ def _colorize(color, text):
     elif color in LIGHT_COLORS:
         escape = COLOR_ESCAPE + "%i;01m" % (LIGHT_COLORS[color] + 30)
     else:
-        raise ValueError(u'no such color %s', color)
+        raise ValueError(u"no such color %s", color)
     return escape + text + RESET_COLOR
 
 
@@ -530,32 +550,35 @@ def colorize(color_name, text):
     """Colorize text if colored output is enabled. (Like _colorize but
     conditional.)
     """
-    if not config['ui']['color'] or 'NO_COLOR' in os.environ.keys():
+    if not config["ui"]["color"] or "NO_COLOR" in os.environ.keys():
         return text
 
     global COLORS
     if not COLORS:
-        COLORS = dict((name,
-                       config['ui']['colors'][name].as_str())
-                      for name in COLOR_NAMES)
+        COLORS = dict(
+            (name, config["ui"]["colors"][name].as_str())
+            for name in COLOR_NAMES
+        )
     # In case a 3rd party plugin is still passing the actual color ('red')
     # instead of the abstract color name ('text_error')
     color = COLORS.get(color_name)
     if not color:
-        log.debug(u'Invalid color_name: {0}', color_name)
+        log.debug(u"Invalid color_name: {0}", color_name)
         color = color_name
     return _colorize(color, text)
 
 
-def _colordiff(a, b, highlight='text_highlight',
-               minor_highlight='text_highlight_minor'):
+def _colordiff(
+    a, b, highlight="text_highlight", minor_highlight="text_highlight_minor"
+):
     """Given two values, return the same pair of strings except with
     their differences highlighted in the specified color. Strings are
     highlighted intelligently to show differences; other values are
     stringified and highlighted in their entirety.
     """
-    if not isinstance(a, six.string_types) \
-       or not isinstance(b, six.string_types):
+    if not isinstance(a, six.string_types) or not isinstance(
+        b, six.string_types
+    ):
         # Non-strings: use ordinary equality.
         a = six.text_type(a)
         b = six.text_type(b)
@@ -574,17 +597,17 @@ def _colordiff(a, b, highlight='text_highlight',
 
     matcher = SequenceMatcher(lambda x: False, a, b)
     for op, a_start, a_end, b_start, b_end in matcher.get_opcodes():
-        if op == 'equal':
+        if op == "equal":
             # In both strings.
             a_out.append(a[a_start:a_end])
             b_out.append(b[b_start:b_end])
-        elif op == 'insert':
+        elif op == "insert":
             # Right only.
             b_out.append(colorize(highlight, b[b_start:b_end]))
-        elif op == 'delete':
+        elif op == "delete":
             # Left only.
             a_out.append(colorize(highlight, a[a_start:a_end]))
-        elif op == 'replace':
+        elif op == "replace":
             # Right and left differ. Colorise with second highlight if
             # it's just a case change.
             if a[a_start:a_end].lower() != b[b_start:b_end].lower():
@@ -594,16 +617,16 @@ def _colordiff(a, b, highlight='text_highlight',
             a_out.append(colorize(color, a[a_start:a_end]))
             b_out.append(colorize(color, b[b_start:b_end]))
         else:
-            assert(False)
+            assert False
 
-    return u''.join(a_out), u''.join(b_out)
+    return u"".join(a_out), u"".join(b_out)
 
 
-def colordiff(a, b, highlight='text_highlight'):
+def colordiff(a, b, highlight="text_highlight"):
     """Colorize differences between two values if color is enabled.
     (Like _colordiff but conditional.)
     """
-    if config['ui']['color']:
+    if config["ui"]["color"]:
         return _colordiff(a, b, highlight)
     else:
         return six.text_type(a), six.text_type(b)
@@ -614,7 +637,7 @@ def get_path_formats(subview=None):
     pairs.
     """
     path_formats = []
-    subview = subview or config['paths']
+    subview = subview or config["paths"]
     for query, view in subview.items():
         query = PF_KEY_QUERIES.get(query, query)  # Expand common queries.
         path_formats.append((query, template(view.as_str())))
@@ -625,22 +648,20 @@ def get_replacements():
     """Confuse validation function that reads regex/string pairs.
     """
     replacements = []
-    for pattern, repl in config['replace'].get(dict).items():
-        repl = repl or ''
+    for pattern, repl in config["replace"].get(dict).items():
+        repl = repl or ""
         try:
             replacements.append((re.compile(pattern), repl))
         except re.error:
             raise UserError(
-                u'malformed regular expression in replace: {0}'.format(
-                    pattern
-                )
+                u"malformed regular expression in replace: {0}".format(pattern)
             )
     return replacements
 
 
 def term_width():
     """Get the width (columns) of the terminal."""
-    fallback = config['ui']['terminal_width'].get(int)
+    fallback = config["ui"]["terminal_width"].get(int)
 
     # The fcntl and termios modules are not available on non-Unix
     # platforms, so we fall back to a constant.
@@ -651,11 +672,11 @@ def term_width():
         return fallback
 
     try:
-        buf = fcntl.ioctl(0, termios.TIOCGWINSZ, ' ' * 4)
+        buf = fcntl.ioctl(0, termios.TIOCGWINSZ, " " * 4)
     except IOError:
         return fallback
     try:
-        height, width = struct.unpack('hh', buf)
+        height, width = struct.unpack("hh", buf)
     except struct.error:
         return fallback
     return width
@@ -673,25 +694,28 @@ def _field_diff(field, old, new):
     newval = new.get(field)
 
     # If no change, abort.
-    if isinstance(oldval, float) and isinstance(newval, float) and \
-            abs(oldval - newval) < FLOAT_EPSILON:
+    if (
+        isinstance(oldval, float)
+        and isinstance(newval, float)
+        and abs(oldval - newval) < FLOAT_EPSILON
+    ):
         return None
     elif oldval == newval:
         return None
 
     # Get formatted values for output.
-    oldstr = old.formatted().get(field, u'')
-    newstr = new.formatted().get(field, u'')
+    oldstr = old.formatted().get(field, u"")
+    newstr = new.formatted().get(field, u"")
 
     # For strings, highlight changes. For others, colorize the whole
     # thing.
     if isinstance(oldval, six.string_types):
         oldstr, newstr = colordiff(oldval, newstr)
     else:
-        oldstr = colorize('text_error', oldstr)
-        newstr = colorize('text_error', newstr)
+        oldstr = colorize("text_error", oldstr)
+        newstr = colorize("text_error", newstr)
 
-    return u'{0} -> {1}'.format(oldstr, newstr)
+    return u"{0} -> {1}".format(oldstr, newstr)
 
 
 def show_model_changes(new, old=None, fields=None, always=False):
@@ -710,29 +734,30 @@ def show_model_changes(new, old=None, fields=None, always=False):
     changes = []
     for field in old:
         # Subset of the fields. Never show mtime.
-        if field == 'mtime' or (fields and field not in fields):
+        if field == "mtime" or (fields and field not in fields):
             continue
 
         # Detect and show difference for this field.
         line = _field_diff(field, old, new)
         if line:
-            changes.append(u'  {0}: {1}'.format(field, line))
+            changes.append(u"  {0}: {1}".format(field, line))
 
     # New fields.
     for field in set(new) - set(old):
         if fields and field not in fields:
             continue
 
-        changes.append(u'  {0}: {1}'.format(
-            field,
-            colorize('text_highlight', new.formatted()[field])
-        ))
+        changes.append(
+            u"  {0}: {1}".format(
+                field, colorize("text_highlight", new.formatted()[field])
+            )
+        )
 
     # Print changes.
     if changes or always:
         print_(format(old))
     if changes:
-        print_(u'\n'.join(changes))
+        print_(u"\n".join(changes))
 
     return bool(changes)
 
@@ -759,24 +784,25 @@ def show_path_changes(path_changes):
     destinations = list(map(util.displayable_path, destinations))
 
     # Calculate widths for terminal split
-    col_width = (term_width() - len(' -> ')) // 2
+    col_width = (term_width() - len(" -> ")) // 2
     max_width = len(max(sources + destinations, key=len))
 
     if max_width > col_width:
         # Print every change over two lines
         for source, dest in zip(sources, destinations):
-            log.info(u'{0} \n  -> {1}', source, dest)
+            log.info(u"{0} \n  -> {1}", source, dest)
     else:
         # Print every change on a single line, and add a header
-        title_pad = max_width - len('Source ') + len(' -> ')
+        title_pad = max_width - len("Source ") + len(" -> ")
 
-        log.info(u'Source {0} Destination', ' ' * title_pad)
+        log.info(u"Source {0} Destination", " " * title_pad)
         for source, dest in zip(sources, destinations):
             pad = max_width - len(source)
-            log.info(u'{0} {1} -> {2}', source, ' ' * pad, dest)
+            log.info(u"{0} {1} -> {2}", source, " " * pad, dest)
 
 
 # Helper functions for option parsing.
+
 
 def _store_dict(option, opt_str, value, parser):
     """Custom action callback to parse options which have ``key=value``
@@ -793,13 +819,15 @@ def _store_dict(option, opt_str, value, parser):
         option_values = getattr(parser.values, dest)
 
     try:
-        key, value = map(lambda s: util.text_string(s), value.split('='))
+        key, value = map(lambda s: util.text_string(s), value.split("="))
         if not (key and value):
             raise ValueError
     except ValueError:
         raise UserError(
-            "supplied argument `{0}' is not of the form `key=value'"
-            .format(value))
+            "supplied argument `{0}' is not of the form `key=value'".format(
+                value
+            )
+        )
 
     option_values[key] = value
 
@@ -819,6 +847,7 @@ class CommonOptionsParser(optparse.OptionParser, object):
 
     Each method is fully documented in the related method.
     """
+
     def __init__(self, *args, **kwargs):
         super(CommonOptionsParser, self).__init__(*args, **kwargs)
         self._album_flags = False
@@ -826,20 +855,29 @@ class CommonOptionsParser(optparse.OptionParser, object):
         # us to check whether it has been specified on the CLI - bypassing the
         # fact that arguments may be in any order
 
-    def add_album_option(self, flags=('-a', '--album')):
+    def add_album_option(self, flags=("-a", "--album")):
         """Add a -a/--album option to match albums instead of tracks.
 
         If used then the format option can auto-detect whether we're setting
         the format for items or albums.
         Sets the album property on the options extracted from the CLI.
         """
-        album = optparse.Option(*flags, action='store_true',
-                                help=u'match albums instead of tracks')
+        album = optparse.Option(
+            *flags, action="store_true", help=u"match albums instead of tracks"
+        )
         self.add_option(album)
         self._album_flags = set(flags)
 
-    def _set_format(self, option, opt_str, value, parser, target=None,
-                    fmt=None, store_true=False):
+    def _set_format(
+        self,
+        option,
+        opt_str,
+        value,
+        parser,
+        target=None,
+        fmt=None,
+        store_true=False,
+    ):
         """Internal callback that sets the correct format while parsing CLI
         arguments.
         """
@@ -850,9 +888,9 @@ class CommonOptionsParser(optparse.OptionParser, object):
         if fmt:
             value = fmt
         elif value:
-            value, = decargs([value])
+            (value,) = decargs([value])
         else:
-            value = u''
+            value = u""
 
         parser.values.format = value
         if target:
@@ -872,7 +910,7 @@ class CommonOptionsParser(optparse.OptionParser, object):
                 config[library.Item._format_config_key].set(value)
                 config[library.Album._format_config_key].set(value)
 
-    def add_path_option(self, flags=('-p', '--path')):
+    def add_path_option(self, flags=("-p", "--path")):
         """Add a -p/--path option to display the path instead of the default
         format.
 
@@ -882,14 +920,17 @@ class CommonOptionsParser(optparse.OptionParser, object):
         Sets the format property to u'$path' on the options extracted from the
         CLI.
         """
-        path = optparse.Option(*flags, nargs=0, action='callback',
-                               callback=self._set_format,
-                               callback_kwargs={'fmt': u'$path',
-                                                'store_true': True},
-                               help=u'print paths for matched items or albums')
+        path = optparse.Option(
+            *flags,
+            nargs=0,
+            action="callback",
+            callback=self._set_format,
+            callback_kwargs={"fmt": u"$path", "store_true": True},
+            help=u"print paths for matched items or albums"
+        )
         self.add_option(path)
 
-    def add_format_option(self, flags=('-f', '--format'), target=None):
+    def add_format_option(self, flags=("-f", "--format"), target=None):
         """Add -f/--format option to print some LibModel instances with a
         custom format.
 
@@ -907,14 +948,16 @@ class CommonOptionsParser(optparse.OptionParser, object):
         kwargs = {}
         if target:
             if isinstance(target, six.string_types):
-                target = {'item': library.Item,
-                          'album': library.Album}[target]
-            kwargs['target'] = target
+                target = {"item": library.Item, "album": library.Album}[target]
+            kwargs["target"] = target
 
-        opt = optparse.Option(*flags, action='callback',
-                              callback=self._set_format,
-                              callback_kwargs=kwargs,
-                              help=u'print with custom format')
+        opt = optparse.Option(
+            *flags,
+            action="callback",
+            callback=self._set_format,
+            callback_kwargs=kwargs,
+            help=u"print with custom format"
+        )
         self.add_option(opt)
 
     def add_all_common_options(self):
@@ -933,11 +976,13 @@ class CommonOptionsParser(optparse.OptionParser, object):
 # There you will also find a better description of the code and a more
 # succinct example program.
 
+
 class Subcommand(object):
     """A subcommand of a root command-line application that may be
     invoked by a SubcommandOptionParser.
     """
-    def __init__(self, name, parser=None, help='', aliases=(), hide=False):
+
+    def __init__(self, name, parser=None, help="", aliases=(), hide=False):
         """Creates a new subcommand. name is the primary way to invoke
         the subcommand; aliases are alternate names. parser is an
         OptionParser responsible for parsing the subcommand's options.
@@ -964,8 +1009,9 @@ class Subcommand(object):
     @root_parser.setter
     def root_parser(self, root_parser):
         self._root_parser = root_parser
-        self.parser.prog = '{0} {1}'.format(
-            as_string(root_parser.get_prog_name()), self.name)
+        self.parser.prog = "{0} {1}".format(
+            as_string(root_parser.get_prog_name()), self.name
+        )
 
 
 class SubcommandsOptionParser(CommonOptionsParser):
@@ -979,11 +1025,13 @@ class SubcommandsOptionParser(CommonOptionsParser):
         to subcommands, a sequence of Subcommand objects.
         """
         # A more helpful default usage.
-        if 'usage' not in kwargs:
-            kwargs['usage'] = u"""
+        if "usage" not in kwargs:
+            kwargs[
+                "usage"
+            ] = u"""
   %prog COMMAND [ARGS...]
   %prog help COMMAND"""
-        kwargs['add_help_option'] = False
+        kwargs["add_help_option"] = False
 
         # Super constructor.
         super(SubcommandsOptionParser, self).__init__(*args, **kwargs)
@@ -1009,7 +1057,7 @@ class SubcommandsOptionParser(CommonOptionsParser):
 
         # Subcommands header.
         result = ["\n"]
-        result.append(formatter.format_heading('Commands'))
+        result.append(formatter.format_heading("Commands"))
         formatter.indent()
 
         # Generate the display names (including aliases).
@@ -1021,7 +1069,7 @@ class SubcommandsOptionParser(CommonOptionsParser):
         for subcommand in subcommands:
             name = subcommand.name
             if subcommand.aliases:
-                name += ' (%s)' % ', '.join(subcommand.aliases)
+                name += " (%s)" % ", ".join(subcommand.aliases)
             disp_names.append(name)
 
             # Set the help position based on the max width.
@@ -1037,16 +1085,24 @@ class SubcommandsOptionParser(CommonOptionsParser):
                 name = "%*s%s\n" % (formatter.current_indent, "", name)
                 indent_first = help_position
             else:
-                name = "%*s%-*s  " % (formatter.current_indent, "",
-                                      name_width, name)
+                name = "%*s%-*s  " % (
+                    formatter.current_indent,
+                    "",
+                    name_width,
+                    name,
+                )
                 indent_first = 0
             result.append(name)
             help_width = formatter.width - help_position
             help_lines = textwrap.wrap(subcommand.help, help_width)
-            help_line = help_lines[0] if help_lines else ''
+            help_line = help_lines[0] if help_lines else ""
             result.append("%*s%s\n" % (indent_first, "", help_line))
-            result.extend(["%*s%s\n" % (help_position, "", line)
-                           for line in help_lines[1:]])
+            result.extend(
+                [
+                    "%*s%s\n" % (help_position, "", line)
+                    for line in help_lines[1:]
+                ]
+            )
         formatter.dedent()
 
         # Concatenate the original help message with the subcommand
@@ -1059,8 +1115,7 @@ class SubcommandsOptionParser(CommonOptionsParser):
         an alias. If no subcommand matches, returns None.
         """
         for subcommand in self.subcommands:
-            if name == subcommand.name or \
-               name in subcommand.aliases:
+            if name == subcommand.name or name in subcommand.aliases:
                 return subcommand
         return None
 
@@ -1072,9 +1127,9 @@ class SubcommandsOptionParser(CommonOptionsParser):
 
         # Force the help command
         if options.help:
-            subargs = ['help']
+            subargs = ["help"]
         elif options.version:
-            subargs = ['version']
+            subargs = ["version"]
         return options, subargs
 
     def parse_subcommand(self, args):
@@ -1084,7 +1139,7 @@ class SubcommandsOptionParser(CommonOptionsParser):
         """
         # Help is default command
         if not args:
-            args = ['help']
+            args = ["help"]
 
         cmdname = args.pop(0)
         subcommand = self._subcommand_for_name(cmdname)
@@ -1095,30 +1150,32 @@ class SubcommandsOptionParser(CommonOptionsParser):
         return subcommand, suboptions, subargs
 
 
-optparse.Option.ALWAYS_TYPED_ACTIONS += ('callback',)
+optparse.Option.ALWAYS_TYPED_ACTIONS += ("callback",)
 
 
 # The main entry point and bootstrapping.
 
+
 def _load_plugins(config):
     """Load the plugins specified in the configuration.
     """
-    paths = config['pluginpath'].as_str_seq(split=False)
+    paths = config["pluginpath"].as_str_seq(split=False)
     paths = [util.normpath(p) for p in paths]
-    log.debug(u'plugin paths: {0}', util.displayable_path(paths))
+    log.debug(u"plugin paths: {0}", util.displayable_path(paths))
 
     # On Python 3, the search paths need to be unicode.
     paths = [util.py3_path(p) for p in paths]
 
     # Extend the `beetsplug` package to include the plugin paths.
     import beetsplug
+
     beetsplug.__path__ = paths + beetsplug.__path__
 
     # For backwards compatibility, also support plugin paths that
     # *contain* a `beetsplug` package.
     sys.path += paths
 
-    plugins.load_plugins(config['plugins'].as_str_seq())
+    plugins.load_plugins(config["plugins"].as_str_seq())
     plugins.send("pluginload")
     return plugins
 
@@ -1160,7 +1217,7 @@ def _configure(options):
     # Add any additional config files specified with --config. This
     # special handling lets specified plugins get loaded before we
     # finish parsing the command line.
-    if getattr(options, 'config', None) is not None:
+    if getattr(options, "config", None) is not None:
         overlay_path = options.config
         del options.config
         config.set_file(overlay_path)
@@ -1169,50 +1226,58 @@ def _configure(options):
     config.set_args(options)
 
     # Configure the logger.
-    if config['verbose'].get(int):
+    if config["verbose"].get(int):
         log.set_global_level(logging.DEBUG)
     else:
         log.set_global_level(logging.INFO)
 
     if overlay_path:
-        log.debug(u'overlaying configuration: {0}',
-                  util.displayable_path(overlay_path))
+        log.debug(
+            u"overlaying configuration: {0}",
+            util.displayable_path(overlay_path),
+        )
 
     config_path = config.user_config_path()
     if os.path.isfile(config_path):
-        log.debug(u'user configuration: {0}',
-                  util.displayable_path(config_path))
+        log.debug(
+            u"user configuration: {0}", util.displayable_path(config_path)
+        )
     else:
-        log.debug(u'no user configuration found at {0}',
-                  util.displayable_path(config_path))
+        log.debug(
+            u"no user configuration found at {0}",
+            util.displayable_path(config_path),
+        )
 
-    log.debug(u'data directory: {0}',
-              util.displayable_path(config.config_dir()))
+    log.debug(
+        u"data directory: {0}", util.displayable_path(config.config_dir())
+    )
     return config
 
 
 def _open_library(config):
     """Create a new library instance from the configuration.
     """
-    dbpath = util.bytestring_path(config['library'].as_filename())
+    dbpath = util.bytestring_path(config["library"].as_filename())
     try:
         lib = library.Library(
             dbpath,
-            config['directory'].as_filename(),
+            config["directory"].as_filename(),
             get_path_formats(),
             get_replacements(),
         )
         lib.get_item(0)  # Test database connection.
     except (sqlite3.OperationalError, sqlite3.DatabaseError) as db_error:
-        log.debug(u'{}', traceback.format_exc())
-        raise UserError(u"database file {0} cannot not be opened: {1}".format(
-            util.displayable_path(dbpath),
-            db_error
-        ))
-    log.debug(u'library database: {0}\n'
-              u'library directory: {1}',
-              util.displayable_path(lib.path),
-              util.displayable_path(lib.directory))
+        log.debug(u"{}", traceback.format_exc())
+        raise UserError(
+            u"database file {0} cannot not be opened: {1}".format(
+                util.displayable_path(dbpath), db_error
+            )
+        )
+    log.debug(
+        u"library database: {0}\n" u"library directory: {1}",
+        util.displayable_path(lib.path),
+        util.displayable_path(lib.directory),
+    )
     return lib
 
 
@@ -1221,29 +1286,53 @@ def _raw_main(args, lib=None):
     handling.
     """
     parser = SubcommandsOptionParser()
-    parser.add_format_option(flags=('--format-item',), target=library.Item)
-    parser.add_format_option(flags=('--format-album',), target=library.Album)
-    parser.add_option('-l', '--library', dest='library',
-                      help=u'library database file to use')
-    parser.add_option('-d', '--directory', dest='directory',
-                      help=u"destination music directory")
-    parser.add_option('-v', '--verbose', dest='verbose', action='count',
-                      help=u'log more details (use twice for even more)')
-    parser.add_option('-c', '--config', dest='config',
-                      help=u'path to configuration file')
-    parser.add_option('-h', '--help', dest='help', action='store_true',
-                      help=u'show this help message and exit')
-    parser.add_option('--version', dest='version', action='store_true',
-                      help=optparse.SUPPRESS_HELP)
+    parser.add_format_option(flags=("--format-item",), target=library.Item)
+    parser.add_format_option(flags=("--format-album",), target=library.Album)
+    parser.add_option(
+        "-l", "--library", dest="library", help=u"library database file to use"
+    )
+    parser.add_option(
+        "-d",
+        "--directory",
+        dest="directory",
+        help=u"destination music directory",
+    )
+    parser.add_option(
+        "-v",
+        "--verbose",
+        dest="verbose",
+        action="count",
+        help=u"log more details (use twice for even more)",
+    )
+    parser.add_option(
+        "-c", "--config", dest="config", help=u"path to configuration file"
+    )
+    parser.add_option(
+        "-h",
+        "--help",
+        dest="help",
+        action="store_true",
+        help=u"show this help message and exit",
+    )
+    parser.add_option(
+        "--version",
+        dest="version",
+        action="store_true",
+        help=optparse.SUPPRESS_HELP,
+    )
 
     options, subargs = parser.parse_global_options(args)
 
     # Special case for the `config --edit` command: bypass _setup so
     # that an invalid configuration does not prevent the editor from
     # starting.
-    if subargs and subargs[0] == 'config' \
-       and ('-e' in subargs or '--edit' in subargs):
+    if (
+        subargs
+        and subargs[0] == "config"
+        and ("-e" in subargs or "--edit" in subargs)
+    ):
         from beets.ui.commands import config_edit
+
         return config_edit()
 
     test_lib = bool(lib)
@@ -1253,7 +1342,7 @@ def _raw_main(args, lib=None):
     subcommand, suboptions, subargs = parser.parse_subcommand(subargs)
     subcommand.func(lib, suboptions, subargs)
 
-    plugins.send('cli_exit', lib=lib)
+    plugins.send("cli_exit", lib=lib)
     if not test_lib:
         # Clean up the library unless it came from the test harness.
         lib._close()
@@ -1267,7 +1356,7 @@ def main(args=None):
         _raw_main(args)
     except UserError as exc:
         message = exc.args[0] if exc.args else None
-        log.error(u'error: {0}', message)
+        log.error(u"error: {0}", message)
         sys.exit(1)
     except util.HumanReadableException as exc:
         exc.log(log)
@@ -1275,14 +1364,14 @@ def main(args=None):
     except library.FileOperationError as exc:
         # These errors have reasonable human-readable descriptions, but
         # we still want to log their tracebacks for debugging.
-        log.debug('{}', traceback.format_exc())
-        log.error('{}', exc)
+        log.debug("{}", traceback.format_exc())
+        log.error("{}", exc)
         sys.exit(1)
     except confuse.ConfigError as exc:
-        log.error(u'configuration error: {0}', exc)
+        log.error(u"configuration error: {0}", exc)
         sys.exit(1)
     except db_query.InvalidQueryError as exc:
-        log.error(u'invalid query: {0}', exc)
+        log.error(u"invalid query: {0}", exc)
         sys.exit(1)
     except IOError as exc:
         if exc.errno == errno.EPIPE:
@@ -1292,11 +1381,11 @@ def main(args=None):
             raise
     except KeyboardInterrupt:
         # Silently ignore ^C except in verbose mode.
-        log.debug(u'{}', traceback.format_exc())
+        log.debug(u"{}", traceback.format_exc())
     except db.DBAccessError as exc:
         log.error(
-            u'database access error: {0}\n'
-            u'the library file might have a permissions problem',
-            exc
+            u"database access error: {0}\n"
+            u"the library file might have a permissions problem",
+            exc,
         )
         sys.exit(1)

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -34,19 +34,24 @@ from beets.autotag import hooks
 from beets import plugins
 from beets import importer
 from beets import util
-from beets.util import syspath, normpath, ancestry, displayable_path, \
-    MoveOperation
+from beets.util import (
+    syspath,
+    normpath,
+    ancestry,
+    displayable_path,
+    MoveOperation,
+)
 from beets import library
 from beets import config
 from beets import logging
 import six
 from . import _store_dict
 
-VARIOUS_ARTISTS = u'Various Artists'
-PromptChoice = namedtuple('PromptChoice', ['short', 'long', 'callback'])
+VARIOUS_ARTISTS = u"Various Artists"
+PromptChoice = namedtuple("PromptChoice", ["short", "long", "callback"])
 
 # Global logger.
-log = logging.getLogger('beets')
+log = logging.getLogger("beets")
 
 # The list of default subcommands. This is populated with Subcommand
 # objects that can be fed to a SubcommandsOptionParser.
@@ -54,6 +59,7 @@ default_commands = []
 
 
 # Utilities.
+
 
 def _do_query(lib, query, album, also_items=True):
     """For commands that operate on matched items, performs a query
@@ -74,27 +80,28 @@ def _do_query(lib, query, album, also_items=True):
         items = list(lib.items(query))
 
     if album and not albums:
-        raise ui.UserError(u'No matching albums found.')
+        raise ui.UserError(u"No matching albums found.")
     elif not album and not items:
-        raise ui.UserError(u'No matching items found.')
+        raise ui.UserError(u"No matching items found.")
 
     return items, albums
 
 
 # fields: Shows a list of available fields for queries and format strings.
 
+
 def _print_keys(query):
     """Given a SQLite query result, print the `key` field of each
     returned row, with indentation of 2 spaces.
     """
     for row in query:
-        print_(u' ' * 2 + row['key'])
+        print_(u" " * 2 + row["key"])
 
 
 def fields_func(lib, opts, args):
     def _print_rows(names):
         names.sort()
-        print_(u'  ' + u'\n  '.join(names))
+        print_(u"  " + u"\n  ".join(names))
 
     print_(u"Item fields:")
     _print_rows(library.Item.all_keys())
@@ -104,7 +111,7 @@ def fields_func(lib, opts, args):
 
     with lib.transaction() as tx:
         # The SQL uses the DISTINCT to get unique values from the query
-        unique_fields = 'SELECT DISTINCT key FROM (%s)'
+        unique_fields = "SELECT DISTINCT key FROM (%s)"
 
         print_(u"Item flexible attributes:")
         _print_keys(tx.query(unique_fields % library.Item._flex_table))
@@ -112,9 +119,9 @@ def fields_func(lib, opts, args):
         print_(u"Album flexible attributes:")
         _print_keys(tx.query(unique_fields % library.Album._flex_table))
 
+
 fields_cmd = ui.Subcommand(
-    'fields',
-    help=u'show fields available for queries and format strings'
+    "fields", help=u"show fields available for queries and format strings"
 )
 fields_cmd.func = fields_func
 default_commands.append(fields_cmd)
@@ -122,12 +129,13 @@ default_commands.append(fields_cmd)
 
 # help: Print help text for commands
 
-class HelpCommand(ui.Subcommand):
 
+class HelpCommand(ui.Subcommand):
     def __init__(self):
         super(HelpCommand, self).__init__(
-            'help', aliases=('?',),
-            help=u'give detailed help on a specific sub-command',
+            "help",
+            aliases=("?",),
+            help=u"give detailed help on a specific sub-command",
         )
 
     def func(self, lib, opts, args):
@@ -148,21 +156,20 @@ default_commands.append(HelpCommand())
 
 # Importer utilities and support.
 
+
 def disambig_string(info):
     """Generate a string for an AlbumInfo or TrackInfo object that
     provides context that helps disambiguate similar-looking albums and
     tracks.
     """
     disambig = []
-    if info.data_source and info.data_source != 'MusicBrainz':
+    if info.data_source and info.data_source != "MusicBrainz":
         disambig.append(info.data_source)
 
     if isinstance(info, hooks.AlbumInfo):
         if info.media:
             if info.mediums and info.mediums > 1:
-                disambig.append(u'{0}x{1}'.format(
-                    info.mediums, info.media
-                ))
+                disambig.append(u"{0}x{1}".format(info.mediums, info.media))
             else:
                 disambig.append(info.media)
         if info.year:
@@ -177,20 +184,20 @@ def disambig_string(info):
             disambig.append(info.albumdisambig)
 
     if disambig:
-        return u', '.join(disambig)
+        return u", ".join(disambig)
 
 
 def dist_string(dist):
     """Formats a distance (a float) as a colorized similarity percentage
     string.
     """
-    out = u'%.1f%%' % ((1 - dist) * 100)
-    if dist <= config['match']['strong_rec_thresh'].as_number():
-        out = ui.colorize('text_success', out)
-    elif dist <= config['match']['medium_rec_thresh'].as_number():
-        out = ui.colorize('text_warning', out)
+    out = u"%.1f%%" % ((1 - dist) * 100)
+    if dist <= config["match"]["strong_rec_thresh"].as_number():
+        out = ui.colorize("text_success", out)
+    elif dist <= config["match"]["medium_rec_thresh"].as_number():
+        out = ui.colorize("text_warning", out)
     else:
-        out = ui.colorize('text_error', out)
+        out = ui.colorize("text_error", out)
     return out
 
 
@@ -200,14 +207,14 @@ def penalty_string(distance, limit=None):
     """
     penalties = []
     for key in distance.keys():
-        key = key.replace('album_', '')
-        key = key.replace('track_', '')
-        key = key.replace('_', ' ')
+        key = key.replace("album_", "")
+        key = key.replace("track_", "")
+        key = key.replace("_", " ")
         penalties.append(key)
     if penalties:
         if limit and len(penalties) > limit:
-            penalties = penalties[:limit] + ['...']
-        return ui.colorize('text_warning', u'(%s)' % ', '.join(penalties))
+            penalties = penalties[:limit] + ["..."]
+        return ui.colorize("text_warning", u"(%s)" % ", ".join(penalties))
 
 
 def show_change(cur_artist, cur_album, match):
@@ -215,13 +222,14 @@ def show_change(cur_artist, cur_album, match):
     album's tags are changed according to `match`, which must be an AlbumMatch
     object.
     """
+
     def show_album(artist, album):
         if artist:
-            album_description = u'    %s - %s' % (artist, album)
+            album_description = u"    %s - %s" % (artist, album)
         elif album:
-            album_description = u'    %s' % album
+            album_description = u"    %s" % album
         else:
-            album_description = u'    (unknown album)'
+            album_description = u"    (unknown album)"
         print_(album_description)
 
     def format_index(track_info):
@@ -237,26 +245,27 @@ def show_change(cur_artist, cur_album, match):
             index = medium_index = track_info.track
             medium = track_info.disc
             mediums = track_info.disctotal
-        if config['per_disc_numbering']:
+        if config["per_disc_numbering"]:
             if mediums and mediums > 1:
-                return u'{0}-{1}'.format(medium, medium_index)
+                return u"{0}-{1}".format(medium, medium_index)
             else:
-                return six.text_type(medium_index if medium_index is not None
-                                     else index)
+                return six.text_type(
+                    medium_index if medium_index is not None else index
+                )
         else:
             return six.text_type(index)
 
     # Identify the album in question.
-    if cur_artist != match.info.artist or \
-            (cur_album != match.info.album and
-             match.info.album != VARIOUS_ARTISTS):
-        artist_l, artist_r = cur_artist or '', match.info.artist
-        album_l,  album_r = cur_album or '', match.info.album
+    if cur_artist != match.info.artist or (
+        cur_album != match.info.album and match.info.album != VARIOUS_ARTISTS
+    ):
+        artist_l, artist_r = cur_artist or "", match.info.artist
+        album_l, album_r = cur_album or "", match.info.album
         if artist_r == VARIOUS_ARTISTS:
             # Hide artists for VA releases.
-            artist_l, artist_r = u'', u''
+            artist_l, artist_r = u"", u""
 
-        if config['artist_credit']:
+        if config["artist_credit"]:
             artist_r = match.info.artist_credit
 
         artist_l, artist_r = ui.colordiff(artist_l, artist_r)
@@ -271,12 +280,12 @@ def show_change(cur_artist, cur_album, match):
 
     # Data URL.
     if match.info.data_url:
-        print_(u'URL:\n    %s' % match.info.data_url)
+        print_(u"URL:\n    %s" % match.info.data_url)
 
     # Info line.
     info = []
     # Similarity.
-    info.append(u'(Similarity: %s)' % dist_string(match.distance))
+    info.append(u"(Similarity: %s)" % dist_string(match.distance))
     # Penalties.
     penalties = penalty_string(match.distance)
     if penalties:
@@ -284,8 +293,8 @@ def show_change(cur_artist, cur_album, match):
     # Disambiguation.
     disambig = disambig_string(match.info)
     if disambig:
-        info.append(ui.colorize('text_highlight_minor', u'(%s)' % disambig))
-    print_(' '.join(info))
+        info.append(ui.colorize("text_highlight_minor", u"(%s)" % disambig))
+    print_(" ".join(info))
 
     # Tracks.
     pairs = list(match.mapping.items())
@@ -300,18 +309,21 @@ def show_change(cur_artist, cur_album, match):
 
         # Medium number and title.
         if medium != track_info.medium or disctitle != track_info.disctitle:
-            media = match.info.media or 'Media'
+            media = match.info.media or "Media"
             if match.info.mediums > 1 and track_info.disctitle:
-                lhs = u'%s %s: %s' % (media, track_info.medium,
-                                      track_info.disctitle)
+                lhs = u"%s %s: %s" % (
+                    media,
+                    track_info.medium,
+                    track_info.disctitle,
+                )
             elif match.info.mediums > 1:
-                lhs = u'%s %s' % (media, track_info.medium)
+                lhs = u"%s %s" % (media, track_info.medium)
             elif track_info.disctitle:
-                lhs = u'%s: %s' % (media, track_info.disctitle)
+                lhs = u"%s: %s" % (media, track_info.disctitle)
             else:
                 lhs = None
             if lhs:
-                lines.append((lhs, u'', 0))
+                lines.append((lhs, u"", 0))
             medium, disctitle = track_info.medium, track_info.disctitle
 
         # Titles.
@@ -329,21 +341,24 @@ def show_change(cur_artist, cur_album, match):
         cur_track, new_track = format_index(item), format_index(track_info)
         if cur_track != new_track:
             if item.track in (track_info.index, track_info.medium_index):
-                color = 'text_highlight_minor'
+                color = "text_highlight_minor"
             else:
-                color = 'text_highlight'
-            templ = ui.colorize(color, u' (#{0})')
+                color = "text_highlight"
+            templ = ui.colorize(color, u" (#{0})")
             lhs += templ.format(cur_track)
             rhs += templ.format(new_track)
             lhs_width += len(cur_track) + 4
 
         # Length change.
-        if item.length and track_info.length and \
-                abs(item.length - track_info.length) > \
-                config['ui']['length_diff_thresh'].as_number():
+        if (
+            item.length
+            and track_info.length
+            and abs(item.length - track_info.length)
+            > config["ui"]["length_diff_thresh"].as_number()
+        ):
             cur_length = ui.human_seconds_short(item.length)
             new_length = ui.human_seconds_short(track_info.length)
-            templ = ui.colorize('text_highlight', u' ({0})')
+            templ = ui.colorize("text_highlight", u" ({0})")
             lhs += templ.format(cur_length)
             rhs += templ.format(new_length)
             lhs_width += len(cur_length) + 3
@@ -351,52 +366,55 @@ def show_change(cur_artist, cur_album, match):
         # Penalties.
         penalties = penalty_string(match.distance.tracks[track_info])
         if penalties:
-            rhs += ' %s' % penalties
+            rhs += " %s" % penalties
 
         if lhs != rhs:
-            lines.append((u' * %s' % lhs, rhs, lhs_width))
-        elif config['import']['detail']:
-            lines.append((u' * %s' % lhs, '', lhs_width))
+            lines.append((u" * %s" % lhs, rhs, lhs_width))
+        elif config["import"]["detail"]:
+            lines.append((u" * %s" % lhs, "", lhs_width))
 
     # Print each track in two columns, or across two lines.
-    col_width = (ui.term_width() - len(''.join([' * ', ' -> ']))) // 2
+    col_width = (ui.term_width() - len("".join([" * ", " -> "]))) // 2
     if lines:
         max_width = max(w for _, _, w in lines)
         for lhs, rhs, lhs_width in lines:
             if not rhs:
                 print_(lhs)
             elif max_width > col_width:
-                print_(u'%s ->\n   %s' % (lhs, rhs))
+                print_(u"%s ->\n   %s" % (lhs, rhs))
             else:
                 pad = max_width - lhs_width
-                print_(u'%s%s -> %s' % (lhs, ' ' * pad, rhs))
+                print_(u"%s%s -> %s" % (lhs, " " * pad, rhs))
 
     # Missing and unmatched tracks.
     if match.extra_tracks:
-        print_(u'Missing tracks ({0}/{1} - {2:.1%}):'.format(
-               len(match.extra_tracks),
-               len(match.info.tracks),
-               len(match.extra_tracks) / len(match.info.tracks)
-               ))
-        pad_width = max(len(track_info.title) for track_info in
-                        match.extra_tracks)
+        print_(
+            u"Missing tracks ({0}/{1} - {2:.1%}):".format(
+                len(match.extra_tracks),
+                len(match.info.tracks),
+                len(match.extra_tracks) / len(match.info.tracks),
+            )
+        )
+        pad_width = max(
+            len(track_info.title) for track_info in match.extra_tracks
+        )
     for track_info in match.extra_tracks:
-        line = u' ! {0: <{width}} (#{1: >2})'.format(track_info.title,
-                                                     format_index(track_info),
-                                                     width=pad_width)
+        line = u" ! {0: <{width}} (#{1: >2})".format(
+            track_info.title, format_index(track_info), width=pad_width
+        )
         if track_info.length:
-            line += u' (%s)' % ui.human_seconds_short(track_info.length)
-        print_(ui.colorize('text_warning', line))
+            line += u" (%s)" % ui.human_seconds_short(track_info.length)
+        print_(ui.colorize("text_warning", line))
     if match.extra_items:
-        print_(u'Unmatched tracks ({0}):'.format(len(match.extra_items)))
+        print_(u"Unmatched tracks ({0}):".format(len(match.extra_items)))
         pad_width = max(len(item.title) for item in match.extra_items)
     for item in match.extra_items:
-        line = u' ! {0: <{width}} (#{1: >2})'.format(item.title,
-                                                     format_index(item),
-                                                     width=pad_width)
+        line = u" ! {0: <{width}} (#{1: >2})".format(
+            item.title, format_index(item), width=pad_width
+        )
         if item.length:
-            line += u' (%s)' % ui.human_seconds_short(item.length)
-        print_(ui.colorize('text_warning', line))
+            line += u" (%s)" % ui.human_seconds_short(item.length)
+        print_(ui.colorize("text_warning", line))
 
 
 def show_item_change(item, match):
@@ -420,12 +438,12 @@ def show_item_change(item, match):
 
     # Data URL.
     if match.info.data_url:
-        print_(u'URL:\n    %s' % match.info.data_url)
+        print_(u"URL:\n    %s" % match.info.data_url)
 
     # Info line.
     info = []
     # Similarity.
-    info.append(u'(Similarity: %s)' % dist_string(match.distance))
+    info.append(u"(Similarity: %s)" % dist_string(match.distance))
     # Penalties.
     penalties = penalty_string(match.distance)
     if penalties:
@@ -433,8 +451,8 @@ def show_item_change(item, match):
     # Disambiguation.
     disambig = disambig_string(match.info)
     if disambig:
-        info.append(ui.colorize('text_highlight_minor', u'(%s)' % disambig))
-    print_(' '.join(info))
+        info.append(ui.colorize("text_highlight_minor", u"(%s)" % disambig))
+    print_(" ".join(info))
 
 
 def summarize_items(items, singleton):
@@ -459,19 +477,19 @@ def summarize_items(items, singleton):
         # Enumerate all the formats by decreasing frequencies:
         for fmt, count in sorted(
             format_counts.items(),
-            key=lambda fmt_and_count: (-fmt_and_count[1], fmt_and_count[0])
+            key=lambda fmt_and_count: (-fmt_and_count[1], fmt_and_count[0]),
         ):
-            summary_parts.append('{0} {1}'.format(fmt, count))
+            summary_parts.append("{0} {1}".format(fmt, count))
 
     if items:
         average_bitrate = sum([item.bitrate for item in items]) / len(items)
         total_duration = sum([item.length for item in items])
         total_filesize = sum([item.filesize for item in items])
-        summary_parts.append(u'{0}kbps'.format(int(average_bitrate / 1000)))
+        summary_parts.append(u"{0}kbps".format(int(average_bitrate / 1000)))
         summary_parts.append(ui.human_seconds_short(total_duration))
         summary_parts.append(ui.human_bytes(total_filesize))
 
-    return u', '.join(summary_parts)
+    return u", ".join(summary_parts)
 
 
 def _summary_judgment(rec):
@@ -482,35 +500,43 @@ def _summary_judgment(rec):
     summary judgment is made.
     """
 
-    if config['import']['quiet']:
+    if config["import"]["quiet"]:
         if rec == Recommendation.strong:
             return importer.action.APPLY
         else:
-            action = config['import']['quiet_fallback'].as_choice({
-                'skip': importer.action.SKIP,
-                'asis': importer.action.ASIS,
-            })
-    elif config['import']['timid']:
+            action = config["import"]["quiet_fallback"].as_choice(
+                {"skip": importer.action.SKIP, "asis": importer.action.ASIS,}
+            )
+    elif config["import"]["timid"]:
         return None
     elif rec == Recommendation.none:
-        action = config['import']['none_rec_action'].as_choice({
-            'skip': importer.action.SKIP,
-            'asis': importer.action.ASIS,
-            'ask': None,
-        })
+        action = config["import"]["none_rec_action"].as_choice(
+            {
+                "skip": importer.action.SKIP,
+                "asis": importer.action.ASIS,
+                "ask": None,
+            }
+        )
     else:
         return None
 
     if action == importer.action.SKIP:
-        print_(u'Skipping.')
+        print_(u"Skipping.")
     elif action == importer.action.ASIS:
-        print_(u'Importing as-is.')
+        print_(u"Importing as-is.")
     return action
 
 
-def choose_candidate(candidates, singleton, rec, cur_artist=None,
-                     cur_album=None, item=None, itemcount=None,
-                     choices=[]):
+def choose_candidate(
+    candidates,
+    singleton,
+    rec,
+    cur_artist=None,
+    cur_album=None,
+    item=None,
+    itemcount=None,
+    choices=[],
+):
     """Given a sorted list of candidates, ask the user for a selection
     of which candidate to use. Applies to both full albums and
     singletons  (tracks). Candidates are either AlbumMatch or TrackMatch
@@ -541,10 +567,13 @@ def choose_candidate(candidates, singleton, rec, cur_artist=None,
         if singleton:
             print_(u"No matching recordings found.")
         else:
-            print_(u"No matching release found for {0} tracks."
-                   .format(itemcount))
-            print_(u'For help, see: '
-                   u'https://beets.readthedocs.org/en/latest/faq.html#nomatch')
+            print_(
+                u"No matching release found for {0} tracks.".format(itemcount)
+            )
+            print_(
+                u"For help, see: "
+                u"https://beets.readthedocs.org/en/latest/faq.html#nomatch"
+            )
         sel = ui.input_options(choice_opts)
         if sel in choice_actions:
             return choice_actions[sel]
@@ -563,22 +592,24 @@ def choose_candidate(candidates, singleton, rec, cur_artist=None,
 
         if not bypass_candidates:
             # Display list of candidates.
-            print_(u'Finding tags for {0} "{1} - {2}".'.format(
-                u'track' if singleton else u'album',
-                item.artist if singleton else cur_artist,
-                item.title if singleton else cur_album,
-            ))
+            print_(
+                u'Finding tags for {0} "{1} - {2}".'.format(
+                    u"track" if singleton else u"album",
+                    item.artist if singleton else cur_artist,
+                    item.title if singleton else cur_album,
+                )
+            )
 
-            print_(u'Candidates:')
+            print_(u"Candidates:")
             for i, match in enumerate(candidates):
                 # Index, metadata, and distance.
                 line = [
-                    u'{0}.'.format(i + 1),
-                    u'{0} - {1}'.format(
+                    u"{0}.".format(i + 1),
+                    u"{0} - {1}".format(
                         match.info.artist,
                         match.info.title if singleton else match.info.album,
                     ),
-                    u'({0})'.format(dist_string(match.distance)),
+                    u"({0})".format(dist_string(match.distance)),
                 ]
 
                 # Penalties.
@@ -589,15 +620,15 @@ def choose_candidate(candidates, singleton, rec, cur_artist=None,
                 # Disambiguation
                 disambig = disambig_string(match.info)
                 if disambig:
-                    line.append(ui.colorize('text_highlight_minor',
-                                            u'(%s)' % disambig))
+                    line.append(
+                        ui.colorize("text_highlight_minor", u"(%s)" % disambig)
+                    )
 
-                print_(u' '.join(line))
+                print_(u" ".join(line))
 
             # Ask the user for a choice.
-            sel = ui.input_options(choice_opts,
-                                   numrange=(1, len(candidates)))
-            if sel == u'm':
+            sel = ui.input_options(choice_opts, numrange=(1, len(candidates)))
+            if sel == u"m":
                 pass
             elif sel in choice_actions:
                 return choice_actions[sel]
@@ -616,24 +647,24 @@ def choose_candidate(candidates, singleton, rec, cur_artist=None,
             show_change(cur_artist, cur_album, match)
 
         # Exact match => tag automatically if we're not in timid mode.
-        if rec == Recommendation.strong and not config['import']['timid']:
+        if rec == Recommendation.strong and not config["import"]["timid"]:
             return match
 
         # Ask for confirmation.
-        default = config['import']['default_action'].as_choice({
-            u'apply': u'a',
-            u'skip': u's',
-            u'asis': u'u',
-            u'none': None,
-        })
+        default = config["import"]["default_action"].as_choice(
+            {u"apply": u"a", u"skip": u"s", u"asis": u"u", u"none": None,}
+        )
         if default is None:
             require = True
         # Bell ring when user interaction is needed.
-        if config['import']['bell']:
-            ui.print_(u'\a', end=u'')
-        sel = ui.input_options((u'Apply', u'More candidates') + choice_opts,
-                               require=require, default=default)
-        if sel == u'a':
+        if config["import"]["bell"]:
+            ui.print_(u"\a", end=u"")
+        sel = ui.input_options(
+            (u"Apply", u"More candidates") + choice_opts,
+            require=require,
+            default=default,
+        )
+        if sel == u"a":
             return match
         elif sel in choice_actions:
             return choice_actions[sel]
@@ -645,13 +676,11 @@ def manual_search(session, task):
     Input either an artist and album (for full albums) or artist and
     track name (for singletons) for manual search.
     """
-    artist = input_(u'Artist:').strip()
-    name = input_(u'Album:' if task.is_album else u'Track:').strip()
+    artist = input_(u"Artist:").strip()
+    name = input_(u"Album:" if task.is_album else u"Track:").strip()
 
     if task.is_album:
-        _, _, prop = autotag.tag_album(
-            task.items, artist, name
-        )
+        _, _, prop = autotag.tag_album(task.items, artist, name)
         return prop
     else:
         return autotag.tag_item(task.item, artist, name)
@@ -662,8 +691,9 @@ def manual_id(session, task):
 
     Input an ID, either for an album ("release") or a track ("recording").
     """
-    prompt = u'Enter {0} ID:'.format(u'release' if task.is_album
-                                     else u'recording')
+    prompt = u"Enter {0} ID:".format(
+        u"release" if task.is_album else u"recording"
+    )
     search_id = input_(prompt).strip()
 
     if task.is_album:
@@ -684,6 +714,7 @@ def abort_action(session, task):
 class TerminalImportSession(importer.ImportSession):
     """An import session that runs in a terminal.
     """
+
     def choose_match(self, task):
         """Given an initial autotagging of items, go through an interactive
         dance with the user to ask for a choice of metadata. Returns an
@@ -691,8 +722,10 @@ class TerminalImportSession(importer.ImportSession):
         """
         # Show what we're tagging.
         print_()
-        print_(displayable_path(task.paths, u'\n') +
-               u' ({0} items)'.format(len(task.items)))
+        print_(
+            displayable_path(task.paths, u"\n")
+            + u" ({0} items)".format(len(task.items))
+        )
 
         # Take immediate action if appropriate.
         action = _summary_judgment(task.rec)
@@ -711,8 +744,13 @@ class TerminalImportSession(importer.ImportSession):
             # `PromptChoice`.
             choices = self._get_choices(task)
             choice = choose_candidate(
-                task.candidates, False, task.rec, task.cur_artist,
-                task.cur_album, itemcount=len(task.items), choices=choices
+                task.candidates,
+                False,
+                task.rec,
+                task.cur_artist,
+                task.cur_album,
+                itemcount=len(task.items),
+                choices=choices,
             )
 
             # Basic choices that require no more action here.
@@ -758,8 +796,9 @@ class TerminalImportSession(importer.ImportSession):
         while True:
             # Ask for a choice.
             choices = self._get_choices(task)
-            choice = choose_candidate(candidates, True, rec, item=task.item,
-                                      choices=choices)
+            choice = choose_candidate(
+                candidates, True, rec, item=task.item, choices=choices
+            )
 
             if choice in (importer.action.SKIP, importer.action.ASIS):
                 return choice
@@ -781,49 +820,57 @@ class TerminalImportSession(importer.ImportSession):
         """Decide what to do when a new album or item seems similar to one
         that's already in the library.
         """
-        log.warning(u"This {0} is already in the library!",
-                    (u"album" if task.is_album else u"item"))
+        log.warning(
+            u"This {0} is already in the library!",
+            (u"album" if task.is_album else u"item"),
+        )
 
-        if config['import']['quiet']:
+        if config["import"]["quiet"]:
             # In quiet mode, don't prompt -- just skip.
-            log.info(u'Skipping.')
-            sel = u's'
+            log.info(u"Skipping.")
+            sel = u"s"
         else:
             # Print some detail about the existing and new items so the
             # user can make an informed decision.
             for duplicate in found_duplicates:
-                print_(u"Old: " + summarize_items(
-                    list(duplicate.items()) if task.is_album else [duplicate],
-                    not task.is_album,
-                ))
+                print_(
+                    u"Old: "
+                    + summarize_items(
+                        list(duplicate.items())
+                        if task.is_album
+                        else [duplicate],
+                        not task.is_album,
+                    )
+                )
 
-            print_(u"New: " + summarize_items(
-                task.imported_items(),
-                not task.is_album,
-            ))
-
-            sel = ui.input_options(
-                (u'Skip new', u'Keep both', u'Remove old', u'Merge all')
+            print_(
+                u"New: "
+                + summarize_items(task.imported_items(), not task.is_album,)
             )
 
-        if sel == u's':
+            sel = ui.input_options(
+                (u"Skip new", u"Keep both", u"Remove old", u"Merge all")
+            )
+
+        if sel == u"s":
             # Skip new.
             task.set_choice(importer.action.SKIP)
-        elif sel == u'k':
+        elif sel == u"k":
             # Keep both. Do nothing; leave the choice intact.
             pass
-        elif sel == u'r':
+        elif sel == u"r":
             # Remove old.
             task.should_remove_duplicates = True
-        elif sel == u'm':
+        elif sel == u"m":
             task.should_merge_duplicates = True
         else:
             assert False
 
     def should_resume(self, path):
-        return ui.input_yn(u"Import of the directory:\n{0}\n"
-                           u"was interrupted. Resume (Y/n)?"
-                           .format(displayable_path(path)))
+        return ui.input_yn(
+            u"Import of the directory:\n{0}\n"
+            u"was interrupted. Resume (Y/n)?".format(displayable_path(path))
+        )
 
     def _get_choices(self, task):
         """Get the list of prompt choices that should be presented to the
@@ -843,47 +890,59 @@ class TerminalImportSession(importer.ImportSession):
         """
         # Standard, built-in choices.
         choices = [
-            PromptChoice(u's', u'Skip',
-                         lambda s, t: importer.action.SKIP),
-            PromptChoice(u'u', u'Use as-is',
-                         lambda s, t: importer.action.ASIS)
+            PromptChoice(u"s", u"Skip", lambda s, t: importer.action.SKIP),
+            PromptChoice(
+                u"u", u"Use as-is", lambda s, t: importer.action.ASIS
+            ),
         ]
         if task.is_album:
             choices += [
-                PromptChoice(u't', u'as Tracks',
-                             lambda s, t: importer.action.TRACKS),
-                PromptChoice(u'g', u'Group albums',
-                             lambda s, t: importer.action.ALBUMS),
+                PromptChoice(
+                    u"t", u"as Tracks", lambda s, t: importer.action.TRACKS
+                ),
+                PromptChoice(
+                    u"g", u"Group albums", lambda s, t: importer.action.ALBUMS
+                ),
             ]
         choices += [
-            PromptChoice(u'e', u'Enter search', manual_search),
-            PromptChoice(u'i', u'enter Id', manual_id),
-            PromptChoice(u'b', u'aBort', abort_action),
+            PromptChoice(u"e", u"Enter search", manual_search),
+            PromptChoice(u"i", u"enter Id", manual_id),
+            PromptChoice(u"b", u"aBort", abort_action),
         ]
 
         # Send the before_choose_candidate event and flatten list.
-        extra_choices = list(chain(*plugins.send('before_choose_candidate',
-                                                 session=self, task=task)))
+        extra_choices = list(
+            chain(
+                *plugins.send(
+                    "before_choose_candidate", session=self, task=task
+                )
+            )
+        )
 
         # Add a "dummy" choice for the other baked-in option, for
         # duplicate checking.
-        all_choices = [
-            PromptChoice(u'a', u'Apply', None),
-        ] + choices + extra_choices
+        all_choices = (
+            [PromptChoice(u"a", u"Apply", None),] + choices + extra_choices
+        )
 
         # Check for conflicts.
         short_letters = [c.short for c in all_choices]
         if len(short_letters) != len(set(short_letters)):
             # Duplicate short letter has been found.
-            duplicates = [i for i, count in Counter(short_letters).items()
-                          if count > 1]
+            duplicates = [
+                i for i, count in Counter(short_letters).items() if count > 1
+            ]
             for short in duplicates:
                 # Keep the first of the choices, removing the rest.
                 dup_choices = [c for c in all_choices if c.short == short]
                 for c in dup_choices[1:]:
-                    log.warning(u"Prompt choice '{0}' removed due to conflict "
-                                u"with '{1}' (short letter: '{2}')",
-                                c.long, dup_choices[0].long, c.short)
+                    log.warning(
+                        u"Prompt choice '{0}' removed due to conflict "
+                        u"with '{1}' (short letter: '{2}')",
+                        c.long,
+                        dup_choices[0].long,
+                        c.short,
+                    )
                     extra_choices.remove(c)
 
         return choices + extra_choices
@@ -899,43 +958,47 @@ def import_files(lib, paths, query):
     # Check the user-specified directories.
     for path in paths:
         if not os.path.exists(syspath(normpath(path))):
-            raise ui.UserError(u'no such file or directory: {0}'.format(
-                displayable_path(path)))
+            raise ui.UserError(
+                u"no such file or directory: {0}".format(
+                    displayable_path(path)
+                )
+            )
 
     # Check parameter consistency.
-    if config['import']['quiet'] and config['import']['timid']:
+    if config["import"]["quiet"] and config["import"]["timid"]:
         raise ui.UserError(u"can't be both quiet and timid")
 
     # Open the log.
-    if config['import']['log'].get() is not None:
-        logpath = syspath(config['import']['log'].as_filename())
+    if config["import"]["log"].get() is not None:
+        logpath = syspath(config["import"]["log"].as_filename())
         try:
             loghandler = logging.FileHandler(logpath)
         except IOError:
-            raise ui.UserError(u"could not open log file for writing: "
-                               u"{0}".format(displayable_path(logpath)))
+            raise ui.UserError(
+                u"could not open log file for writing: "
+                u"{0}".format(displayable_path(logpath))
+            )
     else:
         loghandler = None
 
     # Never ask for input in quiet mode.
-    if config['import']['resume'].get() == 'ask' and \
-            config['import']['quiet']:
-        config['import']['resume'] = False
+    if config["import"]["resume"].get() == "ask" and config["import"]["quiet"]:
+        config["import"]["resume"] = False
 
     session = TerminalImportSession(lib, loghandler, paths, query)
     session.run()
 
     # Emit event.
-    plugins.send('import', lib=lib, paths=paths)
+    plugins.send("import", lib=lib, paths=paths)
 
 
 def import_func(lib, opts, args):
-    config['import'].set_args(opts)
+    config["import"].set_args(opts)
 
     # Special case: --copy flag suppresses import_move (which would
     # otherwise take precedence).
     if opts.copy:
-        config['import']['move'] = False
+        config["import"]["move"] = False
 
     if opts.library:
         query = decargs(args)
@@ -944,111 +1007,172 @@ def import_func(lib, opts, args):
         query = None
         paths = args
         if not paths:
-            raise ui.UserError(u'no path specified')
+            raise ui.UserError(u"no path specified")
 
         # On Python 2, we get filenames as raw bytes, which is what we
         # need. On Python 3, we need to undo the "helpful" conversion to
         # Unicode strings to get the real bytestring filename.
         if not six.PY2:
-            paths = [p.encode(util.arg_encoding(), 'surrogateescape')
-                     for p in paths]
+            paths = [
+                p.encode(util.arg_encoding(), "surrogateescape") for p in paths
+            ]
 
     import_files(lib, paths, query)
 
 
 import_cmd = ui.Subcommand(
-    u'import', help=u'import new music', aliases=(u'imp', u'im')
+    u"import", help=u"import new music", aliases=(u"imp", u"im")
 )
 import_cmd.parser.add_option(
-    u'-c', u'--copy', action='store_true', default=None,
-    help=u"copy tracks into library directory (default)"
+    u"-c",
+    u"--copy",
+    action="store_true",
+    default=None,
+    help=u"copy tracks into library directory (default)",
 )
 import_cmd.parser.add_option(
-    u'-C', u'--nocopy', action='store_false', dest='copy',
-    help=u"don't copy tracks (opposite of -c)"
+    u"-C",
+    u"--nocopy",
+    action="store_false",
+    dest="copy",
+    help=u"don't copy tracks (opposite of -c)",
 )
 import_cmd.parser.add_option(
-    u'-m', u'--move', action='store_true', dest='move',
-    help=u"move tracks into the library (overrides -c)"
+    u"-m",
+    u"--move",
+    action="store_true",
+    dest="move",
+    help=u"move tracks into the library (overrides -c)",
 )
 import_cmd.parser.add_option(
-    u'-w', u'--write', action='store_true', default=None,
-    help=u"write new metadata to files' tags (default)"
+    u"-w",
+    u"--write",
+    action="store_true",
+    default=None,
+    help=u"write new metadata to files' tags (default)",
 )
 import_cmd.parser.add_option(
-    u'-W', u'--nowrite', action='store_false', dest='write',
-    help=u"don't write metadata (opposite of -w)"
+    u"-W",
+    u"--nowrite",
+    action="store_false",
+    dest="write",
+    help=u"don't write metadata (opposite of -w)",
 )
 import_cmd.parser.add_option(
-    u'-a', u'--autotag', action='store_true', dest='autotag',
-    help=u"infer tags for imported files (default)"
+    u"-a",
+    u"--autotag",
+    action="store_true",
+    dest="autotag",
+    help=u"infer tags for imported files (default)",
 )
 import_cmd.parser.add_option(
-    u'-A', u'--noautotag', action='store_false', dest='autotag',
-    help=u"don't infer tags for imported files (opposite of -a)"
+    u"-A",
+    u"--noautotag",
+    action="store_false",
+    dest="autotag",
+    help=u"don't infer tags for imported files (opposite of -a)",
 )
 import_cmd.parser.add_option(
-    u'-p', u'--resume', action='store_true', default=None,
-    help=u"resume importing if interrupted"
+    u"-p",
+    u"--resume",
+    action="store_true",
+    default=None,
+    help=u"resume importing if interrupted",
 )
 import_cmd.parser.add_option(
-    u'-P', u'--noresume', action='store_false', dest='resume',
-    help=u"do not try to resume importing"
+    u"-P",
+    u"--noresume",
+    action="store_false",
+    dest="resume",
+    help=u"do not try to resume importing",
 )
 import_cmd.parser.add_option(
-    u'-q', u'--quiet', action='store_true', dest='quiet',
-    help=u"never prompt for input: skip albums instead"
+    u"-q",
+    u"--quiet",
+    action="store_true",
+    dest="quiet",
+    help=u"never prompt for input: skip albums instead",
 )
 import_cmd.parser.add_option(
-    u'-l', u'--log', dest='log',
-    help=u'file to log untaggable albums for later review'
+    u"-l",
+    u"--log",
+    dest="log",
+    help=u"file to log untaggable albums for later review",
 )
 import_cmd.parser.add_option(
-    u'-s', u'--singletons', action='store_true',
-    help=u'import individual tracks instead of full albums'
+    u"-s",
+    u"--singletons",
+    action="store_true",
+    help=u"import individual tracks instead of full albums",
 )
 import_cmd.parser.add_option(
-    u'-t', u'--timid', dest='timid', action='store_true',
-    help=u'always confirm all actions'
+    u"-t",
+    u"--timid",
+    dest="timid",
+    action="store_true",
+    help=u"always confirm all actions",
 )
 import_cmd.parser.add_option(
-    u'-L', u'--library', dest='library', action='store_true',
-    help=u'retag items matching a query'
+    u"-L",
+    u"--library",
+    dest="library",
+    action="store_true",
+    help=u"retag items matching a query",
 )
 import_cmd.parser.add_option(
-    u'-i', u'--incremental', dest='incremental', action='store_true',
-    help=u'skip already-imported directories'
+    u"-i",
+    u"--incremental",
+    dest="incremental",
+    action="store_true",
+    help=u"skip already-imported directories",
 )
 import_cmd.parser.add_option(
-    u'-I', u'--noincremental', dest='incremental', action='store_false',
-    help=u'do not skip already-imported directories'
+    u"-I",
+    u"--noincremental",
+    dest="incremental",
+    action="store_false",
+    help=u"do not skip already-imported directories",
 )
 import_cmd.parser.add_option(
-    u'--from-scratch', dest='from_scratch', action='store_true',
-    help=u'erase existing metadata before applying new metadata'
+    u"--from-scratch",
+    dest="from_scratch",
+    action="store_true",
+    help=u"erase existing metadata before applying new metadata",
 )
 import_cmd.parser.add_option(
-    u'--flat', dest='flat', action='store_true',
-    help=u'import an entire tree as a single album'
+    u"--flat",
+    dest="flat",
+    action="store_true",
+    help=u"import an entire tree as a single album",
 )
 import_cmd.parser.add_option(
-    u'-g', u'--group-albums', dest='group_albums', action='store_true',
-    help=u'group tracks in a folder into separate albums'
+    u"-g",
+    u"--group-albums",
+    dest="group_albums",
+    action="store_true",
+    help=u"group tracks in a folder into separate albums",
 )
 import_cmd.parser.add_option(
-    u'--pretend', dest='pretend', action='store_true',
-    help=u'just print the files to import'
+    u"--pretend",
+    dest="pretend",
+    action="store_true",
+    help=u"just print the files to import",
 )
 import_cmd.parser.add_option(
-    u'-S', u'--search-id', dest='search_ids', action='append',
-    metavar='ID',
-    help=u'restrict matching to a specific metadata backend ID'
+    u"-S",
+    u"--search-id",
+    dest="search_ids",
+    action="append",
+    metavar="ID",
+    help=u"restrict matching to a specific metadata backend ID",
 )
 import_cmd.parser.add_option(
-    u'--set', dest='set_fields', action='callback',
+    u"--set",
+    dest="set_fields",
+    action="callback",
     callback=_store_dict,
-    metavar='FIELD=VALUE',
-    help=u'set the given fields to the supplied values'
+    metavar="FIELD=VALUE",
+    help=u"set the given fields to the supplied values",
 )
 import_cmd.func = import_func
 default_commands.append(import_cmd)
@@ -1056,7 +1180,8 @@ default_commands.append(import_cmd)
 
 # list: Query and show library contents.
 
-def list_items(lib, query, album, fmt=u''):
+
+def list_items(lib, query, album, fmt=u""):
     """Print out items in lib matching query. If album, then search for
     albums instead of single items.
     """
@@ -1072,15 +1197,17 @@ def list_func(lib, opts, args):
     list_items(lib, decargs(args), opts.album)
 
 
-list_cmd = ui.Subcommand(u'list', help=u'query the library', aliases=(u'ls',))
-list_cmd.parser.usage += u"\n" \
-    u'Example: %prog -f \'$album: $title\' artist:beatles'
+list_cmd = ui.Subcommand(u"list", help=u"query the library", aliases=(u"ls",))
+list_cmd.parser.usage += (
+    u"\n" u"Example: %prog -f '$album: $title' artist:beatles"
+)
 list_cmd.parser.add_all_common_options()
 list_cmd.func = list_func
 default_commands.append(list_cmd)
 
 
 # update: Update library contents according to on-disk tags.
+
 
 def update_items(lib, query, album, move, pretend, fields):
     """For all the items matched by the query, update the library to
@@ -1089,11 +1216,11 @@ def update_items(lib, query, album, move, pretend, fields):
     be.
     """
     with lib.transaction():
-        if move and fields is not None and 'path' not in fields:
+        if move and fields is not None and "path" not in fields:
             # Special case: if an item needs to be moved, the path field has to
             # updated; otherwise the new path will not be reflected in the
             # database.
-            fields.append('path')
+            fields.append("path")
         items, _ = _do_query(lib, query, album)
 
         # Walk through the items and pick up their changes.
@@ -1102,7 +1229,7 @@ def update_items(lib, query, album, move, pretend, fields):
             # Item deleted?
             if not os.path.exists(syspath(item.path)):
                 ui.print_(format(item))
-                ui.print_(ui.colorize('text_error', u'  deleted'))
+                ui.print_(ui.colorize("text_error", u"  deleted"))
                 if not pretend:
                     item.remove(True)
                 affected_albums.add(item.album_id)
@@ -1110,16 +1237,20 @@ def update_items(lib, query, album, move, pretend, fields):
 
             # Did the item change since last checked?
             if item.current_mtime() <= item.mtime:
-                log.debug(u'skipping {0} because mtime is up to date ({1})',
-                          displayable_path(item.path), item.mtime)
+                log.debug(
+                    u"skipping {0} because mtime is up to date ({1})",
+                    displayable_path(item.path),
+                    item.mtime,
+                )
                 continue
 
             # Read new data.
             try:
                 item.read()
             except library.ReadError as exc:
-                log.error(u'error reading {0}: {1}',
-                          displayable_path(item.path), exc)
+                log.error(
+                    u"error reading {0}: {1}", displayable_path(item.path), exc
+                )
                 continue
 
             # Special-case album artist when it matches track artist. (Hacky
@@ -1129,12 +1260,12 @@ def update_items(lib, query, album, move, pretend, fields):
                 old_item = lib.get_item(item.id)
                 if old_item.albumartist == old_item.artist == item.artist:
                     item.albumartist = old_item.albumartist
-                    item._dirty.discard(u'albumartist')
+                    item._dirty.discard(u"albumartist")
 
             # Check for and display changes.
             changed = ui.show_model_changes(
-                item,
-                fields=fields or library.Item._media_fields)
+                item, fields=fields or library.Item._media_fields
+            )
 
             # Save changes.
             if not pretend:
@@ -1162,7 +1293,7 @@ def update_items(lib, query, album, move, pretend, fields):
                 continue
             album = lib.get_album(album_id)
             if not album:  # Empty albums have already been removed.
-                log.debug(u'emptied album {0}', album_id)
+                log.debug(u"emptied album {0}", album_id)
                 continue
             first_item = album.items().get()
 
@@ -1173,7 +1304,7 @@ def update_items(lib, query, album, move, pretend, fields):
 
             # Move album art (and any inconsistent items).
             if move and lib.directory in ancestry(first_item.path):
-                log.debug(u'moving album {0}', album_id)
+                log.debug(u"moving album {0}", album_id)
 
                 # Manually moving and storing the album.
                 items = list(album.items())
@@ -1191,36 +1322,55 @@ def update_func(lib, opts, args):
         ui.print_(lib.directory)
         if not ui.input_yn("Are you sure you want to continue (y/n)?", True):
             return
-    update_items(lib, decargs(args), opts.album, ui.should_move(opts.move),
-                 opts.pretend, opts.fields)
+    update_items(
+        lib,
+        decargs(args),
+        opts.album,
+        ui.should_move(opts.move),
+        opts.pretend,
+        opts.fields,
+    )
 
 
 update_cmd = ui.Subcommand(
-    u'update', help=u'update the library', aliases=(u'upd', u'up',)
+    u"update", help=u"update the library", aliases=(u"upd", u"up",)
 )
 update_cmd.parser.add_album_option()
 update_cmd.parser.add_format_option()
 update_cmd.parser.add_option(
-    u'-m', u'--move', action='store_true', dest='move',
-    help=u"move files in the library directory"
+    u"-m",
+    u"--move",
+    action="store_true",
+    dest="move",
+    help=u"move files in the library directory",
 )
 update_cmd.parser.add_option(
-    u'-M', u'--nomove', action='store_false', dest='move',
-    help=u"don't move files in library"
+    u"-M",
+    u"--nomove",
+    action="store_false",
+    dest="move",
+    help=u"don't move files in library",
 )
 update_cmd.parser.add_option(
-    u'-p', u'--pretend', action='store_true',
-    help=u"show all changes but do nothing"
+    u"-p",
+    u"--pretend",
+    action="store_true",
+    help=u"show all changes but do nothing",
 )
 update_cmd.parser.add_option(
-    u'-F', u'--field', default=None, action='append', dest='fields',
-    help=u'list of fields to update'
+    u"-F",
+    u"--field",
+    default=None,
+    action="append",
+    dest="fields",
+    help=u"list of fields to update",
 )
 update_cmd.func = update_func
 default_commands.append(update_cmd)
 
 
 # remove: Remove items from library, delete files.
+
 
 def remove_items(lib, query, album, delete, force):
     """Remove items matching query from lib. If album, then match and
@@ -1234,13 +1384,17 @@ def remove_items(lib, query, album, delete, force):
         # Prepare confirmation with user.
         print_()
         if delete:
-            fmt = u'$path - $title'
-            prompt = u'Really DELETE %i file%s (y/n)?' % \
-                     (len(items), 's' if len(items) > 1 else '')
+            fmt = u"$path - $title"
+            prompt = u"Really DELETE %i file%s (y/n)?" % (
+                len(items),
+                "s" if len(items) > 1 else "",
+            )
         else:
-            fmt = u''
-            prompt = u'Really remove %i item%s from the library (y/n)?' % \
-                     (len(items), 's' if len(items) > 1 else '')
+            fmt = u""
+            prompt = u"Really remove %i item%s from the library (y/n)?" % (
+                len(items),
+                "s" if len(items) > 1 else "",
+            )
 
         # Show all the items.
         for item in items:
@@ -1252,7 +1406,7 @@ def remove_items(lib, query, album, delete, force):
 
     # Remove (and possibly delete) items.
     with lib.transaction():
-        for obj in (albums if album else items):
+        for obj in albums if album else items:
             obj.remove(delete)
 
 
@@ -1261,15 +1415,19 @@ def remove_func(lib, opts, args):
 
 
 remove_cmd = ui.Subcommand(
-    u'remove', help=u'remove matching items from the library', aliases=(u'rm',)
+    u"remove", help=u"remove matching items from the library", aliases=(u"rm",)
 )
 remove_cmd.parser.add_option(
-    u"-d", u"--delete", action="store_true",
-    help=u"also remove files from disk"
+    u"-d",
+    u"--delete",
+    action="store_true",
+    help=u"also remove files from disk",
 )
 remove_cmd.parser.add_option(
-    u"-f", u"--force", action="store_true",
-    help=u"do not ask when removing items"
+    u"-f",
+    u"--force",
+    action="store_true",
+    help=u"do not ask when removing items",
 )
 remove_cmd.parser.add_album_option()
 remove_cmd.func = remove_func
@@ -1277,6 +1435,7 @@ default_commands.append(remove_cmd)
 
 
 # stats: Show library/query statistics.
+
 
 def show_stats(lib, query, exact):
     """Shows some statistics about the matched items."""
@@ -1294,7 +1453,7 @@ def show_stats(lib, query, exact):
             try:
                 total_size += os.path.getsize(syspath(item.path))
             except OSError as exc:
-                log.info(u'could not get size of {}: {}', item.path, exc)
+                log.info(u"could not get size of {}: {}", item.path, exc)
         else:
             total_size += int(item.length * item.bitrate / 8)
         total_time += item.length
@@ -1304,24 +1463,26 @@ def show_stats(lib, query, exact):
         if item.album_id:
             albums.add(item.album_id)
 
-    size_str = u'' + ui.human_bytes(total_size)
+    size_str = u"" + ui.human_bytes(total_size)
     if exact:
-        size_str += u' ({0} bytes)'.format(total_size)
+        size_str += u" ({0} bytes)".format(total_size)
 
-    print_(u"""Tracks: {0}
+    print_(
+        u"""Tracks: {0}
 Total time: {1}{2}
 {3}: {4}
 Artists: {5}
 Albums: {6}
 Album artists: {7}""".format(
-        total_items,
-        ui.human_seconds(total_time),
-        u' ({0:.2f} seconds)'.format(total_time) if exact else '',
-        u'Total size' if exact else u'Approximate total size',
-        size_str,
-        len(artists),
-        len(albums),
-        len(album_artists)),
+            total_items,
+            ui.human_seconds(total_time),
+            u" ({0:.2f} seconds)".format(total_time) if exact else "",
+            u"Total size" if exact else u"Approximate total size",
+            size_str,
+            len(artists),
+            len(albums),
+            len(album_artists),
+        ),
     )
 
 
@@ -1330,11 +1491,10 @@ def stats_func(lib, opts, args):
 
 
 stats_cmd = ui.Subcommand(
-    u'stats', help=u'show statistics about the library or a query'
+    u"stats", help=u"show statistics about the library or a query"
 )
 stats_cmd.parser.add_option(
-    u'-e', u'--exact', action='store_true',
-    help=u'exact size and time'
+    u"-e", u"--exact", action="store_true", help=u"exact size and time"
 )
 stats_cmd.func = stats_func
 default_commands.append(stats_cmd)
@@ -1342,25 +1502,25 @@ default_commands.append(stats_cmd)
 
 # version: Show current beets version.
 
+
 def show_version(lib, opts, args):
-    print_(u'beets version %s' % beets.__version__)
-    print_(u'Python version {}'.format(python_version()))
+    print_(u"beets version %s" % beets.__version__)
+    print_(u"Python version {}".format(python_version()))
     # Show plugins.
     names = sorted(p.name for p in plugins.find_plugins())
     if names:
-        print_(u'plugins:', ', '.join(names))
+        print_(u"plugins:", ", ".join(names))
     else:
-        print_(u'no plugins loaded')
+        print_(u"no plugins loaded")
 
 
-version_cmd = ui.Subcommand(
-    u'version', help=u'output version information'
-)
+version_cmd = ui.Subcommand(u"version", help=u"output version information")
 version_cmd.func = show_version
 default_commands.append(version_cmd)
 
 
 # modify: Declaratively change metadata.
+
 
 def modify_items(lib, mods, dels, query, write, move, album, confirm):
     """Modifies matching items according to user-specified assignments and
@@ -1381,8 +1541,11 @@ def modify_items(lib, mods, dels, query, write, move, album, confirm):
 
     # Apply changes *temporarily*, preview them, and collect modified
     # objects.
-    print_(u'Modifying {0} {1}s.'
-           .format(len(objs), u'album' if album else u'item'))
+    print_(
+        u"Modifying {0} {1}s.".format(
+            len(objs), u"album" if album else u"item"
+        )
+    )
     changed = []
     for obj in objs:
         if print_and_modify(obj, mods, dels) and obj not in changed:
@@ -1390,23 +1553,24 @@ def modify_items(lib, mods, dels, query, write, move, album, confirm):
 
     # Still something to do?
     if not changed:
-        print_(u'No changes to make.')
+        print_(u"No changes to make.")
         return
 
     # Confirm action.
     if confirm:
         if write and move:
-            extra = u', move and write tags'
+            extra = u", move and write tags"
         elif write:
-            extra = u' and write tags'
+            extra = u" and write tags"
         elif move:
-            extra = u' and move'
+            extra = u" and move"
         else:
-            extra = u''
+            extra = u""
 
         changed = ui.input_select_objects(
-            u'Really modify%s' % extra, changed,
-            lambda o: print_and_modify(o, mods, dels)
+            u"Really modify%s" % extra,
+            changed,
+            lambda o: print_and_modify(o, mods, dels),
         )
 
     # Apply changes to database and files
@@ -1440,10 +1604,10 @@ def modify_parse_args(args):
     dels = []
     query = []
     for arg in args:
-        if arg.endswith('!') and '=' not in arg and ':' not in arg:
+        if arg.endswith("!") and "=" not in arg and ":" not in arg:
             dels.append(arg[:-1])  # Strip trailing !.
-        elif '=' in arg and ':' not in arg.split('=', 1)[0]:
-            key, val = arg.split('=', 1)
+        elif "=" in arg and ":" not in arg.split("=", 1)[0]:
+            key, val = arg.split("=", 1)
             mods[key] = val
         else:
             query.append(arg)
@@ -1453,35 +1617,54 @@ def modify_parse_args(args):
 def modify_func(lib, opts, args):
     query, mods, dels = modify_parse_args(decargs(args))
     if not mods and not dels:
-        raise ui.UserError(u'no modifications specified')
-    modify_items(lib, mods, dels, query, ui.should_write(opts.write),
-                 ui.should_move(opts.move), opts.album, not opts.yes)
+        raise ui.UserError(u"no modifications specified")
+    modify_items(
+        lib,
+        mods,
+        dels,
+        query,
+        ui.should_write(opts.write),
+        ui.should_move(opts.move),
+        opts.album,
+        not opts.yes,
+    )
 
 
 modify_cmd = ui.Subcommand(
-    u'modify', help=u'change metadata fields', aliases=(u'mod',)
+    u"modify", help=u"change metadata fields", aliases=(u"mod",)
 )
 modify_cmd.parser.add_option(
-    u'-m', u'--move', action='store_true', dest='move',
-    help=u"move files in the library directory"
+    u"-m",
+    u"--move",
+    action="store_true",
+    dest="move",
+    help=u"move files in the library directory",
 )
 modify_cmd.parser.add_option(
-    u'-M', u'--nomove', action='store_false', dest='move',
-    help=u"don't move files in library"
+    u"-M",
+    u"--nomove",
+    action="store_false",
+    dest="move",
+    help=u"don't move files in library",
 )
 modify_cmd.parser.add_option(
-    u'-w', u'--write', action='store_true', default=None,
-    help=u"write new metadata to files' tags (default)"
+    u"-w",
+    u"--write",
+    action="store_true",
+    default=None,
+    help=u"write new metadata to files' tags (default)",
 )
 modify_cmd.parser.add_option(
-    u'-W', u'--nowrite', action='store_false', dest='write',
-    help=u"don't write metadata (opposite of -w)"
+    u"-W",
+    u"--nowrite",
+    action="store_false",
+    dest="write",
+    help=u"don't write metadata (opposite of -w)",
 )
 modify_cmd.parser.add_album_option()
-modify_cmd.parser.add_format_option(target='item')
+modify_cmd.parser.add_format_option(target="item")
 modify_cmd.parser.add_option(
-    u'-y', u'--yes', action='store_true',
-    help=u'skip confirmation'
+    u"-y", u"--yes", action="store_true", help=u"skip confirmation"
 )
 modify_cmd.func = modify_func
 default_commands.append(modify_cmd)
@@ -1489,8 +1672,10 @@ default_commands.append(modify_cmd)
 
 # move: Move/copy files to the library or a new base directory.
 
-def move_items(lib, dest, query, copy, album, pretend, confirm=False,
-               export=False):
+
+def move_items(
+    lib, dest, query, copy, album, pretend, confirm=False, export=False
+):
     """Moves or copies items to a new base directory, given by dest. If
     dest is None, then the library's base directory is used, making the
     command "consolidate" files.
@@ -1505,40 +1690,56 @@ def move_items(lib, dest, query, copy, album, pretend, confirm=False,
     objs = [o for o in objs if (isalbummoved if album else isitemmoved)(o)]
     num_unmoved = num_objs - len(objs)
     # Report unmoved files that match the query.
-    unmoved_msg = u''
+    unmoved_msg = u""
     if num_unmoved > 0:
-        unmoved_msg = u' ({} already in place)'.format(num_unmoved)
+        unmoved_msg = u" ({} already in place)".format(num_unmoved)
 
     copy = copy or export  # Exporting always copies.
-    action = u'Copying' if copy else u'Moving'
-    act = u'copy' if copy else u'move'
-    entity = u'album' if album else u'item'
-    log.info(u'{0} {1} {2}{3}{4}.', action, len(objs), entity,
-             u's' if len(objs) != 1 else u'', unmoved_msg)
+    action = u"Copying" if copy else u"Moving"
+    act = u"copy" if copy else u"move"
+    entity = u"album" if album else u"item"
+    log.info(
+        u"{0} {1} {2}{3}{4}.",
+        action,
+        len(objs),
+        entity,
+        u"s" if len(objs) != 1 else u"",
+        unmoved_msg,
+    )
     if not objs:
         return
 
     if pretend:
         if album:
-            show_path_changes([(item.path, item.destination(basedir=dest))
-                               for obj in objs for item in obj.items()])
+            show_path_changes(
+                [
+                    (item.path, item.destination(basedir=dest))
+                    for obj in objs
+                    for item in obj.items()
+                ]
+            )
         else:
-            show_path_changes([(obj.path, obj.destination(basedir=dest))
-                               for obj in objs])
+            show_path_changes(
+                [(obj.path, obj.destination(basedir=dest)) for obj in objs]
+            )
     else:
         if confirm:
             objs = ui.input_select_objects(
-                u'Really %s' % act, objs,
+                u"Really %s" % act,
+                objs,
                 lambda o: show_path_changes(
-                    [(o.path, o.destination(basedir=dest))]))
+                    [(o.path, o.destination(basedir=dest))]
+                ),
+            )
 
         for obj in objs:
-            log.debug(u'moving: {0}', util.displayable_path(obj.path))
+            log.debug(u"moving: {0}", util.displayable_path(obj.path))
 
             if export:
                 # Copy without affecting the database.
-                obj.move(operation=MoveOperation.COPY, basedir=dest,
-                         store=False)
+                obj.move(
+                    operation=MoveOperation.COPY, basedir=dest, store=False
+                )
             else:
                 # Ordinary move/copy: store the new path.
                 if copy:
@@ -1552,34 +1753,51 @@ def move_func(lib, opts, args):
     if dest is not None:
         dest = normpath(dest)
         if not os.path.isdir(dest):
-            raise ui.UserError(u'no such directory: %s' % dest)
+            raise ui.UserError(u"no such directory: %s" % dest)
 
-    move_items(lib, dest, decargs(args), opts.copy, opts.album, opts.pretend,
-               opts.timid, opts.export)
+    move_items(
+        lib,
+        dest,
+        decargs(args),
+        opts.copy,
+        opts.album,
+        opts.pretend,
+        opts.timid,
+        opts.export,
+    )
 
 
-move_cmd = ui.Subcommand(
-    u'move', help=u'move or copy items', aliases=(u'mv',)
+move_cmd = ui.Subcommand(u"move", help=u"move or copy items", aliases=(u"mv",))
+move_cmd.parser.add_option(
+    u"-d", u"--dest", metavar="DIR", dest="dest", help=u"destination directory"
 )
 move_cmd.parser.add_option(
-    u'-d', u'--dest', metavar='DIR', dest='dest',
-    help=u'destination directory'
+    u"-c",
+    u"--copy",
+    default=False,
+    action="store_true",
+    help=u"copy instead of moving",
 )
 move_cmd.parser.add_option(
-    u'-c', u'--copy', default=False, action='store_true',
-    help=u'copy instead of moving'
+    u"-p",
+    u"--pretend",
+    default=False,
+    action="store_true",
+    help=u"show how files would be moved, but don't touch anything",
 )
 move_cmd.parser.add_option(
-    u'-p', u'--pretend', default=False, action='store_true',
-    help=u'show how files would be moved, but don\'t touch anything'
+    u"-t",
+    u"--timid",
+    dest="timid",
+    action="store_true",
+    help=u"always confirm all actions",
 )
 move_cmd.parser.add_option(
-    u'-t', u'--timid', dest='timid', action='store_true',
-    help=u'always confirm all actions'
-)
-move_cmd.parser.add_option(
-    u'-e', u'--export', default=False, action='store_true',
-    help=u'copy without changing the database path'
+    u"-e",
+    u"--export",
+    default=False,
+    action="store_true",
+    help=u"copy without changing the database path",
 )
 move_cmd.parser.add_album_option()
 move_cmd.func = move_func
@@ -1587,6 +1805,7 @@ default_commands.append(move_cmd)
 
 
 # write: Write tags into files.
+
 
 def write_items(lib, query, pretend, force):
     """Write tag information from the database to the respective files
@@ -1597,20 +1816,22 @@ def write_items(lib, query, pretend, force):
     for item in items:
         # Item deleted?
         if not os.path.exists(syspath(item.path)):
-            log.info(u'missing file: {0}', util.displayable_path(item.path))
+            log.info(u"missing file: {0}", util.displayable_path(item.path))
             continue
 
         # Get an Item object reflecting the "clean" (on-disk) state.
         try:
             clean_item = library.Item.from_path(item.path)
         except library.ReadError as exc:
-            log.error(u'error reading {0}: {1}',
-                      displayable_path(item.path), exc)
+            log.error(
+                u"error reading {0}: {1}", displayable_path(item.path), exc
+            )
             continue
 
         # Check for and display changes.
-        changed = ui.show_model_changes(item, clean_item,
-                                        library.Item._media_tag_fields, force)
+        changed = ui.show_model_changes(
+            item, clean_item, library.Item._media_tag_fields, force
+        )
         if (changed or force) and not pretend:
             # We use `try_sync` here to keep the mtime up to date in the
             # database.
@@ -1621,20 +1842,25 @@ def write_func(lib, opts, args):
     write_items(lib, decargs(args), opts.pretend, opts.force)
 
 
-write_cmd = ui.Subcommand(u'write', help=u'write tag information to files')
+write_cmd = ui.Subcommand(u"write", help=u"write tag information to files")
 write_cmd.parser.add_option(
-    u'-p', u'--pretend', action='store_true',
-    help=u"show all changes but do nothing"
+    u"-p",
+    u"--pretend",
+    action="store_true",
+    help=u"show all changes but do nothing",
 )
 write_cmd.parser.add_option(
-    u'-f', u'--force', action='store_true',
-    help=u"write tags even if the existing tags match the database"
+    u"-f",
+    u"--force",
+    action="store_true",
+    help=u"write tags even if the existing tags match the database",
 )
 write_cmd.func = write_func
 default_commands.append(write_cmd)
 
 
 # config: Show and edit user configuration.
+
 
 def config_func(lib, opts, args):
     # Make sure lazy configuration is loaded
@@ -1676,7 +1902,7 @@ def config_edit():
     editor = util.editor_command()
     try:
         if not os.path.isfile(path):
-            open(path, 'w+').close()
+            open(path, "w+").close()
         util.interactive_open([path], editor)
     except OSError as exc:
         message = u"Could not edit configuration: {0}".format(exc)
@@ -1684,24 +1910,35 @@ def config_edit():
             message += u". Please set the EDITOR environment variable"
         raise ui.UserError(message)
 
-config_cmd = ui.Subcommand(u'config',
-                           help=u'show or edit the user configuration')
-config_cmd.parser.add_option(
-    u'-p', u'--paths', action='store_true',
-    help=u'show files that configuration was loaded from'
+
+config_cmd = ui.Subcommand(
+    u"config", help=u"show or edit the user configuration"
 )
 config_cmd.parser.add_option(
-    u'-e', u'--edit', action='store_true',
-    help=u'edit user configuration with $EDITOR'
+    u"-p",
+    u"--paths",
+    action="store_true",
+    help=u"show files that configuration was loaded from",
 )
 config_cmd.parser.add_option(
-    u'-d', u'--defaults', action='store_true',
-    help=u'include the default configuration'
+    u"-e",
+    u"--edit",
+    action="store_true",
+    help=u"edit user configuration with $EDITOR",
 )
 config_cmd.parser.add_option(
-    u'-c', u'--clear', action='store_false',
-    dest='redact', default=True,
-    help=u'do not redact sensitive fields'
+    u"-d",
+    u"--defaults",
+    action="store_true",
+    help=u"include the default configuration",
+)
+config_cmd.parser.add_option(
+    u"-c",
+    u"--clear",
+    action="store_false",
+    dest="redact",
+    default=True,
+    help=u"do not redact sensitive fields",
 )
 config_cmd.func = config_func
 default_commands.append(config_cmd)
@@ -1709,22 +1946,29 @@ default_commands.append(config_cmd)
 
 # completion: print completion script
 
+
 def print_completion(*args):
     for line in completion_script(default_commands + plugins.commands()):
-        print_(line, end=u'')
+        print_(line, end=u"")
     if not any(map(os.path.isfile, BASH_COMPLETION_PATHS)):
-        log.warning(u'Warning: Unable to find the bash-completion package. '
-                    u'Command line completion might not work.')
+        log.warning(
+            u"Warning: Unable to find the bash-completion package. "
+            u"Command line completion might not work."
+        )
 
-BASH_COMPLETION_PATHS = map(syspath, [
-    u'/etc/bash_completion',
-    u'/usr/share/bash-completion/bash_completion',
-    u'/usr/local/share/bash-completion/bash_completion',
-    # SmartOS
-    u'/opt/local/share/bash-completion/bash_completion',
-    # Homebrew (before bash-completion2)
-    u'/usr/local/etc/bash_completion',
-])
+
+BASH_COMPLETION_PATHS = map(
+    syspath,
+    [
+        u"/etc/bash_completion",
+        u"/usr/share/bash-completion/bash_completion",
+        u"/usr/local/share/bash-completion/bash_completion",
+        # SmartOS
+        u"/opt/local/share/bash-completion/bash_completion",
+        # Homebrew (before bash-completion2)
+        u"/usr/local/etc/bash_completion",
+    ],
+)
 
 
 def completion_script(commands):
@@ -1733,8 +1977,8 @@ def completion_script(commands):
     ``commands`` is alist of ``ui.Subcommand`` instances to generate
     completion data for.
     """
-    base_script = os.path.join(os.path.dirname(__file__), 'completion_base.sh')
-    with open(base_script, 'r') as base_script:
+    base_script = os.path.join(os.path.dirname(__file__), "completion_base.sh")
+    with open(base_script, "r") as base_script:
         yield util.text_string(base_script.read())
 
     options = {}
@@ -1747,50 +1991,49 @@ def completion_script(commands):
         command_names.append(name)
 
         for alias in cmd.aliases:
-            if re.match(r'^\w+$', alias):
+            if re.match(r"^\w+$", alias):
                 aliases[alias] = name
 
-        options[name] = {u'flags': [], u'opts': []}
+        options[name] = {u"flags": [], u"opts": []}
         for opts in cmd.parser._get_all_options()[1:]:
-            if opts.action in ('store_true', 'store_false'):
-                option_type = u'flags'
+            if opts.action in ("store_true", "store_false"):
+                option_type = u"flags"
             else:
-                option_type = u'opts'
+                option_type = u"opts"
 
             options[name][option_type].extend(
                 opts._short_opts + opts._long_opts
             )
 
     # Add global options
-    options['_global'] = {
-        u'flags': [u'-v', u'--verbose'],
-        u'opts':
-            u'-l --library -c --config -d --directory -h --help'.split(u' ')
+    options["_global"] = {
+        u"flags": [u"-v", u"--verbose"],
+        u"opts": u"-l --library -c --config -d --directory -h --help".split(
+            u" "
+        ),
     }
 
     # Add flags common to all commands
-    options['_common'] = {
-        u'flags': [u'-h', u'--help']
-    }
+    options["_common"] = {u"flags": [u"-h", u"--help"]}
 
     # Start generating the script
     yield u"_beet() {\n"
 
     # Command names
-    yield u"  local commands='%s'\n" % ' '.join(command_names)
+    yield u"  local commands='%s'\n" % " ".join(command_names)
     yield u"\n"
 
     # Command aliases
-    yield u"  local aliases='%s'\n" % ' '.join(aliases.keys())
+    yield u"  local aliases='%s'\n" % " ".join(aliases.keys())
     for alias, cmd in aliases.items():
-        yield u"  local alias__%s=%s\n" % (alias.replace('-', '_'), cmd)
-    yield u'\n'
+        yield u"  local alias__%s=%s\n" % (alias.replace("-", "_"), cmd)
+    yield u"\n"
 
     # Fields
-    yield u"  fields='%s'\n" % ' '.join(
+    yield u"  fields='%s'\n" % " ".join(
         set(
-            list(library.Item._fields.keys()) +
-            list(library.Album._fields.keys())
+            list(library.Item._fields.keys())
+            + list(library.Album._fields.keys())
         )
     )
 
@@ -1798,17 +2041,20 @@ def completion_script(commands):
     for cmd, opts in options.items():
         for option_type, option_list in opts.items():
             if option_list:
-                option_list = u' '.join(option_list)
+                option_list = u" ".join(option_list)
                 yield u"  local %s__%s='%s'\n" % (
-                    option_type, cmd.replace('-', '_'), option_list)
+                    option_type,
+                    cmd.replace("-", "_"),
+                    option_list,
+                )
 
-    yield u'  _beet_dispatch\n'
-    yield u'}\n'
+    yield u"  _beet_dispatch\n"
+    yield u"}\n"
 
 
 completion_cmd = ui.Subcommand(
-    'completion',
-    help=u'print shell script that provides command line completion'
+    "completion",
+    help=u"print shell script that provides command line completion",
 )
 completion_cmd.func = print_completion
 completion_cmd.hide = True

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -37,7 +37,7 @@ from enum import Enum
 
 
 MAX_FILENAME_LENGTH = 200
-WINDOWS_MAGIC_PREFIX = u'\\\\?\\'
+WINDOWS_MAGIC_PREFIX = u"\\\\?\\"
 SNI_SUPPORTED = sys.version_info >= (2, 7, 9)
 
 
@@ -54,7 +54,8 @@ class HumanReadableException(Exception):
     associated exception. (Note that this is not necessary in Python 3.x
     and should be removed when we make the transition.)
     """
-    error_kind = 'Error'  # Human-readable description of error type.
+
+    error_kind = "Error"  # Human-readable description of error type.
 
     def __init__(self, reason, verb, tb=None):
         self.reason = reason
@@ -65,10 +66,10 @@ class HumanReadableException(Exception):
     def _gerund(self):
         """Generate a (likely) gerund form of the English verb.
         """
-        if u' ' in self.verb:
+        if u" " in self.verb:
             return self.verb
-        gerund = self.verb[:-1] if self.verb.endswith(u'e') else self.verb
-        gerund += u'ing'
+        gerund = self.verb[:-1] if self.verb.endswith(u"e") else self.verb
+        gerund += u"ing"
         return gerund
 
     def _reasonstr(self):
@@ -76,8 +77,8 @@ class HumanReadableException(Exception):
         if isinstance(self.reason, six.text_type):
             return self.reason
         elif isinstance(self.reason, bytes):
-            return self.reason.decode('utf-8', 'ignore')
-        elif hasattr(self.reason, 'strerror'):  # i.e., EnvironmentError
+            return self.reason.decode("utf-8", "ignore")
+        elif hasattr(self.reason, "strerror"):  # i.e., EnvironmentError
             return self.reason.strerror
         else:
             return u'"{0}"'.format(six.text_type(self.reason))
@@ -94,7 +95,7 @@ class HumanReadableException(Exception):
         """
         if self.tb:
             logger.debug(self.tb)
-        logger.error(u'{0}: {1}', self.error_kind, self.args[0])
+        logger.error(u"{0}: {1}", self.error_kind, self.args[0])
 
 
 class FilesystemError(HumanReadableException):
@@ -102,34 +103,35 @@ class FilesystemError(HumanReadableException):
     via a function in this module. The `paths` field is a sequence of
     pathnames involved in the operation.
     """
+
     def __init__(self, reason, verb, paths, tb=None):
         self.paths = paths
         super(FilesystemError, self).__init__(reason, verb, tb)
 
     def get_message(self):
         # Use a nicer English phrasing for some specific verbs.
-        if self.verb in ('move', 'copy', 'rename'):
-            clause = u'while {0} {1} to {2}'.format(
+        if self.verb in ("move", "copy", "rename"):
+            clause = u"while {0} {1} to {2}".format(
                 self._gerund(),
                 displayable_path(self.paths[0]),
-                displayable_path(self.paths[1])
+                displayable_path(self.paths[1]),
             )
-        elif self.verb in ('delete', 'write', 'create', 'read'):
-            clause = u'while {0} {1}'.format(
-                self._gerund(),
-                displayable_path(self.paths[0])
+        elif self.verb in ("delete", "write", "create", "read"):
+            clause = u"while {0} {1}".format(
+                self._gerund(), displayable_path(self.paths[0])
             )
         else:
-            clause = u'during {0} of paths {1}'.format(
-                self.verb, u', '.join(displayable_path(p) for p in self.paths)
+            clause = u"during {0} of paths {1}".format(
+                self.verb, u", ".join(displayable_path(p) for p in self.paths)
             )
 
-        return u'{0} {1}'.format(self._reasonstr(), clause)
+        return u"{0} {1}".format(self._reasonstr(), clause)
 
 
 class MoveOperation(Enum):
     """The file operations that e.g. various move functions can carry out.
     """
+
     MOVE = 0
     COPY = 1
     LINK = 2
@@ -184,9 +186,11 @@ def sorted_walk(path, ignore=(), ignore_hidden=False, logger=None):
         contents = os.listdir(syspath(path))
     except OSError as exc:
         if logger:
-            logger.warning(u'could not list directory {0}: {1}'.format(
-                displayable_path(path), exc.strerror
-            ))
+            logger.warning(
+                u"could not list directory {0}: {1}".format(
+                    displayable_path(path), exc.strerror
+                )
+            )
         return
     dirs = []
     files = []
@@ -227,7 +231,7 @@ def path_as_posix(path):
     """Return the string representation of the path with forward (/)
     slashes.
     """
-    return path.replace(b'\\', b'/')
+    return path.replace(b"\\", b"/")
 
 
 def mkdirall(path):
@@ -239,8 +243,9 @@ def mkdirall(path):
             try:
                 os.mkdir(syspath(ancestor))
             except (OSError, IOError) as exc:
-                raise FilesystemError(exc, 'create', (ancestor,),
-                                      traceback.format_exc())
+                raise FilesystemError(
+                    exc, "create", (ancestor,), traceback.format_exc()
+                )
 
 
 def fnmatch_all(names, patterns):
@@ -258,7 +263,7 @@ def fnmatch_all(names, patterns):
     return True
 
 
-def prune_dirs(path, root=None, clutter=('.DS_Store', 'Thumbs.db')):
+def prune_dirs(path, root=None, clutter=(".DS_Store", "Thumbs.db")):
     """If path is an empty directory, then remove it. Recursively remove
     path's ancestry up to root (which is never removed) where there are
     empty directories. If path is not contained in root, then nothing is
@@ -276,7 +281,7 @@ def prune_dirs(path, root=None, clutter=('.DS_Store', 'Thumbs.db')):
         ancestors = []
     elif root in ancestors:
         # Only remove directories below the root.
-        ancestors = ancestors[ancestors.index(root) + 1:]
+        ancestors = ancestors[ancestors.index(root) + 1 :]
     else:
         # Remove nothing.
         return
@@ -330,11 +335,11 @@ def arg_encoding():
     locale-sensitive strings).
     """
     try:
-        return locale.getdefaultlocale()[1] or 'utf-8'
+        return locale.getdefaultlocale()[1] or "utf-8"
     except ValueError:
         # Invalid locale environment variable setting. To avoid
         # failing entirely for no good reason, assume UTF-8.
-        return 'utf-8'
+        return "utf-8"
 
 
 def _fsencoding():
@@ -342,13 +347,13 @@ def _fsencoding():
     UTF-8 (not MBCS).
     """
     encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
-    if encoding == 'mbcs':
+    if encoding == "mbcs":
         # On Windows, a broken encoding known to Python as "MBCS" is
         # used for the filesystem. However, we only use the Unicode API
         # for Windows paths, so the encoding is actually immaterial so
         # we can avoid dealing with this nastiness. We arbitrarily
         # choose UTF-8.
-        encoding = 'utf-8'
+        encoding = "utf-8"
     return encoding
 
 
@@ -363,20 +368,20 @@ def bytestring_path(path):
     # On Windows, remove the magic prefix added by `syspath`. This makes
     # ``bytestring_path(syspath(X)) == X``, i.e., we can safely
     # round-trip through `syspath`.
-    if os.path.__name__ == 'ntpath' and path.startswith(WINDOWS_MAGIC_PREFIX):
-        path = path[len(WINDOWS_MAGIC_PREFIX):]
+    if os.path.__name__ == "ntpath" and path.startswith(WINDOWS_MAGIC_PREFIX):
+        path = path[len(WINDOWS_MAGIC_PREFIX) :]
 
     # Try to encode with default encodings, but fall back to utf-8.
     try:
         return path.encode(_fsencoding())
     except (UnicodeError, LookupError):
-        return path.encode('utf-8')
+        return path.encode("utf-8")
 
 
 PATH_SEP = bytestring_path(os.sep)
 
 
-def displayable_path(path, separator=u'; '):
+def displayable_path(path, separator=u"; "):
     """Attempts to decode a bytestring path to a unicode object for the
     purpose of displaying it to the user. If the `path` argument is a
     list or a tuple, the elements are joined with `separator`.
@@ -390,9 +395,9 @@ def displayable_path(path, separator=u'; '):
         return six.text_type(path)
 
     try:
-        return path.decode(_fsencoding(), 'ignore')
+        return path.decode(_fsencoding(), "ignore")
     except (UnicodeError, LookupError):
-        return path.decode('utf-8', 'ignore')
+        return path.decode("utf-8", "ignore")
 
 
 def syspath(path, prefix=True):
@@ -403,7 +408,7 @@ def syspath(path, prefix=True):
     *really* know what you're doing.
     """
     # Don't do anything if we're not on windows
-    if os.path.__name__ != 'ntpath':
+    if os.path.__name__ != "ntpath":
         return path
 
     if not isinstance(path, six.text_type):
@@ -411,19 +416,19 @@ def syspath(path, prefix=True):
         # arbitrarily. But earlier versions used MBCS because it is
         # reported as the FS encoding by Windows. Try both.
         try:
-            path = path.decode('utf-8')
+            path = path.decode("utf-8")
         except UnicodeError:
             # The encoding should always be MBCS, Windows' broken
             # Unicode representation.
             encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
-            path = path.decode(encoding, 'replace')
+            path = path.decode(encoding, "replace")
 
     # Add the magic prefix if it isn't already there.
     # https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247.aspx
     if prefix and not path.startswith(WINDOWS_MAGIC_PREFIX):
-        if path.startswith(u'\\\\'):
+        if path.startswith(u"\\\\"):
             # UNC path. Final path should look like \\?\UNC\...
-            path = u'UNC' + path[1:]
+            path = u"UNC" + path[1:]
         path = WINDOWS_MAGIC_PREFIX + path
 
     return path
@@ -446,7 +451,7 @@ def remove(path, soft=True):
     try:
         os.remove(path)
     except (OSError, IOError) as exc:
-        raise FilesystemError(exc, 'delete', (path,), traceback.format_exc())
+        raise FilesystemError(exc, "delete", (path,), traceback.format_exc())
 
 
 def copy(path, dest, replace=False):
@@ -460,12 +465,13 @@ def copy(path, dest, replace=False):
     path = syspath(path)
     dest = syspath(dest)
     if not replace and os.path.exists(dest):
-        raise FilesystemError(u'file exists', 'copy', (path, dest))
+        raise FilesystemError(u"file exists", "copy", (path, dest))
     try:
         shutil.copyfile(path, dest)
     except (OSError, IOError) as exc:
-        raise FilesystemError(exc, 'copy', (path, dest),
-                              traceback.format_exc())
+        raise FilesystemError(
+            exc, "copy", (path, dest), traceback.format_exc()
+        )
 
 
 def move(path, dest, replace=False):
@@ -481,7 +487,7 @@ def move(path, dest, replace=False):
     path = syspath(path)
     dest = syspath(dest)
     if os.path.exists(dest) and not replace:
-        raise FilesystemError(u'file exists', 'rename', (path, dest))
+        raise FilesystemError(u"file exists", "rename", (path, dest))
 
     # First, try renaming the file.
     try:
@@ -492,8 +498,9 @@ def move(path, dest, replace=False):
             shutil.copyfile(path, dest)
             os.remove(path)
         except (OSError, IOError) as exc:
-            raise FilesystemError(exc, 'move', (path, dest),
-                                  traceback.format_exc())
+            raise FilesystemError(
+                exc, "move", (path, dest), traceback.format_exc()
+            )
 
 
 def link(path, dest, replace=False):
@@ -505,20 +512,24 @@ def link(path, dest, replace=False):
         return
 
     if os.path.exists(syspath(dest)) and not replace:
-        raise FilesystemError(u'file exists', 'rename', (path, dest))
+        raise FilesystemError(u"file exists", "rename", (path, dest))
     try:
         os.symlink(syspath(path), syspath(dest))
     except NotImplementedError:
         # raised on python >= 3.2 and Windows versions before Vista
-        raise FilesystemError(u'OS does not support symbolic links.'
-                              'link', (path, dest), traceback.format_exc())
+        raise FilesystemError(
+            u"OS does not support symbolic links." "link",
+            (path, dest),
+            traceback.format_exc(),
+        )
     except OSError as exc:
         # TODO: Windows version checks can be removed for python 3
-        if hasattr('sys', 'getwindowsversion'):
+        if hasattr("sys", "getwindowsversion"):
             if sys.getwindowsversion()[0] < 6:  # is before Vista
-                exc = u'OS does not support symbolic links.'
-        raise FilesystemError(exc, 'link', (path, dest),
-                              traceback.format_exc())
+                exc = u"OS does not support symbolic links."
+        raise FilesystemError(
+            exc, "link", (path, dest), traceback.format_exc()
+        )
 
 
 def hardlink(path, dest, replace=False):
@@ -530,19 +541,26 @@ def hardlink(path, dest, replace=False):
         return
 
     if os.path.exists(syspath(dest)) and not replace:
-        raise FilesystemError(u'file exists', 'rename', (path, dest))
+        raise FilesystemError(u"file exists", "rename", (path, dest))
     try:
         os.link(syspath(path), syspath(dest))
     except NotImplementedError:
-        raise FilesystemError(u'OS does not support hard links.'
-                              'link', (path, dest), traceback.format_exc())
+        raise FilesystemError(
+            u"OS does not support hard links." "link",
+            (path, dest),
+            traceback.format_exc(),
+        )
     except OSError as exc:
         if exc.errno == errno.EXDEV:
-            raise FilesystemError(u'Cannot hard link across devices.'
-                                  'link', (path, dest), traceback.format_exc())
+            raise FilesystemError(
+                u"Cannot hard link across devices." "link",
+                (path, dest),
+                traceback.format_exc(),
+            )
         else:
-            raise FilesystemError(exc, 'link', (path, dest),
-                                  traceback.format_exc())
+            raise FilesystemError(
+                exc, "link", (path, dest), traceback.format_exc()
+            )
 
 
 def unique_path(path):
@@ -554,30 +572,31 @@ def unique_path(path):
         return path
 
     base, ext = os.path.splitext(path)
-    match = re.search(br'\.(\d)+$', base)
+    match = re.search(br"\.(\d)+$", base)
     if match:
         num = int(match.group(1))
-        base = base[:match.start()]
+        base = base[: match.start()]
     else:
         num = 0
     while True:
         num += 1
-        suffix = u'.{}'.format(num).encode() + ext
+        suffix = u".{}".format(num).encode() + ext
         new_path = base + suffix
         if not os.path.exists(new_path):
             return new_path
+
 
 # Note: The Windows "reserved characters" are, of course, allowed on
 # Unix. They are forbidden here because they cause problems on Samba
 # shares, which are sufficiently common as to cause frequent problems.
 # https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247.aspx
 CHAR_REPLACE = [
-    (re.compile(r'[\\/]'), u'_'),  # / and \ -- forbidden everywhere.
-    (re.compile(r'^\.'), u'_'),  # Leading dot (hidden files on Unix).
-    (re.compile(r'[\x00-\x1f]'), u''),  # Control characters.
-    (re.compile(r'[<>:"\?\*\|]'), u'_'),  # Windows "reserved characters".
-    (re.compile(r'\.$'), u'_'),  # Trailing dots.
-    (re.compile(r'\s+$'), u''),  # Trailing whitespace.
+    (re.compile(r"[\\/]"), u"_"),  # / and \ -- forbidden everywhere.
+    (re.compile(r"^\."), u"_"),  # Leading dot (hidden files on Unix).
+    (re.compile(r"[\x00-\x1f]"), u""),  # Control characters.
+    (re.compile(r'[<>:"\?\*\|]'), u"_"),  # Windows "reserved characters".
+    (re.compile(r"\.$"), u"_"),  # Trailing dots.
+    (re.compile(r"\s+$"), u""),  # Trailing whitespace.
 ]
 
 
@@ -594,7 +613,7 @@ def sanitize_path(path, replacements=None):
 
     comps = components(path)
     if not comps:
-        return ''
+        return ""
     for i, comp in enumerate(comps):
         for regex, repl in replacements:
             comp = regex.sub(repl, comp)
@@ -613,7 +632,7 @@ def truncate_path(path, length=MAX_FILENAME_LENGTH):
     base, ext = os.path.splitext(comps[-1])
     if ext:
         # Last component has an extension.
-        base = base[:length - len(ext)]
+        base = base[: length - len(ext)]
         out[-1] = base + ext
 
     return os.path.join(*out)
@@ -667,7 +686,7 @@ def legalize_path(path, replacements, length, extension, fragment):
 
     if fragment:
         # Outputting Unicode.
-        extension = extension.decode('utf-8', 'ignore')
+        extension = extension.decode("utf-8", "ignore")
 
     first_stage_path, _ = _legalize_stage(
         path, replacements, length, extension, fragment
@@ -711,7 +730,7 @@ def py3_path(path):
 
 def str2bool(value):
     """Returns a boolean reflecting a human-entered string."""
-    return value.lower() in (u'yes', u'1', u'true', u't', u'y')
+    return value.lower() in (u"yes", u"1", u"true", u"t", u"y")
 
 
 def as_string(value):
@@ -724,16 +743,16 @@ def as_string(value):
         buffer_types = memoryview
 
     if value is None:
-        return u''
+        return u""
     elif isinstance(value, buffer_types):
-        return bytes(value).decode('utf-8', 'ignore')
+        return bytes(value).decode("utf-8", "ignore")
     elif isinstance(value, bytes):
-        return value.decode('utf-8', 'ignore')
+        return value.decode("utf-8", "ignore")
     else:
         return six.text_type(value)
 
 
-def text_string(value, encoding='utf-8'):
+def text_string(value, encoding="utf-8"):
     """Convert a string, which can either be bytes or unicode, to
     unicode.
 
@@ -753,7 +772,7 @@ def plurality(objs):
     """
     c = Counter(objs)
     if not c:
-        raise ValueError(u'sequence must be non-empty')
+        raise ValueError(u"sequence must be non-empty")
     return c.most_common(1)[0]
 
 
@@ -763,23 +782,21 @@ def cpu_count():
     """
     # Adapted from the soundconverter project:
     # https://github.com/kassoulet/soundconverter
-    if sys.platform == 'win32':
+    if sys.platform == "win32":
         try:
-            num = int(os.environ['NUMBER_OF_PROCESSORS'])
+            num = int(os.environ["NUMBER_OF_PROCESSORS"])
         except (ValueError, KeyError):
             num = 0
-    elif sys.platform == 'darwin':
+    elif sys.platform == "darwin":
         try:
-            num = int(command_output([
-                '/usr/sbin/sysctl',
-                '-n',
-                'hw.ncpu',
-                ]).stdout)
+            num = int(
+                command_output(["/usr/sbin/sysctl", "-n", "hw.ncpu",]).stdout
+            )
         except (ValueError, OSError, subprocess.CalledProcessError):
             num = 0
     else:
         try:
-            num = os.sysconf('SC_NPROCESSORS_ONLN')
+            num = os.sysconf("SC_NPROCESSORS_ONLN")
         except (ValueError, OSError, AttributeError):
             num = 0
     if num >= 1:
@@ -799,7 +816,7 @@ def convert_command_args(args):
                 arg = arg.encode(arg_encoding())
         else:
             if isinstance(arg, bytes):
-                arg = arg.decode(arg_encoding(), 'surrogateescape')
+                arg = arg.decode(arg_encoding(), "surrogateescape")
         return arg
 
     return [convert(a) for a in args]
@@ -832,21 +849,21 @@ def command_output(cmd, shell=False):
     try:  # python >= 3.3
         devnull = subprocess.DEVNULL
     except AttributeError:
-        devnull = open(os.devnull, 'r+b')
+        devnull = open(os.devnull, "r+b")
 
     proc = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         stdin=devnull,
-        close_fds=platform.system() != 'Windows',
-        shell=shell
+        close_fds=platform.system() != "Windows",
+        shell=shell,
     )
     stdout, stderr = proc.communicate()
     if proc.returncode:
         raise subprocess.CalledProcessError(
             returncode=proc.returncode,
-            cmd=' '.join(cmd),
+            cmd=" ".join(cmd),
             output=stdout + stderr,
         )
     return CommandOutput(stdout, stderr)
@@ -859,7 +876,7 @@ def max_filename_length(path, limit=MAX_FILENAME_LENGTH):
     misreports its capacity). If it cannot be determined (e.g., on
     Windows), return `limit`.
     """
-    if hasattr(os, 'statvfs'):
+    if hasattr(os, "statvfs"):
         try:
             res = os.statvfs(path)
         except OSError:
@@ -874,12 +891,12 @@ def open_anything():
     program.
     """
     sys_name = platform.system()
-    if sys_name == 'Darwin':
-        base_cmd = 'open'
-    elif sys_name == 'Windows':
-        base_cmd = 'start'
+    if sys_name == "Darwin":
+        base_cmd = "open"
+    elif sys_name == "Windows":
+        base_cmd = "start"
     else:  # Assume Unix
-        base_cmd = 'xdg-open'
+        base_cmd = "xdg-open"
     return base_cmd
 
 
@@ -890,7 +907,7 @@ def editor_command():
     present, fall back to `open_anything()`, the platform-specific tool
     for opening files in general.
     """
-    editor = os.environ.get('EDITOR')
+    editor = os.environ.get("EDITOR")
     if editor:
         return editor
     return open_anything()
@@ -908,11 +925,11 @@ def shlex_split(s):
     elif isinstance(s, six.text_type):
         # Work around a Python bug.
         # http://bugs.python.org/issue6988
-        bs = s.encode('utf-8')
-        return [c.decode('utf-8') for c in shlex.split(bs)]
+        bs = s.encode("utf-8")
+        return [c.decode("utf-8") for c in shlex.split(bs)]
 
     else:
-        raise TypeError(u'shlex_split called with non-string')
+        raise TypeError(u"shlex_split called with non-string")
 
 
 def interactive_open(targets, command):
@@ -945,6 +962,7 @@ def _windows_long_path_name(short_path):
         short_path = short_path.decode(_fsencoding())
 
     import ctypes
+
     buf = ctypes.create_unicode_buffer(260)
     get_long_path_name_w = ctypes.windll.kernel32.GetLongPathNameW
     return_value = get_long_path_name_w(short_path, buf, 260)
@@ -956,7 +974,7 @@ def _windows_long_path_name(short_path):
         long_path = buf.value
         # GetLongPathNameW does not change the case of the drive
         # letter.
-        if len(long_path) > 1 and long_path[1] == ':':
+        if len(long_path) > 1 and long_path[1] == ":":
             long_path = long_path[0].upper() + long_path[1:]
         return long_path
 
@@ -971,21 +989,24 @@ def case_sensitive(path):
     # A fallback in case the path does not exist.
     if not os.path.exists(syspath(path)):
         # By default, the case sensitivity depends on the platform.
-        return platform.system() != 'Windows'
+        return platform.system() != "Windows"
 
     # If an upper-case version of the path exists but a lower-case
     # version does not, then the filesystem must be case-sensitive.
     # (Otherwise, we have more work to do.)
-    if not (os.path.exists(syspath(path.lower())) and
-            os.path.exists(syspath(path.upper()))):
+    if not (
+        os.path.exists(syspath(path.lower()))
+        and os.path.exists(syspath(path.upper()))
+    ):
         return True
 
     # Both versions of the path exist on the file system. Check whether
     # they refer to different files by their inodes. Alas,
     # `os.path.samefile` is only available on Unix systems on Python 2.
-    if platform.system() != 'Windows':
-        return not os.path.samefile(syspath(path.lower()),
-                                    syspath(path.upper()))
+    if platform.system() != "Windows":
+        return not os.path.samefile(
+            syspath(path.lower()), syspath(path.upper())
+        )
 
     # On Windows, we check whether the canonical, long filenames for the
     # files are the same.
@@ -1000,9 +1021,9 @@ def raw_seconds_short(string):
     Raises ValueError if the conversion cannot take place due to `string` not
     being in the right format.
     """
-    match = re.match(r'^(\d+):([0-5]\d)$', string)
+    match = re.match(r"^(\d+):([0-5]\d)$", string)
     if not match:
-        raise ValueError(u'String not in M:SS format')
+        raise ValueError(u"String not in M:SS format")
     minutes, seconds = map(int, match.groups())
     return float(minutes * 60 + seconds)
 
@@ -1025,8 +1046,7 @@ def asciify_path(path, sep_replace):
         path_components[index] = unidecode(item).replace(os.sep, sep_replace)
         if os.altsep:
             path_components[index] = unidecode(item).replace(
-                os.altsep,
-                sep_replace
+                os.altsep, sep_replace
             )
     return os.sep.join(path_components)
 
@@ -1060,7 +1080,7 @@ def lazy_property(func):
     This behaviour is useful when `func` is expensive to evaluate, and it is
     not certain that the result will be needed.
     """
-    field_name = '_' + func.__name__
+    field_name = "_" + func.__name__
 
     @property
     @functools.wraps(func)

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -33,11 +33,11 @@ IMAGEMAGICK = 2
 WEBPROXY = 3
 
 if util.SNI_SUPPORTED:
-    PROXY_URL = 'https://images.weserv.nl/'
+    PROXY_URL = "https://images.weserv.nl/"
 else:
-    PROXY_URL = 'http://images.weserv.nl/'
+    PROXY_URL = "http://images.weserv.nl/"
 
-log = logging.getLogger('beets')
+log = logging.getLogger("beets")
 
 
 def resize_url(url, maxwidth, quality=0):
@@ -45,14 +45,14 @@ def resize_url(url, maxwidth, quality=0):
     maxwidth (preserving aspect ratio).
     """
     params = {
-        'url': url.replace('http://', ''),
-        'w': maxwidth,
+        "url": url.replace("http://", ""),
+        "w": maxwidth,
     }
 
     if quality > 0:
-        params['q'] = quality
+        params["q"] = quality
 
-    return '{0}?{1}'.format(PROXY_URL, urlencode(params))
+    return "{0}?{1}".format(PROXY_URL, urlencode(params))
 
 
 def temp_file_for(path):
@@ -70,8 +70,12 @@ def pil_resize(maxwidth, path_in, path_out=None, quality=0):
     """
     path_out = path_out or temp_file_for(path_in)
     from PIL import Image
-    log.debug(u'artresizer: PIL resizing {0} to {1}',
-              util.displayable_path(path_in), util.displayable_path(path_out))
+
+    log.debug(
+        u"artresizer: PIL resizing {0} to {1}",
+        util.displayable_path(path_in),
+        util.displayable_path(path_out),
+    )
 
     try:
         im = Image.open(util.syspath(path_in))
@@ -80,8 +84,10 @@ def pil_resize(maxwidth, path_in, path_out=None, quality=0):
         im.save(util.py3_path(path_out), quality=quality)
         return path_out
     except IOError:
-        log.error(u"PIL cannot create thumbnail for '{0}'",
-                  util.displayable_path(path_in))
+        log.error(
+            u"PIL cannot create thumbnail for '{0}'",
+            util.displayable_path(path_in),
+        )
         return path_in
 
 
@@ -92,27 +98,33 @@ def im_resize(maxwidth, path_in, path_out=None, quality=0):
     the output path of resized image.
     """
     path_out = path_out or temp_file_for(path_in)
-    log.debug(u'artresizer: ImageMagick resizing {0} to {1}',
-              util.displayable_path(path_in), util.displayable_path(path_out))
+    log.debug(
+        u"artresizer: ImageMagick resizing {0} to {1}",
+        util.displayable_path(path_in),
+        util.displayable_path(path_out),
+    )
 
     # "-resize WIDTHx>" shrinks images with the width larger
     # than the given width while maintaining the aspect ratio
     # with regards to the height.
     cmd = ArtResizer.shared.im_convert_cmd + [
         util.syspath(path_in, prefix=False),
-        '-resize', '{0}x>'.format(maxwidth),
+        "-resize",
+        "{0}x>".format(maxwidth),
     ]
 
     if quality > 0:
-        cmd += ['-quality', '{0}'.format(quality)]
+        cmd += ["-quality", "{0}".format(quality)]
 
     cmd.append(util.syspath(path_out, prefix=False))
 
     try:
         util.command_output(cmd)
     except subprocess.CalledProcessError:
-        log.warning(u'artresizer: IM convert failed for {0}',
-                    util.displayable_path(path_in))
+        log.warning(
+            u"artresizer: IM convert failed for {0}",
+            util.displayable_path(path_in),
+        )
         return path_in
 
     return path_out
@@ -126,32 +138,41 @@ BACKEND_FUNCS = {
 
 def pil_getsize(path_in):
     from PIL import Image
+
     try:
         im = Image.open(util.syspath(path_in))
         return im.size
     except IOError as exc:
-        log.error(u"PIL could not read file {}: {}",
-                  util.displayable_path(path_in), exc)
+        log.error(
+            u"PIL could not read file {}: {}",
+            util.displayable_path(path_in),
+            exc,
+        )
 
 
 def im_getsize(path_in):
-    cmd = ArtResizer.shared.im_identify_cmd + \
-        ['-format', '%w %h', util.syspath(path_in, prefix=False)]
+    cmd = ArtResizer.shared.im_identify_cmd + [
+        "-format",
+        "%w %h",
+        util.syspath(path_in, prefix=False),
+    ]
 
     try:
         out = util.command_output(cmd).stdout
     except subprocess.CalledProcessError as exc:
-        log.warning(u'ImageMagick size query failed')
+        log.warning(u"ImageMagick size query failed")
         log.debug(
-            u'`convert` exited with (status {}) when '
-            u'getting size with command {}:\n{}',
-            exc.returncode, cmd, exc.output.strip()
+            u"`convert` exited with (status {}) when "
+            u"getting size with command {}:\n{}",
+            exc.returncode,
+            cmd,
+            exc.output.strip(),
         )
         return
     try:
-        return tuple(map(int, out.split(b' ')))
+        return tuple(map(int, out.split(b" ")))
     except IndexError:
-        log.warning(u'Could not understand IM output: {0!r}', out)
+        log.warning(u"Could not understand IM output: {0!r}", out)
 
 
 BACKEND_GET_SIZE = {
@@ -166,6 +187,7 @@ class Shareable(type):
     lazily-created shared instance of ``MyClass`` while calling
     ``MyClass()`` to construct a new object works as usual.
     """
+
     def __init__(cls, name, bases, dict):
         super(Shareable, cls).__init__(name, bases, dict)
         cls._instance = None
@@ -194,11 +216,11 @@ class ArtResizer(six.with_metaclass(Shareable, object)):
         if self.method[0] == IMAGEMAGICK:
             self.im_legacy = self.method[2]
             if self.im_legacy:
-                self.im_convert_cmd = ['convert']
-                self.im_identify_cmd = ['identify']
+                self.im_convert_cmd = ["convert"]
+                self.im_identify_cmd = ["identify"]
             else:
-                self.im_convert_cmd = ['magick']
-                self.im_identify_cmd = ['magick', 'identify']
+                self.im_convert_cmd = ["magick"]
+                self.im_identify_cmd = ["magick", "identify"]
 
     def resize(self, maxwidth, path_in, path_out=None, quality=0):
         """Manipulate an image file according to the method, returning a
@@ -272,21 +294,23 @@ def get_im_version():
     """Get the ImageMagick version and legacy flag as a pair. Or return
     None if ImageMagick is not available.
     """
-    for cmd_name, legacy in ((['magick'], False), (['convert'], True)):
-        cmd = cmd_name + ['--version']
+    for cmd_name, legacy in ((["magick"], False), (["convert"], True)):
+        cmd = cmd_name + ["--version"]
 
         try:
             out = util.command_output(cmd).stdout
         except (subprocess.CalledProcessError, OSError) as exc:
-            log.debug(u'ImageMagick version check failed: {}', exc)
+            log.debug(u"ImageMagick version check failed: {}", exc)
         else:
-            if b'imagemagick' in out.lower():
+            if b"imagemagick" in out.lower():
                 pattern = br".+ (\d+)\.(\d+)\.(\d+).*"
                 match = re.search(pattern, out)
                 if match:
-                    version = (int(match.group(1)),
-                               int(match.group(2)),
-                               int(match.group(3)))
+                    version = (
+                        int(match.group(1)),
+                        int(match.group(2)),
+                        int(match.group(3)),
+                    )
                     return version, legacy
 
     return None
@@ -296,7 +320,7 @@ def get_pil_version():
     """Get the PIL/Pillow version, or None if it is unavailable.
     """
     try:
-        __import__('PIL', fromlist=[str('Image')])
+        __import__("PIL", fromlist=[str("Image")])
         return (0,)
     except ImportError:
         return None

--- a/beets/util/confit.py
+++ b/beets/util/confit.py
@@ -18,11 +18,12 @@ from __future__ import division, absolute_import, print_function
 import confuse
 
 import warnings
+
 warnings.warn("beets.util.confit is deprecated; use confuse instead")
 
 # Import everything from the confuse module into this module.
 for key, value in confuse.__dict__.items():
-    if key not in ['__name__']:
+    if key not in ["__name__"]:
         globals()[key] = value
 
 

--- a/beets/util/enumeration.py
+++ b/beets/util/enumeration.py
@@ -22,6 +22,7 @@ class OrderedEnum(Enum):
     """
     An Enum subclass that allows comparison of members.
     """
+
     def __ge__(self, other):
         if self.__class__ is other.__class__:
             return self.value >= other.value

--- a/beets/util/hidden.py
+++ b/beets/util/hidden.py
@@ -30,7 +30,7 @@ def _is_hidden_osx(path):
     """
     file_stat = os.lstat(beets.util.syspath(path))
 
-    if hasattr(file_stat, 'st_flags') and hasattr(stat, 'UF_HIDDEN'):
+    if hasattr(file_stat, "st_flags") and hasattr(stat, "UF_HIDDEN"):
         return bool(file_stat.st_flags & stat.UF_HIDDEN)
     else:
         return False
@@ -57,7 +57,7 @@ def _is_hidden_dot(path):
 
     Files starting with a dot are seen as "hidden" files on Unix-based OSes.
     """
-    return os.path.basename(path).startswith(b'.')
+    return os.path.basename(path).startswith(b".")
 
 
 def is_hidden(path):
@@ -76,11 +76,12 @@ def is_hidden(path):
     work out if a file is hidden.
     """
     # Run platform specific functions depending on the platform
-    if sys.platform == 'darwin':
+    if sys.platform == "darwin":
         return _is_hidden_osx(path) or _is_hidden_dot(path)
-    elif sys.platform == 'win32':
+    elif sys.platform == "win32":
         return _is_hidden_win(path)
     else:
         return _is_hidden_dot(path)
 
-__all__ = ['is_hidden']
+
+__all__ = ["is_hidden"]

--- a/beets/vfs.py
+++ b/beets/vfs.py
@@ -21,7 +21,7 @@ from __future__ import division, absolute_import, print_function
 from collections import namedtuple
 from beets import util
 
-Node = namedtuple('Node', ['files', 'dirs'])
+Node = namedtuple("Node", ["files", "dirs"])
 
 
 def _insert(node, path, itemid):

--- a/beetsplug/__init__.py
+++ b/beetsplug/__init__.py
@@ -19,4 +19,5 @@ from __future__ import division, absolute_import, print_function
 
 # Make this a namespace package.
 from pkgutil import extend_path
+
 __path__ = extend_path(__path__, __name__)

--- a/beetsplug/acousticbrainz.py
+++ b/beetsplug/acousticbrainz.py
@@ -27,142 +27,91 @@ from beets.dbcore import types
 ACOUSTIC_BASE = "https://acousticbrainz.org/"
 LEVELS = ["/low-level", "/high-level"]
 ABSCHEME = {
-    'highlevel': {
-        'danceability': {
-            'all': {
-                'danceable': 'danceable'
-            }
-        },
-        'gender': {
-            'value': 'gender'
-        },
-        'genre_rosamerica': {
-            'value': 'genre_rosamerica'
-        },
-        'mood_acoustic': {
-            'all': {
-                'acoustic': 'mood_acoustic'
-            }
-        },
-        'mood_aggressive': {
-            'all': {
-                'aggressive': 'mood_aggressive'
-            }
-        },
-        'mood_electronic': {
-            'all': {
-                'electronic': 'mood_electronic'
-            }
-        },
-        'mood_happy': {
-            'all': {
-                'happy': 'mood_happy'
-            }
-        },
-        'mood_party': {
-            'all': {
-                'party': 'mood_party'
-            }
-        },
-        'mood_relaxed': {
-            'all': {
-                'relaxed': 'mood_relaxed'
-            }
-        },
-        'mood_sad': {
-            'all': {
-                'sad': 'mood_sad'
-            }
-        },
-        'moods_mirex': {
-            'value': 'moods_mirex'
-        },
-        'ismir04_rhythm': {
-            'value': 'rhythm'
-        },
-        'tonal_atonal': {
-            'all': {
-                'tonal': 'tonal'
-            }
-        },
-        'timbre': {
-            'value': 'timbre'
-        },
-        'voice_instrumental': {
-            'value': 'voice_instrumental'
-        },
+    "highlevel": {
+        "danceability": {"all": {"danceable": "danceable"}},
+        "gender": {"value": "gender"},
+        "genre_rosamerica": {"value": "genre_rosamerica"},
+        "mood_acoustic": {"all": {"acoustic": "mood_acoustic"}},
+        "mood_aggressive": {"all": {"aggressive": "mood_aggressive"}},
+        "mood_electronic": {"all": {"electronic": "mood_electronic"}},
+        "mood_happy": {"all": {"happy": "mood_happy"}},
+        "mood_party": {"all": {"party": "mood_party"}},
+        "mood_relaxed": {"all": {"relaxed": "mood_relaxed"}},
+        "mood_sad": {"all": {"sad": "mood_sad"}},
+        "moods_mirex": {"value": "moods_mirex"},
+        "ismir04_rhythm": {"value": "rhythm"},
+        "tonal_atonal": {"all": {"tonal": "tonal"}},
+        "timbre": {"value": "timbre"},
+        "voice_instrumental": {"value": "voice_instrumental"},
     },
-    'lowlevel': {
-        'average_loudness': 'average_loudness'
+    "lowlevel": {"average_loudness": "average_loudness"},
+    "rhythm": {"bpm": "bpm"},
+    "tonal": {
+        "chords_changes_rate": "chords_changes_rate",
+        "chords_key": "chords_key",
+        "chords_number_rate": "chords_number_rate",
+        "chords_scale": "chords_scale",
+        "key_key": ("initial_key", 0),
+        "key_scale": ("initial_key", 1),
+        "key_strength": "key_strength",
     },
-    'rhythm': {
-        'bpm': 'bpm'
-    },
-    'tonal': {
-        'chords_changes_rate': 'chords_changes_rate',
-        'chords_key': 'chords_key',
-        'chords_number_rate': 'chords_number_rate',
-        'chords_scale': 'chords_scale',
-        'key_key': ('initial_key', 0),
-        'key_scale': ('initial_key', 1),
-        'key_strength': 'key_strength'
-
-    }
 }
 
 
 class AcousticPlugin(plugins.BeetsPlugin):
     item_types = {
-        'average_loudness': types.Float(6),
-        'chords_changes_rate': types.Float(6),
-        'chords_key': types.STRING,
-        'chords_number_rate': types.Float(6),
-        'chords_scale': types.STRING,
-        'danceable': types.Float(6),
-        'gender': types.STRING,
-        'genre_rosamerica': types.STRING,
-        'initial_key': types.STRING,
-        'key_strength': types.Float(6),
-        'mood_acoustic': types.Float(6),
-        'mood_aggressive': types.Float(6),
-        'mood_electronic': types.Float(6),
-        'mood_happy': types.Float(6),
-        'mood_party': types.Float(6),
-        'mood_relaxed': types.Float(6),
-        'mood_sad': types.Float(6),
-        'moods_mirex': types.STRING,
-        'rhythm': types.Float(6),
-        'timbre': types.STRING,
-        'tonal': types.Float(6),
-        'voice_instrumental': types.STRING,
+        "average_loudness": types.Float(6),
+        "chords_changes_rate": types.Float(6),
+        "chords_key": types.STRING,
+        "chords_number_rate": types.Float(6),
+        "chords_scale": types.STRING,
+        "danceable": types.Float(6),
+        "gender": types.STRING,
+        "genre_rosamerica": types.STRING,
+        "initial_key": types.STRING,
+        "key_strength": types.Float(6),
+        "mood_acoustic": types.Float(6),
+        "mood_aggressive": types.Float(6),
+        "mood_electronic": types.Float(6),
+        "mood_happy": types.Float(6),
+        "mood_party": types.Float(6),
+        "mood_relaxed": types.Float(6),
+        "mood_sad": types.Float(6),
+        "moods_mirex": types.STRING,
+        "rhythm": types.Float(6),
+        "timbre": types.STRING,
+        "tonal": types.Float(6),
+        "voice_instrumental": types.STRING,
     }
 
     def __init__(self):
         super(AcousticPlugin, self).__init__()
 
-        self.config.add({
-            'auto': True,
-            'force': False,
-            'tags': []
-        })
+        self.config.add({"auto": True, "force": False, "tags": []})
 
-        if self.config['auto']:
-            self.register_listener('import_task_files',
-                                   self.import_task_files)
+        if self.config["auto"]:
+            self.register_listener("import_task_files", self.import_task_files)
 
     def commands(self):
-        cmd = ui.Subcommand('acousticbrainz',
-                            help=u"fetch metadata from AcousticBrainz")
+        cmd = ui.Subcommand(
+            "acousticbrainz", help=u"fetch metadata from AcousticBrainz"
+        )
         cmd.parser.add_option(
-            u'-f', u'--force', dest='force_refetch',
-            action='store_true', default=False,
-            help=u're-download data when already present'
+            u"-f",
+            u"--force",
+            dest="force_refetch",
+            action="store_true",
+            default=False,
+            help=u"re-download data when already present",
         )
 
         def func(lib, opts, args):
             items = lib.items(ui.decargs(args))
-            self._fetch_info(items, ui.should_write(),
-                             opts.force_refetch or self.config['force'])
+            self._fetch_info(
+                items,
+                ui.should_write(),
+                opts.force_refetch or self.config["force"],
+            )
 
         cmd.func = func
         return [cmd]
@@ -175,22 +124,22 @@ class AcousticPlugin(plugins.BeetsPlugin):
     def _get_data(self, mbid):
         data = {}
         for url in _generate_urls(mbid):
-            self._log.debug(u'fetching URL: {}', url)
+            self._log.debug(u"fetching URL: {}", url)
 
             try:
                 res = requests.get(url)
             except requests.RequestException as exc:
-                self._log.info(u'request error: {}', exc)
+                self._log.info(u"request error: {}", exc)
                 return {}
 
             if res.status_code == 404:
-                self._log.info(u'recording ID {} not found', mbid)
+                self._log.info(u"recording ID {} not found", mbid)
                 return {}
 
             try:
                 data.update(res.json())
             except ValueError:
-                self._log.debug(u'Invalid Response: {}', res.text)
+                self._log.debug(u"Invalid Response: {}", res.text)
                 return {}
 
         return data
@@ -198,38 +147,39 @@ class AcousticPlugin(plugins.BeetsPlugin):
     def _fetch_info(self, items, write, force):
         """Fetch additional information from AcousticBrainz for the `item`s.
         """
-        tags = self.config['tags'].as_str_seq()
+        tags = self.config["tags"].as_str_seq()
         for item in items:
             # If we're not forcing re-downloading for all tracks, check
             # whether the data is already present. We use one
             # representative field name to check for previously fetched
             # data.
             if not force:
-                mood_str = item.get('mood_acoustic', u'')
+                mood_str = item.get("mood_acoustic", u"")
                 if mood_str:
-                    self._log.info(u'data already present for: {}', item)
+                    self._log.info(u"data already present for: {}", item)
                     continue
 
             # We can only fetch data for tracks with MBIDs.
             if not item.mb_trackid:
                 continue
 
-            self._log.info(u'getting data for: {}', item)
+            self._log.info(u"getting data for: {}", item)
             data = self._get_data(item.mb_trackid)
             if data:
                 for attr, val in self._map_data_to_scheme(data, ABSCHEME):
                     if not tags or attr in tags:
-                        self._log.debug(u'attribute {} of {} set to {}',
-                                        attr,
-                                        item,
-                                        val)
+                        self._log.debug(
+                            u"attribute {} of {} set to {}", attr, item, val
+                        )
                         setattr(item, attr, val)
                     else:
-                        self._log.debug(u'skipping attribute {} of {}'
-                                        u' (value {}) due to config',
-                                        attr,
-                                        item,
-                                        val)
+                        self._log.debug(
+                            u"skipping attribute {} of {}"
+                            u" (value {}) due to config",
+                            attr,
+                            item,
+                            val,
+                        )
                 item.store()
                 if write:
                     item.try_write()
@@ -288,15 +238,13 @@ class AcousticPlugin(plugins.BeetsPlugin):
 
         # The recursive traversal.
         composites = defaultdict(list)
-        for attr, val in self._data_to_scheme_child(data,
-                                                    scheme,
-                                                    composites):
+        for attr, val in self._data_to_scheme_child(data, scheme, composites):
             yield attr, val
 
         # When composites has been populated, yield the composite attributes
         # by joining their parts.
         for composite_attr, value_parts in composites.items():
-            yield composite_attr, ' '.join(value_parts)
+            yield composite_attr, " ".join(value_parts)
 
     def _data_to_scheme_child(self, subdata, subscheme, composites):
         """The recursive business logic of :meth:`_map_data_to_scheme`:
@@ -311,24 +259,30 @@ class AcousticPlugin(plugins.BeetsPlugin):
         for k, v in subscheme.items():
             if k in subdata:
                 if type(v) == dict:
-                    for attr, val in self._data_to_scheme_child(subdata[k],
-                                                                v,
-                                                                composites):
+                    for attr, val in self._data_to_scheme_child(
+                        subdata[k], v, composites
+                    ):
                         yield attr, val
                 elif type(v) == tuple:
                     composite_attribute, part_number = v
                     attribute_parts = composites[composite_attribute]
                     # Parts are not guaranteed to be inserted in order
                     while len(attribute_parts) <= part_number:
-                        attribute_parts.append('')
+                        attribute_parts.append("")
                     attribute_parts[part_number] = subdata[k]
                 else:
                     yield v, subdata[k]
             else:
-                self._log.warning(u'Acousticbrainz did not provide info'
-                                  u'about {}', k)
-                self._log.debug(u'Data {} could not be mapped to scheme {} '
-                                u'because key {} was not found', subdata, v, k)
+                self._log.warning(
+                    u"Acousticbrainz did not provide info" u"about {}", k
+                )
+                self._log.debug(
+                    u"Data {} could not be mapped to scheme {} "
+                    u"because key {} was not found",
+                    subdata,
+                    v,
+                    k,
+                )
 
 
 def _generate_urls(mbid):

--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -55,8 +55,9 @@ class BadFiles(BeetsPlugin):
         self.verbose = False
 
     def run_command(self, cmd):
-        self._log.debug(u"running command: {}",
-                        displayable_path(list2cmdline(cmd)))
+        self._log.debug(
+            u"running command: {}", displayable_path(list2cmdline(cmd))
+        )
         try:
             output = check_output(cmd, stderr=STDOUT)
             errors = 0
@@ -67,7 +68,7 @@ class BadFiles(BeetsPlugin):
             status = e.returncode
         except OSError as e:
             raise CheckerCommandException(cmd, e)
-        output = output.decode(sys.getdefaultencoding(), 'replace')
+        output = output.decode(sys.getdefaultencoding(), "replace")
         return status, errors, [line for line in output.split("\n") if line]
 
     def check_mp3val(self, path):
@@ -85,12 +86,13 @@ class BadFiles(BeetsPlugin):
             cmd = shlex.split(command)
             cmd.append(path)
             return self.run_command(cmd)
+
         return checker
 
     def get_checker(self, ext):
         ext = ext.lower()
         try:
-            command = self.config['commands'].get(dict).get(ext)
+            command = self.config["commands"].get(dict).get(ext)
         except confuse.NotFoundError:
             command = None
         if command:
@@ -106,15 +108,17 @@ class BadFiles(BeetsPlugin):
         dpath = displayable_path(item.path)
         self._log.debug(u"checking path: {}", dpath)
         if not os.path.exists(item.path):
-            ui.print_(u"{}: file does not exist".format(
-                ui.colorize('text_error', dpath)))
+            ui.print_(
+                u"{}: file does not exist".format(
+                    ui.colorize("text_error", dpath)
+                )
+            )
 
         # Run the checker against the file if one is found
-        ext = os.path.splitext(item.path)[1][1:].decode('utf8', 'ignore')
+        ext = os.path.splitext(item.path)[1][1:].decode("utf8", "ignore")
         checker = self.get_checker(ext)
         if not checker:
-            self._log.error(u"no checker specified in the config for {}",
-                            ext)
+            self._log.error(u"no checker specified in the config for {}", ext)
             return
         path = item.path
         if not isinstance(path, six.text_type):
@@ -126,23 +130,29 @@ class BadFiles(BeetsPlugin):
                 self._log.error(
                     u"command not found: {} when validating file: {}",
                     e.checker,
-                    e.path
+                    e.path,
                 )
             else:
                 self._log.error(u"error invoking {}: {}", e.checker, e.msg)
             return
         if status > 0:
-            ui.print_(u"{}: checker exited with status {}"
-                      .format(ui.colorize('text_error', dpath), status))
+            ui.print_(
+                u"{}: checker exited with status {}".format(
+                    ui.colorize("text_error", dpath), status
+                )
+            )
             for line in output:
                 ui.print_(u"  {}".format(line))
         elif errors > 0:
-            ui.print_(u"{}: checker found {} errors or warnings"
-                      .format(ui.colorize('text_warning', dpath), errors))
+            ui.print_(
+                u"{}: checker found {} errors or warnings".format(
+                    ui.colorize("text_warning", dpath), errors
+                )
+            )
             for line in output:
                 ui.print_(u"  {}".format(line))
         elif self.verbose:
-            ui.print_(u"{}: ok".format(ui.colorize('text_success', dpath)))
+            ui.print_(u"{}: ok".format(ui.colorize("text_success", dpath)))
 
     def command(self, lib, opts, args):
         # Get items from arguments
@@ -151,12 +161,16 @@ class BadFiles(BeetsPlugin):
         par_map(self.check_item, items)
 
     def commands(self):
-        bad_command = Subcommand('bad',
-                                 help=u'check for corrupt or missing files')
+        bad_command = Subcommand(
+            "bad", help=u"check for corrupt or missing files"
+        )
         bad_command.parser.add_option(
-            u'-v', u'--verbose',
-            action='store_true', default=False, dest='verbose',
-            help=u'view results for both the bad and uncorrupted files'
+            u"-v",
+            u"--verbose",
+            action="store_true",
+            default=False,
+            dest="verbose",
+            help=u"view results for both the bad and uncorrupted files",
         )
         bad_command.func = self.command
         return [bad_command]

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -23,8 +23,11 @@ import six
 from datetime import datetime, timedelta
 
 from requests_oauthlib import OAuth1Session
-from requests_oauthlib.oauth1_session import (TokenRequestDenied, TokenMissing,
-                                              VerifierMissing)
+from requests_oauthlib.oauth1_session import (
+    TokenRequestDenied,
+    TokenMissing,
+    VerifierMissing,
+)
 
 import beets
 import beets.ui
@@ -34,7 +37,7 @@ import confuse
 
 
 AUTH_ERRORS = (TokenRequestDenied, TokenMissing, VerifierMissing)
-USER_AGENT = u'beets/{0} +https://beets.io/'.format(beets.__version__)
+USER_AGENT = u"beets/{0} +https://beets.io/".format(beets.__version__)
 
 
 class BeatportAPIError(Exception):
@@ -43,21 +46,22 @@ class BeatportAPIError(Exception):
 
 class BeatportObject(object):
     def __init__(self, data):
-        self.beatport_id = data['id']
-        self.name = six.text_type(data['name'])
-        if 'releaseDate' in data:
-            self.release_date = datetime.strptime(data['releaseDate'],
-                                                  '%Y-%m-%d')
-        if 'artists' in data:
-            self.artists = [(x['id'], six.text_type(x['name']))
-                            for x in data['artists']]
-        if 'genres' in data:
-            self.genres = [six.text_type(x['name'])
-                           for x in data['genres']]
+        self.beatport_id = data["id"]
+        self.name = six.text_type(data["name"])
+        if "releaseDate" in data:
+            self.release_date = datetime.strptime(
+                data["releaseDate"], "%Y-%m-%d"
+            )
+        if "artists" in data:
+            self.artists = [
+                (x["id"], six.text_type(x["name"])) for x in data["artists"]
+            ]
+        if "genres" in data:
+            self.genres = [six.text_type(x["name"]) for x in data["genres"]]
 
 
 class BeatportClient(object):
-    _api_base = 'https://oauth-api.beatport.com'
+    _api_base = "https://oauth-api.beatport.com"
 
     def __init__(self, c_key, c_secret, auth_key=None, auth_secret=None):
         """ Initiate the client with OAuth information.
@@ -72,11 +76,13 @@ class BeatportClient(object):
         :param auth_secret: OAuth1 resource owner secret
         """
         self.api = OAuth1Session(
-            client_key=c_key, client_secret=c_secret,
+            client_key=c_key,
+            client_secret=c_secret,
             resource_owner_key=auth_key,
             resource_owner_secret=auth_secret,
-            callback_uri='oob')
-        self.api.headers = {'User-Agent': USER_AGENT}
+            callback_uri="oob",
+        )
+        self.api.headers = {"User-Agent": USER_AGENT}
 
     def get_authorize_url(self):
         """ Generate the URL for the user to authorize the application.
@@ -94,9 +100,11 @@ class BeatportClient(object):
         :rtype:     unicode
         """
         self.api.fetch_request_token(
-            self._make_url('/identity/1/oauth/request-token'))
+            self._make_url("/identity/1/oauth/request-token")
+        )
         return self.api.authorization_url(
-            self._make_url('/identity/1/oauth/authorize'))
+            self._make_url("/identity/1/oauth/authorize")
+        )
 
     def get_access_token(self, auth_data):
         """ Obtain the final access token and secret for the API.
@@ -109,12 +117,14 @@ class BeatportClient(object):
         :rtype:             (unicode, unicode) tuple
         """
         self.api.parse_authorization_response(
-            "https://beets.io/auth?" + auth_data)
+            "https://beets.io/auth?" + auth_data
+        )
         access_data = self.api.fetch_access_token(
-            self._make_url('/identity/1/oauth/access-token'))
-        return access_data['oauth_token'], access_data['oauth_token_secret']
+            self._make_url("/identity/1/oauth/access-token")
+        )
+        return access_data["oauth_token"], access_data["oauth_token_secret"]
 
-    def search(self, query, release_type='release', details=True):
+    def search(self, query, release_type="release", details=True):
         """ Perform a search of the Beatport catalogue.
 
         :param query:           Query string
@@ -129,17 +139,20 @@ class BeatportClient(object):
                                 py:class:`BeatportRelease` or
                                 :py:class:`BeatportTrack`
         """
-        response = self._get('catalog/3/search',
-                             query=query, perPage=5,
-                             facets=['fieldType:{0}'.format(release_type)])
+        response = self._get(
+            "catalog/3/search",
+            query=query,
+            perPage=5,
+            facets=["fieldType:{0}".format(release_type)],
+        )
         for item in response:
-            if release_type == 'release':
+            if release_type == "release":
                 if details:
-                    release = self.get_release(item['id'])
+                    release = self.get_release(item["id"])
                 else:
                     release = BeatportRelease(item)
                 yield release
-            elif release_type == 'track':
+            elif release_type == "track":
                 yield BeatportTrack(item)
 
     def get_release(self, beatport_id):
@@ -149,7 +162,7 @@ class BeatportClient(object):
         :returns:               The matching release
         :rtype:                 :py:class:`BeatportRelease`
         """
-        response = self._get('/catalog/3/releases', id=beatport_id)
+        response = self._get("/catalog/3/releases", id=beatport_id)
         if response:
             release = BeatportRelease(response[0])
             release.tracks = self.get_release_tracks(beatport_id)
@@ -163,8 +176,9 @@ class BeatportClient(object):
         :returns:               Tracks in the matching release
         :rtype:                 list of :py:class:`BeatportTrack`
         """
-        response = self._get('/catalog/3/tracks', releaseId=beatport_id,
-                             perPage=100)
+        response = self._get(
+            "/catalog/3/tracks", releaseId=beatport_id, perPage=100
+        )
         return [BeatportTrack(t) for t in response]
 
     def get_track(self, beatport_id):
@@ -174,13 +188,13 @@ class BeatportClient(object):
         :returns:               The matching track
         :rtype:                 :py:class:`BeatportTrack`
         """
-        response = self._get('/catalog/3/tracks', id=beatport_id)
+        response = self._get("/catalog/3/tracks", id=beatport_id)
         return BeatportTrack(response[0])
 
     def _make_url(self, endpoint):
         """ Get complete URL for a given API endpoint. """
-        if not endpoint.startswith('/'):
-            endpoint = '/' + endpoint
+        if not endpoint.startswith("/"):
+            endpoint = "/" + endpoint
         return self._api_base + endpoint
 
     def _get(self, endpoint, **kwargs):
@@ -192,13 +206,16 @@ class BeatportClient(object):
         try:
             response = self.api.get(self._make_url(endpoint), params=kwargs)
         except Exception as e:
-            raise BeatportAPIError("Error connecting to Beatport API: {}"
-                                   .format(e))
+            raise BeatportAPIError(
+                "Error connecting to Beatport API: {}".format(e)
+            )
         if not response:
             raise BeatportAPIError(
-                "Error {0.status_code} for '{0.request.path_url}"
-                .format(response))
-        return response.json()['results']
+                "Error {0.status_code} for '{0.request.path_url}".format(
+                    response
+                )
+            )
+        return response.json()["results"]
 
 
 @six.python_2_unicode_compatible
@@ -209,86 +226,89 @@ class BeatportRelease(BeatportObject):
         else:
             artist_str = "Various Artists"
         return u"<BeatportRelease: {0} - {1} ({2})>".format(
-            artist_str,
-            self.name,
-            self.catalog_number,
+            artist_str, self.name, self.catalog_number,
         )
 
     def __repr__(self):
-        return six.text_type(self).encode('utf-8')
+        return six.text_type(self).encode("utf-8")
 
     def __init__(self, data):
         BeatportObject.__init__(self, data)
-        if 'catalogNumber' in data:
-            self.catalog_number = data['catalogNumber']
-        if 'label' in data:
-            self.label_name = data['label']['name']
-        if 'category' in data:
-            self.category = data['category']
-        if 'slug' in data:
+        if "catalogNumber" in data:
+            self.catalog_number = data["catalogNumber"]
+        if "label" in data:
+            self.label_name = data["label"]["name"]
+        if "category" in data:
+            self.category = data["category"]
+        if "slug" in data:
             self.url = "https://beatport.com/release/{0}/{1}".format(
-                data['slug'], data['id'])
-        self.genre = data.get('genre')
+                data["slug"], data["id"]
+            )
+        self.genre = data.get("genre")
 
 
 @six.python_2_unicode_compatible
 class BeatportTrack(BeatportObject):
     def __str__(self):
         artist_str = ", ".join(x[1] for x in self.artists)
-        return (u"<BeatportTrack: {0} - {1} ({2})>"
-                .format(artist_str, self.name, self.mix_name))
+        return u"<BeatportTrack: {0} - {1} ({2})>".format(
+            artist_str, self.name, self.mix_name
+        )
 
     def __repr__(self):
-        return six.text_type(self).encode('utf-8')
+        return six.text_type(self).encode("utf-8")
 
     def __init__(self, data):
         BeatportObject.__init__(self, data)
-        if 'title' in data:
-            self.title = six.text_type(data['title'])
-        if 'mixName' in data:
-            self.mix_name = six.text_type(data['mixName'])
-        self.length = timedelta(milliseconds=data.get('lengthMs', 0) or 0)
+        if "title" in data:
+            self.title = six.text_type(data["title"])
+        if "mixName" in data:
+            self.mix_name = six.text_type(data["mixName"])
+        self.length = timedelta(milliseconds=data.get("lengthMs", 0) or 0)
         if not self.length:
             try:
-                min, sec = data.get('length', '0:0').split(':')
+                min, sec = data.get("length", "0:0").split(":")
                 self.length = timedelta(minutes=int(min), seconds=int(sec))
             except ValueError:
                 pass
-        if 'slug' in data:
-            self.url = "https://beatport.com/track/{0}/{1}" \
-                .format(data['slug'], data['id'])
-        self.track_number = data.get('trackNumber')
-        self.bpm = data.get('bpm')
+        if "slug" in data:
+            self.url = "https://beatport.com/track/{0}/{1}".format(
+                data["slug"], data["id"]
+            )
+        self.track_number = data.get("trackNumber")
+        self.bpm = data.get("bpm")
         self.initial_key = six.text_type(
-            (data.get('key') or {}).get('shortName')
+            (data.get("key") or {}).get("shortName")
         )
 
         # Use 'subgenre' and if not present, 'genre' as a fallback.
-        if data.get('subGenres'):
-            self.genre = six.text_type(data['subGenres'][0].get('name'))
-        elif data.get('genres'):
-            self.genre = six.text_type(data['genres'][0].get('name'))
+        if data.get("subGenres"):
+            self.genre = six.text_type(data["subGenres"][0].get("name"))
+        elif data.get("genres"):
+            self.genre = six.text_type(data["genres"][0].get("name"))
 
 
 class BeatportPlugin(BeetsPlugin):
-    data_source = 'Beatport'
+    data_source = "Beatport"
 
     def __init__(self):
         super(BeatportPlugin, self).__init__()
-        self.config.add({
-            'apikey': '57713c3906af6f5def151b33601389176b37b429',
-            'apisecret': 'b3fe08c93c80aefd749fe871a16cd2bb32e2b954',
-            'tokenfile': 'beatport_token.json',
-            'source_weight': 0.5,
-        })
-        self.config['apikey'].redact = True
-        self.config['apisecret'].redact = True
+        self.config.add(
+            {
+                "apikey": "57713c3906af6f5def151b33601389176b37b429",
+                "apisecret": "b3fe08c93c80aefd749fe871a16cd2bb32e2b954",
+                "tokenfile": "beatport_token.json",
+                "source_weight": 0.5,
+            }
+        )
+        self.config["apikey"].redact = True
+        self.config["apisecret"].redact = True
         self.client = None
-        self.register_listener('import_begin', self.setup)
+        self.register_listener("import_begin", self.setup)
 
     def setup(self, session=None):
-        c_key = self.config['apikey'].as_str()
-        c_secret = self.config['apisecret'].as_str()
+        c_key = self.config["apikey"].as_str()
+        c_secret = self.config["apisecret"].as_str()
 
         # Get the OAuth token from a file or log in.
         try:
@@ -298,8 +318,8 @@ class BeatportPlugin(BeetsPlugin):
             # No token yet. Generate one.
             token, secret = self.authenticate(c_key, c_secret)
         else:
-            token = tokendata['token']
-            secret = tokendata['secret']
+            token = tokendata["token"]
+            secret = tokendata["secret"]
 
         self.client = BeatportClient(c_key, c_secret, token, secret)
 
@@ -309,8 +329,8 @@ class BeatportPlugin(BeetsPlugin):
         try:
             url = auth_client.get_authorize_url()
         except AUTH_ERRORS as e:
-            self._log.debug(u'authentication error: {0}', e)
-            raise beets.ui.UserError(u'communication with Beatport failed')
+            self._log.debug(u"authentication error: {0}", e)
+            raise beets.ui.UserError(u"communication with Beatport failed")
 
         beets.ui.print_(u"To authenticate with Beatport, visit:")
         beets.ui.print_(url)
@@ -320,29 +340,27 @@ class BeatportPlugin(BeetsPlugin):
         try:
             token, secret = auth_client.get_access_token(data)
         except AUTH_ERRORS as e:
-            self._log.debug(u'authentication error: {0}', e)
-            raise beets.ui.UserError(u'Beatport token request failed')
+            self._log.debug(u"authentication error: {0}", e)
+            raise beets.ui.UserError(u"Beatport token request failed")
 
         # Save the token for later use.
-        self._log.debug(u'Beatport token {0}, secret {1}', token, secret)
-        with open(self._tokenfile(), 'w') as f:
-            json.dump({'token': token, 'secret': secret}, f)
+        self._log.debug(u"Beatport token {0}, secret {1}", token, secret)
+        with open(self._tokenfile(), "w") as f:
+            json.dump({"token": token, "secret": secret}, f)
 
         return token, secret
 
     def _tokenfile(self):
         """Get the path to the JSON file for storing the OAuth token.
         """
-        return self.config['tokenfile'].get(confuse.Filename(in_app_dir=True))
+        return self.config["tokenfile"].get(confuse.Filename(in_app_dir=True))
 
     def album_distance(self, items, album_info, mapping):
         """Returns the Beatport source weight and the maximum source weight
         for albums.
         """
         return get_distance(
-            data_source=self.data_source,
-            info=album_info,
-            config=self.config
+            data_source=self.data_source, info=album_info, config=self.config
         )
 
     def track_distance(self, item, track_info):
@@ -350,9 +368,7 @@ class BeatportPlugin(BeetsPlugin):
         for individual tracks.
         """
         return get_distance(
-            data_source=self.data_source,
-            info=track_info,
-            config=self.config
+            data_source=self.data_source, info=track_info, config=self.config
         )
 
     def candidates(self, items, artist, release, va_likely, extra_tags=None):
@@ -362,32 +378,32 @@ class BeatportPlugin(BeetsPlugin):
         if va_likely:
             query = release
         else:
-            query = '%s %s' % (artist, release)
+            query = "%s %s" % (artist, release)
         try:
             return self._get_releases(query)
         except BeatportAPIError as e:
-            self._log.debug(u'API Error: {0} (query: {1})', e, query)
+            self._log.debug(u"API Error: {0} (query: {1})", e, query)
             return []
 
     def item_candidates(self, item, artist, title):
         """Returns a list of TrackInfo objects for beatport search results
         matching title and artist.
         """
-        query = '%s %s' % (artist, title)
+        query = "%s %s" % (artist, title)
         try:
             return self._get_tracks(query)
         except BeatportAPIError as e:
-            self._log.debug(u'API Error: {0} (query: {1})', e, query)
+            self._log.debug(u"API Error: {0} (query: {1})", e, query)
             return []
 
     def album_for_id(self, release_id):
         """Fetches a release by its Beatport ID and returns an AlbumInfo object
         or None if the query is not a valid ID or release is not found.
         """
-        self._log.debug(u'Searching for release {0}', release_id)
-        match = re.search(r'(^|beatport\.com/release/.+/)(\d+)$', release_id)
+        self._log.debug(u"Searching for release {0}", release_id)
+        match = re.search(r"(^|beatport\.com/release/.+/)(\d+)$", release_id)
         if not match:
-            self._log.debug(u'Not a valid Beatport release ID.')
+            self._log.debug(u"Not a valid Beatport release ID.")
             return None
         release = self.client.get_release(match.group(2))
         if release:
@@ -398,10 +414,10 @@ class BeatportPlugin(BeetsPlugin):
         """Fetches a track by its Beatport ID and returns a TrackInfo object
         or None if the track is not a valid Beatport ID or track is not found.
         """
-        self._log.debug(u'Searching for track {0}', track_id)
-        match = re.search(r'(^|beatport\.com/track/.+/)(\d+)$', track_id)
+        self._log.debug(u"Searching for track {0}", track_id)
+        match = re.search(r"(^|beatport\.com/track/.+/)(\d+)$", track_id)
         if not match:
-            self._log.debug(u'Not a valid Beatport track ID.')
+            self._log.debug(u"Not a valid Beatport track ID.")
             return None
         bp_track = self.client.get_track(match.group(2))
         if bp_track is not None:
@@ -415,12 +431,11 @@ class BeatportPlugin(BeetsPlugin):
         # cause a query to return no results, even if they match the artist or
         # album title. Use `re.UNICODE` flag to avoid stripping non-english
         # word characters.
-        query = re.sub(r'\W+', ' ', query, flags=re.UNICODE)
+        query = re.sub(r"\W+", " ", query, flags=re.UNICODE)
         # Strip medium information from query, Things like "CD1" and "disk 1"
         # can also negate an otherwise positive result.
-        query = re.sub(r'\b(CD|disc)\s*\d+', '', query, flags=re.I)
-        albums = [self._get_album_info(x)
-                  for x in self.client.search(query)]
+        query = re.sub(r"\b(CD|disc)\s*\d+", "", query, flags=re.I)
+        albums = [self._get_album_info(x) for x in self.client.search(query)]
         return albums
 
     def _get_album_info(self, release):
@@ -432,16 +447,24 @@ class BeatportPlugin(BeetsPlugin):
             artist = u"Various Artists"
         tracks = [self._get_track_info(x) for x in release.tracks]
 
-        return AlbumInfo(album=release.name, album_id=release.beatport_id,
-                         artist=artist, artist_id=artist_id, tracks=tracks,
-                         albumtype=release.category, va=va,
-                         year=release.release_date.year,
-                         month=release.release_date.month,
-                         day=release.release_date.day,
-                         label=release.label_name,
-                         catalognum=release.catalog_number, media=u'Digital',
-                         data_source=self.data_source, data_url=release.url,
-                         genre=release.genre)
+        return AlbumInfo(
+            album=release.name,
+            album_id=release.beatport_id,
+            artist=artist,
+            artist_id=artist_id,
+            tracks=tracks,
+            albumtype=release.category,
+            va=va,
+            year=release.release_date.year,
+            month=release.release_date.month,
+            day=release.release_date.day,
+            label=release.label_name,
+            catalognum=release.catalog_number,
+            media=u"Digital",
+            data_source=self.data_source,
+            data_url=release.url,
+            genre=release.genre,
+        )
 
     def _get_track_info(self, track):
         """Returns a TrackInfo object for a Beatport Track object.
@@ -451,13 +474,20 @@ class BeatportPlugin(BeetsPlugin):
             title += u" ({0})".format(track.mix_name)
         artist, artist_id = self._get_artist(track.artists)
         length = track.length.total_seconds()
-        return TrackInfo(title=title, track_id=track.beatport_id,
-                         artist=artist, artist_id=artist_id,
-                         length=length, index=track.track_number,
-                         medium_index=track.track_number,
-                         data_source=self.data_source, data_url=track.url,
-                         bpm=track.bpm, initial_key=track.initial_key,
-                         genre=track.genre)
+        return TrackInfo(
+            title=title,
+            track_id=track.beatport_id,
+            artist=artist,
+            artist_id=artist_id,
+            length=length,
+            index=track.track_number,
+            medium_index=track.track_number,
+            data_source=self.data_source,
+            data_url=track.url,
+            bpm=track.bpm,
+            initial_key=track.initial_key,
+            genre=track.genre,
+        )
 
     def _get_artist(self, artists):
         """Returns an artist string (all artists) and an artist_id (the main
@@ -470,6 +500,6 @@ class BeatportPlugin(BeetsPlugin):
     def _get_tracks(self, query):
         """Returns a list of TrackInfo objects for a Beatport query.
         """
-        bp_tracks = self.client.search(query, release_type='track')
+        bp_tracks = self.client.search(query, release_type="track")
         tracks = [self._get_track_info(x) for x in bp_tracks]
         return tracks

--- a/beetsplug/bench.py
+++ b/beetsplug/bench.py
@@ -36,74 +36,104 @@ def aunique_benchmark(lib, prof):
 
     # Measure path generation performance with %aunique{} included.
     lib.path_formats = [
-        (library.PF_KEY_DEFAULT,
-         Template('$albumartist/$album%aunique{}/$track $title')),
+        (
+            library.PF_KEY_DEFAULT,
+            Template("$albumartist/$album%aunique{}/$track $title"),
+        ),
     ]
     if prof:
-        cProfile.runctx('_build_tree()', {}, {'_build_tree': _build_tree},
-                        'paths.withaunique.prof')
+        cProfile.runctx(
+            "_build_tree()",
+            {},
+            {"_build_tree": _build_tree},
+            "paths.withaunique.prof",
+        )
     else:
         interval = timeit.timeit(_build_tree, number=1)
-        print('With %aunique:', interval)
+        print("With %aunique:", interval)
 
     # And with %aunique replaceed with a "cheap" no-op function.
     lib.path_formats = [
-        (library.PF_KEY_DEFAULT,
-         Template('$albumartist/$album%lower{}/$track $title')),
+        (
+            library.PF_KEY_DEFAULT,
+            Template("$albumartist/$album%lower{}/$track $title"),
+        ),
     ]
     if prof:
-        cProfile.runctx('_build_tree()', {}, {'_build_tree': _build_tree},
-                        'paths.withoutaunique.prof')
+        cProfile.runctx(
+            "_build_tree()",
+            {},
+            {"_build_tree": _build_tree},
+            "paths.withoutaunique.prof",
+        )
     else:
         interval = timeit.timeit(_build_tree, number=1)
-        print('Without %aunique:', interval)
+        print("Without %aunique:", interval)
 
 
 def match_benchmark(lib, prof, query=None, album_id=None):
     # If no album ID is provided, we'll match against a suitably huge
     # album.
     if not album_id:
-        album_id = '9c5c043e-bc69-4edb-81a4-1aaf9c81e6dc'
+        album_id = "9c5c043e-bc69-4edb-81a4-1aaf9c81e6dc"
 
     # Get an album from the library to use as the source for the match.
     items = lib.albums(query).get().items()
 
     # Ensure fingerprinting is invoked (if enabled).
-    plugins.send('import_task_start',
-                 task=importer.ImportTask(None, None, items),
-                 session=importer.ImportSession(lib, None, None, None))
+    plugins.send(
+        "import_task_start",
+        task=importer.ImportTask(None, None, items),
+        session=importer.ImportSession(lib, None, None, None),
+    )
 
     # Run the match.
     def _run_match():
         match.tag_album(items, search_ids=[album_id])
+
     if prof:
-        cProfile.runctx('_run_match()', {}, {'_run_match': _run_match},
-                        'match.prof')
+        cProfile.runctx(
+            "_run_match()", {}, {"_run_match": _run_match}, "match.prof"
+        )
     else:
         interval = timeit.timeit(_run_match, number=1)
-        print('match duration:', interval)
+        print("match duration:", interval)
 
 
 class BenchmarkPlugin(BeetsPlugin):
     """A plugin for performing some simple performance benchmarks.
     """
-    def commands(self):
-        aunique_bench_cmd = ui.Subcommand('bench_aunique',
-                                          help='benchmark for %aunique{}')
-        aunique_bench_cmd.parser.add_option('-p', '--profile',
-                                            action='store_true', default=False,
-                                            help='performance profiling')
-        aunique_bench_cmd.func = lambda lib, opts, args: \
-            aunique_benchmark(lib, opts.profile)
 
-        match_bench_cmd = ui.Subcommand('bench_match',
-                                        help='benchmark for track matching')
-        match_bench_cmd.parser.add_option('-p', '--profile',
-                                          action='store_true', default=False,
-                                          help='performance profiling')
-        match_bench_cmd.parser.add_option('-i', '--id', default=None,
-                                          help='album ID to match against')
-        match_bench_cmd.func = lambda lib, opts, args: \
-            match_benchmark(lib, opts.profile, ui.decargs(args), opts.id)
+    def commands(self):
+        aunique_bench_cmd = ui.Subcommand(
+            "bench_aunique", help="benchmark for %aunique{}"
+        )
+        aunique_bench_cmd.parser.add_option(
+            "-p",
+            "--profile",
+            action="store_true",
+            default=False,
+            help="performance profiling",
+        )
+        aunique_bench_cmd.func = lambda lib, opts, args: aunique_benchmark(
+            lib, opts.profile
+        )
+
+        match_bench_cmd = ui.Subcommand(
+            "bench_match", help="benchmark for track matching"
+        )
+        match_bench_cmd.parser.add_option(
+            "-p",
+            "--profile",
+            action="store_true",
+            default=False,
+            help="performance profiling",
+        )
+        match_bench_cmd.parser.add_option(
+            "-i", "--id", default=None, help="album ID to match against"
+        )
+        match_bench_cmd.func = lambda lib, opts, args: match_benchmark(
+            lib, opts.profile, ui.decargs(args), opts.id
+        )
 
         return [aunique_bench_cmd, match_bench_cmd]

--- a/beetsplug/bpd/gstplayer.py
+++ b/beetsplug/bpd/gstplayer.py
@@ -29,7 +29,8 @@ from six.moves import urllib
 from beets import ui
 
 import gi
-gi.require_version('Gst', '1.0')
+
+gi.require_version("Gst", "1.0")
 from gi.repository import GLib, Gst  # noqa: E402
 
 
@@ -131,8 +132,8 @@ class GstPlayer(object):
         """
         self.player.set_state(Gst.State.NULL)
         if isinstance(path, six.text_type):
-            path = path.encode('utf-8')
-        uri = 'file://' + urllib.parse.quote(path)
+            path = path.encode("utf-8")
+        uri = "file://" + urllib.parse.quote(path)
         self.player.set_property("uri", uri)
         self.player.set_state(Gst.State.PLAYING)
         self.playing = True
@@ -226,11 +227,13 @@ def get_decoders():
     and file extensions.
     """
     # We only care about audio decoder elements.
-    filt = (Gst.ELEMENT_FACTORY_TYPE_DEPAYLOADER |
-            Gst.ELEMENT_FACTORY_TYPE_DEMUXER |
-            Gst.ELEMENT_FACTORY_TYPE_PARSER |
-            Gst.ELEMENT_FACTORY_TYPE_DECODER |
-            Gst.ELEMENT_FACTORY_TYPE_MEDIA_AUDIO)
+    filt = (
+        Gst.ELEMENT_FACTORY_TYPE_DEPAYLOADER
+        | Gst.ELEMENT_FACTORY_TYPE_DEMUXER
+        | Gst.ELEMENT_FACTORY_TYPE_PARSER
+        | Gst.ELEMENT_FACTORY_TYPE_DECODER
+        | Gst.ELEMENT_FACTORY_TYPE_MEDIA_AUDIO
+    )
 
     decoders = {}
     mime_types = set()
@@ -242,7 +245,7 @@ def get_decoders():
                 for i in range(caps.get_size()):
                     struct = caps.get_structure(i)
                     mime = struct.get_name()
-                    if mime == 'unknown/unknown':
+                    if mime == "unknown/unknown":
                         continue
                     mimes.add(mime)
                     mime_types.add(mime)
@@ -298,10 +301,9 @@ def play_complicated(paths):
         time.sleep(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # A very simple command-line player. Just give it names of audio
     # files on the command line; these are all played in sequence.
-    paths = [os.path.abspath(os.path.expanduser(p))
-             for p in sys.argv[1:]]
+    paths = [os.path.abspath(os.path.expanduser(p)) for p in sys.argv[1:]]
     # play_simple(paths)
     play_complicated(paths)

--- a/beetsplug/bpm.py
+++ b/beetsplug/bpm.py
@@ -33,7 +33,7 @@ def bpm(max_strokes):
     for i in range(max_strokes):
         # Press enter to the rhythm...
         s = input()
-        if s == '':
+        if s == "":
             t1 = time.time()
             # Only start measuring at the second stroke
             if t0:
@@ -49,18 +49,18 @@ def bpm(max_strokes):
 
 
 class BPMPlugin(BeetsPlugin):
-
     def __init__(self):
         super(BPMPlugin, self).__init__()
-        self.config.add({
-            u'max_strokes': 3,
-            u'overwrite': True,
-        })
+        self.config.add(
+            {u"max_strokes": 3, u"overwrite": True,}
+        )
 
     def commands(self):
-        cmd = ui.Subcommand('bpm',
-                            help=u'determine bpm of a song by pressing '
-                            u'a key to the rhythm')
+        cmd = ui.Subcommand(
+            "bpm",
+            help=u"determine bpm of a song by pressing "
+            u"a key to the rhythm",
+        )
         cmd.func = self.command
         return [cmd]
 
@@ -70,21 +70,23 @@ class BPMPlugin(BeetsPlugin):
         self.get_bpm(items, write)
 
     def get_bpm(self, items, write=False):
-        overwrite = self.config['overwrite'].get(bool)
+        overwrite = self.config["overwrite"].get(bool)
         if len(items) > 1:
-            raise ValueError(u'Can only get bpm of one song at time')
+            raise ValueError(u"Can only get bpm of one song at time")
 
         item = items[0]
-        if item['bpm']:
-            self._log.info(u'Found bpm {0}', item['bpm'])
+        if item["bpm"]:
+            self._log.info(u"Found bpm {0}", item["bpm"])
             if not overwrite:
                 return
 
-        self._log.info(u'Press Enter {0} times to the rhythm or Ctrl-D '
-                       u'to exit', self.config['max_strokes'].get(int))
-        new_bpm = bpm(self.config['max_strokes'].get(int))
-        item['bpm'] = int(new_bpm)
+        self._log.info(
+            u"Press Enter {0} times to the rhythm or Ctrl-D " u"to exit",
+            self.config["max_strokes"].get(int),
+        )
+        new_bpm = bpm(self.config["max_strokes"].get(int))
+        item["bpm"] = int(new_bpm)
         if write:
             item.try_write()
         item.store()
-        self._log.info(u'Added new bpm {0}', item['bpm'])
+        self._log.info(u"Added new bpm {0}", item["bpm"])

--- a/beetsplug/bpsync.py
+++ b/beetsplug/bpsync.py
@@ -30,33 +30,33 @@ class BPSyncPlugin(BeetsPlugin):
         self.beatport_plugin.setup()
 
     def commands(self):
-        cmd = ui.Subcommand('bpsync', help=u'update metadata from Beatport')
+        cmd = ui.Subcommand("bpsync", help=u"update metadata from Beatport")
         cmd.parser.add_option(
-            u'-p',
-            u'--pretend',
-            action='store_true',
-            help=u'show all changes but do nothing',
+            u"-p",
+            u"--pretend",
+            action="store_true",
+            help=u"show all changes but do nothing",
         )
         cmd.parser.add_option(
-            u'-m',
-            u'--move',
-            action='store_true',
-            dest='move',
+            u"-m",
+            u"--move",
+            action="store_true",
+            dest="move",
             help=u"move files in the library directory",
         )
         cmd.parser.add_option(
-            u'-M',
-            u'--nomove',
-            action='store_false',
-            dest='move',
+            u"-M",
+            u"--nomove",
+            action="store_false",
+            dest="move",
             help=u"don't move files in library",
         )
         cmd.parser.add_option(
-            u'-W',
-            u'--nowrite',
-            action='store_false',
+            u"-W",
+            u"--nowrite",
+            action="store_false",
             default=None,
-            dest='write',
+            dest="write",
             help=u"don't write updated metadata to files",
         )
         cmd.parser.add_format_option()
@@ -78,16 +78,16 @@ class BPSyncPlugin(BeetsPlugin):
         """Retrieve and apply info from the autotagger for items matched by
         query.
         """
-        for item in lib.items(query + [u'singleton:true']):
+        for item in lib.items(query + [u"singleton:true"]):
             if not item.mb_trackid:
                 self._log.info(
-                    u'Skipping singleton with no mb_trackid: {}', item
+                    u"Skipping singleton with no mb_trackid: {}", item
                 )
                 continue
 
             if not self.is_beatport_track(item):
                 self._log.info(
-                    u'Skipping non-{} singleton: {}',
+                    u"Skipping non-{} singleton: {}",
                     self.beatport_plugin.data_source,
                     item,
                 )
@@ -102,27 +102,27 @@ class BPSyncPlugin(BeetsPlugin):
     @staticmethod
     def is_beatport_track(item):
         return (
-            item.get('data_source') == BeatportPlugin.data_source
+            item.get("data_source") == BeatportPlugin.data_source
             and item.mb_trackid.isnumeric()
         )
 
     def get_album_tracks(self, album):
         if not album.mb_albumid:
-            self._log.info(u'Skipping album with no mb_albumid: {}', album)
+            self._log.info(u"Skipping album with no mb_albumid: {}", album)
             return False
         if not album.mb_albumid.isnumeric():
             self._log.info(
-                u'Skipping album with invalid {} ID: {}',
+                u"Skipping album with invalid {} ID: {}",
                 self.beatport_plugin.data_source,
                 album,
             )
             return False
         items = list(album.items())
-        if album.get('data_source') == self.beatport_plugin.data_source:
+        if album.get("data_source") == self.beatport_plugin.data_source:
             return items
         if not all(self.is_beatport_track(item) for item in items):
             self._log.info(
-                u'Skipping non-{} release: {}',
+                u"Skipping non-{} release: {}",
                 self.beatport_plugin.data_source,
                 album,
             )
@@ -144,7 +144,7 @@ class BPSyncPlugin(BeetsPlugin):
             albuminfo = self.beatport_plugin.album_for_id(album.mb_albumid)
             if not albuminfo:
                 self._log.info(
-                    u'Release ID {} not found for album {}',
+                    u"Release ID {} not found for album {}",
                     album.mb_albumid,
                     album,
                 )
@@ -161,7 +161,7 @@ class BPSyncPlugin(BeetsPlugin):
                 for track_id, item in library_trackid_to_item.items()
             }
 
-            self._log.info(u'applying changes to {}', album)
+            self._log.info(u"applying changes to {}", album)
             with lib.transaction():
                 autotag.apply_metadata(albuminfo, item_to_trackinfo)
                 changed = False
@@ -184,5 +184,5 @@ class BPSyncPlugin(BeetsPlugin):
 
                 # Move album art (and any inconsistent items).
                 if move and lib.directory in util.ancestry(items[0].path):
-                    self._log.debug(u'moving album {}', album)
+                    self._log.debug(u"moving album {}", album)
                     album.move()

--- a/beetsplug/bucket.py
+++ b/beetsplug/bucket.py
@@ -60,31 +60,34 @@ def span_from_str(span_str):
                 d = (yearfrom - yearfrom % 100) + d
         return d
 
-    years = [int(x) for x in re.findall(r'\d+', span_str)]
+    years = [int(x) for x in re.findall(r"\d+", span_str)]
     if not years:
-        raise ui.UserError(u"invalid range defined for year bucket '%s': no "
-                           u"year found" % span_str)
+        raise ui.UserError(
+            u"invalid range defined for year bucket '%s': no "
+            u"year found" % span_str
+        )
     try:
         years = [normalize_year(x, years[0]) for x in years]
     except BucketError as exc:
-        raise ui.UserError(u"invalid range defined for year bucket '%s': %s" %
-                           (span_str, exc))
+        raise ui.UserError(
+            u"invalid range defined for year bucket '%s': %s" % (span_str, exc)
+        )
 
-    res = {'from': years[0], 'str': span_str}
+    res = {"from": years[0], "str": span_str}
     if len(years) > 1:
-        res['to'] = years[-1]
+        res["to"] = years[-1]
     return res
 
 
 def complete_year_spans(spans):
     """Set the `to` value of spans if empty and sort them chronologically.
     """
-    spans.sort(key=lambda x: x['from'])
+    spans.sort(key=lambda x: x["from"])
     for (x, y) in pairwise(spans):
-        if 'to' not in x:
-            x['to'] = y['from'] - 1
-    if spans and 'to' not in spans[-1]:
-        spans[-1]['to'] = datetime.now().year
+        if "to" not in x:
+            x["to"] = y["from"] - 1
+    if spans and "to" not in spans[-1]:
+        spans[-1]["to"] = datetime.now().year
 
 
 def extend_year_spans(spans, spanlen, start=1900, end=2014):
@@ -95,14 +98,14 @@ def extend_year_spans(spans, spanlen, start=1900, end=2014):
     for (x, y) in pairwise(spans):
         # if a gap between two spans, fill the gap with as much spans of
         # spanlen length as necessary
-        for span_from in range(x['to'] + 1, y['from'], spanlen):
-            extended_spans.append({'from': span_from})
+        for span_from in range(x["to"] + 1, y["from"], spanlen):
+            extended_spans.append({"from": span_from})
     # Create spans prior to declared ones
-    for span_from in range(spans[0]['from'] - spanlen, start, -spanlen):
-        extended_spans.append({'from': span_from})
+    for span_from in range(spans[0]["from"] - spanlen, start, -spanlen):
+        extended_spans.append({"from": span_from})
     # Create spans after the declared ones
-    for span_from in range(spans[-1]['to'] + 1, end, spanlen):
-        extended_spans.append({'from': span_from})
+    for span_from in range(spans[-1]["to"] + 1, end, spanlen):
+        extended_spans.append({"from": span_from})
 
     complete_year_spans(extended_spans)
     return extended_spans
@@ -122,23 +125,29 @@ def build_year_spans(year_spans_str):
 def str2fmt(s):
     """Deduces formatting syntax from a span string.
     """
-    regex = re.compile(r"(?P<bef>\D*)(?P<fromyear>\d+)(?P<sep>\D*)"
-                       r"(?P<toyear>\d*)(?P<after>\D*)")
+    regex = re.compile(
+        r"(?P<bef>\D*)(?P<fromyear>\d+)(?P<sep>\D*)"
+        r"(?P<toyear>\d*)(?P<after>\D*)"
+    )
     m = re.match(regex, s)
 
-    res = {'fromnchars': len(m.group('fromyear')),
-           'tonchars': len(m.group('toyear'))}
-    res['fmt'] = "%s%%s%s%s%s" % (m.group('bef'),
-                                  m.group('sep'),
-                                  '%s' if res['tonchars'] else '',
-                                  m.group('after'))
+    res = {
+        "fromnchars": len(m.group("fromyear")),
+        "tonchars": len(m.group("toyear")),
+    }
+    res["fmt"] = "%s%%s%s%s%s" % (
+        m.group("bef"),
+        m.group("sep"),
+        "%s" if res["tonchars"] else "",
+        m.group("after"),
+    )
     return res
 
 
 def format_span(fmt, yearfrom, yearto, fromnchars, tonchars):
     """Return a span string representation.
     """
-    args = (str(yearfrom)[-fromnchars:])
+    args = str(yearfrom)[-fromnchars:]
     if tonchars:
         args = (str(yearfrom)[-fromnchars:], str(yearto)[-tonchars:])
 
@@ -148,9 +157,9 @@ def format_span(fmt, yearfrom, yearto, fromnchars, tonchars):
 def extract_modes(spans):
     """Extract the most common spans lengths and representation formats
     """
-    rangelen = sorted([x['to'] - x['from'] + 1 for x in spans])
+    rangelen = sorted([x["to"] - x["from"] + 1 for x in spans])
     deflen = sorted(rangelen, key=rangelen.count)[-1]
-    reprs = [str2fmt(x['str']) for x in spans]
+    reprs = [str2fmt(x["str"]) for x in spans]
     deffmt = sorted(reprs, key=reprs.count)[-1]
     return deflen, deffmt
 
@@ -170,13 +179,16 @@ def build_alpha_spans(alpha_spans_str, alpha_regexs):
                 begin_index = ASCII_DIGITS.index(bucket[0])
                 end_index = ASCII_DIGITS.index(bucket[-1])
             else:
-                raise ui.UserError(u"invalid range defined for alpha bucket "
-                                   u"'%s': no alphanumeric character found" %
-                                   elem)
+                raise ui.UserError(
+                    u"invalid range defined for alpha bucket "
+                    u"'%s': no alphanumeric character found" % elem
+                )
             spans.append(
                 re.compile(
-                    "^[" + ASCII_DIGITS[begin_index:end_index + 1] +
-                    ASCII_DIGITS[begin_index:end_index + 1].upper() + "]"
+                    "^["
+                    + ASCII_DIGITS[begin_index : end_index + 1]
+                    + ASCII_DIGITS[begin_index : end_index + 1].upper()
+                    + "]"
                 )
             )
     return spans
@@ -185,29 +197,33 @@ def build_alpha_spans(alpha_spans_str, alpha_regexs):
 class BucketPlugin(plugins.BeetsPlugin):
     def __init__(self):
         super(BucketPlugin, self).__init__()
-        self.template_funcs['bucket'] = self._tmpl_bucket
+        self.template_funcs["bucket"] = self._tmpl_bucket
 
-        self.config.add({
-            'bucket_year': [],
-            'bucket_alpha': [],
-            'bucket_alpha_regex': {},
-            'extrapolate': False
-        })
+        self.config.add(
+            {
+                "bucket_year": [],
+                "bucket_alpha": [],
+                "bucket_alpha_regex": {},
+                "extrapolate": False,
+            }
+        )
         self.setup()
 
     def setup(self):
         """Setup plugin from config options
         """
-        self.year_spans = build_year_spans(self.config['bucket_year'].get())
-        if self.year_spans and self.config['extrapolate']:
-            [self.ys_len_mode,
-                self.ys_repr_mode] = extract_modes(self.year_spans)
-            self.year_spans = extend_year_spans(self.year_spans,
-                                                self.ys_len_mode)
+        self.year_spans = build_year_spans(self.config["bucket_year"].get())
+        if self.year_spans and self.config["extrapolate"]:
+            [self.ys_len_mode, self.ys_repr_mode] = extract_modes(
+                self.year_spans
+            )
+            self.year_spans = extend_year_spans(
+                self.year_spans, self.ys_len_mode
+            )
 
         self.alpha_spans = build_alpha_spans(
-            self.config['bucket_alpha'].get(),
-            self.config['bucket_alpha_regex'].get()
+            self.config["bucket_alpha"].get(),
+            self.config["bucket_alpha_regex"].get(),
         )
 
     def find_bucket_year(self, year):
@@ -215,14 +231,17 @@ class BucketPlugin(plugins.BeetsPlugin):
         if no matching bucket.
         """
         for ys in self.year_spans:
-            if ys['from'] <= int(year) <= ys['to']:
-                if 'str' in ys:
-                    return ys['str']
+            if ys["from"] <= int(year) <= ys["to"]:
+                if "str" in ys:
+                    return ys["str"]
                 else:
-                    return format_span(self.ys_repr_mode['fmt'],
-                                       ys['from'], ys['to'],
-                                       self.ys_repr_mode['fromnchars'],
-                                       self.ys_repr_mode['tonchars'])
+                    return format_span(
+                        self.ys_repr_mode["fmt"],
+                        ys["from"],
+                        ys["to"],
+                        self.ys_repr_mode["fromnchars"],
+                        self.ys_repr_mode["tonchars"],
+                    )
         return year
 
     def find_bucket_alpha(self, s):
@@ -231,14 +250,14 @@ class BucketPlugin(plugins.BeetsPlugin):
         """
         for (i, span) in enumerate(self.alpha_spans):
             if span.match(s):
-                return self.config['bucket_alpha'].get()[i]
+                return self.config["bucket_alpha"].get()[i]
         return s[0].upper()
 
     def _tmpl_bucket(self, text, field=None):
         if not field and len(text) == 4 and text.isdigit():
-            field = 'year'
+            field = "year"
 
-        if field == 'year':
+        if field == "year":
             func = self.find_bucket_year
         else:
             func = self.find_bucket_alpha

--- a/beetsplug/chroma.py
+++ b/beetsplug/chroma.py
@@ -29,7 +29,7 @@ from collections import defaultdict
 from functools import partial
 import re
 
-API_KEY = '1vOwZtEn'
+API_KEY = "1vOwZtEn"
 SCORE_THRESH = 0.5
 TRACK_ID_WEIGHT = 10.0
 COMMON_REL_THRESH = 0.6  # How many tracks must have an album in common?
@@ -62,11 +62,11 @@ def prefix(it, count):
 def releases_key(release, countries, original_year):
     """Used as a key to sort releases by date then preferred country
     """
-    date = release.get('date')
+    date = release.get("date")
     if date and original_year:
-        year = date.get('year', 9999)
-        month = date.get('month', 99)
-        day = date.get('day', 99)
+        year = date.get("year", 9999)
+        month = date.get("month", 99)
+        day = date.get("day", 99)
     else:
         year = 9999
         month = 99
@@ -74,9 +74,9 @@ def releases_key(release, countries, original_year):
 
     # Uses index of preferred countries to sort
     country_key = 99
-    if release.get('country'):
+    if release.get("country"):
         for i, country in enumerate(countries):
-            if country.match(release['country']):
+            if country.match(release["country"]):
                 country_key = i
                 break
 
@@ -90,56 +90,65 @@ def acoustid_match(log, path):
     try:
         duration, fp = acoustid.fingerprint_file(util.syspath(path))
     except acoustid.FingerprintGenerationError as exc:
-        log.error(u'fingerprinting of {0} failed: {1}',
-                  util.displayable_path(repr(path)), exc)
+        log.error(
+            u"fingerprinting of {0} failed: {1}",
+            util.displayable_path(repr(path)),
+            exc,
+        )
         return None
     fp = fp.decode()
     _fingerprints[path] = fp
     try:
-        res = acoustid.lookup(API_KEY, fp, duration,
-                              meta='recordings releases')
+        res = acoustid.lookup(
+            API_KEY, fp, duration, meta="recordings releases"
+        )
     except acoustid.AcoustidError as exc:
-        log.debug(u'fingerprint matching {0} failed: {1}',
-                  util.displayable_path(repr(path)), exc)
+        log.debug(
+            u"fingerprint matching {0} failed: {1}",
+            util.displayable_path(repr(path)),
+            exc,
+        )
         return None
-    log.debug(u'chroma: fingerprinted {0}',
-              util.displayable_path(repr(path)))
+    log.debug(u"chroma: fingerprinted {0}", util.displayable_path(repr(path)))
 
     # Ensure the response is usable and parse it.
-    if res['status'] != 'ok' or not res.get('results'):
-        log.debug(u'no match found')
+    if res["status"] != "ok" or not res.get("results"):
+        log.debug(u"no match found")
         return None
-    result = res['results'][0]  # Best match.
-    if result['score'] < SCORE_THRESH:
-        log.debug(u'no results above threshold')
+    result = res["results"][0]  # Best match.
+    if result["score"] < SCORE_THRESH:
+        log.debug(u"no results above threshold")
         return None
-    _acoustids[path] = result['id']
+    _acoustids[path] = result["id"]
 
     # Get recording and releases from the result
-    if not result.get('recordings'):
-        log.debug(u'no recordings found')
+    if not result.get("recordings"):
+        log.debug(u"no recordings found")
         return None
     recording_ids = []
     releases = []
-    for recording in result['recordings']:
-        recording_ids.append(recording['id'])
-        if 'releases' in recording:
-            releases.extend(recording['releases'])
+    for recording in result["recordings"]:
+        recording_ids.append(recording["id"])
+        if "releases" in recording:
+            releases.extend(recording["releases"])
 
     # The releases list is essentially in random order from the Acoustid lookup
     # so we optionally sort it using the match.preferred configuration options.
     # 'original_year' to sort the earliest first and
     # 'countries' to then sort preferred countries first.
-    country_patterns = config['match']['preferred']['countries'].as_str_seq()
+    country_patterns = config["match"]["preferred"]["countries"].as_str_seq()
     countries = [re.compile(pat, re.I) for pat in country_patterns]
-    original_year = config['match']['preferred']['original_year']
-    releases.sort(key=partial(releases_key,
-                              countries=countries,
-                              original_year=original_year))
-    release_ids = [rel['id'] for rel in releases]
+    original_year = config["match"]["preferred"]["original_year"]
+    releases.sort(
+        key=partial(
+            releases_key, countries=countries, original_year=original_year
+        )
+    )
+    release_ids = [rel["id"] for rel in releases]
 
-    log.debug(u'matched recordings {0} on releases {1}',
-              recording_ids, release_ids)
+    log.debug(
+        u"matched recordings {0} on releases {1}", recording_ids, release_ids
+    )
     _matches[path] = recording_ids, release_ids
 
 
@@ -169,14 +178,14 @@ class AcoustidPlugin(plugins.BeetsPlugin):
     def __init__(self):
         super(AcoustidPlugin, self).__init__()
 
-        self.config.add({
-            'auto': True,
-        })
-        config['acoustid']['apikey'].redact = True
+        self.config.add(
+            {"auto": True,}
+        )
+        config["acoustid"]["apikey"].redact = True
 
-        if self.config['auto']:
-            self.register_listener('import_task_start', self.fingerprint_task)
-        self.register_listener('import_task_apply', apply_acoustid_metadata)
+        if self.config["auto"]:
+            self.register_listener("import_task_start", self.fingerprint_task)
+        self.register_listener("import_task_apply", apply_acoustid_metadata)
 
     def fingerprint_task(self, task, session):
         return fingerprint_task(self._log, task, session)
@@ -188,7 +197,7 @@ class AcoustidPlugin(plugins.BeetsPlugin):
             return dist
 
         recording_ids, _ = _matches[item.path]
-        dist.add_expr('track_id', info.track_id not in recording_ids)
+        dist.add_expr("track_id", info.track_id not in recording_ids)
         return dist
 
     def candidates(self, items, artist, album, va_likely, extra_tags=None):
@@ -198,7 +207,7 @@ class AcoustidPlugin(plugins.BeetsPlugin):
             if album:
                 albums.append(album)
 
-        self._log.debug(u'acoustid album candidates: {0}', len(albums))
+        self._log.debug(u"acoustid album candidates: {0}", len(albums))
         return albums
 
     def item_candidates(self, item, artist, title):
@@ -211,29 +220,31 @@ class AcoustidPlugin(plugins.BeetsPlugin):
             track = hooks.track_for_mbid(recording_id)
             if track:
                 tracks.append(track)
-        self._log.debug(u'acoustid item candidates: {0}', len(tracks))
+        self._log.debug(u"acoustid item candidates: {0}", len(tracks))
         return tracks
 
     def commands(self):
-        submit_cmd = ui.Subcommand('submit',
-                                   help=u'submit Acoustid fingerprints')
+        submit_cmd = ui.Subcommand(
+            "submit", help=u"submit Acoustid fingerprints"
+        )
 
         def submit_cmd_func(lib, opts, args):
             try:
-                apikey = config['acoustid']['apikey'].as_str()
+                apikey = config["acoustid"]["apikey"].as_str()
             except confuse.NotFoundError:
-                raise ui.UserError(u'no Acoustid user API key provided')
+                raise ui.UserError(u"no Acoustid user API key provided")
             submit_items(self._log, apikey, lib.items(ui.decargs(args)))
+
         submit_cmd.func = submit_cmd_func
 
         fingerprint_cmd = ui.Subcommand(
-            'fingerprint',
-            help=u'generate fingerprints for items without them'
+            "fingerprint", help=u"generate fingerprints for items without them"
         )
 
         def fingerprint_cmd_func(lib, opts, args):
             for item in lib.items(ui.decargs(args)):
                 fingerprint_item(self._log, item, write=ui.should_write())
+
         fingerprint_cmd.func = fingerprint_cmd_func
 
         return [submit_cmd, fingerprint_cmd]
@@ -271,11 +282,11 @@ def submit_items(log, userkey, items, chunksize=64):
 
     def submit_chunk():
         """Submit the current accumulated fingerprint data."""
-        log.info(u'submitting {0} fingerprints', len(data))
+        log.info(u"submitting {0} fingerprints", len(data))
         try:
             acoustid.submit(API_KEY, userkey, data)
         except acoustid.AcoustidError as exc:
-            log.warning(u'acoustid submission error: {0}', exc)
+            log.warning(u"acoustid submission error: {0}", exc)
         del data[:]
 
     for item in items:
@@ -283,23 +294,25 @@ def submit_items(log, userkey, items, chunksize=64):
 
         # Construct a submission dictionary for this item.
         item_data = {
-            'duration': int(item.length),
-            'fingerprint': fp,
+            "duration": int(item.length),
+            "fingerprint": fp,
         }
         if item.mb_trackid:
-            item_data['mbid'] = item.mb_trackid
-            log.debug(u'submitting MBID')
+            item_data["mbid"] = item.mb_trackid
+            log.debug(u"submitting MBID")
         else:
-            item_data.update({
-                'track': item.title,
-                'artist': item.artist,
-                'album': item.album,
-                'albumartist': item.albumartist,
-                'year': item.year,
-                'trackno': item.track,
-                'discno': item.disc,
-            })
-            log.debug(u'submitting textual metadata')
+            item_data.update(
+                {
+                    "track": item.title,
+                    "artist": item.artist,
+                    "album": item.album,
+                    "albumartist": item.albumartist,
+                    "year": item.year,
+                    "trackno": item.track,
+                    "discno": item.disc,
+                }
+            )
+            log.debug(u"submitting textual metadata")
         data.append(item_data)
 
         # If we have enough data, submit a chunk.
@@ -320,28 +333,34 @@ def fingerprint_item(log, item, write=False):
     """
     # Get a fingerprint and length for this track.
     if not item.length:
-        log.info(u'{0}: no duration available',
-                 util.displayable_path(item.path))
+        log.info(
+            u"{0}: no duration available", util.displayable_path(item.path)
+        )
     elif item.acoustid_fingerprint:
         if write:
-            log.info(u'{0}: fingerprint exists, skipping',
-                     util.displayable_path(item.path))
+            log.info(
+                u"{0}: fingerprint exists, skipping",
+                util.displayable_path(item.path),
+            )
         else:
-            log.info(u'{0}: using existing fingerprint',
-                     util.displayable_path(item.path))
+            log.info(
+                u"{0}: using existing fingerprint",
+                util.displayable_path(item.path),
+            )
             return item.acoustid_fingerprint
     else:
-        log.info(u'{0}: fingerprinting',
-                 util.displayable_path(item.path))
+        log.info(u"{0}: fingerprinting", util.displayable_path(item.path))
         try:
             _, fp = acoustid.fingerprint_file(util.syspath(item.path))
             item.acoustid_fingerprint = fp.decode()
             if write:
-                log.info(u'{0}: writing fingerprint',
-                         util.displayable_path(item.path))
+                log.info(
+                    u"{0}: writing fingerprint",
+                    util.displayable_path(item.path),
+                )
                 item.try_write()
             if item._db:
                 item.store()
             return item.acoustid_fingerprint
         except acoustid.FingerprintGenerationError as exc:
-            log.info(u'fingerprint generation failed: {0}', exc)
+            log.info(u"fingerprint generation failed: {0}", exc)

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -39,11 +39,11 @@ _temp_files = []  # Keep track of temporary transcoded files for deletion.
 
 # Some convenient alternate names for formats.
 ALIASES = {
-    u'wma': u'windows media',
-    u'vorbis': u'ogg',
+    u"wma": u"windows media",
+    u"vorbis": u"ogg",
 }
 
-LOSSLESS_FORMATS = ['ape', 'flac', 'alac', 'wav', 'aiff']
+LOSSLESS_FORMATS = ["ape", "flac", "alac", "wav", "aiff"]
 
 
 def replace_ext(path, ext):
@@ -51,7 +51,7 @@ def replace_ext(path, ext):
 
     The new extension must not contain a leading dot.
     """
-    ext_dot = b'.' + ext
+    ext_dot = b"." + ext
     return os.path.splitext(path)[0] + ext_dot
 
 
@@ -59,129 +59,164 @@ def get_format(fmt=None):
     """Return the command template and the extension from the config.
     """
     if not fmt:
-        fmt = config['convert']['format'].as_str().lower()
+        fmt = config["convert"]["format"].as_str().lower()
     fmt = ALIASES.get(fmt, fmt)
 
     try:
-        format_info = config['convert']['formats'][fmt].get(dict)
-        command = format_info['command']
-        extension = format_info.get('extension', fmt)
+        format_info = config["convert"]["formats"][fmt].get(dict)
+        command = format_info["command"]
+        extension = format_info.get("extension", fmt)
     except KeyError:
         raise ui.UserError(
-            u'convert: format {0} needs the "command" field'
-            .format(fmt)
+            u'convert: format {0} needs the "command" field'.format(fmt)
         )
     except ConfigTypeError:
-        command = config['convert']['formats'][fmt].get(str)
+        command = config["convert"]["formats"][fmt].get(str)
         extension = fmt
 
     # Convenience and backwards-compatibility shortcuts.
-    keys = config['convert'].keys()
-    if 'command' in keys:
-        command = config['convert']['command'].as_str()
-    elif 'opts' in keys:
+    keys = config["convert"].keys()
+    if "command" in keys:
+        command = config["convert"]["command"].as_str()
+    elif "opts" in keys:
         # Undocumented option for backwards compatibility with < 1.3.1.
-        command = u'ffmpeg -i $source -y {0} $dest'.format(
-            config['convert']['opts'].as_str()
+        command = u"ffmpeg -i $source -y {0} $dest".format(
+            config["convert"]["opts"].as_str()
         )
-    if 'extension' in keys:
-        extension = config['convert']['extension'].as_str()
+    if "extension" in keys:
+        extension = config["convert"]["extension"].as_str()
 
-    return (command.encode('utf-8'), extension.encode('utf-8'))
+    return (command.encode("utf-8"), extension.encode("utf-8"))
 
 
 def should_transcode(item, fmt):
     """Determine whether the item should be transcoded as part of
     conversion (i.e., its bitrate is high or it has the wrong format).
     """
-    no_convert_queries = config['convert']['no_convert'].as_str_seq()
+    no_convert_queries = config["convert"]["no_convert"].as_str_seq()
     if no_convert_queries:
         for query_string in no_convert_queries:
             query, _ = parse_query_string(query_string, Item)
             if query.match(item):
                 return False
-    if config['convert']['never_convert_lossy_files'] and \
-            not (item.format.lower() in LOSSLESS_FORMATS):
+    if config["convert"]["never_convert_lossy_files"] and not (
+        item.format.lower() in LOSSLESS_FORMATS
+    ):
         return False
-    maxbr = config['convert']['max_bitrate'].get(int)
-    return fmt.lower() != item.format.lower() or \
-        item.bitrate >= 1000 * maxbr
+    maxbr = config["convert"]["max_bitrate"].get(int)
+    return fmt.lower() != item.format.lower() or item.bitrate >= 1000 * maxbr
 
 
 class ConvertPlugin(BeetsPlugin):
     def __init__(self):
         super(ConvertPlugin, self).__init__()
-        self.config.add({
-            u'dest': None,
-            u'pretend': False,
-            u'link': False,
-            u'hardlink': False,
-            u'threads': util.cpu_count(),
-            u'format': u'mp3',
-            u'id3v23': u'inherit',
-            u'formats': {
-                u'aac': {
-                    u'command': u'ffmpeg -i $source -y -vn -acodec aac '
-                                u'-aq 1 $dest',
-                    u'extension': u'm4a',
+        self.config.add(
+            {
+                u"dest": None,
+                u"pretend": False,
+                u"link": False,
+                u"hardlink": False,
+                u"threads": util.cpu_count(),
+                u"format": u"mp3",
+                u"id3v23": u"inherit",
+                u"formats": {
+                    u"aac": {
+                        u"command": u"ffmpeg -i $source -y -vn -acodec aac "
+                        u"-aq 1 $dest",
+                        u"extension": u"m4a",
+                    },
+                    u"alac": {
+                        u"command": u"ffmpeg -i $source -y -vn -acodec alac $dest",
+                        u"extension": u"m4a",
+                    },
+                    u"flac": u"ffmpeg -i $source -y -vn -acodec flac $dest",
+                    u"mp3": u"ffmpeg -i $source -y -vn -aq 2 $dest",
+                    u"opus": u"ffmpeg -i $source -y -vn -acodec libopus -ab 96k $dest",
+                    u"ogg": u"ffmpeg -i $source -y -vn -acodec libvorbis -aq 3 $dest",
+                    u"wma": u"ffmpeg -i $source -y -vn -acodec wmav2 -vn $dest",
                 },
-                u'alac': {
-                    u'command': u'ffmpeg -i $source -y -vn -acodec alac $dest',
-                    u'extension': u'm4a',
-                },
-                u'flac': u'ffmpeg -i $source -y -vn -acodec flac $dest',
-                u'mp3': u'ffmpeg -i $source -y -vn -aq 2 $dest',
-                u'opus':
-                    u'ffmpeg -i $source -y -vn -acodec libopus -ab 96k $dest',
-                u'ogg':
-                    u'ffmpeg -i $source -y -vn -acodec libvorbis -aq 3 $dest',
-                u'wma':
-                    u'ffmpeg -i $source -y -vn -acodec wmav2 -vn $dest',
-            },
-            u'max_bitrate': 500,
-            u'auto': False,
-            u'tmpdir': None,
-            u'quiet': False,
-            u'embed': True,
-            u'paths': {},
-            u'no_convert': u'',
-            u'never_convert_lossy_files': False,
-            u'copy_album_art': False,
-            u'album_art_maxwidth': 0,
-        })
+                u"max_bitrate": 500,
+                u"auto": False,
+                u"tmpdir": None,
+                u"quiet": False,
+                u"embed": True,
+                u"paths": {},
+                u"no_convert": u"",
+                u"never_convert_lossy_files": False,
+                u"copy_album_art": False,
+                u"album_art_maxwidth": 0,
+            }
+        )
         self.early_import_stages = [self.auto_convert]
 
-        self.register_listener('import_task_files', self._cleanup)
+        self.register_listener("import_task_files", self._cleanup)
 
     def commands(self):
-        cmd = ui.Subcommand('convert', help=u'convert to external location')
-        cmd.parser.add_option('-p', '--pretend', action='store_true',
-                              help=u'show actions but do nothing')
-        cmd.parser.add_option('-t', '--threads', action='store', type='int',
-                              help=u'change the number of threads, \
-                              defaults to maximum available processors')
-        cmd.parser.add_option('-k', '--keep-new', action='store_true',
-                              dest='keep_new', help=u'keep only the converted \
-                              and move the old files')
-        cmd.parser.add_option('-d', '--dest', action='store',
-                              help=u'set the destination directory')
-        cmd.parser.add_option('-f', '--format', action='store', dest='format',
-                              help=u'set the target format of the tracks')
-        cmd.parser.add_option('-y', '--yes', action='store_true', dest='yes',
-                              help=u'do not ask for confirmation')
-        cmd.parser.add_option('-l', '--link', action='store_true', dest='link',
-                              help=u'symlink files that do not \
-                              need transcoding.')
-        cmd.parser.add_option('-H', '--hardlink', action='store_true',
-                              dest='hardlink',
-                              help=u'hardlink files that do not \
-                              need transcoding. Overrides --link.')
+        cmd = ui.Subcommand("convert", help=u"convert to external location")
+        cmd.parser.add_option(
+            "-p",
+            "--pretend",
+            action="store_true",
+            help=u"show actions but do nothing",
+        )
+        cmd.parser.add_option(
+            "-t",
+            "--threads",
+            action="store",
+            type="int",
+            help=u"change the number of threads, \
+                              defaults to maximum available processors",
+        )
+        cmd.parser.add_option(
+            "-k",
+            "--keep-new",
+            action="store_true",
+            dest="keep_new",
+            help=u"keep only the converted \
+                              and move the old files",
+        )
+        cmd.parser.add_option(
+            "-d",
+            "--dest",
+            action="store",
+            help=u"set the destination directory",
+        )
+        cmd.parser.add_option(
+            "-f",
+            "--format",
+            action="store",
+            dest="format",
+            help=u"set the target format of the tracks",
+        )
+        cmd.parser.add_option(
+            "-y",
+            "--yes",
+            action="store_true",
+            dest="yes",
+            help=u"do not ask for confirmation",
+        )
+        cmd.parser.add_option(
+            "-l",
+            "--link",
+            action="store_true",
+            dest="link",
+            help=u"symlink files that do not \
+                              need transcoding.",
+        )
+        cmd.parser.add_option(
+            "-H",
+            "--hardlink",
+            action="store_true",
+            dest="hardlink",
+            help=u"hardlink files that do not \
+                              need transcoding. Overrides --link.",
+        )
         cmd.parser.add_album_option()
         cmd.func = self.convert_func
         return [cmd]
 
     def auto_convert(self, config, task):
-        if self.config['auto']:
+        if self.config["auto"]:
             for item in task.imported_items():
                 self.convert_on_import(config.lib, item)
 
@@ -198,10 +233,10 @@ class ConvertPlugin(BeetsPlugin):
         assert isinstance(source, bytes)
         assert isinstance(dest, bytes)
 
-        quiet = self.config['quiet'].get(bool)
+        quiet = self.config["quiet"].get(bool)
 
         if not quiet and not pretend:
-            self._log.info(u'Encoding {0}', util.displayable_path(source))
+            self._log.info(u"Encoding {0}", util.displayable_path(source))
 
         # On Python 3, we need to construct the command to invoke as a
         # Unicode string. On Unix, this is a little unfortunate---the OS is
@@ -210,57 +245,69 @@ class ConvertPlugin(BeetsPlugin):
         # *reversed* to recover the same bytes before invoking the OS. On
         # Windows, we want to preserve the Unicode filename "as is."
         if not six.PY2:
-            command = command.decode(util.arg_encoding(), 'surrogateescape')
-            if platform.system() == 'Windows':
+            command = command.decode(util.arg_encoding(), "surrogateescape")
+            if platform.system() == "Windows":
                 source = source.decode(util._fsencoding())
                 dest = dest.decode(util._fsencoding())
             else:
-                source = source.decode(util.arg_encoding(), 'surrogateescape')
-                dest = dest.decode(util.arg_encoding(), 'surrogateescape')
+                source = source.decode(util.arg_encoding(), "surrogateescape")
+                dest = dest.decode(util.arg_encoding(), "surrogateescape")
 
         # Substitute $source and $dest in the argument list.
         args = shlex.split(command)
         encode_cmd = []
         for i, arg in enumerate(args):
-            args[i] = Template(arg).safe_substitute({
-                'source': source,
-                'dest': dest,
-            })
+            args[i] = Template(arg).safe_substitute(
+                {"source": source, "dest": dest,}
+            )
             if six.PY2:
                 encode_cmd.append(args[i])
             else:
                 encode_cmd.append(args[i].encode(util.arg_encoding()))
 
         if pretend:
-            self._log.info(u'{0}', u' '.join(ui.decargs(args)))
+            self._log.info(u"{0}", u" ".join(ui.decargs(args)))
             return
 
         try:
             util.command_output(encode_cmd)
         except subprocess.CalledProcessError as exc:
             # Something went wrong (probably Ctrl+C), remove temporary files
-            self._log.info(u'Encoding {0} failed. Cleaning up...',
-                           util.displayable_path(source))
-            self._log.debug(u'Command {0} exited with status {1}: {2}',
-                            args,
-                            exc.returncode,
-                            exc.output)
+            self._log.info(
+                u"Encoding {0} failed. Cleaning up...",
+                util.displayable_path(source),
+            )
+            self._log.debug(
+                u"Command {0} exited with status {1}: {2}",
+                args,
+                exc.returncode,
+                exc.output,
+            )
             util.remove(dest)
             util.prune_dirs(os.path.dirname(dest))
             raise
         except OSError as exc:
             raise ui.UserError(
                 u"convert: couldn't invoke '{0}': {1}".format(
-                    u' '.join(ui.decargs(args)), exc
+                    u" ".join(ui.decargs(args)), exc
                 )
             )
 
         if not quiet and not pretend:
-            self._log.info(u'Finished encoding {0}',
-                           util.displayable_path(source))
+            self._log.info(
+                u"Finished encoding {0}", util.displayable_path(source)
+            )
 
-    def convert_item(self, dest_dir, keep_new, path_formats, fmt,
-                     pretend=False, link=False, hardlink=False):
+    def convert_item(
+        self,
+        dest_dir,
+        keep_new,
+        path_formats,
+        fmt,
+        pretend=False,
+        link=False,
+        hardlink=False,
+    ):
         """A pipeline thread that converts `Item` objects from a
         library.
         """
@@ -268,8 +315,9 @@ class ConvertPlugin(BeetsPlugin):
         item, original, converted = None, None, None
         while True:
             item = yield (item, original, converted)
-            dest = item.destination(basedir=dest_dir,
-                                    path_formats=path_formats)
+            dest = item.destination(
+                basedir=dest_dir, path_formats=path_formats
+            )
 
             # When keeping the new file in the library, we first move the
             # current (pristine) file to the destination. We'll then copy it
@@ -293,18 +341,23 @@ class ConvertPlugin(BeetsPlugin):
                     util.mkdirall(dest)
 
             if os.path.exists(util.syspath(dest)):
-                self._log.info(u'Skipping {0} (target file exists)',
-                               util.displayable_path(item.path))
+                self._log.info(
+                    u"Skipping {0} (target file exists)",
+                    util.displayable_path(item.path),
+                )
                 continue
 
             if keep_new:
                 if pretend:
-                    self._log.info(u'mv {0} {1}',
-                                   util.displayable_path(item.path),
-                                   util.displayable_path(original))
+                    self._log.info(
+                        u"mv {0} {1}",
+                        util.displayable_path(item.path),
+                        util.displayable_path(original),
+                    )
                 else:
-                    self._log.info(u'Moving to {0}',
-                                   util.displayable_path(original))
+                    self._log.info(
+                        u"Moving to {0}", util.displayable_path(original)
+                    )
                     util.move(item.path, original)
 
             if should_transcode(item, fmt):
@@ -316,20 +369,25 @@ class ConvertPlugin(BeetsPlugin):
             else:
                 linked = link or hardlink
                 if pretend:
-                    msg = 'ln' if hardlink else ('ln -s' if link else 'cp')
+                    msg = "ln" if hardlink else ("ln -s" if link else "cp")
 
-                    self._log.info(u'{2} {0} {1}',
-                                   util.displayable_path(original),
-                                   util.displayable_path(converted),
-                                   msg)
+                    self._log.info(
+                        u"{2} {0} {1}",
+                        util.displayable_path(original),
+                        util.displayable_path(converted),
+                        msg,
+                    )
                 else:
                     # No transcoding necessary.
-                    msg = 'Hardlinking' if hardlink \
-                        else ('Linking' if link else 'Copying')
+                    msg = (
+                        "Hardlinking"
+                        if hardlink
+                        else ("Linking" if link else "Copying")
+                    )
 
-                    self._log.info(u'{1} {0}',
-                                   util.displayable_path(item.path),
-                                   msg)
+                    self._log.info(
+                        u"{1} {0}", util.displayable_path(item.path), msg
+                    )
 
                     if hardlink:
                         util.hardlink(original, converted)
@@ -341,8 +399,8 @@ class ConvertPlugin(BeetsPlugin):
             if pretend:
                 continue
 
-            id3v23 = self.config['id3v23'].as_choice([True, False, 'inherit'])
-            if id3v23 == 'inherit':
+            id3v23 = self.config["id3v23"].as_choice([True, False, "inherit"])
+            if id3v23 == "inherit":
                 id3v23 = None
 
             # Write tags from the database to the converted file.
@@ -355,23 +413,39 @@ class ConvertPlugin(BeetsPlugin):
                 item.read()
                 item.store()  # Store new path and audio data.
 
-            if self.config['embed'] and not linked:
+            if self.config["embed"] and not linked:
                 album = item.get_album()
                 if album and album.artpath:
-                    self._log.debug(u'embedding album art from {}',
-                                    util.displayable_path(album.artpath))
-                    art.embed_item(self._log, item, album.artpath,
-                                   itempath=converted, id3v23=id3v23)
+                    self._log.debug(
+                        u"embedding album art from {}",
+                        util.displayable_path(album.artpath),
+                    )
+                    art.embed_item(
+                        self._log,
+                        item,
+                        album.artpath,
+                        itempath=converted,
+                        id3v23=id3v23,
+                    )
 
             if keep_new:
-                plugins.send('after_convert', item=item,
-                             dest=dest, keepnew=True)
+                plugins.send(
+                    "after_convert", item=item, dest=dest, keepnew=True
+                )
             else:
-                plugins.send('after_convert', item=item,
-                             dest=converted, keepnew=False)
+                plugins.send(
+                    "after_convert", item=item, dest=converted, keepnew=False
+                )
 
-    def copy_album_art(self, album, dest_dir, path_formats, pretend=False,
-                       link=False, hardlink=False):
+    def copy_album_art(
+        self,
+        album,
+        dest_dir,
+        path_formats,
+        pretend=False,
+        link=False,
+        hardlink=False,
+    ):
         """Copies or converts the associated cover art of the album. Album must
         have at least one track.
         """
@@ -385,8 +459,9 @@ class ConvertPlugin(BeetsPlugin):
 
         # Get the destination of the first item (track) of the album, we use
         # this function to format the path accordingly to path_formats.
-        dest = album_item.destination(basedir=dest_dir,
-                                      path_formats=path_formats)
+        dest = album_item.destination(
+            basedir=dest_dir, path_formats=path_formats
+        )
 
         # Remove item from the path.
         dest = os.path.join(*util.components(dest)[:-1])
@@ -399,46 +474,59 @@ class ConvertPlugin(BeetsPlugin):
             util.mkdirall(dest)
 
         if os.path.exists(util.syspath(dest)):
-            self._log.info(u'Skipping {0} (target file exists)',
-                           util.displayable_path(album.artpath))
+            self._log.info(
+                u"Skipping {0} (target file exists)",
+                util.displayable_path(album.artpath),
+            )
             return
 
         # Decide whether we need to resize the cover-art image.
         resize = False
         maxwidth = None
-        if self.config['album_art_maxwidth']:
-            maxwidth = self.config['album_art_maxwidth'].get(int)
+        if self.config["album_art_maxwidth"]:
+            maxwidth = self.config["album_art_maxwidth"].get(int)
             size = ArtResizer.shared.get_size(album.artpath)
-            self._log.debug('image size: {}', size)
+            self._log.debug("image size: {}", size)
             if size:
                 resize = size[0] > maxwidth
             else:
-                self._log.warning(u'Could not get size of image (please see '
-                                  u'documentation for dependencies).')
+                self._log.warning(
+                    u"Could not get size of image (please see "
+                    u"documentation for dependencies)."
+                )
 
         # Either copy or resize (while copying) the image.
         if resize:
-            self._log.info(u'Resizing cover art from {0} to {1}',
-                           util.displayable_path(album.artpath),
-                           util.displayable_path(dest))
+            self._log.info(
+                u"Resizing cover art from {0} to {1}",
+                util.displayable_path(album.artpath),
+                util.displayable_path(dest),
+            )
             if not pretend:
                 ArtResizer.shared.resize(maxwidth, album.artpath, dest)
         else:
             if pretend:
-                msg = 'ln' if hardlink else ('ln -s' if link else 'cp')
+                msg = "ln" if hardlink else ("ln -s" if link else "cp")
 
-                self._log.info(u'{2} {0} {1}',
-                               util.displayable_path(album.artpath),
-                               util.displayable_path(dest),
-                               msg)
+                self._log.info(
+                    u"{2} {0} {1}",
+                    util.displayable_path(album.artpath),
+                    util.displayable_path(dest),
+                    msg,
+                )
             else:
-                msg = 'Hardlinking' if hardlink \
-                    else ('Linking' if link else 'Copying')
+                msg = (
+                    "Hardlinking"
+                    if hardlink
+                    else ("Linking" if link else "Copying")
+                )
 
-                self._log.info(u'{2} cover art from {0} to {1}',
-                               util.displayable_path(album.artpath),
-                               util.displayable_path(dest),
-                               msg)
+                self._log.info(
+                    u"{2} cover art from {0} to {1}",
+                    util.displayable_path(album.artpath),
+                    util.displayable_path(dest),
+                    msg,
+                )
                 if hardlink:
                     util.hardlink(album.artpath, dest)
                 elif link:
@@ -447,21 +535,21 @@ class ConvertPlugin(BeetsPlugin):
                     util.copy(album.artpath, dest)
 
     def convert_func(self, lib, opts, args):
-        dest = opts.dest or self.config['dest'].get()
+        dest = opts.dest or self.config["dest"].get()
         if not dest:
-            raise ui.UserError(u'no convert destination set')
+            raise ui.UserError(u"no convert destination set")
         dest = util.bytestring_path(dest)
 
-        threads = opts.threads or self.config['threads'].get(int)
+        threads = opts.threads or self.config["threads"].get(int)
 
-        path_formats = ui.get_path_formats(self.config['paths'] or None)
+        path_formats = ui.get_path_formats(self.config["paths"] or None)
 
-        fmt = opts.format or self.config['format'].as_str().lower()
+        fmt = opts.format or self.config["format"].as_str().lower()
 
         if opts.pretend is not None:
             pretend = opts.pretend
         else:
-            pretend = self.config['pretend'].get(bool)
+            pretend = self.config["pretend"].get(bool)
 
         if opts.hardlink is not None:
             hardlink = opts.hardlink
@@ -470,40 +558,39 @@ class ConvertPlugin(BeetsPlugin):
             hardlink = False
             link = opts.link
         else:
-            hardlink = self.config['hardlink'].get(bool)
-            link = self.config['link'].get(bool)
+            hardlink = self.config["hardlink"].get(bool)
+            link = self.config["link"].get(bool)
 
         if opts.album:
             albums = lib.albums(ui.decargs(args))
             items = [i for a in albums for i in a.items()]
             if not pretend:
                 for a in albums:
-                    ui.print_(format(a, u''))
+                    ui.print_(format(a, u""))
         else:
             items = list(lib.items(ui.decargs(args)))
             if not pretend:
                 for i in items:
-                    ui.print_(format(i, u''))
+                    ui.print_(format(i, u""))
 
         if not items:
-            self._log.error(u'Empty query result.')
+            self._log.error(u"Empty query result.")
             return
         if not (pretend or opts.yes or ui.input_yn(u"Convert? (Y/n)")):
             return
 
-        if opts.album and self.config['copy_album_art']:
+        if opts.album and self.config["copy_album_art"]:
             for album in albums:
-                self.copy_album_art(album, dest, path_formats, pretend,
-                                    link, hardlink)
+                self.copy_album_art(
+                    album, dest, path_formats, pretend, link, hardlink
+                )
 
-        convert = [self.convert_item(dest,
-                                     opts.keep_new,
-                                     path_formats,
-                                     fmt,
-                                     pretend,
-                                     link,
-                                     hardlink)
-                   for _ in range(threads)]
+        convert = [
+            self.convert_item(
+                dest, opts.keep_new, path_formats, fmt, pretend, link, hardlink
+            )
+            for _ in range(threads)
+        ]
         pipe = util.pipeline.Pipeline([iter(items), convert])
         pipe.run_parallel()
 
@@ -511,15 +598,15 @@ class ConvertPlugin(BeetsPlugin):
         """Transcode a file automatically after it is imported into the
         library.
         """
-        fmt = self.config['format'].as_str().lower()
+        fmt = self.config["format"].as_str().lower()
         if should_transcode(item, fmt):
             command, ext = get_format()
 
             # Create a temporary file for the conversion.
-            tmpdir = self.config['tmpdir'].get()
+            tmpdir = self.config["tmpdir"].get()
             if tmpdir:
                 tmpdir = util.py3_path(util.bytestring_path(tmpdir))
-            fd, dest = tempfile.mkstemp(util.py3_path(b'.' + ext), dir=tmpdir)
+            fd, dest = tempfile.mkstemp(util.py3_path(b"." + ext), dir=tmpdir)
             os.close(fd)
             dest = util.bytestring_path(dest)
             _temp_files.append(dest)  # Delete the transcode later.

--- a/beetsplug/cue.py
+++ b/beetsplug/cue.py
@@ -17,15 +17,15 @@ class CuePlugin(BeetsPlugin):
     def __init__(self):
         super(CuePlugin, self).__init__()
         # this does not seem supported by shnsplit
-        self.config.add({
-            'keep_before': .1,
-            'keep_after': .9,
-        })
+        self.config.add(
+            {"keep_before": 0.1, "keep_after": 0.9,}
+        )
 
         # self.register_listener('import_task_start', self.look_for_cues)
 
     def candidates(self, items, artist, album, va_likely, extra_tags=None):
         import pdb
+
         pdb.set_trace()
 
     def item_candidates(self, item, artist, album):
@@ -34,17 +34,19 @@ class CuePlugin(BeetsPlugin):
         if not cues:
             return
         if len(cues) > 1:
-            self._log.info(u"Found multiple cue files doing nothing: {0}",
-                           list(map(displayable_path, cues)))
+            self._log.info(
+                u"Found multiple cue files doing nothing: {0}",
+                list(map(displayable_path, cues)),
+            )
 
         cue_file = cues[0]
         self._log.info("Found {} for {}", displayable_path(cue_file), item)
 
         try:
             # careful: will ask for input in case of conflicts
-            command_output(['shnsplit', '-f', cue_file, item.path])
+            command_output(["shnsplit", "-f", cue_file, item.path])
         except (subprocess.CalledProcessError, OSError):
-            self._log.exception(u'shnsplit execution failed')
+            self._log.exception(u"shnsplit execution failed")
             return
 
         tracks = glob(path.join(dir, "*.wav"))
@@ -52,7 +54,8 @@ class CuePlugin(BeetsPlugin):
         for t in tracks:
             title = "dunno lol"
             track_id = "wtf"
-            index = int(path.basename(t)[len("split-track"):-len(".wav")])
-            yield TrackInfo(title=title, track_id=track_id, index=index,
-                            artist=artist)
+            index = int(path.basename(t)[len("split-track") : -len(".wav")])
+            yield TrackInfo(
+                title=title, track_id=track_id, index=index, artist=artist
+            )
         # generate TrackInfo instances

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -29,17 +29,17 @@ from beets.plugins import MetadataSourcePlugin, BeetsPlugin
 
 
 class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
-    data_source = 'Deezer'
+    data_source = "Deezer"
 
     # Base URLs for the Deezer API
     # Documentation: https://developers.deezer.com/api/
-    search_url = 'https://api.deezer.com/search/'
-    album_url = 'https://api.deezer.com/album/'
-    track_url = 'https://api.deezer.com/track/'
+    search_url = "https://api.deezer.com/search/"
+    album_url = "https://api.deezer.com/album/"
+    track_url = "https://api.deezer.com/track/"
 
     id_regex = {
-        'pattern': r'(^|deezer\.com/)([a-z]*/)?({}/)?(\d+)',
-        'match_group': 4,
+        "pattern": r"(^|deezer\.com/)([a-z]*/)?({}/)?(\d+)",
+        "match_group": 4,
     }
 
     def __init__(self):
@@ -54,15 +54,15 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
         :return: AlbumInfo object for album.
         :rtype: beets.autotag.hooks.AlbumInfo or None
         """
-        deezer_id = self._get_id('album', album_id)
+        deezer_id = self._get_id("album", album_id)
         if deezer_id is None:
             return None
 
         album_data = requests.get(self.album_url + deezer_id).json()
-        artist, artist_id = self.get_artist(album_data['contributors'])
+        artist, artist_id = self.get_artist(album_data["contributors"])
 
-        release_date = album_data['release_date']
-        date_parts = [int(part) for part in release_date.split('-')]
+        release_date = album_data["release_date"]
+        date_parts = [int(part) for part in release_date.split("-")]
         num_date_parts = len(date_parts)
 
         if num_date_parts == 3:
@@ -81,8 +81,8 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
             )
 
         tracks_data = requests.get(
-            self.album_url + deezer_id + '/tracks'
-        ).json()['data']
+            self.album_url + deezer_id + "/tracks"
+        ).json()["data"]
         if not tracks_data:
             return None
         tracks = []
@@ -96,22 +96,22 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
             track.medium_total = medium_totals[track.medium]
 
         return AlbumInfo(
-            album=album_data['title'],
+            album=album_data["title"],
             album_id=deezer_id,
             artist=artist,
-            artist_credit=self.get_artist([album_data['artist']])[0],
+            artist_credit=self.get_artist([album_data["artist"]])[0],
             artist_id=artist_id,
             tracks=tracks,
-            albumtype=album_data['record_type'],
-            va=len(album_data['contributors']) == 1
-            and artist.lower() == 'various artists',
+            albumtype=album_data["record_type"],
+            va=len(album_data["contributors"]) == 1
+            and artist.lower() == "various artists",
             year=year,
             month=month,
             day=day,
-            label=album_data['label'],
+            label=album_data["label"],
             mediums=max(medium_totals.keys()),
             data_source=self.data_source,
-            data_url=album_data['link'],
+            data_url=album_data["link"],
         )
 
     def _get_track(self, track_data):
@@ -123,19 +123,19 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
         :rtype: beets.autotag.hooks.TrackInfo
         """
         artist, artist_id = self.get_artist(
-            track_data.get('contributors', [track_data['artist']])
+            track_data.get("contributors", [track_data["artist"]])
         )
         return TrackInfo(
-            title=track_data['title'],
-            track_id=track_data['id'],
+            title=track_data["title"],
+            track_id=track_data["id"],
             artist=artist,
             artist_id=artist_id,
-            length=track_data['duration'],
-            index=track_data['track_position'],
-            medium=track_data['disk_number'],
-            medium_index=track_data['track_position'],
+            length=track_data["duration"],
+            index=track_data["track_position"],
+            medium=track_data["disk_number"],
+            medium_index=track_data["track_position"],
             data_source=self.data_source,
-            data_url=track_data['link'],
+            data_url=track_data["link"],
         )
 
     def track_for_id(self, track_id=None, track_data=None):
@@ -152,7 +152,7 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
         :rtype: beets.autotag.hooks.TrackInfo or None
         """
         if track_data is None:
-            deezer_id = self._get_id('track', track_id)
+            deezer_id = self._get_id("track", track_id)
             if deezer_id is None:
                 return None
             track_data = requests.get(self.track_url + deezer_id).json()
@@ -162,19 +162,19 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
         # release) and `track.medium_total` (total number of tracks on
         # the track's disc).
         album_tracks_data = requests.get(
-            self.album_url + str(track_data['album']['id']) + '/tracks'
-        ).json()['data']
+            self.album_url + str(track_data["album"]["id"]) + "/tracks"
+        ).json()["data"]
         medium_total = 0
         for i, track_data in enumerate(album_tracks_data, start=1):
-            if track_data['disk_number'] == track.medium:
+            if track_data["disk_number"] == track.medium:
                 medium_total += 1
-                if track_data['id'] == track.track_id:
+                if track_data["id"] == track.track_id:
                     track.index = i
         track.medium_total = medium_total
         return track
 
     @staticmethod
-    def _construct_search_query(filters=None, keywords=''):
+    def _construct_search_query(filters=None, keywords=""):
         """Construct a query string with the specified filters and keywords to
         be provided to the Deezer Search API
         (https://developers.deezer.com/api/search).
@@ -188,14 +188,14 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
         """
         query_components = [
             keywords,
-            ' '.join('{}:"{}"'.format(k, v) for k, v in filters.items()),
+            " ".join('{}:"{}"'.format(k, v) for k, v in filters.items()),
         ]
-        query = ' '.join([q for q in query_components if q])
+        query = " ".join([q for q in query_components if q])
         if not isinstance(query, six.text_type):
-            query = query.decode('utf8')
+            query = query.decode("utf8")
         return unidecode.unidecode(query)
 
-    def _search_api(self, query_type, filters=None, keywords=''):
+    def _search_api(self, query_type, filters=None, keywords=""):
         """Query the Deezer Search API for the specified ``keywords``, applying
         the provided ``filters``.
 
@@ -220,10 +220,10 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
             u"Searching {} for '{}'".format(self.data_source, query)
         )
         response = requests.get(
-            self.search_url + query_type, params={'q': query}
+            self.search_url + query_type, params={"q": query}
         )
         response.raise_for_status()
-        response_data = response.json().get('data', [])
+        response_data = response.json().get("data", [])
         self._log.debug(
             u"Found {} result(s) from {} for '{}'",
             len(response_data),

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -483,9 +483,8 @@ class DiscogsPlugin(BeetsPlugin):
                 and not track.medium_index
                 and (
                     len(track.medium) != 1
-                    or
                     # Not within standard incremental medium values (A, B, C, ...).
-                    ord(track.medium) - 64 != side_count + 1
+                    or ord(track.medium) - 64 != side_count + 1
                 )
             )
 

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -37,45 +37,50 @@ import traceback
 from string import ascii_lowercase
 
 
-USER_AGENT = u'beets/{0} +https://beets.io/'.format(beets.__version__)
-API_KEY = 'rAzVUQYRaoFjeBjyWuWZ'
-API_SECRET = 'plxtUTqoCzwxZpqdPysCwGuBSmZNdZVy'
+USER_AGENT = u"beets/{0} +https://beets.io/".format(beets.__version__)
+API_KEY = "rAzVUQYRaoFjeBjyWuWZ"
+API_SECRET = "plxtUTqoCzwxZpqdPysCwGuBSmZNdZVy"
 
 # Exceptions that discogs_client should really handle but does not.
-CONNECTION_ERRORS = (ConnectionError, socket.error, http_client.HTTPException,
-                     ValueError,  # JSON decoding raises a ValueError.
-                     DiscogsAPIError)
+CONNECTION_ERRORS = (
+    ConnectionError,
+    socket.error,
+    http_client.HTTPException,
+    ValueError,  # JSON decoding raises a ValueError.
+    DiscogsAPIError,
+)
 
 
 class DiscogsPlugin(BeetsPlugin):
-
     def __init__(self):
         super(DiscogsPlugin, self).__init__()
-        self.config.add({
-            'apikey': API_KEY,
-            'apisecret': API_SECRET,
-            'tokenfile': 'discogs_token.json',
-            'source_weight': 0.5,
-            'user_token': '',
-            'separator': u', ',
-            'index_tracks': False,
-        })
-        self.config['apikey'].redact = True
-        self.config['apisecret'].redact = True
-        self.config['user_token'].redact = True
+        self.config.add(
+            {
+                "apikey": API_KEY,
+                "apisecret": API_SECRET,
+                "tokenfile": "discogs_token.json",
+                "source_weight": 0.5,
+                "user_token": "",
+                "separator": u", ",
+                "index_tracks": False,
+            }
+        )
+        self.config["apikey"].redact = True
+        self.config["apisecret"].redact = True
+        self.config["user_token"].redact = True
         self.discogs_client = None
-        self.register_listener('import_begin', self.setup)
+        self.register_listener("import_begin", self.setup)
         self.rate_limit_per_minute = 25
         self.last_request_timestamp = 0
 
     def setup(self, session=None):
         """Create the `discogs_client` field. Authenticate if necessary.
         """
-        c_key = self.config['apikey'].as_str()
-        c_secret = self.config['apisecret'].as_str()
+        c_key = self.config["apikey"].as_str()
+        c_secret = self.config["apisecret"].as_str()
 
         # Try using a configured user token (bypassing OAuth login).
-        user_token = self.config['user_token'].as_str()
+        user_token = self.config["user_token"].as_str()
         if user_token:
             # The rate limit for authenticated users goes up to 60
             # requests per minute.
@@ -91,11 +96,12 @@ class DiscogsPlugin(BeetsPlugin):
             # No token yet. Generate one.
             token, secret = self.authenticate(c_key, c_secret)
         else:
-            token = tokendata['token']
-            secret = tokendata['secret']
+            token = tokendata["token"]
+            secret = tokendata["secret"]
 
-        self.discogs_client = Client(USER_AGENT, c_key, c_secret,
-                                     token, secret)
+        self.discogs_client = Client(
+            USER_AGENT, c_key, c_secret, token, secret
+        )
 
     def _time_to_next_request(self):
         seconds_between_requests = 60 / self.rate_limit_per_minute
@@ -108,8 +114,9 @@ class DiscogsPlugin(BeetsPlugin):
         """
         time_to_next_request = self._time_to_next_request()
         if time_to_next_request > 0:
-            self._log.debug('hit rate limit, waiting for {0} seconds',
-                            time_to_next_request)
+            self._log.debug(
+                "hit rate limit, waiting for {0} seconds", time_to_next_request
+            )
             time.sleep(time_to_next_request)
 
     def request_finished(self):
@@ -126,7 +133,7 @@ class DiscogsPlugin(BeetsPlugin):
     def _tokenfile(self):
         """Get the path to the JSON file for storing the OAuth token.
         """
-        return self.config['tokenfile'].get(confuse.Filename(in_app_dir=True))
+        return self.config["tokenfile"].get(confuse.Filename(in_app_dir=True))
 
     def authenticate(self, c_key, c_secret):
         # Get the link for the OAuth page.
@@ -134,8 +141,8 @@ class DiscogsPlugin(BeetsPlugin):
         try:
             _, _, url = auth_client.get_authorize_url()
         except CONNECTION_ERRORS as e:
-            self._log.debug(u'connection error: {0}', e)
-            raise beets.ui.UserError(u'communication with Discogs failed')
+            self._log.debug(u"connection error: {0}", e)
+            raise beets.ui.UserError(u"communication with Discogs failed")
 
         beets.ui.print_(u"To authenticate with Discogs, visit:")
         beets.ui.print_(url)
@@ -145,15 +152,15 @@ class DiscogsPlugin(BeetsPlugin):
         try:
             token, secret = auth_client.get_access_token(code)
         except DiscogsAPIError:
-            raise beets.ui.UserError(u'Discogs authorization failed')
+            raise beets.ui.UserError(u"Discogs authorization failed")
         except CONNECTION_ERRORS as e:
-            self._log.debug(u'connection error: {0}', e)
-            raise beets.ui.UserError(u'Discogs token request failed')
+            self._log.debug(u"connection error: {0}", e)
+            raise beets.ui.UserError(u"Discogs token request failed")
 
         # Save the token for later use.
-        self._log.debug(u'Discogs token {0}, secret {1}', token, secret)
-        with open(self._tokenfile(), 'w') as f:
-            json.dump({'token': token, 'secret': secret}, f)
+        self._log.debug(u"Discogs token {0}, secret {1}", token, secret)
+        with open(self._tokenfile(), "w") as f:
+            json.dump({"token": token, "secret": secret}, f)
 
         return token, secret
 
@@ -161,18 +168,14 @@ class DiscogsPlugin(BeetsPlugin):
         """Returns the album distance.
         """
         return get_distance(
-            data_source='Discogs',
-            info=album_info,
-            config=self.config
+            data_source="Discogs", info=album_info, config=self.config
         )
 
     def track_distance(self, item, track_info):
         """Returns the track distance.
         """
         return get_distance(
-            data_source='Discogs',
-            info=track_info,
-            config=self.config
+            data_source="Discogs", info=track_info, config=self.config
         )
 
     def candidates(self, items, artist, album, va_likely, extra_tags=None):
@@ -185,18 +188,18 @@ class DiscogsPlugin(BeetsPlugin):
         if va_likely:
             query = album
         else:
-            query = '%s %s' % (artist, album)
+            query = "%s %s" % (artist, album)
         try:
             return self.get_albums(query)
         except DiscogsAPIError as e:
-            self._log.debug(u'API Error: {0} (query: {1})', e, query)
+            self._log.debug(u"API Error: {0} (query: {1})", e, query)
             if e.status_code == 401:
                 self.reset_auth()
                 return self.candidates(items, artist, album, va_likely)
             else:
                 return []
         except CONNECTION_ERRORS:
-            self._log.debug(u'Connection error in album search', exc_info=True)
+            self._log.debug(u"Connection error in album search", exc_info=True)
             return []
 
     def album_for_id(self, album_id):
@@ -206,29 +209,33 @@ class DiscogsPlugin(BeetsPlugin):
         if not self.discogs_client:
             return
 
-        self._log.debug(u'Searching for release {0}', album_id)
+        self._log.debug(u"Searching for release {0}", album_id)
         # Discogs-IDs are simple integers. We only look for those at the end
         # of an input string as to avoid confusion with other metadata plugins.
         # An optional bracket can follow the integer, as this is how discogs
         # displays the release ID on its webpage.
-        match = re.search(r'(^|\[*r|discogs\.com/.+/release/)(\d+)($|\])',
-                          album_id)
+        match = re.search(
+            r"(^|\[*r|discogs\.com/.+/release/)(\d+)($|\])", album_id
+        )
         if not match:
             return None
-        result = Release(self.discogs_client, {'id': int(match.group(2))})
+        result = Release(self.discogs_client, {"id": int(match.group(2))})
         # Try to obtain title to verify that we indeed have a valid Release
         try:
-            getattr(result, 'title')
+            getattr(result, "title")
         except DiscogsAPIError as e:
             if e.status_code != 404:
-                self._log.debug(u'API Error: {0} (query: {1})', e,
-                                result.data['resource_url'])
+                self._log.debug(
+                    u"API Error: {0} (query: {1})",
+                    e,
+                    result.data["resource_url"],
+                )
                 if e.status_code == 401:
                     self.reset_auth()
                     return self.album_for_id(album_id)
             return None
         except CONNECTION_ERRORS:
-            self._log.debug(u'Connection error in album lookup', exc_info=True)
+            self._log.debug(u"Connection error in album lookup", exc_info=True)
             return None
         return self.get_album_info(result)
 
@@ -242,47 +249,56 @@ class DiscogsPlugin(BeetsPlugin):
         # FIXME: Encode as ASCII to work around a bug:
         # https://github.com/beetbox/beets/issues/1051
         # When the library is fixed, we should encode as UTF-8.
-        query = re.sub(r'(?u)\W+', ' ', query).encode('ascii', "replace")
+        query = re.sub(r"(?u)\W+", " ", query).encode("ascii", "replace")
         # Strip medium information from query, Things like "CD1" and "disk 1"
         # can also negate an otherwise positive result.
-        query = re.sub(br'(?i)\b(CD|disc)\s*\d+', b'', query)
+        query = re.sub(br"(?i)\b(CD|disc)\s*\d+", b"", query)
 
         self.request_start()
         try:
-            releases = self.discogs_client.search(query,
-                                                  type='release').page(1)
+            releases = self.discogs_client.search(query, type="release").page(
+                1
+            )
             self.request_finished()
 
         except CONNECTION_ERRORS:
-            self._log.debug(u"Communication error while searching for {0!r}",
-                            query, exc_info=True)
+            self._log.debug(
+                u"Communication error while searching for {0!r}",
+                query,
+                exc_info=True,
+            )
             return []
-        return [album for album in map(self.get_album_info, releases[:5])
-                if album]
+        return [
+            album for album in map(self.get_album_info, releases[:5]) if album
+        ]
 
     def get_master_year(self, master_id):
         """Fetches a master release given its Discogs ID and returns its year
         or None if the master release is not found.
         """
-        self._log.debug(u'Searching for master release {0}', master_id)
-        result = Master(self.discogs_client, {'id': master_id})
+        self._log.debug(u"Searching for master release {0}", master_id)
+        result = Master(self.discogs_client, {"id": master_id})
 
         self.request_start()
         try:
-            year = result.fetch('year')
+            year = result.fetch("year")
             self.request_finished()
             return year
         except DiscogsAPIError as e:
             if e.status_code != 404:
-                self._log.debug(u'API Error: {0} (query: {1})', e,
-                                result.data['resource_url'])
+                self._log.debug(
+                    u"API Error: {0} (query: {1})",
+                    e,
+                    result.data["resource_url"],
+                )
                 if e.status_code == 401:
                     self.reset_auth()
                     return self.get_master_year(master_id)
             return None
         except CONNECTION_ERRORS:
-            self._log.debug(u'Connection error in master release lookup',
-                            exc_info=True)
+            self._log.debug(
+                u"Connection error in master release lookup", exc_info=True
+            )
             return None
 
     def get_album_info(self, result):
@@ -290,7 +306,7 @@ class DiscogsPlugin(BeetsPlugin):
         """
         # Explicitly reload the `Release` fields, as they might not be yet
         # present if the result is from a `discogs_client.search()`.
-        if not result.data.get('artists'):
+        if not result.data.get("artists"):
             result.refresh()
 
         # Sanity check for required fields. The list of required fields is
@@ -298,48 +314,54 @@ class DiscogsPlugin(BeetsPlugin):
         # lacking some of these fields. This function expects at least:
         # `artists` (>0), `title`, `id`, `tracklist` (>0)
         # https://www.discogs.com/help/doc/submission-guidelines-general-rules
-        if not all([result.data.get(k) for k in ['artists', 'title', 'id',
-                                                 'tracklist']]):
+        if not all(
+            [
+                result.data.get(k)
+                for k in ["artists", "title", "id", "tracklist"]
+            ]
+        ):
             self._log.warning(u"Release does not contain the required fields")
             return None
 
         artist, artist_id = MetadataSourcePlugin.get_artist(
             [a.data for a in result.artists]
         )
-        album = re.sub(r' +', ' ', result.title)
-        album_id = result.data['id']
+        album = re.sub(r" +", " ", result.title)
+        album_id = result.data["id"]
         # Use `.data` to access the tracklist directly instead of the
         # convenient `.tracklist` property, which will strip out useful artist
         # information and leave us with skeleton `Artist` objects that will
         # each make an API call just to get the same data back.
-        tracks = self.get_tracks(result.data['tracklist'])
+        tracks = self.get_tracks(result.data["tracklist"])
 
         # Extract information for the optional AlbumInfo fields, if possible.
-        va = result.data['artists'][0].get('name', '').lower() == 'various'
-        year = result.data.get('year')
+        va = result.data["artists"][0].get("name", "").lower() == "various"
+        year = result.data.get("year")
         mediums = [t.medium for t in tracks]
-        country = result.data.get('country')
-        data_url = result.data.get('uri')
-        style = self.format(result.data.get('styles'))
-        genre = self.format(result.data.get('genres'))
-        discogs_albumid = self.extract_release_id(result.data.get('uri'))
+        country = result.data.get("country")
+        data_url = result.data.get("uri")
+        style = self.format(result.data.get("styles"))
+        genre = self.format(result.data.get("genres"))
+        discogs_albumid = self.extract_release_id(result.data.get("uri"))
 
         # Extract information for the optional AlbumInfo fields that are
         # contained on nested discogs fields.
         albumtype = media = label = catalogno = labelid = None
-        if result.data.get('formats'):
-            albumtype = ', '.join(
-                result.data['formats'][0].get('descriptions', [])) or None
-            media = result.data['formats'][0]['name']
-        if result.data.get('labels'):
-            label = result.data['labels'][0].get('name')
-            catalogno = result.data['labels'][0].get('catno')
-            labelid = result.data['labels'][0].get('id')
+        if result.data.get("formats"):
+            albumtype = (
+                ", ".join(result.data["formats"][0].get("descriptions", []))
+                or None
+            )
+            media = result.data["formats"][0]["name"]
+        if result.data.get("labels"):
+            label = result.data["labels"][0].get("name")
+            catalogno = result.data["labels"][0].get("catno")
+            labelid = result.data["labels"][0].get("id")
 
         # Additional cleanups (various artists name, catalog number, media).
         if va:
-            artist = config['va_name'].as_str()
-        if catalogno == 'none':
+            artist = config["va_name"].as_str()
+        if catalogno == "none":
             catalogno = None
         # Explicitly set the `media` for the tracks, since it is expected by
         # `autotag.apply_metadata`, and set `medium_total`.
@@ -351,26 +373,41 @@ class DiscogsPlugin(BeetsPlugin):
             track.track_id = str(album_id) + "-" + track.track_alt
 
         # Retrieve master release id (returns None if there isn't one).
-        master_id = result.data.get('master_id')
+        master_id = result.data.get("master_id")
         # Assume `original_year` is equal to `year` for releases without
         # a master release, otherwise fetch the master release.
         original_year = self.get_master_year(master_id) if master_id else year
 
-        return AlbumInfo(album=album, album_id=album_id, artist=artist,
-                         artist_id=artist_id, tracks=tracks,
-                         albumtype=albumtype, va=va, year=year,
-                         label=label, mediums=len(set(mediums)),
-                         releasegroup_id=master_id, catalognum=catalogno,
-                         country=country, style=style, genre=genre,
-                         media=media, original_year=original_year,
-                         data_source='Discogs', data_url=data_url,
-                         discogs_albumid=discogs_albumid,
-                         discogs_labelid=labelid, discogs_artistid=artist_id)
+        return AlbumInfo(
+            album=album,
+            album_id=album_id,
+            artist=artist,
+            artist_id=artist_id,
+            tracks=tracks,
+            albumtype=albumtype,
+            va=va,
+            year=year,
+            label=label,
+            mediums=len(set(mediums)),
+            releasegroup_id=master_id,
+            catalognum=catalogno,
+            country=country,
+            style=style,
+            genre=genre,
+            media=media,
+            original_year=original_year,
+            data_source="Discogs",
+            data_url=data_url,
+            discogs_albumid=discogs_albumid,
+            discogs_labelid=labelid,
+            discogs_artistid=artist_id,
+        )
 
     def format(self, classification):
         if classification:
-            return self.config['separator'].as_str() \
-                .join(sorted(classification))
+            return (
+                self.config["separator"].as_str().join(sorted(classification))
+            )
         else:
             return None
 
@@ -389,8 +426,8 @@ class DiscogsPlugin(BeetsPlugin):
             # FIXME: this is an extra precaution for making sure there are no
             # side effects after #2222. It should be removed after further
             # testing.
-            self._log.debug(u'{}', traceback.format_exc())
-            self._log.error(u'uncaught exception in coalesce_tracks: {}', exc)
+            self._log.debug(u"{}", traceback.format_exc())
+            self._log.error(u"uncaught exception in coalesce_tracks: {}", exc)
             clean_tracklist = tracklist
         tracks = []
         index_tracks = {}
@@ -399,7 +436,7 @@ class DiscogsPlugin(BeetsPlugin):
         divisions, next_divisions = [], []
         for track in clean_tracklist:
             # Only real tracks have `position`. Otherwise, it's an index track.
-            if track['position']:
+            if track["position"]:
                 index += 1
                 if next_divisions:
                     # End of a block of index tracks: update the current
@@ -407,17 +444,17 @@ class DiscogsPlugin(BeetsPlugin):
                     divisions += next_divisions
                     del next_divisions[:]
                 track_info = self.get_track_info(track, index, divisions)
-                track_info.track_alt = track['position']
+                track_info.track_alt = track["position"]
                 tracks.append(track_info)
             else:
-                next_divisions.append(track['title'])
+                next_divisions.append(track["title"])
                 # We expect new levels of division at the beginning of the
                 # tracklist (and possibly elsewhere).
                 try:
                     divisions.pop()
                 except IndexError:
                     pass
-                index_tracks[index + 1] = track['title']
+                index_tracks[index + 1] = track["title"]
 
         # Fix up medium and medium_index for each track. Discogs position is
         # unreliable, but tracks are in order.
@@ -431,7 +468,7 @@ class DiscogsPlugin(BeetsPlugin):
             m = sorted(set([track.medium.lower() for track in tracks]))
             # If all track.medium are single consecutive letters, assume it is
             # a 2-sided medium.
-            if ''.join(m) in ascii_lowercase:
+            if "".join(m) in ascii_lowercase:
                 sides_per_medium = 2
 
         for track in tracks:
@@ -441,10 +478,15 @@ class DiscogsPlugin(BeetsPlugin):
             # are the track index, not the medium.
             # side_count is the number of mediums or medium sides (in the case
             # of two-sided mediums) that were seen before.
-            medium_is_index = track.medium and not track.medium_index and (
-                len(track.medium) != 1 or
-                # Not within standard incremental medium values (A, B, C, ...).
-                ord(track.medium) - 64 != side_count + 1
+            medium_is_index = (
+                track.medium
+                and not track.medium_index
+                and (
+                    len(track.medium) != 1
+                    or
+                    # Not within standard incremental medium values (A, B, C, ...).
+                    ord(track.medium) - 64 != side_count + 1
+                )
             )
 
             if not medium_is_index and medium != track.medium:
@@ -481,45 +523,47 @@ class DiscogsPlugin(BeetsPlugin):
         title for the merged track is the one from the previous index track,
         if present; otherwise it is a combination of the subtracks titles.
         """
+
         def add_merged_subtracks(tracklist, subtracks):
             """Modify `tracklist` in place, merging a list of `subtracks` into
             a single track into `tracklist`."""
             # Calculate position based on first subtrack, without subindex.
-            idx, medium_idx, sub_idx = \
-                self.get_track_index(subtracks[0]['position'])
-            position = '%s%s' % (idx or '', medium_idx or '')
+            idx, medium_idx, sub_idx = self.get_track_index(
+                subtracks[0]["position"]
+            )
+            position = "%s%s" % (idx or "", medium_idx or "")
 
-            if tracklist and not tracklist[-1]['position']:
+            if tracklist and not tracklist[-1]["position"]:
                 # Assume the previous index track contains the track title.
                 if sub_idx:
                     # "Convert" the track title to a real track, discarding the
                     # subtracks assuming they are logical divisions of a
                     # physical track (12.2.9 Subtracks).
-                    tracklist[-1]['position'] = position
+                    tracklist[-1]["position"] = position
                 else:
                     # Promote the subtracks to real tracks, discarding the
                     # index track, assuming the subtracks are physical tracks.
                     index_track = tracklist.pop()
                     # Fix artists when they are specified on the index track.
-                    if index_track.get('artists'):
+                    if index_track.get("artists"):
                         for subtrack in subtracks:
-                            if not subtrack.get('artists'):
-                                subtrack['artists'] = index_track['artists']
+                            if not subtrack.get("artists"):
+                                subtrack["artists"] = index_track["artists"]
                     tracklist.extend(subtracks)
             else:
                 # Merge the subtracks, pick a title, and append the new track.
                 track = subtracks[0].copy()
-                track['title'] = ' / '.join([t['title'] for t in subtracks])
+                track["title"] = " / ".join([t["title"] for t in subtracks])
                 tracklist.append(track)
 
         # Pre-process the tracklist, trying to identify subtracks.
         subtracks = []
         tracklist = []
-        prev_subindex = ''
+        prev_subindex = ""
         for track in raw_tracklist:
             # Regular subtrack (track with subindex).
-            if track['position']:
-                _, _, subindex = self.get_track_index(track['position'])
+            if track["position"]:
+                _, _, subindex = self.get_track_index(track["position"])
                 if subindex:
                     if subindex.rjust(len(raw_tracklist)) > prev_subindex:
                         # Subtrack still part of the current main track.
@@ -532,17 +576,17 @@ class DiscogsPlugin(BeetsPlugin):
                     continue
 
             # Index track with nested sub_tracks.
-            if not track['position'] and 'sub_tracks' in track:
+            if not track["position"] and "sub_tracks" in track:
                 # Append the index track, assuming it contains the track title.
                 tracklist.append(track)
-                add_merged_subtracks(tracklist, track['sub_tracks'])
+                add_merged_subtracks(tracklist, track["sub_tracks"])
                 continue
 
             # Regular track or index track without nested sub_tracks.
             if subtracks:
                 add_merged_subtracks(tracklist, subtracks)
                 subtracks = []
-                prev_subindex = ''
+                prev_subindex = ""
             tracklist.append(track)
 
         # Merge and add the remaining subtracks, if any.
@@ -554,19 +598,26 @@ class DiscogsPlugin(BeetsPlugin):
     def get_track_info(self, track, index, divisions):
         """Returns a TrackInfo object for a discogs track.
         """
-        title = track['title']
-        if self.config['index_tracks']:
-            prefix = ', '.join(divisions)
-            title = ': '.join([prefix, title])
+        title = track["title"]
+        if self.config["index_tracks"]:
+            prefix = ", ".join(divisions)
+            title = ": ".join([prefix, title])
         track_id = None
-        medium, medium_index, _ = self.get_track_index(track['position'])
+        medium, medium_index, _ = self.get_track_index(track["position"])
         artist, artist_id = MetadataSourcePlugin.get_artist(
-            track.get('artists', [])
+            track.get("artists", [])
         )
-        length = self.get_track_length(track['duration'])
-        return TrackInfo(title=title, track_id=track_id, artist=artist,
-                         artist_id=artist_id, length=length, index=index,
-                         medium=medium, medium_index=medium_index)
+        length = self.get_track_length(track["duration"])
+        return TrackInfo(
+            title=title,
+            track_id=track_id,
+            artist=artist,
+            artist_id=artist_id,
+            length=length,
+            index=index,
+            medium=medium,
+            medium_index=medium_index,
+        )
 
     def get_track_index(self, position):
         """Returns the medium, medium index and subtrack index for a discogs
@@ -574,26 +625,26 @@ class DiscogsPlugin(BeetsPlugin):
         # Match the standard Discogs positions (12.2.9), which can have several
         # forms (1, 1-1, A1, A1.1, A1a, ...).
         match = re.match(
-            r'^(.*?)'           # medium: everything before medium_index.
-            r'(\d*?)'           # medium_index: a number at the end of
-                                # `position`, except if followed by a subtrack
-                                # index.
-                                # subtrack_index: can only be matched if medium
-                                # or medium_index have been matched, and can be
-            r'((?<=\w)\.[\w]+'  # - a dot followed by a string (A.1, 2.A)
-            r'|(?<=\d)[A-Z]+'   # - a string that follows a number (1A, B2a)
-            r')?'
-            r'$',
-            position.upper()
+            r"^(.*?)"  # medium: everything before medium_index.
+            r"(\d*?)"  # medium_index: a number at the end of
+            # `position`, except if followed by a subtrack
+            # index.
+            # subtrack_index: can only be matched if medium
+            # or medium_index have been matched, and can be
+            r"((?<=\w)\.[\w]+"  # - a dot followed by a string (A.1, 2.A)
+            r"|(?<=\d)[A-Z]+"  # - a string that follows a number (1A, B2a)
+            r")?"
+            r"$",
+            position.upper(),
         )
 
         if match:
             medium, index, subindex = match.groups()
 
-            if subindex and subindex.startswith('.'):
+            if subindex and subindex.startswith("."):
                 subindex = subindex[1:]
         else:
-            self._log.debug(u'Invalid position: {0}', position)
+            self._log.debug(u"Invalid position: {0}", position)
             medium = index = subindex = None
         return medium or None, index or None, subindex or None
 
@@ -601,7 +652,7 @@ class DiscogsPlugin(BeetsPlugin):
         """Returns the track length in seconds for a discogs duration.
         """
         try:
-            length = time.strptime(duration, '%M:%S')
+            length = time.strptime(duration, "%M:%S")
         except ValueError:
             return None
         return length.tm_min * 60 + length.tm_sec

--- a/beetsplug/duplicates.py
+++ b/beetsplug/duplicates.py
@@ -21,156 +21,190 @@ import shlex
 
 from beets.plugins import BeetsPlugin
 from beets.ui import decargs, print_, Subcommand, UserError
-from beets.util import command_output, displayable_path, subprocess, \
-    bytestring_path, MoveOperation
+from beets.util import (
+    command_output,
+    displayable_path,
+    subprocess,
+    bytestring_path,
+    MoveOperation,
+)
 from beets.library import Item, Album
 import six
 
-PLUGIN = 'duplicates'
+PLUGIN = "duplicates"
 
 
 class DuplicatesPlugin(BeetsPlugin):
     """List duplicate tracks or albums
     """
+
     def __init__(self):
         super(DuplicatesPlugin, self).__init__()
 
-        self.config.add({
-            'album': False,
-            'checksum': '',
-            'copy': '',
-            'count': False,
-            'delete': False,
-            'format': '',
-            'full': False,
-            'keys': [],
-            'merge': False,
-            'move': '',
-            'path': False,
-            'tiebreak': {},
-            'strict': False,
-            'tag': '',
-        })
+        self.config.add(
+            {
+                "album": False,
+                "checksum": "",
+                "copy": "",
+                "count": False,
+                "delete": False,
+                "format": "",
+                "full": False,
+                "keys": [],
+                "merge": False,
+                "move": "",
+                "path": False,
+                "tiebreak": {},
+                "strict": False,
+                "tag": "",
+            }
+        )
 
-        self._command = Subcommand('duplicates',
-                                   help=__doc__,
-                                   aliases=['dup'])
+        self._command = Subcommand("duplicates", help=__doc__, aliases=["dup"])
         self._command.parser.add_option(
-            u'-c', u'--count', dest='count',
-            action='store_true',
-            help=u'show duplicate counts',
+            u"-c",
+            u"--count",
+            dest="count",
+            action="store_true",
+            help=u"show duplicate counts",
         )
         self._command.parser.add_option(
-            u'-C', u'--checksum', dest='checksum',
-            action='store', metavar='PROG',
-            help=u'report duplicates based on arbitrary command',
+            u"-C",
+            u"--checksum",
+            dest="checksum",
+            action="store",
+            metavar="PROG",
+            help=u"report duplicates based on arbitrary command",
         )
         self._command.parser.add_option(
-            u'-d', u'--delete', dest='delete',
-            action='store_true',
-            help=u'delete items from library and disk',
+            u"-d",
+            u"--delete",
+            dest="delete",
+            action="store_true",
+            help=u"delete items from library and disk",
         )
         self._command.parser.add_option(
-            u'-F', u'--full', dest='full',
-            action='store_true',
-            help=u'show all versions of duplicate tracks or albums',
+            u"-F",
+            u"--full",
+            dest="full",
+            action="store_true",
+            help=u"show all versions of duplicate tracks or albums",
         )
         self._command.parser.add_option(
-            u'-s', u'--strict', dest='strict',
-            action='store_true',
-            help=u'report duplicates only if all attributes are set',
+            u"-s",
+            u"--strict",
+            dest="strict",
+            action="store_true",
+            help=u"report duplicates only if all attributes are set",
         )
         self._command.parser.add_option(
-            u'-k', u'--key', dest='keys',
-            action='append', metavar='KEY',
-            help=u'report duplicates based on keys (use multiple times)',
+            u"-k",
+            u"--key",
+            dest="keys",
+            action="append",
+            metavar="KEY",
+            help=u"report duplicates based on keys (use multiple times)",
         )
         self._command.parser.add_option(
-            u'-M', u'--merge', dest='merge',
-            action='store_true',
-            help=u'merge duplicate items',
+            u"-M",
+            u"--merge",
+            dest="merge",
+            action="store_true",
+            help=u"merge duplicate items",
         )
         self._command.parser.add_option(
-            u'-m', u'--move', dest='move',
-            action='store', metavar='DEST',
-            help=u'move items to dest',
+            u"-m",
+            u"--move",
+            dest="move",
+            action="store",
+            metavar="DEST",
+            help=u"move items to dest",
         )
         self._command.parser.add_option(
-            u'-o', u'--copy', dest='copy',
-            action='store', metavar='DEST',
-            help=u'copy items to dest',
+            u"-o",
+            u"--copy",
+            dest="copy",
+            action="store",
+            metavar="DEST",
+            help=u"copy items to dest",
         )
         self._command.parser.add_option(
-            u'-t', u'--tag', dest='tag',
-            action='store',
-            help=u'tag matched items with \'k=v\' attribute',
+            u"-t",
+            u"--tag",
+            dest="tag",
+            action="store",
+            help=u"tag matched items with 'k=v' attribute",
         )
         self._command.parser.add_all_common_options()
 
     def commands(self):
-
         def _dup(lib, opts, args):
             self.config.set_args(opts)
-            album = self.config['album'].get(bool)
-            checksum = self.config['checksum'].get(str)
-            copy = bytestring_path(self.config['copy'].as_str())
-            count = self.config['count'].get(bool)
-            delete = self.config['delete'].get(bool)
-            fmt = self.config['format'].get(str)
-            full = self.config['full'].get(bool)
-            keys = self.config['keys'].as_str_seq()
-            merge = self.config['merge'].get(bool)
-            move = bytestring_path(self.config['move'].as_str())
-            path = self.config['path'].get(bool)
-            tiebreak = self.config['tiebreak'].get(dict)
-            strict = self.config['strict'].get(bool)
-            tag = self.config['tag'].get(str)
+            album = self.config["album"].get(bool)
+            checksum = self.config["checksum"].get(str)
+            copy = bytestring_path(self.config["copy"].as_str())
+            count = self.config["count"].get(bool)
+            delete = self.config["delete"].get(bool)
+            fmt = self.config["format"].get(str)
+            full = self.config["full"].get(bool)
+            keys = self.config["keys"].as_str_seq()
+            merge = self.config["merge"].get(bool)
+            move = bytestring_path(self.config["move"].as_str())
+            path = self.config["path"].get(bool)
+            tiebreak = self.config["tiebreak"].get(dict)
+            strict = self.config["strict"].get(bool)
+            tag = self.config["tag"].get(str)
 
             if album:
                 if not keys:
-                    keys = ['mb_albumid']
+                    keys = ["mb_albumid"]
                 items = lib.albums(decargs(args))
             else:
                 if not keys:
-                    keys = ['mb_trackid', 'mb_albumid']
+                    keys = ["mb_trackid", "mb_albumid"]
                 items = lib.items(decargs(args))
 
             if path:
-                fmt = u'$path'
+                fmt = u"$path"
 
             # Default format string for count mode.
             if count and not fmt:
                 if album:
-                    fmt = u'$albumartist - $album'
+                    fmt = u"$albumartist - $album"
                 else:
-                    fmt = u'$albumartist - $album - $title'
-                fmt += u': {0}'
+                    fmt = u"$albumartist - $album - $title"
+                fmt += u": {0}"
 
             if checksum:
                 for i in items:
                     k, _ = self._checksum(i, checksum)
                 keys = [k]
 
-            for obj_id, obj_count, objs in self._duplicates(items,
-                                                            keys=keys,
-                                                            full=full,
-                                                            strict=strict,
-                                                            tiebreak=tiebreak,
-                                                            merge=merge):
+            for obj_id, obj_count, objs in self._duplicates(
+                items,
+                keys=keys,
+                full=full,
+                strict=strict,
+                tiebreak=tiebreak,
+                merge=merge,
+            ):
                 if obj_id:  # Skip empty IDs.
                     for o in objs:
-                        self._process_item(o,
-                                           copy=copy,
-                                           move=move,
-                                           delete=delete,
-                                           tag=tag,
-                                           fmt=fmt.format(obj_count))
+                        self._process_item(
+                            o,
+                            copy=copy,
+                            move=move,
+                            delete=delete,
+                            tag=tag,
+                            fmt=fmt.format(obj_count),
+                        )
 
         self._command.func = _dup
         return [self._command]
 
-    def _process_item(self, item, copy=False, move=False, delete=False,
-                      tag=False, fmt=u''):
+    def _process_item(
+        self, item, copy=False, move=False, delete=False, tag=False, fmt=u""
+    ):
         """Process Item `item`.
         """
         print_(format(item, fmt))
@@ -184,7 +218,7 @@ class DuplicatesPlugin(BeetsPlugin):
             item.remove(delete=True)
         if tag:
             try:
-                k, v = tag.split('=')
+                k, v = tag.split("=")
             except Exception:
                 raise UserError(
                     u"{}: can't parse k=v tag: {}".format(PLUGIN, tag)
@@ -201,22 +235,30 @@ class DuplicatesPlugin(BeetsPlugin):
         key = args[0]
         checksum = getattr(item, key, False)
         if not checksum:
-            self._log.debug(u'key {0} on item {1} not cached:'
-                            u'computing checksum',
-                            key, displayable_path(item.path))
+            self._log.debug(
+                u"key {0} on item {1} not cached:" u"computing checksum",
+                key,
+                displayable_path(item.path),
+            )
             try:
                 checksum = command_output(args).stdout
                 setattr(item, key, checksum)
                 item.store()
-                self._log.debug(u'computed checksum for {0} using {1}',
-                                item.title, key)
+                self._log.debug(
+                    u"computed checksum for {0} using {1}", item.title, key
+                )
             except subprocess.CalledProcessError as e:
-                self._log.debug(u'failed to checksum {0}: {1}',
-                                displayable_path(item.path), e)
+                self._log.debug(
+                    u"failed to checksum {0}: {1}",
+                    displayable_path(item.path),
+                    e,
+                )
         else:
-            self._log.debug(u'key {0} on item {1} cached:'
-                            u'not computing checksum',
-                            key, displayable_path(item.path))
+            self._log.debug(
+                u"key {0} on item {1} cached:" u"not computing checksum",
+                key,
+                displayable_path(item.path),
+            )
         return key, checksum
 
     def _group_by(self, objs, keys, strict):
@@ -226,18 +268,25 @@ class DuplicatesPlugin(BeetsPlugin):
         If strict, all attributes must be defined for a duplicate match.
         """
         import collections
+
         counts = collections.defaultdict(list)
         for obj in objs:
             values = [getattr(obj, k, None) for k in keys]
-            values = [v for v in values if v not in (None, '')]
+            values = [v for v in values if v not in (None, "")]
             if strict and len(values) < len(keys):
-                self._log.debug(u'some keys {0} on item {1} are null or empty:'
-                                u' skipping',
-                                keys, displayable_path(obj.path))
-            elif (not strict and not len(values)):
-                self._log.debug(u'all keys {0} on item {1} are null or empty:'
-                                u' skipping',
-                                keys, displayable_path(obj.path))
+                self._log.debug(
+                    u"some keys {0} on item {1} are null or empty:"
+                    u" skipping",
+                    keys,
+                    displayable_path(obj.path),
+                )
+            elif not strict and not len(values):
+                self._log.debug(
+                    u"all keys {0} on item {1} are null or empty:"
+                    u" skipping",
+                    keys,
+                    displayable_path(obj.path),
+                )
             else:
                 key = tuple(values)
                 counts[key].append(obj)
@@ -253,18 +302,21 @@ class DuplicatesPlugin(BeetsPlugin):
         "completeness" (objects with more non-null fields come first)
         and Albums are ordered by their track count.
         """
-        kind = 'items' if all(isinstance(o, Item) for o in objs) else 'albums'
+        kind = "items" if all(isinstance(o, Item) for o in objs) else "albums"
 
         if tiebreak and kind in tiebreak.keys():
             key = lambda x: tuple(getattr(x, k) for k in tiebreak[kind])
         else:
-            if kind == 'items':
+            if kind == "items":
+
                 def truthy(v):
                     # Avoid a Unicode warning by avoiding comparison
                     # between a bytes object and the empty Unicode
                     # string ''.
-                    return v is not None and \
-                        (v != '' if isinstance(v, six.text_type) else True)
+                    return v is not None and (
+                        v != "" if isinstance(v, six.text_type) else True
+                    )
+
                 fields = Item.all_keys()
                 key = lambda x: sum(1 for f in fields if truthy(getattr(x, f)))
             else:
@@ -281,13 +333,16 @@ class DuplicatesPlugin(BeetsPlugin):
         fields = Item.all_keys()
         for f in fields:
             for o in objs[1:]:
-                if getattr(objs[0], f, None) in (None, ''):
+                if getattr(objs[0], f, None) in (None, ""):
                     value = getattr(o, f, None)
                     if value:
-                        self._log.debug(u'key {0} on item {1} is null '
-                                        u'or empty: setting from item {2}',
-                                        f, displayable_path(objs[0].path),
-                                        displayable_path(o.path))
+                        self._log.debug(
+                            u"key {0} on item {1} is null "
+                            u"or empty: setting from item {2}",
+                            f,
+                            displayable_path(objs[0].path),
+                            displayable_path(o.path),
+                        )
                         setattr(objs[0], f, value)
                         objs[0].store()
                         break
@@ -305,12 +360,14 @@ class DuplicatesPlugin(BeetsPlugin):
                     missing = Item.from_path(i.path)
                     missing.album_id = objs[0].id
                     missing.add(i._db)
-                    self._log.debug(u'item {0} missing from album {1}:'
-                                    u' merging from {2} into {3}',
-                                    missing,
-                                    objs[0],
-                                    displayable_path(o.path),
-                                    displayable_path(missing.destination()))
+                    self._log.debug(
+                        u"item {0} missing from album {1}:"
+                        u" merging from {2} into {3}",
+                        missing,
+                        objs[0],
+                        displayable_path(o.path),
+                        displayable_path(missing.destination()),
+                    )
                     missing.move(operation=MoveOperation.COPY)
         return objs
 

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -34,11 +34,9 @@ def _confirm(objs, album):
     `album` is a Boolean indicating whether these are albums (as opposed
     to items).
     """
-    noun = u'album' if album else u'file'
-    prompt = u'Modify artwork for {} {}{} (Y/n)?'.format(
-        len(objs),
-        noun,
-        u's' if len(objs) > 1 else u''
+    noun = u"album" if album else u"file"
+    prompt = u"Modify artwork for {} {}{} (Y/n)?".format(
+        len(objs), noun, u"s" if len(objs) > 1 else u""
     )
 
     # Show all the items or albums.
@@ -52,52 +50,62 @@ def _confirm(objs, album):
 class EmbedCoverArtPlugin(BeetsPlugin):
     """Allows albumart to be embedded into the actual files.
     """
+
     def __init__(self):
         super(EmbedCoverArtPlugin, self).__init__()
-        self.config.add({
-            'maxwidth': 0,
-            'auto': True,
-            'compare_threshold': 0,
-            'ifempty': False,
-            'remove_art_file': False,
-            'quality': 0,
-        })
+        self.config.add(
+            {
+                "maxwidth": 0,
+                "auto": True,
+                "compare_threshold": 0,
+                "ifempty": False,
+                "remove_art_file": False,
+                "quality": 0,
+            }
+        )
 
-        if self.config['maxwidth'].get(int) and not ArtResizer.shared.local:
-            self.config['maxwidth'] = 0
-            self._log.warning(u"ImageMagick or PIL not found; "
-                              u"'maxwidth' option ignored")
-        if self.config['compare_threshold'].get(int) and not \
-                ArtResizer.shared.can_compare:
-            self.config['compare_threshold'] = 0
-            self._log.warning(u"ImageMagick 6.8.7 or higher not installed; "
-                              u"'compare_threshold' option ignored")
+        if self.config["maxwidth"].get(int) and not ArtResizer.shared.local:
+            self.config["maxwidth"] = 0
+            self._log.warning(
+                u"ImageMagick or PIL not found; " u"'maxwidth' option ignored"
+            )
+        if (
+            self.config["compare_threshold"].get(int)
+            and not ArtResizer.shared.can_compare
+        ):
+            self.config["compare_threshold"] = 0
+            self._log.warning(
+                u"ImageMagick 6.8.7 or higher not installed; "
+                u"'compare_threshold' option ignored"
+            )
 
-        self.register_listener('art_set', self.process_album)
+        self.register_listener("art_set", self.process_album)
 
     def commands(self):
         # Embed command.
         embed_cmd = ui.Subcommand(
-            'embedart', help=u'embed image files into file metadata'
+            "embedart", help=u"embed image files into file metadata"
         )
         embed_cmd.parser.add_option(
-            u'-f', u'--file', metavar='PATH', help=u'the image file to embed'
+            u"-f", u"--file", metavar="PATH", help=u"the image file to embed"
         )
         embed_cmd.parser.add_option(
             u"-y", u"--yes", action="store_true", help=u"skip confirmation"
         )
-        maxwidth = self.config['maxwidth'].get(int)
-        quality = self.config['quality'].get(int)
-        compare_threshold = self.config['compare_threshold'].get(int)
-        ifempty = self.config['ifempty'].get(bool)
+        maxwidth = self.config["maxwidth"].get(int)
+        quality = self.config["quality"].get(int)
+        compare_threshold = self.config["compare_threshold"].get(int)
+        ifempty = self.config["ifempty"].get(bool)
 
         def embed_func(lib, opts, args):
             if opts.file:
                 imagepath = normpath(opts.file)
                 if not os.path.isfile(syspath(imagepath)):
-                    raise ui.UserError(u'image file {0} not found'.format(
-                        displayable_path(imagepath)
-                    ))
+                    raise ui.UserError(
+                        u"image file {0} not found".format(
+                            displayable_path(imagepath)
+                        )
+                    )
 
                 items = lib.items(decargs(args))
 
@@ -106,9 +114,16 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                     return
 
                 for item in items:
-                    art.embed_item(self._log, item, imagepath, maxwidth,
-                                   None, compare_threshold, ifempty,
-                                   quality=quality)
+                    art.embed_item(
+                        self._log,
+                        item,
+                        imagepath,
+                        maxwidth,
+                        None,
+                        compare_threshold,
+                        ifempty,
+                        quality=quality,
+                    )
             else:
                 albums = lib.albums(decargs(args))
 
@@ -117,55 +132,66 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                     return
 
                 for album in albums:
-                    art.embed_album(self._log, album, maxwidth,
-                                    False, compare_threshold, ifempty,
-                                    quality=quality)
+                    art.embed_album(
+                        self._log,
+                        album,
+                        maxwidth,
+                        False,
+                        compare_threshold,
+                        ifempty,
+                        quality=quality,
+                    )
                     self.remove_artfile(album)
 
         embed_cmd.func = embed_func
 
         # Extract command.
         extract_cmd = ui.Subcommand(
-            'extractart',
-            help=u'extract an image from file metadata',
+            "extractart", help=u"extract an image from file metadata",
         )
         extract_cmd.parser.add_option(
-            u'-o', dest='outpath',
-            help=u'image output file',
+            u"-o", dest="outpath", help=u"image output file",
         )
         extract_cmd.parser.add_option(
-            u'-n', dest='filename',
-            help=u'image filename to create for all matched albums',
+            u"-n",
+            dest="filename",
+            help=u"image filename to create for all matched albums",
         )
         extract_cmd.parser.add_option(
-            '-a', dest='associate', action='store_true',
-            help='associate the extracted images with the album',
+            "-a",
+            dest="associate",
+            action="store_true",
+            help="associate the extracted images with the album",
         )
 
         def extract_func(lib, opts, args):
             if opts.outpath:
-                art.extract_first(self._log, normpath(opts.outpath),
-                                  lib.items(decargs(args)))
+                art.extract_first(
+                    self._log, normpath(opts.outpath), lib.items(decargs(args))
+                )
             else:
-                filename = bytestring_path(opts.filename or
-                                           config['art_filename'].get())
-                if os.path.dirname(filename) != b'':
+                filename = bytestring_path(
+                    opts.filename or config["art_filename"].get()
+                )
+                if os.path.dirname(filename) != b"":
                     self._log.error(
-                        u"Only specify a name rather than a path for -n")
+                        u"Only specify a name rather than a path for -n"
+                    )
                     return
                 for album in lib.albums(decargs(args)):
                     artpath = normpath(os.path.join(album.path, filename))
-                    artpath = art.extract_first(self._log, artpath,
-                                                album.items())
+                    artpath = art.extract_first(
+                        self._log, artpath, album.items()
+                    )
                     if artpath and opts.associate:
                         album.set_art(artpath)
                         album.store()
+
         extract_cmd.func = extract_func
 
         # Clear command.
         clear_cmd = ui.Subcommand(
-            'clearart',
-            help=u'remove images from file metadata',
+            "clearart", help=u"remove images from file metadata",
         )
         clear_cmd.parser.add_option(
             u"-y", u"--yes", action="store_true", help=u"skip confirmation"
@@ -177,6 +203,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
             if not opts.yes and not _confirm(items, False):
                 return
             art.clear(self._log, lib, decargs(args))
+
         clear_cmd.func = clear_func
 
         return [embed_cmd, extract_cmd, clear_cmd]
@@ -184,20 +211,25 @@ class EmbedCoverArtPlugin(BeetsPlugin):
     def process_album(self, album):
         """Automatically embed art after art has been set
         """
-        if self.config['auto'] and ui.should_write():
-            max_width = self.config['maxwidth'].get(int)
-            art.embed_album(self._log, album, max_width, True,
-                            self.config['compare_threshold'].get(int),
-                            self.config['ifempty'].get(bool))
+        if self.config["auto"] and ui.should_write():
+            max_width = self.config["maxwidth"].get(int)
+            art.embed_album(
+                self._log,
+                album,
+                max_width,
+                True,
+                self.config["compare_threshold"].get(int),
+                self.config["ifempty"].get(bool),
+            )
             self.remove_artfile(album)
 
     def remove_artfile(self, album):
         """Possibly delete the album art file for an album (if the
         appropriate configuration option is enabled).
         """
-        if self.config['remove_art_file'] and album.artpath:
+        if self.config["remove_art_file"] and album.artpath:
             if os.path.isfile(album.artpath):
-                self._log.debug(u'Removing album art file for {0}', album)
+                self._log.debug(u"Removing album art file for {0}", album)
                 os.remove(album.artpath)
                 album.artpath = None
                 album.store()

--- a/beetsplug/embyupdate.py
+++ b/beetsplug/embyupdate.py
@@ -37,24 +37,20 @@ def api_url(host, port, endpoint):
     """
     # check if http or https is defined as host and create hostname
     hostname_list = [host]
-    if host.startswith('http://') or host.startswith('https://'):
-        hostname = ''.join(hostname_list)
+    if host.startswith("http://") or host.startswith("https://"):
+        hostname = "".join(hostname_list)
     else:
-        hostname_list.insert(0, 'http://')
-        hostname = ''.join(hostname_list)
+        hostname_list.insert(0, "http://")
+        hostname = "".join(hostname_list)
 
     joined = urljoin(
-        '{hostname}:{port}'.format(
-            hostname=hostname,
-            port=port
-        ),
-        endpoint
+        "{hostname}:{port}".format(hostname=hostname, port=port), endpoint
     )
 
     scheme, netloc, path, query_string, fragment = urlsplit(joined)
     query_params = parse_qs(query_string)
 
-    query_params['format'] = ['json']
+    query_params["format"] = ["json"]
     new_query_string = urlencode(query_params, doseq=True)
 
     return urlunsplit((scheme, netloc, path, new_query_string, fragment))
@@ -71,9 +67,9 @@ def password_data(username, password):
     :rtype: dict
     """
     return {
-        'username': username,
-        'password': hashlib.sha1(password.encode('utf-8')).hexdigest(),
-        'passwordMd5': hashlib.md5(password.encode('utf-8')).hexdigest()
+        "username": username,
+        "password": hashlib.sha1(password.encode("utf-8")).hexdigest(),
+        "passwordMd5": hashlib.md5(password.encode("utf-8")).hexdigest(),
     }
 
 
@@ -97,10 +93,10 @@ def create_headers(user_id, token=None):
         'Version="0.0.0"'
     ).format(user_id=user_id)
 
-    headers['x-emby-authorization'] = authorization
+    headers["x-emby-authorization"] = authorization
 
     if token:
-        headers['x-mediabrowser-token'] = token
+        headers["x-mediabrowser-token"] = token
 
     return headers
 
@@ -119,10 +115,10 @@ def get_token(host, port, headers, auth_data):
     :returns: Access Token
     :rtype: str
     """
-    url = api_url(host, port, '/Users/AuthenticateByName')
+    url = api_url(host, port, "/Users/AuthenticateByName")
     r = requests.post(url, headers=headers, data=auth_data)
 
-    return r.json().get('AccessToken')
+    return r.json().get("AccessToken")
 
 
 def get_user(host, port, username):
@@ -137,9 +133,9 @@ def get_user(host, port, username):
     :returns: Matched Users
     :rtype: list
     """
-    url = api_url(host, port, '/Users/Public')
+    url = api_url(host, port, "/Users/Public")
     r = requests.get(url)
-    user = [i for i in r.json() if i['Name'] == username]
+    user = [i for i in r.json() if i["Name"] == username]
 
     return user
 
@@ -149,62 +145,64 @@ class EmbyUpdate(BeetsPlugin):
         super(EmbyUpdate, self).__init__()
 
         # Adding defaults.
-        config['emby'].add({
-            u'host': u'http://localhost',
-            u'port': 8096,
-            u'apikey': None,
-            u'password': None,
-        })
+        config["emby"].add(
+            {
+                u"host": u"http://localhost",
+                u"port": 8096,
+                u"apikey": None,
+                u"password": None,
+            }
+        )
 
-        self.register_listener('database_change', self.listen_for_db_change)
+        self.register_listener("database_change", self.listen_for_db_change)
 
     def listen_for_db_change(self, lib, model):
         """Listens for beets db change and register the update for the end.
         """
-        self.register_listener('cli_exit', self.update)
+        self.register_listener("cli_exit", self.update)
 
     def update(self, lib):
         """When the client exists try to send refresh request to Emby.
         """
-        self._log.info(u'Updating Emby library...')
+        self._log.info(u"Updating Emby library...")
 
-        host = config['emby']['host'].get()
-        port = config['emby']['port'].get()
-        username = config['emby']['username'].get()
-        password = config['emby']['password'].get()
-        token = config['emby']['apikey'].get()
+        host = config["emby"]["host"].get()
+        port = config["emby"]["port"].get()
+        username = config["emby"]["username"].get()
+        password = config["emby"]["password"].get()
+        token = config["emby"]["apikey"].get()
 
         # Check if at least a apikey or password is given.
         if not any([password, token]):
-            self._log.warning(u'Provide at least Emby password or apikey.')
+            self._log.warning(u"Provide at least Emby password or apikey.")
             return
 
         # Get user information from the Emby API.
         user = get_user(host, port, username)
         if not user:
-            self._log.warning(u'User {0} could not be found.'.format(username))
+            self._log.warning(u"User {0} could not be found.".format(username))
             return
 
         if not token:
             # Create Authentication data and headers.
             auth_data = password_data(username, password)
-            headers = create_headers(user[0]['Id'])
+            headers = create_headers(user[0]["Id"])
 
             # Get authentication token.
             token = get_token(host, port, headers, auth_data)
             if not token:
                 self._log.warning(
-                    u'Could not get token for user {0}', username
+                    u"Could not get token for user {0}", username
                 )
                 return
 
         # Recreate headers with a token.
-        headers = create_headers(user[0]['Id'], token=token)
+        headers = create_headers(user[0]["Id"], token=token)
 
         # Trigger the Update.
-        url = api_url(host, port, '/Library/Refresh')
+        url = api_url(host, port, "/Library/Refresh")
         r = requests.post(url, headers=headers)
         if r.status_code != 204:
-            self._log.warning(u'Update could not be triggered')
+            self._log.warning(u"Update could not be triggered")
         else:
-            self._log.info(u'Update triggered.')
+            self._log.info(u"Update triggered.")

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -37,10 +37,7 @@ from beets.util import syspath, bytestring_path, py3_path
 import confuse
 import six
 
-CONTENT_TYPES = {
-    'image/jpeg': [b'jpg', b'jpeg'],
-    'image/png': [b'png']
-}
+CONTENT_TYPES = {"image/jpeg": [b"jpg", b"jpeg"], "image/png": [b"png"]}
 IMAGE_EXTENSIONS = [ext for exts in CONTENT_TYPES.values() for ext in exts]
 
 
@@ -48,6 +45,7 @@ class Candidate(object):
     """Holds information about a matching artwork, deals with validation of
     dimension restrictions and resizing.
     """
+
     CANDIDATE_BAD = 0
     CANDIDATE_EXACT = 1
     CANDIDATE_DOWNSCALE = 2
@@ -55,8 +53,9 @@ class Candidate(object):
     MATCH_EXACT = 0
     MATCH_FALLBACK = 1
 
-    def __init__(self, log, path=None, url=None, source=u'',
-                 match=None, size=None):
+    def __init__(
+        self, log, path=None, url=None, source=u"", match=None, size=None
+    ):
         self._log = log
         self.path = path
         self.url = url
@@ -82,13 +81,15 @@ class Candidate(object):
         # get_size returns None if no local imaging backend is available
         if not self.size:
             self.size = ArtResizer.shared.get_size(self.path)
-        self._log.debug(u'image size: {}', self.size)
+        self._log.debug(u"image size: {}", self.size)
 
         if not self.size:
-            self._log.warning(u'Could not get size of image (please see '
-                              u'documentation for dependencies). '
-                              u'The configuration options `minwidth` and '
-                              u'`enforce_ratio` may be violated.')
+            self._log.warning(
+                u"Could not get size of image (please see "
+                u"documentation for dependencies). "
+                u"The configuration options `minwidth` and "
+                u"`enforce_ratio` may be violated."
+            )
             return self.CANDIDATE_EXACT
 
         short_edge = min(self.size)
@@ -96,8 +97,9 @@ class Candidate(object):
 
         # Check minimum size.
         if plugin.minwidth and self.size[0] < plugin.minwidth:
-            self._log.debug(u'image too small ({} < {})',
-                            self.size[0], plugin.minwidth)
+            self._log.debug(
+                u"image too small ({} < {})", self.size[0], plugin.minwidth
+            )
             return self.CANDIDATE_BAD
 
         # Check aspect ratio.
@@ -105,27 +107,41 @@ class Candidate(object):
         if plugin.enforce_ratio:
             if plugin.margin_px:
                 if edge_diff > plugin.margin_px:
-                    self._log.debug(u'image is not close enough to being '
-                                    u'square, ({} - {} > {})',
-                                    long_edge, short_edge, plugin.margin_px)
+                    self._log.debug(
+                        u"image is not close enough to being "
+                        u"square, ({} - {} > {})",
+                        long_edge,
+                        short_edge,
+                        plugin.margin_px,
+                    )
                     return self.CANDIDATE_BAD
             elif plugin.margin_percent:
                 margin_px = plugin.margin_percent * long_edge
                 if edge_diff > margin_px:
-                    self._log.debug(u'image is not close enough to being '
-                                    u'square, ({} - {} > {})',
-                                    long_edge, short_edge, margin_px)
+                    self._log.debug(
+                        u"image is not close enough to being "
+                        u"square, ({} - {} > {})",
+                        long_edge,
+                        short_edge,
+                        margin_px,
+                    )
                     return self.CANDIDATE_BAD
             elif edge_diff:
                 # also reached for margin_px == 0 and margin_percent == 0.0
-                self._log.debug(u'image is not square ({} != {})',
-                                self.size[0], self.size[1])
+                self._log.debug(
+                    u"image is not square ({} != {})",
+                    self.size[0],
+                    self.size[1],
+                )
                 return self.CANDIDATE_BAD
 
         # Check maximum size.
         if plugin.maxwidth and self.size[0] > plugin.maxwidth:
-            self._log.debug(u'image needs resizing ({} > {})',
-                            self.size[0], plugin.maxwidth)
+            self._log.debug(
+                u"image needs resizing ({} > {})",
+                self.size[0],
+                plugin.maxwidth,
+            )
             return self.CANDIDATE_DOWNSCALE
 
         return self.CANDIDATE_EXACT
@@ -136,8 +152,9 @@ class Candidate(object):
 
     def resize(self, plugin):
         if plugin.maxwidth and self.check == self.CANDIDATE_DOWNSCALE:
-            self.path = ArtResizer.shared.resize(plugin.maxwidth, self.path,
-                                                 quality=plugin.quality)
+            self.path = ArtResizer.shared.resize(
+                plugin.maxwidth, self.path, quality=plugin.quality
+            )
 
 
 def _logged_get(log, *args, **kwargs):
@@ -155,26 +172,26 @@ def _logged_get(log, *args, **kwargs):
     # `requests.Session.request`.
     req_kwargs = kwargs
     send_kwargs = {}
-    for arg in ('stream', 'verify', 'proxies', 'cert', 'timeout'):
+    for arg in ("stream", "verify", "proxies", "cert", "timeout"):
         if arg in kwargs:
             send_kwargs[arg] = req_kwargs.pop(arg)
 
     # Our special logging message parameter.
-    if 'message' in kwargs:
-        message = kwargs.pop('message')
+    if "message" in kwargs:
+        message = kwargs.pop("message")
     else:
-        message = 'getting URL'
+        message = "getting URL"
 
-    req = requests.Request('GET', *args, **req_kwargs)
+    req = requests.Request("GET", *args, **req_kwargs)
 
     with requests.Session() as s:
-        s.headers = {'User-Agent': 'beets'}
+        s.headers = {"User-Agent": "beets"}
         prepped = s.prepare_request(req)
         settings = s.merge_environment_settings(
             prepped.url, {}, None, None, None
         )
         send_kwargs.update(settings)
-        log.debug('{}: {}', message, prepped.url)
+        log.debug("{}: {}", message, prepped.url)
         return s.send(prepped, **send_kwargs)
 
 
@@ -193,8 +210,9 @@ class RequestMixin(object):
 
 # ART SOURCES ################################################################
 
+
 class ArtSource(RequestMixin):
-    VALID_MATCHING_CRITERIA = ['default']
+    VALID_MATCHING_CRITERIA = ["default"]
 
     def __init__(self, log, config, match_by=None):
         self._log = log
@@ -216,7 +234,7 @@ class ArtSource(RequestMixin):
 
 class LocalArtSource(ArtSource):
     IS_LOCAL = True
-    LOC_STR = u'local'
+    LOC_STR = u"local"
 
     def fetch_image(self, candidate, plugin):
         pass
@@ -224,7 +242,7 @@ class LocalArtSource(ArtSource):
 
 class RemoteArtSource(ArtSource):
     IS_LOCAL = False
-    LOC_STR = u'remote'
+    LOC_STR = u"remote"
 
     def fetch_image(self, candidate, plugin):
         """Downloads an image from a URL and checks whether it seems to
@@ -232,12 +250,16 @@ class RemoteArtSource(ArtSource):
         Otherwise, returns None.
         """
         if plugin.maxwidth:
-            candidate.url = ArtResizer.shared.proxy_url(plugin.maxwidth,
-                                                        candidate.url)
+            candidate.url = ArtResizer.shared.proxy_url(
+                plugin.maxwidth, candidate.url
+            )
         try:
-            with closing(self.request(candidate.url, stream=True,
-                                      message=u'downloading image')) as resp:
-                ct = resp.headers.get('Content-Type', None)
+            with closing(
+                self.request(
+                    candidate.url, stream=True, message=u"downloading image"
+                )
+            ) as resp:
+                ct = resp.headers.get("Content-Type", None)
 
                 # Download the image to a temporary file. As some servers
                 # (notably fanart.tv) have proven to return wrong Content-Types
@@ -245,7 +267,7 @@ class RemoteArtSource(ArtSource):
                 # rely on it. Instead validate the type using the file magic
                 # and only then determine the extension.
                 data = resp.iter_content(chunk_size=1024)
-                header = b''
+                header = b""
                 for chunk in data:
                     header += chunk
                     if len(header) >= 32:
@@ -264,17 +286,23 @@ class RemoteArtSource(ArtSource):
                     real_ct = ct
 
                 if real_ct not in CONTENT_TYPES:
-                    self._log.debug(u'not a supported image: {}',
-                                    real_ct or u'unknown content type')
+                    self._log.debug(
+                        u"not a supported image: {}",
+                        real_ct or u"unknown content type",
+                    )
                     return
 
-                ext = b'.' + CONTENT_TYPES[real_ct][0]
+                ext = b"." + CONTENT_TYPES[real_ct][0]
 
                 if real_ct != ct:
-                    self._log.warning(u'Server specified {}, but returned a '
-                                      u'{} image. Correcting the extension '
-                                      u'to {}',
-                                      ct, real_ct, ext)
+                    self._log.warning(
+                        u"Server specified {}, but returned a "
+                        u"{} image. Correcting the extension "
+                        u"to {}",
+                        ct,
+                        real_ct,
+                        ext,
+                    )
 
                 suffix = py3_path(ext)
                 with NamedTemporaryFile(suffix=suffix, delete=False) as fh:
@@ -283,15 +311,16 @@ class RemoteArtSource(ArtSource):
                     # download the remaining part of the image
                     for chunk in data:
                         fh.write(chunk)
-                self._log.debug(u'downloaded art to: {0}',
-                                util.displayable_path(fh.name))
+                self._log.debug(
+                    u"downloaded art to: {0}", util.displayable_path(fh.name)
+                )
                 candidate.path = util.bytestring_path(fh.name)
                 return
 
         except (IOError, requests.RequestException, TypeError) as exc:
             # Handling TypeError works around a urllib3 bug:
             # https://github.com/shazow/urllib3/issues/556
-            self._log.debug(u'error fetching art: {}', exc)
+            self._log.debug(u"error fetching art: {}", exc)
             return
 
     def cleanup(self, candidate):
@@ -299,20 +328,20 @@ class RemoteArtSource(ArtSource):
             try:
                 util.remove(path=candidate.path)
             except util.FilesystemError as exc:
-                self._log.debug(u'error cleaning up tmp art: {}', exc)
+                self._log.debug(u"error cleaning up tmp art: {}", exc)
 
 
 class CoverArtArchive(RemoteArtSource):
     NAME = u"Cover Art Archive"
-    VALID_MATCHING_CRITERIA = ['release', 'releasegroup']
+    VALID_MATCHING_CRITERIA = ["release", "releasegroup"]
     VALID_THUMBNAIL_SIZES = [250, 500, 1200]
 
     if util.SNI_SUPPORTED:
-        URL = 'https://coverartarchive.org/release/{mbid}/front'
-        GROUP_URL = 'https://coverartarchive.org/release-group/{mbid}/front'
+        URL = "https://coverartarchive.org/release/{mbid}/front"
+        GROUP_URL = "https://coverartarchive.org/release-group/{mbid}/front"
     else:
-        URL = 'http://coverartarchive.org/release/{mbid}/front'
-        GROUP_URL = 'http://coverartarchive.org/release-group/{mbid}/front'
+        URL = "http://coverartarchive.org/release/{mbid}/front"
+        GROUP_URL = "http://coverartarchive.org/release-group/{mbid}/front"
 
     def get(self, album, plugin, paths):
         """Return the Cover Art Archive and Cover Art Archive release group URLs
@@ -329,28 +358,31 @@ class CoverArtArchive(RemoteArtSource):
         if plugin.maxwidth in self.VALID_THUMBNAIL_SIZES:
             size_suffix = "-" + str(plugin.maxwidth)
 
-        if 'release' in self.match_by and album.mb_albumid:
+        if "release" in self.match_by and album.mb_albumid:
             if size_suffix:
                 release_thumbnail_url = release_url + size_suffix
-                yield self._candidate(url=release_thumbnail_url,
-                                      match=Candidate.MATCH_EXACT)
-            yield self._candidate(url=release_url,
-                                  match=Candidate.MATCH_EXACT)
-        if 'releasegroup' in self.match_by and album.mb_releasegroupid:
+                yield self._candidate(
+                    url=release_thumbnail_url, match=Candidate.MATCH_EXACT
+                )
+            yield self._candidate(url=release_url, match=Candidate.MATCH_EXACT)
+        if "releasegroup" in self.match_by and album.mb_releasegroupid:
             if size_suffix:
                 release_group_thumbnail_url = release_group_url + size_suffix
-                yield self._candidate(url=release_group_thumbnail_url,
-                                      match=Candidate.MATCH_FALLBACK)
-            yield self._candidate(url=release_group_url,
-                                  match=Candidate.MATCH_FALLBACK)
+                yield self._candidate(
+                    url=release_group_thumbnail_url,
+                    match=Candidate.MATCH_FALLBACK,
+                )
+            yield self._candidate(
+                url=release_group_url, match=Candidate.MATCH_FALLBACK
+            )
 
 
 class Amazon(RemoteArtSource):
     NAME = u"Amazon"
     if util.SNI_SUPPORTED:
-        URL = 'https://images.amazon.com/images/P/%s.%02i.LZZZZZZZ.jpg'
+        URL = "https://images.amazon.com/images/P/%s.%02i.LZZZZZZZ.jpg"
     else:
-        URL = 'http://images.amazon.com/images/P/%s.%02i.LZZZZZZZ.jpg'
+        URL = "http://images.amazon.com/images/P/%s.%02i.LZZZZZZZ.jpg"
     INDICES = (1, 2)
 
     def get(self, album, plugin, paths):
@@ -358,16 +390,18 @@ class Amazon(RemoteArtSource):
         """
         if album.asin:
             for index in self.INDICES:
-                yield self._candidate(url=self.URL % (album.asin, index),
-                                      match=Candidate.MATCH_EXACT)
+                yield self._candidate(
+                    url=self.URL % (album.asin, index),
+                    match=Candidate.MATCH_EXACT,
+                )
 
 
 class AlbumArtOrg(RemoteArtSource):
     NAME = u"AlbumArt.org scraper"
     if util.SNI_SUPPORTED:
-        URL = 'https://www.albumart.org/index_detail.php'
+        URL = "https://www.albumart.org/index_detail.php"
     else:
-        URL = 'http://www.albumart.org/index_detail.php'
+        URL = "http://www.albumart.org/index_detail.php"
     PAT = r'href\s*=\s*"([^>"]*)"[^>]*title\s*=\s*"View larger image"'
 
     def get(self, album, plugin, paths):
@@ -377,10 +411,10 @@ class AlbumArtOrg(RemoteArtSource):
             return
         # Get the page from albumart.org.
         try:
-            resp = self.request(self.URL, params={'asin': album.asin})
-            self._log.debug(u'scraped art URL: {0}', resp.url)
+            resp = self.request(self.URL, params={"asin": album.asin})
+            self._log.debug(u"scraped art URL: {0}", resp.url)
         except requests.RequestException:
-            self._log.debug(u'error scraping art page')
+            self._log.debug(u"error scraping art page")
             return
 
         # Search the page for the image URL.
@@ -389,17 +423,17 @@ class AlbumArtOrg(RemoteArtSource):
             image_url = m.group(1)
             yield self._candidate(url=image_url, match=Candidate.MATCH_EXACT)
         else:
-            self._log.debug(u'no image found on page')
+            self._log.debug(u"no image found on page")
 
 
 class GoogleImages(RemoteArtSource):
     NAME = u"Google Images"
-    URL = u'https://www.googleapis.com/customsearch/v1'
+    URL = u"https://www.googleapis.com/customsearch/v1"
 
     def __init__(self, *args, **kwargs):
         super(GoogleImages, self).__init__(*args, **kwargs)
-        self.key = self._config['google_key'].get(),
-        self.cx = self._config['google_engine'].get(),
+        self.key = (self._config["google_key"].get(),)
+        self.cx = (self._config["google_engine"].get(),)
 
     def get(self, album, plugin, paths):
         """Return art URL from google custom search engine
@@ -407,48 +441,54 @@ class GoogleImages(RemoteArtSource):
         """
         if not (album.albumartist and album.album):
             return
-        search_string = (album.albumartist + ',' + album.album).encode('utf-8')
+        search_string = (album.albumartist + "," + album.album).encode("utf-8")
 
         try:
-            response = self.request(self.URL, params={
-                'key': self.key,
-                'cx': self.cx,
-                'q': search_string,
-                'searchType': 'image'
-            })
+            response = self.request(
+                self.URL,
+                params={
+                    "key": self.key,
+                    "cx": self.cx,
+                    "q": search_string,
+                    "searchType": "image",
+                },
+            )
         except requests.RequestException:
-            self._log.debug(u'google: error receiving response')
+            self._log.debug(u"google: error receiving response")
             return
 
         # Get results using JSON.
         try:
             data = response.json()
         except ValueError:
-            self._log.debug(u'google: error loading response: {}'
-                            .format(response.text))
+            self._log.debug(
+                u"google: error loading response: {}".format(response.text)
+            )
             return
 
-        if 'error' in data:
-            reason = data['error']['errors'][0]['reason']
-            self._log.debug(u'google fetchart error: {0}', reason)
+        if "error" in data:
+            reason = data["error"]["errors"][0]["reason"]
+            self._log.debug(u"google fetchart error: {0}", reason)
             return
 
-        if 'items' in data.keys():
-            for item in data['items']:
-                yield self._candidate(url=item['link'],
-                                      match=Candidate.MATCH_EXACT)
+        if "items" in data.keys():
+            for item in data["items"]:
+                yield self._candidate(
+                    url=item["link"], match=Candidate.MATCH_EXACT
+                )
 
 
 class FanartTV(RemoteArtSource):
     """Art from fanart.tv requested using their API"""
+
     NAME = u"fanart.tv"
-    API_URL = 'https://webservice.fanart.tv/v3/'
-    API_ALBUMS = API_URL + 'music/albums/'
-    PROJECT_KEY = '61a7d0ab4e67162b7a0c7c35915cd48e'
+    API_URL = "https://webservice.fanart.tv/v3/"
+    API_ALBUMS = API_URL + "music/albums/"
+    PROJECT_KEY = "61a7d0ab4e67162b7a0c7c35915cd48e"
 
     def __init__(self, *args, **kwargs):
         super(FanartTV, self).__init__(*args, **kwargs)
-        self.client_key = self._config['fanarttv_key'].get()
+        self.client_key = self._config["fanarttv_key"].get()
 
     def get(self, album, plugin, paths):
         if not album.mb_releasegroupid:
@@ -457,54 +497,64 @@ class FanartTV(RemoteArtSource):
         try:
             response = self.request(
                 self.API_ALBUMS + album.mb_releasegroupid,
-                headers={'api-key': self.PROJECT_KEY,
-                         'client-key': self.client_key})
+                headers={
+                    "api-key": self.PROJECT_KEY,
+                    "client-key": self.client_key,
+                },
+            )
         except requests.RequestException:
-            self._log.debug(u'fanart.tv: error receiving response')
+            self._log.debug(u"fanart.tv: error receiving response")
             return
 
         try:
             data = response.json()
         except ValueError:
-            self._log.debug(u'fanart.tv: error loading response: {}',
-                            response.text)
+            self._log.debug(
+                u"fanart.tv: error loading response: {}", response.text
+            )
             return
 
-        if u'status' in data and data[u'status'] == u'error':
-            if u'not found' in data[u'error message'].lower():
-                self._log.debug(u'fanart.tv: no image found')
-            elif u'api key' in data[u'error message'].lower():
-                self._log.warning(u'fanart.tv: Invalid API key given, please '
-                                  u'enter a valid one in your config file.')
+        if u"status" in data and data[u"status"] == u"error":
+            if u"not found" in data[u"error message"].lower():
+                self._log.debug(u"fanart.tv: no image found")
+            elif u"api key" in data[u"error message"].lower():
+                self._log.warning(
+                    u"fanart.tv: Invalid API key given, please "
+                    u"enter a valid one in your config file."
+                )
             else:
-                self._log.debug(u'fanart.tv: error on request: {}',
-                                data[u'error message'])
+                self._log.debug(
+                    u"fanart.tv: error on request: {}", data[u"error message"]
+                )
             return
 
         matches = []
         # can there be more than one releasegroupid per response?
-        for mbid, art in data.get(u'albums', dict()).items():
+        for mbid, art in data.get(u"albums", dict()).items():
             # there might be more art referenced, e.g. cdart, and an albumcover
             # might not be present, even if the request was successful
-            if album.mb_releasegroupid == mbid and u'albumcover' in art:
-                matches.extend(art[u'albumcover'])
+            if album.mb_releasegroupid == mbid and u"albumcover" in art:
+                matches.extend(art[u"albumcover"])
             # can this actually occur?
             else:
-                self._log.debug(u'fanart.tv: unexpected mb_releasegroupid in '
-                                u'response!')
+                self._log.debug(
+                    u"fanart.tv: unexpected mb_releasegroupid in " u"response!"
+                )
 
-        matches.sort(key=lambda x: x[u'likes'], reverse=True)
+        matches.sort(key=lambda x: x[u"likes"], reverse=True)
         for item in matches:
             # fanart.tv has a strict size requirement for album art to be
             # uploaded
-            yield self._candidate(url=item[u'url'],
-                                  match=Candidate.MATCH_EXACT,
-                                  size=(1000, 1000))
+            yield self._candidate(
+                url=item[u"url"],
+                match=Candidate.MATCH_EXACT,
+                size=(1000, 1000),
+            )
 
 
 class ITunesStore(RemoteArtSource):
     NAME = u"iTunes Store"
-    API_URL = u'https://itunes.apple.com/search'
+    API_URL = u"https://itunes.apple.com/search"
 
     def get(self, album, plugin, paths):
         """Return art URL from iTunes Store given an album title.
@@ -513,70 +563,81 @@ class ITunesStore(RemoteArtSource):
             return
 
         payload = {
-            'term': album.albumartist + u' ' + album.album,
-            'entity': u'album',
-            'media': u'music',
-            'limit': 200
+            "term": album.albumartist + u" " + album.album,
+            "entity": u"album",
+            "media": u"music",
+            "limit": 200,
         }
         try:
             r = self.request(self.API_URL, params=payload)
             r.raise_for_status()
         except requests.RequestException as e:
-            self._log.debug(u'iTunes search failed: {0}', e)
+            self._log.debug(u"iTunes search failed: {0}", e)
             return
 
         try:
-            candidates = r.json()['results']
+            candidates = r.json()["results"]
         except ValueError as e:
-            self._log.debug(u'Could not decode json response: {0}', e)
+            self._log.debug(u"Could not decode json response: {0}", e)
             return
         except KeyError as e:
-            self._log.debug(u'{} not found in json. Fields are {} ',
-                            e,
-                            list(r.json().keys()))
+            self._log.debug(
+                u"{} not found in json. Fields are {} ",
+                e,
+                list(r.json().keys()),
+            )
             return
 
         if not candidates:
-            self._log.debug(u'iTunes search for {!r} got no results',
-                            payload['term'])
+            self._log.debug(
+                u"iTunes search for {!r} got no results", payload["term"]
+            )
             return
 
-        if self._config['high_resolution']:
-            image_suffix = '100000x100000-999'
+        if self._config["high_resolution"]:
+            image_suffix = "100000x100000-999"
         else:
-            image_suffix = '1200x1200bb'
+            image_suffix = "1200x1200bb"
 
         for c in candidates:
             try:
-                if (c['artistName'] == album.albumartist
-                        and c['collectionName'] == album.album):
-                    art_url = c['artworkUrl100']
-                    art_url = art_url.replace('100x100bb',
-                                              image_suffix)
-                    yield self._candidate(url=art_url,
-                                          match=Candidate.MATCH_EXACT)
+                if (
+                    c["artistName"] == album.albumartist
+                    and c["collectionName"] == album.album
+                ):
+                    art_url = c["artworkUrl100"]
+                    art_url = art_url.replace("100x100bb", image_suffix)
+                    yield self._candidate(
+                        url=art_url, match=Candidate.MATCH_EXACT
+                    )
             except KeyError as e:
-                self._log.debug(u'Malformed itunes candidate: {} not found in {}',  # NOQA E501
-                                e,
-                                list(c.keys()))
+                self._log.debug(
+                    u"Malformed itunes candidate: {} not found in {}",  # NOQA E501
+                    e,
+                    list(c.keys()),
+                )
 
         try:
-            fallback_art_url = candidates[0]['artworkUrl100']
-            fallback_art_url = fallback_art_url.replace('100x100bb',
-                                                        image_suffix)
-            yield self._candidate(url=fallback_art_url,
-                                  match=Candidate.MATCH_FALLBACK)
+            fallback_art_url = candidates[0]["artworkUrl100"]
+            fallback_art_url = fallback_art_url.replace(
+                "100x100bb", image_suffix
+            )
+            yield self._candidate(
+                url=fallback_art_url, match=Candidate.MATCH_FALLBACK
+            )
         except KeyError as e:
-            self._log.debug(u'Malformed itunes candidate: {} not found in {}',
-                            e,
-                            list(c.keys()))
+            self._log.debug(
+                u"Malformed itunes candidate: {} not found in {}",
+                e,
+                list(c.keys()),
+            )
 
 
 class Wikipedia(RemoteArtSource):
     NAME = u"Wikipedia (queried through DBpedia)"
-    DBPEDIA_URL = 'https://dbpedia.org/sparql'
-    WIKIPEDIA_URL = 'https://en.wikipedia.org/w/api.php'
-    SPARQL_QUERY = u'''PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    DBPEDIA_URL = "https://dbpedia.org/sparql"
+    WIKIPEDIA_URL = "https://en.wikipedia.org/w/api.php"
+    SPARQL_QUERY = u"""PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
                  PREFIX dbpprop: <http://dbpedia.org/property/>
                  PREFIX owl: <http://dbpedia.org/ontology/>
                  PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -596,7 +657,7 @@ class Wikipedia(RemoteArtSource):
                    ?subject dbpprop:cover ?coverFilename .
                    FILTER ( regex(?name, "{album}", "i") )
                   }}
-                 Limit 1'''
+                 Limit 1"""
 
     def get(self, album, plugin, paths):
         if not (album.albumartist and album.album):
@@ -609,28 +670,31 @@ class Wikipedia(RemoteArtSource):
             dbpedia_response = self.request(
                 self.DBPEDIA_URL,
                 params={
-                    'format': 'application/sparql-results+json',
-                    'timeout': 2500,
-                    'query': self.SPARQL_QUERY.format(
-                        artist=album.albumartist.title(), album=album.album)
+                    "format": "application/sparql-results+json",
+                    "timeout": 2500,
+                    "query": self.SPARQL_QUERY.format(
+                        artist=album.albumartist.title(), album=album.album
+                    ),
                 },
-                headers={'content-type': 'application/json'},
+                headers={"content-type": "application/json"},
             )
         except requests.RequestException:
-            self._log.debug(u'dbpedia: error receiving response')
+            self._log.debug(u"dbpedia: error receiving response")
             return
 
         try:
             data = dbpedia_response.json()
-            results = data['results']['bindings']
+            results = data["results"]["bindings"]
             if results:
-                cover_filename = 'File:' + results[0]['coverFilename']['value']
-                page_id = results[0]['pageId']['value']
+                cover_filename = "File:" + results[0]["coverFilename"]["value"]
+                page_id = results[0]["pageId"]["value"]
             else:
-                self._log.debug(u'wikipedia: album not found on dbpedia')
+                self._log.debug(u"wikipedia: album not found on dbpedia")
         except (ValueError, KeyError, IndexError):
-            self._log.debug(u'wikipedia: error scraping dbpedia response: {}',
-                            dbpedia_response.text)
+            self._log.debug(
+                u"wikipedia: error scraping dbpedia response: {}",
+                dbpedia_response.text,
+            )
 
         # Ensure we have a filename before attempting to query wikipedia
         if not (cover_filename and page_id):
@@ -641,43 +705,47 @@ class Wikipedia(RemoteArtSource):
         # An additional Wikipedia call can help to find the real filename.
         # This may be removed once the DBPedia issue is resolved, see:
         # https://github.com/dbpedia/extraction-framework/issues/396
-        if ' .' in cover_filename and \
-           '.' not in cover_filename.split(' .')[-1]:
+        if (
+            " ." in cover_filename
+            and "." not in cover_filename.split(" .")[-1]
+        ):
             self._log.debug(
-                u'wikipedia: dbpedia provided incomplete cover_filename'
+                u"wikipedia: dbpedia provided incomplete cover_filename"
             )
-            lpart, rpart = cover_filename.rsplit(' .', 1)
+            lpart, rpart = cover_filename.rsplit(" .", 1)
 
             # Query all the images in the page
             try:
                 wikipedia_response = self.request(
                     self.WIKIPEDIA_URL,
                     params={
-                        'format': 'json',
-                        'action': 'query',
-                        'continue': '',
-                        'prop': 'images',
-                        'pageids': page_id,
+                        "format": "json",
+                        "action": "query",
+                        "continue": "",
+                        "prop": "images",
+                        "pageids": page_id,
                     },
-                    headers={'content-type': 'application/json'},
+                    headers={"content-type": "application/json"},
                 )
             except requests.RequestException:
-                self._log.debug(u'wikipedia: error receiving response')
+                self._log.debug(u"wikipedia: error receiving response")
                 return
 
             # Try to see if one of the images on the pages matches our
             # incomplete cover_filename
             try:
                 data = wikipedia_response.json()
-                results = data['query']['pages'][page_id]['images']
+                results = data["query"]["pages"][page_id]["images"]
                 for result in results:
-                    if re.match(re.escape(lpart) + r'.*?\.' + re.escape(rpart),
-                                result['title']):
-                        cover_filename = result['title']
+                    if re.match(
+                        re.escape(lpart) + r".*?\." + re.escape(rpart),
+                        result["title"],
+                    ):
+                        cover_filename = result["title"]
                         break
             except (ValueError, KeyError):
                 self._log.debug(
-                    u'wikipedia: failed to retrieve a cover_filename'
+                    u"wikipedia: failed to retrieve a cover_filename"
                 )
                 return
 
@@ -686,28 +754,29 @@ class Wikipedia(RemoteArtSource):
             wikipedia_response = self.request(
                 self.WIKIPEDIA_URL,
                 params={
-                    'format': 'json',
-                    'action': 'query',
-                    'continue': '',
-                    'prop': 'imageinfo',
-                    'iiprop': 'url',
-                    'titles': cover_filename.encode('utf-8'),
+                    "format": "json",
+                    "action": "query",
+                    "continue": "",
+                    "prop": "imageinfo",
+                    "iiprop": "url",
+                    "titles": cover_filename.encode("utf-8"),
                 },
-                headers={'content-type': 'application/json'},
+                headers={"content-type": "application/json"},
             )
         except requests.RequestException:
-            self._log.debug(u'wikipedia: error receiving response')
+            self._log.debug(u"wikipedia: error receiving response")
             return
 
         try:
             data = wikipedia_response.json()
-            results = data['query']['pages']
+            results = data["query"]["pages"]
             for _, result in results.items():
-                image_url = result['imageinfo'][0]['url']
-                yield self._candidate(url=image_url,
-                                      match=Candidate.MATCH_EXACT)
+                image_url = result["imageinfo"][0]["url"]
+                yield self._candidate(
+                    url=image_url, match=Candidate.MATCH_EXACT
+                )
         except (ValueError, KeyError, IndexError):
-            self._log.debug(u'wikipedia: error scraping imageinfo')
+            self._log.debug(u"wikipedia: error scraping imageinfo")
             return
 
 
@@ -730,8 +799,8 @@ class FileSystem(LocalArtSource):
         if not paths:
             return
         cover_names = list(map(util.bytestring_path, plugin.cover_names))
-        cover_names_str = b'|'.join(cover_names)
-        cover_pat = br''.join([br"(\b|_)(", cover_names_str, br")(\b|_)"])
+        cover_names_str = b"|".join(cover_names)
+        cover_pat = br"".join([br"(\b|_)(", cover_names_str, br")(\b|_)"])
 
         for path in paths:
             if not os.path.isdir(syspath(path)):
@@ -739,116 +808,147 @@ class FileSystem(LocalArtSource):
 
             # Find all files that look like images in the directory.
             images = []
-            ignore = config['ignore'].as_str_seq()
-            ignore_hidden = config['ignore_hidden'].get(bool)
-            for _, _, files in sorted_walk(path, ignore=ignore,
-                                           ignore_hidden=ignore_hidden):
+            ignore = config["ignore"].as_str_seq()
+            ignore_hidden = config["ignore_hidden"].get(bool)
+            for _, _, files in sorted_walk(
+                path, ignore=ignore, ignore_hidden=ignore_hidden
+            ):
                 for fn in files:
                     fn = bytestring_path(fn)
                     for ext in IMAGE_EXTENSIONS:
-                        if fn.lower().endswith(b'.' + ext) and \
-                           os.path.isfile(syspath(os.path.join(path, fn))):
+                        if fn.lower().endswith(b"." + ext) and os.path.isfile(
+                            syspath(os.path.join(path, fn))
+                        ):
                             images.append(fn)
 
             # Look for "preferred" filenames.
-            images = sorted(images,
-                            key=lambda x:
-                                self.filename_priority(x, cover_names))
+            images = sorted(
+                images, key=lambda x: self.filename_priority(x, cover_names)
+            )
             remaining = []
             for fn in images:
                 if re.search(cover_pat, os.path.splitext(fn)[0], re.I):
-                    self._log.debug(u'using well-named art file {0}',
-                                    util.displayable_path(fn))
-                    yield self._candidate(path=os.path.join(path, fn),
-                                          match=Candidate.MATCH_EXACT)
+                    self._log.debug(
+                        u"using well-named art file {0}",
+                        util.displayable_path(fn),
+                    )
+                    yield self._candidate(
+                        path=os.path.join(path, fn),
+                        match=Candidate.MATCH_EXACT,
+                    )
                 else:
                     remaining.append(fn)
 
             # Fall back to any image in the folder.
             if remaining and not plugin.cautious:
-                self._log.debug(u'using fallback art file {0}',
-                                util.displayable_path(remaining[0]))
-                yield self._candidate(path=os.path.join(path, remaining[0]),
-                                      match=Candidate.MATCH_FALLBACK)
+                self._log.debug(
+                    u"using fallback art file {0}",
+                    util.displayable_path(remaining[0]),
+                )
+                yield self._candidate(
+                    path=os.path.join(path, remaining[0]),
+                    match=Candidate.MATCH_FALLBACK,
+                )
 
 
 class LastFM(RemoteArtSource):
     NAME = u"Last.fm"
 
     # Sizes in priority order.
-    SIZES = OrderedDict([
-        ('mega', (300, 300)),
-        ('extralarge', (300, 300)),
-        ('large', (174, 174)),
-        ('medium', (64, 64)),
-        ('small', (34, 34)),
-    ])
+    SIZES = OrderedDict(
+        [
+            ("mega", (300, 300)),
+            ("extralarge", (300, 300)),
+            ("large", (174, 174)),
+            ("medium", (64, 64)),
+            ("small", (34, 34)),
+        ]
+    )
 
     if util.SNI_SUPPORTED:
-        API_URL = 'https://ws.audioscrobbler.com/2.0'
+        API_URL = "https://ws.audioscrobbler.com/2.0"
     else:
-        API_URL = 'http://ws.audioscrobbler.com/2.0'
+        API_URL = "http://ws.audioscrobbler.com/2.0"
 
     def __init__(self, *args, **kwargs):
         super(LastFM, self).__init__(*args, **kwargs)
-        self.key = self._config['lastfm_key'].get(),
+        self.key = (self._config["lastfm_key"].get(),)
 
     def get(self, album, plugin, paths):
         if not album.mb_albumid:
             return
 
         try:
-            response = self.request(self.API_URL, params={
-                'method': 'album.getinfo',
-                'api_key': self.key,
-                'mbid': album.mb_albumid,
-                'format': 'json',
-            })
+            response = self.request(
+                self.API_URL,
+                params={
+                    "method": "album.getinfo",
+                    "api_key": self.key,
+                    "mbid": album.mb_albumid,
+                    "format": "json",
+                },
+            )
         except requests.RequestException:
-            self._log.debug(u'lastfm: error receiving response')
+            self._log.debug(u"lastfm: error receiving response")
             return
 
         try:
             data = response.json()
 
-            if 'error' in data:
-                if data['error'] == 6:
-                    self._log.debug('lastfm: no results for {}',
-                                    album.mb_albumid)
+            if "error" in data:
+                if data["error"] == 6:
+                    self._log.debug(
+                        "lastfm: no results for {}", album.mb_albumid
+                    )
                 else:
                     self._log.error(
-                        'lastfm: failed to get album info: {} ({})',
-                        data['message'], data['error'])
+                        "lastfm: failed to get album info: {} ({})",
+                        data["message"],
+                        data["error"],
+                    )
             else:
-                images = {image['size']: image['#text']
-                          for image in data['album']['image']}
+                images = {
+                    image["size"]: image["#text"]
+                    for image in data["album"]["image"]
+                }
 
                 # Provide candidates in order of size.
                 for size in self.SIZES.keys():
                     if size in images:
-                        yield self._candidate(url=images[size],
-                                              size=self.SIZES[size])
+                        yield self._candidate(
+                            url=images[size], size=self.SIZES[size]
+                        )
         except ValueError:
-            self._log.debug(u'lastfm: error loading response: {}'
-                            .format(response.text))
+            self._log.debug(
+                u"lastfm: error loading response: {}".format(response.text)
+            )
             return
+
 
 # Try each source in turn.
 
-SOURCES_ALL = [u'filesystem',
-               u'coverart', u'itunes', u'amazon', u'albumart',
-               u'wikipedia', u'google', u'fanarttv', u'lastfm']
+SOURCES_ALL = [
+    u"filesystem",
+    u"coverart",
+    u"itunes",
+    u"amazon",
+    u"albumart",
+    u"wikipedia",
+    u"google",
+    u"fanarttv",
+    u"lastfm",
+]
 
 ART_SOURCES = {
-    u'filesystem': FileSystem,
-    u'coverart': CoverArtArchive,
-    u'itunes': ITunesStore,
-    u'albumart': AlbumArtOrg,
-    u'amazon': Amazon,
-    u'wikipedia': Wikipedia,
-    u'google': GoogleImages,
-    u'fanarttv': FanartTV,
-    u'lastfm': LastFM,
+    u"filesystem": FileSystem,
+    u"coverart": CoverArtArchive,
+    u"itunes": ITunesStore,
+    u"albumart": AlbumArtOrg,
+    u"amazon": Amazon,
+    u"wikipedia": Wikipedia,
+    u"google": GoogleImages,
+    u"fanarttv": FanartTV,
+    u"lastfm": LastFM,
 }
 SOURCE_NAMES = {v: k for k, v in ART_SOURCES.items()}
 
@@ -866,92 +966,115 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         # fetching them and placing them in the filesystem.
         self.art_candidates = {}
 
-        self.config.add({
-            'auto': True,
-            'minwidth': 0,
-            'maxwidth': 0,
-            'quality': 0,
-            'enforce_ratio': False,
-            'cautious': False,
-            'cover_names': ['cover', 'front', 'art', 'album', 'folder'],
-            'sources': ['filesystem',
-                        'coverart', 'itunes', 'amazon', 'albumart'],
-            'google_key': None,
-            'google_engine': u'001442825323518660753:hrh5ch1gjzm',
-            'fanarttv_key': None,
-            'lastfm_key': None,
-            'store_source': False,
-            'high_resolution': False,
-        })
-        self.config['google_key'].redact = True
-        self.config['fanarttv_key'].redact = True
-        self.config['lastfm_key'].redact = True
+        self.config.add(
+            {
+                "auto": True,
+                "minwidth": 0,
+                "maxwidth": 0,
+                "quality": 0,
+                "enforce_ratio": False,
+                "cautious": False,
+                "cover_names": ["cover", "front", "art", "album", "folder"],
+                "sources": [
+                    "filesystem",
+                    "coverart",
+                    "itunes",
+                    "amazon",
+                    "albumart",
+                ],
+                "google_key": None,
+                "google_engine": u"001442825323518660753:hrh5ch1gjzm",
+                "fanarttv_key": None,
+                "lastfm_key": None,
+                "store_source": False,
+                "high_resolution": False,
+            }
+        )
+        self.config["google_key"].redact = True
+        self.config["fanarttv_key"].redact = True
+        self.config["lastfm_key"].redact = True
 
-        self.minwidth = self.config['minwidth'].get(int)
-        self.maxwidth = self.config['maxwidth'].get(int)
-        self.quality = self.config['quality'].get(int)
+        self.minwidth = self.config["minwidth"].get(int)
+        self.maxwidth = self.config["maxwidth"].get(int)
+        self.quality = self.config["quality"].get(int)
 
         # allow both pixel and percentage-based margin specifications
-        self.enforce_ratio = self.config['enforce_ratio'].get(
-            confuse.OneOf([bool,
-                           confuse.String(pattern=self.PAT_PX),
-                           confuse.String(pattern=self.PAT_PERCENT)]))
+        self.enforce_ratio = self.config["enforce_ratio"].get(
+            confuse.OneOf(
+                [
+                    bool,
+                    confuse.String(pattern=self.PAT_PX),
+                    confuse.String(pattern=self.PAT_PERCENT),
+                ]
+            )
+        )
         self.margin_px = None
         self.margin_percent = None
         if type(self.enforce_ratio) is six.text_type:
-            if self.enforce_ratio[-1] == u'%':
+            if self.enforce_ratio[-1] == u"%":
                 self.margin_percent = float(self.enforce_ratio[:-1]) / 100
-            elif self.enforce_ratio[-2:] == u'px':
+            elif self.enforce_ratio[-2:] == u"px":
                 self.margin_px = int(self.enforce_ratio[:-2])
             else:
                 # shouldn't happen
                 raise confuse.ConfigValueError()
             self.enforce_ratio = True
 
-        cover_names = self.config['cover_names'].as_str_seq()
+        cover_names = self.config["cover_names"].as_str_seq()
         self.cover_names = list(map(util.bytestring_path, cover_names))
-        self.cautious = self.config['cautious'].get(bool)
-        self.store_source = self.config['store_source'].get(bool)
+        self.cautious = self.config["cautious"].get(bool)
+        self.store_source = self.config["store_source"].get(bool)
 
-        self.src_removed = (config['import']['delete'].get(bool) or
-                            config['import']['move'].get(bool))
+        self.src_removed = config["import"]["delete"].get(bool) or config[
+            "import"
+        ]["move"].get(bool)
 
-        if self.config['auto']:
+        if self.config["auto"]:
             # Enable two import hooks when fetching is enabled.
             self.import_stages = [self.fetch_art]
-            self.register_listener('import_task_files', self.assign_art)
+            self.register_listener("import_task_files", self.assign_art)
 
         available_sources = list(SOURCES_ALL)
-        if not self.config['google_key'].get() and \
-                u'google' in available_sources:
-            available_sources.remove(u'google')
-        if not self.config['lastfm_key'].get() and \
-                u'lastfm' in available_sources:
-            available_sources.remove(u'lastfm')
-        available_sources = [(s, c)
-                             for s in available_sources
-                             for c in ART_SOURCES[s].VALID_MATCHING_CRITERIA]
+        if (
+            not self.config["google_key"].get()
+            and u"google" in available_sources
+        ):
+            available_sources.remove(u"google")
+        if (
+            not self.config["lastfm_key"].get()
+            and u"lastfm" in available_sources
+        ):
+            available_sources.remove(u"lastfm")
+        available_sources = [
+            (s, c)
+            for s in available_sources
+            for c in ART_SOURCES[s].VALID_MATCHING_CRITERIA
+        ]
         sources = plugins.sanitize_pairs(
-            self.config['sources'].as_pairs(default_value='*'),
-            available_sources)
+            self.config["sources"].as_pairs(default_value="*"),
+            available_sources,
+        )
 
-        if 'remote_priority' in self.config:
+        if "remote_priority" in self.config:
             self._log.warning(
-                u'The `fetch_art.remote_priority` configuration option has '
-                u'been deprecated. Instead, place `filesystem` at the end of '
-                u'your `sources` list.')
-            if self.config['remote_priority'].get(bool):
+                u"The `fetch_art.remote_priority` configuration option has "
+                u"been deprecated. Instead, place `filesystem` at the end of "
+                u"your `sources` list."
+            )
+            if self.config["remote_priority"].get(bool):
                 fs = []
                 others = []
                 for s, c in sources:
-                    if s == 'filesystem':
+                    if s == "filesystem":
                         fs.append((s, c))
                     else:
                         others.append((s, c))
                 sources = others + fs
 
-        self.sources = [ART_SOURCES[s](self._log, self.config, match_by=[c])
-                        for s, c in sources]
+        self.sources = [
+            ART_SOURCES[s](self._log, self.config, match_by=[c])
+            for s, c in sources
+        ]
 
     # Asynchronous; after music is added to the library.
     def fetch_art(self, session, task):
@@ -963,8 +1086,10 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             if task.choice_flag == importer.action.ASIS:
                 # For as-is imports, don't search Web sources for art.
                 local = True
-            elif task.choice_flag in (importer.action.APPLY,
-                                      importer.action.RETAG):
+            elif task.choice_flag in (
+                importer.action.APPLY,
+                importer.action.RETAG,
+            ):
                 # Search everywhere for art.
                 local = False
             else:
@@ -981,8 +1106,8 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         if self.store_source:
             # store the source of the chosen artwork in a flexible field
             self._log.debug(
-                u"Storing art_source for {0.albumartist} - {0.album}",
-                album)
+                u"Storing art_source for {0.albumartist} - {0.album}", album
+            )
             album.art_source = SOURCE_NAMES[type(candidate.source)]
         album.store()
 
@@ -999,21 +1124,29 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
 
     # Manual album art fetching.
     def commands(self):
-        cmd = ui.Subcommand('fetchart', help='download album art')
+        cmd = ui.Subcommand("fetchart", help="download album art")
         cmd.parser.add_option(
-            u'-f', u'--force', dest='force',
-            action='store_true', default=False,
-            help=u're-download art when already present'
+            u"-f",
+            u"--force",
+            dest="force",
+            action="store_true",
+            default=False,
+            help=u"re-download art when already present",
         )
         cmd.parser.add_option(
-            u'-q', u'--quiet', dest='quiet',
-            action='store_true', default=False,
-            help=u'quiet mode: do not output albums that already have artwork'
+            u"-q",
+            u"--quiet",
+            dest="quiet",
+            action="store_true",
+            default=False,
+            help=u"quiet mode: do not output albums that already have artwork",
         )
 
         def func(lib, opts, args):
-            self.batch_fetch_art(lib, lib.albums(ui.decargs(args)), opts.force,
-                                 opts.quiet)
+            self.batch_fetch_art(
+                lib, lib.albums(ui.decargs(args)), opts.force, opts.quiet
+            )
+
         cmd.func = func
         return [cmd]
 
@@ -1032,7 +1165,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         for source in self.sources:
             if source.IS_LOCAL or not local_only:
                 self._log.debug(
-                    u'trying source {0} for album {1.albumartist} - {1.album}',
+                    u"trying source {0} for album {1.albumartist} - {1.album}",
                     SOURCE_NAMES[type(source)],
                     album,
                 )
@@ -1043,8 +1176,10 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                     if candidate.validate(self):
                         out = candidate
                         self._log.debug(
-                            u'using {0.LOC_STR} image {1}'.format(
-                                source, util.displayable_path(out.path)))
+                            u"using {0.LOC_STR} image {1}".format(
+                                source, util.displayable_path(out.path)
+                            )
+                        )
                         break
                     # Remove temporary files for invalid candidates.
                     source.cleanup(candidate)
@@ -1063,9 +1198,10 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         for album in albums:
             if album.artpath and not force and os.path.isfile(album.artpath):
                 if not quiet:
-                    message = ui.colorize('text_highlight_minor',
-                                          u'has album art')
-                    self._log.info(u'{0}: {1}', album, message)
+                    message = ui.colorize(
+                        "text_highlight_minor", u"has album art"
+                    )
+                    self._log.info(u"{0}: {1}", album, message)
             else:
                 # In ordinary invocations, look for images on the
                 # filesystem. When forcing, however, always go to the Web
@@ -1075,7 +1211,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                 candidate = self.art_for_album(album, local_paths)
                 if candidate:
                     self._set_art(album, candidate)
-                    message = ui.colorize('text_success', u'found album art')
+                    message = ui.colorize("text_success", u"found album art")
                 else:
-                    message = ui.colorize('text_error', u'no art found')
-                self._log.info(u'{0}: {1}', album, message)
+                    message = ui.colorize("text_error", u"no art found")
+                self._log.info(u"{0}: {1}", album, message)

--- a/beetsplug/filefilter.py
+++ b/beetsplug/filefilter.py
@@ -28,29 +28,30 @@ from beets.importer import SingletonImportTask
 class FileFilterPlugin(BeetsPlugin):
     def __init__(self):
         super(FileFilterPlugin, self).__init__()
-        self.register_listener('import_task_created',
-                               self.import_task_created_event)
-        self.config.add({
-            'path': '.*'
-        })
+        self.register_listener(
+            "import_task_created", self.import_task_created_event
+        )
+        self.config.add({"path": ".*"})
 
-        self.path_album_regex = \
-            self.path_singleton_regex = \
-            re.compile(bytestring_path(self.config['path'].get()))
+        self.path_album_regex = self.path_singleton_regex = re.compile(
+            bytestring_path(self.config["path"].get())
+        )
 
-        if 'album_path' in self.config:
+        if "album_path" in self.config:
             self.path_album_regex = re.compile(
-                bytestring_path(self.config['album_path'].get()))
+                bytestring_path(self.config["album_path"].get())
+            )
 
-        if 'singleton_path' in self.config:
+        if "singleton_path" in self.config:
             self.path_singleton_regex = re.compile(
-                bytestring_path(self.config['singleton_path'].get()))
+                bytestring_path(self.config["singleton_path"].get())
+            )
 
     def import_task_created_event(self, session, task):
         if task.items and len(task.items) > 0:
             items_to_import = []
             for item in task.items:
-                if self.file_filter(item['path']):
+                if self.file_filter(item["path"]):
                     items_to_import.append(item)
             if len(items_to_import) > 0:
                 task.items = items_to_import
@@ -60,7 +61,7 @@ class FileFilterPlugin(BeetsPlugin):
                 return []
 
         elif isinstance(task, SingletonImportTask):
-            if not self.file_filter(task.item['path']):
+            if not self.file_filter(task.item["path"]):
                 return []
 
         # If not filtered, return the original task unchanged.
@@ -70,10 +71,12 @@ class FileFilterPlugin(BeetsPlugin):
         """Checks if the configured regular expressions allow the import
         of the file given in full_path.
         """
-        import_config = dict(config['import'])
+        import_config = dict(config["import"])
         full_path = bytestring_path(full_path)
-        if 'singletons' not in import_config or not import_config[
-                'singletons']:
+        if (
+            "singletons" not in import_config
+            or not import_config["singletons"]
+        ):
             # Album
             return self.path_album_regex.match(full_path) is not None
         else:

--- a/beetsplug/fish.py
+++ b/beetsplug/fish.py
@@ -30,12 +30,13 @@ from beets import library, ui
 from beets.ui import commands
 from operator import attrgetter
 import os
+
 BL_NEED2 = """complete -c beet -n '__fish_beet_needs_command' {} {}\n"""
 BL_USE3 = """complete -c beet -n '__fish_beet_using_command {}' {} {}\n"""
 BL_SUBS = """complete -c beet -n '__fish_at_level {} ""' {}  {}\n"""
 BL_EXTRA3 = """complete -c beet -n '__fish_beet_use_extra {}' {} {}\n"""
 
-HEAD = '''
+HEAD = """
 function __fish_beet_needs_command
     set cmd (commandline -opc)
     if test (count $cmd) -eq 1
@@ -64,25 +65,28 @@ function __fish_beet_use_extra
     end
     return 1
 end
-'''
+"""
 
 
 class FishPlugin(BeetsPlugin):
-
     def commands(self):
-        cmd = ui.Subcommand('fish', help='generate Fish shell tab completions')
+        cmd = ui.Subcommand("fish", help="generate Fish shell tab completions")
         cmd.func = self.run
-        cmd.parser.add_option('-f', '--noFields', action='store_true',
-                              default=False,
-                              help='omit album/track field completions')
         cmd.parser.add_option(
-            '-e',
-            '--extravalues',
-            action='append',
-            type='choice',
-            choices=library.Item.all_keys() +
-            library.Album.all_keys(),
-            help='include specified field *values* in completions')
+            "-f",
+            "--noFields",
+            action="store_true",
+            default=False,
+            help="omit album/track field completions",
+        )
+        cmd.parser.add_option(
+            "-e",
+            "--extravalues",
+            action="append",
+            type="choice",
+            choices=library.Item.all_keys() + library.Album.all_keys(),
+            help="include specified field *values* in completions",
+        )
         return [cmd]
 
     def run(self, lib, opts, args):
@@ -92,21 +96,22 @@ class FishPlugin(BeetsPlugin):
         # Make a giant string of all the above, formatted in a way that
         # allows Fish to do tab completion for the `beet` command.
         home_dir = os.path.expanduser("~")
-        completion_dir = os.path.join(home_dir, '.config/fish/completions')
+        completion_dir = os.path.join(home_dir, ".config/fish/completions")
         try:
             os.makedirs(completion_dir)
         except OSError:
             if not os.path.isdir(completion_dir):
                 raise
-        completion_file_path = os.path.join(completion_dir, 'beet.fish')
+        completion_file_path = os.path.join(completion_dir, "beet.fish")
         nobasicfields = opts.noFields  # Do not complete for album/track fields
         extravalues = opts.extravalues  # e.g., Also complete artists names
         beetcmds = sorted(
-            (commands.default_commands +
-             commands.plugins.commands()),
-            key=attrgetter('name'))
-        fields = sorted(set(
-            library.Album.all_keys() + library.Item.all_keys()))
+            (commands.default_commands + commands.plugins.commands()),
+            key=attrgetter("name"),
+        )
+        fields = sorted(
+            set(library.Album.all_keys() + library.Item.all_keys())
+        )
         # Collect commands, their aliases, and their help text
         cmd_names_help = []
         for cmd in beetcmds:
@@ -117,50 +122,58 @@ class FishPlugin(BeetsPlugin):
         # Concatenate the string
         totstring = HEAD + "\n"
         totstring += get_cmds_list([name[0] for name in cmd_names_help])
-        totstring += '' if nobasicfields else get_standard_fields(fields)
-        totstring += get_extravalues(lib, extravalues) if extravalues else ''
-        totstring += "\n" + "# ====== {} =====".format(
-            "setup basic beet completion") + "\n" * 2
+        totstring += "" if nobasicfields else get_standard_fields(fields)
+        totstring += get_extravalues(lib, extravalues) if extravalues else ""
+        totstring += (
+            "\n"
+            + "# ====== {} =====".format("setup basic beet completion")
+            + "\n" * 2
+        )
         totstring += get_basic_beet_options()
-        totstring += "\n" + "# ====== {} =====".format(
-            "setup field completion for subcommands") + "\n"
+        totstring += (
+            "\n"
+            + "# ====== {} =====".format(
+                "setup field completion for subcommands"
+            )
+            + "\n"
+        )
         totstring += get_subcommands(
-            cmd_names_help, nobasicfields, extravalues)
+            cmd_names_help, nobasicfields, extravalues
+        )
         # Set up completion for all the command options
         totstring += get_all_commands(beetcmds)
 
-        with open(completion_file_path, 'w') as fish_file:
+        with open(completion_file_path, "w") as fish_file:
             fish_file.write(totstring)
 
 
 def get_cmds_list(cmds_names):
     # Make a list of all Beets core & plugin commands
-    substr = ''
-    substr += (
-        "set CMDS " + " ".join(cmds_names) + ("\n" * 2)
-    )
+    substr = ""
+    substr += "set CMDS " + " ".join(cmds_names) + ("\n" * 2)
     return substr
 
 
 def get_standard_fields(fields):
     # Make a list of album/track fields and append with ':'
     fields = (field + ":" for field in fields)
-    substr = ''
-    substr += (
-        "set FIELDS " + " ".join(fields) + ("\n" * 2)
-    )
+    substr = ""
+    substr += "set FIELDS " + " ".join(fields) + ("\n" * 2)
     return substr
 
 
 def get_extravalues(lib, extravalues):
     # Make a list of all values from an album/track field.
     # 'beet ls albumartist: <TAB>' yields completions for ABBA, Beatles, etc.
-    word = ''
+    word = ""
     values_set = get_set_of_values_for_field(lib, extravalues)
     for fld in extravalues:
-        extraname = fld.upper() + 'S'
+        extraname = fld.upper() + "S"
         word += (
-            "set  " + extraname + " " + " ".join(sorted(values_set[fld]))
+            "set  "
+            + extraname
+            + " "
+            + " ".join(sorted(values_set[fld]))
             + ("\n" * 2)
         )
     return word
@@ -179,21 +192,26 @@ def get_set_of_values_for_field(lib, fields):
 
 def get_basic_beet_options():
     word = (
-        BL_NEED2.format("-l format-item",
-                        "-f -d 'print with custom format'") +
-        BL_NEED2.format("-l format-album",
-                        "-f -d 'print with custom format'") +
-        BL_NEED2.format("-s  l  -l library",
-                        "-f -r -d 'library database file to use'") +
-        BL_NEED2.format("-s  d  -l directory",
-                        "-f -r -d 'destination music directory'") +
-        BL_NEED2.format("-s  v  -l verbose",
-                        "-f -d 'print debugging information'") +
-
-        BL_NEED2.format("-s  c  -l config",
-                        "-f -r -d 'path to configuration file'") +
-        BL_NEED2.format("-s  h  -l help",
-                        "-f -d 'print this help message and exit'"))
+        BL_NEED2.format("-l format-item", "-f -d 'print with custom format'")
+        + BL_NEED2.format(
+            "-l format-album", "-f -d 'print with custom format'"
+        )
+        + BL_NEED2.format(
+            "-s  l  -l library", "-f -r -d 'library database file to use'"
+        )
+        + BL_NEED2.format(
+            "-s  d  -l directory", "-f -r -d 'destination music directory'"
+        )
+        + BL_NEED2.format(
+            "-s  v  -l verbose", "-f -d 'print debugging information'"
+        )
+        + BL_NEED2.format(
+            "-s  c  -l config", "-f -r -d 'path to configuration file'"
+        )
+        + BL_NEED2.format(
+            "-s  h  -l help", "-f -d 'print this help message and exit'"
+        )
+    )
     return word
 
 
@@ -201,27 +219,36 @@ def get_subcommands(cmd_name_and_help, nobasicfields, extravalues):
     # Formatting for Fish to complete our fields/values
     word = ""
     for cmdname, cmdhelp in cmd_name_and_help:
-        word += "\n" + "# ------ {} -------".format(
-            "fieldsetups for  " + cmdname) + "\n"
         word += (
-            BL_NEED2.format(
-                ("-a " + cmdname),
-                ("-f " + "-d " + wrap(clean_whitespace(cmdhelp)))))
+            "\n"
+            + "# ------ {} -------".format("fieldsetups for  " + cmdname)
+            + "\n"
+        )
+        word += BL_NEED2.format(
+            ("-a " + cmdname),
+            ("-f " + "-d " + wrap(clean_whitespace(cmdhelp))),
+        )
 
         if nobasicfields is False:
-            word += (
-                BL_USE3.format(
-                    cmdname,
-                    ("-a " + wrap("$FIELDS")),
-                    ("-f " + "-d " + wrap("fieldname"))))
+            word += BL_USE3.format(
+                cmdname,
+                ("-a " + wrap("$FIELDS")),
+                ("-f " + "-d " + wrap("fieldname")),
+            )
 
         if extravalues:
             for f in extravalues:
                 setvar = wrap("$" + f.upper() + "S")
-                word += " ".join(BL_EXTRA3.format(
-                    (cmdname + " " + f + ":"),
-                    ('-f ' + '-A ' + '-a ' + setvar),
-                    ('-d ' + wrap(f))).split()) + "\n"
+                word += (
+                    " ".join(
+                        BL_EXTRA3.format(
+                            (cmdname + " " + f + ":"),
+                            ("-f " + "-A " + "-a " + setvar),
+                            ("-d " + wrap(f)),
+                        ).split()
+                    )
+                    + "\n"
+                )
     return word
 
 
@@ -233,30 +260,59 @@ def get_all_commands(beetcmds):
         names.append(cmd.name)
         for name in names:
             word += "\n"
-            word += ("\n" * 2) + "# ====== {} =====".format(
-                "completions for  " + name) + "\n"
+            word += (
+                ("\n" * 2)
+                + "# ====== {} =====".format("completions for  " + name)
+                + "\n"
+            )
 
             for option in cmd.parser._get_all_options()[1:]:
-                cmd_l = (" -l " + option._long_opts[0].replace('--', '')
-                         )if option._long_opts else ''
-                cmd_s = (" -s " + option._short_opts[0].replace('-', '')
-                         ) if option._short_opts else ''
-                cmd_need_arg = ' -r ' if option.nargs in [1] else ''
-                cmd_helpstr = (" -d " + wrap(' '.join(option.help.split()))
-                               ) if option.help else ''
-                cmd_arglist = (' -a ' + wrap(" ".join(option.choices))
-                               ) if option.choices else ''
+                cmd_l = (
+                    (" -l " + option._long_opts[0].replace("--", ""))
+                    if option._long_opts
+                    else ""
+                )
+                cmd_s = (
+                    (" -s " + option._short_opts[0].replace("-", ""))
+                    if option._short_opts
+                    else ""
+                )
+                cmd_need_arg = " -r " if option.nargs in [1] else ""
+                cmd_helpstr = (
+                    (" -d " + wrap(" ".join(option.help.split())))
+                    if option.help
+                    else ""
+                )
+                cmd_arglist = (
+                    (" -a " + wrap(" ".join(option.choices)))
+                    if option.choices
+                    else ""
+                )
 
-                word += " ".join(BL_USE3.format(
+                word += (
+                    " ".join(
+                        BL_USE3.format(
+                            name,
+                            (
+                                cmd_need_arg
+                                + cmd_s
+                                + cmd_l
+                                + " -f "
+                                + cmd_arglist
+                            ),
+                            cmd_helpstr,
+                        ).split()
+                    )
+                    + "\n"
+                )
+
+            word = word + " ".join(
+                BL_USE3.format(
                     name,
-                    (cmd_need_arg + cmd_s + cmd_l + " -f " + cmd_arglist),
-                    cmd_helpstr).split()) + "\n"
-
-            word = (word + " ".join(BL_USE3.format(
-                name,
-                ("-s " + "h " + "-l " + "help" + " -f "),
-                ('-d ' + wrap("print help") + "\n")
-            ).split()))
+                    ("-s " + "h " + "-l " + "help" + " -f "),
+                    ("-d " + wrap("print help") + "\n"),
+                ).split()
+            )
     return word
 
 
@@ -267,7 +323,7 @@ def clean_whitespace(word):
 
 def wrap(word):
     # Need " or ' around strings but watch out if they're in the string
-    sptoken = '\"'
+    sptoken = '"'
     if ('"') in word and ("'") in word:
         word.replace('"', sptoken)
         return '"' + word + '"'

--- a/beetsplug/freedesktop.py
+++ b/beetsplug/freedesktop.py
@@ -26,12 +26,17 @@ class FreedesktopPlugin(BeetsPlugin):
     def commands(self):
         deprecated = ui.Subcommand(
             "freedesktop",
-            help=u"Print a message to redirect to thumbnails --dolphin")
+            help=u"Print a message to redirect to thumbnails --dolphin",
+        )
         deprecated.func = self.deprecation_message
         return [deprecated]
 
     def deprecation_message(self, lib, opts, args):
-        ui.print_(u"This plugin is deprecated. Its functionality is "
-                  u"superseded by the 'thumbnails' plugin")
-        ui.print_(u"'thumbnails --dolphin' replaces freedesktop. See doc & "
-                  u"changelog for more information")
+        ui.print_(
+            u"This plugin is deprecated. Its functionality is "
+            u"superseded by the 'thumbnails' plugin"
+        )
+        ui.print_(
+            u"'thumbnails --dolphin' replaces freedesktop. See doc & "
+            u"changelog for more information"
+        )

--- a/beetsplug/fromfilename.py
+++ b/beetsplug/fromfilename.py
@@ -27,21 +27,21 @@ import six
 
 # Filename field extraction patterns.
 PATTERNS = [
-  # Useful patterns.
-  r'^(?P<artist>.+)[\-_](?P<title>.+)[\-_](?P<tag>.*)$',
-  r'^(?P<track>\d+)[\s.\-_]+(?P<artist>.+)[\-_](?P<title>.+)[\-_](?P<tag>.*)$',
-  r'^(?P<artist>.+)[\-_](?P<title>.+)$',
-  r'^(?P<track>\d+)[\s.\-_]+(?P<artist>.+)[\-_](?P<title>.+)$',
-  r'^(?P<title>.+)$',
-  r'^(?P<track>\d+)[\s.\-_]+(?P<title>.+)$',
-  r'^(?P<track>\d+)\s+(?P<title>.+)$',
-  r'^(?P<title>.+) by (?P<artist>.+)$',
-  r'^(?P<track>\d+).*$',
+    # Useful patterns.
+    r"^(?P<artist>.+)[\-_](?P<title>.+)[\-_](?P<tag>.*)$",
+    r"^(?P<track>\d+)[\s.\-_]+(?P<artist>.+)[\-_](?P<title>.+)[\-_](?P<tag>.*)$",
+    r"^(?P<artist>.+)[\-_](?P<title>.+)$",
+    r"^(?P<track>\d+)[\s.\-_]+(?P<artist>.+)[\-_](?P<title>.+)$",
+    r"^(?P<title>.+)$",
+    r"^(?P<track>\d+)[\s.\-_]+(?P<title>.+)$",
+    r"^(?P<track>\d+)\s+(?P<title>.+)$",
+    r"^(?P<title>.+) by (?P<artist>.+)$",
+    r"^(?P<track>\d+).*$",
 ]
 
 # Titles considered "empty" and in need of replacement.
 BAD_TITLE_PATTERNS = [
-    r'^$',
+    r"^$",
 ]
 
 
@@ -96,19 +96,19 @@ def apply_matches(d):
     keys = some_map.keys()
 
     # Only proceed if the "tag" field is equal across all filenames.
-    if 'tag' in keys and not equal_fields(d, 'tag'):
+    if "tag" in keys and not equal_fields(d, "tag"):
         return
 
     # Given both an "artist" and "title" field, assume that one is
     # *actually* the artist, which must be uniform, and use the other
     # for the title. This, of course, won't work for VA albums.
-    if 'artist' in keys:
-        if equal_fields(d, 'artist'):
-            artist = some_map['artist']
-            title_field = 'title'
-        elif equal_fields(d, 'title'):
-            artist = some_map['title']
-            title_field = 'artist'
+    if "artist" in keys:
+        if equal_fields(d, "artist"):
+            artist = some_map["artist"]
+            title_field = "title"
+        elif equal_fields(d, "title"):
+            artist = some_map["title"]
+            title_field = "artist"
         else:
             # Both vary. Abort.
             return
@@ -119,22 +119,23 @@ def apply_matches(d):
 
     # No artist field: remaining field is the title.
     else:
-        title_field = 'title'
+        title_field = "title"
 
     # Apply the title and track.
     for item in d:
         if bad_title(item.title):
             item.title = six.text_type(d[item][title_field])
-        if 'track' in d[item] and item.track == 0:
-            item.track = int(d[item]['track'])
+        if "track" in d[item] and item.track == 0:
+            item.track = int(d[item]["track"])
 
 
 # Plugin structure and hook into import process.
 
+
 class FromFilenamePlugin(plugins.BeetsPlugin):
     def __init__(self):
         super(FromFilenamePlugin, self).__init__()
-        self.register_listener('import_task_start', filename_task)
+        self.register_listener("import_task_start", filename_task)
 
 
 def filename_task(task, session):

--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -58,7 +58,7 @@ def find_feat_part(artist, albumartist):
     # If the last element of the split (the right-hand side of the
     # album artist) is nonempty, then it probably contains the
     # featured artist.
-    elif albumartist_split[1] != '':
+    elif albumartist_split[1] != "":
         # Extract the featured artist from the right-hand side.
         _, feat_part = split_on_feat(albumartist_split[1])
         return feat_part
@@ -77,29 +77,30 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
     def __init__(self):
         super(FtInTitlePlugin, self).__init__()
 
-        self.config.add({
-            'auto': True,
-            'drop': False,
-            'format': u'feat. {0}',
-        })
+        self.config.add(
+            {"auto": True, "drop": False, "format": u"feat. {0}",}
+        )
 
         self._command = ui.Subcommand(
-            'ftintitle',
-            help=u'move featured artists to the title field')
+            "ftintitle", help=u"move featured artists to the title field"
+        )
 
         self._command.parser.add_option(
-            u'-d', u'--drop', dest='drop',
-            action='store_true', default=None,
-            help=u'drop featuring from artists and ignore title update')
+            u"-d",
+            u"--drop",
+            dest="drop",
+            action="store_true",
+            default=None,
+            help=u"drop featuring from artists and ignore title update",
+        )
 
-        if self.config['auto']:
+        if self.config["auto"]:
             self.import_stages = [self.imported]
 
     def commands(self):
-
         def func(lib, opts, args):
             self.config.set_args(opts)
-            drop_feat = self.config['drop'].get(bool)
+            drop_feat = self.config["drop"].get(bool)
             write = ui.should_write()
 
             for item in lib.items(ui.decargs(args)):
@@ -114,7 +115,7 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
     def imported(self, session, task):
         """Import hook for moving featuring artist automatically.
         """
-        drop_feat = self.config['drop'].get(bool)
+        drop_feat = self.config["drop"].get(bool)
 
         for item in task.imported_items():
             self.ft_in_title(item, drop_feat)
@@ -127,7 +128,7 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
         remove it from the artist field.
         """
         # In all cases, update the artist fields.
-        self._log.info(u'artist: {0} -> {1}', item.artist, item.albumartist)
+        self._log.info(u"artist: {0} -> {1}", item.artist, item.albumartist)
         item.artist = item.albumartist
         if item.artist_sort:
             # Just strip the featured artist from the sort name.
@@ -136,10 +137,10 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
         # Only update the title if it does not already contain a featured
         # artist and if we do not drop featuring information.
         if not drop_feat and not contains_feat(item.title):
-            feat_format = self.config['format'].as_str()
+            feat_format = self.config["format"].as_str()
             new_format = feat_format.format(feat_part)
             new_title = u"{0} {1}".format(item.title, new_format)
-            self._log.info(u'title: {0} -> {1}', item.title, new_title)
+            self._log.info(u"title: {0} -> {1}", item.title, new_title)
             item.title = new_title
 
     def ft_in_title(self, item, drop_feat):
@@ -154,7 +155,7 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
         # that case, we attempt to move the featured artist to the title.
         _, featured = split_on_feat(artist)
         if featured and albumartist != artist and albumartist:
-            self._log.info('{}', displayable_path(item.path))
+            self._log.info("{}", displayable_path(item.path))
 
             feat_part = None
 
@@ -165,4 +166,4 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
             if feat_part:
                 self.update_metadata(item, feat_part, drop_feat)
             else:
-                self._log.info(u'no featuring artists found')
+                self._log.info(u"no featuring artists found")

--- a/beetsplug/fuzzy.py
+++ b/beetsplug/fuzzy.py
@@ -31,18 +31,17 @@ class FuzzyQuery(StringFieldQuery):
         if pattern.islower():
             val = val.lower()
         query_matcher = difflib.SequenceMatcher(None, pattern, val)
-        threshold = config['fuzzy']['threshold'].as_number()
+        threshold = config["fuzzy"]["threshold"].as_number()
         return query_matcher.quick_ratio() >= threshold
 
 
 class FuzzyPlugin(BeetsPlugin):
     def __init__(self):
         super(FuzzyPlugin, self).__init__()
-        self.config.add({
-            'prefix': '~',
-            'threshold': 0.7,
-        })
+        self.config.add(
+            {"prefix": "~", "threshold": 0.7,}
+        )
 
     def queries(self):
-        prefix = self.config['prefix'].as_str()
+        prefix = self.config["prefix"].as_str()
         return {prefix: FuzzyQuery}

--- a/beetsplug/gmusic.py
+++ b/beetsplug/gmusic.py
@@ -33,34 +33,46 @@ class Gmusic(BeetsPlugin):
         self.m = Musicmanager()
 
         # OAUTH_FILEPATH was moved in gmusicapi 12.0.0.
-        if hasattr(Musicmanager, 'OAUTH_FILEPATH'):
+        if hasattr(Musicmanager, "OAUTH_FILEPATH"):
             oauth_file = Musicmanager.OAUTH_FILEPATH
         else:
             oauth_file = gmusicapi.clients.OAUTH_FILEPATH
 
-        self.config.add({
-            u'auto': False,
-            u'uploader_id': '',
-            u'uploader_name': '',
-            u'device_id': '',
-            u'oauth_file': oauth_file,
-        })
-        if self.config['auto']:
+        self.config.add(
+            {
+                u"auto": False,
+                u"uploader_id": "",
+                u"uploader_name": "",
+                u"device_id": "",
+                u"oauth_file": oauth_file,
+            }
+        )
+        if self.config["auto"]:
             self.import_stages = [self.autoupload]
 
     def commands(self):
-        gupload = Subcommand('gmusic-upload',
-                             help=u'upload your tracks to Google Play Music')
+        gupload = Subcommand(
+            "gmusic-upload", help=u"upload your tracks to Google Play Music"
+        )
         gupload.func = self.upload
 
-        search = Subcommand('gmusic-songs',
-                            help=u'list of songs in Google Play Music library')
-        search.parser.add_option('-t', '--track', dest='track',
-                                 action='store_true',
-                                 help='Search by track name')
-        search.parser.add_option('-a', '--artist', dest='artist',
-                                 action='store_true',
-                                 help='Search by artist')
+        search = Subcommand(
+            "gmusic-songs", help=u"list of songs in Google Play Music library"
+        )
+        search.parser.add_option(
+            "-t",
+            "--track",
+            dest="track",
+            action="store_true",
+            help="Search by track name",
+        )
+        search.parser.add_option(
+            "-a",
+            "--artist",
+            dest="artist",
+            action="store_true",
+            help="Search by artist",
+        )
         search.func = self.search
         return [gupload, search]
 
@@ -69,13 +81,15 @@ class Gmusic(BeetsPlugin):
             return
         # Checks for OAuth2 credentials,
         # if they don't exist - performs authorization
-        oauth_file = self.config['oauth_file'].as_filename()
+        oauth_file = self.config["oauth_file"].as_filename()
         if os.path.isfile(oauth_file):
-            uploader_id = self.config['uploader_id']
-            uploader_name = self.config['uploader_name']
-            self.m.login(oauth_credentials=oauth_file,
-                         uploader_id=uploader_id.as_str().upper() or None,
-                         uploader_name=uploader_name.as_str() or None)
+            uploader_id = self.config["uploader_id"]
+            uploader_name = self.config["uploader_name"]
+            self.m.login(
+                oauth_credentials=oauth_file,
+                uploader_id=uploader_id.as_str().upper() or None,
+                uploader_name=uploader_name.as_str() or None,
+            )
         else:
             self.m.perform_oauth(oauth_file)
 
@@ -83,55 +97,63 @@ class Gmusic(BeetsPlugin):
         items = lib.items(ui.decargs(args))
         files = self.getpaths(items)
         self.authenticate()
-        ui.print_(u'Uploading your files...')
+        ui.print_(u"Uploading your files...")
         self.m.upload(filepaths=files)
-        ui.print_(u'Your files were successfully added to library')
+        ui.print_(u"Your files were successfully added to library")
 
     def autoupload(self, session, task):
         items = task.imported_items()
         files = self.getpaths(items)
         self.authenticate()
-        self._log.info(u'Uploading files to Google Play Music...', files)
+        self._log.info(u"Uploading files to Google Play Music...", files)
         self.m.upload(filepaths=files)
-        self._log.info(u'Your files were successfully added to your '
-                       + 'Google Play Music library')
+        self._log.info(
+            u"Your files were successfully added to your "
+            + "Google Play Music library"
+        )
 
     def getpaths(self, items):
         return [x.path for x in items]
 
     def search(self, lib, opts, args):
-        password = config['gmusic']['password']
-        email = config['gmusic']['email']
-        uploader_id = config['gmusic']['uploader_id']
-        device_id = config['gmusic']['device_id']
+        password = config["gmusic"]["password"]
+        email = config["gmusic"]["email"]
+        uploader_id = config["gmusic"]["uploader_id"]
+        device_id = config["gmusic"]["device_id"]
         password.redact = True
         email.redact = True
         # Since Musicmanager doesn't support library management
         # we need to use mobileclient interface
         mobile = Mobileclient()
         try:
-            new_device_id = (device_id.as_str()
-                             or uploader_id.as_str().replace(':', '')
-                             or Mobileclient.FROM_MAC_ADDRESS).upper()
+            new_device_id = (
+                device_id.as_str()
+                or uploader_id.as_str().replace(":", "")
+                or Mobileclient.FROM_MAC_ADDRESS
+            ).upper()
             mobile.login(email.as_str(), password.as_str(), new_device_id)
             files = mobile.get_all_songs()
         except NotLoggedIn:
             ui.print_(
-                u'Authentication error. Please check your email and password.'
+                u"Authentication error. Please check your email and password."
             )
             return
         if not args:
             for i, file in enumerate(files, start=1):
-                print(i, ui.colorize('blue', file['artist']),
-                      file['title'], ui.colorize('red', file['album']))
+                print(
+                    i,
+                    ui.colorize("blue", file["artist"]),
+                    file["title"],
+                    ui.colorize("red", file["album"]),
+                )
         else:
             if opts.track:
-                self.match(files, args, 'title')
+                self.match(files, args, "title")
             else:
-                self.match(files, args, 'artist')
+                self.match(files, args, "artist")
 
     @staticmethod
     def match(files, args, search_by):
         for file in files:
-            if ' '.join(ui.decargs(args)) in file[search_by]:
-                print(file['artist'], file['title'], file['album'])
+            if " ".join(ui.decargs(args)) in file[search_by]:
+                print(file["artist"], file["title"], file["album"])

--- a/beetsplug/hook.py
+++ b/beetsplug/hook.py
@@ -48,8 +48,9 @@ class CodingFormatter(string.Formatter):
         if isinstance(format_string, bytes):
             format_string = format_string.decode(self._coding)
 
-        return super(CodingFormatter, self).format(format_string, *args,
-                                                   **kwargs)
+        return super(CodingFormatter, self).format(
+            format_string, *args, **kwargs
+        )
 
     def convert_field(self, value, conversion):
         """Converts the provided value given a conversion type.
@@ -58,8 +59,9 @@ class CodingFormatter(string.Formatter):
 
         See string.Formatter.convert_field.
         """
-        converted = super(CodingFormatter, self).convert_field(value,
-                                                               conversion)
+        converted = super(CodingFormatter, self).convert_field(
+            value, conversion
+        )
 
         if isinstance(converted, bytes):
             return converted.decode(self._coding)
@@ -69,20 +71,19 @@ class CodingFormatter(string.Formatter):
 
 class HookPlugin(BeetsPlugin):
     """Allows custom commands to be run when an event is emitted by beets"""
+
     def __init__(self):
         super(HookPlugin, self).__init__()
 
-        self.config.add({
-            'hooks': []
-        })
+        self.config.add({"hooks": []})
 
-        hooks = self.config['hooks'].get(list)
+        hooks = self.config["hooks"].get(list)
 
         for hook_index in range(len(hooks)):
-            hook = self.config['hooks'][hook_index]
+            hook = self.config["hooks"][hook_index]
 
-            hook_event = hook['event'].as_str()
-            hook_command = hook['command'].as_str()
+            hook_event = hook["event"].as_str()
+            hook_command = hook["command"].as_str()
 
             self.create_and_register_hook(hook_event, hook_command)
 
@@ -98,18 +99,25 @@ class HookPlugin(BeetsPlugin):
             command_pieces = shlex_split(command)
 
             for i, piece in enumerate(command_pieces):
-                command_pieces[i] = formatter.format(piece, event=event,
-                                                     **kwargs)
+                command_pieces[i] = formatter.format(
+                    piece, event=event, **kwargs
+                )
 
-            self._log.debug(u'running command "{0}" for event {1}',
-                            u' '.join(command_pieces), event)
+            self._log.debug(
+                u'running command "{0}" for event {1}',
+                u" ".join(command_pieces),
+                event,
+            )
 
             try:
                 subprocess.check_call(command_pieces)
             except subprocess.CalledProcessError as exc:
-                self._log.error(u'hook for {0} exited with status {1}',
-                                event, exc.returncode)
+                self._log.error(
+                    u"hook for {0} exited with status {1}",
+                    event,
+                    exc.returncode,
+                )
             except OSError as exc:
-                self._log.error(u'hook for {0} failed: {1}', event, exc)
+                self._log.error(u"hook for {0} failed: {1}", event, exc)
 
         self.register_listener(event, hook_function)

--- a/beetsplug/ihate.py
+++ b/beetsplug/ihate.py
@@ -24,8 +24,8 @@ from beets.library import Item
 from beets.library import Album
 
 
-__author__ = 'baobab@heresiarch.info'
-__version__ = '2.0'
+__author__ = "baobab@heresiarch.info"
+__version__ = "2.0"
 
 
 def summary(task):
@@ -33,20 +33,20 @@ def summary(task):
     object.
     """
     if task.is_album:
-        return u'{0} - {1}'.format(task.cur_artist, task.cur_album)
+        return u"{0} - {1}".format(task.cur_artist, task.cur_album)
     else:
-        return u'{0} - {1}'.format(task.item.artist, task.item.title)
+        return u"{0} - {1}".format(task.item.artist, task.item.title)
 
 
 class IHatePlugin(BeetsPlugin):
     def __init__(self):
         super(IHatePlugin, self).__init__()
-        self.register_listener('import_task_choice',
-                               self.import_task_choice_event)
-        self.config.add({
-            'warn': [],
-            'skip': [],
-        })
+        self.register_listener(
+            "import_task_choice", self.import_task_choice_event
+        )
+        self.config.add(
+            {"warn": [], "skip": [],}
+        )
 
     @classmethod
     def do_i_hate_this(cls, task, action_patterns):
@@ -56,27 +56,26 @@ class IHatePlugin(BeetsPlugin):
         if action_patterns:
             for query_string in action_patterns:
                 query, _ = parse_query_string(
-                    query_string,
-                    Album if task.is_album else Item,
+                    query_string, Album if task.is_album else Item,
                 )
                 if any(query.match(item) for item in task.imported_items()):
                     return True
         return False
 
     def import_task_choice_event(self, session, task):
-        skip_queries = self.config['skip'].as_str_seq()
-        warn_queries = self.config['warn'].as_str_seq()
+        skip_queries = self.config["skip"].as_str_seq()
+        warn_queries = self.config["warn"].as_str_seq()
 
         if task.choice_flag == action.APPLY:
             if skip_queries or warn_queries:
-                self._log.debug(u'processing your hate')
+                self._log.debug(u"processing your hate")
                 if self.do_i_hate_this(task, skip_queries):
                     task.choice_flag = action.SKIP
-                    self._log.info(u'skipped: {0}', summary(task))
+                    self._log.info(u"skipped: {0}", summary(task))
                     return
                 if self.do_i_hate_this(task, warn_queries):
-                    self._log.info(u'you may hate this: {0}', summary(task))
+                    self._log.info(u"you may hate this: {0}", summary(task))
             else:
-                self._log.debug(u'nothing to do')
+                self._log.debug(u"nothing to do")
         else:
-            self._log.debug(u'user made a decision, nothing to do')
+            self._log.debug(u"user made a decision, nothing to do")

--- a/beetsplug/importfeeds.py
+++ b/beetsplug/importfeeds.py
@@ -27,19 +27,21 @@ from beets.plugins import BeetsPlugin
 from beets.util import mkdirall, normpath, syspath, bytestring_path, link
 from beets import config
 
-M3U_DEFAULT_NAME = 'imported.m3u'
+M3U_DEFAULT_NAME = "imported.m3u"
 
 
 def _build_m3u_filename(basename):
     """Builds unique m3u filename by appending given basename to current
     date."""
 
-    basename = re.sub(r"[\s,/\\'\"]", '_', basename)
+    basename = re.sub(r"[\s,/\\'\"]", "_", basename)
     date = datetime.datetime.now().strftime("%Y%m%d_%Hh%M")
-    path = normpath(os.path.join(
-        config['importfeeds']['dir'].as_filename(),
-        date + '_' + basename + '.m3u'
-    ))
+    path = normpath(
+        os.path.join(
+            config["importfeeds"]["dir"].as_filename(),
+            date + "_" + basename + ".m3u",
+        )
+    )
     return path
 
 
@@ -47,50 +49,51 @@ def _write_m3u(m3u_path, items_paths):
     """Append relative paths to items into m3u file.
     """
     mkdirall(m3u_path)
-    with open(syspath(m3u_path), 'ab') as f:
+    with open(syspath(m3u_path), "ab") as f:
         for path in items_paths:
-            f.write(path + b'\n')
+            f.write(path + b"\n")
 
 
 class ImportFeedsPlugin(BeetsPlugin):
     def __init__(self):
         super(ImportFeedsPlugin, self).__init__()
 
-        self.config.add({
-            'formats': [],
-            'm3u_name': u'imported.m3u',
-            'dir': None,
-            'relative_to': None,
-            'absolute_path': False,
-        })
+        self.config.add(
+            {
+                "formats": [],
+                "m3u_name": u"imported.m3u",
+                "dir": None,
+                "relative_to": None,
+                "absolute_path": False,
+            }
+        )
 
-        relative_to = self.config['relative_to'].get()
+        relative_to = self.config["relative_to"].get()
         if relative_to:
-            self.config['relative_to'] = normpath(relative_to)
+            self.config["relative_to"] = normpath(relative_to)
         else:
-            self.config['relative_to'] = self.get_feeds_dir()
+            self.config["relative_to"] = self.get_feeds_dir()
 
-        self.register_listener('album_imported', self.album_imported)
-        self.register_listener('item_imported', self.item_imported)
+        self.register_listener("album_imported", self.album_imported)
+        self.register_listener("item_imported", self.item_imported)
 
     def get_feeds_dir(self):
-        feeds_dir = self.config['dir'].get()
+        feeds_dir = self.config["dir"].get()
         if feeds_dir:
             return os.path.expanduser(bytestring_path(feeds_dir))
-        return config['directory'].as_filename()
+        return config["directory"].as_filename()
 
     def _record_items(self, lib, basename, items):
         """Records relative paths to the given items for each feed format
         """
         feedsdir = bytestring_path(self.get_feeds_dir())
-        formats = self.config['formats'].as_str_seq()
-        relative_to = self.config['relative_to'].get() \
-            or self.get_feeds_dir()
+        formats = self.config["formats"].as_str_seq()
+        relative_to = self.config["relative_to"].get() or self.get_feeds_dir()
         relative_to = bytestring_path(relative_to)
 
         paths = []
         for item in items:
-            if self.config['absolute_path']:
+            if self.config["absolute_path"]:
                 paths.append(item.path)
             else:
                 try:
@@ -101,23 +104,22 @@ class ImportFeedsPlugin(BeetsPlugin):
                     relpath = item.path
                 paths.append(relpath)
 
-        if 'm3u' in formats:
-            m3u_basename = bytestring_path(
-                self.config['m3u_name'].as_str())
+        if "m3u" in formats:
+            m3u_basename = bytestring_path(self.config["m3u_name"].as_str())
             m3u_path = os.path.join(feedsdir, m3u_basename)
             _write_m3u(m3u_path, paths)
 
-        if 'm3u_multi' in formats:
+        if "m3u_multi" in formats:
             m3u_path = _build_m3u_filename(basename)
             _write_m3u(m3u_path, paths)
 
-        if 'link' in formats:
+        if "link" in formats:
             for path in paths:
                 dest = os.path.join(feedsdir, os.path.basename(path))
                 if not os.path.exists(syspath(dest)):
                     link(path, dest)
 
-        if 'echo' in formats:
+        if "echo" in formats:
             self._log.info(u"Location of imported music:")
             for path in paths:
                 self._log.info(u"  {0}", path)

--- a/beetsplug/info.py
+++ b/beetsplug/info.py
@@ -45,16 +45,17 @@ def tag_data(lib, args):
 def tag_data_emitter(path):
     def emitter():
         fields = list(mediafile.MediaFile.readable_fields())
-        fields.remove('images')
+        fields.remove("images")
         mf = mediafile.MediaFile(syspath(path))
         tags = {}
         for field in fields:
             tags[field] = getattr(mf, field)
-        tags['art'] = mf.art is not None
+        tags["art"] = mf.art is not None
         # create a temporary Item to take advantage of __format__
         item = Item.from_path(syspath(path))
 
         return tags, item
+
     return emitter
 
 
@@ -68,6 +69,7 @@ def library_data_emitter(item):
         data = dict(item.formatted())
 
         return data, item
+
     return emitter
 
 
@@ -76,7 +78,7 @@ def update_summary(summary, tags):
         if key not in summary:
             summary[key] = value
         elif summary[key] != value:
-            summary[key] = '[various]'
+            summary[key] = "[various]"
     return summary
 
 
@@ -97,7 +99,7 @@ def print_data(data, item=None, fmt=None):
     formatted = {}
     for key, value in data.items():
         if isinstance(value, list):
-            formatted[key] = u'; '.join(value)
+            formatted[key] = u"; ".join(value)
         if value is not None:
             formatted[key] = value
 
@@ -105,7 +107,7 @@ def print_data(data, item=None, fmt=None):
         return
 
     maxwidth = max(len(key) for key in formatted)
-    lineformat = u'{{0:>{0}}}: {{1}}'.format(maxwidth)
+    lineformat = u"{{0:>{0}}}: {{1}}".format(maxwidth)
 
     if path:
         ui.print_(displayable_path(path))
@@ -113,7 +115,7 @@ def print_data(data, item=None, fmt=None):
     for field in sorted(formatted):
         value = formatted[field]
         if isinstance(value, list):
-            value = u'; '.join(value)
+            value = u"; ".join(value)
         ui.print_(lineformat.format(field, value))
 
 
@@ -128,7 +130,7 @@ def print_data_keys(data, item=None):
     if len(formatted) == 0:
         return
 
-    line_format = u'{0}{{0}}'.format(u' ' * 4)
+    line_format = u"{0}{{0}}".format(u" " * 4)
     if path:
         ui.print_(displayable_path(path))
 
@@ -137,28 +139,36 @@ def print_data_keys(data, item=None):
 
 
 class InfoPlugin(BeetsPlugin):
-
     def commands(self):
-        cmd = ui.Subcommand('info', help=u'show file metadata')
+        cmd = ui.Subcommand("info", help=u"show file metadata")
         cmd.func = self.run
         cmd.parser.add_option(
-            u'-l', u'--library', action='store_true',
-            help=u'show library fields instead of tags',
+            u"-l",
+            u"--library",
+            action="store_true",
+            help=u"show library fields instead of tags",
         )
         cmd.parser.add_option(
-            u'-s', u'--summarize', action='store_true',
-            help=u'summarize the tags of all files',
+            u"-s",
+            u"--summarize",
+            action="store_true",
+            help=u"summarize the tags of all files",
         )
         cmd.parser.add_option(
-            u'-i', u'--include-keys', default=[],
-            action='append', dest='included_keys',
-            help=u'comma separated list of keys to show',
+            u"-i",
+            u"--include-keys",
+            default=[],
+            action="append",
+            dest="included_keys",
+            help=u"comma separated list of keys to show",
         )
         cmd.parser.add_option(
-            u'-k', u'--keys-only', action='store_true',
-            help=u'show only the keys',
+            u"-k",
+            u"--keys-only",
+            action="store_true",
+            help=u"show only the keys",
         )
-        cmd.parser.add_format_option(target='item')
+        cmd.parser.add_format_option(target="item")
         return [cmd]
 
     def run(self, lib, opts, args):
@@ -182,9 +192,9 @@ class InfoPlugin(BeetsPlugin):
 
         included_keys = []
         for keys in opts.included_keys:
-            included_keys.extend(keys.split(','))
+            included_keys.extend(keys.split(","))
         # Drop path even if user provides it multiple times
-        included_keys = [k for k in included_keys if k != 'path']
+        included_keys = [k for k in included_keys if k != "path"]
         key_filter = make_key_filter(included_keys)
 
         first = True
@@ -193,7 +203,7 @@ class InfoPlugin(BeetsPlugin):
             try:
                 data, item = data_emitter()
             except (mediafile.UnreadableFileError, IOError) as ex:
-                self._log.error(u'cannot read file: {0}', ex)
+                self._log.error(u"cannot read file: {0}", ex)
                 continue
 
             data = key_filter(data)
@@ -223,16 +233,17 @@ def make_key_filter(include):
     # By default, if no field inclusions are specified, include
     # everything but `path`.
     if not include:
+
         def filter_(data):
-            return {k: v for k, v in data.items()
-                    if k != 'path'}
+            return {k: v for k, v in data.items() if k != "path"}
+
         return filter_
 
     matchers = []
     for key in include:
         key = re.escape(key)
-        key = key.replace(r'\*', '.*')
-        matchers.append(re.compile(key + '$'))
+        key = key.replace(r"\*", ".*")
+        matchers.append(re.compile(key + "$"))
 
     def filter_(data):
         filtered = dict()

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -27,45 +27,63 @@ import tempfile
 
 
 class IPFSPlugin(BeetsPlugin):
-
     def __init__(self):
         super(IPFSPlugin, self).__init__()
-        self.config.add({
-            'auto': True,
-            'nocopy': False,
-        })
+        self.config.add(
+            {"auto": True, "nocopy": False,}
+        )
 
-        if self.config['auto']:
+        if self.config["auto"]:
             self.import_stages = [self.auto_add]
 
     def commands(self):
-        cmd = ui.Subcommand('ipfs',
-                            help='interact with ipfs')
-        cmd.parser.add_option('-a', '--add', dest='add',
-                                    action='store_true',
-                                    help='Add to ipfs')
-        cmd.parser.add_option('-g', '--get', dest='get',
-                                    action='store_true',
-                                    help='Get from ipfs')
-        cmd.parser.add_option('-p', '--publish', dest='publish',
-                                    action='store_true',
-                                    help='Publish local library to ipfs')
-        cmd.parser.add_option('-i', '--import', dest='_import',
-                                    action='store_true',
-                                    help='Import remote library from ipfs')
-        cmd.parser.add_option('-l', '--list', dest='_list',
-                                    action='store_true',
-                                    help='Query imported libraries')
-        cmd.parser.add_option('-m', '--play', dest='play',
-                                    action='store_true',
-                                    help='Play music from remote libraries')
+        cmd = ui.Subcommand("ipfs", help="interact with ipfs")
+        cmd.parser.add_option(
+            "-a", "--add", dest="add", action="store_true", help="Add to ipfs"
+        )
+        cmd.parser.add_option(
+            "-g",
+            "--get",
+            dest="get",
+            action="store_true",
+            help="Get from ipfs",
+        )
+        cmd.parser.add_option(
+            "-p",
+            "--publish",
+            dest="publish",
+            action="store_true",
+            help="Publish local library to ipfs",
+        )
+        cmd.parser.add_option(
+            "-i",
+            "--import",
+            dest="_import",
+            action="store_true",
+            help="Import remote library from ipfs",
+        )
+        cmd.parser.add_option(
+            "-l",
+            "--list",
+            dest="_list",
+            action="store_true",
+            help="Query imported libraries",
+        )
+        cmd.parser.add_option(
+            "-m",
+            "--play",
+            dest="play",
+            action="store_true",
+            help="Play music from remote libraries",
+        )
 
         def func(lib, opts, args):
             if opts.add:
                 for album in lib.albums(ui.decargs(args)):
                     if len(album.items()) == 0:
-                        self._log.info('{0} does not contain items, aborting',
-                                       album)
+                        self._log.info(
+                            "{0} does not contain items, aborting", album
+                        )
 
                     self.ipfs_add(album)
                     album.store()
@@ -98,7 +116,7 @@ class IPFSPlugin(BeetsPlugin):
 
         jlib = self.get_remote_lib(lib)
         player = PlayPlugin()
-        config['play']['relative_to'] = None
+        config["play"]["relative_to"] = None
         player.album = True
         player.play_music(jlib, player, args)
 
@@ -109,15 +127,15 @@ class IPFSPlugin(BeetsPlugin):
             return False
         try:
             if album.ipfs:
-                self._log.debug('{0} already added', album_dir)
+                self._log.debug("{0} already added", album_dir)
                 # Already added to ipfs
                 return False
         except AttributeError:
             pass
 
-        self._log.info('Adding {0} to ipfs', album_dir)
+        self._log.info("Adding {0} to ipfs", album_dir)
 
-        if self.config['nocopy']:
+        if self.config["nocopy"]:
             cmd = "ipfs add --nocopy -q -r".split()
         else:
             cmd = "ipfs add -q -r".split()
@@ -125,7 +143,7 @@ class IPFSPlugin(BeetsPlugin):
         try:
             output = util.command_output(cmd).stdout.split()
         except (OSError, subprocess.CalledProcessError) as exc:
-            self._log.error(u'Failed to add {0}, error: {1}', album_dir, exc)
+            self._log.error(u"Failed to add {0}, error: {1}", album_dir, exc)
             return False
         length = len(output)
 
@@ -166,13 +184,15 @@ class IPFSPlugin(BeetsPlugin):
             cmd.append(_hash)
             util.command_output(cmd)
         except (OSError, subprocess.CalledProcessError) as err:
-            self._log.error('Failed to get {0} from ipfs.\n{1}',
-                            _hash, err.output)
+            self._log.error(
+                "Failed to get {0} from ipfs.\n{1}", _hash, err.output
+            )
             return False
 
-        self._log.info('Getting {0} from ipfs', _hash)
-        imp = ui.commands.TerminalImportSession(lib, loghandler=None,
-                                                query=None, paths=[_hash])
+        self._log.info("Getting {0} from ipfs", _hash)
+        imp = ui.commands.TerminalImportSession(
+            lib, loghandler=None, query=None, paths=[_hash]
+        )
         imp.run()
         shutil.rmtree(_hash)
 
@@ -180,7 +200,7 @@ class IPFSPlugin(BeetsPlugin):
         with tempfile.NamedTemporaryFile() as tmp:
             self.ipfs_added_albums(lib, tmp.name)
             try:
-                if self.config['nocopy']:
+                if self.config["nocopy"]:
                     cmd = "ipfs add --nocopy -q ".split()
                 else:
                     cmd = "ipfs add -q ".split()
@@ -238,7 +258,7 @@ class IPFSPlugin(BeetsPlugin):
         return False
 
     def ipfs_list(self, lib, args):
-        fmt = config['format_album'].get()
+        fmt = config["format_album"].get()
         try:
             albums = self.query(lib, args)
         except IOError:
@@ -282,10 +302,10 @@ class IPFSPlugin(BeetsPlugin):
             except AttributeError:
                 pass
             item_path = os.path.basename(item.path).decode(
-                util._fsencoding(), 'ignore'
+                util._fsencoding(), "ignore"
             )
             # Clear current path from item
-            item.path = '/ipfs/{0}/{1}'.format(album.ipfs, item_path)
+            item.path = "/ipfs/{0}/{1}".format(album.ipfs, item_path)
 
             item.id = None
             items.append(item)

--- a/beetsplug/keyfinder.py
+++ b/beetsplug/keyfinder.py
@@ -27,21 +27,19 @@ from beets.plugins import BeetsPlugin
 
 
 class KeyFinderPlugin(BeetsPlugin):
-
     def __init__(self):
         super(KeyFinderPlugin, self).__init__()
-        self.config.add({
-            u'bin': u'KeyFinder',
-            u'auto': True,
-            u'overwrite': False,
-        })
+        self.config.add(
+            {u"bin": u"KeyFinder", u"auto": True, u"overwrite": False,}
+        )
 
-        if self.config['auto'].get(bool):
+        if self.config["auto"].get(bool):
             self.import_stages = [self.imported]
 
     def commands(self):
-        cmd = ui.Subcommand('keyfinder',
-                            help=u'detect and add initial key from audio')
+        cmd = ui.Subcommand(
+            "keyfinder", help=u"detect and add initial key from audio"
+        )
         cmd.func = self.command
         return [cmd]
 
@@ -52,40 +50,45 @@ class KeyFinderPlugin(BeetsPlugin):
         self.find_key(task.imported_items())
 
     def find_key(self, items, write=False):
-        overwrite = self.config['overwrite'].get(bool)
-        command = [self.config['bin'].as_str()]
+        overwrite = self.config["overwrite"].get(bool)
+        command = [self.config["bin"].as_str()]
         # The KeyFinder GUI program needs the -f flag before the path.
         # keyfinder-cli is similar, but just wants the path with no flag.
-        if 'keyfinder-cli' not in os.path.basename(command[0]).lower():
-            command.append('-f')
+        if "keyfinder-cli" not in os.path.basename(command[0]).lower():
+            command.append("-f")
 
         for item in items:
-            if item['initial_key'] and not overwrite:
+            if item["initial_key"] and not overwrite:
                 continue
 
             try:
-                output = util.command_output(command + [util.syspath(
-                                                        item.path)]).stdout
+                output = util.command_output(
+                    command + [util.syspath(item.path)]
+                ).stdout
             except (subprocess.CalledProcessError, OSError) as exc:
-                self._log.error(u'execution failed: {0}', exc)
+                self._log.error(u"execution failed: {0}", exc)
                 continue
             except UnicodeEncodeError:
                 # Workaround for Python 2 Windows bug.
                 # https://bugs.python.org/issue1759845
-                self._log.error(u'execution failed for Unicode path: {0!r}',
-                                item.path)
+                self._log.error(
+                    u"execution failed for Unicode path: {0!r}", item.path
+                )
                 continue
 
             key_raw = output.rsplit(None, 1)[-1]
             try:
                 key = util.text_string(key_raw)
             except UnicodeDecodeError:
-                self._log.error(u'output is invalid UTF-8')
+                self._log.error(u"output is invalid UTF-8")
                 continue
 
-            item['initial_key'] = key
-            self._log.info(u'added computed initial key {0} for {1}',
-                           key, util.displayable_path(item.path))
+            item["initial_key"] = key
+            self._log.info(
+                u"added computed initial key {0} for {1}",
+                key,
+                util.displayable_path(item.path),
+            )
 
             if write:
                 item.try_write()

--- a/beetsplug/kodiupdate.py
+++ b/beetsplug/kodiupdate.py
@@ -39,15 +39,13 @@ def update_kodi(host, port, user, password):
     """Content-Type: application/json is mandatory
     according to the kodi jsonrpc documentation"""
 
-    headers = {'Content-Type': 'application/json'}
+    headers = {"Content-Type": "application/json"}
 
     # Create the payload. Id seems to be mandatory.
-    payload = {'jsonrpc': '2.0', 'method': 'AudioLibrary.Scan', 'id': 1}
+    payload = {"jsonrpc": "2.0", "method": "AudioLibrary.Scan", "id": 1}
     r = requests.post(
-        url,
-        auth=(user, password),
-        json=payload,
-        headers=headers)
+        url, auth=(user, password), json=payload, headers=headers
+    )
 
     return r
 
@@ -57,42 +55,46 @@ class KodiUpdate(BeetsPlugin):
         super(KodiUpdate, self).__init__()
 
         # Adding defaults.
-        config['kodi'].add({
-            u'host': u'localhost',
-            u'port': 8080,
-            u'user': u'kodi',
-            u'pwd': u'kodi'})
+        config["kodi"].add(
+            {
+                u"host": u"localhost",
+                u"port": 8080,
+                u"user": u"kodi",
+                u"pwd": u"kodi",
+            }
+        )
 
-        config['kodi']['pwd'].redact = True
-        self.register_listener('database_change', self.listen_for_db_change)
+        config["kodi"]["pwd"].redact = True
+        self.register_listener("database_change", self.listen_for_db_change)
 
     def listen_for_db_change(self, lib, model):
         """Listens for beets db change and register the update"""
-        self.register_listener('cli_exit', self.update)
+        self.register_listener("cli_exit", self.update)
 
     def update(self, lib):
         """When the client exists try to send refresh request to Kodi server.
         """
-        self._log.info(u'Requesting a Kodi library update...')
+        self._log.info(u"Requesting a Kodi library update...")
 
         # Try to send update request.
         try:
             r = update_kodi(
-                config['kodi']['host'].get(),
-                config['kodi']['port'].get(),
-                config['kodi']['user'].get(),
-                config['kodi']['pwd'].get())
+                config["kodi"]["host"].get(),
+                config["kodi"]["port"].get(),
+                config["kodi"]["user"].get(),
+                config["kodi"]["pwd"].get(),
+            )
             r.raise_for_status()
 
         except requests.exceptions.RequestException as e:
-            self._log.warning(u'Kodi update failed: {0}',
-                              six.text_type(e))
+            self._log.warning(u"Kodi update failed: {0}", six.text_type(e))
             return
 
         json = r.json()
-        if json.get('result') != 'OK':
-            self._log.warning(u'Kodi update failed: JSON response was {0!r}',
-                              json)
+        if json.get("result") != "OK":
+            self._log.warning(
+                u"Kodi update failed: JSON response was {0!r}", json
+            )
             return
 
-        self._log.info(u'Kodi update triggered')
+        self._log.info(u"Kodi update triggered")

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -47,7 +47,7 @@ PYLAST_EXCEPTIONS = (
 )
 
 REPLACE = {
-    u'\u2010': '-',
+    u"\u2010": "-",
 }
 
 
@@ -59,6 +59,7 @@ def deduplicate(seq):
 
 
 # Canonicalization tree processing.
+
 
 def flatten_tree(elem, path, branches):
     """Flatten nested lists/dictionaries into lists of strings
@@ -84,7 +85,7 @@ def find_parents(candidate, branches):
     for branch in branches:
         try:
             idx = branch.index(candidate.lower())
-            return list(reversed(branch[:idx + 1]))
+            return list(reversed(branch[: idx + 1]))
         except ValueError:
             continue
     return [candidate]
@@ -92,67 +93,69 @@ def find_parents(candidate, branches):
 
 # Main plugin logic.
 
-WHITELIST = os.path.join(os.path.dirname(__file__), 'genres.txt')
-C14N_TREE = os.path.join(os.path.dirname(__file__), 'genres-tree.yaml')
+WHITELIST = os.path.join(os.path.dirname(__file__), "genres.txt")
+C14N_TREE = os.path.join(os.path.dirname(__file__), "genres-tree.yaml")
 
 
 class LastGenrePlugin(plugins.BeetsPlugin):
     def __init__(self):
         super(LastGenrePlugin, self).__init__()
 
-        self.config.add({
-            'whitelist': True,
-            'min_weight': 10,
-            'count': 1,
-            'fallback': None,
-            'canonical': False,
-            'source': 'album',
-            'force': True,
-            'auto': True,
-            'separator': u', ',
-            'prefer_specific': False,
-        })
+        self.config.add(
+            {
+                "whitelist": True,
+                "min_weight": 10,
+                "count": 1,
+                "fallback": None,
+                "canonical": False,
+                "source": "album",
+                "force": True,
+                "auto": True,
+                "separator": u", ",
+                "prefer_specific": False,
+            }
+        )
 
         self.setup()
 
     def setup(self):
         """Setup plugin from config options
         """
-        if self.config['auto']:
+        if self.config["auto"]:
             self.import_stages = [self.imported]
 
         self._genre_cache = {}
 
         # Read the whitelist file if enabled.
         self.whitelist = set()
-        wl_filename = self.config['whitelist'].get()
-        if wl_filename in (True, ''):  # Indicates the default whitelist.
+        wl_filename = self.config["whitelist"].get()
+        if wl_filename in (True, ""):  # Indicates the default whitelist.
             wl_filename = WHITELIST
         if wl_filename:
             wl_filename = normpath(wl_filename)
-            with open(wl_filename, 'rb') as f:
+            with open(wl_filename, "rb") as f:
                 for line in f:
-                    line = line.decode('utf-8').strip().lower()
-                    if line and not line.startswith(u'#'):
+                    line = line.decode("utf-8").strip().lower()
+                    if line and not line.startswith(u"#"):
                         self.whitelist.add(line)
 
         # Read the genres tree for canonicalization if enabled.
         self.c14n_branches = []
-        c14n_filename = self.config['canonical'].get()
+        c14n_filename = self.config["canonical"].get()
         self.canonicalize = c14n_filename is not False
 
         # Default tree
-        if c14n_filename in (True, ''):
+        if c14n_filename in (True, ""):
             c14n_filename = C14N_TREE
-        elif not self.canonicalize and self.config['prefer_specific'].get():
+        elif not self.canonicalize and self.config["prefer_specific"].get():
             # prefer_specific requires a tree, load default tree
             c14n_filename = C14N_TREE
 
         # Read the tree
         if c14n_filename:
-            self._log.debug('Loading canonicalization tree {0}', c14n_filename)
+            self._log.debug("Loading canonicalization tree {0}", c14n_filename)
             c14n_filename = normpath(c14n_filename)
-            with codecs.open(c14n_filename, 'r', encoding='utf-8') as f:
+            with codecs.open(c14n_filename, "r", encoding="utf-8") as f:
                 genres_tree = yaml.safe_load(f)
             flatten_tree(genres_tree, [], self.c14n_branches)
 
@@ -161,13 +164,13 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         """A tuple of allowed genre sources. May contain 'track',
         'album', or 'artist.'
         """
-        source = self.config['source'].as_choice(('track', 'album', 'artist'))
-        if source == 'track':
-            return 'track', 'album', 'artist'
-        elif source == 'album':
-            return 'album', 'artist'
-        elif source == 'artist':
-            return 'artist',
+        source = self.config["source"].as_choice(("track", "album", "artist"))
+        if source == "track":
+            return "track", "album", "artist"
+        elif source == "album":
+            return "album", "artist"
+        elif source == "artist":
+            return ("artist",)
 
     def _get_depth(self, tag):
         """Find the depth of a tag in the genres tree.
@@ -195,7 +198,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         if not tags:
             return None
 
-        count = self.config['count'].get(int)
+        count = self.config["count"].get(int)
         if self.canonicalize:
             # Extend the list to consider tags parents in the c14n tree
             tags_all = []
@@ -203,38 +206,45 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 # Add parents that are in the whitelist, or add the oldest
                 # ancestor if no whitelist
                 if self.whitelist:
-                    parents = [x for x in find_parents(tag, self.c14n_branches)
-                               if self._is_allowed(x)]
+                    parents = [
+                        x
+                        for x in find_parents(tag, self.c14n_branches)
+                        if self._is_allowed(x)
+                    ]
                 else:
                     parents = [find_parents(tag, self.c14n_branches)[-1]]
 
                 tags_all += parents
                 # Stop if we have enough tags already, unless we need to find
                 # the most specific tag (instead of the most popular).
-                if (not self.config['prefer_specific'] and
-                        len(tags_all) >= count):
+                if (
+                    not self.config["prefer_specific"]
+                    and len(tags_all) >= count
+                ):
                     break
             tags = tags_all
 
         tags = deduplicate(tags)
 
         # Sort the tags by specificity.
-        if self.config['prefer_specific']:
+        if self.config["prefer_specific"]:
             tags = self._sort_by_depth(tags)
 
         # c14n only adds allowed genres but we may have had forbidden genres in
         # the original tags list
         tags = [x.title() for x in tags if self._is_allowed(x)]
 
-        return self.config['separator'].as_str().join(
-            tags[:self.config['count'].get(int)]
+        return (
+            self.config["separator"]
+            .as_str()
+            .join(tags[: self.config["count"].get(int)])
         )
 
     def fetch_genre(self, lastfm_obj):
         """Return the genre for a pylast entity or None if no suitable genre
         can be found. Ex. 'Electronic, House, Dance'
         """
-        min_weight = self.config['min_weight'].get(int)
+        min_weight = self.config["min_weight"].get(int)
         return self._resolve_genres(self._tags_for(lastfm_obj, min_weight))
 
     def _is_allowed(self, genre):
@@ -261,8 +271,9 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         if any(not s for s in args):
             return None
 
-        key = u'{0}.{1}'.format(entity,
-                                u'-'.join(six.text_type(a) for a in args))
+        key = u"{0}.{1}".format(
+            entity, u"-".join(six.text_type(a) for a in args)
+        )
         if key in self._genre_cache:
             return self._genre_cache[key]
         else:
@@ -280,28 +291,24 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         """Return the album genre for this Item or Album.
         """
         return self._last_lookup(
-            u'album', LASTFM.get_album, obj.albumartist, obj.album
+            u"album", LASTFM.get_album, obj.albumartist, obj.album
         )
 
     def fetch_album_artist_genre(self, obj):
         """Return the album artist genre for this Item or Album.
         """
-        return self._last_lookup(
-            u'artist', LASTFM.get_artist, obj.albumartist
-        )
+        return self._last_lookup(u"artist", LASTFM.get_artist, obj.albumartist)
 
     def fetch_artist_genre(self, item):
         """Returns the track artist genre for this Item.
         """
-        return self._last_lookup(
-            u'artist', LASTFM.get_artist, item.artist
-        )
+        return self._last_lookup(u"artist", LASTFM.get_artist, item.artist)
 
     def fetch_track_genre(self, obj):
         """Returns the track genre for this Item.
         """
         return self._last_lookup(
-            u'track', LASTFM.get_track, obj.artist, obj.title
+            u"track", LASTFM.get_track, obj.artist, obj.title
         )
 
     def _get_genre(self, obj):
@@ -317,35 +324,35 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         """
 
         # Shortcut to existing genre if not forcing.
-        if not self.config['force'] and self._is_allowed(obj.genre):
-            return obj.genre, 'keep'
+        if not self.config["force"] and self._is_allowed(obj.genre):
+            return obj.genre, "keep"
 
         # Track genre (for Items only).
         if isinstance(obj, library.Item):
-            if 'track' in self.sources:
+            if "track" in self.sources:
                 result = self.fetch_track_genre(obj)
                 if result:
-                    return result, 'track'
+                    return result, "track"
 
         # Album genre.
-        if 'album' in self.sources:
+        if "album" in self.sources:
             result = self.fetch_album_genre(obj)
             if result:
-                return result, 'album'
+                return result, "album"
 
         # Artist (or album artist) genre.
-        if 'artist' in self.sources:
+        if "artist" in self.sources:
             result = None
             if isinstance(obj, library.Item):
                 result = self.fetch_artist_genre(obj)
-            elif obj.albumartist != config['va_name'].as_str():
+            elif obj.albumartist != config["va_name"].as_str():
                 result = self.fetch_album_artist_genre(obj)
             else:
                 # For "Various Artists", pick the most popular track genre.
                 item_genres = []
                 for item in obj.items():
                     item_genre = None
-                    if 'track' in self.sources:
+                    if "track" in self.sources:
                         item_genre = self.fetch_track_genre(item)
                     if not item_genre:
                         item_genre = self.fetch_artist_genre(item)
@@ -355,38 +362,51 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                     result, _ = plurality(item_genres)
 
             if result:
-                return result, 'artist'
+                return result, "artist"
 
         # Filter the existing genre.
         if obj.genre:
             result = self._resolve_genres([obj.genre])
             if result:
-                return result, 'original'
+                return result, "original"
 
         # Fallback string.
-        fallback = self.config['fallback'].get()
+        fallback = self.config["fallback"].get()
         if fallback:
-            return fallback, 'fallback'
+            return fallback, "fallback"
 
         return None, None
 
     def commands(self):
-        lastgenre_cmd = ui.Subcommand('lastgenre', help=u'fetch genres')
+        lastgenre_cmd = ui.Subcommand("lastgenre", help=u"fetch genres")
         lastgenre_cmd.parser.add_option(
-            u'-f', u'--force', dest='force',
-            action='store_true',
-            help=u're-download genre when already present'
+            u"-f",
+            u"--force",
+            dest="force",
+            action="store_true",
+            help=u"re-download genre when already present",
         )
         lastgenre_cmd.parser.add_option(
-            u'-s', u'--source', dest='source', type='string',
-            help=u'genre source: artist, album, or track'
+            u"-s",
+            u"--source",
+            dest="source",
+            type="string",
+            help=u"genre source: artist, album, or track",
         )
         lastgenre_cmd.parser.add_option(
-            u'-A', u'--items', action='store_false', dest='album',
-            help=u'match items instead of albums')
+            u"-A",
+            u"--items",
+            action="store_false",
+            dest="album",
+            help=u"match items instead of albums",
+        )
         lastgenre_cmd.parser.add_option(
-            u'-a', u'--albums', action='store_true', dest='album',
-            help=u'match albums instead of items')
+            u"-a",
+            u"--albums",
+            action="store_true",
+            dest="album",
+            help=u"match albums instead of items",
+        )
         lastgenre_cmd.parser.set_defaults(album=True)
 
         def lastgenre_func(lib, opts, args):
@@ -397,19 +417,22 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 # Fetch genres for whole albums
                 for album in lib.albums(ui.decargs(args)):
                     album.genre, src = self._get_genre(album)
-                    self._log.info(u'genre for album {0} ({1}): {0.genre}',
-                                   album, src)
+                    self._log.info(
+                        u"genre for album {0} ({1}): {0.genre}", album, src
+                    )
                     album.store()
 
                     for item in album.items():
                         # If we're using track-level sources, also look up each
                         # track on the album.
-                        if 'track' in self.sources:
+                        if "track" in self.sources:
                             item.genre, src = self._get_genre(item)
                             item.store()
                             self._log.info(
-                                u'genre for track {0} ({1}): {0.genre}',
-                                item, src)
+                                u"genre for track {0} ({1}): {0.genre}",
+                                item,
+                                src,
+                            )
 
                         if write:
                             item.try_write()
@@ -418,8 +441,9 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 # an album
                 for item in lib.items(ui.decargs(args)):
                     item.genre, src = self._get_genre(item)
-                    self._log.debug(u'added last.fm item genre ({0}): {1}',
-                                    src, item.genre)
+                    self._log.debug(
+                        u"added last.fm item genre ({0}): {1}", src, item.genre
+                    )
                     item.store()
 
         lastgenre_cmd.func = lastgenre_func
@@ -430,22 +454,25 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         if task.is_album:
             album = task.album
             album.genre, src = self._get_genre(album)
-            self._log.debug(u'added last.fm album genre ({0}): {1}',
-                            src, album.genre)
+            self._log.debug(
+                u"added last.fm album genre ({0}): {1}", src, album.genre
+            )
             album.store()
 
-            if 'track' in self.sources:
+            if "track" in self.sources:
                 for item in album.items():
                     item.genre, src = self._get_genre(item)
-                    self._log.debug(u'added last.fm item genre ({0}): {1}',
-                                    src, item.genre)
+                    self._log.debug(
+                        u"added last.fm item genre ({0}): {1}", src, item.genre
+                    )
                     item.store()
 
         else:
             item = task.item
             item.genre, src = self._get_genre(item)
-            self._log.debug(u'added last.fm item genre ({0}): {1}',
-                            src, item.genre)
+            self._log.debug(
+                u"added last.fm item genre ({0}): {1}", src, item.genre
+            )
             item.store()
 
     def _tags_for(self, obj, min_weight=None):
@@ -466,12 +493,12 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         try:
             res = obj.get_top_tags()
         except PYLAST_EXCEPTIONS as exc:
-            self._log.debug(u'last.fm error: {0}', exc)
+            self._log.debug(u"last.fm error: {0}", exc)
             return []
         except Exception as exc:
             # Isolate bugs in pylast.
-            self._log.debug(u'{}', traceback.format_exc())
-            self._log.error(u'error in pylast library: {0}', exc)
+            self._log.debug(u"{}", traceback.format_exc())
+            self._log.error(u"error in pylast library: {0}", exc)
             return []
 
         # Filter by weight (optionally).

--- a/beetsplug/lastimport.py
+++ b/beetsplug/lastimport.py
@@ -23,27 +23,25 @@ from beets import config
 from beets import plugins
 from beets.dbcore import types
 
-API_URL = 'https://ws.audioscrobbler.com/2.0/'
+API_URL = "https://ws.audioscrobbler.com/2.0/"
 
 
 class LastImportPlugin(plugins.BeetsPlugin):
     def __init__(self):
         super(LastImportPlugin, self).__init__()
-        config['lastfm'].add({
-            'user':     '',
-            'api_key':  plugins.LASTFM_KEY,
-        })
-        config['lastfm']['api_key'].redact = True
-        self.config.add({
-            'per_page': 500,
-            'retry_limit': 3,
-        })
+        config["lastfm"].add(
+            {"user": "", "api_key": plugins.LASTFM_KEY,}
+        )
+        config["lastfm"]["api_key"].redact = True
+        self.config.add(
+            {"per_page": 500, "retry_limit": 3,}
+        )
         self.item_types = {
-            'play_count':  types.INTEGER,
+            "play_count": types.INTEGER,
         }
 
     def commands(self):
-        cmd = ui.Subcommand('lastimport', help=u'import last.fm play-count')
+        cmd = ui.Subcommand("lastimport", help=u"import last.fm play-count")
 
         def func(lib, opts, args):
             import_lastfm(lib, self._log)
@@ -58,20 +56,21 @@ class CustomUser(pylast.User):
     get_top_tracks_by_page method to allow access to more than one page of top
     tracks.
     """
+
     def __init__(self, *args, **kwargs):
         super(CustomUser, self).__init__(*args, **kwargs)
 
-    def _get_things(self, method, thing, thing_type, params=None,
-                    cacheable=True):
+    def _get_things(
+        self, method, thing, thing_type, params=None, cacheable=True
+    ):
         """Returns a list of the most played thing_types by this thing, in a
         tuple with the total number of pages of results. Includes an MBID, if
         found.
         """
-        doc = self._request(
-            self.ws_prefix + "." + method, cacheable, params)
+        doc = self._request(self.ws_prefix + "." + method, cacheable, params)
 
-        toptracks_node = doc.getElementsByTagName('toptracks')[0]
-        total_pages = int(toptracks_node.getAttribute('totalPages'))
+        toptracks_node = doc.getElementsByTagName("toptracks")[0]
+        total_pages = int(toptracks_node.getAttribute("totalPages"))
 
         seq = []
         for node in doc.getElementsByTagName(thing):
@@ -86,8 +85,9 @@ class CustomUser(pylast.User):
 
         return seq, total_pages
 
-    def get_top_tracks_by_page(self, period=pylast.PERIOD_OVERALL, limit=None,
-                               page=1, cacheable=True):
+    def get_top_tracks_by_page(
+        self, period=pylast.PERIOD_OVERALL, limit=None, page=1, cacheable=True
+    ):
         """Returns the top tracks played by a user, in a tuple with the total
         number of pages of results.
         * period: The period of time. Possible values:
@@ -100,40 +100,43 @@ class CustomUser(pylast.User):
         """
 
         params = self._get_params()
-        params['period'] = period
-        params['page'] = page
+        params["period"] = period
+        params["page"] = page
         if limit:
-            params['limit'] = limit
+            params["limit"] = limit
 
         return self._get_things(
-            "getTopTracks", "track", pylast.Track, params, cacheable)
+            "getTopTracks", "track", pylast.Track, params, cacheable
+        )
 
 
 def import_lastfm(lib, log):
-    user = config['lastfm']['user'].as_str()
-    per_page = config['lastimport']['per_page'].get(int)
+    user = config["lastfm"]["user"].as_str()
+    per_page = config["lastimport"]["per_page"].get(int)
 
     if not user:
-        raise ui.UserError(u'You must specify a user name for lastimport')
+        raise ui.UserError(u"You must specify a user name for lastimport")
 
-    log.info(u'Fetching last.fm library for @{0}', user)
+    log.info(u"Fetching last.fm library for @{0}", user)
 
     page_total = 1
     page_current = 0
     found_total = 0
     unknown_total = 0
-    retry_limit = config['lastimport']['retry_limit'].get(int)
+    retry_limit = config["lastimport"]["retry_limit"].get(int)
     # Iterate through a yet to be known page total count
     while page_current < page_total:
-        log.info(u'Querying page #{0}{1}...',
-                 page_current + 1,
-                 '/{}'.format(page_total) if page_total > 1 else '')
+        log.info(
+            u"Querying page #{0}{1}...",
+            page_current + 1,
+            "/{}".format(page_total) if page_total > 1 else "",
+        )
 
         for retry in range(0, retry_limit):
             tracks, page_total = fetch_tracks(user, page_current + 1, per_page)
             if page_total < 1:
                 # It means nothing to us!
-                raise ui.UserError(u'Last.fm reported no data.')
+                raise ui.UserError(u"Last.fm reported no data.")
 
             if tracks:
                 found, unknown = process_tracks(lib, tracks, log)
@@ -141,22 +144,27 @@ def import_lastfm(lib, log):
                 unknown_total += unknown
                 break
             else:
-                log.error(u'ERROR: unable to read page #{0}',
-                          page_current + 1)
+                log.error(u"ERROR: unable to read page #{0}", page_current + 1)
                 if retry < retry_limit:
                     log.info(
-                        u'Retrying page #{0}... ({1}/{2} retry)',
-                        page_current + 1, retry + 1, retry_limit
+                        u"Retrying page #{0}... ({1}/{2} retry)",
+                        page_current + 1,
+                        retry + 1,
+                        retry_limit,
                     )
                 else:
-                    log.error(u'FAIL: unable to fetch page #{0}, ',
-                              u'tried {1} times', page_current, retry + 1)
+                    log.error(
+                        u"FAIL: unable to fetch page #{0}, ",
+                        u"tried {1} times",
+                        page_current,
+                        retry + 1,
+                    )
         page_current += 1
 
-    log.info(u'... done!')
-    log.info(u'finished processing {0} song pages', page_total)
-    log.info(u'{0} unknown play-counts', unknown_total)
-    log.info(u'{0} play-counts imported', found_total)
+    log.info(u"... done!")
+    log.info(u"finished processing {0} song pages", page_total)
+    log.info(u"{0} unknown play-counts", unknown_total)
+    log.info(u"{0} play-counts imported", found_total)
 
 
 def fetch_tracks(user, page, limit):
@@ -170,80 +178,95 @@ def fetch_tracks(user, page, limit):
             }
         ]
     """
-    network = pylast.LastFMNetwork(api_key=config['lastfm']['api_key'])
+    network = pylast.LastFMNetwork(api_key=config["lastfm"]["api_key"])
     user_obj = CustomUser(user, network)
-    results, total_pages =\
-        user_obj.get_top_tracks_by_page(limit=limit, page=page)
-    return [
-        {
-            "mbid": track.item.mbid if track.item.mbid else '',
-            "artist": {
-                "name": track.item.artist.name
-            },
-            "name": track.item.title,
-            "playcount": track.weight
-        } for track in results
-    ], total_pages
+    results, total_pages = user_obj.get_top_tracks_by_page(
+        limit=limit, page=page
+    )
+    return (
+        [
+            {
+                "mbid": track.item.mbid if track.item.mbid else "",
+                "artist": {"name": track.item.artist.name},
+                "name": track.item.title,
+                "playcount": track.weight,
+            }
+            for track in results
+        ],
+        total_pages,
+    )
 
 
 def process_tracks(lib, tracks, log):
     total = len(tracks)
     total_found = 0
     total_fails = 0
-    log.info(u'Received {0} tracks in this page, processing...', total)
+    log.info(u"Received {0} tracks in this page, processing...", total)
 
     for num in range(0, total):
         song = None
-        trackid = tracks[num]['mbid'].strip()
-        artist = tracks[num]['artist'].get('name', '').strip()
-        title = tracks[num]['name'].strip()
-        album = ''
-        if 'album' in tracks[num]:
-            album = tracks[num]['album'].get('name', '').strip()
+        trackid = tracks[num]["mbid"].strip()
+        artist = tracks[num]["artist"].get("name", "").strip()
+        title = tracks[num]["name"].strip()
+        album = ""
+        if "album" in tracks[num]:
+            album = tracks[num]["album"].get("name", "").strip()
 
-        log.debug(u'query: {0} - {1} ({2})', artist, title, album)
+        log.debug(u"query: {0} - {1} ({2})", artist, title, album)
 
         # First try to query by musicbrainz's trackid
         if trackid:
             song = lib.items(
-                dbcore.query.MatchQuery('mb_trackid', trackid)
+                dbcore.query.MatchQuery("mb_trackid", trackid)
             ).get()
 
         # If not, try just artist/title
         if song is None:
-            log.debug(u'no album match, trying by artist/title')
-            query = dbcore.AndQuery([
-                dbcore.query.SubstringQuery('artist', artist),
-                dbcore.query.SubstringQuery('title', title)
-            ])
+            log.debug(u"no album match, trying by artist/title")
+            query = dbcore.AndQuery(
+                [
+                    dbcore.query.SubstringQuery("artist", artist),
+                    dbcore.query.SubstringQuery("title", title),
+                ]
+            )
             song = lib.items(query).get()
 
         # Last resort, try just replacing to utf-8 quote
         if song is None:
-            title = title.replace("'", u'\u2019')
-            log.debug(u'no title match, trying utf-8 single quote')
-            query = dbcore.AndQuery([
-                dbcore.query.SubstringQuery('artist', artist),
-                dbcore.query.SubstringQuery('title', title)
-            ])
+            title = title.replace("'", u"\u2019")
+            log.debug(u"no title match, trying utf-8 single quote")
+            query = dbcore.AndQuery(
+                [
+                    dbcore.query.SubstringQuery("artist", artist),
+                    dbcore.query.SubstringQuery("title", title),
+                ]
+            )
             song = lib.items(query).get()
 
         if song is not None:
-            count = int(song.get('play_count', 0))
-            new_count = int(tracks[num]['playcount'])
-            log.debug(u'match: {0} - {1} ({2}) '
-                      u'updating: play_count {3} => {4}',
-                      song.artist, song.title, song.album, count, new_count)
-            song['play_count'] = new_count
+            count = int(song.get("play_count", 0))
+            new_count = int(tracks[num]["playcount"])
+            log.debug(
+                u"match: {0} - {1} ({2}) " u"updating: play_count {3} => {4}",
+                song.artist,
+                song.title,
+                song.album,
+                count,
+                new_count,
+            )
+            song["play_count"] = new_count
             song.store()
             total_found += 1
         else:
             total_fails += 1
-            log.info(u'  - No match: {0} - {1} ({2})',
-                     artist, title, album)
+            log.info(u"  - No match: {0} - {1} ({2})", artist, title, album)
 
     if total_fails > 0:
-        log.info(u'Acquired {0}/{1} play-counts ({2} unknown)',
-                 total_found, total, total_fails)
+        log.info(
+            u"Acquired {0}/{1} play-counts ({2} unknown)",
+            total_found,
+            total,
+            total_fails,
+        )
 
     return total_found, total_fails

--- a/beetsplug/loadext.py
+++ b/beetsplug/loadext.py
@@ -28,19 +28,21 @@ class LoadExtPlugin(BeetsPlugin):
         super(LoadExtPlugin, self).__init__()
 
         if not Database.supports_extensions:
-            self._log.warn('loadext is enabled but the current SQLite '
-                           'installation does not support extensions')
+            self._log.warn(
+                "loadext is enabled but the current SQLite "
+                "installation does not support extensions"
+            )
             return
 
-        self.register_listener('library_opened', self.library_opened)
+        self.register_listener("library_opened", self.library_opened)
 
     def library_opened(self, lib):
         for v in self.config:
             ext = v.as_filename()
 
-            self._log.debug(u'loading extension {}', ext)
+            self._log.debug(u"loading extension {}", ext)
 
             try:
                 lib.load_extension(ext)
             except sqlite3.OperationalError as e:
-                self._log.error(u'failed to load extension {}: {}', ext, e)
+                self._log.error(u"failed to load extension {}: {}", ext, e)

--- a/beetsplug/mbcollection.py
+++ b/beetsplug/mbcollection.py
@@ -25,7 +25,7 @@ import re
 
 SUBMISSION_CHUNK_SIZE = 200
 FETCH_CHUNK_SIZE = 100
-UUID_REGEX = r'^[a-f0-9]{8}(-[a-f0-9]{4}){3}-[a-f0-9]{12}$'
+UUID_REGEX = r"^[a-f0-9]{8}(-[a-f0-9]{4}){3}-[a-f0-9]{12}$"
 
 
 def mb_call(func, *args, **kwargs):
@@ -34,11 +34,11 @@ def mb_call(func, *args, **kwargs):
     try:
         return func(*args, **kwargs)
     except musicbrainzngs.AuthenticationError:
-        raise ui.UserError(u'authentication with MusicBrainz failed')
+        raise ui.UserError(u"authentication with MusicBrainz failed")
     except (musicbrainzngs.ResponseError, musicbrainzngs.NetworkError) as exc:
-        raise ui.UserError(u'MusicBrainz API error: {0}'.format(exc))
+        raise ui.UserError(u"MusicBrainz API error: {0}".format(exc))
     except musicbrainzngs.UsageError:
-        raise ui.UserError(u'MusicBrainz credentials missing')
+        raise ui.UserError(u"MusicBrainz credentials missing")
 
 
 def submit_albums(collection_id, release_ids):
@@ -46,45 +46,43 @@ def submit_albums(collection_id, release_ids):
     requests are made if there are many release IDs to submit.
     """
     for i in range(0, len(release_ids), SUBMISSION_CHUNK_SIZE):
-        chunk = release_ids[i:i + SUBMISSION_CHUNK_SIZE]
+        chunk = release_ids[i : i + SUBMISSION_CHUNK_SIZE]
         mb_call(
-            musicbrainzngs.add_releases_to_collection,
-            collection_id, chunk
+            musicbrainzngs.add_releases_to_collection, collection_id, chunk
         )
 
 
 class MusicBrainzCollectionPlugin(BeetsPlugin):
     def __init__(self):
         super(MusicBrainzCollectionPlugin, self).__init__()
-        config['musicbrainz']['pass'].redact = True
+        config["musicbrainz"]["pass"].redact = True
         musicbrainzngs.auth(
-            config['musicbrainz']['user'].as_str(),
-            config['musicbrainz']['pass'].as_str(),
+            config["musicbrainz"]["user"].as_str(),
+            config["musicbrainz"]["pass"].as_str(),
         )
-        self.config.add({
-            'auto': False,
-            'collection': u'',
-            'remove': False,
-        })
-        if self.config['auto']:
+        self.config.add(
+            {"auto": False, "collection": u"", "remove": False,}
+        )
+        if self.config["auto"]:
             self.import_stages = [self.imported]
 
     def _get_collection(self):
         collections = mb_call(musicbrainzngs.get_collections)
-        if not collections['collection-list']:
-            raise ui.UserError(u'no collections exist for user')
+        if not collections["collection-list"]:
+            raise ui.UserError(u"no collections exist for user")
 
         # Get all collection IDs, avoiding event collections
-        collection_ids = [x['id'] for x in collections['collection-list']]
+        collection_ids = [x["id"] for x in collections["collection-list"]]
         if not collection_ids:
-            raise ui.UserError(u'No collection found.')
+            raise ui.UserError(u"No collection found.")
 
         # Check that the collection exists so we can present a nice error
-        collection = self.config['collection'].as_str()
+        collection = self.config["collection"].as_str()
         if collection:
             if collection not in collection_ids:
-                raise ui.UserError(u'invalid collection ID: {}'
-                                   .format(collection))
+                raise ui.UserError(
+                    u"invalid collection ID: {}".format(collection)
+                )
             return collection
 
         # No specified collection. Just return the first collection ID
@@ -96,9 +94,9 @@ class MusicBrainzCollectionPlugin(BeetsPlugin):
                 musicbrainzngs.get_releases_in_collection,
                 id,
                 limit=FETCH_CHUNK_SIZE,
-                offset=offset
-            )['collection']
-            return [x['id'] for x in res['release-list']], res['release-count']
+                offset=offset,
+            )["collection"]
+            return [x["id"] for x in res["release-list"]], res["release-count"]
 
         offset = 0
         albums_in_collection, release_count = _fetch(offset)
@@ -109,13 +107,17 @@ class MusicBrainzCollectionPlugin(BeetsPlugin):
         return albums_in_collection
 
     def commands(self):
-        mbupdate = Subcommand('mbupdate',
-                              help=u'Update MusicBrainz collection')
-        mbupdate.parser.add_option('-r', '--remove',
-                                   action='store_true',
-                                   default=None,
-                                   dest='remove',
-                                   help='Remove albums not in beets library')
+        mbupdate = Subcommand(
+            "mbupdate", help=u"Update MusicBrainz collection"
+        )
+        mbupdate.parser.add_option(
+            "-r",
+            "--remove",
+            action="store_true",
+            default=None,
+            dest="remove",
+            help="Remove albums not in beets library",
+        )
         mbupdate.func = self.update_collection
         return [mbupdate]
 
@@ -124,15 +126,16 @@ class MusicBrainzCollectionPlugin(BeetsPlugin):
         albums_in_collection = self._get_albums_in_collection(collection_id)
         remove_me = list(set(albums_in_collection) - lib_ids)
         for i in range(0, len(remove_me), FETCH_CHUNK_SIZE):
-            chunk = remove_me[i:i + FETCH_CHUNK_SIZE]
+            chunk = remove_me[i : i + FETCH_CHUNK_SIZE]
             mb_call(
                 musicbrainzngs.remove_releases_from_collection,
-                collection_id, chunk
+                collection_id,
+                chunk,
             )
 
     def update_collection(self, lib, opts, args):
         self.config.set_args(opts)
-        remove_missing = self.config['remove'].get(bool)
+        remove_missing = self.config["remove"].get(bool)
         self.update_album_list(lib, lib.albums(), remove_missing)
 
     def imported(self, session, task):
@@ -154,13 +157,13 @@ class MusicBrainzCollectionPlugin(BeetsPlugin):
                 if re.match(UUID_REGEX, aid):
                     album_ids.append(aid)
                 else:
-                    self._log.info(u'skipping invalid MBID: {0}', aid)
+                    self._log.info(u"skipping invalid MBID: {0}", aid)
 
         # Submit to MusicBrainz.
         self._log.info(
-            u'Updating MusicBrainz collection {0}...', collection_id
+            u"Updating MusicBrainz collection {0}...", collection_id
         )
         submit_albums(collection_id, album_ids)
         if remove_missing:
             self.remove_missing(collection_id, lib.albums())
-        self._log.info(u'...MusicBrainz collection updated.')
+        self._log.info(u"...MusicBrainz collection updated.")

--- a/beetsplug/mbsubmit.py
+++ b/beetsplug/mbsubmit.py
@@ -35,26 +35,31 @@ class MBSubmitPlugin(BeetsPlugin):
     def __init__(self):
         super(MBSubmitPlugin, self).__init__()
 
-        self.config.add({
-            'format': u'$track. $title - $artist ($length)',
-            'threshold': 'medium',
-        })
+        self.config.add(
+            {
+                "format": u"$track. $title - $artist ($length)",
+                "threshold": "medium",
+            }
+        )
 
         # Validate and store threshold.
-        self.threshold = self.config['threshold'].as_choice({
-            'none': Recommendation.none,
-            'low': Recommendation.low,
-            'medium': Recommendation.medium,
-            'strong': Recommendation.strong
-        })
+        self.threshold = self.config["threshold"].as_choice(
+            {
+                "none": Recommendation.none,
+                "low": Recommendation.low,
+                "medium": Recommendation.medium,
+                "strong": Recommendation.strong,
+            }
+        )
 
-        self.register_listener('before_choose_candidate',
-                               self.before_choose_candidate_event)
+        self.register_listener(
+            "before_choose_candidate", self.before_choose_candidate_event
+        )
 
     def before_choose_candidate_event(self, session, task):
         if task.rec <= self.threshold:
-            return [PromptChoice(u'p', u'Print tracks', self.print_tracks)]
+            return [PromptChoice(u"p", u"Print tracks", self.print_tracks)]
 
     def print_tracks(self, session, task):
         for i in sorted(task.items, key=lambda i: i.track):
-            print_data(None, i, self.config['format'].as_str())
+            print_data(None, i, self.config["format"].as_str())

--- a/beetsplug/mbsync.py
+++ b/beetsplug/mbsync.py
@@ -32,21 +32,35 @@ class MBSyncPlugin(BeetsPlugin):
         super(MBSyncPlugin, self).__init__()
 
     def commands(self):
-        cmd = ui.Subcommand('mbsync',
-                            help=u'update metadata from musicbrainz')
+        cmd = ui.Subcommand("mbsync", help=u"update metadata from musicbrainz")
         cmd.parser.add_option(
-            u'-p', u'--pretend', action='store_true',
-            help=u'show all changes but do nothing')
+            u"-p",
+            u"--pretend",
+            action="store_true",
+            help=u"show all changes but do nothing",
+        )
         cmd.parser.add_option(
-            u'-m', u'--move', action='store_true', dest='move',
-            help=u"move files in the library directory")
+            u"-m",
+            u"--move",
+            action="store_true",
+            dest="move",
+            help=u"move files in the library directory",
+        )
         cmd.parser.add_option(
-            u'-M', u'--nomove', action='store_false', dest='move',
-            help=u"don't move files in library")
+            u"-M",
+            u"--nomove",
+            action="store_false",
+            dest="move",
+            help=u"don't move files in library",
+        )
         cmd.parser.add_option(
-            u'-W', u'--nowrite', action='store_false',
-            default=None, dest='write',
-            help=u"don't write updated metadata to files")
+            u"-W",
+            u"--nowrite",
+            action="store_false",
+            default=None,
+            dest="write",
+            help=u"don't write updated metadata to files",
+        )
         cmd.parser.add_format_option()
         cmd.func = self.func
         return [cmd]
@@ -66,25 +80,31 @@ class MBSyncPlugin(BeetsPlugin):
         """Retrieve and apply info from the autotagger for items matched by
         query.
         """
-        for item in lib.items(query + [u'singleton:true']):
+        for item in lib.items(query + [u"singleton:true"]):
             item_formatted = format(item)
             if not item.mb_trackid:
-                self._log.info(u'Skipping singleton with no mb_trackid: {0}',
-                               item_formatted)
+                self._log.info(
+                    u"Skipping singleton with no mb_trackid: {0}",
+                    item_formatted,
+                )
                 continue
 
             # Do we have a valid MusicBrainz track ID?
             if not re.match(MBID_REGEX, item.mb_trackid):
-                self._log.info(u'Skipping singleton with invalid mb_trackid:' +
-                               ' {0}', item_formatted)
+                self._log.info(
+                    u"Skipping singleton with invalid mb_trackid:" + " {0}",
+                    item_formatted,
+                )
                 continue
 
             # Get the MusicBrainz recording info.
             track_info = hooks.track_for_mbid(item.mb_trackid)
             if not track_info:
-                self._log.info(u'Recording ID not found: {0} for track {0}',
-                               item.mb_trackid,
-                               item_formatted)
+                self._log.info(
+                    u"Recording ID not found: {0} for track {0}",
+                    item.mb_trackid,
+                    item_formatted,
+                )
                 continue
 
             # Apply.
@@ -100,24 +120,29 @@ class MBSyncPlugin(BeetsPlugin):
         for a in lib.albums(query):
             album_formatted = format(a)
             if not a.mb_albumid:
-                self._log.info(u'Skipping album with no mb_albumid: {0}',
-                               album_formatted)
+                self._log.info(
+                    u"Skipping album with no mb_albumid: {0}", album_formatted
+                )
                 continue
 
             items = list(a.items())
 
             # Do we have a valid MusicBrainz album ID?
             if not re.match(MBID_REGEX, a.mb_albumid):
-                self._log.info(u'Skipping album with invalid mb_albumid: {0}',
-                               album_formatted)
+                self._log.info(
+                    u"Skipping album with invalid mb_albumid: {0}",
+                    album_formatted,
+                )
                 continue
 
             # Get the MusicBrainz album information.
             album_info = hooks.album_for_mbid(a.mb_albumid)
             if not album_info:
-                self._log.info(u'Release ID {0} not found for album {1}',
-                               a.mb_albumid,
-                               album_formatted)
+                self._log.info(
+                    u"Release ID {0} not found for album {1}",
+                    a.mb_albumid,
+                    album_formatted,
+                )
                 continue
 
             # Map release track and recording MBIDs to their information.
@@ -134,8 +159,10 @@ class MBSyncPlugin(BeetsPlugin):
             # work for albums that have missing or extra tracks.
             mapping = {}
             for item in items:
-                if item.mb_releasetrackid and \
-                        item.mb_releasetrackid in releasetrack_index:
+                if (
+                    item.mb_releasetrackid
+                    and item.mb_releasetrackid in releasetrack_index
+                ):
                     mapping[item] = releasetrack_index[item.mb_releasetrackid]
                 else:
                     candidates = track_index[item.mb_trackid]
@@ -145,13 +172,15 @@ class MBSyncPlugin(BeetsPlugin):
                         # If there are multiple copies of a recording, they are
                         # disambiguated using their disc and track number.
                         for c in candidates:
-                            if (c.medium_index == item.track and
-                                    c.medium == item.disc):
+                            if (
+                                c.medium_index == item.track
+                                and c.medium == item.disc
+                            ):
                                 mapping[item] = c
                                 break
 
             # Apply.
-            self._log.debug(u'applying changes to {}', album_formatted)
+            self._log.debug(u"applying changes to {}", album_formatted)
             with lib.transaction():
                 autotag.apply_metadata(album_info, mapping)
                 changed = False
@@ -176,5 +205,5 @@ class MBSyncPlugin(BeetsPlugin):
 
                     # Move album art (and any inconsistent items).
                     if move and lib.directory in util.ancestry(items[0].path):
-                        self._log.debug(u'moving album {0}', album_formatted)
+                        self._log.debug(u"moving album {0}", album_formatted)
                         a.move()

--- a/beetsplug/metasync/__init__.py
+++ b/beetsplug/metasync/__init__.py
@@ -27,12 +27,12 @@ from beets.plugins import BeetsPlugin
 import six
 
 
-METASYNC_MODULE = 'beetsplug.metasync'
+METASYNC_MODULE = "beetsplug.metasync"
 
 # Dictionary to map the MODULE and the CLASS NAME of meta sources
 SOURCES = {
-    'amarok': 'Amarok',
-    'itunes': 'Itunes',
+    "amarok": "Amarok",
+    "itunes": "Itunes",
 }
 
 
@@ -54,7 +54,7 @@ def load_meta_sources():
     meta_sources = {}
 
     for module_path, class_name in SOURCES.items():
-        module = import_module(METASYNC_MODULE + '.' + module_path)
+        module = import_module(METASYNC_MODULE + "." + module_path)
         meta_sources[class_name.lower()] = getattr(module, class_name)
 
     return meta_sources
@@ -80,13 +80,23 @@ class MetaSyncPlugin(BeetsPlugin):
         super(MetaSyncPlugin, self).__init__()
 
     def commands(self):
-        cmd = ui.Subcommand('metasync',
-                            help='update metadata from music player libraries')
-        cmd.parser.add_option('-p', '--pretend', action='store_true',
-                              help='show all changes but do nothing')
-        cmd.parser.add_option('-s', '--source', default=[],
-                              action='append', dest='sources',
-                              help='comma-separated list of sources to sync')
+        cmd = ui.Subcommand(
+            "metasync", help="update metadata from music player libraries"
+        )
+        cmd.parser.add_option(
+            "-p",
+            "--pretend",
+            action="store_true",
+            help="show all changes but do nothing",
+        )
+        cmd.parser.add_option(
+            "-s",
+            "--source",
+            default=[],
+            action="append",
+            dest="sources",
+            help="comma-separated list of sources to sync",
+        )
         cmd.parser.add_format_option()
         cmd.func = self.func
         return [cmd]
@@ -99,16 +109,16 @@ class MetaSyncPlugin(BeetsPlugin):
 
         sources = []
         for source in opts.sources:
-            sources.extend(source.split(','))
+            sources.extend(source.split(","))
 
-        sources = sources or self.config['source'].as_str_seq()
+        sources = sources or self.config["source"].as_str_seq()
 
         meta_source_instances = {}
         items = lib.items(query)
 
         # Avoid needlessly instantiating meta sources (can be expensive)
         if not items:
-            self._log.info(u'No items found matching query')
+            self._log.info(u"No items found matching query")
             return
 
         # Instantiate the meta sources
@@ -116,18 +126,21 @@ class MetaSyncPlugin(BeetsPlugin):
             try:
                 cls = META_SOURCES[player]
             except KeyError:
-                self._log.error(u'Unknown metadata source \'{0}\''.format(
-                    player))
+                self._log.error(
+                    u"Unknown metadata source '{0}'".format(player)
+                )
 
             try:
                 meta_source_instances[player] = cls(self.config, self._log)
             except (ImportError, ConfigValueError) as e:
-                self._log.error(u'Failed to instantiate metadata source '
-                                u'\'{0}\': {1}'.format(player, e))
+                self._log.error(
+                    u"Failed to instantiate metadata source "
+                    u"'{0}': {1}".format(player, e)
+                )
 
         # Avoid needlessly iterating over items
         if not meta_source_instances:
-            self._log.error(u'No valid metadata sources found')
+            self._log.error(u"No valid metadata sources found")
             return
 
         # Sync the items with all of the meta sources

--- a/beetsplug/metasync/amarok.py
+++ b/beetsplug/metasync/amarok.py
@@ -31,9 +31,10 @@ from beetsplug.metasync import MetaSource
 
 def import_dbus():
     try:
-        return __import__('dbus')
+        return __import__("dbus")
     except ImportError:
         return None
+
 
 dbus = import_dbus()
 
@@ -41,12 +42,12 @@ dbus = import_dbus()
 class Amarok(MetaSource):
 
     item_types = {
-        'amarok_rating':      types.INTEGER,
-        'amarok_score':       types.FLOAT,
-        'amarok_uid':         types.STRING,
-        'amarok_playcount':   types.INTEGER,
-        'amarok_firstplayed': DateType(),
-        'amarok_lastplayed':  DateType(),
+        "amarok_rating": types.INTEGER,
+        "amarok_score": types.FLOAT,
+        "amarok_uid": types.STRING,
+        "amarok_playcount": types.INTEGER,
+        "amarok_firstplayed": DateType(),
+        "amarok_lastplayed": DateType(),
     }
 
     query_xml = u'<query version="1.0"> \
@@ -59,10 +60,11 @@ class Amarok(MetaSource):
         super(Amarok, self).__init__(config, log)
 
         if not dbus:
-            raise ImportError('failed to import dbus')
+            raise ImportError("failed to import dbus")
 
-        self.collection = \
-            dbus.SessionBus().get_object('org.kde.amarok', '/Collection')
+        self.collection = dbus.SessionBus().get_object(
+            "org.kde.amarok", "/Collection"
+        )
 
     def sync_from_source(self, item):
         path = displayable_path(item.path)
@@ -75,35 +77,36 @@ class Amarok(MetaSource):
             self.query_xml % quoteattr(basename(path))
         )
         for result in results:
-            if result['xesam:url'] != path:
+            if result["xesam:url"] != path:
                 continue
 
-            item.amarok_rating = result['xesam:userRating']
-            item.amarok_score = result['xesam:autoRating']
-            item.amarok_playcount = result['xesam:useCount']
-            item.amarok_uid = \
-                result['xesam:id'].replace('amarok-sqltrackuid://', '')
+            item.amarok_rating = result["xesam:userRating"]
+            item.amarok_score = result["xesam:autoRating"]
+            item.amarok_playcount = result["xesam:useCount"]
+            item.amarok_uid = result["xesam:id"].replace(
+                "amarok-sqltrackuid://", ""
+            )
 
-            if result['xesam:firstUsed'][0][0] != 0:
+            if result["xesam:firstUsed"][0][0] != 0:
                 # These dates are stored as timestamps in amarok's db, but
                 # exposed over dbus as fixed integers in the current timezone.
                 first_played = datetime(
-                    result['xesam:firstUsed'][0][0],
-                    result['xesam:firstUsed'][0][1],
-                    result['xesam:firstUsed'][0][2],
-                    result['xesam:firstUsed'][1][0],
-                    result['xesam:firstUsed'][1][1],
-                    result['xesam:firstUsed'][1][2]
+                    result["xesam:firstUsed"][0][0],
+                    result["xesam:firstUsed"][0][1],
+                    result["xesam:firstUsed"][0][2],
+                    result["xesam:firstUsed"][1][0],
+                    result["xesam:firstUsed"][1][1],
+                    result["xesam:firstUsed"][1][2],
                 )
 
-                if result['xesam:lastUsed'][0][0] != 0:
+                if result["xesam:lastUsed"][0][0] != 0:
                     last_played = datetime(
-                        result['xesam:lastUsed'][0][0],
-                        result['xesam:lastUsed'][0][1],
-                        result['xesam:lastUsed'][0][2],
-                        result['xesam:lastUsed'][1][0],
-                        result['xesam:lastUsed'][1][1],
-                        result['xesam:lastUsed'][1][2]
+                        result["xesam:lastUsed"][0][0],
+                        result["xesam:lastUsed"][0][1],
+                        result["xesam:lastUsed"][0][2],
+                        result["xesam:lastUsed"][1][0],
+                        result["xesam:lastUsed"][1][1],
+                        result["xesam:lastUsed"][1][2],
                     )
                 else:
                     last_played = first_played

--- a/beetsplug/missing.py
+++ b/beetsplug/missing.py
@@ -47,41 +47,43 @@ def _item(track_info, album_info, album_id):
     t = track_info
     a = album_info
 
-    return Item(**{
-        'album_id':           album_id,
-        'album':              a.album,
-        'albumartist':        a.artist,
-        'albumartist_credit': a.artist_credit,
-        'albumartist_sort':   a.artist_sort,
-        'albumdisambig':      a.albumdisambig,
-        'albumstatus':        a.albumstatus,
-        'albumtype':          a.albumtype,
-        'artist':             t.artist,
-        'artist_credit':      t.artist_credit,
-        'artist_sort':        t.artist_sort,
-        'asin':               a.asin,
-        'catalognum':         a.catalognum,
-        'comp':               a.va,
-        'country':            a.country,
-        'day':                a.day,
-        'disc':               t.medium,
-        'disctitle':          t.disctitle,
-        'disctotal':          a.mediums,
-        'label':              a.label,
-        'language':           a.language,
-        'length':             t.length,
-        'mb_albumid':         a.album_id,
-        'mb_artistid':        t.artist_id,
-        'mb_releasegroupid':  a.releasegroup_id,
-        'mb_trackid':         t.track_id,
-        'media':              t.media,
-        'month':              a.month,
-        'script':             a.script,
-        'title':              t.title,
-        'track':              t.index,
-        'tracktotal':         len(a.tracks),
-        'year':               a.year,
-    })
+    return Item(
+        **{
+            "album_id": album_id,
+            "album": a.album,
+            "albumartist": a.artist,
+            "albumartist_credit": a.artist_credit,
+            "albumartist_sort": a.artist_sort,
+            "albumdisambig": a.albumdisambig,
+            "albumstatus": a.albumstatus,
+            "albumtype": a.albumtype,
+            "artist": t.artist,
+            "artist_credit": t.artist_credit,
+            "artist_sort": t.artist_sort,
+            "asin": a.asin,
+            "catalognum": a.catalognum,
+            "comp": a.va,
+            "country": a.country,
+            "day": a.day,
+            "disc": t.medium,
+            "disctitle": t.disctitle,
+            "disctotal": a.mediums,
+            "label": a.label,
+            "language": a.language,
+            "length": t.length,
+            "mb_albumid": a.album_id,
+            "mb_artistid": t.artist_id,
+            "mb_releasegroupid": a.releasegroup_id,
+            "mb_trackid": t.track_id,
+            "media": t.media,
+            "month": a.month,
+            "script": a.script,
+            "title": t.title,
+            "track": t.index,
+            "tracktotal": len(a.tracks),
+            "year": a.year,
+        }
+    )
 
 
 class MissingPlugin(BeetsPlugin):
@@ -89,38 +91,46 @@ class MissingPlugin(BeetsPlugin):
     """
 
     album_types = {
-        'missing':  types.INTEGER,
+        "missing": types.INTEGER,
     }
 
     def __init__(self):
         super(MissingPlugin, self).__init__()
 
-        self.config.add({
-            'count': False,
-            'total': False,
-            'album': False,
-        })
+        self.config.add(
+            {"count": False, "total": False, "album": False,}
+        )
 
-        self.album_template_fields['missing'] = _missing_count
+        self.album_template_fields["missing"] = _missing_count
 
-        self._command = Subcommand('missing',
-                                   help=__doc__,
-                                   aliases=['miss'])
+        self._command = Subcommand("missing", help=__doc__, aliases=["miss"])
         self._command.parser.add_option(
-            u'-c', u'--count', dest='count', action='store_true',
-            help=u'count missing tracks per album')
+            u"-c",
+            u"--count",
+            dest="count",
+            action="store_true",
+            help=u"count missing tracks per album",
+        )
         self._command.parser.add_option(
-            u'-t', u'--total', dest='total', action='store_true',
-            help=u'count total of missing tracks')
+            u"-t",
+            u"--total",
+            dest="total",
+            action="store_true",
+            help=u"count total of missing tracks",
+        )
         self._command.parser.add_option(
-            u'-a', u'--album', dest='album', action='store_true',
-            help=u'show missing albums for artist instead of tracks')
+            u"-a",
+            u"--album",
+            dest="album",
+            action="store_true",
+            help=u"show missing albums for artist instead of tracks",
+        )
         self._command.parser.add_format_option()
 
     def commands(self):
         def _miss(lib, opts, args):
             self.config.set_args(opts)
-            albms = self.config['album'].get()
+            albms = self.config["album"].get()
 
             helper = self._missing_albums if albms else self._missing_tracks
             helper(lib, decargs(args))
@@ -134,9 +144,9 @@ class MissingPlugin(BeetsPlugin):
         """
         albums = lib.albums(query)
 
-        count = self.config['count'].get()
-        total = self.config['total'].get()
-        fmt = config['format_album' if count else 'format_item'].get()
+        count = self.config["count"].get()
+        total = self.config["total"].get()
+        fmt = config["format_album" if count else "format_item"].get()
 
         if total:
             print(sum([_missing_count(a) for a in albums]))
@@ -144,7 +154,7 @@ class MissingPlugin(BeetsPlugin):
 
         # Default format string for count mode.
         if count:
-            fmt += ': $missing'
+            fmt += ": $missing"
 
         for album in albums:
             if count:
@@ -159,13 +169,13 @@ class MissingPlugin(BeetsPlugin):
         """Print a listing of albums missing from each artist in the library
         matching query.
         """
-        total = self.config['total'].get()
+        total = self.config["total"].get()
 
         albums = lib.albums(query)
         # build dict mapping artist to list of their albums in library
         albums_by_artist = defaultdict(list)
         for alb in albums:
-            artist = (alb['albumartist'], alb['mb_albumartistid'])
+            artist = (alb["albumartist"], alb["mb_albumartistid"])
             albums_by_artist[artist].append(alb)
 
         total_missing = 0
@@ -173,20 +183,24 @@ class MissingPlugin(BeetsPlugin):
         # build dict mapping artist to list of all albums
         for artist, albums in albums_by_artist.items():
             if artist[1] is None or artist[1] == "":
-                albs_no_mbid = [u"'" + a['album'] + u"'" for a in albums]
+                albs_no_mbid = [u"'" + a["album"] + u"'" for a in albums]
                 self._log.info(
                     u"No musicbrainz ID for artist '{}' found in album(s) {}; "
-                    "skipping", artist[0], u", ".join(albs_no_mbid)
+                    "skipping",
+                    artist[0],
+                    u", ".join(albs_no_mbid),
                 )
                 continue
 
             try:
                 resp = musicbrainzngs.browse_release_groups(artist=artist[1])
-                release_groups = resp['release-group-list']
+                release_groups = resp["release-group-list"]
             except MusicBrainzError as err:
                 self._log.info(
                     u"Couldn't fetch info for artist '{}' ({}) - '{}'",
-                    artist[0], artist[1], err
+                    artist[0],
+                    artist[1],
+                    err,
                 )
                 continue
 
@@ -195,7 +209,7 @@ class MissingPlugin(BeetsPlugin):
             for rg in release_groups:
                 missing.append(rg)
                 for alb in albums:
-                    if alb['mb_releasegroupid'] == rg['id']:
+                    if alb["mb_releasegroupid"] == rg["id"]:
                         missing.remove(rg)
                         present.append(rg)
                         break
@@ -204,7 +218,7 @@ class MissingPlugin(BeetsPlugin):
             if total:
                 continue
 
-            missing_titles = {rg['title'] for rg in missing}
+            missing_titles = {rg["title"] for rg in missing}
 
             for release_title in missing_titles:
                 print_(u"{} - {}".format(artist[0], release_title))
@@ -220,9 +234,12 @@ class MissingPlugin(BeetsPlugin):
             # fetch missing items
             # TODO: Implement caching that without breaking other stuff
             album_info = hooks.album_for_mbid(album.mb_albumid)
-            for track_info in getattr(album_info, 'tracks', []):
+            for track_info in getattr(album_info, "tracks", []):
                 if track_info.track_id not in item_mbids:
                     item = _item(track_info, album_info, album.id)
-                    self._log.debug(u'track {0} in album {1}',
-                                    track_info.track_id, album_info.album_id)
+                    self._log.debug(
+                        u"track {0} in album {1}",
+                        track_info.track_id,
+                        album_info.album_id,
+                    )
                     yield item

--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -34,7 +34,7 @@ RETRIES = 10
 RETRY_INTERVAL = 5
 
 
-mpd_config = config['mpd']
+mpd_config = config["mpd"]
 
 
 def is_url(path):
@@ -42,40 +42,39 @@ def is_url(path):
     """
     if isinstance(path, bytes):  # if it's bytes, then it's a path
         return False
-    return path.split('://', 1)[0] in ['http', 'https']
+    return path.split("://", 1)[0] in ["http", "https"]
 
 
 class MPDClientWrapper(object):
     def __init__(self, log):
         self._log = log
 
-        self.music_directory = (
-            mpd_config['music_directory'].as_str())
+        self.music_directory = mpd_config["music_directory"].as_str()
 
         self.client = mpd.MPDClient(use_unicode=True)
 
     def connect(self):
         """Connect to the MPD.
         """
-        host = mpd_config['host'].as_str()
-        port = mpd_config['port'].get(int)
+        host = mpd_config["host"].as_str()
+        port = mpd_config["port"].get(int)
 
-        if host[0] in ['/', '~']:
+        if host[0] in ["/", "~"]:
             host = os.path.expanduser(host)
 
-        self._log.info(u'connecting to {0}:{1}', host, port)
+        self._log.info(u"connecting to {0}:{1}", host, port)
         try:
             self.client.connect(host, port)
         except socket.error as e:
-            raise ui.UserError(u'could not connect to MPD: {0}'.format(e))
+            raise ui.UserError(u"could not connect to MPD: {0}".format(e))
 
-        password = mpd_config['password'].as_str()
+        password = mpd_config["password"].as_str()
         if password:
             try:
                 self.client.password(password)
             except mpd.CommandError as e:
                 raise ui.UserError(
-                    u'could not authenticate to MPD: {0}'.format(e)
+                    u"could not authenticate to MPD: {0}".format(e)
                 )
 
     def disconnect(self):
@@ -91,11 +90,11 @@ class MPDClientWrapper(object):
         try:
             return getattr(self.client, command)()
         except (select.error, mpd.ConnectionError) as err:
-            self._log.error(u'{0}', err)
+            self._log.error(u"{0}", err)
 
         if retries <= 0:
             # if we exited without breaking, we couldn't reconnect in time :(
-            raise ui.UserError(u'communication with MPD server failed')
+            raise ui.UserError(u"communication with MPD server failed")
 
         time.sleep(RETRY_INTERVAL)
 
@@ -112,24 +111,24 @@ class MPDClientWrapper(object):
         music_directory, to get the absolute path.
         """
         result = None
-        entry = self.get('currentsong')
-        if 'file' in entry:
-            if not is_url(entry['file']):
-                result = os.path.join(self.music_directory, entry['file'])
+        entry = self.get("currentsong")
+        if "file" in entry:
+            if not is_url(entry["file"]):
+                result = os.path.join(self.music_directory, entry["file"])
             else:
-                result = entry['file']
+                result = entry["file"]
         return result
 
     def status(self):
         """Return the current status of the MPD.
         """
-        return self.get('status')
+        return self.get("status")
 
     def events(self):
         """Return list of events. This may block a long time while waiting for
         an answer from MPD.
         """
-        return self.get('idle')
+        return self.get("idle")
 
 
 class MPDStats(object):
@@ -137,8 +136,8 @@ class MPDStats(object):
         self.lib = lib
         self._log = log
 
-        self.do_rating = mpd_config['rating'].get(bool)
-        self.rating_mix = mpd_config['rating_mix'].get(float)
+        self.do_rating = mpd_config["rating"].get(bool)
+        self.rating_mix = mpd_config["rating_mix"].get(float)
         self.time_threshold = 10.0  # TODO: maybe add config option?
 
         self.now_playing = None
@@ -149,22 +148,21 @@ class MPDStats(object):
         old rating and the fact if it was skipped or not.
         """
         if skipped:
-            rolling = (rating - rating / 2.0)
+            rolling = rating - rating / 2.0
         else:
-            rolling = (rating + (1.0 - rating) / 2.0)
+            rolling = rating + (1.0 - rating) / 2.0
         stable = (play_count + 1.0) / (play_count + skip_count + 2.0)
-        return (self.rating_mix * stable +
-                (1.0 - self.rating_mix) * rolling)
+        return self.rating_mix * stable + (1.0 - self.rating_mix) * rolling
 
     def get_item(self, path):
         """Return the beets item related to path.
         """
-        query = library.PathQuery('path', path)
+        query = library.PathQuery("path", path)
         item = self.lib.items(query).get()
         if item:
             return item
         else:
-            self._log.info(u'item not found: {0}', displayable_path(path))
+            self._log.info(u"item not found: {0}", displayable_path(path))
 
     def update_item(self, item, attribute, value=None, increment=None):
         """Update the beets item. Set attribute to value or increment the value
@@ -182,10 +180,12 @@ class MPDStats(object):
             item[attribute] = value
             item.store()
 
-            self._log.debug(u'updated: {0} = {1} [{2}]',
-                            attribute,
-                            item[attribute],
-                            displayable_path(item.path))
+            self._log.debug(
+                u"updated: {0} = {1} [{2}]",
+                attribute,
+                item[attribute],
+                displayable_path(item.path),
+            )
 
     def update_rating(self, item, skipped):
         """Update the rating for a beets item. The `item` can either be a
@@ -196,12 +196,13 @@ class MPDStats(object):
 
         item.load()
         rating = self.rating(
-            int(item.get('play_count', 0)),
-            int(item.get('skip_count', 0)),
-            float(item.get('rating', 0.5)),
-            skipped)
+            int(item.get("play_count", 0)),
+            int(item.get("skip_count", 0)),
+            float(item.get("rating", 0.5)),
+            skipped,
+        )
 
-        self.update_item(item, 'rating', rating)
+        self.update_item(item, "rating", rating)
 
     def handle_song_change(self, song):
         """Determine if a song was skipped or not and update its attributes.
@@ -211,7 +212,7 @@ class MPDStats(object):
 
         Returns whether the change was manual (skipped previous song or not)
         """
-        diff = abs(song['remaining'] - (time.time() - song['started']))
+        diff = abs(song["remaining"] - (time.time() - song["started"]))
 
         skipped = diff >= self.time_threshold
 
@@ -221,24 +222,24 @@ class MPDStats(object):
             self.handle_played(song)
 
         if self.do_rating:
-            self.update_rating(song['beets_item'], skipped)
+            self.update_rating(song["beets_item"], skipped)
 
         return skipped
 
     def handle_played(self, song):
         """Updates the play count of a song.
         """
-        self.update_item(song['beets_item'], 'play_count', increment=1)
-        self._log.info(u'played {0}', displayable_path(song['path']))
+        self.update_item(song["beets_item"], "play_count", increment=1)
+        self._log.info(u"played {0}", displayable_path(song["path"]))
 
     def handle_skipped(self, song):
         """Updates the skip count of a song.
         """
-        self.update_item(song['beets_item'], 'skip_count', increment=1)
-        self._log.info(u'skipped {0}', displayable_path(song['path']))
+        self.update_item(song["beets_item"], "skip_count", increment=1)
+        self._log.info(u"skipped {0}", displayable_path(song["path"]))
 
     def on_stop(self, status):
-        self._log.info(u'stop')
+        self._log.info(u"stop")
 
         if self.now_playing:
             self.handle_song_change(self.now_playing)
@@ -246,7 +247,7 @@ class MPDStats(object):
         self.now_playing = None
 
     def on_pause(self, status):
-        self._log.info(u'pause')
+        self._log.info(u"pause")
         self.now_playing = None
 
     def on_play(self, status):
@@ -256,51 +257,54 @@ class MPDStats(object):
         if not path:
             return
 
-        played, duration = map(int, status['time'].split(':', 1))
+        played, duration = map(int, status["time"].split(":", 1))
         remaining = duration - played
 
         if self.now_playing:
-            if self.now_playing['path'] != path:
+            if self.now_playing["path"] != path:
                 self.handle_song_change(self.now_playing)
             else:
                 # In case we got mpd play event with same song playing
                 # multiple times,
                 # assume low diff means redundant second play event
                 # after natural song start.
-                diff = abs(time.time() - self.now_playing['started'])
+                diff = abs(time.time() - self.now_playing["started"])
 
                 if diff <= self.time_threshold:
                     return
 
-                if self.now_playing['path'] == path and played == 0:
+                if self.now_playing["path"] == path and played == 0:
                     self.handle_song_change(self.now_playing)
 
         if is_url(path):
-            self._log.info(u'playing stream {0}', displayable_path(path))
+            self._log.info(u"playing stream {0}", displayable_path(path))
             self.now_playing = None
             return
 
-        self._log.info(u'playing {0}', displayable_path(path))
+        self._log.info(u"playing {0}", displayable_path(path))
 
         self.now_playing = {
-            'started':    time.time(),
-            'remaining':  remaining,
-            'path':       path,
-            'beets_item': self.get_item(path),
+            "started": time.time(),
+            "remaining": remaining,
+            "path": path,
+            "beets_item": self.get_item(path),
         }
 
-        self.update_item(self.now_playing['beets_item'],
-                         'last_played', value=int(time.time()))
+        self.update_item(
+            self.now_playing["beets_item"],
+            "last_played",
+            value=int(time.time()),
+        )
 
     def run(self):
         self.mpd.connect()
-        events = ['player']
+        events = ["player"]
 
         while True:
-            if 'player' in events:
+            if "player" in events:
                 status = self.mpd.status()
 
-                handler = getattr(self, 'on_' + status['state'], None)
+                handler = getattr(self, "on_" + status["state"], None)
 
                 if handler:
                     handler(status)
@@ -313,48 +317,59 @@ class MPDStats(object):
 class MPDStatsPlugin(plugins.BeetsPlugin):
 
     item_types = {
-        'play_count':  types.INTEGER,
-        'skip_count':  types.INTEGER,
-        'last_played': library.DateType(),
-        'rating':      types.FLOAT,
+        "play_count": types.INTEGER,
+        "skip_count": types.INTEGER,
+        "last_played": library.DateType(),
+        "rating": types.FLOAT,
     }
 
     def __init__(self):
         super(MPDStatsPlugin, self).__init__()
-        mpd_config.add({
-            'music_directory': config['directory'].as_filename(),
-            'rating':          True,
-            'rating_mix':      0.75,
-            'host':            os.environ.get('MPD_HOST', u'localhost'),
-            'port':            int(os.environ.get('MPD_PORT', 6600)),
-            'password':        u'',
-        })
-        mpd_config['password'].redact = True
+        mpd_config.add(
+            {
+                "music_directory": config["directory"].as_filename(),
+                "rating": True,
+                "rating_mix": 0.75,
+                "host": os.environ.get("MPD_HOST", u"localhost"),
+                "port": int(os.environ.get("MPD_PORT", 6600)),
+                "password": u"",
+            }
+        )
+        mpd_config["password"].redact = True
 
     def commands(self):
         cmd = ui.Subcommand(
-            'mpdstats',
-            help=u'run a MPD client to gather play statistics')
+            "mpdstats", help=u"run a MPD client to gather play statistics"
+        )
         cmd.parser.add_option(
-            u'--host', dest='host', type='string',
-            help=u'set the hostname of the server to connect to')
+            u"--host",
+            dest="host",
+            type="string",
+            help=u"set the hostname of the server to connect to",
+        )
         cmd.parser.add_option(
-            u'--port', dest='port', type='int',
-            help=u'set the port of the MPD server to connect to')
+            u"--port",
+            dest="port",
+            type="int",
+            help=u"set the port of the MPD server to connect to",
+        )
         cmd.parser.add_option(
-            u'--password', dest='password', type='string',
-            help=u'set the password of the MPD server to connect to')
+            u"--password",
+            dest="password",
+            type="string",
+            help=u"set the password of the MPD server to connect to",
+        )
 
         def func(lib, opts, args):
             mpd_config.set_args(opts)
 
             # Overrides for MPD settings.
             if opts.host:
-                mpd_config['host'] = opts.host.decode('utf-8')
+                mpd_config["host"] = opts.host.decode("utf-8")
             if opts.port:
-                mpd_config['host'] = int(opts.port)
+                mpd_config["host"] = int(opts.port)
             if opts.password:
-                mpd_config['password'] = opts.password.decode('utf-8')
+                mpd_config["password"] = opts.password.decode("utf-8")
 
             try:
                 MPDStats(lib, self._log).run()

--- a/beetsplug/mpdupdate.py
+++ b/beetsplug/mpdupdate.py
@@ -35,14 +35,15 @@ import six
 # easier.
 class BufferedSocket(object):
     """Socket abstraction that allows reading by line."""
-    def __init__(self, host, port, sep=b'\n'):
-        if host[0] in ['/', '~']:
+
+    def __init__(self, host, port, sep=b"\n"):
+        if host[0] in ["/", "~"]:
             self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             self.sock.connect(os.path.expanduser(host))
         else:
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.sock.connect((host, port))
-        self.buf = b''
+        self.buf = b""
         self.sep = sep
 
     def readline(self):
@@ -55,7 +56,7 @@ class BufferedSocket(object):
             res, self.buf = self.buf.split(self.sep, 1)
             return res + self.sep
         else:
-            return b''
+            return b""
 
     def send(self, data):
         self.sock.send(data)
@@ -67,63 +68,66 @@ class BufferedSocket(object):
 class MPDUpdatePlugin(BeetsPlugin):
     def __init__(self):
         super(MPDUpdatePlugin, self).__init__()
-        config['mpd'].add({
-            'host':     os.environ.get('MPD_HOST', u'localhost'),
-            'port':     int(os.environ.get('MPD_PORT', 6600)),
-            'password': u'',
-        })
-        config['mpd']['password'].redact = True
+        config["mpd"].add(
+            {
+                "host": os.environ.get("MPD_HOST", u"localhost"),
+                "port": int(os.environ.get("MPD_PORT", 6600)),
+                "password": u"",
+            }
+        )
+        config["mpd"]["password"].redact = True
 
         # For backwards compatibility, use any values from the
         # plugin-specific "mpdupdate" section.
-        for key in config['mpd'].keys():
+        for key in config["mpd"].keys():
             if self.config[key].exists():
-                config['mpd'][key] = self.config[key].get()
+                config["mpd"][key] = self.config[key].get()
 
-        self.register_listener('database_change', self.db_change)
+        self.register_listener("database_change", self.db_change)
 
     def db_change(self, lib, model):
-        self.register_listener('cli_exit', self.update)
+        self.register_listener("cli_exit", self.update)
 
     def update(self, lib):
         self.update_mpd(
-            config['mpd']['host'].as_str(),
-            config['mpd']['port'].get(int),
-            config['mpd']['password'].as_str(),
+            config["mpd"]["host"].as_str(),
+            config["mpd"]["port"].get(int),
+            config["mpd"]["password"].as_str(),
         )
 
-    def update_mpd(self, host='localhost', port=6600, password=None):
+    def update_mpd(self, host="localhost", port=6600, password=None):
         """Sends the "update" command to the MPD server indicated,
         possibly authenticating with a password first.
         """
-        self._log.info('Updating MPD database...')
+        self._log.info("Updating MPD database...")
 
         try:
             s = BufferedSocket(host, port)
         except socket.error as e:
-            self._log.warning(u'MPD connection failed: {0}',
-                              six.text_type(e.strerror))
+            self._log.warning(
+                u"MPD connection failed: {0}", six.text_type(e.strerror)
+            )
             return
 
         resp = s.readline()
-        if b'OK MPD' not in resp:
-            self._log.warning(u'MPD connection failed: {0!r}', resp)
+        if b"OK MPD" not in resp:
+            self._log.warning(u"MPD connection failed: {0!r}", resp)
             return
 
         if password:
-            s.send(b'password "%s"\n' % password.encode('utf8'))
+            s.send(b'password "%s"\n' % password.encode("utf8"))
             resp = s.readline()
-            if b'OK' not in resp:
-                self._log.warning(u'Authentication failed: {0!r}', resp)
-                s.send(b'close\n')
+            if b"OK" not in resp:
+                self._log.warning(u"Authentication failed: {0!r}", resp)
+                s.send(b"close\n")
                 s.close()
                 return
 
-        s.send(b'update\n')
+        s.send(b"update\n")
         resp = s.readline()
-        if b'updating_db' not in resp:
-            self._log.warning(u'Update failed: {0!r}', resp)
+        if b"updating_db" not in resp:
+            self._log.warning(u"Update failed: {0!r}", resp)
 
-        s.send(b'close\n')
+        s.send(b"close\n")
         s.close()
-        self._log.info(u'Database updated.')
+        self._log.info(u"Database updated.")

--- a/beetsplug/parentwork.py
+++ b/beetsplug/parentwork.py
@@ -29,20 +29,22 @@ def direct_parent_id(mb_workid, work_date=None):
     """Given a Musicbrainz work id, find the id one of the works the work is
     part of and the first composition date it encounters.
     """
-    work_info = musicbrainzngs.get_work_by_id(mb_workid,
-                                              includes=["work-rels",
-                                                        "artist-rels"])
-    if 'artist-relation-list' in work_info['work'] and work_date is None:
-        for artist in work_info['work']['artist-relation-list']:
-            if artist['type'] == 'composer':
-                if 'end' in artist.keys():
-                    work_date = artist['end']
+    work_info = musicbrainzngs.get_work_by_id(
+        mb_workid, includes=["work-rels", "artist-rels"]
+    )
+    if "artist-relation-list" in work_info["work"] and work_date is None:
+        for artist in work_info["work"]["artist-relation-list"]:
+            if artist["type"] == "composer":
+                if "end" in artist.keys():
+                    work_date = artist["end"]
 
-    if 'work-relation-list' in work_info['work']:
-        for direct_parent in work_info['work']['work-relation-list']:
-            if direct_parent['type'] == 'parts' \
-                    and direct_parent.get('direction') == 'backward':
-                direct_id = direct_parent['work']['id']
+    if "work-relation-list" in work_info["work"]:
+        for direct_parent in work_info["work"]["work-relation-list"]:
+            if (
+                direct_parent["type"] == "parts"
+                and direct_parent.get("direction") == "backward"
+            ):
+                direct_id = direct_parent["work"]["id"]
                 return direct_id, work_date
     return None, work_date
 
@@ -64,8 +66,9 @@ def find_parentwork_info(mb_workid):
     the artist relations, and the composition date for a work's parent work.
     """
     parent_id, work_date = work_parent_id(mb_workid)
-    work_info = musicbrainzngs.get_work_by_id(parent_id,
-                                              includes=["artist-rels"])
+    work_info = musicbrainzngs.get_work_by_id(
+        parent_id, includes=["artist-rels"]
+    )
     return work_info, work_date
 
 
@@ -73,19 +76,17 @@ class ParentWorkPlugin(BeetsPlugin):
     def __init__(self):
         super(ParentWorkPlugin, self).__init__()
 
-        self.config.add({
-            'auto': False,
-            'force': False,
-        })
+        self.config.add(
+            {"auto": False, "force": False,}
+        )
 
-        if self.config['auto']:
+        if self.config["auto"]:
             self.import_stages = [self.imported]
 
     def commands(self):
-
         def func(lib, opts, args):
             self.config.set_args(opts)
-            force_parent = self.config['force'].get(bool)
+            force_parent = self.config["force"].get(bool)
             write = ui.should_write()
 
             for item in lib.items(ui.decargs(args)):
@@ -94,14 +95,19 @@ class ParentWorkPlugin(BeetsPlugin):
                     item.store()
                     if write:
                         item.try_write()
+
         command = ui.Subcommand(
-            'parentwork',
-            help=u'fetche parent works, composers and dates')
+            "parentwork", help=u"fetche parent works, composers and dates"
+        )
 
         command.parser.add_option(
-            u'-f', u'--force', dest='force',
-            action='store_true', default=None,
-            help=u're-fetch when parent work is already present')
+            u"-f",
+            u"--force",
+            dest="force",
+            action="store_true",
+            default=None,
+            help=u"re-fetch when parent work is already present",
+        )
 
         command.func = func
         return [command]
@@ -109,7 +115,7 @@ class ParentWorkPlugin(BeetsPlugin):
     def imported(self, session, task):
         """Import hook for fetching parent works automatically.
         """
-        force_parent = self.config['force'].get(bool)
+        force_parent = self.config["force"].get(bool)
 
         for item in task.imported_items():
             self.find_work(item, force_parent)
@@ -126,34 +132,37 @@ class ParentWorkPlugin(BeetsPlugin):
         parentwork_info = {}
 
         composer_exists = False
-        if 'artist-relation-list' in work_info['work']:
-            for artist in work_info['work']['artist-relation-list']:
-                if artist['type'] == 'composer':
-                    parent_composer.append(artist['artist']['name'])
-                    parent_composer_sort.append(artist['artist']['sort-name'])
-                    if 'end' in artist.keys():
-                        parentwork_info["parentwork_date"] = artist['end']
+        if "artist-relation-list" in work_info["work"]:
+            for artist in work_info["work"]["artist-relation-list"]:
+                if artist["type"] == "composer":
+                    parent_composer.append(artist["artist"]["name"])
+                    parent_composer_sort.append(artist["artist"]["sort-name"])
+                    if "end" in artist.keys():
+                        parentwork_info["parentwork_date"] = artist["end"]
 
-            parentwork_info['parent_composer'] = u', '.join(parent_composer)
-            parentwork_info['parent_composer_sort'] = u', '.join(
-                    parent_composer_sort)
+            parentwork_info["parent_composer"] = u", ".join(parent_composer)
+            parentwork_info["parent_composer_sort"] = u", ".join(
+                parent_composer_sort
+            )
 
         if not composer_exists:
             self._log.debug(
-                'no composer for {}; add one at '
-                'https://musicbrainz.org/work/{}',
-                item, work_info['work']['id'],
+                "no composer for {}; add one at "
+                "https://musicbrainz.org/work/{}",
+                item,
+                work_info["work"]["id"],
             )
 
-        parentwork_info['parentwork'] = work_info['work']['title']
-        parentwork_info['mb_parentworkid'] = work_info['work']['id']
+        parentwork_info["parentwork"] = work_info["work"]["title"]
+        parentwork_info["mb_parentworkid"] = work_info["work"]["id"]
 
-        if 'disambiguation' in work_info['work']:
-            parentwork_info['parentwork_disambig'] = work_info[
-                    'work']['disambiguation']
+        if "disambiguation" in work_info["work"]:
+            parentwork_info["parentwork_disambig"] = work_info["work"][
+                "disambiguation"
+            ]
 
         else:
-            parentwork_info['parentwork_disambig'] = None
+            parentwork_info["parentwork_disambig"] = None
 
         return parentwork_info
 
@@ -170,13 +179,17 @@ class ParentWorkPlugin(BeetsPlugin):
         """
 
         if not item.mb_workid:
-            self._log.info('No work for {}, \
-add one at https://musicbrainz.org/recording/{}', item, item.mb_trackid)
+            self._log.info(
+                "No work for {}, \
+add one at https://musicbrainz.org/recording/{}",
+                item,
+                item.mb_trackid,
+            )
             return
 
-        hasparent = hasattr(item, 'parentwork')
+        hasparent = hasattr(item, "parentwork")
         work_changed = True
-        if hasattr(item, 'parentwork_workid_current'):
+        if hasattr(item, "parentwork_workid_current"):
             work_changed = item.parentwork_workid_current != item.mb_workid
         if force or not hasparent or work_changed:
             try:
@@ -185,14 +198,18 @@ add one at https://musicbrainz.org/recording/{}', item, item.mb_trackid)
                 self._log.debug("error fetching work: {}", e)
                 return
             parent_info = self.get_info(item, work_info)
-            parent_info['parentwork_workid_current'] = item.mb_workid
-            if 'parent_composer' in parent_info:
-                self._log.debug("Work fetched: {} - {}",
-                                parent_info['parentwork'],
-                                parent_info['parent_composer'])
+            parent_info["parentwork_workid_current"] = item.mb_workid
+            if "parent_composer" in parent_info:
+                self._log.debug(
+                    "Work fetched: {} - {}",
+                    parent_info["parentwork"],
+                    parent_info["parent_composer"],
+                )
             else:
-                self._log.debug("Work fetched: {} - no parent composer",
-                                parent_info['parentwork'])
+                self._log.debug(
+                    "Work fetched: {} - no parent composer",
+                    parent_info["parentwork"],
+                )
 
         elif hasparent:
             self._log.debug("{}: Work present, skipping", item)
@@ -204,9 +221,17 @@ add one at https://musicbrainz.org/recording/{}', item, item.mb_trackid)
                 item[key] = value
 
         if work_date:
-            item['work_date'] = work_date
+            item["work_date"] = work_date
         return ui.show_model_changes(
-            item, fields=['parentwork', 'parentwork_disambig',
-                          'mb_parentworkid', 'parent_composer',
-                          'parent_composer_sort', 'work_date',
-                          'parentwork_workid_current', 'parentwork_date'])
+            item,
+            fields=[
+                "parentwork",
+                "parentwork_disambig",
+                "mb_parentworkid",
+                "parent_composer",
+                "parent_composer_sort",
+                "work_date",
+                "parentwork_workid_current",
+                "parentwork_date",
+            ],
+        )

--- a/beetsplug/permissions.py
+++ b/beetsplug/permissions.py
@@ -40,11 +40,10 @@ def assert_permissions(path, permission, log):
     """
     if not check_permissions(util.syspath(path), permission):
         log.warning(
-            u'could not set permissions on {}',
-            util.displayable_path(path),
+            u"could not set permissions on {}", util.displayable_path(path),
         )
         log.debug(
-            u'set permissions to {}, but permissions are now {}',
+            u"set permissions to {}, but permissions are now {}",
             permission,
             os.stat(util.syspath(path)).st_mode & 0o777,
         )
@@ -53,9 +52,9 @@ def assert_permissions(path, permission, log):
 def dirs_in_library(library, item):
     """Creates a list of ancestor directories in the beets library path.
     """
-    return [ancestor
-            for ancestor in ancestry(item)
-            if ancestor.startswith(library)][1:]
+    return [
+        ancestor for ancestor in ancestry(item) if ancestor.startswith(library)
+    ][1:]
 
 
 class Permissions(BeetsPlugin):
@@ -63,13 +62,12 @@ class Permissions(BeetsPlugin):
         super(Permissions, self).__init__()
 
         # Adding defaults.
-        self.config.add({
-            u'file': '644',
-            u'dir': '755',
-        })
+        self.config.add(
+            {u"file": "644", u"dir": "755",}
+        )
 
-        self.register_listener('item_imported', self.fix)
-        self.register_listener('album_imported', self.fix)
+        self.register_listener("item_imported", self.fix)
+        self.register_listener("album_imported", self.fix)
 
     def fix(self, lib, item=None, album=None):
         """Fix the permissions for an imported Item or Album.
@@ -78,8 +76,8 @@ class Permissions(BeetsPlugin):
         # string (in YAML quotes) or, for convenience, as an integer so the
         # quotes can be omitted. In the latter case, we need to reinterpret the
         # integer as octal, not decimal.
-        file_perm = config['permissions']['file'].get()
-        dir_perm = config['permissions']['dir'].get()
+        file_perm = config["permissions"]["file"].get()
+        dir_perm = config["permissions"]["dir"].get()
         file_perm = convert_perm(file_perm)
         dir_perm = convert_perm(dir_perm)
 
@@ -97,8 +95,7 @@ class Permissions(BeetsPlugin):
         for path in file_chmod_queue:
             # Changing permissions on the destination file.
             self._log.debug(
-                u'setting file permissions on {}',
-                util.displayable_path(path),
+                u"setting file permissions on {}", util.displayable_path(path),
             )
             os.chmod(util.syspath(path), file_perm)
 
@@ -106,15 +103,13 @@ class Permissions(BeetsPlugin):
             assert_permissions(path, file_perm, self._log)
 
             # Adding directories to the directory chmod queue.
-            dir_chmod_queue.update(
-                dirs_in_library(lib.directory,
-                                path))
+            dir_chmod_queue.update(dirs_in_library(lib.directory, path))
 
         # Change permissions for the directories.
         for path in dir_chmod_queue:
             # Chaning permissions on the destination directory.
             self._log.debug(
-                u'setting directory permissions on {}',
+                u"setting directory permissions on {}",
                 util.displayable_path(path),
             )
             os.chmod(util.syspath(path), dir_perm)

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -29,18 +29,25 @@ import subprocess
 
 # Indicate where arguments should be inserted into the command string.
 # If this is missing, they're placed at the end.
-ARGS_MARKER = '$args'
+ARGS_MARKER = "$args"
 
 
-def play(command_str, selection, paths, open_args, log, item_type='track',
-         keep_open=False):
+def play(
+    command_str,
+    selection,
+    paths,
+    open_args,
+    log,
+    item_type="track",
+    keep_open=False,
+):
     """Play items in paths with command_str and optional arguments. If
     keep_open, return to beets, otherwise exit once command runs.
     """
     # Print number of tracks or albums to be played, log command to be run.
-    item_type += 's' if len(selection) > 1 else ''
-    ui.print_(u'Playing {0} {1}.'.format(len(selection), item_type))
-    log.debug(u'executing command: {} {!r}', command_str, open_args)
+    item_type += "s" if len(selection) > 1 else ""
+    ui.print_(u"Playing {0} {1}.".format(len(selection), item_type))
+    log.debug(u"executing command: {} {!r}", command_str, open_args)
 
     try:
         if keep_open:
@@ -50,42 +57,44 @@ def play(command_str, selection, paths, open_args, log, item_type='track',
         else:
             util.interactive_open(open_args, command_str)
     except OSError as exc:
-        raise ui.UserError(
-            "Could not play the query: {0}".format(exc))
+        raise ui.UserError("Could not play the query: {0}".format(exc))
 
 
 class PlayPlugin(BeetsPlugin):
-
     def __init__(self):
         super(PlayPlugin, self).__init__()
 
-        config['play'].add({
-            'command': None,
-            'use_folders': False,
-            'relative_to': None,
-            'raw': False,
-            'warning_threshold': 100,
-            'bom': False,
-        })
+        config["play"].add(
+            {
+                "command": None,
+                "use_folders": False,
+                "relative_to": None,
+                "raw": False,
+                "warning_threshold": 100,
+                "bom": False,
+            }
+        )
 
-        self.register_listener('before_choose_candidate',
-                               self.before_choose_candidate_listener)
+        self.register_listener(
+            "before_choose_candidate", self.before_choose_candidate_listener
+        )
 
     def commands(self):
         play_command = Subcommand(
-            'play',
-            help=u'send music to a player as a playlist'
+            "play", help=u"send music to a player as a playlist"
         )
         play_command.parser.add_album_option()
         play_command.parser.add_option(
-            u'-A', u'--args',
-            action='store',
-            help=u'add additional arguments to the command',
+            u"-A",
+            u"--args",
+            action="store",
+            help=u"add additional arguments to the command",
         )
         play_command.parser.add_option(
-            u'-y', u'--yes',
+            u"-y",
+            u"--yes",
             action="store_true",
-            help=u'skip the warning threshold',
+            help=u"skip the warning threshold",
         )
         play_command.func = self._play_command
         return [play_command]
@@ -94,8 +103,8 @@ class PlayPlugin(BeetsPlugin):
         """The CLI command function for `beet play`. Create a list of paths
         from query, determine if tracks or albums are to be played.
         """
-        use_folders = config['play']['use_folders'].get(bool)
-        relative_to = config['play']['relative_to'].get()
+        use_folders = config["play"]["use_folders"].get(bool)
+        relative_to = config["play"]["relative_to"].get()
         if relative_to:
             relative_to = util.normpath(relative_to)
         # Perform search by album and add folders rather than tracks to
@@ -109,22 +118,26 @@ class PlayPlugin(BeetsPlugin):
                 if use_folders:
                     paths.append(album.item_dir())
                 else:
-                    paths.extend(item.path
-                                 for item in sort.sort(album.items()))
-            item_type = 'album'
+                    paths.extend(
+                        item.path for item in sort.sort(album.items())
+                    )
+            item_type = "album"
 
         # Perform item query and add tracks to playlist.
         else:
             selection = lib.items(ui.decargs(args))
             paths = [item.path for item in selection]
-            item_type = 'track'
+            item_type = "track"
 
         if relative_to:
             paths = [relpath(path, relative_to) for path in paths]
 
         if not selection:
-            ui.print_(ui.colorize('text_warning',
-                                  u'No {0} to play.'.format(item_type)))
+            ui.print_(
+                ui.colorize(
+                    "text_warning", u"No {0} to play.".format(item_type)
+                )
+            )
             return
 
         open_args = self._playlist_or_paths(paths)
@@ -133,14 +146,16 @@ class PlayPlugin(BeetsPlugin):
         # Check if the selection exceeds configured threshold. If True,
         # cancel, otherwise proceed with play command.
         if opts.yes or not self._exceeds_threshold(
-                selection, command_str, open_args, item_type):
-            play(command_str, selection, paths, open_args, self._log,
-                 item_type)
+            selection, command_str, open_args, item_type
+        ):
+            play(
+                command_str, selection, paths, open_args, self._log, item_type
+            )
 
     def _command_str(self, args=None):
         """Create a command string from the config command and optional args.
         """
-        command_str = config['play']['command'].get()
+        command_str = config["play"]["command"].get()
         if not command_str:
             return util.open_anything()
         # Add optional arguments to the player command.
@@ -156,29 +171,34 @@ class PlayPlugin(BeetsPlugin):
     def _playlist_or_paths(self, paths):
         """Return either the raw paths of items or a playlist of the items.
         """
-        if config['play']['raw']:
+        if config["play"]["raw"]:
             return paths
         else:
             return [self._create_tmp_playlist(paths)]
 
-    def _exceeds_threshold(self, selection, command_str, open_args,
-                           item_type='track'):
+    def _exceeds_threshold(
+        self, selection, command_str, open_args, item_type="track"
+    ):
         """Prompt user whether to abort if playlist exceeds threshold. If
         True, cancel playback. If False, execute play command.
         """
-        warning_threshold = config['play']['warning_threshold'].get(int)
+        warning_threshold = config["play"]["warning_threshold"].get(int)
 
         # Warn user before playing any huge playlists.
         if warning_threshold and len(selection) > warning_threshold:
             if len(selection) > 1:
-                item_type += 's'
+                item_type += "s"
 
-            ui.print_(ui.colorize(
-                'text_warning',
-                u'You are about to queue {0} {1}.'.format(
-                    len(selection), item_type)))
+            ui.print_(
+                ui.colorize(
+                    "text_warning",
+                    u"You are about to queue {0} {1}.".format(
+                        len(selection), item_type
+                    ),
+                )
+            )
 
-            if ui.input_options((u'Continue', u'Abort')) == 'a':
+            if ui.input_options((u"Continue", u"Abort")) == "a":
                 return True
 
         return False
@@ -186,21 +206,21 @@ class PlayPlugin(BeetsPlugin):
     def _create_tmp_playlist(self, paths_list):
         """Create a temporary .m3u file. Return the filename.
         """
-        utf8_bom = config['play']['bom'].get(bool)
-        m3u = NamedTemporaryFile('wb', suffix='.m3u', delete=False)
+        utf8_bom = config["play"]["bom"].get(bool)
+        m3u = NamedTemporaryFile("wb", suffix=".m3u", delete=False)
 
         if utf8_bom:
-            m3u.write(b'\xEF\xBB\xBF')
+            m3u.write(b"\xEF\xBB\xBF")
 
         for item in paths_list:
-            m3u.write(item + b'\n')
+            m3u.write(item + b"\n")
         m3u.close()
         return m3u.name
 
     def before_choose_candidate_listener(self, session, task):
         """Append a "Play" choice to the interactive importer prompt.
         """
-        return [PromptChoice('y', 'plaY', self.importer_play)]
+        return [PromptChoice("y", "plaY", self.importer_play)]
 
     def importer_play(self, session, task):
         """Get items from current import task and send to play function.
@@ -212,5 +232,11 @@ class PlayPlugin(BeetsPlugin):
         command_str = self._command_str()
 
         if not self._exceeds_threshold(selection, command_str, open_args):
-            play(command_str, selection, paths, open_args, self._log,
-                 keep_open=True)
+            play(
+                command_str,
+                selection,
+                paths,
+                open_args,
+                self._log,
+                keep_open=True,
+            )

--- a/beetsplug/playlist.py
+++ b/beetsplug/playlist.py
@@ -24,54 +24,59 @@ from beets.util import path_as_posix
 class PlaylistQuery(beets.dbcore.Query):
     """Matches files listed by a playlist file.
     """
+
     def __init__(self, pattern):
         self.pattern = pattern
-        config = beets.config['playlist']
+        config = beets.config["playlist"]
 
         # Get the full path to the playlist
         playlist_paths = (
             pattern,
-            os.path.abspath(os.path.join(
-                config['playlist_dir'].as_filename(),
-                '{0}.m3u'.format(pattern),
-            )),
+            os.path.abspath(
+                os.path.join(
+                    config["playlist_dir"].as_filename(),
+                    "{0}.m3u".format(pattern),
+                )
+            ),
         )
 
         self.paths = []
         for playlist_path in playlist_paths:
-            if not fnmatch.fnmatch(playlist_path, '*.[mM]3[uU]'):
+            if not fnmatch.fnmatch(playlist_path, "*.[mM]3[uU]"):
                 # This is not am M3U playlist, skip this candidate
                 continue
 
             try:
-                f = open(beets.util.syspath(playlist_path), mode='rb')
+                f = open(beets.util.syspath(playlist_path), mode="rb")
             except (OSError, IOError):
                 continue
 
-            if config['relative_to'].get() == 'library':
-                relative_to = beets.config['directory'].as_filename()
-            elif config['relative_to'].get() == 'playlist':
+            if config["relative_to"].get() == "library":
+                relative_to = beets.config["directory"].as_filename()
+            elif config["relative_to"].get() == "playlist":
                 relative_to = os.path.dirname(playlist_path)
             else:
-                relative_to = config['relative_to'].as_filename()
+                relative_to = config["relative_to"].as_filename()
             relative_to = beets.util.bytestring_path(relative_to)
 
             for line in f:
-                if line[0] == '#':
+                if line[0] == "#":
                     # ignore comments, and extm3u extension
                     continue
 
-                self.paths.append(beets.util.normpath(
-                    os.path.join(relative_to, line.rstrip())
-                ))
+                self.paths.append(
+                    beets.util.normpath(
+                        os.path.join(relative_to, line.rstrip())
+                    )
+                )
             f.close()
             break
 
     def col_clause(self):
         if not self.paths:
             # Playlist is empty
-            return '0', ()
-        clause = 'path IN ({0})'.format(', '.join('?' for path in self.paths))
+            return "0", ()
+        clause = "path IN ({0})".format(", ".join("?" for path in self.paths))
         return clause, (beets.library.BLOB_TYPE(p) for p in self.paths)
 
     def match(self, item):
@@ -79,33 +84,37 @@ class PlaylistQuery(beets.dbcore.Query):
 
 
 class PlaylistPlugin(beets.plugins.BeetsPlugin):
-    item_queries = {'playlist': PlaylistQuery}
+    item_queries = {"playlist": PlaylistQuery}
 
     def __init__(self):
         super(PlaylistPlugin, self).__init__()
-        self.config.add({
-            'auto': False,
-            'playlist_dir': '.',
-            'relative_to': 'library',
-            'forward_slash': False,
-        })
+        self.config.add(
+            {
+                "auto": False,
+                "playlist_dir": ".",
+                "relative_to": "library",
+                "forward_slash": False,
+            }
+        )
 
-        self.playlist_dir = self.config['playlist_dir'].as_filename()
+        self.playlist_dir = self.config["playlist_dir"].as_filename()
         self.changes = {}
 
-        if self.config['relative_to'].get() == 'library':
+        if self.config["relative_to"].get() == "library":
             self.relative_to = beets.util.bytestring_path(
-                beets.config['directory'].as_filename())
-        elif self.config['relative_to'].get() != 'playlist':
+                beets.config["directory"].as_filename()
+            )
+        elif self.config["relative_to"].get() != "playlist":
             self.relative_to = beets.util.bytestring_path(
-                self.config['relative_to'].as_filename())
+                self.config["relative_to"].as_filename()
+            )
         else:
             self.relative_to = None
 
-        if self.config['auto']:
-            self.register_listener('item_moved', self.item_moved)
-            self.register_listener('item_removed', self.item_removed)
-            self.register_listener('cli_exit', self.cli_exit)
+        if self.config["auto"]:
+            self.register_listener("item_moved", self.item_moved)
+            self.register_listener("item_removed", self.item_removed)
+            self.register_listener("cli_exit", self.cli_exit)
 
     def item_moved(self, item, source, destination):
         self.changes[source] = destination
@@ -116,29 +125,36 @@ class PlaylistPlugin(beets.plugins.BeetsPlugin):
 
     def cli_exit(self, lib):
         for playlist in self.find_playlists():
-            self._log.info('Updating playlist: {0}'.format(playlist))
+            self._log.info("Updating playlist: {0}".format(playlist))
             base_dir = beets.util.bytestring_path(
-                self.relative_to if self.relative_to
+                self.relative_to
+                if self.relative_to
                 else os.path.dirname(playlist)
             )
 
             try:
                 self.update_playlist(playlist, base_dir)
             except beets.util.FilesystemError:
-                self._log.error('Failed to update playlist: {0}'.format(
-                    beets.util.displayable_path(playlist)))
+                self._log.error(
+                    "Failed to update playlist: {0}".format(
+                        beets.util.displayable_path(playlist)
+                    )
+                )
 
     def find_playlists(self):
         """Find M3U playlists in the playlist directory."""
         try:
             dir_contents = os.listdir(beets.util.syspath(self.playlist_dir))
         except OSError:
-            self._log.warning('Unable to open playlist directory {0}'.format(
-                beets.util.displayable_path(self.playlist_dir)))
+            self._log.warning(
+                "Unable to open playlist directory {0}".format(
+                    beets.util.displayable_path(self.playlist_dir)
+                )
+            )
             return
 
         for filename in dir_contents:
-            if fnmatch.fnmatch(filename, '*.[mM]3[uU]'):
+            if fnmatch.fnmatch(filename, "*.[mM]3[uU]"):
                 yield os.path.join(self.playlist_dir, filename)
 
     def update_playlist(self, filename, base_dir):
@@ -146,11 +162,11 @@ class PlaylistPlugin(beets.plugins.BeetsPlugin):
         changes = 0
         deletions = 0
 
-        with tempfile.NamedTemporaryFile(mode='w+b', delete=False) as tempfp:
+        with tempfile.NamedTemporaryFile(mode="w+b", delete=False) as tempfp:
             new_playlist = tempfp.name
-            with open(filename, mode='rb') as fp:
+            with open(filename, mode="rb") as fp:
                 for line in fp:
-                    original_path = line.rstrip(b'\r\n')
+                    original_path = line.rstrip(b"\r\n")
 
                     # Ensure that path from playlist is absolute
                     is_relative = not os.path.isabs(line)
@@ -162,7 +178,7 @@ class PlaylistPlugin(beets.plugins.BeetsPlugin):
                     try:
                         new_path = self.changes[beets.util.normpath(lookup)]
                     except KeyError:
-                        if self.config['forward_slash']:
+                        if self.config["forward_slash"]:
                             line = path_as_posix(line)
                         tempfp.write(line)
                     else:
@@ -175,13 +191,15 @@ class PlaylistPlugin(beets.plugins.BeetsPlugin):
                         if is_relative:
                             new_path = os.path.relpath(new_path, base_dir)
                         line = line.replace(original_path, new_path)
-                        if self.config['forward_slash']:
+                        if self.config["forward_slash"]:
                             line = path_as_posix(line)
                         tempfp.write(line)
 
         if changes or deletions:
             self._log.info(
-                'Updated playlist {0} ({1} changes, {2} deletions)'.format(
-                    filename, changes, deletions))
+                "Updated playlist {0} ({1} changes, {2} deletions)".format(
+                    filename, changes, deletions
+                )
+            )
             beets.util.copy(new_playlist, filename, replace=True)
         beets.util.remove(new_playlist)

--- a/beetsplug/plexupdate.py
+++ b/beetsplug/plexupdate.py
@@ -18,40 +18,44 @@ from beets import config
 from beets.plugins import BeetsPlugin
 
 
-def get_music_section(host, port, token, library_name, secure,
-                      ignore_cert_errors):
+def get_music_section(
+    host, port, token, library_name, secure, ignore_cert_errors
+):
     """Getting the section key for the music library in Plex.
     """
-    api_endpoint = append_token('library/sections', token)
-    url = urljoin('{0}://{1}:{2}'.format(get_protocol(secure), host,
-                  port), api_endpoint)
+    api_endpoint = append_token("library/sections", token)
+    url = urljoin(
+        "{0}://{1}:{2}".format(get_protocol(secure), host, port), api_endpoint
+    )
 
     # Sends request.
     r = requests.get(url, verify=not ignore_cert_errors)
 
     # Parse xml tree and extract music section key.
     tree = ElementTree.fromstring(r.content)
-    for child in tree.findall('Directory'):
-        if child.get('title') == library_name:
-            return child.get('key')
+    for child in tree.findall("Directory"):
+        if child.get("title") == library_name:
+            return child.get("key")
 
 
-def update_plex(host, port, token, library_name, secure,
-                ignore_cert_errors):
+def update_plex(host, port, token, library_name, secure, ignore_cert_errors):
     """Ignore certificate errors if configured to.
     """
     if ignore_cert_errors:
         import urllib3
+
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
     """Sends request to the Plex api to start a library refresh.
     """
     # Getting section key and build url.
-    section_key = get_music_section(host, port, token, library_name,
-                                    secure, ignore_cert_errors)
-    api_endpoint = 'library/sections/{0}/refresh'.format(section_key)
+    section_key = get_music_section(
+        host, port, token, library_name, secure, ignore_cert_errors
+    )
+    api_endpoint = "library/sections/{0}/refresh".format(section_key)
     api_endpoint = append_token(api_endpoint, token)
-    url = urljoin('{0}://{1}:{2}'.format(get_protocol(secure), host,
-                  port), api_endpoint)
+    url = urljoin(
+        "{0}://{1}:{2}".format(get_protocol(secure), host, port), api_endpoint
+    )
 
     # Sends request and returns requests object.
     r = requests.get(url, verify=not ignore_cert_errors)
@@ -62,15 +66,15 @@ def append_token(url, token):
     """Appends the Plex Home token to the api call if required.
     """
     if token:
-        url += '?' + urlencode({'X-Plex-Token': token})
+        url += "?" + urlencode({"X-Plex-Token": token})
     return url
 
 
 def get_protocol(secure):
     if secure:
-        return 'https'
+        return "https"
     else:
-        return 'http'
+        return "http"
 
 
 class PlexUpdate(BeetsPlugin):
@@ -78,36 +82,40 @@ class PlexUpdate(BeetsPlugin):
         super(PlexUpdate, self).__init__()
 
         # Adding defaults.
-        config['plex'].add({
-            u'host': u'localhost',
-            u'port': 32400,
-            u'token': u'',
-            u'library_name': u'Music',
-            u'secure': False,
-            u'ignore_cert_errors': False})
+        config["plex"].add(
+            {
+                u"host": u"localhost",
+                u"port": 32400,
+                u"token": u"",
+                u"library_name": u"Music",
+                u"secure": False,
+                u"ignore_cert_errors": False,
+            }
+        )
 
-        config['plex']['token'].redact = True
-        self.register_listener('database_change', self.listen_for_db_change)
+        config["plex"]["token"].redact = True
+        self.register_listener("database_change", self.listen_for_db_change)
 
     def listen_for_db_change(self, lib, model):
         """Listens for beets db change and register the update for the end"""
-        self.register_listener('cli_exit', self.update)
+        self.register_listener("cli_exit", self.update)
 
     def update(self, lib):
         """When the client exists try to send refresh request to Plex server.
         """
-        self._log.info(u'Updating Plex library...')
+        self._log.info(u"Updating Plex library...")
 
         # Try to send update request.
         try:
             update_plex(
-                config['plex']['host'].get(),
-                config['plex']['port'].get(),
-                config['plex']['token'].get(),
-                config['plex']['library_name'].get(),
-                config['plex']['secure'].get(bool),
-                config['plex']['ignore_cert_errors'].get(bool))
-            self._log.info(u'... started.')
+                config["plex"]["host"].get(),
+                config["plex"]["port"].get(),
+                config["plex"]["token"].get(),
+                config["plex"]["library_name"].get(),
+                config["plex"]["secure"].get(bool),
+                config["plex"]["ignore_cert_errors"].get(bool),
+            )
+            self._log.info(u"... started.")
 
         except requests.exceptions.RequestException:
-            self._log.warning(u'Update failed.')
+            self._log.warning(u"Update failed.")

--- a/beetsplug/random.py
+++ b/beetsplug/random.py
@@ -33,23 +33,35 @@ def random_func(lib, opts, args):
         objs = list(lib.items(query))
 
     # Print a random subset.
-    objs = random_objs(objs, opts.album, opts.number, opts.time,
-                       opts.equal_chance)
+    objs = random_objs(
+        objs, opts.album, opts.number, opts.time, opts.equal_chance
+    )
     for obj in objs:
         print_(format(obj))
 
 
-random_cmd = Subcommand('random',
-                        help=u'choose a random track or album')
+random_cmd = Subcommand("random", help=u"choose a random track or album")
 random_cmd.parser.add_option(
-    u'-n', u'--number', action='store', type="int",
-    help=u'number of objects to choose', default=1)
+    u"-n",
+    u"--number",
+    action="store",
+    type="int",
+    help=u"number of objects to choose",
+    default=1,
+)
 random_cmd.parser.add_option(
-    u'-e', u'--equal-chance', action='store_true',
-    help=u'each artist has the same chance')
+    u"-e",
+    u"--equal-chance",
+    action="store_true",
+    help=u"each artist has the same chance",
+)
 random_cmd.parser.add_option(
-    u'-t', u'--time', action='store', type="float",
-    help=u'total length in minutes of objects to choose')
+    u"-t",
+    u"--time",
+    action="store",
+    type="float",
+    help=u"total length in minutes of objects to choose",
+)
 random_cmd.parser.add_all_common_options()
 random_cmd.func = random_func
 

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -28,11 +28,17 @@ from six.moves import zip
 
 from beets import ui
 from beets.plugins import BeetsPlugin
-from beets.util import (syspath, command_output, bytestring_path,
-                        displayable_path, py3_path)
+from beets.util import (
+    syspath,
+    command_output,
+    bytestring_path,
+    displayable_path,
+    py3_path,
+)
 
 
 # Utilities.
+
 
 class ReplayGainError(Exception):
     """Raised when a local (to a track or an album) error occurs in one
@@ -68,8 +74,9 @@ def call(args, **kwargs):
 
 
 def after_version(version_a, version_b):
-    return tuple(int(s) for s in version_a.split('.')) \
-            >= tuple(int(s) for s in version_b.split('.'))
+    return tuple(int(s) for s in version_a.split(".")) >= tuple(
+        int(s) for s in version_b.split(".")
+    )
 
 
 def db_to_lufs(db):
@@ -143,29 +150,26 @@ class Bs1770gainBackend(Backend):
 
     def __init__(self, config, log):
         super(Bs1770gainBackend, self).__init__(config, log)
-        config.add({
-            'chunk_at': 5000,
-            'method': '',
-        })
-        self.chunk_at = config['chunk_at'].as_number()
+        config.add(
+            {"chunk_at": 5000, "method": "",}
+        )
+        self.chunk_at = config["chunk_at"].as_number()
         # backward compatibility to `method` config option
-        self.__method = config['method'].as_str()
+        self.__method = config["method"].as_str()
 
-        cmd = 'bs1770gain'
+        cmd = "bs1770gain"
         try:
-            version_out = call([cmd, '--version'])
+            version_out = call([cmd, "--version"])
             self.command = cmd
             self.version = re.search(
-                'bs1770gain ([0-9]+.[0-9]+.[0-9]+), ',
-                version_out.stdout.decode('utf-8')
+                "bs1770gain ([0-9]+.[0-9]+.[0-9]+), ",
+                version_out.stdout.decode("utf-8"),
             ).group(1)
         except OSError:
-            raise FatalReplayGainError(
-                u'Is bs1770gain installed?'
-            )
+            raise FatalReplayGainError(u"Is bs1770gain installed?")
         if not self.command:
             raise FatalReplayGainError(
-                u'no replaygain command found: install bs1770gain'
+                u"no replaygain command found: install bs1770gain"
             )
 
     def compute_track_gain(self, items, target_level, peak):
@@ -186,7 +190,7 @@ class Bs1770gainBackend(Backend):
         output = self.compute_gain(items, target_level, True)
 
         if not output:
-            raise ReplayGainError(u'no output from bs1770gain')
+            raise ReplayGainError(u"no output from bs1770gain")
         return AlbumGain(output[-1], output[:-1])
 
     def isplitter(self, items, chunk_at):
@@ -230,9 +234,7 @@ class Bs1770gainBackend(Backend):
             for chunk in self.isplitter(items, self.chunk_at):
                 i += 1
                 returnchunk = self.compute_chunk_gain(
-                    chunk,
-                    is_album,
-                    target_level
+                    chunk, is_album, target_level
                 )
                 albumgaintot += returnchunk[-1].gain
                 albumpeaktot = max(albumpeaktot, returnchunk[-1].peak)
@@ -251,8 +253,10 @@ class Bs1770gainBackend(Backend):
         if self.__method != "":
             # backward compatibility to `method` option
             method = self.__method
-            gain_adjustment = target_level \
+            gain_adjustment = (
+                target_level
                 - [k for k, v in self.methods.items() if v == method][0]
+            )
         elif target_level in self.methods:
             method = self.methods[target_level]
             gain_adjustment = 0
@@ -264,10 +268,10 @@ class Bs1770gainBackend(Backend):
         # Construct shell command.
         cmd = [self.command]
         cmd += ["--" + method]
-        cmd += ['--xml', '-p']
-        if after_version(self.version, '0.6.0'):
-            cmd += ['--unit=ebu']            # set units to LU
-            cmd += ['--suppress-progress']   # don't print % to XML output
+        cmd += ["--xml", "-p"]
+        if after_version(self.version, "0.6.0"):
+            cmd += ["--unit=ebu"]  # set units to LU
+            cmd += ["--suppress-progress"]  # don't print % to XML output
 
         # Workaround for Windows: the underlying tool fails on paths
         # with the \\?\ prefix, so we don't use it here. This
@@ -277,20 +281,19 @@ class Bs1770gainBackend(Backend):
 
         # Invoke the command.
         self._log.debug(
-            u'executing {0}', u' '.join(map(displayable_path, args))
+            u"executing {0}", u" ".join(map(displayable_path, args))
         )
         output = call(args).stdout
 
-        self._log.debug(u'analysis finished: {0}', output)
+        self._log.debug(u"analysis finished: {0}", output)
         results = self.parse_tool_output(output, path_list, is_album)
 
         if gain_adjustment:
             results = [
-                Gain(res.gain + gain_adjustment, res.peak)
-                for res in results
+                Gain(res.gain + gain_adjustment, res.peak) for res in results
             ]
 
-        self._log.debug(u'{0} items, {1} results', len(items), len(results))
+        self._log.debug(u"{0} items, {1} results", len(items), len(results))
         return results
 
     def parse_tool_output(self, text, path_list, is_album):
@@ -300,49 +303,58 @@ class Bs1770gainBackend(Backend):
         """
         per_file_gain = {}
         album_gain = {}  # mutable variable so it can be set from handlers
-        parser = xml.parsers.expat.ParserCreate(encoding='utf-8')
-        state = {'file': None, 'gain': None, 'peak': None}
-        album_state = {'gain': None, 'peak': None}
+        parser = xml.parsers.expat.ParserCreate(encoding="utf-8")
+        state = {"file": None, "gain": None, "peak": None}
+        album_state = {"gain": None, "peak": None}
 
         def start_element_handler(name, attrs):
-            if name == u'track':
-                state['file'] = bytestring_path(attrs[u'file'])
-                if state['file'] in per_file_gain:
+            if name == u"track":
+                state["file"] = bytestring_path(attrs[u"file"])
+                if state["file"] in per_file_gain:
                     raise ReplayGainError(
-                        u'duplicate filename in bs1770gain output')
-            elif name == u'integrated':
-                if 'lu' in attrs:
-                    state['gain'] = float(attrs[u'lu'])
-            elif name == u'sample-peak':
-                if 'factor' in attrs:
-                    state['peak'] = float(attrs[u'factor'])
-                elif 'amplitude' in attrs:
-                    state['peak'] = float(attrs[u'amplitude'])
+                        u"duplicate filename in bs1770gain output"
+                    )
+            elif name == u"integrated":
+                if "lu" in attrs:
+                    state["gain"] = float(attrs[u"lu"])
+            elif name == u"sample-peak":
+                if "factor" in attrs:
+                    state["peak"] = float(attrs[u"factor"])
+                elif "amplitude" in attrs:
+                    state["peak"] = float(attrs[u"amplitude"])
 
         def end_element_handler(name):
-            if name == u'track':
-                if state['gain'] is None or state['peak'] is None:
-                    raise ReplayGainError(u'could not parse gain or peak from '
-                                          'the output of bs1770gain')
-                per_file_gain[state['file']] = Gain(state['gain'],
-                                                    state['peak'])
-                state['gain'] = state['peak'] = None
-            elif name == u'summary':
-                if state['gain'] is None or state['peak'] is None:
-                    raise ReplayGainError(u'could not parse gain or peak from '
-                                          'the output of bs1770gain')
-                album_gain["album"] = Gain(state['gain'], state['peak'])
-                state['gain'] = state['peak'] = None
+            if name == u"track":
+                if state["gain"] is None or state["peak"] is None:
+                    raise ReplayGainError(
+                        u"could not parse gain or peak from "
+                        "the output of bs1770gain"
+                    )
+                per_file_gain[state["file"]] = Gain(
+                    state["gain"], state["peak"]
+                )
+                state["gain"] = state["peak"] = None
+            elif name == u"summary":
+                if state["gain"] is None or state["peak"] is None:
+                    raise ReplayGainError(
+                        u"could not parse gain or peak from "
+                        "the output of bs1770gain"
+                    )
+                album_gain["album"] = Gain(state["gain"], state["peak"])
+                state["gain"] = state["peak"] = None
             elif len(per_file_gain) == len(path_list):
-                if state['gain'] is not None:
-                    album_state['gain'] = state['gain']
-                if state['peak'] is not None:
-                    album_state['peak'] = state['peak']
-                if album_state['gain'] is not None \
-                        and album_state['peak'] is not None:
+                if state["gain"] is not None:
+                    album_state["gain"] = state["gain"]
+                if state["peak"] is not None:
+                    album_state["peak"] = state["peak"]
+                if (
+                    album_state["gain"] is not None
+                    and album_state["peak"] is not None
+                ):
                     album_gain["album"] = Gain(
-                        album_state['gain'], album_state['peak'])
-                state['gain'] = state['peak'] = None
+                        album_state["gain"], album_state["peak"]
+                    )
+                state["gain"] = state["peak"] = None
 
         parser.StartElementHandler = start_element_handler
         parser.EndElementHandler = end_element_handler
@@ -351,14 +363,15 @@ class Bs1770gainBackend(Backend):
             parser.Parse(text, True)
         except xml.parsers.expat.ExpatError:
             raise ReplayGainError(
-                u'The bs1770gain tool produced malformed XML. '
-                'Using version >=0.4.10 may solve this problem.'
+                u"The bs1770gain tool produced malformed XML. "
+                "Using version >=0.4.10 may solve this problem."
             )
 
         if len(per_file_gain) != len(path_list):
             raise ReplayGainError(
-                u'the number of results returned by bs1770gain does not match '
-                'the number of files passed to it')
+                u"the number of results returned by bs1770gain does not match "
+                "the number of files passed to it"
+            )
 
         # bs1770gain does not return the analysis results in the order that
         # files are passed on the command line, because it is sorting the files
@@ -367,8 +380,9 @@ class Bs1770gainBackend(Backend):
             out = [per_file_gain[os.path.basename(p)] for p in path_list]
         except KeyError:
             raise ReplayGainError(
-                u'unrecognized filename in bs1770gain output '
-                '(bs1770gain can only deal with utf-8 file names)')
+                u"unrecognized filename in bs1770gain output "
+                "(bs1770gain can only deal with utf-8 file names)"
+            )
         if is_album:
             out.append(album_gain["album"])
         return out
@@ -378,6 +392,7 @@ class Bs1770gainBackend(Backend):
 class FfmpegBackend(Backend):
     """A replaygain backend using ffmpeg's ebur128 filter.
     """
+
     def __init__(self, config, log):
         super(FfmpegBackend, self).__init__(config, log)
         self._ffmpeg_path = "ffmpeg"
@@ -414,11 +429,10 @@ class FfmpegBackend(Backend):
         for item in items:
             gains.append(
                 self._analyse_item(
-                    item,
-                    target_level,
-                    peak,
-                    count_blocks=False,
-                )[0]  # take only the gain, discarding number of gating blocks
+                    item, target_level, peak, count_blocks=False,
+                )[
+                    0
+                ]  # take only the gain, discarding number of gating blocks
             )
         return gains
 
@@ -456,7 +470,7 @@ class FfmpegBackend(Backend):
             # This reverses ITU-R BS.1770-4 p. 6 equation (5) to convert
             # from loudness to power. The result is the average gating
             # block power.
-            track_power = 10**((track_loudness + 0.691) / 10)
+            track_power = 10 ** ((track_loudness + 0.691) / 10)
 
             # Weight that average power by the number of gating blocks to
             # get the sum of all their powers. Add that to the sum of all
@@ -474,9 +488,8 @@ class FfmpegBackend(Backend):
         album_gain = target_level_lufs - album_gain
 
         self._log.debug(
-            u"{0}: gain {1} LU, peak {2}"
-            .format(items, album_gain, album_peak)
-            )
+            u"{0}: gain {1} LU, peak {2}".format(items, album_gain, album_peak)
+        )
 
         return AlbumGain(Gain(album_gain, album_peak), track_gains)
 
@@ -511,7 +524,7 @@ class FfmpegBackend(Backend):
         self._log.debug(u"analyzing {0}".format(item))
         cmd = self._construct_cmd(item, peak_method)
         self._log.debug(
-            u'executing {0}', u' '.join(map(displayable_path, cmd))
+            u"executing {0}", u" ".join(map(displayable_path, cmd))
         )
         output = call(cmd).stderr.splitlines()
 
@@ -523,26 +536,25 @@ class FfmpegBackend(Backend):
             line_peak = self._find_line(
                 output,
                 "  {0} peak:".format(peak_method.capitalize()).encode(),
-                start_line=len(output) - 1, step_size=-1,
+                start_line=len(output) - 1,
+                step_size=-1,
             )
             peak = self._parse_float(
-                output[self._find_line(
-                    output, b"    Peak:",
-                    line_peak,
-                )]
+                output[self._find_line(output, b"    Peak:", line_peak,)]
             )
             # convert TPFS -> part of FS
-            peak = 10**(peak / 20)
+            peak = 10 ** (peak / 20)
 
         line_integrated_loudness = self._find_line(
-            output, b"  Integrated loudness:",
-            start_line=len(output) - 1, step_size=-1,
+            output,
+            b"  Integrated loudness:",
+            start_line=len(output) - 1,
+            step_size=-1,
         )
         gain = self._parse_float(
-            output[self._find_line(
-                output, b"    I:",
-                line_integrated_loudness,
-            )]
+            output[
+                self._find_line(output, b"    I:", line_integrated_loudness,)
+            ]
         )
         # convert LUFS -> LU from target level
         gain = target_level_lufs - gain
@@ -551,10 +563,13 @@ class FfmpegBackend(Backend):
         n_blocks = 0
         if count_blocks:
             gating_threshold = self._parse_float(
-                output[self._find_line(
-                    output, b"    Threshold:",
-                    start_line=line_integrated_loudness,
-                )]
+                output[
+                    self._find_line(
+                        output,
+                        b"    Threshold:",
+                        start_line=line_integrated_loudness,
+                    )
+                ]
             )
             for line in output:
                 if not line.startswith(b"[Parsed_ebur128"):
@@ -567,14 +582,12 @@ class FfmpegBackend(Backend):
                 if self._parse_float(b"M: " + line[1]) >= gating_threshold:
                     n_blocks += 1
             self._log.debug(
-                u"{0}: {1} blocks over {2} LUFS"
-                .format(item, n_blocks, gating_threshold)
+                u"{0}: {1} blocks over {2} LUFS".format(
+                    item, n_blocks, gating_threshold
+                )
             )
 
-        self._log.debug(
-            u"{0}: gain {1} LU, peak {2}"
-            .format(item, gain, peak)
-        )
+        self._log.debug(u"{0}: gain {1} LU, peak {2}".format(item, gain, peak))
 
         return Gain(gain, peak), n_blocks
 
@@ -588,9 +601,10 @@ class FfmpegBackend(Backend):
             if output[i].startswith(search):
                 return i
         raise ReplayGainError(
-            u"ffmpeg output: missing {0} after line {1}"
-            .format(repr(search), start_line)
+            u"ffmpeg output: missing {0} after line {1}".format(
+                repr(search), start_line
             )
+        )
 
     def _parse_float(self, line):
         """Extract a float from a key value pair in `line`.
@@ -602,9 +616,10 @@ class FfmpegBackend(Backend):
         value = line.split(b":", 1)
         if len(value) < 2:
             raise ReplayGainError(
-                u"ffmpeg output: expected key value pair, found {0}"
-                .format(line)
+                u"ffmpeg output: expected key value pair, found {0}".format(
+                    line
                 )
+            )
         value = value[1].lstrip()
         # strip unit
         value = value.split(b" ", 1)[0]
@@ -613,20 +628,17 @@ class FfmpegBackend(Backend):
             return float(value)
         except ValueError:
             raise ReplayGainError(
-                u"ffmpeg output: expected float value, found {0}"
-                .format(value)
-                )
+                u"ffmpeg output: expected float value, found {0}".format(value)
+            )
 
 
 # mpgain/aacgain CLI tool backend.
 class CommandBackend(Backend):
-
     def __init__(self, config, log):
         super(CommandBackend, self).__init__(config, log)
-        config.add({
-            'command': u"",
-            'noclip': True,
-        })
+        config.add(
+            {"command": u"", "noclip": True,}
+        )
 
         self.command = config["command"].as_str()
 
@@ -634,23 +646,24 @@ class CommandBackend(Backend):
             # Explicit executable path.
             if not os.path.isfile(self.command):
                 raise FatalReplayGainError(
-                    u'replaygain command does not exist: {0}'.format(
-                        self.command)
+                    u"replaygain command does not exist: {0}".format(
+                        self.command
+                    )
                 )
         else:
             # Check whether the program is in $PATH.
-            for cmd in ('mp3gain', 'aacgain'):
+            for cmd in ("mp3gain", "aacgain"):
                 try:
-                    call([cmd, '-v'])
+                    call([cmd, "-v"])
                     self.command = cmd
                 except OSError:
                     pass
         if not self.command:
             raise FatalReplayGainError(
-                u'no replaygain command found: install mp3gain or aacgain'
+                u"no replaygain command found: install mp3gain or aacgain"
             )
 
-        self.noclip = config['noclip'].get(bool)
+        self.noclip = config["noclip"].get(bool)
 
     def compute_track_gain(self, items, target_level, peak):
         """Computes the track gain of the given tracks, returns a list
@@ -669,7 +682,7 @@ class CommandBackend(Backend):
 
         supported_items = list(filter(self.format_supported, items))
         if len(supported_items) != len(items):
-            self._log.debug(u'tracks are of unsupported format')
+            self._log.debug(u"tracks are of unsupported format")
             return AlbumGain(None, [])
 
         output = self.compute_gain(supported_items, target_level, True)
@@ -678,9 +691,9 @@ class CommandBackend(Backend):
     def format_supported(self, item):
         """Checks whether the given item is supported by the selected tool.
         """
-        if 'mp3gain' in self.command and item.format != 'MP3':
+        if "mp3gain" in self.command and item.format != "MP3":
             return False
-        elif 'aacgain' in self.command and item.format not in ('MP3', 'AAC'):
+        elif "aacgain" in self.command and item.format not in ("MP3", "AAC"):
             return False
         return True
 
@@ -692,7 +705,7 @@ class CommandBackend(Backend):
         the album gain
         """
         if len(items) == 0:
-            self._log.debug(u'no supported tracks to analyze')
+            self._log.debug(u"no supported tracks to analyze")
             return []
 
         """Compute ReplayGain values and return a list of results
@@ -704,22 +717,23 @@ class CommandBackend(Backend):
         # tag-writing; this turns the mp3gain/aacgain tool into a gain
         # calculator rather than a tag manipulator because we take care
         # of changing tags ourselves.
-        cmd = [self.command, '-o', '-s', 's']
+        cmd = [self.command, "-o", "-s", "s"]
         if self.noclip:
             # Adjust to avoid clipping.
-            cmd = cmd + ['-k']
+            cmd = cmd + ["-k"]
         else:
             # Disable clipping warning.
-            cmd = cmd + ['-c']
-        cmd = cmd + ['-d', str(int(target_level - 89))]
+            cmd = cmd + ["-c"]
+        cmd = cmd + ["-d", str(int(target_level - 89))]
         cmd = cmd + [syspath(i.path) for i in items]
 
-        self._log.debug(u'analyzing {0} files', len(items))
+        self._log.debug(u"analyzing {0} files", len(items))
         self._log.debug(u"executing {0}", " ".join(map(displayable_path, cmd)))
         output = call(cmd).stdout
-        self._log.debug(u'analysis finished')
-        return self.parse_tool_output(output,
-                                      len(items) + (1 if is_album else 0))
+        self._log.debug(u"analysis finished")
+        return self.parse_tool_output(
+            output, len(items) + (1 if is_album else 0)
+        )
 
     def parse_tool_output(self, text, num_lines):
         """Given the tab-delimited output from an invocation of mp3gain
@@ -727,28 +741,27 @@ class CommandBackend(Backend):
         containing information about each analyzed file.
         """
         out = []
-        for line in text.split(b'\n')[1:num_lines + 1]:
-            parts = line.split(b'\t')
-            if len(parts) != 6 or parts[0] == b'File':
-                self._log.debug(u'bad tool output: {0}', text)
-                raise ReplayGainError(u'mp3gain failed')
+        for line in text.split(b"\n")[1 : num_lines + 1]:
+            parts = line.split(b"\t")
+            if len(parts) != 6 or parts[0] == b"File":
+                self._log.debug(u"bad tool output: {0}", text)
+                raise ReplayGainError(u"mp3gain failed")
             d = {
-                'file': parts[0],
-                'mp3gain': int(parts[1]),
-                'gain': float(parts[2]),
-                'peak': float(parts[3]) / (1 << 15),
-                'maxgain': int(parts[4]),
-                'mingain': int(parts[5]),
-
+                "file": parts[0],
+                "mp3gain": int(parts[1]),
+                "gain": float(parts[2]),
+                "peak": float(parts[3]) / (1 << 15),
+                "maxgain": int(parts[4]),
+                "mingain": int(parts[5]),
             }
-            out.append(Gain(d['gain'], d['peak']))
+            out.append(Gain(d["gain"], d["peak"]))
         return out
 
 
 # GStreamer-based backend.
 
-class GStreamerBackend(Backend):
 
+class GStreamerBackend(Backend):
     def __init__(self, config, log):
         super(GStreamerBackend, self).__init__(config, log)
         self._import_gst()
@@ -764,8 +777,13 @@ class GStreamerBackend(Backend):
         self._res = self.Gst.ElementFactory.make("audioresample", "res")
         self._rg = self.Gst.ElementFactory.make("rganalysis", "rg")
 
-        if self._src is None or self._decbin is None or self._conv is None \
-           or self._res is None or self._rg is None:
+        if (
+            self._src is None
+            or self._decbin is None
+            or self._conv is None
+            or self._res is None
+            or self._rg is None
+        ):
             raise FatalGstreamerPluginReplayGainError(
                 u"Failed to load required GStreamer plugins"
             )
@@ -816,13 +834,14 @@ class GStreamerBackend(Backend):
             )
 
         try:
-            gi.require_version('Gst', '1.0')
+            gi.require_version("Gst", "1.0")
         except ValueError as e:
             raise FatalReplayGainError(
                 u"Failed to load GStreamer 1.0: {0}".format(e)
             )
 
         from gi.repository import GObject, Gst, GLib
+
         # Calling GObject.threads_init() is not needed for
         # PyGObject 3.10.2+
         with warnings.catch_warnings():
@@ -860,8 +879,12 @@ class GStreamerBackend(Backend):
 
         ret = []
         for item in items:
-            ret.append(Gain(self._file_tags[item]["TRACK_GAIN"],
-                            self._file_tags[item]["TRACK_PEAK"]))
+            ret.append(
+                Gain(
+                    self._file_tags[item]["TRACK_GAIN"],
+                    self._file_tags[item]["TRACK_PEAK"],
+                )
+            )
 
         return ret
 
@@ -921,20 +944,25 @@ class GStreamerBackend(Backend):
             # store the computed tags, we overwrite the RG values of
             # received a second time.
             if tag == self.Gst.TAG_TRACK_GAIN:
-                self._file_tags[self._file]["TRACK_GAIN"] = \
-                    taglist.get_double(tag)[1]
+                self._file_tags[self._file]["TRACK_GAIN"] = taglist.get_double(
+                    tag
+                )[1]
             elif tag == self.Gst.TAG_TRACK_PEAK:
-                self._file_tags[self._file]["TRACK_PEAK"] = \
-                    taglist.get_double(tag)[1]
+                self._file_tags[self._file]["TRACK_PEAK"] = taglist.get_double(
+                    tag
+                )[1]
             elif tag == self.Gst.TAG_ALBUM_GAIN:
-                self._file_tags[self._file]["ALBUM_GAIN"] = \
-                    taglist.get_double(tag)[1]
+                self._file_tags[self._file]["ALBUM_GAIN"] = taglist.get_double(
+                    tag
+                )[1]
             elif tag == self.Gst.TAG_ALBUM_PEAK:
-                self._file_tags[self._file]["ALBUM_PEAK"] = \
-                    taglist.get_double(tag)[1]
+                self._file_tags[self._file]["ALBUM_PEAK"] = taglist.get_double(
+                    tag
+                )[1]
             elif tag == self.Gst.TAG_REFERENCE_LEVEL:
-                self._file_tags[self._file]["REFERENCE_LEVEL"] = \
-                    taglist.get_double(tag)[1]
+                self._file_tags[self._file][
+                    "REFERENCE_LEVEL"
+                ] = taglist.get_double(tag)[1]
 
         tags.foreach(handle_tag, None)
 
@@ -996,23 +1024,23 @@ class GStreamerBackend(Backend):
         if ret:
             # Seek to the beginning in order to clear the EOS state of the
             # various elements of the pipeline
-            self._pipe.seek_simple(self.Gst.Format.TIME,
-                                   self.Gst.SeekFlags.FLUSH,
-                                   0)
+            self._pipe.seek_simple(
+                self.Gst.Format.TIME, self.Gst.SeekFlags.FLUSH, 0
+            )
             self._pipe.set_state(self.Gst.State.PLAYING)
 
         return ret
 
     def _on_pad_added(self, decbin, pad):
         sink_pad = self._conv.get_compatible_pad(pad, None)
-        assert(sink_pad is not None)
+        assert sink_pad is not None
         pad.link(sink_pad)
 
     def _on_pad_removed(self, decbin, pad):
         # Called when the decodebin element is disconnected from the
         # rest of the pipeline while switching input files
         peer = pad.get_peer()
-        assert(peer is None)
+        assert peer is None
 
 
 class AudioToolsBackend(Backend):
@@ -1053,9 +1081,7 @@ class AudioToolsBackend(Backend):
         try:
             audiofile = self._mod_audiotools.open(py3_path(syspath(item.path)))
         except IOError:
-            raise ReplayGainError(
-                u"File {} was not found".format(item.path)
-            )
+            raise ReplayGainError(u"File {} was not found".format(item.path))
         except self._mod_audiotools.UnsupportedFile:
             raise ReplayGainError(
                 u"Unsupported file type {}".format(item.format)
@@ -1077,7 +1103,8 @@ class AudioToolsBackend(Backend):
             rg = self._mod_replaygain.ReplayGain(audiofile.sample_rate())
         except ValueError:
             raise ReplayGainError(
-                u"Unsupported sample rate {}".format(item.samplerate))
+                u"Unsupported sample rate {}".format(item.samplerate)
+            )
             return
         return rg
 
@@ -1109,8 +1136,8 @@ class AudioToolsBackend(Backend):
         except ValueError as exc:
             # `audiotools.replaygain` can raise a `ValueError` if the sample
             # rate is incorrect.
-            self._log.debug(u'error in rg.title_gain() call: {}', exc)
-            raise ReplayGainError(u'audiotools audio data error')
+            self._log.debug(u"error in rg.title_gain() call: {}", exc)
+            raise ReplayGainError(u"audiotools audio data error")
         return self._with_target_level(gain, target_level), peak
 
     def _compute_track_gain(self, item, target_level):
@@ -1127,8 +1154,13 @@ class AudioToolsBackend(Backend):
             rg, audiofile, target_level
         )
 
-        self._log.debug(u'ReplayGain for track {0} - {1}: {2:.2f}, {3:.2f}',
-                        item.artist, item.title, rg_track_gain, rg_track_peak)
+        self._log.debug(
+            u"ReplayGain for track {0} - {1}: {2:.2f}, {3:.2f}",
+            item.artist,
+            item.title,
+            rg_track_gain,
+            rg_track_peak,
+        )
         return Gain(gain=rg_track_gain, peak=rg_track_peak)
 
     def compute_album_gain(self, items, target_level, peak):
@@ -1149,26 +1181,33 @@ class AudioToolsBackend(Backend):
             rg_track_gain, rg_track_peak = self._title_gain(
                 rg, audiofile, target_level
             )
-            track_gains.append(
-                Gain(gain=rg_track_gain, peak=rg_track_peak)
+            track_gains.append(Gain(gain=rg_track_gain, peak=rg_track_peak))
+            self._log.debug(
+                u"ReplayGain for track {0}: {1:.2f}, {2:.2f}",
+                item,
+                rg_track_gain,
+                rg_track_peak,
             )
-            self._log.debug(u'ReplayGain for track {0}: {1:.2f}, {2:.2f}',
-                            item, rg_track_gain, rg_track_peak)
 
         # After getting the values for all tracks, it's possible to get the
         # album values.
         rg_album_gain, rg_album_peak = rg.album_gain()
         rg_album_gain = self._with_target_level(rg_album_gain, target_level)
-        self._log.debug(u'ReplayGain for album {0}: {1:.2f}, {2:.2f}',
-                        items[0].album, rg_album_gain, rg_album_peak)
+        self._log.debug(
+            u"ReplayGain for album {0}: {1:.2f}, {2:.2f}",
+            items[0].album,
+            rg_album_gain,
+            rg_album_peak,
+        )
 
         return AlbumGain(
             Gain(gain=rg_album_gain, peak=rg_album_peak),
-            track_gains=track_gains
+            track_gains=track_gains,
         )
 
 
 # Main plugin logic.
+
 
 class ReplayGainPlugin(BeetsPlugin):
     """Provides ReplayGain analysis.
@@ -1191,26 +1230,27 @@ class ReplayGainPlugin(BeetsPlugin):
         super(ReplayGainPlugin, self).__init__()
 
         # default backend is 'command' for backward-compatibility.
-        self.config.add({
-            'overwrite': False,
-            'auto': True,
-            'backend': u'command',
-            'per_disc': False,
-            'peak': 'true',
-            'targetlevel': 89,
-            'r128': ['Opus'],
-            'r128_targetlevel': lufs_to_db(-23),
-        })
+        self.config.add(
+            {
+                "overwrite": False,
+                "auto": True,
+                "backend": u"command",
+                "per_disc": False,
+                "peak": "true",
+                "targetlevel": 89,
+                "r128": ["Opus"],
+                "r128_targetlevel": lufs_to_db(-23),
+            }
+        )
 
-        self.overwrite = self.config['overwrite'].get(bool)
-        self.per_disc = self.config['per_disc'].get(bool)
-        backend_name = self.config['backend'].as_str()
+        self.overwrite = self.config["overwrite"].get(bool)
+        self.per_disc = self.config["per_disc"].get(bool)
+        backend_name = self.config["backend"].as_str()
         if backend_name not in self.backends:
             raise ui.UserError(
                 u"Selected ReplayGain backend {0} is not supported. "
                 u"Please select one of: {1}".format(
-                    backend_name,
-                    u', '.join(self.backends.keys())
+                    backend_name, u", ".join(self.backends.keys())
                 )
             )
         peak_method = self.config["peak"].as_str()
@@ -1218,18 +1258,17 @@ class ReplayGainPlugin(BeetsPlugin):
             raise ui.UserError(
                 u"Selected ReplayGain peak method {0} is not supported. "
                 u"Please select one of: {1}".format(
-                    peak_method,
-                    u', '.join(self.peak_methods.keys())
+                    peak_method, u", ".join(self.peak_methods.keys())
                 )
             )
         self._peak_method = self.peak_methods[peak_method]
 
         # On-import analysis.
-        if self.config['auto']:
+        if self.config["auto"]:
             self.import_stages = [self.imported]
 
         # Formats to use R128.
-        self.r128_whitelist = self.config['r128'].as_str_seq()
+        self.r128_whitelist = self.config["r128"].as_str_seq()
 
         try:
             self.backend_instance = self.backends[backend_name](
@@ -1237,7 +1276,8 @@ class ReplayGainPlugin(BeetsPlugin):
             )
         except (ReplayGainError, FatalReplayGainError) as e:
             raise ui.UserError(
-                u'replaygain initialization failed: {0}'.format(e))
+                u"replaygain initialization failed: {0}".format(e)
+            )
 
     def should_use_r128(self, item):
         """Checks the plugin setting to decide whether the calculation
@@ -1246,50 +1286,72 @@ class ReplayGainPlugin(BeetsPlugin):
         return item.format in self.r128_whitelist
 
     def track_requires_gain(self, item):
-        return self.overwrite or \
-            (self.should_use_r128(item) and not item.r128_track_gain) or \
-            (not self.should_use_r128(item) and
-                (not item.rg_track_gain or not item.rg_track_peak))
+        return (
+            self.overwrite
+            or (self.should_use_r128(item) and not item.r128_track_gain)
+            or (
+                not self.should_use_r128(item)
+                and (not item.rg_track_gain or not item.rg_track_peak)
+            )
+        )
 
     def album_requires_gain(self, album):
         # Skip calculating gain only when *all* files don't need
         # recalculation. This way, if any file among an album's tracks
         # needs recalculation, we still get an accurate album gain
         # value.
-        return self.overwrite or \
-            any([self.should_use_r128(item) and
-                (not item.r128_track_gain or not item.r128_album_gain)
-                for item in album.items()]) or \
-            any([not self.should_use_r128(item) and
-                (not item.rg_album_gain or not item.rg_album_peak)
-                for item in album.items()])
+        return (
+            self.overwrite
+            or any(
+                [
+                    self.should_use_r128(item)
+                    and (not item.r128_track_gain or not item.r128_album_gain)
+                    for item in album.items()
+                ]
+            )
+            or any(
+                [
+                    not self.should_use_r128(item)
+                    and (not item.rg_album_gain or not item.rg_album_peak)
+                    for item in album.items()
+                ]
+            )
+        )
 
     def store_track_gain(self, item, track_gain):
         item.rg_track_gain = track_gain.gain
         item.rg_track_peak = track_gain.peak
         item.store()
-        self._log.debug(u'applied track gain {0} LU, peak {1} of FS',
-                        item.rg_track_gain, item.rg_track_peak)
+        self._log.debug(
+            u"applied track gain {0} LU, peak {1} of FS",
+            item.rg_track_gain,
+            item.rg_track_peak,
+        )
 
     def store_album_gain(self, item, album_gain):
         item.rg_album_gain = album_gain.gain
         item.rg_album_peak = album_gain.peak
         item.store()
-        self._log.debug(u'applied album gain {0} LU, peak {1} of FS',
-                        item.rg_album_gain, item.rg_album_peak)
+        self._log.debug(
+            u"applied album gain {0} LU, peak {1} of FS",
+            item.rg_album_gain,
+            item.rg_album_peak,
+        )
 
     def store_track_r128_gain(self, item, track_gain):
         item.r128_track_gain = track_gain.gain
         item.store()
 
-        self._log.debug(u'applied r128 track gain {0} LU',
-                        item.r128_track_gain)
+        self._log.debug(
+            u"applied r128 track gain {0} LU", item.r128_track_gain
+        )
 
     def store_album_r128_gain(self, item, album_gain):
         item.r128_album_gain = album_gain.gain
         item.store()
-        self._log.debug(u'applied r128 album gain {0} LU',
-                        item.r128_album_gain)
+        self._log.debug(
+            u"applied r128 album gain {0} LU", item.r128_album_gain
+        )
 
     def tag_specific_values(self, items):
         """Return some tag specific values.
@@ -1300,12 +1362,12 @@ class ReplayGainPlugin(BeetsPlugin):
         if any([self.should_use_r128(item) for item in items]):
             store_track_gain = self.store_track_r128_gain
             store_album_gain = self.store_album_r128_gain
-            target_level = self.config['r128_targetlevel'].as_number()
+            target_level = self.config["r128_targetlevel"].as_number()
             peak = Peak.none  # R128_* tags do not store the track/album peak
         else:
             store_track_gain = self.store_track_gain
             store_album_gain = self.store_album_gain
-            target_level = self.config['targetlevel'].as_number()
+            target_level = self.config["targetlevel"].as_number()
             peak = self._peak_method
 
         return store_track_gain, store_album_gain, target_level, peak
@@ -1319,16 +1381,20 @@ class ReplayGainPlugin(BeetsPlugin):
         items, nothing is done.
         """
         if not force and not self.album_requires_gain(album):
-            self._log.info(u'Skipping album {0}', album)
+            self._log.info(u"Skipping album {0}", album)
             return
 
-        self._log.info(u'analyzing {0}', album)
+        self._log.info(u"analyzing {0}", album)
 
-        if (any([self.should_use_r128(item) for item in album.items()]) and not
-                all(([self.should_use_r128(item) for item in album.items()]))):
+        if any(
+            [self.should_use_r128(item) for item in album.items()]
+        ) and not all(
+            ([self.should_use_r128(item) for item in album.items()])
+        ):
             self._log.error(
                 u"Cannot calculate gain for album {0} (incompatible formats)",
-                album)
+                album,
+            )
             return
 
         tag_vals = self.tag_specific_values(album.items())
@@ -1362,8 +1428,7 @@ class ReplayGainPlugin(BeetsPlugin):
             except ReplayGainError as e:
                 self._log.info(u"ReplayGain error: {0}", e)
             except FatalReplayGainError as e:
-                raise ui.UserError(
-                    u"Fatal replay gain error: {0}".format(e))
+                raise ui.UserError(u"Fatal replay gain error: {0}".format(e))
 
     def handle_track(self, item, write, force=False):
         """Compute track replay gain and store it in the item.
@@ -1373,10 +1438,10 @@ class ReplayGainPlugin(BeetsPlugin):
         in the item, nothing is done.
         """
         if not force and not self.track_requires_gain(item):
-            self._log.info(u'Skipping track {0}', item)
+            self._log.info(u"Skipping track {0}", item)
             return
 
-        self._log.info(u'analyzing {0}', item)
+        self._log.info(u"analyzing {0}", item)
 
         tag_vals = self.tag_specific_values([item])
         store_track_gain, store_album_gain, target_level, peak = tag_vals
@@ -1396,8 +1461,7 @@ class ReplayGainPlugin(BeetsPlugin):
         except ReplayGainError as e:
             self._log.info(u"ReplayGain error: {0}", e)
         except FatalReplayGainError as e:
-            raise ui.UserError(
-                u"Fatal replay gain error: {0}".format(e))
+            raise ui.UserError(u"Fatal replay gain error: {0}".format(e))
 
     def imported(self, session, task):
         """Add replay gain info to items or albums of ``task``.
@@ -1410,6 +1474,7 @@ class ReplayGainPlugin(BeetsPlugin):
     def commands(self):
         """Return the "replaygain" ui subcommand.
         """
+
         def func(lib, opts, args):
             write = ui.should_write(opts.write)
             force = opts.force
@@ -1422,17 +1487,30 @@ class ReplayGainPlugin(BeetsPlugin):
                 for item in lib.items(ui.decargs(args)):
                     self.handle_track(item, write, force)
 
-        cmd = ui.Subcommand('replaygain', help=u'analyze for ReplayGain')
+        cmd = ui.Subcommand("replaygain", help=u"analyze for ReplayGain")
         cmd.parser.add_album_option()
         cmd.parser.add_option(
-            "-f", "--force", dest="force", action="store_true", default=False,
+            "-f",
+            "--force",
+            dest="force",
+            action="store_true",
+            default=False,
             help=u"analyze all files, including those that "
-            "already have ReplayGain metadata")
+            "already have ReplayGain metadata",
+        )
         cmd.parser.add_option(
-            "-w", "--write", default=None, action="store_true",
-            help=u"write new metadata to files' tags")
+            "-w",
+            "--write",
+            default=None,
+            action="store_true",
+            help=u"write new metadata to files' tags",
+        )
         cmd.parser.add_option(
-            "-W", "--nowrite", dest="write", action="store_false",
-            help=u"don't write metadata (opposite of -w)")
+            "-W",
+            "--nowrite",
+            dest="write",
+            action="store_false",
+            help=u"don't write metadata (opposite of -w)",
+        )
         cmd.func = func
         return [cmd]

--- a/beetsplug/rewrite.py
+++ b/beetsplug/rewrite.py
@@ -31,6 +31,7 @@ def rewriter(field, rules):
     with the given rewriting rules. ``rules`` must be a list of
     (pattern, replacement) pairs.
     """
+
     def fieldfunc(item):
         value = item._values_fixed[field]
         for pattern, replacement in rules:
@@ -39,6 +40,7 @@ def rewriter(field, rules):
                 return replacement
         # Not activated; return original value.
         return value
+
     return fieldfunc
 
 
@@ -57,15 +59,16 @@ class RewritePlugin(BeetsPlugin):
             except ValueError:
                 raise ui.UserError(u"invalid rewrite specification")
             if fieldname not in library.Item._fields:
-                raise ui.UserError(u"invalid field name (%s) in rewriter" %
-                                   fieldname)
-            self._log.debug(u'adding template field {0}', key)
+                raise ui.UserError(
+                    u"invalid field name (%s) in rewriter" % fieldname
+                )
+            self._log.debug(u"adding template field {0}", key)
             pattern = re.compile(pattern.lower())
             rules[fieldname].append((pattern, value))
-            if fieldname == 'artist':
+            if fieldname == "artist":
                 # Special case for the artist field: apply the same
                 # rewrite for "albumartist" as well.
-                rules['albumartist'].append((pattern, value))
+                rules["albumartist"].append((pattern, value))
 
         # Replace each template field with the new rewriter function.
         for fieldname, fieldrules in rules.items():

--- a/beetsplug/scrub.py
+++ b/beetsplug/scrub.py
@@ -27,48 +27,54 @@ import mediafile
 import mutagen
 
 _MUTAGEN_FORMATS = {
-    'asf': 'ASF',
-    'apev2': 'APEv2File',
-    'flac': 'FLAC',
-    'id3': 'ID3FileType',
-    'mp3': 'MP3',
-    'mp4': 'MP4',
-    'oggflac': 'OggFLAC',
-    'oggspeex': 'OggSpeex',
-    'oggtheora': 'OggTheora',
-    'oggvorbis': 'OggVorbis',
-    'oggopus': 'OggOpus',
-    'trueaudio': 'TrueAudio',
-    'wavpack': 'WavPack',
-    'monkeysaudio': 'MonkeysAudio',
-    'optimfrog': 'OptimFROG',
+    "asf": "ASF",
+    "apev2": "APEv2File",
+    "flac": "FLAC",
+    "id3": "ID3FileType",
+    "mp3": "MP3",
+    "mp4": "MP4",
+    "oggflac": "OggFLAC",
+    "oggspeex": "OggSpeex",
+    "oggtheora": "OggTheora",
+    "oggvorbis": "OggVorbis",
+    "oggopus": "OggOpus",
+    "trueaudio": "TrueAudio",
+    "wavpack": "WavPack",
+    "monkeysaudio": "MonkeysAudio",
+    "optimfrog": "OptimFROG",
 }
 
 
 class ScrubPlugin(BeetsPlugin):
     """Removes extraneous metadata from files' tags."""
+
     def __init__(self):
         super(ScrubPlugin, self).__init__()
-        self.config.add({
-            'auto': True,
-        })
+        self.config.add(
+            {"auto": True,}
+        )
 
-        if self.config['auto']:
+        if self.config["auto"]:
             self.register_listener("import_task_files", self.import_task_files)
 
     def commands(self):
         def scrub_func(lib, opts, args):
             # Walk through matching files and remove tags.
             for item in lib.items(ui.decargs(args)):
-                self._log.info(u'scrubbing: {0}',
-                               util.displayable_path(item.path))
+                self._log.info(
+                    u"scrubbing: {0}", util.displayable_path(item.path)
+                )
                 self._scrub_item(item, opts.write)
 
-        scrub_cmd = ui.Subcommand('scrub', help=u'clean audio tags')
+        scrub_cmd = ui.Subcommand("scrub", help=u"clean audio tags")
         scrub_cmd.parser.add_option(
-            u'-W', u'--nowrite', dest='write',
-            action='store_false', default=True,
-            help=u'leave tags empty')
+            u"-W",
+            u"--nowrite",
+            dest="write",
+            action="store_false",
+            default=True,
+            help=u"leave tags empty",
+        )
         scrub_cmd.func = scrub_func
 
         return [scrub_cmd]
@@ -79,8 +85,7 @@ class ScrubPlugin(BeetsPlugin):
         """
         classes = []
         for modname, clsname in _MUTAGEN_FORMATS.items():
-            mod = __import__('mutagen.{0}'.format(modname),
-                             fromlist=[clsname])
+            mod = __import__("mutagen.{0}".format(modname), fromlist=[clsname])
             classes.append(getattr(mod, clsname))
         return classes
 
@@ -108,8 +113,11 @@ class ScrubPlugin(BeetsPlugin):
                     del f[tag]
                 f.save()
             except (IOError, mutagen.MutagenError) as exc:
-                self._log.error(u'could not scrub {0}: {1}',
-                                util.displayable_path(path), exc)
+                self._log.error(
+                    u"could not scrub {0}: {1}",
+                    util.displayable_path(path),
+                    exc,
+                )
 
     def _scrub_item(self, item, restore=True):
         """Remove tags from an Item's associated file and, if `restore`
@@ -118,11 +126,11 @@ class ScrubPlugin(BeetsPlugin):
         # Get album art if we need to restore it.
         if restore:
             try:
-                mf = mediafile.MediaFile(util.syspath(item.path),
-                                         config['id3v23'].get(bool))
+                mf = mediafile.MediaFile(
+                    util.syspath(item.path), config["id3v23"].get(bool)
+                )
             except mediafile.UnreadableFileError as exc:
-                self._log.error(u'could not open file to scrub: {0}',
-                                exc)
+                self._log.error(u"could not open file to scrub: {0}", exc)
                 return
             images = mf.images
 
@@ -131,21 +139,23 @@ class ScrubPlugin(BeetsPlugin):
 
         # Restore tags, if enabled.
         if restore:
-            self._log.debug(u'writing new tags after scrub')
+            self._log.debug(u"writing new tags after scrub")
             item.try_write()
             if images:
-                self._log.debug(u'restoring art')
+                self._log.debug(u"restoring art")
                 try:
-                    mf = mediafile.MediaFile(util.syspath(item.path),
-                                             config['id3v23'].get(bool))
+                    mf = mediafile.MediaFile(
+                        util.syspath(item.path), config["id3v23"].get(bool)
+                    )
                     mf.images = images
                     mf.save()
                 except mediafile.UnreadableFileError as exc:
-                    self._log.error(u'could not write tags: {0}', exc)
+                    self._log.error(u"could not write tags: {0}", exc)
 
     def import_task_files(self, session, task):
         """Automatically scrub imported files."""
         for item in task.imported_items():
-            self._log.debug(u'auto-scrubbing {0}',
-                            util.displayable_path(item.path))
+            self._log.debug(
+                u"auto-scrubbing {0}", util.displayable_path(item.path)
+            )
             self._scrub_item(item)

--- a/beetsplug/sonosupdate.py
+++ b/beetsplug/sonosupdate.py
@@ -25,24 +25,24 @@ import soco
 class SonosUpdate(BeetsPlugin):
     def __init__(self):
         super(SonosUpdate, self).__init__()
-        self.register_listener('database_change', self.listen_for_db_change)
+        self.register_listener("database_change", self.listen_for_db_change)
 
     def listen_for_db_change(self, lib, model):
         """Listens for beets db change and register the update"""
-        self.register_listener('cli_exit', self.update)
+        self.register_listener("cli_exit", self.update)
 
     def update(self, lib):
         """When the client exists try to send refresh request to a Sonos
         controler.
         """
-        self._log.info(u'Requesting a Sonos library update...')
+        self._log.info(u"Requesting a Sonos library update...")
 
         device = soco.discovery.any_soco()
 
         if device:
             device.music_library.start_library_update()
         else:
-            self._log.warning(u'Could not find a Sonos device.')
+            self._log.warning(u"Could not find a Sonos device.")
             return
 
-        self._log.info(u'Sonos update triggered')
+        self._log.info(u"Sonos update triggered")

--- a/beetsplug/subsonicplaylist.py
+++ b/beetsplug/subsonicplaylist.py
@@ -28,7 +28,7 @@ from beets.dbcore.query import MatchQuery
 from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand
 
-__author__ = 'https://github.com/MrNuggelz'
+__author__ = "https://github.com/MrNuggelz"
 
 
 def filter_to_be_removed(items, keys):
@@ -36,17 +36,22 @@ def filter_to_be_removed(items, keys):
         dont_remove = []
         for artist, album, title in keys:
             for item in items:
-                if artist == item['artist'] and \
-                        album == item['album'] and \
-                        title == item['title']:
+                if (
+                    artist == item["artist"]
+                    and album == item["album"]
+                    and title == item["title"]
+                ):
                     dont_remove.append(item)
         return [item for item in items if item not in dont_remove]
     else:
+
         def to_be_removed(item):
             for artist, album, title in keys:
-                if artist == item['artist'] and\
-                           album == item['album'] and\
-                           title == item['title']:
+                if (
+                    artist == item["artist"]
+                    and album == item["album"]
+                    and title == item["title"]
+                ):
                     return False
             return True
 
@@ -54,111 +59,121 @@ def filter_to_be_removed(items, keys):
 
 
 class SubsonicPlaylistPlugin(BeetsPlugin):
-
     def __init__(self):
         super(SubsonicPlaylistPlugin, self).__init__()
         self.config.add(
             {
-                'delete': False,
-                'playlist_ids': [],
-                'playlist_names': [],
-                'username': '',
-                'password': ''
+                "delete": False,
+                "playlist_ids": [],
+                "playlist_names": [],
+                "username": "",
+                "password": "",
             }
         )
-        self.config['password'].redact = True
+        self.config["password"].redact = True
 
     def update_tags(self, playlist_dict, lib):
         with lib.transaction():
             for query, playlist_tag in playlist_dict.items():
-                query = AndQuery([MatchQuery("artist", query[0]),
-                                  MatchQuery("album", query[1]),
-                                  MatchQuery("title", query[2])])
+                query = AndQuery(
+                    [
+                        MatchQuery("artist", query[0]),
+                        MatchQuery("album", query[1]),
+                        MatchQuery("title", query[2]),
+                    ]
+                )
                 items = lib.items(query)
                 if not items:
-                    self._log.warn(u"{} | track not found ({})", playlist_tag,
-                                   query)
+                    self._log.warn(
+                        u"{} | track not found ({})", playlist_tag, query
+                    )
                     continue
                 for item in items:
                     item.subsonic_playlist = playlist_tag
                     item.try_sync(write=True, move=False)
 
     def get_playlist(self, playlist_id):
-        xml = self.send('getPlaylist', {'id': playlist_id}).text
+        xml = self.send("getPlaylist", {"id": playlist_id}).text
         playlist = ElementTree.fromstring(xml)[0]
-        if playlist.attrib.get('code', '200') != '200':
-            alt_error = 'error getting playlist, but no error message found'
-            self._log.warn(playlist.attrib.get('message', alt_error))
+        if playlist.attrib.get("code", "200") != "200":
+            alt_error = "error getting playlist, but no error message found"
+            self._log.warn(playlist.attrib.get("message", alt_error))
             return
 
-        name = playlist.attrib.get('name', 'undefined')
-        tracks = [(t.attrib['artist'], t.attrib['album'], t.attrib['title'])
-                  for t in playlist]
+        name = playlist.attrib.get("name", "undefined")
+        tracks = [
+            (t.attrib["artist"], t.attrib["album"], t.attrib["title"])
+            for t in playlist
+        ]
         return name, tracks
 
     def commands(self):
         def build_playlist(lib, opts, args):
             self.config.set_args(opts)
-            ids = self.config['playlist_ids'].as_str_seq()
-            if self.config['playlist_names'].as_str_seq():
+            ids = self.config["playlist_ids"].as_str_seq()
+            if self.config["playlist_names"].as_str_seq():
                 playlists = ElementTree.fromstring(
-                    self.send('getPlaylists').text)[0]
-                if playlists.attrib.get('code', '200') != '200':
-                    alt_error = 'error getting playlists,' \
-                                ' but no error message found'
-                    self._log.warn(
-                        playlists.attrib.get('message', alt_error))
+                    self.send("getPlaylists").text
+                )[0]
+                if playlists.attrib.get("code", "200") != "200":
+                    alt_error = (
+                        "error getting playlists,"
+                        " but no error message found"
+                    )
+                    self._log.warn(playlists.attrib.get("message", alt_error))
                     return
-                for name in self.config['playlist_names'].as_str_seq():
+                for name in self.config["playlist_names"].as_str_seq():
                     for playlist in playlists:
-                        if name == playlist.attrib['name']:
-                            ids.append(playlist.attrib['id'])
+                        if name == playlist.attrib["name"]:
+                            ids.append(playlist.attrib["id"])
 
             playlist_dict = self.get_playlists(ids)
 
             # delete old tags
-            if self.config['delete']:
+            if self.config["delete"]:
                 existing = list(lib.items('subsonic_playlist:";"'))
                 to_be_removed = filter_to_be_removed(
-                    existing,
-                    playlist_dict.keys())
+                    existing, playlist_dict.keys()
+                )
                 for item in to_be_removed:
-                    item['subsonic_playlist'] = ''
+                    item["subsonic_playlist"] = ""
                     with lib.transaction():
                         item.try_sync(write=True, move=False)
 
             self.update_tags(playlist_dict, lib)
 
         subsonicplaylist_cmds = Subcommand(
-            'subsonicplaylist', help=u'import a subsonic playlist'
+            "subsonicplaylist", help=u"import a subsonic playlist"
         )
         subsonicplaylist_cmds.parser.add_option(
-            u'-d',
-            u'--delete',
-            action='store_true',
-            help=u'delete tag from items not in any playlist anymore',
+            u"-d",
+            u"--delete",
+            action="store_true",
+            help=u"delete tag from items not in any playlist anymore",
         )
         subsonicplaylist_cmds.func = build_playlist
         return [subsonicplaylist_cmds]
 
     def generate_token(self):
-        salt = ''.join(random.choices(string.ascii_lowercase + string.digits))
-        return md5(
-            (self.config['password'].get() + salt).encode()).hexdigest(), salt
+        salt = "".join(random.choices(string.ascii_lowercase + string.digits))
+        return (
+            md5((self.config["password"].get() + salt).encode()).hexdigest(),
+            salt,
+        )
 
     def send(self, endpoint, params=None):
         if params is None:
             params = dict()
         a, b = self.generate_token()
-        params['u'] = self.config['username']
-        params['t'] = a
-        params['s'] = b
-        params['v'] = '1.12.0'
-        params['c'] = 'beets'
-        resp = requests.get('{}/rest/{}?{}'.format(
-            self.config['base_url'].get(),
-            endpoint,
-            urlencode(params))
+        params["u"] = self.config["username"]
+        params["t"] = a
+        params["s"] = b
+        params["v"] = "1.12.0"
+        params["c"] = "beets"
+        resp = requests.get(
+            "{}/rest/{}?{}".format(
+                self.config["base_url"].get(), endpoint, urlencode(params)
+            )
         )
         return resp
 
@@ -168,6 +183,6 @@ class SubsonicPlaylistPlugin(BeetsPlugin):
             name, tracks = self.get_playlist(playlist_id)
             for track in tracks:
                 if track not in output:
-                    output[track] = ';'
-                output[track] += name + ';'
+                    output[track] = ";"
+                output[track] += name + ";"
         return output

--- a/beetsplug/the.py
+++ b/beetsplug/the.py
@@ -20,12 +20,12 @@ from __future__ import division, absolute_import, print_function
 import re
 from beets.plugins import BeetsPlugin
 
-__author__ = 'baobab@heresiarch.info'
-__version__ = '1.1'
+__author__ = "baobab@heresiarch.info"
+__version__ = "1.1"
 
-PATTERN_THE = u'^the\\s'
-PATTERN_A = u'^[a][n]?\\s'
-FORMAT = u'{0}, {1}'
+PATTERN_THE = u"^the\\s"
+PATTERN_A = u"^[a][n]?\\s"
+FORMAT = u"{0}, {1}"
 
 
 class ThePlugin(BeetsPlugin):
@@ -35,33 +35,38 @@ class ThePlugin(BeetsPlugin):
     def __init__(self):
         super(ThePlugin, self).__init__()
 
-        self.template_funcs['the'] = self.the_template_func
+        self.template_funcs["the"] = self.the_template_func
 
-        self.config.add({
-            'the': True,
-            'a': True,
-            'format': u'{0}, {1}',
-            'strip': False,
-            'patterns': [],
-        })
+        self.config.add(
+            {
+                "the": True,
+                "a": True,
+                "format": u"{0}, {1}",
+                "strip": False,
+                "patterns": [],
+            }
+        )
 
-        self.patterns = self.config['patterns'].as_str_seq()
+        self.patterns = self.config["patterns"].as_str_seq()
         for p in self.patterns:
             if p:
                 try:
                     re.compile(p)
                 except re.error:
-                    self._log.error(u'invalid pattern: {0}', p)
+                    self._log.error(u"invalid pattern: {0}", p)
                 else:
-                    if not (p.startswith('^') or p.endswith('$')):
-                        self._log.warning(u'warning: \"{0}\" will not '
-                                          u'match string start/end', p)
-        if self.config['a']:
+                    if not (p.startswith("^") or p.endswith("$")):
+                        self._log.warning(
+                            u'warning: "{0}" will not '
+                            u"match string start/end",
+                            p,
+                        )
+        if self.config["a"]:
             self.patterns = [PATTERN_A] + self.patterns
-        if self.config['the']:
+        if self.config["the"]:
             self.patterns = [PATTERN_THE] + self.patterns
         if not self.patterns:
-            self._log.warning(u'no patterns defined!')
+            self._log.warning(u"no patterns defined!")
 
     def unthe(self, text, pattern):
         """Moves pattern in the path format string or strips it
@@ -77,14 +82,14 @@ class ThePlugin(BeetsPlugin):
             except IndexError:
                 return text
             else:
-                r = re.sub(r, '', text).strip()
-                if self.config['strip']:
+                r = re.sub(r, "", text).strip()
+                if self.config["strip"]:
                     return r
                 else:
-                    fmt = self.config['format'].as_str()
+                    fmt = self.config["format"].as_str()
                     return fmt.format(r, t.strip()).strip()
         else:
-            return u''
+            return u""
 
     def the_template_func(self, text):
         if not self.patterns:
@@ -93,8 +98,8 @@ class ThePlugin(BeetsPlugin):
             for p in self.patterns:
                 r = self.unthe(text, p)
                 if r != text:
-                    self._log.debug(u'\"{0}\" -> \"{1}\"', text, r)
+                    self._log.debug(u'"{0}" -> "{1}"', text, r)
                     break
             return r
         else:
-            return u''
+            return u""

--- a/beetsplug/thumbnails.py
+++ b/beetsplug/thumbnails.py
@@ -46,27 +46,34 @@ LARGE_DIR = util.bytestring_path(os.path.join(BASE_DIR, "large"))
 class ThumbnailsPlugin(BeetsPlugin):
     def __init__(self):
         super(ThumbnailsPlugin, self).__init__()
-        self.config.add({
-            'auto': True,
-            'force': False,
-            'dolphin': False,
-        })
+        self.config.add(
+            {"auto": True, "force": False, "dolphin": False,}
+        )
 
         self.write_metadata = None
-        if self.config['auto'] and self._check_local_ok():
-            self.register_listener('art_set', self.process_album)
+        if self.config["auto"] and self._check_local_ok():
+            self.register_listener("art_set", self.process_album)
 
     def commands(self):
-        thumbnails_command = Subcommand("thumbnails",
-                                        help=u"Create album thumbnails")
+        thumbnails_command = Subcommand(
+            "thumbnails", help=u"Create album thumbnails"
+        )
         thumbnails_command.parser.add_option(
-            u'-f', u'--force',
-            dest='force', action='store_true', default=False,
-            help=u'force regeneration of thumbnails deemed fine (existing & '
-                 u'recent enough)')
+            u"-f",
+            u"--force",
+            dest="force",
+            action="store_true",
+            default=False,
+            help=u"force regeneration of thumbnails deemed fine (existing & "
+            u"recent enough)",
+        )
         thumbnails_command.parser.add_option(
-            u'--dolphin', dest='dolphin', action='store_true', default=False,
-            help=u"create Dolphin-compatible thumbnail information (for KDE)")
+            u"--dolphin",
+            dest="dolphin",
+            action="store_true",
+            default=False,
+            help=u"create Dolphin-compatible thumbnail information (for KDE)",
+        )
         thumbnails_command.func = self.process_query
 
         return [thumbnails_command]
@@ -85,8 +92,10 @@ class ThumbnailsPlugin(BeetsPlugin):
             - detect whether we'll use GIO or Python to get URIs
         """
         if not ArtResizer.shared.local:
-            self._log.warning(u"No local image resizing capabilities, "
-                              u"cannot generate thumbnails")
+            self._log.warning(
+                u"No local image resizing capabilities, "
+                u"cannot generate thumbnails"
+            )
             return False
 
         for dir in (NORMAL_DIR, LARGE_DIR):
@@ -113,18 +122,19 @@ class ThumbnailsPlugin(BeetsPlugin):
     def process_album(self, album):
         """Produce thumbnails for the album folder.
         """
-        self._log.debug(u'generating thumbnail for {0}', album)
+        self._log.debug(u"generating thumbnail for {0}", album)
         if not album.artpath:
-            self._log.info(u'album {0} has no art', album)
+            self._log.info(u"album {0} has no art", album)
             return
 
-        if self.config['dolphin']:
+        if self.config["dolphin"]:
             self.make_dolphin_cover_thumbnail(album)
 
         size = ArtResizer.shared.get_size(album.artpath)
         if not size:
-            self._log.warning(u'problem getting the picture size for {0}',
-                              album.artpath)
+            self._log.warning(
+                u"problem getting the picture size for {0}", album.artpath
+            )
             return
 
         wrote = True
@@ -133,9 +143,9 @@ class ThumbnailsPlugin(BeetsPlugin):
         wrote &= self.make_cover_thumbnail(album, 128, NORMAL_DIR)
 
         if wrote:
-            self._log.info(u'wrote thumbnail for {0}', album)
+            self._log.info(u"wrote thumbnail for {0}", album)
         else:
-            self._log.info(u'nothing to do for {0}', album)
+            self._log.info(u"nothing to do for {0}", album)
 
     def make_cover_thumbnail(self, album, size, target_dir):
         """Make a thumbnail of given size for `album` and put it in
@@ -143,17 +153,28 @@ class ThumbnailsPlugin(BeetsPlugin):
         """
         target = os.path.join(target_dir, self.thumbnail_file_name(album.path))
 
-        if os.path.exists(target) and \
-           os.stat(target).st_mtime > os.stat(album.artpath).st_mtime:
-            if self.config['force']:
-                self._log.debug(u"found a suitable {1}x{1} thumbnail for {0}, "
-                                u"forcing regeneration", album, size)
+        if (
+            os.path.exists(target)
+            and os.stat(target).st_mtime > os.stat(album.artpath).st_mtime
+        ):
+            if self.config["force"]:
+                self._log.debug(
+                    u"found a suitable {1}x{1} thumbnail for {0}, "
+                    u"forcing regeneration",
+                    album,
+                    size,
+                )
             else:
-                self._log.debug(u"{1}x{1} thumbnail for {0} exists and is "
-                                u"recent enough", album, size)
+                self._log.debug(
+                    u"{1}x{1} thumbnail for {0} exists and is "
+                    u"recent enough",
+                    album,
+                    size,
+                )
                 return False
-        resized = ArtResizer.shared.resize(size, album.artpath,
-                                           util.syspath(target))
+        resized = ArtResizer.shared.resize(
+            size, album.artpath, util.syspath(target)
+        )
         self.add_tags(album, util.syspath(resized))
         shutil.move(resized, target)
         return True
@@ -163,7 +184,7 @@ class ThumbnailsPlugin(BeetsPlugin):
         See https://standards.freedesktop.org/thumbnail-spec/latest/x227.html
         """
         uri = self.get_uri(path)
-        hash = md5(uri.encode('utf-8')).hexdigest()
+        hash = md5(uri.encode("utf-8")).hexdigest()
         return util.bytestring_path("{0}.png".format(hash))
 
     def add_tags(self, album, image_path):
@@ -171,31 +192,39 @@ class ThumbnailsPlugin(BeetsPlugin):
         See https://standards.freedesktop.org/thumbnail-spec/latest/x142.html
         """
         mtime = os.stat(album.artpath).st_mtime
-        metadata = {"Thumb::URI": self.get_uri(album.artpath),
-                    "Thumb::MTime": six.text_type(mtime)}
+        metadata = {
+            "Thumb::URI": self.get_uri(album.artpath),
+            "Thumb::MTime": six.text_type(mtime),
+        }
         try:
             self.write_metadata(image_path, metadata)
         except Exception:
-            self._log.exception(u"could not write metadata to {0}",
-                                util.displayable_path(image_path))
+            self._log.exception(
+                u"could not write metadata to {0}",
+                util.displayable_path(image_path),
+            )
 
     def make_dolphin_cover_thumbnail(self, album):
         outfilename = os.path.join(album.path, b".directory")
         if os.path.exists(outfilename):
             return
         artfile = os.path.split(album.artpath)[1]
-        with open(outfilename, 'w') as f:
-            f.write('[Desktop Entry]\n')
-            f.write('Icon=./{0}'.format(artfile.decode('utf-8')))
+        with open(outfilename, "w") as f:
+            f.write("[Desktop Entry]\n")
+            f.write("Icon=./{0}".format(artfile.decode("utf-8")))
             f.close()
         self._log.debug(u"Wrote file {0}", util.displayable_path(outfilename))
 
 
 def write_metadata_im(file, metadata):
     """Enrich the file metadata with `metadata` dict thanks to IM."""
-    command = ['convert', file] + \
-        list(chain.from_iterable(('-set', k, v)
-                                 for k, v in metadata.items())) + [file]
+    command = (
+        ["convert", file]
+        + list(
+            chain.from_iterable(("-set", k, v) for k, v in metadata.items())
+        )
+        + [file]
+    )
     util.command_output(command)
     return True
 
@@ -203,6 +232,7 @@ def write_metadata_im(file, metadata):
 def write_metadata_pil(file, metadata):
     """Enrich the file metadata with `metadata` dict thanks to PIL."""
     from PIL import Image, PngImagePlugin
+
     im = Image.open(file)
     meta = PngImagePlugin.PngInfo()
     for k, v in metadata.items():
@@ -235,12 +265,13 @@ def copy_c_string(c_string):
     # work. A more surefire way would be to allocate a ctypes buffer and copy
     # the data with `memcpy` or somesuch.
     s = ctypes.cast(c_string, ctypes.c_char_p).value
-    return b'' + s
+    return b"" + s
 
 
 class GioURI(URIGetter):
     """Use gio URI function g_file_get_uri. Paths must be utf-8 encoded.
     """
+
     name = "GIO"
 
     def __init__(self):
@@ -269,8 +300,11 @@ class GioURI(URIGetter):
     def uri(self, path):
         g_file_ptr = self.libgio.g_file_new_for_path(path)
         if not g_file_ptr:
-            raise RuntimeError(u"No gfile pointer received for {0}".format(
-                util.displayable_path(path)))
+            raise RuntimeError(
+                u"No gfile pointer received for {0}".format(
+                    util.displayable_path(path)
+                )
+            )
 
         try:
             uri_ptr = self.libgio.g_file_get_uri(g_file_ptr)
@@ -278,8 +312,10 @@ class GioURI(URIGetter):
             self.libgio.g_object_unref(g_file_ptr)
         if not uri_ptr:
             self.libgio.g_free(uri_ptr)
-            raise RuntimeError(u"No URI received from the gfile pointer for "
-                               u"{0}".format(util.displayable_path(path)))
+            raise RuntimeError(
+                u"No URI received from the gfile pointer for "
+                u"{0}".format(util.displayable_path(path))
+            )
 
         try:
             uri = copy_c_string(uri_ptr)

--- a/beetsplug/types.py
+++ b/beetsplug/types.py
@@ -22,7 +22,6 @@ from beets import library
 
 
 class TypesPlugin(BeetsPlugin):
-
     @property
     def item_types(self):
         return self._types()
@@ -37,16 +36,18 @@ class TypesPlugin(BeetsPlugin):
 
         mytypes = {}
         for key, value in self.config.items():
-            if value.get() == 'int':
+            if value.get() == "int":
                 mytypes[key] = types.INTEGER
-            elif value.get() == 'float':
+            elif value.get() == "float":
                 mytypes[key] = types.FLOAT
-            elif value.get() == 'bool':
+            elif value.get() == "bool":
                 mytypes[key] = types.BOOLEAN
-            elif value.get() == 'date':
+            elif value.get() == "date":
                 mytypes[key] = library.DateType()
             else:
                 raise ConfigValueError(
-                    u"unknown type '{0}' for the '{1}' field"
-                    .format(value, key))
+                    u"unknown type '{0}' for the '{1}' field".format(
+                        value, key
+                    )
+                )
         return mytypes

--- a/beetsplug/unimported.py
+++ b/beetsplug/unimported.py
@@ -25,36 +25,39 @@ from beets import util
 from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand, print_
 
-__author__ = 'https://github.com/MrNuggelz'
+__author__ = "https://github.com/MrNuggelz"
 
 
 class Unimported(BeetsPlugin):
-
     def __init__(self):
         super(Unimported, self).__init__()
-        self.config.add(
-            {
-                'ignore_extensions': []
-            }
-        )
+        self.config.add({"ignore_extensions": []})
 
     def commands(self):
         def print_unimported(lib, opts, args):
-            ignore_exts = [('.' + x).encode() for x
-                           in self.config['ignore_extensions'].as_str_seq()]
+            ignore_exts = [
+                ("." + x).encode()
+                for x in self.config["ignore_extensions"].as_str_seq()
+            ]
             in_folder = set(
-                (os.path.join(r, file) for r, d, f in os.walk(lib.directory)
-                 for file in f if not any(
-                    [file.endswith(extension) for extension in
-                     ignore_exts])))
+                (
+                    os.path.join(r, file)
+                    for r, d, f in os.walk(lib.directory)
+                    for file in f
+                    if not any(
+                        [file.endswith(extension) for extension in ignore_exts]
+                    )
+                )
+            )
             in_library = set(x.path for x in lib.items())
             art_files = set(x.artpath for x in lib.albums())
             for f in in_folder - in_library - art_files:
                 print_(util.displayable_path(f))
 
         unimported = Subcommand(
-            'unimported',
-            help='list all files in the library folder which are not listed'
-                 ' in the beets library database')
+            "unimported",
+            help="list all files in the library folder which are not listed"
+            " in the beets library database",
+        )
         unimported.func = print_unimported
         return [unimported]

--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -31,6 +31,7 @@ import base64
 
 # Utilities.
 
+
 def _rep(obj, expand=False):
     """Get a flat -- i.e., JSON-ish -- representation of a beets Item or
     Album object. For Albums, `expand` dictates whether tracks are
@@ -39,29 +40,29 @@ def _rep(obj, expand=False):
     out = dict(obj)
 
     if isinstance(obj, beets.library.Item):
-        if app.config.get('INCLUDE_PATHS', False):
-            out['path'] = util.displayable_path(out['path'])
+        if app.config.get("INCLUDE_PATHS", False):
+            out["path"] = util.displayable_path(out["path"])
         else:
-            del out['path']
+            del out["path"]
 
         # Filter all bytes attributes and convert them to strings.
         for key, value in out.items():
             if isinstance(out[key], bytes):
-                out[key] = base64.b64encode(value).decode('ascii')
+                out[key] = base64.b64encode(value).decode("ascii")
 
         # Get the size (in bytes) of the backing file. This is useful
         # for the Tomahawk resolver API.
         try:
-            out['size'] = os.path.getsize(util.syspath(obj.path))
+            out["size"] = os.path.getsize(util.syspath(obj.path))
         except OSError:
-            out['size'] = 0
+            out["size"] = 0
 
         return out
 
     elif isinstance(obj, beets.library.Album):
-        del out['artpath']
+        del out["artpath"]
         if expand:
-            out['items'] = [_rep(item) for item in obj.items()]
+            out["items"] = [_rep(item) for item in obj.items()]
         return out
 
 
@@ -80,20 +81,21 @@ def json_generator(items, root, expand=False):
         if first:
             first = False
         else:
-            yield ','
+            yield ","
         yield json.dumps(_rep(item, expand=expand))
-    yield ']}'
+    yield "]}"
 
 
 def is_expand():
     """Returns whether the current request is for an expanded response."""
 
-    return flask.request.args.get('expand') is not None
+    return flask.request.args.get("expand") is not None
 
 
 def resource(name):
     """Decorates a function to handle RESTful HTTP requests for a resource.
     """
+
     def make_responder(retriever):
         def responder(ids):
             entities = [retriever(id) for id in ids]
@@ -104,29 +106,33 @@ def resource(name):
             elif entities:
                 return app.response_class(
                     json_generator(entities, root=name),
-                    mimetype='application/json'
+                    mimetype="application/json",
                 )
             else:
                 return flask.abort(404)
-        responder.__name__ = 'get_{0}'.format(name)
+
+        responder.__name__ = "get_{0}".format(name)
         return responder
+
     return make_responder
 
 
 def resource_query(name):
     """Decorates a function to handle RESTful HTTP queries for resources.
     """
+
     def make_responder(query_func):
         def responder(queries):
             return app.response_class(
                 json_generator(
-                    query_func(queries),
-                    root='results', expand=is_expand()
+                    query_func(queries), root="results", expand=is_expand()
                 ),
-                mimetype='application/json'
+                mimetype="application/json",
             )
-        responder.__name__ = 'query_{0}'.format(name)
+
+        responder.__name__ = "query_{0}".format(name)
         return responder
+
     return make_responder
 
 
@@ -134,14 +140,17 @@ def resource_list(name):
     """Decorates a function to handle RESTful HTTP request for a list of
     resources.
     """
+
     def make_responder(list_all):
         def responder():
             return app.response_class(
                 json_generator(list_all(), root=name, expand=is_expand()),
-                mimetype='application/json'
+                mimetype="application/json",
             )
-        responder.__name__ = 'all_{0}'.format(name)
+
+        responder.__name__ = "all_{0}".format(name)
         return responder
+
     return make_responder
 
 
@@ -150,8 +159,11 @@ def _get_unique_table_field_values(model, field, sort_field):
     if field not in model.all_keys() or sort_field not in model.all_keys():
         raise KeyError
     with g.lib.transaction() as tx:
-        rows = tx.query('SELECT DISTINCT "{0}" FROM "{1}" ORDER BY "{2}"'
-                        .format(field, model._table, sort_field))
+        rows = tx.query(
+            'SELECT DISTINCT "{0}" FROM "{1}" ORDER BY "{2}"'.format(
+                field, model._table, sort_field
+            )
+        )
     return [row[0] for row in rows]
 
 
@@ -161,7 +173,7 @@ class IdListConverter(BaseConverter):
 
     def to_python(self, value):
         ids = []
-        for id in value.split(','):
+        for id in value.split(","):
             try:
                 ids.append(int(id))
             except ValueError:
@@ -169,7 +181,7 @@ class IdListConverter(BaseConverter):
         return ids
 
     def to_url(self, value):
-        return ','.join(str(v) for v in value)
+        return ",".join(str(v) for v in value)
 
 
 class QueryConverter(PathConverter):
@@ -177,52 +189,53 @@ class QueryConverter(PathConverter):
     """
 
     def to_python(self, value):
-        queries = value.split('/')
-        return [query.replace('\\', os.sep) for query in queries]
+        queries = value.split("/")
+        return [query.replace("\\", os.sep) for query in queries]
 
     def to_url(self, value):
-        return ','.join([v.replace(os.sep, '\\') for v in value])
+        return ",".join([v.replace(os.sep, "\\") for v in value])
 
 
 class EverythingConverter(PathConverter):
-    regex = '.*?'
+    regex = ".*?"
 
 
 # Flask setup.
 
 app = flask.Flask(__name__)
-app.url_map.converters['idlist'] = IdListConverter
-app.url_map.converters['query'] = QueryConverter
-app.url_map.converters['everything'] = EverythingConverter
+app.url_map.converters["idlist"] = IdListConverter
+app.url_map.converters["query"] = QueryConverter
+app.url_map.converters["everything"] = EverythingConverter
 
 
 @app.before_request
 def before_request():
-    g.lib = app.config['lib']
+    g.lib = app.config["lib"]
 
 
 # Items.
 
-@app.route('/item/<idlist:ids>')
-@resource('items')
+
+@app.route("/item/<idlist:ids>")
+@resource("items")
 def get_item(id):
     return g.lib.get_item(id)
 
 
-@app.route('/item/')
-@app.route('/item/query/')
-@resource_list('items')
+@app.route("/item/")
+@app.route("/item/query/")
+@resource_list("items")
 def all_items():
     return g.lib.items()
 
 
-@app.route('/item/<int:item_id>/file')
+@app.route("/item/<int:item_id>/file")
 def item_file(item_id):
     item = g.lib.get_item(item_id)
 
     # On Windows under Python 2, Flask wants a Unicode path. On Python 3, it
     # *always* wants a Unicode path.
-    if os.name == 'nt':
+    if os.name == "nt":
         item_path = util.syspath(item.path)
     else:
         item_path = util.py3_path(item.path)
@@ -242,23 +255,21 @@ def item_file(item_id):
         safe_filename = base_filename
 
     response = flask.send_file(
-        item_path,
-        as_attachment=True,
-        attachment_filename=safe_filename
+        item_path, as_attachment=True, attachment_filename=safe_filename
     )
-    response.headers['Content-Length'] = os.path.getsize(item_path)
+    response.headers["Content-Length"] = os.path.getsize(item_path)
     return response
 
 
-@app.route('/item/query/<query:queries>')
-@resource_query('items')
+@app.route("/item/query/<query:queries>")
+@resource_query("items")
 def item_query(queries):
     return g.lib.items(queries)
 
 
-@app.route('/item/path/<everything:path>')
+@app.route("/item/path/<everything:path>")
 def item_at_path(path):
-    query = beets.library.PathQuery('path', path.encode('utf-8'))
+    query = beets.library.PathQuery("path", path.encode("utf-8"))
     item = g.lib.items(query).get()
     if item:
         return flask.jsonify(_rep(item))
@@ -266,12 +277,13 @@ def item_at_path(path):
         return flask.abort(404)
 
 
-@app.route('/item/values/<string:key>')
+@app.route("/item/values/<string:key>")
 def item_unique_field_values(key):
-    sort_key = flask.request.args.get('sort_key', key)
+    sort_key = flask.request.args.get("sort_key", key)
     try:
-        values = _get_unique_table_field_values(beets.library.Item, key,
-                                                sort_key)
+        values = _get_unique_table_field_values(
+            beets.library.Item, key, sort_key
+        )
     except KeyError:
         return flask.abort(404)
     return flask.jsonify(values=values)
@@ -279,26 +291,27 @@ def item_unique_field_values(key):
 
 # Albums.
 
-@app.route('/album/<idlist:ids>')
-@resource('albums')
+
+@app.route("/album/<idlist:ids>")
+@resource("albums")
 def get_album(id):
     return g.lib.get_album(id)
 
 
-@app.route('/album/')
-@app.route('/album/query/')
-@resource_list('albums')
+@app.route("/album/")
+@app.route("/album/query/")
+@resource_list("albums")
 def all_albums():
     return g.lib.albums()
 
 
-@app.route('/album/query/<query:queries>')
-@resource_query('albums')
+@app.route("/album/query/<query:queries>")
+@resource_query("albums")
 def album_query(queries):
     return g.lib.albums(queries)
 
 
-@app.route('/album/<int:album_id>/art')
+@app.route("/album/<int:album_id>/art")
 def album_art(album_id):
     album = g.lib.get_album(album_id)
     if album and album.artpath:
@@ -307,12 +320,13 @@ def album_art(album_id):
         return flask.abort(404)
 
 
-@app.route('/album/values/<string:key>')
+@app.route("/album/values/<string:key>")
 def album_unique_field_values(key):
-    sort_key = flask.request.args.get('sort_key', key)
+    sort_key = flask.request.args.get("sort_key", key)
     try:
-        values = _get_unique_table_field_values(beets.library.Album, key,
-                                                sort_key)
+        values = _get_unique_table_field_values(
+            beets.library.Album, key, sort_key
+        )
     except KeyError:
         return flask.abort(404)
     return flask.jsonify(values=values)
@@ -320,7 +334,8 @@ def album_unique_field_values(key):
 
 # Artists.
 
-@app.route('/artist/')
+
+@app.route("/artist/")
 def all_artists():
     with g.lib.transaction() as tx:
         rows = tx.query("SELECT DISTINCT albumartist FROM albums")
@@ -330,86 +345,101 @@ def all_artists():
 
 # Library information.
 
-@app.route('/stats')
+
+@app.route("/stats")
 def stats():
     with g.lib.transaction() as tx:
         item_rows = tx.query("SELECT COUNT(*) FROM items")
         album_rows = tx.query("SELECT COUNT(*) FROM albums")
-    return flask.jsonify({
-        'items': item_rows[0][0],
-        'albums': album_rows[0][0],
-    })
+    return flask.jsonify(
+        {"items": item_rows[0][0], "albums": album_rows[0][0],}
+    )
 
 
 # UI.
 
-@app.route('/')
+
+@app.route("/")
 def home():
-    return flask.render_template('index.html')
+    return flask.render_template("index.html")
 
 
 # Plugin hook.
 
+
 class WebPlugin(BeetsPlugin):
     def __init__(self):
         super(WebPlugin, self).__init__()
-        self.config.add({
-            'host': u'127.0.0.1',
-            'port': 8337,
-            'cors': '',
-            'cors_supports_credentials': False,
-            'reverse_proxy': False,
-            'include_paths': False,
-        })
+        self.config.add(
+            {
+                "host": u"127.0.0.1",
+                "port": 8337,
+                "cors": "",
+                "cors_supports_credentials": False,
+                "reverse_proxy": False,
+                "include_paths": False,
+            }
+        )
 
     def commands(self):
-        cmd = ui.Subcommand('web', help=u'start a Web interface')
-        cmd.parser.add_option(u'-d', u'--debug', action='store_true',
-                              default=False, help=u'debug mode')
+        cmd = ui.Subcommand("web", help=u"start a Web interface")
+        cmd.parser.add_option(
+            u"-d",
+            u"--debug",
+            action="store_true",
+            default=False,
+            help=u"debug mode",
+        )
 
         def func(lib, opts, args):
             args = ui.decargs(args)
             if args:
-                self.config['host'] = args.pop(0)
+                self.config["host"] = args.pop(0)
             if args:
-                self.config['port'] = int(args.pop(0))
+                self.config["port"] = int(args.pop(0))
 
-            app.config['lib'] = lib
+            app.config["lib"] = lib
             # Normalizes json output
-            app.config['JSONIFY_PRETTYPRINT_REGULAR'] = False
+            app.config["JSONIFY_PRETTYPRINT_REGULAR"] = False
 
-            app.config['INCLUDE_PATHS'] = self.config['include_paths']
+            app.config["INCLUDE_PATHS"] = self.config["include_paths"]
 
             # Enable CORS if required.
-            if self.config['cors']:
-                self._log.info(u'Enabling CORS with origin: {0}',
-                               self.config['cors'])
+            if self.config["cors"]:
+                self._log.info(
+                    u"Enabling CORS with origin: {0}", self.config["cors"]
+                )
                 from flask_cors import CORS
-                app.config['CORS_ALLOW_HEADERS'] = "Content-Type"
-                app.config['CORS_RESOURCES'] = {
-                    r"/*": {"origins": self.config['cors'].get(str)}
+
+                app.config["CORS_ALLOW_HEADERS"] = "Content-Type"
+                app.config["CORS_RESOURCES"] = {
+                    r"/*": {"origins": self.config["cors"].get(str)}
                 }
                 CORS(
                     app,
                     supports_credentials=self.config[
-                        'cors_supports_credentials'
-                    ].get(bool)
+                        "cors_supports_credentials"
+                    ].get(bool),
                 )
 
             # Allow serving behind a reverse proxy
-            if self.config['reverse_proxy']:
+            if self.config["reverse_proxy"]:
                 app.wsgi_app = ReverseProxied(app.wsgi_app)
 
             # Start the web application.
-            app.run(host=self.config['host'].as_str(),
-                    port=self.config['port'].get(int),
-                    debug=opts.debug, threaded=True)
+            app.run(
+                host=self.config["host"].as_str(),
+                port=self.config["port"].get(int),
+                debug=opts.debug,
+                threaded=True,
+            )
+
         cmd.func = func
         return [cmd]
 
 
 class ReverseProxied(object):
-    '''Wrap the application in this middleware and configure the
+    """Wrap the application in this middleware and configure the
     front-end server to add these headers, to let you quietly bind
     this to a URL other than / and to an HTTP scheme that is
     different than what is used locally.
@@ -426,19 +456,20 @@ class ReverseProxied(object):
     From: http://flask.pocoo.org/snippets/35/
 
     :param app: the WSGI application
-    '''
+    """
+
     def __init__(self, app):
         self.app = app
 
     def __call__(self, environ, start_response):
-        script_name = environ.get('HTTP_X_SCRIPT_NAME', '')
+        script_name = environ.get("HTTP_X_SCRIPT_NAME", "")
         if script_name:
-            environ['SCRIPT_NAME'] = script_name
-            path_info = environ['PATH_INFO']
+            environ["SCRIPT_NAME"] = script_name
+            path_info = environ["PATH_INFO"]
             if path_info.startswith(script_name):
-                environ['PATH_INFO'] = path_info[len(script_name):]
+                environ["PATH_INFO"] = path_info[len(script_name) :]
 
-        scheme = environ.get('HTTP_X_SCHEME', '')
+        scheme = environ.get("HTTP_X_SCHEME", "")
         if scheme:
-            environ['wsgi.url_scheme'] = scheme
+            environ["wsgi.url_scheme"] = scheme
         return self.app(environ, start_response)

--- a/beetsplug/zero.py
+++ b/beetsplug/zero.py
@@ -70,9 +70,8 @@ class ZeroPlugin(BeetsPlugin):
             for field in MediaFile.fields():
                 if (
                     field not in self.config["keep_fields"].as_str_seq()
-                    and
                     # These fields should always be preserved.
-                    field not in ("id", "path", "album_id")
+                    and field not in ("id", "path", "album_id")
                 ):
                     self._set_pattern(field)
 

--- a/beetsplug/zero.py
+++ b/beetsplug/zero.py
@@ -26,23 +26,26 @@ from beets.importer import action
 from beets.ui import Subcommand, decargs, input_yn
 import confuse
 
-__author__ = 'baobab@heresiarch.info'
+__author__ = "baobab@heresiarch.info"
 
 
 class ZeroPlugin(BeetsPlugin):
     def __init__(self):
         super(ZeroPlugin, self).__init__()
 
-        self.register_listener('write', self.write_event)
-        self.register_listener('import_task_choice',
-                               self.import_task_choice_event)
+        self.register_listener("write", self.write_event)
+        self.register_listener(
+            "import_task_choice", self.import_task_choice_event
+        )
 
-        self.config.add({
-            'auto': True,
-            'fields': [],
-            'keep_fields': [],
-            'update_database': False,
-        })
+        self.config.add(
+            {
+                "auto": True,
+                "fields": [],
+                "keep_fields": [],
+                "update_database": False,
+            }
+        )
 
         self.fields_to_progs = {}
         self.warned = False
@@ -54,29 +57,32 @@ class ZeroPlugin(BeetsPlugin):
         A field is zeroed if its value matches one of the associated progs. If
         progs is empty, then the associated field is always zeroed.
         """
-        if self.config['fields'] and self.config['keep_fields']:
+        if self.config["fields"] and self.config["keep_fields"]:
             self._log.warning(
-                u'cannot blacklist and whitelist at the same time'
+                u"cannot blacklist and whitelist at the same time"
             )
         # Blacklist mode.
-        elif self.config['fields']:
-            for field in self.config['fields'].as_str_seq():
+        elif self.config["fields"]:
+            for field in self.config["fields"].as_str_seq():
                 self._set_pattern(field)
         # Whitelist mode.
-        elif self.config['keep_fields']:
+        elif self.config["keep_fields"]:
             for field in MediaFile.fields():
-                if (field not in self.config['keep_fields'].as_str_seq() and
-                        # These fields should always be preserved.
-                        field not in ('id', 'path', 'album_id')):
+                if (
+                    field not in self.config["keep_fields"].as_str_seq()
+                    and
+                    # These fields should always be preserved.
+                    field not in ("id", "path", "album_id")
+                ):
                     self._set_pattern(field)
 
     def commands(self):
-        zero_command = Subcommand('zero', help='set fields to null')
+        zero_command = Subcommand("zero", help="set fields to null")
 
         def zero_fields(lib, opts, args):
             if not decargs(args) and not input_yn(
-                    u"Remove fields for all items? (Y/n)",
-                    True):
+                u"Remove fields for all items? (Y/n)", True
+            ):
                 return
             for item in lib.items(decargs(args)):
                 self.process_item(item)
@@ -89,10 +95,12 @@ class ZeroPlugin(BeetsPlugin):
         Do some sanity checks then compile the regexes.
         """
         if field not in MediaFile.fields():
-            self._log.error(u'invalid field: {0}', field)
-        elif field in ('id', 'path', 'album_id'):
-            self._log.warning(u'field \'{0}\' ignored, zeroing '
-                              u'it would be dangerous', field)
+            self._log.error(u"invalid field: {0}", field)
+        elif field in ("id", "path", "album_id"):
+            self._log.warning(
+                u"field '{0}' ignored, zeroing " u"it would be dangerous",
+                field,
+            )
         else:
             try:
                 for pattern in self.config[field].as_str_seq():
@@ -104,12 +112,12 @@ class ZeroPlugin(BeetsPlugin):
 
     def import_task_choice_event(self, session, task):
         if task.choice_flag == action.ASIS and not self.warned:
-            self._log.warning(u'cannot zero in \"as-is\" mode')
+            self._log.warning(u'cannot zero in "as-is" mode')
             self.warned = True
         # TODO request write in as-is mode
 
     def write_event(self, item, path, tags):
-        if self.config['auto']:
+        if self.config["auto"]:
             self.set_fields(item, tags)
 
     def set_fields(self, item, tags):
@@ -122,7 +130,7 @@ class ZeroPlugin(BeetsPlugin):
         fields_set = False
 
         if not self.fields_to_progs:
-            self._log.warning(u'no fields, nothing to do')
+            self._log.warning(u"no fields, nothing to do")
             return False
 
         for field, progs in self.fields_to_progs.items():
@@ -130,14 +138,14 @@ class ZeroPlugin(BeetsPlugin):
                 value = tags[field]
                 match = _match_progs(tags[field], progs)
             else:
-                value = ''
+                value = ""
                 match = not progs
 
             if match:
                 fields_set = True
-                self._log.debug(u'{0}: {1} -> None', field, value)
+                self._log.debug(u"{0}: {1} -> None", field, value)
                 tags[field] = None
-                if self.config['update_database']:
+                if self.config["update_database"]:
                     item[field] = None
 
         return fields_set
@@ -147,7 +155,7 @@ class ZeroPlugin(BeetsPlugin):
 
         if self.set_fields(item, tags):
             item.write(tags=tags)
-            if self.config['update_database']:
+            if self.config["update_database"]:
                 item.store(fields=tags)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,45 +2,54 @@
 
 from __future__ import division, absolute_import, print_function
 
-AUTHOR = u'Adrian Sampson'
+AUTHOR = u"Adrian Sampson"
 
 # General configuration
 
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.extlinks']
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.extlinks"]
 
-exclude_patterns = ['_build']
-source_suffix = '.rst'
-master_doc = 'index'
+exclude_patterns = ["_build"]
+source_suffix = ".rst"
+master_doc = "index"
 
-project = u'beets'
-copyright = u'2016, Adrian Sampson'
+project = u"beets"
+copyright = u"2016, Adrian Sampson"
 
-version = '1.5'
-release = '1.5.0'
+version = "1.5"
+release = "1.5.0"
 
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # External links to the bug tracker and other sites.
 extlinks = {
-    'bug': ('https://github.com/beetbox/beets/issues/%s', '#'),
-    'user': ('https://github.com/%s', ''),
-    'pypi': ('https://pypi.org/project/%s/', ''),
-    'stdlib': ('https://docs.python.org/3/library/%s.html', ''),
+    "bug": ("https://github.com/beetbox/beets/issues/%s", "#"),
+    "user": ("https://github.com/%s", ""),
+    "pypi": ("https://pypi.org/project/%s/", ""),
+    "stdlib": ("https://docs.python.org/3/library/%s.html", ""),
 }
 
 # Options for HTML output
-htmlhelp_basename = 'beetsdoc'
+htmlhelp_basename = "beetsdoc"
 
 # Options for LaTeX output
 latex_documents = [
-    ('index', 'beets.tex', u'beets Documentation',
-     AUTHOR, 'manual'),
+    ("index", "beets.tex", u"beets Documentation", AUTHOR, "manual"),
 ]
 
 # Options for manual page output
 man_pages = [
-    ('reference/cli', 'beet', u'music tagger and library organizer',
-     [AUTHOR], 1),
-    ('reference/config', 'beetsconfig', u'beets configuration file',
-     [AUTHOR], 5),
+    (
+        "reference/cli",
+        "beet",
+        u"music tagger and library organizer",
+        [AUTHOR],
+        1,
+    ),
+    (
+        "reference/config",
+        "beetsconfig",
+        u"beets configuration file",
+        [AUTHOR],
+        5,
+    ),
 ]

--- a/extra/release.py
+++ b/extra/release.py
@@ -3,6 +3,10 @@
 
 """A utility script for automating the beets release process.
 """
+from __future__ import division
+from __future__ import absolute_import
+from __future__ import print_function
+
 import click
 import os
 import re

--- a/extra/release.py
+++ b/extra/release.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 import datetime
 
 BASE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-CHANGELOG = os.path.join(BASE, 'docs', 'changelog.rst')
+CHANGELOG = os.path.join(BASE, "docs", "changelog.rst")
 
 
 @contextmanager
@@ -32,50 +32,44 @@ def release():
 # Locations (filenames and patterns) of the version number.
 VERSION_LOCS = [
     (
-        os.path.join(BASE, 'beets', '__init__.py'),
+        os.path.join(BASE, "beets", "__init__.py"),
         [
             (
                 r'__version__\s*=\s*u[\'"]([0-9\.]+)[\'"]',
                 "__version__ = u'{version}'",
             )
-        ]
+        ],
     ),
     (
-        os.path.join(BASE, 'docs', 'conf.py'),
+        os.path.join(BASE, "docs", "conf.py"),
         [
-            (
-                r'version\s*=\s*[\'"]([0-9\.]+)[\'"]',
-                "version = '{minor}'",
-            ),
-            (
-                r'release\s*=\s*[\'"]([0-9\.]+)[\'"]',
-                "release = '{version}'",
-            ),
-        ]
+            (r'version\s*=\s*[\'"]([0-9\.]+)[\'"]', "version = '{minor}'",),
+            (r'release\s*=\s*[\'"]([0-9\.]+)[\'"]', "release = '{version}'",),
+        ],
     ),
     (
-        os.path.join(BASE, 'setup.py'),
+        os.path.join(BASE, "setup.py"),
         [
             (
                 r'\s*version\s*=\s*[\'"]([0-9\.]+)[\'"]',
                 "    version='{version}',",
             )
-        ]
+        ],
     ),
 ]
 
-GITHUB_USER = 'beetbox'
-GITHUB_REPO = 'beets'
+GITHUB_USER = "beetbox"
+GITHUB_REPO = "beets"
 
 
 def bump_version(version):
     """Update the version number in setup.py, docs config, changelog,
     and root module.
     """
-    version_parts = [int(p) for p in version.split('.')]
+    version_parts = [int(p) for p in version.split(".")]
     assert len(version_parts) == 3, "invalid version number"
-    minor = '{}.{}'.format(*version_parts)
-    major = '{}'.format(*version_parts)
+    minor = "{}.{}".format(*version_parts)
+    major = "{}".format(*version_parts)
 
     # Replace the version each place where it lives.
     for filename, locations in VERSION_LOCS:
@@ -89,18 +83,18 @@ def bump_version(version):
                     if match:
                         # Check that this version is actually newer.
                         old_version = match.group(1)
-                        old_parts = [int(p) for p in old_version.split('.')]
-                        assert version_parts > old_parts, \
-                            "version must be newer than {}".format(
-                                old_version
-                            )
+                        old_parts = [int(p) for p in old_version.split(".")]
+                        assert (
+                            version_parts > old_parts
+                        ), "version must be newer than {}".format(old_version)
 
                         # Insert the new version.
-                        out_lines.append(template.format(
-                            version=version,
-                            major=major,
-                            minor=minor,
-                        ) + '\n')
+                        out_lines.append(
+                            template.format(
+                                version=version, major=major, minor=minor,
+                            )
+                            + "\n"
+                        )
 
                         found = True
                         break
@@ -113,27 +107,27 @@ def bump_version(version):
                 print("No pattern found in {}".format(filename))
 
         # Write the file back.
-        with open(filename, 'w') as f:
-            f.write(''.join(out_lines))
+        with open(filename, "w") as f:
+            f.write("".join(out_lines))
 
     # Generate bits to insert into changelog.
-    header_line = '{} (in development)'.format(version)
-    header = '\n\n' + header_line + '\n' + '-' * len(header_line) + '\n\n'
-    header += 'Changelog goes here!\n'
+    header_line = "{} (in development)".format(version)
+    header = "\n\n" + header_line + "\n" + "-" * len(header_line) + "\n\n"
+    header += "Changelog goes here!\n"
 
     # Insert into the right place.
     with open(CHANGELOG) as f:
         contents = f.read()
-    location = contents.find('\n\n')  # First blank line.
+    location = contents.find("\n\n")  # First blank line.
     contents = contents[:location] + header + contents[location:]
 
     # Write back.
-    with open(CHANGELOG, 'w') as f:
+    with open(CHANGELOG, "w") as f:
         f.write(contents)
 
 
 @release.command()
-@click.argument('version')
+@click.argument("version")
 def bump(version):
     """Bump the version number.
     """
@@ -147,7 +141,7 @@ def get_latest_changelog():
     lines = []
     with open(CHANGELOG) as f:
         for line in f:
-            if re.match(r'^--+$', line.strip()):
+            if re.match(r"^--+$", line.strip()):
                 # Section boundary. Start or end.
                 if started:
                     # Remove last line, which is the header of the next
@@ -159,21 +153,23 @@ def get_latest_changelog():
 
             elif started:
                 lines.append(line)
-    return ''.join(lines).strip()
+    return "".join(lines).strip()
 
 
 def rst2md(text):
     """Use Pandoc to convert text from ReST to Markdown.
     """
     pandoc = subprocess.Popen(
-        ['pandoc', '--from=rst', '--to=markdown', '--wrap=none'],
-        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        ["pandoc", "--from=rst", "--to=markdown", "--wrap=none"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
-    stdout, _ = pandoc.communicate(text.encode('utf-8'))
-    md = stdout.decode('utf-8').strip()
+    stdout, _ = pandoc.communicate(text.encode("utf-8"))
+    md = stdout.decode("utf-8").strip()
 
     # Fix up odd spacing in lists.
-    return re.sub(r'^-   ', '- ', md, flags=re.M)
+    return re.sub(r"^-   ", "- ", md, flags=re.M)
 
 
 def changelog_as_markdown():
@@ -182,28 +178,28 @@ def changelog_as_markdown():
     rst = get_latest_changelog()
 
     # Replace plugin links with plugin names.
-    rst = re.sub(r':doc:`/plugins/(\w+)`', r'``\1``', rst)
+    rst = re.sub(r":doc:`/plugins/(\w+)`", r"``\1``", rst)
 
     # References with text.
-    rst = re.sub(r':ref:`([^<]+)(<[^>]+>)`', r'\1', rst)
+    rst = re.sub(r":ref:`([^<]+)(<[^>]+>)`", r"\1", rst)
 
     # Other backslashes with verbatim ranges.
-    rst = re.sub(r'(\s)`([^`]+)`([^_])', r'\1``\2``\3', rst)
+    rst = re.sub(r"(\s)`([^`]+)`([^_])", r"\1``\2``\3", rst)
 
     # Command links with command names.
-    rst = re.sub(r':ref:`(\w+)-cmd`', r'``\1``', rst)
+    rst = re.sub(r":ref:`(\w+)-cmd`", r"``\1``", rst)
 
     # Bug numbers.
-    rst = re.sub(r':bug:`(\d+)`', r'#\1', rst)
+    rst = re.sub(r":bug:`(\d+)`", r"#\1", rst)
 
     # Users.
-    rst = re.sub(r':user:`(\w+)`', r'@\1', rst)
+    rst = re.sub(r":user:`(\w+)`", r"@\1", rst)
 
     # Convert with Pandoc.
     md = rst2md(rst)
 
     # Restore escaped issue numbers.
-    md = re.sub(r'\\#(\d+)\b', r'#\1', md)
+    md = re.sub(r"\\#(\d+)\b", r"#\1", md)
 
     return md
 
@@ -221,7 +217,7 @@ def get_version(index=0):
     with open(CHANGELOG) as f:
         cur_index = 0
         for line in f:
-            match = re.search(r'^\d+\.\d+\.\d+', line)
+            match = re.search(r"^\d+\.\d+\.\d+", line)
             if match:
                 if cur_index == index:
                     return match.group(0)
@@ -241,8 +237,8 @@ def datestamp():
     """Enter today's date as the release date in the changelog.
     """
     dt = datetime.datetime.now()
-    stamp = '({} {}, {})'.format(dt.strftime('%B'), dt.day, dt.year)
-    marker = '(in development)'
+    stamp = "({} {}, {})".format(dt.strftime("%B"), dt.day, dt.year)
+    marker = "(in development)"
 
     lines = []
     underline_length = None
@@ -255,12 +251,12 @@ def datestamp():
                 underline_length = len(line.strip())
             elif underline_length:
                 # This is the line after the header. Rewrite the dashes.
-                lines.append('-' * underline_length + '\n')
+                lines.append("-" * underline_length + "\n")
                 underline_length = None
             else:
                 lines.append(line)
 
-    with open(CHANGELOG, 'w') as f:
+    with open(CHANGELOG, "w") as f:
         for line in lines:
             f.write(line)
 
@@ -277,22 +273,22 @@ def prep():
     cur_version = get_version()
 
     # Tag.
-    subprocess.check_output(['git', 'tag', 'v{}'.format(cur_version)])
+    subprocess.check_output(["git", "tag", "v{}".format(cur_version)])
 
     # Build.
     with chdir(BASE):
-        subprocess.check_call(['python', 'setup.py', 'sdist'])
+        subprocess.check_call(["python", "setup.py", "sdist"])
 
     # Generate Markdown changelog.
     cl = changelog_as_markdown()
-    with open(os.path.join(BASE, 'changelog.md'), 'w') as f:
+    with open(os.path.join(BASE, "changelog.md"), "w") as f:
         f.write(cl)
 
     # Version number bump.
     # FIXME It should be possible to specify this as an argument.
-    version_parts = [int(n) for n in cur_version.split('.')]
+    version_parts = [int(n) for n in cur_version.split(".")]
     version_parts[-1] += 1
-    next_version = u'.'.join(map(str, version_parts))
+    next_version = u".".join(map(str, version_parts))
     bump_version(next_version)
 
 
@@ -307,12 +303,12 @@ def publish():
 
     # Push to GitHub.
     with chdir(BASE):
-        subprocess.check_call(['git', 'push'])
-        subprocess.check_call(['git', 'push', '--tags'])
+        subprocess.check_call(["git", "push"])
+        subprocess.check_call(["git", "push", "--tags"])
 
     # Upload to PyPI.
-    path = os.path.join(BASE, 'dist', 'beets-{}.tar.gz'.format(version))
-    subprocess.check_call(['twine', 'upload', path])
+    path = os.path.join(BASE, "dist", "beets-{}.tar.gz".format(version))
+    subprocess.check_call(["twine", "upload", path])
 
 
 @release.command()
@@ -324,31 +320,49 @@ def ghrelease():
     tarball from the `dist` directory.
     """
     version = get_version(1)
-    tag = 'v' + version
+    tag = "v" + version
 
     # Load the changelog.
-    with open(os.path.join(BASE, 'changelog.md')) as f:
+    with open(os.path.join(BASE, "changelog.md")) as f:
         cl_md = f.read()
 
     # Create the release.
-    subprocess.check_call([
-        'github-release', 'release',
-        '-u', GITHUB_USER, '-r', GITHUB_REPO,
-        '--tag', tag,
-        '--name', '{} {}'.format(GITHUB_REPO, version),
-        '--description', cl_md,
-    ])
+    subprocess.check_call(
+        [
+            "github-release",
+            "release",
+            "-u",
+            GITHUB_USER,
+            "-r",
+            GITHUB_REPO,
+            "--tag",
+            tag,
+            "--name",
+            "{} {}".format(GITHUB_REPO, version),
+            "--description",
+            cl_md,
+        ]
+    )
 
     # Attach the release tarball.
-    tarball = os.path.join(BASE, 'dist', 'beets-{}.tar.gz'.format(version))
-    subprocess.check_call([
-        'github-release', 'upload',
-        '-u', GITHUB_USER, '-r', GITHUB_REPO,
-        '--tag', tag,
-        '--name', os.path.basename(tarball),
-        '--file', tarball,
-    ])
+    tarball = os.path.join(BASE, "dist", "beets-{}.tar.gz".format(version))
+    subprocess.check_call(
+        [
+            "github-release",
+            "upload",
+            "-u",
+            GITHUB_USER,
+            "-r",
+            GITHUB_REPO,
+            "--tag",
+            tag,
+            "--name",
+            os.path.basename(tarball),
+            "--file",
+            tarball,
+        ]
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     release()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 79

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,16 +5,14 @@ docstring-convention = google
 # errors we ignore; see https://www.flake8rules.com/ for more info
 ignore =
     # pycodestyle errors
-    E121,  # continuation line under-indented for hanging indent
-    E123,  # closing bracket does not match indentation of opening bracket's line
-    E126,  # continuation line over-indented for hangin indent
-    E241,  # multiple spaces after non-arithmetic operators (for vertical alignment)
-    E305,  # expected 2 blank lines after end of function or class
+    E203,
+    E231,
+    E266,
+    E501,
     E731,  # do not assign a lamba expression, use a def
     E741,  # do not use variables name 'I', 'O', or 'l'
     # pycodestyle warnings
     W503,  # line break occurred before a binary operator
-    W504,  # line break occurred after a binary operator
     # pyflakes errors
     F405,  # name be undefined, or defined from star imports: module
     # mccabe error

--- a/setup.py
+++ b/setup.py
@@ -31,11 +31,11 @@ def _read(fn):
 
 def build_manpages():
     # Go into the docs directory and build the manpage.
-    docdir = os.path.join(os.path.dirname(__file__), 'docs')
+    docdir = os.path.join(os.path.dirname(__file__), "docs")
     curdir = os.getcwd()
     os.chdir(docdir)
     try:
-        subprocess.check_call(['make', 'man'])
+        subprocess.check_call(["make", "man"])
     except OSError:
         print("Could not build manpages (make man failed)!", file=sys.stderr)
         return
@@ -43,123 +43,130 @@ def build_manpages():
         os.chdir(curdir)
 
     # Copy resulting manpages.
-    mandir = os.path.join(os.path.dirname(__file__), 'man')
+    mandir = os.path.join(os.path.dirname(__file__), "man")
     if os.path.exists(mandir):
         shutil.rmtree(mandir)
-    shutil.copytree(os.path.join(docdir, '_build', 'man'), mandir)
+    shutil.copytree(os.path.join(docdir, "_build", "man"), mandir)
 
 
 # Build manpages if we're making a source distribution tarball.
-if 'sdist' in sys.argv:
+if "sdist" in sys.argv:
     build_manpages()
 
 
 setup(
-    name='beets',
-    version='1.5.0',
-    description='music tagger and library organizer',
-    author='Adrian Sampson',
-    author_email='adrian@radbox.org',
-    url='https://beets.io/',
-    license='MIT',
-    platforms='ALL',
-    long_description=_read('README.rst'),
-    test_suite='test.testall.suite',
+    name="beets",
+    version="1.5.0",
+    description="music tagger and library organizer",
+    author="Adrian Sampson",
+    author_email="adrian@radbox.org",
+    url="https://beets.io/",
+    license="MIT",
+    platforms="ALL",
+    long_description=_read("README.rst"),
+    test_suite="test.testall.suite",
     zip_safe=False,
     include_package_data=True,  # Install plugin resources.
-
     packages=[
-        'beets',
-        'beets.ui',
-        'beets.autotag',
-        'beets.util',
-        'beets.dbcore',
-        'beetsplug',
-        'beetsplug.bpd',
-        'beetsplug.web',
-        'beetsplug.lastgenre',
-        'beetsplug.metasync',
+        "beets",
+        "beets.ui",
+        "beets.autotag",
+        "beets.util",
+        "beets.dbcore",
+        "beetsplug",
+        "beetsplug.bpd",
+        "beetsplug.web",
+        "beetsplug.lastgenre",
+        "beetsplug.metasync",
     ],
-    entry_points={
-        'console_scripts': [
-            'beet = beets.ui:main',
-        ],
-    },
-
+    entry_points={"console_scripts": ["beet = beets.ui:main",],},
     install_requires=[
-        'six>=1.9',
-        'unidecode',
-        'musicbrainzngs>=0.4',
-        'pyyaml',
-        'mediafile>=0.2.0',
-        'confuse>=1.0.0',
-    ] + [
+        "six>=1.9",
+        "unidecode",
+        "musicbrainzngs>=0.4",
+        "pyyaml",
+        "mediafile>=0.2.0",
+        "confuse>=1.0.0",
+    ]
+    + [
         # Avoid a version of munkres incompatible with Python 3.
-        'munkres~=1.0.0' if sys.version_info < (3, 5, 0) else
-        'munkres!=1.1.0,!=1.1.1' if sys.version_info < (3, 6, 0) else
-        'munkres>=1.0.0',
-    ] + (
+        "munkres~=1.0.0"
+        if sys.version_info < (3, 5, 0)
+        else "munkres!=1.1.0,!=1.1.1"
+        if sys.version_info < (3, 6, 0)
+        else "munkres>=1.0.0",
+    ]
+    + (
         # Use the backport of Python 3.4's `enum` module.
-        ['enum34>=1.0.4'] if sys.version_info < (3, 4, 0) else []
-    ) + (
+        ["enum34>=1.0.4"]
+        if sys.version_info < (3, 4, 0)
+        else []
+    )
+    + (
         # Pin a Python 2-compatible version of Jellyfish.
-        ['jellyfish==0.6.0'] if sys.version_info < (3, 4, 0) else ['jellyfish']
-    ) + (
+        ["jellyfish==0.6.0"]
+        if sys.version_info < (3, 4, 0)
+        else ["jellyfish"]
+    )
+    + (
         # Support for ANSI console colors on Windows.
-        ['colorama'] if (sys.platform == 'win32') else []
+        ["colorama"]
+        if (sys.platform == "win32")
+        else []
     ),
-
     extras_require={
-        'test': [
-            'beautifulsoup4',
-            'coverage',
-            'discogs-client',
-            'flask',
-            'mock',
-            'pylast',
-            'pytest',
-            'python-mpd2',
-            'pyxdg',
-            'rarfile',
-            'responses>=0.3.0',
-            'requests_oauthlib',
-        ] + (
+        "test": [
+            "beautifulsoup4",
+            "coverage",
+            "discogs-client",
+            "flask",
+            "mock",
+            "pylast",
+            "pytest",
+            "python-mpd2",
+            "pyxdg",
+            "rarfile",
+            "responses>=0.3.0",
+            "requests_oauthlib",
+        ]
+        + (
             # Tests for the thumbnails plugin need pathlib on Python 2 too.
-            ['pathlib'] if (sys.version_info < (3, 4, 0)) else []
-            ),
-        'lint': [
-            'flake8',
-            'flake8-blind-except',
-            'flake8-coding',
-            'flake8-docstrings',
-            'flake8-future-import',
-            'pep8-naming',
+            ["pathlib"]
+            if (sys.version_info < (3, 4, 0))
+            else []
+        ),
+        "lint": [
+            "flake8",
+            "flake8-blind-except",
+            "flake8-coding",
+            "flake8-docstrings",
+            "flake8-future-import",
+            "pep8-naming",
         ],
-
         # Plugin (optional) dependencies:
-        'absubmit': ['requests'],
-        'fetchart': ['requests', 'Pillow'],
-        'embedart': ['Pillow'],
-        'embyupdate': ['requests'],
-        'chroma': ['pyacoustid'],
-        'gmusic': ['gmusicapi'],
-        'discogs': ['discogs-client>=2.2.1'],
-        'beatport': ['requests-oauthlib>=0.6.1'],
-        'kodiupdate': ['requests'],
-        'lastgenre': ['pylast'],
-        'lastimport': ['pylast'],
-        'lyrics': ['requests', 'beautifulsoup4', 'langdetect'],
-        'mpdstats': ['python-mpd2>=0.4.2'],
-        'plexupdate': ['requests'],
-        'web': ['flask', 'flask-cors'],
-        'import': ['rarfile'],
-        'thumbnails': ['pyxdg', 'Pillow'] +
-        (['pathlib'] if (sys.version_info < (3, 4, 0)) else []),
-        'metasync': ['dbus-python'],
-        'sonosupdate': ['soco'],
-        'scrub': ['mutagen>=1.33'],
-        'bpd': ['PyGObject'],
-        'replaygain': ['PyGObject'],
+        "absubmit": ["requests"],
+        "fetchart": ["requests", "Pillow"],
+        "embedart": ["Pillow"],
+        "embyupdate": ["requests"],
+        "chroma": ["pyacoustid"],
+        "gmusic": ["gmusicapi"],
+        "discogs": ["discogs-client>=2.2.1"],
+        "beatport": ["requests-oauthlib>=0.6.1"],
+        "kodiupdate": ["requests"],
+        "lastgenre": ["pylast"],
+        "lastimport": ["pylast"],
+        "lyrics": ["requests", "beautifulsoup4", "langdetect"],
+        "mpdstats": ["python-mpd2>=0.4.2"],
+        "plexupdate": ["requests"],
+        "web": ["flask", "flask-cors"],
+        "import": ["rarfile"],
+        "thumbnails": ["pyxdg", "Pillow"]
+        + (["pathlib"] if (sys.version_info < (3, 4, 0)) else []),
+        "metasync": ["dbus-python"],
+        "sonosupdate": ["soco"],
+        "scrub": ["mutagen>=1.33"],
+        "bpd": ["PyGObject"],
+        "replaygain": ["PyGObject"],
     },
     # Non-Python/non-PyPI plugin dependencies:
     #   chroma: chromaprint or fpcalc
@@ -172,21 +179,20 @@ setup(
     #   replaygain: python-gi and GStreamer 1.0+ or mp3gain/aacgain
     #               or Python Audio Tools
     #   ipfs: go-ipfs
-
     classifiers=[
-        'Topic :: Multimedia :: Sound/Audio',
-        'Topic :: Multimedia :: Sound/Audio :: Players :: MP3',
-        'License :: OSI Approved :: MIT License',
-        'Environment :: Console',
-        'Environment :: Web Environment',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: Implementation :: CPython',
+        "Topic :: Multimedia :: Sound/Audio",
+        "Topic :: Multimedia :: Sound/Audio :: Players :: MP3",
+        "License :: OSI Approved :: MIT License",
+        "Environment :: Console",
+        "Environment :: Web Environment",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: Implementation :: CPython",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -136,12 +136,14 @@ setup(
             else []
         ),
         "lint": [
+            "black",
             "flake8",
             "flake8-blind-except",
             "flake8-coding",
             "flake8-docstrings",
             "flake8-future-import",
             "pep8-naming",
+            "pre-commit",
         ],
         # Plugin (optional) dependencies:
         "absubmit": ["requests"],

--- a/test/_common.py
+++ b/test/_common.py
@@ -27,7 +27,7 @@ from contextlib import contextmanager
 
 
 # Mangle the search path to include the beets sources.
-sys.path.insert(0, '..')
+sys.path.insert(0, "..")
 import beets.library  # noqa: E402
 from beets import importer, logging  # noqa: E402
 from beets.ui import commands  # noqa: E402
@@ -36,16 +36,17 @@ import beets  # noqa: E402
 
 # Make sure the development versions of the plugins are used
 import beetsplug  # noqa: E402
-beetsplug.__path__ = [os.path.abspath(
-    os.path.join(__file__, '..', '..', 'beetsplug')
-)]
+
+beetsplug.__path__ = [
+    os.path.abspath(os.path.join(__file__, "..", "..", "beetsplug"))
+]
 
 # Test resources path.
-RSRC = util.bytestring_path(os.path.join(os.path.dirname(__file__), 'rsrc'))
-PLUGINPATH = os.path.join(os.path.dirname(__file__), 'rsrc', 'beetsplug')
+RSRC = util.bytestring_path(os.path.join(os.path.dirname(__file__), "rsrc"))
+PLUGINPATH = os.path.join(os.path.dirname(__file__), "rsrc", "beetsplug")
 
 # Propagate to root logger so the test runner can capture it
-log = logging.getLogger('beets')
+log = logging.getLogger("beets")
 log.propagate = True
 log.setLevel(logging.DEBUG)
 
@@ -53,26 +54,26 @@ log.setLevel(logging.DEBUG)
 _item_ident = 0
 
 # OS feature test.
-HAVE_SYMLINK = sys.platform != 'win32'
-HAVE_HARDLINK = sys.platform != 'win32'
+HAVE_SYMLINK = sys.platform != "win32"
+HAVE_HARDLINK = sys.platform != "win32"
 
 
 def item(lib=None):
     global _item_ident
     _item_ident += 1
     i = beets.library.Item(
-        title=u'the title',
-        artist=u'the artist',
-        albumartist=u'the album artist',
-        album=u'the album',
-        genre=u'the genre',
-        lyricist=u'the lyricist',
-        composer=u'the composer',
-        arranger=u'the arranger',
-        grouping=u'the grouping',
-        work=u'the work title',
-        mb_workid=u'the work musicbrainz id',
-        work_disambig=u'the work disambiguation',
+        title=u"the title",
+        artist=u"the artist",
+        albumartist=u"the album artist",
+        album=u"the album",
+        genre=u"the genre",
+        lyricist=u"the lyricist",
+        composer=u"the composer",
+        arranger=u"the arranger",
+        grouping=u"the grouping",
+        work=u"the work title",
+        mb_workid=u"the work musicbrainz id",
+        work_disambig=u"the work disambiguation",
         year=1,
         month=2,
         day=3,
@@ -80,25 +81,26 @@ def item(lib=None):
         tracktotal=5,
         disc=6,
         disctotal=7,
-        lyrics=u'the lyrics',
-        comments=u'the comments',
+        lyrics=u"the lyrics",
+        comments=u"the comments",
         bpm=8,
         comp=True,
-        path='somepath{0}'.format(_item_ident),
+        path="somepath{0}".format(_item_ident),
         length=60.0,
         bitrate=128000,
-        format='FLAC',
-        mb_trackid='someID-1',
-        mb_albumid='someID-2',
-        mb_artistid='someID-3',
-        mb_albumartistid='someID-4',
-        mb_releasetrackid='someID-5',
+        format="FLAC",
+        mb_trackid="someID-1",
+        mb_albumid="someID-2",
+        mb_artistid="someID-3",
+        mb_albumartistid="someID-4",
+        mb_releasetrackid="someID-5",
         album_id=None,
         mtime=12345,
     )
     if lib:
         lib.add(i)
     return i
+
 
 _album_ident = 0
 
@@ -108,19 +110,19 @@ def album(lib=None):
     _item_ident += 1
     i = beets.library.Album(
         artpath=None,
-        albumartist=u'some album artist',
-        albumartist_sort=u'some sort album artist',
-        albumartist_credit=u'some album artist credit',
-        album=u'the album',
-        genre=u'the genre',
+        albumartist=u"some album artist",
+        albumartist_sort=u"some sort album artist",
+        albumartist_credit=u"some album artist credit",
+        album=u"the album",
+        genre=u"the genre",
         year=2014,
         month=2,
         day=5,
         tracktotal=0,
         disctotal=1,
         comp=False,
-        mb_albumid='someID-1',
-        mb_albumartistid='someID-1'
+        mb_albumid="someID-1",
+        mb_albumartistid="someID-1",
     )
     if lib:
         lib.add(i)
@@ -137,17 +139,24 @@ class Assertions(object):
     """A mixin with additional unit test assertions."""
 
     def assertExists(self, path):  # noqa
-        self.assertTrue(os.path.exists(util.syspath(path)),
-                        u'file does not exist: {!r}'.format(path))
+        self.assertTrue(
+            os.path.exists(util.syspath(path)),
+            u"file does not exist: {!r}".format(path),
+        )
 
     def assertNotExists(self, path):  # noqa
-        self.assertFalse(os.path.exists(util.syspath(path)),
-                         u'file exists: {!r}'.format((path)))
+        self.assertFalse(
+            os.path.exists(util.syspath(path)),
+            u"file exists: {!r}".format((path)),
+        )
 
     def assert_equal_path(self, a, b):
         """Check that two paths are equal."""
-        self.assertEqual(util.normpath(a), util.normpath(b),
-                         u'paths are not equal: {!r} and {!r}'.format(a, b))
+        self.assertEqual(
+            util.normpath(a),
+            util.normpath(b),
+            u"paths are not equal: {!r} and {!r}".format(a, b),
+        )
 
 
 # A test harness for all beets tests.
@@ -159,6 +168,7 @@ class TestCase(unittest.TestCase, Assertions):
     completes. Also provides some additional assertion methods, a
     temporary directory, and a DummyIO.
     """
+
     def setUp(self):
         # A "clean" source list including only the defaults.
         beets.config.sources = []
@@ -168,16 +178,19 @@ class TestCase(unittest.TestCase, Assertions):
         # temporary directory.
         self.temp_dir = util.bytestring_path(tempfile.mkdtemp())
 
-        beets.config['statefile'] = \
-            util.py3_path(os.path.join(self.temp_dir, b'state.pickle'))
-        beets.config['library'] = \
-            util.py3_path(os.path.join(self.temp_dir, b'library.db'))
-        beets.config['directory'] = \
-            util.py3_path(os.path.join(self.temp_dir, b'libdir'))
+        beets.config["statefile"] = util.py3_path(
+            os.path.join(self.temp_dir, b"state.pickle")
+        )
+        beets.config["library"] = util.py3_path(
+            os.path.join(self.temp_dir, b"library.db")
+        )
+        beets.config["directory"] = util.py3_path(
+            os.path.join(self.temp_dir, b"libdir")
+        )
 
         # Set $HOME, which is used by Confuse to create directories.
-        self._old_home = os.environ.get('HOME')
-        os.environ['HOME'] = util.py3_path(self.temp_dir)
+        self._old_home = os.environ.get("HOME")
+        os.environ["HOME"] = util.py3_path(self.temp_dir)
 
         # Initialize, but don't install, a DummyIO.
         self.io = DummyIO()
@@ -186,9 +199,9 @@ class TestCase(unittest.TestCase, Assertions):
         if os.path.isdir(self.temp_dir):
             shutil.rmtree(self.temp_dir)
         if self._old_home is None:
-            del os.environ['HOME']
+            del os.environ["HOME"]
         else:
-            os.environ['HOME'] = self._old_home
+            os.environ["HOME"] = self._old_home
         self.io.restore()
 
         beets.config.clear()
@@ -199,9 +212,10 @@ class LibTestCase(TestCase):
     """A test case that includes an in-memory library object (`lib`) and
     an item added to the library (`i`).
     """
+
     def setUp(self):
         super(LibTestCase, self).setUp()
-        self.lib = beets.library.Library(':memory:')
+        self.lib = beets.library.Library(":memory:")
         self.i = item(self.lib)
 
     def tearDown(self):
@@ -211,10 +225,12 @@ class LibTestCase(TestCase):
 
 # Mock timing.
 
+
 class Timecop(object):
     """Mocks the timing system (namely time() and sleep()) for testing.
     Inspired by the Ruby timecop library.
     """
+
     def __init__(self):
         self.now = time.time()
 
@@ -226,18 +242,19 @@ class Timecop(object):
 
     def install(self):
         self.orig = {
-            'time': time.time,
-            'sleep': time.sleep,
+            "time": time.time,
+            "sleep": time.sleep,
         }
         time.time = self.time
         time.sleep = self.sleep
 
     def restore(self):
-        time.time = self.orig['time']
-        time.sleep = self.orig['sleep']
+        time.time = self.orig["time"]
+        time.sleep = self.orig["sleep"]
 
 
 # Mock I/O.
+
 
 class InputException(Exception):
     def __init__(self, output=None):
@@ -251,7 +268,7 @@ class InputException(Exception):
 
 
 class DummyOut(object):
-    encoding = 'utf-8'
+    encoding = "utf-8"
 
     def __init__(self):
         self.buf = []
@@ -261,9 +278,9 @@ class DummyOut(object):
 
     def get(self):
         if six.PY2:
-            return b''.join(self.buf)
+            return b"".join(self.buf)
         else:
-            return ''.join(self.buf)
+            return "".join(self.buf)
 
     def flush(self):
         self.clear()
@@ -273,7 +290,7 @@ class DummyOut(object):
 
 
 class DummyIn(object):
-    encoding = 'utf-8'
+    encoding = "utf-8"
 
     def __init__(self, out=None):
         self.buf = []
@@ -282,9 +299,9 @@ class DummyIn(object):
 
     def add(self, s):
         if six.PY2:
-            self.buf.append(s + b'\n')
+            self.buf.append(s + b"\n")
         else:
-            self.buf.append(s + '\n')
+            self.buf.append(s + "\n")
 
     def close(self):
         pass
@@ -301,6 +318,7 @@ class DummyIn(object):
 
 class DummyIO(object):
     """Mocks input and output streams for testing UI code."""
+
     def __init__(self):
         self.stdout = DummyOut()
         self.stdin = DummyIn(self.stdout)
@@ -327,8 +345,9 @@ class DummyIO(object):
 
 # Utility.
 
+
 def touch(path):
-    open(path, 'a').close()
+    open(path, "a").close()
 
 
 class Bag(object):
@@ -336,6 +355,7 @@ class Bag(object):
     arguments. Any field not found in the dictionary appears to be None.
     Used for mocking Album objects and the like.
     """
+
     def __init__(self, **fields):
         self.fields = fields
 
@@ -345,6 +365,7 @@ class Bag(object):
 
 # Convenience methods for setting up a temporary sandbox directory for tests
 # that need to interact with the filesystem.
+
 
 class TempDirMixin(object):
     """Text mixin for creating and deleting a temporary directory.
@@ -356,7 +377,7 @@ class TempDirMixin(object):
         """
         path = tempfile.mkdtemp()
         if not isinstance(path, bytes):
-            path = path.encode('utf8')
+            path = path.encode("utf8")
         self.temp_dir = path
 
     def remove_temp_dir(self):
@@ -368,9 +389,11 @@ class TempDirMixin(object):
 
 # Platform mocking.
 
+
 @contextmanager
 def platform_windows():
     import ntpath
+
     old_path = os.path
     try:
         os.path = ntpath
@@ -382,6 +405,7 @@ def platform_windows():
 @contextmanager
 def platform_posix():
     import posixpath
+
     old_path = os.path
     try:
         os.path = posixpath
@@ -393,6 +417,7 @@ def platform_posix():
 @contextmanager
 def system_mock(name):
     import platform
+
     old_system = platform.system
     platform.system = lambda: name
     try:
@@ -404,6 +429,7 @@ def system_mock(name):
 def slow_test(unused=None):
     def _id(obj):
         return obj
-    if 'SKIP_SLOW_TESTS' in os.environ:
-        return unittest.skip(u'test is slow')
+
+    if "SKIP_SLOW_TESTS" in os.environ:
+        return unittest.skip(u"test is slow")
     return _id

--- a/test/helper.py
+++ b/test/helper.py
@@ -60,7 +60,6 @@ import six
 
 
 class LogCapture(logging.Handler):
-
     def __init__(self):
         logging.Handler.__init__(self)
         self.messages = []
@@ -70,7 +69,7 @@ class LogCapture(logging.Handler):
 
 
 @contextmanager
-def capture_log(logger='beets'):
+def capture_log(logger="beets"):
     capture = LogCapture()
     log = logging.getLogger(logger)
     log.addHandler(capture)
@@ -91,7 +90,7 @@ def control_stdin(input=None):
     org = sys.stdin
     sys.stdin = StringIO(input)
     if six.PY2:  # StringIO encoding attr isn't writable in python >= 3
-        sys.stdin.encoding = 'utf-8'
+        sys.stdin.encoding = "utf-8"
     try:
         yield sys.stdin
     finally:
@@ -111,7 +110,7 @@ def capture_stdout():
     org = sys.stdout
     sys.stdout = capture = StringIO()
     if six.PY2:  # StringIO encoding attr isn't writable in python >= 3
-        sys.stdout.encoding = 'utf-8'
+        sys.stdout.encoding = "utf-8"
     try:
         yield sys.stdout
     finally:
@@ -134,14 +133,15 @@ def _convert_args(args):
     return args
 
 
-def has_program(cmd, args=['--version']):
+def has_program(cmd, args=["--version"]):
     """Returns `True` if `cmd` can be executed.
     """
     full_cmd = _convert_args([cmd] + args)
     try:
-        with open(os.devnull, 'wb') as devnull:
-            subprocess.check_call(full_cmd, stderr=devnull,
-                                  stdout=devnull, stdin=devnull)
+        with open(os.devnull, "wb") as devnull:
+            subprocess.check_call(
+                full_cmd, stderr=devnull, stdout=devnull, stdin=devnull
+            )
     except OSError:
         return False
     except subprocess.CalledProcessError:
@@ -156,6 +156,7 @@ class TestHelper(object):
     This mixin provides methods to isolate beets' global state provide
     fixtures.
     """
+
     # TODO automate teardown through hook registration
 
     def setup_beets(self, disk=False):
@@ -181,33 +182,31 @@ class TestHelper(object):
         Make sure you call ``teardown_beets()`` afterwards.
         """
         self.create_temp_dir()
-        os.environ['BEETSDIR'] = util.py3_path(self.temp_dir)
+        os.environ["BEETSDIR"] = util.py3_path(self.temp_dir)
 
         self.config = beets.config
         self.config.clear()
         self.config.read()
 
-        self.config['plugins'] = []
-        self.config['verbose'] = 1
-        self.config['ui']['color'] = False
-        self.config['threaded'] = False
+        self.config["plugins"] = []
+        self.config["verbose"] = 1
+        self.config["ui"]["color"] = False
+        self.config["threaded"] = False
 
-        self.libdir = os.path.join(self.temp_dir, b'libdir')
+        self.libdir = os.path.join(self.temp_dir, b"libdir")
         os.mkdir(self.libdir)
-        self.config['directory'] = util.py3_path(self.libdir)
+        self.config["directory"] = util.py3_path(self.libdir)
 
         if disk:
-            dbpath = util.bytestring_path(
-                self.config['library'].as_filename()
-            )
+            dbpath = util.bytestring_path(self.config["library"].as_filename())
         else:
-            dbpath = ':memory:'
+            dbpath = ":memory:"
         self.lib = Library(dbpath, self.libdir)
 
     def teardown_beets(self):
         self.lib._close()
-        if 'BEETSDIR' in os.environ:
-            del os.environ['BEETSDIR']
+        if "BEETSDIR" in os.environ:
+            del os.environ["BEETSDIR"]
         self.remove_temp_dir()
         self.config.clear()
         beets.config.read(user=False, defaults=True)
@@ -219,7 +218,7 @@ class TestHelper(object):
         sure you call ``unload_plugins()`` afterwards.
         """
         # FIXME this should eventually be handled by a plugin manager
-        beets.config['plugins'] = plugins
+        beets.config["plugins"] = plugins
         beets.plugins.load_plugins(plugins)
         beets.plugins.find_plugins()
 
@@ -239,7 +238,7 @@ class TestHelper(object):
         """Unload all plugins and remove the from the configuration.
         """
         # FIXME this should eventually be handled by a plugin manager
-        beets.config['plugins'] = []
+        beets.config["plugins"] = []
         beets.plugins._classes = set()
         beets.plugins._instances = {}
         Item._types = Item._original_types
@@ -253,13 +252,13 @@ class TestHelper(object):
         Copies the specified number of files to a subdirectory of
         `self.temp_dir` and creates a `ImportSessionFixture` for this path.
         """
-        import_dir = os.path.join(self.temp_dir, b'import')
+        import_dir = os.path.join(self.temp_dir, b"import")
         if not os.path.isdir(import_dir):
             os.mkdir(import_dir)
 
         album_no = 0
         while album_count:
-            album = util.bytestring_path(u'album {0}'.format(album_no))
+            album = util.bytestring_path(u"album {0}".format(album_no))
             album_dir = os.path.join(import_dir, album)
             if os.path.exists(album_dir):
                 album_no += 1
@@ -270,9 +269,9 @@ class TestHelper(object):
             track_no = 0
             album_item_count = item_count
             while album_item_count:
-                title = u'track {0}'.format(track_no)
-                src = os.path.join(_common.RSRC, b'full.mp3')
-                title_file = util.bytestring_path('{0}.mp3'.format(title))
+                title = u"track {0}".format(track_no)
+                src = os.path.join(_common.RSRC, b"full.mp3")
+                title_file = util.bytestring_path("{0}.mp3".format(title))
                 dest = os.path.join(album_dir, title_file)
                 if os.path.exists(dest):
                     track_no += 1
@@ -280,22 +279,25 @@ class TestHelper(object):
                 album_item_count -= 1
                 shutil.copy(src, dest)
                 mediafile = MediaFile(dest)
-                mediafile.update({
-                    'artist': 'artist',
-                    'albumartist': 'album artist',
-                    'title': title,
-                    'album': album,
-                    'mb_albumid': None,
-                    'mb_trackid': None,
-                })
+                mediafile.update(
+                    {
+                        "artist": "artist",
+                        "albumartist": "album artist",
+                        "title": title,
+                        "album": album,
+                        "mb_albumid": None,
+                        "mb_trackid": None,
+                    }
+                )
                 mediafile.save()
 
-        config['import']['quiet'] = True
-        config['import']['autotag'] = False
-        config['import']['resume'] = False
+        config["import"]["quiet"] = True
+        config["import"]["autotag"] = False
+        config["import"]["resume"] = False
 
-        return ImportSessionFixture(self.lib, loghandler=None, query=None,
-                                    paths=[import_dir])
+        return ImportSessionFixture(
+            self.lib, loghandler=None, query=None, paths=[import_dir]
+        )
 
     # Library fixtures methods
 
@@ -313,18 +315,18 @@ class TestHelper(object):
         """
         item_count = self._get_item_count()
         values_ = {
-            'title': u't\u00eftle {0}',
-            'artist': u'the \u00e4rtist',
-            'album': u'the \u00e4lbum',
-            'track': item_count,
-            'format': 'MP3',
+            "title": u"t\u00eftle {0}",
+            "artist": u"the \u00e4rtist",
+            "album": u"the \u00e4lbum",
+            "track": item_count,
+            "format": "MP3",
         }
         values_.update(values)
-        values_['title'] = values_['title'].format(item_count)
-        values_['db'] = self.lib
+        values_["title"] = values_["title"].format(item_count)
+        values_["db"] = self.lib
         item = Item(**values_)
-        if 'path' not in values:
-            item['path'] = 'audio.' + item['format'].lower()
+        if "path" not in values:
+            item["path"] = "audio." + item["format"].lower()
         # mtime needs to be set last since other assignments reset it.
         item.mtime = 12345
         return item
@@ -338,15 +340,15 @@ class TestHelper(object):
         """
         # When specifying a path, store it normalized (as beets does
         # ordinarily).
-        if 'path' in values:
-            values['path'] = util.normpath(values['path'])
+        if "path" in values:
+            values["path"] = util.normpath(values["path"])
 
         item = self.create_item(**values)
         item.add(self.lib)
 
         # Ensure every item has a path.
-        if 'path' not in values:
-            item['path'] = item.destination()
+        if "path" not in values:
+            item["path"] = item.destination()
             item.store()
 
         return item
@@ -355,9 +357,10 @@ class TestHelper(object):
         """Add an item with an actual audio file to the library.
         """
         item = self.create_item(**values)
-        extension = item['format'].lower()
-        item['path'] = os.path.join(_common.RSRC,
-                                    util.bytestring_path('min.' + extension))
+        extension = item["format"].lower()
+        item["path"] = os.path.join(
+            _common.RSRC, util.bytestring_path("min." + extension)
+        )
         item.add(self.lib)
         item.move(operation=MoveOperation.COPY)
         item.store()
@@ -367,16 +370,16 @@ class TestHelper(object):
         item = self.add_item(**values)
         return self.lib.add_album([item])
 
-    def add_item_fixtures(self, ext='mp3', count=1):
+    def add_item_fixtures(self, ext="mp3", count=1):
         """Add a number of items with files to the database.
         """
         # TODO base this on `add_item()`
         items = []
-        path = os.path.join(_common.RSRC, util.bytestring_path('full.' + ext))
+        path = os.path.join(_common.RSRC, util.bytestring_path("full." + ext))
         for i in range(count):
             item = Item.from_path(path)
-            item.album = u'\u00e4lbum {0}'.format(i)  # Check unicode paths
-            item.title = u't\u00eftle {0}'.format(i)
+            item.album = u"\u00e4lbum {0}".format(i)  # Check unicode paths
+            item.title = u"t\u00eftle {0}".format(i)
             # mtime needs to be set last since other assignments reset it.
             item.mtime = 12345
             item.add(self.lib)
@@ -385,15 +388,15 @@ class TestHelper(object):
             items.append(item)
         return items
 
-    def add_album_fixture(self, track_count=1, ext='mp3'):
+    def add_album_fixture(self, track_count=1, ext="mp3"):
         """Add an album with files to the database.
         """
         items = []
-        path = os.path.join(_common.RSRC, util.bytestring_path('full.' + ext))
+        path = os.path.join(_common.RSRC, util.bytestring_path("full." + ext))
         for i in range(track_count):
             item = Item.from_path(path)
-            item.album = u'\u00e4lbum'  # Check unicode paths
-            item.title = u't\u00eftle {0}'.format(i)
+            item.album = u"\u00e4lbum"  # Check unicode paths
+            item.title = u"t\u00eftle {0}".format(i)
             # mtime needs to be set last since other assignments reset it.
             item.mtime = 12345
             item.add(self.lib)
@@ -402,7 +405,7 @@ class TestHelper(object):
             items.append(item)
         return self.lib.add_album(items)
 
-    def create_mediafile_fixture(self, ext='mp3', images=[]):
+    def create_mediafile_fixture(self, ext="mp3", images=[]):
         """Copies a fixture mediafile with the extension to a temporary
         location and returns the path.
 
@@ -413,7 +416,7 @@ class TestHelper(object):
         specified extension a cover art image is added to the media
         file.
         """
-        src = os.path.join(_common.RSRC, util.bytestring_path('full.' + ext))
+        src = os.path.join(_common.RSRC, util.bytestring_path("full." + ext))
         handle, path = mkstemp()
         os.close(handle)
         shutil.copyfile(src, path)
@@ -422,26 +425,26 @@ class TestHelper(object):
             mediafile = MediaFile(path)
             imgs = []
             for img_ext in images:
-                file = util.bytestring_path('image-2x3.{0}'.format(img_ext))
+                file = util.bytestring_path("image-2x3.{0}".format(img_ext))
                 img_path = os.path.join(_common.RSRC, file)
-                with open(img_path, 'rb') as f:
+                with open(img_path, "rb") as f:
                     imgs.append(Image(f.read()))
             mediafile.images = imgs
             mediafile.save()
 
-        if not hasattr(self, '_mediafile_fixtures'):
+        if not hasattr(self, "_mediafile_fixtures"):
             self._mediafile_fixtures = []
         self._mediafile_fixtures.append(path)
 
         return path
 
     def remove_mediafile_fixtures(self):
-        if hasattr(self, '_mediafile_fixtures'):
+        if hasattr(self, "_mediafile_fixtures"):
             for path in self._mediafile_fixtures:
                 os.remove(path)
 
     def _get_item_count(self):
-        if not hasattr(self, '__item_count'):
+        if not hasattr(self, "__item_count"):
             count = 0
         self.__item_count = count + 1
         return count
@@ -453,11 +456,11 @@ class TestHelper(object):
            Library` defaults to `self.lib`, but can be overridden with
            the keyword argument `lib`.
         """
-        sys.argv = ['beet']  # avoid leakage from test suite args
+        sys.argv = ["beet"]  # avoid leakage from test suite args
         lib = None
-        if hasattr(self, 'lib'):
+        if hasattr(self, "lib"):
             lib = self.lib
-        lib = kwargs.get('lib', lib)
+        lib = kwargs.get("lib", lib)
         beets.ui._raw_main(_convert_args(list(args)), lib)
 
     def run_with_output(self, *args):
@@ -479,7 +482,7 @@ class TestHelper(object):
         """
         shutil.rmtree(self.temp_dir)
 
-    def touch(self, path, dir=None, content=''):
+    def touch(self, path, dir=None, content=""):
         """Create a file at `path` with given content.
 
         If `dir` is given, it is prepended to `path`. After that, if the
@@ -496,7 +499,7 @@ class TestHelper(object):
         if not os.path.isdir(parent):
             os.makedirs(util.syspath(parent))
 
-        with open(util.syspath(path), 'a+') as f:
+        with open(util.syspath(path), "a+") as f:
             f.write(content)
         return path
 
@@ -544,9 +547,9 @@ class ImportSessionFixture(importer.ImportSession):
 
     choose_item = choose_match
 
-    Resolution = Enum('Resolution', 'REMOVE SKIP KEEPBOTH MERGE')
+    Resolution = Enum("Resolution", "REMOVE SKIP KEEPBOTH MERGE")
 
-    default_resolution = 'REMOVE'
+    default_resolution = "REMOVE"
 
     def add_resolution(self, resolution):
         assert isinstance(resolution, self.Resolution)
@@ -577,41 +580,62 @@ def generate_album_info(album_id, track_values):
     """
     tracks = [generate_track_info(id, values) for id, values in track_values]
     album = AlbumInfo(
-        album_id=u'album info',
-        album=u'album info',
-        artist=u'album info',
-        artist_id=u'album info',
+        album_id=u"album info",
+        album=u"album info",
+        artist=u"album info",
+        artist_id=u"album info",
         tracks=tracks,
     )
     for field in ALBUM_INFO_FIELDS:
-        setattr(album, field, u'album info')
+        setattr(album, field, u"album info")
 
     return album
 
-ALBUM_INFO_FIELDS = ['album', 'album_id', 'artist', 'artist_id',
-                     'asin', 'albumtype', 'va', 'label',
-                     'artist_sort', 'releasegroup_id', 'catalognum',
-                     'language', 'country', 'albumstatus', 'media',
-                     'albumdisambig', 'releasegroupdisambig', 'artist_credit',
-                     'data_source', 'data_url']
+
+ALBUM_INFO_FIELDS = [
+    "album",
+    "album_id",
+    "artist",
+    "artist_id",
+    "asin",
+    "albumtype",
+    "va",
+    "label",
+    "artist_sort",
+    "releasegroup_id",
+    "catalognum",
+    "language",
+    "country",
+    "albumstatus",
+    "media",
+    "albumdisambig",
+    "releasegroupdisambig",
+    "artist_credit",
+    "data_source",
+    "data_url",
+]
 
 
-def generate_track_info(track_id='track info', values={}):
+def generate_track_info(track_id="track info", values={}):
     """Return `TrackInfo` populated with mock data.
 
     The `track_id` field is set to the corresponding argument. All other
     string fields are set to "track info".
     """
-    track = TrackInfo(
-        title=u'track info',
-        track_id=track_id,
-    )
+    track = TrackInfo(title=u"track info", track_id=track_id,)
     for field in TRACK_INFO_FIELDS:
-        setattr(track, field, u'track info')
+        setattr(track, field, u"track info")
     for field, value in values.items():
         setattr(track, field, value)
     return track
 
-TRACK_INFO_FIELDS = ['artist', 'artist_id', 'artist_sort',
-                     'disctitle', 'artist_credit', 'data_source',
-                     'data_url']
+
+TRACK_INFO_FIELDS = [
+    "artist",
+    "artist_id",
+    "artist_sort",
+    "disctitle",
+    "artist_credit",
+    "data_source",
+    "data_url",
+]

--- a/test/lyrics_download_samples.py
+++ b/test/lyrics_download_samples.py
@@ -36,7 +36,7 @@ def safe_open_w(path):
     """Open "path" for writing, creating any parent directories as needed.
     """
     mkdir_p(os.path.dirname(path))
-    return open(path, 'w')
+    return open(path, "w")
 
 
 def main(argv=None):
@@ -44,15 +44,16 @@ def main(argv=None):
     """
     if argv is None:
         argv = sys.argv
-    print(u'Fetching samples from:')
+    print(u"Fetching samples from:")
     for s in test_lyrics.GOOGLE_SOURCES + test_lyrics.DEFAULT_SOURCES:
-        print(s['url'])
-        url = s['url'] + s['path']
+        print(s["url"])
+        url = s["url"] + s["path"]
         fn = test_lyrics.url_to_filename(url)
         if not os.path.isfile(fn):
             html = requests.get(url, verify=False).text
             with safe_open_w(fn) as f:
-                f.write(html.encode('utf-8'))
+                f.write(html.encode("utf-8"))
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/test/rsrc/beetsplug/test.py
+++ b/test/rsrc/beetsplug/test.py
@@ -12,12 +12,12 @@ class TestPlugin(BeetsPlugin):
         self.is_test_plugin = True
 
     def commands(self):
-        test = ui.Subcommand('test')
+        test = ui.Subcommand("test")
         test.func = lambda *args: None
 
         # Used in CompletionTest
-        test.parser.add_option(u'-o', u'--option', dest='my_opt')
+        test.parser.add_option(u"-o", u"--option", dest="my_opt")
 
-        plugin = ui.Subcommand('plugin')
+        plugin = ui.Subcommand("plugin")
         plugin.func = lambda *args: None
         return [test, plugin]

--- a/test/rsrc/convert_stub.py
+++ b/test/rsrc/convert_stub.py
@@ -16,9 +16,9 @@ PY2 = sys.version_info[0] == 2
 # From `beets.util`.
 def arg_encoding():
     try:
-        return locale.getdefaultlocale()[1] or 'utf-8'
+        return locale.getdefaultlocale()[1] or "utf-8"
     except ValueError:
-        return 'utf-8'
+        return "utf-8"
 
 
 def convert(in_file, out_file, tag):
@@ -26,19 +26,19 @@ def convert(in_file, out_file, tag):
     """
     # On Python 3, encode the tag argument as bytes.
     if not isinstance(tag, bytes):
-        tag = tag.encode('utf-8')
+        tag = tag.encode("utf-8")
 
     # On Windows, use Unicode paths. On Python 3, we get the actual,
     # Unicode filenames. On Python 2, we get them as UTF-8 byes.
-    if platform.system() == 'Windows' and PY2:
-        in_file = in_file.decode('utf-8')
-        out_file = out_file.decode('utf-8')
+    if platform.system() == "Windows" and PY2:
+        in_file = in_file.decode("utf-8")
+        out_file = out_file.decode("utf-8")
 
-    with open(out_file, 'wb') as out_f:
-        with open(in_file, 'rb') as in_f:
+    with open(out_file, "wb") as out_f:
+        with open(in_file, "rb") as in_f:
             out_f.write(in_f.read())
         out_f.write(tag)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     convert(sys.argv[1], sys.argv[2], sys.argv[3])

--- a/test/test_acousticbrainz.py
+++ b/test/test_acousticbrainz.py
@@ -30,74 +30,76 @@ from beetsplug.acousticbrainz import AcousticPlugin, ABSCHEME
 class MapDataToSchemeTest(unittest.TestCase):
     def test_basic(self):
         ab = AcousticPlugin()
-        data = {'key 1': 'value 1', 'key 2': 'value 2'}
-        scheme = {'key 1': 'attribute 1', 'key 2': 'attribute 2'}
+        data = {"key 1": "value 1", "key 2": "value 2"}
+        scheme = {"key 1": "attribute 1", "key 2": "attribute 2"}
         mapping = set(ab._map_data_to_scheme(data, scheme))
-        self.assertEqual(mapping, {('attribute 1', 'value 1'),
-                                   ('attribute 2', 'value 2')})
+        self.assertEqual(
+            mapping, {("attribute 1", "value 1"), ("attribute 2", "value 2")}
+        )
 
     def test_recurse(self):
         ab = AcousticPlugin()
         data = {
-            'key': 'value',
-            'group': {
-                'subkey': 'subvalue',
-                'subgroup': {
-                    'subsubkey': 'subsubvalue'
-                }
-            }
+            "key": "value",
+            "group": {
+                "subkey": "subvalue",
+                "subgroup": {"subsubkey": "subsubvalue"},
+            },
         }
         scheme = {
-            'key': 'attribute 1',
-            'group': {
-                'subkey': 'attribute 2',
-                'subgroup': {
-                    'subsubkey': 'attribute 3'
-                }
-            }
+            "key": "attribute 1",
+            "group": {
+                "subkey": "attribute 2",
+                "subgroup": {"subsubkey": "attribute 3"},
+            },
         }
         mapping = set(ab._map_data_to_scheme(data, scheme))
-        self.assertEqual(mapping, {('attribute 1', 'value'),
-                                   ('attribute 2', 'subvalue'),
-                                   ('attribute 3', 'subsubvalue')})
+        self.assertEqual(
+            mapping,
+            {
+                ("attribute 1", "value"),
+                ("attribute 2", "subvalue"),
+                ("attribute 3", "subsubvalue"),
+            },
+        )
 
     def test_composite(self):
         ab = AcousticPlugin()
-        data = {'key 1': 'part 1', 'key 2': 'part 2'}
-        scheme = {'key 1': ('attribute', 0), 'key 2': ('attribute', 1)}
+        data = {"key 1": "part 1", "key 2": "part 2"}
+        scheme = {"key 1": ("attribute", 0), "key 2": ("attribute", 1)}
         mapping = set(ab._map_data_to_scheme(data, scheme))
-        self.assertEqual(mapping, {('attribute', 'part 1 part 2')})
+        self.assertEqual(mapping, {("attribute", "part 1 part 2")})
 
     def test_realistic(self):
         ab = AcousticPlugin()
-        data_path = os.path.join(RSRC, b'acousticbrainz/data.json')
+        data_path = os.path.join(RSRC, b"acousticbrainz/data.json")
         with open(data_path) as res:
             data = json.load(res)
         mapping = set(ab._map_data_to_scheme(data, ABSCHEME))
         expected = {
-            ('chords_key', 'A'),
-            ('average_loudness', 0.815025985241),
-            ('mood_acoustic', 0.415711194277),
-            ('chords_changes_rate', 0.0445116683841),
-            ('tonal', 0.874250173569),
-            ('mood_sad', 0.299694597721),
-            ('bpm', 162.532119751),
-            ('gender', 'female'),
-            ('initial_key', 'A minor'),
-            ('chords_number_rate', 0.00194468453992),
-            ('mood_relaxed', 0.123632438481),
-            ('chords_scale', 'minor'),
-            ('voice_instrumental', 'instrumental'),
-            ('key_strength', 0.636936545372),
-            ('genre_rosamerica', 'roc'),
-            ('mood_party', 0.234383180737),
-            ('mood_aggressive', 0.0779221653938),
-            ('danceable', 0.143928021193),
-            ('rhythm', 'VienneseWaltz'),
-            ('mood_electronic', 0.339881360531),
-            ('mood_happy', 0.0894767045975),
-            ('moods_mirex', "Cluster3"),
-            ('timbre', "bright")
+            ("chords_key", "A"),
+            ("average_loudness", 0.815025985241),
+            ("mood_acoustic", 0.415711194277),
+            ("chords_changes_rate", 0.0445116683841),
+            ("tonal", 0.874250173569),
+            ("mood_sad", 0.299694597721),
+            ("bpm", 162.532119751),
+            ("gender", "female"),
+            ("initial_key", "A minor"),
+            ("chords_number_rate", 0.00194468453992),
+            ("mood_relaxed", 0.123632438481),
+            ("chords_scale", "minor"),
+            ("voice_instrumental", "instrumental"),
+            ("key_strength", 0.636936545372),
+            ("genre_rosamerica", "roc"),
+            ("mood_party", 0.234383180737),
+            ("mood_aggressive", 0.0779221653938),
+            ("danceable", 0.143928021193),
+            ("rhythm", "VienneseWaltz"),
+            ("mood_electronic", 0.339881360531),
+            ("mood_happy", 0.0894767045975),
+            ("moods_mirex", "Cluster3"),
+            ("timbre", "bright"),
         }
         self.assertEqual(mapping, expected)
 
@@ -105,5 +107,6 @@ class MapDataToSchemeTest(unittest.TestCase):
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -37,13 +37,14 @@ from beets.util.artresizer import ArtResizer, WEBPROXY
 import confuse
 
 
-logger = logging.getLogger('beets.test_art')
+logger = logging.getLogger("beets.test_art")
 
 
-class Settings():
+class Settings:
     """Used to pass settings to the ArtSources when the plugin isn't fully
     instantiated.
     """
+
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -59,84 +60,88 @@ class FetchImageHelper(_common.TestCase):
     """Helper mixin for mocking requests when fetching images
     with remote art sources.
     """
+
     @responses.activate
     def run(self, *args, **kwargs):
         super(FetchImageHelper, self).run(*args, **kwargs)
 
-    IMAGEHEADER = {'image/jpeg': b'\x00' * 6 + b'JFIF',
-                   'image/png': b'\211PNG\r\n\032\n', }
+    IMAGEHEADER = {
+        "image/jpeg": b"\x00" * 6 + b"JFIF",
+        "image/png": b"\211PNG\r\n\032\n",
+    }
 
-    def mock_response(self, url, content_type='image/jpeg', file_type=None):
+    def mock_response(self, url, content_type="image/jpeg", file_type=None):
         if file_type is None:
             file_type = content_type
-        responses.add(responses.GET, url,
-                      content_type=content_type,
-                      # imghdr reads 32 bytes
-                      body=self.IMAGEHEADER.get(
-                          file_type, b'').ljust(32, b'\x00'))
+        responses.add(
+            responses.GET,
+            url,
+            content_type=content_type,
+            # imghdr reads 32 bytes
+            body=self.IMAGEHEADER.get(file_type, b"").ljust(32, b"\x00"),
+        )
 
 
 class FetchImageTest(FetchImageHelper, UseThePlugin):
-    URL = 'http://example.com/test.jpg'
+    URL = "http://example.com/test.jpg"
 
     def setUp(self):
         super(FetchImageTest, self).setUp()
-        self.dpath = os.path.join(self.temp_dir, b'arttest')
+        self.dpath = os.path.join(self.temp_dir, b"arttest")
         self.source = fetchart.RemoteArtSource(logger, self.plugin.config)
         self.settings = Settings(maxwidth=0)
         self.candidate = fetchart.Candidate(logger, url=self.URL)
 
     def test_invalid_type_returns_none(self):
-        self.mock_response(self.URL, 'image/watercolour')
+        self.mock_response(self.URL, "image/watercolour")
         self.source.fetch_image(self.candidate, self.settings)
         self.assertEqual(self.candidate.path, None)
 
     def test_jpeg_type_returns_path(self):
-        self.mock_response(self.URL, 'image/jpeg')
+        self.mock_response(self.URL, "image/jpeg")
         self.source.fetch_image(self.candidate, self.settings)
         self.assertNotEqual(self.candidate.path, None)
 
     def test_extension_set_by_content_type(self):
-        self.mock_response(self.URL, 'image/png')
+        self.mock_response(self.URL, "image/png")
         self.source.fetch_image(self.candidate, self.settings)
-        self.assertEqual(os.path.splitext(self.candidate.path)[1], b'.png')
+        self.assertEqual(os.path.splitext(self.candidate.path)[1], b".png")
         self.assertExists(self.candidate.path)
 
     def test_does_not_rely_on_server_content_type(self):
-        self.mock_response(self.URL, 'image/jpeg', 'image/png')
+        self.mock_response(self.URL, "image/jpeg", "image/png")
         self.source.fetch_image(self.candidate, self.settings)
-        self.assertEqual(os.path.splitext(self.candidate.path)[1], b'.png')
+        self.assertEqual(os.path.splitext(self.candidate.path)[1], b".png")
         self.assertExists(self.candidate.path)
 
 
 class FSArtTest(UseThePlugin):
     def setUp(self):
         super(FSArtTest, self).setUp()
-        self.dpath = os.path.join(self.temp_dir, b'arttest')
+        self.dpath = os.path.join(self.temp_dir, b"arttest")
         os.mkdir(self.dpath)
 
         self.source = fetchart.FileSystem(logger, self.plugin.config)
-        self.settings = Settings(cautious=False,
-                                 cover_names=('art',))
+        self.settings = Settings(cautious=False, cover_names=("art",))
 
     def test_finds_jpg_in_directory(self):
-        _common.touch(os.path.join(self.dpath, b'a.jpg'))
+        _common.touch(os.path.join(self.dpath, b"a.jpg"))
         candidate = next(self.source.get(None, self.settings, [self.dpath]))
-        self.assertEqual(candidate.path, os.path.join(self.dpath, b'a.jpg'))
+        self.assertEqual(candidate.path, os.path.join(self.dpath, b"a.jpg"))
 
     def test_appropriately_named_file_takes_precedence(self):
-        _common.touch(os.path.join(self.dpath, b'a.jpg'))
-        _common.touch(os.path.join(self.dpath, b'art.jpg'))
+        _common.touch(os.path.join(self.dpath, b"a.jpg"))
+        _common.touch(os.path.join(self.dpath, b"art.jpg"))
         candidate = next(self.source.get(None, self.settings, [self.dpath]))
-        self.assertEqual(candidate.path, os.path.join(self.dpath, b'art.jpg'))
+        self.assertEqual(candidate.path, os.path.join(self.dpath, b"art.jpg"))
 
     def test_non_image_file_not_identified(self):
-        _common.touch(os.path.join(self.dpath, b'a.txt'))
+        _common.touch(os.path.join(self.dpath, b"a.txt"))
         with self.assertRaises(StopIteration):
             next(self.source.get(None, self.settings, [self.dpath]))
 
     def test_cautious_skips_fallback(self):
-        _common.touch(os.path.join(self.dpath, b'a.jpg'))
+        _common.touch(os.path.join(self.dpath, b"a.jpg"))
         self.settings.cautious = True
         with self.assertRaises(StopIteration):
             next(self.source.get(None, self.settings, [self.dpath]))
@@ -146,29 +151,30 @@ class FSArtTest(UseThePlugin):
             next(self.source.get(None, self.settings, [self.dpath]))
 
     def test_precedence_amongst_correct_files(self):
-        images = [b'front-cover.jpg', b'front.jpg', b'back.jpg']
+        images = [b"front-cover.jpg", b"front.jpg", b"back.jpg"]
         paths = [os.path.join(self.dpath, i) for i in images]
         for p in paths:
             _common.touch(p)
-        self.settings.cover_names = ['cover', 'front', 'back']
-        candidates = [candidate.path for candidate in
-                      self.source.get(None, self.settings, [self.dpath])]
+        self.settings.cover_names = ["cover", "front", "back"]
+        candidates = [
+            candidate.path
+            for candidate in self.source.get(None, self.settings, [self.dpath])
+        ]
         self.assertEqual(candidates, paths)
 
 
 class CombinedTest(FetchImageHelper, UseThePlugin):
-    ASIN = 'xxxx'
-    MBID = 'releaseid'
-    AMAZON_URL = 'https://images.amazon.com/images/P/{0}.01.LZZZZZZZ.jpg' \
-                 .format(ASIN)
-    AAO_URL = 'https://www.albumart.org/index_detail.php?asin={0}' \
-              .format(ASIN)
-    CAA_URL = 'coverartarchive.org/release/{0}/front' \
-              .format(MBID)
+    ASIN = "xxxx"
+    MBID = "releaseid"
+    AMAZON_URL = "https://images.amazon.com/images/P/{0}.01.LZZZZZZZ.jpg".format(
+        ASIN
+    )
+    AAO_URL = "https://www.albumart.org/index_detail.php?asin={0}".format(ASIN)
+    CAA_URL = "coverartarchive.org/release/{0}/front".format(MBID)
 
     def setUp(self):
         super(CombinedTest, self).setUp()
-        self.dpath = os.path.join(self.temp_dir, b'arttest')
+        self.dpath = os.path.join(self.temp_dir, b"arttest")
         os.mkdir(self.dpath)
 
     def test_main_interface_returns_amazon_art(self):
@@ -183,12 +189,12 @@ class CombinedTest(FetchImageHelper, UseThePlugin):
         self.assertIsNone(candidate)
 
     def test_main_interface_gives_precedence_to_fs_art(self):
-        _common.touch(os.path.join(self.dpath, b'art.jpg'))
+        _common.touch(os.path.join(self.dpath, b"art.jpg"))
         self.mock_response(self.AMAZON_URL)
         album = _common.Bag(asin=self.ASIN)
         candidate = self.plugin.art_for_album(album, [self.dpath])
         self.assertIsNotNone(candidate)
-        self.assertEqual(candidate.path, os.path.join(self.dpath, b'art.jpg'))
+        self.assertEqual(candidate.path, os.path.join(self.dpath, b"art.jpg"))
 
     def test_main_interface_falls_back_to_amazon(self):
         self.mock_response(self.AMAZON_URL)
@@ -205,7 +211,7 @@ class CombinedTest(FetchImageHelper, UseThePlugin):
         self.assertEqual(responses.calls[0].request.url, self.AMAZON_URL)
 
     def test_main_interface_falls_back_to_aao(self):
-        self.mock_response(self.AMAZON_URL, content_type='text/html')
+        self.mock_response(self.AMAZON_URL, content_type="text/html")
         album = _common.Bag(asin=self.ASIN)
         self.plugin.art_for_album(album, [self.dpath])
         self.assertEqual(responses.calls[-1].request.url, self.AAO_URL)
@@ -229,18 +235,19 @@ class CombinedTest(FetchImageHelper, UseThePlugin):
         self.assertEqual(len(responses.calls), 0)
 
     def test_local_only_gets_fs_image(self):
-        _common.touch(os.path.join(self.dpath, b'art.jpg'))
+        _common.touch(os.path.join(self.dpath, b"art.jpg"))
         album = _common.Bag(mb_albumid=self.MBID, asin=self.ASIN)
-        candidate = self.plugin.art_for_album(album, [self.dpath],
-                                              local_only=True)
+        candidate = self.plugin.art_for_album(
+            album, [self.dpath], local_only=True
+        )
         self.assertIsNotNone(candidate)
-        self.assertEqual(candidate.path, os.path.join(self.dpath, b'art.jpg'))
+        self.assertEqual(candidate.path, os.path.join(self.dpath, b"art.jpg"))
         self.assertEqual(len(responses.calls), 0)
 
 
 class AAOTest(UseThePlugin):
-    ASIN = 'xxxx'
-    AAO_URL = 'https://www.albumart.org/index_detail.php?asin={0}'.format(ASIN)
+    ASIN = "xxxx"
+    AAO_URL = "https://www.albumart.org/index_detail.php?asin={0}".format(ASIN)
 
     def setUp(self):
         super(AAOTest, self).setUp()
@@ -252,8 +259,13 @@ class AAOTest(UseThePlugin):
         super(AAOTest, self).run(*args, **kwargs)
 
     def mock_response(self, url, body):
-        responses.add(responses.GET, url, body=body, content_type='text/html',
-                      match_querystring=True)
+        responses.add(
+            responses.GET,
+            url,
+            body=body,
+            content_type="text/html",
+            match_querystring=True,
+        )
 
     def test_aao_scraper_finds_image(self):
         body = """
@@ -266,10 +278,10 @@ class AAOTest(UseThePlugin):
         self.mock_response(self.AAO_URL, body)
         album = _common.Bag(asin=self.ASIN)
         candidate = next(self.source.get(album, self.settings, []))
-        self.assertEqual(candidate.url, 'TARGET_URL')
+        self.assertEqual(candidate.url, "TARGET_URL")
 
     def test_aao_scraper_returns_no_result_when_no_image_present(self):
-        self.mock_response(self.AAO_URL, 'blah blah')
+        self.mock_response(self.AAO_URL, "blah blah")
         album = _common.Bag(asin=self.ASIN)
         with self.assertRaises(StopIteration):
             next(self.source.get(album, self.settings, []))
@@ -287,8 +299,9 @@ class ITunesStoreTest(UseThePlugin):
         super(ITunesStoreTest, self).run(*args, **kwargs)
 
     def mock_response(self, url, json):
-        responses.add(responses.GET, url, body=json,
-                      content_type='application/json')
+        responses.add(
+            responses.GET, url, body=json, content_type="application/json"
+        )
 
     def test_itunesstore_finds_image(self):
         json = """{
@@ -303,7 +316,7 @@ class ITunesStoreTest(UseThePlugin):
                   }"""
         self.mock_response(fetchart.ITunesStore.API_URL, json)
         candidate = next(self.source.get(self.album, self.settings, []))
-        self.assertEqual(candidate.url, 'url_to_the_image')
+        self.assertEqual(candidate.url, "url_to_the_image")
         self.assertEqual(candidate.match, fetchart.Candidate.MATCH_EXACT)
 
     def test_itunesstore_no_result(self):
@@ -311,17 +324,21 @@ class ITunesStoreTest(UseThePlugin):
         self.mock_response(fetchart.ITunesStore.API_URL, json)
         expected = u"got no results"
 
-        with capture_log('beets.test_art') as logs:
+        with capture_log("beets.test_art") as logs:
             with self.assertRaises(StopIteration):
                 next(self.source.get(self.album, self.settings, []))
         self.assertIn(expected, logs[1])
 
     def test_itunesstore_requestexception(self):
-        responses.add(responses.GET, fetchart.ITunesStore.API_URL,
-                      json={'error': 'not found'}, status=404)
-        expected = u'iTunes search failed: 404 Client Error'
+        responses.add(
+            responses.GET,
+            fetchart.ITunesStore.API_URL,
+            json={"error": "not found"},
+            status=404,
+        )
+        expected = u"iTunes search failed: 404 Client Error"
 
-        with capture_log('beets.test_art') as logs:
+        with capture_log("beets.test_art") as logs:
             with self.assertRaises(StopIteration):
                 next(self.source.get(self.album, self.settings, []))
         self.assertIn(expected, logs[1])
@@ -338,7 +355,7 @@ class ITunesStoreTest(UseThePlugin):
                   }"""
         self.mock_response(fetchart.ITunesStore.API_URL, json)
         candidate = next(self.source.get(self.album, self.settings, []))
-        self.assertEqual(candidate.url, 'url_to_the_image')
+        self.assertEqual(candidate.url, "url_to_the_image")
         self.assertEqual(candidate.match, fetchart.Candidate.MATCH_FALLBACK)
 
     def test_itunesstore_returns_result_without_artwork(self):
@@ -352,9 +369,9 @@ class ITunesStoreTest(UseThePlugin):
                         ]
                   }"""
         self.mock_response(fetchart.ITunesStore.API_URL, json)
-        expected = u'Malformed itunes candidate'
+        expected = u"Malformed itunes candidate"
 
-        with capture_log('beets.test_art') as logs:
+        with capture_log("beets.test_art") as logs:
             with self.assertRaises(StopIteration):
                 next(self.source.get(self.album, self.settings, []))
         self.assertIn(expected, logs[1])
@@ -364,7 +381,7 @@ class ITunesStoreTest(UseThePlugin):
         self.mock_response(fetchart.ITunesStore.API_URL, json)
         expected = u"not found in json. Fields are"
 
-        with capture_log('beets.test_art') as logs:
+        with capture_log("beets.test_art") as logs:
             with self.assertRaises(StopIteration):
                 next(self.source.get(self.album, self.settings, []))
         self.assertIn(expected, logs[1])
@@ -374,7 +391,7 @@ class ITunesStoreTest(UseThePlugin):
         self.mock_response(fetchart.ITunesStore.API_URL, json)
         expected = u"Could not decode json response:"
 
-        with capture_log('beets.test_art') as logs:
+        with capture_log("beets.test_art") as logs:
             with self.assertRaises(StopIteration):
                 next(self.source.get(self.album, self.settings, []))
         self.assertIn(expected, logs[1])
@@ -391,15 +408,16 @@ class GoogleImageTest(UseThePlugin):
         super(GoogleImageTest, self).run(*args, **kwargs)
 
     def mock_response(self, url, json):
-        responses.add(responses.GET, url, body=json,
-                      content_type='application/json')
+        responses.add(
+            responses.GET, url, body=json, content_type="application/json"
+        )
 
     def test_google_art_finds_image(self):
         album = _common.Bag(albumartist="some artist", album="some album")
         json = '{"items": [{"link": "url_to_the_image"}]}'
         self.mock_response(fetchart.GoogleImages.URL, json)
         candidate = next(self.source.get(album, self.settings, []))
-        self.assertEqual(candidate.url, 'url_to_the_image')
+        self.assertEqual(candidate.url, "url_to_the_image")
 
     def test_google_art_returns_no_result_when_error_received(self):
         album = _common.Bag(albumartist="some artist", album="some album")
@@ -484,35 +502,44 @@ class FanartTVTest(UseThePlugin):
         super(FanartTVTest, self).run(*args, **kwargs)
 
     def mock_response(self, url, json):
-        responses.add(responses.GET, url, body=json,
-                      content_type='application/json')
+        responses.add(
+            responses.GET, url, body=json, content_type="application/json"
+        )
 
     def test_fanarttv_finds_image(self):
-        album = _common.Bag(mb_releasegroupid=u'thereleasegroupid')
-        self.mock_response(fetchart.FanartTV.API_ALBUMS + u'thereleasegroupid',
-                           self.RESPONSE_MULTIPLE)
+        album = _common.Bag(mb_releasegroupid=u"thereleasegroupid")
+        self.mock_response(
+            fetchart.FanartTV.API_ALBUMS + u"thereleasegroupid",
+            self.RESPONSE_MULTIPLE,
+        )
         candidate = next(self.source.get(album, self.settings, []))
-        self.assertEqual(candidate.url, 'http://example.com/1.jpg')
+        self.assertEqual(candidate.url, "http://example.com/1.jpg")
 
     def test_fanarttv_returns_no_result_when_error_received(self):
-        album = _common.Bag(mb_releasegroupid=u'thereleasegroupid')
-        self.mock_response(fetchart.FanartTV.API_ALBUMS + u'thereleasegroupid',
-                           self.RESPONSE_ERROR)
+        album = _common.Bag(mb_releasegroupid=u"thereleasegroupid")
+        self.mock_response(
+            fetchart.FanartTV.API_ALBUMS + u"thereleasegroupid",
+            self.RESPONSE_ERROR,
+        )
         with self.assertRaises(StopIteration):
             next(self.source.get(album, self.settings, []))
 
     def test_fanarttv_returns_no_result_with_malformed_response(self):
-        album = _common.Bag(mb_releasegroupid=u'thereleasegroupid')
-        self.mock_response(fetchart.FanartTV.API_ALBUMS + u'thereleasegroupid',
-                           self.RESPONSE_MALFORMED)
+        album = _common.Bag(mb_releasegroupid=u"thereleasegroupid")
+        self.mock_response(
+            fetchart.FanartTV.API_ALBUMS + u"thereleasegroupid",
+            self.RESPONSE_MALFORMED,
+        )
         with self.assertRaises(StopIteration):
             next(self.source.get(album, self.settings, []))
 
     def test_fanarttv_only_other_images(self):
         # The source used to fail when there were images present, but no cover
-        album = _common.Bag(mb_releasegroupid=u'thereleasegroupid')
-        self.mock_response(fetchart.FanartTV.API_ALBUMS + u'thereleasegroupid',
-                           self.RESPONSE_NO_ART)
+        album = _common.Bag(mb_releasegroupid=u"thereleasegroupid")
+        self.mock_response(
+            fetchart.FanartTV.API_ALBUMS + u"thereleasegroupid",
+            self.RESPONSE_NO_ART,
+        )
         with self.assertRaises(StopIteration):
             next(self.source.get(album, self.settings, []))
 
@@ -523,7 +550,7 @@ class ArtImporterTest(UseThePlugin):
         super(ArtImporterTest, self).setUp()
 
         # Mock the album art fetcher to always return our test file.
-        self.art_file = os.path.join(self.temp_dir, b'tmpcover.jpg')
+        self.art_file = os.path.join(self.temp_dir, b"tmpcover.jpg")
         _common.touch(self.art_file)
         self.old_afa = self.plugin.art_for_album
         self.afa_response = fetchart.Candidate(logger, path=self.art_file)
@@ -534,12 +561,12 @@ class ArtImporterTest(UseThePlugin):
         self.plugin.art_for_album = art_for_album
 
         # Test library.
-        self.libpath = os.path.join(self.temp_dir, b'tmplib.blb')
-        self.libdir = os.path.join(self.temp_dir, b'tmplib')
+        self.libpath = os.path.join(self.temp_dir, b"tmplib.blb")
+        self.libdir = os.path.join(self.temp_dir, b"tmplib")
         os.mkdir(self.libdir)
-        os.mkdir(os.path.join(self.libdir, b'album'))
-        itempath = os.path.join(self.libdir, b'album', b'test.mp3')
-        shutil.copyfile(os.path.join(_common.RSRC, b'full.mp3'), itempath)
+        os.mkdir(os.path.join(self.libdir, b"album"))
+        itempath = os.path.join(self.libdir, b"album", b"test.mp3")
+        shutil.copyfile(os.path.join(_common.RSRC, b"full.mp3"), itempath)
         self.lib = library.Library(self.libpath)
         self.i = _common.item()
         self.i.path = itempath
@@ -554,10 +581,10 @@ class ArtImporterTest(UseThePlugin):
         self.task.is_album = True
         self.task.album = self.album
         info = AlbumInfo(
-            album=u'some album',
-            album_id=u'albumid',
-            artist=u'some artist',
-            artist_id=u'artistid',
+            album=u"some album",
+            album_id=u"albumid",
+            artist=u"some artist",
+            artist_id=u"artistid",
             tracks=[],
         )
         self.task.set_choice(AlbumMatch(0, info, {}, set(), set()))
@@ -581,7 +608,7 @@ class ArtImporterTest(UseThePlugin):
         if should_exist:
             self.assertEqual(
                 artpath,
-                os.path.join(os.path.dirname(self.i.path), b'cover.jpg')
+                os.path.join(os.path.dirname(self.i.path), b"cover.jpg"),
             )
             self.assertExists(artpath)
         else:
@@ -610,7 +637,7 @@ class ArtImporterTest(UseThePlugin):
         self.assertNotExists(self.art_file)
 
     def test_do_not_delete_original_if_already_in_place(self):
-        artdest = os.path.join(os.path.dirname(self.i.path), b'cover.jpg')
+        artdest = os.path.join(os.path.dirname(self.i.path), b"cover.jpg")
         shutil.copyfile(self.art_file, artdest)
         self.afa_response = fetchart.Candidate(logger, path=artdest)
         self._fetch_art(True)
@@ -624,8 +651,9 @@ class ArtImporterTest(UseThePlugin):
         # message "<album> has album art".
         self._fetch_art(True)
         util.remove(self.album.artpath)
-        self.plugin.batch_fetch_art(self.lib, self.lib.albums(), force=False,
-                                    quiet=False)
+        self.plugin.batch_fetch_art(
+            self.lib, self.lib.albums(), force=False, quiet=False
+        )
         self.assertExists(self.album.artpath)
 
 
@@ -634,9 +662,9 @@ class ArtForAlbumTest(UseThePlugin):
     configuration (e.g., minwidth, enforce_ratio)
     """
 
-    IMG_225x225 = os.path.join(_common.RSRC, b'abbey.jpg')
-    IMG_348x348 = os.path.join(_common.RSRC, b'abbey-different.jpg')
-    IMG_500x490 = os.path.join(_common.RSRC, b'abbey-similar.jpg')
+    IMG_225x225 = os.path.join(_common.RSRC, b"abbey.jpg")
+    IMG_348x348 = os.path.join(_common.RSRC, b"abbey-different.jpg")
+    IMG_500x490 = os.path.join(_common.RSRC, b"abbey-similar.jpg")
 
     def setUp(self):
         super(ArtForAlbumTest, self).setUp()
@@ -659,7 +687,7 @@ class ArtForAlbumTest(UseThePlugin):
         self.assertExists(image_file)
         self.image_file = image_file
 
-        candidate = self.plugin.art_for_album(self.album, [''], True)
+        candidate = self.plugin.art_for_album(self.album, [""], True)
 
         if should_exist:
             self.assertNotEqual(candidate, None)
@@ -670,8 +698,8 @@ class ArtForAlbumTest(UseThePlugin):
 
     def _assertImageResized(self, image_file, should_resize):  # noqa
         self.image_file = image_file
-        with patch.object(ArtResizer.shared, 'resize') as mock_resize:
-            self.plugin.art_for_album(self.album, [''], True)
+        with patch.object(ArtResizer.shared, "resize") as mock_resize:
+            self.plugin.art_for_album(self.album, [""], True)
             self.assertEqual(mock_resize.called, should_resize)
 
     def _require_backend(self):
@@ -739,7 +767,7 @@ class DeprecatedConfigTest(_common.TestCase):
     # plugin object
     def setUp(self):
         super(DeprecatedConfigTest, self).setUp()
-        config['fetchart']['remote_priority'] = True
+        config["fetchart"]["remote_priority"] = True
         self.plugin = fetchart.FetchArtPlugin()
 
     def test_moves_filesystem_to_end(self):
@@ -752,26 +780,26 @@ class EnforceRatioConfigTest(_common.TestCase):
     def _load_with_config(self, values, should_raise):
         if should_raise:
             for v in values:
-                config['fetchart']['enforce_ratio'] = v
+                config["fetchart"]["enforce_ratio"] = v
                 with self.assertRaises(confuse.ConfigValueError):
                     fetchart.FetchArtPlugin()
         else:
             for v in values:
-                config['fetchart']['enforce_ratio'] = v
+                config["fetchart"]["enforce_ratio"] = v
                 fetchart.FetchArtPlugin()
 
     def test_px(self):
-        self._load_with_config(u'0px 4px 12px 123px'.split(), False)
-        self._load_with_config(u'00px stuff5px'.split(), True)
+        self._load_with_config(u"0px 4px 12px 123px".split(), False)
+        self._load_with_config(u"00px stuff5px".split(), True)
 
     def test_percent(self):
-        self._load_with_config(u'0% 0.00% 5.1% 5% 100%'.split(), False)
-        self._load_with_config(u'00% 1.234% foo5% 100.1%'.split(), True)
+        self._load_with_config(u"0% 0.00% 5.1% 5% 100%".split(), False)
+        self._load_with_config(u"00% 1.234% foo5% 100.1%".split(), True)
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_autotag.py
+++ b/test/test_autotag.py
@@ -54,63 +54,99 @@ class PluralityTest(_common.TestCase):
             plurality([])
 
     def test_current_metadata_finds_pluralities(self):
-        items = [Item(artist='The Beetles', album='The White Album'),
-                 Item(artist='The Beatles', album='The White Album'),
-                 Item(artist='The Beatles', album='Teh White Album')]
+        items = [
+            Item(artist="The Beetles", album="The White Album"),
+            Item(artist="The Beatles", album="The White Album"),
+            Item(artist="The Beatles", album="Teh White Album"),
+        ]
         likelies, consensus = match.current_metadata(items)
-        self.assertEqual(likelies['artist'], 'The Beatles')
-        self.assertEqual(likelies['album'], 'The White Album')
-        self.assertFalse(consensus['artist'])
+        self.assertEqual(likelies["artist"], "The Beatles")
+        self.assertEqual(likelies["album"], "The White Album")
+        self.assertFalse(consensus["artist"])
 
     def test_current_metadata_artist_consensus(self):
-        items = [Item(artist='The Beatles', album='The White Album'),
-                 Item(artist='The Beatles', album='The White Album'),
-                 Item(artist='The Beatles', album='Teh White Album')]
+        items = [
+            Item(artist="The Beatles", album="The White Album"),
+            Item(artist="The Beatles", album="The White Album"),
+            Item(artist="The Beatles", album="Teh White Album"),
+        ]
         likelies, consensus = match.current_metadata(items)
-        self.assertEqual(likelies['artist'], 'The Beatles')
-        self.assertEqual(likelies['album'], 'The White Album')
-        self.assertTrue(consensus['artist'])
+        self.assertEqual(likelies["artist"], "The Beatles")
+        self.assertEqual(likelies["album"], "The White Album")
+        self.assertTrue(consensus["artist"])
 
     def test_albumartist_consensus(self):
-        items = [Item(artist='tartist1', album='album',
-                      albumartist='aartist'),
-                 Item(artist='tartist2', album='album',
-                      albumartist='aartist'),
-                 Item(artist='tartist3', album='album',
-                      albumartist='aartist')]
+        items = [
+            Item(artist="tartist1", album="album", albumartist="aartist"),
+            Item(artist="tartist2", album="album", albumartist="aartist"),
+            Item(artist="tartist3", album="album", albumartist="aartist"),
+        ]
         likelies, consensus = match.current_metadata(items)
-        self.assertEqual(likelies['artist'], 'aartist')
-        self.assertFalse(consensus['artist'])
+        self.assertEqual(likelies["artist"], "aartist")
+        self.assertFalse(consensus["artist"])
 
     def test_current_metadata_likelies(self):
-        fields = ['artist', 'album', 'albumartist', 'year', 'disctotal',
-                  'mb_albumid', 'label', 'catalognum', 'country', 'media',
-                  'albumdisambig']
-        items = [Item(**dict((f, '%s_%s' % (f, i or 1)) for f in fields))
-                 for i in range(5)]
+        fields = [
+            "artist",
+            "album",
+            "albumartist",
+            "year",
+            "disctotal",
+            "mb_albumid",
+            "label",
+            "catalognum",
+            "country",
+            "media",
+            "albumdisambig",
+        ]
+        items = [
+            Item(**dict((f, "%s_%s" % (f, i or 1)) for f in fields))
+            for i in range(5)
+        ]
         likelies, _ = match.current_metadata(items)
         for f in fields:
             if isinstance(likelies[f], int):
                 self.assertEqual(likelies[f], 0)
             else:
-                self.assertEqual(likelies[f], '%s_1' % f)
+                self.assertEqual(likelies[f], "%s_1" % f)
 
 
-def _make_item(title, track, artist=u'some artist'):
-    return Item(title=title, track=track,
-                artist=artist, album=u'some album',
-                length=1,
-                mb_trackid='', mb_albumid='', mb_artistid='')
+def _make_item(title, track, artist=u"some artist"):
+    return Item(
+        title=title,
+        track=track,
+        artist=artist,
+        album=u"some album",
+        length=1,
+        mb_trackid="",
+        mb_albumid="",
+        mb_artistid="",
+    )
 
 
 def _make_trackinfo():
     return [
-        TrackInfo(title=u'one', track_id=None, artist=u'some artist',
-                  length=1, index=1),
-        TrackInfo(title=u'two', track_id=None, artist=u'some artist',
-                  length=1, index=2),
-        TrackInfo(title=u'three', track_id=None, artist=u'some artist',
-                  length=1, index=3),
+        TrackInfo(
+            title=u"one",
+            track_id=None,
+            artist=u"some artist",
+            length=1,
+            index=1,
+        ),
+        TrackInfo(
+            title=u"two",
+            track_id=None,
+            artist=u"some artist",
+            length=1,
+            index=2,
+        ),
+        TrackInfo(
+            title=u"three",
+            track_id=None,
+            artist=u"some artist",
+            length=1,
+            index=3,
+        ),
     ]
 
 
@@ -118,7 +154,7 @@ def _clear_weights():
     """Hack around the lazy descriptor used to cache weights for
     Distance calculations.
     """
-    Distance.__dict__['_weights'].computed = False
+    Distance.__dict__["_weights"].computed = False
 
 
 class DistanceTest(_common.TestCase):
@@ -128,131 +164,132 @@ class DistanceTest(_common.TestCase):
 
     def test_add(self):
         dist = Distance()
-        dist.add('add', 1.0)
-        self.assertEqual(dist._penalties, {'add': [1.0]})
+        dist.add("add", 1.0)
+        self.assertEqual(dist._penalties, {"add": [1.0]})
 
     def test_add_equality(self):
         dist = Distance()
-        dist.add_equality('equality', 'ghi', ['abc', 'def', 'ghi'])
-        self.assertEqual(dist._penalties['equality'], [0.0])
+        dist.add_equality("equality", "ghi", ["abc", "def", "ghi"])
+        self.assertEqual(dist._penalties["equality"], [0.0])
 
-        dist.add_equality('equality', 'xyz', ['abc', 'def', 'ghi'])
-        self.assertEqual(dist._penalties['equality'], [0.0, 1.0])
+        dist.add_equality("equality", "xyz", ["abc", "def", "ghi"])
+        self.assertEqual(dist._penalties["equality"], [0.0, 1.0])
 
-        dist.add_equality('equality', 'abc', re.compile(r'ABC', re.I))
-        self.assertEqual(dist._penalties['equality'], [0.0, 1.0, 0.0])
+        dist.add_equality("equality", "abc", re.compile(r"ABC", re.I))
+        self.assertEqual(dist._penalties["equality"], [0.0, 1.0, 0.0])
 
     def test_add_expr(self):
         dist = Distance()
-        dist.add_expr('expr', True)
-        self.assertEqual(dist._penalties['expr'], [1.0])
+        dist.add_expr("expr", True)
+        self.assertEqual(dist._penalties["expr"], [1.0])
 
-        dist.add_expr('expr', False)
-        self.assertEqual(dist._penalties['expr'], [1.0, 0.0])
+        dist.add_expr("expr", False)
+        self.assertEqual(dist._penalties["expr"], [1.0, 0.0])
 
     def test_add_number(self):
         dist = Distance()
         # Add a full penalty for each number of difference between two numbers.
 
-        dist.add_number('number', 1, 1)
-        self.assertEqual(dist._penalties['number'], [0.0])
+        dist.add_number("number", 1, 1)
+        self.assertEqual(dist._penalties["number"], [0.0])
 
-        dist.add_number('number', 1, 2)
-        self.assertEqual(dist._penalties['number'], [0.0, 1.0])
+        dist.add_number("number", 1, 2)
+        self.assertEqual(dist._penalties["number"], [0.0, 1.0])
 
-        dist.add_number('number', 2, 1)
-        self.assertEqual(dist._penalties['number'], [0.0, 1.0, 1.0])
+        dist.add_number("number", 2, 1)
+        self.assertEqual(dist._penalties["number"], [0.0, 1.0, 1.0])
 
-        dist.add_number('number', -1, 2)
-        self.assertEqual(dist._penalties['number'], [0.0, 1.0, 1.0, 1.0,
-                                                     1.0, 1.0])
+        dist.add_number("number", -1, 2)
+        self.assertEqual(
+            dist._penalties["number"], [0.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+        )
 
     def test_add_priority(self):
         dist = Distance()
-        dist.add_priority('priority', 'abc', 'abc')
-        self.assertEqual(dist._penalties['priority'], [0.0])
+        dist.add_priority("priority", "abc", "abc")
+        self.assertEqual(dist._penalties["priority"], [0.0])
 
-        dist.add_priority('priority', 'def', ['abc', 'def'])
-        self.assertEqual(dist._penalties['priority'], [0.0, 0.5])
+        dist.add_priority("priority", "def", ["abc", "def"])
+        self.assertEqual(dist._penalties["priority"], [0.0, 0.5])
 
-        dist.add_priority('priority', 'gh', ['ab', 'cd', 'ef',
-                                             re.compile('GH', re.I)])
-        self.assertEqual(dist._penalties['priority'], [0.0, 0.5, 0.75])
+        dist.add_priority(
+            "priority", "gh", ["ab", "cd", "ef", re.compile("GH", re.I)]
+        )
+        self.assertEqual(dist._penalties["priority"], [0.0, 0.5, 0.75])
 
-        dist.add_priority('priority', 'xyz', ['abc', 'def'])
-        self.assertEqual(dist._penalties['priority'], [0.0, 0.5, 0.75,
-                                                       1.0])
+        dist.add_priority("priority", "xyz", ["abc", "def"])
+        self.assertEqual(dist._penalties["priority"], [0.0, 0.5, 0.75, 1.0])
 
     def test_add_ratio(self):
         dist = Distance()
-        dist.add_ratio('ratio', 25, 100)
-        self.assertEqual(dist._penalties['ratio'], [0.25])
+        dist.add_ratio("ratio", 25, 100)
+        self.assertEqual(dist._penalties["ratio"], [0.25])
 
-        dist.add_ratio('ratio', 10, 5)
-        self.assertEqual(dist._penalties['ratio'], [0.25, 1.0])
+        dist.add_ratio("ratio", 10, 5)
+        self.assertEqual(dist._penalties["ratio"], [0.25, 1.0])
 
-        dist.add_ratio('ratio', -5, 5)
-        self.assertEqual(dist._penalties['ratio'], [0.25, 1.0, 0.0])
+        dist.add_ratio("ratio", -5, 5)
+        self.assertEqual(dist._penalties["ratio"], [0.25, 1.0, 0.0])
 
-        dist.add_ratio('ratio', 5, 0)
-        self.assertEqual(dist._penalties['ratio'], [0.25, 1.0, 0.0, 0.0])
+        dist.add_ratio("ratio", 5, 0)
+        self.assertEqual(dist._penalties["ratio"], [0.25, 1.0, 0.0, 0.0])
 
     def test_add_string(self):
         dist = Distance()
-        sdist = string_dist(u'abc', u'bcd')
-        dist.add_string('string', u'abc', u'bcd')
-        self.assertEqual(dist._penalties['string'], [sdist])
-        self.assertNotEqual(dist._penalties['string'], [0])
+        sdist = string_dist(u"abc", u"bcd")
+        dist.add_string("string", u"abc", u"bcd")
+        self.assertEqual(dist._penalties["string"], [sdist])
+        self.assertNotEqual(dist._penalties["string"], [0])
 
     def test_add_string_none(self):
         dist = Distance()
-        dist.add_string('string', None, 'string')
-        self.assertEqual(dist._penalties['string'], [1])
+        dist.add_string("string", None, "string")
+        self.assertEqual(dist._penalties["string"], [1])
 
     def test_add_string_both_none(self):
         dist = Distance()
-        dist.add_string('string', None, None)
-        self.assertEqual(dist._penalties['string'], [0])
+        dist.add_string("string", None, None)
+        self.assertEqual(dist._penalties["string"], [0])
 
     def test_distance(self):
-        config['match']['distance_weights']['album'] = 2.0
-        config['match']['distance_weights']['medium'] = 1.0
+        config["match"]["distance_weights"]["album"] = 2.0
+        config["match"]["distance_weights"]["medium"] = 1.0
         _clear_weights()
 
         dist = Distance()
-        dist.add('album', 0.5)
-        dist.add('media', 0.25)
-        dist.add('media', 0.75)
+        dist.add("album", 0.5)
+        dist.add("media", 0.25)
+        dist.add("media", 0.75)
         self.assertEqual(dist.distance, 0.5)
 
         # __getitem__()
-        self.assertEqual(dist['album'], 0.25)
-        self.assertEqual(dist['media'], 0.25)
+        self.assertEqual(dist["album"], 0.25)
+        self.assertEqual(dist["media"], 0.25)
 
     def test_max_distance(self):
-        config['match']['distance_weights']['album'] = 3.0
-        config['match']['distance_weights']['medium'] = 1.0
+        config["match"]["distance_weights"]["album"] = 3.0
+        config["match"]["distance_weights"]["medium"] = 1.0
         _clear_weights()
 
         dist = Distance()
-        dist.add('album', 0.5)
-        dist.add('medium', 0.0)
-        dist.add('medium', 0.0)
+        dist.add("album", 0.5)
+        dist.add("medium", 0.0)
+        dist.add("medium", 0.0)
         self.assertEqual(dist.max_distance, 5.0)
 
     def test_operators(self):
-        config['match']['distance_weights']['source'] = 1.0
-        config['match']['distance_weights']['album'] = 2.0
-        config['match']['distance_weights']['medium'] = 1.0
+        config["match"]["distance_weights"]["source"] = 1.0
+        config["match"]["distance_weights"]["album"] = 2.0
+        config["match"]["distance_weights"]["medium"] = 1.0
         _clear_weights()
 
         dist = Distance()
-        dist.add('source', 0.0)
-        dist.add('album', 0.5)
-        dist.add('medium', 0.25)
-        dist.add('medium', 0.75)
+        dist.add("source", 0.0)
+        dist.add("album", 0.5)
+        dist.add("medium", 0.25)
+        dist.add("medium", 0.75)
         self.assertEqual(len(dist), 2)
-        self.assertEqual(list(dist), [('album', 0.2), ('medium', 0.2)])
+        self.assertEqual(list(dist), [("album", 0.2), ("medium", 0.2)])
         self.assertTrue(dist == 0.4)
         self.assertTrue(dist < 1.0)
         self.assertTrue(dist > 0.0)
@@ -261,71 +298,73 @@ class DistanceTest(_common.TestCase):
         self.assertEqual(float(dist), 0.4)
 
     def test_raw_distance(self):
-        config['match']['distance_weights']['album'] = 3.0
-        config['match']['distance_weights']['medium'] = 1.0
+        config["match"]["distance_weights"]["album"] = 3.0
+        config["match"]["distance_weights"]["medium"] = 1.0
         _clear_weights()
 
         dist = Distance()
-        dist.add('album', 0.5)
-        dist.add('medium', 0.25)
-        dist.add('medium', 0.5)
+        dist.add("album", 0.5)
+        dist.add("medium", 0.25)
+        dist.add("medium", 0.5)
         self.assertEqual(dist.raw_distance, 2.25)
 
     def test_items(self):
-        config['match']['distance_weights']['album'] = 4.0
-        config['match']['distance_weights']['medium'] = 2.0
+        config["match"]["distance_weights"]["album"] = 4.0
+        config["match"]["distance_weights"]["medium"] = 2.0
         _clear_weights()
 
         dist = Distance()
-        dist.add('album', 0.1875)
-        dist.add('medium', 0.75)
-        self.assertEqual(dist.items(), [('medium', 0.25), ('album', 0.125)])
+        dist.add("album", 0.1875)
+        dist.add("medium", 0.75)
+        self.assertEqual(dist.items(), [("medium", 0.25), ("album", 0.125)])
 
         # Sort by key if distance is equal.
         dist = Distance()
-        dist.add('album', 0.375)
-        dist.add('medium', 0.75)
-        self.assertEqual(dist.items(), [('album', 0.25), ('medium', 0.25)])
+        dist.add("album", 0.375)
+        dist.add("medium", 0.75)
+        self.assertEqual(dist.items(), [("album", 0.25), ("medium", 0.25)])
 
     def test_update(self):
         dist1 = Distance()
-        dist1.add('album', 0.5)
-        dist1.add('media', 1.0)
+        dist1.add("album", 0.5)
+        dist1.add("media", 1.0)
 
         dist2 = Distance()
-        dist2.add('album', 0.75)
-        dist2.add('album', 0.25)
-        dist2.add('media', 0.05)
+        dist2.add("album", 0.75)
+        dist2.add("album", 0.25)
+        dist2.add("media", 0.05)
 
         dist1.update(dist2)
 
-        self.assertEqual(dist1._penalties, {'album': [0.5, 0.75, 0.25],
-                                            'media': [1.0, 0.05]})
+        self.assertEqual(
+            dist1._penalties,
+            {"album": [0.5, 0.75, 0.25], "media": [1.0, 0.05]},
+        )
 
 
 class TrackDistanceTest(_common.TestCase):
     def test_identical_tracks(self):
-        item = _make_item(u'one', 1)
+        item = _make_item(u"one", 1)
         info = _make_trackinfo()[0]
         dist = match.track_distance(item, info, incl_artist=True)
         self.assertEqual(dist, 0.0)
 
     def test_different_title(self):
-        item = _make_item(u'foo', 1)
+        item = _make_item(u"foo", 1)
         info = _make_trackinfo()[0]
         dist = match.track_distance(item, info, incl_artist=True)
         self.assertNotEqual(dist, 0.0)
 
     def test_different_artist(self):
-        item = _make_item(u'one', 1)
-        item.artist = u'foo'
+        item = _make_item(u"one", 1)
+        item.artist = u"foo"
         info = _make_trackinfo()[0]
         dist = match.track_distance(item, info, incl_artist=True)
         self.assertNotEqual(dist, 0.0)
 
     def test_various_artists_tolerated(self):
-        item = _make_item(u'one', 1)
-        item.artist = u'Various Artists'
+        item = _make_item(u"one", 1)
+        item.artist = u"Various Artists"
         info = _make_trackinfo()[0]
         dist = match.track_distance(item, info, incl_artist=True)
         self.assertEqual(dist, 0.0)
@@ -343,26 +382,26 @@ class AlbumDistanceTest(_common.TestCase):
 
     def test_identical_albums(self):
         items = []
-        items.append(_make_item(u'one', 1))
-        items.append(_make_item(u'two', 2))
-        items.append(_make_item(u'three', 3))
+        items.append(_make_item(u"one", 1))
+        items.append(_make_item(u"two", 2))
+        items.append(_make_item(u"three", 3))
         info = AlbumInfo(
-            artist=u'some artist',
-            album=u'some album',
+            artist=u"some artist",
+            album=u"some album",
             tracks=_make_trackinfo(),
-            va=False
+            va=False,
         )
         self.assertEqual(self._dist(items, info), 0)
 
     def test_incomplete_album(self):
         items = []
-        items.append(_make_item(u'one', 1))
-        items.append(_make_item(u'three', 3))
+        items.append(_make_item(u"one", 1))
+        items.append(_make_item(u"three", 3))
         info = AlbumInfo(
-            artist=u'some artist',
-            album=u'some album',
+            artist=u"some artist",
+            album=u"some album",
             tracks=_make_trackinfo(),
-            va=False
+            va=False,
         )
         dist = self._dist(items, info)
         self.assertNotEqual(dist, 0)
@@ -371,41 +410,41 @@ class AlbumDistanceTest(_common.TestCase):
 
     def test_global_artists_differ(self):
         items = []
-        items.append(_make_item(u'one', 1))
-        items.append(_make_item(u'two', 2))
-        items.append(_make_item(u'three', 3))
+        items.append(_make_item(u"one", 1))
+        items.append(_make_item(u"two", 2))
+        items.append(_make_item(u"three", 3))
         info = AlbumInfo(
-            artist=u'someone else',
-            album=u'some album',
+            artist=u"someone else",
+            album=u"some album",
             tracks=_make_trackinfo(),
-            va=False
+            va=False,
         )
         self.assertNotEqual(self._dist(items, info), 0)
 
     def test_comp_track_artists_match(self):
         items = []
-        items.append(_make_item(u'one', 1))
-        items.append(_make_item(u'two', 2))
-        items.append(_make_item(u'three', 3))
+        items.append(_make_item(u"one", 1))
+        items.append(_make_item(u"two", 2))
+        items.append(_make_item(u"three", 3))
         info = AlbumInfo(
-            artist=u'should be ignored',
-            album=u'some album',
+            artist=u"should be ignored",
+            album=u"some album",
             tracks=_make_trackinfo(),
-            va=True
+            va=True,
         )
         self.assertEqual(self._dist(items, info), 0)
 
     def test_comp_no_track_artists(self):
         # Some VA releases don't have track artists (incomplete metadata).
         items = []
-        items.append(_make_item(u'one', 1))
-        items.append(_make_item(u'two', 2))
-        items.append(_make_item(u'three', 3))
+        items.append(_make_item(u"one", 1))
+        items.append(_make_item(u"two", 2))
+        items.append(_make_item(u"three", 3))
         info = AlbumInfo(
-            artist=u'should be ignored',
-            album=u'some album',
+            artist=u"should be ignored",
+            album=u"some album",
             tracks=_make_trackinfo(),
-            va=True
+            va=True,
         )
         info.tracks[0].artist = None
         info.tracks[1].artist = None
@@ -414,41 +453,41 @@ class AlbumDistanceTest(_common.TestCase):
 
     def test_comp_track_artists_do_not_match(self):
         items = []
-        items.append(_make_item(u'one', 1))
-        items.append(_make_item(u'two', 2, u'someone else'))
-        items.append(_make_item(u'three', 3))
+        items.append(_make_item(u"one", 1))
+        items.append(_make_item(u"two", 2, u"someone else"))
+        items.append(_make_item(u"three", 3))
         info = AlbumInfo(
-            artist=u'some artist',
-            album=u'some album',
+            artist=u"some artist",
+            album=u"some album",
             tracks=_make_trackinfo(),
-            va=True
+            va=True,
         )
         self.assertNotEqual(self._dist(items, info), 0)
 
     def test_tracks_out_of_order(self):
         items = []
-        items.append(_make_item(u'one', 1))
-        items.append(_make_item(u'three', 2))
-        items.append(_make_item(u'two', 3))
+        items.append(_make_item(u"one", 1))
+        items.append(_make_item(u"three", 2))
+        items.append(_make_item(u"two", 3))
         info = AlbumInfo(
-            artist=u'some artist',
-            album=u'some album',
+            artist=u"some artist",
+            album=u"some album",
             tracks=_make_trackinfo(),
-            va=False
+            va=False,
         )
         dist = self._dist(items, info)
         self.assertTrue(0 < dist < 0.2)
 
     def test_two_medium_release(self):
         items = []
-        items.append(_make_item(u'one', 1))
-        items.append(_make_item(u'two', 2))
-        items.append(_make_item(u'three', 3))
+        items.append(_make_item(u"one", 1))
+        items.append(_make_item(u"two", 2))
+        items.append(_make_item(u"three", 3))
         info = AlbumInfo(
-            artist=u'some artist',
-            album=u'some album',
+            artist=u"some artist",
+            album=u"some album",
             tracks=_make_trackinfo(),
-            va=False
+            va=False,
         )
         info.tracks[0].medium_index = 1
         info.tracks[1].medium_index = 2
@@ -458,14 +497,14 @@ class AlbumDistanceTest(_common.TestCase):
 
     def test_per_medium_track_numbers(self):
         items = []
-        items.append(_make_item(u'one', 1))
-        items.append(_make_item(u'two', 2))
-        items.append(_make_item(u'three', 1))
+        items.append(_make_item(u"one", 1))
+        items.append(_make_item(u"two", 2))
+        items.append(_make_item(u"three", 1))
         info = AlbumInfo(
-            artist=u'some artist',
-            album=u'some album',
+            artist=u"some artist",
+            album=u"some album",
             tracks=_make_trackinfo(),
-            va=False
+            va=False,
         )
         info.tracks[0].medium_index = 1
         info.tracks[1].medium_index = 2
@@ -477,93 +516,107 @@ class AlbumDistanceTest(_common.TestCase):
 class AssignmentTest(unittest.TestCase):
     def item(self, title, track):
         return Item(
-            title=title, track=track,
-            mb_trackid='', mb_albumid='', mb_artistid='',
+            title=title,
+            track=track,
+            mb_trackid="",
+            mb_albumid="",
+            mb_artistid="",
         )
 
     def test_reorder_when_track_numbers_incorrect(self):
         items = []
-        items.append(self.item(u'one', 1))
-        items.append(self.item(u'three', 2))
-        items.append(self.item(u'two', 3))
+        items.append(self.item(u"one", 1))
+        items.append(self.item(u"three", 2))
+        items.append(self.item(u"two", 3))
         trackinfo = []
-        trackinfo.append(TrackInfo(title=u'one'))
-        trackinfo.append(TrackInfo(title=u'two'))
-        trackinfo.append(TrackInfo(title=u'three'))
-        mapping, extra_items, extra_tracks = \
-            match.assign_items(items, trackinfo)
+        trackinfo.append(TrackInfo(title=u"one"))
+        trackinfo.append(TrackInfo(title=u"two"))
+        trackinfo.append(TrackInfo(title=u"three"))
+        mapping, extra_items, extra_tracks = match.assign_items(
+            items, trackinfo
+        )
         self.assertEqual(extra_items, [])
         self.assertEqual(extra_tracks, [])
-        self.assertEqual(mapping, {
-            items[0]: trackinfo[0],
-            items[1]: trackinfo[2],
-            items[2]: trackinfo[1],
-        })
+        self.assertEqual(
+            mapping,
+            {
+                items[0]: trackinfo[0],
+                items[1]: trackinfo[2],
+                items[2]: trackinfo[1],
+            },
+        )
 
     def test_order_works_with_invalid_track_numbers(self):
         items = []
-        items.append(self.item(u'one', 1))
-        items.append(self.item(u'three', 1))
-        items.append(self.item(u'two', 1))
+        items.append(self.item(u"one", 1))
+        items.append(self.item(u"three", 1))
+        items.append(self.item(u"two", 1))
         trackinfo = []
-        trackinfo.append(TrackInfo(title=u'one'))
-        trackinfo.append(TrackInfo(title=u'two'))
-        trackinfo.append(TrackInfo(title=u'three'))
-        mapping, extra_items, extra_tracks = \
-            match.assign_items(items, trackinfo)
+        trackinfo.append(TrackInfo(title=u"one"))
+        trackinfo.append(TrackInfo(title=u"two"))
+        trackinfo.append(TrackInfo(title=u"three"))
+        mapping, extra_items, extra_tracks = match.assign_items(
+            items, trackinfo
+        )
         self.assertEqual(extra_items, [])
         self.assertEqual(extra_tracks, [])
-        self.assertEqual(mapping, {
-            items[0]: trackinfo[0],
-            items[1]: trackinfo[2],
-            items[2]: trackinfo[1],
-        })
+        self.assertEqual(
+            mapping,
+            {
+                items[0]: trackinfo[0],
+                items[1]: trackinfo[2],
+                items[2]: trackinfo[1],
+            },
+        )
 
     def test_order_works_with_missing_tracks(self):
         items = []
-        items.append(self.item(u'one', 1))
-        items.append(self.item(u'three', 3))
+        items.append(self.item(u"one", 1))
+        items.append(self.item(u"three", 3))
         trackinfo = []
-        trackinfo.append(TrackInfo(title=u'one'))
-        trackinfo.append(TrackInfo(title=u'two'))
-        trackinfo.append(TrackInfo(title=u'three'))
-        mapping, extra_items, extra_tracks = \
-            match.assign_items(items, trackinfo)
+        trackinfo.append(TrackInfo(title=u"one"))
+        trackinfo.append(TrackInfo(title=u"two"))
+        trackinfo.append(TrackInfo(title=u"three"))
+        mapping, extra_items, extra_tracks = match.assign_items(
+            items, trackinfo
+        )
         self.assertEqual(extra_items, [])
         self.assertEqual(extra_tracks, [trackinfo[1]])
-        self.assertEqual(mapping, {
-            items[0]: trackinfo[0],
-            items[1]: trackinfo[2],
-        })
+        self.assertEqual(
+            mapping, {items[0]: trackinfo[0], items[1]: trackinfo[2],}
+        )
 
     def test_order_works_with_extra_tracks(self):
         items = []
-        items.append(self.item(u'one', 1))
-        items.append(self.item(u'two', 2))
-        items.append(self.item(u'three', 3))
+        items.append(self.item(u"one", 1))
+        items.append(self.item(u"two", 2))
+        items.append(self.item(u"three", 3))
         trackinfo = []
-        trackinfo.append(TrackInfo(title=u'one'))
-        trackinfo.append(TrackInfo(title=u'three'))
-        mapping, extra_items, extra_tracks = \
-            match.assign_items(items, trackinfo)
+        trackinfo.append(TrackInfo(title=u"one"))
+        trackinfo.append(TrackInfo(title=u"three"))
+        mapping, extra_items, extra_tracks = match.assign_items(
+            items, trackinfo
+        )
         self.assertEqual(extra_items, [items[1]])
         self.assertEqual(extra_tracks, [])
-        self.assertEqual(mapping, {
-            items[0]: trackinfo[0],
-            items[2]: trackinfo[1],
-        })
+        self.assertEqual(
+            mapping, {items[0]: trackinfo[0], items[2]: trackinfo[1],}
+        )
 
     def test_order_works_when_track_names_are_entirely_wrong(self):
         # A real-world test case contributed by a user.
         def item(i, length):
             return Item(
-                artist=u'ben harper',
-                album=u'burn to shine',
-                title=u'ben harper - Burn to Shine {0}'.format(i),
+                artist=u"ben harper",
+                album=u"burn to shine",
+                title=u"ben harper - Burn to Shine {0}".format(i),
                 track=i,
                 length=length,
-                mb_trackid='', mb_albumid='', mb_artistid='',
+                mb_trackid="",
+                mb_albumid="",
+                mb_artistid="",
             )
+
         items = []
         items.append(item(1, 241.37243007106997))
         items.append(item(2, 342.27781704375036))
@@ -579,24 +632,25 @@ class AssignmentTest(unittest.TestCase):
         items.append(item(12, 186.45916150485752))
 
         def info(index, title, length):
-            return TrackInfo(title=title, length=length,
-                             index=index)
-        trackinfo = []
-        trackinfo.append(info(1, u'Alone', 238.893))
-        trackinfo.append(info(2, u'The Woman in You', 341.44))
-        trackinfo.append(info(3, u'Less', 245.59999999999999))
-        trackinfo.append(info(4, u'Two Hands of a Prayer', 470.49299999999999))
-        trackinfo.append(info(5, u'Please Bleed', 277.86599999999999))
-        trackinfo.append(info(6, u'Suzie Blue', 269.30599999999998))
-        trackinfo.append(info(7, u'Steal My Kisses', 245.36000000000001))
-        trackinfo.append(info(8, u'Burn to Shine', 214.90600000000001))
-        trackinfo.append(info(9, u'Show Me a Little Shame', 224.0929999999999))
-        trackinfo.append(info(10, u'Forgiven', 317.19999999999999))
-        trackinfo.append(info(11, u'Beloved One', 243.733))
-        trackinfo.append(info(12, u'In the Lord\'s Arms', 186.13300000000001))
+            return TrackInfo(title=title, length=length, index=index)
 
-        mapping, extra_items, extra_tracks = \
-            match.assign_items(items, trackinfo)
+        trackinfo = []
+        trackinfo.append(info(1, u"Alone", 238.893))
+        trackinfo.append(info(2, u"The Woman in You", 341.44))
+        trackinfo.append(info(3, u"Less", 245.59999999999999))
+        trackinfo.append(info(4, u"Two Hands of a Prayer", 470.49299999999999))
+        trackinfo.append(info(5, u"Please Bleed", 277.86599999999999))
+        trackinfo.append(info(6, u"Suzie Blue", 269.30599999999998))
+        trackinfo.append(info(7, u"Steal My Kisses", 245.36000000000001))
+        trackinfo.append(info(8, u"Burn to Shine", 214.90600000000001))
+        trackinfo.append(info(9, u"Show Me a Little Shame", 224.0929999999999))
+        trackinfo.append(info(10, u"Forgiven", 317.19999999999999))
+        trackinfo.append(info(11, u"Beloved One", 243.733))
+        trackinfo.append(info(12, u"In the Lord's Arms", 186.13300000000001))
+
+        mapping, extra_items, extra_tracks = match.assign_items(
+            items, trackinfo
+        )
         self.assertEqual(extra_items, [])
         self.assertEqual(extra_tracks, [])
         for item, info in mapping.items():
@@ -609,8 +663,8 @@ class ApplyTestUtil(object):
         mapping = {}
         for i, t in zip(self.items, info.tracks):
             mapping[i] = t
-        config['per_disc_numbering'] = per_disc_numbering
-        config['artist_credit'] = artist_credit
+        config["per_disc_numbering"] = per_disc_numbering
+        config["artist_credit"] = artist_credit
         autotag.apply_metadata(info, mapping)
 
 
@@ -622,48 +676,52 @@ class ApplyTest(_common.TestCase, ApplyTestUtil):
         self.items.append(Item({}))
         self.items.append(Item({}))
         trackinfo = []
-        trackinfo.append(TrackInfo(
-            title=u'oneNew',
-            track_id=u'dfa939ec-118c-4d0f-84a0-60f3d1e6522c',
-            medium=1,
-            medium_index=1,
-            medium_total=1,
-            index=1,
-            artist_credit='trackArtistCredit',
-            artist_sort='trackArtistSort',
-        ))
-        trackinfo.append(TrackInfo(
-            title=u'twoNew',
-            track_id=u'40130ed1-a27c-42fd-a328-1ebefb6caef4',
-            medium=2,
-            medium_index=1,
-            index=2,
-            medium_total=1,
-        ))
+        trackinfo.append(
+            TrackInfo(
+                title=u"oneNew",
+                track_id=u"dfa939ec-118c-4d0f-84a0-60f3d1e6522c",
+                medium=1,
+                medium_index=1,
+                medium_total=1,
+                index=1,
+                artist_credit="trackArtistCredit",
+                artist_sort="trackArtistSort",
+            )
+        )
+        trackinfo.append(
+            TrackInfo(
+                title=u"twoNew",
+                track_id=u"40130ed1-a27c-42fd-a328-1ebefb6caef4",
+                medium=2,
+                medium_index=1,
+                index=2,
+                medium_total=1,
+            )
+        )
         self.info = AlbumInfo(
             tracks=trackinfo,
-            artist=u'artistNew',
-            album=u'albumNew',
-            album_id='7edb51cb-77d6-4416-a23c-3a8c2994a2c7',
-            artist_id='a6623d39-2d8e-4f70-8242-0a9553b91e50',
-            artist_credit=u'albumArtistCredit',
-            artist_sort=u'albumArtistSort',
-            albumtype=u'album',
+            artist=u"artistNew",
+            album=u"albumNew",
+            album_id="7edb51cb-77d6-4416-a23c-3a8c2994a2c7",
+            artist_id="a6623d39-2d8e-4f70-8242-0a9553b91e50",
+            artist_credit=u"albumArtistCredit",
+            artist_sort=u"albumArtistSort",
+            albumtype=u"album",
             va=False,
             mediums=2,
         )
 
     def test_titles_applied(self):
         self._apply()
-        self.assertEqual(self.items[0].title, 'oneNew')
-        self.assertEqual(self.items[1].title, 'twoNew')
+        self.assertEqual(self.items[0].title, "oneNew")
+        self.assertEqual(self.items[1].title, "twoNew")
 
     def test_album_and_artist_applied_to_all(self):
         self._apply()
-        self.assertEqual(self.items[0].album, 'albumNew')
-        self.assertEqual(self.items[1].album, 'albumNew')
-        self.assertEqual(self.items[0].artist, 'artistNew')
-        self.assertEqual(self.items[1].artist, 'artistNew')
+        self.assertEqual(self.items[0].album, "albumNew")
+        self.assertEqual(self.items[1].album, "albumNew")
+        self.assertEqual(self.items[0].artist, "artistNew")
+        self.assertEqual(self.items[1].artist, "artistNew")
 
     def test_track_index_applied(self):
         self._apply()
@@ -697,69 +755,73 @@ class ApplyTest(_common.TestCase, ApplyTestUtil):
 
     def test_artist_credit(self):
         self._apply(artist_credit=True)
-        self.assertEqual(self.items[0].artist, 'trackArtistCredit')
-        self.assertEqual(self.items[1].artist, 'albumArtistCredit')
-        self.assertEqual(self.items[0].albumartist, 'albumArtistCredit')
-        self.assertEqual(self.items[1].albumartist, 'albumArtistCredit')
+        self.assertEqual(self.items[0].artist, "trackArtistCredit")
+        self.assertEqual(self.items[1].artist, "albumArtistCredit")
+        self.assertEqual(self.items[0].albumartist, "albumArtistCredit")
+        self.assertEqual(self.items[1].albumartist, "albumArtistCredit")
 
     def test_artist_credit_prefers_artist_over_albumartist_credit(self):
-        self.info.tracks[0].artist = 'oldArtist'
+        self.info.tracks[0].artist = "oldArtist"
         self.info.tracks[0].artist_credit = None
         self._apply(artist_credit=True)
-        self.assertEqual(self.items[0].artist, 'oldArtist')
+        self.assertEqual(self.items[0].artist, "oldArtist")
 
     def test_artist_credit_falls_back_to_albumartist(self):
         self.info.artist_credit = None
         self._apply(artist_credit=True)
-        self.assertEqual(self.items[1].artist, 'artistNew')
+        self.assertEqual(self.items[1].artist, "artistNew")
 
     def test_mb_trackid_applied(self):
         self._apply()
-        self.assertEqual(self.items[0].mb_trackid,
-                         'dfa939ec-118c-4d0f-84a0-60f3d1e6522c')
-        self.assertEqual(self.items[1].mb_trackid,
-                         '40130ed1-a27c-42fd-a328-1ebefb6caef4')
+        self.assertEqual(
+            self.items[0].mb_trackid, "dfa939ec-118c-4d0f-84a0-60f3d1e6522c"
+        )
+        self.assertEqual(
+            self.items[1].mb_trackid, "40130ed1-a27c-42fd-a328-1ebefb6caef4"
+        )
 
     def test_mb_albumid_and_artistid_applied(self):
         self._apply()
         for item in self.items:
-            self.assertEqual(item.mb_albumid,
-                             '7edb51cb-77d6-4416-a23c-3a8c2994a2c7')
-            self.assertEqual(item.mb_artistid,
-                             'a6623d39-2d8e-4f70-8242-0a9553b91e50')
+            self.assertEqual(
+                item.mb_albumid, "7edb51cb-77d6-4416-a23c-3a8c2994a2c7"
+            )
+            self.assertEqual(
+                item.mb_artistid, "a6623d39-2d8e-4f70-8242-0a9553b91e50"
+            )
 
     def test_albumtype_applied(self):
         self._apply()
-        self.assertEqual(self.items[0].albumtype, 'album')
-        self.assertEqual(self.items[1].albumtype, 'album')
+        self.assertEqual(self.items[0].albumtype, "album")
+        self.assertEqual(self.items[1].albumtype, "album")
 
     def test_album_artist_overrides_empty_track_artist(self):
         my_info = self.info.copy()
         self._apply(info=my_info)
-        self.assertEqual(self.items[0].artist, 'artistNew')
-        self.assertEqual(self.items[1].artist, 'artistNew')
+        self.assertEqual(self.items[0].artist, "artistNew")
+        self.assertEqual(self.items[1].artist, "artistNew")
 
     def test_album_artist_overridden_by_nonempty_track_artist(self):
         my_info = self.info.copy()
-        my_info.tracks[0].artist = 'artist1!'
-        my_info.tracks[1].artist = 'artist2!'
+        my_info.tracks[0].artist = "artist1!"
+        my_info.tracks[1].artist = "artist2!"
         self._apply(info=my_info)
-        self.assertEqual(self.items[0].artist, 'artist1!')
-        self.assertEqual(self.items[1].artist, 'artist2!')
+        self.assertEqual(self.items[0].artist, "artist1!")
+        self.assertEqual(self.items[1].artist, "artist2!")
 
     def test_artist_credit_applied(self):
         self._apply()
-        self.assertEqual(self.items[0].albumartist_credit, 'albumArtistCredit')
-        self.assertEqual(self.items[0].artist_credit, 'trackArtistCredit')
-        self.assertEqual(self.items[1].albumartist_credit, 'albumArtistCredit')
-        self.assertEqual(self.items[1].artist_credit, 'albumArtistCredit')
+        self.assertEqual(self.items[0].albumartist_credit, "albumArtistCredit")
+        self.assertEqual(self.items[0].artist_credit, "trackArtistCredit")
+        self.assertEqual(self.items[1].albumartist_credit, "albumArtistCredit")
+        self.assertEqual(self.items[1].artist_credit, "albumArtistCredit")
 
     def test_artist_sort_applied(self):
         self._apply()
-        self.assertEqual(self.items[0].albumartist_sort, 'albumArtistSort')
-        self.assertEqual(self.items[0].artist_sort, 'trackArtistSort')
-        self.assertEqual(self.items[1].albumartist_sort, 'albumArtistSort')
-        self.assertEqual(self.items[1].artist_sort, 'albumArtistSort')
+        self.assertEqual(self.items[0].albumartist_sort, "albumArtistSort")
+        self.assertEqual(self.items[0].artist_sort, "trackArtistSort")
+        self.assertEqual(self.items[1].albumartist_sort, "albumArtistSort")
+        self.assertEqual(self.items[1].artist_sort, "albumArtistSort")
 
     def test_full_date_applied(self):
         my_info = self.info.copy()
@@ -798,10 +860,10 @@ class ApplyTest(_common.TestCase, ApplyTestUtil):
 
     def test_data_source_applied(self):
         my_info = self.info.copy()
-        my_info.data_source = 'MusicBrainz'
+        my_info.data_source = "MusicBrainz"
         self._apply(info=my_info)
 
-        self.assertEqual(self.items[0].data_source, 'MusicBrainz')
+        self.assertEqual(self.items[0].data_source, "MusicBrainz")
 
 
 class ApplyCompilationTest(_common.TestCase, ApplyTestUtil):
@@ -812,46 +874,56 @@ class ApplyCompilationTest(_common.TestCase, ApplyTestUtil):
         self.items.append(Item({}))
         self.items.append(Item({}))
         trackinfo = []
-        trackinfo.append(TrackInfo(
-            title=u'oneNew',
-            track_id=u'dfa939ec-118c-4d0f-84a0-60f3d1e6522c',
-            artist=u'artistOneNew',
-            artist_id=u'a05686fc-9db2-4c23-b99e-77f5db3e5282',
-            index=1,
-        ))
-        trackinfo.append(TrackInfo(
-            title=u'twoNew',
-            track_id=u'40130ed1-a27c-42fd-a328-1ebefb6caef4',
-            artist=u'artistTwoNew',
-            artist_id=u'80b3cf5e-18fe-4c59-98c7-e5bb87210710',
-            index=2,
-        ))
+        trackinfo.append(
+            TrackInfo(
+                title=u"oneNew",
+                track_id=u"dfa939ec-118c-4d0f-84a0-60f3d1e6522c",
+                artist=u"artistOneNew",
+                artist_id=u"a05686fc-9db2-4c23-b99e-77f5db3e5282",
+                index=1,
+            )
+        )
+        trackinfo.append(
+            TrackInfo(
+                title=u"twoNew",
+                track_id=u"40130ed1-a27c-42fd-a328-1ebefb6caef4",
+                artist=u"artistTwoNew",
+                artist_id=u"80b3cf5e-18fe-4c59-98c7-e5bb87210710",
+                index=2,
+            )
+        )
         self.info = AlbumInfo(
             tracks=trackinfo,
-            artist=u'variousNew',
-            album=u'albumNew',
-            album_id='3b69ea40-39b8-487f-8818-04b6eff8c21a',
-            artist_id='89ad4ac3-39f7-470e-963a-56509c546377',
-            albumtype=u'compilation',
+            artist=u"variousNew",
+            album=u"albumNew",
+            album_id="3b69ea40-39b8-487f-8818-04b6eff8c21a",
+            artist_id="89ad4ac3-39f7-470e-963a-56509c546377",
+            albumtype=u"compilation",
         )
 
     def test_album_and_track_artists_separate(self):
         self._apply()
-        self.assertEqual(self.items[0].artist, 'artistOneNew')
-        self.assertEqual(self.items[1].artist, 'artistTwoNew')
-        self.assertEqual(self.items[0].albumartist, 'variousNew')
-        self.assertEqual(self.items[1].albumartist, 'variousNew')
+        self.assertEqual(self.items[0].artist, "artistOneNew")
+        self.assertEqual(self.items[1].artist, "artistTwoNew")
+        self.assertEqual(self.items[0].albumartist, "variousNew")
+        self.assertEqual(self.items[1].albumartist, "variousNew")
 
     def test_mb_albumartistid_applied(self):
         self._apply()
-        self.assertEqual(self.items[0].mb_albumartistid,
-                         '89ad4ac3-39f7-470e-963a-56509c546377')
-        self.assertEqual(self.items[1].mb_albumartistid,
-                         '89ad4ac3-39f7-470e-963a-56509c546377')
-        self.assertEqual(self.items[0].mb_artistid,
-                         'a05686fc-9db2-4c23-b99e-77f5db3e5282')
-        self.assertEqual(self.items[1].mb_artistid,
-                         '80b3cf5e-18fe-4c59-98c7-e5bb87210710')
+        self.assertEqual(
+            self.items[0].mb_albumartistid,
+            "89ad4ac3-39f7-470e-963a-56509c546377",
+        )
+        self.assertEqual(
+            self.items[1].mb_albumartistid,
+            "89ad4ac3-39f7-470e-963a-56509c546377",
+        )
+        self.assertEqual(
+            self.items[0].mb_artistid, "a05686fc-9db2-4c23-b99e-77f5db3e5282"
+        )
+        self.assertEqual(
+            self.items[1].mb_artistid, "80b3cf5e-18fe-4c59-98c7-e5bb87210710"
+        )
 
     def test_va_flag_cleared_does_not_set_comp(self):
         self._apply()
@@ -868,77 +940,77 @@ class ApplyCompilationTest(_common.TestCase, ApplyTestUtil):
 
 class StringDistanceTest(unittest.TestCase):
     def test_equal_strings(self):
-        dist = string_dist(u'Some String', u'Some String')
+        dist = string_dist(u"Some String", u"Some String")
         self.assertEqual(dist, 0.0)
 
     def test_different_strings(self):
-        dist = string_dist(u'Some String', u'Totally Different')
+        dist = string_dist(u"Some String", u"Totally Different")
         self.assertNotEqual(dist, 0.0)
 
     def test_punctuation_ignored(self):
-        dist = string_dist(u'Some String', u'Some.String!')
+        dist = string_dist(u"Some String", u"Some.String!")
         self.assertEqual(dist, 0.0)
 
     def test_case_ignored(self):
-        dist = string_dist(u'Some String', u'sOME sTring')
+        dist = string_dist(u"Some String", u"sOME sTring")
         self.assertEqual(dist, 0.0)
 
     def test_leading_the_has_lower_weight(self):
-        dist1 = string_dist(u'XXX Band Name', u'Band Name')
-        dist2 = string_dist(u'The Band Name', u'Band Name')
+        dist1 = string_dist(u"XXX Band Name", u"Band Name")
+        dist2 = string_dist(u"The Band Name", u"Band Name")
         self.assertTrue(dist2 < dist1)
 
     def test_parens_have_lower_weight(self):
-        dist1 = string_dist(u'One .Two.', u'One')
-        dist2 = string_dist(u'One (Two)', u'One')
+        dist1 = string_dist(u"One .Two.", u"One")
+        dist2 = string_dist(u"One (Two)", u"One")
         self.assertTrue(dist2 < dist1)
 
     def test_brackets_have_lower_weight(self):
-        dist1 = string_dist(u'One .Two.', u'One')
-        dist2 = string_dist(u'One [Two]', u'One')
+        dist1 = string_dist(u"One .Two.", u"One")
+        dist2 = string_dist(u"One [Two]", u"One")
         self.assertTrue(dist2 < dist1)
 
     def test_ep_label_has_zero_weight(self):
-        dist = string_dist(u'My Song (EP)', u'My Song')
+        dist = string_dist(u"My Song (EP)", u"My Song")
         self.assertEqual(dist, 0.0)
 
     def test_featured_has_lower_weight(self):
-        dist1 = string_dist(u'My Song blah Someone', u'My Song')
-        dist2 = string_dist(u'My Song feat Someone', u'My Song')
+        dist1 = string_dist(u"My Song blah Someone", u"My Song")
+        dist2 = string_dist(u"My Song feat Someone", u"My Song")
         self.assertTrue(dist2 < dist1)
 
     def test_postfix_the(self):
-        dist = string_dist(u'The Song Title', u'Song Title, The')
+        dist = string_dist(u"The Song Title", u"Song Title, The")
         self.assertEqual(dist, 0.0)
 
     def test_postfix_a(self):
-        dist = string_dist(u'A Song Title', u'Song Title, A')
+        dist = string_dist(u"A Song Title", u"Song Title, A")
         self.assertEqual(dist, 0.0)
 
     def test_postfix_an(self):
-        dist = string_dist(u'An Album Title', u'Album Title, An')
+        dist = string_dist(u"An Album Title", u"Album Title, An")
         self.assertEqual(dist, 0.0)
 
     def test_empty_strings(self):
-        dist = string_dist(u'', u'')
+        dist = string_dist(u"", u"")
         self.assertEqual(dist, 0.0)
 
     def test_solo_pattern(self):
         # Just make sure these don't crash.
-        string_dist(u'The ', u'')
-        string_dist(u'(EP)', u'(EP)')
-        string_dist(u', An', u'')
+        string_dist(u"The ", u"")
+        string_dist(u"(EP)", u"(EP)")
+        string_dist(u", An", u"")
 
     def test_heuristic_does_not_harm_distance(self):
-        dist = string_dist(u'Untitled', u'[Untitled]')
+        dist = string_dist(u"Untitled", u"[Untitled]")
         self.assertEqual(dist, 0.0)
 
     def test_ampersand_expansion(self):
-        dist = string_dist(u'And', u'&')
+        dist = string_dist(u"And", u"&")
         self.assertEqual(dist, 0.0)
 
     def test_accented_characters(self):
-        dist = string_dist(u'\xe9\xe1\xf1', u'ean')
+        dist = string_dist(u"\xe9\xe1\xf1", u"ean")
         self.assertEqual(dist, 0.0)
 
 
@@ -946,8 +1018,11 @@ class EnumTest(_common.TestCase):
     """
     Test Enum Subclasses defined in beets.util.enumeration
     """
+
     def test_ordered_enum(self):
-        OrderedEnumClass = match.OrderedEnum('OrderedEnumTest', ['a', 'b', 'c'])  # noqa
+        OrderedEnumClass = match.OrderedEnum(
+            "OrderedEnumTest", ["a", "b", "c"]
+        )  # noqa
         self.assertLess(OrderedEnumClass.a, OrderedEnumClass.b)
         self.assertLess(OrderedEnumClass.a, OrderedEnumClass.c)
         self.assertLess(OrderedEnumClass.b, OrderedEnumClass.c)
@@ -959,5 +1034,6 @@ class EnumTest(_common.TestCase):
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_autotag.py
+++ b/test/test_autotag.py
@@ -1020,9 +1020,9 @@ class EnumTest(_common.TestCase):
     """
 
     def test_ordered_enum(self):
-        OrderedEnumClass = match.OrderedEnum(
+        OrderedEnumClass = match.OrderedEnum(  # noqa: N806
             "OrderedEnumTest", ["a", "b", "c"]
-        )  # noqa
+        )
         self.assertLess(OrderedEnumClass.a, OrderedEnumClass.b)
         self.assertLess(OrderedEnumClass.a, OrderedEnumClass.c)
         self.assertLess(OrderedEnumClass.b, OrderedEnumClass.c)

--- a/test/test_beatport.py
+++ b/test/test_beatport.py
@@ -270,8 +270,8 @@ class BeatportTest(_common.TestCase, TestHelper):
                 "name": "A List of Instructions for When I'm Human",
                 "trackNumber": 4,
                 "mixName": "Original Mix",
-                "title": "A List of Instructions for When I'm Human (Original Mix)",
-                "slug": "a-list-of-instructions-for-when-im-human-original-mix",
+                "title": "A List of Instructions for When I'm Human (Original Mix)",  # noqa: E501
+                "slug": "a-list-of-instructions-for-when-im-human-original-mix",  # noqa: E501
                 "releaseDate": "2016-04-11",
                 "publishDate": "2016-04-11",
                 "currentStatus": "General Content",

--- a/test/test_beatport.py
+++ b/test/test_beatport.py
@@ -37,35 +37,34 @@ class BeatportTest(_common.TestCase, TestHelper):
         those required for the tests on this class.
         """
         results = {
-          "id": 1742984,
-          "type": "release",
-          "name": "Charade",
-          "slug": "charade",
-          "releaseDate": "2016-04-11",
-          "publishDate": "2016-04-11",
-          "audioFormat": "",
-          "category": "Release",
-          "currentStatus": "General Content",
-          "catalogNumber": "GR089",
-          "description": "",
-          "label": {
-            "id": 24539,
-            "name": "Gravitas Recordings",
-            "type": "label",
-            "slug": "gravitas-recordings"
-          },
-          "artists": [{
-            "id": 326158,
-            "name": "Supersillyus",
-            "slug": "supersillyus",
-            "type": "artist"
-          }],
-          "genres": [{
-            "id": 9,
-            "name": "Breaks",
-            "slug": "breaks",
-            "type": "genre"
-          }],
+            "id": 1742984,
+            "type": "release",
+            "name": "Charade",
+            "slug": "charade",
+            "releaseDate": "2016-04-11",
+            "publishDate": "2016-04-11",
+            "audioFormat": "",
+            "category": "Release",
+            "currentStatus": "General Content",
+            "catalogNumber": "GR089",
+            "description": "",
+            "label": {
+                "id": 24539,
+                "name": "Gravitas Recordings",
+                "type": "label",
+                "slug": "gravitas-recordings",
+            },
+            "artists": [
+                {
+                    "id": 326158,
+                    "name": "Supersillyus",
+                    "slug": "supersillyus",
+                    "type": "artist",
+                }
+            ],
+            "genres": [
+                {"id": 9, "name": "Breaks", "slug": "breaks", "type": "genre"}
+            ],
         }
         return results
 
@@ -77,343 +76,386 @@ class BeatportTest(_common.TestCase, TestHelper):
         The list of elements on the returned list is incomplete, including just
         those required for the tests on this class.
         """
-        results = [{
-          "id": 7817567,
-          "type": "track",
-          "sku": "track-7817567",
-          "name": "Mirage a Trois",
-          "trackNumber": 1,
-          "mixName": "Original Mix",
-          "title": "Mirage a Trois (Original Mix)",
-          "slug": "mirage-a-trois-original-mix",
-          "releaseDate": "2016-04-11",
-          "publishDate": "2016-04-11",
-          "currentStatus": "General Content",
-          "length": "7:05",
-          "lengthMs": 425421,
-          "bpm": 90,
-          "key": {
-            "standard": {
-              "letter": "G",
-              "sharp": False,
-              "flat": False,
-              "chord": "minor"
+        results = [
+            {
+                "id": 7817567,
+                "type": "track",
+                "sku": "track-7817567",
+                "name": "Mirage a Trois",
+                "trackNumber": 1,
+                "mixName": "Original Mix",
+                "title": "Mirage a Trois (Original Mix)",
+                "slug": "mirage-a-trois-original-mix",
+                "releaseDate": "2016-04-11",
+                "publishDate": "2016-04-11",
+                "currentStatus": "General Content",
+                "length": "7:05",
+                "lengthMs": 425421,
+                "bpm": 90,
+                "key": {
+                    "standard": {
+                        "letter": "G",
+                        "sharp": False,
+                        "flat": False,
+                        "chord": "minor",
+                    },
+                    "shortName": "Gmin",
+                },
+                "artists": [
+                    {
+                        "id": 326158,
+                        "name": "Supersillyus",
+                        "slug": "supersillyus",
+                        "type": "artist",
+                    }
+                ],
+                "genres": [
+                    {
+                        "id": 9,
+                        "name": "Breaks",
+                        "slug": "breaks",
+                        "type": "genre",
+                    }
+                ],
+                "subGenres": [
+                    {
+                        "id": 209,
+                        "name": "Glitch Hop",
+                        "slug": "glitch-hop",
+                        "type": "subgenre",
+                    }
+                ],
+                "release": {
+                    "id": 1742984,
+                    "name": "Charade",
+                    "type": "release",
+                    "slug": "charade",
+                },
+                "label": {
+                    "id": 24539,
+                    "name": "Gravitas Recordings",
+                    "type": "label",
+                    "slug": "gravitas-recordings",
+                    "status": True,
+                },
             },
-            "shortName": "Gmin"
-          },
-          "artists": [{
-            "id": 326158,
-            "name": "Supersillyus",
-            "slug": "supersillyus",
-            "type": "artist"
-          }],
-          "genres": [{
-            "id": 9,
-            "name": "Breaks",
-            "slug": "breaks",
-            "type": "genre"
-          }],
-          "subGenres": [{
-            "id": 209,
-            "name": "Glitch Hop",
-            "slug": "glitch-hop",
-            "type": "subgenre"
-          }],
-          "release": {
-            "id": 1742984,
-            "name": "Charade",
-            "type": "release",
-            "slug": "charade"
-          },
-          "label": {
-            "id": 24539,
-            "name": "Gravitas Recordings",
-            "type": "label",
-            "slug": "gravitas-recordings",
-            "status": True
-          }
-        }, {
-          "id": 7817568,
-          "type": "track",
-          "sku": "track-7817568",
-          "name": "Aeon Bahamut",
-          "trackNumber": 2,
-          "mixName": "Original Mix",
-          "title": "Aeon Bahamut (Original Mix)",
-          "slug": "aeon-bahamut-original-mix",
-          "releaseDate": "2016-04-11",
-          "publishDate": "2016-04-11",
-          "currentStatus": "General Content",
-          "length": "7:38",
-          "lengthMs": 458000,
-          "bpm": 100,
-          "key": {
-            "standard": {
-              "letter": "G",
-              "sharp": False,
-              "flat": False,
-              "chord": "major"
+            {
+                "id": 7817568,
+                "type": "track",
+                "sku": "track-7817568",
+                "name": "Aeon Bahamut",
+                "trackNumber": 2,
+                "mixName": "Original Mix",
+                "title": "Aeon Bahamut (Original Mix)",
+                "slug": "aeon-bahamut-original-mix",
+                "releaseDate": "2016-04-11",
+                "publishDate": "2016-04-11",
+                "currentStatus": "General Content",
+                "length": "7:38",
+                "lengthMs": 458000,
+                "bpm": 100,
+                "key": {
+                    "standard": {
+                        "letter": "G",
+                        "sharp": False,
+                        "flat": False,
+                        "chord": "major",
+                    },
+                    "shortName": "Gmaj",
+                },
+                "artists": [
+                    {
+                        "id": 326158,
+                        "name": "Supersillyus",
+                        "slug": "supersillyus",
+                        "type": "artist",
+                    }
+                ],
+                "genres": [
+                    {
+                        "id": 9,
+                        "name": "Breaks",
+                        "slug": "breaks",
+                        "type": "genre",
+                    }
+                ],
+                "subGenres": [
+                    {
+                        "id": 209,
+                        "name": "Glitch Hop",
+                        "slug": "glitch-hop",
+                        "type": "subgenre",
+                    }
+                ],
+                "release": {
+                    "id": 1742984,
+                    "name": "Charade",
+                    "type": "release",
+                    "slug": "charade",
+                },
+                "label": {
+                    "id": 24539,
+                    "name": "Gravitas Recordings",
+                    "type": "label",
+                    "slug": "gravitas-recordings",
+                    "status": True,
+                },
             },
-            "shortName": "Gmaj"
-          },
-          "artists": [{
-            "id": 326158,
-            "name": "Supersillyus",
-            "slug": "supersillyus",
-            "type": "artist"
-          }],
-          "genres": [{
-            "id": 9,
-            "name": "Breaks",
-            "slug": "breaks",
-            "type": "genre"
-          }],
-          "subGenres": [{
-            "id": 209,
-            "name": "Glitch Hop",
-            "slug": "glitch-hop",
-            "type": "subgenre"
-          }],
-          "release": {
-            "id": 1742984,
-            "name": "Charade",
-            "type": "release",
-            "slug": "charade"
-          },
-          "label": {
-            "id": 24539,
-            "name": "Gravitas Recordings",
-            "type": "label",
-            "slug": "gravitas-recordings",
-            "status": True
-          }
-        }, {
-          "id": 7817569,
-          "type": "track",
-          "sku": "track-7817569",
-          "name": "Trancendental Medication",
-          "trackNumber": 3,
-          "mixName": "Original Mix",
-          "title": "Trancendental Medication (Original Mix)",
-          "slug": "trancendental-medication-original-mix",
-          "releaseDate": "2016-04-11",
-          "publishDate": "2016-04-11",
-          "currentStatus": "General Content",
-          "length": "1:08",
-          "lengthMs": 68571,
-          "bpm": 141,
-          "key": {
-            "standard": {
-              "letter": "F",
-              "sharp": False,
-              "flat": False,
-              "chord": "major"
+            {
+                "id": 7817569,
+                "type": "track",
+                "sku": "track-7817569",
+                "name": "Trancendental Medication",
+                "trackNumber": 3,
+                "mixName": "Original Mix",
+                "title": "Trancendental Medication (Original Mix)",
+                "slug": "trancendental-medication-original-mix",
+                "releaseDate": "2016-04-11",
+                "publishDate": "2016-04-11",
+                "currentStatus": "General Content",
+                "length": "1:08",
+                "lengthMs": 68571,
+                "bpm": 141,
+                "key": {
+                    "standard": {
+                        "letter": "F",
+                        "sharp": False,
+                        "flat": False,
+                        "chord": "major",
+                    },
+                    "shortName": "Fmaj",
+                },
+                "artists": [
+                    {
+                        "id": 326158,
+                        "name": "Supersillyus",
+                        "slug": "supersillyus",
+                        "type": "artist",
+                    }
+                ],
+                "genres": [
+                    {
+                        "id": 9,
+                        "name": "Breaks",
+                        "slug": "breaks",
+                        "type": "genre",
+                    }
+                ],
+                "subGenres": [
+                    {
+                        "id": 209,
+                        "name": "Glitch Hop",
+                        "slug": "glitch-hop",
+                        "type": "subgenre",
+                    }
+                ],
+                "release": {
+                    "id": 1742984,
+                    "name": "Charade",
+                    "type": "release",
+                    "slug": "charade",
+                },
+                "label": {
+                    "id": 24539,
+                    "name": "Gravitas Recordings",
+                    "type": "label",
+                    "slug": "gravitas-recordings",
+                    "status": True,
+                },
             },
-            "shortName": "Fmaj"
-          },
-          "artists": [{
-            "id": 326158,
-            "name": "Supersillyus",
-            "slug": "supersillyus",
-            "type": "artist"
-          }],
-          "genres": [{
-            "id": 9,
-            "name": "Breaks",
-            "slug": "breaks",
-            "type": "genre"
-          }],
-          "subGenres": [{
-            "id": 209,
-            "name": "Glitch Hop",
-            "slug": "glitch-hop",
-            "type": "subgenre"
-          }],
-          "release": {
-            "id": 1742984,
-            "name": "Charade",
-            "type": "release",
-            "slug": "charade"
-          },
-          "label": {
-            "id": 24539,
-            "name": "Gravitas Recordings",
-            "type": "label",
-            "slug": "gravitas-recordings",
-            "status": True
-          }
-        }, {
-          "id": 7817570,
-          "type": "track",
-          "sku": "track-7817570",
-          "name": "A List of Instructions for When I'm Human",
-          "trackNumber": 4,
-          "mixName": "Original Mix",
-          "title": "A List of Instructions for When I'm Human (Original Mix)",
-          "slug": "a-list-of-instructions-for-when-im-human-original-mix",
-          "releaseDate": "2016-04-11",
-          "publishDate": "2016-04-11",
-          "currentStatus": "General Content",
-          "length": "6:57",
-          "lengthMs": 417913,
-          "bpm": 88,
-          "key": {
-            "standard": {
-              "letter": "A",
-              "sharp": False,
-              "flat": False,
-              "chord": "minor"
+            {
+                "id": 7817570,
+                "type": "track",
+                "sku": "track-7817570",
+                "name": "A List of Instructions for When I'm Human",
+                "trackNumber": 4,
+                "mixName": "Original Mix",
+                "title": "A List of Instructions for When I'm Human (Original Mix)",
+                "slug": "a-list-of-instructions-for-when-im-human-original-mix",
+                "releaseDate": "2016-04-11",
+                "publishDate": "2016-04-11",
+                "currentStatus": "General Content",
+                "length": "6:57",
+                "lengthMs": 417913,
+                "bpm": 88,
+                "key": {
+                    "standard": {
+                        "letter": "A",
+                        "sharp": False,
+                        "flat": False,
+                        "chord": "minor",
+                    },
+                    "shortName": "Amin",
+                },
+                "artists": [
+                    {
+                        "id": 326158,
+                        "name": "Supersillyus",
+                        "slug": "supersillyus",
+                        "type": "artist",
+                    }
+                ],
+                "genres": [
+                    {
+                        "id": 9,
+                        "name": "Breaks",
+                        "slug": "breaks",
+                        "type": "genre",
+                    }
+                ],
+                "subGenres": [
+                    {
+                        "id": 209,
+                        "name": "Glitch Hop",
+                        "slug": "glitch-hop",
+                        "type": "subgenre",
+                    }
+                ],
+                "release": {
+                    "id": 1742984,
+                    "name": "Charade",
+                    "type": "release",
+                    "slug": "charade",
+                },
+                "label": {
+                    "id": 24539,
+                    "name": "Gravitas Recordings",
+                    "type": "label",
+                    "slug": "gravitas-recordings",
+                    "status": True,
+                },
             },
-            "shortName": "Amin"
-          },
-          "artists": [{
-            "id": 326158,
-            "name": "Supersillyus",
-            "slug": "supersillyus",
-            "type": "artist"
-          }],
-          "genres": [{
-            "id": 9,
-            "name": "Breaks",
-            "slug": "breaks",
-            "type": "genre"
-          }],
-          "subGenres": [{
-            "id": 209,
-            "name": "Glitch Hop",
-            "slug": "glitch-hop",
-            "type": "subgenre"
-          }],
-          "release": {
-            "id": 1742984,
-            "name": "Charade",
-            "type": "release",
-            "slug": "charade"
-          },
-          "label": {
-            "id": 24539,
-            "name": "Gravitas Recordings",
-            "type": "label",
-            "slug": "gravitas-recordings",
-            "status": True
-          }
-        }, {
-          "id": 7817571,
-          "type": "track",
-          "sku": "track-7817571",
-          "name": "The Great Shenanigan",
-          "trackNumber": 5,
-          "mixName": "Original Mix",
-          "title": "The Great Shenanigan (Original Mix)",
-          "slug": "the-great-shenanigan-original-mix",
-          "releaseDate": "2016-04-11",
-          "publishDate": "2016-04-11",
-          "currentStatus": "General Content",
-          "length": "9:49",
-          "lengthMs": 589875,
-          "bpm": 123,
-          "key": {
-            "standard": {
-              "letter": "E",
-              "sharp": False,
-              "flat": True,
-              "chord": "major"
+            {
+                "id": 7817571,
+                "type": "track",
+                "sku": "track-7817571",
+                "name": "The Great Shenanigan",
+                "trackNumber": 5,
+                "mixName": "Original Mix",
+                "title": "The Great Shenanigan (Original Mix)",
+                "slug": "the-great-shenanigan-original-mix",
+                "releaseDate": "2016-04-11",
+                "publishDate": "2016-04-11",
+                "currentStatus": "General Content",
+                "length": "9:49",
+                "lengthMs": 589875,
+                "bpm": 123,
+                "key": {
+                    "standard": {
+                        "letter": "E",
+                        "sharp": False,
+                        "flat": True,
+                        "chord": "major",
+                    },
+                    "shortName": "E&#9837;maj",
+                },
+                "artists": [
+                    {
+                        "id": 326158,
+                        "name": "Supersillyus",
+                        "slug": "supersillyus",
+                        "type": "artist",
+                    }
+                ],
+                "genres": [
+                    {
+                        "id": 9,
+                        "name": "Breaks",
+                        "slug": "breaks",
+                        "type": "genre",
+                    }
+                ],
+                "subGenres": [
+                    {
+                        "id": 209,
+                        "name": "Glitch Hop",
+                        "slug": "glitch-hop",
+                        "type": "subgenre",
+                    }
+                ],
+                "release": {
+                    "id": 1742984,
+                    "name": "Charade",
+                    "type": "release",
+                    "slug": "charade",
+                },
+                "label": {
+                    "id": 24539,
+                    "name": "Gravitas Recordings",
+                    "type": "label",
+                    "slug": "gravitas-recordings",
+                    "status": True,
+                },
             },
-            "shortName": "E&#9837;maj"
-          },
-          "artists": [{
-            "id": 326158,
-            "name": "Supersillyus",
-            "slug": "supersillyus",
-            "type": "artist"
-          }],
-          "genres": [{
-            "id": 9,
-            "name": "Breaks",
-            "slug": "breaks",
-            "type": "genre"
-          }],
-          "subGenres": [{
-            "id": 209,
-            "name": "Glitch Hop",
-            "slug": "glitch-hop",
-            "type": "subgenre"
-          }],
-          "release": {
-            "id": 1742984,
-            "name": "Charade",
-            "type": "release",
-            "slug": "charade"
-          },
-          "label": {
-            "id": 24539,
-            "name": "Gravitas Recordings",
-            "type": "label",
-            "slug": "gravitas-recordings",
-            "status": True
-          }
-        }, {
-          "id": 7817572,
-          "type": "track",
-          "sku": "track-7817572",
-          "name": "Charade",
-          "trackNumber": 6,
-          "mixName": "Original Mix",
-          "title": "Charade (Original Mix)",
-          "slug": "charade-original-mix",
-          "releaseDate": "2016-04-11",
-          "publishDate": "2016-04-11",
-          "currentStatus": "General Content",
-          "length": "7:05",
-          "lengthMs": 425423,
-          "bpm": 123,
-          "key": {
-            "standard": {
-              "letter": "A",
-              "sharp": False,
-              "flat": False,
-              "chord": "major"
+            {
+                "id": 7817572,
+                "type": "track",
+                "sku": "track-7817572",
+                "name": "Charade",
+                "trackNumber": 6,
+                "mixName": "Original Mix",
+                "title": "Charade (Original Mix)",
+                "slug": "charade-original-mix",
+                "releaseDate": "2016-04-11",
+                "publishDate": "2016-04-11",
+                "currentStatus": "General Content",
+                "length": "7:05",
+                "lengthMs": 425423,
+                "bpm": 123,
+                "key": {
+                    "standard": {
+                        "letter": "A",
+                        "sharp": False,
+                        "flat": False,
+                        "chord": "major",
+                    },
+                    "shortName": "Amaj",
+                },
+                "artists": [
+                    {
+                        "id": 326158,
+                        "name": "Supersillyus",
+                        "slug": "supersillyus",
+                        "type": "artist",
+                    }
+                ],
+                "genres": [
+                    {
+                        "id": 9,
+                        "name": "Breaks",
+                        "slug": "breaks",
+                        "type": "genre",
+                    }
+                ],
+                "subGenres": [
+                    {
+                        "id": 209,
+                        "name": "Glitch Hop",
+                        "slug": "glitch-hop",
+                        "type": "subgenre",
+                    }
+                ],
+                "release": {
+                    "id": 1742984,
+                    "name": "Charade",
+                    "type": "release",
+                    "slug": "charade",
+                },
+                "label": {
+                    "id": 24539,
+                    "name": "Gravitas Recordings",
+                    "type": "label",
+                    "slug": "gravitas-recordings",
+                    "status": True,
+                },
             },
-            "shortName": "Amaj"
-          },
-          "artists": [{
-            "id": 326158,
-            "name": "Supersillyus",
-            "slug": "supersillyus",
-            "type": "artist"
-          }],
-          "genres": [{
-            "id": 9,
-            "name": "Breaks",
-            "slug": "breaks",
-            "type": "genre"
-          }],
-          "subGenres": [{
-            "id": 209,
-            "name": "Glitch Hop",
-            "slug": "glitch-hop",
-            "type": "subgenre"
-          }],
-          "release": {
-            "id": 1742984,
-            "name": "Charade",
-            "type": "release",
-            "slug": "charade"
-          },
-          "label": {
-            "id": 24539,
-            "name": "Gravitas Recordings",
-            "type": "label",
-            "slug": "gravitas-recordings",
-            "status": True
-          }
-        }]
+        ]
         return results
 
     def setUp(self):
         self.setup_beets()
-        self.load_plugins('beatport')
-        self.lib = library.Library(':memory:')
+        self.load_plugins("beatport")
+        self.lib = library.Library(":memory:")
 
         # Set up 'album'.
         response_release = self._make_release_response()
@@ -436,25 +478,25 @@ class BeatportTest(_common.TestCase, TestHelper):
     def mk_test_album(self):
         items = [_common.item() for _ in range(6)]
         for item in items:
-            item.album = 'Charade'
-            item.catalognum = 'GR089'
-            item.label = 'Gravitas Recordings'
-            item.artist = 'Supersillyus'
+            item.album = "Charade"
+            item.catalognum = "GR089"
+            item.label = "Gravitas Recordings"
+            item.artist = "Supersillyus"
             item.year = 2016
             item.comp = False
-            item.label_name = 'Gravitas Recordings'
-            item.genre = 'Glitch Hop'
+            item.label_name = "Gravitas Recordings"
+            item.genre = "Glitch Hop"
             item.year = 2016
             item.month = 4
             item.day = 11
-            item.mix_name = 'Original Mix'
+            item.mix_name = "Original Mix"
 
-        items[0].title = 'Mirage a Trois'
-        items[1].title = 'Aeon Bahamut'
-        items[2].title = 'Trancendental Medication'
-        items[3].title = 'A List of Instructions for When I\'m Human'
-        items[4].title = 'The Great Shenanigan'
-        items[5].title = 'Charade'
+        items[0].title = "Mirage a Trois"
+        items[1].title = "Aeon Bahamut"
+        items[2].title = "Trancendental Medication"
+        items[3].title = "A List of Instructions for When I'm Human"
+        items[4].title = "The Great Shenanigan"
+        items[5].title = "Charade"
 
         items[0].length = timedelta(minutes=7, seconds=5).total_seconds()
         items[1].length = timedelta(minutes=7, seconds=38).total_seconds()
@@ -463,12 +505,12 @@ class BeatportTest(_common.TestCase, TestHelper):
         items[4].length = timedelta(minutes=9, seconds=49).total_seconds()
         items[5].length = timedelta(minutes=7, seconds=5).total_seconds()
 
-        items[0].url = 'mirage-a-trois-original-mix'
-        items[1].url = 'aeon-bahamut-original-mix'
-        items[2].url = 'trancendental-medication-original-mix'
-        items[3].url = 'a-list-of-instructions-for-when-im-human-original-mix'
-        items[4].url = 'the-great-shenanigan-original-mix'
-        items[5].url = 'charade-original-mix'
+        items[0].url = "mirage-a-trois-original-mix"
+        items[1].url = "aeon-bahamut-original-mix"
+        items[2].url = "trancendental-medication-original-mix"
+        items[3].url = "a-list-of-instructions-for-when-im-human-original-mix"
+        items[4].url = "the-great-shenanigan-original-mix"
+        items[5].url = "charade-original-mix"
 
         counter = 0
         for item in items:
@@ -482,12 +524,12 @@ class BeatportTest(_common.TestCase, TestHelper):
         items[4].bpm = 123
         items[5].bpm = 123
 
-        items[0].initial_key = 'Gmin'
-        items[1].initial_key = 'Gmaj'
-        items[2].initial_key = 'Fmaj'
-        items[3].initial_key = 'Amin'
-        items[4].initial_key = 'E&#9837;maj'
-        items[5].initial_key = 'Amaj'
+        items[0].initial_key = "Gmin"
+        items[1].initial_key = "Gmaj"
+        items[2].initial_key = "Fmaj"
+        items[3].initial_key = "Amin"
+        items[4].initial_key = "E&#9837;maj"
+        items[5].initial_key = "Amaj"
 
         for item in items:
             self.lib.add(item)
@@ -499,21 +541,23 @@ class BeatportTest(_common.TestCase, TestHelper):
 
     # Test BeatportRelease.
     def test_album_name_applied(self):
-        self.assertEqual(self.album.name, self.test_album['album'])
+        self.assertEqual(self.album.name, self.test_album["album"])
 
     def test_catalog_number_applied(self):
-        self.assertEqual(self.album.catalog_number,
-                         self.test_album['catalognum'])
+        self.assertEqual(
+            self.album.catalog_number, self.test_album["catalognum"]
+        )
 
     def test_label_applied(self):
-        self.assertEqual(self.album.label_name, self.test_album['label'])
+        self.assertEqual(self.album.label_name, self.test_album["label"])
 
     def test_category_applied(self):
-        self.assertEqual(self.album.category, 'Release')
+        self.assertEqual(self.album.category, "Release")
 
     def test_album_url_applied(self):
-        self.assertEqual(self.album.url,
-                         'https://beatport.com/release/charade/1742984')
+        self.assertEqual(
+            self.album.url, "https://beatport.com/release/charade/1742984"
+        )
 
     # Test BeatportTrack.
     def test_title_applied(self):
@@ -526,8 +570,9 @@ class BeatportTest(_common.TestCase, TestHelper):
 
     def test_length_applied(self):
         for track, test_track in zip(self.tracks, self.test_tracks):
-            self.assertEqual(int(track.length.total_seconds()),
-                             int(test_track.length))
+            self.assertEqual(
+                int(track.length.total_seconds()), int(test_track.length)
+            )
 
     def test_track_url_applied(self):
         # Specify beatport ids here because an 'item.id' is beets-internal.
@@ -542,8 +587,12 @@ class BeatportTest(_common.TestCase, TestHelper):
         # Concatenate with 'id' to pass strict equality test.
         for track, test_track, id in zip(self.tracks, self.test_tracks, ids):
             self.assertEqual(
-                track.url, 'https://beatport.com/track/' +
-                test_track.url + '/' + six.text_type(id))
+                track.url,
+                "https://beatport.com/track/"
+                + test_track.url
+                + "/"
+                + six.text_type(id),
+            )
 
     def test_bpm_applied(self):
         for track, test_track in zip(self.tracks, self.test_tracks):
@@ -560,28 +609,34 @@ class BeatportTest(_common.TestCase, TestHelper):
 
 class BeatportResponseEmptyTest(_common.TestCase, TestHelper):
     def _make_tracks_response(self):
-        results = [{
-            "id": 7817567,
-            "name": "Mirage a Trois",
-            "genres": [{
-              "id": 9,
-              "name": "Breaks",
-              "slug": "breaks",
-              "type": "genre"
-            }],
-            "subGenres": [{
-              "id": 209,
-              "name": "Glitch Hop",
-              "slug": "glitch-hop",
-              "type": "subgenre"
-            }],
-        }]
+        results = [
+            {
+                "id": 7817567,
+                "name": "Mirage a Trois",
+                "genres": [
+                    {
+                        "id": 9,
+                        "name": "Breaks",
+                        "slug": "breaks",
+                        "type": "genre",
+                    }
+                ],
+                "subGenres": [
+                    {
+                        "id": 209,
+                        "name": "Glitch Hop",
+                        "slug": "glitch-hop",
+                        "type": "subgenre",
+                    }
+                ],
+            }
+        ]
         return results
 
     def setUp(self):
         self.setup_beets()
-        self.load_plugins('beatport')
-        self.lib = library.Library(':memory:')
+        self.load_plugins("beatport")
+        self.lib = library.Library(":memory:")
 
         # Set up 'tracks'.
         self.response_tracks = self._make_tracks_response()
@@ -602,29 +657,31 @@ class BeatportResponseEmptyTest(_common.TestCase, TestHelper):
     def test_sub_genre_empty_fallback(self):
         """No 'sub_genre' is provided. Test if fallback to 'genre' works.
         """
-        self.response_tracks[0]['subGenres'] = []
+        self.response_tracks[0]["subGenres"] = []
         tracks = [beatport.BeatportTrack(t) for t in self.response_tracks]
 
-        self.test_tracks[0]['subGenres'] = []
+        self.test_tracks[0]["subGenres"] = []
 
-        self.assertEqual(tracks[0].genre,
-                         self.test_tracks[0]['genres'][0]['name'])
+        self.assertEqual(
+            tracks[0].genre, self.test_tracks[0]["genres"][0]["name"]
+        )
 
     def test_genre_empty(self):
         """No 'genre' is provided. Test if 'sub_genre' is applied.
         """
-        self.response_tracks[0]['genres'] = []
+        self.response_tracks[0]["genres"] = []
         tracks = [beatport.BeatportTrack(t) for t in self.response_tracks]
 
-        self.test_tracks[0]['genres'] = []
+        self.test_tracks[0]["genres"] = []
 
-        self.assertEqual(tracks[0].genre,
-                         self.test_tracks[0]['subGenres'][0]['name'])
+        self.assertEqual(
+            tracks[0].genre, self.test_tracks[0]["subGenres"][0]["name"]
+        )
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_bucket.py
+++ b/test/test_bucket.py
@@ -32,127 +32,140 @@ class BucketPluginTest(unittest.TestCase, TestHelper):
     def tearDown(self):
         self.teardown_beets()
 
-    def _setup_config(self, bucket_year=[], bucket_alpha=[],
-                      bucket_alpha_regex={}, extrapolate=False):
-        config['bucket']['bucket_year'] = bucket_year
-        config['bucket']['bucket_alpha'] = bucket_alpha
-        config['bucket']['bucket_alpha_regex'] = bucket_alpha_regex
-        config['bucket']['extrapolate'] = extrapolate
+    def _setup_config(
+        self,
+        bucket_year=[],
+        bucket_alpha=[],
+        bucket_alpha_regex={},
+        extrapolate=False,
+    ):
+        config["bucket"]["bucket_year"] = bucket_year
+        config["bucket"]["bucket_alpha"] = bucket_alpha
+        config["bucket"]["bucket_alpha_regex"] = bucket_alpha_regex
+        config["bucket"]["extrapolate"] = extrapolate
         self.plugin.setup()
 
     def test_year_single_year(self):
         """If a single year is given, range starts from this year and stops at
         the year preceding the one of next bucket."""
-        self._setup_config(bucket_year=['1950s', '1970s'])
-        self.assertEqual(self.plugin._tmpl_bucket('1959'), '1950s')
-        self.assertEqual(self.plugin._tmpl_bucket('1969'), '1950s')
+        self._setup_config(bucket_year=["1950s", "1970s"])
+        self.assertEqual(self.plugin._tmpl_bucket("1959"), "1950s")
+        self.assertEqual(self.plugin._tmpl_bucket("1969"), "1950s")
 
     def test_year_single_year_last_folder(self):
         """If a single year is given for the last bucket, extend it to current
         year."""
-        self._setup_config(bucket_year=['1950', '1970'])
-        self.assertEqual(self.plugin._tmpl_bucket('2014'), '1970')
-        self.assertEqual(self.plugin._tmpl_bucket('2025'), '2025')
+        self._setup_config(bucket_year=["1950", "1970"])
+        self.assertEqual(self.plugin._tmpl_bucket("2014"), "1970")
+        self.assertEqual(self.plugin._tmpl_bucket("2025"), "2025")
 
     def test_year_two_years(self):
         """Buckets can be named with the 'from-to' syntax."""
-        self._setup_config(bucket_year=['1950-59', '1960-1969'])
-        self.assertEqual(self.plugin._tmpl_bucket('1959'), '1950-59')
-        self.assertEqual(self.plugin._tmpl_bucket('1969'), '1960-1969')
+        self._setup_config(bucket_year=["1950-59", "1960-1969"])
+        self.assertEqual(self.plugin._tmpl_bucket("1959"), "1950-59")
+        self.assertEqual(self.plugin._tmpl_bucket("1969"), "1960-1969")
 
     def test_year_multiple_years(self):
         """Buckets can be named by listing all the years"""
-        self._setup_config(bucket_year=['1950,51,52,53'])
-        self.assertEqual(self.plugin._tmpl_bucket('1953'), '1950,51,52,53')
-        self.assertEqual(self.plugin._tmpl_bucket('1974'), '1974')
+        self._setup_config(bucket_year=["1950,51,52,53"])
+        self.assertEqual(self.plugin._tmpl_bucket("1953"), "1950,51,52,53")
+        self.assertEqual(self.plugin._tmpl_bucket("1974"), "1974")
 
     def test_year_out_of_range(self):
         """If no range match, return the year"""
-        self._setup_config(bucket_year=['1950-59', '1960-69'])
-        self.assertEqual(self.plugin._tmpl_bucket('1974'), '1974')
+        self._setup_config(bucket_year=["1950-59", "1960-69"])
+        self.assertEqual(self.plugin._tmpl_bucket("1974"), "1974")
         self._setup_config(bucket_year=[])
-        self.assertEqual(self.plugin._tmpl_bucket('1974'), '1974')
+        self.assertEqual(self.plugin._tmpl_bucket("1974"), "1974")
 
     def test_year_out_of_range_extrapolate(self):
         """If no defined range match, extrapolate all ranges using the most
         common syntax amongst existing buckets and return the matching one."""
-        self._setup_config(bucket_year=['1950-59', '1960-69'],
-                           extrapolate=True)
-        self.assertEqual(self.plugin._tmpl_bucket('1914'), '1910-19')
+        self._setup_config(
+            bucket_year=["1950-59", "1960-69"], extrapolate=True
+        )
+        self.assertEqual(self.plugin._tmpl_bucket("1914"), "1910-19")
         # pick single year format
-        self._setup_config(bucket_year=['1962-81', '2002', '2012'],
-                           extrapolate=True)
-        self.assertEqual(self.plugin._tmpl_bucket('1983'), '1982')
+        self._setup_config(
+            bucket_year=["1962-81", "2002", "2012"], extrapolate=True
+        )
+        self.assertEqual(self.plugin._tmpl_bucket("1983"), "1982")
         # pick from-end format
-        self._setup_config(bucket_year=['1962-81', '2002', '2012-14'],
-                           extrapolate=True)
-        self.assertEqual(self.plugin._tmpl_bucket('1983'), '1982-01')
+        self._setup_config(
+            bucket_year=["1962-81", "2002", "2012-14"], extrapolate=True
+        )
+        self.assertEqual(self.plugin._tmpl_bucket("1983"), "1982-01")
         # extrapolate add ranges, but never modifies existing ones
-        self._setup_config(bucket_year=['1932', '1942', '1952', '1962-81',
-                                        '2002'], extrapolate=True)
-        self.assertEqual(self.plugin._tmpl_bucket('1975'), '1962-81')
+        self._setup_config(
+            bucket_year=["1932", "1942", "1952", "1962-81", "2002"],
+            extrapolate=True,
+        )
+        self.assertEqual(self.plugin._tmpl_bucket("1975"), "1962-81")
 
     def test_alpha_all_chars(self):
         """Alphabet buckets can be named by listing all their chars"""
-        self._setup_config(bucket_alpha=['ABCD', 'FGH', 'IJKL'])
-        self.assertEqual(self.plugin._tmpl_bucket('garry'), 'FGH')
+        self._setup_config(bucket_alpha=["ABCD", "FGH", "IJKL"])
+        self.assertEqual(self.plugin._tmpl_bucket("garry"), "FGH")
 
     def test_alpha_first_last_chars(self):
         """Alphabet buckets can be named by listing the 'from-to' syntax"""
-        self._setup_config(bucket_alpha=['0->9', 'A->D', 'F-H', 'I->Z'])
-        self.assertEqual(self.plugin._tmpl_bucket('garry'), 'F-H')
-        self.assertEqual(self.plugin._tmpl_bucket('2pac'), '0->9')
+        self._setup_config(bucket_alpha=["0->9", "A->D", "F-H", "I->Z"])
+        self.assertEqual(self.plugin._tmpl_bucket("garry"), "F-H")
+        self.assertEqual(self.plugin._tmpl_bucket("2pac"), "0->9")
 
     def test_alpha_out_of_range(self):
         """If no range match, return the initial"""
-        self._setup_config(bucket_alpha=['ABCD', 'FGH', 'IJKL'])
-        self.assertEqual(self.plugin._tmpl_bucket('errol'), 'E')
+        self._setup_config(bucket_alpha=["ABCD", "FGH", "IJKL"])
+        self.assertEqual(self.plugin._tmpl_bucket("errol"), "E")
         self._setup_config(bucket_alpha=[])
-        self.assertEqual(self.plugin._tmpl_bucket('errol'), 'E')
+        self.assertEqual(self.plugin._tmpl_bucket("errol"), "E")
 
     def test_alpha_regex(self):
         """Check regex is used"""
-        self._setup_config(bucket_alpha=['foo', 'bar'],
-                           bucket_alpha_regex={'foo': '^[a-d]',
-                                               'bar': '^[e-z]'})
-        self.assertEqual(self.plugin._tmpl_bucket('alpha'), 'foo')
-        self.assertEqual(self.plugin._tmpl_bucket('delta'), 'foo')
-        self.assertEqual(self.plugin._tmpl_bucket('zeta'), 'bar')
-        self.assertEqual(self.plugin._tmpl_bucket('Alpha'), 'A')
+        self._setup_config(
+            bucket_alpha=["foo", "bar"],
+            bucket_alpha_regex={"foo": "^[a-d]", "bar": "^[e-z]"},
+        )
+        self.assertEqual(self.plugin._tmpl_bucket("alpha"), "foo")
+        self.assertEqual(self.plugin._tmpl_bucket("delta"), "foo")
+        self.assertEqual(self.plugin._tmpl_bucket("zeta"), "bar")
+        self.assertEqual(self.plugin._tmpl_bucket("Alpha"), "A")
 
     def test_alpha_regex_mix(self):
         """Check mixing regex and non-regex is possible"""
-        self._setup_config(bucket_alpha=['A - D', 'E - L'],
-                           bucket_alpha_regex={'A - D': '^[0-9a-dA-D…äÄ]'})
-        self.assertEqual(self.plugin._tmpl_bucket('alpha'), 'A - D')
-        self.assertEqual(self.plugin._tmpl_bucket('Ärzte'), 'A - D')
-        self.assertEqual(self.plugin._tmpl_bucket('112'), 'A - D')
-        self.assertEqual(self.plugin._tmpl_bucket('…and Oceans'), 'A - D')
-        self.assertEqual(self.plugin._tmpl_bucket('Eagles'), 'E - L')
+        self._setup_config(
+            bucket_alpha=["A - D", "E - L"],
+            bucket_alpha_regex={"A - D": "^[0-9a-dA-D…äÄ]"},
+        )
+        self.assertEqual(self.plugin._tmpl_bucket("alpha"), "A - D")
+        self.assertEqual(self.plugin._tmpl_bucket("Ärzte"), "A - D")
+        self.assertEqual(self.plugin._tmpl_bucket("112"), "A - D")
+        self.assertEqual(self.plugin._tmpl_bucket("…and Oceans"), "A - D")
+        self.assertEqual(self.plugin._tmpl_bucket("Eagles"), "E - L")
 
     def test_bad_alpha_range_def(self):
         """If bad alpha range definition, a UserError is raised."""
         with self.assertRaises(ui.UserError):
-            self._setup_config(bucket_alpha=['$%'])
+            self._setup_config(bucket_alpha=["$%"])
 
     def test_bad_year_range_def_no4digits(self):
         """If bad year range definition, a UserError is raised.
         Range origin must be expressed on 4 digits.
         """
         with self.assertRaises(ui.UserError):
-            self._setup_config(bucket_year=['62-64'])
+            self._setup_config(bucket_year=["62-64"])
 
     def test_bad_year_range_def_nodigits(self):
         """If bad year range definition, a UserError is raised.
         At least the range origin must be declared.
         """
         with self.assertRaises(ui.UserError):
-            self._setup_config(bucket_year=['nodigits'])
+            self._setup_config(bucket_year=["nodigits"])
 
     def check_span_from_str(self, sstr, dfrom, dto):
         d = bucket.span_from_str(sstr)
-        self.assertEqual(dfrom, d['from'])
-        self.assertEqual(dto, d['to'])
+        self.assertEqual(dfrom, d["from"])
+        self.assertEqual(dto, d["to"])
 
     def test_span_from_str(self):
         self.check_span_from_str("1980 2000", 1980, 2000)
@@ -164,5 +177,6 @@ class BucketPluginTest(unittest.TestCase, TestHelper):
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_config_command.py
+++ b/test/test_config_command.py
@@ -18,26 +18,25 @@ import six
 
 
 class ConfigCommandTest(unittest.TestCase, TestHelper):
-
     def setUp(self):
-        self.lib = Library(':memory:')
+        self.lib = Library(":memory:")
         self.temp_dir = mkdtemp()
-        if 'EDITOR' in os.environ:
-            del os.environ['EDITOR']
+        if "EDITOR" in os.environ:
+            del os.environ["EDITOR"]
 
-        os.environ['BEETSDIR'] = self.temp_dir
-        self.config_path = os.path.join(self.temp_dir, 'config.yaml')
-        with open(self.config_path, 'w') as file:
-            file.write('library: lib\n')
-            file.write('option: value\n')
-            file.write('password: password_value')
+        os.environ["BEETSDIR"] = self.temp_dir
+        self.config_path = os.path.join(self.temp_dir, "config.yaml")
+        with open(self.config_path, "w") as file:
+            file.write("library: lib\n")
+            file.write("option: value\n")
+            file.write("password: password_value")
 
-        self.cli_config_path = os.path.join(self.temp_dir, 'cli_config.yaml')
-        with open(self.cli_config_path, 'w') as file:
-            file.write('option: cli overwrite')
+        self.cli_config_path = os.path.join(self.temp_dir, "cli_config.yaml")
+        with open(self.cli_config_path, "w") as file:
+            file.write("option: cli overwrite")
 
         config.clear()
-        config['password'].redact = True
+        config["password"].redact = True
         config._materialized = False
 
     def tearDown(self):
@@ -48,92 +47,99 @@ class ConfigCommandTest(unittest.TestCase, TestHelper):
         return yaml.safe_load(output)
 
     def test_show_user_config(self):
-        output = self._run_with_yaml_output('config', '-c')
+        output = self._run_with_yaml_output("config", "-c")
 
-        self.assertEqual(output['option'], 'value')
-        self.assertEqual(output['password'], 'password_value')
+        self.assertEqual(output["option"], "value")
+        self.assertEqual(output["password"], "password_value")
 
     def test_show_user_config_with_defaults(self):
-        output = self._run_with_yaml_output('config', '-dc')
+        output = self._run_with_yaml_output("config", "-dc")
 
-        self.assertEqual(output['option'], 'value')
-        self.assertEqual(output['password'], 'password_value')
-        self.assertEqual(output['library'], 'lib')
-        self.assertEqual(output['import']['timid'], False)
+        self.assertEqual(output["option"], "value")
+        self.assertEqual(output["password"], "password_value")
+        self.assertEqual(output["library"], "lib")
+        self.assertEqual(output["import"]["timid"], False)
 
     def test_show_user_config_with_cli(self):
-        output = self._run_with_yaml_output('--config', self.cli_config_path,
-                                            'config')
+        output = self._run_with_yaml_output(
+            "--config", self.cli_config_path, "config"
+        )
 
-        self.assertEqual(output['library'], 'lib')
-        self.assertEqual(output['option'], 'cli overwrite')
+        self.assertEqual(output["library"], "lib")
+        self.assertEqual(output["option"], "cli overwrite")
 
     def test_show_redacted_user_config(self):
-        output = self._run_with_yaml_output('config')
+        output = self._run_with_yaml_output("config")
 
-        self.assertEqual(output['option'], 'value')
-        self.assertEqual(output['password'], 'REDACTED')
+        self.assertEqual(output["option"], "value")
+        self.assertEqual(output["password"], "REDACTED")
 
     def test_show_redacted_user_config_with_defaults(self):
-        output = self._run_with_yaml_output('config', '-d')
+        output = self._run_with_yaml_output("config", "-d")
 
-        self.assertEqual(output['option'], 'value')
-        self.assertEqual(output['password'], 'REDACTED')
-        self.assertEqual(output['import']['timid'], False)
+        self.assertEqual(output["option"], "value")
+        self.assertEqual(output["password"], "REDACTED")
+        self.assertEqual(output["import"]["timid"], False)
 
     def test_config_paths(self):
-        output = self.run_with_output('config', '-p')
+        output = self.run_with_output("config", "-p")
 
-        paths = output.split('\n')
+        paths = output.split("\n")
         self.assertEqual(len(paths), 2)
         self.assertEqual(paths[0], self.config_path)
 
     def test_config_paths_with_cli(self):
-        output = self.run_with_output('--config', self.cli_config_path,
-                                      'config', '-p')
-        paths = output.split('\n')
+        output = self.run_with_output(
+            "--config", self.cli_config_path, "config", "-p"
+        )
+        paths = output.split("\n")
         self.assertEqual(len(paths), 3)
         self.assertEqual(paths[0], self.cli_config_path)
 
     def test_edit_config_with_editor_env(self):
-        os.environ['EDITOR'] = 'myeditor'
-        with patch('os.execlp') as execlp:
-            self.run_command('config', '-e')
+        os.environ["EDITOR"] = "myeditor"
+        with patch("os.execlp") as execlp:
+            self.run_command("config", "-e")
         execlp.assert_called_once_with(
-            'myeditor', 'myeditor', self.config_path)
+            "myeditor", "myeditor", self.config_path
+        )
 
     def test_edit_config_with_automatic_open(self):
-        with patch('beets.util.open_anything') as open:
-            open.return_value = 'please_open'
-            with patch('os.execlp') as execlp:
-                self.run_command('config', '-e')
+        with patch("beets.util.open_anything") as open:
+            open.return_value = "please_open"
+            with patch("os.execlp") as execlp:
+                self.run_command("config", "-e")
         execlp.assert_called_once_with(
-            'please_open', 'please_open', self.config_path)
+            "please_open", "please_open", self.config_path
+        )
 
     def test_config_editor_not_found(self):
         with self.assertRaises(ui.UserError) as user_error:
-            with patch('os.execlp') as execlp:
-                execlp.side_effect = OSError('here is problem')
-                self.run_command('config', '-e')
-        self.assertIn('Could not edit configuration',
-                      six.text_type(user_error.exception))
-        self.assertIn('here is problem', six.text_type(user_error.exception))
+            with patch("os.execlp") as execlp:
+                execlp.side_effect = OSError("here is problem")
+                self.run_command("config", "-e")
+        self.assertIn(
+            "Could not edit configuration", six.text_type(user_error.exception)
+        )
+        self.assertIn("here is problem", six.text_type(user_error.exception))
 
     def test_edit_invalid_config_file(self):
-        with open(self.config_path, 'w') as file:
-            file.write('invalid: [')
+        with open(self.config_path, "w") as file:
+            file.write("invalid: [")
         config.clear()
         config._materialized = False
 
-        os.environ['EDITOR'] = 'myeditor'
-        with patch('os.execlp') as execlp:
-            self.run_command('config', '-e')
+        os.environ["EDITOR"] = "myeditor"
+        with patch("os.execlp") as execlp:
+            self.run_command("config", "-e")
         execlp.assert_called_once_with(
-            'myeditor', 'myeditor', self.config_path)
+            "myeditor", "myeditor", self.config_path
+        )
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -31,76 +31,84 @@ from beets import util
 def shell_quote(text):
     if sys.version_info[0] < 3:
         import pipes
+
         return pipes.quote(text)
     else:
         import shlex
+
         return shlex.quote(text)
 
 
 class TestHelper(helper.TestHelper):
-
     def tagged_copy_cmd(self, tag):
         """Return a conversion command that copies files and appends
         `tag` to the copy.
         """
-        if re.search('[^a-zA-Z0-9]', tag):
-            raise ValueError(u"tag '{0}' must only contain letters and digits"
-                             .format(tag))
+        if re.search("[^a-zA-Z0-9]", tag):
+            raise ValueError(
+                u"tag '{0}' must only contain letters and digits".format(tag)
+            )
 
         # A Python script that copies the file and appends a tag.
-        stub = os.path.join(_common.RSRC, b'convert_stub.py').decode('utf-8')
-        return u"{} {} $source $dest {}".format(shell_quote(sys.executable),
-                                                shell_quote(stub), tag)
+        stub = os.path.join(_common.RSRC, b"convert_stub.py").decode("utf-8")
+        return u"{} {} $source $dest {}".format(
+            shell_quote(sys.executable), shell_quote(stub), tag
+        )
 
     def assertFileTag(self, path, tag):  # noqa
         """Assert that the path is a file and the files content ends with `tag`.
         """
         display_tag = tag
-        tag = tag.encode('utf-8')
-        self.assertTrue(os.path.isfile(path),
-                        u'{0} is not a file'.format(
-                            util.displayable_path(path)))
-        with open(path, 'rb') as f:
+        tag = tag.encode("utf-8")
+        self.assertTrue(
+            os.path.isfile(path),
+            u"{0} is not a file".format(util.displayable_path(path)),
+        )
+        with open(path, "rb") as f:
             f.seek(-len(display_tag), os.SEEK_END)
-            self.assertEqual(f.read(), tag,
-                             u'{0} is not tagged with {1}'
-                             .format(
-                                 util.displayable_path(path),
-                                 display_tag))
+            self.assertEqual(
+                f.read(),
+                tag,
+                u"{0} is not tagged with {1}".format(
+                    util.displayable_path(path), display_tag
+                ),
+            )
 
     def assertNoFileTag(self, path, tag):  # noqa
         """Assert that the path is a file and the files content does not
         end with `tag`.
         """
         display_tag = tag
-        tag = tag.encode('utf-8')
-        self.assertTrue(os.path.isfile(path),
-                        u'{0} is not a file'.format(
-                            util.displayable_path(path)))
-        with open(path, 'rb') as f:
+        tag = tag.encode("utf-8")
+        self.assertTrue(
+            os.path.isfile(path),
+            u"{0} is not a file".format(util.displayable_path(path)),
+        )
+        with open(path, "rb") as f:
             f.seek(-len(tag), os.SEEK_END)
-            self.assertNotEqual(f.read(), tag,
-                                u'{0} is unexpectedly tagged with {1}'
-                                .format(
-                                    util.displayable_path(path),
-                                    display_tag))
+            self.assertNotEqual(
+                f.read(),
+                tag,
+                u"{0} is unexpectedly tagged with {1}".format(
+                    util.displayable_path(path), display_tag
+                ),
+            )
 
 
 @_common.slow_test()
 class ImportConvertTest(unittest.TestCase, TestHelper):
-
     def setUp(self):
         self.setup_beets(disk=True)  # Converter is threaded
         self.importer = self.create_importer()
-        self.load_plugins('convert')
+        self.load_plugins("convert")
 
-        self.config['convert'] = {
-            'dest': os.path.join(self.temp_dir, b'convert'),
-            'command': self.tagged_copy_cmd('convert'),
+        self.config["convert"] = {
+            "dest": os.path.join(self.temp_dir, b"convert"),
+            "command": self.tagged_copy_cmd("convert"),
             # Enforce running convert
-            'max_bitrate': 1,
-            'auto': True,
-            'quiet': False,
+            "max_bitrate": 1,
+            "auto": True,
+            "quiet": False,
         }
 
     def tearDown(self):
@@ -110,11 +118,11 @@ class ImportConvertTest(unittest.TestCase, TestHelper):
     def test_import_converted(self):
         self.importer.run()
         item = self.lib.items().get()
-        self.assertFileTag(item.path, 'convert')
+        self.assertFileTag(item.path, "convert")
 
     def test_import_original_on_convert_error(self):
         # `false` exits with non-zero code
-        self.config['convert']['command'] = u'false'
+        self.config["convert"]["command"] = u"false"
         self.importer.run()
 
         item = self.lib.items().get()
@@ -126,14 +134,15 @@ class ConvertCommand(object):
     """A mixin providing a utility method to run the `convert`command
     in tests.
     """
+
     def run_convert_path(self, path, *args):
         """Run the `convert` command on a given path."""
         # The path is currently a filesystem bytestring. Convert it to
         # an argument bytestring.
         path = path.decode(util._fsencoding()).encode(util.arg_encoding())
 
-        args = args + (b'path:' + path,)
-        return self.run_command('convert', *args)
+        args = args + (b"path:" + path,)
+        return self.run_command("convert", *args)
 
     def run_convert(self, *args):
         """Run the `convert` command on `self.item`."""
@@ -142,27 +151,26 @@ class ConvertCommand(object):
 
 @_common.slow_test()
 class ConvertCliTest(unittest.TestCase, TestHelper, ConvertCommand):
-
     def setUp(self):
         self.setup_beets(disk=True)  # Converter is threaded
-        self.album = self.add_album_fixture(ext='ogg')
+        self.album = self.add_album_fixture(ext="ogg")
         self.item = self.album.items()[0]
-        self.load_plugins('convert')
+        self.load_plugins("convert")
 
         self.convert_dest = util.bytestring_path(
-            os.path.join(self.temp_dir, b'convert_dest')
+            os.path.join(self.temp_dir, b"convert_dest")
         )
-        self.config['convert'] = {
-            'dest': self.convert_dest,
-            'paths': {'default': 'converted'},
-            'format': 'mp3',
-            'formats': {
-                'mp3': self.tagged_copy_cmd('mp3'),
-                'opus': {
-                    'command': self.tagged_copy_cmd('opus'),
-                    'extension': 'ops',
-                }
-            }
+        self.config["convert"] = {
+            "dest": self.convert_dest,
+            "paths": {"default": "converted"},
+            "format": "mp3",
+            "formats": {
+                "mp3": self.tagged_copy_cmd("mp3"),
+                "opus": {
+                    "command": self.tagged_copy_cmd("opus"),
+                    "extension": "ops",
+                },
+            },
         }
 
     def tearDown(self):
@@ -170,88 +178,87 @@ class ConvertCliTest(unittest.TestCase, TestHelper, ConvertCommand):
         self.teardown_beets()
 
     def test_convert(self):
-        with control_stdin('y'):
+        with control_stdin("y"):
             self.run_convert()
-        converted = os.path.join(self.convert_dest, b'converted.mp3')
-        self.assertFileTag(converted, 'mp3')
+        converted = os.path.join(self.convert_dest, b"converted.mp3")
+        self.assertFileTag(converted, "mp3")
 
     def test_convert_with_auto_confirmation(self):
-        self.run_convert('--yes')
-        converted = os.path.join(self.convert_dest, b'converted.mp3')
-        self.assertFileTag(converted, 'mp3')
+        self.run_convert("--yes")
+        converted = os.path.join(self.convert_dest, b"converted.mp3")
+        self.assertFileTag(converted, "mp3")
 
     def test_reject_confirmation(self):
-        with control_stdin('n'):
+        with control_stdin("n"):
             self.run_convert()
-        converted = os.path.join(self.convert_dest, b'converted.mp3')
+        converted = os.path.join(self.convert_dest, b"converted.mp3")
         self.assertFalse(os.path.isfile(converted))
 
     def test_convert_keep_new(self):
-        self.assertEqual(os.path.splitext(self.item.path)[1], b'.ogg')
+        self.assertEqual(os.path.splitext(self.item.path)[1], b".ogg")
 
-        with control_stdin('y'):
-            self.run_convert('--keep-new')
+        with control_stdin("y"):
+            self.run_convert("--keep-new")
 
         self.item.load()
-        self.assertEqual(os.path.splitext(self.item.path)[1], b'.mp3')
+        self.assertEqual(os.path.splitext(self.item.path)[1], b".mp3")
 
     def test_format_option(self):
-        with control_stdin('y'):
-            self.run_convert('--format', 'opus')
-            converted = os.path.join(self.convert_dest, b'converted.ops')
-        self.assertFileTag(converted, 'opus')
+        with control_stdin("y"):
+            self.run_convert("--format", "opus")
+            converted = os.path.join(self.convert_dest, b"converted.ops")
+        self.assertFileTag(converted, "opus")
 
     def test_embed_album_art(self):
-        self.config['convert']['embed'] = True
-        image_path = os.path.join(_common.RSRC, b'image-2x3.jpg')
+        self.config["convert"]["embed"] = True
+        image_path = os.path.join(_common.RSRC, b"image-2x3.jpg")
         self.album.artpath = image_path
         self.album.store()
-        with open(os.path.join(image_path), 'rb') as f:
+        with open(os.path.join(image_path), "rb") as f:
             image_data = f.read()
 
-        with control_stdin('y'):
+        with control_stdin("y"):
             self.run_convert()
-        converted = os.path.join(self.convert_dest, b'converted.mp3')
+        converted = os.path.join(self.convert_dest, b"converted.mp3")
         mediafile = MediaFile(converted)
         self.assertEqual(mediafile.images[0].data, image_data)
 
     def test_skip_existing(self):
-        converted = os.path.join(self.convert_dest, b'converted.mp3')
-        self.touch(converted, content='XXX')
-        self.run_convert('--yes')
-        with open(converted, 'r') as f:
-            self.assertEqual(f.read(), 'XXX')
+        converted = os.path.join(self.convert_dest, b"converted.mp3")
+        self.touch(converted, content="XXX")
+        self.run_convert("--yes")
+        with open(converted, "r") as f:
+            self.assertEqual(f.read(), "XXX")
 
     def test_pretend(self):
-        self.run_convert('--pretend')
-        converted = os.path.join(self.convert_dest, b'converted.mp3')
+        self.run_convert("--pretend")
+        converted = os.path.join(self.convert_dest, b"converted.mp3")
         self.assertFalse(os.path.exists(converted))
 
     def test_empty_query(self):
-        with capture_log('beets.convert') as logs:
-            self.run_convert('An impossible query')
-        self.assertEqual(logs[0], u'convert: Empty query result.')
+        with capture_log("beets.convert") as logs:
+            self.run_convert("An impossible query")
+        self.assertEqual(logs[0], u"convert: Empty query result.")
 
 
 @_common.slow_test()
-class NeverConvertLossyFilesTest(unittest.TestCase, TestHelper,
-                                 ConvertCommand):
+class NeverConvertLossyFilesTest(
+    unittest.TestCase, TestHelper, ConvertCommand
+):
     """Test the effect of the `never_convert_lossy_files` option.
     """
 
     def setUp(self):
         self.setup_beets(disk=True)  # Converter is threaded
-        self.load_plugins('convert')
+        self.load_plugins("convert")
 
-        self.convert_dest = os.path.join(self.temp_dir, b'convert_dest')
-        self.config['convert'] = {
-            'dest': self.convert_dest,
-            'paths': {'default': 'converted'},
-            'never_convert_lossy_files': True,
-            'format': 'mp3',
-            'formats': {
-                'mp3': self.tagged_copy_cmd('mp3'),
-            }
+        self.convert_dest = os.path.join(self.temp_dir, b"convert_dest")
+        self.config["convert"] = {
+            "dest": self.convert_dest,
+            "paths": {"default": "converted"},
+            "never_convert_lossy_files": True,
+            "format": "mp3",
+            "formats": {"mp3": self.tagged_copy_cmd("mp3"),},
         }
 
     def tearDown(self):
@@ -259,31 +266,31 @@ class NeverConvertLossyFilesTest(unittest.TestCase, TestHelper,
         self.teardown_beets()
 
     def test_transcode_from_lossles(self):
-        [item] = self.add_item_fixtures(ext='flac')
-        with control_stdin('y'):
+        [item] = self.add_item_fixtures(ext="flac")
+        with control_stdin("y"):
             self.run_convert_path(item.path)
-        converted = os.path.join(self.convert_dest, b'converted.mp3')
-        self.assertFileTag(converted, 'mp3')
+        converted = os.path.join(self.convert_dest, b"converted.mp3")
+        self.assertFileTag(converted, "mp3")
 
     def test_transcode_from_lossy(self):
-        self.config['convert']['never_convert_lossy_files'] = False
-        [item] = self.add_item_fixtures(ext='ogg')
-        with control_stdin('y'):
+        self.config["convert"]["never_convert_lossy_files"] = False
+        [item] = self.add_item_fixtures(ext="ogg")
+        with control_stdin("y"):
             self.run_convert_path(item.path)
-        converted = os.path.join(self.convert_dest, b'converted.mp3')
-        self.assertFileTag(converted, 'mp3')
+        converted = os.path.join(self.convert_dest, b"converted.mp3")
+        self.assertFileTag(converted, "mp3")
 
     def test_transcode_from_lossy_prevented(self):
-        [item] = self.add_item_fixtures(ext='ogg')
-        with control_stdin('y'):
+        [item] = self.add_item_fixtures(ext="ogg")
+        with control_stdin("y"):
             self.run_convert_path(item.path)
-        converted = os.path.join(self.convert_dest, b'converted.ogg')
-        self.assertNoFileTag(converted, 'mp3')
+        converted = os.path.join(self.convert_dest, b"converted.ogg")
+        self.assertNoFileTag(converted, "mp3")
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_datequery.py
+++ b/test/test_datequery.py
@@ -21,101 +21,121 @@ from test import _common
 from datetime import datetime, timedelta
 import unittest
 import time
-from beets.dbcore.query import _parse_periods, DateInterval, DateQuery,\
-    InvalidQueryArgumentValueError
+from beets.dbcore.query import (
+    _parse_periods,
+    DateInterval,
+    DateQuery,
+    InvalidQueryArgumentValueError,
+)
 
 
 def _date(string):
-    return datetime.strptime(string, '%Y-%m-%dT%H:%M:%S')
+    return datetime.strptime(string, "%Y-%m-%dT%H:%M:%S")
 
 
 def _datepattern(datetimedate):
-    return datetimedate.strftime('%Y-%m-%dT%H:%M:%S')
+    return datetimedate.strftime("%Y-%m-%dT%H:%M:%S")
 
 
 class DateIntervalTest(unittest.TestCase):
     def test_year_precision_intervals(self):
-        self.assertContains('2000..2001', '2000-01-01T00:00:00')
-        self.assertContains('2000..2001', '2001-06-20T14:15:16')
-        self.assertContains('2000..2001', '2001-12-31T23:59:59')
-        self.assertExcludes('2000..2001', '1999-12-31T23:59:59')
-        self.assertExcludes('2000..2001', '2002-01-01T00:00:00')
+        self.assertContains("2000..2001", "2000-01-01T00:00:00")
+        self.assertContains("2000..2001", "2001-06-20T14:15:16")
+        self.assertContains("2000..2001", "2001-12-31T23:59:59")
+        self.assertExcludes("2000..2001", "1999-12-31T23:59:59")
+        self.assertExcludes("2000..2001", "2002-01-01T00:00:00")
 
-        self.assertContains('2000..', '2000-01-01T00:00:00')
-        self.assertContains('2000..', '2099-10-11T00:00:00')
-        self.assertExcludes('2000..', '1999-12-31T23:59:59')
+        self.assertContains("2000..", "2000-01-01T00:00:00")
+        self.assertContains("2000..", "2099-10-11T00:00:00")
+        self.assertExcludes("2000..", "1999-12-31T23:59:59")
 
-        self.assertContains('..2001', '2001-12-31T23:59:59')
-        self.assertExcludes('..2001', '2002-01-01T00:00:00')
+        self.assertContains("..2001", "2001-12-31T23:59:59")
+        self.assertExcludes("..2001", "2002-01-01T00:00:00")
 
-        self.assertContains('-1d..1d', _datepattern(datetime.now()))
-        self.assertExcludes('-2d..-1d', _datepattern(datetime.now()))
+        self.assertContains("-1d..1d", _datepattern(datetime.now()))
+        self.assertExcludes("-2d..-1d", _datepattern(datetime.now()))
 
     def test_day_precision_intervals(self):
-        self.assertContains('2000-06-20..2000-06-20', '2000-06-20T00:00:00')
-        self.assertContains('2000-06-20..2000-06-20', '2000-06-20T10:20:30')
-        self.assertContains('2000-06-20..2000-06-20', '2000-06-20T23:59:59')
-        self.assertExcludes('2000-06-20..2000-06-20', '2000-06-19T23:59:59')
-        self.assertExcludes('2000-06-20..2000-06-20', '2000-06-21T00:00:00')
+        self.assertContains("2000-06-20..2000-06-20", "2000-06-20T00:00:00")
+        self.assertContains("2000-06-20..2000-06-20", "2000-06-20T10:20:30")
+        self.assertContains("2000-06-20..2000-06-20", "2000-06-20T23:59:59")
+        self.assertExcludes("2000-06-20..2000-06-20", "2000-06-19T23:59:59")
+        self.assertExcludes("2000-06-20..2000-06-20", "2000-06-21T00:00:00")
 
     def test_month_precision_intervals(self):
-        self.assertContains('1999-12..2000-02', '1999-12-01T00:00:00')
-        self.assertContains('1999-12..2000-02', '2000-02-15T05:06:07')
-        self.assertContains('1999-12..2000-02', '2000-02-29T23:59:59')
-        self.assertExcludes('1999-12..2000-02', '1999-11-30T23:59:59')
-        self.assertExcludes('1999-12..2000-02', '2000-03-01T00:00:00')
+        self.assertContains("1999-12..2000-02", "1999-12-01T00:00:00")
+        self.assertContains("1999-12..2000-02", "2000-02-15T05:06:07")
+        self.assertContains("1999-12..2000-02", "2000-02-29T23:59:59")
+        self.assertExcludes("1999-12..2000-02", "1999-11-30T23:59:59")
+        self.assertExcludes("1999-12..2000-02", "2000-03-01T00:00:00")
 
     def test_hour_precision_intervals(self):
         # test with 'T' separator
-        self.assertExcludes('2000-01-01T12..2000-01-01T13',
-                            '2000-01-01T11:59:59')
-        self.assertContains('2000-01-01T12..2000-01-01T13',
-                            '2000-01-01T12:00:00')
-        self.assertContains('2000-01-01T12..2000-01-01T13',
-                            '2000-01-01T12:30:00')
-        self.assertContains('2000-01-01T12..2000-01-01T13',
-                            '2000-01-01T13:30:00')
-        self.assertContains('2000-01-01T12..2000-01-01T13',
-                            '2000-01-01T13:59:59')
-        self.assertExcludes('2000-01-01T12..2000-01-01T13',
-                            '2000-01-01T14:00:00')
-        self.assertExcludes('2000-01-01T12..2000-01-01T13',
-                            '2000-01-01T14:30:00')
+        self.assertExcludes(
+            "2000-01-01T12..2000-01-01T13", "2000-01-01T11:59:59"
+        )
+        self.assertContains(
+            "2000-01-01T12..2000-01-01T13", "2000-01-01T12:00:00"
+        )
+        self.assertContains(
+            "2000-01-01T12..2000-01-01T13", "2000-01-01T12:30:00"
+        )
+        self.assertContains(
+            "2000-01-01T12..2000-01-01T13", "2000-01-01T13:30:00"
+        )
+        self.assertContains(
+            "2000-01-01T12..2000-01-01T13", "2000-01-01T13:59:59"
+        )
+        self.assertExcludes(
+            "2000-01-01T12..2000-01-01T13", "2000-01-01T14:00:00"
+        )
+        self.assertExcludes(
+            "2000-01-01T12..2000-01-01T13", "2000-01-01T14:30:00"
+        )
 
         # test non-range query
-        self.assertContains('2008-12-01T22',
-                            '2008-12-01T22:30:00')
-        self.assertExcludes('2008-12-01T22',
-                            '2008-12-01T23:30:00')
+        self.assertContains("2008-12-01T22", "2008-12-01T22:30:00")
+        self.assertExcludes("2008-12-01T22", "2008-12-01T23:30:00")
 
     def test_minute_precision_intervals(self):
-        self.assertExcludes('2000-01-01T12:30..2000-01-01T12:31',
-                            '2000-01-01T12:29:59')
-        self.assertContains('2000-01-01T12:30..2000-01-01T12:31',
-                            '2000-01-01T12:30:00')
-        self.assertContains('2000-01-01T12:30..2000-01-01T12:31',
-                            '2000-01-01T12:30:30')
-        self.assertContains('2000-01-01T12:30..2000-01-01T12:31',
-                            '2000-01-01T12:31:59')
-        self.assertExcludes('2000-01-01T12:30..2000-01-01T12:31',
-                            '2000-01-01T12:32:00')
+        self.assertExcludes(
+            "2000-01-01T12:30..2000-01-01T12:31", "2000-01-01T12:29:59"
+        )
+        self.assertContains(
+            "2000-01-01T12:30..2000-01-01T12:31", "2000-01-01T12:30:00"
+        )
+        self.assertContains(
+            "2000-01-01T12:30..2000-01-01T12:31", "2000-01-01T12:30:30"
+        )
+        self.assertContains(
+            "2000-01-01T12:30..2000-01-01T12:31", "2000-01-01T12:31:59"
+        )
+        self.assertExcludes(
+            "2000-01-01T12:30..2000-01-01T12:31", "2000-01-01T12:32:00"
+        )
 
     def test_second_precision_intervals(self):
-        self.assertExcludes('2000-01-01T12:30:50..2000-01-01T12:30:55',
-                            '2000-01-01T12:30:49')
-        self.assertContains('2000-01-01T12:30:50..2000-01-01T12:30:55',
-                            '2000-01-01T12:30:50')
-        self.assertContains('2000-01-01T12:30:50..2000-01-01T12:30:55',
-                            '2000-01-01T12:30:55')
-        self.assertExcludes('2000-01-01T12:30:50..2000-01-01T12:30:55',
-                            '2000-01-01T12:30:56')
+        self.assertExcludes(
+            "2000-01-01T12:30:50..2000-01-01T12:30:55", "2000-01-01T12:30:49"
+        )
+        self.assertContains(
+            "2000-01-01T12:30:50..2000-01-01T12:30:55", "2000-01-01T12:30:50"
+        )
+        self.assertContains(
+            "2000-01-01T12:30:50..2000-01-01T12:30:55", "2000-01-01T12:30:55"
+        )
+        self.assertExcludes(
+            "2000-01-01T12:30:50..2000-01-01T12:30:55", "2000-01-01T12:30:56"
+        )
 
     def test_unbounded_endpoints(self):
-        self.assertContains('..', date=datetime.max)
-        self.assertContains('..', date=datetime.min)
-        self.assertContains('..', '1000-01-01T00:00:00')
+        self.assertContains("..", date=datetime.max)
+        self.assertContains("..", date=datetime.min)
+        self.assertContains("..", "1000-01-01T00:00:00")
 
-    def assertContains(self, interval_pattern, date_pattern=None, date=None):  # noqa
+    def assertContains(
+        self, interval_pattern, date_pattern=None, date=None
+    ):  # noqa
         if date is None:
             date = _date(date_pattern)
         (start, end) = _parse_periods(interval_pattern)
@@ -130,40 +150,40 @@ class DateIntervalTest(unittest.TestCase):
 
 
 def _parsetime(s):
-    return time.mktime(datetime.strptime(s, '%Y-%m-%d %H:%M').timetuple())
+    return time.mktime(datetime.strptime(s, "%Y-%m-%d %H:%M").timetuple())
 
 
 class DateQueryTest(_common.LibTestCase):
     def setUp(self):
         super(DateQueryTest, self).setUp()
-        self.i.added = _parsetime('2013-03-30 22:21')
+        self.i.added = _parsetime("2013-03-30 22:21")
         self.i.store()
 
     def test_single_month_match_fast(self):
-        query = DateQuery('added', '2013-03')
+        query = DateQuery("added", "2013-03")
         matched = self.lib.items(query)
         self.assertEqual(len(matched), 1)
 
     def test_single_month_nonmatch_fast(self):
-        query = DateQuery('added', '2013-04')
+        query = DateQuery("added", "2013-04")
         matched = self.lib.items(query)
         self.assertEqual(len(matched), 0)
 
     def test_single_month_match_slow(self):
-        query = DateQuery('added', '2013-03')
+        query = DateQuery("added", "2013-03")
         self.assertTrue(query.match(self.i))
 
     def test_single_month_nonmatch_slow(self):
-        query = DateQuery('added', '2013-04')
+        query = DateQuery("added", "2013-04")
         self.assertFalse(query.match(self.i))
 
     def test_single_day_match_fast(self):
-        query = DateQuery('added', '2013-03-30')
+        query = DateQuery("added", "2013-03-30")
         matched = self.lib.items(query)
         self.assertEqual(len(matched), 1)
 
     def test_single_day_nonmatch_fast(self):
-        query = DateQuery('added', '2013-03-31')
+        query = DateQuery("added", "2013-03-31")
         matched = self.lib.items(query)
         self.assertEqual(len(matched), 0)
 
@@ -176,37 +196,40 @@ class DateQueryTestRelative(_common.LibTestCase):
         # zone bugs.
         self._now = datetime(2017, 12, 31, 22, 55, 4, 101332)
 
-        self.i.added = _parsetime(self._now.strftime('%Y-%m-%d %H:%M'))
+        self.i.added = _parsetime(self._now.strftime("%Y-%m-%d %H:%M"))
         self.i.store()
 
     def test_single_month_match_fast(self):
-        query = DateQuery('added', self._now.strftime('%Y-%m'))
+        query = DateQuery("added", self._now.strftime("%Y-%m"))
         matched = self.lib.items(query)
         self.assertEqual(len(matched), 1)
 
     def test_single_month_nonmatch_fast(self):
-        query = DateQuery('added', (self._now + timedelta(days=30))
-                          .strftime('%Y-%m'))
+        query = DateQuery(
+            "added", (self._now + timedelta(days=30)).strftime("%Y-%m")
+        )
         matched = self.lib.items(query)
         self.assertEqual(len(matched), 0)
 
     def test_single_month_match_slow(self):
-        query = DateQuery('added', self._now.strftime('%Y-%m'))
+        query = DateQuery("added", self._now.strftime("%Y-%m"))
         self.assertTrue(query.match(self.i))
 
     def test_single_month_nonmatch_slow(self):
-        query = DateQuery('added', (self._now + timedelta(days=30))
-                          .strftime('%Y-%m'))
+        query = DateQuery(
+            "added", (self._now + timedelta(days=30)).strftime("%Y-%m")
+        )
         self.assertFalse(query.match(self.i))
 
     def test_single_day_match_fast(self):
-        query = DateQuery('added', self._now.strftime('%Y-%m-%d'))
+        query = DateQuery("added", self._now.strftime("%Y-%m-%d"))
         matched = self.lib.items(query)
         self.assertEqual(len(matched), 1)
 
     def test_single_day_nonmatch_fast(self):
-        query = DateQuery('added', (self._now + timedelta(days=1))
-                          .strftime('%Y-%m-%d'))
+        query = DateQuery(
+            "added", (self._now + timedelta(days=1)).strftime("%Y-%m-%d")
+        )
         matched = self.lib.items(query)
         self.assertEqual(len(matched), 0)
 
@@ -214,42 +237,42 @@ class DateQueryTestRelative(_common.LibTestCase):
 class DateQueryTestRelativeMore(_common.LibTestCase):
     def setUp(self):
         super(DateQueryTestRelativeMore, self).setUp()
-        self.i.added = _parsetime(datetime.now().strftime('%Y-%m-%d %H:%M'))
+        self.i.added = _parsetime(datetime.now().strftime("%Y-%m-%d %H:%M"))
         self.i.store()
 
     def test_relative(self):
-        for timespan in ['d', 'w', 'm', 'y']:
-            query = DateQuery('added', '-4' + timespan + '..+4' + timespan)
+        for timespan in ["d", "w", "m", "y"]:
+            query = DateQuery("added", "-4" + timespan + "..+4" + timespan)
             matched = self.lib.items(query)
             self.assertEqual(len(matched), 1)
 
     def test_relative_fail(self):
-        for timespan in ['d', 'w', 'm', 'y']:
-            query = DateQuery('added', '-2' + timespan + '..-1' + timespan)
+        for timespan in ["d", "w", "m", "y"]:
+            query = DateQuery("added", "-2" + timespan + "..-1" + timespan)
             matched = self.lib.items(query)
             self.assertEqual(len(matched), 0)
 
     def test_start_relative(self):
-        for timespan in ['d', 'w', 'm', 'y']:
-            query = DateQuery('added', '-4' + timespan + '..')
+        for timespan in ["d", "w", "m", "y"]:
+            query = DateQuery("added", "-4" + timespan + "..")
             matched = self.lib.items(query)
             self.assertEqual(len(matched), 1)
 
     def test_start_relative_fail(self):
-        for timespan in ['d', 'w', 'm', 'y']:
-            query = DateQuery('added', '4' + timespan + '..')
+        for timespan in ["d", "w", "m", "y"]:
+            query = DateQuery("added", "4" + timespan + "..")
             matched = self.lib.items(query)
             self.assertEqual(len(matched), 0)
 
     def test_end_relative(self):
-        for timespan in ['d', 'w', 'm', 'y']:
-            query = DateQuery('added', '..+4' + timespan)
+        for timespan in ["d", "w", "m", "y"]:
+            query = DateQuery("added", "..+4" + timespan)
             matched = self.lib.items(query)
             self.assertEqual(len(matched), 1)
 
     def test_end_relative_fail(self):
-        for timespan in ['d', 'w', 'm', 'y']:
-            query = DateQuery('added', '..-4' + timespan)
+        for timespan in ["d", "w", "m", "y"]:
+            query = DateQuery("added", "..-4" + timespan)
             matched = self.lib.items(query)
             self.assertEqual(len(matched), 0)
 
@@ -257,50 +280,50 @@ class DateQueryTestRelativeMore(_common.LibTestCase):
 class DateQueryConstructTest(unittest.TestCase):
     def test_long_numbers(self):
         with self.assertRaises(InvalidQueryArgumentValueError):
-            DateQuery('added', '1409830085..1412422089')
+            DateQuery("added", "1409830085..1412422089")
 
     def test_too_many_components(self):
         with self.assertRaises(InvalidQueryArgumentValueError):
-            DateQuery('added', '12-34-56-78')
+            DateQuery("added", "12-34-56-78")
 
     def test_invalid_date_query(self):
         q_list = [
-            '2001-01-0a',
-            '2001-0a',
-            '200a',
-            '2001-01-01..2001-01-0a',
-            '2001-0a..2001-01',
-            '200a..2002',
-            '20aa..',
-            '..2aa'
+            "2001-01-0a",
+            "2001-0a",
+            "200a",
+            "2001-01-01..2001-01-0a",
+            "2001-0a..2001-01",
+            "200a..2002",
+            "20aa..",
+            "..2aa",
         ]
         for q in q_list:
             with self.assertRaises(InvalidQueryArgumentValueError):
-                DateQuery('added', q)
+                DateQuery("added", q)
 
     def test_datetime_uppercase_t_separator(self):
-        date_query = DateQuery('added', '2000-01-01T12')
+        date_query = DateQuery("added", "2000-01-01T12")
         self.assertEqual(date_query.interval.start, datetime(2000, 1, 1, 12))
         self.assertEqual(date_query.interval.end, datetime(2000, 1, 1, 13))
 
     def test_datetime_lowercase_t_separator(self):
-        date_query = DateQuery('added', '2000-01-01t12')
+        date_query = DateQuery("added", "2000-01-01t12")
         self.assertEqual(date_query.interval.start, datetime(2000, 1, 1, 12))
         self.assertEqual(date_query.interval.end, datetime(2000, 1, 1, 13))
 
     def test_datetime_space_separator(self):
-        date_query = DateQuery('added', '2000-01-01 12')
+        date_query = DateQuery("added", "2000-01-01 12")
         self.assertEqual(date_query.interval.start, datetime(2000, 1, 1, 12))
         self.assertEqual(date_query.interval.end, datetime(2000, 1, 1, 13))
 
     def test_datetime_invalid_separator(self):
         with self.assertRaises(InvalidQueryArgumentValueError):
-            DateQuery('added', '2000-01-01x12')
+            DateQuery("added", "2000-01-01x12")
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_datequery.py
+++ b/test/test_datequery.py
@@ -133,9 +133,9 @@ class DateIntervalTest(unittest.TestCase):
         self.assertContains("..", date=datetime.min)
         self.assertContains("..", "1000-01-01T00:00:00")
 
-    def assertContains(
+    def assertContains(  # noqa: N802
         self, interval_pattern, date_pattern=None, date=None
-    ):  # noqa
+    ):
         if date is None:
             date = _date(date_pattern)
         (start, end) = _parse_periods(interval_pattern)

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -32,6 +32,7 @@ import six
 # Fixture: concrete database and model classes. For migration tests, we
 # have multiple models with different numbers of fields.
 
+
 class SortFixture(dbcore.query.FieldSort):
     pass
 
@@ -48,21 +49,21 @@ class QueryFixture(dbcore.query.Query):
 
 
 class ModelFixture1(dbcore.Model):
-    _table = 'test'
-    _flex_table = 'testflex'
+    _table = "test"
+    _flex_table = "testflex"
     _fields = {
-        'id': dbcore.types.PRIMARY_ID,
-        'field_one': dbcore.types.INTEGER,
-        'field_two': dbcore.types.STRING,
+        "id": dbcore.types.PRIMARY_ID,
+        "field_one": dbcore.types.INTEGER,
+        "field_two": dbcore.types.STRING,
     }
     _types = {
-        'some_float_field': dbcore.types.FLOAT,
+        "some_float_field": dbcore.types.FLOAT,
     }
     _sorts = {
-        'some_sort': SortFixture,
+        "some_sort": SortFixture,
     }
     _queries = {
-        'some_query': QueryFixture,
+        "some_query": QueryFixture,
     }
 
     @classmethod
@@ -80,9 +81,9 @@ class DatabaseFixture1(dbcore.Database):
 
 class ModelFixture2(ModelFixture1):
     _fields = {
-        'id': dbcore.types.PRIMARY_ID,
-        'field_one': dbcore.types.INTEGER,
-        'field_two': dbcore.types.INTEGER,
+        "id": dbcore.types.PRIMARY_ID,
+        "field_one": dbcore.types.INTEGER,
+        "field_two": dbcore.types.INTEGER,
     }
 
 
@@ -93,10 +94,10 @@ class DatabaseFixture2(dbcore.Database):
 
 class ModelFixture3(ModelFixture1):
     _fields = {
-        'id': dbcore.types.PRIMARY_ID,
-        'field_one': dbcore.types.INTEGER,
-        'field_two': dbcore.types.INTEGER,
-        'field_three': dbcore.types.INTEGER,
+        "id": dbcore.types.PRIMARY_ID,
+        "field_one": dbcore.types.INTEGER,
+        "field_two": dbcore.types.INTEGER,
+        "field_three": dbcore.types.INTEGER,
     }
 
 
@@ -107,11 +108,11 @@ class DatabaseFixture3(dbcore.Database):
 
 class ModelFixture4(ModelFixture1):
     _fields = {
-        'id': dbcore.types.PRIMARY_ID,
-        'field_one': dbcore.types.INTEGER,
-        'field_two': dbcore.types.INTEGER,
-        'field_three': dbcore.types.INTEGER,
-        'field_four': dbcore.types.INTEGER,
+        "id": dbcore.types.PRIMARY_ID,
+        "field_one": dbcore.types.INTEGER,
+        "field_two": dbcore.types.INTEGER,
+        "field_three": dbcore.types.INTEGER,
+        "field_four": dbcore.types.INTEGER,
     }
 
 
@@ -121,19 +122,19 @@ class DatabaseFixture4(dbcore.Database):
 
 
 class AnotherModelFixture(ModelFixture1):
-    _table = 'another'
-    _flex_table = 'anotherflex'
+    _table = "another"
+    _flex_table = "anotherflex"
     _fields = {
-        'id': dbcore.types.PRIMARY_ID,
-        'foo': dbcore.types.INTEGER,
+        "id": dbcore.types.PRIMARY_ID,
+        "foo": dbcore.types.INTEGER,
     }
 
 
 class ModelFixture5(ModelFixture1):
     _fields = {
-        'some_string_field': dbcore.types.STRING,
-        'some_float_field': dbcore.types.FLOAT,
-        'some_boolean_field': dbcore.types.BOOLEAN,
+        "some_string_field": dbcore.types.STRING,
+        "some_float_field": dbcore.types.FLOAT,
+        "some_boolean_field": dbcore.types.BOOLEAN,
     }
 
 
@@ -148,10 +149,9 @@ class DatabaseFixtureTwoModels(dbcore.Database):
 
 
 class ModelFixtureWithGetters(dbcore.Model):
-
     @classmethod
     def _getters(cls):
-        return {'aComputedField': (lambda s: 'thing')}
+        return {"aComputedField": (lambda s: "thing")}
 
     def _template_funcs(self):
         return {}
@@ -165,14 +165,14 @@ class MigrationTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        handle, cls.orig_libfile = mkstemp('orig_db')
+        handle, cls.orig_libfile = mkstemp("orig_db")
         os.close(handle)
         # Set up a database with the two-field schema.
         old_lib = DatabaseFixture2(cls.orig_libfile)
 
         # Add an item to the old library.
         old_lib._connection().execute(
-            'insert into test (field_one, field_two) values (4, 2)'
+            "insert into test (field_one, field_two) values (4, 2)"
         )
         old_lib._connection().commit()
         del old_lib
@@ -182,7 +182,7 @@ class MigrationTest(unittest.TestCase):
         os.remove(cls.orig_libfile)
 
     def setUp(self):
-        handle, self.libfile = mkstemp('db')
+        handle, self.libfile = mkstemp("db")
         os.close(handle)
         shutil.copyfile(self.orig_libfile, self.libfile)
 
@@ -227,7 +227,7 @@ class MigrationTest(unittest.TestCase):
 
 class ModelTest(unittest.TestCase):
     def setUp(self):
-        self.db = DatabaseFixture1(':memory:')
+        self.db = DatabaseFixture1(":memory:")
 
     def tearDown(self):
         self.db._connection().close()
@@ -235,7 +235,7 @@ class ModelTest(unittest.TestCase):
     def test_add_model(self):
         model = ModelFixture1()
         model.add(self.db)
-        rows = self.db._connection().execute('select * from test').fetchall()
+        rows = self.db._connection().execute("select * from test").fetchall()
         self.assertEqual(len(rows), 1)
 
     def test_store_fixed_field(self):
@@ -243,8 +243,8 @@ class ModelTest(unittest.TestCase):
         model.add(self.db)
         model.field_one = 123
         model.store()
-        row = self.db._connection().execute('select * from test').fetchone()
-        self.assertEqual(row['field_one'], 123)
+        row = self.db._connection().execute("select * from test").fetchone()
+        self.assertEqual(row["field_one"], 123)
 
     def test_retrieve_by_id(self):
         model = ModelFixture1()
@@ -255,47 +255,47 @@ class ModelTest(unittest.TestCase):
     def test_store_and_retrieve_flexattr(self):
         model = ModelFixture1()
         model.add(self.db)
-        model.foo = 'bar'
+        model.foo = "bar"
         model.store()
 
         other_model = self.db._get(ModelFixture1, model.id)
-        self.assertEqual(other_model.foo, 'bar')
+        self.assertEqual(other_model.foo, "bar")
 
     def test_delete_flexattr(self):
         model = ModelFixture1()
-        model['foo'] = 'bar'
-        self.assertTrue('foo' in model)
-        del model['foo']
-        self.assertFalse('foo' in model)
+        model["foo"] = "bar"
+        self.assertTrue("foo" in model)
+        del model["foo"]
+        self.assertFalse("foo" in model)
 
     def test_delete_flexattr_via_dot(self):
         model = ModelFixture1()
-        model['foo'] = 'bar'
-        self.assertTrue('foo' in model)
+        model["foo"] = "bar"
+        self.assertTrue("foo" in model)
         del model.foo
-        self.assertFalse('foo' in model)
+        self.assertFalse("foo" in model)
 
     def test_delete_flexattr_persists(self):
         model = ModelFixture1()
         model.add(self.db)
-        model.foo = 'bar'
+        model.foo = "bar"
         model.store()
 
         model = self.db._get(ModelFixture1, model.id)
-        del model['foo']
+        del model["foo"]
         model.store()
 
         model = self.db._get(ModelFixture1, model.id)
-        self.assertFalse('foo' in model)
+        self.assertFalse("foo" in model)
 
     def test_delete_non_existent_attribute(self):
         model = ModelFixture1()
         with self.assertRaises(KeyError):
-            del model['foo']
+            del model["foo"]
 
     def test_delete_fixed_attribute(self):
         model = ModelFixture5()
-        model.some_string_field = 'foo'
+        model.some_string_field = "foo"
         model.some_float_field = 1.23
         model.some_boolean_field = True
 
@@ -323,22 +323,22 @@ class ModelTest(unittest.TestCase):
 
     def test_load_deleted_flex_field(self):
         model1 = ModelFixture1()
-        model1['flex_field'] = True
+        model1["flex_field"] = True
         model1.add(self.db)
 
         model2 = self.db._get(ModelFixture1, model1.id)
-        self.assertIn('flex_field', model2)
+        self.assertIn("flex_field", model2)
 
-        del model1['flex_field']
+        del model1["flex_field"]
         model1.store()
 
         model2.load()
-        self.assertNotIn('flex_field', model2)
+        self.assertNotIn("flex_field", model2)
 
     def test_check_db_fails(self):
-        with assertRaisesRegex(self, ValueError, 'no database'):
+        with assertRaisesRegex(self, ValueError, "no database"):
             dbcore.Model()._check_db()
-        with assertRaisesRegex(self, ValueError, 'no id'):
+        with assertRaisesRegex(self, ValueError, "no id"):
             ModelFixture1(self.db)._check_db()
 
         dbcore.Model(self.db)._check_db(need_id=False)
@@ -349,15 +349,17 @@ class ModelTest(unittest.TestCase):
 
     def test_computed_field(self):
         model = ModelFixtureWithGetters()
-        self.assertEqual(model.aComputedField, 'thing')
-        with assertRaisesRegex(self, KeyError, u'computed field .+ deleted'):
+        self.assertEqual(model.aComputedField, "thing")
+        with assertRaisesRegex(self, KeyError, u"computed field .+ deleted"):
             del model.aComputedField
 
     def test_items(self):
         model = ModelFixture1(self.db)
         model.id = 5
-        self.assertEqual({('id', 5), ('field_one', 0), ('field_two', '')},
-                         set(model.items()))
+        self.assertEqual(
+            {("id", 5), ("field_one", 0), ("field_two", "")},
+            set(model.items()),
+        )
 
     def test_delete_internal_field(self):
         model = dbcore.Model()
@@ -374,50 +376,50 @@ class FormatTest(unittest.TestCase):
     def test_format_fixed_field_integer(self):
         model = ModelFixture1()
         model.field_one = 155
-        value = model.formatted().get('field_one')
-        self.assertEqual(value, u'155')
+        value = model.formatted().get("field_one")
+        self.assertEqual(value, u"155")
 
     def test_format_fixed_field_integer_normalized(self):
         """The normalize method of the Integer class rounds floats
         """
         model = ModelFixture1()
         model.field_one = 142.432
-        value = model.formatted().get('field_one')
-        self.assertEqual(value, u'142')
+        value = model.formatted().get("field_one")
+        self.assertEqual(value, u"142")
 
         model.field_one = 142.863
-        value = model.formatted().get('field_one')
-        self.assertEqual(value, u'143')
+        value = model.formatted().get("field_one")
+        self.assertEqual(value, u"143")
 
     def test_format_fixed_field_string(self):
         model = ModelFixture1()
-        model.field_two = u'caf\xe9'
-        value = model.formatted().get('field_two')
-        self.assertEqual(value, u'caf\xe9')
+        model.field_two = u"caf\xe9"
+        value = model.formatted().get("field_two")
+        self.assertEqual(value, u"caf\xe9")
 
     def test_format_flex_field(self):
         model = ModelFixture1()
-        model.other_field = u'caf\xe9'
-        value = model.formatted().get('other_field')
-        self.assertEqual(value, u'caf\xe9')
+        model.other_field = u"caf\xe9"
+        value = model.formatted().get("other_field")
+        self.assertEqual(value, u"caf\xe9")
 
     def test_format_flex_field_bytes(self):
         model = ModelFixture1()
-        model.other_field = u'caf\xe9'.encode('utf-8')
-        value = model.formatted().get('other_field')
+        model.other_field = u"caf\xe9".encode("utf-8")
+        value = model.formatted().get("other_field")
         self.assertTrue(isinstance(value, six.text_type))
-        self.assertEqual(value, u'caf\xe9')
+        self.assertEqual(value, u"caf\xe9")
 
     def test_format_unset_field(self):
         model = ModelFixture1()
-        value = model.formatted().get('other_field')
-        self.assertEqual(value, u'')
+        value = model.formatted().get("other_field")
+        self.assertEqual(value, u"")
 
     def test_format_typed_flex_field(self):
         model = ModelFixture1()
         model.some_float_field = 3.14159265358979
-        value = model.formatted().get('some_float_field')
-        self.assertEqual(value, u'3.1')
+        value = model.formatted().get("some_float_field")
+        self.assertEqual(value, u"3.1")
 
 
 class FormattedMappingTest(unittest.TestCase):
@@ -430,91 +432,93 @@ class FormattedMappingTest(unittest.TestCase):
         model = ModelFixture1()
         formatted = model.formatted()
         with self.assertRaises(KeyError):
-            formatted['other_field']
+            formatted["other_field"]
 
     def test_get_method_with_default(self):
         model = ModelFixture1()
         formatted = model.formatted()
-        self.assertEqual(formatted.get('other_field'), u'')
+        self.assertEqual(formatted.get("other_field"), u"")
 
     def test_get_method_with_specified_default(self):
         model = ModelFixture1()
         formatted = model.formatted()
-        self.assertEqual(formatted.get('other_field', 'default'), 'default')
+        self.assertEqual(formatted.get("other_field", "default"), "default")
 
 
 class ParseTest(unittest.TestCase):
     def test_parse_fixed_field(self):
-        value = ModelFixture1._parse('field_one', u'2')
+        value = ModelFixture1._parse("field_one", u"2")
         self.assertIsInstance(value, int)
         self.assertEqual(value, 2)
 
     def test_parse_flex_field(self):
-        value = ModelFixture1._parse('some_float_field', u'2')
+        value = ModelFixture1._parse("some_float_field", u"2")
         self.assertIsInstance(value, float)
         self.assertEqual(value, 2.0)
 
     def test_parse_untyped_field(self):
-        value = ModelFixture1._parse('field_nine', u'2')
-        self.assertEqual(value, u'2')
+        value = ModelFixture1._parse("field_nine", u"2")
+        self.assertEqual(value, u"2")
 
 
 class QueryParseTest(unittest.TestCase):
     def pqp(self, part):
         return dbcore.queryparse.parse_query_part(
             part,
-            {'year': dbcore.query.NumericQuery},
-            {':': dbcore.query.RegexpQuery},
-        )[:-1]  # remove the negate flag
+            {"year": dbcore.query.NumericQuery},
+            {":": dbcore.query.RegexpQuery},
+        )[
+            :-1
+        ]  # remove the negate flag
 
     def test_one_basic_term(self):
-        q = 'test'
-        r = (None, 'test', dbcore.query.SubstringQuery)
+        q = "test"
+        r = (None, "test", dbcore.query.SubstringQuery)
         self.assertEqual(self.pqp(q), r)
 
     def test_one_keyed_term(self):
-        q = 'test:val'
-        r = ('test', 'val', dbcore.query.SubstringQuery)
+        q = "test:val"
+        r = ("test", "val", dbcore.query.SubstringQuery)
         self.assertEqual(self.pqp(q), r)
 
     def test_colon_at_end(self):
-        q = 'test:'
-        r = ('test', '', dbcore.query.SubstringQuery)
+        q = "test:"
+        r = ("test", "", dbcore.query.SubstringQuery)
         self.assertEqual(self.pqp(q), r)
 
     def test_one_basic_regexp(self):
-        q = r':regexp'
-        r = (None, 'regexp', dbcore.query.RegexpQuery)
+        q = r":regexp"
+        r = (None, "regexp", dbcore.query.RegexpQuery)
         self.assertEqual(self.pqp(q), r)
 
     def test_keyed_regexp(self):
-        q = r'test::regexp'
-        r = ('test', 'regexp', dbcore.query.RegexpQuery)
+        q = r"test::regexp"
+        r = ("test", "regexp", dbcore.query.RegexpQuery)
         self.assertEqual(self.pqp(q), r)
 
     def test_escaped_colon(self):
-        q = r'test\:val'
-        r = (None, 'test:val', dbcore.query.SubstringQuery)
+        q = r"test\:val"
+        r = (None, "test:val", dbcore.query.SubstringQuery)
         self.assertEqual(self.pqp(q), r)
 
     def test_escaped_colon_in_regexp(self):
-        q = r':test\:regexp'
-        r = (None, 'test:regexp', dbcore.query.RegexpQuery)
+        q = r":test\:regexp"
+        r = (None, "test:regexp", dbcore.query.RegexpQuery)
         self.assertEqual(self.pqp(q), r)
 
     def test_single_year(self):
-        q = 'year:1999'
-        r = ('year', '1999', dbcore.query.NumericQuery)
+        q = "year:1999"
+        r = ("year", "1999", dbcore.query.NumericQuery)
         self.assertEqual(self.pqp(q), r)
 
     def test_multiple_years(self):
-        q = 'year:1999..2010'
-        r = ('year', '1999..2010', dbcore.query.NumericQuery)
+        q = "year:1999..2010"
+        r = ("year", "1999..2010", dbcore.query.NumericQuery)
         self.assertEqual(self.pqp(q), r)
 
     def test_empty_query_part(self):
-        q = ''
-        r = (None, '', dbcore.query.SubstringQuery)
+        q = ""
+        r = (None, "", dbcore.query.SubstringQuery)
         self.assertEqual(self.pqp(q), r)
 
 
@@ -523,7 +527,7 @@ class QueryFromStringsTest(unittest.TestCase):
         return dbcore.queryparse.query_from_strings(
             dbcore.query.AndQuery,
             ModelFixture1,
-            {':': dbcore.query.RegexpQuery},
+            {":": dbcore.query.RegexpQuery},
             strings,
         )
 
@@ -534,35 +538,32 @@ class QueryFromStringsTest(unittest.TestCase):
         self.assertIsInstance(q.subqueries[0], dbcore.query.TrueQuery)
 
     def test_two_parts(self):
-        q = self.qfs(['foo', 'bar:baz'])
+        q = self.qfs(["foo", "bar:baz"])
         self.assertIsInstance(q, dbcore.query.AndQuery)
         self.assertEqual(len(q.subqueries), 2)
         self.assertIsInstance(q.subqueries[0], dbcore.query.AnyFieldQuery)
         self.assertIsInstance(q.subqueries[1], dbcore.query.SubstringQuery)
 
     def test_parse_fixed_type_query(self):
-        q = self.qfs(['field_one:2..3'])
+        q = self.qfs(["field_one:2..3"])
         self.assertIsInstance(q.subqueries[0], dbcore.query.NumericQuery)
 
     def test_parse_flex_type_query(self):
-        q = self.qfs(['some_float_field:2..3'])
+        q = self.qfs(["some_float_field:2..3"])
         self.assertIsInstance(q.subqueries[0], dbcore.query.NumericQuery)
 
     def test_empty_query_part(self):
-        q = self.qfs([''])
+        q = self.qfs([""])
         self.assertIsInstance(q.subqueries[0], dbcore.query.TrueQuery)
 
     def test_parse_named_query(self):
-        q = self.qfs(['some_query:foo'])
+        q = self.qfs(["some_query:foo"])
         self.assertIsInstance(q.subqueries[0], QueryFixture)
 
 
 class SortFromStringsTest(unittest.TestCase):
     def sfs(self, strings):
-        return dbcore.queryparse.sort_from_strings(
-            ModelFixture1,
-            strings,
-        )
+        return dbcore.queryparse.sort_from_strings(ModelFixture1, strings,)
 
     def test_zero_parts(self):
         s = self.sfs([])
@@ -570,74 +571,71 @@ class SortFromStringsTest(unittest.TestCase):
         self.assertEqual(s, dbcore.query.NullSort())
 
     def test_one_parts(self):
-        s = self.sfs(['field+'])
+        s = self.sfs(["field+"])
         self.assertIsInstance(s, dbcore.query.Sort)
 
     def test_two_parts(self):
-        s = self.sfs(['field+', 'another_field-'])
+        s = self.sfs(["field+", "another_field-"])
         self.assertIsInstance(s, dbcore.query.MultipleSort)
         self.assertEqual(len(s.sorts), 2)
 
     def test_fixed_field_sort(self):
-        s = self.sfs(['field_one+'])
+        s = self.sfs(["field_one+"])
         self.assertIsInstance(s, dbcore.query.FixedFieldSort)
-        self.assertEqual(s, dbcore.query.FixedFieldSort('field_one'))
+        self.assertEqual(s, dbcore.query.FixedFieldSort("field_one"))
 
     def test_flex_field_sort(self):
-        s = self.sfs(['flex_field+'])
+        s = self.sfs(["flex_field+"])
         self.assertIsInstance(s, dbcore.query.SlowFieldSort)
-        self.assertEqual(s, dbcore.query.SlowFieldSort('flex_field'))
+        self.assertEqual(s, dbcore.query.SlowFieldSort("flex_field"))
 
     def test_special_sort(self):
-        s = self.sfs(['some_sort+'])
+        s = self.sfs(["some_sort+"])
         self.assertIsInstance(s, SortFixture)
 
 
 class ParseSortedQueryTest(unittest.TestCase):
     def psq(self, parts):
-        return dbcore.parse_sorted_query(
-            ModelFixture1,
-            parts.split(),
-        )
+        return dbcore.parse_sorted_query(ModelFixture1, parts.split(),)
 
     def test_and_query(self):
-        q, s = self.psq('foo bar')
+        q, s = self.psq("foo bar")
         self.assertIsInstance(q, dbcore.query.AndQuery)
         self.assertIsInstance(s, dbcore.query.NullSort)
         self.assertEqual(len(q.subqueries), 2)
 
     def test_or_query(self):
-        q, s = self.psq('foo , bar')
+        q, s = self.psq("foo , bar")
         self.assertIsInstance(q, dbcore.query.OrQuery)
         self.assertIsInstance(s, dbcore.query.NullSort)
         self.assertEqual(len(q.subqueries), 2)
 
     def test_no_space_before_comma_or_query(self):
-        q, s = self.psq('foo, bar')
+        q, s = self.psq("foo, bar")
         self.assertIsInstance(q, dbcore.query.OrQuery)
         self.assertIsInstance(s, dbcore.query.NullSort)
         self.assertEqual(len(q.subqueries), 2)
 
     def test_no_spaces_or_query(self):
-        q, s = self.psq('foo,bar')
+        q, s = self.psq("foo,bar")
         self.assertIsInstance(q, dbcore.query.AndQuery)
         self.assertIsInstance(s, dbcore.query.NullSort)
         self.assertEqual(len(q.subqueries), 1)
 
     def test_trailing_comma_or_query(self):
-        q, s = self.psq('foo , bar ,')
+        q, s = self.psq("foo , bar ,")
         self.assertIsInstance(q, dbcore.query.OrQuery)
         self.assertIsInstance(s, dbcore.query.NullSort)
         self.assertEqual(len(q.subqueries), 3)
 
     def test_leading_comma_or_query(self):
-        q, s = self.psq(', foo , bar')
+        q, s = self.psq(", foo , bar")
         self.assertIsInstance(q, dbcore.query.OrQuery)
         self.assertIsInstance(s, dbcore.query.NullSort)
         self.assertEqual(len(q.subqueries), 3)
 
     def test_only_direction(self):
-        q, s = self.psq('-')
+        q, s = self.psq("-")
         self.assertIsInstance(q, dbcore.query.AndQuery)
         self.assertIsInstance(s, dbcore.query.NullSort)
         self.assertEqual(len(q.subqueries), 1)
@@ -645,12 +643,12 @@ class ParseSortedQueryTest(unittest.TestCase):
 
 class ResultsIteratorTest(unittest.TestCase):
     def setUp(self):
-        self.db = DatabaseFixture1(':memory:')
+        self.db = DatabaseFixture1(":memory:")
         model = ModelFixture1()
-        model['foo'] = 'baz'
+        model["foo"] = "baz"
         model.add(self.db)
         model = ModelFixture1()
-        model['foo'] = 'bar'
+        model["foo"] = "bar"
         model.add(self.db)
 
     def tearDown(self):
@@ -674,32 +672,32 @@ class ResultsIteratorTest(unittest.TestCase):
         self.assertEqual(len(list(it1)), 1)
 
     def test_slow_query(self):
-        q = dbcore.query.SubstringQuery('foo', 'ba', False)
+        q = dbcore.query.SubstringQuery("foo", "ba", False)
         objs = self.db._fetch(ModelFixture1, q)
         self.assertEqual(len(list(objs)), 2)
 
     def test_slow_query_negative(self):
-        q = dbcore.query.SubstringQuery('foo', 'qux', False)
+        q = dbcore.query.SubstringQuery("foo", "qux", False)
         objs = self.db._fetch(ModelFixture1, q)
         self.assertEqual(len(list(objs)), 0)
 
     def test_iterate_slow_sort(self):
-        s = dbcore.query.SlowFieldSort('foo')
+        s = dbcore.query.SlowFieldSort("foo")
         res = self.db._fetch(ModelFixture1, sort=s)
         objs = list(res)
-        self.assertEqual(objs[0].foo, 'bar')
-        self.assertEqual(objs[1].foo, 'baz')
+        self.assertEqual(objs[0].foo, "bar")
+        self.assertEqual(objs[1].foo, "baz")
 
     def test_unsorted_subscript(self):
         objs = self.db._fetch(ModelFixture1)
-        self.assertEqual(objs[0].foo, 'baz')
-        self.assertEqual(objs[1].foo, 'bar')
+        self.assertEqual(objs[0].foo, "baz")
+        self.assertEqual(objs[1].foo, "bar")
 
     def test_slow_sort_subscript(self):
-        s = dbcore.query.SlowFieldSort('foo')
+        s = dbcore.query.SlowFieldSort("foo")
         objs = self.db._fetch(ModelFixture1, sort=s)
-        self.assertEqual(objs[0].foo, 'bar')
-        self.assertEqual(objs[1].foo, 'baz')
+        self.assertEqual(objs[0].foo, "bar")
+        self.assertEqual(objs[1].foo, "baz")
 
     def test_length(self):
         objs = self.db._fetch(ModelFixture1)
@@ -711,12 +709,14 @@ class ResultsIteratorTest(unittest.TestCase):
             objs[100]
 
     def test_no_results(self):
-        self.assertIsNone(self.db._fetch(
-            ModelFixture1, dbcore.query.FalseQuery()).get())
+        self.assertIsNone(
+            self.db._fetch(ModelFixture1, dbcore.query.FalseQuery()).get()
+        )
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_discogs.py
+++ b/test/test_discogs.py
@@ -31,77 +31,72 @@ class DGAlbumInfoTest(_common.TestCase):
         of elements on the returned Bag is incomplete, including just
         those required for the tests on this class."""
         data = {
-            'id': 'ALBUM ID',
-            'uri': 'https://www.discogs.com/release/release/13633721',
-            'title': 'ALBUM TITLE',
-            'year': '3001',
-            'artists': [{
-                'name': 'ARTIST NAME',
-                'id': 'ARTIST ID',
-                'join': ','
-            }],
-            'formats': [{
-                'descriptions': ['FORMAT DESC 1', 'FORMAT DESC 2'],
-                'name': 'FORMAT',
-                'qty': 1
-            }],
-            'styles': [
-                'STYLE1', 'STYLE2'
+            "id": "ALBUM ID",
+            "uri": "https://www.discogs.com/release/release/13633721",
+            "title": "ALBUM TITLE",
+            "year": "3001",
+            "artists": [
+                {"name": "ARTIST NAME", "id": "ARTIST ID", "join": ","}
             ],
-            'genres': [
-                'GENRE1', 'GENRE2'
+            "formats": [
+                {
+                    "descriptions": ["FORMAT DESC 1", "FORMAT DESC 2"],
+                    "name": "FORMAT",
+                    "qty": 1,
+                }
             ],
-            'labels': [{
-                'name': 'LABEL NAME',
-                'catno': 'CATALOG NUMBER',
-            }],
-            'tracklist': []
+            "styles": ["STYLE1", "STYLE2"],
+            "genres": ["GENRE1", "GENRE2"],
+            "labels": [{"name": "LABEL NAME", "catno": "CATALOG NUMBER",}],
+            "tracklist": [],
         }
 
         if tracks:
             for recording in tracks:
-                data['tracklist'].append(recording)
+                data["tracklist"].append(recording)
 
-        return Bag(data=data,
-                   # Make some fields available as properties, as they are
-                   # accessed by DiscogsPlugin methods.
-                   title=data['title'],
-                   artists=[Bag(data=d) for d in data['artists']])
+        return Bag(
+            data=data,
+            # Make some fields available as properties, as they are
+            # accessed by DiscogsPlugin methods.
+            title=data["title"],
+            artists=[Bag(data=d) for d in data["artists"]],
+        )
 
-    def _make_track(self, title, position='', duration='', type_=None):
-        track = {
-            'title': title,
-            'position': position,
-            'duration': duration
-        }
+    def _make_track(self, title, position="", duration="", type_=None):
+        track = {"title": title, "position": position, "duration": duration}
         if type_ is not None:
             # Test samples on discogs_client do not have a 'type_' field, but
             # the API seems to return it. Values: 'track' for regular tracks,
             # 'heading' for descriptive texts (ie. not real tracks - 12.13.2).
-            track['type_'] = type_
+            track["type_"] = type_
 
         return track
 
     def _make_release_from_positions(self, positions):
         """Return a Bag that mimics a discogs_client.Release with a
         tracklist where tracks have the specified `positions`."""
-        tracks = [self._make_track('TITLE%s' % i, position) for
-                  (i, position) in enumerate(positions, start=1)]
+        tracks = [
+            self._make_track("TITLE%s" % i, position)
+            for (i, position) in enumerate(positions, start=1)
+        ]
         return self._make_release(tracks)
 
     def test_parse_media_for_tracks(self):
-        tracks = [self._make_track('TITLE ONE', '1', '01:01'),
-                  self._make_track('TITLE TWO', '2', '02:02')]
+        tracks = [
+            self._make_track("TITLE ONE", "1", "01:01"),
+            self._make_track("TITLE TWO", "2", "02:02"),
+        ]
         release = self._make_release(tracks=tracks)
 
         d = DiscogsPlugin().get_album_info(release)
         t = d.tracks
-        self.assertEqual(d.media, 'FORMAT')
+        self.assertEqual(d.media, "FORMAT")
         self.assertEqual(t[0].media, d.media)
         self.assertEqual(t[1].media, d.media)
 
     def test_parse_medium_numbers_single_medium(self):
-        release = self._make_release_from_positions(['1', '2'])
+        release = self._make_release_from_positions(["1", "2"])
         d = DiscogsPlugin().get_album_info(release)
         t = d.tracks
 
@@ -112,7 +107,7 @@ class DGAlbumInfoTest(_common.TestCase):
         self.assertEqual(t[0].medium_total, 2)
 
     def test_parse_medium_numbers_two_mediums(self):
-        release = self._make_release_from_positions(['1-1', '2-1'])
+        release = self._make_release_from_positions(["1-1", "2-1"])
         d = DiscogsPlugin().get_album_info(release)
         t = d.tracks
 
@@ -123,7 +118,7 @@ class DGAlbumInfoTest(_common.TestCase):
         self.assertEqual(t[1].medium_total, 1)
 
     def test_parse_medium_numbers_two_mediums_two_sided(self):
-        release = self._make_release_from_positions(['A1', 'B1', 'C1'])
+        release = self._make_release_from_positions(["A1", "B1", "C1"])
         d = DiscogsPlugin().get_album_info(release)
         t = d.tracks
 
@@ -139,7 +134,7 @@ class DGAlbumInfoTest(_common.TestCase):
         self.assertEqual(t[2].medium_index, 1)
 
     def test_parse_track_indices(self):
-        release = self._make_release_from_positions(['1', '2'])
+        release = self._make_release_from_positions(["1", "2"])
         d = DiscogsPlugin().get_album_info(release)
         t = d.tracks
 
@@ -151,8 +146,9 @@ class DGAlbumInfoTest(_common.TestCase):
         self.assertEqual(t[1].medium_total, 2)
 
     def test_parse_track_indices_several_media(self):
-        release = self._make_release_from_positions(['1-1', '1-2', '2-1',
-                                                     '3-1'])
+        release = self._make_release_from_positions(
+            ["1-1", "1-2", "2-1", "3-1"]
+        )
         d = DiscogsPlugin().get_album_info(release)
         t = d.tracks
 
@@ -174,17 +170,18 @@ class DGAlbumInfoTest(_common.TestCase):
         """Test the conversion of discogs `position` to medium, medium_index
         and subtrack_index."""
         # List of tuples (discogs_position, (medium, medium_index, subindex)
-        positions = [('1',       (None,   '1',  None)),
-                     ('A12',     ('A',    '12', None)),
-                     ('12-34',   ('12-',  '34', None)),
-                     ('CD1-1',   ('CD1-', '1',  None)),
-                     ('1.12',    (None,   '1',  '12')),
-                     ('12.a',    (None,   '12', 'A')),
-                     ('12.34',   (None,   '12', '34')),
-                     ('1ab',     (None,   '1',  'AB')),
-                     # Non-standard
-                     ('IV',      ('IV',   None, None)),
-                     ]
+        positions = [
+            ("1", (None, "1", None)),
+            ("A12", ("A", "12", None)),
+            ("12-34", ("12-", "34", None)),
+            ("CD1-1", ("CD1-", "1", None)),
+            ("1.12", (None, "1", "12")),
+            ("12.a", (None, "12", "A")),
+            ("12.34", (None, "12", "34")),
+            ("1ab", (None, "1", "AB")),
+            # Non-standard
+            ("IV", ("IV", None, None)),
+        ]
 
         d = DiscogsPlugin()
         for position, expected in positions:
@@ -192,7 +189,7 @@ class DGAlbumInfoTest(_common.TestCase):
 
     def test_parse_tracklist_without_sides(self):
         """Test standard Discogs position 12.2.9#1: "without sides"."""
-        release = self._make_release_from_positions(['1', '2', '3'])
+        release = self._make_release_from_positions(["1", "2", "3"])
         d = DiscogsPlugin().get_album_info(release)
 
         self.assertEqual(d.mediums, 1)
@@ -200,7 +197,7 @@ class DGAlbumInfoTest(_common.TestCase):
 
     def test_parse_tracklist_with_sides(self):
         """Test standard Discogs position 12.2.9#2: "with sides"."""
-        release = self._make_release_from_positions(['A1', 'A2', 'B1', 'B2'])
+        release = self._make_release_from_positions(["A1", "A2", "B1", "B2"])
         d = DiscogsPlugin().get_album_info(release)
 
         self.assertEqual(d.mediums, 1)  # 2 sides = 1 LP
@@ -208,7 +205,7 @@ class DGAlbumInfoTest(_common.TestCase):
 
     def test_parse_tracklist_multiple_lp(self):
         """Test standard Discogs position 12.2.9#3: "multiple LP"."""
-        release = self._make_release_from_positions(['A1', 'A2', 'B1', 'C1'])
+        release = self._make_release_from_positions(["A1", "A2", "B1", "C1"])
         d = DiscogsPlugin().get_album_info(release)
 
         self.assertEqual(d.mediums, 2)  # 3 sides = 1 LP + 1 LP
@@ -216,8 +213,9 @@ class DGAlbumInfoTest(_common.TestCase):
 
     def test_parse_tracklist_multiple_cd(self):
         """Test standard Discogs position 12.2.9#4: "multiple CDs"."""
-        release = self._make_release_from_positions(['1-1', '1-2', '2-1',
-                                                     '3-1'])
+        release = self._make_release_from_positions(
+            ["1-1", "1-2", "2-1", "3-1"]
+        )
         d = DiscogsPlugin().get_album_info(release)
 
         self.assertEqual(d.mediums, 3)
@@ -225,7 +223,7 @@ class DGAlbumInfoTest(_common.TestCase):
 
     def test_parse_tracklist_non_standard(self):
         """Test non standard Discogs position."""
-        release = self._make_release_from_positions(['I', 'II', 'III', 'IV'])
+        release = self._make_release_from_positions(["I", "II", "III", "IV"])
         d = DiscogsPlugin().get_album_info(release)
 
         self.assertEqual(d.mediums, 1)
@@ -233,14 +231,15 @@ class DGAlbumInfoTest(_common.TestCase):
 
     def test_parse_tracklist_subtracks_dot(self):
         """Test standard Discogs position 12.2.9#5: "sub tracks, dots"."""
-        release = self._make_release_from_positions(['1', '2.1', '2.2', '3'])
+        release = self._make_release_from_positions(["1", "2.1", "2.2", "3"])
         d = DiscogsPlugin().get_album_info(release)
 
         self.assertEqual(d.mediums, 1)
         self.assertEqual(len(d.tracks), 3)
 
-        release = self._make_release_from_positions(['A1', 'A2.1', 'A2.2',
-                                                     'A3'])
+        release = self._make_release_from_positions(
+            ["A1", "A2.1", "A2.2", "A3"]
+        )
         d = DiscogsPlugin().get_album_info(release)
 
         self.assertEqual(d.mediums, 1)
@@ -248,14 +247,15 @@ class DGAlbumInfoTest(_common.TestCase):
 
     def test_parse_tracklist_subtracks_letter(self):
         """Test standard Discogs position 12.2.9#5: "sub tracks, letter"."""
-        release = self._make_release_from_positions(['A1', 'A2a', 'A2b', 'A3'])
+        release = self._make_release_from_positions(["A1", "A2a", "A2b", "A3"])
         d = DiscogsPlugin().get_album_info(release)
 
         self.assertEqual(d.mediums, 1)
         self.assertEqual(len(d.tracks), 3)
 
-        release = self._make_release_from_positions(['A1', 'A2.a', 'A2.b',
-                                                     'A3'])
+        release = self._make_release_from_positions(
+            ["A1", "A2.a", "A2.b", "A3"]
+        )
         d = DiscogsPlugin().get_album_info(release)
 
         self.assertEqual(d.mediums, 1)
@@ -263,7 +263,7 @@ class DGAlbumInfoTest(_common.TestCase):
 
     def test_parse_tracklist_subtracks_extra_material(self):
         """Test standard Discogs position 12.2.9#6: "extra material"."""
-        release = self._make_release_from_positions(['1', '2', 'Video 1'])
+        release = self._make_release_from_positions(["1", "2", "Video 1"])
         d = DiscogsPlugin().get_album_info(release)
 
         self.assertEqual(d.mediums, 2)
@@ -271,81 +271,86 @@ class DGAlbumInfoTest(_common.TestCase):
 
     def test_parse_tracklist_subtracks_indices(self):
         """Test parsing of subtracks that include index tracks."""
-        release = self._make_release_from_positions(['', '', '1.1', '1.2'])
+        release = self._make_release_from_positions(["", "", "1.1", "1.2"])
         # Track 1: Index track with medium title
-        release.data['tracklist'][0]['title'] = 'MEDIUM TITLE'
+        release.data["tracklist"][0]["title"] = "MEDIUM TITLE"
         # Track 2: Index track with track group title
-        release.data['tracklist'][1]['title'] = 'TRACK GROUP TITLE'
+        release.data["tracklist"][1]["title"] = "TRACK GROUP TITLE"
 
         d = DiscogsPlugin().get_album_info(release)
         self.assertEqual(d.mediums, 1)
-        self.assertEqual(d.tracks[0].disctitle, 'MEDIUM TITLE')
+        self.assertEqual(d.tracks[0].disctitle, "MEDIUM TITLE")
         self.assertEqual(len(d.tracks), 1)
-        self.assertEqual(d.tracks[0].title, 'TRACK GROUP TITLE')
+        self.assertEqual(d.tracks[0].title, "TRACK GROUP TITLE")
 
     def test_parse_tracklist_subtracks_nested_logical(self):
         """Test parsing of subtracks defined inside a index track that are
         logical subtracks (ie. should be grouped together into a single track).
         """
-        release = self._make_release_from_positions(['1', '', '3'])
+        release = self._make_release_from_positions(["1", "", "3"])
         # Track 2: Index track with track group title, and sub_tracks
-        release.data['tracklist'][1]['title'] = 'TRACK GROUP TITLE'
-        release.data['tracklist'][1]['sub_tracks'] = [
-            self._make_track('TITLE ONE', '2.1', '01:01'),
-            self._make_track('TITLE TWO', '2.2', '02:02')
+        release.data["tracklist"][1]["title"] = "TRACK GROUP TITLE"
+        release.data["tracklist"][1]["sub_tracks"] = [
+            self._make_track("TITLE ONE", "2.1", "01:01"),
+            self._make_track("TITLE TWO", "2.2", "02:02"),
         ]
 
         d = DiscogsPlugin().get_album_info(release)
         self.assertEqual(d.mediums, 1)
         self.assertEqual(len(d.tracks), 3)
-        self.assertEqual(d.tracks[1].title, 'TRACK GROUP TITLE')
+        self.assertEqual(d.tracks[1].title, "TRACK GROUP TITLE")
 
     def test_parse_tracklist_subtracks_nested_physical(self):
         """Test parsing of subtracks defined inside a index track that are
         physical subtracks (ie. should not be grouped together).
         """
-        release = self._make_release_from_positions(['1', '', '4'])
+        release = self._make_release_from_positions(["1", "", "4"])
         # Track 2: Index track with track group title, and sub_tracks
-        release.data['tracklist'][1]['title'] = 'TRACK GROUP TITLE'
-        release.data['tracklist'][1]['sub_tracks'] = [
-            self._make_track('TITLE ONE', '2', '01:01'),
-            self._make_track('TITLE TWO', '3', '02:02')
+        release.data["tracklist"][1]["title"] = "TRACK GROUP TITLE"
+        release.data["tracklist"][1]["sub_tracks"] = [
+            self._make_track("TITLE ONE", "2", "01:01"),
+            self._make_track("TITLE TWO", "3", "02:02"),
         ]
 
         d = DiscogsPlugin().get_album_info(release)
         self.assertEqual(d.mediums, 1)
         self.assertEqual(len(d.tracks), 4)
-        self.assertEqual(d.tracks[1].title, 'TITLE ONE')
-        self.assertEqual(d.tracks[2].title, 'TITLE TWO')
+        self.assertEqual(d.tracks[1].title, "TITLE ONE")
+        self.assertEqual(d.tracks[2].title, "TITLE TWO")
 
     def test_parse_tracklist_disctitles(self):
         """Test parsing of index tracks that act as disc titles."""
-        release = self._make_release_from_positions(['', '1-1', '1-2', '',
-                                                     '2-1'])
+        release = self._make_release_from_positions(
+            ["", "1-1", "1-2", "", "2-1"]
+        )
         # Track 1: Index track with medium title (Cd1)
-        release.data['tracklist'][0]['title'] = 'MEDIUM TITLE CD1'
+        release.data["tracklist"][0]["title"] = "MEDIUM TITLE CD1"
         # Track 4: Index track with medium title (Cd2)
-        release.data['tracklist'][3]['title'] = 'MEDIUM TITLE CD2'
+        release.data["tracklist"][3]["title"] = "MEDIUM TITLE CD2"
 
         d = DiscogsPlugin().get_album_info(release)
         self.assertEqual(d.mediums, 2)
-        self.assertEqual(d.tracks[0].disctitle, 'MEDIUM TITLE CD1')
-        self.assertEqual(d.tracks[1].disctitle, 'MEDIUM TITLE CD1')
-        self.assertEqual(d.tracks[2].disctitle, 'MEDIUM TITLE CD2')
+        self.assertEqual(d.tracks[0].disctitle, "MEDIUM TITLE CD1")
+        self.assertEqual(d.tracks[1].disctitle, "MEDIUM TITLE CD1")
+        self.assertEqual(d.tracks[2].disctitle, "MEDIUM TITLE CD2")
         self.assertEqual(len(d.tracks), 3)
 
     def test_parse_minimal_release(self):
         """Test parsing of a release with the minimal amount of information."""
-        data = {'id': 123,
-                'tracklist': [self._make_track('A', '1', '01:01')],
-                'artists': [{'name': 'ARTIST NAME', 'id': 321, 'join': ''}],
-                'title': 'TITLE'}
-        release = Bag(data=data,
-                      title=data['title'],
-                      artists=[Bag(data=d) for d in data['artists']])
+        data = {
+            "id": 123,
+            "tracklist": [self._make_track("A", "1", "01:01")],
+            "artists": [{"name": "ARTIST NAME", "id": 321, "join": ""}],
+            "title": "TITLE",
+        }
+        release = Bag(
+            data=data,
+            title=data["title"],
+            artists=[Bag(data=d) for d in data["artists"]],
+        )
         d = DiscogsPlugin().get_album_info(release)
-        self.assertEqual(d.artist, 'ARTIST NAME')
-        self.assertEqual(d.album, 'TITLE')
+        self.assertEqual(d.artist, "ARTIST NAME")
+        self.assertEqual(d.album, "TITLE")
         self.assertEqual(len(d.tracks), 1)
 
     def test_parse_release_without_required_fields(self):
@@ -355,11 +360,12 @@ class DGAlbumInfoTest(_common.TestCase):
             d = DiscogsPlugin().get_album_info(release)
 
         self.assertEqual(d, None)
-        self.assertIn('Release does not contain the required fields', logs[0])
+        self.assertIn("Release does not contain the required fields", logs[0])
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_edit.py
+++ b/test/test_edit.py
@@ -74,8 +74,8 @@ class ModifyFileMocker(object):
 class EditMixin(object):
     """Helper containing some common functionality used for the Edit tests."""
 
-    def assertItemFieldsModified(
-        self, library_items, items, fields=[], allowed=["path"]  # noqa
+    def assertItemFieldsModified(  # noqa: N802
+        self, library_items, items, fields=[], allowed=["path"]
     ):
         """Assert that items in the library (`lib_items`) have different values
         on the specified `fields` (and *only* on those fields), compared to
@@ -137,11 +137,11 @@ class EditCommandTest(unittest.TestCase, TestHelper, EditMixin):
         self.teardown_beets()
         self.unload_plugins()
 
-    def assertCounts(
+    def assertCounts(  # noqa: N802
         self,
         mock_write,
         album_count=ALBUM_COUNT,
-        track_count=TRACK_COUNT,  # noqa
+        track_count=TRACK_COUNT,
         write_call_count=TRACK_COUNT,
         title_starts_with="",
     ):

--- a/test/test_edit.py
+++ b/test/test_edit.py
@@ -56,25 +56,27 @@ class ModifyFileMocker(object):
         `self.contents` is empty, the file remains unchanged.
         """
         if self.contents:
-            with codecs.open(filename, 'w', encoding='utf-8') as f:
+            with codecs.open(filename, "w", encoding="utf-8") as f:
                 f.write(self.contents)
 
     def replace_contents(self, filename, log):
         """Modify `filename`, reading its contents and replacing the strings
         specified in `self.replacements`.
         """
-        with codecs.open(filename, 'r', encoding='utf-8') as f:
+        with codecs.open(filename, "r", encoding="utf-8") as f:
             contents = f.read()
         for old, new_ in self.replacements.items():
             contents = contents.replace(old, new_)
-        with codecs.open(filename, 'w', encoding='utf-8') as f:
+        with codecs.open(filename, "w", encoding="utf-8") as f:
             f.write(contents)
 
 
 class EditMixin(object):
     """Helper containing some common functionality used for the Edit tests."""
-    def assertItemFieldsModified(self, library_items, items, fields=[],  # noqa
-                                 allowed=['path']):
+
+    def assertItemFieldsModified(
+        self, library_items, items, fields=[], allowed=["path"]  # noqa
+    ):
         """Assert that items in the library (`lib_items`) have different values
         on the specified `fields` (and *only* on those fields), compared to
         `items`.
@@ -84,111 +86,139 @@ class EditMixin(object):
         (they may or may not have changed; the assertion doesn't care).
         """
         for lib_item, item in zip(library_items, items):
-            diff_fields = [field for field in lib_item._fields
-                           if lib_item[field] != item[field]]
-            self.assertEqual(set(diff_fields).difference(allowed),
-                             set(fields))
+            diff_fields = [
+                field
+                for field in lib_item._fields
+                if lib_item[field] != item[field]
+            ]
+            self.assertEqual(set(diff_fields).difference(allowed), set(fields))
 
     def run_mocked_interpreter(self, modify_file_args={}, stdin=[]):
         """Run the edit command during an import session, with mocked stdin and
         yaml writing.
         """
         m = ModifyFileMocker(**modify_file_args)
-        with patch('beetsplug.edit.edit', side_effect=m.action):
-            with control_stdin('\n'.join(stdin)):
+        with patch("beetsplug.edit.edit", side_effect=m.action):
+            with control_stdin("\n".join(stdin)):
                 self.importer.run()
 
     def run_mocked_command(self, modify_file_args={}, stdin=[], args=[]):
         """Run the edit command, with mocked stdin and yaml writing, and
         passing `args` to `run_command`."""
         m = ModifyFileMocker(**modify_file_args)
-        with patch('beetsplug.edit.edit', side_effect=m.action):
-            with control_stdin('\n'.join(stdin)):
-                self.run_command('edit', *args)
+        with patch("beetsplug.edit.edit", side_effect=m.action):
+            with control_stdin("\n".join(stdin)):
+                self.run_command("edit", *args)
 
 
 @_common.slow_test()
-@patch('beets.library.Item.write')
+@patch("beets.library.Item.write")
 class EditCommandTest(unittest.TestCase, TestHelper, EditMixin):
     """Black box tests for `beetsplug.edit`. Command line interaction is
     simulated using `test.helper.control_stdin()`, and yaml editing via an
     external editor is simulated using `ModifyFileMocker`.
     """
+
     ALBUM_COUNT = 1
     TRACK_COUNT = 10
 
     def setUp(self):
         self.setup_beets()
-        self.load_plugins('edit')
+        self.load_plugins("edit")
         # Add an album, storing the original fields for comparison.
         self.album = self.add_album_fixture(track_count=self.TRACK_COUNT)
         self.album_orig = {f: self.album[f] for f in self.album._fields}
-        self.items_orig = [{f: item[f] for f in item._fields} for
-                           item in self.album.items()]
+        self.items_orig = [
+            {f: item[f] for f in item._fields} for item in self.album.items()
+        ]
 
     def tearDown(self):
         EditPlugin.listeners = None
         self.teardown_beets()
         self.unload_plugins()
 
-    def assertCounts(self, mock_write, album_count=ALBUM_COUNT, track_count=TRACK_COUNT,  # noqa
-                     write_call_count=TRACK_COUNT, title_starts_with=''):
+    def assertCounts(
+        self,
+        mock_write,
+        album_count=ALBUM_COUNT,
+        track_count=TRACK_COUNT,  # noqa
+        write_call_count=TRACK_COUNT,
+        title_starts_with="",
+    ):
         """Several common assertions on Album, Track and call counts."""
         self.assertEqual(len(self.lib.albums()), album_count)
         self.assertEqual(len(self.lib.items()), track_count)
         self.assertEqual(mock_write.call_count, write_call_count)
-        self.assertTrue(all(i.title.startswith(title_starts_with)
-                            for i in self.lib.items()))
+        self.assertTrue(
+            all(
+                i.title.startswith(title_starts_with) for i in self.lib.items()
+            )
+        )
 
     def test_title_edit_discard(self, mock_write):
         """Edit title for all items in the library, then discard changes."""
         # Edit track titles.
-        self.run_mocked_command({'replacements': {u't\u00eftle':
-                                                  u'modified t\u00eftle'}},
-                                # Cancel.
-                                ['c'])
+        self.run_mocked_command(
+            {"replacements": {u"t\u00eftle": u"modified t\u00eftle"}},
+            # Cancel.
+            ["c"],
+        )
 
-        self.assertCounts(mock_write, write_call_count=0,
-                          title_starts_with=u't\u00eftle')
+        self.assertCounts(
+            mock_write, write_call_count=0, title_starts_with=u"t\u00eftle"
+        )
         self.assertItemFieldsModified(self.album.items(), self.items_orig, [])
 
     def test_title_edit_apply(self, mock_write):
         """Edit title for all items in the library, then apply changes."""
         # Edit track titles.
-        self.run_mocked_command({'replacements': {u't\u00eftle':
-                                                  u'modified t\u00eftle'}},
-                                # Apply changes.
-                                ['a'])
+        self.run_mocked_command(
+            {"replacements": {u"t\u00eftle": u"modified t\u00eftle"}},
+            # Apply changes.
+            ["a"],
+        )
 
-        self.assertCounts(mock_write, write_call_count=self.TRACK_COUNT,
-                          title_starts_with=u'modified t\u00eftle')
-        self.assertItemFieldsModified(self.album.items(), self.items_orig,
-                                      ['title', 'mtime'])
+        self.assertCounts(
+            mock_write,
+            write_call_count=self.TRACK_COUNT,
+            title_starts_with=u"modified t\u00eftle",
+        )
+        self.assertItemFieldsModified(
+            self.album.items(), self.items_orig, ["title", "mtime"]
+        )
 
     def test_single_title_edit_apply(self, mock_write):
         """Edit title for one item in the library, then apply changes."""
         # Edit one track title.
-        self.run_mocked_command({'replacements': {u't\u00eftle 9':
-                                                  u'modified t\u00eftle 9'}},
-                                # Apply changes.
-                                ['a'])
+        self.run_mocked_command(
+            {"replacements": {u"t\u00eftle 9": u"modified t\u00eftle 9"}},
+            # Apply changes.
+            ["a"],
+        )
 
-        self.assertCounts(mock_write, write_call_count=1,)
+        self.assertCounts(
+            mock_write, write_call_count=1,
+        )
         # No changes except on last item.
-        self.assertItemFieldsModified(list(self.album.items())[:-1],
-                                      self.items_orig[:-1], [])
-        self.assertEqual(list(self.album.items())[-1].title,
-                         u'modified t\u00eftle 9')
+        self.assertItemFieldsModified(
+            list(self.album.items())[:-1], self.items_orig[:-1], []
+        )
+        self.assertEqual(
+            list(self.album.items())[-1].title, u"modified t\u00eftle 9"
+        )
 
     def test_noedit(self, mock_write):
         """Do not edit anything."""
         # Do not edit anything.
-        self.run_mocked_command({'contents': None},
-                                # No stdin.
-                                [])
+        self.run_mocked_command(
+            {"contents": None},
+            # No stdin.
+            [],
+        )
 
-        self.assertCounts(mock_write, write_call_count=0,
-                          title_starts_with=u't\u00eftle')
+        self.assertCounts(
+            mock_write, write_call_count=0, title_starts_with=u"t\u00eftle"
+        )
         self.assertItemFieldsModified(self.album.items(), self.items_orig, [])
 
     def test_album_edit_apply(self, mock_write):
@@ -196,102 +226,122 @@ class EditCommandTest(unittest.TestCase, TestHelper, EditMixin):
         By design, the album should not be updated.""
         """
         # Edit album.
-        self.run_mocked_command({'replacements': {u'\u00e4lbum':
-                                                  u'modified \u00e4lbum'}},
-                                # Apply changes.
-                                ['a'])
+        self.run_mocked_command(
+            {"replacements": {u"\u00e4lbum": u"modified \u00e4lbum"}},
+            # Apply changes.
+            ["a"],
+        )
 
         self.assertCounts(mock_write, write_call_count=self.TRACK_COUNT)
-        self.assertItemFieldsModified(self.album.items(), self.items_orig,
-                                      ['album', 'mtime'])
+        self.assertItemFieldsModified(
+            self.album.items(), self.items_orig, ["album", "mtime"]
+        )
         # Ensure album is *not* modified.
         self.album.load()
-        self.assertEqual(self.album.album, u'\u00e4lbum')
+        self.assertEqual(self.album.album, u"\u00e4lbum")
 
     def test_single_edit_add_field(self, mock_write):
         """Edit the yaml file appending an extra field to the first item, then
         apply changes."""
         # Append "foo: bar" to item with id == 2. ("id: 1" would match both
         # "id: 1" and "id: 10")
-        self.run_mocked_command({'replacements': {u"id: 2":
-                                                  u"id: 2\nfoo: bar"}},
-                                # Apply changes.
-                                ['a'])
+        self.run_mocked_command(
+            {"replacements": {u"id: 2": u"id: 2\nfoo: bar"}},
+            # Apply changes.
+            ["a"],
+        )
 
-        self.assertEqual(self.lib.items(u'id:2')[0].foo, 'bar')
+        self.assertEqual(self.lib.items(u"id:2")[0].foo, "bar")
         # Even though a flexible attribute was written (which is not directly
         # written to the tags), write should still be called since templates
         # might use it.
-        self.assertCounts(mock_write, write_call_count=1,
-                          title_starts_with=u't\u00eftle')
+        self.assertCounts(
+            mock_write, write_call_count=1, title_starts_with=u"t\u00eftle"
+        )
 
     def test_a_album_edit_apply(self, mock_write):
         """Album query (-a), edit album field, apply changes."""
-        self.run_mocked_command({'replacements': {u'\u00e4lbum':
-                                                  u'modified \u00e4lbum'}},
-                                # Apply changes.
-                                ['a'],
-                                args=['-a'])
+        self.run_mocked_command(
+            {"replacements": {u"\u00e4lbum": u"modified \u00e4lbum"}},
+            # Apply changes.
+            ["a"],
+            args=["-a"],
+        )
 
         self.album.load()
         self.assertCounts(mock_write, write_call_count=self.TRACK_COUNT)
-        self.assertEqual(self.album.album, u'modified \u00e4lbum')
-        self.assertItemFieldsModified(self.album.items(), self.items_orig,
-                                      ['album', 'mtime'])
+        self.assertEqual(self.album.album, u"modified \u00e4lbum")
+        self.assertItemFieldsModified(
+            self.album.items(), self.items_orig, ["album", "mtime"]
+        )
 
     def test_a_albumartist_edit_apply(self, mock_write):
         """Album query (-a), edit albumartist field, apply changes."""
-        self.run_mocked_command({'replacements': {u'album artist':
-                                                  u'modified album artist'}},
-                                # Apply changes.
-                                ['a'],
-                                args=['-a'])
+        self.run_mocked_command(
+            {"replacements": {u"album artist": u"modified album artist"}},
+            # Apply changes.
+            ["a"],
+            args=["-a"],
+        )
 
         self.album.load()
         self.assertCounts(mock_write, write_call_count=self.TRACK_COUNT)
-        self.assertEqual(self.album.albumartist, u'the modified album artist')
-        self.assertItemFieldsModified(self.album.items(), self.items_orig,
-                                      ['albumartist', 'mtime'])
+        self.assertEqual(self.album.albumartist, u"the modified album artist")
+        self.assertItemFieldsModified(
+            self.album.items(), self.items_orig, ["albumartist", "mtime"]
+        )
 
     def test_malformed_yaml(self, mock_write):
         """Edit the yaml file incorrectly (resulting in a malformed yaml
         document)."""
         # Edit the yaml file to an invalid file.
-        self.run_mocked_command({'contents': '!MALFORMED'},
-                                # Edit again to fix? No.
-                                ['n'])
+        self.run_mocked_command(
+            {"contents": "!MALFORMED"},
+            # Edit again to fix? No.
+            ["n"],
+        )
 
-        self.assertCounts(mock_write, write_call_count=0,
-                          title_starts_with=u't\u00eftle')
+        self.assertCounts(
+            mock_write, write_call_count=0, title_starts_with=u"t\u00eftle"
+        )
 
     def test_invalid_yaml(self, mock_write):
         """Edit the yaml file incorrectly (resulting in a well-formed but
         invalid yaml document)."""
         # Edit the yaml file to an invalid but parseable file.
-        self.run_mocked_command({'contents': u'wellformed: yes, but invalid'},
-                                # No stdin.
-                                [])
+        self.run_mocked_command(
+            {"contents": u"wellformed: yes, but invalid"},
+            # No stdin.
+            [],
+        )
 
-        self.assertCounts(mock_write, write_call_count=0,
-                          title_starts_with=u't\u00eftle')
+        self.assertCounts(
+            mock_write, write_call_count=0, title_starts_with=u"t\u00eftle"
+        )
 
 
 @_common.slow_test()
-class EditDuringImporterTest(TerminalImportSessionSetup, unittest.TestCase,
-                             ImportHelper, TestHelper, EditMixin):
+class EditDuringImporterTest(
+    TerminalImportSessionSetup,
+    unittest.TestCase,
+    ImportHelper,
+    TestHelper,
+    EditMixin,
+):
     """TODO
     """
-    IGNORED = ['added', 'album_id', 'id', 'mtime', 'path']
+
+    IGNORED = ["added", "album_id", "id", "mtime", "path"]
 
     def setUp(self):
         self.setup_beets()
-        self.load_plugins('edit')
+        self.load_plugins("edit")
         # Create some mediafiles, and store them for comparison.
         self._create_import_dir(3)
         self.items_orig = [Item.from_path(f.path) for f in self.media_files]
         self.matcher = AutotagStub().install()
         self.matcher.matching = AutotagStub.GOOD
-        self.config['import']['timid'] = True
+        self.config["import"]["timid"] = True
 
     def tearDown(self):
         EditPlugin.listeners = None
@@ -305,21 +355,25 @@ class EditDuringImporterTest(TerminalImportSessionSetup, unittest.TestCase,
         """
         self._setup_import_session()
         # Edit track titles.
-        self.run_mocked_interpreter({'replacements': {u'Tag Title':
-                                                      u'Edited Title'}},
-                                    # eDit, Apply changes.
-                                    ['d', 'a'])
+        self.run_mocked_interpreter(
+            {"replacements": {u"Tag Title": u"Edited Title"}},
+            # eDit, Apply changes.
+            ["d", "a"],
+        )
 
         # Check that only the 'title' field is modified.
-        self.assertItemFieldsModified(self.lib.items(), self.items_orig,
-                                      ['title'],
-                                      self.IGNORED + ['albumartist',
-                                                      'mb_albumartistid'])
-        self.assertTrue(all('Edited Title' in i.title
-                            for i in self.lib.items()))
+        self.assertItemFieldsModified(
+            self.lib.items(),
+            self.items_orig,
+            ["title"],
+            self.IGNORED + ["albumartist", "mb_albumartistid"],
+        )
+        self.assertTrue(
+            all("Edited Title" in i.title for i in self.lib.items())
+        )
 
         # Ensure album is *not* fetched from a candidate.
-        self.assertEqual(self.lib.albums()[0].mb_albumid, u'')
+        self.assertEqual(self.lib.albums()[0].mb_albumid, u"")
 
     def test_edit_discard_asis(self):
         """Edit the album field for all items in the library, discard changes,
@@ -327,21 +381,23 @@ class EditDuringImporterTest(TerminalImportSessionSetup, unittest.TestCase,
         """
         self._setup_import_session()
         # Edit track titles.
-        self.run_mocked_interpreter({'replacements': {u'Tag Title':
-                                                      u'Edited Title'}},
-                                    # eDit, Cancel, Use as-is.
-                                    ['d', 'c', 'u'])
+        self.run_mocked_interpreter(
+            {"replacements": {u"Tag Title": u"Edited Title"}},
+            # eDit, Cancel, Use as-is.
+            ["d", "c", "u"],
+        )
 
         # Check that nothing is modified, the album is imported ASIS.
-        self.assertItemFieldsModified(self.lib.items(), self.items_orig,
-                                      [],
-                                      self.IGNORED + ['albumartist',
-                                                      'mb_albumartistid'])
-        self.assertTrue(all('Tag Title' in i.title
-                            for i in self.lib.items()))
+        self.assertItemFieldsModified(
+            self.lib.items(),
+            self.items_orig,
+            [],
+            self.IGNORED + ["albumartist", "mb_albumartistid"],
+        )
+        self.assertTrue(all("Tag Title" in i.title for i in self.lib.items()))
 
         # Ensure album is *not* fetched from a candidate.
-        self.assertEqual(self.lib.albums()[0].mb_albumid, u'')
+        self.assertEqual(self.lib.albums()[0].mb_albumid, u"")
 
     def test_edit_apply_candidate(self):
         """Edit the album field for all items in the library, apply changes,
@@ -349,48 +405,56 @@ class EditDuringImporterTest(TerminalImportSessionSetup, unittest.TestCase,
         """
         self._setup_import_session()
         # Edit track titles.
-        self.run_mocked_interpreter({'replacements': {u'Applied Title':
-                                                      u'Edited Title'}},
-                                    # edit Candidates, 1, Apply changes.
-                                    ['c', '1', 'a'])
+        self.run_mocked_interpreter(
+            {"replacements": {u"Applied Title": u"Edited Title"}},
+            # edit Candidates, 1, Apply changes.
+            ["c", "1", "a"],
+        )
 
         # Check that 'title' field is modified, and other fields come from
         # the candidate.
-        self.assertTrue(all('Edited Title ' in i.title
-                            for i in self.lib.items()))
-        self.assertTrue(all('match ' in i.mb_trackid
-                            for i in self.lib.items()))
+        self.assertTrue(
+            all("Edited Title " in i.title for i in self.lib.items())
+        )
+        self.assertTrue(
+            all("match " in i.mb_trackid for i in self.lib.items())
+        )
 
         # Ensure album is fetched from a candidate.
-        self.assertIn('albumid', self.lib.albums()[0].mb_albumid)
+        self.assertIn("albumid", self.lib.albums()[0].mb_albumid)
 
     def test_edit_retag_apply(self):
         """Import the album using a candidate, then retag and edit and apply
         changes.
         """
         self._setup_import_session()
-        self.run_mocked_interpreter({},
-                                    # 1, Apply changes.
-                                    ['1', 'a'])
+        self.run_mocked_interpreter(
+            {},
+            # 1, Apply changes.
+            ["1", "a"],
+        )
 
         # Retag and edit track titles.  On retag, the importer will reset items
         # ids but not the db connections.
         self.importer.paths = []
         self.importer.query = TrueQuery()
-        self.run_mocked_interpreter({'replacements': {u'Applied Title':
-                                                      u'Edited Title'}},
-                                    # eDit, Apply changes.
-                                    ['d', 'a'])
+        self.run_mocked_interpreter(
+            {"replacements": {u"Applied Title": u"Edited Title"}},
+            # eDit, Apply changes.
+            ["d", "a"],
+        )
 
         # Check that 'title' field is modified, and other fields come from
         # the candidate.
-        self.assertTrue(all('Edited Title ' in i.title
-                            for i in self.lib.items()))
-        self.assertTrue(all('match ' in i.mb_trackid
-                            for i in self.lib.items()))
+        self.assertTrue(
+            all("Edited Title " in i.title for i in self.lib.items())
+        )
+        self.assertTrue(
+            all("match " in i.mb_trackid for i in self.lib.items())
+        )
 
         # Ensure album is fetched from a candidate.
-        self.assertIn('albumid', self.lib.albums()[0].mb_albumid)
+        self.assertIn("albumid", self.lib.albums()[0].mb_albumid)
 
     def test_edit_discard_candidate(self):
         """Edit the album field for all items in the library, discard changes,
@@ -398,20 +462,23 @@ class EditDuringImporterTest(TerminalImportSessionSetup, unittest.TestCase,
         """
         self._setup_import_session()
         # Edit track titles.
-        self.run_mocked_interpreter({'replacements': {u'Applied Title':
-                                                      u'Edited Title'}},
-                                    # edit Candidates, 1, Apply changes.
-                                    ['c', '1', 'a'])
+        self.run_mocked_interpreter(
+            {"replacements": {u"Applied Title": u"Edited Title"}},
+            # edit Candidates, 1, Apply changes.
+            ["c", "1", "a"],
+        )
 
         # Check that 'title' field is modified, and other fields come from
         # the candidate.
-        self.assertTrue(all('Edited Title ' in i.title
-                            for i in self.lib.items()))
-        self.assertTrue(all('match ' in i.mb_trackid
-                            for i in self.lib.items()))
+        self.assertTrue(
+            all("Edited Title " in i.title for i in self.lib.items())
+        )
+        self.assertTrue(
+            all("match " in i.mb_trackid for i in self.lib.items())
+        )
 
         # Ensure album is fetched from a candidate.
-        self.assertIn('albumid', self.lib.albums()[0].mb_albumid)
+        self.assertIn("albumid", self.lib.albums()[0].mb_albumid)
 
     def test_edit_apply_asis_singleton(self):
         """Edit the album field for all items in the library, apply changes,
@@ -419,18 +486,22 @@ class EditDuringImporterTest(TerminalImportSessionSetup, unittest.TestCase,
         """
         self._setup_import_session(singletons=True)
         # Edit track titles.
-        self.run_mocked_interpreter({'replacements': {u'Tag Title':
-                                                      u'Edited Title'}},
-                                    # eDit, Apply changes, aBort.
-                                    ['d', 'a', 'b'])
+        self.run_mocked_interpreter(
+            {"replacements": {u"Tag Title": u"Edited Title"}},
+            # eDit, Apply changes, aBort.
+            ["d", "a", "b"],
+        )
 
         # Check that only the 'title' field is modified.
-        self.assertItemFieldsModified(self.lib.items(), self.items_orig,
-                                      ['title'],
-                                      self.IGNORED + ['albumartist',
-                                                      'mb_albumartistid'])
-        self.assertTrue(all('Edited Title' in i.title
-                            for i in self.lib.items()))
+        self.assertItemFieldsModified(
+            self.lib.items(),
+            self.items_orig,
+            ["title"],
+            self.IGNORED + ["albumartist", "mb_albumartistid"],
+        )
+        self.assertTrue(
+            all("Edited Title" in i.title for i in self.lib.items())
+        )
 
     def test_edit_apply_candidate_singleton(self):
         """Edit the album field for all items in the library, apply changes,
@@ -438,21 +509,25 @@ class EditDuringImporterTest(TerminalImportSessionSetup, unittest.TestCase,
         """
         self._setup_import_session()
         # Edit track titles.
-        self.run_mocked_interpreter({'replacements': {u'Applied Title':
-                                                      u'Edited Title'}},
-                                    # edit Candidates, 1, Apply changes, aBort.
-                                    ['c', '1', 'a', 'b'])
+        self.run_mocked_interpreter(
+            {"replacements": {u"Applied Title": u"Edited Title"}},
+            # edit Candidates, 1, Apply changes, aBort.
+            ["c", "1", "a", "b"],
+        )
 
         # Check that 'title' field is modified, and other fields come from
         # the candidate.
-        self.assertTrue(all('Edited Title ' in i.title
-                            for i in self.lib.items()))
-        self.assertTrue(all('match ' in i.mb_trackid
-                            for i in self.lib.items()))
+        self.assertTrue(
+            all("Edited Title " in i.title for i in self.lib.items())
+        )
+        self.assertTrue(
+            all("match " in i.mb_trackid for i in self.lib.items())
+        )
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_embedart.py
+++ b/test/test_embedart.py
@@ -32,7 +32,6 @@ from beets import art
 
 
 def require_artresizer_compare(test):
-
     def wrapper(*args, **kwargs):
         if not ArtResizer.shared.can_compare:
             raise unittest.SkipTest("compare not available")
@@ -45,21 +44,21 @@ def require_artresizer_compare(test):
 
 class EmbedartCliTest(_common.TestCase, TestHelper):
 
-    small_artpath = os.path.join(_common.RSRC, b'image-2x3.jpg')
-    abbey_artpath = os.path.join(_common.RSRC, b'abbey.jpg')
-    abbey_similarpath = os.path.join(_common.RSRC, b'abbey-similar.jpg')
-    abbey_differentpath = os.path.join(_common.RSRC, b'abbey-different.jpg')
+    small_artpath = os.path.join(_common.RSRC, b"image-2x3.jpg")
+    abbey_artpath = os.path.join(_common.RSRC, b"abbey.jpg")
+    abbey_similarpath = os.path.join(_common.RSRC, b"abbey-similar.jpg")
+    abbey_differentpath = os.path.join(_common.RSRC, b"abbey-different.jpg")
 
     def setUp(self):
         super(EmbedartCliTest, self).setUp()
         self.io.install()
         self.setup_beets()  # Converter is threaded
-        self.load_plugins('embedart')
+        self.load_plugins("embedart")
 
     def _setup_data(self, artpath=None):
         if not artpath:
             artpath = self.small_artpath
-        with open(syspath(artpath), 'rb') as f:
+        with open(syspath(artpath), "rb") as f:
             self.image_data = f.read()
 
     def tearDown(self):
@@ -70,8 +69,8 @@ class EmbedartCliTest(_common.TestCase, TestHelper):
         self._setup_data()
         album = self.add_album_fixture()
         item = album.items()[0]
-        self.io.addinput('y')
-        self.run_command('embedart', '-f', self.small_artpath)
+        self.io.addinput("y")
+        self.run_command("embedart", "-f", self.small_artpath)
         mediafile = MediaFile(syspath(item.path))
         self.assertEqual(mediafile.images[0].data, self.image_data)
 
@@ -79,8 +78,8 @@ class EmbedartCliTest(_common.TestCase, TestHelper):
         self._setup_data()
         album = self.add_album_fixture()
         item = album.items()[0]
-        self.io.addinput('n')
-        self.run_command('embedart', '-f', self.small_artpath)
+        self.io.addinput("n")
+        self.run_command("embedart", "-f", self.small_artpath)
         mediafile = MediaFile(syspath(item.path))
         # make sure that images array is empty (nothing embedded)
         self.assertEqual(len(mediafile.images), 0)
@@ -89,7 +88,7 @@ class EmbedartCliTest(_common.TestCase, TestHelper):
         self._setup_data()
         album = self.add_album_fixture()
         item = album.items()[0]
-        self.run_command('embedart', '-y', '-f', self.small_artpath)
+        self.run_command("embedart", "-y", "-f", self.small_artpath)
         mediafile = MediaFile(syspath(item.path))
         self.assertEqual(mediafile.images[0].data, self.image_data)
 
@@ -99,7 +98,7 @@ class EmbedartCliTest(_common.TestCase, TestHelper):
         item = album.items()[0]
         album.artpath = self.small_artpath
         album.store()
-        self.run_command('embedart', '-y')
+        self.run_command("embedart", "-y")
         mediafile = MediaFile(syspath(item.path))
         self.assertEqual(mediafile.images[0].data, self.image_data)
 
@@ -107,7 +106,7 @@ class EmbedartCliTest(_common.TestCase, TestHelper):
         self._setup_data()
         album = self.add_album_fixture()
 
-        logging.getLogger('beets.embedart').setLevel(logging.DEBUG)
+        logging.getLogger("beets.embedart").setLevel(logging.DEBUG)
 
         handle, tmp_path = tempfile.mkstemp()
         os.write(handle, self.image_data)
@@ -116,29 +115,29 @@ class EmbedartCliTest(_common.TestCase, TestHelper):
         album.artpath = tmp_path
         album.store()
 
-        config['embedart']['remove_art_file'] = True
-        self.run_command('embedart', '-y')
+        config["embedart"]["remove_art_file"] = True
+        self.run_command("embedart", "-y")
 
         if os.path.isfile(tmp_path):
             os.remove(tmp_path)
-            self.fail(u'Artwork file {0} was not deleted'.format(tmp_path))
+            self.fail(u"Artwork file {0} was not deleted".format(tmp_path))
 
     def test_art_file_missing(self):
         self.add_album_fixture()
-        logging.getLogger('beets.embedart').setLevel(logging.DEBUG)
+        logging.getLogger("beets.embedart").setLevel(logging.DEBUG)
         with self.assertRaises(ui.UserError):
-            self.run_command('embedart', '-y', '-f', '/doesnotexist')
+            self.run_command("embedart", "-y", "-f", "/doesnotexist")
 
     def test_embed_non_image_file(self):
         album = self.add_album_fixture()
-        logging.getLogger('beets.embedart').setLevel(logging.DEBUG)
+        logging.getLogger("beets.embedart").setLevel(logging.DEBUG)
 
         handle, tmp_path = tempfile.mkstemp()
-        os.write(handle, b'I am not an image.')
+        os.write(handle, b"I am not an image.")
         os.close(handle)
 
         try:
-            self.run_command('embedart', '-y', '-f', tmp_path)
+            self.run_command("embedart", "-y", "-f", tmp_path)
         finally:
             os.remove(tmp_path)
 
@@ -150,59 +149,67 @@ class EmbedartCliTest(_common.TestCase, TestHelper):
         self._setup_data(self.abbey_artpath)
         album = self.add_album_fixture()
         item = album.items()[0]
-        self.run_command('embedart', '-y', '-f', self.abbey_artpath)
-        config['embedart']['compare_threshold'] = 20
-        self.run_command('embedart', '-y', '-f', self.abbey_differentpath)
+        self.run_command("embedart", "-y", "-f", self.abbey_artpath)
+        config["embedart"]["compare_threshold"] = 20
+        self.run_command("embedart", "-y", "-f", self.abbey_differentpath)
         mediafile = MediaFile(syspath(item.path))
 
-        self.assertEqual(mediafile.images[0].data, self.image_data,
-                         u'Image written is not {0}'.format(
-                         displayable_path(self.abbey_artpath)))
+        self.assertEqual(
+            mediafile.images[0].data,
+            self.image_data,
+            u"Image written is not {0}".format(
+                displayable_path(self.abbey_artpath)
+            ),
+        )
 
     @require_artresizer_compare
     def test_accept_similar_art(self):
         self._setup_data(self.abbey_similarpath)
         album = self.add_album_fixture()
         item = album.items()[0]
-        self.run_command('embedart', '-y', '-f', self.abbey_artpath)
-        config['embedart']['compare_threshold'] = 20
-        self.run_command('embedart', '-y', '-f', self.abbey_similarpath)
+        self.run_command("embedart", "-y", "-f", self.abbey_artpath)
+        config["embedart"]["compare_threshold"] = 20
+        self.run_command("embedart", "-y", "-f", self.abbey_similarpath)
         mediafile = MediaFile(syspath(item.path))
 
-        self.assertEqual(mediafile.images[0].data, self.image_data,
-                         u'Image written is not {0}'.format(
-                         displayable_path(self.abbey_similarpath)))
+        self.assertEqual(
+            mediafile.images[0].data,
+            self.image_data,
+            u"Image written is not {0}".format(
+                displayable_path(self.abbey_similarpath)
+            ),
+        )
 
     def test_non_ascii_album_path(self):
-        resource_path = os.path.join(_common.RSRC, b'image.mp3')
+        resource_path = os.path.join(_common.RSRC, b"image.mp3")
         album = self.add_album_fixture()
         trackpath = album.items()[0].path
         albumpath = album.path
         shutil.copy(syspath(resource_path), syspath(trackpath))
 
-        self.run_command('extractart', '-n', 'extracted')
+        self.run_command("extractart", "-n", "extracted")
 
-        self.assertExists(os.path.join(albumpath, b'extracted.png'))
+        self.assertExists(os.path.join(albumpath, b"extracted.png"))
 
     def test_extracted_extension(self):
-        resource_path = os.path.join(_common.RSRC, b'image-jpeg.mp3')
+        resource_path = os.path.join(_common.RSRC, b"image-jpeg.mp3")
         album = self.add_album_fixture()
         trackpath = album.items()[0].path
         albumpath = album.path
         shutil.copy(syspath(resource_path), syspath(trackpath))
 
-        self.run_command('extractart', '-n', 'extracted')
+        self.run_command("extractart", "-n", "extracted")
 
-        self.assertExists(os.path.join(albumpath, b'extracted.jpg'))
+        self.assertExists(os.path.join(albumpath, b"extracted.jpg"))
 
     def test_clear_art_with_yes_input(self):
         self._setup_data()
         album = self.add_album_fixture()
         item = album.items()[0]
-        self.io.addinput('y')
-        self.run_command('embedart', '-f', self.small_artpath)
-        self.io.addinput('y')
-        self.run_command('clearart')
+        self.io.addinput("y")
+        self.run_command("embedart", "-f", self.small_artpath)
+        self.io.addinput("y")
+        self.run_command("clearart")
         mediafile = MediaFile(syspath(item.path))
         self.assertEqual(len(mediafile.images), 0)
 
@@ -210,24 +217,25 @@ class EmbedartCliTest(_common.TestCase, TestHelper):
         self._setup_data()
         album = self.add_album_fixture()
         item = album.items()[0]
-        self.io.addinput('y')
-        self.run_command('embedart', '-f', self.small_artpath)
-        self.io.addinput('n')
-        self.run_command('clearart')
+        self.io.addinput("y")
+        self.run_command("embedart", "-f", self.small_artpath)
+        self.io.addinput("n")
+        self.run_command("clearart")
         mediafile = MediaFile(syspath(item.path))
         self.assertEqual(mediafile.images[0].data, self.image_data)
 
 
-@patch('beets.art.subprocess')
-@patch('beets.art.extract')
+@patch("beets.art.subprocess")
+@patch("beets.art.extract")
 class ArtSimilarityTest(unittest.TestCase):
     def setUp(self):
         self.item = _common.item()
-        self.log = logging.getLogger('beets.embedart')
+        self.log = logging.getLogger("beets.embedart")
 
     def _similarity(self, threshold):
-        return art.check_art_similarity(self.log, self.item, b'path',
-                                        threshold)
+        return art.check_art_similarity(
+            self.log, self.item, b"path", threshold
+        )
 
     def _popen(self, status=0, stdout="", stderr=""):
         """Create a mock `Popen` object."""
@@ -235,9 +243,16 @@ class ArtSimilarityTest(unittest.TestCase):
         popen.communicate.return_value = stdout, stderr
         return popen
 
-    def _mock_popens(self, mock_extract, mock_subprocess, compare_status=0,
-                     compare_stdout="", compare_stderr="", convert_status=0):
-        mock_extract.return_value = b'extracted_path'
+    def _mock_popens(
+        self,
+        mock_extract,
+        mock_subprocess,
+        compare_status=0,
+        compare_stdout="",
+        compare_stderr="",
+        convert_status=0,
+    ):
+        mock_extract.return_value = b"extracted_path"
         mock_subprocess.Popen.side_effect = [
             # The `convert` call.
             self._popen(convert_status),
@@ -269,8 +284,9 @@ class ArtSimilarityTest(unittest.TestCase):
         self._mock_popens(mock_extract, mock_subprocess, 0, "foo", "bar")
         self.assertIsNone(self._similarity(20))
 
-    def test_compare_parsing_error_and_failure(self, mock_extract,
-                                               mock_subprocess):
+    def test_compare_parsing_error_and_failure(
+        self, mock_extract, mock_subprocess
+    ):
         self._mock_popens(mock_extract, mock_subprocess, 1, "foo", "bar")
         self.assertIsNone(self._similarity(20))
 
@@ -282,5 +298,6 @@ class ArtSimilarityTest(unittest.TestCase):
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_embyupdate.py
+++ b/test/test_embyupdate.py
@@ -11,13 +11,13 @@ import responses
 class EmbyUpdateTest(unittest.TestCase, TestHelper):
     def setUp(self):
         self.setup_beets()
-        self.load_plugins('embyupdate')
+        self.load_plugins("embyupdate")
 
-        self.config['emby'] = {
-            u'host': u'localhost',
-            u'port': 8096,
-            u'username': u'username',
-            u'password': u'password'
+        self.config["emby"] = {
+            u"host": u"localhost",
+            u"port": 8096,
+            u"username": u"username",
+            u"password": u"password",
         }
 
     def tearDown(self):
@@ -26,134 +26,146 @@ class EmbyUpdateTest(unittest.TestCase, TestHelper):
 
     def test_api_url_only_name(self):
         self.assertEqual(
-            embyupdate.api_url(self.config['emby']['host'].get(),
-                               self.config['emby']['port'].get(),
-                               '/Library/Refresh'),
-            'http://localhost:8096/Library/Refresh?format=json'
+            embyupdate.api_url(
+                self.config["emby"]["host"].get(),
+                self.config["emby"]["port"].get(),
+                "/Library/Refresh",
+            ),
+            "http://localhost:8096/Library/Refresh?format=json",
         )
 
     def test_api_url_http(self):
         self.assertEqual(
-            embyupdate.api_url(u'http://localhost',
-                               self.config['emby']['port'].get(),
-                               '/Library/Refresh'),
-            'http://localhost:8096/Library/Refresh?format=json'
+            embyupdate.api_url(
+                u"http://localhost",
+                self.config["emby"]["port"].get(),
+                "/Library/Refresh",
+            ),
+            "http://localhost:8096/Library/Refresh?format=json",
         )
 
     def test_api_url_https(self):
         self.assertEqual(
-            embyupdate.api_url(u'https://localhost',
-                               self.config['emby']['port'].get(),
-                               '/Library/Refresh'),
-            'https://localhost:8096/Library/Refresh?format=json'
+            embyupdate.api_url(
+                u"https://localhost",
+                self.config["emby"]["port"].get(),
+                "/Library/Refresh",
+            ),
+            "https://localhost:8096/Library/Refresh?format=json",
         )
 
     def test_password_data(self):
         self.assertEqual(
-            embyupdate.password_data(self.config['emby']['username'].get(),
-                                     self.config['emby']['password'].get()),
+            embyupdate.password_data(
+                self.config["emby"]["username"].get(),
+                self.config["emby"]["password"].get(),
+            ),
             {
-                'username': 'username',
-                'password': '5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8',
-                'passwordMd5': '5f4dcc3b5aa765d61d8327deb882cf99'
-            }
+                "username": "username",
+                "password": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+                "passwordMd5": "5f4dcc3b5aa765d61d8327deb882cf99",
+            },
         )
 
     def test_create_header_no_token(self):
         self.assertEqual(
-            embyupdate.create_headers('e8837bc1-ad67-520e-8cd2-f629e3155721'),
+            embyupdate.create_headers("e8837bc1-ad67-520e-8cd2-f629e3155721"),
             {
-                'x-emby-authorization': (
-                    'MediaBrowser '
+                "x-emby-authorization": (
+                    "MediaBrowser "
                     'UserId="e8837bc1-ad67-520e-8cd2-f629e3155721", '
                     'Client="other", '
                     'Device="beets", '
                     'DeviceId="beets", '
                     'Version="0.0.0"'
                 )
-            }
+            },
         )
 
     def test_create_header_with_token(self):
         self.assertEqual(
-            embyupdate.create_headers('e8837bc1-ad67-520e-8cd2-f629e3155721',
-                                      token='abc123'),
+            embyupdate.create_headers(
+                "e8837bc1-ad67-520e-8cd2-f629e3155721", token="abc123"
+            ),
             {
-                'x-emby-authorization': (
-                    'MediaBrowser '
+                "x-emby-authorization": (
+                    "MediaBrowser "
                     'UserId="e8837bc1-ad67-520e-8cd2-f629e3155721", '
                     'Client="other", '
                     'Device="beets", '
                     'DeviceId="beets", '
                     'Version="0.0.0"'
                 ),
-                'x-mediabrowser-token': 'abc123'
-            }
+                "x-mediabrowser-token": "abc123",
+            },
         )
 
     @responses.activate
     def test_get_token(self):
-        body = ('{"User":{"Name":"username", '
-                '"ServerId":"1efa5077976bfa92bc71652404f646ec",'
-                '"Id":"2ec276a2642e54a19b612b9418a8bd3b","HasPassword":true,'
-                '"HasConfiguredPassword":true,'
-                '"HasConfiguredEasyPassword":false,'
-                '"LastLoginDate":"2015-11-09T08:35:03.6357440Z",'
-                '"LastActivityDate":"2015-11-09T08:35:03.6665060Z",'
-                '"Configuration":{"AudioLanguagePreference":"",'
-                '"PlayDefaultAudioTrack":true,"SubtitleLanguagePreference":"",'
-                '"DisplayMissingEpisodes":false,'
-                '"DisplayUnairedEpisodes":false,'
-                '"GroupMoviesIntoBoxSets":false,'
-                '"DisplayChannelsWithinViews":[],'
-                '"ExcludeFoldersFromGrouping":[],"GroupedFolders":[],'
-                '"SubtitleMode":"Default","DisplayCollectionsView":true,'
-                '"DisplayFoldersView":false,"EnableLocalPassword":false,'
-                '"OrderedViews":[],"IncludeTrailersInSuggestions":true,'
-                '"EnableCinemaMode":true,"LatestItemsExcludes":[],'
-                '"PlainFolderViews":[],"HidePlayedInLatest":true,'
-                '"DisplayChannelsInline":false},'
-                '"Policy":{"IsAdministrator":true,"IsHidden":false,'
-                '"IsDisabled":false,"BlockedTags":[],'
-                '"EnableUserPreferenceAccess":true,"AccessSchedules":[],'
-                '"BlockUnratedItems":[],'
-                '"EnableRemoteControlOfOtherUsers":false,'
-                '"EnableSharedDeviceControl":true,'
-                '"EnableLiveTvManagement":true,"EnableLiveTvAccess":true,'
-                '"EnableMediaPlayback":true,'
-                '"EnableAudioPlaybackTranscoding":true,'
-                '"EnableVideoPlaybackTranscoding":true,'
-                '"EnableContentDeletion":false,'
-                '"EnableContentDownloading":true,"EnableSync":true,'
-                '"EnableSyncTranscoding":true,"EnabledDevices":[],'
-                '"EnableAllDevices":true,"EnabledChannels":[],'
-                '"EnableAllChannels":true,"EnabledFolders":[],'
-                '"EnableAllFolders":true,"InvalidLoginAttemptCount":0,'
-                '"EnablePublicSharing":true}},'
-                '"SessionInfo":{"SupportedCommands":[],'
-                '"QueueableMediaTypes":[],"PlayableMediaTypes":[],'
-                '"Id":"89f3b33f8b3a56af22088733ad1d76b3",'
-                '"UserId":"2ec276a2642e54a19b612b9418a8bd3b",'
-                '"UserName":"username","AdditionalUsers":[],'
-                '"ApplicationVersion":"Unknown version",'
-                '"Client":"Unknown app",'
-                '"LastActivityDate":"2015-11-09T08:35:03.6665060Z",'
-                '"DeviceName":"Unknown device","DeviceId":"Unknown device id",'
-                '"SupportsRemoteControl":false,"PlayState":{"CanSeek":false,'
-                '"IsPaused":false,"IsMuted":false,"RepeatMode":"RepeatNone"}},'
-                '"AccessToken":"4b19180cf02748f7b95c7e8e76562fc8",'
-                '"ServerId":"1efa5077976bfa92bc71652404f646ec"}')
+        body = (
+            '{"User":{"Name":"username", '
+            '"ServerId":"1efa5077976bfa92bc71652404f646ec",'
+            '"Id":"2ec276a2642e54a19b612b9418a8bd3b","HasPassword":true,'
+            '"HasConfiguredPassword":true,'
+            '"HasConfiguredEasyPassword":false,'
+            '"LastLoginDate":"2015-11-09T08:35:03.6357440Z",'
+            '"LastActivityDate":"2015-11-09T08:35:03.6665060Z",'
+            '"Configuration":{"AudioLanguagePreference":"",'
+            '"PlayDefaultAudioTrack":true,"SubtitleLanguagePreference":"",'
+            '"DisplayMissingEpisodes":false,'
+            '"DisplayUnairedEpisodes":false,'
+            '"GroupMoviesIntoBoxSets":false,'
+            '"DisplayChannelsWithinViews":[],'
+            '"ExcludeFoldersFromGrouping":[],"GroupedFolders":[],'
+            '"SubtitleMode":"Default","DisplayCollectionsView":true,'
+            '"DisplayFoldersView":false,"EnableLocalPassword":false,'
+            '"OrderedViews":[],"IncludeTrailersInSuggestions":true,'
+            '"EnableCinemaMode":true,"LatestItemsExcludes":[],'
+            '"PlainFolderViews":[],"HidePlayedInLatest":true,'
+            '"DisplayChannelsInline":false},'
+            '"Policy":{"IsAdministrator":true,"IsHidden":false,'
+            '"IsDisabled":false,"BlockedTags":[],'
+            '"EnableUserPreferenceAccess":true,"AccessSchedules":[],'
+            '"BlockUnratedItems":[],'
+            '"EnableRemoteControlOfOtherUsers":false,'
+            '"EnableSharedDeviceControl":true,'
+            '"EnableLiveTvManagement":true,"EnableLiveTvAccess":true,'
+            '"EnableMediaPlayback":true,'
+            '"EnableAudioPlaybackTranscoding":true,'
+            '"EnableVideoPlaybackTranscoding":true,'
+            '"EnableContentDeletion":false,'
+            '"EnableContentDownloading":true,"EnableSync":true,'
+            '"EnableSyncTranscoding":true,"EnabledDevices":[],'
+            '"EnableAllDevices":true,"EnabledChannels":[],'
+            '"EnableAllChannels":true,"EnabledFolders":[],'
+            '"EnableAllFolders":true,"InvalidLoginAttemptCount":0,'
+            '"EnablePublicSharing":true}},'
+            '"SessionInfo":{"SupportedCommands":[],'
+            '"QueueableMediaTypes":[],"PlayableMediaTypes":[],'
+            '"Id":"89f3b33f8b3a56af22088733ad1d76b3",'
+            '"UserId":"2ec276a2642e54a19b612b9418a8bd3b",'
+            '"UserName":"username","AdditionalUsers":[],'
+            '"ApplicationVersion":"Unknown version",'
+            '"Client":"Unknown app",'
+            '"LastActivityDate":"2015-11-09T08:35:03.6665060Z",'
+            '"DeviceName":"Unknown device","DeviceId":"Unknown device id",'
+            '"SupportsRemoteControl":false,"PlayState":{"CanSeek":false,'
+            '"IsPaused":false,"IsMuted":false,"RepeatMode":"RepeatNone"}},'
+            '"AccessToken":"4b19180cf02748f7b95c7e8e76562fc8",'
+            '"ServerId":"1efa5077976bfa92bc71652404f646ec"}'
+        )
 
-        responses.add(responses.POST,
-                      ('http://localhost:8096'
-                       '/Users/AuthenticateByName'),
-                      body=body,
-                      status=200,
-                      content_type='application/json')
+        responses.add(
+            responses.POST,
+            ("http://localhost:8096" "/Users/AuthenticateByName"),
+            body=body,
+            status=200,
+            content_type="application/json",
+        )
 
         headers = {
-            'x-emby-authorization': (
-                'MediaBrowser '
+            "x-emby-authorization": (
+                "MediaBrowser "
                 'UserId="e8837bc1-ad67-520e-8cd2-f629e3155721", '
                 'Client="other", '
                 'Device="beets", '
@@ -163,73 +175,76 @@ class EmbyUpdateTest(unittest.TestCase, TestHelper):
         }
 
         auth_data = {
-            'username': 'username',
-            'password': '5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8',
-            'passwordMd5': '5f4dcc3b5aa765d61d8327deb882cf99'
+            "username": "username",
+            "password": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+            "passwordMd5": "5f4dcc3b5aa765d61d8327deb882cf99",
         }
 
         self.assertEqual(
-            embyupdate.get_token('http://localhost', 8096, headers, auth_data),
-            '4b19180cf02748f7b95c7e8e76562fc8')
+            embyupdate.get_token("http://localhost", 8096, headers, auth_data),
+            "4b19180cf02748f7b95c7e8e76562fc8",
+        )
 
     @responses.activate
     def test_get_user(self):
-        body = ('[{"Name":"username",'
-                '"ServerId":"1efa5077976bfa92bc71652404f646ec",'
-                '"Id":"2ec276a2642e54a19b612b9418a8bd3b","HasPassword":true,'
-                '"HasConfiguredPassword":true,'
-                '"HasConfiguredEasyPassword":false,'
-                '"LastLoginDate":"2015-11-09T08:35:03.6357440Z",'
-                '"LastActivityDate":"2015-11-09T08:42:39.3693220Z",'
-                '"Configuration":{"AudioLanguagePreference":"",'
-                '"PlayDefaultAudioTrack":true,"SubtitleLanguagePreference":"",'
-                '"DisplayMissingEpisodes":false,'
-                '"DisplayUnairedEpisodes":false,'
-                '"GroupMoviesIntoBoxSets":false,'
-                '"DisplayChannelsWithinViews":[],'
-                '"ExcludeFoldersFromGrouping":[],"GroupedFolders":[],'
-                '"SubtitleMode":"Default","DisplayCollectionsView":true,'
-                '"DisplayFoldersView":false,"EnableLocalPassword":false,'
-                '"OrderedViews":[],"IncludeTrailersInSuggestions":true,'
-                '"EnableCinemaMode":true,"LatestItemsExcludes":[],'
-                '"PlainFolderViews":[],"HidePlayedInLatest":true,'
-                '"DisplayChannelsInline":false},'
-                '"Policy":{"IsAdministrator":true,"IsHidden":false,'
-                '"IsDisabled":false,"BlockedTags":[],'
-                '"EnableUserPreferenceAccess":true,"AccessSchedules":[],'
-                '"BlockUnratedItems":[],'
-                '"EnableRemoteControlOfOtherUsers":false,'
-                '"EnableSharedDeviceControl":true,'
-                '"EnableLiveTvManagement":true,"EnableLiveTvAccess":true,'
-                '"EnableMediaPlayback":true,'
-                '"EnableAudioPlaybackTranscoding":true,'
-                '"EnableVideoPlaybackTranscoding":true,'
-                '"EnableContentDeletion":false,'
-                '"EnableContentDownloading":true,'
-                '"EnableSync":true,"EnableSyncTranscoding":true,'
-                '"EnabledDevices":[],"EnableAllDevices":true,'
-                '"EnabledChannels":[],"EnableAllChannels":true,'
-                '"EnabledFolders":[],"EnableAllFolders":true,'
-                '"InvalidLoginAttemptCount":0,"EnablePublicSharing":true}}]')
+        body = (
+            '[{"Name":"username",'
+            '"ServerId":"1efa5077976bfa92bc71652404f646ec",'
+            '"Id":"2ec276a2642e54a19b612b9418a8bd3b","HasPassword":true,'
+            '"HasConfiguredPassword":true,'
+            '"HasConfiguredEasyPassword":false,'
+            '"LastLoginDate":"2015-11-09T08:35:03.6357440Z",'
+            '"LastActivityDate":"2015-11-09T08:42:39.3693220Z",'
+            '"Configuration":{"AudioLanguagePreference":"",'
+            '"PlayDefaultAudioTrack":true,"SubtitleLanguagePreference":"",'
+            '"DisplayMissingEpisodes":false,'
+            '"DisplayUnairedEpisodes":false,'
+            '"GroupMoviesIntoBoxSets":false,'
+            '"DisplayChannelsWithinViews":[],'
+            '"ExcludeFoldersFromGrouping":[],"GroupedFolders":[],'
+            '"SubtitleMode":"Default","DisplayCollectionsView":true,'
+            '"DisplayFoldersView":false,"EnableLocalPassword":false,'
+            '"OrderedViews":[],"IncludeTrailersInSuggestions":true,'
+            '"EnableCinemaMode":true,"LatestItemsExcludes":[],'
+            '"PlainFolderViews":[],"HidePlayedInLatest":true,'
+            '"DisplayChannelsInline":false},'
+            '"Policy":{"IsAdministrator":true,"IsHidden":false,'
+            '"IsDisabled":false,"BlockedTags":[],'
+            '"EnableUserPreferenceAccess":true,"AccessSchedules":[],'
+            '"BlockUnratedItems":[],'
+            '"EnableRemoteControlOfOtherUsers":false,'
+            '"EnableSharedDeviceControl":true,'
+            '"EnableLiveTvManagement":true,"EnableLiveTvAccess":true,'
+            '"EnableMediaPlayback":true,'
+            '"EnableAudioPlaybackTranscoding":true,'
+            '"EnableVideoPlaybackTranscoding":true,'
+            '"EnableContentDeletion":false,'
+            '"EnableContentDownloading":true,'
+            '"EnableSync":true,"EnableSyncTranscoding":true,'
+            '"EnabledDevices":[],"EnableAllDevices":true,'
+            '"EnabledChannels":[],"EnableAllChannels":true,'
+            '"EnabledFolders":[],"EnableAllFolders":true,'
+            '"InvalidLoginAttemptCount":0,"EnablePublicSharing":true}}]'
+        )
 
-        responses.add(responses.GET,
-                      'http://localhost:8096/Users/Public',
-                      body=body,
-                      status=200,
-                      content_type='application/json')
+        responses.add(
+            responses.GET,
+            "http://localhost:8096/Users/Public",
+            body=body,
+            status=200,
+            content_type="application/json",
+        )
 
-        response = embyupdate.get_user('http://localhost', 8096, 'username')
+        response = embyupdate.get_user("http://localhost", 8096, "username")
 
-        self.assertEqual(response[0]['Id'],
-                         '2ec276a2642e54a19b612b9418a8bd3b')
+        self.assertEqual(response[0]["Id"], "2ec276a2642e54a19b612b9418a8bd3b")
 
-        self.assertEqual(response[0]['Name'],
-                         'username')
+        self.assertEqual(response[0]["Name"], "username")
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_export.py
+++ b/test/test_export.py
@@ -29,38 +29,32 @@ from xml.etree import ElementTree
 class ExportPluginTest(unittest.TestCase, TestHelper):
     def setUp(self):
         self.setup_beets()
-        self.load_plugins('export')
-        self.test_values = {'title': 'xtitle', 'album': 'xalbum'}
+        self.load_plugins("export")
+        self.test_values = {"title": "xtitle", "album": "xalbum"}
 
     def tearDown(self):
         self.unload_plugins()
         self.teardown_beets()
 
     def execute_command(self, format_type, artist):
-        query = ','.join(self.test_values.keys())
+        query = ",".join(self.test_values.keys())
         out = self.run_with_output(
-            'export',
-            '-f', format_type,
-            '-i', query,
-            artist
+            "export", "-f", format_type, "-i", query, artist
         )
         return out
 
     def create_item(self):
-        item, = self.add_item_fixtures()
-        item.artist = 'xartist'
-        item.title = self.test_values['title']
-        item.album = self.test_values['album']
+        (item,) = self.add_item_fixtures()
+        item.artist = "xartist"
+        item.title = self.test_values["title"]
+        item.album = self.test_values["album"]
         item.write()
         item.store()
         return item
 
     def test_json_output(self):
         item1 = self.create_item()
-        out = self.execute_command(
-            format_type='json',
-            artist=item1.artist
-        )
+        out = self.execute_command(format_type="json", artist=item1.artist)
         json_data = json.loads(out)[0]
         for key, val in self.test_values.items():
             self.assertTrue(key in json_data)
@@ -68,23 +62,17 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
 
     def test_csv_output(self):
         item1 = self.create_item()
-        out = self.execute_command(
-            format_type='csv',
-            artist=item1.artist
-        )
-        csv_list = re.split('\r', re.sub('\n', '', out))
-        head = re.split(',', csv_list[0])
-        vals = re.split(',|\r', csv_list[1])
+        out = self.execute_command(format_type="csv", artist=item1.artist)
+        csv_list = re.split("\r", re.sub("\n", "", out))
+        head = re.split(",", csv_list[0])
+        vals = re.split(",|\r", csv_list[1])
         for index, column in enumerate(head):
             self.assertTrue(self.test_values.get(column, None) is not None)
             self.assertEqual(vals[index], self.test_values[column])
 
     def test_xml_output(self):
         item1 = self.create_item()
-        out = self.execute_command(
-            format_type='xml',
-            artist=item1.artist
-        )
+        out = self.execute_command(format_type="xml", artist=item1.artist)
         library = ElementTree.fromstring(out)
         self.assertIsInstance(library, Element)
         for track in library[0]:
@@ -98,5 +86,6 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_fetchart.py
+++ b/test/test_fetchart.py
@@ -24,83 +24,83 @@ from beets import util
 
 
 class FetchartCliTest(unittest.TestCase, TestHelper):
-
     def setUp(self):
         self.setup_beets()
-        self.load_plugins('fetchart')
-        self.config['fetchart']['cover_names'] = 'c\xc3\xb6ver.jpg'
-        self.config['art_filename'] = 'mycover'
+        self.load_plugins("fetchart")
+        self.config["fetchart"]["cover_names"] = "c\xc3\xb6ver.jpg"
+        self.config["art_filename"] = "mycover"
         self.album = self.add_album()
-        self.cover_path = os.path.join(self.album.path, b'mycover.jpg')
+        self.cover_path = os.path.join(self.album.path, b"mycover.jpg")
 
     def tearDown(self):
         self.unload_plugins()
         self.teardown_beets()
 
     def check_cover_is_stored(self):
-        self.assertEqual(self.album['artpath'], self.cover_path)
-        with open(util.syspath(self.cover_path), 'r') as f:
-            self.assertEqual(f.read(), 'IMAGE')
+        self.assertEqual(self.album["artpath"], self.cover_path)
+        with open(util.syspath(self.cover_path), "r") as f:
+            self.assertEqual(f.read(), "IMAGE")
 
     def hide_file_windows(self):
         hidden_mask = 2
-        success = ctypes.windll.kernel32.SetFileAttributesW(self.cover_path,
-                                                            hidden_mask)
+        success = ctypes.windll.kernel32.SetFileAttributesW(
+            self.cover_path, hidden_mask
+        )
         if not success:
             self.skipTest("unable to set file attributes")
 
     def test_set_art_from_folder(self):
-        self.touch(b'c\xc3\xb6ver.jpg', dir=self.album.path, content='IMAGE')
+        self.touch(b"c\xc3\xb6ver.jpg", dir=self.album.path, content="IMAGE")
 
-        self.run_command('fetchart')
+        self.run_command("fetchart")
 
         self.album.load()
         self.check_cover_is_stored()
 
     def test_filesystem_does_not_pick_up_folder(self):
-        os.makedirs(os.path.join(self.album.path, b'mycover.jpg'))
-        self.run_command('fetchart')
+        os.makedirs(os.path.join(self.album.path, b"mycover.jpg"))
+        self.run_command("fetchart")
         self.album.load()
-        self.assertEqual(self.album['artpath'], None)
+        self.assertEqual(self.album["artpath"], None)
 
     def test_filesystem_does_not_pick_up_ignored_file(self):
-        self.touch(b'co_ver.jpg', dir=self.album.path, content='IMAGE')
-        self.config['ignore'] = ['*_*']
-        self.run_command('fetchart')
+        self.touch(b"co_ver.jpg", dir=self.album.path, content="IMAGE")
+        self.config["ignore"] = ["*_*"]
+        self.run_command("fetchart")
         self.album.load()
-        self.assertEqual(self.album['artpath'], None)
+        self.assertEqual(self.album["artpath"], None)
 
     def test_filesystem_picks_up_non_ignored_file(self):
-        self.touch(b'cover.jpg', dir=self.album.path, content='IMAGE')
-        self.config['ignore'] = ['*_*']
-        self.run_command('fetchart')
+        self.touch(b"cover.jpg", dir=self.album.path, content="IMAGE")
+        self.config["ignore"] = ["*_*"]
+        self.run_command("fetchart")
         self.album.load()
         self.check_cover_is_stored()
 
     def test_filesystem_does_not_pick_up_hidden_file(self):
-        self.touch(b'.cover.jpg', dir=self.album.path, content='IMAGE')
-        if sys.platform == 'win32':
+        self.touch(b".cover.jpg", dir=self.album.path, content="IMAGE")
+        if sys.platform == "win32":
             self.hide_file_windows()
-        self.config['ignore'] = []  # By default, ignore includes '.*'.
-        self.config['ignore_hidden'] = True
-        self.run_command('fetchart')
+        self.config["ignore"] = []  # By default, ignore includes '.*'.
+        self.config["ignore_hidden"] = True
+        self.run_command("fetchart")
         self.album.load()
-        self.assertEqual(self.album['artpath'], None)
+        self.assertEqual(self.album["artpath"], None)
 
     def test_filesystem_picks_up_non_hidden_file(self):
-        self.touch(b'cover.jpg', dir=self.album.path, content='IMAGE')
-        self.config['ignore_hidden'] = True
-        self.run_command('fetchart')
+        self.touch(b"cover.jpg", dir=self.album.path, content="IMAGE")
+        self.config["ignore_hidden"] = True
+        self.run_command("fetchart")
         self.album.load()
         self.check_cover_is_stored()
 
     def test_filesystem_picks_up_hidden_file(self):
-        self.touch(b'.cover.jpg', dir=self.album.path, content='IMAGE')
-        if sys.platform == 'win32':
+        self.touch(b".cover.jpg", dir=self.album.path, content="IMAGE")
+        if sys.platform == "win32":
             self.hide_file_windows()
-        self.config['ignore'] = []  # By default, ignore includes '.*'.
-        self.config['ignore_hidden'] = False
-        self.run_command('fetchart')
+        self.config["ignore"] = []  # By default, ignore includes '.*'.
+        self.config["ignore_hidden"] = False
+        self.run_command("fetchart")
         self.album.load()
         self.check_cover_is_stored()
 
@@ -108,5 +108,6 @@ class FetchartCliTest(unittest.TestCase, TestHelper):
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_filefilter.py
+++ b/test/test_filefilter.py
@@ -36,14 +36,14 @@ class FileFilterPluginTest(unittest.TestCase, ImportHelper):
         self.setup_beets()
         self.__create_import_dir(2)
         self._setup_import_session()
-        config['import']['pretend'] = True
+        config["import"]["pretend"] = True
 
     def tearDown(self):
         self.teardown_beets()
 
     def __copy_file(self, dest_path, metadata):
         # Copy files
-        resource_path = os.path.join(_common.RSRC, b'full.mp3')
+        resource_path = os.path.join(_common.RSRC, b"full.mp3")
         shutil.copy(resource_path, dest_path)
         medium = MediaFile(dest_path)
         # Set metadata
@@ -52,55 +52,55 @@ class FileFilterPluginTest(unittest.TestCase, ImportHelper):
         medium.save()
 
     def __create_import_dir(self, count):
-        self.import_dir = os.path.join(self.temp_dir, b'testsrcdir')
+        self.import_dir = os.path.join(self.temp_dir, b"testsrcdir")
         if os.path.isdir(self.import_dir):
             shutil.rmtree(self.import_dir)
 
-        self.artist_path = os.path.join(self.import_dir, b'artist')
-        self.album_path = os.path.join(self.artist_path, b'album')
-        self.misc_path = os.path.join(self.import_dir, b'misc')
+        self.artist_path = os.path.join(self.import_dir, b"artist")
+        self.album_path = os.path.join(self.artist_path, b"album")
+        self.misc_path = os.path.join(self.import_dir, b"misc")
         os.makedirs(self.album_path)
         os.makedirs(self.misc_path)
 
         metadata = {
-            'artist': 'Tag Artist',
-            'album':  'Tag Album',
-            'albumartist':  None,
-            'mb_trackid': None,
-            'mb_albumid': None,
-            'comp': None,
+            "artist": "Tag Artist",
+            "album": "Tag Album",
+            "albumartist": None,
+            "mb_trackid": None,
+            "mb_albumid": None,
+            "comp": None,
         }
         self.album_paths = []
         for i in range(count):
-            metadata['track'] = i + 1
-            metadata['title'] = 'Tag Title Album %d' % (i + 1)
-            track_file = bytestring_path('%02d - track.mp3' % (i + 1))
+            metadata["track"] = i + 1
+            metadata["title"] = "Tag Title Album %d" % (i + 1)
+            track_file = bytestring_path("%02d - track.mp3" % (i + 1))
             dest_path = os.path.join(self.album_path, track_file)
             self.__copy_file(dest_path, metadata)
             self.album_paths.append(dest_path)
 
         self.artist_paths = []
-        metadata['album'] = None
+        metadata["album"] = None
         for i in range(count):
-            metadata['track'] = i + 10
-            metadata['title'] = 'Tag Title Artist %d' % (i + 1)
-            track_file = bytestring_path('track_%d.mp3' % (i + 1))
+            metadata["track"] = i + 10
+            metadata["title"] = "Tag Title Artist %d" % (i + 1)
+            track_file = bytestring_path("track_%d.mp3" % (i + 1))
             dest_path = os.path.join(self.artist_path, track_file)
             self.__copy_file(dest_path, metadata)
             self.artist_paths.append(dest_path)
 
         self.misc_paths = []
         for i in range(count):
-            metadata['artist'] = 'Artist %d' % (i + 42)
-            metadata['track'] = i + 5
-            metadata['title'] = 'Tag Title Misc %d' % (i + 1)
-            track_file = bytestring_path('track_%d.mp3' % (i + 1))
+            metadata["artist"] = "Artist %d" % (i + 42)
+            metadata["track"] = i + 5
+            metadata["title"] = "Tag Title Misc %d" % (i + 1)
+            track_file = bytestring_path("track_%d.mp3" % (i + 1))
             dest_path = os.path.join(self.misc_path, track_file)
             self.__copy_file(dest_path, metadata)
             self.misc_paths.append(dest_path)
 
     def __run(self, expected_lines, singletons=False):
-        self.load_plugins('filefilter')
+        self.load_plugins("filefilter")
 
         import_files = [self.import_dir]
         self._setup_import_session(singletons=singletons)
@@ -111,99 +111,123 @@ class FileFilterPluginTest(unittest.TestCase, ImportHelper):
         self.unload_plugins()
         FileFilterPlugin.listeners = None
 
-        logs = [line for line in logs if not line.startswith('Sending event:')]
+        logs = [line for line in logs if not line.startswith("Sending event:")]
 
         self.assertEqual(logs, expected_lines)
 
     def test_import_default(self):
         """ The default configuration should import everything.
         """
-        self.__run([
-            'Album: %s' % displayable_path(self.artist_path),
-            '  %s' % displayable_path(self.artist_paths[0]),
-            '  %s' % displayable_path(self.artist_paths[1]),
-            'Album: %s' % displayable_path(self.album_path),
-            '  %s' % displayable_path(self.album_paths[0]),
-            '  %s' % displayable_path(self.album_paths[1]),
-            'Album: %s' % displayable_path(self.misc_path),
-            '  %s' % displayable_path(self.misc_paths[0]),
-            '  %s' % displayable_path(self.misc_paths[1])
-        ])
+        self.__run(
+            [
+                "Album: %s" % displayable_path(self.artist_path),
+                "  %s" % displayable_path(self.artist_paths[0]),
+                "  %s" % displayable_path(self.artist_paths[1]),
+                "Album: %s" % displayable_path(self.album_path),
+                "  %s" % displayable_path(self.album_paths[0]),
+                "  %s" % displayable_path(self.album_paths[1]),
+                "Album: %s" % displayable_path(self.misc_path),
+                "  %s" % displayable_path(self.misc_paths[0]),
+                "  %s" % displayable_path(self.misc_paths[1]),
+            ]
+        )
 
     def test_import_nothing(self):
-        config['filefilter']['path'] = 'not_there'
-        self.__run(['No files imported from %s' % displayable_path(
-            self.import_dir)])
+        config["filefilter"]["path"] = "not_there"
+        self.__run(
+            ["No files imported from %s" % displayable_path(self.import_dir)]
+        )
 
     # Global options
     def test_import_global(self):
-        config['filefilter']['path'] = '.*track_1.*\\.mp3'
-        self.__run([
-            'Album: %s' % displayable_path(self.artist_path),
-            '  %s' % displayable_path(self.artist_paths[0]),
-            'Album: %s' % displayable_path(self.misc_path),
-            '  %s' % displayable_path(self.misc_paths[0]),
-        ])
-        self.__run([
-            'Singleton: %s' % displayable_path(self.artist_paths[0]),
-            'Singleton: %s' % displayable_path(self.misc_paths[0])
-        ], singletons=True)
+        config["filefilter"]["path"] = ".*track_1.*\\.mp3"
+        self.__run(
+            [
+                "Album: %s" % displayable_path(self.artist_path),
+                "  %s" % displayable_path(self.artist_paths[0]),
+                "Album: %s" % displayable_path(self.misc_path),
+                "  %s" % displayable_path(self.misc_paths[0]),
+            ]
+        )
+        self.__run(
+            [
+                "Singleton: %s" % displayable_path(self.artist_paths[0]),
+                "Singleton: %s" % displayable_path(self.misc_paths[0]),
+            ],
+            singletons=True,
+        )
 
     # Album options
     def test_import_album(self):
-        config['filefilter']['album_path'] = '.*track_1.*\\.mp3'
-        self.__run([
-            'Album: %s' % displayable_path(self.artist_path),
-            '  %s' % displayable_path(self.artist_paths[0]),
-            'Album: %s' % displayable_path(self.misc_path),
-            '  %s' % displayable_path(self.misc_paths[0]),
-        ])
-        self.__run([
-            'Singleton: %s' % displayable_path(self.artist_paths[0]),
-            'Singleton: %s' % displayable_path(self.artist_paths[1]),
-            'Singleton: %s' % displayable_path(self.album_paths[0]),
-            'Singleton: %s' % displayable_path(self.album_paths[1]),
-            'Singleton: %s' % displayable_path(self.misc_paths[0]),
-            'Singleton: %s' % displayable_path(self.misc_paths[1])
-        ], singletons=True)
+        config["filefilter"]["album_path"] = ".*track_1.*\\.mp3"
+        self.__run(
+            [
+                "Album: %s" % displayable_path(self.artist_path),
+                "  %s" % displayable_path(self.artist_paths[0]),
+                "Album: %s" % displayable_path(self.misc_path),
+                "  %s" % displayable_path(self.misc_paths[0]),
+            ]
+        )
+        self.__run(
+            [
+                "Singleton: %s" % displayable_path(self.artist_paths[0]),
+                "Singleton: %s" % displayable_path(self.artist_paths[1]),
+                "Singleton: %s" % displayable_path(self.album_paths[0]),
+                "Singleton: %s" % displayable_path(self.album_paths[1]),
+                "Singleton: %s" % displayable_path(self.misc_paths[0]),
+                "Singleton: %s" % displayable_path(self.misc_paths[1]),
+            ],
+            singletons=True,
+        )
 
     # Singleton options
     def test_import_singleton(self):
-        config['filefilter']['singleton_path'] = '.*track_1.*\\.mp3'
-        self.__run([
-            'Singleton: %s' % displayable_path(self.artist_paths[0]),
-            'Singleton: %s' % displayable_path(self.misc_paths[0])
-        ], singletons=True)
-        self.__run([
-            'Album: %s' % displayable_path(self.artist_path),
-            '  %s' % displayable_path(self.artist_paths[0]),
-            '  %s' % displayable_path(self.artist_paths[1]),
-            'Album: %s' % displayable_path(self.album_path),
-            '  %s' % displayable_path(self.album_paths[0]),
-            '  %s' % displayable_path(self.album_paths[1]),
-            'Album: %s' % displayable_path(self.misc_path),
-            '  %s' % displayable_path(self.misc_paths[0]),
-            '  %s' % displayable_path(self.misc_paths[1])
-        ])
+        config["filefilter"]["singleton_path"] = ".*track_1.*\\.mp3"
+        self.__run(
+            [
+                "Singleton: %s" % displayable_path(self.artist_paths[0]),
+                "Singleton: %s" % displayable_path(self.misc_paths[0]),
+            ],
+            singletons=True,
+        )
+        self.__run(
+            [
+                "Album: %s" % displayable_path(self.artist_path),
+                "  %s" % displayable_path(self.artist_paths[0]),
+                "  %s" % displayable_path(self.artist_paths[1]),
+                "Album: %s" % displayable_path(self.album_path),
+                "  %s" % displayable_path(self.album_paths[0]),
+                "  %s" % displayable_path(self.album_paths[1]),
+                "Album: %s" % displayable_path(self.misc_path),
+                "  %s" % displayable_path(self.misc_paths[0]),
+                "  %s" % displayable_path(self.misc_paths[1]),
+            ]
+        )
 
     # Album and singleton options
     def test_import_both(self):
-        config['filefilter']['album_path'] = '.*track_1.*\\.mp3'
-        config['filefilter']['singleton_path'] = '.*track_2.*\\.mp3'
-        self.__run([
-            'Album: %s' % displayable_path(self.artist_path),
-            '  %s' % displayable_path(self.artist_paths[0]),
-            'Album: %s' % displayable_path(self.misc_path),
-            '  %s' % displayable_path(self.misc_paths[0]),
-        ])
-        self.__run([
-            'Singleton: %s' % displayable_path(self.artist_paths[1]),
-            'Singleton: %s' % displayable_path(self.misc_paths[1])
-        ], singletons=True)
+        config["filefilter"]["album_path"] = ".*track_1.*\\.mp3"
+        config["filefilter"]["singleton_path"] = ".*track_2.*\\.mp3"
+        self.__run(
+            [
+                "Album: %s" % displayable_path(self.artist_path),
+                "  %s" % displayable_path(self.artist_paths[0]),
+                "Album: %s" % displayable_path(self.misc_path),
+                "  %s" % displayable_path(self.misc_paths[0]),
+            ]
+        )
+        self.__run(
+            [
+                "Singleton: %s" % displayable_path(self.artist_paths[1]),
+                "Singleton: %s" % displayable_path(self.misc_paths[1]),
+            ],
+            singletons=True,
+        )
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -35,26 +35,27 @@ class MoveTest(_common.TestCase):
         super(MoveTest, self).setUp()
 
         # make a temporary file
-        self.path = join(self.temp_dir, b'temp.mp3')
-        shutil.copy(join(_common.RSRC, b'full.mp3'), self.path)
+        self.path = join(self.temp_dir, b"temp.mp3")
+        shutil.copy(join(_common.RSRC, b"full.mp3"), self.path)
 
         # add it to a temporary library
-        self.lib = beets.library.Library(':memory:')
+        self.lib = beets.library.Library(":memory:")
         self.i = beets.library.Item.from_path(self.path)
         self.lib.add(self.i)
 
         # set up the destination
-        self.libdir = join(self.temp_dir, b'testlibdir')
+        self.libdir = join(self.temp_dir, b"testlibdir")
         os.mkdir(self.libdir)
         self.lib.directory = self.libdir
-        self.lib.path_formats = [('default',
-                                  join('$artist', '$album', '$title'))]
-        self.i.artist = 'one'
-        self.i.album = 'two'
-        self.i.title = 'three'
-        self.dest = join(self.libdir, b'one', b'two', b'three.mp3')
+        self.lib.path_formats = [
+            ("default", join("$artist", "$album", "$title"))
+        ]
+        self.i.artist = "one"
+        self.i.album = "two"
+        self.i.title = "three"
+        self.dest = join(self.libdir, b"one", b"two", b"three.mp3")
 
-        self.otherdir = join(self.temp_dir, b'testotherdir')
+        self.otherdir = join(self.temp_dir, b"testotherdir")
 
     def test_move_arrives(self):
         self.i.move()
@@ -62,7 +63,7 @@ class MoveTest(_common.TestCase):
 
     def test_move_to_custom_dir(self):
         self.i.move(basedir=self.otherdir)
-        self.assertExists(join(self.otherdir, b'one', b'two', b'three.mp3'))
+        self.assertExists(join(self.otherdir, b"one", b"two", b"three.mp3"))
 
     def test_move_departs(self):
         self.i.move()
@@ -73,7 +74,7 @@ class MoveTest(_common.TestCase):
         old_path = self.i.path
         self.assertExists(old_path)
 
-        self.i.artist = u'newArtist'
+        self.i.artist = u"newArtist"
         self.i.move()
         self.assertNotExists(old_path)
         self.assertNotExists(os.path.dirname(old_path))
@@ -103,22 +104,22 @@ class MoveTest(_common.TestCase):
         self.assertEqual(self.i.path, old_path)
 
     def test_move_file_with_colon(self):
-        self.i.artist = u'C:DOS'
+        self.i.artist = u"C:DOS"
         self.i.move()
-        self.assertIn('C_DOS', self.i.path.decode())
+        self.assertIn("C_DOS", self.i.path.decode())
 
     def test_move_file_with_multiple_colons(self):
-        print(beets.config['replace'])
-        self.i.artist = u'COM:DOS'
+        print(beets.config["replace"])
+        self.i.artist = u"COM:DOS"
         self.i.move()
-        self.assertIn('COM_DOS', self.i.path.decode())
+        self.assertIn("COM_DOS", self.i.path.decode())
 
     def test_move_file_with_colon_alt_separator(self):
-        old = beets.config['drive_sep_replace']
-        beets.config["drive_sep_replace"] = '0'
-        self.i.artist = u'C:DOS'
+        old = beets.config["drive_sep_replace"]
+        beets.config["drive_sep_replace"] = "0"
+        self.i.artist = u"C:DOS"
         self.i.move()
-        self.assertIn('C0DOS', self.i.path.decode())
+        self.assertIn("C0DOS", self.i.path.decode())
         beets.config["drive_sep_replace"] = old
 
     def test_read_only_file_copied_writable(self):
@@ -141,8 +142,7 @@ class MoveTest(_common.TestCase):
 
         self.i.move()
         self.assertNotEqual(self.i.path, dest)
-        self.assertEqual(os.path.dirname(self.i.path),
-                         os.path.dirname(dest))
+        self.assertEqual(os.path.dirname(self.i.path), os.path.dirname(dest))
 
     @unittest.skipUnless(_common.HAVE_SYMLINK, "need symlinks")
     def test_link_arrives(self):
@@ -168,8 +168,8 @@ class MoveTest(_common.TestCase):
         s1 = os.stat(self.path)
         s2 = os.stat(self.dest)
         self.assertTrue(
-            (s1[stat.ST_INO], s1[stat.ST_DEV]) ==
-            (s2[stat.ST_INO], s2[stat.ST_DEV])
+            (s1[stat.ST_INO], s1[stat.ST_DEV])
+            == (s2[stat.ST_INO], s2[stat.ST_DEV])
         )
 
     @unittest.skipUnless(_common.HAVE_HARDLINK, "need hardlinks")
@@ -185,38 +185,38 @@ class MoveTest(_common.TestCase):
 
 class HelperTest(_common.TestCase):
     def test_ancestry_works_on_file(self):
-        p = '/a/b/c'
-        a = ['/', '/a', '/a/b']
+        p = "/a/b/c"
+        a = ["/", "/a", "/a/b"]
         self.assertEqual(util.ancestry(p), a)
 
     def test_ancestry_works_on_dir(self):
-        p = '/a/b/c/'
-        a = ['/', '/a', '/a/b', '/a/b/c']
+        p = "/a/b/c/"
+        a = ["/", "/a", "/a/b", "/a/b/c"]
         self.assertEqual(util.ancestry(p), a)
 
     def test_ancestry_works_on_relative(self):
-        p = 'a/b/c'
-        a = ['a', 'a/b']
+        p = "a/b/c"
+        a = ["a", "a/b"]
         self.assertEqual(util.ancestry(p), a)
 
     def test_components_works_on_file(self):
-        p = '/a/b/c'
-        a = ['/', 'a', 'b', 'c']
+        p = "/a/b/c"
+        a = ["/", "a", "b", "c"]
         self.assertEqual(util.components(p), a)
 
     def test_components_works_on_dir(self):
-        p = '/a/b/c/'
-        a = ['/', 'a', 'b', 'c']
+        p = "/a/b/c/"
+        a = ["/", "a", "b", "c"]
         self.assertEqual(util.components(p), a)
 
     def test_components_works_on_relative(self):
-        p = 'a/b/c'
-        a = ['a', 'b', 'c']
+        p = "a/b/c"
+        a = ["a", "b", "c"]
         self.assertEqual(util.components(p), a)
 
     def test_forward_slash(self):
-        p = br'C:\a\b\c'
-        a = br'C:/a/b/c'
+        p = br"C:\a\b\c"
+        a = br"C:/a/b/c"
         self.assertEqual(util.path_as_posix(p), a)
 
 
@@ -225,10 +225,11 @@ class AlbumFileTest(_common.TestCase):
         super(AlbumFileTest, self).setUp()
 
         # Make library and item.
-        self.lib = beets.library.Library(':memory:')
-        self.lib.path_formats = \
-            [('default', join('$albumartist', '$album', '$title'))]
-        self.libdir = os.path.join(self.temp_dir, b'testlibdir')
+        self.lib = beets.library.Library(":memory:")
+        self.lib.path_formats = [
+            ("default", join("$albumartist", "$album", "$title"))
+        ]
+        self.libdir = os.path.join(self.temp_dir, b"testlibdir")
         self.lib.directory = self.libdir
         self.i = item(self.lib)
         # Make a file for the item.
@@ -238,19 +239,19 @@ class AlbumFileTest(_common.TestCase):
         # Make an album.
         self.ai = self.lib.add_album((self.i,))
         # Alternate destination dir.
-        self.otherdir = os.path.join(self.temp_dir, b'testotherdir')
+        self.otherdir = os.path.join(self.temp_dir, b"testotherdir")
 
     def test_albuminfo_move_changes_paths(self):
-        self.ai.album = u'newAlbumName'
+        self.ai.album = u"newAlbumName"
         self.ai.move()
         self.ai.store()
         self.i.load()
 
-        self.assertTrue(b'newAlbumName' in self.i.path)
+        self.assertTrue(b"newAlbumName" in self.i.path)
 
     def test_albuminfo_move_moves_file(self):
         oldpath = self.i.path
-        self.ai.album = u'newAlbumName'
+        self.ai.album = u"newAlbumName"
         self.ai.move()
         self.ai.store()
         self.i.load()
@@ -260,7 +261,7 @@ class AlbumFileTest(_common.TestCase):
 
     def test_albuminfo_move_copies_file(self):
         oldpath = self.i.path
-        self.ai.album = u'newAlbumName'
+        self.ai.album = u"newAlbumName"
         self.ai.move(operation=MoveOperation.COPY)
         self.ai.store()
         self.i.load()
@@ -272,7 +273,7 @@ class AlbumFileTest(_common.TestCase):
         self.ai.move(basedir=self.otherdir)
         self.i.load()
         self.ai.store()
-        self.assertTrue(b'testotherdir' in self.i.path)
+        self.assertTrue(b"testotherdir" in self.i.path)
 
 
 class ArtFileTest(_common.TestCase):
@@ -280,8 +281,8 @@ class ArtFileTest(_common.TestCase):
         super(ArtFileTest, self).setUp()
 
         # Make library and item.
-        self.lib = beets.library.Library(':memory:')
-        self.libdir = os.path.join(self.temp_dir, b'testlibdir')
+        self.lib = beets.library.Library(":memory:")
+        self.libdir = os.path.join(self.temp_dir, b"testlibdir")
         self.lib.directory = self.libdir
         self.i = item(self.lib)
         self.i.path = self.i.destination()
@@ -291,12 +292,12 @@ class ArtFileTest(_common.TestCase):
         # Make an album.
         self.ai = self.lib.add_album((self.i,))
         # Make an art file too.
-        self.art = self.lib.get_album(self.i).art_destination('something.jpg')
+        self.art = self.lib.get_album(self.i).art_destination("something.jpg")
         touch(self.art)
         self.ai.artpath = self.art
         self.ai.store()
         # Alternate destination dir.
-        self.otherdir = os.path.join(self.temp_dir, b'testotherdir')
+        self.otherdir = os.path.join(self.temp_dir, b"testotherdir")
 
     def test_art_deleted_when_items_deleted(self):
         self.assertTrue(os.path.exists(self.art))
@@ -306,7 +307,7 @@ class ArtFileTest(_common.TestCase):
     def test_art_moves_with_album(self):
         self.assertTrue(os.path.exists(self.art))
         oldpath = self.i.path
-        self.ai.album = u'newAlbum'
+        self.ai.album = u"newAlbum"
         self.ai.move()
         self.i.load()
 
@@ -325,16 +326,16 @@ class ArtFileTest(_common.TestCase):
         self.assertNotExists(self.art)
         newart = self.lib.get_album(self.i).artpath
         self.assertExists(newart)
-        self.assertTrue(b'testotherdir' in newart)
+        self.assertTrue(b"testotherdir" in newart)
 
     def test_setart_copies_image(self):
         os.remove(self.art)
 
-        newart = os.path.join(self.libdir, b'newart.jpg')
+        newart = os.path.join(self.libdir, b"newart.jpg")
         touch(newart)
         i2 = item()
         i2.path = self.i.path
-        i2.artist = u'someArtist'
+        i2.artist = u"someArtist"
         ai = self.lib.add_album((i2,))
         i2.move(operation=MoveOperation.COPY)
 
@@ -346,11 +347,11 @@ class ArtFileTest(_common.TestCase):
         os.remove(self.art)
 
         # Original art.
-        newart = os.path.join(self.libdir, b'newart.jpg')
+        newart = os.path.join(self.libdir, b"newart.jpg")
         touch(newart)
         i2 = item()
         i2.path = self.i.path
-        i2.artist = u'someArtist'
+        i2.artist = u"someArtist"
         ai = self.lib.add_album((i2,))
         i2.move(operation=MoveOperation.COPY)
         ai.set_art(newart)
@@ -360,11 +361,11 @@ class ArtFileTest(_common.TestCase):
         self.assertTrue(os.path.exists(ai.artpath))
 
     def test_setart_to_existing_but_unset_art_works(self):
-        newart = os.path.join(self.libdir, b'newart.jpg')
+        newart = os.path.join(self.libdir, b"newart.jpg")
         touch(newart)
         i2 = item()
         i2.path = self.i.path
-        i2.artist = u'someArtist'
+        i2.artist = u"someArtist"
         ai = self.lib.add_album((i2,))
         i2.move(operation=MoveOperation.COPY)
 
@@ -377,11 +378,11 @@ class ArtFileTest(_common.TestCase):
         self.assertTrue(os.path.exists(ai.artpath))
 
     def test_setart_to_conflicting_file_gets_new_path(self):
-        newart = os.path.join(self.libdir, b'newart.jpg')
+        newart = os.path.join(self.libdir, b"newart.jpg")
         touch(newart)
         i2 = item()
         i2.path = self.i.path
-        i2.artist = u'someArtist'
+        i2.artist = u"someArtist"
         ai = self.lib.add_album((i2,))
         i2.move(operation=MoveOperation.COPY)
 
@@ -392,20 +393,19 @@ class ArtFileTest(_common.TestCase):
         # Set the art.
         ai.set_art(newart)
         self.assertNotEqual(artdest, ai.artpath)
-        self.assertEqual(os.path.dirname(artdest),
-                         os.path.dirname(ai.artpath))
+        self.assertEqual(os.path.dirname(artdest), os.path.dirname(ai.artpath))
 
     def test_setart_sets_permissions(self):
         os.remove(self.art)
 
-        newart = os.path.join(self.libdir, b'newart.jpg')
+        newart = os.path.join(self.libdir, b"newart.jpg")
         touch(newart)
         os.chmod(newart, 0o400)  # read-only
 
         try:
             i2 = item()
             i2.path = self.i.path
-            i2.artist = u'someArtist'
+            i2.artist = u"someArtist"
             ai = self.lib.add_album((i2,))
             i2.move(operation=MoveOperation.COPY)
             ai.set_art(newart)
@@ -423,12 +423,12 @@ class ArtFileTest(_common.TestCase):
         oldartpath = self.lib.albums()[0].artpath
         self.assertExists(oldartpath)
 
-        self.ai.album = u'different_album'
+        self.ai.album = u"different_album"
         self.ai.store()
         self.ai.items()[0].move()
 
         artpath = self.lib.albums()[0].artpath
-        self.assertTrue(b'different_album' in artpath)
+        self.assertTrue(b"different_album" in artpath)
         self.assertExists(artpath)
         self.assertNotExists(oldartpath)
 
@@ -440,12 +440,12 @@ class ArtFileTest(_common.TestCase):
         oldartpath = self.lib.albums()[0].artpath
         self.assertExists(oldartpath)
 
-        self.i.album = u'different_album'
+        self.i.album = u"different_album"
         self.i.album_id = None  # detach from album
         self.i.move()
 
         artpath = self.lib.albums()[0].artpath
-        self.assertFalse(b'different_album' in artpath)
+        self.assertFalse(b"different_album" in artpath)
         self.assertEqual(artpath, oldartpath)
         self.assertExists(oldartpath)
 
@@ -455,8 +455,8 @@ class RemoveTest(_common.TestCase):
         super(RemoveTest, self).setUp()
 
         # Make library and item.
-        self.lib = beets.library.Library(':memory:')
-        self.libdir = os.path.join(self.temp_dir, b'testlibdir')
+        self.lib = beets.library.Library(":memory:")
+        self.libdir = os.path.join(self.temp_dir, b"testlibdir")
         self.lib.directory = self.libdir
         self.i = item(self.lib)
         self.i.path = self.i.destination()
@@ -474,13 +474,13 @@ class RemoveTest(_common.TestCase):
 
     def test_removing_last_item_preserves_nonempty_dir(self):
         parent = os.path.dirname(self.i.path)
-        touch(os.path.join(parent, b'dummy.txt'))
+        touch(os.path.join(parent, b"dummy.txt"))
         self.i.remove(True)
         self.assertExists(parent)
 
     def test_removing_last_item_prunes_dir_with_blacklisted_file(self):
         parent = os.path.dirname(self.i.path)
-        touch(os.path.join(parent, b'.DS_Store'))
+        touch(os.path.join(parent, b".DS_Store"))
         self.i.remove(True)
         self.assertNotExists(parent)
 
@@ -494,13 +494,13 @@ class RemoveTest(_common.TestCase):
         self.assertExists(self.libdir)
 
     def test_removing_item_outside_of_library_deletes_nothing(self):
-        self.lib.directory = os.path.join(self.temp_dir, b'xxx')
+        self.lib.directory = os.path.join(self.temp_dir, b"xxx")
         parent = os.path.dirname(self.i.path)
         self.i.remove(True)
         self.assertExists(parent)
 
     def test_removing_last_item_in_album_with_albumart_prunes_dir(self):
-        artfile = os.path.join(self.temp_dir, b'testart.jpg')
+        artfile = os.path.join(self.temp_dir, b"testart.jpg")
         touch(artfile)
         self.ai.set_art(artfile)
         self.ai.store()
@@ -515,7 +515,7 @@ class SoftRemoveTest(_common.TestCase):
     def setUp(self):
         super(SoftRemoveTest, self).setUp()
 
-        self.path = os.path.join(self.temp_dir, b'testfile')
+        self.path = os.path.join(self.temp_dir, b"testfile")
         touch(self.path)
 
     def test_soft_remove_deletes_file(self):
@@ -524,20 +524,20 @@ class SoftRemoveTest(_common.TestCase):
 
     def test_soft_remove_silent_on_no_file(self):
         try:
-            util.remove(self.path + b'XXX', True)
+            util.remove(self.path + b"XXX", True)
         except OSError:
-            self.fail(u'OSError when removing path')
+            self.fail(u"OSError when removing path")
 
 
 class SafeMoveCopyTest(_common.TestCase):
     def setUp(self):
         super(SafeMoveCopyTest, self).setUp()
 
-        self.path = os.path.join(self.temp_dir, b'testfile')
+        self.path = os.path.join(self.temp_dir, b"testfile")
         touch(self.path)
-        self.otherpath = os.path.join(self.temp_dir, b'testfile2')
+        self.otherpath = os.path.join(self.temp_dir, b"testfile2")
         touch(self.otherpath)
-        self.dest = self.path + b'.dest'
+        self.dest = self.path + b".dest"
 
     def test_successful_move(self):
         util.move(self.path, self.dest)
@@ -570,9 +570,9 @@ class PruneTest(_common.TestCase):
     def setUp(self):
         super(PruneTest, self).setUp()
 
-        self.base = os.path.join(self.temp_dir, b'testdir')
+        self.base = os.path.join(self.temp_dir, b"testdir")
         os.mkdir(self.base)
-        self.sub = os.path.join(self.base, b'subdir')
+        self.sub = os.path.join(self.base, b"subdir")
         os.mkdir(self.sub)
 
     def test_prune_existent_directory(self):
@@ -581,7 +581,7 @@ class PruneTest(_common.TestCase):
         self.assertNotExists(self.sub)
 
     def test_prune_nonexistent_directory(self):
-        util.prune_dirs(os.path.join(self.sub, b'another'), self.base)
+        util.prune_dirs(os.path.join(self.sub, b"another"), self.base)
         self.assertExists(self.base)
         self.assertNotExists(self.sub)
 
@@ -590,88 +590,85 @@ class WalkTest(_common.TestCase):
     def setUp(self):
         super(WalkTest, self).setUp()
 
-        self.base = os.path.join(self.temp_dir, b'testdir')
+        self.base = os.path.join(self.temp_dir, b"testdir")
         os.mkdir(self.base)
-        touch(os.path.join(self.base, b'y'))
-        touch(os.path.join(self.base, b'x'))
-        os.mkdir(os.path.join(self.base, b'd'))
-        touch(os.path.join(self.base, b'd', b'z'))
+        touch(os.path.join(self.base, b"y"))
+        touch(os.path.join(self.base, b"x"))
+        os.mkdir(os.path.join(self.base, b"d"))
+        touch(os.path.join(self.base, b"d", b"z"))
 
     def test_sorted_files(self):
         res = list(util.sorted_walk(self.base))
         self.assertEqual(len(res), 2)
-        self.assertEqual(res[0],
-                         (self.base, [b'd'], [b'x', b'y']))
-        self.assertEqual(res[1],
-                         (os.path.join(self.base, b'd'), [], [b'z']))
+        self.assertEqual(res[0], (self.base, [b"d"], [b"x", b"y"]))
+        self.assertEqual(res[1], (os.path.join(self.base, b"d"), [], [b"z"]))
 
     def test_ignore_file(self):
-        res = list(util.sorted_walk(self.base, (b'x',)))
+        res = list(util.sorted_walk(self.base, (b"x",)))
         self.assertEqual(len(res), 2)
-        self.assertEqual(res[0],
-                         (self.base, [b'd'], [b'y']))
-        self.assertEqual(res[1],
-                         (os.path.join(self.base, b'd'), [], [b'z']))
+        self.assertEqual(res[0], (self.base, [b"d"], [b"y"]))
+        self.assertEqual(res[1], (os.path.join(self.base, b"d"), [], [b"z"]))
 
     def test_ignore_directory(self):
-        res = list(util.sorted_walk(self.base, (b'd',)))
+        res = list(util.sorted_walk(self.base, (b"d",)))
         self.assertEqual(len(res), 1)
-        self.assertEqual(res[0],
-                         (self.base, [], [b'x', b'y']))
+        self.assertEqual(res[0], (self.base, [], [b"x", b"y"]))
 
     def test_ignore_everything(self):
-        res = list(util.sorted_walk(self.base, (b'*',)))
+        res = list(util.sorted_walk(self.base, (b"*",)))
         self.assertEqual(len(res), 1)
-        self.assertEqual(res[0],
-                         (self.base, [], []))
+        self.assertEqual(res[0], (self.base, [], []))
 
 
 class UniquePathTest(_common.TestCase):
     def setUp(self):
         super(UniquePathTest, self).setUp()
 
-        self.base = os.path.join(self.temp_dir, b'testdir')
+        self.base = os.path.join(self.temp_dir, b"testdir")
         os.mkdir(self.base)
-        touch(os.path.join(self.base, b'x.mp3'))
-        touch(os.path.join(self.base, b'x.1.mp3'))
-        touch(os.path.join(self.base, b'x.2.mp3'))
-        touch(os.path.join(self.base, b'y.mp3'))
+        touch(os.path.join(self.base, b"x.mp3"))
+        touch(os.path.join(self.base, b"x.1.mp3"))
+        touch(os.path.join(self.base, b"x.2.mp3"))
+        touch(os.path.join(self.base, b"y.mp3"))
 
     def test_new_file_unchanged(self):
-        path = util.unique_path(os.path.join(self.base, b'z.mp3'))
-        self.assertEqual(path, os.path.join(self.base, b'z.mp3'))
+        path = util.unique_path(os.path.join(self.base, b"z.mp3"))
+        self.assertEqual(path, os.path.join(self.base, b"z.mp3"))
 
     def test_conflicting_file_appends_1(self):
-        path = util.unique_path(os.path.join(self.base, b'y.mp3'))
-        self.assertEqual(path, os.path.join(self.base, b'y.1.mp3'))
+        path = util.unique_path(os.path.join(self.base, b"y.mp3"))
+        self.assertEqual(path, os.path.join(self.base, b"y.1.mp3"))
 
     def test_conflicting_file_appends_higher_number(self):
-        path = util.unique_path(os.path.join(self.base, b'x.mp3'))
-        self.assertEqual(path, os.path.join(self.base, b'x.3.mp3'))
+        path = util.unique_path(os.path.join(self.base, b"x.mp3"))
+        self.assertEqual(path, os.path.join(self.base, b"x.3.mp3"))
 
     def test_conflicting_file_with_number_increases_number(self):
-        path = util.unique_path(os.path.join(self.base, b'x.1.mp3'))
-        self.assertEqual(path, os.path.join(self.base, b'x.3.mp3'))
+        path = util.unique_path(os.path.join(self.base, b"x.1.mp3"))
+        self.assertEqual(path, os.path.join(self.base, b"x.3.mp3"))
 
 
 class MkDirAllTest(_common.TestCase):
     def test_parent_exists(self):
-        path = os.path.join(self.temp_dir, b'foo', b'bar', b'baz', b'qux.mp3')
+        path = os.path.join(self.temp_dir, b"foo", b"bar", b"baz", b"qux.mp3")
         util.mkdirall(path)
-        self.assertTrue(os.path.isdir(
-            os.path.join(self.temp_dir, b'foo', b'bar', b'baz')
-        ))
+        self.assertTrue(
+            os.path.isdir(os.path.join(self.temp_dir, b"foo", b"bar", b"baz"))
+        )
 
     def test_child_does_not_exist(self):
-        path = os.path.join(self.temp_dir, b'foo', b'bar', b'baz', b'qux.mp3')
+        path = os.path.join(self.temp_dir, b"foo", b"bar", b"baz", b"qux.mp3")
         util.mkdirall(path)
-        self.assertTrue(not os.path.exists(
-            os.path.join(self.temp_dir, b'foo', b'bar', b'baz', b'qux.mp3')
-        ))
+        self.assertTrue(
+            not os.path.exists(
+                os.path.join(self.temp_dir, b"foo", b"bar", b"baz", b"qux.mp3")
+            )
+        )
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_ftintitle.py
+++ b/test/test_ftintitle.py
@@ -26,60 +26,62 @@ class FtInTitlePluginFunctional(unittest.TestCase, TestHelper):
     def setUp(self):
         """Set up configuration"""
         self.setup_beets()
-        self.load_plugins('ftintitle')
+        self.load_plugins("ftintitle")
 
     def tearDown(self):
         self.unload_plugins()
         self.teardown_beets()
 
     def _ft_add_item(self, path, artist, title, aartist):
-        return self.add_item(path=path,
-                             artist=artist,
-                             artist_sort=artist,
-                             title=title,
-                             albumartist=aartist)
+        return self.add_item(
+            path=path,
+            artist=artist,
+            artist_sort=artist,
+            title=title,
+            albumartist=aartist,
+        )
 
     def _ft_set_config(self, ftformat, drop=False, auto=True):
-        self.config['ftintitle']['format'] = ftformat
-        self.config['ftintitle']['drop'] = drop
-        self.config['ftintitle']['auto'] = auto
+        self.config["ftintitle"]["format"] = ftformat
+        self.config["ftintitle"]["drop"] = drop
+        self.config["ftintitle"]["auto"] = auto
 
     def test_functional_drop(self):
-        item = self._ft_add_item('/', u'Alice ft Bob', u'Song 1', u'Alice')
-        self.run_command('ftintitle', '-d')
+        item = self._ft_add_item("/", u"Alice ft Bob", u"Song 1", u"Alice")
+        self.run_command("ftintitle", "-d")
         item.load()
-        self.assertEqual(item['artist'], u'Alice')
-        self.assertEqual(item['title'], u'Song 1')
+        self.assertEqual(item["artist"], u"Alice")
+        self.assertEqual(item["title"], u"Song 1")
 
     def test_functional_not_found(self):
-        item = self._ft_add_item('/', u'Alice ft Bob', u'Song 1', u'George')
-        self.run_command('ftintitle', '-d')
+        item = self._ft_add_item("/", u"Alice ft Bob", u"Song 1", u"George")
+        self.run_command("ftintitle", "-d")
         item.load()
         # item should be unchanged
-        self.assertEqual(item['artist'], u'Alice ft Bob')
-        self.assertEqual(item['title'], u'Song 1')
+        self.assertEqual(item["artist"], u"Alice ft Bob")
+        self.assertEqual(item["title"], u"Song 1")
 
     def test_functional_custom_format(self):
-        self._ft_set_config('feat. {0}')
-        item = self._ft_add_item('/', u'Alice ft Bob', u'Song 1', u'Alice')
-        self.run_command('ftintitle')
+        self._ft_set_config("feat. {0}")
+        item = self._ft_add_item("/", u"Alice ft Bob", u"Song 1", u"Alice")
+        self.run_command("ftintitle")
         item.load()
-        self.assertEqual(item['artist'], u'Alice')
-        self.assertEqual(item['title'], u'Song 1 feat. Bob')
+        self.assertEqual(item["artist"], u"Alice")
+        self.assertEqual(item["title"], u"Song 1 feat. Bob")
 
-        self._ft_set_config('featuring {0}')
-        item = self._ft_add_item('/', u'Alice feat. Bob', u'Song 1', u'Alice')
-        self.run_command('ftintitle')
+        self._ft_set_config("featuring {0}")
+        item = self._ft_add_item("/", u"Alice feat. Bob", u"Song 1", u"Alice")
+        self.run_command("ftintitle")
         item.load()
-        self.assertEqual(item['artist'], u'Alice')
-        self.assertEqual(item['title'], u'Song 1 featuring Bob')
+        self.assertEqual(item["artist"], u"Alice")
+        self.assertEqual(item["title"], u"Song 1 featuring Bob")
 
-        self._ft_set_config('with {0}')
-        item = self._ft_add_item('/', u'Alice feat Bob', u'Song 1', u'Alice')
-        self.run_command('ftintitle')
+        self._ft_set_config("with {0}")
+        item = self._ft_add_item("/", u"Alice feat Bob", u"Song 1", u"Alice")
+        self.run_command("ftintitle")
         item.load()
-        self.assertEqual(item['artist'], u'Alice')
-        self.assertEqual(item['title'], u'Song 1 with Bob')
+        self.assertEqual(item["artist"], u"Alice")
+        self.assertEqual(item["title"], u"Song 1 with Bob")
 
 
 class FtInTitlePluginTest(unittest.TestCase):
@@ -90,96 +92,96 @@ class FtInTitlePluginTest(unittest.TestCase):
     def test_find_feat_part(self):
         test_cases = [
             {
-                'artist': 'Alice ft. Bob',
-                'album_artist': 'Alice',
-                'feat_part': 'Bob'
+                "artist": "Alice ft. Bob",
+                "album_artist": "Alice",
+                "feat_part": "Bob",
             },
             {
-                'artist': 'Alice feat Bob',
-                'album_artist': 'Alice',
-                'feat_part': 'Bob'
+                "artist": "Alice feat Bob",
+                "album_artist": "Alice",
+                "feat_part": "Bob",
             },
             {
-                'artist': 'Alice featuring Bob',
-                'album_artist': 'Alice',
-                'feat_part': 'Bob'
+                "artist": "Alice featuring Bob",
+                "album_artist": "Alice",
+                "feat_part": "Bob",
             },
             {
-                'artist': 'Alice & Bob',
-                'album_artist': 'Alice',
-                'feat_part': 'Bob'
+                "artist": "Alice & Bob",
+                "album_artist": "Alice",
+                "feat_part": "Bob",
             },
             {
-                'artist': 'Alice and Bob',
-                'album_artist': 'Alice',
-                'feat_part': 'Bob'
+                "artist": "Alice and Bob",
+                "album_artist": "Alice",
+                "feat_part": "Bob",
             },
             {
-                'artist': 'Alice With Bob',
-                'album_artist': 'Alice',
-                'feat_part': 'Bob'
+                "artist": "Alice With Bob",
+                "album_artist": "Alice",
+                "feat_part": "Bob",
             },
             {
-                'artist': 'Alice defeat Bob',
-                'album_artist': 'Alice',
-                'feat_part': None
+                "artist": "Alice defeat Bob",
+                "album_artist": "Alice",
+                "feat_part": None,
             },
             {
-                'artist': 'Alice & Bob',
-                'album_artist': 'Bob',
-                'feat_part': 'Alice'
+                "artist": "Alice & Bob",
+                "album_artist": "Bob",
+                "feat_part": "Alice",
             },
             {
-                'artist': 'Alice ft. Bob',
-                'album_artist': 'Bob',
-                'feat_part': 'Alice'
+                "artist": "Alice ft. Bob",
+                "album_artist": "Bob",
+                "feat_part": "Alice",
             },
             {
-                'artist': 'Alice ft. Carol',
-                'album_artist': 'Bob',
-                'feat_part': None
+                "artist": "Alice ft. Carol",
+                "album_artist": "Bob",
+                "feat_part": None,
             },
         ]
 
         for test_case in test_cases:
             feat_part = ftintitle.find_feat_part(
-                test_case['artist'],
-                test_case['album_artist']
+                test_case["artist"], test_case["album_artist"]
             )
-            self.assertEqual(feat_part, test_case['feat_part'])
+            self.assertEqual(feat_part, test_case["feat_part"])
 
     def test_split_on_feat(self):
-        parts = ftintitle.split_on_feat(u'Alice ft. Bob')
-        self.assertEqual(parts, (u'Alice', u'Bob'))
-        parts = ftintitle.split_on_feat(u'Alice feat Bob')
-        self.assertEqual(parts, (u'Alice', u'Bob'))
-        parts = ftintitle.split_on_feat(u'Alice feat. Bob')
-        self.assertEqual(parts, (u'Alice', u'Bob'))
-        parts = ftintitle.split_on_feat(u'Alice featuring Bob')
-        self.assertEqual(parts, (u'Alice', u'Bob'))
-        parts = ftintitle.split_on_feat(u'Alice & Bob')
-        self.assertEqual(parts, (u'Alice', u'Bob'))
-        parts = ftintitle.split_on_feat(u'Alice and Bob')
-        self.assertEqual(parts, (u'Alice', u'Bob'))
-        parts = ftintitle.split_on_feat(u'Alice With Bob')
-        self.assertEqual(parts, (u'Alice', u'Bob'))
-        parts = ftintitle.split_on_feat(u'Alice defeat Bob')
-        self.assertEqual(parts, (u'Alice defeat Bob', None))
+        parts = ftintitle.split_on_feat(u"Alice ft. Bob")
+        self.assertEqual(parts, (u"Alice", u"Bob"))
+        parts = ftintitle.split_on_feat(u"Alice feat Bob")
+        self.assertEqual(parts, (u"Alice", u"Bob"))
+        parts = ftintitle.split_on_feat(u"Alice feat. Bob")
+        self.assertEqual(parts, (u"Alice", u"Bob"))
+        parts = ftintitle.split_on_feat(u"Alice featuring Bob")
+        self.assertEqual(parts, (u"Alice", u"Bob"))
+        parts = ftintitle.split_on_feat(u"Alice & Bob")
+        self.assertEqual(parts, (u"Alice", u"Bob"))
+        parts = ftintitle.split_on_feat(u"Alice and Bob")
+        self.assertEqual(parts, (u"Alice", u"Bob"))
+        parts = ftintitle.split_on_feat(u"Alice With Bob")
+        self.assertEqual(parts, (u"Alice", u"Bob"))
+        parts = ftintitle.split_on_feat(u"Alice defeat Bob")
+        self.assertEqual(parts, (u"Alice defeat Bob", None))
 
     def test_contains_feat(self):
-        self.assertTrue(ftintitle.contains_feat(u'Alice ft. Bob'))
-        self.assertTrue(ftintitle.contains_feat(u'Alice feat. Bob'))
-        self.assertTrue(ftintitle.contains_feat(u'Alice feat Bob'))
-        self.assertTrue(ftintitle.contains_feat(u'Alice featuring Bob'))
-        self.assertTrue(ftintitle.contains_feat(u'Alice & Bob'))
-        self.assertTrue(ftintitle.contains_feat(u'Alice and Bob'))
-        self.assertTrue(ftintitle.contains_feat(u'Alice With Bob'))
-        self.assertFalse(ftintitle.contains_feat(u'Alice defeat Bob'))
-        self.assertFalse(ftintitle.contains_feat(u'Aliceft.Bob'))
+        self.assertTrue(ftintitle.contains_feat(u"Alice ft. Bob"))
+        self.assertTrue(ftintitle.contains_feat(u"Alice feat. Bob"))
+        self.assertTrue(ftintitle.contains_feat(u"Alice feat Bob"))
+        self.assertTrue(ftintitle.contains_feat(u"Alice featuring Bob"))
+        self.assertTrue(ftintitle.contains_feat(u"Alice & Bob"))
+        self.assertTrue(ftintitle.contains_feat(u"Alice and Bob"))
+        self.assertTrue(ftintitle.contains_feat(u"Alice With Bob"))
+        self.assertFalse(ftintitle.contains_feat(u"Alice defeat Bob"))
+        self.assertFalse(ftintitle.contains_feat(u"Aliceft.Bob"))
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_hidden.py
+++ b/test/test_hidden.py
@@ -32,8 +32,8 @@ class HiddenFileTest(unittest.TestCase):
         pass
 
     def test_osx_hidden(self):
-        if not sys.platform == 'darwin':
-            self.skipTest('sys.platform is not darwin')
+        if not sys.platform == "darwin":
+            self.skipTest("sys.platform is not darwin")
             return
 
         with tempfile.NamedTemporaryFile(delete=False) as f:
@@ -49,8 +49,8 @@ class HiddenFileTest(unittest.TestCase):
             self.assertTrue(hidden.is_hidden(f.name))
 
     def test_windows_hidden(self):
-        if not sys.platform == 'win32':
-            self.skipTest('sys.platform is not windows')
+        if not sys.platform == "win32":
+            self.skipTest("sys.platform is not windows")
             return
 
         # FILE_ATTRIBUTE_HIDDEN = 2 (0x2) from GetFileAttributes documentation.
@@ -58,8 +58,9 @@ class HiddenFileTest(unittest.TestCase):
 
         with tempfile.NamedTemporaryFile() as f:
             # Hide the file using
-            success = ctypes.windll.kernel32.SetFileAttributesW(f.name,
-                                                                hidden_mask)
+            success = ctypes.windll.kernel32.SetFileAttributesW(
+                f.name, hidden_mask
+            )
 
             if not success:
                 self.skipTest("unable to set file attributes")
@@ -67,11 +68,11 @@ class HiddenFileTest(unittest.TestCase):
             self.assertTrue(hidden.is_hidden(f.name))
 
     def test_other_hidden(self):
-        if sys.platform == 'darwin' or sys.platform == 'win32':
-            self.skipTest('sys.platform is known')
+        if sys.platform == "darwin" or sys.platform == "win32":
+            self.skipTest("sys.platform is known")
             return
 
-        with tempfile.NamedTemporaryFile(prefix='.tmp') as f:
+        with tempfile.NamedTemporaryFile(prefix=".tmp") as f:
             fn = util.bytestring_path(f.name)
             self.assertTrue(hidden.is_hidden(fn))
 
@@ -79,5 +80,6 @@ class HiddenFileTest(unittest.TestCase):
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_hook.py
+++ b/test/test_hook.py
@@ -44,47 +44,47 @@ class HookTest(_common.TestCase, TestHelper):
         self.teardown_beets()
 
     def _add_hook(self, event, command):
-        hook = {
-            'event': event,
-            'command': command
-        }
+        hook = {"event": event, "command": command}
 
-        hooks = config['hook']['hooks'].get(list) if 'hook' in config else []
+        hooks = config["hook"]["hooks"].get(list) if "hook" in config else []
         hooks.append(hook)
 
-        config['hook']['hooks'] = hooks
+        config["hook"]["hooks"] = hooks
 
     def test_hook_empty_command(self):
-        self._add_hook('test_event', '')
+        self._add_hook("test_event", "")
 
-        self.load_plugins('hook')
+        self.load_plugins("hook")
 
-        with capture_log('beets.hook') as logs:
-            plugins.send('test_event')
+        with capture_log("beets.hook") as logs:
+            plugins.send("test_event")
 
         self.assertIn('hook: invalid command ""', logs)
 
     def test_hook_non_zero_exit(self):
-        self._add_hook('test_event', 'sh -c "exit 1"')
+        self._add_hook("test_event", 'sh -c "exit 1"')
 
-        self.load_plugins('hook')
+        self.load_plugins("hook")
 
-        with capture_log('beets.hook') as logs:
-            plugins.send('test_event')
+        with capture_log("beets.hook") as logs:
+            plugins.send("test_event")
 
-        self.assertIn('hook: hook for test_event exited with status 1', logs)
+        self.assertIn("hook: hook for test_event exited with status 1", logs)
 
     def test_hook_non_existent_command(self):
-        self._add_hook('test_event', 'non-existent-command')
+        self._add_hook("test_event", "non-existent-command")
 
-        self.load_plugins('hook')
+        self.load_plugins("hook")
 
-        with capture_log('beets.hook') as logs:
-            plugins.send('test_event')
+        with capture_log("beets.hook") as logs:
+            plugins.send("test_event")
 
-        self.assertTrue(any(
-            message.startswith("hook: hook for test_event failed: ")
-            for message in logs))
+        self.assertTrue(
+            any(
+                message.startswith("hook: hook for test_event failed: ")
+                for message in logs
+            )
+        )
 
     def test_hook_no_arguments(self):
         temporary_paths = [
@@ -92,13 +92,15 @@ class HookTest(_common.TestCase, TestHelper):
         ]
 
         for index, path in enumerate(temporary_paths):
-            self._add_hook('test_no_argument_event_{0}'.format(index),
-                           'touch "{0}"'.format(path))
+            self._add_hook(
+                "test_no_argument_event_{0}".format(index),
+                'touch "{0}"'.format(path),
+            )
 
-        self.load_plugins('hook')
+        self.load_plugins("hook")
 
         for index in range(len(temporary_paths)):
-            plugins.send('test_no_argument_event_{0}'.format(index))
+            plugins.send("test_no_argument_event_{0}".format(index))
 
         for path in temporary_paths:
             self.assertTrue(os.path.isfile(path))
@@ -106,14 +108,17 @@ class HookTest(_common.TestCase, TestHelper):
 
     def test_hook_event_substitution(self):
         temporary_directory = tempfile._get_default_tempdir()
-        event_names = ['test_event_event_{0}'.format(i) for i in
-                       range(self.TEST_HOOK_COUNT)]
+        event_names = [
+            "test_event_event_{0}".format(i)
+            for i in range(self.TEST_HOOK_COUNT)
+        ]
 
         for event in event_names:
-            self._add_hook(event,
-                           'touch "{0}/{{event}}"'.format(temporary_directory))
+            self._add_hook(
+                event, 'touch "{0}/{{event}}"'.format(temporary_directory)
+            )
 
-        self.load_plugins('hook')
+        self.load_plugins("hook")
 
         for event in event_names:
             plugins.send(event)
@@ -130,13 +135,14 @@ class HookTest(_common.TestCase, TestHelper):
         ]
 
         for index, path in enumerate(temporary_paths):
-            self._add_hook('test_argument_event_{0}'.format(index),
-                           'touch "{path}"')
+            self._add_hook(
+                "test_argument_event_{0}".format(index), 'touch "{path}"'
+            )
 
-        self.load_plugins('hook')
+        self.load_plugins("hook")
 
         for index, path in enumerate(temporary_paths):
-            plugins.send('test_argument_event_{0}'.format(index), path=path)
+            plugins.send("test_argument_event_{0}".format(index), path=path)
 
         for path in temporary_paths:
             self.assertTrue(os.path.isfile(path))
@@ -144,18 +150,19 @@ class HookTest(_common.TestCase, TestHelper):
 
     def test_hook_bytes_interpolation(self):
         temporary_paths = [
-            get_temporary_path().encode('utf-8')
+            get_temporary_path().encode("utf-8")
             for i in range(self.TEST_HOOK_COUNT)
         ]
 
         for index, path in enumerate(temporary_paths):
-            self._add_hook('test_bytes_event_{0}'.format(index),
-                           'touch "{path}"')
+            self._add_hook(
+                "test_bytes_event_{0}".format(index), 'touch "{path}"'
+            )
 
-        self.load_plugins('hook')
+        self.load_plugins("hook")
 
         for index, path in enumerate(temporary_paths):
-            plugins.send('test_bytes_event_{0}'.format(index), path=path)
+            plugins.send("test_bytes_event_{0}".format(index), path=path)
 
         for path in temporary_paths:
             self.assertTrue(os.path.isfile(path))
@@ -165,5 +172,6 @@ class HookTest(_common.TestCase, TestHelper):
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_ihate.py
+++ b/test/test_ihate.py
@@ -11,14 +11,12 @@ from beetsplug.ihate import IHatePlugin
 
 
 class IHatePluginTest(unittest.TestCase):
-
     def test_hate(self):
 
         match_pattern = {}
         test_item = Item(
-            genre=u'TestGenre',
-            album=u'TestAlbum',
-            artist=u'TestArtist')
+            genre=u"TestGenre", album=u"TestAlbum", artist=u"TestArtist"
+        )
         task = importer.SingletonImportTask(None, test_item)
 
         # Empty query should let it pass.
@@ -37,18 +35,23 @@ class IHatePluginTest(unittest.TestCase):
         self.assertFalse(IHatePlugin.do_i_hate_this(task, match_pattern))
 
         # Both queries are blocked by AND clause with unmatched condition.
-        match_pattern = [u"album:notthis genre:testgenre",
-                         u"artist:testartist album:notthis"]
+        match_pattern = [
+            u"album:notthis genre:testgenre",
+            u"artist:testartist album:notthis",
+        ]
         self.assertFalse(IHatePlugin.do_i_hate_this(task, match_pattern))
 
         # Only one query should fire.
-        match_pattern = [u"album:testalbum genre:testgenre",
-                         u"artist:testartist album:notthis"]
+        match_pattern = [
+            u"album:testalbum genre:testgenre",
+            u"artist:testartist album:notthis",
+        ]
         self.assertTrue(IHatePlugin.do_i_hate_this(task, match_pattern))
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_importadded.py
+++ b/test/test_importadded.py
@@ -50,13 +50,14 @@ class ImportAddedTest(unittest.TestCase, ImportHelper):
     def setUp(self):
         preserve_plugin_listeners()
         self.setup_beets()
-        self.load_plugins('importadded')
+        self.load_plugins("importadded")
         self._create_import_dir(2)
         # Different mtimes on the files to be imported in order to test the
         # plugin
         modify_mtimes((mfile.path for mfile in self.media_files))
-        self.min_mtime = min(os.path.getmtime(mfile.path)
-                             for mfile in self.media_files)
+        self.min_mtime = min(
+            os.path.getmtime(mfile.path) for mfile in self.media_files
+        )
         self.matcher = AutotagStub().install()
         self.matcher.macthin = AutotagStub.GOOD
         self._setup_import_session()
@@ -70,10 +71,11 @@ class ImportAddedTest(unittest.TestCase, ImportHelper):
     def find_media_file(self, item):
         """Find the pre-import MediaFile for an Item"""
         for m in self.media_files:
-            if m.title.replace('Tag', 'Applied') == item.title:
+            if m.title.replace("Tag", "Applied") == item.title:
                 return m
-        raise AssertionError(u"No MediaFile found for Item " +
-                             util.displayable_path(item.path))
+        raise AssertionError(
+            u"No MediaFile found for Item " + util.displayable_path(item.path)
+        )
 
     def assertEqualTimes(self, first, second, msg=None):  # noqa
         """For comparing file modification times at a sufficient precision"""
@@ -90,14 +92,14 @@ class ImportAddedTest(unittest.TestCase, ImportHelper):
         self.assertAlbumImport()
 
     def test_import_album_inplace_with_added_dates(self):
-        self.config['import']['copy'] = False
-        self.config['import']['move'] = False
-        self.config['import']['link'] = False
-        self.config['import']['hardlink'] = False
+        self.config["import"]["copy"] = False
+        self.config["import"]["move"] = False
+        self.config["import"]["link"] = False
+        self.config["import"]["hardlink"] = False
         self.assertAlbumImport()
 
     def test_import_album_with_preserved_mtimes(self):
-        self.config['importadded']['preserve_mtimes'] = True
+        self.config["importadded"]["preserve_mtimes"] = True
         self.importer.run()
         album = self.lib.albums().get()
         self.assertEqual(album.added, self.min_mtime)
@@ -105,16 +107,16 @@ class ImportAddedTest(unittest.TestCase, ImportHelper):
             self.assertEqualTimes(item.added, self.min_mtime)
             mediafile_mtime = os.path.getmtime(self.find_media_file(item).path)
             self.assertEqualTimes(item.mtime, mediafile_mtime)
-            self.assertEqualTimes(os.path.getmtime(item.path),
-                                  mediafile_mtime)
+            self.assertEqualTimes(os.path.getmtime(item.path), mediafile_mtime)
 
     def test_reimported_album_skipped(self):
         # Import and record the original added dates
         self.importer.run()
         album = self.lib.albums().get()
         album_added_before = album.added
-        items_added_before = dict((item.path, item.added)
-                                  for item in album.items())
+        items_added_before = dict(
+            (item.path, item.added) for item in album.items()
+        )
         # Newer Item path mtimes as if Beets had modified them
         modify_mtimes(items_added_before.keys(), offset=10000)
         # Reimport
@@ -123,37 +125,41 @@ class ImportAddedTest(unittest.TestCase, ImportHelper):
         # Verify the reimported items
         album = self.lib.albums().get()
         self.assertEqualTimes(album.added, album_added_before)
-        items_added_after = dict((item.path, item.added)
-                                 for item in album.items())
+        items_added_after = dict(
+            (item.path, item.added) for item in album.items()
+        )
         for item_path, added_after in items_added_after.items():
-            self.assertEqualTimes(items_added_before[item_path], added_after,
-                                  u"reimport modified Item.added for " +
-                                  util.displayable_path(item_path))
+            self.assertEqualTimes(
+                items_added_before[item_path],
+                added_after,
+                u"reimport modified Item.added for "
+                + util.displayable_path(item_path),
+            )
 
     def test_import_singletons_with_added_dates(self):
-        self.config['import']['singletons'] = True
+        self.config["import"]["singletons"] = True
         self.importer.run()
         for item in self.lib.items():
             mfile = self.find_media_file(item)
             self.assertEqualTimes(item.added, os.path.getmtime(mfile.path))
 
     def test_import_singletons_with_preserved_mtimes(self):
-        self.config['import']['singletons'] = True
-        self.config['importadded']['preserve_mtimes'] = True
+        self.config["import"]["singletons"] = True
+        self.config["importadded"]["preserve_mtimes"] = True
         self.importer.run()
         for item in self.lib.items():
             mediafile_mtime = os.path.getmtime(self.find_media_file(item).path)
             self.assertEqualTimes(item.added, mediafile_mtime)
             self.assertEqualTimes(item.mtime, mediafile_mtime)
-            self.assertEqualTimes(os.path.getmtime(item.path),
-                                  mediafile_mtime)
+            self.assertEqualTimes(os.path.getmtime(item.path), mediafile_mtime)
 
     def test_reimported_singletons_skipped(self):
-        self.config['import']['singletons'] = True
+        self.config["import"]["singletons"] = True
         # Import and record the original added dates
         self.importer.run()
-        items_added_before = dict((item.path, item.added)
-                                  for item in self.lib.items())
+        items_added_before = dict(
+            (item.path, item.added) for item in self.lib.items()
+        )
         # Newer Item path mtimes as if Beets had modified them
         modify_mtimes(items_added_before.keys(), offset=10000)
         # Reimport
@@ -161,16 +167,21 @@ class ImportAddedTest(unittest.TestCase, ImportHelper):
         self._setup_import_session(import_dir=import_dir, singletons=True)
         self.importer.run()
         # Verify the reimported items
-        items_added_after = dict((item.path, item.added)
-                                 for item in self.lib.items())
+        items_added_after = dict(
+            (item.path, item.added) for item in self.lib.items()
+        )
         for item_path, added_after in items_added_after.items():
-            self.assertEqualTimes(items_added_before[item_path], added_after,
-                                  u"reimport modified Item.added for " +
-                                  util.displayable_path(item_path))
+            self.assertEqualTimes(
+                items_added_before[item_path],
+                added_after,
+                u"reimport modified Item.added for "
+                + util.displayable_path(item_path),
+            )
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -49,11 +49,11 @@ class AutotagStub(object):
     autotagger returns.
     """
 
-    NONE = 'NONE'
-    IDENT = 'IDENT'
-    GOOD = 'GOOD'
-    BAD = 'BAD'
-    MISSING = 'MISSING'
+    NONE = "NONE"
+    IDENT = "IDENT"
+    GOOD = "GOOD"
+    BAD = "BAD"
+    MISSING = "MISSING"
     """Generate an album match for all but one track
     """
 
@@ -96,10 +96,10 @@ class AutotagStub(object):
 
     def match_track(self, artist, title):
         yield TrackInfo(
-            title=title.replace('Tag', 'Applied'),
-            track_id=u'trackid',
-            artist=artist.replace('Tag', 'Applied'),
-            artist_id=u'artistid',
+            title=title.replace("Tag", "Applied"),
+            track_id=u"trackid",
+            artist=artist.replace("Tag", "Applied"),
+            artist_id=u"artistid",
             length=1,
             index=0,
         )
@@ -112,8 +112,8 @@ class AutotagStub(object):
 
     def _make_track_match(self, artist, album, number):
         return TrackInfo(
-            title=u'Applied Title %d' % number,
-            track_id=u'match %d' % number,
+            title=u"Applied Title %d" % number,
+            track_id=u"match %d" % number,
             artist=artist,
             length=1,
             index=0,
@@ -121,14 +121,14 @@ class AutotagStub(object):
 
     def _make_album_match(self, artist, album, tracks, distance=0, missing=0):
         if distance:
-            id = ' ' + 'M' * distance
+            id = " " + "M" * distance
         else:
-            id = ''
+            id = ""
         if artist is None:
             artist = u"Various Artists"
         else:
-            artist = artist.replace('Tag', 'Applied') + id
-        album = album.replace('Tag', 'Applied') + id
+            artist = artist.replace("Tag", "Applied") + id
+        album = album.replace("Tag", "Applied") + id
 
         track_infos = []
         for i in range(tracks - missing):
@@ -139,9 +139,9 @@ class AutotagStub(object):
             album=album,
             tracks=track_infos,
             va=False,
-            album_id=u'albumid' + id,
-            artist_id=u'artistid' + id,
-            albumtype=u'soundtrack'
+            album_id=u"albumid" + id,
+            artist_id=u"artistid" + id,
+            albumtype=u"soundtrack",
         )
 
 
@@ -154,9 +154,9 @@ class ImportHelper(TestHelper):
     def setup_beets(self, disk=False):
         super(ImportHelper, self).setup_beets(disk)
         self.lib.path_formats = [
-            (u'default', os.path.join('$artist', '$album', '$title')),
-            (u'singleton:true', os.path.join('singletons', '$title')),
-            (u'comp:true', os.path.join('compilations', '$album', '$title')),
+            (u"default", os.path.join("$artist", "$album", "$title")),
+            (u"singleton:true", os.path.join("singletons", "$title")),
+            (u"comp:true", os.path.join("compilations", "$album", "$title")),
         ]
 
     def _create_import_dir(self, count=3):
@@ -173,60 +173,69 @@ class ImportHelper(TestHelper):
 
         :param count:  Number of files to create
         """
-        self.import_dir = os.path.join(self.temp_dir, b'testsrcdir')
+        self.import_dir = os.path.join(self.temp_dir, b"testsrcdir")
         if os.path.isdir(self.import_dir):
             shutil.rmtree(self.import_dir)
 
-        album_path = os.path.join(self.import_dir, b'the_album')
+        album_path = os.path.join(self.import_dir, b"the_album")
         os.makedirs(album_path)
 
-        resource_path = os.path.join(_common.RSRC, b'full.mp3')
+        resource_path = os.path.join(_common.RSRC, b"full.mp3")
 
         metadata = {
-            'artist': u'Tag Artist',
-            'album':  u'Tag Album',
-            'albumartist':  None,
-            'mb_trackid': None,
-            'mb_albumid': None,
-            'comp': None
+            "artist": u"Tag Artist",
+            "album": u"Tag Album",
+            "albumartist": None,
+            "mb_trackid": None,
+            "mb_albumid": None,
+            "comp": None,
         }
         self.media_files = []
         for i in range(count):
             # Copy files
             medium_path = os.path.join(
-                album_path,
-                bytestring_path('track_%d.mp3' % (i + 1))
+                album_path, bytestring_path("track_%d.mp3" % (i + 1))
             )
             shutil.copy(resource_path, medium_path)
             medium = MediaFile(medium_path)
 
             # Set metadata
-            metadata['track'] = i + 1
-            metadata['title'] = u'Tag Title %d' % (i + 1)
+            metadata["track"] = i + 1
+            metadata["title"] = u"Tag Title %d" % (i + 1)
             for attr in metadata:
                 setattr(medium, attr, metadata[attr])
             medium.save()
             self.media_files.append(medium)
         self.import_media = self.media_files
 
-    def _setup_import_session(self, import_dir=None, delete=False,
-                              threaded=False, copy=True, singletons=False,
-                              move=False, autotag=True, link=False,
-                              hardlink=False):
-        config['import']['copy'] = copy
-        config['import']['delete'] = delete
-        config['import']['timid'] = True
-        config['threaded'] = False
-        config['import']['singletons'] = singletons
-        config['import']['move'] = move
-        config['import']['autotag'] = autotag
-        config['import']['resume'] = False
-        config['import']['link'] = link
-        config['import']['hardlink'] = hardlink
+    def _setup_import_session(
+        self,
+        import_dir=None,
+        delete=False,
+        threaded=False,
+        copy=True,
+        singletons=False,
+        move=False,
+        autotag=True,
+        link=False,
+        hardlink=False,
+    ):
+        config["import"]["copy"] = copy
+        config["import"]["delete"] = delete
+        config["import"]["timid"] = True
+        config["threaded"] = False
+        config["import"]["singletons"] = singletons
+        config["import"]["move"] = move
+        config["import"]["autotag"] = autotag
+        config["import"]["resume"] = False
+        config["import"]["link"] = link
+        config["import"]["hardlink"] = hardlink
 
         self.importer = ImportSessionFixture(
-            self.lib, loghandler=None, query=None,
-            paths=[import_dir or self.import_dir]
+            self.lib,
+            loghandler=None,
+            query=None,
+            paths=[import_dir or self.import_dir],
         )
 
     def assert_file_in_lib(self, *segments):
@@ -259,26 +268,30 @@ class NonAutotaggedImportTest(_common.TestCase, ImportHelper):
         self.importer.run()
         albums = self.lib.albums()
         self.assertEqual(len(albums), 1)
-        self.assertEqual(albums[0].albumartist, u'Tag Artist')
+        self.assertEqual(albums[0].albumartist, u"Tag Artist")
 
     def test_import_copy_arrives(self):
         self.importer.run()
         for mediafile in self.import_media:
             self.assert_file_in_lib(
-                b'Tag Artist', b'Tag Album',
-                util.bytestring_path('{0}.mp3'.format(mediafile.title)))
+                b"Tag Artist",
+                b"Tag Album",
+                util.bytestring_path("{0}.mp3".format(mediafile.title)),
+            )
 
     def test_threaded_import_copy_arrives(self):
-        config['threaded'] = True
+        config["threaded"] = True
 
         self.importer.run()
         for mediafile in self.import_media:
             self.assert_file_in_lib(
-                b'Tag Artist', b'Tag Album',
-                util.bytestring_path('{0}.mp3'.format(mediafile.title)))
+                b"Tag Artist",
+                b"Tag Album",
+                util.bytestring_path("{0}.mp3".format(mediafile.title)),
+            )
 
     def test_import_with_move_deletes_import_files(self):
-        config['import']['move'] = True
+        config["import"]["move"] = True
 
         for mediafile in self.import_media:
             self.assertExists(mediafile.path)
@@ -287,101 +300,103 @@ class NonAutotaggedImportTest(_common.TestCase, ImportHelper):
             self.assertNotExists(mediafile.path)
 
     def test_import_with_move_prunes_directory_empty(self):
-        config['import']['move'] = True
+        config["import"]["move"] = True
 
-        self.assertExists(os.path.join(self.import_dir, b'the_album'))
+        self.assertExists(os.path.join(self.import_dir, b"the_album"))
         self.importer.run()
-        self.assertNotExists(os.path.join(self.import_dir, b'the_album'))
+        self.assertNotExists(os.path.join(self.import_dir, b"the_album"))
 
     def test_import_with_move_prunes_with_extra_clutter(self):
-        f = open(os.path.join(self.import_dir, b'the_album', b'alog.log'), 'w')
+        f = open(os.path.join(self.import_dir, b"the_album", b"alog.log"), "w")
         f.close()
-        config['clutter'] = ['*.log']
-        config['import']['move'] = True
+        config["clutter"] = ["*.log"]
+        config["import"]["move"] = True
 
-        self.assertExists(os.path.join(self.import_dir, b'the_album'))
+        self.assertExists(os.path.join(self.import_dir, b"the_album"))
         self.importer.run()
-        self.assertNotExists(os.path.join(self.import_dir, b'the_album'))
+        self.assertNotExists(os.path.join(self.import_dir, b"the_album"))
 
     def test_threaded_import_move_arrives(self):
-        config['import']['move'] = True
-        config['import']['threaded'] = True
+        config["import"]["move"] = True
+        config["import"]["threaded"] = True
 
         self.importer.run()
         for mediafile in self.import_media:
             self.assert_file_in_lib(
-                b'Tag Artist', b'Tag Album',
-                util.bytestring_path('{0}.mp3'.format(mediafile.title)))
+                b"Tag Artist",
+                b"Tag Album",
+                util.bytestring_path("{0}.mp3".format(mediafile.title)),
+            )
 
     def test_threaded_import_move_deletes_import(self):
-        config['import']['move'] = True
-        config['threaded'] = True
+        config["import"]["move"] = True
+        config["threaded"] = True
 
         self.importer.run()
         for mediafile in self.import_media:
             self.assertNotExists(mediafile.path)
 
     def test_import_without_delete_retains_files(self):
-        config['import']['delete'] = False
+        config["import"]["delete"] = False
         self.importer.run()
         for mediafile in self.import_media:
             self.assertExists(mediafile.path)
 
     def test_import_with_delete_removes_files(self):
-        config['import']['delete'] = True
+        config["import"]["delete"] = True
 
         self.importer.run()
         for mediafile in self.import_media:
             self.assertNotExists(mediafile.path)
 
     def test_import_with_delete_prunes_directory_empty(self):
-        config['import']['delete'] = True
-        self.assertExists(os.path.join(self.import_dir, b'the_album'))
+        config["import"]["delete"] = True
+        self.assertExists(os.path.join(self.import_dir, b"the_album"))
         self.importer.run()
-        self.assertNotExists(os.path.join(self.import_dir, b'the_album'))
+        self.assertNotExists(os.path.join(self.import_dir, b"the_album"))
 
     @unittest.skipUnless(_common.HAVE_SYMLINK, "need symlinks")
     def test_import_link_arrives(self):
-        config['import']['link'] = True
+        config["import"]["link"] = True
         self.importer.run()
         for mediafile in self.import_media:
             filename = os.path.join(
                 self.libdir,
-                b'Tag Artist', b'Tag Album',
-                util.bytestring_path('{0}.mp3'.format(mediafile.title))
+                b"Tag Artist",
+                b"Tag Album",
+                util.bytestring_path("{0}.mp3".format(mediafile.title)),
             )
             self.assertExists(filename)
             self.assertTrue(os.path.islink(filename))
             self.assert_equal_path(
-                util.bytestring_path(os.readlink(filename)),
-                mediafile.path
+                util.bytestring_path(os.readlink(filename)), mediafile.path
             )
 
     @unittest.skipUnless(_common.HAVE_HARDLINK, "need hardlinks")
     def test_import_hardlink_arrives(self):
-        config['import']['hardlink'] = True
+        config["import"]["hardlink"] = True
         self.importer.run()
         for mediafile in self.import_media:
             filename = os.path.join(
                 self.libdir,
-                b'Tag Artist', b'Tag Album',
-                util.bytestring_path('{0}.mp3'.format(mediafile.title))
+                b"Tag Artist",
+                b"Tag Album",
+                util.bytestring_path("{0}.mp3".format(mediafile.title)),
             )
             self.assertExists(filename)
             s1 = os.stat(mediafile.path)
             s2 = os.stat(filename)
             self.assertTrue(
-                (s1[stat.ST_INO], s1[stat.ST_DEV]) ==
-                (s2[stat.ST_INO], s2[stat.ST_DEV])
+                (s1[stat.ST_INO], s1[stat.ST_DEV])
+                == (s2[stat.ST_INO], s2[stat.ST_DEV])
             )
 
 
 def create_archive(session):
     (handle, path) = mkstemp(dir=py3_path(session.temp_dir))
     os.close(handle)
-    archive = ZipFile(py3_path(path), mode='w')
-    archive.write(os.path.join(_common.RSRC, b'full.mp3'),
-                  'full.mp3')
+    archive = ZipFile(py3_path(path), mode="w")
+    archive.write(os.path.join(_common.RSRC, b"full.mp3"), "full.mp3")
     archive.close()
     path = bytestring_path(path)
     return path
@@ -395,7 +410,7 @@ class RmTempTest(unittest.TestCase, ImportHelper, _common.Assertions):
     def setUp(self):
         self.setup_beets()
         self.want_resume = False
-        self.config['incremental'] = False
+        self.config["incremental"] = False
         self._old_home = None
 
     def tearDown(self):
@@ -413,7 +428,6 @@ class RmTempTest(unittest.TestCase, ImportHelper, _common.Assertions):
 
 
 class ImportZipTest(unittest.TestCase, ImportHelper):
-
     def setUp(self):
         self.setup_beets()
 
@@ -432,29 +446,25 @@ class ImportZipTest(unittest.TestCase, ImportHelper):
 
 
 class ImportTarTest(ImportZipTest):
-
     def create_archive(self):
         (handle, path) = mkstemp(dir=self.temp_dir)
         os.close(handle)
-        archive = TarFile(py3_path(path), mode='w')
-        archive.add(os.path.join(_common.RSRC, b'full.mp3'),
-                    'full.mp3')
+        archive = TarFile(py3_path(path), mode="w")
+        archive.add(os.path.join(_common.RSRC, b"full.mp3"), "full.mp3")
         archive.close()
         return path
 
 
-@unittest.skipIf(not has_program('unrar'), u'unrar program not found')
+@unittest.skipIf(not has_program("unrar"), u"unrar program not found")
 class ImportRarTest(ImportZipTest):
-
     def create_archive(self):
-        return os.path.join(_common.RSRC, b'archive.rar')
+        return os.path.join(_common.RSRC, b"archive.rar")
 
 
-@unittest.skip('Implement me!')
+@unittest.skip("Implement me!")
 class ImportPasswordRarTest(ImportZipTest):
-
     def create_archive(self):
-        return os.path.join(_common.RSRC, b'password.rar')
+        return os.path.join(_common.RSRC, b"password.rar")
 
 
 class ImportSingletonTest(_common.TestCase, ImportHelper):
@@ -466,7 +476,7 @@ class ImportSingletonTest(_common.TestCase, ImportHelper):
         self.setup_beets()
         self._create_import_dir(1)
         self._setup_import_session()
-        config['import']['singletons'] = True
+        config["import"]["singletons"] = True
         self.matcher = AutotagStub().install()
 
     def tearDown(self):
@@ -478,7 +488,7 @@ class ImportSingletonTest(_common.TestCase, ImportHelper):
 
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
-        self.assertEqual(self.lib.items().get().title, u'Tag Title 1')
+        self.assertEqual(self.lib.items().get().title, u"Tag Title 1")
 
     def test_apply_asis_does_not_add_album(self):
         self.assertEqual(self.lib.albums().get(), None)
@@ -492,14 +502,14 @@ class ImportSingletonTest(_common.TestCase, ImportHelper):
 
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
-        self.assert_file_in_lib(b'singletons', b'Tag Title 1.mp3')
+        self.assert_file_in_lib(b"singletons", b"Tag Title 1.mp3")
 
     def test_apply_candidate_adds_track(self):
         self.assertEqual(self.lib.items().get(), None)
 
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
-        self.assertEqual(self.lib.items().get().title, u'Applied Title 1')
+        self.assertEqual(self.lib.items().get().title, u"Applied Title 1")
 
     def test_apply_candidate_does_not_add_album(self):
         self.importer.add_choice(importer.action.APPLY)
@@ -511,7 +521,7 @@ class ImportSingletonTest(_common.TestCase, ImportHelper):
 
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
-        self.assert_file_in_lib(b'singletons', b'Applied Title 1.mp3')
+        self.assert_file_in_lib(b"singletons", b"Applied Title 1.mp3")
 
     def test_skip_does_not_add_first_track(self):
         self.importer.add_choice(importer.action.SKIP)
@@ -526,13 +536,13 @@ class ImportSingletonTest(_common.TestCase, ImportHelper):
         self.assertEqual(len(self.lib.items()), 1)
 
     def test_import_single_files(self):
-        resource_path = os.path.join(_common.RSRC, b'empty.mp3')
-        single_path = os.path.join(self.import_dir, b'track_2.mp3')
+        resource_path = os.path.join(_common.RSRC, b"empty.mp3")
+        single_path = os.path.join(self.import_dir, b"track_2.mp3")
 
         shutil.copy(resource_path, single_path)
         import_files = [
-            os.path.join(self.import_dir, b'the_album'),
-            single_path
+            os.path.join(self.import_dir, b"the_album"),
+            single_path,
         ]
         self._setup_import_session(singletons=False)
         self.importer.paths = import_files
@@ -548,9 +558,9 @@ class ImportSingletonTest(_common.TestCase, ImportHelper):
         genre = u"\U0001F3B7 Jazz"
         collection = u"To Listen"
 
-        config['import']['set_fields'] = {
-            u'collection': collection,
-            u'genre': genre
+        config["import"]["set_fields"] = {
+            u"collection": collection,
+            u"genre": genre,
         }
 
         # As-is item import.
@@ -580,6 +590,7 @@ class ImportSingletonTest(_common.TestCase, ImportHelper):
 class ImportTest(_common.TestCase, ImportHelper):
     """Test APPLY, ASIS and SKIP choices.
     """
+
     def setUp(self):
         self.setup_beets()
         self._create_import_dir(1)
@@ -596,13 +607,13 @@ class ImportTest(_common.TestCase, ImportHelper):
 
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
-        self.assertEqual(self.lib.albums().get().album, u'Tag Album')
+        self.assertEqual(self.lib.albums().get().album, u"Tag Album")
 
     def test_apply_asis_adds_tracks(self):
         self.assertEqual(self.lib.items().get(), None)
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
-        self.assertEqual(self.lib.items().get().title, u'Tag Title 1')
+        self.assertEqual(self.lib.items().get().title, u"Tag Title 1")
 
     def test_apply_asis_adds_album_path(self):
         self.assert_lib_dir_empty()
@@ -610,21 +621,22 @@ class ImportTest(_common.TestCase, ImportHelper):
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
         self.assert_file_in_lib(
-            b'Tag Artist', b'Tag Album', b'Tag Title 1.mp3')
+            b"Tag Artist", b"Tag Album", b"Tag Title 1.mp3"
+        )
 
     def test_apply_candidate_adds_album(self):
         self.assertEqual(self.lib.albums().get(), None)
 
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
-        self.assertEqual(self.lib.albums().get().album, u'Applied Album')
+        self.assertEqual(self.lib.albums().get().album, u"Applied Album")
 
     def test_apply_candidate_adds_tracks(self):
         self.assertEqual(self.lib.items().get(), None)
 
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
-        self.assertEqual(self.lib.items().get().title, u'Applied Title 1')
+        self.assertEqual(self.lib.items().get().title, u"Applied Title 1")
 
     def test_apply_candidate_adds_album_path(self):
         self.assert_lib_dir_empty()
@@ -632,28 +644,29 @@ class ImportTest(_common.TestCase, ImportHelper):
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
         self.assert_file_in_lib(
-            b'Applied Artist', b'Applied Album', b'Applied Title 1.mp3')
+            b"Applied Artist", b"Applied Album", b"Applied Title 1.mp3"
+        )
 
     def test_apply_from_scratch_removes_other_metadata(self):
-        config['import']['from_scratch'] = True
+        config["import"]["from_scratch"] = True
 
         for mediafile in self.import_media:
-            mediafile.genre = u'Tag Genre'
+            mediafile.genre = u"Tag Genre"
             mediafile.save()
 
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
-        self.assertEqual(self.lib.items().get().genre, u'')
+        self.assertEqual(self.lib.items().get().genre, u"")
 
     def test_apply_from_scratch_keeps_format(self):
-        config['import']['from_scratch'] = True
+        config["import"]["from_scratch"] = True
 
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
-        self.assertEqual(self.lib.items().get().format, u'MP3')
+        self.assertEqual(self.lib.items().get().format, u"MP3")
 
     def test_apply_from_scratch_keeps_bitrate(self):
-        config['import']['from_scratch'] = True
+        config["import"]["from_scratch"] = True
         bitrate = 80000
 
         self.importer.add_choice(importer.action.APPLY)
@@ -661,10 +674,11 @@ class ImportTest(_common.TestCase, ImportHelper):
         self.assertEqual(self.lib.items().get().bitrate, bitrate)
 
     def test_apply_with_move_deletes_import(self):
-        config['import']['move'] = True
+        config["import"]["move"] = True
 
         import_file = os.path.join(
-            self.import_dir, b'the_album', b'track_1.mp3')
+            self.import_dir, b"the_album", b"track_1.mp3"
+        )
         self.assertExists(import_file)
 
         self.importer.add_choice(importer.action.APPLY)
@@ -672,10 +686,11 @@ class ImportTest(_common.TestCase, ImportHelper):
         self.assertNotExists(import_file)
 
     def test_apply_with_delete_deletes_import(self):
-        config['import']['delete'] = True
+        config["import"]["delete"] = True
 
-        import_file = os.path.join(self.import_dir,
-                                   b'the_album', b'track_1.mp3')
+        import_file = os.path.join(
+            self.import_dir, b"the_album", b"track_1.mp3"
+        )
         self.assertExists(import_file)
 
         self.importer.add_choice(importer.action.APPLY)
@@ -688,9 +703,10 @@ class ImportTest(_common.TestCase, ImportHelper):
         self.assertEqual(self.lib.items().get(), None)
 
     def test_skip_non_album_dirs(self):
-        self.assertTrue(os.path.isdir(
-            os.path.join(self.import_dir, b'the_album')))
-        self.touch(b'cruft', dir=self.import_dir)
+        self.assertTrue(
+            os.path.isdir(os.path.join(self.import_dir, b"the_album"))
+        )
+        self.touch(b"cruft", dir=self.import_dir)
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
         self.assertEqual(len(self.lib.albums()), 1)
@@ -703,24 +719,24 @@ class ImportTest(_common.TestCase, ImportHelper):
         self.assertEqual(len(self.lib.items()), 1)
 
     def test_empty_directory_warning(self):
-        import_dir = os.path.join(self.temp_dir, b'empty')
-        self.touch(b'non-audio', dir=import_dir)
+        import_dir = os.path.join(self.temp_dir, b"empty")
+        self.touch(b"non-audio", dir=import_dir)
         self._setup_import_session(import_dir=import_dir)
         with capture_log() as logs:
             self.importer.run()
 
         import_dir = displayable_path(import_dir)
-        self.assertIn(u'No files imported from {0}'.format(import_dir), logs)
+        self.assertIn(u"No files imported from {0}".format(import_dir), logs)
 
     def test_empty_directory_singleton_warning(self):
-        import_dir = os.path.join(self.temp_dir, b'empty')
-        self.touch(b'non-audio', dir=import_dir)
+        import_dir = os.path.join(self.temp_dir, b"empty")
+        self.touch(b"non-audio", dir=import_dir)
         self._setup_import_session(import_dir=import_dir, singletons=True)
         with capture_log() as logs:
             self.importer.run()
 
         import_dir = displayable_path(import_dir)
-        self.assertIn(u'No files imported from {0}'.format(import_dir), logs)
+        self.assertIn(u"No files imported from {0}".format(import_dir), logs)
 
     def test_asis_no_data_source(self):
         self.assertEqual(self.lib.items().get(), None)
@@ -735,9 +751,9 @@ class ImportTest(_common.TestCase, ImportHelper):
         genre = u"\U0001F3B7 Jazz"
         collection = u"To Listen"
 
-        config['import']['set_fields'] = {
-            u'collection': collection,
-            u'genre': genre
+        config["import"]["set_fields"] = {
+            u"collection": collection,
+            u"genre": genre,
         }
 
         # As-is album import.
@@ -767,6 +783,7 @@ class ImportTest(_common.TestCase, ImportHelper):
 class ImportTracksTest(_common.TestCase, ImportHelper):
     """Test TRACKS and APPLY choice.
     """
+
     def setUp(self):
         self.setup_beets()
         self._create_import_dir(1)
@@ -785,7 +802,7 @@ class ImportTracksTest(_common.TestCase, ImportHelper):
         self.importer.add_choice(importer.action.APPLY)
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
-        self.assertEqual(self.lib.items().get().title, u'Applied Title 1')
+        self.assertEqual(self.lib.items().get().title, u"Applied Title 1")
         self.assertEqual(self.lib.albums().get(), None)
 
     def test_apply_tracks_adds_singleton_path(self):
@@ -795,12 +812,13 @@ class ImportTracksTest(_common.TestCase, ImportHelper):
         self.importer.add_choice(importer.action.APPLY)
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
-        self.assert_file_in_lib(b'singletons', b'Applied Title 1.mp3')
+        self.assert_file_in_lib(b"singletons", b"Applied Title 1.mp3")
 
 
 class ImportCompilationTest(_common.TestCase, ImportHelper):
     """Test ASIS import of a folder containing tracks with different artists.
     """
+
     def setUp(self):
         self.setup_beets()
         self._create_import_dir(3)
@@ -814,27 +832,28 @@ class ImportCompilationTest(_common.TestCase, ImportHelper):
     def test_asis_homogenous_sets_albumartist(self):
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
-        self.assertEqual(self.lib.albums().get().albumartist, u'Tag Artist')
+        self.assertEqual(self.lib.albums().get().albumartist, u"Tag Artist")
         for item in self.lib.items():
-            self.assertEqual(item.albumartist, u'Tag Artist')
+            self.assertEqual(item.albumartist, u"Tag Artist")
 
     def test_asis_heterogenous_sets_various_albumartist(self):
-        self.import_media[0].artist = u'Other Artist'
+        self.import_media[0].artist = u"Other Artist"
         self.import_media[0].save()
-        self.import_media[1].artist = u'Another Artist'
+        self.import_media[1].artist = u"Another Artist"
         self.import_media[1].save()
 
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
-        self.assertEqual(self.lib.albums().get().albumartist,
-                         u'Various Artists')
+        self.assertEqual(
+            self.lib.albums().get().albumartist, u"Various Artists"
+        )
         for item in self.lib.items():
-            self.assertEqual(item.albumartist, u'Various Artists')
+            self.assertEqual(item.albumartist, u"Various Artists")
 
     def test_asis_heterogenous_sets_sompilation(self):
-        self.import_media[0].artist = u'Other Artist'
+        self.import_media[0].artist = u"Other Artist"
         self.import_media[0].save()
-        self.import_media[1].artist = u'Another Artist'
+        self.import_media[1].artist = u"Another Artist"
         self.import_media[1].save()
 
         self.importer.add_choice(importer.action.ASIS)
@@ -843,38 +862,40 @@ class ImportCompilationTest(_common.TestCase, ImportHelper):
             self.assertTrue(item.comp)
 
     def test_asis_sets_majority_albumartist(self):
-        self.import_media[0].artist = u'Other Artist'
+        self.import_media[0].artist = u"Other Artist"
         self.import_media[0].save()
-        self.import_media[1].artist = u'Other Artist'
+        self.import_media[1].artist = u"Other Artist"
         self.import_media[1].save()
 
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
-        self.assertEqual(self.lib.albums().get().albumartist, u'Other Artist')
+        self.assertEqual(self.lib.albums().get().albumartist, u"Other Artist")
         for item in self.lib.items():
-            self.assertEqual(item.albumartist, u'Other Artist')
+            self.assertEqual(item.albumartist, u"Other Artist")
 
     def test_asis_albumartist_tag_sets_albumartist(self):
-        self.import_media[0].artist = u'Other Artist'
-        self.import_media[1].artist = u'Another Artist'
+        self.import_media[0].artist = u"Other Artist"
+        self.import_media[1].artist = u"Another Artist"
         for mediafile in self.import_media:
-            mediafile.albumartist = u'Album Artist'
-            mediafile.mb_albumartistid = u'Album Artist ID'
+            mediafile.albumartist = u"Album Artist"
+            mediafile.mb_albumartistid = u"Album Artist ID"
             mediafile.save()
 
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
-        self.assertEqual(self.lib.albums().get().albumartist, u'Album Artist')
-        self.assertEqual(self.lib.albums().get().mb_albumartistid,
-                         u'Album Artist ID')
+        self.assertEqual(self.lib.albums().get().albumartist, u"Album Artist")
+        self.assertEqual(
+            self.lib.albums().get().mb_albumartistid, u"Album Artist ID"
+        )
         for item in self.lib.items():
-            self.assertEqual(item.albumartist, u'Album Artist')
-            self.assertEqual(item.mb_albumartistid, u'Album Artist ID')
+            self.assertEqual(item.albumartist, u"Album Artist")
+            self.assertEqual(item.mb_albumartistid, u"Album Artist ID")
 
 
 class ImportExistingTest(_common.TestCase, ImportHelper):
     """Test importing files that are already in the library directory.
     """
+
     def setUp(self):
         self.setup_beets()
         self._create_import_dir(1)
@@ -920,68 +941,76 @@ class ImportExistingTest(_common.TestCase, ImportHelper):
     def test_asis_updates_metadata(self):
         self.setup_importer.run()
         medium = MediaFile(self.lib.items().get().path)
-        medium.title = u'New Title'
+        medium.title = u"New Title"
         medium.save()
 
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
-        self.assertEqual(self.lib.items().get().title, u'New Title')
+        self.assertEqual(self.lib.items().get().title, u"New Title")
 
     def test_asis_updated_moves_file(self):
         self.setup_importer.run()
         medium = MediaFile(self.lib.items().get().path)
-        medium.title = u'New Title'
+        medium.title = u"New Title"
         medium.save()
 
-        old_path = os.path.join(b'Applied Artist', b'Applied Album',
-                                b'Applied Title 1.mp3')
+        old_path = os.path.join(
+            b"Applied Artist", b"Applied Album", b"Applied Title 1.mp3"
+        )
         self.assert_file_in_lib(old_path)
 
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
-        self.assert_file_in_lib(b'Applied Artist', b'Applied Album',
-                                b'New Title.mp3')
+        self.assert_file_in_lib(
+            b"Applied Artist", b"Applied Album", b"New Title.mp3"
+        )
         self.assert_file_not_in_lib(old_path)
 
     def test_asis_updated_without_copy_does_not_move_file(self):
         self.setup_importer.run()
         medium = MediaFile(self.lib.items().get().path)
-        medium.title = u'New Title'
+        medium.title = u"New Title"
         medium.save()
 
-        old_path = os.path.join(b'Applied Artist', b'Applied Album',
-                                b'Applied Title 1.mp3')
+        old_path = os.path.join(
+            b"Applied Artist", b"Applied Album", b"Applied Title 1.mp3"
+        )
         self.assert_file_in_lib(old_path)
 
-        config['import']['copy'] = False
+        config["import"]["copy"] = False
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
-        self.assert_file_not_in_lib(b'Applied Artist', b'Applied Album',
-                                    b'New Title.mp3')
+        self.assert_file_not_in_lib(
+            b"Applied Artist", b"Applied Album", b"New Title.mp3"
+        )
         self.assert_file_in_lib(old_path)
 
     def test_outside_file_is_copied(self):
-        config['import']['copy'] = False
+        config["import"]["copy"] = False
         self.setup_importer.run()
-        self.assert_equal_path(self.lib.items().get().path,
-                               self.import_media[0].path)
+        self.assert_equal_path(
+            self.lib.items().get().path, self.import_media[0].path
+        )
 
-        config['import']['copy'] = True
+        config["import"]["copy"] = True
         self._setup_import_session()
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
-        new_path = os.path.join(b'Applied Artist', b'Applied Album',
-                                b'Applied Title 1.mp3')
+        new_path = os.path.join(
+            b"Applied Artist", b"Applied Album", b"Applied Title 1.mp3"
+        )
 
         self.assert_file_in_lib(new_path)
-        self.assert_equal_path(self.lib.items().get().path,
-                               os.path.join(self.libdir, new_path))
+        self.assert_equal_path(
+            self.lib.items().get().path, os.path.join(self.libdir, new_path)
+        )
 
     def test_outside_file_is_moved(self):
-        config['import']['copy'] = False
+        config["import"]["copy"] = False
         self.setup_importer.run()
-        self.assert_equal_path(self.lib.items().get().path,
-                               self.import_media[0].path)
+        self.assert_equal_path(
+            self.lib.items().get().path, self.import_media[0].path
+        )
 
         self._setup_import_session(move=True)
         self.importer.add_choice(importer.action.APPLY)
@@ -1013,7 +1042,7 @@ class GroupAlbumsImportTest(_common.TestCase, ImportHelper):
 
         self.importer.run()
         albums = set([album.album for album in self.lib.albums()])
-        self.assertEqual(albums, set(['Album B', 'Tag Album']))
+        self.assertEqual(albums, set(["Album B", "Tag Album"]))
 
     def test_add_album_for_different_artist_and_same_albumartist(self):
         self.import_media[0].artist = u"Artist B"
@@ -1025,7 +1054,7 @@ class GroupAlbumsImportTest(_common.TestCase, ImportHelper):
 
         self.importer.run()
         artists = set([album.albumartist for album in self.lib.albums()])
-        self.assertEqual(artists, set(['Album Artist', 'Tag Artist']))
+        self.assertEqual(artists, set(["Album Artist", "Tag Artist"]))
 
     def test_add_album_for_same_artist_and_different_album(self):
         self.import_media[0].album = u"Album B"
@@ -1033,7 +1062,7 @@ class GroupAlbumsImportTest(_common.TestCase, ImportHelper):
 
         self.importer.run()
         albums = set([album.album for album in self.lib.albums()])
-        self.assertEqual(albums, set(['Album B', 'Tag Album']))
+        self.assertEqual(albums, set(["Album B", "Tag Album"]))
 
     def test_add_album_for_same_album_and_different_artist(self):
         self.import_media[0].artist = u"Artist B"
@@ -1041,25 +1070,24 @@ class GroupAlbumsImportTest(_common.TestCase, ImportHelper):
 
         self.importer.run()
         artists = set([album.albumartist for album in self.lib.albums()])
-        self.assertEqual(artists, set(['Artist B', 'Tag Artist']))
+        self.assertEqual(artists, set(["Artist B", "Tag Artist"]))
 
     def test_incremental(self):
-        config['import']['incremental'] = True
+        config["import"]["incremental"] = True
         self.import_media[0].album = u"Album B"
         self.import_media[0].save()
 
         self.importer.run()
         albums = set([album.album for album in self.lib.albums()])
-        self.assertEqual(albums, set(['Album B', 'Tag Album']))
+        self.assertEqual(albums, set(["Album B", "Tag Album"]))
 
 
 class GlobalGroupAlbumsImportTest(GroupAlbumsImportTest):
-
     def setUp(self):
         super(GlobalGroupAlbumsImportTest, self).setUp()
         self.importer.clear_choices()
         self.importer.default_choice = importer.action.ASIS
-        config['import']['group_albums'] = True
+        config["import"]["group_albums"] = True
 
 
 class ChooseCandidateTest(_common.TestCase, ImportHelper):
@@ -1077,12 +1105,12 @@ class ChooseCandidateTest(_common.TestCase, ImportHelper):
     def test_choose_first_candidate(self):
         self.importer.add_choice(1)
         self.importer.run()
-        self.assertEqual(self.lib.albums().get().album, u'Applied Album M')
+        self.assertEqual(self.lib.albums().get().album, u"Applied Album M")
 
     def test_choose_second_candidate(self):
         self.importer.add_choice(2)
         self.importer.run()
-        self.assertEqual(self.lib.albums().get().album, u'Applied Album MM')
+        self.assertEqual(self.lib.albums().get().album, u"Applied Album MM")
 
 
 class InferAlbumDataTest(_common.TestCase):
@@ -1092,16 +1120,17 @@ class InferAlbumDataTest(_common.TestCase):
         i1 = _common.item()
         i2 = _common.item()
         i3 = _common.item()
-        i1.title = u'first item'
-        i2.title = u'second item'
-        i3.title = u'third item'
+        i1.title = u"first item"
+        i2.title = u"second item"
+        i3.title = u"third item"
         i1.comp = i2.comp = i3.comp = False
-        i1.albumartist = i2.albumartist = i3.albumartist = ''
-        i1.mb_albumartistid = i2.mb_albumartistid = i3.mb_albumartistid = ''
+        i1.albumartist = i2.albumartist = i3.albumartist = ""
+        i1.mb_albumartistid = i2.mb_albumartistid = i3.mb_albumartistid = ""
         self.items = [i1, i2, i3]
 
-        self.task = importer.ImportTask(paths=['a path'], toppath='top path',
-                                        items=self.items)
+        self.task = importer.ImportTask(
+            paths=["a path"], toppath="top path", items=self.items
+        )
 
     def test_asis_homogenous_single_artist(self):
         self.task.set_choice(importer.action.ASIS)
@@ -1110,28 +1139,28 @@ class InferAlbumDataTest(_common.TestCase):
         self.assertEqual(self.items[0].albumartist, self.items[2].artist)
 
     def test_asis_heterogenous_va(self):
-        self.items[0].artist = u'another artist'
-        self.items[1].artist = u'some other artist'
+        self.items[0].artist = u"another artist"
+        self.items[1].artist = u"some other artist"
         self.task.set_choice(importer.action.ASIS)
 
         self.task.align_album_level_fields()
 
         self.assertTrue(self.items[0].comp)
-        self.assertEqual(self.items[0].albumartist, u'Various Artists')
+        self.assertEqual(self.items[0].albumartist, u"Various Artists")
 
     def test_asis_comp_applied_to_all_items(self):
-        self.items[0].artist = u'another artist'
-        self.items[1].artist = u'some other artist'
+        self.items[0].artist = u"another artist"
+        self.items[1].artist = u"some other artist"
         self.task.set_choice(importer.action.ASIS)
 
         self.task.align_album_level_fields()
 
         for item in self.items:
             self.assertTrue(item.comp)
-            self.assertEqual(item.albumartist, u'Various Artists')
+            self.assertEqual(item.albumartist, u"Various Artists")
 
     def test_asis_majority_artist_single_artist(self):
-        self.items[0].artist = u'another artist'
+        self.items[0].artist = u"another artist"
         self.task.set_choice(importer.action.ASIS)
 
         self.task.align_album_level_fields()
@@ -1140,19 +1169,19 @@ class InferAlbumDataTest(_common.TestCase):
         self.assertEqual(self.items[0].albumartist, self.items[2].artist)
 
     def test_asis_track_albumartist_override(self):
-        self.items[0].artist = u'another artist'
-        self.items[1].artist = u'some other artist'
+        self.items[0].artist = u"another artist"
+        self.items[1].artist = u"some other artist"
         for item in self.items:
-            item.albumartist = u'some album artist'
-            item.mb_albumartistid = u'some album artist id'
+            item.albumartist = u"some album artist"
+            item.mb_albumartistid = u"some album artist id"
         self.task.set_choice(importer.action.ASIS)
 
         self.task.align_album_level_fields()
 
-        self.assertEqual(self.items[0].albumartist,
-                         u'some album artist')
-        self.assertEqual(self.items[0].mb_albumartistid,
-                         u'some album artist id')
+        self.assertEqual(self.items[0].albumartist, u"some album artist")
+        self.assertEqual(
+            self.items[0].mb_albumartistid, u"some album artist id"
+        )
 
     def test_apply_gets_artist_and_id(self):
         self.task.set_choice(AlbumMatch(0, None, {}, set(), set()))  # APPLY
@@ -1160,21 +1189,22 @@ class InferAlbumDataTest(_common.TestCase):
         self.task.align_album_level_fields()
 
         self.assertEqual(self.items[0].albumartist, self.items[0].artist)
-        self.assertEqual(self.items[0].mb_albumartistid,
-                         self.items[0].mb_artistid)
+        self.assertEqual(
+            self.items[0].mb_albumartistid, self.items[0].mb_artistid
+        )
 
     def test_apply_lets_album_values_override(self):
         for item in self.items:
-            item.albumartist = u'some album artist'
-            item.mb_albumartistid = u'some album artist id'
+            item.albumartist = u"some album artist"
+            item.mb_albumartistid = u"some album artist id"
         self.task.set_choice(AlbumMatch(0, None, {}, set(), set()))  # APPLY
 
         self.task.align_album_level_fields()
 
-        self.assertEqual(self.items[0].albumartist,
-                         u'some album artist')
-        self.assertEqual(self.items[0].mb_albumartistid,
-                         u'some album artist id')
+        self.assertEqual(self.items[0].albumartist, u"some album artist")
+        self.assertEqual(
+            self.items[0].mb_albumartistid, u"some album artist id"
+        )
 
     def test_small_single_artist_album(self):
         self.items = [self.items[0]]
@@ -1187,41 +1217,37 @@ class InferAlbumDataTest(_common.TestCase):
 def test_album_info(*args, **kwargs):
     """Create an AlbumInfo object for testing.
     """
-    track_info = TrackInfo(
-        title=u'new title',
-        track_id=u'trackid',
-        index=0,
-    )
+    track_info = TrackInfo(title=u"new title", track_id=u"trackid", index=0,)
     album_info = AlbumInfo(
-        artist=u'artist',
-        album=u'album',
+        artist=u"artist",
+        album=u"album",
         tracks=[track_info],
-        album_id=u'albumid',
-        artist_id=u'artistid',
+        album_id=u"albumid",
+        artist_id=u"artistid",
     )
     return iter([album_info])
 
 
-@patch('beets.autotag.mb.match_album', Mock(side_effect=test_album_info))
-class ImportDuplicateAlbumTest(unittest.TestCase, TestHelper,
-                               _common.Assertions):
-
+@patch("beets.autotag.mb.match_album", Mock(side_effect=test_album_info))
+class ImportDuplicateAlbumTest(
+    unittest.TestCase, TestHelper, _common.Assertions
+):
     def setUp(self):
         self.setup_beets()
 
         # Original album
-        self.add_album_fixture(albumartist=u'artist', album=u'album')
+        self.add_album_fixture(albumartist=u"artist", album=u"album")
 
         # Create import session
         self.importer = self.create_importer()
-        config['import']['autotag'] = True
+        config["import"]["autotag"] = True
 
     def tearDown(self):
         self.teardown_beets()
 
     def test_remove_duplicate_album(self):
         item = self.lib.items().get()
-        self.assertEqual(item.title, u't\xeftle 0')
+        self.assertEqual(item.title, u"t\xeftle 0")
         self.assertExists(item.path)
 
         self.importer.default_resolution = self.importer.Resolution.REMOVE
@@ -1231,23 +1257,24 @@ class ImportDuplicateAlbumTest(unittest.TestCase, TestHelper,
         self.assertEqual(len(self.lib.albums()), 1)
         self.assertEqual(len(self.lib.items()), 1)
         item = self.lib.items().get()
-        self.assertEqual(item.title, u'new title')
+        self.assertEqual(item.title, u"new title")
 
     def test_no_autotag_keeps_duplicate_album(self):
-        config['import']['autotag'] = False
+        config["import"]["autotag"] = False
         item = self.lib.items().get()
-        self.assertEqual(item.title, u't\xeftle 0')
+        self.assertEqual(item.title, u"t\xeftle 0")
         self.assertExists(item.path)
 
         # Imported item has the same artist and album as the one in the
         # library.
-        import_file = os.path.join(self.importer.paths[0],
-                                   b'album 0', b'track 0.mp3')
+        import_file = os.path.join(
+            self.importer.paths[0], b"album 0", b"track 0.mp3"
+        )
         import_file = MediaFile(import_file)
-        import_file.artist = item['artist']
-        import_file.albumartist = item['artist']
-        import_file.album = item['album']
-        import_file.title = 'new title'
+        import_file.artist = item["artist"]
+        import_file.albumartist = item["artist"]
+        import_file.album = item["album"]
+        import_file.title = "new title"
 
         self.importer.default_resolution = self.importer.Resolution.REMOVE
         self.importer.run()
@@ -1265,7 +1292,7 @@ class ImportDuplicateAlbumTest(unittest.TestCase, TestHelper,
 
     def test_skip_duplicate_album(self):
         item = self.lib.items().get()
-        self.assertEqual(item.title, u't\xeftle 0')
+        self.assertEqual(item.title, u"t\xeftle 0")
 
         self.importer.default_resolution = self.importer.Resolution.SKIP
         self.importer.run()
@@ -1273,7 +1300,7 @@ class ImportDuplicateAlbumTest(unittest.TestCase, TestHelper,
         self.assertEqual(len(self.lib.albums()), 1)
         self.assertEqual(len(self.lib.items()), 1)
         item = self.lib.items().get()
-        self.assertEqual(item.title, u't\xeftle 0')
+        self.assertEqual(item.title, u"t\xeftle 0")
 
     def test_merge_duplicate_album(self):
         self.importer.default_resolution = self.importer.Resolution.MERGE
@@ -1282,7 +1309,7 @@ class ImportDuplicateAlbumTest(unittest.TestCase, TestHelper,
         self.assertEqual(len(self.lib.albums()), 1)
 
     def test_twice_in_import_dir(self):
-        self.skipTest('write me')
+        self.skipTest("write me")
 
     def add_album_fixture(self, **kwargs):
         # TODO move this into upstream
@@ -1293,33 +1320,41 @@ class ImportDuplicateAlbumTest(unittest.TestCase, TestHelper,
 
 
 def test_track_info(*args, **kwargs):
-    return iter([TrackInfo(
-        artist=u'artist', title=u'title',
-        track_id=u'new trackid', index=0,)])
+    return iter(
+        [
+            TrackInfo(
+                artist=u"artist",
+                title=u"title",
+                track_id=u"new trackid",
+                index=0,
+            )
+        ]
+    )
 
 
-@patch('beets.autotag.mb.match_track', Mock(side_effect=test_track_info))
-class ImportDuplicateSingletonTest(unittest.TestCase, TestHelper,
-                                   _common.Assertions):
-
+@patch("beets.autotag.mb.match_track", Mock(side_effect=test_track_info))
+class ImportDuplicateSingletonTest(
+    unittest.TestCase, TestHelper, _common.Assertions
+):
     def setUp(self):
         self.setup_beets()
 
         # Original file in library
-        self.add_item_fixture(artist=u'artist', title=u'title',
-                              mb_trackid='old trackid')
+        self.add_item_fixture(
+            artist=u"artist", title=u"title", mb_trackid="old trackid"
+        )
 
         # Import session
         self.importer = self.create_importer()
-        config['import']['autotag'] = True
-        config['import']['singletons'] = True
+        config["import"]["autotag"] = True
+        config["import"]["singletons"] = True
 
     def tearDown(self):
         self.teardown_beets()
 
     def test_remove_duplicate(self):
         item = self.lib.items().get()
-        self.assertEqual(item.mb_trackid, u'old trackid')
+        self.assertEqual(item.mb_trackid, u"old trackid")
         self.assertExists(item.path)
 
         self.importer.default_resolution = self.importer.Resolution.REMOVE
@@ -1328,7 +1363,7 @@ class ImportDuplicateSingletonTest(unittest.TestCase, TestHelper,
         self.assertNotExists(item.path)
         self.assertEqual(len(self.lib.items()), 1)
         item = self.lib.items().get()
-        self.assertEqual(item.mb_trackid, u'new trackid')
+        self.assertEqual(item.mb_trackid, u"new trackid")
 
     def test_keep_duplicate(self):
         self.assertEqual(len(self.lib.items()), 1)
@@ -1340,17 +1375,17 @@ class ImportDuplicateSingletonTest(unittest.TestCase, TestHelper,
 
     def test_skip_duplicate(self):
         item = self.lib.items().get()
-        self.assertEqual(item.mb_trackid, u'old trackid')
+        self.assertEqual(item.mb_trackid, u"old trackid")
 
         self.importer.default_resolution = self.importer.Resolution.SKIP
         self.importer.run()
 
         self.assertEqual(len(self.lib.items()), 1)
         item = self.lib.items().get()
-        self.assertEqual(item.mb_trackid, u'old trackid')
+        self.assertEqual(item.mb_trackid, u"old trackid")
 
     def test_twice_in_import_dir(self):
-        self.skipTest('write me')
+        self.skipTest("write me")
 
     def add_item_fixture(self, **kwargs):
         # Move this to TestHelper
@@ -1365,72 +1400,72 @@ class TagLogTest(_common.TestCase):
         sio = StringIO()
         handler = logging.StreamHandler(sio)
         session = _common.import_session(loghandler=handler)
-        session.tag_log('status', 'path')
-        self.assertIn('status path', sio.getvalue())
+        session.tag_log("status", "path")
+        self.assertIn("status path", sio.getvalue())
 
     def test_tag_log_unicode(self):
         sio = StringIO()
         handler = logging.StreamHandler(sio)
         session = _common.import_session(loghandler=handler)
-        session.tag_log('status', u'caf\xe9')  # send unicode
-        self.assertIn(u'status caf\xe9', sio.getvalue())
+        session.tag_log("status", u"caf\xe9")  # send unicode
+        self.assertIn(u"status caf\xe9", sio.getvalue())
 
 
 class ResumeImportTest(unittest.TestCase, TestHelper):
-
     def setUp(self):
         self.setup_beets()
 
     def tearDown(self):
         self.teardown_beets()
 
-    @patch('beets.plugins.send')
+    @patch("beets.plugins.send")
     def test_resume_album(self, plugins_send):
         self.importer = self.create_importer(album_count=2)
-        self.config['import']['resume'] = True
+        self.config["import"]["resume"] = True
 
         # Aborts import after one album. This also ensures that we skip
         # the first album in the second try.
         def raise_exception(event, **kwargs):
-            if event == 'album_imported':
+            if event == "album_imported":
                 raise importer.ImportAbort
+
         plugins_send.side_effect = raise_exception
 
         self.importer.run()
         self.assertEqual(len(self.lib.albums()), 1)
-        self.assertIsNotNone(self.lib.albums(u'album:album 0').get())
+        self.assertIsNotNone(self.lib.albums(u"album:album 0").get())
 
         self.importer.run()
         self.assertEqual(len(self.lib.albums()), 2)
-        self.assertIsNotNone(self.lib.albums(u'album:album 1').get())
+        self.assertIsNotNone(self.lib.albums(u"album:album 1").get())
 
-    @patch('beets.plugins.send')
+    @patch("beets.plugins.send")
     def test_resume_singleton(self, plugins_send):
         self.importer = self.create_importer(item_count=2)
-        self.config['import']['resume'] = True
-        self.config['import']['singletons'] = True
+        self.config["import"]["resume"] = True
+        self.config["import"]["singletons"] = True
 
         # Aborts import after one track. This also ensures that we skip
         # the first album in the second try.
         def raise_exception(event, **kwargs):
-            if event == 'item_imported':
+            if event == "item_imported":
                 raise importer.ImportAbort
+
         plugins_send.side_effect = raise_exception
 
         self.importer.run()
         self.assertEqual(len(self.lib.items()), 1)
-        self.assertIsNotNone(self.lib.items(u'title:track 0').get())
+        self.assertIsNotNone(self.lib.items(u"title:track 0").get())
 
         self.importer.run()
         self.assertEqual(len(self.lib.items()), 2)
-        self.assertIsNotNone(self.lib.items(u'title:track 1').get())
+        self.assertIsNotNone(self.lib.items(u"title:track 1").get())
 
 
 class IncrementalImportTest(unittest.TestCase, TestHelper):
-
     def setUp(self):
         self.setup_beets()
-        self.config['import']['incremental'] = True
+        self.config["import"]["incremental"] = True
 
     def tearDown(self):
         self.teardown_beets()
@@ -1442,7 +1477,7 @@ class IncrementalImportTest(unittest.TestCase, TestHelper):
         # Change album name so the original file would be imported again
         # if incremental was off.
         album = self.lib.albums().get()
-        album['album'] = 'edited album'
+        album["album"] = "edited album"
         album.store()
 
         importer = self.create_importer(album_count=1)
@@ -1450,14 +1485,14 @@ class IncrementalImportTest(unittest.TestCase, TestHelper):
         self.assertEqual(len(self.lib.albums()), 2)
 
     def test_incremental_item(self):
-        self.config['import']['singletons'] = True
+        self.config["import"]["singletons"] = True
         importer = self.create_importer(item_count=1)
         importer.run()
 
         # Change track name so the original file would be imported again
         # if incremental was off.
         item = self.lib.items().get()
-        item['artist'] = 'edited artist'
+        item["artist"] = "edited artist"
         item.store()
 
         importer = self.create_importer(item_count=1)
@@ -1466,14 +1501,14 @@ class IncrementalImportTest(unittest.TestCase, TestHelper):
 
     def test_invalid_state_file(self):
         importer = self.create_importer()
-        with open(self.config['statefile'].as_filename(), 'wb') as f:
-            f.write(b'000')
+        with open(self.config["statefile"].as_filename(), "wb") as f:
+            f.write(b"000")
         importer.run()
         self.assertEqual(len(self.lib.albums()), 1)
 
 
 def _mkmp3(path):
-    shutil.copyfile(os.path.join(_common.RSRC, b'min.mp3'), path)
+    shutil.copyfile(os.path.join(_common.RSRC, b"min.mp3"), path)
 
 
 class AlbumsInDirTest(_common.TestCase):
@@ -1481,20 +1516,20 @@ class AlbumsInDirTest(_common.TestCase):
         super(AlbumsInDirTest, self).setUp()
 
         # create a directory structure for testing
-        self.base = os.path.abspath(os.path.join(self.temp_dir, b'tempdir'))
+        self.base = os.path.abspath(os.path.join(self.temp_dir, b"tempdir"))
         os.mkdir(self.base)
 
-        os.mkdir(os.path.join(self.base, b'album1'))
-        os.mkdir(os.path.join(self.base, b'album2'))
-        os.mkdir(os.path.join(self.base, b'more'))
-        os.mkdir(os.path.join(self.base, b'more', b'album3'))
-        os.mkdir(os.path.join(self.base, b'more', b'album4'))
+        os.mkdir(os.path.join(self.base, b"album1"))
+        os.mkdir(os.path.join(self.base, b"album2"))
+        os.mkdir(os.path.join(self.base, b"more"))
+        os.mkdir(os.path.join(self.base, b"more", b"album3"))
+        os.mkdir(os.path.join(self.base, b"more", b"album4"))
 
-        _mkmp3(os.path.join(self.base, b'album1', b'album1song1.mp3'))
-        _mkmp3(os.path.join(self.base, b'album1', b'album1song2.mp3'))
-        _mkmp3(os.path.join(self.base, b'album2', b'album2song.mp3'))
-        _mkmp3(os.path.join(self.base, b'more', b'album3', b'album3song.mp3'))
-        _mkmp3(os.path.join(self.base, b'more', b'album4', b'album4song.mp3'))
+        _mkmp3(os.path.join(self.base, b"album1", b"album1song1.mp3"))
+        _mkmp3(os.path.join(self.base, b"album1", b"album1song2.mp3"))
+        _mkmp3(os.path.join(self.base, b"album2", b"album2song.mp3"))
+        _mkmp3(os.path.join(self.base, b"more", b"album3", b"album3song.mp3"))
+        _mkmp3(os.path.join(self.base, b"more", b"album4", b"album4song.mp3"))
 
     def test_finds_all_albums(self):
         albums = list(albums_in_dir(self.base))
@@ -1503,16 +1538,16 @@ class AlbumsInDirTest(_common.TestCase):
     def test_separates_contents(self):
         found = []
         for _, album in albums_in_dir(self.base):
-            found.append(re.search(br'album(.)song', album[0]).group(1))
-        self.assertTrue(b'1' in found)
-        self.assertTrue(b'2' in found)
-        self.assertTrue(b'3' in found)
-        self.assertTrue(b'4' in found)
+            found.append(re.search(br"album(.)song", album[0]).group(1))
+        self.assertTrue(b"1" in found)
+        self.assertTrue(b"2" in found)
+        self.assertTrue(b"3" in found)
+        self.assertTrue(b"4" in found)
 
     def test_finds_multiple_songs(self):
         for _, album in albums_in_dir(self.base):
-            n = re.search(br'album(.)song', album[0]).group(1)
-            if n == b'1':
+            n = re.search(br"album(.)song", album[0]).group(1)
+            if n == b"1":
                 self.assertEqual(len(album), 2)
             else:
                 self.assertEqual(len(album), 1)
@@ -1526,47 +1561,53 @@ class MultiDiscAlbumsInDirTest(_common.TestCase):
         directories are made). `ascii` indicates ACII-only filenames;
         otherwise, we use Unicode names.
         """
-        self.base = os.path.abspath(os.path.join(self.temp_dir, b'tempdir'))
+        self.base = os.path.abspath(os.path.join(self.temp_dir, b"tempdir"))
         os.mkdir(self.base)
 
-        name = b'CAT' if ascii else util.bytestring_path(u'C\xc1T')
-        name_alt_case = b'CAt' if ascii else util.bytestring_path(u'C\xc1t')
+        name = b"CAT" if ascii else util.bytestring_path(u"C\xc1T")
+        name_alt_case = b"CAt" if ascii else util.bytestring_path(u"C\xc1t")
 
         self.dirs = [
             # Nested album, multiple subdirs.
             # Also, false positive marker in root dir, and subtitle for disc 3.
-            os.path.join(self.base, b'ABCD1234'),
-            os.path.join(self.base, b'ABCD1234', b'cd 1'),
-            os.path.join(self.base, b'ABCD1234', b'cd 3 - bonus'),
-
+            os.path.join(self.base, b"ABCD1234"),
+            os.path.join(self.base, b"ABCD1234", b"cd 1"),
+            os.path.join(self.base, b"ABCD1234", b"cd 3 - bonus"),
             # Nested album, single subdir.
             # Also, punctuation between marker and disc number.
-            os.path.join(self.base, b'album'),
-            os.path.join(self.base, b'album', b'cd _ 1'),
-
+            os.path.join(self.base, b"album"),
+            os.path.join(self.base, b"album", b"cd _ 1"),
             # Flattened album, case typo.
             # Also, false positive marker in parent dir.
-            os.path.join(self.base, b'artist [CD5]'),
-            os.path.join(self.base, b'artist [CD5]', name + b' disc 1'),
-            os.path.join(self.base, b'artist [CD5]',
-                         name_alt_case + b' disc 2'),
-
+            os.path.join(self.base, b"artist [CD5]"),
+            os.path.join(self.base, b"artist [CD5]", name + b" disc 1"),
+            os.path.join(
+                self.base, b"artist [CD5]", name_alt_case + b" disc 2"
+            ),
             # Single disc album, sorted between CAT discs.
-            os.path.join(self.base, b'artist [CD5]', name + b'S'),
+            os.path.join(self.base, b"artist [CD5]", name + b"S"),
         ]
         self.files = [
-            os.path.join(self.base, b'ABCD1234', b'cd 1', b'song1.mp3'),
-            os.path.join(self.base, b'ABCD1234',
-                         b'cd 3 - bonus', b'song2.mp3'),
-            os.path.join(self.base, b'ABCD1234',
-                         b'cd 3 - bonus', b'song3.mp3'),
-            os.path.join(self.base, b'album', b'cd _ 1', b'song4.mp3'),
-            os.path.join(self.base, b'artist [CD5]', name + b' disc 1',
-                         b'song5.mp3'),
-            os.path.join(self.base, b'artist [CD5]',
-                         name_alt_case + b' disc 2', b'song6.mp3'),
-            os.path.join(self.base, b'artist [CD5]', name + b'S',
-                         b'song7.mp3'),
+            os.path.join(self.base, b"ABCD1234", b"cd 1", b"song1.mp3"),
+            os.path.join(
+                self.base, b"ABCD1234", b"cd 3 - bonus", b"song2.mp3"
+            ),
+            os.path.join(
+                self.base, b"ABCD1234", b"cd 3 - bonus", b"song3.mp3"
+            ),
+            os.path.join(self.base, b"album", b"cd _ 1", b"song4.mp3"),
+            os.path.join(
+                self.base, b"artist [CD5]", name + b" disc 1", b"song5.mp3"
+            ),
+            os.path.join(
+                self.base,
+                b"artist [CD5]",
+                name_alt_case + b" disc 2",
+                b"song6.mp3",
+            ),
+            os.path.join(
+                self.base, b"artist [CD5]", name + b"S", b"song7.mp3"
+            ),
         ]
 
         if not ascii:
@@ -1583,10 +1624,10 @@ class MultiDiscAlbumsInDirTest(_common.TestCase):
         """Normalize a path's Unicode combining form according to the
         platform.
         """
-        path = path.decode('utf-8')
-        norm_form = 'NFD' if sys.platform == 'darwin' else 'NFC'
+        path = path.decode("utf-8")
+        norm_form = "NFD" if sys.platform == "darwin" else "NFC"
         path = unicodedata.normalize(norm_form, path)
-        return path.encode('utf-8')
+        return path.encode("utf-8")
 
     def test_coalesce_nested_album_multiple_subdirs(self):
         self.create_music()
@@ -1653,10 +1694,10 @@ class ReimportTest(unittest.TestCase, ImportHelper, _common.Assertions):
         # The existing album.
         album = self.add_album_fixture()
         album.added = 4242.0
-        album.foo = u'bar'  # Some flexible attribute.
+        album.foo = u"bar"  # Some flexible attribute.
         album.store()
         item = album.items().get()
-        item.baz = u'qux'
+        item.baz = u"qux"
         item.added = 4747.0
         item.store()
 
@@ -1680,14 +1721,14 @@ class ReimportTest(unittest.TestCase, ImportHelper, _common.Assertions):
 
     def test_reimported_album_gets_new_metadata(self):
         self._setup_session()
-        self.assertEqual(self._album().album, u'\xe4lbum')
+        self.assertEqual(self._album().album, u"\xe4lbum")
         self.importer.run()
-        self.assertEqual(self._album().album, u'the album')
+        self.assertEqual(self._album().album, u"the album")
 
     def test_reimported_album_preserves_flexattr(self):
         self._setup_session()
         self.importer.run()
-        self.assertEqual(self._album().foo, u'bar')
+        self.assertEqual(self._album().foo, u"bar")
 
     def test_reimported_album_preserves_added(self):
         self._setup_session()
@@ -1697,7 +1738,7 @@ class ReimportTest(unittest.TestCase, ImportHelper, _common.Assertions):
     def test_reimported_album_preserves_item_flexattr(self):
         self._setup_session()
         self.importer.run()
-        self.assertEqual(self._item().baz, u'qux')
+        self.assertEqual(self._item().baz, u"qux")
 
     def test_reimported_album_preserves_item_added(self):
         self._setup_session()
@@ -1706,14 +1747,14 @@ class ReimportTest(unittest.TestCase, ImportHelper, _common.Assertions):
 
     def test_reimported_item_gets_new_metadata(self):
         self._setup_session(True)
-        self.assertEqual(self._item().title, u't\xeftle 0')
+        self.assertEqual(self._item().title, u"t\xeftle 0")
         self.importer.run()
-        self.assertEqual(self._item().title, u'full')
+        self.assertEqual(self._item().title, u"full")
 
     def test_reimported_item_preserves_flexattr(self):
         self._setup_session(True)
         self.importer.run()
-        self.assertEqual(self._item().baz, u'qux')
+        self.assertEqual(self._item().baz, u"qux")
 
     def test_reimported_item_preserves_added(self):
         self._setup_session(True)
@@ -1722,7 +1763,7 @@ class ReimportTest(unittest.TestCase, ImportHelper, _common.Assertions):
 
     def test_reimported_item_preserves_art(self):
         self._setup_session()
-        art_source = os.path.join(_common.RSRC, b'abbey.jpg')
+        art_source = os.path.join(_common.RSRC, b"abbey.jpg")
         replaced_album = self._album()
         replaced_album.set_art(art_source)
         replaced_album.store()
@@ -1740,7 +1781,7 @@ class ImportPretendTest(_common.TestCase, ImportHelper):
     """ Test the pretend commandline option
     """
 
-    def __init__(self, method_name='runTest'):
+    def __init__(self, method_name="runTest"):
         super(ImportPretendTest, self).__init__(method_name)
         self.matcher = None
 
@@ -1750,7 +1791,7 @@ class ImportPretendTest(_common.TestCase, ImportHelper):
         self.__create_import_dir()
         self.__create_empty_import_dir()
         self._setup_import_session()
-        config['import']['pretend'] = True
+        config["import"]["pretend"] = True
         self.matcher = AutotagStub().install()
         self.io.install()
 
@@ -1760,21 +1801,22 @@ class ImportPretendTest(_common.TestCase, ImportHelper):
 
     def __create_import_dir(self):
         self._create_import_dir(1)
-        resource_path = os.path.join(_common.RSRC, b'empty.mp3')
-        single_path = os.path.join(self.import_dir, b'track_2.mp3')
+        resource_path = os.path.join(_common.RSRC, b"empty.mp3")
+        single_path = os.path.join(self.import_dir, b"track_2.mp3")
         shutil.copy(resource_path, single_path)
         self.import_paths = [
-            os.path.join(self.import_dir, b'the_album'),
-            single_path
+            os.path.join(self.import_dir, b"the_album"),
+            single_path,
         ]
         self.import_files = [
             displayable_path(
-                os.path.join(self.import_paths[0], b'track_1.mp3')),
-            displayable_path(single_path)
+                os.path.join(self.import_paths[0], b"track_1.mp3")
+            ),
+            displayable_path(single_path),
         ]
 
     def __create_empty_import_dir(self):
-        path = os.path.join(self.temp_dir, b'empty')
+        path = os.path.join(self.temp_dir, b"empty")
         os.makedirs(path)
         self.empty_path = path
 
@@ -1785,7 +1827,7 @@ class ImportPretendTest(_common.TestCase, ImportHelper):
         with capture_log() as logs:
             self.importer.run()
 
-        logs = [line for line in logs if not line.startswith('Sending event:')]
+        logs = [line for line in logs if not line.startswith("Sending event:")]
 
         self.assertEqual(len(self.lib.items()), 0)
         self.assertEqual(len(self.lib.albums()), 0)
@@ -1795,110 +1837,139 @@ class ImportPretendTest(_common.TestCase, ImportHelper):
     def test_import_singletons_pretend(self):
         logs = self.__run(self.import_paths)
 
-        self.assertEqual(logs, [
-            'Singleton: %s' % displayable_path(self.import_files[0]),
-            'Singleton: %s' % displayable_path(self.import_paths[1])])
+        self.assertEqual(
+            logs,
+            [
+                "Singleton: %s" % displayable_path(self.import_files[0]),
+                "Singleton: %s" % displayable_path(self.import_paths[1]),
+            ],
+        )
 
     def test_import_album_pretend(self):
         logs = self.__run(self.import_paths, singletons=False)
 
-        self.assertEqual(logs, [
-            'Album: %s' % displayable_path(self.import_paths[0]),
-            '  %s' % displayable_path(self.import_files[0]),
-            'Album: %s' % displayable_path(self.import_paths[1]),
-            '  %s' % displayable_path(self.import_paths[1])])
+        self.assertEqual(
+            logs,
+            [
+                "Album: %s" % displayable_path(self.import_paths[0]),
+                "  %s" % displayable_path(self.import_files[0]),
+                "Album: %s" % displayable_path(self.import_paths[1]),
+                "  %s" % displayable_path(self.import_paths[1]),
+            ],
+        )
 
     def test_import_pretend_empty(self):
         logs = self.__run([self.empty_path])
 
-        self.assertEqual(logs, [u'No files imported from {0}'
-                         .format(displayable_path(self.empty_path))])
+        self.assertEqual(
+            logs,
+            [
+                u"No files imported from {0}".format(
+                    displayable_path(self.empty_path)
+                )
+            ],
+        )
+
 
 # Helpers for ImportMusicBrainzIdTest.
 
 
-def mocked_get_release_by_id(id_, includes=[], release_status=[],
-                             release_type=[]):
+def mocked_get_release_by_id(
+    id_, includes=[], release_status=[], release_type=[]
+):
     """Mimic musicbrainzngs.get_release_by_id, accepting only a restricted list
     of MB ids (ID_RELEASE_0, ID_RELEASE_1). The returned dict differs only in
     the release title and artist name, so that ID_RELEASE_0 is a closer match
     to the items created by ImportHelper._create_import_dir()."""
     # Map IDs to (release title, artist), so the distances are different.
-    releases = {ImportMusicBrainzIdTest.ID_RELEASE_0: ('VALID_RELEASE_0',
-                                                       'TAG ARTIST'),
-                ImportMusicBrainzIdTest.ID_RELEASE_1: ('VALID_RELEASE_1',
-                                                       'DISTANT_MATCH')}
+    releases = {
+        ImportMusicBrainzIdTest.ID_RELEASE_0: (
+            "VALID_RELEASE_0",
+            "TAG ARTIST",
+        ),
+        ImportMusicBrainzIdTest.ID_RELEASE_1: (
+            "VALID_RELEASE_1",
+            "DISTANT_MATCH",
+        ),
+    }
 
     return {
-        'release': {
-            'title': releases[id_][0],
-            'id': id_,
-            'medium-list': [{
-                'track-list': [{
-                    'id': 'baz',
-                    'recording': {
-                        'title': 'foo',
-                        'id': 'bar',
-                        'length': 59,
-                    },
-                    'position': 9,
-                    'number': 'A2'
-                }],
-                'position': 5,
-            }],
-            'artist-credit': [{
-                'artist': {
-                    'name': releases[id_][1],
-                    'id': 'some-id',
-                },
-            }],
-            'release-group': {
-                'id': 'another-id',
-            }
+        "release": {
+            "title": releases[id_][0],
+            "id": id_,
+            "medium-list": [
+                {
+                    "track-list": [
+                        {
+                            "id": "baz",
+                            "recording": {
+                                "title": "foo",
+                                "id": "bar",
+                                "length": 59,
+                            },
+                            "position": 9,
+                            "number": "A2",
+                        }
+                    ],
+                    "position": 5,
+                }
+            ],
+            "artist-credit": [
+                {"artist": {"name": releases[id_][1], "id": "some-id",},}
+            ],
+            "release-group": {"id": "another-id",},
         }
     }
 
 
-def mocked_get_recording_by_id(id_, includes=[], release_status=[],
-                               release_type=[]):
+def mocked_get_recording_by_id(
+    id_, includes=[], release_status=[], release_type=[]
+):
     """Mimic musicbrainzngs.get_recording_by_id, accepting only a restricted
     list of MB ids (ID_RECORDING_0, ID_RECORDING_1). The returned dict differs
     only in the recording title and artist name, so that ID_RECORDING_0 is a
     closer match to the items created by ImportHelper._create_import_dir()."""
     # Map IDs to (recording title, artist), so the distances are different.
-    releases = {ImportMusicBrainzIdTest.ID_RECORDING_0: ('VALID_RECORDING_0',
-                                                         'TAG ARTIST'),
-                ImportMusicBrainzIdTest.ID_RECORDING_1: ('VALID_RECORDING_1',
-                                                         'DISTANT_MATCH')}
+    releases = {
+        ImportMusicBrainzIdTest.ID_RECORDING_0: (
+            "VALID_RECORDING_0",
+            "TAG ARTIST",
+        ),
+        ImportMusicBrainzIdTest.ID_RECORDING_1: (
+            "VALID_RECORDING_1",
+            "DISTANT_MATCH",
+        ),
+    }
 
     return {
-        'recording': {
-            'title': releases[id_][0],
-            'id': id_,
-            'length': 59,
-            'artist-credit': [{
-                'artist': {
-                    'name': releases[id_][1],
-                    'id': 'some-id',
-                },
-            }],
+        "recording": {
+            "title": releases[id_][0],
+            "id": id_,
+            "length": 59,
+            "artist-credit": [
+                {"artist": {"name": releases[id_][1], "id": "some-id",},}
+            ],
         }
     }
 
 
-@patch('musicbrainzngs.get_recording_by_id',
-       Mock(side_effect=mocked_get_recording_by_id))
-@patch('musicbrainzngs.get_release_by_id',
-       Mock(side_effect=mocked_get_release_by_id))
+@patch(
+    "musicbrainzngs.get_recording_by_id",
+    Mock(side_effect=mocked_get_recording_by_id),
+)
+@patch(
+    "musicbrainzngs.get_release_by_id",
+    Mock(side_effect=mocked_get_release_by_id),
+)
 class ImportMusicBrainzIdTest(_common.TestCase, ImportHelper):
     """Test the --musicbrainzid argument."""
 
-    MB_RELEASE_PREFIX = 'https://musicbrainz.org/release/'
-    MB_RECORDING_PREFIX = 'https://musicbrainz.org/recording/'
-    ID_RELEASE_0 = '00000000-0000-0000-0000-000000000000'
-    ID_RELEASE_1 = '11111111-1111-1111-1111-111111111111'
-    ID_RECORDING_0 = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
-    ID_RECORDING_1 = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'
+    MB_RELEASE_PREFIX = "https://musicbrainz.org/release/"
+    MB_RECORDING_PREFIX = "https://musicbrainz.org/recording/"
+    ID_RELEASE_0 = "00000000-0000-0000-0000-000000000000"
+    ID_RELEASE_1 = "11111111-1111-1111-1111-111111111111"
+    ID_RECORDING_0 = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    ID_RECORDING_1 = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 
     def setUp(self):
         self.setup_beets()
@@ -1908,73 +1979,87 @@ class ImportMusicBrainzIdTest(_common.TestCase, ImportHelper):
         self.teardown_beets()
 
     def test_one_mbid_one_album(self):
-        self.config['import']['search_ids'] = \
-            [self.MB_RELEASE_PREFIX + self.ID_RELEASE_0]
+        self.config["import"]["search_ids"] = [
+            self.MB_RELEASE_PREFIX + self.ID_RELEASE_0
+        ]
         self._setup_import_session()
 
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
-        self.assertEqual(self.lib.albums().get().album, 'VALID_RELEASE_0')
+        self.assertEqual(self.lib.albums().get().album, "VALID_RELEASE_0")
 
     def test_several_mbid_one_album(self):
-        self.config['import']['search_ids'] = \
-            [self.MB_RELEASE_PREFIX + self.ID_RELEASE_0,
-             self.MB_RELEASE_PREFIX + self.ID_RELEASE_1]
+        self.config["import"]["search_ids"] = [
+            self.MB_RELEASE_PREFIX + self.ID_RELEASE_0,
+            self.MB_RELEASE_PREFIX + self.ID_RELEASE_1,
+        ]
         self._setup_import_session()
 
         self.importer.add_choice(2)  # Pick the 2nd best match (release 1).
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
-        self.assertEqual(self.lib.albums().get().album, 'VALID_RELEASE_1')
+        self.assertEqual(self.lib.albums().get().album, "VALID_RELEASE_1")
 
     def test_one_mbid_one_singleton(self):
-        self.config['import']['search_ids'] = \
-            [self.MB_RECORDING_PREFIX + self.ID_RECORDING_0]
+        self.config["import"]["search_ids"] = [
+            self.MB_RECORDING_PREFIX + self.ID_RECORDING_0
+        ]
         self._setup_import_session(singletons=True)
 
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
-        self.assertEqual(self.lib.items().get().title, 'VALID_RECORDING_0')
+        self.assertEqual(self.lib.items().get().title, "VALID_RECORDING_0")
 
     def test_several_mbid_one_singleton(self):
-        self.config['import']['search_ids'] = \
-            [self.MB_RECORDING_PREFIX + self.ID_RECORDING_0,
-             self.MB_RECORDING_PREFIX + self.ID_RECORDING_1]
+        self.config["import"]["search_ids"] = [
+            self.MB_RECORDING_PREFIX + self.ID_RECORDING_0,
+            self.MB_RECORDING_PREFIX + self.ID_RECORDING_1,
+        ]
         self._setup_import_session(singletons=True)
 
         self.importer.add_choice(2)  # Pick the 2nd best match (recording 1).
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
-        self.assertEqual(self.lib.items().get().title, 'VALID_RECORDING_1')
+        self.assertEqual(self.lib.items().get().title, "VALID_RECORDING_1")
 
     def test_candidates_album(self):
         """Test directly ImportTask.lookup_candidates()."""
-        task = importer.ImportTask(paths=self.import_dir,
-                                   toppath='top path',
-                                   items=[_common.item()])
-        task.search_ids = [self.MB_RELEASE_PREFIX + self.ID_RELEASE_0,
-                           self.MB_RELEASE_PREFIX + self.ID_RELEASE_1,
-                           'an invalid and discarded id']
+        task = importer.ImportTask(
+            paths=self.import_dir, toppath="top path", items=[_common.item()]
+        )
+        task.search_ids = [
+            self.MB_RELEASE_PREFIX + self.ID_RELEASE_0,
+            self.MB_RELEASE_PREFIX + self.ID_RELEASE_1,
+            "an invalid and discarded id",
+        ]
 
         task.lookup_candidates()
-        self.assertEqual(set(['VALID_RELEASE_0', 'VALID_RELEASE_1']),
-                         set([c.info.album for c in task.candidates]))
+        self.assertEqual(
+            set(["VALID_RELEASE_0", "VALID_RELEASE_1"]),
+            set([c.info.album for c in task.candidates]),
+        )
 
     def test_candidates_singleton(self):
         """Test directly SingletonImportTask.lookup_candidates()."""
-        task = importer.SingletonImportTask(toppath='top path',
-                                            item=_common.item())
-        task.search_ids = [self.MB_RECORDING_PREFIX + self.ID_RECORDING_0,
-                           self.MB_RECORDING_PREFIX + self.ID_RECORDING_1,
-                           'an invalid and discarded id']
+        task = importer.SingletonImportTask(
+            toppath="top path", item=_common.item()
+        )
+        task.search_ids = [
+            self.MB_RECORDING_PREFIX + self.ID_RECORDING_0,
+            self.MB_RECORDING_PREFIX + self.ID_RECORDING_1,
+            "an invalid and discarded id",
+        ]
 
         task.lookup_candidates()
-        self.assertEqual(set(['VALID_RECORDING_0', 'VALID_RECORDING_1']),
-                         set([c.info.title for c in task.candidates]))
+        self.assertEqual(
+            set(["VALID_RECORDING_0", "VALID_RECORDING_1"]),
+            set([c.info.title for c in task.candidates]),
+        )
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_importfeeds.py
+++ b/test/test_importfeeds.py
@@ -14,46 +14,48 @@ from beetsplug.importfeeds import ImportFeedsPlugin
 
 
 class ImportfeedsTestTest(unittest.TestCase):
-
     def setUp(self):
         config.clear()
         config.read(user=False)
         self.importfeeds = ImportFeedsPlugin()
-        self.lib = Library(':memory:')
+        self.lib = Library(":memory:")
         self.feeds_dir = tempfile.mkdtemp()
-        config['importfeeds']['dir'] = self.feeds_dir
+        config["importfeeds"]["dir"] = self.feeds_dir
 
     def tearDown(self):
         shutil.rmtree(self.feeds_dir)
 
     def test_multi_format_album_playlist(self):
-        config['importfeeds']['formats'] = 'm3u_multi'
-        album = Album(album='album/name', id=1)
-        item_path = os.path.join('path', 'to', 'item')
-        item = Item(title='song', album_id=1, path=item_path)
+        config["importfeeds"]["formats"] = "m3u_multi"
+        album = Album(album="album/name", id=1)
+        item_path = os.path.join("path", "to", "item")
+        item = Item(title="song", album_id=1, path=item_path)
         self.lib.add(album)
         self.lib.add(item)
 
         self.importfeeds.album_imported(self.lib, album)
-        playlist_path = os.path.join(self.feeds_dir,
-                                     os.listdir(self.feeds_dir)[0])
-        self.assertTrue(playlist_path.endswith('album_name.m3u'))
+        playlist_path = os.path.join(
+            self.feeds_dir, os.listdir(self.feeds_dir)[0]
+        )
+        self.assertTrue(playlist_path.endswith("album_name.m3u"))
         with open(playlist_path) as playlist:
             self.assertIn(item_path, playlist.read())
 
     def test_playlist_in_subdir(self):
-        config['importfeeds']['formats'] = 'm3u'
-        config['importfeeds']['m3u_name'] = \
-            os.path.join('subdir', 'imported.m3u')
-        album = Album(album='album/name', id=1)
-        item_path = os.path.join('path', 'to', 'item')
-        item = Item(title='song', album_id=1, path=item_path)
+        config["importfeeds"]["formats"] = "m3u"
+        config["importfeeds"]["m3u_name"] = os.path.join(
+            "subdir", "imported.m3u"
+        )
+        album = Album(album="album/name", id=1)
+        item_path = os.path.join("path", "to", "item")
+        item = Item(title="song", album_id=1, path=item_path)
         self.lib.add(album)
         self.lib.add(item)
 
         self.importfeeds.album_imported(self.lib, album)
-        playlist = os.path.join(self.feeds_dir,
-                                config['importfeeds']['m3u_name'].get())
+        playlist = os.path.join(
+            self.feeds_dir, config["importfeeds"]["m3u_name"].get()
+        )
         playlist_subdir = os.path.dirname(playlist)
         self.assertTrue(os.path.isdir(playlist_subdir))
         self.assertTrue(os.path.isfile(playlist))
@@ -62,5 +64,6 @@ class ImportfeedsTestTest(unittest.TestCase):
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_info.py
+++ b/test/test_info.py
@@ -23,10 +23,9 @@ from beets.util import displayable_path
 
 
 class InfoTest(unittest.TestCase, TestHelper):
-
     def setUp(self):
         self.setup_beets()
-        self.load_plugins('info')
+        self.load_plugins("info")
 
     def tearDown(self):
         self.unload_plugins()
@@ -36,82 +35,88 @@ class InfoTest(unittest.TestCase, TestHelper):
         path = self.create_mediafile_fixture()
 
         mediafile = MediaFile(path)
-        mediafile.albumartist = 'AAA'
-        mediafile.disctitle = 'DDD'
-        mediafile.genres = ['a', 'b', 'c']
+        mediafile.albumartist = "AAA"
+        mediafile.disctitle = "DDD"
+        mediafile.genres = ["a", "b", "c"]
         mediafile.composer = None
         mediafile.save()
 
-        out = self.run_with_output('info', path)
+        out = self.run_with_output("info", path)
         self.assertIn(path, out)
-        self.assertIn('albumartist: AAA', out)
-        self.assertIn('disctitle: DDD', out)
-        self.assertIn('genres: a; b; c', out)
-        self.assertNotIn('composer:', out)
+        self.assertIn("albumartist: AAA", out)
+        self.assertIn("disctitle: DDD", out)
+        self.assertIn("genres: a; b; c", out)
+        self.assertNotIn("composer:", out)
         self.remove_mediafile_fixtures()
 
     def test_item_query(self):
         item1, item2 = self.add_item_fixtures(count=2)
-        item1.album = 'xxxx'
+        item1.album = "xxxx"
         item1.write()
-        item1.album = 'yyyy'
+        item1.album = "yyyy"
         item1.store()
 
-        out = self.run_with_output('info', 'album:yyyy')
+        out = self.run_with_output("info", "album:yyyy")
         self.assertIn(displayable_path(item1.path), out)
-        self.assertIn(u'album: xxxx', out)
+        self.assertIn(u"album: xxxx", out)
 
         self.assertNotIn(displayable_path(item2.path), out)
 
     def test_item_library_query(self):
-        item, = self.add_item_fixtures()
-        item.album = 'xxxx'
+        (item,) = self.add_item_fixtures()
+        item.album = "xxxx"
         item.store()
 
-        out = self.run_with_output('info', '--library', 'album:xxxx')
+        out = self.run_with_output("info", "--library", "album:xxxx")
         self.assertIn(displayable_path(item.path), out)
-        self.assertIn(u'album: xxxx', out)
+        self.assertIn(u"album: xxxx", out)
 
     def test_collect_item_and_path(self):
         path = self.create_mediafile_fixture()
         mediafile = MediaFile(path)
-        item, = self.add_item_fixtures()
+        (item,) = self.add_item_fixtures()
 
-        item.album = mediafile.album = 'AAA'
+        item.album = mediafile.album = "AAA"
         item.tracktotal = mediafile.tracktotal = 5
-        item.title = 'TTT'
-        mediafile.title = 'SSS'
+        item.title = "TTT"
+        mediafile.title = "SSS"
 
         item.write()
         item.store()
         mediafile.save()
 
-        out = self.run_with_output('info', '--summarize', 'album:AAA', path)
-        self.assertIn(u'album: AAA', out)
-        self.assertIn(u'tracktotal: 5', out)
-        self.assertIn(u'title: [various]', out)
+        out = self.run_with_output("info", "--summarize", "album:AAA", path)
+        self.assertIn(u"album: AAA", out)
+        self.assertIn(u"tracktotal: 5", out)
+        self.assertIn(u"title: [various]", out)
         self.remove_mediafile_fixtures()
 
     def test_include_pattern(self):
-        item, = self.add_item_fixtures()
-        item.album = 'xxxx'
+        (item,) = self.add_item_fixtures()
+        item.album = "xxxx"
         item.store()
 
-        out = self.run_with_output('info', '--library', 'album:xxxx',
-                                   '--include-keys', '*lbu*')
+        out = self.run_with_output(
+            "info", "--library", "album:xxxx", "--include-keys", "*lbu*"
+        )
         self.assertIn(displayable_path(item.path), out)
-        self.assertNotIn(u'title:', out)
-        self.assertIn(u'album: xxxx', out)
+        self.assertNotIn(u"title:", out)
+        self.assertIn(u"album: xxxx", out)
 
     def test_custom_format(self):
         self.add_item_fixtures()
-        out = self.run_with_output('info', '--library', '--format',
-                                   '$track. $title - $artist ($length)')
-        self.assertEqual(u'02. tïtle 0 - the artist (0:01)\n', out)
+        out = self.run_with_output(
+            "info",
+            "--library",
+            "--format",
+            "$track. $title - $artist ($length)",
+        )
+        self.assertEqual(u"02. tïtle 0 - the artist (0:01)\n", out)
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_ipfs.py
+++ b/test/test_ipfs.py
@@ -27,12 +27,11 @@ from test import _common
 from test.helper import TestHelper
 
 
-@patch('beets.util.command_output', Mock())
+@patch("beets.util.command_output", Mock())
 class IPFSPluginTest(unittest.TestCase, TestHelper):
-
     def setUp(self):
         self.setup_beets()
-        self.load_plugins('ipfs')
+        self.load_plugins("ipfs")
         self.lib = library.Library(":memory:")
 
     def tearDown(self):
@@ -53,8 +52,9 @@ class IPFSPluginTest(unittest.TestCase, TestHelper):
                     ipfs_item = os.path.basename(want_item.path).decode(
                         _fsencoding(),
                     )
-                    want_path = '/ipfs/{0}/{1}'.format(test_album.ipfs,
-                                                       ipfs_item)
+                    want_path = "/ipfs/{0}/{1}".format(
+                        test_album.ipfs, ipfs_item
+                    )
                     want_path = bytestring_path(want_path)
                     self.assertEqual(check_item.path, want_path)
                     self.assertEqual(check_item.ipfs, want_item.ipfs)
@@ -66,22 +66,22 @@ class IPFSPluginTest(unittest.TestCase, TestHelper):
 
     def mk_test_album(self):
         items = [_common.item() for _ in range(3)]
-        items[0].title = 'foo bar'
-        items[0].artist = '1one'
-        items[0].album = 'baz'
+        items[0].title = "foo bar"
+        items[0].artist = "1one"
+        items[0].album = "baz"
         items[0].year = 2001
         items[0].comp = True
-        items[1].title = 'baz qux'
-        items[1].artist = '2two'
-        items[1].album = 'baz'
+        items[1].title = "baz qux"
+        items[1].artist = "2two"
+        items[1].album = "baz"
         items[1].year = 2002
         items[1].comp = True
-        items[2].title = 'beets 4 eva'
-        items[2].artist = '3three'
-        items[2].album = 'foo'
+        items[2].title = "beets 4 eva"
+        items[2].artist = "3three"
+        items[2].album = "foo"
         items[2].year = 2003
         items[2].comp = False
-        items[2].ipfs = 'QmfM9ic5LJj7V6ecozFx1MkSoaaiq3PXfhJoFvyqzpLXSk'
+        items[2].ipfs = "QmfM9ic5LJj7V6ecozFx1MkSoaaiq3PXfhJoFvyqzpLXSk"
 
         for item in items:
             self.lib.add(item)
@@ -96,5 +96,6 @@ class IPFSPluginTest(unittest.TestCase, TestHelper):
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_keyfinder.py
+++ b/test/test_keyfinder.py
@@ -23,28 +23,28 @@ from beets.library import Item
 from beets import util
 
 
-@patch('beets.util.command_output')
+@patch("beets.util.command_output")
 class KeyFinderTest(unittest.TestCase, TestHelper):
-
     def setUp(self):
         self.setup_beets()
-        self.load_plugins('keyfinder')
+        self.load_plugins("keyfinder")
 
     def tearDown(self):
         self.teardown_beets()
         self.unload_plugins()
 
     def test_add_key(self, command_output):
-        item = Item(path='/file')
+        item = Item(path="/file")
         item.add(self.lib)
 
         command_output.return_value = util.CommandOutput(b"dbm", b"")
-        self.run_command('keyfinder')
+        self.run_command("keyfinder")
 
         item.load()
-        self.assertEqual(item['initial_key'], 'C#m')
+        self.assertEqual(item["initial_key"], "C#m")
         command_output.assert_called_with(
-            ['KeyFinder', '-f', util.syspath(item.path)])
+            ["KeyFinder", "-f", util.syspath(item.path)]
+        )
 
     def test_add_key_on_import(self, command_output):
         command_output.return_value = util.CommandOutput(b"dbm", b"")
@@ -52,33 +52,34 @@ class KeyFinderTest(unittest.TestCase, TestHelper):
         importer.run()
 
         item = self.lib.items().get()
-        self.assertEqual(item['initial_key'], 'C#m')
+        self.assertEqual(item["initial_key"], "C#m")
 
     def test_force_overwrite(self, command_output):
-        self.config['keyfinder']['overwrite'] = True
+        self.config["keyfinder"]["overwrite"] = True
 
-        item = Item(path='/file', initial_key='F')
+        item = Item(path="/file", initial_key="F")
         item.add(self.lib)
 
         command_output.return_value = util.CommandOutput(b"C#m", b"")
-        self.run_command('keyfinder')
+        self.run_command("keyfinder")
 
         item.load()
-        self.assertEqual(item['initial_key'], 'C#m')
+        self.assertEqual(item["initial_key"], "C#m")
 
     def test_do_not_overwrite(self, command_output):
-        item = Item(path='/file', initial_key='F')
+        item = Item(path="/file", initial_key="F")
         item.add(self.lib)
 
         command_output.return_value = util.CommandOutput(b"dbm", b"")
-        self.run_command('keyfinder')
+        self.run_command("keyfinder")
 
         item.load()
-        self.assertEqual(item['initial_key'], 'F')
+        self.assertEqual(item["initial_key"], "F")
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_lastgenre.py
+++ b/test/test_lastgenre.py
@@ -36,14 +36,15 @@ class LastGenrePluginTest(unittest.TestCase, TestHelper):
     def tearDown(self):
         self.teardown_beets()
 
-    def _setup_config(self, whitelist=False, canonical=False, count=1,
-                      prefer_specific=False):
-        config['lastgenre']['canonical'] = canonical
-        config['lastgenre']['count'] = count
-        config['lastgenre']['prefer_specific'] = prefer_specific
+    def _setup_config(
+        self, whitelist=False, canonical=False, count=1, prefer_specific=False
+    ):
+        config["lastgenre"]["canonical"] = canonical
+        config["lastgenre"]["count"] = count
+        config["lastgenre"]["prefer_specific"] = prefer_specific
         if isinstance(whitelist, (bool, six.string_types)):
             # Filename, default, or disabled.
-            config['lastgenre']['whitelist'] = whitelist
+            config["lastgenre"]["whitelist"] = whitelist
         self.plugin.setup()
         if not isinstance(whitelist, (bool, six.string_types)):
             # Explicit list of genres.
@@ -53,90 +54,94 @@ class LastGenrePluginTest(unittest.TestCase, TestHelper):
         """Fetch genres with whitelist and c14n deactivated
         """
         self._setup_config()
-        self.assertEqual(self.plugin._resolve_genres(['delta blues']),
-                         u'Delta Blues')
+        self.assertEqual(
+            self.plugin._resolve_genres(["delta blues"]), u"Delta Blues"
+        )
 
     def test_c14n_only(self):
         """Default c14n tree funnels up to most common genre except for *wrong*
         genres that stay unchanged.
         """
         self._setup_config(canonical=True, count=99)
-        self.assertEqual(self.plugin._resolve_genres(['delta blues']),
-                         u'Blues')
-        self.assertEqual(self.plugin._resolve_genres(['iota blues']),
-                         u'Iota Blues')
+        self.assertEqual(
+            self.plugin._resolve_genres(["delta blues"]), u"Blues"
+        )
+        self.assertEqual(
+            self.plugin._resolve_genres(["iota blues"]), u"Iota Blues"
+        )
 
     def test_whitelist_only(self):
         """Default whitelist rejects *wrong* (non existing) genres.
         """
         self._setup_config(whitelist=True)
-        self.assertEqual(self.plugin._resolve_genres(['iota blues']),
-                         u'')
+        self.assertEqual(self.plugin._resolve_genres(["iota blues"]), u"")
 
     def test_whitelist_c14n(self):
         """Default whitelist and c14n both activated result in all parents
         genres being selected (from specific to common).
         """
         self._setup_config(canonical=True, whitelist=True, count=99)
-        self.assertEqual(self.plugin._resolve_genres(['delta blues']),
-                         u'Delta Blues, Blues')
+        self.assertEqual(
+            self.plugin._resolve_genres(["delta blues"]), u"Delta Blues, Blues"
+        )
 
     def test_whitelist_custom(self):
         """Keep only genres that are in the whitelist.
         """
-        self._setup_config(whitelist=set(['blues', 'rock', 'jazz']),
-                           count=2)
-        self.assertEqual(self.plugin._resolve_genres(['pop', 'blues']),
-                         u'Blues')
+        self._setup_config(whitelist=set(["blues", "rock", "jazz"]), count=2)
+        self.assertEqual(
+            self.plugin._resolve_genres(["pop", "blues"]), u"Blues"
+        )
 
-        self._setup_config(canonical='', whitelist=set(['rock']))
-        self.assertEqual(self.plugin._resolve_genres(['delta blues']),
-                         u'')
+        self._setup_config(canonical="", whitelist=set(["rock"]))
+        self.assertEqual(self.plugin._resolve_genres(["delta blues"]), u"")
 
     def test_count(self):
         """Keep the n first genres, as we expect them to be sorted from more to
         less popular.
         """
-        self._setup_config(whitelist=set(['blues', 'rock', 'jazz']),
-                           count=2)
-        self.assertEqual(self.plugin._resolve_genres(
-                         ['jazz', 'pop', 'rock', 'blues']),
-                         u'Jazz, Rock')
+        self._setup_config(whitelist=set(["blues", "rock", "jazz"]), count=2)
+        self.assertEqual(
+            self.plugin._resolve_genres(["jazz", "pop", "rock", "blues"]),
+            u"Jazz, Rock",
+        )
 
     def test_count_c14n(self):
         """Keep the n first genres, after having applied c14n when necessary
         """
-        self._setup_config(whitelist=set(['blues', 'rock', 'jazz']),
-                           canonical=True,
-                           count=2)
+        self._setup_config(
+            whitelist=set(["blues", "rock", "jazz"]), canonical=True, count=2
+        )
         # thanks to c14n, 'blues' superseeds 'country blues' and takes the
         # second slot
-        self.assertEqual(self.plugin._resolve_genres(
-                         ['jazz', 'pop', 'country blues', 'rock']),
-                         u'Jazz, Blues')
+        self.assertEqual(
+            self.plugin._resolve_genres(
+                ["jazz", "pop", "country blues", "rock"]
+            ),
+            u"Jazz, Blues",
+        )
 
     def test_c14n_whitelist(self):
         """Genres first pass through c14n and are then filtered
         """
-        self._setup_config(canonical=True, whitelist=set(['rock']))
-        self.assertEqual(self.plugin._resolve_genres(['delta blues']),
-                         u'')
+        self._setup_config(canonical=True, whitelist=set(["rock"]))
+        self.assertEqual(self.plugin._resolve_genres(["delta blues"]), u"")
 
     def test_empty_string_enables_canonical(self):
         """For backwards compatibility, setting the `canonical` option
         to the empty string enables it using the default tree.
         """
-        self._setup_config(canonical='', count=99)
-        self.assertEqual(self.plugin._resolve_genres(['delta blues']),
-                         u'Blues')
+        self._setup_config(canonical="", count=99)
+        self.assertEqual(
+            self.plugin._resolve_genres(["delta blues"]), u"Blues"
+        )
 
     def test_empty_string_enables_whitelist(self):
         """Again for backwards compatibility, setting the `whitelist`
         option to the empty string enables the default set of genres.
         """
-        self._setup_config(whitelist='')
-        self.assertEqual(self.plugin._resolve_genres(['iota blues']),
-                         u'')
+        self._setup_config(whitelist="")
+        self.assertEqual(self.plugin._resolve_genres(["iota blues"]), u"")
 
     def test_prefer_specific_loads_tree(self):
         """When prefer_specific is enabled but canonical is not the
@@ -149,16 +154,18 @@ class LastGenrePluginTest(unittest.TestCase, TestHelper):
         """Prefer_specific works without canonical.
         """
         self._setup_config(prefer_specific=True, canonical=False, count=4)
-        self.assertEqual(self.plugin._resolve_genres(
-                         ['math rock', 'post-rock']),
-                         u'Post-Rock, Math Rock')
+        self.assertEqual(
+            self.plugin._resolve_genres(["math rock", "post-rock"]),
+            u"Post-Rock, Math Rock",
+        )
 
     def test_no_duplicate(self):
         """Remove duplicated genres.
         """
         self._setup_config(count=99)
-        self.assertEqual(self.plugin._resolve_genres(['blues', 'blues']),
-                         u'Blues')
+        self.assertEqual(
+            self.plugin._resolve_genres(["blues", "blues"]), u"Blues"
+        )
 
     def test_tags_for(self):
         class MockPylastElem(object):
@@ -172,29 +179,29 @@ class LastGenrePluginTest(unittest.TestCase, TestHelper):
             def get_top_tags(self):
                 tag1 = Mock()
                 tag1.weight = 90
-                tag1.item = MockPylastElem(u'Pop')
+                tag1.item = MockPylastElem(u"Pop")
                 tag2 = Mock()
                 tag2.weight = 40
-                tag2.item = MockPylastElem(u'Rap')
+                tag2.item = MockPylastElem(u"Rap")
                 return [tag1, tag2]
 
         plugin = lastgenre.LastGenrePlugin()
         res = plugin._tags_for(MockPylastObj())
-        self.assertEqual(res, [u'pop', u'rap'])
+        self.assertEqual(res, [u"pop", u"rap"])
         res = plugin._tags_for(MockPylastObj(), min_weight=50)
-        self.assertEqual(res, [u'pop'])
+        self.assertEqual(res, [u"pop"])
 
     def test_get_genre(self):
-        mock_genres = {'track': u'1', 'album': u'2', 'artist': u'3'}
+        mock_genres = {"track": u"1", "album": u"2", "artist": u"3"}
 
         def mock_fetch_track_genre(self, obj=None):
-            return mock_genres['track']
+            return mock_genres["track"]
 
         def mock_fetch_album_genre(self, obj):
-            return mock_genres['album']
+            return mock_genres["album"]
 
         def mock_fetch_artist_genre(self, obj):
-            return mock_genres['artist']
+            return mock_genres["artist"]
 
         lastgenre.LastGenrePlugin.fetch_track_genre = mock_fetch_track_genre
         lastgenre.LastGenrePlugin.fetch_album_genre = mock_fetch_album_genre
@@ -202,49 +209,52 @@ class LastGenrePluginTest(unittest.TestCase, TestHelper):
 
         self._setup_config(whitelist=False)
         item = _common.item()
-        item.genre = mock_genres['track']
+        item.genre = mock_genres["track"]
 
-        config['lastgenre'] = {'force': False}
+        config["lastgenre"] = {"force": False}
         res = self.plugin._get_genre(item)
-        self.assertEqual(res, (item.genre, u'keep'))
+        self.assertEqual(res, (item.genre, u"keep"))
 
-        config['lastgenre'] = {'force': True, 'source': u'track'}
+        config["lastgenre"] = {"force": True, "source": u"track"}
         res = self.plugin._get_genre(item)
-        self.assertEqual(res, (mock_genres['track'], u'track'))
+        self.assertEqual(res, (mock_genres["track"], u"track"))
 
-        config['lastgenre'] = {'source': u'album'}
+        config["lastgenre"] = {"source": u"album"}
         res = self.plugin._get_genre(item)
-        self.assertEqual(res, (mock_genres['album'], u'album'))
+        self.assertEqual(res, (mock_genres["album"], u"album"))
 
-        config['lastgenre'] = {'source': u'artist'}
+        config["lastgenre"] = {"source": u"artist"}
         res = self.plugin._get_genre(item)
-        self.assertEqual(res, (mock_genres['artist'], u'artist'))
+        self.assertEqual(res, (mock_genres["artist"], u"artist"))
 
-        mock_genres['artist'] = None
+        mock_genres["artist"] = None
         res = self.plugin._get_genre(item)
-        self.assertEqual(res, (item.genre, u'original'))
+        self.assertEqual(res, (item.genre, u"original"))
 
-        config['lastgenre'] = {'fallback': u'rap'}
+        config["lastgenre"] = {"fallback": u"rap"}
         item.genre = None
         res = self.plugin._get_genre(item)
-        self.assertEqual(res, (config['lastgenre']['fallback'].get(),
-                         u'fallback'))
+        self.assertEqual(
+            res, (config["lastgenre"]["fallback"].get(), u"fallback")
+        )
 
     def test_sort_by_depth(self):
         self._setup_config(canonical=True)
         # Normal case.
-        tags = ('electronic', 'ambient', 'post-rock', 'downtempo')
+        tags = ("electronic", "ambient", "post-rock", "downtempo")
         res = self.plugin._sort_by_depth(tags)
         self.assertEqual(
-            res, ['post-rock', 'downtempo', 'ambient', 'electronic'])
+            res, ["post-rock", "downtempo", "ambient", "electronic"]
+        )
         # Non-canonical tag ('chillout') present.
-        tags = ('electronic', 'ambient', 'chillout')
+        tags = ("electronic", "ambient", "chillout")
         res = self.plugin._sort_by_depth(tags)
-        self.assertEqual(res, ['ambient', 'electronic'])
+        self.assertEqual(res, ["ambient", "electronic"])
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -46,69 +46,81 @@ np = util.normpath
 class LoadTest(_common.LibTestCase):
     def test_load_restores_data_from_db(self):
         original_title = self.i.title
-        self.i.title = u'something'
+        self.i.title = u"something"
         self.i.load()
         self.assertEqual(original_title, self.i.title)
 
     def test_load_clears_dirty_flags(self):
-        self.i.artist = u'something'
-        self.assertTrue('artist' in self.i._dirty)
+        self.i.artist = u"something"
+        self.assertTrue("artist" in self.i._dirty)
         self.i.load()
-        self.assertTrue('artist' not in self.i._dirty)
+        self.assertTrue("artist" not in self.i._dirty)
 
 
 class StoreTest(_common.LibTestCase):
     def test_store_changes_database_value(self):
         self.i.year = 1987
         self.i.store()
-        new_year = self.lib._connection().execute(
-            'select year from items where '
-            'title="the title"').fetchone()['year']
+        new_year = (
+            self.lib._connection()
+            .execute("select year from items where " 'title="the title"')
+            .fetchone()["year"]
+        )
         self.assertEqual(new_year, 1987)
 
     def test_store_only_writes_dirty_fields(self):
         original_genre = self.i.genre
-        self.i._values_fixed['genre'] = u'beatboxing'  # change w/o dirtying
+        self.i._values_fixed["genre"] = u"beatboxing"  # change w/o dirtying
         self.i.store()
-        new_genre = self.lib._connection().execute(
-            'select genre from items where '
-            'title="the title"').fetchone()['genre']
+        new_genre = (
+            self.lib._connection()
+            .execute("select genre from items where " 'title="the title"')
+            .fetchone()["genre"]
+        )
         self.assertEqual(new_genre, original_genre)
 
     def test_store_clears_dirty_flags(self):
-        self.i.composer = u'tvp'
+        self.i.composer = u"tvp"
         self.i.store()
-        self.assertTrue('composer' not in self.i._dirty)
+        self.assertTrue("composer" not in self.i._dirty)
 
 
 class AddTest(_common.TestCase):
     def setUp(self):
         super(AddTest, self).setUp()
-        self.lib = beets.library.Library(':memory:')
+        self.lib = beets.library.Library(":memory:")
         self.i = item()
 
     def test_item_add_inserts_row(self):
         self.lib.add(self.i)
-        new_grouping = self.lib._connection().execute(
-            'select grouping from items '
-            'where composer="the composer"').fetchone()['grouping']
+        new_grouping = (
+            self.lib._connection()
+            .execute(
+                "select grouping from items " 'where composer="the composer"'
+            )
+            .fetchone()["grouping"]
+        )
         self.assertEqual(new_grouping, self.i.grouping)
 
     def test_library_add_path_inserts_row(self):
         i = beets.library.Item.from_path(
-            os.path.join(_common.RSRC, b'full.mp3')
+            os.path.join(_common.RSRC, b"full.mp3")
         )
         self.lib.add(i)
-        new_grouping = self.lib._connection().execute(
-            'select grouping from items '
-            'where composer="the composer"').fetchone()['grouping']
+        new_grouping = (
+            self.lib._connection()
+            .execute(
+                "select grouping from items " 'where composer="the composer"'
+            )
+            .fetchone()["grouping"]
+        )
         self.assertEqual(new_grouping, self.i.grouping)
 
 
 class RemoveTest(_common.LibTestCase):
     def test_remove_deletes_from_db(self):
         self.i.remove()
-        c = self.lib._connection().execute('select * from items')
+        c = self.lib._connection().execute("select * from items")
         self.assertEqual(c.fetchone(), None)
 
 
@@ -123,20 +135,20 @@ class GetSetTest(_common.TestCase):
 
     def test_set_sets_dirty_flag(self):
         self.i.comp = not self.i.comp
-        self.assertTrue('comp' in self.i._dirty)
+        self.assertTrue("comp" in self.i._dirty)
 
     def test_set_does_not_dirty_if_value_unchanged(self):
         self.i.title = self.i.title
-        self.assertTrue('title' not in self.i._dirty)
+        self.assertTrue("title" not in self.i._dirty)
 
     def test_invalid_field_raises_attributeerror(self):
-        self.assertRaises(AttributeError, getattr, self.i, u'xyzzy')
+        self.assertRaises(AttributeError, getattr, self.i, u"xyzzy")
 
 
 class DestinationTest(_common.TestCase):
     def setUp(self):
         super(DestinationTest, self).setUp()
-        self.lib = beets.library.Library(':memory:')
+        self.lib = beets.library.Library(":memory:")
         self.i = item(self.lib)
 
     def tearDown(self):
@@ -148,413 +160,411 @@ class DestinationTest(_common.TestCase):
         config.read(user=False, defaults=True)
 
     def test_directory_works_with_trailing_slash(self):
-        self.lib.directory = b'one/'
-        self.lib.path_formats = [(u'default', u'two')]
-        self.assertEqual(self.i.destination(), np('one/two'))
+        self.lib.directory = b"one/"
+        self.lib.path_formats = [(u"default", u"two")]
+        self.assertEqual(self.i.destination(), np("one/two"))
 
     def test_directory_works_without_trailing_slash(self):
-        self.lib.directory = b'one'
-        self.lib.path_formats = [(u'default', u'two')]
-        self.assertEqual(self.i.destination(), np('one/two'))
+        self.lib.directory = b"one"
+        self.lib.path_formats = [(u"default", u"two")]
+        self.assertEqual(self.i.destination(), np("one/two"))
 
     def test_destination_substitutes_metadata_values(self):
-        self.lib.directory = b'base'
-        self.lib.path_formats = [(u'default', u'$album/$artist $title')]
-        self.i.title = 'three'
-        self.i.artist = 'two'
-        self.i.album = 'one'
-        self.assertEqual(self.i.destination(),
-                         np('base/one/two three'))
+        self.lib.directory = b"base"
+        self.lib.path_formats = [(u"default", u"$album/$artist $title")]
+        self.i.title = "three"
+        self.i.artist = "two"
+        self.i.album = "one"
+        self.assertEqual(self.i.destination(), np("base/one/two three"))
 
     def test_destination_preserves_extension(self):
-        self.lib.directory = b'base'
-        self.lib.path_formats = [(u'default', u'$title')]
-        self.i.path = 'hey.audioformat'
-        self.assertEqual(self.i.destination(),
-                         np('base/the title.audioformat'))
+        self.lib.directory = b"base"
+        self.lib.path_formats = [(u"default", u"$title")]
+        self.i.path = "hey.audioformat"
+        self.assertEqual(
+            self.i.destination(), np("base/the title.audioformat")
+        )
 
     def test_lower_case_extension(self):
-        self.lib.directory = b'base'
-        self.lib.path_formats = [(u'default', u'$title')]
-        self.i.path = 'hey.MP3'
-        self.assertEqual(self.i.destination(),
-                         np('base/the title.mp3'))
+        self.lib.directory = b"base"
+        self.lib.path_formats = [(u"default", u"$title")]
+        self.i.path = "hey.MP3"
+        self.assertEqual(self.i.destination(), np("base/the title.mp3"))
 
     def test_destination_pads_some_indices(self):
-        self.lib.directory = b'base'
-        self.lib.path_formats = [(u'default',
-                                  u'$track $tracktotal $disc $disctotal $bpm')]
+        self.lib.directory = b"base"
+        self.lib.path_formats = [
+            (u"default", u"$track $tracktotal $disc $disctotal $bpm")
+        ]
         self.i.track = 1
         self.i.tracktotal = 2
         self.i.disc = 3
         self.i.disctotal = 4
         self.i.bpm = 5
-        self.assertEqual(self.i.destination(),
-                         np('base/01 02 03 04 5'))
+        self.assertEqual(self.i.destination(), np("base/01 02 03 04 5"))
 
     def test_destination_pads_date_values(self):
-        self.lib.directory = b'base'
-        self.lib.path_formats = [(u'default', u'$year-$month-$day')]
+        self.lib.directory = b"base"
+        self.lib.path_formats = [(u"default", u"$year-$month-$day")]
         self.i.year = 1
         self.i.month = 2
         self.i.day = 3
-        self.assertEqual(self.i.destination(),
-                         np('base/0001-02-03'))
+        self.assertEqual(self.i.destination(), np("base/0001-02-03"))
 
     def test_destination_escapes_slashes(self):
-        self.i.album = 'one/two'
+        self.i.album = "one/two"
         dest = self.i.destination()
-        self.assertTrue(b'one' in dest)
-        self.assertTrue(b'two' in dest)
-        self.assertFalse(b'one/two' in dest)
+        self.assertTrue(b"one" in dest)
+        self.assertTrue(b"two" in dest)
+        self.assertFalse(b"one/two" in dest)
 
     def test_destination_escapes_leading_dot(self):
-        self.i.album = '.something'
+        self.i.album = ".something"
         dest = self.i.destination()
-        self.assertTrue(b'something' in dest)
-        self.assertFalse(b'/.' in dest)
+        self.assertTrue(b"something" in dest)
+        self.assertFalse(b"/." in dest)
 
     def test_destination_preserves_legitimate_slashes(self):
-        self.i.artist = 'one'
-        self.i.album = 'two'
+        self.i.artist = "one"
+        self.i.album = "two"
         dest = self.i.destination()
-        self.assertTrue(os.path.join(b'one', b'two') in dest)
+        self.assertTrue(os.path.join(b"one", b"two") in dest)
 
     def test_destination_long_names_truncated(self):
-        self.i.title = u'X' * 300
-        self.i.artist = u'Y' * 300
+        self.i.title = u"X" * 300
+        self.i.artist = u"Y" * 300
         for c in self.i.destination().split(util.PATH_SEP):
             self.assertTrue(len(c) <= 255)
 
     def test_destination_long_names_keep_extension(self):
-        self.i.title = u'X' * 300
-        self.i.path = b'something.extn'
+        self.i.title = u"X" * 300
+        self.i.path = b"something.extn"
         dest = self.i.destination()
-        self.assertEqual(dest[-5:], b'.extn')
+        self.assertEqual(dest[-5:], b".extn")
 
     def test_distination_windows_removes_both_separators(self):
-        self.i.title = 'one \\ two / three.mp3'
+        self.i.title = "one \\ two / three.mp3"
         with _common.platform_windows():
             p = self.i.destination()
-        self.assertFalse(b'one \\ two' in p)
-        self.assertFalse(b'one / two' in p)
-        self.assertFalse(b'two \\ three' in p)
-        self.assertFalse(b'two / three' in p)
+        self.assertFalse(b"one \\ two" in p)
+        self.assertFalse(b"one / two" in p)
+        self.assertFalse(b"two \\ three" in p)
+        self.assertFalse(b"two / three" in p)
 
     def test_path_with_format(self):
-        self.lib.path_formats = [(u'default', u'$artist/$album ($format)')]
+        self.lib.path_formats = [(u"default", u"$artist/$album ($format)")]
         p = self.i.destination()
-        self.assertTrue(b'(FLAC)' in p)
+        self.assertTrue(b"(FLAC)" in p)
 
     def test_heterogeneous_album_gets_single_directory(self):
         i1, i2 = item(), item()
         self.lib.add_album([i1, i2])
         i1.year, i2.year = 2009, 2010
-        self.lib.path_formats = [(u'default', u'$album ($year)/$track $title')]
+        self.lib.path_formats = [(u"default", u"$album ($year)/$track $title")]
         dest1, dest2 = i1.destination(), i2.destination()
         self.assertEqual(os.path.dirname(dest1), os.path.dirname(dest2))
 
     def test_default_path_for_non_compilations(self):
         self.i.comp = False
         self.lib.add_album([self.i])
-        self.lib.directory = b'one'
-        self.lib.path_formats = [(u'default', u'two'),
-                                 (u'comp:true', u'three')]
-        self.assertEqual(self.i.destination(), np('one/two'))
+        self.lib.directory = b"one"
+        self.lib.path_formats = [
+            (u"default", u"two"),
+            (u"comp:true", u"three"),
+        ]
+        self.assertEqual(self.i.destination(), np("one/two"))
 
     def test_singleton_path(self):
         i = item(self.lib)
-        self.lib.directory = b'one'
+        self.lib.directory = b"one"
         self.lib.path_formats = [
-            (u'default', u'two'),
-            (u'singleton:true', u'four'),
-            (u'comp:true', u'three'),
+            (u"default", u"two"),
+            (u"singleton:true", u"four"),
+            (u"comp:true", u"three"),
         ]
-        self.assertEqual(i.destination(), np('one/four'))
+        self.assertEqual(i.destination(), np("one/four"))
 
     def test_comp_before_singleton_path(self):
         i = item(self.lib)
         i.comp = True
-        self.lib.directory = b'one'
+        self.lib.directory = b"one"
         self.lib.path_formats = [
-            (u'default', u'two'),
-            (u'comp:true', u'three'),
-            (u'singleton:true', u'four'),
+            (u"default", u"two"),
+            (u"comp:true", u"three"),
+            (u"singleton:true", u"four"),
         ]
-        self.assertEqual(i.destination(), np('one/three'))
+        self.assertEqual(i.destination(), np("one/three"))
 
     def test_comp_path(self):
         self.i.comp = True
         self.lib.add_album([self.i])
-        self.lib.directory = b'one'
+        self.lib.directory = b"one"
         self.lib.path_formats = [
-            (u'default', u'two'),
-            (u'comp:true', u'three'),
+            (u"default", u"two"),
+            (u"comp:true", u"three"),
         ]
-        self.assertEqual(self.i.destination(), np('one/three'))
+        self.assertEqual(self.i.destination(), np("one/three"))
 
     def test_albumtype_query_path(self):
         self.i.comp = True
         self.lib.add_album([self.i])
-        self.i.albumtype = u'sometype'
-        self.lib.directory = b'one'
+        self.i.albumtype = u"sometype"
+        self.lib.directory = b"one"
         self.lib.path_formats = [
-            (u'default', u'two'),
-            (u'albumtype:sometype', u'four'),
-            (u'comp:true', u'three'),
+            (u"default", u"two"),
+            (u"albumtype:sometype", u"four"),
+            (u"comp:true", u"three"),
         ]
-        self.assertEqual(self.i.destination(), np('one/four'))
+        self.assertEqual(self.i.destination(), np("one/four"))
 
     def test_albumtype_path_fallback_to_comp(self):
         self.i.comp = True
         self.lib.add_album([self.i])
-        self.i.albumtype = u'sometype'
-        self.lib.directory = b'one'
+        self.i.albumtype = u"sometype"
+        self.lib.directory = b"one"
         self.lib.path_formats = [
-            (u'default', u'two'),
-            (u'albumtype:anothertype', u'four'),
-            (u'comp:true', u'three'),
+            (u"default", u"two"),
+            (u"albumtype:anothertype", u"four"),
+            (u"comp:true", u"three"),
         ]
-        self.assertEqual(self.i.destination(), np('one/three'))
+        self.assertEqual(self.i.destination(), np("one/three"))
 
     def test_get_formatted_does_not_replace_separators(self):
         with _common.platform_posix():
-            name = os.path.join('a', 'b')
+            name = os.path.join("a", "b")
             self.i.title = name
-            newname = self.i.formatted().get('title')
+            newname = self.i.formatted().get("title")
         self.assertEqual(name, newname)
 
     def test_get_formatted_pads_with_zero(self):
         with _common.platform_posix():
             self.i.track = 1
-            name = self.i.formatted().get('track')
-        self.assertTrue(name.startswith('0'))
+            name = self.i.formatted().get("track")
+        self.assertTrue(name.startswith("0"))
 
     def test_get_formatted_uses_kbps_bitrate(self):
         with _common.platform_posix():
             self.i.bitrate = 12345
-            val = self.i.formatted().get('bitrate')
-        self.assertEqual(val, u'12kbps')
+            val = self.i.formatted().get("bitrate")
+        self.assertEqual(val, u"12kbps")
 
     def test_get_formatted_uses_khz_samplerate(self):
         with _common.platform_posix():
             self.i.samplerate = 12345
-            val = self.i.formatted().get('samplerate')
-        self.assertEqual(val, u'12kHz')
+            val = self.i.formatted().get("samplerate")
+        self.assertEqual(val, u"12kHz")
 
     def test_get_formatted_datetime(self):
         with _common.platform_posix():
             self.i.added = 1368302461.210265
-            val = self.i.formatted().get('added')
-        self.assertTrue(val.startswith('2013'))
+            val = self.i.formatted().get("added")
+        self.assertTrue(val.startswith("2013"))
 
     def test_get_formatted_none(self):
         with _common.platform_posix():
             self.i.some_other_field = None
-            val = self.i.formatted().get('some_other_field')
-        self.assertEqual(val, u'')
+            val = self.i.formatted().get("some_other_field")
+        self.assertEqual(val, u"")
 
     def test_artist_falls_back_to_albumartist(self):
-        self.i.artist = u''
-        self.i.albumartist = u'something'
-        self.lib.path_formats = [(u'default', u'$artist')]
+        self.i.artist = u""
+        self.i.albumartist = u"something"
+        self.lib.path_formats = [(u"default", u"$artist")]
         p = self.i.destination()
-        self.assertEqual(p.rsplit(util.PATH_SEP, 1)[1], b'something')
+        self.assertEqual(p.rsplit(util.PATH_SEP, 1)[1], b"something")
 
     def test_albumartist_falls_back_to_artist(self):
-        self.i.artist = u'trackartist'
-        self.i.albumartist = u''
-        self.lib.path_formats = [(u'default', u'$albumartist')]
+        self.i.artist = u"trackartist"
+        self.i.albumartist = u""
+        self.lib.path_formats = [(u"default", u"$albumartist")]
         p = self.i.destination()
-        self.assertEqual(p.rsplit(util.PATH_SEP, 1)[1], b'trackartist')
+        self.assertEqual(p.rsplit(util.PATH_SEP, 1)[1], b"trackartist")
 
     def test_artist_overrides_albumartist(self):
-        self.i.artist = u'theartist'
-        self.i.albumartist = u'something'
-        self.lib.path_formats = [(u'default', u'$artist')]
+        self.i.artist = u"theartist"
+        self.i.albumartist = u"something"
+        self.lib.path_formats = [(u"default", u"$artist")]
         p = self.i.destination()
-        self.assertEqual(p.rsplit(util.PATH_SEP, 1)[1], b'theartist')
+        self.assertEqual(p.rsplit(util.PATH_SEP, 1)[1], b"theartist")
 
     def test_albumartist_overrides_artist(self):
-        self.i.artist = u'theartist'
-        self.i.albumartist = u'something'
-        self.lib.path_formats = [(u'default', u'$albumartist')]
+        self.i.artist = u"theartist"
+        self.i.albumartist = u"something"
+        self.lib.path_formats = [(u"default", u"$albumartist")]
         p = self.i.destination()
-        self.assertEqual(p.rsplit(util.PATH_SEP, 1)[1], b'something')
+        self.assertEqual(p.rsplit(util.PATH_SEP, 1)[1], b"something")
 
     def test_unicode_normalized_nfd_on_mac(self):
-        instr = unicodedata.normalize('NFC', u'caf\xe9')
-        self.lib.path_formats = [(u'default', instr)]
-        dest = self.i.destination(platform='darwin', fragment=True)
-        self.assertEqual(dest, unicodedata.normalize('NFD', instr))
+        instr = unicodedata.normalize("NFC", u"caf\xe9")
+        self.lib.path_formats = [(u"default", instr)]
+        dest = self.i.destination(platform="darwin", fragment=True)
+        self.assertEqual(dest, unicodedata.normalize("NFD", instr))
 
     def test_unicode_normalized_nfc_on_linux(self):
-        instr = unicodedata.normalize('NFD', u'caf\xe9')
-        self.lib.path_formats = [(u'default', instr)]
-        dest = self.i.destination(platform='linux', fragment=True)
-        self.assertEqual(dest, unicodedata.normalize('NFC', instr))
+        instr = unicodedata.normalize("NFD", u"caf\xe9")
+        self.lib.path_formats = [(u"default", instr)]
+        dest = self.i.destination(platform="linux", fragment=True)
+        self.assertEqual(dest, unicodedata.normalize("NFC", instr))
 
     def test_non_mbcs_characters_on_windows(self):
         oldfunc = sys.getfilesystemencoding
-        sys.getfilesystemencoding = lambda: 'mbcs'
+        sys.getfilesystemencoding = lambda: "mbcs"
         try:
-            self.i.title = u'h\u0259d'
-            self.lib.path_formats = [(u'default', u'$title')]
+            self.i.title = u"h\u0259d"
+            self.lib.path_formats = [(u"default", u"$title")]
             p = self.i.destination()
-            self.assertFalse(b'?' in p)
+            self.assertFalse(b"?" in p)
             # We use UTF-8 to encode Windows paths now.
-            self.assertTrue(u'h\u0259d'.encode('utf-8') in p)
+            self.assertTrue(u"h\u0259d".encode("utf-8") in p)
         finally:
             sys.getfilesystemencoding = oldfunc
 
     def test_unicode_extension_in_fragment(self):
-        self.lib.path_formats = [(u'default', u'foo')]
-        self.i.path = util.bytestring_path(u'bar.caf\xe9')
-        dest = self.i.destination(platform='linux', fragment=True)
-        self.assertEqual(dest, u'foo.caf\xe9')
+        self.lib.path_formats = [(u"default", u"foo")]
+        self.i.path = util.bytestring_path(u"bar.caf\xe9")
+        dest = self.i.destination(platform="linux", fragment=True)
+        self.assertEqual(dest, u"foo.caf\xe9")
 
     def test_asciify_and_replace(self):
-        config['asciify_paths'] = True
-        self.lib.replacements = [(re.compile(u'"'), u'q')]
-        self.lib.directory = b'lib'
-        self.lib.path_formats = [(u'default', u'$title')]
-        self.i.title = u'\u201c\u00f6\u2014\u00cf\u201d'
-        self.assertEqual(self.i.destination(), np('lib/qo--Iq'))
+        config["asciify_paths"] = True
+        self.lib.replacements = [(re.compile(u'"'), u"q")]
+        self.lib.directory = b"lib"
+        self.lib.path_formats = [(u"default", u"$title")]
+        self.i.title = u"\u201c\u00f6\u2014\u00cf\u201d"
+        self.assertEqual(self.i.destination(), np("lib/qo--Iq"))
 
     def test_asciify_character_expanding_to_slash(self):
-        config['asciify_paths'] = True
-        self.lib.directory = b'lib'
-        self.lib.path_formats = [(u'default', u'$title')]
-        self.i.title = u'ab\xa2\xbdd'
-        self.assertEqual(self.i.destination(), np('lib/abC_ 1_2 d'))
+        config["asciify_paths"] = True
+        self.lib.directory = b"lib"
+        self.lib.path_formats = [(u"default", u"$title")]
+        self.i.title = u"ab\xa2\xbdd"
+        self.assertEqual(self.i.destination(), np("lib/abC_ 1_2 d"))
 
     def test_destination_with_replacements(self):
-        self.lib.directory = b'base'
-        self.lib.replacements = [(re.compile(r'a'), u'e')]
-        self.lib.path_formats = [(u'default', u'$album/$title')]
-        self.i.title = u'foo'
-        self.i.album = u'bar'
-        self.assertEqual(self.i.destination(),
-                         np('base/ber/foo'))
+        self.lib.directory = b"base"
+        self.lib.replacements = [(re.compile(r"a"), u"e")]
+        self.lib.path_formats = [(u"default", u"$album/$title")]
+        self.i.title = u"foo"
+        self.i.album = u"bar"
+        self.assertEqual(self.i.destination(), np("base/ber/foo"))
 
-    @unittest.skip('unimplemented: #359')
+    @unittest.skip("unimplemented: #359")
     def test_destination_with_empty_component(self):
-        self.lib.directory = b'base'
-        self.lib.replacements = [(re.compile(r'^$'), u'_')]
-        self.lib.path_formats = [(u'default', u'$album/$artist/$title')]
-        self.i.title = u'three'
-        self.i.artist = u''
-        self.i.albumartist = u''
-        self.i.album = u'one'
-        self.assertEqual(self.i.destination(),
-                         np('base/one/_/three'))
+        self.lib.directory = b"base"
+        self.lib.replacements = [(re.compile(r"^$"), u"_")]
+        self.lib.path_formats = [(u"default", u"$album/$artist/$title")]
+        self.i.title = u"three"
+        self.i.artist = u""
+        self.i.albumartist = u""
+        self.i.album = u"one"
+        self.assertEqual(self.i.destination(), np("base/one/_/three"))
 
-    @unittest.skip('unimplemented: #359')
+    @unittest.skip("unimplemented: #359")
     def test_destination_with_empty_final_component(self):
-        self.lib.directory = b'base'
-        self.lib.replacements = [(re.compile(r'^$'), u'_')]
-        self.lib.path_formats = [(u'default', u'$album/$title')]
-        self.i.title = u''
-        self.i.album = u'one'
-        self.i.path = 'foo.mp3'
-        self.assertEqual(self.i.destination(),
-                         np('base/one/_.mp3'))
+        self.lib.directory = b"base"
+        self.lib.replacements = [(re.compile(r"^$"), u"_")]
+        self.lib.path_formats = [(u"default", u"$album/$title")]
+        self.i.title = u""
+        self.i.album = u"one"
+        self.i.path = "foo.mp3"
+        self.assertEqual(self.i.destination(), np("base/one/_.mp3"))
 
     def test_legalize_path_one_for_one_replacement(self):
         # Use a replacement that should always replace the last X in any
         # path component with a Z.
         self.lib.replacements = [
-            (re.compile(r'X$'), u'Z'),
+            (re.compile(r"X$"), u"Z"),
         ]
 
         # Construct an item whose untruncated path ends with a Y but whose
         # truncated version ends with an X.
-        self.i.title = u'X' * 300 + u'Y'
+        self.i.title = u"X" * 300 + u"Y"
 
         # The final path should reflect the replacement.
         dest = self.i.destination()
-        self.assertEqual(dest[-2:], b'XZ')
+        self.assertEqual(dest[-2:], b"XZ")
 
     def test_legalize_path_one_for_many_replacement(self):
         # Use a replacement that should always replace the last X in any
         # path component with four Zs.
         self.lib.replacements = [
-            (re.compile(r'X$'), u'ZZZZ'),
+            (re.compile(r"X$"), u"ZZZZ"),
         ]
 
         # Construct an item whose untruncated path ends with a Y but whose
         # truncated version ends with an X.
-        self.i.title = u'X' * 300 + u'Y'
+        self.i.title = u"X" * 300 + u"Y"
 
         # The final path should ignore the user replacement and create a path
         # of the correct length, containing Xs.
         dest = self.i.destination()
-        self.assertEqual(dest[-2:], b'XX')
+        self.assertEqual(dest[-2:], b"XX")
 
 
 class ItemFormattedMappingTest(_common.LibTestCase):
     def test_formatted_item_value(self):
         formatted = self.i.formatted()
-        self.assertEqual(formatted['artist'], u'the artist')
+        self.assertEqual(formatted["artist"], u"the artist")
 
     def test_get_unset_field(self):
         formatted = self.i.formatted()
         with self.assertRaises(KeyError):
-            formatted['other_field']
+            formatted["other_field"]
 
     def test_get_method_with_default(self):
         formatted = self.i.formatted()
-        self.assertEqual(formatted.get('other_field'), u'')
+        self.assertEqual(formatted.get("other_field"), u"")
 
     def test_get_method_with_specified_default(self):
         formatted = self.i.formatted()
-        self.assertEqual(formatted.get('other_field', u'default'), u'default')
+        self.assertEqual(formatted.get("other_field", u"default"), u"default")
 
     def test_item_precedence(self):
         album = self.lib.add_album([self.i])
-        album['artist'] = u'foo'
+        album["artist"] = u"foo"
         album.store()
-        self.assertNotEqual(u'foo', self.i.formatted().get('artist'))
+        self.assertNotEqual(u"foo", self.i.formatted().get("artist"))
 
     def test_album_flex_field(self):
         album = self.lib.add_album([self.i])
-        album['flex'] = u'foo'
+        album["flex"] = u"foo"
         album.store()
-        self.assertEqual(u'foo', self.i.formatted().get('flex'))
+        self.assertEqual(u"foo", self.i.formatted().get("flex"))
 
     def test_album_field_overrides_item_field_for_path(self):
         # Make the album inconsistent with the item.
         album = self.lib.add_album([self.i])
-        album.album = u'foo'
+        album.album = u"foo"
         album.store()
-        self.i.album = u'bar'
+        self.i.album = u"bar"
         self.i.store()
 
         # Ensure the album takes precedence.
         formatted = self.i.formatted(for_path=True)
-        self.assertEqual(formatted['album'], u'foo')
+        self.assertEqual(formatted["album"], u"foo")
 
     def test_artist_falls_back_to_albumartist(self):
-        self.i.artist = u''
+        self.i.artist = u""
         formatted = self.i.formatted()
-        self.assertEqual(formatted['artist'], u'the album artist')
+        self.assertEqual(formatted["artist"], u"the album artist")
 
     def test_albumartist_falls_back_to_artist(self):
-        self.i.albumartist = u''
+        self.i.albumartist = u""
         formatted = self.i.formatted()
-        self.assertEqual(formatted['albumartist'], u'the artist')
+        self.assertEqual(formatted["albumartist"], u"the artist")
 
     def test_both_artist_and_albumartist_empty(self):
-        self.i.artist = u''
-        self.i.albumartist = u''
+        self.i.artist = u""
+        self.i.albumartist = u""
         formatted = self.i.formatted()
-        self.assertEqual(formatted['albumartist'], u'')
+        self.assertEqual(formatted["albumartist"], u"")
 
 
 class PathFormattingMixin(object):
     """Utilities for testing path formatting."""
+
     def _setf(self, fmt):
-        self.lib.path_formats.insert(0, (u'default', fmt))
+        self.lib.path_formats.insert(0, (u"default", fmt))
 
     def _assert_dest(self, dest, i=None):
         if i is None:
@@ -567,9 +577,9 @@ class PathFormattingMixin(object):
 class DestinationFunctionTest(_common.TestCase, PathFormattingMixin):
     def setUp(self):
         super(DestinationFunctionTest, self).setUp()
-        self.lib = beets.library.Library(':memory:')
-        self.lib.directory = b'/base'
-        self.lib.path_formats = [(u'default', u'path')]
+        self.lib = beets.library.Library(":memory:")
+        self.lib.directory = b"/base"
+        self.lib.path_formats = [(u"default", u"path")]
         self.i = item(self.lib)
 
     def tearDown(self):
@@ -577,108 +587,108 @@ class DestinationFunctionTest(_common.TestCase, PathFormattingMixin):
         self.lib._connection().close()
 
     def test_upper_case_literal(self):
-        self._setf(u'%upper{foo}')
-        self._assert_dest(b'/base/FOO')
+        self._setf(u"%upper{foo}")
+        self._assert_dest(b"/base/FOO")
 
     def test_upper_case_variable(self):
-        self._setf(u'%upper{$title}')
-        self._assert_dest(b'/base/THE TITLE')
+        self._setf(u"%upper{$title}")
+        self._assert_dest(b"/base/THE TITLE")
 
     def test_title_case_variable(self):
-        self._setf(u'%title{$title}')
-        self._assert_dest(b'/base/The Title')
+        self._setf(u"%title{$title}")
+        self._assert_dest(b"/base/The Title")
 
     def test_title_case_variable_aphostrophe(self):
-        self._setf(u'%title{I can\'t}')
-        self._assert_dest(b'/base/I Can\'t')
+        self._setf(u"%title{I can't}")
+        self._assert_dest(b"/base/I Can't")
 
     def test_asciify_variable(self):
-        self._setf(u'%asciify{ab\xa2\xbdd}')
-        self._assert_dest(b'/base/abC_ 1_2 d')
+        self._setf(u"%asciify{ab\xa2\xbdd}")
+        self._assert_dest(b"/base/abC_ 1_2 d")
 
     def test_left_variable(self):
-        self._setf(u'%left{$title, 3}')
-        self._assert_dest(b'/base/the')
+        self._setf(u"%left{$title, 3}")
+        self._assert_dest(b"/base/the")
 
     def test_right_variable(self):
-        self._setf(u'%right{$title,3}')
-        self._assert_dest(b'/base/tle')
+        self._setf(u"%right{$title,3}")
+        self._assert_dest(b"/base/tle")
 
     def test_if_false(self):
-        self._setf(u'x%if{,foo}')
-        self._assert_dest(b'/base/x')
+        self._setf(u"x%if{,foo}")
+        self._assert_dest(b"/base/x")
 
     def test_if_false_value(self):
-        self._setf(u'x%if{false,foo}')
-        self._assert_dest(b'/base/x')
+        self._setf(u"x%if{false,foo}")
+        self._assert_dest(b"/base/x")
 
     def test_if_true(self):
-        self._setf(u'%if{bar,foo}')
-        self._assert_dest(b'/base/foo')
+        self._setf(u"%if{bar,foo}")
+        self._assert_dest(b"/base/foo")
 
     def test_if_else_false(self):
-        self._setf(u'%if{,foo,baz}')
-        self._assert_dest(b'/base/baz')
+        self._setf(u"%if{,foo,baz}")
+        self._assert_dest(b"/base/baz")
 
     def test_if_else_false_value(self):
-        self._setf(u'%if{false,foo,baz}')
-        self._assert_dest(b'/base/baz')
+        self._setf(u"%if{false,foo,baz}")
+        self._assert_dest(b"/base/baz")
 
     def test_if_int_value(self):
-        self._setf(u'%if{0,foo,baz}')
-        self._assert_dest(b'/base/baz')
+        self._setf(u"%if{0,foo,baz}")
+        self._assert_dest(b"/base/baz")
 
     def test_nonexistent_function(self):
-        self._setf(u'%foo{bar}')
-        self._assert_dest(b'/base/%foo{bar}')
+        self._setf(u"%foo{bar}")
+        self._assert_dest(b"/base/%foo{bar}")
 
     def test_if_def_field_return_self(self):
         self.i.bar = 3
-        self._setf(u'%ifdef{bar}')
-        self._assert_dest(b'/base/3')
+        self._setf(u"%ifdef{bar}")
+        self._assert_dest(b"/base/3")
 
     def test_if_def_field_not_defined(self):
-        self._setf(u' %ifdef{bar}/$artist')
-        self._assert_dest(b'/base/the artist')
+        self._setf(u" %ifdef{bar}/$artist")
+        self._assert_dest(b"/base/the artist")
 
     def test_if_def_field_not_defined_2(self):
-        self._setf(u'$artist/%ifdef{bar}')
-        self._assert_dest(b'/base/the artist')
+        self._setf(u"$artist/%ifdef{bar}")
+        self._assert_dest(b"/base/the artist")
 
     def test_if_def_true(self):
-        self._setf(u'%ifdef{artist,cool}')
-        self._assert_dest(b'/base/cool')
+        self._setf(u"%ifdef{artist,cool}")
+        self._assert_dest(b"/base/cool")
 
     def test_if_def_true_complete(self):
         self.i.series = "Now"
-        self._setf(u'%ifdef{series,$series Series,Albums}/$album')
-        self._assert_dest(b'/base/Now Series/the album')
+        self._setf(u"%ifdef{series,$series Series,Albums}/$album")
+        self._assert_dest(b"/base/Now Series/the album")
 
     def test_if_def_false_complete(self):
-        self._setf(u'%ifdef{plays,$plays,not_played}')
-        self._assert_dest(b'/base/not_played')
+        self._setf(u"%ifdef{plays,$plays,not_played}")
+        self._assert_dest(b"/base/not_played")
 
     def test_first(self):
         self.i.genres = "Pop; Rock; Classical Crossover"
-        self._setf(u'%first{$genres}')
-        self._assert_dest(b'/base/Pop')
+        self._setf(u"%first{$genres}")
+        self._assert_dest(b"/base/Pop")
 
     def test_first_skip(self):
         self.i.genres = "Pop; Rock; Classical Crossover"
-        self._setf(u'%first{$genres,1,2}')
-        self._assert_dest(b'/base/Classical Crossover')
+        self._setf(u"%first{$genres,1,2}")
+        self._assert_dest(b"/base/Classical Crossover")
 
     def test_first_different_sep(self):
-        self._setf(u'%first{Alice / Bob / Eve,2,0, / , & }')
-        self._assert_dest(b'/base/Alice & Bob')
+        self._setf(u"%first{Alice / Bob / Eve,2,0, / , & }")
+        self._assert_dest(b"/base/Alice & Bob")
 
 
 class DisambiguationTest(_common.TestCase, PathFormattingMixin):
     def setUp(self):
         super(DisambiguationTest, self).setUp()
-        self.lib = beets.library.Library(':memory:')
-        self.lib.directory = b'/base'
-        self.lib.path_formats = [(u'default', u'path')]
+        self.lib = beets.library.Library(":memory:")
+        self.lib.directory = b"/base"
+        self.lib.path_formats = [(u"default", u"path")]
 
         self.i1 = item()
         self.i1.year = 2001
@@ -688,68 +698,68 @@ class DisambiguationTest(_common.TestCase, PathFormattingMixin):
         self.lib.add_album([self.i2])
         self.lib._connection().commit()
 
-        self._setf(u'foo%aunique{albumartist album,year}/$title')
+        self._setf(u"foo%aunique{albumartist album,year}/$title")
 
     def tearDown(self):
         super(DisambiguationTest, self).tearDown()
         self.lib._connection().close()
 
     def test_unique_expands_to_disambiguating_year(self):
-        self._assert_dest(b'/base/foo [2001]/the title', self.i1)
+        self._assert_dest(b"/base/foo [2001]/the title", self.i1)
 
     def test_unique_with_default_arguments_uses_albumtype(self):
         album2 = self.lib.get_album(self.i1)
-        album2.albumtype = u'bar'
+        album2.albumtype = u"bar"
         album2.store()
-        self._setf(u'foo%aunique{}/$title')
-        self._assert_dest(b'/base/foo [bar]/the title', self.i1)
+        self._setf(u"foo%aunique{}/$title")
+        self._assert_dest(b"/base/foo [bar]/the title", self.i1)
 
     def test_unique_expands_to_nothing_for_distinct_albums(self):
         album2 = self.lib.get_album(self.i2)
-        album2.album = u'different album'
+        album2.album = u"different album"
         album2.store()
 
-        self._assert_dest(b'/base/foo/the title', self.i1)
+        self._assert_dest(b"/base/foo/the title", self.i1)
 
     def test_use_fallback_numbers_when_identical(self):
         album2 = self.lib.get_album(self.i2)
         album2.year = 2001
         album2.store()
 
-        self._assert_dest(b'/base/foo [1]/the title', self.i1)
-        self._assert_dest(b'/base/foo [2]/the title', self.i2)
+        self._assert_dest(b"/base/foo [1]/the title", self.i1)
+        self._assert_dest(b"/base/foo [2]/the title", self.i2)
 
     def test_unique_falls_back_to_second_distinguishing_field(self):
-        self._setf(u'foo%aunique{albumartist album,month year}/$title')
-        self._assert_dest(b'/base/foo [2001]/the title', self.i1)
+        self._setf(u"foo%aunique{albumartist album,month year}/$title")
+        self._assert_dest(b"/base/foo [2001]/the title", self.i1)
 
     def test_unique_sanitized(self):
         album2 = self.lib.get_album(self.i2)
         album2.year = 2001
         album1 = self.lib.get_album(self.i1)
-        album1.albumtype = u'foo/bar'
+        album1.albumtype = u"foo/bar"
         album2.store()
         album1.store()
-        self._setf(u'foo%aunique{albumartist album,albumtype}/$title')
-        self._assert_dest(b'/base/foo [foo_bar]/the title', self.i1)
+        self._setf(u"foo%aunique{albumartist album,albumtype}/$title")
+        self._assert_dest(b"/base/foo [foo_bar]/the title", self.i1)
 
     def test_drop_empty_disambig_string(self):
         album1 = self.lib.get_album(self.i1)
         album1.albumdisambig = None
         album2 = self.lib.get_album(self.i2)
-        album2.albumdisambig = u'foo'
+        album2.albumdisambig = u"foo"
         album1.store()
         album2.store()
-        self._setf(u'foo%aunique{albumartist album,albumdisambig}/$title')
-        self._assert_dest(b'/base/foo/the title', self.i1)
+        self._setf(u"foo%aunique{albumartist album,albumdisambig}/$title")
+        self._assert_dest(b"/base/foo/the title", self.i1)
 
     def test_change_brackets(self):
-        self._setf(u'foo%aunique{albumartist album,year,()}/$title')
-        self._assert_dest(b'/base/foo (2001)/the title', self.i1)
+        self._setf(u"foo%aunique{albumartist album,year,()}/$title")
+        self._assert_dest(b"/base/foo (2001)/the title", self.i1)
 
     def test_remove_brackets(self):
-        self._setf(u'foo%aunique{albumartist album,year,}/$title')
-        self._assert_dest(b'/base/foo 2001/the title', self.i1)
+        self._setf(u"foo%aunique{albumartist album,year,}/$title")
+        self._assert_dest(b"/base/foo 2001/the title", self.i1)
 
 
 class PluginDestinationTest(_common.TestCase):
@@ -768,9 +778,9 @@ class PluginDestinationTest(_common.TestCase):
         self.old_field_getters = plugins.item_field_getters
         plugins.item_field_getters = field_getters
 
-        self.lib = beets.library.Library(':memory:')
-        self.lib.directory = b'/base'
-        self.lib.path_formats = [(u'default', u'$artist $foo')]
+        self.lib = beets.library.Library(":memory:")
+        self.lib.directory = b"/base"
+        self.lib.path_formats = [(u"default", u"$artist $foo")]
         self.i = item(self.lib)
 
     def tearDown(self):
@@ -780,34 +790,34 @@ class PluginDestinationTest(_common.TestCase):
     def _assert_dest(self, dest):
         with _common.platform_posix():
             the_dest = self.i.destination()
-        self.assertEqual(the_dest, b'/base/' + dest)
+        self.assertEqual(the_dest, b"/base/" + dest)
 
     def test_undefined_value_not_substituted(self):
-        self._assert_dest(b'the artist $foo')
+        self._assert_dest(b"the artist $foo")
 
     def test_plugin_value_not_substituted(self):
         self._tv_map = {
-            'foo': 'bar',
+            "foo": "bar",
         }
-        self._assert_dest(b'the artist bar')
+        self._assert_dest(b"the artist bar")
 
     def test_plugin_value_overrides_attribute(self):
         self._tv_map = {
-            'artist': 'bar',
+            "artist": "bar",
         }
-        self._assert_dest(b'bar $foo')
+        self._assert_dest(b"bar $foo")
 
     def test_plugin_value_sanitized(self):
         self._tv_map = {
-            'foo': 'bar/baz',
+            "foo": "bar/baz",
         }
-        self._assert_dest(b'the artist bar_baz')
+        self._assert_dest(b"the artist bar_baz")
 
 
 class AlbumInfoTest(_common.TestCase):
     def setUp(self):
         super(AlbumInfoTest, self).setUp()
-        self.lib = beets.library.Library(':memory:')
+        self.lib = beets.library.Library(":memory:")
         self.i = item()
         self.lib.add_album((self.i,))
 
@@ -820,10 +830,10 @@ class AlbumInfoTest(_common.TestCase):
 
     def test_albuminfo_stores_art(self):
         ai = self.lib.get_album(self.i)
-        ai.artpath = '/my/great/art'
+        ai.artpath = "/my/great/art"
         ai.store()
         new_ai = self.lib.get_album(self.i)
-        self.assertEqual(new_ai.artpath, b'/my/great/art')
+        self.assertEqual(new_ai.artpath, b"/my/great/art")
 
     def test_albuminfo_for_two_items_doesnt_duplicate_row(self):
         i2 = item(self.lib)
@@ -831,14 +841,14 @@ class AlbumInfoTest(_common.TestCase):
         self.lib.get_album(i2)
 
         c = self.lib._connection().cursor()
-        c.execute('select * from albums where album=?', (self.i.album,))
+        c.execute("select * from albums where album=?", (self.i.album,))
         # Cursor should only return one row.
         self.assertNotEqual(c.fetchone(), None)
         self.assertEqual(c.fetchone(), None)
 
     def test_individual_tracks_have_no_albuminfo(self):
         i2 = item()
-        i2.album = u'aTotallyDifferentAlbum'
+        i2.album = u"aTotallyDifferentAlbum"
         self.lib.add(i2)
         ai = self.lib.get_album(i2)
         self.assertEqual(ai, None)
@@ -858,31 +868,31 @@ class AlbumInfoTest(_common.TestCase):
 
     def test_albuminfo_changes_affect_items(self):
         ai = self.lib.get_album(self.i)
-        ai.album = u'myNewAlbum'
+        ai.album = u"myNewAlbum"
         ai.store()
         i = self.lib.items()[0]
-        self.assertEqual(i.album, u'myNewAlbum')
+        self.assertEqual(i.album, u"myNewAlbum")
 
     def test_albuminfo_change_albumartist_changes_items(self):
         ai = self.lib.get_album(self.i)
-        ai.albumartist = u'myNewArtist'
+        ai.albumartist = u"myNewArtist"
         ai.store()
         i = self.lib.items()[0]
-        self.assertEqual(i.albumartist, u'myNewArtist')
-        self.assertNotEqual(i.artist, u'myNewArtist')
+        self.assertEqual(i.albumartist, u"myNewArtist")
+        self.assertNotEqual(i.artist, u"myNewArtist")
 
     def test_albuminfo_change_artist_does_not_change_items(self):
         ai = self.lib.get_album(self.i)
-        ai.artist = u'myNewArtist'
+        ai.artist = u"myNewArtist"
         ai.store()
         i = self.lib.items()[0]
-        self.assertNotEqual(i.artist, u'myNewArtist')
+        self.assertNotEqual(i.artist, u"myNewArtist")
 
     def test_albuminfo_remove_removes_items(self):
         item_id = self.i.id
         self.lib.get_album(self.i).remove()
         c = self.lib._connection().execute(
-            'SELECT id FROM items WHERE id=?', (item_id,)
+            "SELECT id FROM items WHERE id=?", (item_id,)
         )
         self.assertEqual(c.fetchone(), None)
 
@@ -893,7 +903,7 @@ class AlbumInfoTest(_common.TestCase):
 
     def test_noop_albuminfo_changes_affect_items(self):
         i = self.lib.items()[0]
-        i.album = u'foobar'
+        i.album = u"foobar"
         i.store()
         ai = self.lib.get_album(self.i)
         ai.album = ai.album
@@ -905,35 +915,35 @@ class AlbumInfoTest(_common.TestCase):
 class ArtDestinationTest(_common.TestCase):
     def setUp(self):
         super(ArtDestinationTest, self).setUp()
-        config['art_filename'] = u'artimage'
-        config['replace'] = {u'X': u'Y'}
+        config["art_filename"] = u"artimage"
+        config["replace"] = {u"X": u"Y"}
         self.lib = beets.library.Library(
-            ':memory:', replacements=[(re.compile(u'X'), u'Y')]
+            ":memory:", replacements=[(re.compile(u"X"), u"Y")]
         )
         self.i = item(self.lib)
         self.i.path = self.i.destination()
         self.ai = self.lib.add_album((self.i,))
 
     def test_art_filename_respects_setting(self):
-        art = self.ai.art_destination('something.jpg')
-        new_art = bytestring_path('%sartimage.jpg' % os.path.sep)
+        art = self.ai.art_destination("something.jpg")
+        new_art = bytestring_path("%sartimage.jpg" % os.path.sep)
         self.assertTrue(new_art in art)
 
     def test_art_path_in_item_dir(self):
-        art = self.ai.art_destination('something.jpg')
+        art = self.ai.art_destination("something.jpg")
         track = self.i.destination()
         self.assertEqual(os.path.dirname(art), os.path.dirname(track))
 
     def test_art_path_sanitized(self):
-        config['art_filename'] = u'artXimage'
-        art = self.ai.art_destination('something.jpg')
-        self.assertTrue(b'artYimage' in art)
+        config["art_filename"] = u"artXimage"
+        art = self.ai.art_destination("something.jpg")
+        self.assertTrue(b"artYimage" in art)
 
 
 class PathStringTest(_common.TestCase):
     def setUp(self):
         super(PathStringTest, self).setUp()
-        self.lib = beets.library.Library(':memory:')
+        self.lib = beets.library.Library(":memory:")
         self.i = item(self.lib)
 
     def test_item_path_is_bytestring(self):
@@ -944,18 +954,21 @@ class PathStringTest(_common.TestCase):
         self.assertTrue(isinstance(i.path, bytes))
 
     def test_unicode_path_becomes_bytestring(self):
-        self.i.path = u'unicodepath'
+        self.i.path = u"unicodepath"
         self.assertTrue(isinstance(self.i.path, bytes))
 
     def test_unicode_in_database_becomes_bytestring(self):
-        self.lib._connection().execute("""
+        self.lib._connection().execute(
+            """
         update items set path=? where id=?
-        """, (self.i.id, u'somepath'))
+        """,
+            (self.i.id, u"somepath"),
+        )
         i = list(self.lib.items())[0]
         self.assertTrue(isinstance(i.path, bytes))
 
     def test_special_chars_preserved_in_database(self):
-        path = u'b\xe1r'.encode('utf-8')
+        path = u"b\xe1r".encode("utf-8")
         self.i.path = path
         self.i.store()
         i = list(self.lib.items())[0]
@@ -963,7 +976,7 @@ class PathStringTest(_common.TestCase):
 
     def test_special_char_path_added_to_database(self):
         self.i.remove()
-        path = u'b\xe1r'.encode('utf-8')
+        path = u"b\xe1r".encode("utf-8")
         i = item()
         i.path = path
         self.lib.add(i)
@@ -971,18 +984,18 @@ class PathStringTest(_common.TestCase):
         self.assertEqual(i.path, path)
 
     def test_destination_returns_bytestring(self):
-        self.i.artist = u'b\xe1r'
+        self.i.artist = u"b\xe1r"
         dest = self.i.destination()
         self.assertTrue(isinstance(dest, bytes))
 
     def test_art_destination_returns_bytestring(self):
-        self.i.artist = u'b\xe1r'
+        self.i.artist = u"b\xe1r"
         alb = self.lib.add_album([self.i])
-        dest = alb.art_destination(u'image.jpg')
+        dest = alb.art_destination(u"image.jpg")
         self.assertTrue(isinstance(dest, bytes))
 
     def test_artpath_stores_special_chars(self):
-        path = b'b\xe1r'
+        path = b"b\xe1r"
         alb = self.lib.add_album([self.i])
         alb.artpath = path
         alb.store()
@@ -990,25 +1003,24 @@ class PathStringTest(_common.TestCase):
         self.assertEqual(path, alb.artpath)
 
     def test_sanitize_path_with_special_chars(self):
-        path = u'b\xe1r?'
+        path = u"b\xe1r?"
         new_path = util.sanitize_path(path)
-        self.assertTrue(new_path.startswith(u'b\xe1r'))
+        self.assertTrue(new_path.startswith(u"b\xe1r"))
 
     def test_sanitize_path_returns_unicode(self):
-        path = u'b\xe1r?'
+        path = u"b\xe1r?"
         new_path = util.sanitize_path(path)
         self.assertTrue(isinstance(new_path, six.text_type))
 
     def test_unicode_artpath_becomes_bytestring(self):
         alb = self.lib.add_album([self.i])
-        alb.artpath = u'somep\xe1th'
+        alb.artpath = u"somep\xe1th"
         self.assertTrue(isinstance(alb.artpath, bytes))
 
     def test_unicode_artpath_in_database_decoded(self):
         alb = self.lib.add_album([self.i])
         self.lib._connection().execute(
-            "update albums set artpath=? where id=?",
-            (u'somep\xe1th', alb.id)
+            "update albums set artpath=? where id=?", (u"somep\xe1th", alb.id)
         )
         alb = self.lib.get_album(alb.id)
         self.assertTrue(isinstance(alb.artpath, bytes))
@@ -1017,10 +1029,10 @@ class PathStringTest(_common.TestCase):
 class MtimeTest(_common.TestCase):
     def setUp(self):
         super(MtimeTest, self).setUp()
-        self.ipath = os.path.join(self.temp_dir, b'testfile.mp3')
-        shutil.copy(os.path.join(_common.RSRC, b'full.mp3'), self.ipath)
+        self.ipath = os.path.join(self.temp_dir, b"testfile.mp3")
+        shutil.copy(os.path.join(_common.RSRC, b"full.mp3"), self.ipath)
         self.i = beets.library.Item.from_path(self.ipath)
-        self.lib = beets.library.Library(':memory:')
+        self.lib = beets.library.Library(":memory:")
         self.lib.add(self.i)
 
     def tearDown(self):
@@ -1035,16 +1047,16 @@ class MtimeTest(_common.TestCase):
         self.assertGreaterEqual(self.i.mtime, self._mtime())
 
     def test_mtime_reset_on_db_modify(self):
-        self.i.title = u'something else'
+        self.i.title = u"something else"
         self.assertLess(self.i.mtime, self._mtime())
 
     def test_mtime_up_to_date_after_write(self):
-        self.i.title = u'something else'
+        self.i.title = u"something else"
         self.i.write()
         self.assertGreaterEqual(self.i.mtime, self._mtime())
 
     def test_mtime_up_to_date_after_read(self):
-        self.i.title = u'something else'
+        self.i.title = u"something else"
         self.i.read()
         self.assertGreaterEqual(self.i.mtime, self._mtime())
 
@@ -1052,7 +1064,7 @@ class MtimeTest(_common.TestCase):
 class ImportTimeTest(_common.TestCase):
     def setUp(self):
         super(ImportTimeTest, self).setUp()
-        self.lib = beets.library.Library(':memory:')
+        self.lib = beets.library.Library(":memory:")
 
     def added(self):
         self.track = item()
@@ -1069,36 +1081,37 @@ class TemplateTest(_common.LibTestCase):
     def test_year_formatted_in_template(self):
         self.i.year = 123
         self.i.store()
-        self.assertEqual(self.i.evaluate_template('$year'), u'0123')
+        self.assertEqual(self.i.evaluate_template("$year"), u"0123")
 
     def test_album_flexattr_appears_in_item_template(self):
         self.album = self.lib.add_album([self.i])
-        self.album.foo = u'baz'
+        self.album.foo = u"baz"
         self.album.store()
-        self.assertEqual(self.i.evaluate_template('$foo'), u'baz')
+        self.assertEqual(self.i.evaluate_template("$foo"), u"baz")
 
     def test_album_and_item_format(self):
-        config['format_album'] = u'foö $foo'
+        config["format_album"] = u"foö $foo"
         album = beets.library.Album()
-        album.foo = u'bar'
-        album.tagada = u'togodo'
+        album.foo = u"bar"
+        album.tagada = u"togodo"
         self.assertEqual(u"{0}".format(album), u"foö bar")
         self.assertEqual(u"{0:$tagada}".format(album), u"togodo")
         self.assertEqual(six.text_type(album), u"foö bar")
         self.assertEqual(bytes(album), b"fo\xc3\xb6 bar")
 
-        config['format_item'] = u'bar $foo'
+        config["format_item"] = u"bar $foo"
         item = beets.library.Item()
-        item.foo = u'bar'
-        item.tagada = u'togodo'
+        item.foo = u"bar"
+        item.tagada = u"togodo"
         self.assertEqual(u"{0}".format(item), u"bar bar")
         self.assertEqual(u"{0:$tagada}".format(item), u"togodo")
 
 
 class UnicodePathTest(_common.LibTestCase):
     def test_unicode_path(self):
-        self.i.path = os.path.join(_common.RSRC,
-                                   u'unicode\u2019d.mp3'.encode('utf-8'))
+        self.i.path = os.path.join(
+            _common.RSRC, u"unicode\u2019d.mp3".encode("utf-8")
+        )
         # If there are any problems with unicode paths, we will raise
         # here and fail.
         self.i.read()
@@ -1114,7 +1127,7 @@ class WriteTest(unittest.TestCase, TestHelper):
 
     def test_write_nonexistant(self):
         item = self.create_item()
-        item.path = b'/path/does/not/exist'
+        item.path = b"/path/does/not/exist"
         with self.assertRaises(beets.library.ReadError):
             item.write()
 
@@ -1132,48 +1145,46 @@ class WriteTest(unittest.TestCase, TestHelper):
 
     def test_write_with_custom_path(self):
         item = self.add_item_fixture()
-        custom_path = os.path.join(self.temp_dir, b'custom.mp3')
+        custom_path = os.path.join(self.temp_dir, b"custom.mp3")
         shutil.copy(syspath(item.path), syspath(custom_path))
 
-        item['artist'] = 'new artist'
-        self.assertNotEqual(MediaFile(syspath(custom_path)).artist,
-                            'new artist')
-        self.assertNotEqual(MediaFile(syspath(item.path)).artist,
-                            'new artist')
+        item["artist"] = "new artist"
+        self.assertNotEqual(
+            MediaFile(syspath(custom_path)).artist, "new artist"
+        )
+        self.assertNotEqual(MediaFile(syspath(item.path)).artist, "new artist")
 
         item.write(custom_path)
-        self.assertEqual(MediaFile(syspath(custom_path)).artist, 'new artist')
-        self.assertNotEqual(MediaFile(syspath(item.path)).artist, 'new artist')
+        self.assertEqual(MediaFile(syspath(custom_path)).artist, "new artist")
+        self.assertNotEqual(MediaFile(syspath(item.path)).artist, "new artist")
 
     def test_write_custom_tags(self):
-        item = self.add_item_fixture(artist='old artist')
-        item.write(tags={'artist': 'new artist'})
-        self.assertNotEqual(item.artist, 'new artist')
-        self.assertEqual(MediaFile(syspath(item.path)).artist, 'new artist')
+        item = self.add_item_fixture(artist="old artist")
+        item.write(tags={"artist": "new artist"})
+        self.assertNotEqual(item.artist, "new artist")
+        self.assertEqual(MediaFile(syspath(item.path)).artist, "new artist")
 
     def test_write_date_field(self):
         # Since `date` is not a MediaField, this should do nothing.
         item = self.add_item_fixture()
         clean_year = item.year
-        item.date = u'foo'
+        item.date = u"foo"
         item.write()
         self.assertEqual(MediaFile(syspath(item.path)).year, clean_year)
 
 
 class ItemReadTest(unittest.TestCase):
-
     def test_unreadable_raise_read_error(self):
-        unreadable = os.path.join(_common.RSRC, b'image-2x3.png')
+        unreadable = os.path.join(_common.RSRC, b"image-2x3.png")
         item = beets.library.Item()
         with self.assertRaises(beets.library.ReadError) as cm:
             item.read(unreadable)
-        self.assertIsInstance(cm.exception.reason,
-                              UnreadableFileError)
+        self.assertIsInstance(cm.exception.reason, UnreadableFileError)
 
     def test_nonexistent_raise_read_error(self):
         item = beets.library.Item()
         with self.assertRaises(beets.library.ReadError):
-            item.read('/thisfiledoesnotexist')
+            item.read("/thisfiledoesnotexist")
 
 
 class FilesizeTest(unittest.TestCase, TestHelper):
@@ -1196,8 +1207,9 @@ class ParseQueryTest(unittest.TestCase):
     def test_parse_invalid_query_string(self):
         with self.assertRaises(beets.dbcore.InvalidQueryError) as raised:
             beets.library.parse_query_string(u'foo"', None)
-        self.assertIsInstance(raised.exception,
-                              beets.dbcore.query.ParsingError)
+        self.assertIsInstance(
+            raised.exception, beets.dbcore.query.ParsingError
+        )
 
     def test_parse_bytes(self):
         with self.assertRaises(AssertionError):
@@ -1206,54 +1218,55 @@ class ParseQueryTest(unittest.TestCase):
 
 class LibraryFieldTypesTest(unittest.TestCase):
     """Test format() and parse() for library-specific field types"""
+
     def test_datetype(self):
         t = beets.library.DateType()
 
         # format
-        time_format = beets.config['time_format'].as_str()
-        time_local = time.strftime(time_format,
-                                   time.localtime(123456789))
+        time_format = beets.config["time_format"].as_str()
+        time_local = time.strftime(time_format, time.localtime(123456789))
         self.assertEqual(time_local, t.format(123456789))
         # parse
         self.assertEqual(123456789.0, t.parse(time_local))
-        self.assertEqual(123456789.0, t.parse(u'123456789.0'))
-        self.assertEqual(t.null, t.parse(u'not123456789.0'))
-        self.assertEqual(t.null, t.parse(u'1973-11-29'))
+        self.assertEqual(123456789.0, t.parse(u"123456789.0"))
+        self.assertEqual(t.null, t.parse(u"not123456789.0"))
+        self.assertEqual(t.null, t.parse(u"1973-11-29"))
 
     def test_pathtype(self):
         t = beets.library.PathType()
 
         # format
-        self.assertEqual('/tmp', t.format('/tmp'))
-        self.assertEqual(u'/tmp/\xe4lbum', t.format(u'/tmp/\u00e4lbum'))
+        self.assertEqual("/tmp", t.format("/tmp"))
+        self.assertEqual(u"/tmp/\xe4lbum", t.format(u"/tmp/\u00e4lbum"))
         # parse
-        self.assertEqual(np(b'/tmp'), t.parse('/tmp'))
-        self.assertEqual(np(b'/tmp/\xc3\xa4lbum'),
-                         t.parse(u'/tmp/\u00e4lbum/'))
+        self.assertEqual(np(b"/tmp"), t.parse("/tmp"))
+        self.assertEqual(
+            np(b"/tmp/\xc3\xa4lbum"), t.parse(u"/tmp/\u00e4lbum/")
+        )
 
     def test_musicalkey(self):
         t = beets.library.MusicalKey()
 
         # parse
-        self.assertEqual(u'C#m', t.parse(u'c#m'))
-        self.assertEqual(u'Gm', t.parse(u'g   minor'))
-        self.assertEqual(u'Not c#m', t.parse(u'not C#m'))
+        self.assertEqual(u"C#m", t.parse(u"c#m"))
+        self.assertEqual(u"Gm", t.parse(u"g   minor"))
+        self.assertEqual(u"Not c#m", t.parse(u"not C#m"))
 
     def test_durationtype(self):
         t = beets.library.DurationType()
 
         # format
-        self.assertEqual(u'1:01', t.format(61.23))
-        self.assertEqual(u'60:01', t.format(3601.23))
-        self.assertEqual(u'0:00', t.format(None))
+        self.assertEqual(u"1:01", t.format(61.23))
+        self.assertEqual(u"60:01", t.format(3601.23))
+        self.assertEqual(u"0:00", t.format(None))
         # parse
-        self.assertEqual(61.0, t.parse(u'1:01'))
-        self.assertEqual(61.23, t.parse(u'61.23'))
-        self.assertEqual(3601.0, t.parse(u'60:01'))
-        self.assertEqual(t.null, t.parse(u'1:00:01'))
-        self.assertEqual(t.null, t.parse(u'not61.23'))
+        self.assertEqual(61.0, t.parse(u"1:01"))
+        self.assertEqual(61.23, t.parse(u"61.23"))
+        self.assertEqual(3601.0, t.parse(u"60:01"))
+        self.assertEqual(t.null, t.parse(u"1:00:01"))
+        self.assertEqual(t.null, t.parse(u"not61.23"))
         # config format_raw_length
-        beets.config['format_raw_length'] = True
+        beets.config["format_raw_length"] = True
         self.assertEqual(61.23, t.format(61.23))
         self.assertEqual(3601.23, t.format(3601.23))
 
@@ -1262,5 +1275,5 @@ def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -29,8 +29,9 @@ class LoggingTest(TestCase):
         l4 = log.getLogger("bar123")
         self.assertEqual(l3, l4)
         self.assertEqual(l3.__class__, blog.BeetsLogger)
-        self.assertIsInstance(l3, (blog.StrFormatLogger,
-                                   blog.ThreadLocalLevelLogger))
+        self.assertIsInstance(
+            l3, (blog.StrFormatLogger, blog.ThreadLocalLevelLogger)
+        )
 
         l5 = l3.getChild("shalala")
         self.assertEqual(l5.__class__, blog.BeetsLogger)
@@ -55,114 +56,114 @@ class LoggingLevelTest(unittest.TestCase, helper.TestHelper):
     class DummyModule(object):
         class DummyPlugin(plugins.BeetsPlugin):
             def __init__(self):
-                plugins.BeetsPlugin.__init__(self, 'dummy')
+                plugins.BeetsPlugin.__init__(self, "dummy")
                 self.import_stages = [self.import_stage]
-                self.register_listener('dummy_event', self.listener)
+                self.register_listener("dummy_event", self.listener)
 
             def log_all(self, name):
-                self._log.debug(u'debug ' + name)
-                self._log.info(u'info ' + name)
-                self._log.warning(u'warning ' + name)
+                self._log.debug(u"debug " + name)
+                self._log.info(u"info " + name)
+                self._log.warning(u"warning " + name)
 
             def commands(self):
-                cmd = ui.Subcommand('dummy')
-                cmd.func = lambda _, __, ___: self.log_all('cmd')
+                cmd = ui.Subcommand("dummy")
+                cmd.func = lambda _, __, ___: self.log_all("cmd")
                 return (cmd,)
 
             def import_stage(self, session, task):
-                self.log_all('import_stage')
+                self.log_all("import_stage")
 
             def listener(self):
-                self.log_all('listener')
+                self.log_all("listener")
 
     def setUp(self):
-        sys.modules['beetsplug.dummy'] = self.DummyModule
+        sys.modules["beetsplug.dummy"] = self.DummyModule
         beetsplug.dummy = self.DummyModule
         self.setup_beets()
-        self.load_plugins('dummy')
+        self.load_plugins("dummy")
 
     def tearDown(self):
         self.unload_plugins()
         self.teardown_beets()
         del beetsplug.dummy
-        sys.modules.pop('beetsplug.dummy')
+        sys.modules.pop("beetsplug.dummy")
         self.DummyModule.DummyPlugin.listeners = None
         self.DummyModule.DummyPlugin._raw_listeners = None
 
     def test_command_level0(self):
-        self.config['verbose'] = 0
+        self.config["verbose"] = 0
         with helper.capture_log() as logs:
-            self.run_command('dummy')
-        self.assertIn(u'dummy: warning cmd', logs)
-        self.assertIn(u'dummy: info cmd', logs)
-        self.assertNotIn(u'dummy: debug cmd', logs)
+            self.run_command("dummy")
+        self.assertIn(u"dummy: warning cmd", logs)
+        self.assertIn(u"dummy: info cmd", logs)
+        self.assertNotIn(u"dummy: debug cmd", logs)
 
     def test_command_level1(self):
-        self.config['verbose'] = 1
+        self.config["verbose"] = 1
         with helper.capture_log() as logs:
-            self.run_command('dummy')
-        self.assertIn(u'dummy: warning cmd', logs)
-        self.assertIn(u'dummy: info cmd', logs)
-        self.assertIn(u'dummy: debug cmd', logs)
+            self.run_command("dummy")
+        self.assertIn(u"dummy: warning cmd", logs)
+        self.assertIn(u"dummy: info cmd", logs)
+        self.assertIn(u"dummy: debug cmd", logs)
 
     def test_command_level2(self):
-        self.config['verbose'] = 2
+        self.config["verbose"] = 2
         with helper.capture_log() as logs:
-            self.run_command('dummy')
-        self.assertIn(u'dummy: warning cmd', logs)
-        self.assertIn(u'dummy: info cmd', logs)
-        self.assertIn(u'dummy: debug cmd', logs)
+            self.run_command("dummy")
+        self.assertIn(u"dummy: warning cmd", logs)
+        self.assertIn(u"dummy: info cmd", logs)
+        self.assertIn(u"dummy: debug cmd", logs)
 
     def test_listener_level0(self):
-        self.config['verbose'] = 0
+        self.config["verbose"] = 0
         with helper.capture_log() as logs:
-            plugins.send('dummy_event')
-        self.assertIn(u'dummy: warning listener', logs)
-        self.assertNotIn(u'dummy: info listener', logs)
-        self.assertNotIn(u'dummy: debug listener', logs)
+            plugins.send("dummy_event")
+        self.assertIn(u"dummy: warning listener", logs)
+        self.assertNotIn(u"dummy: info listener", logs)
+        self.assertNotIn(u"dummy: debug listener", logs)
 
     def test_listener_level1(self):
-        self.config['verbose'] = 1
+        self.config["verbose"] = 1
         with helper.capture_log() as logs:
-            plugins.send('dummy_event')
-        self.assertIn(u'dummy: warning listener', logs)
-        self.assertIn(u'dummy: info listener', logs)
-        self.assertNotIn(u'dummy: debug listener', logs)
+            plugins.send("dummy_event")
+        self.assertIn(u"dummy: warning listener", logs)
+        self.assertIn(u"dummy: info listener", logs)
+        self.assertNotIn(u"dummy: debug listener", logs)
 
     def test_listener_level2(self):
-        self.config['verbose'] = 2
+        self.config["verbose"] = 2
         with helper.capture_log() as logs:
-            plugins.send('dummy_event')
-        self.assertIn(u'dummy: warning listener', logs)
-        self.assertIn(u'dummy: info listener', logs)
-        self.assertIn(u'dummy: debug listener', logs)
+            plugins.send("dummy_event")
+        self.assertIn(u"dummy: warning listener", logs)
+        self.assertIn(u"dummy: info listener", logs)
+        self.assertIn(u"dummy: debug listener", logs)
 
     def test_import_stage_level0(self):
-        self.config['verbose'] = 0
+        self.config["verbose"] = 0
         with helper.capture_log() as logs:
             importer = self.create_importer()
             importer.run()
-        self.assertIn(u'dummy: warning import_stage', logs)
-        self.assertNotIn(u'dummy: info import_stage', logs)
-        self.assertNotIn(u'dummy: debug import_stage', logs)
+        self.assertIn(u"dummy: warning import_stage", logs)
+        self.assertNotIn(u"dummy: info import_stage", logs)
+        self.assertNotIn(u"dummy: debug import_stage", logs)
 
     def test_import_stage_level1(self):
-        self.config['verbose'] = 1
+        self.config["verbose"] = 1
         with helper.capture_log() as logs:
             importer = self.create_importer()
             importer.run()
-        self.assertIn(u'dummy: warning import_stage', logs)
-        self.assertIn(u'dummy: info import_stage', logs)
-        self.assertNotIn(u'dummy: debug import_stage', logs)
+        self.assertIn(u"dummy: warning import_stage", logs)
+        self.assertIn(u"dummy: info import_stage", logs)
+        self.assertNotIn(u"dummy: debug import_stage", logs)
 
     def test_import_stage_level2(self):
-        self.config['verbose'] = 2
+        self.config["verbose"] = 2
         with helper.capture_log() as logs:
             importer = self.create_importer()
             importer.run()
-        self.assertIn(u'dummy: warning import_stage', logs)
-        self.assertIn(u'dummy: info import_stage', logs)
-        self.assertIn(u'dummy: debug import_stage', logs)
+        self.assertIn(u"dummy: warning import_stage", logs)
+        self.assertIn(u"dummy: info import_stage", logs)
+        self.assertIn(u"dummy: debug import_stage", logs)
 
 
 @_common.slow_test()
@@ -171,11 +172,12 @@ class ConcurrentEventsTest(TestCase, helper.TestHelper):
     events interaction. Since this is a bit heavy we don't do it in
     LoggingLevelTest.
     """
+
     class DummyPlugin(plugins.BeetsPlugin):
         def __init__(self, test_case):
-            plugins.BeetsPlugin.__init__(self, 'dummy')
-            self.register_listener('dummy_event1', self.listener1)
-            self.register_listener('dummy_event2', self.listener2)
+            plugins.BeetsPlugin.__init__(self, "dummy")
+            self.register_listener("dummy_event1", self.listener1)
+            self.register_listener("dummy_event2", self.listener2)
             self.lock1 = threading.Lock()
             self.lock2 = threading.Lock()
             self.test_case = test_case
@@ -183,9 +185,9 @@ class ConcurrentEventsTest(TestCase, helper.TestHelper):
             self.t1_step = self.t2_step = 0
 
         def log_all(self, name):
-            self._log.debug(u'debug ' + name)
-            self._log.info(u'info ' + name)
-            self._log.warning(u'warning ' + name)
+            self._log.debug(u"debug " + name)
+            self._log.info(u"info " + name)
+            self._log.warning(u"warning " + name)
 
         def listener1(self):
             try:
@@ -196,6 +198,7 @@ class ConcurrentEventsTest(TestCase, helper.TestHelper):
                 self.t1_step = 2
             except Exception:
                 import sys
+
                 self.exc_info = sys.exc_info()
 
         def listener2(self):
@@ -207,6 +210,7 @@ class ConcurrentEventsTest(TestCase, helper.TestHelper):
                 self.t2_step = 2
             except Exception:
                 import sys
+
                 self.exc_info = sys.exc_info()
 
     def setUp(self):
@@ -227,16 +231,16 @@ class ConcurrentEventsTest(TestCase, helper.TestHelper):
             dp.lock2.acquire()
             self.assertEqual(dp._log.level, log.NOTSET)
 
-            self.config['verbose'] = 1
-            t1 = threading.Thread(target=dp.listeners['dummy_event1'][0])
+            self.config["verbose"] = 1
+            t1 = threading.Thread(target=dp.listeners["dummy_event1"][0])
             t1.start()  # blocked. t1 tested its log level
             while dp.t1_step != 1:
                 check_dp_exc()
             self.assertTrue(t1.is_alive())
             self.assertEqual(dp._log.level, log.NOTSET)
 
-            self.config['verbose'] = 2
-            t2 = threading.Thread(target=dp.listeners['dummy_event2'][0])
+            self.config["verbose"] = 2
+            t2 = threading.Thread(target=dp.listeners["dummy_event2"][0])
             t2.start()  # blocked. t2 tested its log level
             while dp.t2_step != 1:
                 check_dp_exc()
@@ -246,7 +250,7 @@ class ConcurrentEventsTest(TestCase, helper.TestHelper):
             dp.lock1.release()  # dummy_event1 tests its log level + finishes
             while dp.t1_step != 2:
                 check_dp_exc()
-            t1.join(.1)
+            t1.join(0.1)
             self.assertFalse(t1.is_alive())
             self.assertTrue(t2.is_alive())
             self.assertEqual(dp._log.level, log.NOTSET)
@@ -254,7 +258,7 @@ class ConcurrentEventsTest(TestCase, helper.TestHelper):
             dp.lock2.release()  # dummy_event2 tests its log level + finishes
             while dp.t2_step != 2:
                 check_dp_exc()
-            t2.join(.1)
+            t2.join(0.1)
             self.assertFalse(t2.is_alive())
 
         except Exception:
@@ -271,15 +275,15 @@ class ConcurrentEventsTest(TestCase, helper.TestHelper):
     def test_root_logger_levels(self):
         """Root logger level should be shared between threads.
         """
-        self.config['threaded'] = True
+        self.config["threaded"] = True
 
-        blog.getLogger('beets').set_global_level(blog.WARNING)
+        blog.getLogger("beets").set_global_level(blog.WARNING)
         with helper.capture_log() as logs:
             importer = self.create_importer()
             importer.run()
         self.assertEqual(logs, [])
 
-        blog.getLogger('beets').set_global_level(blog.INFO)
+        blog.getLogger("beets").set_global_level(blog.INFO)
         with helper.capture_log() as logs:
             importer = self.create_importer()
             importer.run()
@@ -287,7 +291,7 @@ class ConcurrentEventsTest(TestCase, helper.TestHelper):
             self.assertIn(u"import", l)
             self.assertIn(u"album", l)
 
-        blog.getLogger('beets').set_global_level(blog.DEBUG)
+        blog.getLogger("beets").set_global_level(blog.DEBUG)
         with helper.capture_log() as logs:
             importer = self.create_importer()
             importer.run()
@@ -298,5 +302,5 @@ def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_lyrics.py
+++ b/test/test_lyrics.py
@@ -35,133 +35,118 @@ from beetsplug import lyrics
 from test import _common
 
 
-log = logging.getLogger('beets.test_lyrics')
+log = logging.getLogger("beets.test_lyrics")
 raw_backend = lyrics.Backend({}, log)
 google = lyrics.Google(MagicMock(), log)
 genius = lyrics.Genius(MagicMock(), log)
 
 
 class LyricsPluginTest(unittest.TestCase):
-
     def setUp(self):
         """Set up configuration."""
         lyrics.LyricsPlugin()
 
     def test_search_artist(self):
-        item = Item(artist='Alice ft. Bob', title='song')
-        self.assertIn(('Alice ft. Bob', ['song']),
-                      lyrics.search_pairs(item))
-        self.assertIn(('Alice', ['song']),
-                      lyrics.search_pairs(item))
+        item = Item(artist="Alice ft. Bob", title="song")
+        self.assertIn(("Alice ft. Bob", ["song"]), lyrics.search_pairs(item))
+        self.assertIn(("Alice", ["song"]), lyrics.search_pairs(item))
 
-        item = Item(artist='Alice feat Bob', title='song')
-        self.assertIn(('Alice feat Bob', ['song']),
-                      lyrics.search_pairs(item))
-        self.assertIn(('Alice', ['song']),
-                      lyrics.search_pairs(item))
+        item = Item(artist="Alice feat Bob", title="song")
+        self.assertIn(("Alice feat Bob", ["song"]), lyrics.search_pairs(item))
+        self.assertIn(("Alice", ["song"]), lyrics.search_pairs(item))
 
-        item = Item(artist='Alice feat. Bob', title='song')
-        self.assertIn(('Alice feat. Bob', ['song']),
-                      lyrics.search_pairs(item))
-        self.assertIn(('Alice', ['song']),
-                      lyrics.search_pairs(item))
+        item = Item(artist="Alice feat. Bob", title="song")
+        self.assertIn(("Alice feat. Bob", ["song"]), lyrics.search_pairs(item))
+        self.assertIn(("Alice", ["song"]), lyrics.search_pairs(item))
 
-        item = Item(artist='Alice feats Bob', title='song')
-        self.assertIn(('Alice feats Bob', ['song']),
-                      lyrics.search_pairs(item))
-        self.assertNotIn(('Alice', ['song']),
-                         lyrics.search_pairs(item))
+        item = Item(artist="Alice feats Bob", title="song")
+        self.assertIn(("Alice feats Bob", ["song"]), lyrics.search_pairs(item))
+        self.assertNotIn(("Alice", ["song"]), lyrics.search_pairs(item))
 
-        item = Item(artist='Alice featuring Bob', title='song')
-        self.assertIn(('Alice featuring Bob', ['song']),
-                      lyrics.search_pairs(item))
-        self.assertIn(('Alice', ['song']),
-                      lyrics.search_pairs(item))
+        item = Item(artist="Alice featuring Bob", title="song")
+        self.assertIn(
+            ("Alice featuring Bob", ["song"]), lyrics.search_pairs(item)
+        )
+        self.assertIn(("Alice", ["song"]), lyrics.search_pairs(item))
 
-        item = Item(artist='Alice & Bob', title='song')
-        self.assertIn(('Alice & Bob', ['song']),
-                      lyrics.search_pairs(item))
-        self.assertIn(('Alice', ['song']),
-                      lyrics.search_pairs(item))
+        item = Item(artist="Alice & Bob", title="song")
+        self.assertIn(("Alice & Bob", ["song"]), lyrics.search_pairs(item))
+        self.assertIn(("Alice", ["song"]), lyrics.search_pairs(item))
 
-        item = Item(artist='Alice and Bob', title='song')
-        self.assertIn(('Alice and Bob', ['song']),
-                      lyrics.search_pairs(item))
-        self.assertIn(('Alice', ['song']),
-                      lyrics.search_pairs(item))
+        item = Item(artist="Alice and Bob", title="song")
+        self.assertIn(("Alice and Bob", ["song"]), lyrics.search_pairs(item))
+        self.assertIn(("Alice", ["song"]), lyrics.search_pairs(item))
 
-        item = Item(artist='Alice and Bob', title='song')
-        self.assertEqual(('Alice and Bob', ['song']),
-                         list(lyrics.search_pairs(item))[0])
+        item = Item(artist="Alice and Bob", title="song")
+        self.assertEqual(
+            ("Alice and Bob", ["song"]), list(lyrics.search_pairs(item))[0]
+        )
 
     def test_search_artist_sort(self):
-        item = Item(artist='CHVRCHΞS', title='song', artist_sort='CHVRCHES')
-        self.assertIn(('CHVRCHΞS', ['song']),
-                      lyrics.search_pairs(item))
-        self.assertIn(('CHVRCHES', ['song']),
-                      lyrics.search_pairs(item))
+        item = Item(artist="CHVRCHΞS", title="song", artist_sort="CHVRCHES")
+        self.assertIn(("CHVRCHΞS", ["song"]), lyrics.search_pairs(item))
+        self.assertIn(("CHVRCHES", ["song"]), lyrics.search_pairs(item))
 
         # Make sure that the original artist name is still the first entry
-        self.assertEqual(('CHVRCHΞS', ['song']),
-                         list(lyrics.search_pairs(item))[0])
+        self.assertEqual(
+            ("CHVRCHΞS", ["song"]), list(lyrics.search_pairs(item))[0]
+        )
 
-        item = Item(artist='横山克', title='song', artist_sort='Masaru Yokoyama')
-        self.assertIn(('横山克', ['song']),
-                      lyrics.search_pairs(item))
-        self.assertIn(('Masaru Yokoyama', ['song']),
-                      lyrics.search_pairs(item))
+        item = Item(artist="横山克", title="song", artist_sort="Masaru Yokoyama")
+        self.assertIn(("横山克", ["song"]), lyrics.search_pairs(item))
+        self.assertIn(("Masaru Yokoyama", ["song"]), lyrics.search_pairs(item))
 
         # Make sure that the original artist name is still the first entry
-        self.assertEqual(('横山克', ['song']),
-                         list(lyrics.search_pairs(item))[0])
+        self.assertEqual(("横山克", ["song"]), list(lyrics.search_pairs(item))[0])
 
     def test_search_pairs_multi_titles(self):
-        item = Item(title='1 / 2', artist='A')
-        self.assertIn(('A', ['1 / 2']), lyrics.search_pairs(item))
-        self.assertIn(('A', ['1', '2']), lyrics.search_pairs(item))
+        item = Item(title="1 / 2", artist="A")
+        self.assertIn(("A", ["1 / 2"]), lyrics.search_pairs(item))
+        self.assertIn(("A", ["1", "2"]), lyrics.search_pairs(item))
 
-        item = Item(title='1/2', artist='A')
-        self.assertIn(('A', ['1/2']), lyrics.search_pairs(item))
-        self.assertIn(('A', ['1', '2']), lyrics.search_pairs(item))
+        item = Item(title="1/2", artist="A")
+        self.assertIn(("A", ["1/2"]), lyrics.search_pairs(item))
+        self.assertIn(("A", ["1", "2"]), lyrics.search_pairs(item))
 
     def test_search_pairs_titles(self):
-        item = Item(title='Song (live)', artist='A')
-        self.assertIn(('A', ['Song']), lyrics.search_pairs(item))
-        self.assertIn(('A', ['Song (live)']), lyrics.search_pairs(item))
+        item = Item(title="Song (live)", artist="A")
+        self.assertIn(("A", ["Song"]), lyrics.search_pairs(item))
+        self.assertIn(("A", ["Song (live)"]), lyrics.search_pairs(item))
 
-        item = Item(title='Song (live) (new)', artist='A')
-        self.assertIn(('A', ['Song']), lyrics.search_pairs(item))
-        self.assertIn(('A', ['Song (live) (new)']), lyrics.search_pairs(item))
+        item = Item(title="Song (live) (new)", artist="A")
+        self.assertIn(("A", ["Song"]), lyrics.search_pairs(item))
+        self.assertIn(("A", ["Song (live) (new)"]), lyrics.search_pairs(item))
 
-        item = Item(title='Song (live (new))', artist='A')
-        self.assertIn(('A', ['Song']), lyrics.search_pairs(item))
-        self.assertIn(('A', ['Song (live (new))']), lyrics.search_pairs(item))
+        item = Item(title="Song (live (new))", artist="A")
+        self.assertIn(("A", ["Song"]), lyrics.search_pairs(item))
+        self.assertIn(("A", ["Song (live (new))"]), lyrics.search_pairs(item))
 
-        item = Item(title='Song ft. B', artist='A')
-        self.assertIn(('A', ['Song']), lyrics.search_pairs(item))
-        self.assertIn(('A', ['Song ft. B']), lyrics.search_pairs(item))
+        item = Item(title="Song ft. B", artist="A")
+        self.assertIn(("A", ["Song"]), lyrics.search_pairs(item))
+        self.assertIn(("A", ["Song ft. B"]), lyrics.search_pairs(item))
 
-        item = Item(title='Song featuring B', artist='A')
-        self.assertIn(('A', ['Song']), lyrics.search_pairs(item))
-        self.assertIn(('A', ['Song featuring B']), lyrics.search_pairs(item))
+        item = Item(title="Song featuring B", artist="A")
+        self.assertIn(("A", ["Song"]), lyrics.search_pairs(item))
+        self.assertIn(("A", ["Song featuring B"]), lyrics.search_pairs(item))
 
-        item = Item(title='Song and B', artist='A')
-        self.assertNotIn(('A', ['Song']), lyrics.search_pairs(item))
-        self.assertIn(('A', ['Song and B']), lyrics.search_pairs(item))
+        item = Item(title="Song and B", artist="A")
+        self.assertNotIn(("A", ["Song"]), lyrics.search_pairs(item))
+        self.assertIn(("A", ["Song and B"]), lyrics.search_pairs(item))
 
-        item = Item(title='Song: B', artist='A')
-        self.assertIn(('A', ['Song']), lyrics.search_pairs(item))
-        self.assertIn(('A', ['Song: B']), lyrics.search_pairs(item))
+        item = Item(title="Song: B", artist="A")
+        self.assertIn(("A", ["Song"]), lyrics.search_pairs(item))
+        self.assertIn(("A", ["Song: B"]), lyrics.search_pairs(item))
 
     def test_remove_credits(self):
         self.assertEqual(
-            lyrics.remove_credits("""It's close to midnight
-                                     Lyrics brought by example.com"""),
-            "It's close to midnight"
+            lyrics.remove_credits(
+                """It's close to midnight
+                                     Lyrics brought by example.com"""
+            ),
+            "It's close to midnight",
         )
         self.assertEqual(
-            lyrics.remove_credits("""Lyrics brought by example.com"""),
-            ""
+            lyrics.remove_credits("""Lyrics brought by example.com"""), ""
         )
 
         # don't remove 2nd verse for the only reason it contains 'lyrics' word
@@ -171,16 +156,17 @@ class LyricsPluginTest(unittest.TestCase):
         self.assertEqual(lyrics.remove_credits(text), text)
 
     def test_is_lyrics(self):
-        texts = ['LyricsMania.com - Copyright (c) 2013 - All Rights Reserved']
-        texts += ["""All material found on this site is property\n
-                     of mywickedsongtext brand"""]
+        texts = ["LyricsMania.com - Copyright (c) 2013 - All Rights Reserved"]
+        texts += [
+            """All material found on this site is property\n
+                     of mywickedsongtext brand"""
+        ]
         for t in texts:
             self.assertFalse(google.is_lyrics(t))
 
     def test_slugify(self):
         text = u"http://site.com/\xe7afe-au_lait(boisson)"
-        self.assertEqual(google.slugify(text),
-                         'http://site.com/cafe_au_lait')
+        self.assertEqual(google.slugify(text), "http://site.com/cafe_au_lait")
 
     def test_scrape_strip_cruft(self):
         text = u"""<!--lyrics below-->
@@ -189,48 +175,49 @@ class LyricsPluginTest(unittest.TestCase):
                   two  !
                   <br><br \\>
                   <blink>four</blink>"""
-        self.assertEqual(lyrics._scrape_strip_cruft(text, True),
-                         "one\ntwo !\n\nfour")
+        self.assertEqual(
+            lyrics._scrape_strip_cruft(text, True), "one\ntwo !\n\nfour"
+        )
 
     def test_scrape_strip_scripts(self):
         text = u"""foo<script>bar</script>baz"""
-        self.assertEqual(lyrics._scrape_strip_cruft(text, True),
-                         "foobaz")
+        self.assertEqual(lyrics._scrape_strip_cruft(text, True), "foobaz")
 
     def test_scrape_strip_tag_in_comment(self):
         text = u"""foo<!--<bar>-->qux"""
-        self.assertEqual(lyrics._scrape_strip_cruft(text, True),
-                         "fooqux")
+        self.assertEqual(lyrics._scrape_strip_cruft(text, True), "fooqux")
 
     def test_scrape_merge_paragraphs(self):
         text = u"one</p>   <p class='myclass'>two</p><p>three"
-        self.assertEqual(lyrics._scrape_merge_paragraphs(text),
-                         "one\ntwo\nthree")
+        self.assertEqual(
+            lyrics._scrape_merge_paragraphs(text), "one\ntwo\nthree"
+        )
 
     def test_missing_lyrics(self):
-        self.assertFalse(google.is_lyrics(LYRICS_TEXTS['missing_texts']))
+        self.assertFalse(google.is_lyrics(LYRICS_TEXTS["missing_texts"]))
 
 
 def url_to_filename(url):
-    url = re.sub(r'https?://|www.', '', url)
-    fn = "".join(x for x in url if (x.isalnum() or x == '/'))
-    fn = fn.split('/')
-    fn = os.path.join(LYRICS_ROOT_DIR,
-                      bytestring_path(fn[0]),
-                      bytestring_path(fn[-1] + '.txt'))
+    url = re.sub(r"https?://|www.", "", url)
+    fn = "".join(x for x in url if (x.isalnum() or x == "/"))
+    fn = fn.split("/")
+    fn = os.path.join(
+        LYRICS_ROOT_DIR,
+        bytestring_path(fn[0]),
+        bytestring_path(fn[-1] + ".txt"),
+    )
     return fn
 
 
 class MockFetchUrl(object):
-
-    def __init__(self, pathval='fetched_path'):
+    def __init__(self, pathval="fetched_path"):
         self.pathval = pathval
         self.fetched = None
 
     def __call__(self, url, filename=None):
         self.fetched = url
         fn = url_to_filename(url)
-        with open(fn, 'r', encoding="utf8") as f:
+        with open(fn, "r", encoding="utf8") as f:
             content = f.read()
         return content
 
@@ -243,19 +230,19 @@ def is_lyrics_content_ok(title, text):
     words = set(x.strip(".?, ") for x in text.lower().split())
     return keywords <= words
 
-LYRICS_ROOT_DIR = os.path.join(_common.RSRC, b'lyrics')
-yaml_path = os.path.join(_common.RSRC, b'lyricstext.yaml')
+
+LYRICS_ROOT_DIR = os.path.join(_common.RSRC, b"lyrics")
+yaml_path = os.path.join(_common.RSRC, b"lyricstext.yaml")
 LYRICS_TEXTS = confuse.load_yaml(yaml_path)
 
 
 class LyricsGoogleBaseTest(unittest.TestCase):
-
     def setUp(self):
         """Set up configuration."""
         try:
-            __import__('bs4')
+            __import__("bs4")
         except ImportError:
-            self.skipTest('Beautiful Soup 4 not available')
+            self.skipTest("Beautiful Soup 4 not available")
         if sys.version_info[:3] < (2, 7, 3):
             self.skipTest("Python's built-in HTML parser is not good enough")
 
@@ -265,7 +252,7 @@ class LyricsPluginSourcesTest(LyricsGoogleBaseTest):
        scraped.
     """
 
-    DEFAULT_SONG = dict(artist=u'The Beatles', title=u'Lady Madonna')
+    DEFAULT_SONG = dict(artist=u"The Beatles", title=u"Lady Madonna")
 
     DEFAULT_SOURCES = [
         dict(DEFAULT_SONG, backend=lyrics.LyricsWiki),
@@ -275,48 +262,77 @@ class LyricsPluginSourcesTest(LyricsGoogleBaseTest):
     ]
 
     GOOGLE_SOURCES = [
-        dict(DEFAULT_SONG,
-             url=u'http://www.absolutelyrics.com',
-             path=u'/lyrics/view/the_beatles/lady_madonna'),
-        dict(DEFAULT_SONG,
-             url=u'http://www.azlyrics.com',
-             path=u'/lyrics/beatles/ladymadonna.html'),
-        dict(DEFAULT_SONG,
-             url=u'http://www.chartlyrics.com',
-             path=u'/_LsLsZ7P4EK-F-LD4dJgDQ/Lady+Madonna.aspx'),
+        dict(
+            DEFAULT_SONG,
+            url=u"http://www.absolutelyrics.com",
+            path=u"/lyrics/view/the_beatles/lady_madonna",
+        ),
+        dict(
+            DEFAULT_SONG,
+            url=u"http://www.azlyrics.com",
+            path=u"/lyrics/beatles/ladymadonna.html",
+        ),
+        dict(
+            DEFAULT_SONG,
+            url=u"http://www.chartlyrics.com",
+            path=u"/_LsLsZ7P4EK-F-LD4dJgDQ/Lady+Madonna.aspx",
+        ),
         # dict(DEFAULT_SONG,
         #      url=u'http://www.elyricsworld.com',
         #      path=u'/lady_madonna_lyrics_beatles.html'),
-        dict(url=u'http://www.lacoccinelle.net',
-             artist=u'Jacques Brel', title=u"Amsterdam",
-             path=u'/paroles-officielles/275679.html'),
-        dict(DEFAULT_SONG,
-             url=u'http://letras.mus.br/', path=u'the-beatles/275/'),
-        dict(DEFAULT_SONG,
-             url='http://www.lyricsmania.com/',
-             path='lady_madonna_lyrics_the_beatles.html'),
-        dict(DEFAULT_SONG, url=u'http://lyrics.wikia.com/',
-             path=u'The_Beatles:Lady_Madonna'),
-        dict(DEFAULT_SONG,
-             url=u'http://www.lyricsmode.com',
-             path=u'/lyrics/b/beatles/lady_madonna.html'),
-        dict(url=u'http://www.lyricsontop.com',
-             artist=u'Amy Winehouse', title=u"Jazz'n'blues",
-             path=u'/amy-winehouse-songs/jazz-n-blues-lyrics.html'),
+        dict(
+            url=u"http://www.lacoccinelle.net",
+            artist=u"Jacques Brel",
+            title=u"Amsterdam",
+            path=u"/paroles-officielles/275679.html",
+        ),
+        dict(
+            DEFAULT_SONG,
+            url=u"http://letras.mus.br/",
+            path=u"the-beatles/275/",
+        ),
+        dict(
+            DEFAULT_SONG,
+            url="http://www.lyricsmania.com/",
+            path="lady_madonna_lyrics_the_beatles.html",
+        ),
+        dict(
+            DEFAULT_SONG,
+            url=u"http://lyrics.wikia.com/",
+            path=u"The_Beatles:Lady_Madonna",
+        ),
+        dict(
+            DEFAULT_SONG,
+            url=u"http://www.lyricsmode.com",
+            path=u"/lyrics/b/beatles/lady_madonna.html",
+        ),
+        dict(
+            url=u"http://www.lyricsontop.com",
+            artist=u"Amy Winehouse",
+            title=u"Jazz'n'blues",
+            path=u"/amy-winehouse-songs/jazz-n-blues-lyrics.html",
+        ),
         # dict(DEFAULT_SONG,
         #      url='http://www.metrolyrics.com/',
         #      path='lady-madonna-lyrics-beatles.html'),
         # dict(url='http://www.musica.com/', path='letras.asp?letra=2738',
         #      artist=u'Santana', title=u'Black magic woman'),
-        dict(url=u'http://www.paroles.net/',
-             artist=u'Lilly Wood & the prick', title=u"Hey it's ok",
-             path=u'lilly-wood-the-prick/paroles-hey-it-s-ok'),
-        dict(DEFAULT_SONG,
-             url='http://www.songlyrics.com',
-             path=u'/the-beatles/lady-madonna-lyrics'),
-        dict(DEFAULT_SONG,
-             url=u'http://www.sweetslyrics.com',
-             path=u'/761696.The%20Beatles%20-%20Lady%20Madonna.html')
+        dict(
+            url=u"http://www.paroles.net/",
+            artist=u"Lilly Wood & the prick",
+            title=u"Hey it's ok",
+            path=u"lilly-wood-the-prick/paroles-hey-it-s-ok",
+        ),
+        dict(
+            DEFAULT_SONG,
+            url="http://www.songlyrics.com",
+            path=u"/the-beatles/lady-madonna-lyrics",
+        ),
+        dict(
+            DEFAULT_SONG,
+            url=u"http://www.sweetslyrics.com",
+            path=u"/761696.The%20Beatles%20-%20Lady%20Madonna.html",
+        ),
     ]
 
     def setUp(self):
@@ -324,85 +340,102 @@ class LyricsPluginSourcesTest(LyricsGoogleBaseTest):
         self.plugin = lyrics.LyricsPlugin()
 
     @unittest.skipUnless(
-        os.environ.get('INTEGRATION_TEST', '0') == '1',
-        'integration testing not enabled')
+        os.environ.get("INTEGRATION_TEST", "0") == "1",
+        "integration testing not enabled",
+    )
     def test_backend_sources_ok(self):
         """Test default backends with songs known to exist in respective databases.
         """
         errors = []
         for s in self.DEFAULT_SOURCES:
-            res = s['backend'](self.plugin.config, self.plugin._log).fetch(
-                s['artist'], s['title'])
-            if not is_lyrics_content_ok(s['title'], res):
-                errors.append(s['backend'].__name__)
+            res = s["backend"](self.plugin.config, self.plugin._log).fetch(
+                s["artist"], s["title"]
+            )
+            if not is_lyrics_content_ok(s["title"], res):
+                errors.append(s["backend"].__name__)
         self.assertFalse(errors)
 
     @unittest.skipUnless(
-        os.environ.get('INTEGRATION_TEST', '0') == '1',
-        'integration testing not enabled')
+        os.environ.get("INTEGRATION_TEST", "0") == "1",
+        "integration testing not enabled",
+    )
     def test_google_sources_ok(self):
         """Test if lyrics present on websites registered in beets google custom
            search engine are correctly scraped.
         """
         for s in self.GOOGLE_SOURCES:
-            url = s['url'] + s['path']
-            res = lyrics.scrape_lyrics_from_html(
-                raw_backend.fetch_url(url))
+            url = s["url"] + s["path"]
+            res = lyrics.scrape_lyrics_from_html(raw_backend.fetch_url(url))
             self.assertTrue(google.is_lyrics(res), url)
-            self.assertTrue(is_lyrics_content_ok(s['title'], res), url)
+            self.assertTrue(is_lyrics_content_ok(s["title"], res), url)
 
 
 class LyricsGooglePluginMachineryTest(LyricsGoogleBaseTest):
     """Test scraping heuristics on a fake html page.
     """
 
-    source = dict(url=u'http://www.example.com', artist=u'John Doe',
-                  title=u'Beets song', path=u'/lyrics/beetssong')
+    source = dict(
+        url=u"http://www.example.com",
+        artist=u"John Doe",
+        title=u"Beets song",
+        path=u"/lyrics/beetssong",
+    )
 
     def setUp(self):
         """Set up configuration"""
         LyricsGoogleBaseTest.setUp(self)
         self.plugin = lyrics.LyricsPlugin()
 
-    @patch.object(lyrics.Backend, 'fetch_url', MockFetchUrl())
+    @patch.object(lyrics.Backend, "fetch_url", MockFetchUrl())
     def test_mocked_source_ok(self):
         """Test that lyrics of the mocked page are correctly scraped"""
-        url = self.source['url'] + self.source['path']
+        url = self.source["url"] + self.source["path"]
         res = lyrics.scrape_lyrics_from_html(raw_backend.fetch_url(url))
         self.assertTrue(google.is_lyrics(res), url)
-        self.assertTrue(is_lyrics_content_ok(self.source['title'], res),
-                        url)
+        self.assertTrue(is_lyrics_content_ok(self.source["title"], res), url)
 
-    @patch.object(lyrics.Backend, 'fetch_url', MockFetchUrl())
+    @patch.object(lyrics.Backend, "fetch_url", MockFetchUrl())
     def test_is_page_candidate_exact_match(self):
         """Test matching html page title with song infos -- when song infos are
            present in the title.
         """
         from bs4 import SoupStrainer, BeautifulSoup
+
         s = self.source
-        url = six.text_type(s['url'] + s['path'])
+        url = six.text_type(s["url"] + s["path"])
         html = raw_backend.fetch_url(url)
-        soup = BeautifulSoup(html, "html.parser",
-                             parse_only=SoupStrainer('title'))
+        soup = BeautifulSoup(
+            html, "html.parser", parse_only=SoupStrainer("title")
+        )
         self.assertEqual(
-            google.is_page_candidate(url, soup.title.string,
-                                     s['title'], s['artist']), True, url)
+            google.is_page_candidate(
+                url, soup.title.string, s["title"], s["artist"]
+            ),
+            True,
+            url,
+        )
 
     def test_is_page_candidate_fuzzy_match(self):
         """Test matching html page title with song infos -- when song infos are
            not present in the title.
         """
         s = self.source
-        url = s['url'] + s['path']
-        url_title = u'example.com | Beats song by John doe'
+        url = s["url"] + s["path"]
+        url_title = u"example.com | Beats song by John doe"
 
         # very small diffs (typo) are ok eg 'beats' vs 'beets' with same artist
-        self.assertEqual(google.is_page_candidate(url, url_title, s['title'],
-                                                  s['artist']), True, url)
+        self.assertEqual(
+            google.is_page_candidate(url, url_title, s["title"], s["artist"]),
+            True,
+            url,
+        )
         # reject different title
-        url_title = u'example.com | seets bong lyrics by John doe'
-        self.assertEqual(google.is_page_candidate(url, url_title, s['title'],
-                                                  s['artist']), False, url)
+        url_title = u"example.com | seets bong lyrics by John doe"
+        self.assertEqual(
+            google.is_page_candidate(url, url_title, s["title"], s["artist"]),
+            False,
+            url,
+        )
 
     def test_is_page_candidate_special_chars(self):
         """Ensure that `is_page_candidate` doesn't crash when the artist
@@ -410,21 +443,22 @@ class LyricsGooglePluginMachineryTest(LyricsGoogleBaseTest):
         """
         # https://github.com/beetbox/beets/issues/1673
         s = self.source
-        url = s['url'] + s['path']
-        url_title = u'foo'
+        url = s["url"] + s["path"]
+        url_title = u"foo"
 
-        google.is_page_candidate(url, url_title, s['title'], u'Sunn O)))')
+        google.is_page_candidate(url, url_title, s["title"], u"Sunn O)))")
 
 
 # test Genius backend
+
 
 class GeniusBaseTest(unittest.TestCase):
     def setUp(self):
         """Set up configuration."""
         try:
-            __import__('bs4')
+            __import__("bs4")
         except ImportError:
-            self.skipTest('Beautiful Soup 4 not available')
+            self.skipTest("Beautiful Soup 4 not available")
         if sys.version_info[:3] < (2, 7, 3):
             self.skipTest("Python's built-in HTML parser is not good enough")
 
@@ -443,13 +477,13 @@ class GeniusScrapeLyricsFromHtmlTest(GeniusBaseTest):
         """
         # https://github.com/beetbox/beets/issues/3535
         # expected return value None
-        url = 'https://genius.com/sample'
+        url = "https://genius.com/sample"
         mock = MockFetchUrl()
         self.assertEqual(genius._scrape_lyrics_from_html(mock(url)), None)
 
     def test_good_lyrics(self):
         """Ensure we are able to scrape a page with lyrics"""
-        url = 'https://genius.com/Wu-tang-clan-cream-lyrics'
+        url = "https://genius.com/Wu-tang-clan-cream-lyrics"
         mock = MockFetchUrl()
         self.assertIsNotNone(genius._scrape_lyrics_from_html(mock(url)))
 
@@ -464,83 +498,84 @@ class GeniusFetchTest(GeniusBaseTest):
         GeniusBaseTest.setUp(self)
         self.plugin = lyrics.LyricsPlugin()
 
-    @patch.object(lyrics.Genius, '_scrape_lyrics_from_html')
-    @patch.object(lyrics.Backend, 'fetch_url', return_value=True)
+    @patch.object(lyrics.Genius, "_scrape_lyrics_from_html")
+    @patch.object(lyrics.Backend, "fetch_url", return_value=True)
     def test_json(self, mock_fetch_url, mock_scrape):
         """Ensure we're finding artist matches"""
         with patch.object(
-            lyrics.Genius, '_search', return_value={
+            lyrics.Genius,
+            "_search",
+            return_value={
                 "response": {
                     "hits": [
                         {
                             "result": {
                                 "primary_artist": {
                                     "name": u"\u200Bblackbear",
-                                    },
-                                "url": "blackbear_url"
-                                }
+                                },
+                                "url": "blackbear_url",
+                            }
                         },
                         {
                             "result": {
-                                "primary_artist": {
-                                    "name": u"El\u002Dp"
-                                    },
-                                "url": "El-p_url"
-                                }
-                        }
+                                "primary_artist": {"name": u"El\u002Dp"},
+                                "url": "El-p_url",
+                            }
+                        },
                     ]
                 }
-            }
+            },
         ) as mock_json:
             # genius uses zero-width-spaces (\u200B) for lowercase
             # artists so we make sure we can match those
-            self.assertIsNotNone(genius.fetch('blackbear', 'Idfc'))
+            self.assertIsNotNone(genius.fetch("blackbear", "Idfc"))
             mock_fetch_url.assert_called_once_with("blackbear_url")
             mock_scrape.assert_called_once_with(True)
 
             # genius uses the hypen minus (\u002D) as their dash
-            self.assertIsNotNone(genius.fetch('El-p', 'Idfc'))
-            mock_fetch_url.assert_called_with('El-p_url')
+            self.assertIsNotNone(genius.fetch("El-p", "Idfc"))
+            mock_fetch_url.assert_called_with("El-p_url")
             mock_scrape.assert_called_with(True)
 
             # test no matching artist
-            self.assertIsNone(genius.fetch('doesntexist', 'none'))
+            self.assertIsNone(genius.fetch("doesntexist", "none"))
 
             # test invalid json
             mock_json.return_value = None
-            self.assertIsNone(genius.fetch('blackbear', 'Idfc'))
+            self.assertIsNone(genius.fetch("blackbear", "Idfc"))
 
     # TODO: add integration test hitting real api
 
 
 # test utilties
 
-class SlugTests(unittest.TestCase):
 
+class SlugTests(unittest.TestCase):
     def test_slug(self):
         # plain ascii passthrough
         text = u"test"
-        self.assertEqual(lyrics.slug(text), 'test')
+        self.assertEqual(lyrics.slug(text), "test")
 
         # german unicode and capitals
         text = u"Mørdag"
-        self.assertEqual(lyrics.slug(text), 'mordag')
+        self.assertEqual(lyrics.slug(text), "mordag")
 
         # more accents and quotes
         text = u"l'été c'est fait pour jouer"
-        self.assertEqual(lyrics.slug(text), 'l-ete-c-est-fait-pour-jouer')
+        self.assertEqual(lyrics.slug(text), "l-ete-c-est-fait-pour-jouer")
 
         # accents, parens and spaces
         text = u"\xe7afe au lait (boisson)"
-        self.assertEqual(lyrics.slug(text), 'cafe-au-lait-boisson')
+        self.assertEqual(lyrics.slug(text), "cafe-au-lait-boisson")
         text = u"Multiple  spaces -- and symbols! -- merged"
-        self.assertEqual(lyrics.slug(text),
-                         'multiple-spaces-and-symbols-merged')
+        self.assertEqual(
+            lyrics.slug(text), "multiple-spaces-and-symbols-merged"
+        )
         text = u"\u200Bno-width-space"
-        self.assertEqual(lyrics.slug(text), 'no-width-space')
+        self.assertEqual(lyrics.slug(text), "no-width-space")
 
         # variations of dashes should get standardized
-        dashes = [u'\u200D', u'\u2010']
+        dashes = [u"\u200D", u"\u2010"]
         for dash1, dash2 in itertools.combinations(dashes, 2):
             self.assertEqual(lyrics.slug(dash1), lyrics.slug(dash2))
 
@@ -548,5 +583,6 @@ class SlugTests(unittest.TestCase):
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -26,42 +26,50 @@ import mock
 
 
 class MBAlbumInfoTest(_common.TestCase):
-    def _make_release(self, date_str='2009', tracks=None, track_length=None,
-                      track_artist=False, data_tracks=None,
-                      medium_format='FORMAT'):
+    def _make_release(
+        self,
+        date_str="2009",
+        tracks=None,
+        track_length=None,
+        track_artist=False,
+        data_tracks=None,
+        medium_format="FORMAT",
+    ):
         release = {
-            'title': 'ALBUM TITLE',
-            'id': 'ALBUM ID',
-            'asin': 'ALBUM ASIN',
-            'disambiguation': 'R_DISAMBIGUATION',
-            'release-group': {
-                'type': 'Album',
-                'first-release-date': date_str,
-                'id': 'RELEASE GROUP ID',
-                'disambiguation': 'RG_DISAMBIGUATION',
+            "title": "ALBUM TITLE",
+            "id": "ALBUM ID",
+            "asin": "ALBUM ASIN",
+            "disambiguation": "R_DISAMBIGUATION",
+            "release-group": {
+                "type": "Album",
+                "first-release-date": date_str,
+                "id": "RELEASE GROUP ID",
+                "disambiguation": "RG_DISAMBIGUATION",
             },
-            'artist-credit': [
+            "artist-credit": [
                 {
-                    'artist': {
-                        'name': 'ARTIST NAME',
-                        'id': 'ARTIST ID',
-                        'sort-name': 'ARTIST SORT NAME',
+                    "artist": {
+                        "name": "ARTIST NAME",
+                        "id": "ARTIST ID",
+                        "sort-name": "ARTIST SORT NAME",
                     },
-                    'name': 'ARTIST CREDIT',
+                    "name": "ARTIST CREDIT",
                 }
             ],
-            'date': '3001',
-            'medium-list': [],
-            'label-info-list': [{
-                'catalog-number': 'CATALOG NUMBER',
-                'label': {'name': 'LABEL NAME'},
-            }],
-            'text-representation': {
-                'script': 'SCRIPT',
-                'language': 'LANGUAGE',
+            "date": "3001",
+            "medium-list": [],
+            "label-info-list": [
+                {
+                    "catalog-number": "CATALOG NUMBER",
+                    "label": {"name": "LABEL NAME"},
+                }
+            ],
+            "text-representation": {
+                "script": "SCRIPT",
+                "language": "LANGUAGE",
             },
-            'country': 'COUNTRY',
-            'status': 'STATUS',
+            "country": "COUNTRY",
+            "status": "STATUS",
         }
         i = 0
         track_list = []
@@ -69,25 +77,25 @@ class MBAlbumInfoTest(_common.TestCase):
             for recording in tracks:
                 i += 1
                 track = {
-                    'id': 'RELEASE TRACK ID %d' % i,
-                    'recording': recording,
-                    'position': i,
-                    'number': 'A1',
+                    "id": "RELEASE TRACK ID %d" % i,
+                    "recording": recording,
+                    "position": i,
+                    "number": "A1",
                 }
                 if track_length:
                     # Track lengths are distinct from recording lengths.
-                    track['length'] = track_length
+                    track["length"] = track_length
                 if track_artist:
                     # Similarly, track artists can differ from recording
                     # artists.
-                    track['artist-credit'] = [
+                    track["artist-credit"] = [
                         {
-                            'artist': {
-                                'name': 'TRACK ARTIST NAME',
-                                'id': 'TRACK ARTIST ID',
-                                'sort-name': 'TRACK ARTIST SORT NAME',
+                            "artist": {
+                                "name": "TRACK ARTIST NAME",
+                                "id": "TRACK ARTIST ID",
+                                "sort-name": "TRACK ARTIST SORT NAME",
                             },
-                            'name': 'TRACK ARTIST CREDIT',
+                            "name": "TRACK ARTIST CREDIT",
                         }
                     ]
                 track_list.append(track)
@@ -96,84 +104,90 @@ class MBAlbumInfoTest(_common.TestCase):
             for recording in data_tracks:
                 i += 1
                 data_track = {
-                    'id': 'RELEASE TRACK ID %d' % i,
-                    'recording': recording,
-                    'position': i,
-                    'number': 'A1',
+                    "id": "RELEASE TRACK ID %d" % i,
+                    "recording": recording,
+                    "position": i,
+                    "number": "A1",
                 }
                 data_track_list.append(data_track)
-        release['medium-list'].append({
-            'position': '1',
-            'track-list': track_list,
-            'data-track-list': data_track_list,
-            'format': medium_format,
-            'title': 'MEDIUM TITLE',
-        })
+        release["medium-list"].append(
+            {
+                "position": "1",
+                "track-list": track_list,
+                "data-track-list": data_track_list,
+                "format": medium_format,
+                "title": "MEDIUM TITLE",
+            }
+        )
         return release
 
     def _make_track(self, title, tr_id, duration, artist=False, video=False):
         track = {
-            'title': title,
-            'id': tr_id,
+            "title": title,
+            "id": tr_id,
         }
         if duration is not None:
-            track['length'] = duration
+            track["length"] = duration
         if artist:
-            track['artist-credit'] = [
+            track["artist-credit"] = [
                 {
-                    'artist': {
-                        'name': 'RECORDING ARTIST NAME',
-                        'id': 'RECORDING ARTIST ID',
-                        'sort-name': 'RECORDING ARTIST SORT NAME',
+                    "artist": {
+                        "name": "RECORDING ARTIST NAME",
+                        "id": "RECORDING ARTIST ID",
+                        "sort-name": "RECORDING ARTIST SORT NAME",
                     },
-                    'name': 'RECORDING ARTIST CREDIT',
+                    "name": "RECORDING ARTIST CREDIT",
                 }
             ]
         if video:
-            track['video'] = 'true'
+            track["video"] = "true"
         return track
 
     def test_parse_release_with_year(self):
-        release = self._make_release('1984')
+        release = self._make_release("1984")
         d = mb.album_info(release)
-        self.assertEqual(d.album, 'ALBUM TITLE')
-        self.assertEqual(d.album_id, 'ALBUM ID')
-        self.assertEqual(d.artist, 'ARTIST NAME')
-        self.assertEqual(d.artist_id, 'ARTIST ID')
+        self.assertEqual(d.album, "ALBUM TITLE")
+        self.assertEqual(d.album_id, "ALBUM ID")
+        self.assertEqual(d.artist, "ARTIST NAME")
+        self.assertEqual(d.artist_id, "ARTIST ID")
         self.assertEqual(d.original_year, 1984)
         self.assertEqual(d.year, 3001)
-        self.assertEqual(d.artist_credit, 'ARTIST CREDIT')
+        self.assertEqual(d.artist_credit, "ARTIST CREDIT")
 
     def test_parse_release_type(self):
-        release = self._make_release('1984')
+        release = self._make_release("1984")
         d = mb.album_info(release)
-        self.assertEqual(d.albumtype, 'album')
+        self.assertEqual(d.albumtype, "album")
 
     def test_parse_release_full_date(self):
-        release = self._make_release('1987-03-31')
+        release = self._make_release("1987-03-31")
         d = mb.album_info(release)
         self.assertEqual(d.original_year, 1987)
         self.assertEqual(d.original_month, 3)
         self.assertEqual(d.original_day, 31)
 
     def test_parse_tracks(self):
-        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
-                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
+        tracks = [
+            self._make_track("TITLE ONE", "ID ONE", 100.0 * 1000.0),
+            self._make_track("TITLE TWO", "ID TWO", 200.0 * 1000.0),
+        ]
         release = self._make_release(tracks=tracks)
 
         d = mb.album_info(release)
         t = d.tracks
         self.assertEqual(len(t), 2)
-        self.assertEqual(t[0].title, 'TITLE ONE')
-        self.assertEqual(t[0].track_id, 'ID ONE')
+        self.assertEqual(t[0].title, "TITLE ONE")
+        self.assertEqual(t[0].track_id, "ID ONE")
         self.assertEqual(t[0].length, 100.0)
-        self.assertEqual(t[1].title, 'TITLE TWO')
-        self.assertEqual(t[1].track_id, 'ID TWO')
+        self.assertEqual(t[1].title, "TITLE TWO")
+        self.assertEqual(t[1].track_id, "ID TWO")
         self.assertEqual(t[1].length, 200.0)
 
     def test_parse_track_indices(self):
-        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
-                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
+        tracks = [
+            self._make_track("TITLE ONE", "ID ONE", 100.0 * 1000.0),
+            self._make_track("TITLE TWO", "ID TWO", 200.0 * 1000.0),
+        ]
         release = self._make_release(tracks=tracks)
 
         d = mb.album_info(release)
@@ -184,8 +198,10 @@ class MBAlbumInfoTest(_common.TestCase):
         self.assertEqual(t[1].index, 2)
 
     def test_parse_medium_numbers_single_medium(self):
-        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
-                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
+        tracks = [
+            self._make_track("TITLE ONE", "ID ONE", 100.0 * 1000.0),
+            self._make_track("TITLE TWO", "ID TWO", 200.0 * 1000.0),
+        ]
         release = self._make_release(tracks=tracks)
 
         d = mb.album_info(release)
@@ -195,19 +211,22 @@ class MBAlbumInfoTest(_common.TestCase):
         self.assertEqual(t[1].medium, 1)
 
     def test_parse_medium_numbers_two_mediums(self):
-        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
-                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
+        tracks = [
+            self._make_track("TITLE ONE", "ID ONE", 100.0 * 1000.0),
+            self._make_track("TITLE TWO", "ID TWO", 200.0 * 1000.0),
+        ]
         release = self._make_release(tracks=[tracks[0]])
-        second_track_list = [{
-            'id': 'RELEASE TRACK ID 2',
-            'recording': tracks[1],
-            'position': '1',
-            'number': 'A1',
-        }]
-        release['medium-list'].append({
-            'position': '2',
-            'track-list': second_track_list,
-        })
+        second_track_list = [
+            {
+                "id": "RELEASE TRACK ID 2",
+                "recording": tracks[1],
+                "position": "1",
+                "number": "A1",
+            }
+        ]
+        release["medium-list"].append(
+            {"position": "2", "track-list": second_track_list,}
+        )
 
         d = mb.album_info(release)
         self.assertEqual(d.mediums, 2)
@@ -220,19 +239,19 @@ class MBAlbumInfoTest(_common.TestCase):
         self.assertEqual(t[1].index, 2)
 
     def test_parse_release_year_month_only(self):
-        release = self._make_release('1987-03')
+        release = self._make_release("1987-03")
         d = mb.album_info(release)
         self.assertEqual(d.original_year, 1987)
         self.assertEqual(d.original_month, 3)
 
     def test_no_durations(self):
-        tracks = [self._make_track('TITLE', 'ID', None)]
+        tracks = [self._make_track("TITLE", "ID", None)]
         release = self._make_release(tracks=tracks)
         d = mb.album_info(release)
         self.assertEqual(d.tracks[0].length, None)
 
     def test_track_length_overrides_recording_length(self):
-        tracks = [self._make_track('TITLE', 'ID', 1.0 * 1000.0)]
+        tracks = [self._make_track("TITLE", "ID", 1.0 * 1000.0)]
         release = self._make_release(tracks=tracks, track_length=2.0 * 1000.0)
         d = mb.album_info(release)
         self.assertEqual(d.tracks[0].length, 2.0)
@@ -251,199 +270,234 @@ class MBAlbumInfoTest(_common.TestCase):
 
     def test_detect_various_artists(self):
         release = self._make_release(None)
-        release['artist-credit'][0]['artist']['id'] = \
-            mb.VARIOUS_ARTISTS_ID
+        release["artist-credit"][0]["artist"]["id"] = mb.VARIOUS_ARTISTS_ID
         d = mb.album_info(release)
         self.assertTrue(d.va)
 
     def test_parse_artist_sort_name(self):
         release = self._make_release(None)
         d = mb.album_info(release)
-        self.assertEqual(d.artist_sort, 'ARTIST SORT NAME')
+        self.assertEqual(d.artist_sort, "ARTIST SORT NAME")
 
     def test_parse_releasegroupid(self):
         release = self._make_release(None)
         d = mb.album_info(release)
-        self.assertEqual(d.releasegroup_id, 'RELEASE GROUP ID')
+        self.assertEqual(d.releasegroup_id, "RELEASE GROUP ID")
 
     def test_parse_asin(self):
         release = self._make_release(None)
         d = mb.album_info(release)
-        self.assertEqual(d.asin, 'ALBUM ASIN')
+        self.assertEqual(d.asin, "ALBUM ASIN")
 
     def test_parse_catalognum(self):
         release = self._make_release(None)
         d = mb.album_info(release)
-        self.assertEqual(d.catalognum, 'CATALOG NUMBER')
+        self.assertEqual(d.catalognum, "CATALOG NUMBER")
 
     def test_parse_textrepr(self):
         release = self._make_release(None)
         d = mb.album_info(release)
-        self.assertEqual(d.script, 'SCRIPT')
-        self.assertEqual(d.language, 'LANGUAGE')
+        self.assertEqual(d.script, "SCRIPT")
+        self.assertEqual(d.language, "LANGUAGE")
 
     def test_parse_country(self):
         release = self._make_release(None)
         d = mb.album_info(release)
-        self.assertEqual(d.country, 'COUNTRY')
+        self.assertEqual(d.country, "COUNTRY")
 
     def test_parse_status(self):
         release = self._make_release(None)
         d = mb.album_info(release)
-        self.assertEqual(d.albumstatus, 'STATUS')
+        self.assertEqual(d.albumstatus, "STATUS")
 
     def test_parse_media(self):
-        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
-                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
+        tracks = [
+            self._make_track("TITLE ONE", "ID ONE", 100.0 * 1000.0),
+            self._make_track("TITLE TWO", "ID TWO", 200.0 * 1000.0),
+        ]
         release = self._make_release(None, tracks=tracks)
         d = mb.album_info(release)
-        self.assertEqual(d.media, 'FORMAT')
+        self.assertEqual(d.media, "FORMAT")
 
     def test_parse_disambig(self):
         release = self._make_release(None)
         d = mb.album_info(release)
-        self.assertEqual(d.albumdisambig, 'R_DISAMBIGUATION')
-        self.assertEqual(d.releasegroupdisambig, 'RG_DISAMBIGUATION')
+        self.assertEqual(d.albumdisambig, "R_DISAMBIGUATION")
+        self.assertEqual(d.releasegroupdisambig, "RG_DISAMBIGUATION")
 
     def test_parse_disctitle(self):
-        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
-                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
+        tracks = [
+            self._make_track("TITLE ONE", "ID ONE", 100.0 * 1000.0),
+            self._make_track("TITLE TWO", "ID TWO", 200.0 * 1000.0),
+        ]
         release = self._make_release(None, tracks=tracks)
         d = mb.album_info(release)
         t = d.tracks
-        self.assertEqual(t[0].disctitle, 'MEDIUM TITLE')
-        self.assertEqual(t[1].disctitle, 'MEDIUM TITLE')
+        self.assertEqual(t[0].disctitle, "MEDIUM TITLE")
+        self.assertEqual(t[1].disctitle, "MEDIUM TITLE")
 
     def test_missing_language(self):
         release = self._make_release(None)
-        del release['text-representation']['language']
+        del release["text-representation"]["language"]
         d = mb.album_info(release)
         self.assertEqual(d.language, None)
 
     def test_parse_recording_artist(self):
-        tracks = [self._make_track('a', 'b', 1, True)]
+        tracks = [self._make_track("a", "b", 1, True)]
         release = self._make_release(None, tracks=tracks)
         track = mb.album_info(release).tracks[0]
-        self.assertEqual(track.artist, 'RECORDING ARTIST NAME')
-        self.assertEqual(track.artist_id, 'RECORDING ARTIST ID')
-        self.assertEqual(track.artist_sort, 'RECORDING ARTIST SORT NAME')
-        self.assertEqual(track.artist_credit, 'RECORDING ARTIST CREDIT')
+        self.assertEqual(track.artist, "RECORDING ARTIST NAME")
+        self.assertEqual(track.artist_id, "RECORDING ARTIST ID")
+        self.assertEqual(track.artist_sort, "RECORDING ARTIST SORT NAME")
+        self.assertEqual(track.artist_credit, "RECORDING ARTIST CREDIT")
 
     def test_track_artist_overrides_recording_artist(self):
-        tracks = [self._make_track('a', 'b', 1, True)]
+        tracks = [self._make_track("a", "b", 1, True)]
         release = self._make_release(None, tracks=tracks, track_artist=True)
         track = mb.album_info(release).tracks[0]
-        self.assertEqual(track.artist, 'TRACK ARTIST NAME')
-        self.assertEqual(track.artist_id, 'TRACK ARTIST ID')
-        self.assertEqual(track.artist_sort, 'TRACK ARTIST SORT NAME')
-        self.assertEqual(track.artist_credit, 'TRACK ARTIST CREDIT')
+        self.assertEqual(track.artist, "TRACK ARTIST NAME")
+        self.assertEqual(track.artist_id, "TRACK ARTIST ID")
+        self.assertEqual(track.artist_sort, "TRACK ARTIST SORT NAME")
+        self.assertEqual(track.artist_credit, "TRACK ARTIST CREDIT")
 
     def test_data_source(self):
         release = self._make_release()
         d = mb.album_info(release)
-        self.assertEqual(d.data_source, 'MusicBrainz')
+        self.assertEqual(d.data_source, "MusicBrainz")
 
     def test_ignored_media(self):
-        config['match']['ignored_media'] = ['IGNORED1', 'IGNORED2']
-        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
-                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
+        config["match"]["ignored_media"] = ["IGNORED1", "IGNORED2"]
+        tracks = [
+            self._make_track("TITLE ONE", "ID ONE", 100.0 * 1000.0),
+            self._make_track("TITLE TWO", "ID TWO", 200.0 * 1000.0),
+        ]
         release = self._make_release(tracks=tracks, medium_format="IGNORED1")
         d = mb.album_info(release)
         self.assertEqual(len(d.tracks), 0)
 
     def test_no_ignored_media(self):
-        config['match']['ignored_media'] = ['IGNORED1', 'IGNORED2']
-        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
-                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
-        release = self._make_release(tracks=tracks,
-                                     medium_format="NON-IGNORED")
+        config["match"]["ignored_media"] = ["IGNORED1", "IGNORED2"]
+        tracks = [
+            self._make_track("TITLE ONE", "ID ONE", 100.0 * 1000.0),
+            self._make_track("TITLE TWO", "ID TWO", 200.0 * 1000.0),
+        ]
+        release = self._make_release(
+            tracks=tracks, medium_format="NON-IGNORED"
+        )
         d = mb.album_info(release)
         self.assertEqual(len(d.tracks), 2)
 
     def test_skip_data_track(self):
-        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
-                  self._make_track('[data track]', 'ID DATA TRACK',
-                                   100.0 * 1000.0),
-                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
+        tracks = [
+            self._make_track("TITLE ONE", "ID ONE", 100.0 * 1000.0),
+            self._make_track("[data track]", "ID DATA TRACK", 100.0 * 1000.0),
+            self._make_track("TITLE TWO", "ID TWO", 200.0 * 1000.0),
+        ]
         release = self._make_release(tracks=tracks)
         d = mb.album_info(release)
         self.assertEqual(len(d.tracks), 2)
-        self.assertEqual(d.tracks[0].title, 'TITLE ONE')
-        self.assertEqual(d.tracks[1].title, 'TITLE TWO')
+        self.assertEqual(d.tracks[0].title, "TITLE ONE")
+        self.assertEqual(d.tracks[1].title, "TITLE TWO")
 
     def test_skip_audio_data_tracks_by_default(self):
-        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
-                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
-        data_tracks = [self._make_track('TITLE AUDIO DATA', 'ID DATA TRACK',
-                                        100.0 * 1000.0)]
+        tracks = [
+            self._make_track("TITLE ONE", "ID ONE", 100.0 * 1000.0),
+            self._make_track("TITLE TWO", "ID TWO", 200.0 * 1000.0),
+        ]
+        data_tracks = [
+            self._make_track(
+                "TITLE AUDIO DATA", "ID DATA TRACK", 100.0 * 1000.0
+            )
+        ]
         release = self._make_release(tracks=tracks, data_tracks=data_tracks)
         d = mb.album_info(release)
         self.assertEqual(len(d.tracks), 2)
-        self.assertEqual(d.tracks[0].title, 'TITLE ONE')
-        self.assertEqual(d.tracks[1].title, 'TITLE TWO')
+        self.assertEqual(d.tracks[0].title, "TITLE ONE")
+        self.assertEqual(d.tracks[1].title, "TITLE TWO")
 
     def test_no_skip_audio_data_tracks_if_configured(self):
-        config['match']['ignore_data_tracks'] = False
-        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
-                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
-        data_tracks = [self._make_track('TITLE AUDIO DATA', 'ID DATA TRACK',
-                                        100.0 * 1000.0)]
+        config["match"]["ignore_data_tracks"] = False
+        tracks = [
+            self._make_track("TITLE ONE", "ID ONE", 100.0 * 1000.0),
+            self._make_track("TITLE TWO", "ID TWO", 200.0 * 1000.0),
+        ]
+        data_tracks = [
+            self._make_track(
+                "TITLE AUDIO DATA", "ID DATA TRACK", 100.0 * 1000.0
+            )
+        ]
         release = self._make_release(tracks=tracks, data_tracks=data_tracks)
         d = mb.album_info(release)
         self.assertEqual(len(d.tracks), 3)
-        self.assertEqual(d.tracks[0].title, 'TITLE ONE')
-        self.assertEqual(d.tracks[1].title, 'TITLE TWO')
-        self.assertEqual(d.tracks[2].title, 'TITLE AUDIO DATA')
+        self.assertEqual(d.tracks[0].title, "TITLE ONE")
+        self.assertEqual(d.tracks[1].title, "TITLE TWO")
+        self.assertEqual(d.tracks[2].title, "TITLE AUDIO DATA")
 
     def test_skip_video_tracks_by_default(self):
-        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
-                  self._make_track('TITLE VIDEO', 'ID VIDEO', 100.0 * 1000.0,
-                                   False, True),
-                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
+        tracks = [
+            self._make_track("TITLE ONE", "ID ONE", 100.0 * 1000.0),
+            self._make_track(
+                "TITLE VIDEO", "ID VIDEO", 100.0 * 1000.0, False, True
+            ),
+            self._make_track("TITLE TWO", "ID TWO", 200.0 * 1000.0),
+        ]
         release = self._make_release(tracks=tracks)
         d = mb.album_info(release)
         self.assertEqual(len(d.tracks), 2)
-        self.assertEqual(d.tracks[0].title, 'TITLE ONE')
-        self.assertEqual(d.tracks[1].title, 'TITLE TWO')
+        self.assertEqual(d.tracks[0].title, "TITLE ONE")
+        self.assertEqual(d.tracks[1].title, "TITLE TWO")
 
     def test_skip_video_data_tracks_by_default(self):
-        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
-                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
-        data_tracks = [self._make_track('TITLE VIDEO', 'ID VIDEO',
-                                        100.0 * 1000.0, False, True)]
+        tracks = [
+            self._make_track("TITLE ONE", "ID ONE", 100.0 * 1000.0),
+            self._make_track("TITLE TWO", "ID TWO", 200.0 * 1000.0),
+        ]
+        data_tracks = [
+            self._make_track(
+                "TITLE VIDEO", "ID VIDEO", 100.0 * 1000.0, False, True
+            )
+        ]
         release = self._make_release(tracks=tracks, data_tracks=data_tracks)
         d = mb.album_info(release)
         self.assertEqual(len(d.tracks), 2)
-        self.assertEqual(d.tracks[0].title, 'TITLE ONE')
-        self.assertEqual(d.tracks[1].title, 'TITLE TWO')
+        self.assertEqual(d.tracks[0].title, "TITLE ONE")
+        self.assertEqual(d.tracks[1].title, "TITLE TWO")
 
     def test_no_skip_video_tracks_if_configured(self):
-        config['match']['ignore_data_tracks'] = False
-        config['match']['ignore_video_tracks'] = False
-        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
-                  self._make_track('TITLE VIDEO', 'ID VIDEO', 100.0 * 1000.0,
-                                   False, True),
-                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
+        config["match"]["ignore_data_tracks"] = False
+        config["match"]["ignore_video_tracks"] = False
+        tracks = [
+            self._make_track("TITLE ONE", "ID ONE", 100.0 * 1000.0),
+            self._make_track(
+                "TITLE VIDEO", "ID VIDEO", 100.0 * 1000.0, False, True
+            ),
+            self._make_track("TITLE TWO", "ID TWO", 200.0 * 1000.0),
+        ]
         release = self._make_release(tracks=tracks)
         d = mb.album_info(release)
         self.assertEqual(len(d.tracks), 3)
-        self.assertEqual(d.tracks[0].title, 'TITLE ONE')
-        self.assertEqual(d.tracks[1].title, 'TITLE VIDEO')
-        self.assertEqual(d.tracks[2].title, 'TITLE TWO')
+        self.assertEqual(d.tracks[0].title, "TITLE ONE")
+        self.assertEqual(d.tracks[1].title, "TITLE VIDEO")
+        self.assertEqual(d.tracks[2].title, "TITLE TWO")
 
     def test_no_skip_video_data_tracks_if_configured(self):
-        config['match']['ignore_data_tracks'] = False
-        config['match']['ignore_video_tracks'] = False
-        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
-                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0)]
-        data_tracks = [self._make_track('TITLE VIDEO', 'ID VIDEO',
-                                        100.0 * 1000.0, False, True)]
+        config["match"]["ignore_data_tracks"] = False
+        config["match"]["ignore_video_tracks"] = False
+        tracks = [
+            self._make_track("TITLE ONE", "ID ONE", 100.0 * 1000.0),
+            self._make_track("TITLE TWO", "ID TWO", 200.0 * 1000.0),
+        ]
+        data_tracks = [
+            self._make_track(
+                "TITLE VIDEO", "ID VIDEO", 100.0 * 1000.0, False, True
+            )
+        ]
         release = self._make_release(tracks=tracks, data_tracks=data_tracks)
         d = mb.album_info(release)
         self.assertEqual(len(d.tracks), 3)
-        self.assertEqual(d.tracks[0].title, 'TITLE ONE')
-        self.assertEqual(d.tracks[1].title, 'TITLE TWO')
-        self.assertEqual(d.tracks[2].title, 'TITLE VIDEO')
+        self.assertEqual(d.tracks[0].title, "TITLE ONE")
+        self.assertEqual(d.tracks[1].title, "TITLE TWO")
+        self.assertEqual(d.tracks[2].title, "TITLE VIDEO")
 
 
 class ParseIDTest(_common.TestCase):
@@ -465,151 +519,149 @@ class ParseIDTest(_common.TestCase):
 
 
 class ArtistFlatteningTest(_common.TestCase):
-    def _credit_dict(self, suffix=''):
+    def _credit_dict(self, suffix=""):
         return {
-            'artist': {
-                'name': 'NAME' + suffix,
-                'sort-name': 'SORT' + suffix,
-            },
-            'name': 'CREDIT' + suffix,
+            "artist": {"name": "NAME" + suffix, "sort-name": "SORT" + suffix,},
+            "name": "CREDIT" + suffix,
         }
 
-    def _add_alias(self, credit_dict, suffix='', locale='', primary=False):
+    def _add_alias(self, credit_dict, suffix="", locale="", primary=False):
         alias = {
-            'alias': 'ALIAS' + suffix,
-            'locale': locale,
-            'sort-name': 'ALIASSORT' + suffix
+            "alias": "ALIAS" + suffix,
+            "locale": locale,
+            "sort-name": "ALIASSORT" + suffix,
         }
         if primary:
-            alias['primary'] = 'primary'
-        if 'alias-list' not in credit_dict['artist']:
-            credit_dict['artist']['alias-list'] = []
-        credit_dict['artist']['alias-list'].append(alias)
+            alias["primary"] = "primary"
+        if "alias-list" not in credit_dict["artist"]:
+            credit_dict["artist"]["alias-list"] = []
+        credit_dict["artist"]["alias-list"].append(alias)
 
     def test_single_artist(self):
         a, s, c = mb._flatten_artist_credit([self._credit_dict()])
-        self.assertEqual(a, 'NAME')
-        self.assertEqual(s, 'SORT')
-        self.assertEqual(c, 'CREDIT')
+        self.assertEqual(a, "NAME")
+        self.assertEqual(s, "SORT")
+        self.assertEqual(c, "CREDIT")
 
     def test_two_artists(self):
         a, s, c = mb._flatten_artist_credit(
-            [self._credit_dict('a'), ' AND ', self._credit_dict('b')]
+            [self._credit_dict("a"), " AND ", self._credit_dict("b")]
         )
-        self.assertEqual(a, 'NAMEa AND NAMEb')
-        self.assertEqual(s, 'SORTa AND SORTb')
-        self.assertEqual(c, 'CREDITa AND CREDITb')
+        self.assertEqual(a, "NAMEa AND NAMEb")
+        self.assertEqual(s, "SORTa AND SORTb")
+        self.assertEqual(c, "CREDITa AND CREDITb")
 
     def test_alias(self):
         credit_dict = self._credit_dict()
-        self._add_alias(credit_dict, suffix='en', locale='en', primary=True)
-        self._add_alias(credit_dict, suffix='en_GB', locale='en_GB',
-                        primary=True)
-        self._add_alias(credit_dict, suffix='fr', locale='fr')
-        self._add_alias(credit_dict, suffix='fr_P', locale='fr', primary=True)
-        self._add_alias(credit_dict, suffix='pt_BR', locale='pt_BR')
+        self._add_alias(credit_dict, suffix="en", locale="en", primary=True)
+        self._add_alias(
+            credit_dict, suffix="en_GB", locale="en_GB", primary=True
+        )
+        self._add_alias(credit_dict, suffix="fr", locale="fr")
+        self._add_alias(credit_dict, suffix="fr_P", locale="fr", primary=True)
+        self._add_alias(credit_dict, suffix="pt_BR", locale="pt_BR")
 
         # test no alias
-        config['import']['languages'] = ['']
+        config["import"]["languages"] = [""]
         flat = mb._flatten_artist_credit([credit_dict])
-        self.assertEqual(flat, ('NAME', 'SORT', 'CREDIT'))
+        self.assertEqual(flat, ("NAME", "SORT", "CREDIT"))
 
         # test en primary
-        config['import']['languages'] = ['en']
+        config["import"]["languages"] = ["en"]
         flat = mb._flatten_artist_credit([credit_dict])
-        self.assertEqual(flat, ('ALIASen', 'ALIASSORTen', 'CREDIT'))
+        self.assertEqual(flat, ("ALIASen", "ALIASSORTen", "CREDIT"))
 
         # test en_GB en primary
-        config['import']['languages'] = ['en_GB', 'en']
+        config["import"]["languages"] = ["en_GB", "en"]
         flat = mb._flatten_artist_credit([credit_dict])
-        self.assertEqual(flat, ('ALIASen_GB', 'ALIASSORTen_GB', 'CREDIT'))
+        self.assertEqual(flat, ("ALIASen_GB", "ALIASSORTen_GB", "CREDIT"))
 
         # test en en_GB primary
-        config['import']['languages'] = ['en', 'en_GB']
+        config["import"]["languages"] = ["en", "en_GB"]
         flat = mb._flatten_artist_credit([credit_dict])
-        self.assertEqual(flat, ('ALIASen', 'ALIASSORTen', 'CREDIT'))
+        self.assertEqual(flat, ("ALIASen", "ALIASSORTen", "CREDIT"))
 
         # test fr primary
-        config['import']['languages'] = ['fr']
+        config["import"]["languages"] = ["fr"]
         flat = mb._flatten_artist_credit([credit_dict])
-        self.assertEqual(flat, ('ALIASfr_P', 'ALIASSORTfr_P', 'CREDIT'))
+        self.assertEqual(flat, ("ALIASfr_P", "ALIASSORTfr_P", "CREDIT"))
 
         # test for not matching non-primary
-        config['import']['languages'] = ['pt_BR', 'fr']
+        config["import"]["languages"] = ["pt_BR", "fr"]
         flat = mb._flatten_artist_credit([credit_dict])
-        self.assertEqual(flat, ('ALIASfr_P', 'ALIASSORTfr_P', 'CREDIT'))
+        self.assertEqual(flat, ("ALIASfr_P", "ALIASSORTfr_P", "CREDIT"))
 
 
 class MBLibraryTest(unittest.TestCase):
     def test_match_track(self):
-        with mock.patch('musicbrainzngs.search_recordings') as p:
+        with mock.patch("musicbrainzngs.search_recordings") as p:
             p.return_value = {
-                'recording-list': [{
-                    'title': 'foo',
-                    'id': 'bar',
-                    'length': 42,
-                }],
+                "recording-list": [
+                    {"title": "foo", "id": "bar", "length": 42,}
+                ],
             }
-            ti = list(mb.match_track('hello', 'there'))[0]
+            ti = list(mb.match_track("hello", "there"))[0]
 
-            p.assert_called_with(artist='hello', recording='there', limit=5)
-            self.assertEqual(ti.title, 'foo')
-            self.assertEqual(ti.track_id, 'bar')
+            p.assert_called_with(artist="hello", recording="there", limit=5)
+            self.assertEqual(ti.title, "foo")
+            self.assertEqual(ti.track_id, "bar")
 
     def test_match_album(self):
-        mbid = 'd2a6f856-b553-40a0-ac54-a321e8e2da99'
-        with mock.patch('musicbrainzngs.search_releases') as sp:
+        mbid = "d2a6f856-b553-40a0-ac54-a321e8e2da99"
+        with mock.patch("musicbrainzngs.search_releases") as sp:
             sp.return_value = {
-                'release-list': [{
-                    'id': mbid,
-                }],
+                "release-list": [{"id": mbid,}],
             }
-            with mock.patch('musicbrainzngs.get_release_by_id') as gp:
+            with mock.patch("musicbrainzngs.get_release_by_id") as gp:
                 gp.return_value = {
-                    'release': {
-                        'title': 'hi',
-                        'id': mbid,
-                        'medium-list': [{
-                            'track-list': [{
-                                'id': 'baz',
-                                'recording': {
-                                    'title': 'foo',
-                                    'id': 'bar',
-                                    'length': 42,
+                    "release": {
+                        "title": "hi",
+                        "id": mbid,
+                        "medium-list": [
+                            {
+                                "track-list": [
+                                    {
+                                        "id": "baz",
+                                        "recording": {
+                                            "title": "foo",
+                                            "id": "bar",
+                                            "length": 42,
+                                        },
+                                        "position": 9,
+                                        "number": "A1",
+                                    }
+                                ],
+                                "position": 5,
+                            }
+                        ],
+                        "artist-credit": [
+                            {
+                                "artist": {
+                                    "name": "some-artist",
+                                    "id": "some-id",
                                 },
-                                'position': 9,
-                                'number': 'A1',
-                            }],
-                            'position': 5,
-                        }],
-                        'artist-credit': [{
-                            'artist': {
-                                'name': 'some-artist',
-                                'id': 'some-id',
-                            },
-                        }],
-                        'release-group': {
-                            'id': 'another-id',
-                        }
+                            }
+                        ],
+                        "release-group": {"id": "another-id",},
                     }
                 }
 
-                ai = list(mb.match_album('hello', 'there'))[0]
+                ai = list(mb.match_album("hello", "there"))[0]
 
-                sp.assert_called_with(artist='hello', release='there', limit=5)
+                sp.assert_called_with(artist="hello", release="there", limit=5)
                 gp.assert_called_with(mbid, mock.ANY)
-                self.assertEqual(ai.tracks[0].title, 'foo')
-                self.assertEqual(ai.album, 'hi')
+                self.assertEqual(ai.tracks[0].title, "foo")
+                self.assertEqual(ai.album, "hi")
 
     def test_match_track_empty(self):
-        with mock.patch('musicbrainzngs.search_recordings') as p:
-            til = list(mb.match_track(' ', ' '))
+        with mock.patch("musicbrainzngs.search_recordings") as p:
+            til = list(mb.match_track(" ", " "))
             self.assertFalse(p.called)
             self.assertEqual(til, [])
 
     def test_match_album_empty(self):
-        with mock.patch('musicbrainzngs.search_releases') as p:
-            ail = list(mb.match_album(' ', ' '))
+        with mock.patch("musicbrainzngs.search_releases") as p:
+            ail = list(mb.match_album(" ", " "))
             self.assertFalse(p.called)
             self.assertEqual(ail, [])
 
@@ -617,5 +669,6 @@ class MBLibraryTest(unittest.TestCase):
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_mbsubmit.py
+++ b/test/test_mbsubmit.py
@@ -21,11 +21,12 @@ from test.test_importer import ImportHelper, AutotagStub
 from test.test_ui_importer import TerminalImportSessionSetup
 
 
-class MBSubmitPluginTest(TerminalImportSessionSetup, unittest.TestCase,
-                         ImportHelper, TestHelper):
+class MBSubmitPluginTest(
+    TerminalImportSessionSetup, unittest.TestCase, ImportHelper, TestHelper
+):
     def setUp(self):
         self.setup_beets()
-        self.load_plugins('mbsubmit')
+        self.load_plugins("mbsubmit")
         self._create_import_dir(2)
         self._setup_import_session()
         self.matcher = AutotagStub().install()
@@ -40,14 +41,16 @@ class MBSubmitPluginTest(TerminalImportSessionSetup, unittest.TestCase,
         self.matcher.matching = AutotagStub.BAD
 
         with capture_stdout() as output:
-            with control_stdin('\n'.join(['p', 's'])):
+            with control_stdin("\n".join(["p", "s"])):
                 # Print tracks; Skip
                 self.importer.run()
 
         # Manually build the string for comparing the output.
-        tracklist = (u'Print tracks? '
-                     u'01. Tag Title 1 - Tag Artist (0:01)\n'
-                     u'02. Tag Title 2 - Tag Artist (0:01)')
+        tracklist = (
+            u"Print tracks? "
+            u"01. Tag Title 1 - Tag Artist (0:01)\n"
+            u"02. Tag Title 2 - Tag Artist (0:01)"
+        )
         self.assertIn(tracklist, output.getvalue())
 
     def test_print_tracks_output_as_tracks(self):
@@ -55,18 +58,18 @@ class MBSubmitPluginTest(TerminalImportSessionSetup, unittest.TestCase,
         self.matcher.matching = AutotagStub.BAD
 
         with capture_stdout() as output:
-            with control_stdin('\n'.join(['t', 's', 'p', 's'])):
+            with control_stdin("\n".join(["t", "s", "p", "s"])):
                 # as Tracks; Skip; Print tracks; Skip
                 self.importer.run()
 
         # Manually build the string for comparing the output.
-        tracklist = (u'Print tracks? '
-                     u'02. Tag Title 2 - Tag Artist (0:01)')
+        tracklist = u"Print tracks? " u"02. Tag Title 2 - Tag Artist (0:01)"
         self.assertIn(tracklist, output.getvalue())
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_mbsync.py
+++ b/test/test_mbsync.py
@@ -18,178 +18,184 @@ from __future__ import division, absolute_import, print_function
 import unittest
 from mock import patch
 
-from test.helper import TestHelper,\
-    generate_album_info, \
-    generate_track_info, \
-    capture_log
+from test.helper import (
+    TestHelper,
+    generate_album_info,
+    generate_track_info,
+    capture_log,
+)
 
 from beets import config
 from beets.library import Item
 
 
 class MbsyncCliTest(unittest.TestCase, TestHelper):
-
     def setUp(self):
         self.setup_beets()
-        self.load_plugins('mbsync')
+        self.load_plugins("mbsync")
 
     def tearDown(self):
         self.unload_plugins()
         self.teardown_beets()
 
-    @patch('beets.autotag.mb.album_for_id')
-    @patch('beets.autotag.mb.track_for_id')
+    @patch("beets.autotag.mb.album_for_id")
+    @patch("beets.autotag.mb.track_for_id")
     def test_update_library(self, track_for_id, album_for_id):
-        album_for_id.return_value = \
-            generate_album_info(
-                'album id',
-                [('track id', {'release_track_id': u'release track id'})]
-            )
-        track_for_id.return_value = \
-            generate_track_info(u'singleton track id',
-                                {'title': u'singleton info'})
+        album_for_id.return_value = generate_album_info(
+            "album id",
+            [("track id", {"release_track_id": u"release track id"})],
+        )
+        track_for_id.return_value = generate_track_info(
+            u"singleton track id", {"title": u"singleton info"}
+        )
 
         album_item = Item(
-            album=u'old title',
-            mb_albumid=u'81ae60d4-5b75-38df-903a-db2cfa51c2c6',
-            mb_trackid=u'old track id',
-            mb_releasetrackid=u'release track id',
-            path=''
+            album=u"old title",
+            mb_albumid=u"81ae60d4-5b75-38df-903a-db2cfa51c2c6",
+            mb_trackid=u"old track id",
+            mb_releasetrackid=u"release track id",
+            path="",
         )
         album = self.lib.add_album([album_item])
 
         item = Item(
-            title=u'old title',
-            mb_trackid=u'b8c2cf90-83f9-3b5f-8ccd-31fb866fcf37',
-            path='',
+            title=u"old title",
+            mb_trackid=u"b8c2cf90-83f9-3b5f-8ccd-31fb866fcf37",
+            path="",
         )
         self.lib.add(item)
 
         with capture_log() as logs:
-            self.run_command('mbsync')
+            self.run_command("mbsync")
 
-        self.assertIn('Sending event: albuminfo_received', logs)
-        self.assertIn('Sending event: trackinfo_received', logs)
+        self.assertIn("Sending event: albuminfo_received", logs)
+        self.assertIn("Sending event: trackinfo_received", logs)
 
         item.load()
-        self.assertEqual(item.title, u'singleton info')
+        self.assertEqual(item.title, u"singleton info")
 
         album_item.load()
-        self.assertEqual(album_item.title, u'track info')
-        self.assertEqual(album_item.mb_trackid, u'track id')
+        self.assertEqual(album_item.title, u"track info")
+        self.assertEqual(album_item.mb_trackid, u"track id")
 
         album.load()
-        self.assertEqual(album.album, u'album info')
+        self.assertEqual(album.album, u"album info")
 
     def test_message_when_skipping(self):
-        config['format_item'] = u'$artist - $album - $title'
-        config['format_album'] = u'$albumartist - $album'
+        config["format_item"] = u"$artist - $album - $title"
+        config["format_album"] = u"$albumartist - $album"
 
         # Test album with no mb_albumid.
         # The default format for an album include $albumartist so
         # set that here, too.
         album_invalid = Item(
-            albumartist=u'album info',
-            album=u'album info',
-            path=''
+            albumartist=u"album info", album=u"album info", path=""
         )
         self.lib.add_album([album_invalid])
 
         # default format
-        with capture_log('beets.mbsync') as logs:
-            self.run_command('mbsync')
-        e = u'mbsync: Skipping album with no mb_albumid: ' + \
-            u'album info - album info'
+        with capture_log("beets.mbsync") as logs:
+            self.run_command("mbsync")
+        e = (
+            u"mbsync: Skipping album with no mb_albumid: "
+            + u"album info - album info"
+        )
         self.assertEqual(e, logs[0])
 
         # custom format
-        with capture_log('beets.mbsync') as logs:
-            self.run_command('mbsync', '-f', "'$album'")
+        with capture_log("beets.mbsync") as logs:
+            self.run_command("mbsync", "-f", "'$album'")
         e = u"mbsync: Skipping album with no mb_albumid: 'album info'"
         self.assertEqual(e, logs[0])
 
         # restore the config
-        config['format_item'] = u'$artist - $album - $title'
-        config['format_album'] = u'$albumartist - $album'
+        config["format_item"] = u"$artist - $album - $title"
+        config["format_album"] = u"$albumartist - $album"
 
         # Test singleton with no mb_trackid.
         # The default singleton format includes $artist and $album
         # so we need to stub them here
         item_invalid = Item(
-            artist=u'album info',
-            album=u'album info',
-            title=u'old title',
-            path='',
+            artist=u"album info",
+            album=u"album info",
+            title=u"old title",
+            path="",
         )
         self.lib.add(item_invalid)
 
         # default format
-        with capture_log('beets.mbsync') as logs:
-            self.run_command('mbsync')
-        e = u'mbsync: Skipping singleton with no mb_trackid: ' + \
-            u'album info - album info - old title'
+        with capture_log("beets.mbsync") as logs:
+            self.run_command("mbsync")
+        e = (
+            u"mbsync: Skipping singleton with no mb_trackid: "
+            + u"album info - album info - old title"
+        )
         self.assertEqual(e, logs[0])
 
         # custom format
-        with capture_log('beets.mbsync') as logs:
-            self.run_command('mbsync', '-f', "'$title'")
+        with capture_log("beets.mbsync") as logs:
+            self.run_command("mbsync", "-f", "'$title'")
         e = u"mbsync: Skipping singleton with no mb_trackid: 'old title'"
         self.assertEqual(e, logs[0])
 
     def test_message_when_invalid(self):
-        config['format_item'] = u'$artist - $album - $title'
-        config['format_album'] = u'$albumartist - $album'
+        config["format_item"] = u"$artist - $album - $title"
+        config["format_album"] = u"$albumartist - $album"
 
         # Test album with invalid mb_albumid.
         # The default format for an album include $albumartist so
         # set that here, too.
         album_invalid = Item(
-            albumartist=u'album info',
-            album=u'album info',
-            mb_albumid=u'a1b2c3d4',
-            path=''
+            albumartist=u"album info",
+            album=u"album info",
+            mb_albumid=u"a1b2c3d4",
+            path="",
         )
         self.lib.add_album([album_invalid])
 
         # default format
-        with capture_log('beets.mbsync') as logs:
-            self.run_command('mbsync')
-        e = u'mbsync: Skipping album with invalid mb_albumid: ' + \
-            u'album info - album info'
+        with capture_log("beets.mbsync") as logs:
+            self.run_command("mbsync")
+        e = (
+            u"mbsync: Skipping album with invalid mb_albumid: "
+            + u"album info - album info"
+        )
         self.assertEqual(e, logs[0])
 
         # custom format
-        with capture_log('beets.mbsync') as logs:
-            self.run_command('mbsync', '-f', "'$album'")
+        with capture_log("beets.mbsync") as logs:
+            self.run_command("mbsync", "-f", "'$album'")
         e = u"mbsync: Skipping album with invalid mb_albumid: 'album info'"
         self.assertEqual(e, logs[0])
 
         # restore the config
-        config['format_item'] = u'$artist - $album - $title'
-        config['format_album'] = u'$albumartist - $album'
+        config["format_item"] = u"$artist - $album - $title"
+        config["format_album"] = u"$albumartist - $album"
 
         # Test singleton with invalid mb_trackid.
         # The default singleton format includes $artist and $album
         # so we need to stub them here
         item_invalid = Item(
-            artist=u'album info',
-            album=u'album info',
-            title=u'old title',
-            mb_trackid=u'a1b2c3d4',
-            path='',
+            artist=u"album info",
+            album=u"album info",
+            title=u"old title",
+            mb_trackid=u"a1b2c3d4",
+            path="",
         )
         self.lib.add(item_invalid)
 
         # default format
-        with capture_log('beets.mbsync') as logs:
-            self.run_command('mbsync')
-        e = u'mbsync: Skipping singleton with invalid mb_trackid: ' + \
-            u'album info - album info - old title'
+        with capture_log("beets.mbsync") as logs:
+            self.run_command("mbsync")
+        e = (
+            u"mbsync: Skipping singleton with invalid mb_trackid: "
+            + u"album info - album info - old title"
+        )
         self.assertEqual(e, logs[0])
 
         # custom format
-        with capture_log('beets.mbsync') as logs:
-            self.run_command('mbsync', '-f', "'$title'")
+        with capture_log("beets.mbsync") as logs:
+            self.run_command("mbsync", "-f", "'$title'")
         e = u"mbsync: Skipping singleton with invalid mb_trackid: 'old title'"
         self.assertEqual(e, logs[0])
 
@@ -197,5 +203,6 @@ class MbsyncCliTest(unittest.TestCase, TestHelper):
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_metasync.py
+++ b/test/test_metasync.py
@@ -28,7 +28,7 @@ from test.helper import TestHelper
 
 
 def _parsetime(s):
-    return time.mktime(datetime.strptime(s, '%Y-%m-%d %H:%M:%S').timetuple())
+    return time.mktime(datetime.strptime(s, "%Y-%m-%d %H:%M:%S").timetuple())
 
 
 def _is_windows():
@@ -36,48 +36,54 @@ def _is_windows():
 
 
 class MetaSyncTest(_common.TestCase, TestHelper):
-    itunes_library_unix = os.path.join(_common.RSRC,
-                                       b'itunes_library_unix.xml')
-    itunes_library_windows = os.path.join(_common.RSRC,
-                                          b'itunes_library_windows.xml')
+    itunes_library_unix = os.path.join(
+        _common.RSRC, b"itunes_library_unix.xml"
+    )
+    itunes_library_windows = os.path.join(
+        _common.RSRC, b"itunes_library_windows.xml"
+    )
 
     def setUp(self):
         self.setup_beets()
-        self.load_plugins('metasync')
+        self.load_plugins("metasync")
 
-        self.config['metasync']['source'] = 'itunes'
+        self.config["metasync"]["source"] = "itunes"
 
         if _is_windows():
-            self.config['metasync']['itunes']['library'] = \
-                py3_path(self.itunes_library_windows)
+            self.config["metasync"]["itunes"]["library"] = py3_path(
+                self.itunes_library_windows
+            )
         else:
-            self.config['metasync']['itunes']['library'] = \
-                py3_path(self.itunes_library_unix)
+            self.config["metasync"]["itunes"]["library"] = py3_path(
+                self.itunes_library_unix
+            )
 
         self._set_up_data()
 
     def _set_up_data(self):
         items = [_common.item() for _ in range(2)]
 
-        items[0].title = 'Tessellate'
-        items[0].artist = 'alt-J'
-        items[0].albumartist = 'alt-J'
-        items[0].album = 'An Awesome Wave'
+        items[0].title = "Tessellate"
+        items[0].artist = "alt-J"
+        items[0].albumartist = "alt-J"
+        items[0].album = "An Awesome Wave"
         items[0].itunes_rating = 60
 
-        items[1].title = 'Breezeblocks'
-        items[1].artist = 'alt-J'
-        items[1].albumartist = 'alt-J'
-        items[1].album = 'An Awesome Wave'
+        items[1].title = "Breezeblocks"
+        items[1].artist = "alt-J"
+        items[1].albumartist = "alt-J"
+        items[1].album = "An Awesome Wave"
 
         if _is_windows():
-            items[0].path = \
-                u'G:\\Music\\Alt-J\\An Awesome Wave\\03 Tessellate.mp3'
-            items[1].path = \
-                u'G:\\Music\\Alt-J\\An Awesome Wave\\04 Breezeblocks.mp3'
+            items[
+                0
+            ].path = u"G:\\Music\\Alt-J\\An Awesome Wave\\03 Tessellate.mp3"
+            items[
+                1
+            ].path = u"G:\\Music\\Alt-J\\An Awesome Wave\\04 Breezeblocks.mp3"
         else:
-            items[0].path = u'/Music/Alt-J/An Awesome Wave/03 Tessellate.mp3'
-            items[1].path = u'/Music/Alt-J/An Awesome Wave/04 Breezeblocks.mp3'
+            items[0].path = u"/Music/Alt-J/An Awesome Wave/03 Tessellate.mp3"
+            items[1].path = u"/Music/Alt-J/An Awesome Wave/04 Breezeblocks.mp3"
 
         for item in items:
             self.lib.add(item)
@@ -88,41 +94,45 @@ class MetaSyncTest(_common.TestCase, TestHelper):
 
     def test_load_item_types(self):
         # This test also verifies that the MetaSources have loaded correctly
-        self.assertIn('amarok_score', Item._types)
-        self.assertIn('itunes_rating', Item._types)
+        self.assertIn("amarok_score", Item._types)
+        self.assertIn("itunes_rating", Item._types)
 
     def test_pretend_sync_from_itunes(self):
-        out = self.run_with_output('metasync', '-p')
+        out = self.run_with_output("metasync", "-p")
 
-        self.assertIn('itunes_rating: 60 -> 80', out)
-        self.assertIn('itunes_rating: 100', out)
-        self.assertIn('itunes_playcount: 31', out)
-        self.assertIn('itunes_skipcount: 3', out)
-        self.assertIn('itunes_lastplayed: 2015-05-04 12:20:51', out)
-        self.assertIn('itunes_lastskipped: 2015-02-05 15:41:04', out)
+        self.assertIn("itunes_rating: 60 -> 80", out)
+        self.assertIn("itunes_rating: 100", out)
+        self.assertIn("itunes_playcount: 31", out)
+        self.assertIn("itunes_skipcount: 3", out)
+        self.assertIn("itunes_lastplayed: 2015-05-04 12:20:51", out)
+        self.assertIn("itunes_lastskipped: 2015-02-05 15:41:04", out)
         self.assertEqual(self.lib.items()[0].itunes_rating, 60)
 
     def test_sync_from_itunes(self):
-        self.run_command('metasync')
+        self.run_command("metasync")
 
         self.assertEqual(self.lib.items()[0].itunes_rating, 80)
         self.assertEqual(self.lib.items()[0].itunes_playcount, 0)
         self.assertEqual(self.lib.items()[0].itunes_skipcount, 3)
-        self.assertFalse(hasattr(self.lib.items()[0], 'itunes_lastplayed'))
-        self.assertEqual(self.lib.items()[0].itunes_lastskipped,
-                         _parsetime('2015-02-05 15:41:04'))
+        self.assertFalse(hasattr(self.lib.items()[0], "itunes_lastplayed"))
+        self.assertEqual(
+            self.lib.items()[0].itunes_lastskipped,
+            _parsetime("2015-02-05 15:41:04"),
+        )
 
         self.assertEqual(self.lib.items()[1].itunes_rating, 100)
         self.assertEqual(self.lib.items()[1].itunes_playcount, 31)
         self.assertEqual(self.lib.items()[1].itunes_skipcount, 0)
-        self.assertEqual(self.lib.items()[1].itunes_lastplayed,
-                         _parsetime('2015-05-04 12:20:51'))
-        self.assertFalse(hasattr(self.lib.items()[1], 'itunes_lastskipped'))
+        self.assertEqual(
+            self.lib.items()[1].itunes_lastplayed,
+            _parsetime("2015-05-04 12:20:51"),
+        )
+        self.assertFalse(hasattr(self.lib.items()[1], "itunes_lastskipped"))
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_mpdstats.py
+++ b/test/test_mpdstats.py
@@ -27,14 +27,14 @@ from beets import util
 class MPDStatsTest(unittest.TestCase, TestHelper):
     def setUp(self):
         self.setup_beets()
-        self.load_plugins('mpdstats')
+        self.load_plugins("mpdstats")
 
     def tearDown(self):
         self.teardown_beets()
         self.unload_plugins()
 
     def test_update_rating(self):
-        item = Item(title=u'title', path='', id=1)
+        item = Item(title=u"title", path="", id=1)
         item.add(self.lib)
 
         log = Mock()
@@ -44,30 +44,39 @@ class MPDStatsTest(unittest.TestCase, TestHelper):
         self.assertFalse(mpdstats.update_rating(None, True))
 
     def test_get_item(self):
-        item_path = util.normpath('/foo/bar.flac')
-        item = Item(title=u'title', path=item_path, id=1)
+        item_path = util.normpath("/foo/bar.flac")
+        item = Item(title=u"title", path=item_path, id=1)
         item.add(self.lib)
 
         log = Mock()
         mpdstats = MPDStats(self.lib, log)
 
         self.assertEqual(str(mpdstats.get_item(item_path)), str(item))
-        self.assertIsNone(mpdstats.get_item('/some/non-existing/path'))
-        self.assertIn(u'item not found:', log.info.call_args[0][0])
+        self.assertIsNone(mpdstats.get_item("/some/non-existing/path"))
+        self.assertIn(u"item not found:", log.info.call_args[0][0])
 
-    FAKE_UNKNOWN_STATE = 'some-unknown-one'
-    STATUSES = [{'state': FAKE_UNKNOWN_STATE},
-                {'state': u'pause'},
-                {'state': u'play', 'songid': 1, 'time': u'0:1'},
-                {'state': u'stop'}]
+    FAKE_UNKNOWN_STATE = "some-unknown-one"
+    STATUSES = [
+        {"state": FAKE_UNKNOWN_STATE},
+        {"state": u"pause"},
+        {"state": u"play", "songid": 1, "time": u"0:1"},
+        {"state": u"stop"},
+    ]
     EVENTS = [["player"]] * (len(STATUSES) - 1) + [KeyboardInterrupt]
-    item_path = util.normpath('/foo/bar.flac')
+    item_path = util.normpath("/foo/bar.flac")
 
-    @patch("beetsplug.mpdstats.MPDClientWrapper", return_value=Mock(**{
-        "events.side_effect": EVENTS, "status.side_effect": STATUSES,
-        "currentsong.return_value": item_path}))
+    @patch(
+        "beetsplug.mpdstats.MPDClientWrapper",
+        return_value=Mock(
+            **{
+                "events.side_effect": EVENTS,
+                "status.side_effect": STATUSES,
+                "currentsong.return_value": item_path,
+            }
+        ),
+    )
     def test_run_mpdstats(self, mpd_mock):
-        item = Item(title=u'title', path=self.item_path, id=1)
+        item = Item(title=u"title", path=self.item_path, id=1)
         item.add(self.lib)
 
         log = Mock()
@@ -76,14 +85,15 @@ class MPDStatsTest(unittest.TestCase, TestHelper):
         except KeyboardInterrupt:
             pass
 
-        log.debug.assert_has_calls(
-            [call(u'unhandled status "{0}"', ANY)])
+        log.debug.assert_has_calls([call(u'unhandled status "{0}"', ANY)])
         log.info.assert_has_calls(
-            [call(u'pause'), call(u'playing {0}', ANY), call(u'stop')])
+            [call(u"pause"), call(u"playing {0}", ANY), call(u"stop")]
+        )
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_parentwork.py
+++ b/test/test_parentwork.py
@@ -29,73 +29,90 @@ class ParentWorkTest(unittest.TestCase, TestHelper):
     def setUp(self):
         """Set up configuration"""
         self.setup_beets()
-        self.load_plugins('parentwork')
+        self.load_plugins("parentwork")
 
     def tearDown(self):
         self.unload_plugins()
         self.teardown_beets()
 
     @unittest.skipUnless(
-        os.environ.get('INTEGRATION_TEST', '0') == '1',
-        'integration testing not enabled')
+        os.environ.get("INTEGRATION_TEST", "0") == "1",
+        "integration testing not enabled",
+    )
     def test_normal_case(self):
-        item = Item(path='/file',
-                    mb_workid=u'e27bda6e-531e-36d3-9cd7-b8ebc18e8c53')
+        item = Item(
+            path="/file", mb_workid=u"e27bda6e-531e-36d3-9cd7-b8ebc18e8c53"
+        )
         item.add(self.lib)
 
-        self.run_command('parentwork')
+        self.run_command("parentwork")
 
         item.load()
-        self.assertEqual(item['mb_parentworkid'],
-                         u'32c8943f-1b27-3a23-8660-4567f4847c94')
+        self.assertEqual(
+            item["mb_parentworkid"], u"32c8943f-1b27-3a23-8660-4567f4847c94"
+        )
 
     @unittest.skipUnless(
-        os.environ.get('INTEGRATION_TEST', '0') == '1',
-        'integration testing not enabled')
+        os.environ.get("INTEGRATION_TEST", "0") == "1",
+        "integration testing not enabled",
+    )
     def test_force(self):
-        self.config['parentwork']['force'] = True
-        item = Item(path='/file',
-                    mb_workid=u'e27bda6e-531e-36d3-9cd7-b8ebc18e8c53',
-                    mb_parentworkid=u'XXX')
+        self.config["parentwork"]["force"] = True
+        item = Item(
+            path="/file",
+            mb_workid=u"e27bda6e-531e-36d3-9cd7-b8ebc18e8c53",
+            mb_parentworkid=u"XXX",
+        )
         item.add(self.lib)
 
-        self.run_command('parentwork')
+        self.run_command("parentwork")
 
         item.load()
-        self.assertEqual(item['mb_parentworkid'],
-                         u'32c8943f-1b27-3a23-8660-4567f4847c94')
+        self.assertEqual(
+            item["mb_parentworkid"], u"32c8943f-1b27-3a23-8660-4567f4847c94"
+        )
 
     @unittest.skipUnless(
-        os.environ.get('INTEGRATION_TEST', '0') == '1',
-        'integration testing not enabled')
+        os.environ.get("INTEGRATION_TEST", "0") == "1",
+        "integration testing not enabled",
+    )
     def test_no_force(self):
-        self.config['parentwork']['force'] = True
-        item = Item(path='/file', mb_workid=u'e27bda6e-531e-36d3-9cd7-\
-                    b8ebc18e8c53', mb_parentworkid=u'XXX')
+        self.config["parentwork"]["force"] = True
+        item = Item(
+            path="/file",
+            mb_workid=u"e27bda6e-531e-36d3-9cd7-\
+                    b8ebc18e8c53",
+            mb_parentworkid=u"XXX",
+        )
         item.add(self.lib)
 
-        self.run_command('parentwork')
+        self.run_command("parentwork")
 
         item.load()
-        self.assertEqual(item['mb_parentworkid'], u'XXX')
+        self.assertEqual(item["mb_parentworkid"], u"XXX")
 
     # test different cases, still with Matthew Passion Ouverture or Mozart
     # requiem
 
     @unittest.skipUnless(
-        os.environ.get('INTEGRATION_TEST', '0') == '1',
-        'integration testing not enabled')
+        os.environ.get("INTEGRATION_TEST", "0") == "1",
+        "integration testing not enabled",
+    )
     def test_direct_parent_work(self):
-        mb_workid = u'2e4a3668-458d-3b2a-8be2-0b08e0d8243a'
-        self.assertEqual(u'f04b42df-7251-4d86-a5ee-67cfa49580d1',
-                         parentwork.direct_parent_id(mb_workid)[0])
-        self.assertEqual(u'45afb3b2-18ac-4187-bc72-beb1b1c194ba',
-                         parentwork.work_parent_id(mb_workid)[0])
+        mb_workid = u"2e4a3668-458d-3b2a-8be2-0b08e0d8243a"
+        self.assertEqual(
+            u"f04b42df-7251-4d86-a5ee-67cfa49580d1",
+            parentwork.direct_parent_id(mb_workid)[0],
+        )
+        self.assertEqual(
+            u"45afb3b2-18ac-4187-bc72-beb1b1c194ba",
+            parentwork.work_parent_id(mb_workid)[0],
+        )
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_permissions.py
+++ b/test/test_permissions.py
@@ -11,19 +11,19 @@ from mock import patch, Mock
 
 from test.helper import TestHelper
 from beets.util import displayable_path
-from beetsplug.permissions import (check_permissions,
-                                   convert_perm,
-                                   dirs_in_library)
+from beetsplug.permissions import (
+    check_permissions,
+    convert_perm,
+    dirs_in_library,
+)
 
 
 class PermissionsPluginTest(unittest.TestCase, TestHelper):
     def setUp(self):
         self.setup_beets()
-        self.load_plugins('permissions')
+        self.load_plugins("permissions")
 
-        self.config['permissions'] = {
-            'file': '777',
-            'dir': '777'}
+        self.config["permissions"] = {"file": "777", "dir": "777"}
 
     def tearDown(self):
         self.teardown_beets()
@@ -33,7 +33,7 @@ class PermissionsPluginTest(unittest.TestCase, TestHelper):
         self.do_thing(True)
 
     def test_permissions_on_item_imported(self):
-        self.config['import']['singletons'] = True
+        self.config["import"]["singletons"] = True
         self.do_thing(True)
 
     @patch("os.chmod", Mock())
@@ -41,43 +41,50 @@ class PermissionsPluginTest(unittest.TestCase, TestHelper):
         self.do_thing(False)
 
     def do_thing(self, expect_success):
-        if platform.system() == 'Windows':
-            self.skipTest('permissions not available on Windows')
+        if platform.system() == "Windows":
+            self.skipTest("permissions not available on Windows")
 
         def get_stat(v):
-            return os.stat(
-                os.path.join(self.temp_dir, b'import', *v)).st_mode & 0o777
-        self.importer = self.create_importer()
-        typs = ['file', 'dir']
+            return (
+                os.stat(os.path.join(self.temp_dir, b"import", *v)).st_mode
+                & 0o777
+            )
 
-        track_file = (b'album 0', b'track 0.mp3')
+        self.importer = self.create_importer()
+        typs = ["file", "dir"]
+
+        track_file = (b"album 0", b"track 0.mp3")
         self.exp_perms = {
-            True: {k: convert_perm(self.config['permissions'][k].get())
-                   for k in typs},
-            False: {k: get_stat(v) for (k, v) in zip(typs, (track_file, ()))}
+            True: {
+                k: convert_perm(self.config["permissions"][k].get())
+                for k in typs
+            },
+            False: {k: get_stat(v) for (k, v) in zip(typs, (track_file, ()))},
         }
 
         self.importer.run()
         item = self.lib.items().get()
 
-        self.assertPerms(item.path, 'file', expect_success)
+        self.assertPerms(item.path, "file", expect_success)
 
         for path in dirs_in_library(self.lib.directory, item.path):
-            self.assertPerms(path, 'dir', expect_success)
+            self.assertPerms(path, "dir", expect_success)
 
     def assertPerms(self, path, typ, expect_success):  # noqa
-        for x in [(True, self.exp_perms[expect_success][typ], '!='),
-                  (False, self.exp_perms[not expect_success][typ], '==')]:
-            msg = u'{} : {} {} {}'.format(
+        for x in [
+            (True, self.exp_perms[expect_success][typ], "!="),
+            (False, self.exp_perms[not expect_success][typ], "=="),
+        ]:
+            msg = u"{} : {} {} {}".format(
                 displayable_path(path),
                 oct(os.stat(path).st_mode),
                 x[2],
-                oct(x[1])
+                oct(x[1]),
             )
             self.assertEqual(x[0], check_permissions(path, x[1]), msg=msg)
 
     def test_convert_perm_from_string(self):
-        self.assertEqual(convert_perm('10'), 8)
+        self.assertEqual(convert_perm("10"), 8)
 
     def test_convert_perm_from_int(self):
         self.assertEqual(convert_perm(10), 8)
@@ -87,5 +94,5 @@ def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -101,9 +101,9 @@ class SimplePipelineTest(unittest.TestCase):
 class ParallelStageTest(unittest.TestCase):
     def setUp(self):
         self.l = []
-        self.pl = pipeline.Pipeline((
-            _produce(), (_work(), _work()), _consume(self.l)
-        ))
+        self.pl = pipeline.Pipeline(
+            (_produce(), (_work(), _work()), _consume(self.l))
+        )
 
     def test_run_sequential(self):
         self.pl.run_sequential()
@@ -122,8 +122,9 @@ class ParallelStageTest(unittest.TestCase):
 class ExceptionTest(unittest.TestCase):
     def setUp(self):
         self.l = []
-        self.pl = pipeline.Pipeline((_produce(), _exc_work(),
-                                     _consume(self.l)))
+        self.pl = pipeline.Pipeline(
+            (_produce(), _exc_work(), _consume(self.l))
+        )
 
     def test_run_sequential(self):
         self.assertRaises(ExceptionFixture, self.pl.run_sequential)
@@ -145,9 +146,9 @@ class ExceptionTest(unittest.TestCase):
 class ParallelExceptionTest(unittest.TestCase):
     def setUp(self):
         self.l = []
-        self.pl = pipeline.Pipeline((
-            _produce(), (_exc_work(), _exc_work()), _consume(self.l)
-        ))
+        self.pl = pipeline.Pipeline(
+            (_produce(), (_exc_work(), _exc_work()), _consume(self.l))
+        )
 
     def test_run_parallel(self):
         self.assertRaises(ExceptionFixture, self.pl.run_parallel)
@@ -170,9 +171,9 @@ class ConstrainedThreadedPipelineTest(unittest.TestCase):
 
     def test_constrained_parallel(self):
         l = []
-        pl = pipeline.Pipeline((
-            _produce(1000), (_work(), _work()), _consume(l)
-        ))
+        pl = pipeline.Pipeline(
+            (_produce(1000), (_work(), _work()), _consume(l))
+        )
         pl.run_parallel(1)
         self.assertEqual(set(l), set(i * 2 for i in range(1000)))
 
@@ -180,8 +181,9 @@ class ConstrainedThreadedPipelineTest(unittest.TestCase):
 class BubbleTest(unittest.TestCase):
     def setUp(self):
         self.l = []
-        self.pl = pipeline.Pipeline((_produce(), _bub_work(),
-                                     _consume(self.l)))
+        self.pl = pipeline.Pipeline(
+            (_produce(), _bub_work(), _consume(self.l))
+        )
 
     def test_run_sequential(self):
         self.pl.run_sequential()
@@ -199,9 +201,9 @@ class BubbleTest(unittest.TestCase):
 class MultiMessageTest(unittest.TestCase):
     def setUp(self):
         self.l = []
-        self.pl = pipeline.Pipeline((
-            _produce(), _multi_work(), _consume(self.l)
-        ))
+        self.pl = pipeline.Pipeline(
+            (_produce(), _multi_work(), _consume(self.l))
+        )
 
     def test_run_sequential(self):
         self.pl.run_sequential()
@@ -217,16 +219,12 @@ class MultiMessageTest(unittest.TestCase):
 
 
 class StageDecoratorTest(unittest.TestCase):
-
     def test_stage_decorator(self):
         @pipeline.stage
         def add(n, i):
             return i + n
 
-        pl = pipeline.Pipeline([
-            iter([1, 2, 3]),
-            add(2)
-        ])
+        pl = pipeline.Pipeline([iter([1, 2, 3]), add(2)])
         self.assertEqual(list(pl.pull()), [3, 4, 5])
 
     def test_mutator_stage_decorator(self):
@@ -234,16 +232,17 @@ class StageDecoratorTest(unittest.TestCase):
         def setkey(key, item):
             item[key] = True
 
-        pl = pipeline.Pipeline([
-            iter([{'x': False}, {'a': False}]),
-            setkey('x'),
-        ])
-        self.assertEqual(list(pl.pull()),
-                         [{'x': True}, {'a': False, 'x': True}])
+        pl = pipeline.Pipeline(
+            [iter([{"x": False}, {"a": False}]), setkey("x"),]
+        )
+        self.assertEqual(
+            list(pl.pull()), [{"x": True}, {"a": False, "x": True}]
+        )
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_play.py
+++ b/test/test_play.py
@@ -28,116 +28,127 @@ from beets.ui import UserError
 from beets.util import open_anything
 
 
-@patch('beetsplug.play.util.interactive_open')
+@patch("beetsplug.play.util.interactive_open")
 class PlayPluginTest(unittest.TestCase, TestHelper):
     def setUp(self):
         self.setup_beets()
-        self.load_plugins('play')
-        self.item = self.add_item(album=u'a nice älbum', title=u'aNiceTitle')
+        self.load_plugins("play")
+        self.item = self.add_item(album=u"a nice älbum", title=u"aNiceTitle")
         self.lib.add_album([self.item])
-        self.config['play']['command'] = 'echo'
+        self.config["play"]["command"] = "echo"
 
     def tearDown(self):
         self.teardown_beets()
         self.unload_plugins()
 
-    def run_and_assert(self, open_mock, args=('title:aNiceTitle',),
-                       expected_cmd='echo', expected_playlist=None):
-        self.run_command('play', *args)
+    def run_and_assert(
+        self,
+        open_mock,
+        args=("title:aNiceTitle",),
+        expected_cmd="echo",
+        expected_playlist=None,
+    ):
+        self.run_command("play", *args)
 
         open_mock.assert_called_once_with(ANY, expected_cmd)
-        expected_playlist = expected_playlist or self.item.path.decode('utf-8')
-        exp_playlist = expected_playlist + u'\n'
-        with open(open_mock.call_args[0][0][0], 'rb') as playlist:
-            self.assertEqual(exp_playlist, playlist.read().decode('utf-8'))
+        expected_playlist = expected_playlist or self.item.path.decode("utf-8")
+        exp_playlist = expected_playlist + u"\n"
+        with open(open_mock.call_args[0][0][0], "rb") as playlist:
+            self.assertEqual(exp_playlist, playlist.read().decode("utf-8"))
 
     def test_basic(self, open_mock):
         self.run_and_assert(open_mock)
 
     def test_album_option(self, open_mock):
-        self.run_and_assert(open_mock, [u'-a', u'nice'])
+        self.run_and_assert(open_mock, [u"-a", u"nice"])
 
     def test_args_option(self, open_mock):
         self.run_and_assert(
-            open_mock, [u'-A', u'foo', u'title:aNiceTitle'], u'echo foo')
+            open_mock, [u"-A", u"foo", u"title:aNiceTitle"], u"echo foo"
+        )
 
     def test_args_option_in_middle(self, open_mock):
-        self.config['play']['command'] = 'echo $args other'
+        self.config["play"]["command"] = "echo $args other"
 
         self.run_and_assert(
-            open_mock, [u'-A', u'foo', u'title:aNiceTitle'], u'echo foo other')
+            open_mock, [u"-A", u"foo", u"title:aNiceTitle"], u"echo foo other"
+        )
 
     def test_unset_args_option_in_middle(self, open_mock):
-        self.config['play']['command'] = 'echo $args other'
+        self.config["play"]["command"] = "echo $args other"
 
-        self.run_and_assert(
-            open_mock, [u'title:aNiceTitle'], u'echo other')
+        self.run_and_assert(open_mock, [u"title:aNiceTitle"], u"echo other")
 
     def test_relative_to(self, open_mock):
-        self.config['play']['command'] = 'echo'
-        self.config['play']['relative_to'] = '/something'
+        self.config["play"]["command"] = "echo"
+        self.config["play"]["relative_to"] = "/something"
 
-        path = os.path.relpath(self.item.path, b'/something')
-        playlist = path.decode('utf-8')
+        path = os.path.relpath(self.item.path, b"/something")
+        playlist = path.decode("utf-8")
         self.run_and_assert(
-            open_mock, expected_cmd='echo', expected_playlist=playlist)
+            open_mock, expected_cmd="echo", expected_playlist=playlist
+        )
 
     def test_use_folders(self, open_mock):
-        self.config['play']['command'] = None
-        self.config['play']['use_folders'] = True
-        self.run_command('play', '-a', 'nice')
+        self.config["play"]["command"] = None
+        self.config["play"]["use_folders"] = True
+        self.run_command("play", "-a", "nice")
 
         open_mock.assert_called_once_with(ANY, open_anything())
-        with open(open_mock.call_args[0][0][0], 'rb') as f:
-            playlist = f.read().decode('utf-8')
-        self.assertEqual(u'{}\n'.format(
-            os.path.dirname(self.item.path.decode('utf-8'))),
-            playlist)
+        with open(open_mock.call_args[0][0][0], "rb") as f:
+            playlist = f.read().decode("utf-8")
+        self.assertEqual(
+            u"{}\n".format(os.path.dirname(self.item.path.decode("utf-8"))),
+            playlist,
+        )
 
     def test_raw(self, open_mock):
-        self.config['play']['raw'] = True
+        self.config["play"]["raw"] = True
 
-        self.run_command(u'play', u'nice')
+        self.run_command(u"play", u"nice")
 
-        open_mock.assert_called_once_with([self.item.path], 'echo')
+        open_mock.assert_called_once_with([self.item.path], "echo")
 
     def test_not_found(self, open_mock):
-        self.run_command(u'play', u'not found')
+        self.run_command(u"play", u"not found")
 
         open_mock.assert_not_called()
 
     def test_warning_threshold(self, open_mock):
-        self.config['play']['warning_threshold'] = 1
-        self.add_item(title='another NiceTitle')
+        self.config["play"]["warning_threshold"] = 1
+        self.add_item(title="another NiceTitle")
 
         with control_stdin("a"):
-            self.run_command(u'play', u'nice')
+            self.run_command(u"play", u"nice")
 
         open_mock.assert_not_called()
 
     def test_skip_warning_threshold_bypass(self, open_mock):
-        self.config['play']['warning_threshold'] = 1
-        self.other_item = self.add_item(title='another NiceTitle')
+        self.config["play"]["warning_threshold"] = 1
+        self.other_item = self.add_item(title="another NiceTitle")
 
-        expected_playlist = u'{0}\n{1}'.format(
-            self.item.path.decode('utf-8'),
-            self.other_item.path.decode('utf-8'))
+        expected_playlist = u"{0}\n{1}".format(
+            self.item.path.decode("utf-8"),
+            self.other_item.path.decode("utf-8"),
+        )
 
         with control_stdin("a"):
             self.run_and_assert(
                 open_mock,
-                [u'-y', u'NiceTitle'],
-                expected_playlist=expected_playlist)
+                [u"-y", u"NiceTitle"],
+                expected_playlist=expected_playlist,
+            )
 
     def test_command_failed(self, open_mock):
         open_mock.side_effect = OSError(u"some reason")
 
         with self.assertRaises(UserError):
-            self.run_command(u'play', u'title:aNiceTitle')
+            self.run_command(u"play", u"title:aNiceTitle")
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -38,22 +38,37 @@ import confuse
 # Mock GstPlayer so that the forked process doesn't attempt to import gi:
 import mock
 import imp
+
 gstplayer = imp.new_module("beetsplug.bpd.gstplayer")
+
+
 def _gstplayer_play(*_):  # noqa: 42
     bpd.gstplayer._GstPlayer.playing = True
     return mock.DEFAULT
+
+
 gstplayer._GstPlayer = mock.MagicMock(
     spec_set=[
-        "time", "volume", "playing", "run", "play_file", "pause", "stop",
-        "seek", "play", "get_decoders",
-    ], **{
-        'playing': False,
-        'volume': 0,
-        'time.return_value': (0, 0),
-        'play_file.side_effect': _gstplayer_play,
-        'play.side_effect': _gstplayer_play,
-        'get_decoders.return_value': {'default': ({'audio/mpeg'}, {'mp3'})},
-    })
+        "time",
+        "volume",
+        "playing",
+        "run",
+        "play_file",
+        "pause",
+        "stop",
+        "seek",
+        "play",
+        "get_decoders",
+    ],
+    **{
+        "playing": False,
+        "volume": 0,
+        "time.return_value": (0, 0),
+        "play_file.side_effect": _gstplayer_play,
+        "play.side_effect": _gstplayer_play,
+        "get_decoders.return_value": {"default": ({"audio/mpeg"}, {"mp3"})},
+    }
+)
 gstplayer.GstPlayer = lambda _: gstplayer._GstPlayer
 sys.modules["beetsplug.bpd.gstplayer"] = gstplayer
 bpd.gstplayer = gstplayer
@@ -61,34 +76,34 @@ bpd.gstplayer = gstplayer
 
 class CommandParseTest(unittest.TestCase):
     def test_no_args(self):
-        s = r'command'
+        s = r"command"
         c = bpd.Command(s)
-        self.assertEqual(c.name, u'command')
+        self.assertEqual(c.name, u"command")
         self.assertEqual(c.args, [])
 
     def test_one_unquoted_arg(self):
-        s = r'command hello'
+        s = r"command hello"
         c = bpd.Command(s)
-        self.assertEqual(c.name, u'command')
-        self.assertEqual(c.args, [u'hello'])
+        self.assertEqual(c.name, u"command")
+        self.assertEqual(c.args, [u"hello"])
 
     def test_two_unquoted_args(self):
-        s = r'command hello there'
+        s = r"command hello there"
         c = bpd.Command(s)
-        self.assertEqual(c.name, u'command')
-        self.assertEqual(c.args, [u'hello', u'there'])
+        self.assertEqual(c.name, u"command")
+        self.assertEqual(c.args, [u"hello", u"there"])
 
     def test_one_quoted_arg(self):
         s = r'command "hello there"'
         c = bpd.Command(s)
-        self.assertEqual(c.name, u'command')
-        self.assertEqual(c.args, [u'hello there'])
+        self.assertEqual(c.name, u"command")
+        self.assertEqual(c.args, [u"hello there"])
 
     def test_heterogenous_args(self):
         s = r'command "hello there" sir'
         c = bpd.Command(s)
-        self.assertEqual(c.name, u'command')
-        self.assertEqual(c.args, [u'hello there', u'sir'])
+        self.assertEqual(c.name, u"command")
+        self.assertEqual(c.args, [u"hello there", u"sir"])
 
     def test_quote_in_arg(self):
         s = r'command "hello \" there"'
@@ -98,28 +113,28 @@ class CommandParseTest(unittest.TestCase):
     def test_backslash_in_arg(self):
         s = r'command "hello \\ there"'
         c = bpd.Command(s)
-        self.assertEqual(c.args, [u'hello \\ there'])
+        self.assertEqual(c.args, [u"hello \\ there"])
 
 
 class MPCResponse(object):
     def __init__(self, raw_response):
-        body = b'\n'.join(raw_response.split(b'\n')[:-2]).decode('utf-8')
+        body = b"\n".join(raw_response.split(b"\n")[:-2]).decode("utf-8")
         self.data = self._parse_body(body)
-        status = raw_response.split(b'\n')[-2].decode('utf-8')
+        status = raw_response.split(b"\n")[-2].decode("utf-8")
         self.ok, self.err_data = self._parse_status(status)
 
     def _parse_status(self, status):
         """ Parses the first response line, which contains the status.
         """
-        if status.startswith('OK') or status.startswith('list_OK'):
+        if status.startswith("OK") or status.startswith("list_OK"):
             return True, None
-        elif status.startswith('ACK'):
-            code, rest = status[5:].split('@', 1)
-            pos, rest = rest.split(']', 1)
-            cmd, rest = rest[2:].split('}')
+        elif status.startswith("ACK"):
+            code, rest = status[5:].split("@", 1)
+            pos, rest = rest.split("]", 1)
+            cmd, rest = rest[2:].split("}")
             return False, (int(code), int(pos), cmd, rest[1:])
         else:
-            raise RuntimeError('Unexpected status: {!r}'.format(status))
+            raise RuntimeError("Unexpected status: {!r}".format(status))
 
     def _parse_body(self, body):
         """ Messages are generally in the format "header: content".
@@ -128,12 +143,12 @@ class MPCResponse(object):
         """
         data = {}
         repeated_headers = set()
-        for line in body.split('\n'):
+        for line in body.split("\n"):
             if not line:
                 continue
-            if ':' not in line:
-                raise RuntimeError('Unexpected line: {!r}'.format(line))
-            header, content = line.split(':', 1)
+            if ":" not in line:
+                raise RuntimeError("Unexpected line: {!r}".format(line))
+            header, content = line.split(":", 1)
             content = content.lstrip()
             if header in repeated_headers:
                 data[header].append(content)
@@ -148,11 +163,11 @@ class MPCResponse(object):
 class MPCClient(object):
     def __init__(self, sock, do_hello=True):
         self.sock = sock
-        self.buf = b''
+        self.buf = b""
         if do_hello:
             hello = self.get_response()
             if not hello.ok:
-                raise RuntimeError('Bad hello')
+                raise RuntimeError("Bad hello")
 
     def get_response(self, force_multi=None):
         """ Wait for a full server response and wrap it in a helper class.
@@ -160,34 +175,34 @@ class MPCClient(object):
         `MPCResponse`s, one for each processed subcommand.
         """
 
-        response = b''
+        response = b""
         responses = []
         while True:
             line = self.readline()
             response += line
-            if line.startswith(b'OK') or line.startswith(b'ACK'):
+            if line.startswith(b"OK") or line.startswith(b"ACK"):
                 if force_multi or any(responses):
-                    if line.startswith(b'ACK'):
+                    if line.startswith(b"ACK"):
                         responses.append(MPCResponse(response))
                         n_remaining = force_multi - len(responses)
                         responses.extend([None] * n_remaining)
                     return responses
                 else:
                     return MPCResponse(response)
-            if line.startswith(b'list_OK'):
+            if line.startswith(b"list_OK"):
                 responses.append(MPCResponse(response))
-                response = b''
+                response = b""
             elif not line:
-                raise RuntimeError('Unexpected response: {!r}'.format(line))
+                raise RuntimeError("Unexpected response: {!r}".format(line))
 
     def serialise_command(self, command, *args):
-        cmd = [command.encode('utf-8')]
-        for arg in [a.encode('utf-8') for a in args]:
-            if b' ' in arg:
+        cmd = [command.encode("utf-8")]
+        for arg in [a.encode("utf-8") for a in args]:
+            if b" " in arg:
                 cmd.append(b'"' + arg + b'"')
             else:
                 cmd.append(arg)
-        return b' '.join(cmd) + b'\n'
+        return b" ".join(cmd) + b"\n"
 
     def send_command(self, command, *args):
         request = self.serialise_command(command, *args)
@@ -205,13 +220,13 @@ class MPCClient(object):
             command = command_and_args[0]
             args = command_and_args[1:]
             requests.append(self.serialise_command(command, *args))
-        requests.insert(0, b'command_list_ok_begin\n')
-        requests.append(b'command_list_end\n')
-        request = b''.join(requests)
+        requests.insert(0, b"command_list_ok_begin\n")
+        requests.append(b"command_list_end\n")
+        request = b"".join(requests)
         self.sock.sendall(request)
         return self.get_response(force_multi=len(commands))
 
-    def readline(self, terminator=b'\n', bufsize=1024):
+    def readline(self, terminator=b"\n", bufsize=1024):
         """ Reads a line of data from the socket.
         """
 
@@ -226,17 +241,18 @@ class MPCClient(object):
                 self.buf += data
             else:
                 line = self.buf
-                self.buf = b''
+                self.buf = b""
                 return line
 
 
 def implements(commands, expectedFailure=False):  # noqa: N803
     def _test(self):
         with self.run_bpd() as client:
-            response = client.send_command('commands')
+            response = client.send_command("commands")
         self._assert_ok(response)
-        implemented = response.data['command']
+        implemented = response.data["command"]
         self.assertEqual(commands.intersection(implemented), commands)
+
     return unittest.expectedFailure(_test) if expectedFailure else _test
 
 
@@ -247,6 +263,7 @@ bluelet_listener = bluelet.Listener
 def start_server(args, assigned_port, listener_patch):
     """Start the bpd server, writing the port to `assigned_port`.
     """
+
     def listener_wrap(host, port):
         """Wrap `bluelet.Listener`, writing the port to `assigend_port`.
         """
@@ -257,22 +274,30 @@ def start_server(args, assigned_port, listener_patch):
         # read port assigned by OS
         assigned_port.put_nowait(listener.sock.getsockname()[1])
         return listener
+
     listener_patch.side_effect = listener_wrap
 
     import beets.ui
+
     beets.ui.main(args)
 
 
 class BPDTestHelper(unittest.TestCase, TestHelper):
     def setUp(self):
         self.setup_beets(disk=True)
-        self.load_plugins('bpd')
+        self.load_plugins("bpd")
         self.item1 = self.add_item(
-                title='Track One Title', track=1,
-                album='Album Title', artist='Artist Name')
+            title="Track One Title",
+            track=1,
+            album="Album Title",
+            artist="Artist Name",
+        )
         self.item2 = self.add_item(
-                title='Track Two Title', track=2,
-                album='Album Title', artist='Artist Name')
+            title="Track Two Title",
+            track=2,
+            album="Album Title",
+            artist="Artist Name",
+        )
         self.lib.add_album([self.item1, self.item2])
 
     def tearDown(self):
@@ -280,36 +305,54 @@ class BPDTestHelper(unittest.TestCase, TestHelper):
         self.unload_plugins()
 
     @contextmanager
-    def run_bpd(self, host='localhost', password=None, do_hello=True,
-                second_client=False):
+    def run_bpd(
+        self,
+        host="localhost",
+        password=None,
+        do_hello=True,
+        second_client=False,
+    ):
         """ Runs BPD in another process, configured with the same library
         database as we created in the setUp method. Exposes a client that is
         connected to the server, and kills the server at the end.
         """
         # Create a config file:
         config = {
-                'pluginpath': [py3_path(self.temp_dir)],
-                'plugins': 'bpd',
-                # use port 0 to let the OS choose a free port
-                'bpd': {'host': host, 'port': 0, 'control_port': 0},
+            "pluginpath": [py3_path(self.temp_dir)],
+            "plugins": "bpd",
+            # use port 0 to let the OS choose a free port
+            "bpd": {"host": host, "port": 0, "control_port": 0},
         }
         if password:
-            config['bpd']['password'] = password
+            config["bpd"]["password"] = password
         config_file = tempfile.NamedTemporaryFile(
-                mode='wb', dir=py3_path(self.temp_dir), suffix='.yaml',
-                delete=False)
+            mode="wb",
+            dir=py3_path(self.temp_dir),
+            suffix=".yaml",
+            delete=False,
+        )
         config_file.write(
-                yaml.dump(config, Dumper=confuse.Dumper, encoding='utf-8'))
+            yaml.dump(config, Dumper=confuse.Dumper, encoding="utf-8")
+        )
         config_file.close()
 
         # Fork and launch BPD in the new process:
         assigned_port = mp.Queue(2)  # 2 slots, `control_port` and `port`
-        server = mp.Process(target=start_server, args=([
-            '--library', self.config['library'].as_filename(),
-            '--directory', py3_path(self.libdir),
-            '--config', py3_path(config_file.name),
-            'bpd'
-        ], assigned_port))
+        server = mp.Process(
+            target=start_server,
+            args=(
+                [
+                    "--library",
+                    self.config["library"].as_filename(),
+                    "--directory",
+                    py3_path(self.libdir),
+                    "--config",
+                    py3_path(config_file.name),
+                    "bpd",
+                ],
+                assigned_port,
+            ),
+        )
         server.start()
 
         try:
@@ -342,8 +385,9 @@ class BPDTestHelper(unittest.TestCase, TestHelper):
     def _assert_ok(self, *responses):
         for response in responses:
             self.assertTrue(response is not None)
-            self.assertTrue(response.ok, 'Response failed: {}'.format(
-                response.err_data))
+            self.assertTrue(
+                response.ok, "Response failed: {}".format(response.err_data)
+            )
 
     def _assert_failed(self, response, code, pos=None):
         """ Check that a command failed with a specific error code. If this
@@ -362,14 +406,21 @@ class BPDTestHelper(unittest.TestCase, TestHelper):
     def _bpd_add(self, client, *items, **kwargs):
         """ Add the given item to the BPD playlist or queue.
         """
-        paths = ['/'.join([
-            item.artist, item.album,
-            py3_path(os.path.basename(item.path))]) for item in items]
-        playlist = kwargs.get('playlist')
+        paths = [
+            "/".join(
+                [
+                    item.artist,
+                    item.album,
+                    py3_path(os.path.basename(item.path)),
+                ]
+            )
+            for item in items
+        ]
+        playlist = kwargs.get("playlist")
         if playlist:
-            commands = [('playlistadd', playlist, path) for path in paths]
+            commands = [("playlistadd", playlist, path) for path in paths]
         else:
-            commands = [('add', path) for path in paths]
+            commands = [("add", path) for path in paths]
         responses = client.send_commands(*commands)
         self._assert_ok(*responses)
 
@@ -377,97 +428,112 @@ class BPDTestHelper(unittest.TestCase, TestHelper):
 class BPDTest(BPDTestHelper):
     def test_server_hello(self):
         with self.run_bpd(do_hello=False) as client:
-            self.assertEqual(client.readline(), b'OK MPD 0.16.0\n')
+            self.assertEqual(client.readline(), b"OK MPD 0.16.0\n")
 
     def test_unknown_cmd(self):
         with self.run_bpd() as client:
-            response = client.send_command('notacommand')
+            response = client.send_command("notacommand")
         self._assert_failed(response, bpd.ERROR_UNKNOWN)
 
     def test_unexpected_argument(self):
         with self.run_bpd() as client:
-            response = client.send_command('ping', 'extra argument')
+            response = client.send_command("ping", "extra argument")
         self._assert_failed(response, bpd.ERROR_ARG)
 
     def test_missing_argument(self):
         with self.run_bpd() as client:
-            response = client.send_command('add')
+            response = client.send_command("add")
         self._assert_failed(response, bpd.ERROR_ARG)
 
     def test_system_error(self):
         with self.run_bpd() as client:
-            response = client.send_command('crash_TypeError')
+            response = client.send_command("crash_TypeError")
         self._assert_failed(response, bpd.ERROR_SYSTEM)
 
     def test_empty_request(self):
         with self.run_bpd() as client:
-            response = client.send_command('')
+            response = client.send_command("")
         self._assert_failed(response, bpd.ERROR_UNKNOWN)
 
 
 class BPDQueryTest(BPDTestHelper):
-    test_implements_query = implements({
-        'clearerror',
-    })
+    test_implements_query = implements({"clearerror",})
 
     def test_cmd_currentsong(self):
         with self.run_bpd() as client:
             self._bpd_add(client, self.item1)
             responses = client.send_commands(
-                    ('play',),
-                    ('currentsong',),
-                    ('stop',),
-                    ('currentsong',))
+                ("play",), ("currentsong",), ("stop",), ("currentsong",)
+            )
         self._assert_ok(*responses)
-        self.assertEqual('1', responses[1].data['Id'])
-        self.assertNotIn('Id', responses[3].data)
+        self.assertEqual("1", responses[1].data["Id"])
+        self.assertNotIn("Id", responses[3].data)
 
     def test_cmd_currentsong_tagtypes(self):
         with self.run_bpd() as client:
             self._bpd_add(client, self.item1)
-            responses = client.send_commands(
-                    ('play',),
-                    ('currentsong',))
+            responses = client.send_commands(("play",), ("currentsong",))
         self._assert_ok(*responses)
         self.assertEqual(
-                BPDConnectionTest.TAGTYPES.union(BPDQueueTest.METADATA),
-                set(responses[1].data.keys()))
+            BPDConnectionTest.TAGTYPES.union(BPDQueueTest.METADATA),
+            set(responses[1].data.keys()),
+        )
 
     def test_cmd_status(self):
         with self.run_bpd() as client:
             self._bpd_add(client, self.item1, self.item2)
             responses = client.send_commands(
-                    ('status',),
-                    ('play',),
-                    ('status',))
+                ("status",), ("play",), ("status",)
+            )
         self._assert_ok(*responses)
         fields_not_playing = {
-            'repeat', 'random', 'single', 'consume', 'playlist',
-            'playlistlength', 'mixrampdb', 'state',
-            'volume'
+            "repeat",
+            "random",
+            "single",
+            "consume",
+            "playlist",
+            "playlistlength",
+            "mixrampdb",
+            "state",
+            "volume",
         }
         self.assertEqual(fields_not_playing, set(responses[0].data.keys()))
         fields_playing = fields_not_playing | {
-            'song', 'songid', 'time', 'elapsed', 'bitrate', 'duration',
-            'audio', 'nextsong', 'nextsongid'
+            "song",
+            "songid",
+            "time",
+            "elapsed",
+            "bitrate",
+            "duration",
+            "audio",
+            "nextsong",
+            "nextsongid",
         }
         self.assertEqual(fields_playing, set(responses[2].data.keys()))
 
     def test_cmd_stats(self):
         with self.run_bpd() as client:
-            response = client.send_command('stats')
+            response = client.send_command("stats")
         self._assert_ok(response)
-        details = {'artists', 'albums', 'songs', 'uptime', 'db_playtime',
-                   'db_update', 'playtime'}
+        details = {
+            "artists",
+            "albums",
+            "songs",
+            "uptime",
+            "db_playtime",
+            "db_update",
+            "playtime",
+        }
         self.assertEqual(details, set(response.data.keys()))
 
     def test_cmd_idle(self):
         def _toggle(c):
             for _ in range(3):
-                rs = c.send_commands(('play',), ('pause',))
+                rs = c.send_commands(("play",), ("pause",))
                 # time.sleep(0.05)  # uncomment if test is flaky
                 if any(not r.ok for r in rs):
-                    raise RuntimeError('Toggler failed')
+                    raise RuntimeError("Toggler failed")
+
         with self.run_bpd(second_client=True) as (client, client2):
             self._bpd_add(client, self.item1, self.item2)
             toggler = threading.Thread(target=_toggle, args=(client2,))
@@ -476,319 +542,342 @@ class BPDQueryTest(BPDTestHelper):
             # Since the client sockets have a 1s timeout set at worst this will
             # raise a socket.timeout and fail the test if the toggler thread
             # manages to finish before the idle command is sent here.
-            response = client.send_command('idle', 'player')
+            response = client.send_command("idle", "player")
             toggler.join()
         self._assert_ok(response)
 
     def test_cmd_idle_with_pending(self):
         with self.run_bpd(second_client=True) as (client, client2):
-            response1 = client.send_command('random', '1')
-            response2 = client2.send_command('idle')
+            response1 = client.send_command("random", "1")
+            response2 = client2.send_command("idle")
         self._assert_ok(response1, response2)
-        self.assertEqual('options', response2.data['changed'])
+        self.assertEqual("options", response2.data["changed"])
 
     def test_cmd_noidle(self):
         with self.run_bpd() as client:
             # Manually send a command without reading a response.
-            request = client.serialise_command('idle')
+            request = client.serialise_command("idle")
             client.sock.sendall(request)
             time.sleep(0.01)
-            response = client.send_command('noidle')
+            response = client.send_command("noidle")
         self._assert_ok(response)
 
     def test_cmd_noidle_when_not_idle(self):
         with self.run_bpd() as client:
             # Manually send a command without reading a response.
-            request = client.serialise_command('noidle')
+            request = client.serialise_command("noidle")
             client.sock.sendall(request)
-            response = client.send_command('notacommand')
+            response = client.send_command("notacommand")
         self._assert_failed(response, bpd.ERROR_UNKNOWN)
 
 
 class BPDPlaybackTest(BPDTestHelper):
-    test_implements_playback = implements({
-            'random',
-            })
+    test_implements_playback = implements({"random",})
 
     def test_cmd_consume(self):
         with self.run_bpd() as client:
             self._bpd_add(client, self.item1, self.item2)
             responses = client.send_commands(
-                    ('consume', '0'),
-                    ('playlistinfo',),
-                    ('next',),
-                    ('playlistinfo',),
-                    ('consume', '1'),
-                    ('playlistinfo',),
-                    ('play', '0'),
-                    ('next',),
-                    ('playlistinfo',),
-                    ('status',))
+                ("consume", "0"),
+                ("playlistinfo",),
+                ("next",),
+                ("playlistinfo",),
+                ("consume", "1"),
+                ("playlistinfo",),
+                ("play", "0"),
+                ("next",),
+                ("playlistinfo",),
+                ("status",),
+            )
         self._assert_ok(*responses)
-        self.assertEqual(responses[1].data['Id'], responses[3].data['Id'])
-        self.assertEqual(['1', '2'], responses[5].data['Id'])
-        self.assertEqual('2', responses[8].data['Id'])
-        self.assertEqual('1', responses[9].data['consume'])
-        self.assertEqual('play', responses[9].data['state'])
+        self.assertEqual(responses[1].data["Id"], responses[3].data["Id"])
+        self.assertEqual(["1", "2"], responses[5].data["Id"])
+        self.assertEqual("2", responses[8].data["Id"])
+        self.assertEqual("1", responses[9].data["consume"])
+        self.assertEqual("play", responses[9].data["state"])
 
     def test_cmd_consume_in_reverse(self):
         with self.run_bpd() as client:
             self._bpd_add(client, self.item1, self.item2)
             responses = client.send_commands(
-                    ('consume', '1'),
-                    ('play', '1'),
-                    ('playlistinfo',),
-                    ('previous',),
-                    ('playlistinfo',),
-                    ('status',))
+                ("consume", "1"),
+                ("play", "1"),
+                ("playlistinfo",),
+                ("previous",),
+                ("playlistinfo",),
+                ("status",),
+            )
         self._assert_ok(*responses)
-        self.assertEqual(['1', '2'], responses[2].data['Id'])
-        self.assertEqual('1', responses[4].data['Id'])
-        self.assertEqual('play', responses[5].data['state'])
+        self.assertEqual(["1", "2"], responses[2].data["Id"])
+        self.assertEqual("1", responses[4].data["Id"])
+        self.assertEqual("play", responses[5].data["state"])
 
     def test_cmd_single(self):
         with self.run_bpd() as client:
             self._bpd_add(client, self.item1, self.item2)
             responses = client.send_commands(
-                    ('status',),
-                    ('single', '1'),
-                    ('play',),
-                    ('status',),
-                    ('next',),
-                    ('status',))
+                ("status",),
+                ("single", "1"),
+                ("play",),
+                ("status",),
+                ("next",),
+                ("status",),
+            )
         self._assert_ok(*responses)
-        self.assertEqual('0', responses[0].data['single'])
-        self.assertEqual('1', responses[3].data['single'])
-        self.assertEqual('play', responses[3].data['state'])
-        self.assertEqual('stop', responses[5].data['state'])
+        self.assertEqual("0", responses[0].data["single"])
+        self.assertEqual("1", responses[3].data["single"])
+        self.assertEqual("play", responses[3].data["state"])
+        self.assertEqual("stop", responses[5].data["state"])
 
     def test_cmd_repeat(self):
         with self.run_bpd() as client:
             self._bpd_add(client, self.item1, self.item2)
             responses = client.send_commands(
-                    ('repeat', '1'),
-                    ('play',),
-                    ('currentsong',),
-                    ('next',),
-                    ('currentsong',),
-                    ('next',),
-                    ('currentsong',))
+                ("repeat", "1"),
+                ("play",),
+                ("currentsong",),
+                ("next",),
+                ("currentsong",),
+                ("next",),
+                ("currentsong",),
+            )
         self._assert_ok(*responses)
-        self.assertEqual('1', responses[2].data['Id'])
-        self.assertEqual('2', responses[4].data['Id'])
-        self.assertEqual('1', responses[6].data['Id'])
+        self.assertEqual("1", responses[2].data["Id"])
+        self.assertEqual("2", responses[4].data["Id"])
+        self.assertEqual("1", responses[6].data["Id"])
 
     def test_cmd_repeat_with_single(self):
         with self.run_bpd() as client:
             self._bpd_add(client, self.item1, self.item2)
             responses = client.send_commands(
-                    ('repeat', '1'),
-                    ('single', '1'),
-                    ('play',),
-                    ('currentsong',),
-                    ('next',),
-                    ('status',),
-                    ('currentsong',))
+                ("repeat", "1"),
+                ("single", "1"),
+                ("play",),
+                ("currentsong",),
+                ("next",),
+                ("status",),
+                ("currentsong",),
+            )
         self._assert_ok(*responses)
-        self.assertEqual('1', responses[3].data['Id'])
-        self.assertEqual('play', responses[5].data['state'])
-        self.assertEqual('1', responses[6].data['Id'])
+        self.assertEqual("1", responses[3].data["Id"])
+        self.assertEqual("play", responses[5].data["state"])
+        self.assertEqual("1", responses[6].data["Id"])
 
     def test_cmd_repeat_in_reverse(self):
         with self.run_bpd() as client:
             self._bpd_add(client, self.item1, self.item2)
             responses = client.send_commands(
-                    ('repeat', '1'),
-                    ('play',),
-                    ('currentsong',),
-                    ('previous',),
-                    ('currentsong',))
+                ("repeat", "1"),
+                ("play",),
+                ("currentsong",),
+                ("previous",),
+                ("currentsong",),
+            )
         self._assert_ok(*responses)
-        self.assertEqual('1', responses[2].data['Id'])
-        self.assertEqual('2', responses[4].data['Id'])
+        self.assertEqual("1", responses[2].data["Id"])
+        self.assertEqual("2", responses[4].data["Id"])
 
     def test_cmd_repeat_with_single_in_reverse(self):
         with self.run_bpd() as client:
             self._bpd_add(client, self.item1, self.item2)
             responses = client.send_commands(
-                    ('repeat', '1'),
-                    ('single', '1'),
-                    ('play',),
-                    ('currentsong',),
-                    ('previous',),
-                    ('status',),
-                    ('currentsong',))
+                ("repeat", "1"),
+                ("single", "1"),
+                ("play",),
+                ("currentsong",),
+                ("previous",),
+                ("status",),
+                ("currentsong",),
+            )
         self._assert_ok(*responses)
-        self.assertEqual('1', responses[3].data['Id'])
-        self.assertEqual('play', responses[5].data['state'])
-        self.assertEqual('1', responses[6].data['Id'])
+        self.assertEqual("1", responses[3].data["Id"])
+        self.assertEqual("play", responses[5].data["state"])
+        self.assertEqual("1", responses[6].data["Id"])
 
     def test_cmd_crossfade(self):
         with self.run_bpd() as client:
             responses = client.send_commands(
-                    ('status',),
-                    ('crossfade', '123'),
-                    ('status',),
-                    ('crossfade', '-2'))
-            response = client.send_command('crossfade', '0.5')
+                ("status",),
+                ("crossfade", "123"),
+                ("status",),
+                ("crossfade", "-2"),
+            )
+            response = client.send_command("crossfade", "0.5")
         self._assert_failed(responses, bpd.ERROR_ARG, pos=3)
         self._assert_failed(response, bpd.ERROR_ARG)
-        self.assertNotIn('xfade', responses[0].data)
-        self.assertAlmostEqual(123, int(responses[2].data['xfade']))
+        self.assertNotIn("xfade", responses[0].data)
+        self.assertAlmostEqual(123, int(responses[2].data["xfade"]))
 
     def test_cmd_mixrampdb(self):
         with self.run_bpd() as client:
-            responses = client.send_commands(
-                    ('mixrampdb', '-17'),
-                    ('status',))
+            responses = client.send_commands(("mixrampdb", "-17"), ("status",))
         self._assert_ok(*responses)
-        self.assertAlmostEqual(-17, float(responses[1].data['mixrampdb']))
+        self.assertAlmostEqual(-17, float(responses[1].data["mixrampdb"]))
 
     def test_cmd_mixrampdelay(self):
         with self.run_bpd() as client:
             responses = client.send_commands(
-                    ('mixrampdelay', '2'),
-                    ('status',),
-                    ('mixrampdelay', 'nan'),
-                    ('status',),
-                    ('mixrampdelay', '-2'))
+                ("mixrampdelay", "2"),
+                ("status",),
+                ("mixrampdelay", "nan"),
+                ("status",),
+                ("mixrampdelay", "-2"),
+            )
         self._assert_failed(responses, bpd.ERROR_ARG, pos=4)
-        self.assertAlmostEqual(2, float(responses[1].data['mixrampdelay']))
-        self.assertNotIn('mixrampdelay', responses[3].data)
+        self.assertAlmostEqual(2, float(responses[1].data["mixrampdelay"]))
+        self.assertNotIn("mixrampdelay", responses[3].data)
 
     def test_cmd_setvol(self):
         with self.run_bpd() as client:
             responses = client.send_commands(
-                    ('setvol', '67'),
-                    ('status',),
-                    ('setvol', '32'),
-                    ('status',),
-                    ('setvol', '101'))
+                ("setvol", "67"),
+                ("status",),
+                ("setvol", "32"),
+                ("status",),
+                ("setvol", "101"),
+            )
         self._assert_failed(responses, bpd.ERROR_ARG, pos=4)
-        self.assertEqual('67', responses[1].data['volume'])
-        self.assertEqual('32', responses[3].data['volume'])
+        self.assertEqual("67", responses[1].data["volume"])
+        self.assertEqual("32", responses[3].data["volume"])
 
     def test_cmd_volume(self):
         with self.run_bpd() as client:
             responses = client.send_commands(
-                    ('setvol', '10'),
-                    ('volume', '5'),
-                    ('volume', '-2'),
-                    ('status',))
+                ("setvol", "10"),
+                ("volume", "5"),
+                ("volume", "-2"),
+                ("status",),
+            )
         self._assert_ok(*responses)
-        self.assertEqual('13', responses[3].data['volume'])
+        self.assertEqual("13", responses[3].data["volume"])
 
     def test_cmd_replay_gain(self):
         with self.run_bpd() as client:
             responses = client.send_commands(
-                    ('replay_gain_mode', 'track'),
-                    ('replay_gain_status',),
-                    ('replay_gain_mode', 'notanoption'))
+                ("replay_gain_mode", "track"),
+                ("replay_gain_status",),
+                ("replay_gain_mode", "notanoption"),
+            )
         self._assert_failed(responses, bpd.ERROR_ARG, pos=2)
-        self.assertAlmostEqual('track', responses[1].data['replay_gain_mode'])
+        self.assertAlmostEqual("track", responses[1].data["replay_gain_mode"])
 
 
 class BPDControlTest(BPDTestHelper):
-    test_implements_control = implements({
-        'seek', 'seekid', 'seekcur',
-    }, expectedFailure=True)
+    test_implements_control = implements(
+        {"seek", "seekid", "seekcur",}, expectedFailure=True
+    )
 
     def test_cmd_play(self):
         with self.run_bpd() as client:
             self._bpd_add(client, self.item1, self.item2)
             responses = client.send_commands(
-                    ('status',),
-                    ('play',),
-                    ('status',),
-                    ('play', '1'),
-                    ('currentsong',))
+                ("status",),
+                ("play",),
+                ("status",),
+                ("play", "1"),
+                ("currentsong",),
+            )
         self._assert_ok(*responses)
-        self.assertEqual('stop', responses[0].data['state'])
-        self.assertEqual('play', responses[2].data['state'])
-        self.assertEqual('2', responses[4].data['Id'])
+        self.assertEqual("stop", responses[0].data["state"])
+        self.assertEqual("play", responses[2].data["state"])
+        self.assertEqual("2", responses[4].data["Id"])
 
     def test_cmd_playid(self):
         with self.run_bpd() as client:
             self._bpd_add(client, self.item1, self.item2)
             responses = client.send_commands(
-                    ('playid', '2'),
-                    ('currentsong',),
-                    ('clear',))
+                ("playid", "2"), ("currentsong",), ("clear",)
+            )
             self._bpd_add(client, self.item2, self.item1)
-            responses.extend(client.send_commands(
-                    ('playid', '2'),
-                    ('currentsong',)))
+            responses.extend(
+                client.send_commands(("playid", "2"), ("currentsong",))
+            )
         self._assert_ok(*responses)
-        self.assertEqual('2', responses[1].data['Id'])
-        self.assertEqual('2', responses[4].data['Id'])
+        self.assertEqual("2", responses[1].data["Id"])
+        self.assertEqual("2", responses[4].data["Id"])
 
     def test_cmd_pause(self):
         with self.run_bpd() as client:
             self._bpd_add(client, self.item1)
             responses = client.send_commands(
-                    ('play',),
-                    ('pause',),
-                    ('status',),
-                    ('currentsong',))
+                ("play",), ("pause",), ("status",), ("currentsong",)
+            )
         self._assert_ok(*responses)
-        self.assertEqual('pause', responses[2].data['state'])
-        self.assertEqual('1', responses[3].data['Id'])
+        self.assertEqual("pause", responses[2].data["state"])
+        self.assertEqual("1", responses[3].data["Id"])
 
     def test_cmd_stop(self):
         with self.run_bpd() as client:
             self._bpd_add(client, self.item1)
             responses = client.send_commands(
-                    ('play',),
-                    ('stop',),
-                    ('status',),
-                    ('currentsong',))
+                ("play",), ("stop",), ("status",), ("currentsong",)
+            )
         self._assert_ok(*responses)
-        self.assertEqual('stop', responses[2].data['state'])
-        self.assertNotIn('Id', responses[3].data)
+        self.assertEqual("stop", responses[2].data["state"])
+        self.assertNotIn("Id", responses[3].data)
 
     def test_cmd_next(self):
         with self.run_bpd() as client:
             self._bpd_add(client, self.item1, self.item2)
             responses = client.send_commands(
-                    ('play',),
-                    ('currentsong',),
-                    ('next',),
-                    ('currentsong',),
-                    ('next',),
-                    ('status',))
+                ("play",),
+                ("currentsong",),
+                ("next",),
+                ("currentsong",),
+                ("next",),
+                ("status",),
+            )
         self._assert_ok(*responses)
-        self.assertEqual('1', responses[1].data['Id'])
-        self.assertEqual('2', responses[3].data['Id'])
-        self.assertEqual('stop', responses[5].data['state'])
+        self.assertEqual("1", responses[1].data["Id"])
+        self.assertEqual("2", responses[3].data["Id"])
+        self.assertEqual("stop", responses[5].data["state"])
 
     def test_cmd_previous(self):
         with self.run_bpd() as client:
             self._bpd_add(client, self.item1, self.item2)
             responses = client.send_commands(
-                    ('play', '1'),
-                    ('currentsong',),
-                    ('previous',),
-                    ('currentsong',),
-                    ('previous',),
-                    ('status',),
-                    ('currentsong',))
+                ("play", "1"),
+                ("currentsong",),
+                ("previous",),
+                ("currentsong",),
+                ("previous",),
+                ("status",),
+                ("currentsong",),
+            )
         self._assert_ok(*responses)
-        self.assertEqual('2', responses[1].data['Id'])
-        self.assertEqual('1', responses[3].data['Id'])
-        self.assertEqual('play', responses[5].data['state'])
-        self.assertEqual('1', responses[6].data['Id'])
+        self.assertEqual("2", responses[1].data["Id"])
+        self.assertEqual("1", responses[3].data["Id"])
+        self.assertEqual("play", responses[5].data["state"])
+        self.assertEqual("1", responses[6].data["Id"])
 
 
 class BPDQueueTest(BPDTestHelper):
-    test_implements_queue = implements({
-            'addid', 'clear', 'delete', 'deleteid', 'move',
-            'moveid', 'playlist', 'playlistfind',
-            'playlistsearch', 'plchanges',
-            'plchangesposid', 'prio', 'prioid', 'rangeid', 'shuffle',
-            'swap', 'swapid', 'addtagid', 'cleartagid',
-            }, expectedFailure=True)
+    test_implements_queue = implements(
+        {
+            "addid",
+            "clear",
+            "delete",
+            "deleteid",
+            "move",
+            "moveid",
+            "playlist",
+            "playlistfind",
+            "playlistsearch",
+            "plchanges",
+            "plchangesposid",
+            "prio",
+            "prioid",
+            "rangeid",
+            "shuffle",
+            "swap",
+            "swapid",
+            "addtagid",
+            "cleartagid",
+        },
+        expectedFailure=True,
+    )
 
-    METADATA = {'Pos', 'Time', 'Id', 'file', 'duration'}
+    METADATA = {"Pos", "Time", "Id", "file", "duration"}
 
     def test_cmd_add(self):
         with self.run_bpd() as client:
@@ -798,248 +887,287 @@ class BPDQueueTest(BPDTestHelper):
         with self.run_bpd() as client:
             self._bpd_add(client, self.item1, self.item2)
             responses = client.send_commands(
-                    ('playlistinfo',),
-                    ('playlistinfo', '0'),
-                    ('playlistinfo', '0:2'),
-                    ('playlistinfo', '200'))
+                ("playlistinfo",),
+                ("playlistinfo", "0"),
+                ("playlistinfo", "0:2"),
+                ("playlistinfo", "200"),
+            )
         self._assert_failed(responses, bpd.ERROR_ARG, pos=3)
-        self.assertEqual('1', responses[1].data['Id'])
-        self.assertEqual(['1', '2'], responses[2].data['Id'])
+        self.assertEqual("1", responses[1].data["Id"])
+        self.assertEqual(["1", "2"], responses[2].data["Id"])
 
     def test_cmd_playlistinfo_tagtypes(self):
         with self.run_bpd() as client:
             self._bpd_add(client, self.item1)
-            response = client.send_command('playlistinfo', '0')
+            response = client.send_command("playlistinfo", "0")
         self._assert_ok(response)
         self.assertEqual(
-                BPDConnectionTest.TAGTYPES.union(BPDQueueTest.METADATA),
-                set(response.data.keys()))
+            BPDConnectionTest.TAGTYPES.union(BPDQueueTest.METADATA),
+            set(response.data.keys()),
+        )
 
     def test_cmd_playlistid(self):
         with self.run_bpd() as client:
             self._bpd_add(client, self.item1, self.item2)
             responses = client.send_commands(
-                    ('playlistid', '2'),
-                    ('playlistid',))
+                ("playlistid", "2"), ("playlistid",)
+            )
         self._assert_ok(*responses)
-        self.assertEqual('Track Two Title', responses[0].data['Title'])
-        self.assertEqual(['1', '2'], responses[1].data['Track'])
+        self.assertEqual("Track Two Title", responses[0].data["Title"])
+        self.assertEqual(["1", "2"], responses[1].data["Track"])
 
 
 class BPDPlaylistsTest(BPDTestHelper):
-    test_implements_playlists = implements({'playlistadd'})
+    test_implements_playlists = implements({"playlistadd"})
 
     def test_cmd_listplaylist(self):
         with self.run_bpd() as client:
-            response = client.send_command('listplaylist', 'anything')
+            response = client.send_command("listplaylist", "anything")
         self._assert_failed(response, bpd.ERROR_NO_EXIST)
 
     def test_cmd_listplaylistinfo(self):
         with self.run_bpd() as client:
-            response = client.send_command('listplaylistinfo', 'anything')
+            response = client.send_command("listplaylistinfo", "anything")
         self._assert_failed(response, bpd.ERROR_NO_EXIST)
 
     def test_cmd_listplaylists(self):
         with self.run_bpd() as client:
-            response = client.send_command('listplaylists')
+            response = client.send_command("listplaylists")
         self._assert_failed(response, bpd.ERROR_UNKNOWN)
 
     def test_cmd_load(self):
         with self.run_bpd() as client:
-            response = client.send_command('load', 'anything')
+            response = client.send_command("load", "anything")
         self._assert_failed(response, bpd.ERROR_NO_EXIST)
 
     @unittest.skip
     def test_cmd_playlistadd(self):
         with self.run_bpd() as client:
-            self._bpd_add(client, self.item1, playlist='anything')
+            self._bpd_add(client, self.item1, playlist="anything")
 
     def test_cmd_playlistclear(self):
         with self.run_bpd() as client:
-            response = client.send_command('playlistclear', 'anything')
+            response = client.send_command("playlistclear", "anything")
         self._assert_failed(response, bpd.ERROR_UNKNOWN)
 
     def test_cmd_playlistdelete(self):
         with self.run_bpd() as client:
-            response = client.send_command('playlistdelete', 'anything', '0')
+            response = client.send_command("playlistdelete", "anything", "0")
         self._assert_failed(response, bpd.ERROR_UNKNOWN)
 
     def test_cmd_playlistmove(self):
         with self.run_bpd() as client:
             response = client.send_command(
-                    'playlistmove', 'anything', '0', '1')
+                "playlistmove", "anything", "0", "1"
+            )
         self._assert_failed(response, bpd.ERROR_UNKNOWN)
 
     def test_cmd_rename(self):
         with self.run_bpd() as client:
-            response = client.send_command('rename', 'anything', 'newname')
+            response = client.send_command("rename", "anything", "newname")
         self._assert_failed(response, bpd.ERROR_UNKNOWN)
 
     def test_cmd_rm(self):
         with self.run_bpd() as client:
-            response = client.send_command('rm', 'anything')
+            response = client.send_command("rm", "anything")
         self._assert_failed(response, bpd.ERROR_UNKNOWN)
 
     def test_cmd_save(self):
         with self.run_bpd() as client:
             self._bpd_add(client, self.item1)
-            response = client.send_command('save', 'newplaylist')
+            response = client.send_command("save", "newplaylist")
         self._assert_failed(response, bpd.ERROR_UNKNOWN)
 
 
 class BPDDatabaseTest(BPDTestHelper):
-    test_implements_database = implements({
-            'albumart', 'find', 'findadd', 'listall',
-            'listallinfo', 'listfiles', 'readcomments',
-            'searchadd', 'searchaddpl', 'update', 'rescan',
-            }, expectedFailure=True)
+    test_implements_database = implements(
+        {
+            "albumart",
+            "find",
+            "findadd",
+            "listall",
+            "listallinfo",
+            "listfiles",
+            "readcomments",
+            "searchadd",
+            "searchaddpl",
+            "update",
+            "rescan",
+        },
+        expectedFailure=True,
+    )
 
     def test_cmd_search(self):
         with self.run_bpd() as client:
-            response = client.send_command('search', 'track', '1')
+            response = client.send_command("search", "track", "1")
         self._assert_ok(response)
-        self.assertEqual(self.item1.title, response.data['Title'])
+        self.assertEqual(self.item1.title, response.data["Title"])
 
     def test_cmd_list(self):
         with self.run_bpd() as client:
             responses = client.send_commands(
-                    ('list', 'album'),
-                    ('list', 'track'),
-                    ('list', 'album', 'artist', 'Artist Name', 'track'))
+                ("list", "album"),
+                ("list", "track"),
+                ("list", "album", "artist", "Artist Name", "track"),
+            )
         self._assert_failed(responses, bpd.ERROR_ARG, pos=2)
-        self.assertEqual('Album Title', responses[0].data['Album'])
-        self.assertEqual(['1', '2'], responses[1].data['Track'])
+        self.assertEqual("Album Title", responses[0].data["Album"])
+        self.assertEqual(["1", "2"], responses[1].data["Track"])
 
     def test_cmd_list_three_arg_form(self):
         with self.run_bpd() as client:
             responses = client.send_commands(
-                    ('list', 'album', 'artist', 'Artist Name'),
-                    ('list', 'album', 'Artist Name'),
-                    ('list', 'track', 'Artist Name'))
+                ("list", "album", "artist", "Artist Name"),
+                ("list", "album", "Artist Name"),
+                ("list", "track", "Artist Name"),
+            )
         self._assert_failed(responses, bpd.ERROR_ARG, pos=2)
         self.assertEqual(responses[0].data, responses[1].data)
 
     def test_cmd_lsinfo(self):
         with self.run_bpd() as client:
-            response1 = client.send_command('lsinfo')
+            response1 = client.send_command("lsinfo")
             self._assert_ok(response1)
             response2 = client.send_command(
-                    'lsinfo', response1.data['directory'])
+                "lsinfo", response1.data["directory"]
+            )
             self._assert_ok(response2)
             response3 = client.send_command(
-                    'lsinfo', response2.data['directory'])
+                "lsinfo", response2.data["directory"]
+            )
             self._assert_ok(response3)
-        self.assertIn(self.item1.title, response3.data['Title'])
+        self.assertIn(self.item1.title, response3.data["Title"])
 
     def test_cmd_count(self):
         with self.run_bpd() as client:
-            response = client.send_command('count', 'track', '1')
+            response = client.send_command("count", "track", "1")
         self._assert_ok(response)
-        self.assertEqual('1', response.data['songs'])
-        self.assertEqual('0', response.data['playtime'])
+        self.assertEqual("1", response.data["songs"])
+        self.assertEqual("0", response.data["playtime"])
 
 
 class BPDMountsTest(BPDTestHelper):
-    test_implements_mounts = implements({
-            'mount', 'unmount', 'listmounts', 'listneighbors',
-            }, expectedFailure=True)
+    test_implements_mounts = implements(
+        {"mount", "unmount", "listmounts", "listneighbors",},
+        expectedFailure=True,
+    )
 
 
 class BPDStickerTest(BPDTestHelper):
-    test_implements_stickers = implements({
-            'sticker',
-            }, expectedFailure=True)
+    test_implements_stickers = implements({"sticker",}, expectedFailure=True)
 
 
 class BPDConnectionTest(BPDTestHelper):
-    test_implements_connection = implements({
-        'close', 'kill',
-    })
+    test_implements_connection = implements({"close", "kill",})
 
     ALL_MPD_TAGTYPES = {
-        'Artist', 'ArtistSort', 'Album', 'AlbumSort', 'AlbumArtist',
-        'AlbumArtistSort', 'Title', 'Track', 'Name', 'Genre', 'Date',
-        'Composer', 'Performer', 'Comment', 'Disc', 'Label',
-        'OriginalDate', 'MUSICBRAINZ_ARTISTID', 'MUSICBRAINZ_ALBUMID',
-        'MUSICBRAINZ_ALBUMARTISTID', 'MUSICBRAINZ_TRACKID',
-        'MUSICBRAINZ_RELEASETRACKID', 'MUSICBRAINZ_WORKID',
+        "Artist",
+        "ArtistSort",
+        "Album",
+        "AlbumSort",
+        "AlbumArtist",
+        "AlbumArtistSort",
+        "Title",
+        "Track",
+        "Name",
+        "Genre",
+        "Date",
+        "Composer",
+        "Performer",
+        "Comment",
+        "Disc",
+        "Label",
+        "OriginalDate",
+        "MUSICBRAINZ_ARTISTID",
+        "MUSICBRAINZ_ALBUMID",
+        "MUSICBRAINZ_ALBUMARTISTID",
+        "MUSICBRAINZ_TRACKID",
+        "MUSICBRAINZ_RELEASETRACKID",
+        "MUSICBRAINZ_WORKID",
     }
     UNSUPPORTED_TAGTYPES = {
-        'MUSICBRAINZ_WORKID',  # not tracked by beets
-        'Performer',           # not tracked by beets
-        'AlbumSort',           # not tracked by beets
-        'Name',                # junk field for internet radio
+        "MUSICBRAINZ_WORKID",  # not tracked by beets
+        "Performer",  # not tracked by beets
+        "AlbumSort",  # not tracked by beets
+        "Name",  # junk field for internet radio
     }
     TAGTYPES = ALL_MPD_TAGTYPES.difference(UNSUPPORTED_TAGTYPES)
 
     def test_cmd_password(self):
-        with self.run_bpd(password='abc123') as client:
-            response = client.send_command('status')
+        with self.run_bpd(password="abc123") as client:
+            response = client.send_command("status")
             self._assert_failed(response, bpd.ERROR_PERMISSION)
 
-            response = client.send_command('password', 'wrong')
+            response = client.send_command("password", "wrong")
             self._assert_failed(response, bpd.ERROR_PASSWORD)
 
             responses = client.send_commands(
-                    ('password', 'abc123'),
-                    ('status',))
+                ("password", "abc123"), ("status",)
+            )
         self._assert_ok(*responses)
 
     def test_cmd_ping(self):
         with self.run_bpd() as client:
-            response = client.send_command('ping')
+            response = client.send_command("ping")
         self._assert_ok(response)
 
     def test_cmd_tagtypes(self):
         with self.run_bpd() as client:
-            response = client.send_command('tagtypes')
+            response = client.send_command("tagtypes")
         self._assert_ok(response)
-        self.assertEqual(
-                self.TAGTYPES,
-                set(response.data['tagtype']))
+        self.assertEqual(self.TAGTYPES, set(response.data["tagtype"]))
 
     @unittest.skip
     def test_tagtypes_mask(self):
         with self.run_bpd() as client:
-            response = client.send_command('tagtypes', 'clear')
+            response = client.send_command("tagtypes", "clear")
         self._assert_ok(response)
 
 
 class BPDPartitionTest(BPDTestHelper):
-    test_implements_partitions = implements({
-            'partition', 'listpartitions', 'newpartition',
-            }, expectedFailure=True)
+    test_implements_partitions = implements(
+        {"partition", "listpartitions", "newpartition",}, expectedFailure=True
+    )
 
 
 class BPDDeviceTest(BPDTestHelper):
-    test_implements_devices = implements({
-            'disableoutput', 'enableoutput', 'toggleoutput', 'outputs',
-            }, expectedFailure=True)
+    test_implements_devices = implements(
+        {"disableoutput", "enableoutput", "toggleoutput", "outputs",},
+        expectedFailure=True,
+    )
 
 
 class BPDReflectionTest(BPDTestHelper):
-    test_implements_reflection = implements({
-        'config', 'commands', 'notcommands', 'urlhandlers',
-    }, expectedFailure=True)
+    test_implements_reflection = implements(
+        {"config", "commands", "notcommands", "urlhandlers",},
+        expectedFailure=True,
+    )
 
     def test_cmd_decoders(self):
         with self.run_bpd() as client:
-            response = client.send_command('decoders')
+            response = client.send_command("decoders")
         self._assert_ok(response)
-        self.assertEqual('default', response.data['plugin'])
-        self.assertEqual('mp3', response.data['suffix'])
-        self.assertEqual('audio/mpeg', response.data['mime_type'])
+        self.assertEqual("default", response.data["plugin"])
+        self.assertEqual("mp3", response.data["suffix"])
+        self.assertEqual("audio/mpeg", response.data["mime_type"])
 
 
 class BPDPeersTest(BPDTestHelper):
-    test_implements_peers = implements({
-            'subscribe', 'unsubscribe', 'channels', 'readmessages',
-            'sendmessage',
-            }, expectedFailure=True)
+    test_implements_peers = implements(
+        {
+            "subscribe",
+            "unsubscribe",
+            "channels",
+            "readmessages",
+            "sendmessage",
+        },
+        expectedFailure=True,
+    )
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_playlist.py
+++ b/test/test_playlist.py
@@ -30,46 +30,43 @@ import beets
 class PlaylistTestHelper(helper.TestHelper):
     def setUp(self):
         self.setup_beets()
-        self.lib = beets.library.Library(':memory:')
+        self.lib = beets.library.Library(":memory:")
 
-        self.music_dir = os.path.expanduser(os.path.join('~', 'Music'))
+        self.music_dir = os.path.expanduser(os.path.join("~", "Music"))
 
         i1 = _common.item()
-        i1.path = beets.util.normpath(os.path.join(
-            self.music_dir,
-            'a', 'b', 'c.mp3',
-        ))
-        i1.title = u'some item'
-        i1.album = u'some album'
+        i1.path = beets.util.normpath(
+            os.path.join(self.music_dir, "a", "b", "c.mp3",)
+        )
+        i1.title = u"some item"
+        i1.album = u"some album"
         self.lib.add(i1)
         self.lib.add_album([i1])
 
         i2 = _common.item()
-        i2.path = beets.util.normpath(os.path.join(
-            self.music_dir,
-            'd', 'e', 'f.mp3',
-        ))
-        i2.title = 'another item'
-        i2.album = 'another album'
+        i2.path = beets.util.normpath(
+            os.path.join(self.music_dir, "d", "e", "f.mp3",)
+        )
+        i2.title = "another item"
+        i2.album = "another album"
         self.lib.add(i2)
         self.lib.add_album([i2])
 
         i3 = _common.item()
-        i3.path = beets.util.normpath(os.path.join(
-            self.music_dir,
-            'x', 'y', 'z.mp3',
-        ))
-        i3.title = 'yet another item'
-        i3.album = 'yet another album'
+        i3.path = beets.util.normpath(
+            os.path.join(self.music_dir, "x", "y", "z.mp3",)
+        )
+        i3.title = "yet another item"
+        i3.album = "yet another album"
         self.lib.add(i3)
         self.lib.add_album([i3])
 
         self.playlist_dir = tempfile.mkdtemp()
-        self.config['directory'] = self.music_dir
-        self.config['playlist']['playlist_dir'] = self.playlist_dir
+        self.config["directory"] = self.music_dir
+        self.config["playlist"]["playlist_dir"] = self.playlist_dir
 
         self.setup_test()
-        self.load_plugins('playlist')
+        self.load_plugins("playlist")
 
     def setup_test(self):
         raise NotImplementedError
@@ -82,227 +79,280 @@ class PlaylistTestHelper(helper.TestHelper):
 
 class PlaylistQueryTestHelper(PlaylistTestHelper):
     def test_name_query_with_absolute_paths_in_playlist(self):
-        q = u'playlist:absolute'
+        q = u"playlist:absolute"
         results = self.lib.items(q)
-        self.assertEqual(set([i.title for i in results]), set([
-            u'some item',
-            u'another item',
-        ]))
+        self.assertEqual(
+            set([i.title for i in results]),
+            set([u"some item", u"another item",]),
+        )
 
     def test_path_query_with_absolute_paths_in_playlist(self):
-        q = u'playlist:{0}'.format(shlex_quote(os.path.join(
-            self.playlist_dir,
-            'absolute.m3u',
-        )))
+        q = u"playlist:{0}".format(
+            shlex_quote(os.path.join(self.playlist_dir, "absolute.m3u",))
+        )
         results = self.lib.items(q)
-        self.assertEqual(set([i.title for i in results]), set([
-            u'some item',
-            u'another item',
-        ]))
+        self.assertEqual(
+            set([i.title for i in results]),
+            set([u"some item", u"another item",]),
+        )
 
     def test_name_query_with_relative_paths_in_playlist(self):
-        q = u'playlist:relative'
+        q = u"playlist:relative"
         results = self.lib.items(q)
-        self.assertEqual(set([i.title for i in results]), set([
-            u'some item',
-            u'another item',
-        ]))
+        self.assertEqual(
+            set([i.title for i in results]),
+            set([u"some item", u"another item",]),
+        )
 
     def test_path_query_with_relative_paths_in_playlist(self):
-        q = u'playlist:{0}'.format(shlex_quote(os.path.join(
-            self.playlist_dir,
-            'relative.m3u',
-        )))
+        q = u"playlist:{0}".format(
+            shlex_quote(os.path.join(self.playlist_dir, "relative.m3u",))
+        )
         results = self.lib.items(q)
-        self.assertEqual(set([i.title for i in results]), set([
-            u'some item',
-            u'another item',
-        ]))
+        self.assertEqual(
+            set([i.title for i in results]),
+            set([u"some item", u"another item",]),
+        )
 
     def test_name_query_with_nonexisting_playlist(self):
-        q = u'playlist:nonexisting'
+        q = u"playlist:nonexisting"
         results = self.lib.items(q)
         self.assertEqual(set(results), set())
 
     def test_path_query_with_nonexisting_playlist(self):
-        q = u'playlist:{0}'.format(shlex_quote(os.path.join(
-            self.playlist_dir,
-            self.playlist_dir,
-            'nonexisting.m3u',
-        )))
+        q = u"playlist:{0}".format(
+            shlex_quote(
+                os.path.join(
+                    self.playlist_dir, self.playlist_dir, "nonexisting.m3u",
+                )
+            )
+        )
         results = self.lib.items(q)
         self.assertEqual(set(results), set())
 
 
 class PlaylistTestRelativeToLib(PlaylistQueryTestHelper, unittest.TestCase):
     def setup_test(self):
-        with open(os.path.join(self.playlist_dir, 'absolute.m3u'), 'w') as f:
-            f.write('{0}\n'.format(os.path.join(
-                self.music_dir, 'a', 'b', 'c.mp3')))
-            f.write('{0}\n'.format(os.path.join(
-                self.music_dir, 'd', 'e', 'f.mp3')))
-            f.write('{0}\n'.format(os.path.join(
-                self.music_dir, 'nonexisting.mp3')))
+        with open(os.path.join(self.playlist_dir, "absolute.m3u"), "w") as f:
+            f.write(
+                "{0}\n".format(os.path.join(self.music_dir, "a", "b", "c.mp3"))
+            )
+            f.write(
+                "{0}\n".format(os.path.join(self.music_dir, "d", "e", "f.mp3"))
+            )
+            f.write(
+                "{0}\n".format(os.path.join(self.music_dir, "nonexisting.mp3"))
+            )
 
-        with open(os.path.join(self.playlist_dir, 'relative.m3u'), 'w') as f:
-            f.write('{0}\n'.format(os.path.join('a', 'b', 'c.mp3')))
-            f.write('{0}\n'.format(os.path.join('d', 'e', 'f.mp3')))
-            f.write('{0}\n'.format('nonexisting.mp3'))
+        with open(os.path.join(self.playlist_dir, "relative.m3u"), "w") as f:
+            f.write("{0}\n".format(os.path.join("a", "b", "c.mp3")))
+            f.write("{0}\n".format(os.path.join("d", "e", "f.mp3")))
+            f.write("{0}\n".format("nonexisting.mp3"))
 
-        self.config['playlist']['relative_to'] = 'library'
+        self.config["playlist"]["relative_to"] = "library"
 
 
 class PlaylistTestRelativeToDir(PlaylistQueryTestHelper, unittest.TestCase):
     def setup_test(self):
-        with open(os.path.join(self.playlist_dir, 'absolute.m3u'), 'w') as f:
-            f.write('{0}\n'.format(os.path.join(
-                self.music_dir, 'a', 'b', 'c.mp3')))
-            f.write('{0}\n'.format(os.path.join(
-                self.music_dir, 'd', 'e', 'f.mp3')))
-            f.write('{0}\n'.format(os.path.join(
-                self.music_dir, 'nonexisting.mp3')))
+        with open(os.path.join(self.playlist_dir, "absolute.m3u"), "w") as f:
+            f.write(
+                "{0}\n".format(os.path.join(self.music_dir, "a", "b", "c.mp3"))
+            )
+            f.write(
+                "{0}\n".format(os.path.join(self.music_dir, "d", "e", "f.mp3"))
+            )
+            f.write(
+                "{0}\n".format(os.path.join(self.music_dir, "nonexisting.mp3"))
+            )
 
-        with open(os.path.join(self.playlist_dir, 'relative.m3u'), 'w') as f:
-            f.write('{0}\n'.format(os.path.join('a', 'b', 'c.mp3')))
-            f.write('{0}\n'.format(os.path.join('d', 'e', 'f.mp3')))
-            f.write('{0}\n'.format('nonexisting.mp3'))
+        with open(os.path.join(self.playlist_dir, "relative.m3u"), "w") as f:
+            f.write("{0}\n".format(os.path.join("a", "b", "c.mp3")))
+            f.write("{0}\n".format(os.path.join("d", "e", "f.mp3")))
+            f.write("{0}\n".format("nonexisting.mp3"))
 
-        self.config['playlist']['relative_to'] = self.music_dir
+        self.config["playlist"]["relative_to"] = self.music_dir
 
 
 class PlaylistTestRelativeToPls(PlaylistQueryTestHelper, unittest.TestCase):
     def setup_test(self):
-        with open(os.path.join(self.playlist_dir, 'absolute.m3u'), 'w') as f:
-            f.write('{0}\n'.format(os.path.join(
-                self.music_dir, 'a', 'b', 'c.mp3')))
-            f.write('{0}\n'.format(os.path.join(
-                self.music_dir, 'd', 'e', 'f.mp3')))
-            f.write('{0}\n'.format(os.path.join(
-                self.music_dir, 'nonexisting.mp3')))
+        with open(os.path.join(self.playlist_dir, "absolute.m3u"), "w") as f:
+            f.write(
+                "{0}\n".format(os.path.join(self.music_dir, "a", "b", "c.mp3"))
+            )
+            f.write(
+                "{0}\n".format(os.path.join(self.music_dir, "d", "e", "f.mp3"))
+            )
+            f.write(
+                "{0}\n".format(os.path.join(self.music_dir, "nonexisting.mp3"))
+            )
 
-        with open(os.path.join(self.playlist_dir, 'relative.m3u'), 'w') as f:
-            f.write('{0}\n'.format(os.path.relpath(
-                os.path.join(self.music_dir, 'a', 'b', 'c.mp3'),
-                start=self.playlist_dir,
-            )))
-            f.write('{0}\n'.format(os.path.relpath(
-                os.path.join(self.music_dir, 'd', 'e', 'f.mp3'),
-                start=self.playlist_dir,
-            )))
-            f.write('{0}\n'.format(os.path.relpath(
-                os.path.join(self.music_dir, 'nonexisting.mp3'),
-                start=self.playlist_dir,
-            )))
+        with open(os.path.join(self.playlist_dir, "relative.m3u"), "w") as f:
+            f.write(
+                "{0}\n".format(
+                    os.path.relpath(
+                        os.path.join(self.music_dir, "a", "b", "c.mp3"),
+                        start=self.playlist_dir,
+                    )
+                )
+            )
+            f.write(
+                "{0}\n".format(
+                    os.path.relpath(
+                        os.path.join(self.music_dir, "d", "e", "f.mp3"),
+                        start=self.playlist_dir,
+                    )
+                )
+            )
+            f.write(
+                "{0}\n".format(
+                    os.path.relpath(
+                        os.path.join(self.music_dir, "nonexisting.mp3"),
+                        start=self.playlist_dir,
+                    )
+                )
+            )
 
-        self.config['playlist']['relative_to'] = 'playlist'
-        self.config['playlist']['playlist_dir'] = self.playlist_dir
+        self.config["playlist"]["relative_to"] = "playlist"
+        self.config["playlist"]["playlist_dir"] = self.playlist_dir
 
 
 class PlaylistUpdateTestHelper(PlaylistTestHelper):
     def setup_test(self):
-        with open(os.path.join(self.playlist_dir, 'absolute.m3u'), 'w') as f:
-            f.write('{0}\n'.format(os.path.join(
-                self.music_dir, 'a', 'b', 'c.mp3')))
-            f.write('{0}\n'.format(os.path.join(
-                self.music_dir, 'd', 'e', 'f.mp3')))
-            f.write('{0}\n'.format(os.path.join(
-                self.music_dir, 'nonexisting.mp3')))
+        with open(os.path.join(self.playlist_dir, "absolute.m3u"), "w") as f:
+            f.write(
+                "{0}\n".format(os.path.join(self.music_dir, "a", "b", "c.mp3"))
+            )
+            f.write(
+                "{0}\n".format(os.path.join(self.music_dir, "d", "e", "f.mp3"))
+            )
+            f.write(
+                "{0}\n".format(os.path.join(self.music_dir, "nonexisting.mp3"))
+            )
 
-        with open(os.path.join(self.playlist_dir, 'relative.m3u'), 'w') as f:
-            f.write('{0}\n'.format(os.path.join('a', 'b', 'c.mp3')))
-            f.write('{0}\n'.format(os.path.join('d', 'e', 'f.mp3')))
-            f.write('{0}\n'.format('nonexisting.mp3'))
+        with open(os.path.join(self.playlist_dir, "relative.m3u"), "w") as f:
+            f.write("{0}\n".format(os.path.join("a", "b", "c.mp3")))
+            f.write("{0}\n".format(os.path.join("d", "e", "f.mp3")))
+            f.write("{0}\n".format("nonexisting.mp3"))
 
-        self.config['playlist']['auto'] = True
-        self.config['playlist']['relative_to'] = 'library'
+        self.config["playlist"]["auto"] = True
+        self.config["playlist"]["relative_to"] = "library"
 
 
 class PlaylistTestItemMoved(PlaylistUpdateTestHelper, unittest.TestCase):
     def test_item_moved(self):
         # Emit item_moved event for an item that is in a playlist
-        results = self.lib.items(u'path:{0}'.format(shlex_quote(
-            os.path.join(self.music_dir, 'd', 'e', 'f.mp3'))))
+        results = self.lib.items(
+            u"path:{0}".format(
+                shlex_quote(os.path.join(self.music_dir, "d", "e", "f.mp3"))
+            )
+        )
         item = results[0]
         beets.plugins.send(
-            'item_moved', item=item, source=item.path,
+            "item_moved",
+            item=item,
+            source=item.path,
             destination=beets.util.bytestring_path(
-                os.path.join(self.music_dir, 'g', 'h', 'i.mp3')))
+                os.path.join(self.music_dir, "g", "h", "i.mp3")
+            ),
+        )
 
         # Emit item_moved event for an item that is not in a playlist
-        results = self.lib.items(u'path:{0}'.format(shlex_quote(
-            os.path.join(self.music_dir, 'x', 'y', 'z.mp3'))))
+        results = self.lib.items(
+            u"path:{0}".format(
+                shlex_quote(os.path.join(self.music_dir, "x", "y", "z.mp3"))
+            )
+        )
         item = results[0]
         beets.plugins.send(
-            'item_moved', item=item, source=item.path,
+            "item_moved",
+            item=item,
+            source=item.path,
             destination=beets.util.bytestring_path(
-                os.path.join(self.music_dir, 'u', 'v', 'w.mp3')))
+                os.path.join(self.music_dir, "u", "v", "w.mp3")
+            ),
+        )
 
         # Emit cli_exit event
-        beets.plugins.send('cli_exit', lib=self.lib)
+        beets.plugins.send("cli_exit", lib=self.lib)
 
         # Check playlist with absolute paths
-        playlist_path = os.path.join(self.playlist_dir, 'absolute.m3u')
-        with open(playlist_path, 'r') as f:
+        playlist_path = os.path.join(self.playlist_dir, "absolute.m3u")
+        with open(playlist_path, "r") as f:
             lines = [line.strip() for line in f.readlines()]
 
-        self.assertEqual(lines, [
-            os.path.join(self.music_dir, 'a', 'b', 'c.mp3'),
-            os.path.join(self.music_dir, 'g', 'h', 'i.mp3'),
-            os.path.join(self.music_dir, 'nonexisting.mp3'),
-        ])
+        self.assertEqual(
+            lines,
+            [
+                os.path.join(self.music_dir, "a", "b", "c.mp3"),
+                os.path.join(self.music_dir, "g", "h", "i.mp3"),
+                os.path.join(self.music_dir, "nonexisting.mp3"),
+            ],
+        )
 
         # Check playlist with relative paths
-        playlist_path = os.path.join(self.playlist_dir, 'relative.m3u')
-        with open(playlist_path, 'r') as f:
+        playlist_path = os.path.join(self.playlist_dir, "relative.m3u")
+        with open(playlist_path, "r") as f:
             lines = [line.strip() for line in f.readlines()]
 
-        self.assertEqual(lines, [
-            os.path.join('a', 'b', 'c.mp3'),
-            os.path.join('g', 'h', 'i.mp3'),
-            'nonexisting.mp3',
-        ])
+        self.assertEqual(
+            lines,
+            [
+                os.path.join("a", "b", "c.mp3"),
+                os.path.join("g", "h", "i.mp3"),
+                "nonexisting.mp3",
+            ],
+        )
 
 
 class PlaylistTestItemRemoved(PlaylistUpdateTestHelper, unittest.TestCase):
     def test_item_removed(self):
         # Emit item_removed event for an item that is in a playlist
-        results = self.lib.items(u'path:{0}'.format(shlex_quote(
-            os.path.join(self.music_dir, 'd', 'e', 'f.mp3'))))
+        results = self.lib.items(
+            u"path:{0}".format(
+                shlex_quote(os.path.join(self.music_dir, "d", "e", "f.mp3"))
+            )
+        )
         item = results[0]
-        beets.plugins.send('item_removed', item=item)
+        beets.plugins.send("item_removed", item=item)
 
         # Emit item_removed event for an item that is not in a playlist
-        results = self.lib.items(u'path:{0}'.format(shlex_quote(
-            os.path.join(self.music_dir, 'x', 'y', 'z.mp3'))))
+        results = self.lib.items(
+            u"path:{0}".format(
+                shlex_quote(os.path.join(self.music_dir, "x", "y", "z.mp3"))
+            )
+        )
         item = results[0]
-        beets.plugins.send('item_removed', item=item)
+        beets.plugins.send("item_removed", item=item)
 
         # Emit cli_exit event
-        beets.plugins.send('cli_exit', lib=self.lib)
+        beets.plugins.send("cli_exit", lib=self.lib)
 
         # Check playlist with absolute paths
-        playlist_path = os.path.join(self.playlist_dir, 'absolute.m3u')
-        with open(playlist_path, 'r') as f:
+        playlist_path = os.path.join(self.playlist_dir, "absolute.m3u")
+        with open(playlist_path, "r") as f:
             lines = [line.strip() for line in f.readlines()]
 
-        self.assertEqual(lines, [
-            os.path.join(self.music_dir, 'a', 'b', 'c.mp3'),
-            os.path.join(self.music_dir, 'nonexisting.mp3'),
-        ])
+        self.assertEqual(
+            lines,
+            [
+                os.path.join(self.music_dir, "a", "b", "c.mp3"),
+                os.path.join(self.music_dir, "nonexisting.mp3"),
+            ],
+        )
 
         # Check playlist with relative paths
-        playlist_path = os.path.join(self.playlist_dir, 'relative.m3u')
-        with open(playlist_path, 'r') as f:
+        playlist_path = os.path.join(self.playlist_dir, "relative.m3u")
+        with open(playlist_path, "r") as f:
             lines = [line.strip() for line in f.readlines()]
 
-        self.assertEqual(lines, [
-            os.path.join('a', 'b', 'c.mp3'),
-            'nonexisting.mp3',
-        ])
+        self.assertEqual(
+            lines, [os.path.join("a", "b", "c.mp3"), "nonexisting.mp3",]
+        )
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_plexupdate.py
+++ b/test/test_plexupdate.py
@@ -9,7 +9,7 @@ import responses
 
 
 class PlexUpdateTest(unittest.TestCase, TestHelper):
-    def add_response_get_music_section(self, section_name='Music'):
+    def add_response_get_music_section(self, section_name="Music"):
         """Create response for mocking the get_music_section function.
         """
 
@@ -29,7 +29,7 @@ class PlexUpdateTest(unittest.TestCase, TestHelper):
             'language="de" uuid="92f68526-21eb-4ee2-8e22-d36355a17f1f" '
             'updatedAt="1416232668" createdAt="1415720680">'
             '<Location id="3" path="/home/marv/Media/Videos/Movies" />'
-            '</Directory>'
+            "</Directory>"
             '<Directory allowSync="0" art="/:/resources/artist-fanart.jpg" '
             'filters="1" refreshing="0" thumb="/:/resources/artist.png" '
             'key="2" type="artist" title="' + escaped_section_name + '" '
@@ -38,7 +38,7 @@ class PlexUpdateTest(unittest.TestCase, TestHelper):
             'language="en" uuid="90897c95-b3bd-4778-a9c8-1f43cb78f047" '
             'updatedAt="1416929243" createdAt="1415691331">'
             '<Location id="2" path="/home/marv/Media/Musik" />'
-            '</Directory>'
+            "</Directory>"
             '<Directory allowSync="0" art="/:/resources/show-fanart.jpg" '
             'filters="1" refreshing="0" thumb="/:/resources/show.png" '
             'key="1" type="show" title="TV Shows" '
@@ -47,37 +47,40 @@ class PlexUpdateTest(unittest.TestCase, TestHelper):
             'language="de" uuid="04d2249b-160a-4ae9-8100-106f4ec1a218" '
             'updatedAt="1416320800" createdAt="1415690983">'
             '<Location id="1" path="/home/marv/Media/Videos/Series" />'
-            '</Directory>'
-            '</MediaContainer>')
+            "</Directory>"
+            "</MediaContainer>"
+        )
         status = 200
-        content_type = 'text/xml;charset=utf-8'
+        content_type = "text/xml;charset=utf-8"
 
-        responses.add(responses.GET,
-                      'http://localhost:32400/library/sections',
-                      body=body,
-                      status=status,
-                      content_type=content_type)
+        responses.add(
+            responses.GET,
+            "http://localhost:32400/library/sections",
+            body=body,
+            status=status,
+            content_type=content_type,
+        )
 
     def add_response_update_plex(self):
         """Create response for mocking the update_plex function.
         """
-        body = ''
+        body = ""
         status = 200
-        content_type = 'text/html'
+        content_type = "text/html"
 
-        responses.add(responses.GET,
-                      'http://localhost:32400/library/sections/2/refresh',
-                      body=body,
-                      status=status,
-                      content_type=content_type)
+        responses.add(
+            responses.GET,
+            "http://localhost:32400/library/sections/2/refresh",
+            body=body,
+            status=status,
+            content_type=content_type,
+        )
 
     def setUp(self):
         self.setup_beets()
-        self.load_plugins('plexupdate')
+        self.load_plugins("plexupdate")
 
-        self.config['plex'] = {
-            u'host': u'localhost',
-            u'port': 32400}
+        self.config["plex"] = {u"host": u"localhost", u"port": 32400}
 
     def tearDown(self):
         self.teardown_beets()
@@ -89,26 +92,34 @@ class PlexUpdateTest(unittest.TestCase, TestHelper):
         self.add_response_get_music_section()
 
         # Test if section key is "2" out of the mocking data.
-        self.assertEqual(get_music_section(
-            self.config['plex']['host'],
-            self.config['plex']['port'],
-            self.config['plex']['token'],
-            self.config['plex']['library_name'].get(),
-            self.config['plex']['secure'],
-            self.config['plex']['ignore_cert_errors']), '2')
+        self.assertEqual(
+            get_music_section(
+                self.config["plex"]["host"],
+                self.config["plex"]["port"],
+                self.config["plex"]["token"],
+                self.config["plex"]["library_name"].get(),
+                self.config["plex"]["secure"],
+                self.config["plex"]["ignore_cert_errors"],
+            ),
+            "2",
+        )
 
     @responses.activate
     def test_get_named_music_section(self):
         # Adding response.
-        self.add_response_get_music_section('My Music Library')
+        self.add_response_get_music_section("My Music Library")
 
-        self.assertEqual(get_music_section(
-            self.config['plex']['host'],
-            self.config['plex']['port'],
-            self.config['plex']['token'],
-            'My Music Library',
-            self.config['plex']['secure'],
-            self.config['plex']['ignore_cert_errors']), '2')
+        self.assertEqual(
+            get_music_section(
+                self.config["plex"]["host"],
+                self.config["plex"]["port"],
+                self.config["plex"]["token"],
+                "My Music Library",
+                self.config["plex"]["secure"],
+                self.config["plex"]["ignore_cert_errors"],
+            ),
+            "2",
+        )
 
     @responses.activate
     def test_update_plex(self):
@@ -117,18 +128,22 @@ class PlexUpdateTest(unittest.TestCase, TestHelper):
         self.add_response_update_plex()
 
         # Testing status code of the mocking request.
-        self.assertEqual(update_plex(
-            self.config['plex']['host'],
-            self.config['plex']['port'],
-            self.config['plex']['token'],
-            self.config['plex']['library_name'].get(),
-            self.config['plex']['secure'],
-            self.config['plex']['ignore_cert_errors']).status_code, 200)
+        self.assertEqual(
+            update_plex(
+                self.config["plex"]["host"],
+                self.config["plex"]["port"],
+                self.config["plex"]["token"],
+                self.config["plex"]["library_name"].get(),
+                self.config["plex"]["secure"],
+                self.config["plex"]["ignore_cert_errors"],
+            ).status_code,
+            200,
+        )
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_plugin_mediafield.py
+++ b/test/test_plugin_mediafield.py
@@ -30,17 +30,16 @@ from beets.util import bytestring_path
 
 
 field_extension = mediafile.MediaField(
-    mediafile.MP3DescStorageStyle(u'customtag'),
-    mediafile.MP4StorageStyle('----:com.apple.iTunes:customtag'),
-    mediafile.StorageStyle('customtag'),
-    mediafile.ASFStorageStyle('customtag'),
+    mediafile.MP3DescStorageStyle(u"customtag"),
+    mediafile.MP4StorageStyle("----:com.apple.iTunes:customtag"),
+    mediafile.StorageStyle("customtag"),
+    mediafile.ASFStorageStyle("customtag"),
 )
 
 
 class ExtendedFieldTestMixin(_common.TestCase):
-
-    def _mediafile_fixture(self, name, extension='mp3'):
-        name = bytestring_path(name + '.' + extension)
+    def _mediafile_fixture(self, name, extension="mp3"):
+        name = bytestring_path(name + "." + extension)
         src = os.path.join(_common.RSRC, name)
         target = os.path.join(self.temp_dir, name)
         shutil.copy(src, target)
@@ -48,68 +47,71 @@ class ExtendedFieldTestMixin(_common.TestCase):
 
     def test_extended_field_write(self):
         plugin = BeetsPlugin()
-        plugin.add_media_field('customtag', field_extension)
+        plugin.add_media_field("customtag", field_extension)
 
         try:
-            mf = self._mediafile_fixture('empty')
-            mf.customtag = u'F#'
+            mf = self._mediafile_fixture("empty")
+            mf.customtag = u"F#"
             mf.save()
 
             mf = mediafile.MediaFile(mf.path)
-            self.assertEqual(mf.customtag, u'F#')
+            self.assertEqual(mf.customtag, u"F#")
 
         finally:
-            delattr(mediafile.MediaFile, 'customtag')
-            Item._media_fields.remove('customtag')
+            delattr(mediafile.MediaFile, "customtag")
+            Item._media_fields.remove("customtag")
 
     def test_write_extended_tag_from_item(self):
         plugin = BeetsPlugin()
-        plugin.add_media_field('customtag', field_extension)
+        plugin.add_media_field("customtag", field_extension)
 
         try:
-            mf = self._mediafile_fixture('empty')
+            mf = self._mediafile_fixture("empty")
             self.assertIsNone(mf.customtag)
 
-            item = Item(path=mf.path, customtag=u'Gb')
+            item = Item(path=mf.path, customtag=u"Gb")
             item.write()
             mf = mediafile.MediaFile(mf.path)
-            self.assertEqual(mf.customtag, u'Gb')
+            self.assertEqual(mf.customtag, u"Gb")
 
         finally:
-            delattr(mediafile.MediaFile, 'customtag')
-            Item._media_fields.remove('customtag')
+            delattr(mediafile.MediaFile, "customtag")
+            Item._media_fields.remove("customtag")
 
     def test_read_flexible_attribute_from_file(self):
         plugin = BeetsPlugin()
-        plugin.add_media_field('customtag', field_extension)
+        plugin.add_media_field("customtag", field_extension)
 
         try:
-            mf = self._mediafile_fixture('empty')
-            mf.update({'customtag': u'F#'})
+            mf = self._mediafile_fixture("empty")
+            mf.update({"customtag": u"F#"})
             mf.save()
 
             item = Item.from_path(mf.path)
-            self.assertEqual(item['customtag'], u'F#')
+            self.assertEqual(item["customtag"], u"F#")
 
         finally:
-            delattr(mediafile.MediaFile, 'customtag')
-            Item._media_fields.remove('customtag')
+            delattr(mediafile.MediaFile, "customtag")
+            Item._media_fields.remove("customtag")
 
     def test_invalid_descriptor(self):
         with self.assertRaises(ValueError) as cm:
-            mediafile.MediaFile.add_field('somekey', True)
-        self.assertIn(u'must be an instance of MediaField',
-                      six.text_type(cm.exception))
+            mediafile.MediaFile.add_field("somekey", True)
+        self.assertIn(
+            u"must be an instance of MediaField", six.text_type(cm.exception)
+        )
 
     def test_overwrite_property(self):
         with self.assertRaises(ValueError) as cm:
-            mediafile.MediaFile.add_field('artist', mediafile.MediaField())
-        self.assertIn(u'property "artist" already exists',
-                      six.text_type(cm.exception))
+            mediafile.MediaFile.add_field("artist", mediafile.MediaField())
+        self.assertIn(
+            u'property "artist" already exists', six.text_type(cm.exception)
+        )
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -21,8 +21,12 @@ import shutil
 import itertools
 import unittest
 
-from beets.importer import SingletonImportTask, SentinelImportTask, \
-    ArchiveImportTask, action
+from beets.importer import (
+    SingletonImportTask,
+    SentinelImportTask,
+    ArchiveImportTask,
+    action,
+)
 from beets import plugins, config, ui
 from beets.library import Item
 from beets.dbcore import types
@@ -36,17 +40,17 @@ from test import helper
 
 
 class TestHelper(helper.TestHelper):
-
     def setup_plugin_loader(self):
         # FIXME the mocking code is horrific, but this is the lowest and
         # earliest level of the plugin mechanism we can hook into.
         self.load_plugins()
-        self._plugin_loader_patch = patch('beets.plugins.load_plugins')
+        self._plugin_loader_patch = patch("beets.plugins.load_plugins")
         self._plugin_classes = set()
         load_plugins = self._plugin_loader_patch.start()
 
         def myload(names=()):
             plugins._classes.update(self._plugin_classes)
+
         load_plugins.side_effect = myload
         self.setup_beets()
 
@@ -59,7 +63,6 @@ class TestHelper(helper.TestHelper):
 
 
 class ItemTypesTest(unittest.TestCase, TestHelper):
-
     def setUp(self):
         self.setup_plugin_loader()
 
@@ -69,37 +72,37 @@ class ItemTypesTest(unittest.TestCase, TestHelper):
 
     def test_flex_field_type(self):
         class RatingPlugin(plugins.BeetsPlugin):
-            item_types = {'rating': types.Float()}
+            item_types = {"rating": types.Float()}
 
         self.register_plugin(RatingPlugin)
-        self.config['plugins'] = 'rating'
+        self.config["plugins"] = "rating"
 
-        item = Item(path=u'apath', artist=u'aaa')
+        item = Item(path=u"apath", artist=u"aaa")
         item.add(self.lib)
 
         # Do not match unset values
-        out = self.run_with_output(u'ls', u'rating:1..3')
-        self.assertNotIn(u'aaa', out)
+        out = self.run_with_output(u"ls", u"rating:1..3")
+        self.assertNotIn(u"aaa", out)
 
-        self.run_command(u'modify', u'rating=2', u'--yes')
+        self.run_command(u"modify", u"rating=2", u"--yes")
 
         # Match in range
-        out = self.run_with_output(u'ls', u'rating:1..3')
-        self.assertIn(u'aaa', out)
+        out = self.run_with_output(u"ls", u"rating:1..3")
+        self.assertIn(u"aaa", out)
 
         # Don't match out of range
-        out = self.run_with_output(u'ls', u'rating:3..5')
-        self.assertNotIn(u'aaa', out)
+        out = self.run_with_output(u"ls", u"rating:3..5")
+        self.assertNotIn(u"aaa", out)
 
 
 class ItemWriteTest(unittest.TestCase, TestHelper):
-
     def setUp(self):
         self.setup_plugin_loader()
         self.setup_beets()
 
         class EventListenerPlugin(plugins.BeetsPlugin):
             pass
+
         self.event_listener_plugin = EventListenerPlugin()
         self.register_plugin(EventListenerPlugin)
 
@@ -108,25 +111,23 @@ class ItemWriteTest(unittest.TestCase, TestHelper):
         self.teardown_beets()
 
     def test_change_tags(self):
-
         def on_write(item=None, path=None, tags=None):
-            if tags['artist'] == u'XXX':
-                tags['artist'] = u'YYY'
+            if tags["artist"] == u"XXX":
+                tags["artist"] = u"YYY"
 
-        self.register_listener('write', on_write)
+        self.register_listener("write", on_write)
 
-        item = self.add_item_fixture(artist=u'XXX')
+        item = self.add_item_fixture(artist=u"XXX")
         item.write()
 
         mediafile = MediaFile(syspath(item.path))
-        self.assertEqual(mediafile.artist, u'YYY')
+        self.assertEqual(mediafile.artist, u"YYY")
 
     def register_listener(self, event, func):
         self.event_listener_plugin.register_listener(event, func)
 
 
 class ItemTypeConflictTest(unittest.TestCase, TestHelper):
-
     def setUp(self):
         self.setup_plugin_loader()
         self.setup_beets()
@@ -137,25 +138,23 @@ class ItemTypeConflictTest(unittest.TestCase, TestHelper):
 
     def test_mismatch(self):
         class EventListenerPlugin(plugins.BeetsPlugin):
-            item_types = {'duplicate': types.INTEGER}
+            item_types = {"duplicate": types.INTEGER}
 
         class AdventListenerPlugin(plugins.BeetsPlugin):
-            item_types = {'duplicate': types.FLOAT}
+            item_types = {"duplicate": types.FLOAT}
 
         self.event_listener_plugin = EventListenerPlugin
         self.advent_listener_plugin = AdventListenerPlugin
         self.register_plugin(EventListenerPlugin)
         self.register_plugin(AdventListenerPlugin)
-        self.assertRaises(plugins.PluginConflictException,
-                          plugins.types, Item
-                          )
+        self.assertRaises(plugins.PluginConflictException, plugins.types, Item)
 
     def test_match(self):
         class EventListenerPlugin(plugins.BeetsPlugin):
-            item_types = {'duplicate': types.INTEGER}
+            item_types = {"duplicate": types.INTEGER}
 
         class AdventListenerPlugin(plugins.BeetsPlugin):
-            item_types = {'duplicate': types.INTEGER}
+            item_types = {"duplicate": types.INTEGER}
 
         self.event_listener_plugin = EventListenerPlugin
         self.advent_listener_plugin = AdventListenerPlugin
@@ -165,12 +164,11 @@ class ItemTypeConflictTest(unittest.TestCase, TestHelper):
 
 
 class EventsTest(unittest.TestCase, ImportHelper, TestHelper):
-
     def setUp(self):
         self.setup_plugin_loader()
         self.setup_beets()
         self.__create_import_dir(2)
-        config['import']['pretend'] = True
+        config["import"]["pretend"] = True
 
     def tearDown(self):
         self.teardown_plugin_loader()
@@ -178,7 +176,7 @@ class EventsTest(unittest.TestCase, ImportHelper, TestHelper):
 
     def __copy_file(self, dest_path, metadata):
         # Copy files
-        resource_path = os.path.join(RSRC, b'full.mp3')
+        resource_path = os.path.join(RSRC, b"full.mp3")
         shutil.copy(resource_path, dest_path)
         medium = MediaFile(dest_path)
         # Set metadata
@@ -187,26 +185,26 @@ class EventsTest(unittest.TestCase, ImportHelper, TestHelper):
         medium.save()
 
     def __create_import_dir(self, count):
-        self.import_dir = os.path.join(self.temp_dir, b'testsrcdir')
+        self.import_dir = os.path.join(self.temp_dir, b"testsrcdir")
         if os.path.isdir(self.import_dir):
             shutil.rmtree(self.import_dir)
 
-        self.album_path = os.path.join(self.import_dir, b'album')
+        self.album_path = os.path.join(self.import_dir, b"album")
         os.makedirs(self.album_path)
 
         metadata = {
-            'artist': u'Tag Artist',
-            'album':  u'Tag Album',
-            'albumartist':  None,
-            'mb_trackid': None,
-            'mb_albumid': None,
-            'comp': None
+            "artist": u"Tag Artist",
+            "album": u"Tag Album",
+            "albumartist": None,
+            "mb_trackid": None,
+            "mb_albumid": None,
+            "comp": None,
         }
         self.file_paths = []
         for i in range(count):
-            metadata['track'] = i + 1
-            metadata['title'] = u'Tag Title Album %d' % (i + 1)
-            track_file = bytestring_path('%02d - track.mp3' % (i + 1))
+            metadata["track"] = i + 1
+            metadata["title"] = u"Tag Title Album %d" % (i + 1)
+            track_file = bytestring_path("%02d - track.mp3" % (i + 1))
             dest_path = os.path.join(self.album_path, track_file)
             self.__copy_file(dest_path, metadata)
             self.file_paths.append(dest_path)
@@ -222,29 +220,37 @@ class EventsTest(unittest.TestCase, ImportHelper, TestHelper):
 
         # Exactly one event should have been imported (for the album).
         # Sentinels do not get emitted.
-        self.assertEqual(logs.count(u'Sending event: import_task_created'), 1)
+        self.assertEqual(logs.count(u"Sending event: import_task_created"), 1)
 
-        logs = [line for line in logs if not line.startswith(
-            u'Sending event:')]
-        self.assertEqual(logs, [
-            u'Album: {0}'.format(displayable_path(
-                os.path.join(self.import_dir, b'album'))),
-            u'  {0}'.format(displayable_path(self.file_paths[0])),
-            u'  {0}'.format(displayable_path(self.file_paths[1])),
-        ])
+        logs = [
+            line for line in logs if not line.startswith(u"Sending event:")
+        ]
+        self.assertEqual(
+            logs,
+            [
+                u"Album: {0}".format(
+                    displayable_path(os.path.join(self.import_dir, b"album"))
+                ),
+                u"  {0}".format(displayable_path(self.file_paths[0])),
+                u"  {0}".format(displayable_path(self.file_paths[1])),
+            ],
+        )
 
     def test_import_task_created_with_plugin(self):
         class ToSingletonPlugin(plugins.BeetsPlugin):
             def __init__(self):
                 super(ToSingletonPlugin, self).__init__()
 
-                self.register_listener('import_task_created',
-                                       self.import_task_created_event)
+                self.register_listener(
+                    "import_task_created", self.import_task_created_event
+                )
 
             def import_task_created_event(self, session, task):
-                if isinstance(task, SingletonImportTask) \
-                        or isinstance(task, SentinelImportTask)\
-                        or isinstance(task, ArchiveImportTask):
+                if (
+                    isinstance(task, SingletonImportTask)
+                    or isinstance(task, SentinelImportTask)
+                    or isinstance(task, ArchiveImportTask)
+                ):
                     return task
 
                 new_tasks = []
@@ -266,27 +272,34 @@ class EventsTest(unittest.TestCase, ImportHelper, TestHelper):
 
         # Exactly one event should have been imported (for the album).
         # Sentinels do not get emitted.
-        self.assertEqual(logs.count(u'Sending event: import_task_created'), 1)
+        self.assertEqual(logs.count(u"Sending event: import_task_created"), 1)
 
-        logs = [line for line in logs if not line.startswith(
-            u'Sending event:')]
-        self.assertEqual(logs, [
-            u'Singleton: {0}'.format(displayable_path(self.file_paths[0])),
-            u'Singleton: {0}'.format(displayable_path(self.file_paths[1])),
-        ])
+        logs = [
+            line for line in logs if not line.startswith(u"Sending event:")
+        ]
+        self.assertEqual(
+            logs,
+            [
+                u"Singleton: {0}".format(displayable_path(self.file_paths[0])),
+                u"Singleton: {0}".format(displayable_path(self.file_paths[1])),
+            ],
+        )
 
 
 class HelpersTest(unittest.TestCase):
-
     def test_sanitize_choices(self):
         self.assertEqual(
-            plugins.sanitize_choices([u'A', u'Z'], (u'A', u'B')), [u'A'])
+            plugins.sanitize_choices([u"A", u"Z"], (u"A", u"B")), [u"A"]
+        )
         self.assertEqual(
-            plugins.sanitize_choices([u'A', u'A'], (u'A')), [u'A'])
+            plugins.sanitize_choices([u"A", u"A"], (u"A")), [u"A"]
+        )
         self.assertEqual(
-            plugins.sanitize_choices([u'D', u'*', u'A'],
-                                     (u'A', u'B', u'C', u'D')),
-            [u'D', u'B', u'C', u'A'])
+            plugins.sanitize_choices(
+                [u"D", u"*", u"A"], (u"A", u"B", u"C", u"D")
+            ),
+            [u"D", u"B", u"C", u"A"],
+        )
 
 
 class ListenersTest(unittest.TestCase, TestHelper):
@@ -298,52 +311,53 @@ class ListenersTest(unittest.TestCase, TestHelper):
         self.teardown_beets()
 
     def test_register(self):
-
         class DummyPlugin(plugins.BeetsPlugin):
             def __init__(self):
                 super(DummyPlugin, self).__init__()
-                self.register_listener('cli_exit', self.dummy)
-                self.register_listener('cli_exit', self.dummy)
+                self.register_listener("cli_exit", self.dummy)
+                self.register_listener("cli_exit", self.dummy)
 
             def dummy(self):
                 pass
 
         d = DummyPlugin()
-        self.assertEqual(DummyPlugin._raw_listeners['cli_exit'], [d.dummy])
+        self.assertEqual(DummyPlugin._raw_listeners["cli_exit"], [d.dummy])
 
         d2 = DummyPlugin()
-        self.assertEqual(DummyPlugin._raw_listeners['cli_exit'],
-                         [d.dummy, d2.dummy])
+        self.assertEqual(
+            DummyPlugin._raw_listeners["cli_exit"], [d.dummy, d2.dummy]
+        )
 
-        d.register_listener('cli_exit', d2.dummy)
-        self.assertEqual(DummyPlugin._raw_listeners['cli_exit'],
-                         [d.dummy, d2.dummy])
+        d.register_listener("cli_exit", d2.dummy)
+        self.assertEqual(
+            DummyPlugin._raw_listeners["cli_exit"], [d.dummy, d2.dummy]
+        )
 
-    @patch('beets.plugins.find_plugins')
-    @patch('beets.plugins.inspect')
+    @patch("beets.plugins.find_plugins")
+    @patch("beets.plugins.inspect")
     def test_events_called(self, mock_inspect, mock_find_plugins):
         mock_inspect.getargspec.args.return_value = None
 
         class DummyPlugin(plugins.BeetsPlugin):
             def __init__(self):
                 super(DummyPlugin, self).__init__()
-                self.foo = Mock(__name__='foo')
-                self.register_listener('event_foo', self.foo)
-                self.bar = Mock(__name__='bar')
-                self.register_listener('event_bar', self.bar)
+                self.foo = Mock(__name__="foo")
+                self.register_listener("event_foo", self.foo)
+                self.bar = Mock(__name__="bar")
+                self.register_listener("event_bar", self.bar)
 
         d = DummyPlugin()
-        mock_find_plugins.return_value = d,
+        mock_find_plugins.return_value = (d,)
 
-        plugins.send('event')
+        plugins.send("event")
         d.foo.assert_has_calls([])
         d.bar.assert_has_calls([])
 
-        plugins.send('event_foo', var=u"tagada")
+        plugins.send("event_foo", var=u"tagada")
         d.foo.assert_called_once_with(var=u"tagada")
         d.bar.assert_has_calls([])
 
-    @patch('beets.plugins.find_plugins')
+    @patch("beets.plugins.find_plugins")
     def test_listener_params(self, mock_find_plugins):
         test = self
 
@@ -352,10 +366,10 @@ class ListenersTest(unittest.TestCase, TestHelper):
                 super(DummyPlugin, self).__init__()
                 for i in itertools.count(1):
                     try:
-                        meth = getattr(self, 'dummy{0}'.format(i))
+                        meth = getattr(self, "dummy{0}".format(i))
                     except AttributeError:
                         break
-                    self.register_listener('event{0}'.format(i), meth)
+                    self.register_listener("event{0}".format(i), meth)
 
             def dummy1(self, foo):
                 test.assertEqual(foo, 5)
@@ -391,27 +405,28 @@ class ListenersTest(unittest.TestCase, TestHelper):
                 test.assertEqual(kwargs, {"foo": 5})
 
         d = DummyPlugin()
-        mock_find_plugins.return_value = d,
+        mock_find_plugins.return_value = (d,)
 
-        plugins.send('event1', foo=5)
-        plugins.send('event2', foo=5)
-        plugins.send('event3', foo=5)
-        plugins.send('event4', foo=5)
-
-        with self.assertRaises(TypeError):
-            plugins.send('event5', foo=5)
-
-        plugins.send('event6', foo=5)
-        plugins.send('event7', foo=5)
+        plugins.send("event1", foo=5)
+        plugins.send("event2", foo=5)
+        plugins.send("event3", foo=5)
+        plugins.send("event4", foo=5)
 
         with self.assertRaises(TypeError):
-            plugins.send('event8', foo=5)
+            plugins.send("event5", foo=5)
 
-        plugins.send('event9', foo=5)
+        plugins.send("event6", foo=5)
+        plugins.send("event7", foo=5)
+
+        with self.assertRaises(TypeError):
+            plugins.send("event8", foo=5)
+
+        plugins.send("event9", foo=5)
 
 
-class PromptChoicesTest(TerminalImportSessionSetup, unittest.TestCase,
-                        ImportHelper, TestHelper):
+class PromptChoicesTest(
+    TerminalImportSessionSetup, unittest.TestCase, ImportHelper, TestHelper
+):
     def setUp(self):
         self.setup_plugin_loader()
         self.setup_beets()
@@ -419,8 +434,9 @@ class PromptChoicesTest(TerminalImportSessionSetup, unittest.TestCase,
         self._setup_import_session()
         self.matcher = AutotagStub().install()
         # keep track of ui.input_option() calls
-        self.input_options_patcher = patch('beets.ui.input_options',
-                                           side_effect=ui.input_options)
+        self.input_options_patcher = patch(
+            "beets.ui.input_options", side_effect=ui.input_options
+        )
         self.mock_input_options = self.input_options_patcher.start()
 
     def tearDown(self):
@@ -431,137 +447,197 @@ class PromptChoicesTest(TerminalImportSessionSetup, unittest.TestCase,
 
     def test_plugin_choices_in_ui_input_options_album(self):
         """Test the presence of plugin choices on the prompt (album)."""
+
         class DummyPlugin(plugins.BeetsPlugin):
             def __init__(self):
                 super(DummyPlugin, self).__init__()
-                self.register_listener('before_choose_candidate',
-                                       self.return_choices)
+                self.register_listener(
+                    "before_choose_candidate", self.return_choices
+                )
 
             def return_choices(self, session, task):
-                return [ui.commands.PromptChoice('f', u'Foo', None),
-                        ui.commands.PromptChoice('r', u'baR', None)]
+                return [
+                    ui.commands.PromptChoice("f", u"Foo", None),
+                    ui.commands.PromptChoice("r", u"baR", None),
+                ]
 
         self.register_plugin(DummyPlugin)
         # Default options + extra choices by the plugin ('Foo', 'Bar')
-        opts = (u'Apply', u'More candidates', u'Skip', u'Use as-is',
-                u'as Tracks', u'Group albums', u'Enter search',
-                u'enter Id', u'aBort') + (u'Foo', u'baR')
+        opts = (
+            u"Apply",
+            u"More candidates",
+            u"Skip",
+            u"Use as-is",
+            u"as Tracks",
+            u"Group albums",
+            u"Enter search",
+            u"enter Id",
+            u"aBort",
+        ) + (u"Foo", u"baR")
 
         self.importer.add_choice(action.SKIP)
         self.importer.run()
-        self.mock_input_options.assert_called_once_with(opts, default='a',
-                                                        require=ANY)
+        self.mock_input_options.assert_called_once_with(
+            opts, default="a", require=ANY
+        )
 
     def test_plugin_choices_in_ui_input_options_singleton(self):
         """Test the presence of plugin choices on the prompt (singleton)."""
+
         class DummyPlugin(plugins.BeetsPlugin):
             def __init__(self):
                 super(DummyPlugin, self).__init__()
-                self.register_listener('before_choose_candidate',
-                                       self.return_choices)
+                self.register_listener(
+                    "before_choose_candidate", self.return_choices
+                )
 
             def return_choices(self, session, task):
-                return [ui.commands.PromptChoice('f', u'Foo', None),
-                        ui.commands.PromptChoice('r', u'baR', None)]
+                return [
+                    ui.commands.PromptChoice("f", u"Foo", None),
+                    ui.commands.PromptChoice("r", u"baR", None),
+                ]
 
         self.register_plugin(DummyPlugin)
         # Default options + extra choices by the plugin ('Foo', 'Bar')
-        opts = (u'Apply', u'More candidates', u'Skip', u'Use as-is',
-                u'Enter search',
-                u'enter Id', u'aBort') + (u'Foo', u'baR')
+        opts = (
+            u"Apply",
+            u"More candidates",
+            u"Skip",
+            u"Use as-is",
+            u"Enter search",
+            u"enter Id",
+            u"aBort",
+        ) + (u"Foo", u"baR")
 
-        config['import']['singletons'] = True
+        config["import"]["singletons"] = True
         self.importer.add_choice(action.SKIP)
         self.importer.run()
-        self.mock_input_options.assert_called_with(opts, default='a',
-                                                   require=ANY)
+        self.mock_input_options.assert_called_with(
+            opts, default="a", require=ANY
+        )
 
     def test_choices_conflicts(self):
         """Test the short letter conflict solving."""
+
         class DummyPlugin(plugins.BeetsPlugin):
             def __init__(self):
                 super(DummyPlugin, self).__init__()
-                self.register_listener('before_choose_candidate',
-                                       self.return_choices)
+                self.register_listener(
+                    "before_choose_candidate", self.return_choices
+                )
 
             def return_choices(self, session, task):
-                return [ui.commands.PromptChoice('a', u'A foo', None),  # dupe
-                        ui.commands.PromptChoice('z', u'baZ', None),    # ok
-                        ui.commands.PromptChoice('z', u'Zupe', None),   # dupe
-                        ui.commands.PromptChoice('z', u'Zoo', None)]    # dupe
+                return [
+                    ui.commands.PromptChoice("a", u"A foo", None),  # dupe
+                    ui.commands.PromptChoice("z", u"baZ", None),  # ok
+                    ui.commands.PromptChoice("z", u"Zupe", None),  # dupe
+                    ui.commands.PromptChoice("z", u"Zoo", None),
+                ]  # dupe
 
         self.register_plugin(DummyPlugin)
         # Default options + not dupe extra choices by the plugin ('baZ')
-        opts = (u'Apply', u'More candidates', u'Skip', u'Use as-is',
-                u'as Tracks', u'Group albums', u'Enter search',
-                u'enter Id', u'aBort') + (u'baZ',)
+        opts = (
+            u"Apply",
+            u"More candidates",
+            u"Skip",
+            u"Use as-is",
+            u"as Tracks",
+            u"Group albums",
+            u"Enter search",
+            u"enter Id",
+            u"aBort",
+        ) + (u"baZ",)
         self.importer.add_choice(action.SKIP)
         self.importer.run()
-        self.mock_input_options.assert_called_once_with(opts, default='a',
-                                                        require=ANY)
+        self.mock_input_options.assert_called_once_with(
+            opts, default="a", require=ANY
+        )
 
     def test_plugin_callback(self):
         """Test that plugin callbacks are being called upon user choice."""
+
         class DummyPlugin(plugins.BeetsPlugin):
             def __init__(self):
                 super(DummyPlugin, self).__init__()
-                self.register_listener('before_choose_candidate',
-                                       self.return_choices)
+                self.register_listener(
+                    "before_choose_candidate", self.return_choices
+                )
 
             def return_choices(self, session, task):
-                return [ui.commands.PromptChoice('f', u'Foo', self.foo)]
+                return [ui.commands.PromptChoice("f", u"Foo", self.foo)]
 
             def foo(self, session, task):
                 pass
 
         self.register_plugin(DummyPlugin)
         # Default options + extra choices by the plugin ('Foo', 'Bar')
-        opts = (u'Apply', u'More candidates', u'Skip', u'Use as-is',
-                u'as Tracks', u'Group albums', u'Enter search',
-                u'enter Id', u'aBort') + (u'Foo',)
+        opts = (
+            u"Apply",
+            u"More candidates",
+            u"Skip",
+            u"Use as-is",
+            u"as Tracks",
+            u"Group albums",
+            u"Enter search",
+            u"enter Id",
+            u"aBort",
+        ) + (u"Foo",)
 
         # DummyPlugin.foo() should be called once
-        with patch.object(DummyPlugin, 'foo', autospec=True) as mock_foo:
-            with helper.control_stdin('\n'.join(['f', 's'])):
+        with patch.object(DummyPlugin, "foo", autospec=True) as mock_foo:
+            with helper.control_stdin("\n".join(["f", "s"])):
                 self.importer.run()
             self.assertEqual(mock_foo.call_count, 1)
 
         # input_options should be called twice, as foo() returns None
         self.assertEqual(self.mock_input_options.call_count, 2)
-        self.mock_input_options.assert_called_with(opts, default='a',
-                                                   require=ANY)
+        self.mock_input_options.assert_called_with(
+            opts, default="a", require=ANY
+        )
 
     def test_plugin_callback_return(self):
         """Test that plugin callbacks that return a value exit the loop."""
+
         class DummyPlugin(plugins.BeetsPlugin):
             def __init__(self):
                 super(DummyPlugin, self).__init__()
-                self.register_listener('before_choose_candidate',
-                                       self.return_choices)
+                self.register_listener(
+                    "before_choose_candidate", self.return_choices
+                )
 
             def return_choices(self, session, task):
-                return [ui.commands.PromptChoice('f', u'Foo', self.foo)]
+                return [ui.commands.PromptChoice("f", u"Foo", self.foo)]
 
             def foo(self, session, task):
                 return action.SKIP
 
         self.register_plugin(DummyPlugin)
         # Default options + extra choices by the plugin ('Foo', 'Bar')
-        opts = (u'Apply', u'More candidates', u'Skip', u'Use as-is',
-                u'as Tracks', u'Group albums', u'Enter search',
-                u'enter Id', u'aBort') + (u'Foo',)
+        opts = (
+            u"Apply",
+            u"More candidates",
+            u"Skip",
+            u"Use as-is",
+            u"as Tracks",
+            u"Group albums",
+            u"Enter search",
+            u"enter Id",
+            u"aBort",
+        ) + (u"Foo",)
 
         # DummyPlugin.foo() should be called once
-        with helper.control_stdin('f\n'):
+        with helper.control_stdin("f\n"):
             self.importer.run()
 
         # input_options should be called once, as foo() returns SKIP
-        self.mock_input_options.assert_called_once_with(opts, default='a',
-                                                        require=ANY)
+        self.mock_input_options.assert_called_once_with(
+            opts, default="a", require=ANY
+        )
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -29,8 +29,11 @@ from test import helper
 import beets.library
 from beets import dbcore
 from beets.dbcore import types
-from beets.dbcore.query import (NoneQuery, ParsingError,
-                                InvalidQueryArgumentValueError)
+from beets.dbcore.query import (
+    NoneQuery,
+    ParsingError,
+    InvalidQueryArgumentValueError,
+)
 from beets.library import Library, Item
 from beets import util
 import platform
@@ -38,7 +41,6 @@ import six
 
 
 class TestHelper(helper.TestHelper):
-
     def assertInResult(self, item, results):  # noqa
         result_ids = [i.id for i in results]
         self.assertIn(item.id, result_ids)
@@ -51,26 +53,31 @@ class TestHelper(helper.TestHelper):
 class AnyFieldQueryTest(_common.LibTestCase):
     def test_no_restriction(self):
         q = dbcore.query.AnyFieldQuery(
-            'title', beets.library.Item._fields.keys(),
-            dbcore.query.SubstringQuery
+            "title",
+            beets.library.Item._fields.keys(),
+            dbcore.query.SubstringQuery,
         )
-        self.assertEqual(self.lib.items(q).get().title, 'the title')
+        self.assertEqual(self.lib.items(q).get().title, "the title")
 
     def test_restriction_completeness(self):
-        q = dbcore.query.AnyFieldQuery('title', [u'title'],
-                                       dbcore.query.SubstringQuery)
-        self.assertEqual(self.lib.items(q).get().title, u'the title')
+        q = dbcore.query.AnyFieldQuery(
+            "title", [u"title"], dbcore.query.SubstringQuery
+        )
+        self.assertEqual(self.lib.items(q).get().title, u"the title")
 
     def test_restriction_soundness(self):
-        q = dbcore.query.AnyFieldQuery('title', [u'artist'],
-                                       dbcore.query.SubstringQuery)
+        q = dbcore.query.AnyFieldQuery(
+            "title", [u"artist"], dbcore.query.SubstringQuery
+        )
         self.assertEqual(self.lib.items(q).get(), None)
 
     def test_eq(self):
-        q1 = dbcore.query.AnyFieldQuery('foo', [u'bar'],
-                                        dbcore.query.SubstringQuery)
-        q2 = dbcore.query.AnyFieldQuery('foo', [u'bar'],
-                                        dbcore.query.SubstringQuery)
+        q1 = dbcore.query.AnyFieldQuery(
+            "foo", [u"bar"], dbcore.query.SubstringQuery
+        )
+        q2 = dbcore.query.AnyFieldQuery(
+            "foo", [u"bar"], dbcore.query.SubstringQuery
+        )
         self.assertEqual(q1, q2)
 
         q2.query_class = None
@@ -90,21 +97,21 @@ class AssertsMixin(object):
 class DummyDataTestCase(_common.TestCase, AssertsMixin):
     def setUp(self):
         super(DummyDataTestCase, self).setUp()
-        self.lib = beets.library.Library(':memory:')
+        self.lib = beets.library.Library(":memory:")
         items = [_common.item() for _ in range(3)]
-        items[0].title = u'foo bar'
-        items[0].artist = u'one'
-        items[0].album = u'baz'
+        items[0].title = u"foo bar"
+        items[0].artist = u"one"
+        items[0].album = u"baz"
         items[0].year = 2001
         items[0].comp = True
-        items[1].title = u'baz qux'
-        items[1].artist = u'two'
-        items[1].album = u'baz'
+        items[1].title = u"baz qux"
+        items[1].artist = u"two"
+        items[1].album = u"baz"
         items[1].year = 2002
         items[1].comp = True
-        items[2].title = u'beets 4 eva'
-        items[2].artist = u'three'
-        items[2].album = u'foo'
+        items[2].title = u"beets 4 eva"
+        items[2].artist = u"three"
+        items[2].album = u"foo"
         items[2].year = 2003
         items[2].comp = False
         for item in items:
@@ -112,16 +119,14 @@ class DummyDataTestCase(_common.TestCase, AssertsMixin):
         self.lib.add_album(items[:2])
 
     def assert_items_matched_all(self, results):
-        self.assert_items_matched(results, [
-            u'foo bar',
-            u'baz qux',
-            u'beets 4 eva',
-        ])
+        self.assert_items_matched(
+            results, [u"foo bar", u"baz qux", u"beets 4 eva",]
+        )
 
 
 class GetTest(DummyDataTestCase):
     def test_get_empty(self):
-        q = u''
+        q = u""
         results = self.lib.items(q)
         self.assert_items_matched_all(results)
 
@@ -131,188 +136,175 @@ class GetTest(DummyDataTestCase):
         self.assert_items_matched_all(results)
 
     def test_get_one_keyed_term(self):
-        q = u'title:qux'
+        q = u"title:qux"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'baz qux'])
+        self.assert_items_matched(results, [u"baz qux"])
 
     def test_get_one_keyed_regexp(self):
-        q = u'artist::t.+r'
+        q = u"artist::t.+r"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'beets 4 eva'])
+        self.assert_items_matched(results, [u"beets 4 eva"])
 
     def test_get_one_unkeyed_term(self):
-        q = u'three'
+        q = u"three"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'beets 4 eva'])
+        self.assert_items_matched(results, [u"beets 4 eva"])
 
     def test_get_one_unkeyed_regexp(self):
-        q = u':x$'
+        q = u":x$"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'baz qux'])
+        self.assert_items_matched(results, [u"baz qux"])
 
     def test_get_no_matches(self):
-        q = u'popebear'
+        q = u"popebear"
         results = self.lib.items(q)
         self.assert_items_matched(results, [])
 
     def test_invalid_key(self):
-        q = u'pope:bear'
+        q = u"pope:bear"
         results = self.lib.items(q)
         # Matches nothing since the flexattr is not present on the
         # objects.
         self.assert_items_matched(results, [])
 
     def test_term_case_insensitive(self):
-        q = u'oNE'
+        q = u"oNE"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'foo bar'])
+        self.assert_items_matched(results, [u"foo bar"])
 
     def test_regexp_case_sensitive(self):
-        q = u':oNE'
+        q = u":oNE"
         results = self.lib.items(q)
         self.assert_items_matched(results, [])
-        q = u':one'
+        q = u":one"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'foo bar'])
+        self.assert_items_matched(results, [u"foo bar"])
 
     def test_term_case_insensitive_with_key(self):
-        q = u'artist:thrEE'
+        q = u"artist:thrEE"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'beets 4 eva'])
+        self.assert_items_matched(results, [u"beets 4 eva"])
 
     def test_key_case_insensitive(self):
-        q = u'ArTiST:three'
+        q = u"ArTiST:three"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'beets 4 eva'])
+        self.assert_items_matched(results, [u"beets 4 eva"])
 
     def test_unkeyed_term_matches_multiple_columns(self):
-        q = u'baz'
+        q = u"baz"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [
-            u'foo bar',
-            u'baz qux',
-        ])
+        self.assert_items_matched(results, [u"foo bar", u"baz qux",])
 
     def test_unkeyed_regexp_matches_multiple_columns(self):
-        q = u':z$'
+        q = u":z$"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [
-            u'foo bar',
-            u'baz qux',
-        ])
+        self.assert_items_matched(results, [u"foo bar", u"baz qux",])
 
     def test_keyed_term_matches_only_one_column(self):
-        q = u'title:baz'
+        q = u"title:baz"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'baz qux'])
+        self.assert_items_matched(results, [u"baz qux"])
 
     def test_keyed_regexp_matches_only_one_column(self):
-        q = u'title::baz'
+        q = u"title::baz"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [
-            u'baz qux',
-        ])
+        self.assert_items_matched(results, [u"baz qux",])
 
     def test_multiple_terms_narrow_search(self):
-        q = u'qux baz'
+        q = u"qux baz"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [
-            u'baz qux',
-        ])
+        self.assert_items_matched(results, [u"baz qux",])
 
     def test_multiple_regexps_narrow_search(self):
-        q = u':baz :qux'
+        q = u":baz :qux"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'baz qux'])
+        self.assert_items_matched(results, [u"baz qux"])
 
     def test_mixed_terms_regexps_narrow_search(self):
-        q = u':baz qux'
+        q = u":baz qux"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'baz qux'])
+        self.assert_items_matched(results, [u"baz qux"])
 
     def test_single_year(self):
-        q = u'year:2001'
+        q = u"year:2001"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'foo bar'])
+        self.assert_items_matched(results, [u"foo bar"])
 
     def test_year_range(self):
-        q = u'year:2000..2002'
+        q = u"year:2000..2002"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [
-            u'foo bar',
-            u'baz qux',
-        ])
+        self.assert_items_matched(results, [u"foo bar", u"baz qux",])
 
     def test_singleton_true(self):
-        q = u'singleton:true'
+        q = u"singleton:true"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'beets 4 eva'])
+        self.assert_items_matched(results, [u"beets 4 eva"])
 
     def test_singleton_false(self):
-        q = u'singleton:false'
+        q = u"singleton:false"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'foo bar', u'baz qux'])
+        self.assert_items_matched(results, [u"foo bar", u"baz qux"])
 
     def test_compilation_true(self):
-        q = u'comp:true'
+        q = u"comp:true"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'foo bar', u'baz qux'])
+        self.assert_items_matched(results, [u"foo bar", u"baz qux"])
 
     def test_compilation_false(self):
-        q = u'comp:false'
+        q = u"comp:false"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'beets 4 eva'])
+        self.assert_items_matched(results, [u"beets 4 eva"])
 
     def test_unknown_field_name_no_results(self):
-        q = u'xyzzy:nonsense'
+        q = u"xyzzy:nonsense"
         results = self.lib.items(q)
         titles = [i.title for i in results]
         self.assertEqual(titles, [])
 
     def test_unknown_field_name_no_results_in_album_query(self):
-        q = u'xyzzy:nonsense'
+        q = u"xyzzy:nonsense"
         results = self.lib.albums(q)
         names = [a.album for a in results]
         self.assertEqual(names, [])
 
     def test_item_field_name_matches_nothing_in_album_query(self):
-        q = u'format:nonsense'
+        q = u"format:nonsense"
         results = self.lib.albums(q)
         names = [a.album for a in results]
         self.assertEqual(names, [])
 
     def test_unicode_query(self):
         item = self.lib.items().get()
-        item.title = u'caf\xe9'
+        item.title = u"caf\xe9"
         item.store()
 
-        q = u'title:caf\xe9'
+        q = u"title:caf\xe9"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'caf\xe9'])
+        self.assert_items_matched(results, [u"caf\xe9"])
 
     def test_numeric_search_positive(self):
-        q = dbcore.query.NumericQuery('year', u'2001')
+        q = dbcore.query.NumericQuery("year", u"2001")
         results = self.lib.items(q)
         self.assertTrue(results)
 
     def test_numeric_search_negative(self):
-        q = dbcore.query.NumericQuery('year', u'1999')
+        q = dbcore.query.NumericQuery("year", u"1999")
         results = self.lib.items(q)
         self.assertFalse(results)
 
     def test_invalid_query(self):
         with self.assertRaises(InvalidQueryArgumentValueError) as raised:
-            dbcore.query.NumericQuery('year', u'199a')
-        self.assertIn(u'not an int', six.text_type(raised.exception))
+            dbcore.query.NumericQuery("year", u"199a")
+        self.assertIn(u"not an int", six.text_type(raised.exception))
 
         with self.assertRaises(InvalidQueryArgumentValueError) as raised:
-            dbcore.query.RegexpQuery('year', u'199(')
+            dbcore.query.RegexpQuery("year", u"199(")
         exception_text = six.text_type(raised.exception)
-        self.assertIn(u'not a regular expression', exception_text)
+        self.assertIn(u"not a regular expression", exception_text)
         if sys.version_info >= (3, 5):
-            self.assertIn(u'unterminated subpattern', exception_text)
+            self.assertIn(u"unterminated subpattern", exception_text)
         else:
-            self.assertIn(u'unbalanced parenthesis', exception_text)
+            self.assertIn(u"unbalanced parenthesis", exception_text)
         self.assertIsInstance(raised.exception, ParsingError)
 
 
@@ -322,53 +314,53 @@ class MatchTest(_common.TestCase):
         self.item = _common.item()
 
     def test_regex_match_positive(self):
-        q = dbcore.query.RegexpQuery('album', u'^the album$')
+        q = dbcore.query.RegexpQuery("album", u"^the album$")
         self.assertTrue(q.match(self.item))
 
     def test_regex_match_negative(self):
-        q = dbcore.query.RegexpQuery('album', u'^album$')
+        q = dbcore.query.RegexpQuery("album", u"^album$")
         self.assertFalse(q.match(self.item))
 
     def test_regex_match_non_string_value(self):
-        q = dbcore.query.RegexpQuery('disc', u'^6$')
+        q = dbcore.query.RegexpQuery("disc", u"^6$")
         self.assertTrue(q.match(self.item))
 
     def test_substring_match_positive(self):
-        q = dbcore.query.SubstringQuery('album', u'album')
+        q = dbcore.query.SubstringQuery("album", u"album")
         self.assertTrue(q.match(self.item))
 
     def test_substring_match_negative(self):
-        q = dbcore.query.SubstringQuery('album', u'ablum')
+        q = dbcore.query.SubstringQuery("album", u"ablum")
         self.assertFalse(q.match(self.item))
 
     def test_substring_match_non_string_value(self):
-        q = dbcore.query.SubstringQuery('disc', u'6')
+        q = dbcore.query.SubstringQuery("disc", u"6")
         self.assertTrue(q.match(self.item))
 
     def test_year_match_positive(self):
-        q = dbcore.query.NumericQuery('year', u'1')
+        q = dbcore.query.NumericQuery("year", u"1")
         self.assertTrue(q.match(self.item))
 
     def test_year_match_negative(self):
-        q = dbcore.query.NumericQuery('year', u'10')
+        q = dbcore.query.NumericQuery("year", u"10")
         self.assertFalse(q.match(self.item))
 
     def test_bitrate_range_positive(self):
-        q = dbcore.query.NumericQuery('bitrate', u'100000..200000')
+        q = dbcore.query.NumericQuery("bitrate", u"100000..200000")
         self.assertTrue(q.match(self.item))
 
     def test_bitrate_range_negative(self):
-        q = dbcore.query.NumericQuery('bitrate', u'200000..300000')
+        q = dbcore.query.NumericQuery("bitrate", u"200000..300000")
         self.assertFalse(q.match(self.item))
 
     def test_open_range(self):
-        dbcore.query.NumericQuery('bitrate', u'100000..')
+        dbcore.query.NumericQuery("bitrate", u"100000..")
 
     def test_eq(self):
-        q1 = dbcore.query.MatchQuery('foo', u'bar')
-        q2 = dbcore.query.MatchQuery('foo', u'bar')
-        q3 = dbcore.query.MatchQuery('foo', u'baz')
-        q4 = dbcore.query.StringFieldQuery('foo', u'bar')
+        q1 = dbcore.query.MatchQuery("foo", u"bar")
+        q2 = dbcore.query.MatchQuery("foo", u"bar")
+        q3 = dbcore.query.MatchQuery("foo", u"baz")
+        q4 = dbcore.query.StringFieldQuery("foo", u"bar")
         self.assertEqual(q1, q2)
         self.assertNotEqual(q1, q3)
         self.assertNotEqual(q1, q4)
@@ -380,30 +372,31 @@ class PathQueryTest(_common.LibTestCase, TestHelper, AssertsMixin):
         super(PathQueryTest, self).setUp()
 
         # This is the item we'll try to match.
-        self.i.path = util.normpath('/a/b/c.mp3')
-        self.i.title = u'path item'
-        self.i.album = u'path album'
+        self.i.path = util.normpath("/a/b/c.mp3")
+        self.i.title = u"path item"
+        self.i.album = u"path album"
         self.i.store()
         self.lib.add_album([self.i])
 
         # A second item for testing exclusion.
         i2 = _common.item()
-        i2.path = util.normpath('/x/y/z.mp3')
-        i2.title = 'another item'
-        i2.album = 'another album'
+        i2.path = util.normpath("/x/y/z.mp3")
+        i2.title = "another item"
+        i2.album = "another album"
         self.lib.add(i2)
         self.lib.add_album([i2])
 
         # Unadorned path queries with path separators in them are considered
         # path queries only when the path in question actually exists. So we
         # mock the existence check to return true.
-        self.patcher_exists = patch('beets.library.os.path.exists')
+        self.patcher_exists = patch("beets.library.os.path.exists")
         self.patcher_exists.start().return_value = True
 
         # We have to create function samefile as it does not exist on
         # Windows and python 2.7
-        self.patcher_samefile = patch('beets.library.os.path.samefile',
-                                      create=True)
+        self.patcher_samefile = patch(
+            "beets.library.os.path.samefile", create=True
+        )
         self.patcher_samefile.start().return_value = True
 
     def tearDown(self):
@@ -413,31 +406,31 @@ class PathQueryTest(_common.LibTestCase, TestHelper, AssertsMixin):
         self.patcher_exists.stop()
 
     def test_path_exact_match(self):
-        q = u'path:/a/b/c.mp3'
+        q = u"path:/a/b/c.mp3"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'path item'])
+        self.assert_items_matched(results, [u"path item"])
 
         results = self.lib.albums(q)
         self.assert_albums_matched(results, [])
 
     def test_parent_directory_no_slash(self):
-        q = u'path:/a'
+        q = u"path:/a"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'path item'])
+        self.assert_items_matched(results, [u"path item"])
 
         results = self.lib.albums(q)
-        self.assert_albums_matched(results, [u'path album'])
+        self.assert_albums_matched(results, [u"path album"])
 
     def test_parent_directory_with_slash(self):
-        q = u'path:/a/'
+        q = u"path:/a/"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'path item'])
+        self.assert_items_matched(results, [u"path item"])
 
         results = self.lib.albums(q)
-        self.assert_albums_matched(results, [u'path album'])
+        self.assert_albums_matched(results, [u"path album"])
 
     def test_no_match(self):
-        q = u'path:/xyzzy/'
+        q = u"path:/xyzzy/"
         results = self.lib.items(q)
         self.assert_items_matched(results, [])
 
@@ -445,7 +438,7 @@ class PathQueryTest(_common.LibTestCase, TestHelper, AssertsMixin):
         self.assert_albums_matched(results, [])
 
     def test_fragment_no_match(self):
-        q = u'path:/b/'
+        q = u"path:/b/"
         results = self.lib.items(q)
         self.assert_items_matched(results, [])
 
@@ -453,29 +446,29 @@ class PathQueryTest(_common.LibTestCase, TestHelper, AssertsMixin):
         self.assert_albums_matched(results, [])
 
     def test_nonnorm_path(self):
-        q = u'path:/x/../a/b'
+        q = u"path:/x/../a/b"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'path item'])
+        self.assert_items_matched(results, [u"path item"])
 
         results = self.lib.albums(q)
-        self.assert_albums_matched(results, [u'path album'])
+        self.assert_albums_matched(results, [u"path album"])
 
     def test_slashed_query_matches_path(self):
-        q = u'/a/b'
+        q = u"/a/b"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'path item'])
+        self.assert_items_matched(results, [u"path item"])
 
         results = self.lib.albums(q)
-        self.assert_albums_matched(results, [u'path album'])
+        self.assert_albums_matched(results, [u"path album"])
 
-    @unittest.skip('unfixed (#1865)')
+    @unittest.skip("unfixed (#1865)")
     def test_path_query_in_or_query(self):
-        q = '/a/b , /a/b'
+        q = "/a/b , /a/b"
         results = self.lib.items(q)
-        self.assert_items_matched(results, ['path item'])
+        self.assert_items_matched(results, ["path item"])
 
     def test_non_slashed_does_not_match_path(self):
-        q = u'c.mp3'
+        q = u"c.mp3"
         results = self.lib.items(q)
         self.assert_items_matched(results, [])
 
@@ -483,64 +476,73 @@ class PathQueryTest(_common.LibTestCase, TestHelper, AssertsMixin):
         self.assert_albums_matched(results, [])
 
     def test_slashes_in_explicit_field_does_not_match_path(self):
-        q = u'title:/a/b'
+        q = u"title:/a/b"
         results = self.lib.items(q)
         self.assert_items_matched(results, [])
 
     def test_path_item_regex(self):
-        q = u'path::c\\.mp3$'
+        q = u"path::c\\.mp3$"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'path item'])
+        self.assert_items_matched(results, [u"path item"])
 
     def test_path_album_regex(self):
-        q = u'path::b'
+        q = u"path::b"
         results = self.lib.albums(q)
-        self.assert_albums_matched(results, [u'path album'])
+        self.assert_albums_matched(results, [u"path album"])
 
     def test_escape_underscore(self):
-        self.add_album(path=b'/a/_/title.mp3', title=u'with underscore',
-                       album=u'album with underscore')
-        q = u'path:/a/_'
+        self.add_album(
+            path=b"/a/_/title.mp3",
+            title=u"with underscore",
+            album=u"album with underscore",
+        )
+        q = u"path:/a/_"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'with underscore'])
+        self.assert_items_matched(results, [u"with underscore"])
 
         results = self.lib.albums(q)
-        self.assert_albums_matched(results, [u'album with underscore'])
+        self.assert_albums_matched(results, [u"album with underscore"])
 
     def test_escape_percent(self):
-        self.add_album(path=b'/a/%/title.mp3', title=u'with percent',
-                       album=u'album with percent')
-        q = u'path:/a/%'
+        self.add_album(
+            path=b"/a/%/title.mp3",
+            title=u"with percent",
+            album=u"album with percent",
+        )
+        q = u"path:/a/%"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'with percent'])
+        self.assert_items_matched(results, [u"with percent"])
 
         results = self.lib.albums(q)
-        self.assert_albums_matched(results, [u'album with percent'])
+        self.assert_albums_matched(results, [u"album with percent"])
 
     def test_escape_backslash(self):
-        self.add_album(path=br'/a/\x/title.mp3', title=u'with backslash',
-                       album=u'album with backslash')
-        q = u'path:/a/\\\\x'
+        self.add_album(
+            path=br"/a/\x/title.mp3",
+            title=u"with backslash",
+            album=u"album with backslash",
+        )
+        q = u"path:/a/\\\\x"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'with backslash'])
+        self.assert_items_matched(results, [u"with backslash"])
 
         results = self.lib.albums(q)
-        self.assert_albums_matched(results, [u'album with backslash'])
+        self.assert_albums_matched(results, [u"album with backslash"])
 
     def test_case_sensitivity(self):
-        self.add_album(path=b'/A/B/C2.mp3', title=u'caps path')
+        self.add_album(path=b"/A/B/C2.mp3", title=u"caps path")
 
-        makeq = partial(beets.library.PathQuery, u'path', '/A/B')
+        makeq = partial(beets.library.PathQuery, u"path", "/A/B")
 
         results = self.lib.items(makeq(case_sensitive=True))
-        self.assert_items_matched(results, [u'caps path'])
+        self.assert_items_matched(results, [u"caps path"])
 
         results = self.lib.items(makeq(case_sensitive=False))
-        self.assert_items_matched(results, [u'path item', u'caps path'])
+        self.assert_items_matched(results, [u"path item", u"caps path"])
 
         # Check for correct case sensitivity selection (this check
         # only works on non-Windows OSes).
-        with _common.system_mock('Darwin'):
+        with _common.system_mock("Darwin"):
             # exists = True and samefile = True => Case insensitive
             q = makeq()
             self.assertEqual(q.case_sensitive, False)
@@ -561,11 +563,11 @@ class PathQueryTest(_common.LibTestCase, TestHelper, AssertsMixin):
         self.patcher_exists.stop()
         self.patcher_exists.start().return_value = False
         try:
-            with _common.system_mock('Darwin'):
+            with _common.system_mock("Darwin"):
                 q = makeq()
                 self.assertEqual(q.case_sensitive, True)
 
-            with _common.system_mock('Windows'):
+            with _common.system_mock("Windows"):
                 q = makeq()
                 self.assertEqual(q.case_sensitive, False)
         finally:
@@ -573,26 +575,26 @@ class PathQueryTest(_common.LibTestCase, TestHelper, AssertsMixin):
             self.patcher_exists.stop()
             self.patcher_exists.start().return_value = True
 
-    @patch('beets.library.os')
+    @patch("beets.library.os")
     def test_path_sep_detection(self, mock_os):
-        mock_os.sep = '/'
+        mock_os.sep = "/"
         mock_os.altsep = None
         mock_os.path.exists = lambda p: True
         is_path = beets.library.PathQuery.is_path_query
 
-        self.assertTrue(is_path('/foo/bar'))
-        self.assertTrue(is_path('foo/bar'))
-        self.assertTrue(is_path('foo/'))
-        self.assertFalse(is_path('foo'))
-        self.assertTrue(is_path('foo/:bar'))
-        self.assertFalse(is_path('foo:bar/'))
-        self.assertFalse(is_path('foo:/bar'))
+        self.assertTrue(is_path("/foo/bar"))
+        self.assertTrue(is_path("foo/bar"))
+        self.assertTrue(is_path("foo/"))
+        self.assertFalse(is_path("foo"))
+        self.assertTrue(is_path("foo/:bar"))
+        self.assertFalse(is_path("foo:bar/"))
+        self.assertFalse(is_path("foo:/bar"))
 
     def test_detect_absolute_path(self):
-        if platform.system() == 'Windows':
+        if platform.system() == "Windows":
             # Because the absolute path begins with something like C:, we
             # can't disambiguate it from an ordinary query.
-            self.skipTest('Windows absolute paths do not work as queries')
+            self.skipTest("Windows absolute paths do not work as queries")
 
         # Don't patch `os.path.exists`; we'll actually create a file when
         # it exists.
@@ -600,8 +602,8 @@ class PathQueryTest(_common.LibTestCase, TestHelper, AssertsMixin):
         is_path = beets.library.PathQuery.is_path_query
 
         try:
-            path = self.touch(os.path.join(b'foo', b'bar'))
-            path = path.decode('utf-8')
+            path = self.touch(os.path.join(b"foo", b"bar"))
+            path = path.decode("utf-8")
 
             # The file itself.
             self.assertTrue(is_path(path))
@@ -611,7 +613,7 @@ class PathQueryTest(_common.LibTestCase, TestHelper, AssertsMixin):
             self.assertTrue(is_path(parent))
 
             # Some non-existent path.
-            self.assertFalse(is_path(path + u'baz'))
+            self.assertFalse(is_path(path + u"baz"))
 
         finally:
             # Restart the `os.path.exists` patch.
@@ -622,16 +624,16 @@ class PathQueryTest(_common.LibTestCase, TestHelper, AssertsMixin):
         is_path = beets.library.PathQuery.is_path_query
 
         try:
-            self.touch(os.path.join(b'foo', b'bar'))
+            self.touch(os.path.join(b"foo", b"bar"))
 
             # Temporarily change directory so relative paths work.
             cur_dir = os.getcwd()
             try:
                 os.chdir(self.temp_dir)
-                self.assertTrue(is_path(u'foo/'))
-                self.assertTrue(is_path(u'foo/bar'))
-                self.assertTrue(is_path(u'foo/bar:tagada'))
-                self.assertFalse(is_path(u'bar'))
+                self.assertTrue(is_path(u"foo/"))
+                self.assertTrue(is_path(u"foo/bar"))
+                self.assertTrue(is_path(u"foo/bar:tagada"))
+                self.assertFalse(is_path(u"bar"))
             finally:
                 os.chdir(cur_dir)
 
@@ -640,49 +642,47 @@ class PathQueryTest(_common.LibTestCase, TestHelper, AssertsMixin):
 
 
 class IntQueryTest(unittest.TestCase, TestHelper):
-
     def setUp(self):
-        self.lib = Library(':memory:')
+        self.lib = Library(":memory:")
 
     def tearDown(self):
         Item._types = {}
 
     def test_exact_value_match(self):
         item = self.add_item(bpm=120)
-        matched = self.lib.items(u'bpm:120').get()
+        matched = self.lib.items(u"bpm:120").get()
         self.assertEqual(item.id, matched.id)
 
     def test_range_match(self):
         item = self.add_item(bpm=120)
         self.add_item(bpm=130)
 
-        matched = self.lib.items(u'bpm:110..125')
+        matched = self.lib.items(u"bpm:110..125")
         self.assertEqual(1, len(matched))
         self.assertEqual(item.id, matched.get().id)
 
     def test_flex_range_match(self):
-        Item._types = {'myint': types.Integer()}
+        Item._types = {"myint": types.Integer()}
         item = self.add_item(myint=2)
-        matched = self.lib.items(u'myint:2').get()
+        matched = self.lib.items(u"myint:2").get()
         self.assertEqual(item.id, matched.id)
 
     def test_flex_dont_match_missing(self):
-        Item._types = {'myint': types.Integer()}
+        Item._types = {"myint": types.Integer()}
         self.add_item()
-        matched = self.lib.items(u'myint:2').get()
+        matched = self.lib.items(u"myint:2").get()
         self.assertIsNone(matched)
 
     def test_no_substring_match(self):
         self.add_item(bpm=120)
-        matched = self.lib.items(u'bpm:12').get()
+        matched = self.lib.items(u"bpm:12").get()
         self.assertIsNone(matched)
 
 
 class BoolQueryTest(unittest.TestCase, TestHelper):
-
     def setUp(self):
-        self.lib = Library(':memory:')
-        Item._types = {'flexbool': types.Boolean()}
+        self.lib = Library(":memory:")
+        Item._types = {"flexbool": types.Boolean()}
 
     def tearDown(self):
         Item._types = {}
@@ -690,35 +690,35 @@ class BoolQueryTest(unittest.TestCase, TestHelper):
     def test_parse_true(self):
         item_true = self.add_item(comp=True)
         item_false = self.add_item(comp=False)
-        matched = self.lib.items(u'comp:true')
+        matched = self.lib.items(u"comp:true")
         self.assertInResult(item_true, matched)
         self.assertNotInResult(item_false, matched)
 
     def test_flex_parse_true(self):
         item_true = self.add_item(flexbool=True)
         item_false = self.add_item(flexbool=False)
-        matched = self.lib.items(u'flexbool:true')
+        matched = self.lib.items(u"flexbool:true")
         self.assertInResult(item_true, matched)
         self.assertNotInResult(item_false, matched)
 
     def test_flex_parse_false(self):
         item_true = self.add_item(flexbool=True)
         item_false = self.add_item(flexbool=False)
-        matched = self.lib.items(u'flexbool:false')
+        matched = self.lib.items(u"flexbool:false")
         self.assertInResult(item_false, matched)
         self.assertNotInResult(item_true, matched)
 
     def test_flex_parse_1(self):
         item_true = self.add_item(flexbool=True)
         item_false = self.add_item(flexbool=False)
-        matched = self.lib.items(u'flexbool:1')
+        matched = self.lib.items(u"flexbool:1")
         self.assertInResult(item_true, matched)
         self.assertNotInResult(item_false, matched)
 
     def test_flex_parse_0(self):
         item_true = self.add_item(flexbool=True)
         item_false = self.add_item(flexbool=False)
-        matched = self.lib.items(u'flexbool:0')
+        matched = self.lib.items(u"flexbool:0")
         self.assertInResult(item_false, matched)
         self.assertNotInResult(item_true, matched)
 
@@ -726,65 +726,64 @@ class BoolQueryTest(unittest.TestCase, TestHelper):
         # TODO this should be the other way around
         item_true = self.add_item(flexbool=True)
         item_false = self.add_item(flexbool=False)
-        matched = self.lib.items(u'flexbool:something')
+        matched = self.lib.items(u"flexbool:something")
         self.assertInResult(item_false, matched)
         self.assertNotInResult(item_true, matched)
 
 
 class DefaultSearchFieldsTest(DummyDataTestCase):
     def test_albums_matches_album(self):
-        albums = list(self.lib.albums(u'baz'))
+        albums = list(self.lib.albums(u"baz"))
         self.assertEqual(len(albums), 1)
 
     def test_albums_matches_albumartist(self):
-        albums = list(self.lib.albums([u'album artist']))
+        albums = list(self.lib.albums([u"album artist"]))
         self.assertEqual(len(albums), 1)
 
     def test_items_matches_title(self):
-        items = self.lib.items(u'beets')
-        self.assert_items_matched(items, [u'beets 4 eva'])
+        items = self.lib.items(u"beets")
+        self.assert_items_matched(items, [u"beets 4 eva"])
 
     def test_items_does_not_match_year(self):
-        items = self.lib.items(u'2001')
+        items = self.lib.items(u"2001")
         self.assert_items_matched(items, [])
 
 
 class NoneQueryTest(unittest.TestCase, TestHelper):
-
     def setUp(self):
-        self.lib = Library(':memory:')
+        self.lib = Library(":memory:")
 
     def test_match_singletons(self):
         singleton = self.add_item()
         album_item = self.add_album().items().get()
 
-        matched = self.lib.items(NoneQuery(u'album_id'))
+        matched = self.lib.items(NoneQuery(u"album_id"))
         self.assertInResult(singleton, matched)
         self.assertNotInResult(album_item, matched)
 
     def test_match_after_set_none(self):
         item = self.add_item(rg_track_gain=0)
-        matched = self.lib.items(NoneQuery(u'rg_track_gain'))
+        matched = self.lib.items(NoneQuery(u"rg_track_gain"))
         self.assertNotInResult(item, matched)
 
-        item['rg_track_gain'] = None
+        item["rg_track_gain"] = None
         item.store()
-        matched = self.lib.items(NoneQuery(u'rg_track_gain'))
+        matched = self.lib.items(NoneQuery(u"rg_track_gain"))
         self.assertInResult(item, matched)
 
     def test_match_slow(self):
         item = self.add_item()
-        matched = self.lib.items(NoneQuery(u'rg_track_peak', fast=False))
+        matched = self.lib.items(NoneQuery(u"rg_track_peak", fast=False))
         self.assertInResult(item, matched)
 
     def test_match_slow_after_set_none(self):
         item = self.add_item(rg_track_gain=0)
-        matched = self.lib.items(NoneQuery(u'rg_track_gain', fast=False))
+        matched = self.lib.items(NoneQuery(u"rg_track_gain", fast=False))
         self.assertNotInResult(item, matched)
 
-        item['rg_track_gain'] = None
+        item["rg_track_gain"] = None
         item.store()
-        matched = self.lib.items(NoneQuery(u'rg_track_gain', fast=False))
+        matched = self.lib.items(NoneQuery(u"rg_track_gain", fast=False))
         self.assertInResult(item, matched)
 
 
@@ -793,62 +792,63 @@ class NotQueryMatchTest(_common.TestCase):
     cases and assertions as on `MatchTest`, plus assertion on the negated
     queries (ie. assertTrue(q) -> assertFalse(NotQuery(q))).
     """
+
     def setUp(self):
         super(NotQueryMatchTest, self).setUp()
         self.item = _common.item()
 
     def test_regex_match_positive(self):
-        q = dbcore.query.RegexpQuery(u'album', u'^the album$')
+        q = dbcore.query.RegexpQuery(u"album", u"^the album$")
         self.assertTrue(q.match(self.item))
         self.assertFalse(dbcore.query.NotQuery(q).match(self.item))
 
     def test_regex_match_negative(self):
-        q = dbcore.query.RegexpQuery(u'album', u'^album$')
+        q = dbcore.query.RegexpQuery(u"album", u"^album$")
         self.assertFalse(q.match(self.item))
         self.assertTrue(dbcore.query.NotQuery(q).match(self.item))
 
     def test_regex_match_non_string_value(self):
-        q = dbcore.query.RegexpQuery(u'disc', u'^6$')
+        q = dbcore.query.RegexpQuery(u"disc", u"^6$")
         self.assertTrue(q.match(self.item))
         self.assertFalse(dbcore.query.NotQuery(q).match(self.item))
 
     def test_substring_match_positive(self):
-        q = dbcore.query.SubstringQuery(u'album', u'album')
+        q = dbcore.query.SubstringQuery(u"album", u"album")
         self.assertTrue(q.match(self.item))
         self.assertFalse(dbcore.query.NotQuery(q).match(self.item))
 
     def test_substring_match_negative(self):
-        q = dbcore.query.SubstringQuery(u'album', u'ablum')
+        q = dbcore.query.SubstringQuery(u"album", u"ablum")
         self.assertFalse(q.match(self.item))
         self.assertTrue(dbcore.query.NotQuery(q).match(self.item))
 
     def test_substring_match_non_string_value(self):
-        q = dbcore.query.SubstringQuery(u'disc', u'6')
+        q = dbcore.query.SubstringQuery(u"disc", u"6")
         self.assertTrue(q.match(self.item))
         self.assertFalse(dbcore.query.NotQuery(q).match(self.item))
 
     def test_year_match_positive(self):
-        q = dbcore.query.NumericQuery(u'year', u'1')
+        q = dbcore.query.NumericQuery(u"year", u"1")
         self.assertTrue(q.match(self.item))
         self.assertFalse(dbcore.query.NotQuery(q).match(self.item))
 
     def test_year_match_negative(self):
-        q = dbcore.query.NumericQuery(u'year', u'10')
+        q = dbcore.query.NumericQuery(u"year", u"10")
         self.assertFalse(q.match(self.item))
         self.assertTrue(dbcore.query.NotQuery(q).match(self.item))
 
     def test_bitrate_range_positive(self):
-        q = dbcore.query.NumericQuery(u'bitrate', u'100000..200000')
+        q = dbcore.query.NumericQuery(u"bitrate", u"100000..200000")
         self.assertTrue(q.match(self.item))
         self.assertFalse(dbcore.query.NotQuery(q).match(self.item))
 
     def test_bitrate_range_negative(self):
-        q = dbcore.query.NumericQuery(u'bitrate', u'200000..300000')
+        q = dbcore.query.NumericQuery(u"bitrate", u"200000..300000")
         self.assertFalse(q.match(self.item))
         self.assertTrue(dbcore.query.NotQuery(q).match(self.item))
 
     def test_open_range(self):
-        q = dbcore.query.NumericQuery(u'bitrate', u'100000..')
+        q = dbcore.query.NumericQuery(u"bitrate", u"100000..")
         dbcore.query.NotQuery(q)
 
 
@@ -857,6 +857,7 @@ class NotQueryTest(DummyDataTestCase):
     - `test_type_xxx`: tests for the negation of a particular XxxQuery class.
     - `test_get_yyy`: tests on query strings (similar to `GetTest`)
     """
+
     def assertNegationProperties(self, q):  # noqa
         """Given a Query `q`, assert that:
         - q OR not(q) == all items
@@ -879,39 +880,47 @@ class NotQueryTest(DummyDataTestCase):
 
         # round trip
         not_not_q = dbcore.query.NotQuery(not_q)
-        self.assertEqual(set([i.title for i in self.lib.items(q)]),
-                         set([i.title for i in self.lib.items(not_not_q)]))
+        self.assertEqual(
+            set([i.title for i in self.lib.items(q)]),
+            set([i.title for i in self.lib.items(not_not_q)]),
+        )
 
     def test_type_and(self):
         # not(a and b) <-> not(a) or not(b)
-        q = dbcore.query.AndQuery([
-            dbcore.query.BooleanQuery(u'comp', True),
-            dbcore.query.NumericQuery(u'year', u'2002')],
+        q = dbcore.query.AndQuery(
+            [
+                dbcore.query.BooleanQuery(u"comp", True),
+                dbcore.query.NumericQuery(u"year", u"2002"),
+            ],
         )
         not_results = self.lib.items(dbcore.query.NotQuery(q))
-        self.assert_items_matched(not_results, [u'foo bar', u'beets 4 eva'])
+        self.assert_items_matched(not_results, [u"foo bar", u"beets 4 eva"])
         self.assertNegationProperties(q)
 
     def test_type_anyfield(self):
-        q = dbcore.query.AnyFieldQuery(u'foo', [u'title', u'artist', u'album'],
-                                       dbcore.query.SubstringQuery)
+        q = dbcore.query.AnyFieldQuery(
+            u"foo",
+            [u"title", u"artist", u"album"],
+            dbcore.query.SubstringQuery,
+        )
         not_results = self.lib.items(dbcore.query.NotQuery(q))
-        self.assert_items_matched(not_results, [u'baz qux'])
+        self.assert_items_matched(not_results, [u"baz qux"])
         self.assertNegationProperties(q)
 
     def test_type_boolean(self):
-        q = dbcore.query.BooleanQuery(u'comp', True)
+        q = dbcore.query.BooleanQuery(u"comp", True)
         not_results = self.lib.items(dbcore.query.NotQuery(q))
-        self.assert_items_matched(not_results, [u'beets 4 eva'])
+        self.assert_items_matched(not_results, [u"beets 4 eva"])
         self.assertNegationProperties(q)
 
     def test_type_date(self):
-        q = dbcore.query.DateQuery(u'added', u'2000-01-01')
+        q = dbcore.query.DateQuery(u"added", u"2000-01-01")
         not_results = self.lib.items(dbcore.query.NotQuery(q))
         # query date is in the past, thus the 'not' results should contain all
         # items
-        self.assert_items_matched(not_results, [u'foo bar', u'baz qux',
-                                                u'beets 4 eva'])
+        self.assert_items_matched(
+            not_results, [u"foo bar", u"baz qux", u"beets 4 eva"]
+        )
         self.assertNegationProperties(q)
 
     def test_type_false(self):
@@ -921,41 +930,45 @@ class NotQueryTest(DummyDataTestCase):
         self.assertNegationProperties(q)
 
     def test_type_match(self):
-        q = dbcore.query.MatchQuery(u'year', u'2003')
+        q = dbcore.query.MatchQuery(u"year", u"2003")
         not_results = self.lib.items(dbcore.query.NotQuery(q))
-        self.assert_items_matched(not_results, [u'foo bar', u'baz qux'])
+        self.assert_items_matched(not_results, [u"foo bar", u"baz qux"])
         self.assertNegationProperties(q)
 
     def test_type_none(self):
-        q = dbcore.query.NoneQuery(u'rg_track_gain')
+        q = dbcore.query.NoneQuery(u"rg_track_gain")
         not_results = self.lib.items(dbcore.query.NotQuery(q))
         self.assert_items_matched(not_results, [])
         self.assertNegationProperties(q)
 
     def test_type_numeric(self):
-        q = dbcore.query.NumericQuery(u'year', u'2001..2002')
+        q = dbcore.query.NumericQuery(u"year", u"2001..2002")
         not_results = self.lib.items(dbcore.query.NotQuery(q))
-        self.assert_items_matched(not_results, [u'beets 4 eva'])
+        self.assert_items_matched(not_results, [u"beets 4 eva"])
         self.assertNegationProperties(q)
 
     def test_type_or(self):
         # not(a or b) <-> not(a) and not(b)
-        q = dbcore.query.OrQuery([dbcore.query.BooleanQuery(u'comp', True),
-                                  dbcore.query.NumericQuery(u'year', u'2002')])
+        q = dbcore.query.OrQuery(
+            [
+                dbcore.query.BooleanQuery(u"comp", True),
+                dbcore.query.NumericQuery(u"year", u"2002"),
+            ]
+        )
         not_results = self.lib.items(dbcore.query.NotQuery(q))
-        self.assert_items_matched(not_results, [u'beets 4 eva'])
+        self.assert_items_matched(not_results, [u"beets 4 eva"])
         self.assertNegationProperties(q)
 
     def test_type_regexp(self):
-        q = dbcore.query.RegexpQuery(u'artist', u'^t')
+        q = dbcore.query.RegexpQuery(u"artist", u"^t")
         not_results = self.lib.items(dbcore.query.NotQuery(q))
-        self.assert_items_matched(not_results, [u'foo bar'])
+        self.assert_items_matched(not_results, [u"foo bar"])
         self.assertNegationProperties(q)
 
     def test_type_substring(self):
-        q = dbcore.query.SubstringQuery(u'album', u'ba')
+        q = dbcore.query.SubstringQuery(u"album", u"ba")
         not_results = self.lib.items(dbcore.query.NotQuery(q))
-        self.assert_items_matched(not_results, [u'beets 4 eva'])
+        self.assert_items_matched(not_results, [u"beets 4 eva"])
         self.assertNegationProperties(q)
 
     def test_type_true(self):
@@ -966,41 +979,41 @@ class NotQueryTest(DummyDataTestCase):
 
     def test_get_prefixes_keyed(self):
         """Test both negation prefixes on a keyed query."""
-        q0 = u'-title:qux'
-        q1 = u'^title:qux'
+        q0 = u"-title:qux"
+        q1 = u"^title:qux"
         results0 = self.lib.items(q0)
         results1 = self.lib.items(q1)
-        self.assert_items_matched(results0, [u'foo bar', u'beets 4 eva'])
-        self.assert_items_matched(results1, [u'foo bar', u'beets 4 eva'])
+        self.assert_items_matched(results0, [u"foo bar", u"beets 4 eva"])
+        self.assert_items_matched(results1, [u"foo bar", u"beets 4 eva"])
 
     def test_get_prefixes_unkeyed(self):
         """Test both negation prefixes on an unkeyed query."""
-        q0 = u'-qux'
-        q1 = u'^qux'
+        q0 = u"-qux"
+        q1 = u"^qux"
         results0 = self.lib.items(q0)
         results1 = self.lib.items(q1)
-        self.assert_items_matched(results0, [u'foo bar', u'beets 4 eva'])
-        self.assert_items_matched(results1, [u'foo bar', u'beets 4 eva'])
+        self.assert_items_matched(results0, [u"foo bar", u"beets 4 eva"])
+        self.assert_items_matched(results1, [u"foo bar", u"beets 4 eva"])
 
     def test_get_one_keyed_regexp(self):
-        q = u'-artist::t.+r'
+        q = u"-artist::t.+r"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'foo bar', u'baz qux'])
+        self.assert_items_matched(results, [u"foo bar", u"baz qux"])
 
     def test_get_one_unkeyed_regexp(self):
-        q = u'-:x$'
+        q = u"-:x$"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'foo bar', u'beets 4 eva'])
+        self.assert_items_matched(results, [u"foo bar", u"beets 4 eva"])
 
     def test_get_multiple_terms(self):
-        q = u'baz -bar'
+        q = u"baz -bar"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'baz qux'])
+        self.assert_items_matched(results, [u"baz qux"])
 
     def test_get_mixed_terms(self):
-        q = u'baz -title:bar'
+        q = u"baz -title:bar"
         results = self.lib.items(q)
-        self.assert_items_matched(results, [u'baz qux'])
+        self.assert_items_matched(results, [u"baz qux"])
 
     def test_fast_vs_slow(self):
         """Test that the results are the same regardless of the `fast` flag
@@ -1010,21 +1023,25 @@ class NotQueryTest(DummyDataTestCase):
         AttributeError: type object 'NoneQuery' has no attribute 'field'
         at NoneQuery.match() (due to being @classmethod, and no self?)
         """
-        classes = [(dbcore.query.DateQuery, [u'added', u'2001-01-01']),
-                   (dbcore.query.MatchQuery, [u'artist', u'one']),
-                   # (dbcore.query.NoneQuery, ['rg_track_gain']),
-                   (dbcore.query.NumericQuery, [u'year', u'2002']),
-                   (dbcore.query.StringFieldQuery, [u'year', u'2001']),
-                   (dbcore.query.RegexpQuery, [u'album', u'^.a']),
-                   (dbcore.query.SubstringQuery, [u'title', u'x'])]
+        classes = [
+            (dbcore.query.DateQuery, [u"added", u"2001-01-01"]),
+            (dbcore.query.MatchQuery, [u"artist", u"one"]),
+            # (dbcore.query.NoneQuery, ['rg_track_gain']),
+            (dbcore.query.NumericQuery, [u"year", u"2002"]),
+            (dbcore.query.StringFieldQuery, [u"year", u"2001"]),
+            (dbcore.query.RegexpQuery, [u"album", u"^.a"]),
+            (dbcore.query.SubstringQuery, [u"title", u"x"]),
+        ]
 
         for klass, args in classes:
             q_fast = dbcore.query.NotQuery(klass(*(args + [True])))
             q_slow = dbcore.query.NotQuery(klass(*(args + [False])))
 
             try:
-                self.assertEqual([i.title for i in self.lib.items(q_fast)],
-                                 [i.title for i in self.lib.items(q_slow)])
+                self.assertEqual(
+                    [i.title for i in self.lib.items(q_fast)],
+                    [i.title for i in self.lib.items(q_slow)],
+                )
             except NotImplementedError:
                 # ignore classes that do not provide `fast` implementation
                 pass
@@ -1034,5 +1051,5 @@ def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_random.py
+++ b/test/test_random.py
@@ -30,8 +30,8 @@ from beets import random
 class RandomTest(unittest.TestCase, TestHelper):
     def setUp(self):
         self.lib = None
-        self.artist1 = 'Artist 1'
-        self.artist2 = 'Artist 2'
+        self.artist1 = "Artist 1"
+        self.artist2 = "Artist 2"
         self.item1 = self.create_item(artist=self.artist1)
         self.item2 = self.create_item(artist=self.artist2)
         self.items = [self.item1, self.item2]
@@ -45,13 +45,12 @@ class RandomTest(unittest.TestCase, TestHelper):
 
     def _stats(self, data):
         mean = sum(data) / len(data)
-        stdev = math.sqrt(
-                sum((p - mean) ** 2 for p in data) / (len(data) - 1))
+        stdev = math.sqrt(sum((p - mean) ** 2 for p in data) / (len(data) - 1))
         quot, rem = divmod(len(data), 2)
         if rem:
             median = sorted(data)[quot]
         else:
-            median = sum(sorted(data)[quot - 1:quot + 1]) / 2
+            median = sum(sorted(data)[quot - 1 : quot + 1]) / 2
         return mean, stdev, median
 
     def test_equal_permutation(self):
@@ -60,23 +59,27 @@ class RandomTest(unittest.TestCase, TestHelper):
         the solo track will almost always end up near the start. If we use a
         different field then it'll be in the middle on average.
         """
+
         def experiment(field, histogram=False):
             """Permutes the list of items 500 times and calculates the position
             of self.item1 each time. Returns stats about that position.
             """
             positions = []
             for _ in range(500):
-                shuffled = list(random._equal_chance_permutation(
-                    self.items, field=field, random_gen=self.random_gen))
+                shuffled = list(
+                    random._equal_chance_permutation(
+                        self.items, field=field, random_gen=self.random_gen
+                    )
+                )
                 positions.append(shuffled.index(self.item1))
             # Print a histogram (useful for debugging).
             if histogram:
                 for i in range(len(self.items)):
-                    print('{:2d} {}'.format(i, '*' * positions.count(i)))
+                    print("{:2d} {}".format(i, "*" * positions.count(i)))
             return self._stats(positions)
 
-        mean1, stdev1, median1 = experiment('artist')
-        mean2, stdev2, median2 = experiment('track')
+        mean1, stdev1, median1 = experiment("artist")
+        mean2, stdev2, median2 = experiment("track")
         self.assertAlmostEqual(0, median1, delta=1)
         self.assertAlmostEqual(len(self.items) // 2, median2, delta=1)
         self.assertGreater(stdev2, stdev1)
@@ -85,5 +88,6 @@ class RandomTest(unittest.TestCase, TestHelper):
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_smartplaylist.py
+++ b/test/test_smartplaylist.py
@@ -39,64 +39,85 @@ class SmartPlaylistTest(unittest.TestCase):
         self.assertEqual(spl._matched_playlists, None)
         self.assertEqual(spl._unmatched_playlists, None)
 
-        config['smartplaylist']['playlists'].set([])
+        config["smartplaylist"]["playlists"].set([])
         spl.build_queries()
         self.assertEqual(spl._matched_playlists, set())
         self.assertEqual(spl._unmatched_playlists, set())
 
-        config['smartplaylist']['playlists'].set([
-            {'name': u'foo',
-             'query': u'FOO foo'},
-            {'name': u'bar',
-             'album_query': [u'BAR bar1', u'BAR bar2']},
-            {'name': u'baz',
-             'query': u'BAZ baz',
-             'album_query': u'BAZ baz'}
-        ])
+        config["smartplaylist"]["playlists"].set(
+            [
+                {"name": u"foo", "query": u"FOO foo"},
+                {"name": u"bar", "album_query": [u"BAR bar1", u"BAR bar2"]},
+                {
+                    "name": u"baz",
+                    "query": u"BAZ baz",
+                    "album_query": u"BAZ baz",
+                },
+            ]
+        )
         spl.build_queries()
         self.assertEqual(spl._matched_playlists, set())
-        foo_foo = parse_query_string(u'FOO foo', Item)
-        baz_baz = parse_query_string(u'BAZ baz', Item)
-        baz_baz2 = parse_query_string(u'BAZ baz', Album)
-        bar_bar = OrQuery((parse_query_string(u'BAR bar1', Album)[0],
-                           parse_query_string(u'BAR bar2', Album)[0]))
-        self.assertEqual(spl._unmatched_playlists, set([
-            (u'foo', foo_foo, (None, None)),
-            (u'baz', baz_baz, baz_baz2),
-            (u'bar', (None, None), (bar_bar, None)),
-        ]))
+        foo_foo = parse_query_string(u"FOO foo", Item)
+        baz_baz = parse_query_string(u"BAZ baz", Item)
+        baz_baz2 = parse_query_string(u"BAZ baz", Album)
+        bar_bar = OrQuery(
+            (
+                parse_query_string(u"BAR bar1", Album)[0],
+                parse_query_string(u"BAR bar2", Album)[0],
+            )
+        )
+        self.assertEqual(
+            spl._unmatched_playlists,
+            set(
+                [
+                    (u"foo", foo_foo, (None, None)),
+                    (u"baz", baz_baz, baz_baz2),
+                    (u"bar", (None, None), (bar_bar, None)),
+                ]
+            ),
+        )
 
     def test_build_queries_with_sorts(self):
         spl = SmartPlaylistPlugin()
-        config['smartplaylist']['playlists'].set([
-            {'name': u'no_sort',
-             'query': u'foo'},
-            {'name': u'one_sort',
-             'query': u'foo year+'},
-            {'name': u'only_empty_sorts',
-             'query': [u'foo', u'bar']},
-            {'name': u'one_non_empty_sort',
-             'query': [u'foo year+', u'bar']},
-            {'name': u'multiple_sorts',
-             'query': [u'foo year+', u'bar genre-']},
-            {'name': u'mixed',
-             'query': [u'foo year+', u'bar', u'baz genre+ id-']}
-        ])
+        config["smartplaylist"]["playlists"].set(
+            [
+                {"name": u"no_sort", "query": u"foo"},
+                {"name": u"one_sort", "query": u"foo year+"},
+                {"name": u"only_empty_sorts", "query": [u"foo", u"bar"]},
+                {
+                    "name": u"one_non_empty_sort",
+                    "query": [u"foo year+", u"bar"],
+                },
+                {
+                    "name": u"multiple_sorts",
+                    "query": [u"foo year+", u"bar genre-"],
+                },
+                {
+                    "name": u"mixed",
+                    "query": [u"foo year+", u"bar", u"baz genre+ id-"],
+                },
+            ]
+        )
 
         spl.build_queries()
-        sorts = dict((name, sort)
-                     for name, (_, sort), _ in spl._unmatched_playlists)
+        sorts = dict(
+            (name, sort) for name, (_, sort), _ in spl._unmatched_playlists
+        )
 
         asseq = self.assertEqual  # less cluttered code
         sort = FixedFieldSort  # short cut since we're only dealing with this
         asseq(sorts["no_sort"], NullSort())
-        asseq(sorts["one_sort"], sort(u'year'))
+        asseq(sorts["one_sort"], sort(u"year"))
         asseq(sorts["only_empty_sorts"], None)
-        asseq(sorts["one_non_empty_sort"], sort(u'year'))
-        asseq(sorts["multiple_sorts"],
-              MultipleSort([sort('year'), sort(u'genre', False)]))
-        asseq(sorts["mixed"],
-              MultipleSort([sort('year'), sort(u'genre'), sort(u'id', False)]))
+        asseq(sorts["one_non_empty_sort"], sort(u"year"))
+        asseq(
+            sorts["multiple_sorts"],
+            MultipleSort([sort("year"), sort(u"genre", False)]),
+        )
+        asseq(
+            sorts["mixed"],
+            MultipleSort([sort("year"), sort(u"genre"), sort(u"id", False)]),
+        )
 
     def test_matches(self):
         spl = SmartPlaylistPlugin()
@@ -124,9 +145,9 @@ class SmartPlaylistTest(unittest.TestCase):
         spl = SmartPlaylistPlugin()
 
         nones = None, None
-        pl1 = '1', (u'q1', None), nones
-        pl2 = '2', (u'q2', None), nones
-        pl3 = '3', (u'q3', None), nones
+        pl1 = "1", (u"q1", None), nones
+        pl2 = "2", (u"q2", None), nones
+        pl3 = "3", (u"q3", None), nones
 
         spl._unmatched_playlists = set([pl1, pl2, pl3])
         spl._matched_playlists = set()
@@ -136,12 +157,12 @@ class SmartPlaylistTest(unittest.TestCase):
         self.assertEqual(spl._unmatched_playlists, set([pl1, pl2, pl3]))
         self.assertEqual(spl._matched_playlists, set())
 
-        spl.matches.side_effect = lambda _, q, __: q == u'q3'
+        spl.matches.side_effect = lambda _, q, __: q == u"q3"
         spl.db_change(None, u"matches 3")
         self.assertEqual(spl._unmatched_playlists, set([pl1, pl2]))
         self.assertEqual(spl._matched_playlists, set([pl3]))
 
-        spl.matches.side_effect = lambda _, q, __: q == u'q1'
+        spl.matches.side_effect = lambda _, q, __: q == u"q1"
         spl.db_change(None, u"matches 3")
         self.assertEqual(spl._matched_playlists, set([pl1, pl3]))
         self.assertEqual(spl._unmatched_playlists, set([pl2]))
@@ -149,9 +170,10 @@ class SmartPlaylistTest(unittest.TestCase):
     def test_playlist_update(self):
         spl = SmartPlaylistPlugin()
 
-        i = Mock(path=b'/tagada.mp3')
-        i.evaluate_template.side_effect = \
-            lambda pl, _: pl.replace(b'$title', b'ta:ga:da').decode()
+        i = Mock(path=b"/tagada.mp3")
+        i.evaluate_template.side_effect = lambda pl, _: pl.replace(
+            b"$title", b"ta:ga:da"
+        ).decode()
 
         lib = Mock()
         lib.replacements = CHAR_REPLACE
@@ -160,12 +182,12 @@ class SmartPlaylistTest(unittest.TestCase):
 
         q = Mock()
         a_q = Mock()
-        pl = b'$title-my<playlist>.m3u', (q, None), (a_q, None)
+        pl = b"$title-my<playlist>.m3u", (q, None), (a_q, None)
         spl._matched_playlists = [pl]
 
         dir = bytestring_path(mkdtemp())
-        config['smartplaylist']['relative_to'] = False
-        config['smartplaylist']['playlist_dir'] = py3_path(dir)
+        config["smartplaylist"]["relative_to"] = False
+        config["smartplaylist"]["playlist_dir"] = py3_path(dir)
         try:
             spl.update_playlists(lib)
         except Exception:
@@ -175,13 +197,13 @@ class SmartPlaylistTest(unittest.TestCase):
         lib.items.assert_called_once_with(q, None)
         lib.albums.assert_called_once_with(a_q, None)
 
-        m3u_filepath = path.join(dir, b'ta_ga_da-my_playlist_.m3u')
+        m3u_filepath = path.join(dir, b"ta_ga_da-my_playlist_.m3u")
         self.assertTrue(path.exists(m3u_filepath))
-        with open(syspath(m3u_filepath), 'rb') as f:
+        with open(syspath(m3u_filepath), "rb") as f:
             content = f.read()
         rmtree(dir)
 
-        self.assertEqual(content, b'/tagada.mp3\n')
+        self.assertEqual(content, b"/tagada.mp3\n")
 
 
 class SmartPlaylistCLITest(unittest.TestCase, TestHelper):
@@ -189,14 +211,14 @@ class SmartPlaylistCLITest(unittest.TestCase, TestHelper):
         self.setup_beets()
 
         self.item = self.add_item()
-        config['smartplaylist']['playlists'].set([
-            {'name': 'my_playlist.m3u',
-             'query': self.item.title},
-            {'name': 'all.m3u',
-             'query': u''}
-        ])
-        config['smartplaylist']['playlist_dir'].set(py3_path(self.temp_dir))
-        self.load_plugins('smartplaylist')
+        config["smartplaylist"]["playlists"].set(
+            [
+                {"name": "my_playlist.m3u", "query": self.item.title},
+                {"name": "all.m3u", "query": u""},
+            ]
+        )
+        config["smartplaylist"]["playlist_dir"].set(py3_path(self.temp_dir))
+        self.load_plugins("smartplaylist")
 
     def tearDown(self):
         self.unload_plugins()
@@ -204,23 +226,23 @@ class SmartPlaylistCLITest(unittest.TestCase, TestHelper):
 
     def test_splupdate(self):
         with self.assertRaises(UserError):
-            self.run_with_output(u'splupdate', u'tagada')
+            self.run_with_output(u"splupdate", u"tagada")
 
-        self.run_with_output(u'splupdate', u'my_playlist')
-        m3u_path = path.join(self.temp_dir, b'my_playlist.m3u')
+        self.run_with_output(u"splupdate", u"my_playlist")
+        m3u_path = path.join(self.temp_dir, b"my_playlist.m3u")
         self.assertTrue(path.exists(m3u_path))
-        with open(m3u_path, 'rb') as f:
+        with open(m3u_path, "rb") as f:
             self.assertEqual(f.read(), self.item.path + b"\n")
         remove(m3u_path)
 
-        self.run_with_output(u'splupdate', u'my_playlist.m3u')
-        with open(m3u_path, 'rb') as f:
+        self.run_with_output(u"splupdate", u"my_playlist.m3u")
+        with open(m3u_path, "rb") as f:
             self.assertEqual(f.read(), self.item.path + b"\n")
         remove(m3u_path)
 
-        self.run_with_output(u'splupdate')
-        for name in (b'my_playlist.m3u', b'all.m3u'):
-            with open(path.join(self.temp_dir, name), 'rb') as f:
+        self.run_with_output(u"splupdate")
+        for name in (b"my_playlist.m3u", b"all.m3u"):
+            with open(path.join(self.temp_dir, name), "rb") as f:
                 self.assertEqual(f.read(), self.item.path + b"\n")
 
 
@@ -228,5 +250,5 @@ def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_sort.py
+++ b/test/test_sort.py
@@ -29,7 +29,7 @@ from beets import config
 class DummyDataTestCase(_common.TestCase):
     def setUp(self):
         super(DummyDataTestCase, self).setUp()
-        self.lib = beets.library.Library(':memory:')
+        self.lib = beets.library.Library(":memory:")
 
         albums = [_common.album() for _ in range(3)]
         albums[0].album = u"Album A"
@@ -57,9 +57,9 @@ class DummyDataTestCase(_common.TestCase):
             self.lib.add(album)
 
         items = [_common.item() for _ in range(4)]
-        items[0].title = u'Foo bar'
-        items[0].artist = u'One'
-        items[0].album = u'Baz'
+        items[0].title = u"Foo bar"
+        items[0].artist = u"One"
+        items[0].album = u"Baz"
         items[0].year = 2001
         items[0].comp = True
         items[0].flex1 = u"Flex1-0"
@@ -68,9 +68,9 @@ class DummyDataTestCase(_common.TestCase):
         items[0].artist_sort = None
         items[0].path = "/path0.mp3"
         items[0].track = 1
-        items[1].title = u'Baz qux'
-        items[1].artist = u'Two'
-        items[1].album = u'Baz'
+        items[1].title = u"Baz qux"
+        items[1].artist = u"Two"
+        items[1].album = u"Baz"
         items[1].year = 2002
         items[1].comp = True
         items[1].flex1 = u"Flex1-1"
@@ -79,9 +79,9 @@ class DummyDataTestCase(_common.TestCase):
         items[1].artist_sort = None
         items[1].path = "/patH1.mp3"
         items[1].track = 2
-        items[2].title = u'Beets 4 eva'
-        items[2].artist = u'Three'
-        items[2].album = u'Foo'
+        items[2].title = u"Beets 4 eva"
+        items[2].artist = u"Three"
+        items[2].album = u"Foo"
         items[2].year = 2003
         items[2].comp = False
         items[2].flex1 = u"Flex1-2"
@@ -90,9 +90,9 @@ class DummyDataTestCase(_common.TestCase):
         items[2].artist_sort = None
         items[2].path = "/paTH2.mp3"
         items[2].track = 3
-        items[3].title = u'Beets 4 eva'
-        items[3].artist = u'Three'
-        items[3].album = u'Foo2'
+        items[3].title = u"Beets 4 eva"
+        items[3].artist = u"Three"
+        items[3].album = u"Foo2"
         items[3].year = 2004
         items[3].comp = False
         items[3].flex1 = u"Flex1-2"
@@ -107,100 +107,100 @@ class DummyDataTestCase(_common.TestCase):
 
 class SortFixedFieldTest(DummyDataTestCase):
     def test_sort_asc(self):
-        q = u''
+        q = u""
         sort = dbcore.query.FixedFieldSort(u"year", True)
         results = self.lib.items(q, sort)
-        self.assertLessEqual(results[0]['year'], results[1]['year'])
-        self.assertEqual(results[0]['year'], 2001)
+        self.assertLessEqual(results[0]["year"], results[1]["year"])
+        self.assertEqual(results[0]["year"], 2001)
         # same thing with query string
-        q = u'year+'
+        q = u"year+"
         results2 = self.lib.items(q)
         for r1, r2 in zip(results, results2):
             self.assertEqual(r1.id, r2.id)
 
     def test_sort_desc(self):
-        q = u''
+        q = u""
         sort = dbcore.query.FixedFieldSort(u"year", False)
         results = self.lib.items(q, sort)
-        self.assertGreaterEqual(results[0]['year'], results[1]['year'])
-        self.assertEqual(results[0]['year'], 2004)
+        self.assertGreaterEqual(results[0]["year"], results[1]["year"])
+        self.assertEqual(results[0]["year"], 2004)
         # same thing with query string
-        q = u'year-'
+        q = u"year-"
         results2 = self.lib.items(q)
         for r1, r2 in zip(results, results2):
             self.assertEqual(r1.id, r2.id)
 
     def test_sort_two_field_asc(self):
-        q = u''
+        q = u""
         s1 = dbcore.query.FixedFieldSort(u"album", True)
         s2 = dbcore.query.FixedFieldSort(u"year", True)
         sort = dbcore.query.MultipleSort()
         sort.add_sort(s1)
         sort.add_sort(s2)
         results = self.lib.items(q, sort)
-        self.assertLessEqual(results[0]['album'], results[1]['album'])
-        self.assertLessEqual(results[1]['album'], results[2]['album'])
-        self.assertEqual(results[0]['album'], u'Baz')
-        self.assertEqual(results[1]['album'], u'Baz')
-        self.assertLessEqual(results[0]['year'], results[1]['year'])
+        self.assertLessEqual(results[0]["album"], results[1]["album"])
+        self.assertLessEqual(results[1]["album"], results[2]["album"])
+        self.assertEqual(results[0]["album"], u"Baz")
+        self.assertEqual(results[1]["album"], u"Baz")
+        self.assertLessEqual(results[0]["year"], results[1]["year"])
         # same thing with query string
-        q = u'album+ year+'
+        q = u"album+ year+"
         results2 = self.lib.items(q)
         for r1, r2 in zip(results, results2):
             self.assertEqual(r1.id, r2.id)
 
     def test_sort_path_field(self):
-        q = u''
-        sort = dbcore.query.FixedFieldSort('path', True)
+        q = u""
+        sort = dbcore.query.FixedFieldSort("path", True)
         results = self.lib.items(q, sort)
-        self.assertEqual(results[0]['path'], b'/path0.mp3')
-        self.assertEqual(results[1]['path'], b'/patH1.mp3')
-        self.assertEqual(results[2]['path'], b'/paTH2.mp3')
-        self.assertEqual(results[3]['path'], b'/PATH3.mp3')
+        self.assertEqual(results[0]["path"], b"/path0.mp3")
+        self.assertEqual(results[1]["path"], b"/patH1.mp3")
+        self.assertEqual(results[2]["path"], b"/paTH2.mp3")
+        self.assertEqual(results[3]["path"], b"/PATH3.mp3")
 
 
 class SortFlexFieldTest(DummyDataTestCase):
     def test_sort_asc(self):
-        q = u''
+        q = u""
         sort = dbcore.query.SlowFieldSort(u"flex1", True)
         results = self.lib.items(q, sort)
-        self.assertLessEqual(results[0]['flex1'], results[1]['flex1'])
-        self.assertEqual(results[0]['flex1'], u'Flex1-0')
+        self.assertLessEqual(results[0]["flex1"], results[1]["flex1"])
+        self.assertEqual(results[0]["flex1"], u"Flex1-0")
         # same thing with query string
-        q = u'flex1+'
+        q = u"flex1+"
         results2 = self.lib.items(q)
         for r1, r2 in zip(results, results2):
             self.assertEqual(r1.id, r2.id)
 
     def test_sort_desc(self):
-        q = u''
+        q = u""
         sort = dbcore.query.SlowFieldSort(u"flex1", False)
         results = self.lib.items(q, sort)
-        self.assertGreaterEqual(results[0]['flex1'], results[1]['flex1'])
-        self.assertGreaterEqual(results[1]['flex1'], results[2]['flex1'])
-        self.assertGreaterEqual(results[2]['flex1'], results[3]['flex1'])
-        self.assertEqual(results[0]['flex1'], u'Flex1-2')
+        self.assertGreaterEqual(results[0]["flex1"], results[1]["flex1"])
+        self.assertGreaterEqual(results[1]["flex1"], results[2]["flex1"])
+        self.assertGreaterEqual(results[2]["flex1"], results[3]["flex1"])
+        self.assertEqual(results[0]["flex1"], u"Flex1-2")
         # same thing with query string
-        q = u'flex1-'
+        q = u"flex1-"
         results2 = self.lib.items(q)
         for r1, r2 in zip(results, results2):
             self.assertEqual(r1.id, r2.id)
 
     def test_sort_two_field(self):
-        q = u''
+        q = u""
         s1 = dbcore.query.SlowFieldSort(u"flex2", False)
         s2 = dbcore.query.SlowFieldSort(u"flex1", True)
         sort = dbcore.query.MultipleSort()
         sort.add_sort(s1)
         sort.add_sort(s2)
         results = self.lib.items(q, sort)
-        self.assertGreaterEqual(results[0]['flex2'], results[1]['flex2'])
-        self.assertGreaterEqual(results[1]['flex2'], results[2]['flex2'])
-        self.assertEqual(results[0]['flex2'], u'Flex2-A')
-        self.assertEqual(results[1]['flex2'], u'Flex2-A')
-        self.assertLessEqual(results[0]['flex1'], results[1]['flex1'])
+        self.assertGreaterEqual(results[0]["flex2"], results[1]["flex2"])
+        self.assertGreaterEqual(results[1]["flex2"], results[2]["flex2"])
+        self.assertEqual(results[0]["flex2"], u"Flex2-A")
+        self.assertEqual(results[1]["flex2"], u"Flex2-A")
+        self.assertLessEqual(results[0]["flex1"], results[1]["flex1"])
         # same thing with query string
-        q = u'flex2- flex1+'
+        q = u"flex2- flex1+"
         results2 = self.lib.items(q)
         for r1, r2 in zip(results, results2):
             self.assertEqual(r1.id, r2.id)
@@ -208,44 +208,44 @@ class SortFlexFieldTest(DummyDataTestCase):
 
 class SortAlbumFixedFieldTest(DummyDataTestCase):
     def test_sort_asc(self):
-        q = u''
+        q = u""
         sort = dbcore.query.FixedFieldSort(u"year", True)
         results = self.lib.albums(q, sort)
-        self.assertLessEqual(results[0]['year'], results[1]['year'])
-        self.assertEqual(results[0]['year'], 2001)
+        self.assertLessEqual(results[0]["year"], results[1]["year"])
+        self.assertEqual(results[0]["year"], 2001)
         # same thing with query string
-        q = u'year+'
+        q = u"year+"
         results2 = self.lib.albums(q)
         for r1, r2 in zip(results, results2):
             self.assertEqual(r1.id, r2.id)
 
     def test_sort_desc(self):
-        q = u''
+        q = u""
         sort = dbcore.query.FixedFieldSort(u"year", False)
         results = self.lib.albums(q, sort)
-        self.assertGreaterEqual(results[0]['year'], results[1]['year'])
-        self.assertEqual(results[0]['year'], 2005)
+        self.assertGreaterEqual(results[0]["year"], results[1]["year"])
+        self.assertEqual(results[0]["year"], 2005)
         # same thing with query string
-        q = u'year-'
+        q = u"year-"
         results2 = self.lib.albums(q)
         for r1, r2 in zip(results, results2):
             self.assertEqual(r1.id, r2.id)
 
     def test_sort_two_field_asc(self):
-        q = u''
+        q = u""
         s1 = dbcore.query.FixedFieldSort(u"genre", True)
         s2 = dbcore.query.FixedFieldSort(u"album", True)
         sort = dbcore.query.MultipleSort()
         sort.add_sort(s1)
         sort.add_sort(s2)
         results = self.lib.albums(q, sort)
-        self.assertLessEqual(results[0]['genre'], results[1]['genre'])
-        self.assertLessEqual(results[1]['genre'], results[2]['genre'])
-        self.assertEqual(results[1]['genre'], u'Rock')
-        self.assertEqual(results[2]['genre'], u'Rock')
-        self.assertLessEqual(results[1]['album'], results[2]['album'])
+        self.assertLessEqual(results[0]["genre"], results[1]["genre"])
+        self.assertLessEqual(results[1]["genre"], results[2]["genre"])
+        self.assertEqual(results[1]["genre"], u"Rock")
+        self.assertEqual(results[2]["genre"], u"Rock")
+        self.assertLessEqual(results[1]["album"], results[2]["album"])
         # same thing with query string
-        q = u'genre+ album+'
+        q = u"genre+ album+"
         results2 = self.lib.albums(q)
         for r1, r2 in zip(results, results2):
             self.assertEqual(r1.id, r2.id)
@@ -253,44 +253,44 @@ class SortAlbumFixedFieldTest(DummyDataTestCase):
 
 class SortAlbumFlexFieldTest(DummyDataTestCase):
     def test_sort_asc(self):
-        q = u''
+        q = u""
         sort = dbcore.query.SlowFieldSort(u"flex1", True)
         results = self.lib.albums(q, sort)
-        self.assertLessEqual(results[0]['flex1'], results[1]['flex1'])
-        self.assertLessEqual(results[1]['flex1'], results[2]['flex1'])
+        self.assertLessEqual(results[0]["flex1"], results[1]["flex1"])
+        self.assertLessEqual(results[1]["flex1"], results[2]["flex1"])
         # same thing with query string
-        q = u'flex1+'
+        q = u"flex1+"
         results2 = self.lib.albums(q)
         for r1, r2 in zip(results, results2):
             self.assertEqual(r1.id, r2.id)
 
     def test_sort_desc(self):
-        q = u''
+        q = u""
         sort = dbcore.query.SlowFieldSort(u"flex1", False)
         results = self.lib.albums(q, sort)
-        self.assertGreaterEqual(results[0]['flex1'], results[1]['flex1'])
-        self.assertGreaterEqual(results[1]['flex1'], results[2]['flex1'])
+        self.assertGreaterEqual(results[0]["flex1"], results[1]["flex1"])
+        self.assertGreaterEqual(results[1]["flex1"], results[2]["flex1"])
         # same thing with query string
-        q = u'flex1-'
+        q = u"flex1-"
         results2 = self.lib.albums(q)
         for r1, r2 in zip(results, results2):
             self.assertEqual(r1.id, r2.id)
 
     def test_sort_two_field_asc(self):
-        q = u''
+        q = u""
         s1 = dbcore.query.SlowFieldSort(u"flex2", True)
         s2 = dbcore.query.SlowFieldSort(u"flex1", True)
         sort = dbcore.query.MultipleSort()
         sort.add_sort(s1)
         sort.add_sort(s2)
         results = self.lib.albums(q, sort)
-        self.assertLessEqual(results[0]['flex2'], results[1]['flex2'])
-        self.assertLessEqual(results[1]['flex2'], results[2]['flex2'])
-        self.assertEqual(results[0]['flex2'], u'Flex2-A')
-        self.assertEqual(results[1]['flex2'], u'Flex2-A')
-        self.assertLessEqual(results[0]['flex1'], results[1]['flex1'])
+        self.assertLessEqual(results[0]["flex2"], results[1]["flex2"])
+        self.assertLessEqual(results[1]["flex2"], results[2]["flex2"])
+        self.assertEqual(results[0]["flex2"], u"Flex2-A")
+        self.assertEqual(results[1]["flex2"], u"Flex2-A")
+        self.assertLessEqual(results[0]["flex1"], results[1]["flex1"])
         # same thing with query string
-        q = u'flex2+ flex1+'
+        q = u"flex2+ flex1+"
         results2 = self.lib.albums(q)
         for r1, r2 in zip(results, results2):
             self.assertEqual(r1.id, r2.id)
@@ -298,25 +298,25 @@ class SortAlbumFlexFieldTest(DummyDataTestCase):
 
 class SortAlbumComputedFieldTest(DummyDataTestCase):
     def test_sort_asc(self):
-        q = u''
+        q = u""
         sort = dbcore.query.SlowFieldSort(u"path", True)
         results = self.lib.albums(q, sort)
-        self.assertLessEqual(results[0]['path'], results[1]['path'])
-        self.assertLessEqual(results[1]['path'], results[2]['path'])
+        self.assertLessEqual(results[0]["path"], results[1]["path"])
+        self.assertLessEqual(results[1]["path"], results[2]["path"])
         # same thing with query string
-        q = u'path+'
+        q = u"path+"
         results2 = self.lib.albums(q)
         for r1, r2 in zip(results, results2):
             self.assertEqual(r1.id, r2.id)
 
     def test_sort_desc(self):
-        q = u''
+        q = u""
         sort = dbcore.query.SlowFieldSort(u"path", False)
         results = self.lib.albums(q, sort)
-        self.assertGreaterEqual(results[0]['path'], results[1]['path'])
-        self.assertGreaterEqual(results[1]['path'], results[2]['path'])
+        self.assertGreaterEqual(results[0]["path"], results[1]["path"])
+        self.assertGreaterEqual(results[1]["path"], results[2]["path"])
         # same thing with query string
-        q = u'path-'
+        q = u"path-"
         results2 = self.lib.albums(q)
         for r1, r2 in zip(results, results2):
             self.assertEqual(r1.id, r2.id)
@@ -324,32 +324,32 @@ class SortAlbumComputedFieldTest(DummyDataTestCase):
 
 class SortCombinedFieldTest(DummyDataTestCase):
     def test_computed_first(self):
-        q = u''
+        q = u""
         s1 = dbcore.query.SlowFieldSort(u"path", True)
         s2 = dbcore.query.FixedFieldSort(u"year", True)
         sort = dbcore.query.MultipleSort()
         sort.add_sort(s1)
         sort.add_sort(s2)
         results = self.lib.albums(q, sort)
-        self.assertLessEqual(results[0]['path'], results[1]['path'])
-        self.assertLessEqual(results[1]['path'], results[2]['path'])
-        q = u'path+ year+'
+        self.assertLessEqual(results[0]["path"], results[1]["path"])
+        self.assertLessEqual(results[1]["path"], results[2]["path"])
+        q = u"path+ year+"
         results2 = self.lib.albums(q)
         for r1, r2 in zip(results, results2):
             self.assertEqual(r1.id, r2.id)
 
     def test_computed_second(self):
-        q = u''
+        q = u""
         s1 = dbcore.query.FixedFieldSort(u"year", True)
         s2 = dbcore.query.SlowFieldSort(u"path", True)
         sort = dbcore.query.MultipleSort()
         sort.add_sort(s1)
         sort.add_sort(s2)
         results = self.lib.albums(q, sort)
-        self.assertLessEqual(results[0]['year'], results[1]['year'])
-        self.assertLessEqual(results[1]['year'], results[2]['year'])
-        self.assertLessEqual(results[0]['path'], results[1]['path'])
-        q = u'year+ path+'
+        self.assertLessEqual(results[0]["year"], results[1]["year"])
+        self.assertLessEqual(results[1]["year"], results[2]["year"])
+        self.assertLessEqual(results[0]["path"], results[1]["path"])
+        q = u"year+ path+"
         results2 = self.lib.albums(q)
         for r1, r2 in zip(results, results2):
             self.assertEqual(r1.id, r2.id)
@@ -361,7 +361,7 @@ class ConfigSortTest(DummyDataTestCase):
         self.assertLess(results[0].artist, results[1].artist)
 
     def test_config_opposite_sort_item(self):
-        config['sort_item'] = 'artist-'
+        config["sort_item"] = "artist-"
         results = list(self.lib.items())
         self.assertGreater(results[0].artist, results[1].artist)
 
@@ -370,7 +370,7 @@ class ConfigSortTest(DummyDataTestCase):
         self.assertLess(results[0].albumartist, results[1].albumartist)
 
     def test_config_opposite_sort_album(self):
-        config['sort_album'] = 'albumartist-'
+        config["sort_album"] = "albumartist-"
         results = list(self.lib.albums())
         self.assertGreater(results[0].albumartist, results[1].albumartist)
 
@@ -394,9 +394,9 @@ class CaseSensitivityTest(DummyDataTestCase, _common.TestCase):
         self.lib.add(album)
 
         item = _common.item()
-        item.title = u'another'
-        item.artist = u'lowercase'
-        item.album = u'album'
+        item.title = u"another"
+        item.artist = u"lowercase"
+        item.album = u"album"
         item.year = 2001
         item.comp = True
         item.flex1 = u"flex1"
@@ -415,50 +415,50 @@ class CaseSensitivityTest(DummyDataTestCase, _common.TestCase):
         super(CaseSensitivityTest, self).tearDown()
 
     def test_smart_artist_case_insensitive(self):
-        config['sort_case_insensitive'] = True
-        q = u'artist+'
+        config["sort_case_insensitive"] = True
+        q = u"artist+"
         results = list(self.lib.items(q))
-        self.assertEqual(results[0].artist, u'lowercase')
-        self.assertEqual(results[1].artist, u'One')
+        self.assertEqual(results[0].artist, u"lowercase")
+        self.assertEqual(results[1].artist, u"One")
 
     def test_smart_artist_case_sensitive(self):
-        config['sort_case_insensitive'] = False
-        q = u'artist+'
+        config["sort_case_insensitive"] = False
+        q = u"artist+"
         results = list(self.lib.items(q))
-        self.assertEqual(results[0].artist, u'One')
-        self.assertEqual(results[-1].artist, u'lowercase')
+        self.assertEqual(results[0].artist, u"One")
+        self.assertEqual(results[-1].artist, u"lowercase")
 
     def test_fixed_field_case_insensitive(self):
-        config['sort_case_insensitive'] = True
-        q = u'album+'
+        config["sort_case_insensitive"] = True
+        q = u"album+"
         results = list(self.lib.albums(q))
-        self.assertEqual(results[0].album, u'album')
-        self.assertEqual(results[1].album, u'Album A')
+        self.assertEqual(results[0].album, u"album")
+        self.assertEqual(results[1].album, u"Album A")
 
     def test_fixed_field_case_sensitive(self):
-        config['sort_case_insensitive'] = False
-        q = u'album+'
+        config["sort_case_insensitive"] = False
+        q = u"album+"
         results = list(self.lib.albums(q))
-        self.assertEqual(results[0].album, u'Album A')
-        self.assertEqual(results[-1].album, u'album')
+        self.assertEqual(results[0].album, u"Album A")
+        self.assertEqual(results[-1].album, u"album")
 
     def test_flex_field_case_insensitive(self):
-        config['sort_case_insensitive'] = True
-        q = u'flex1+'
+        config["sort_case_insensitive"] = True
+        q = u"flex1+"
         results = list(self.lib.items(q))
-        self.assertEqual(results[0].flex1, u'flex1')
-        self.assertEqual(results[1].flex1, u'Flex1-0')
+        self.assertEqual(results[0].flex1, u"flex1")
+        self.assertEqual(results[1].flex1, u"Flex1-0")
 
     def test_flex_field_case_sensitive(self):
-        config['sort_case_insensitive'] = False
-        q = u'flex1+'
+        config["sort_case_insensitive"] = False
+        q = u"flex1+"
         results = list(self.lib.items(q))
-        self.assertEqual(results[0].flex1, u'Flex1-0')
-        self.assertEqual(results[-1].flex1, u'flex1')
+        self.assertEqual(results[0].flex1, u"Flex1-0")
+        self.assertEqual(results[-1].flex1, u"flex1")
 
     def test_case_sensitive_only_affects_text(self):
-        config['sort_case_insensitive'] = True
-        q = u'track+'
+        config["sort_case_insensitive"] = True
+        q = u"track+"
         results = list(self.lib.items(q))
         # If the numerical values were sorted as strings,
         # then ['1', '10', '2'] would be valid.
@@ -472,10 +472,19 @@ class NonExistingFieldTest(DummyDataTestCase):
     """Test sorting by non-existing fields"""
 
     def test_non_existing_fields_not_fail(self):
-        qs = [u'foo+', u'foo-', u'--', u'-+', u'+-',
-              u'++', u'-foo-', u'-foo+', u'---']
+        qs = [
+            u"foo+",
+            u"foo-",
+            u"--",
+            u"-+",
+            u"+-",
+            u"++",
+            u"-foo-",
+            u"-foo+",
+            u"---",
+        ]
 
-        q0 = u'foo+'
+        q0 = u"foo+"
         results0 = list(self.lib.items(q0))
         for q1 in qs:
             results1 = list(self.lib.items(q1))
@@ -483,16 +492,16 @@ class NonExistingFieldTest(DummyDataTestCase):
                 self.assertEqual(r1.id, r2.id)
 
     def test_combined_non_existing_field_asc(self):
-        all_results = list(self.lib.items(u'id+'))
-        q = u'foo+ id+'
+        all_results = list(self.lib.items(u"id+"))
+        q = u"foo+ id+"
         results = list(self.lib.items(q))
         self.assertEqual(len(all_results), len(results))
         for r1, r2 in zip(all_results, results):
             self.assertEqual(r1.id, r2.id)
 
     def test_combined_non_existing_field_desc(self):
-        all_results = list(self.lib.items(u'id+'))
-        q = u'foo- id+'
+        all_results = list(self.lib.items(u"id+"))
+        q = u"foo- id+"
         results = list(self.lib.items(q))
         self.assertEqual(len(all_results), len(results))
         for r1, r2 in zip(all_results, results):
@@ -501,21 +510,25 @@ class NonExistingFieldTest(DummyDataTestCase):
     def test_field_present_in_some_items(self):
         """Test ordering by a field not present on all items."""
         # append 'foo' to two to items (1,2)
-        items = self.lib.items(u'id+')
+        items = self.lib.items(u"id+")
         ids = [i.id for i in items]
-        items[1].foo = u'bar1'
-        items[2].foo = u'bar2'
+        items[1].foo = u"bar1"
+        items[2].foo = u"bar2"
         items[1].store()
         items[2].store()
 
-        results_asc = list(self.lib.items(u'foo+ id+'))
-        self.assertEqual([i.id for i in results_asc],
-                         # items without field first
-                         [ids[0], ids[3], ids[1], ids[2]])
-        results_desc = list(self.lib.items(u'foo- id+'))
-        self.assertEqual([i.id for i in results_desc],
-                         # items without field last
-                         [ids[2], ids[1], ids[0], ids[3]])
+        results_asc = list(self.lib.items(u"foo+ id+"))
+        self.assertEqual(
+            [i.id for i in results_asc],
+            # items without field first
+            [ids[0], ids[3], ids[1], ids[2]],
+        )
+        results_desc = list(self.lib.items(u"foo- id+"))
+        self.assertEqual(
+            [i.id for i in results_desc],
+            # items without field last
+            [ids[2], ids[1], ids[0], ids[3]],
+        )
 
     def test_negation_interaction(self):
         """Test the handling of negation and sorting together.
@@ -523,18 +536,20 @@ class NonExistingFieldTest(DummyDataTestCase):
         If a string ends with a sorting suffix, it takes precedence over the
         NotQuery parsing.
         """
-        query, sort = beets.library.parse_query_string(u'-bar+',
-                                                       beets.library.Item)
+        query, sort = beets.library.parse_query_string(
+            u"-bar+", beets.library.Item
+        )
         self.assertEqual(len(query.subqueries), 1)
-        self.assertTrue(isinstance(query.subqueries[0],
-                                   dbcore.query.TrueQuery))
+        self.assertTrue(
+            isinstance(query.subqueries[0], dbcore.query.TrueQuery)
+        )
         self.assertTrue(isinstance(sort, dbcore.query.SlowFieldSort))
-        self.assertEqual(sort.field, u'-bar')
+        self.assertEqual(sort.field, u"-bar")
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_spotify.py
+++ b/test/test_spotify.py
@@ -38,11 +38,11 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
             spotify.SpotifyPlugin.oauth_token_url,
             status=200,
             json={
-                'access_token': '3XyiC3raJySbIAV5LVYj1DaWbcocNi3LAJTNXRnYY'
-                'GVUl6mbbqXNhW3YcZnQgYXNWHFkVGSMlc0tMuvq8CF',
-                'token_type': 'Bearer',
-                'expires_in': 3600,
-                'scope': '',
+                "access_token": "3XyiC3raJySbIAV5LVYj1DaWbcocNi3LAJTNXRnYY"
+                "GVUl6mbbqXNhW3YcZnQgYXNWHFkVGSMlc0tMuvq8CF",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "scope": "",
             },
         )
         self.spotify = spotify.SpotifyPlugin()
@@ -66,9 +66,9 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
     @responses.activate
     def test_missing_request(self):
         json_file = os.path.join(
-            _common.RSRC, b'spotify', b'missing_request.json'
+            _common.RSRC, b"spotify", b"missing_request.json"
         )
-        with open(json_file, 'rb') as f:
+        with open(json_file, "rb") as f:
             response_body = f.read()
 
         responses.add(
@@ -76,31 +76,31 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
             spotify.SpotifyPlugin.search_url,
             body=response_body,
             status=200,
-            content_type='application/json',
+            content_type="application/json",
         )
         item = Item(
-            mb_trackid=u'01234',
-            album=u'lkajsdflakjsd',
-            albumartist=u'ujydfsuihse',
-            title=u'duifhjslkef',
+            mb_trackid=u"01234",
+            album=u"lkajsdflakjsd",
+            albumartist=u"ujydfsuihse",
+            title=u"duifhjslkef",
             length=10,
         )
         item.add(self.lib)
         self.assertEqual([], self.spotify._match_library_tracks(self.lib, u""))
 
         params = _params(responses.calls[0].request.url)
-        query = params['q'][0]
-        self.assertIn(u'duifhjslkef', query)
-        self.assertIn(u'artist:ujydfsuihse', query)
-        self.assertIn(u'album:lkajsdflakjsd', query)
-        self.assertEqual(params['type'], [u'track'])
+        query = params["q"][0]
+        self.assertIn(u"duifhjslkef", query)
+        self.assertIn(u"artist:ujydfsuihse", query)
+        self.assertIn(u"album:lkajsdflakjsd", query)
+        self.assertEqual(params["type"], [u"track"])
 
     @responses.activate
     def test_track_request(self):
         json_file = os.path.join(
-            _common.RSRC, b'spotify', b'track_request.json'
+            _common.RSRC, b"spotify", b"track_request.json"
         )
-        with open(json_file, 'rb') as f:
+        with open(json_file, "rb") as f:
             response_body = f.read()
 
         responses.add(
@@ -108,32 +108,32 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
             spotify.SpotifyPlugin.search_url,
             body=response_body,
             status=200,
-            content_type='application/json',
+            content_type="application/json",
         )
         item = Item(
-            mb_trackid=u'01234',
-            album=u'Despicable Me 2',
-            albumartist=u'Pharrell Williams',
-            title=u'Happy',
+            mb_trackid=u"01234",
+            album=u"Despicable Me 2",
+            albumartist=u"Pharrell Williams",
+            title=u"Happy",
             length=10,
         )
         item.add(self.lib)
         results = self.spotify._match_library_tracks(self.lib, u"Happy")
         self.assertEqual(1, len(results))
-        self.assertEqual(u"6NPVjNh8Jhru9xOmyQigds", results[0]['id'])
+        self.assertEqual(u"6NPVjNh8Jhru9xOmyQigds", results[0]["id"])
         self.spotify._output_match_results(results)
 
         params = _params(responses.calls[0].request.url)
-        query = params['q'][0]
-        self.assertIn(u'Happy', query)
-        self.assertIn(u'artist:Pharrell Williams', query)
-        self.assertIn(u'album:Despicable Me 2', query)
-        self.assertEqual(params['type'], [u'track'])
+        query = params["q"][0]
+        self.assertIn(u"Happy", query)
+        self.assertIn(u"artist:Pharrell Williams", query)
+        self.assertIn(u"album:Despicable Me 2", query)
+        self.assertEqual(params["type"], [u"track"])
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_subsonic.py
+++ b/test/test_subsonic.py
@@ -45,9 +45,7 @@ class SubsonicPluginTest(_common.TestCase, TestHelper):
     @responses.activate
     def test_start_scan(self):
         responses.add(
-            responses.POST,
-            'http://localhost:4040/rest/startScan',
-            status=200
+            responses.POST, "http://localhost:4040/rest/startScan", status=200
         )
 
         self.subsonicupdate.start_scan()
@@ -58,8 +56,8 @@ class SubsonicPluginTest(_common.TestCase, TestHelper):
 
         responses.add(
             responses.POST,
-            'http://localhost:4040/contextPath/rest/startScan',
-            status=200
+            "http://localhost:4040/contextPath/rest/startScan",
+            status=200,
         )
 
         self.subsonicupdate.start_scan()
@@ -69,9 +67,7 @@ class SubsonicPluginTest(_common.TestCase, TestHelper):
         config["subsonic"]["url"] = "http://localhost:4040/"
 
         responses.add(
-            responses.POST,
-            'http://localhost:4040/rest/startScan',
-            status=200
+            responses.POST, "http://localhost:4040/rest/startScan", status=200
         )
 
         self.subsonicupdate.start_scan()
@@ -81,9 +77,7 @@ class SubsonicPluginTest(_common.TestCase, TestHelper):
         config["subsonic"]["url"] = "http://localhost/airsonic"
 
         responses.add(
-            responses.POST,
-            'http://localhost:4040/rest/startScan',
-            status=200
+            responses.POST, "http://localhost:4040/rest/startScan", status=200
         )
 
         with self.assertRaises(requests.exceptions.ConnectionError):
@@ -94,9 +88,7 @@ class SubsonicPluginTest(_common.TestCase, TestHelper):
         config["subsonic"]["url"] = "localhost:4040/airsonic"
 
         responses.add(
-            responses.POST,
-            'http://localhost:4040/rest/startScan',
-            status=200
+            responses.POST, "http://localhost:4040/rest/startScan", status=200
         )
 
         with self.assertRaises(requests.exceptions.InvalidSchema):
@@ -107,5 +99,5 @@ def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -33,13 +33,13 @@ def _normexpr(expr):
             textbuf.append(part)
         else:
             if textbuf:
-                text = u''.join(textbuf)
+                text = u"".join(textbuf)
                 if text:
                     yield text
                     textbuf = []
             yield part
     if textbuf:
-        text = u''.join(textbuf)
+        text = u"".join(textbuf)
         if text:
             yield text
 
@@ -51,141 +51,154 @@ def _normparse(text):
 
 class ParseTest(unittest.TestCase):
     def test_empty_string(self):
-        self.assertEqual(list(_normparse(u'')), [])
+        self.assertEqual(list(_normparse(u"")), [])
 
     def _assert_symbol(self, obj, ident):
         """Assert that an object is a Symbol with the given identifier.
         """
-        self.assertTrue(isinstance(obj, functemplate.Symbol),
-                        u"not a Symbol: %s" % repr(obj))
-        self.assertEqual(obj.ident, ident,
-                         u"wrong identifier: %s vs. %s" %
-                         (repr(obj.ident), repr(ident)))
+        self.assertTrue(
+            isinstance(obj, functemplate.Symbol),
+            u"not a Symbol: %s" % repr(obj),
+        )
+        self.assertEqual(
+            obj.ident,
+            ident,
+            u"wrong identifier: %s vs. %s" % (repr(obj.ident), repr(ident)),
+        )
 
     def _assert_call(self, obj, ident, numargs):
         """Assert that an object is a Call with the given identifier and
         argument count.
         """
-        self.assertTrue(isinstance(obj, functemplate.Call),
-                        u"not a Call: %s" % repr(obj))
-        self.assertEqual(obj.ident, ident,
-                         u"wrong identifier: %s vs. %s" %
-                         (repr(obj.ident), repr(ident)))
-        self.assertEqual(len(obj.args), numargs,
-                         u"wrong argument count in %s: %i vs. %i" %
-                         (repr(obj.ident), len(obj.args), numargs))
+        self.assertTrue(
+            isinstance(obj, functemplate.Call), u"not a Call: %s" % repr(obj)
+        )
+        self.assertEqual(
+            obj.ident,
+            ident,
+            u"wrong identifier: %s vs. %s" % (repr(obj.ident), repr(ident)),
+        )
+        self.assertEqual(
+            len(obj.args),
+            numargs,
+            u"wrong argument count in %s: %i vs. %i"
+            % (repr(obj.ident), len(obj.args), numargs),
+        )
 
     def test_plain_text(self):
-        self.assertEqual(list(_normparse(u'hello world')), [u'hello world'])
+        self.assertEqual(list(_normparse(u"hello world")), [u"hello world"])
 
     def test_escaped_character_only(self):
-        self.assertEqual(list(_normparse(u'$$')), [u'$'])
+        self.assertEqual(list(_normparse(u"$$")), [u"$"])
 
     def test_escaped_character_in_text(self):
-        self.assertEqual(list(_normparse(u'a $$ b')), [u'a $ b'])
+        self.assertEqual(list(_normparse(u"a $$ b")), [u"a $ b"])
 
     def test_escaped_character_at_start(self):
-        self.assertEqual(list(_normparse(u'$$ hello')), [u'$ hello'])
+        self.assertEqual(list(_normparse(u"$$ hello")), [u"$ hello"])
 
     def test_escaped_character_at_end(self):
-        self.assertEqual(list(_normparse(u'hello $$')), [u'hello $'])
+        self.assertEqual(list(_normparse(u"hello $$")), [u"hello $"])
 
     def test_escaped_function_delim(self):
-        self.assertEqual(list(_normparse(u'a $% b')), [u'a % b'])
+        self.assertEqual(list(_normparse(u"a $% b")), [u"a % b"])
 
     def test_escaped_sep(self):
-        self.assertEqual(list(_normparse(u'a $, b')), [u'a , b'])
+        self.assertEqual(list(_normparse(u"a $, b")), [u"a , b"])
 
     def test_escaped_close_brace(self):
-        self.assertEqual(list(_normparse(u'a $} b')), [u'a } b'])
+        self.assertEqual(list(_normparse(u"a $} b")), [u"a } b"])
 
     def test_bare_value_delim_kept_intact(self):
-        self.assertEqual(list(_normparse(u'a $ b')), [u'a $ b'])
+        self.assertEqual(list(_normparse(u"a $ b")), [u"a $ b"])
 
     def test_bare_function_delim_kept_intact(self):
-        self.assertEqual(list(_normparse(u'a % b')), [u'a % b'])
+        self.assertEqual(list(_normparse(u"a % b")), [u"a % b"])
 
     def test_bare_opener_kept_intact(self):
-        self.assertEqual(list(_normparse(u'a { b')), [u'a { b'])
+        self.assertEqual(list(_normparse(u"a { b")), [u"a { b"])
 
     def test_bare_closer_kept_intact(self):
-        self.assertEqual(list(_normparse(u'a } b')), [u'a } b'])
+        self.assertEqual(list(_normparse(u"a } b")), [u"a } b"])
 
     def test_bare_sep_kept_intact(self):
-        self.assertEqual(list(_normparse(u'a , b')), [u'a , b'])
+        self.assertEqual(list(_normparse(u"a , b")), [u"a , b"])
 
     def test_symbol_alone(self):
-        parts = list(_normparse(u'$foo'))
+        parts = list(_normparse(u"$foo"))
         self.assertEqual(len(parts), 1)
         self._assert_symbol(parts[0], u"foo")
 
     def test_symbol_in_text(self):
-        parts = list(_normparse(u'hello $foo world'))
+        parts = list(_normparse(u"hello $foo world"))
         self.assertEqual(len(parts), 3)
-        self.assertEqual(parts[0], u'hello ')
+        self.assertEqual(parts[0], u"hello ")
         self._assert_symbol(parts[1], u"foo")
-        self.assertEqual(parts[2], u' world')
+        self.assertEqual(parts[2], u" world")
 
     def test_symbol_with_braces(self):
-        parts = list(_normparse(u'hello${foo}world'))
+        parts = list(_normparse(u"hello${foo}world"))
         self.assertEqual(len(parts), 3)
-        self.assertEqual(parts[0], u'hello')
+        self.assertEqual(parts[0], u"hello")
         self._assert_symbol(parts[1], u"foo")
-        self.assertEqual(parts[2], u'world')
+        self.assertEqual(parts[2], u"world")
 
     def test_unclosed_braces_symbol(self):
-        self.assertEqual(list(_normparse(u'a ${ b')), [u'a ${ b'])
+        self.assertEqual(list(_normparse(u"a ${ b")), [u"a ${ b"])
 
     def test_empty_braces_symbol(self):
-        self.assertEqual(list(_normparse(u'a ${} b')), [u'a ${} b'])
+        self.assertEqual(list(_normparse(u"a ${} b")), [u"a ${} b"])
 
     def test_call_without_args_at_end(self):
-        self.assertEqual(list(_normparse(u'foo %bar')), [u'foo %bar'])
+        self.assertEqual(list(_normparse(u"foo %bar")), [u"foo %bar"])
 
     def test_call_without_args(self):
-        self.assertEqual(list(_normparse(u'foo %bar baz')), [u'foo %bar baz'])
+        self.assertEqual(list(_normparse(u"foo %bar baz")), [u"foo %bar baz"])
 
     def test_call_with_unclosed_args(self):
-        self.assertEqual(list(_normparse(u'foo %bar{ baz')),
-                         [u'foo %bar{ baz'])
+        self.assertEqual(
+            list(_normparse(u"foo %bar{ baz")), [u"foo %bar{ baz"]
+        )
 
     def test_call_with_unclosed_multiple_args(self):
-        self.assertEqual(list(_normparse(u'foo %bar{bar,bar baz')),
-                         [u'foo %bar{bar,bar baz'])
+        self.assertEqual(
+            list(_normparse(u"foo %bar{bar,bar baz")),
+            [u"foo %bar{bar,bar baz"],
+        )
 
     def test_call_empty_arg(self):
-        parts = list(_normparse(u'%foo{}'))
+        parts = list(_normparse(u"%foo{}"))
         self.assertEqual(len(parts), 1)
         self._assert_call(parts[0], u"foo", 1)
         self.assertEqual(list(_normexpr(parts[0].args[0])), [])
 
     def test_call_single_arg(self):
-        parts = list(_normparse(u'%foo{bar}'))
+        parts = list(_normparse(u"%foo{bar}"))
         self.assertEqual(len(parts), 1)
         self._assert_call(parts[0], u"foo", 1)
-        self.assertEqual(list(_normexpr(parts[0].args[0])), [u'bar'])
+        self.assertEqual(list(_normexpr(parts[0].args[0])), [u"bar"])
 
     def test_call_two_args(self):
-        parts = list(_normparse(u'%foo{bar,baz}'))
+        parts = list(_normparse(u"%foo{bar,baz}"))
         self.assertEqual(len(parts), 1)
         self._assert_call(parts[0], u"foo", 2)
-        self.assertEqual(list(_normexpr(parts[0].args[0])), [u'bar'])
-        self.assertEqual(list(_normexpr(parts[0].args[1])), [u'baz'])
+        self.assertEqual(list(_normexpr(parts[0].args[0])), [u"bar"])
+        self.assertEqual(list(_normexpr(parts[0].args[1])), [u"baz"])
 
     def test_call_with_escaped_sep(self):
-        parts = list(_normparse(u'%foo{bar$,baz}'))
+        parts = list(_normparse(u"%foo{bar$,baz}"))
         self.assertEqual(len(parts), 1)
         self._assert_call(parts[0], u"foo", 1)
-        self.assertEqual(list(_normexpr(parts[0].args[0])), [u'bar,baz'])
+        self.assertEqual(list(_normexpr(parts[0].args[0])), [u"bar,baz"])
 
     def test_call_with_escaped_close(self):
-        parts = list(_normparse(u'%foo{bar$}baz}'))
+        parts = list(_normparse(u"%foo{bar$}baz}"))
         self.assertEqual(len(parts), 1)
         self._assert_call(parts[0], u"foo", 1)
-        self.assertEqual(list(_normexpr(parts[0].args[0])), [u'bar}baz'])
+        self.assertEqual(list(_normexpr(parts[0].args[0])), [u"bar}baz"])
 
     def test_call_with_symbol_argument(self):
-        parts = list(_normparse(u'%foo{$bar,baz}'))
+        parts = list(_normparse(u"%foo{$bar,baz}"))
         self.assertEqual(len(parts), 1)
         self._assert_call(parts[0], u"foo", 2)
         arg_parts = list(_normexpr(parts[0].args[0]))
@@ -194,7 +207,7 @@ class ParseTest(unittest.TestCase):
         self.assertEqual(list(_normexpr(parts[0].args[1])), [u"baz"])
 
     def test_call_with_nested_call_argument(self):
-        parts = list(_normparse(u'%foo{%bar{},baz}'))
+        parts = list(_normparse(u"%foo{%bar{},baz}"))
         self.assertEqual(len(parts), 1)
         self._assert_call(parts[0], u"foo", 2)
         arg_parts = list(_normexpr(parts[0].args[0]))
@@ -203,45 +216,45 @@ class ParseTest(unittest.TestCase):
         self.assertEqual(list(_normexpr(parts[0].args[1])), [u"baz"])
 
     def test_nested_call_with_argument(self):
-        parts = list(_normparse(u'%foo{%bar{baz}}'))
+        parts = list(_normparse(u"%foo{%bar{baz}}"))
         self.assertEqual(len(parts), 1)
         self._assert_call(parts[0], u"foo", 1)
         arg_parts = list(_normexpr(parts[0].args[0]))
         self.assertEqual(len(arg_parts), 1)
         self._assert_call(arg_parts[0], u"bar", 1)
-        self.assertEqual(list(_normexpr(arg_parts[0].args[0])), [u'baz'])
+        self.assertEqual(list(_normexpr(arg_parts[0].args[0])), [u"baz"])
 
     def test_sep_before_call_two_args(self):
-        parts = list(_normparse(u'hello, %foo{bar,baz}'))
+        parts = list(_normparse(u"hello, %foo{bar,baz}"))
         self.assertEqual(len(parts), 2)
-        self.assertEqual(parts[0], u'hello, ')
+        self.assertEqual(parts[0], u"hello, ")
         self._assert_call(parts[1], u"foo", 2)
-        self.assertEqual(list(_normexpr(parts[1].args[0])), [u'bar'])
-        self.assertEqual(list(_normexpr(parts[1].args[1])), [u'baz'])
+        self.assertEqual(list(_normexpr(parts[1].args[0])), [u"bar"])
+        self.assertEqual(list(_normexpr(parts[1].args[1])), [u"baz"])
 
     def test_sep_with_symbols(self):
-        parts = list(_normparse(u'hello,$foo,$bar'))
+        parts = list(_normparse(u"hello,$foo,$bar"))
         self.assertEqual(len(parts), 4)
-        self.assertEqual(parts[0], u'hello,')
+        self.assertEqual(parts[0], u"hello,")
         self._assert_symbol(parts[1], u"foo")
-        self.assertEqual(parts[2], u',')
+        self.assertEqual(parts[2], u",")
         self._assert_symbol(parts[3], u"bar")
 
     def test_newline_at_end(self):
-        parts = list(_normparse(u'foo\n'))
+        parts = list(_normparse(u"foo\n"))
         self.assertEqual(len(parts), 1)
-        self.assertEqual(parts[0], u'foo\n')
+        self.assertEqual(parts[0], u"foo\n")
 
 
 class EvalTest(unittest.TestCase):
     def _eval(self, template):
         values = {
-            u'foo': u'bar',
-            u'baz': u'BaR',
+            u"foo": u"bar",
+            u"baz": u"BaR",
         }
         functions = {
-            u'lower': six.text_type.lower,
-            u'len': len,
+            u"lower": six.text_type.lower,
+            u"len": len,
         }
         return functemplate.Template(template).substitute(values, functions)
 
@@ -289,5 +302,6 @@ class EvalTest(unittest.TestCase):
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_the.py
+++ b/test/test_the.py
@@ -11,60 +11,72 @@ from beetsplug.the import ThePlugin, PATTERN_A, PATTERN_THE, FORMAT
 
 
 class ThePluginTest(_common.TestCase):
-
     def test_unthe_with_default_patterns(self):
-        self.assertEqual(ThePlugin().unthe(u'', PATTERN_THE), '')
-        self.assertEqual(ThePlugin().unthe(u'The Something', PATTERN_THE),
-                         u'Something, The')
-        self.assertEqual(ThePlugin().unthe(u'The The', PATTERN_THE),
-                         u'The, The')
-        self.assertEqual(ThePlugin().unthe(u'The    The', PATTERN_THE),
-                         u'The, The')
-        self.assertEqual(ThePlugin().unthe(u'The   The   X', PATTERN_THE),
-                         u'The   X, The')
-        self.assertEqual(ThePlugin().unthe(u'the The', PATTERN_THE),
-                         u'The, the')
-        self.assertEqual(ThePlugin().unthe(u'Protected The', PATTERN_THE),
-                         u'Protected The')
-        self.assertEqual(ThePlugin().unthe(u'A Boy', PATTERN_A),
-                         u'Boy, A')
-        self.assertEqual(ThePlugin().unthe(u'a girl', PATTERN_A),
-                         u'girl, a')
-        self.assertEqual(ThePlugin().unthe(u'An Apple', PATTERN_A),
-                         u'Apple, An')
-        self.assertEqual(ThePlugin().unthe(u'An A Thing', PATTERN_A),
-                         u'A Thing, An')
-        self.assertEqual(ThePlugin().unthe(u'the An Arse', PATTERN_A),
-                         u'the An Arse')
-        self.assertEqual(ThePlugin().unthe(u'TET - Travailleur', PATTERN_THE),
-                         u'TET - Travailleur')
+        self.assertEqual(ThePlugin().unthe(u"", PATTERN_THE), "")
+        self.assertEqual(
+            ThePlugin().unthe(u"The Something", PATTERN_THE), u"Something, The"
+        )
+        self.assertEqual(
+            ThePlugin().unthe(u"The The", PATTERN_THE), u"The, The"
+        )
+        self.assertEqual(
+            ThePlugin().unthe(u"The    The", PATTERN_THE), u"The, The"
+        )
+        self.assertEqual(
+            ThePlugin().unthe(u"The   The   X", PATTERN_THE), u"The   X, The"
+        )
+        self.assertEqual(
+            ThePlugin().unthe(u"the The", PATTERN_THE), u"The, the"
+        )
+        self.assertEqual(
+            ThePlugin().unthe(u"Protected The", PATTERN_THE), u"Protected The"
+        )
+        self.assertEqual(ThePlugin().unthe(u"A Boy", PATTERN_A), u"Boy, A")
+        self.assertEqual(ThePlugin().unthe(u"a girl", PATTERN_A), u"girl, a")
+        self.assertEqual(
+            ThePlugin().unthe(u"An Apple", PATTERN_A), u"Apple, An"
+        )
+        self.assertEqual(
+            ThePlugin().unthe(u"An A Thing", PATTERN_A), u"A Thing, An"
+        )
+        self.assertEqual(
+            ThePlugin().unthe(u"the An Arse", PATTERN_A), u"the An Arse"
+        )
+        self.assertEqual(
+            ThePlugin().unthe(u"TET - Travailleur", PATTERN_THE),
+            u"TET - Travailleur",
+        )
 
     def test_unthe_with_strip(self):
-        config['the']['strip'] = True
-        self.assertEqual(ThePlugin().unthe(u'The Something', PATTERN_THE),
-                         u'Something')
-        self.assertEqual(ThePlugin().unthe(u'An A', PATTERN_A), u'A')
+        config["the"]["strip"] = True
+        self.assertEqual(
+            ThePlugin().unthe(u"The Something", PATTERN_THE), u"Something"
+        )
+        self.assertEqual(ThePlugin().unthe(u"An A", PATTERN_A), u"A")
 
     def test_template_function_with_defaults(self):
         ThePlugin().patterns = [PATTERN_THE, PATTERN_A]
-        self.assertEqual(ThePlugin().the_template_func(u'The The'),
-                         u'The, The')
-        self.assertEqual(ThePlugin().the_template_func(u'An A'), u'A, An')
+        self.assertEqual(
+            ThePlugin().the_template_func(u"The The"), u"The, The"
+        )
+        self.assertEqual(ThePlugin().the_template_func(u"An A"), u"A, An")
 
     def test_custom_pattern(self):
-        config['the']['patterns'] = [u'^test\\s']
-        config['the']['format'] = FORMAT
-        self.assertEqual(ThePlugin().the_template_func(u'test passed'),
-                         u'passed, test')
+        config["the"]["patterns"] = [u"^test\\s"]
+        config["the"]["format"] = FORMAT
+        self.assertEqual(
+            ThePlugin().the_template_func(u"test passed"), u"passed, test"
+        )
 
     def test_custom_format(self):
-        config['the']['patterns'] = [PATTERN_THE, PATTERN_A]
-        config['the']['format'] = u'{1} ({0})'
-        self.assertEqual(ThePlugin().the_template_func(u'The A'), u'The (A)')
+        config["the"]["patterns"] = [PATTERN_THE, PATTERN_A]
+        config["the"]["format"] = u"{1} ({0})"
+        self.assertEqual(ThePlugin().the_template_func(u"The A"), u"The (A)")
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_thumbnails.py
+++ b/test/test_thumbnails.py
@@ -24,9 +24,15 @@ import unittest
 from test.helper import TestHelper
 
 from beets.util import bytestring_path
-from beetsplug.thumbnails import (ThumbnailsPlugin, NORMAL_DIR, LARGE_DIR,
-                                  write_metadata_im, write_metadata_pil,
-                                  PathlibURI, GioURI)
+from beetsplug.thumbnails import (
+    ThumbnailsPlugin,
+    NORMAL_DIR,
+    LARGE_DIR,
+    write_metadata_im,
+    write_metadata_pil,
+    PathlibURI,
+    GioURI,
+)
 
 
 class ThumbnailsTest(unittest.TestCase, TestHelper):
@@ -36,42 +42,44 @@ class ThumbnailsTest(unittest.TestCase, TestHelper):
     def tearDown(self):
         self.teardown_beets()
 
-    @patch('beetsplug.thumbnails.util')
+    @patch("beetsplug.thumbnails.util")
     def test_write_metadata_im(self, mock_util):
         metadata = {"a": u"A", "b": u"B"}
         write_metadata_im("foo", metadata)
         try:
-            command = u"convert foo -set a A -set b B foo".split(' ')
+            command = u"convert foo -set a A -set b B foo".split(" ")
             mock_util.command_output.assert_called_once_with(command)
         except AssertionError:
-            command = u"convert foo -set b B -set a A foo".split(' ')
+            command = u"convert foo -set b B -set a A foo".split(" ")
             mock_util.command_output.assert_called_once_with(command)
 
-    @patch('beetsplug.thumbnails.ThumbnailsPlugin._check_local_ok')
-    @patch('beetsplug.thumbnails.os.stat')
+    @patch("beetsplug.thumbnails.ThumbnailsPlugin._check_local_ok")
+    @patch("beetsplug.thumbnails.os.stat")
     def test_add_tags(self, mock_stat, _):
         plugin = ThumbnailsPlugin()
         plugin.write_metadata = Mock()
-        plugin.get_uri = Mock(side_effect={b"/path/to/cover":
-                                           "COVER_URI"}.__getitem__)
+        plugin.get_uri = Mock(
+            side_effect={b"/path/to/cover": "COVER_URI"}.__getitem__
+        )
         album = Mock(artpath=b"/path/to/cover")
         mock_stat.return_value.st_mtime = 12345
 
         plugin.add_tags(album, b"/path/to/thumbnail")
 
-        metadata = {"Thumb::URI": "COVER_URI",
-                    "Thumb::MTime": u"12345"}
-        plugin.write_metadata.assert_called_once_with(b"/path/to/thumbnail",
-                                                      metadata)
+        metadata = {"Thumb::URI": "COVER_URI", "Thumb::MTime": u"12345"}
+        plugin.write_metadata.assert_called_once_with(
+            b"/path/to/thumbnail", metadata
+        )
         mock_stat.assert_called_once_with(album.artpath)
 
-    @patch('beetsplug.thumbnails.os')
-    @patch('beetsplug.thumbnails.ArtResizer')
-    @patch('beetsplug.thumbnails.get_im_version')
-    @patch('beetsplug.thumbnails.get_pil_version')
-    @patch('beetsplug.thumbnails.GioURI')
-    def test_check_local_ok(self, mock_giouri, mock_pil, mock_im,
-                            mock_artresizer, mock_os):
+    @patch("beetsplug.thumbnails.os")
+    @patch("beetsplug.thumbnails.ArtResizer")
+    @patch("beetsplug.thumbnails.get_im_version")
+    @patch("beetsplug.thumbnails.get_pil_version")
+    @patch("beetsplug.thumbnails.GioURI")
+    def test_check_local_ok(
+        self, mock_giouri, mock_pil, mock_im, mock_artresizer, mock_os
+    ):
         # test local resizing capability
         mock_artresizer.shared.local = False
         plugin = ThumbnailsPlugin()
@@ -86,6 +94,7 @@ class ThumbnailsTest(unittest.TestCase, TestHelper):
             if path == LARGE_DIR:
                 return True
             raise ValueError(u"unexpected path {0!r}".format(path))
+
         mock_os.path.exists = exists
         plugin = ThumbnailsPlugin()
         mock_os.makedirs.assert_called_once_with(NORMAL_DIR)
@@ -115,16 +124,18 @@ class ThumbnailsTest(unittest.TestCase, TestHelper):
         self.assertEqual(ThumbnailsPlugin().get_uri, giouri_inst.uri)
 
         giouri_inst.available = False
-        self.assertEqual(ThumbnailsPlugin().get_uri.__self__.__class__,
-                         PathlibURI)
+        self.assertEqual(
+            ThumbnailsPlugin().get_uri.__self__.__class__, PathlibURI
+        )
 
-    @patch('beetsplug.thumbnails.ThumbnailsPlugin._check_local_ok')
-    @patch('beetsplug.thumbnails.ArtResizer')
-    @patch('beetsplug.thumbnails.util')
-    @patch('beetsplug.thumbnails.os')
-    @patch('beetsplug.thumbnails.shutil')
-    def test_make_cover_thumbnail(self, mock_shutils, mock_os, mock_util,
-                                  mock_artresizer, _):
+    @patch("beetsplug.thumbnails.ThumbnailsPlugin._check_local_ok")
+    @patch("beetsplug.thumbnails.ArtResizer")
+    @patch("beetsplug.thumbnails.util")
+    @patch("beetsplug.thumbnails.os")
+    @patch("beetsplug.thumbnails.shutil")
+    def test_make_cover_thumbnail(
+        self, mock_shutils, mock_os, mock_util, mock_artresizer, _
+    ):
         thumbnail_dir = os.path.normpath(b"/thumbnail/dir")
         md5_file = os.path.join(thumbnail_dir, b"md5")
         path_to_art = os.path.normpath(b"/path/to/art")
@@ -135,7 +146,7 @@ class ThumbnailsTest(unittest.TestCase, TestHelper):
 
         album = Mock(artpath=path_to_art)
         mock_util.syspath.side_effect = lambda x: x
-        plugin.thumbnail_file_name = Mock(return_value=b'md5')
+        plugin.thumbnail_file_name = Mock(return_value=b"md5")
         mock_os.path.exists.return_value = False
 
         def os_stat(target):
@@ -145,19 +156,22 @@ class ThumbnailsTest(unittest.TestCase, TestHelper):
                 return Mock(st_mtime=2)
             else:
                 raise ValueError(u"invalid target {0}".format(target))
+
         mock_os.stat.side_effect = os_stat
 
         plugin.make_cover_thumbnail(album, 12345, thumbnail_dir)
 
         mock_os.path.exists.assert_called_once_with(md5_file)
-        mock_os.stat.has_calls([call(md5_file), call(path_to_art)],
-                               any_order=True)
+        mock_os.stat.has_calls(
+            [call(md5_file), call(path_to_art)], any_order=True
+        )
 
         resize = mock_artresizer.shared.resize
         resize.assert_called_once_with(12345, path_to_art, md5_file)
         plugin.add_tags.assert_called_once_with(album, resize.return_value)
-        mock_shutils.move.assert_called_once_with(resize.return_value,
-                                                  md5_file)
+        mock_shutils.move.assert_called_once_with(
+            resize.return_value, md5_file
+        )
 
         # now test with recent thumbnail & with force
         mock_os.path.exists.return_value = True
@@ -171,27 +185,27 @@ class ThumbnailsTest(unittest.TestCase, TestHelper):
                 return Mock(st_mtime=2)
             else:
                 raise ValueError(u"invalid target {0}".format(target))
+
         mock_os.stat.side_effect = os_stat
 
         plugin.make_cover_thumbnail(album, 12345, thumbnail_dir)
         self.assertEqual(resize.call_count, 0)
 
         # and with force
-        plugin.config['force'] = True
+        plugin.config["force"] = True
         plugin.make_cover_thumbnail(album, 12345, thumbnail_dir)
         resize.assert_called_once_with(12345, path_to_art, md5_file)
 
-    @patch('beetsplug.thumbnails.ThumbnailsPlugin._check_local_ok')
+    @patch("beetsplug.thumbnails.ThumbnailsPlugin._check_local_ok")
     def test_make_dolphin_cover_thumbnail(self, _):
         plugin = ThumbnailsPlugin()
         tmp = bytestring_path(mkdtemp())
-        album = Mock(path=tmp,
-                     artpath=os.path.join(tmp, b"cover.jpg"))
+        album = Mock(path=tmp, artpath=os.path.join(tmp, b"cover.jpg"))
         plugin.make_dolphin_cover_thumbnail(album)
         with open(os.path.join(tmp, b".directory"), "rb") as f:
             self.assertEqual(
                 f.read().splitlines(),
-                [b"[Desktop Entry]", b"Icon=./cover.jpg"]
+                [b"[Desktop Entry]", b"Icon=./cover.jpg"],
             )
 
         # not rewritten when it already exists (yup that's a big limitation)
@@ -200,13 +214,13 @@ class ThumbnailsTest(unittest.TestCase, TestHelper):
         with open(os.path.join(tmp, b".directory"), "rb") as f:
             self.assertEqual(
                 f.read().splitlines(),
-                [b"[Desktop Entry]", b"Icon=./cover.jpg"]
+                [b"[Desktop Entry]", b"Icon=./cover.jpg"],
             )
 
         rmtree(tmp)
 
-    @patch('beetsplug.thumbnails.ThumbnailsPlugin._check_local_ok')
-    @patch('beetsplug.thumbnails.ArtResizer')
+    @patch("beetsplug.thumbnails.ThumbnailsPlugin._check_local_ok")
+    @patch("beetsplug.thumbnails.ArtResizer")
     def test_process_album(self, mock_artresizer, _):
         get_size = mock_artresizer.shared.get_size
 
@@ -228,11 +242,11 @@ class ThumbnailsTest(unittest.TestCase, TestHelper):
         self.assertEqual(make_cover.call_count, 0)
 
         # dolphin tests
-        plugin.config['dolphin'] = False
+        plugin.config["dolphin"] = False
         plugin.process_album(album)
         self.assertEqual(make_dolphin.call_count, 0)
 
-        plugin.config['dolphin'] = True
+        plugin.config["dolphin"] = True
         plugin.process_album(album)
         make_dolphin.assert_called_once_with(album)
 
@@ -245,11 +259,13 @@ class ThumbnailsTest(unittest.TestCase, TestHelper):
         make_cover.reset_mock()
         get_size.return_value = 500, 500
         plugin.process_album(album)
-        make_cover.has_calls([call(album, 128, NORMAL_DIR),
-                              call(album, 256, LARGE_DIR)], any_order=True)
+        make_cover.has_calls(
+            [call(album, 128, NORMAL_DIR), call(album, 256, LARGE_DIR)],
+            any_order=True,
+        )
 
-    @patch('beetsplug.thumbnails.ThumbnailsPlugin._check_local_ok')
-    @patch('beetsplug.thumbnails.decargs')
+    @patch("beetsplug.thumbnails.ThumbnailsPlugin._check_local_ok")
+    @patch("beetsplug.thumbnails.decargs")
     def test_invokations(self, mock_decargs, _):
         plugin = ThumbnailsPlugin()
         plugin.process_album = Mock()
@@ -261,15 +277,18 @@ class ThumbnailsTest(unittest.TestCase, TestHelper):
         lib.albums.return_value = [album, album2]
         plugin.process_query(lib, Mock(), None)
         lib.albums.assert_called_once_with(mock_decargs.return_value)
-        plugin.process_album.has_calls([call(album), call(album2)],
-                                       any_order=True)
+        plugin.process_album.has_calls(
+            [call(album), call(album2)], any_order=True
+        )
 
-    @patch('beetsplug.thumbnails.BaseDirectory')
+    @patch("beetsplug.thumbnails.BaseDirectory")
     def test_thumbnail_file_name(self, mock_basedir):
         plug = ThumbnailsPlugin()
         plug.get_uri = Mock(return_value=u"file:///my/uri")
-        self.assertEqual(plug.thumbnail_file_name(b'idontcare'),
-                         b"9488f5797fbe12ffb316d607dfd93d04.png")
+        self.assertEqual(
+            plug.thumbnail_file_name(b"idontcare"),
+            b"9488f5797fbe12ffb316d607dfd93d04.png",
+        )
 
     def test_uri(self):
         gio = GioURI()
@@ -280,21 +299,24 @@ class ThumbnailsTest(unittest.TestCase, TestHelper):
         self.assertEqual(gio.uri(b"/foo"), u"file:///foo")
         self.assertEqual(gio.uri(b"/foo!"), u"file:///foo!")
         self.assertEqual(
-            gio.uri(b'/music/\xec\x8b\xb8\xec\x9d\xb4'),
-            u'file:///music/%EC%8B%B8%EC%9D%B4')
+            gio.uri(b"/music/\xec\x8b\xb8\xec\x9d\xb4"),
+            u"file:///music/%EC%8B%B8%EC%9D%B4",
+        )
 
 
-class TestPathlibURI():
+class TestPathlibURI:
     """Test PathlibURI class"""
+
     def test_uri(self):
         test_uri = PathlibURI()
 
         # test it won't break if we pass it bytes for a path
-        test_uri.uri(b'/')
+        test_uri.uri(b"/")
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_types_plugin.py
+++ b/test/test_types_plugin.py
@@ -25,88 +25,87 @@ from confuse import ConfigValueError
 
 
 class TypesPluginTest(unittest.TestCase, TestHelper):
-
     def setUp(self):
         self.setup_beets()
-        self.load_plugins('types')
+        self.load_plugins("types")
 
     def tearDown(self):
         self.unload_plugins()
         self.teardown_beets()
 
     def test_integer_modify_and_query(self):
-        self.config['types'] = {'myint': 'int'}
-        item = self.add_item(artist=u'aaa')
+        self.config["types"] = {"myint": "int"}
+        item = self.add_item(artist=u"aaa")
 
         # Do not match unset values
-        out = self.list(u'myint:1..3')
-        self.assertEqual(u'', out)
+        out = self.list(u"myint:1..3")
+        self.assertEqual(u"", out)
 
-        self.modify(u'myint=2')
+        self.modify(u"myint=2")
         item.load()
-        self.assertEqual(item['myint'], 2)
+        self.assertEqual(item["myint"], 2)
 
         # Match in range
-        out = self.list(u'myint:1..3')
-        self.assertIn('aaa', out)
+        out = self.list(u"myint:1..3")
+        self.assertIn("aaa", out)
 
     def test_album_integer_modify_and_query(self):
-        self.config['types'] = {'myint': u'int'}
-        album = self.add_album(albumartist=u'aaa')
+        self.config["types"] = {"myint": u"int"}
+        album = self.add_album(albumartist=u"aaa")
 
         # Do not match unset values
-        out = self.list_album(u'myint:1..3')
-        self.assertEqual(u'', out)
+        out = self.list_album(u"myint:1..3")
+        self.assertEqual(u"", out)
 
-        self.modify(u'-a', u'myint=2')
+        self.modify(u"-a", u"myint=2")
         album.load()
-        self.assertEqual(album['myint'], 2)
+        self.assertEqual(album["myint"], 2)
 
         # Match in range
-        out = self.list_album(u'myint:1..3')
-        self.assertIn('aaa', out)
+        out = self.list_album(u"myint:1..3")
+        self.assertIn("aaa", out)
 
     def test_float_modify_and_query(self):
-        self.config['types'] = {'myfloat': u'float'}
-        item = self.add_item(artist=u'aaa')
+        self.config["types"] = {"myfloat": u"float"}
+        item = self.add_item(artist=u"aaa")
 
         # Do not match unset values
-        out = self.list(u'myfloat:10..0')
-        self.assertEqual(u'', out)
+        out = self.list(u"myfloat:10..0")
+        self.assertEqual(u"", out)
 
-        self.modify(u'myfloat=-9.1')
+        self.modify(u"myfloat=-9.1")
         item.load()
-        self.assertEqual(item['myfloat'], -9.1)
+        self.assertEqual(item["myfloat"], -9.1)
 
         # Match in range
-        out = self.list(u'myfloat:-10..0')
-        self.assertIn('aaa', out)
+        out = self.list(u"myfloat:-10..0")
+        self.assertIn("aaa", out)
 
     def test_bool_modify_and_query(self):
-        self.config['types'] = {'mybool': u'bool'}
-        true = self.add_item(artist=u'true')
-        false = self.add_item(artist=u'false')
-        self.add_item(artist=u'unset')
+        self.config["types"] = {"mybool": u"bool"}
+        true = self.add_item(artist=u"true")
+        false = self.add_item(artist=u"false")
+        self.add_item(artist=u"unset")
 
         # Do not match unset values
-        out = self.list(u'mybool:true, mybool:false')
-        self.assertEqual(u'', out)
+        out = self.list(u"mybool:true, mybool:false")
+        self.assertEqual(u"", out)
 
         # Set true
-        self.modify(u'mybool=1', u'artist:true')
+        self.modify(u"mybool=1", u"artist:true")
         true.load()
-        self.assertEqual(true['mybool'], True)
+        self.assertEqual(true["mybool"], True)
 
         # Set false
-        self.modify(u'mybool=false', u'artist:false')
+        self.modify(u"mybool=false", u"artist:false")
         false.load()
-        self.assertEqual(false['mybool'], False)
+        self.assertEqual(false["mybool"], False)
 
         # Query bools
-        out = self.list(u'mybool:true', u'$artist $mybool')
-        self.assertEqual(u'true True', out)
+        out = self.list(u"mybool:true", u"$artist $mybool")
+        self.assertEqual(u"true True", out)
 
-        out = self.list(u'mybool:false', u'$artist $mybool')
+        out = self.list(u"mybool:false", u"$artist $mybool")
 
         # Dealing with unset fields?
         # self.assertEqual('false False', out)
@@ -114,46 +113,47 @@ class TypesPluginTest(unittest.TestCase, TestHelper):
         # self.assertIn('unset $mybool', out)
 
     def test_date_modify_and_query(self):
-        self.config['types'] = {'mydate': u'date'}
+        self.config["types"] = {"mydate": u"date"}
         # FIXME parsing should also work with default time format
-        self.config['time_format'] = '%Y-%m-%d'
-        old = self.add_item(artist=u'prince')
-        new = self.add_item(artist=u'britney')
+        self.config["time_format"] = "%Y-%m-%d"
+        old = self.add_item(artist=u"prince")
+        new = self.add_item(artist=u"britney")
 
         # Do not match unset values
-        out = self.list(u'mydate:..2000')
-        self.assertEqual(u'', out)
+        out = self.list(u"mydate:..2000")
+        self.assertEqual(u"", out)
 
-        self.modify(u'mydate=1999-01-01', u'artist:prince')
+        self.modify(u"mydate=1999-01-01", u"artist:prince")
         old.load()
-        self.assertEqual(old['mydate'], mktime(1999, 1, 1))
+        self.assertEqual(old["mydate"], mktime(1999, 1, 1))
 
-        self.modify(u'mydate=1999-12-30', u'artist:britney')
+        self.modify(u"mydate=1999-12-30", u"artist:britney")
         new.load()
-        self.assertEqual(new['mydate'], mktime(1999, 12, 30))
+        self.assertEqual(new["mydate"], mktime(1999, 12, 30))
 
         # Match in range
-        out = self.list(u'mydate:..1999-07', u'$artist $mydate')
-        self.assertEqual(u'prince 1999-01-01', out)
+        out = self.list(u"mydate:..1999-07", u"$artist $mydate")
+        self.assertEqual(u"prince 1999-01-01", out)
 
         # FIXME some sort of timezone issue here
         # out = self.list('mydate:1999-12-30', '$artist $mydate')
         # self.assertEqual('britney 1999-12-30', out)
 
     def test_unknown_type_error(self):
-        self.config['types'] = {'flex': 'unkown type'}
+        self.config["types"] = {"flex": "unkown type"}
         with self.assertRaises(ConfigValueError):
-            self.run_command(u'ls')
+            self.run_command(u"ls")
 
     def modify(self, *args):
-        return self.run_with_output(u'modify', u'--yes', u'--nowrite',
-                                    u'--nomove', *args)
+        return self.run_with_output(
+            u"modify", u"--yes", u"--nowrite", u"--nomove", *args
+        )
 
-    def list(self, query, fmt=u'$artist - $album - $title'):
-        return self.run_with_output(u'ls', u'-f', fmt, query).strip()
+    def list(self, query, fmt=u"$artist - $album - $title"):
+        return self.run_with_output(u"ls", u"-f", fmt, query).strip()
 
-    def list_album(self, query, fmt=u'$albumartist - $album - $title'):
-        return self.run_with_output(u'ls', u'-a', u'-f', fmt, query).strip()
+    def list_album(self, query, fmt=u"$albumartist - $album - $title"):
+        return self.run_with_output(u"ls", u"-a", u"-f", fmt, query).strip()
 
 
 def mktime(*args):
@@ -163,5 +163,6 @@ def mktime(*args):
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -44,71 +44,72 @@ from beets.util import syspath, MoveOperation
 
 class ListTest(unittest.TestCase):
     def setUp(self):
-        self.lib = library.Library(':memory:')
+        self.lib = library.Library(":memory:")
         self.item = _common.item()
-        self.item.path = 'xxx/yyy'
+        self.item.path = "xxx/yyy"
         self.lib.add(self.item)
         self.lib.add_album([self.item])
 
-    def _run_list(self, query=u'', album=False, path=False, fmt=u''):
+    def _run_list(self, query=u"", album=False, path=False, fmt=u""):
         with capture_stdout() as stdout:
             commands.list_items(self.lib, query, album, fmt)
         return stdout
 
     def test_list_outputs_item(self):
         stdout = self._run_list()
-        self.assertIn(u'the title', stdout.getvalue())
+        self.assertIn(u"the title", stdout.getvalue())
 
     def test_list_unicode_query(self):
-        self.item.title = u'na\xefve'
+        self.item.title = u"na\xefve"
         self.item.store()
         self.lib._connection().commit()
 
-        stdout = self._run_list([u'na\xefve'])
+        stdout = self._run_list([u"na\xefve"])
         out = stdout.getvalue()
         if six.PY2:
             out = out.decode(stdout.encoding)
-        self.assertTrue(u'na\xefve' in out)
+        self.assertTrue(u"na\xefve" in out)
 
     def test_list_item_path(self):
-        stdout = self._run_list(fmt=u'$path')
-        self.assertEqual(stdout.getvalue().strip(), u'xxx/yyy')
+        stdout = self._run_list(fmt=u"$path")
+        self.assertEqual(stdout.getvalue().strip(), u"xxx/yyy")
 
     def test_list_album_outputs_something(self):
         stdout = self._run_list(album=True)
         self.assertGreater(len(stdout.getvalue()), 0)
 
     def test_list_album_path(self):
-        stdout = self._run_list(album=True, fmt=u'$path')
-        self.assertEqual(stdout.getvalue().strip(), u'xxx')
+        stdout = self._run_list(album=True, fmt=u"$path")
+        self.assertEqual(stdout.getvalue().strip(), u"xxx")
 
     def test_list_album_omits_title(self):
         stdout = self._run_list(album=True)
-        self.assertNotIn(u'the title', stdout.getvalue())
+        self.assertNotIn(u"the title", stdout.getvalue())
 
     def test_list_uses_track_artist(self):
         stdout = self._run_list()
-        self.assertIn(u'the artist', stdout.getvalue())
-        self.assertNotIn(u'the album artist', stdout.getvalue())
+        self.assertIn(u"the artist", stdout.getvalue())
+        self.assertNotIn(u"the album artist", stdout.getvalue())
 
     def test_list_album_uses_album_artist(self):
         stdout = self._run_list(album=True)
-        self.assertNotIn(u'the artist', stdout.getvalue())
-        self.assertIn(u'the album artist', stdout.getvalue())
+        self.assertNotIn(u"the artist", stdout.getvalue())
+        self.assertIn(u"the album artist", stdout.getvalue())
 
     def test_list_item_format_artist(self):
-        stdout = self._run_list(fmt=u'$artist')
-        self.assertIn(u'the artist', stdout.getvalue())
+        stdout = self._run_list(fmt=u"$artist")
+        self.assertIn(u"the artist", stdout.getvalue())
 
     def test_list_item_format_multiple(self):
-        stdout = self._run_list(fmt=u'$artist - $album - $year')
-        self.assertEqual(u'the artist - the album - 0001',
-                         stdout.getvalue().strip())
+        stdout = self._run_list(fmt=u"$artist - $album - $year")
+        self.assertEqual(
+            u"the artist - the album - 0001", stdout.getvalue().strip()
+        )
 
     def test_list_album_format(self):
-        stdout = self._run_list(album=True, fmt=u'$genre')
-        self.assertIn(u'the genre', stdout.getvalue())
-        self.assertNotIn(u'the album', stdout.getvalue())
+        stdout = self._run_list(album=True, fmt=u"$genre")
+        self.assertIn(u"the genre", stdout.getvalue())
+        self.assertNotIn(u"the album", stdout.getvalue())
 
 
 class RemoveTest(_common.TestCase):
@@ -117,45 +118,44 @@ class RemoveTest(_common.TestCase):
 
         self.io.install()
 
-        self.libdir = os.path.join(self.temp_dir, b'testlibdir')
+        self.libdir = os.path.join(self.temp_dir, b"testlibdir")
         os.mkdir(self.libdir)
 
         # Copy a file into the library.
-        self.lib = library.Library(':memory:', self.libdir)
-        item_path = os.path.join(_common.RSRC, b'full.mp3')
+        self.lib = library.Library(":memory:", self.libdir)
+        item_path = os.path.join(_common.RSRC, b"full.mp3")
         self.i = library.Item.from_path(item_path)
         self.lib.add(self.i)
         self.i.move(operation=MoveOperation.COPY)
 
     def test_remove_items_no_delete(self):
-        self.io.addinput('y')
-        commands.remove_items(self.lib, u'', False, False, False)
+        self.io.addinput("y")
+        commands.remove_items(self.lib, u"", False, False, False)
         items = self.lib.items()
         self.assertEqual(len(list(items)), 0)
         self.assertTrue(os.path.exists(self.i.path))
 
     def test_remove_items_with_delete(self):
-        self.io.addinput('y')
-        commands.remove_items(self.lib, u'', False, True, False)
+        self.io.addinput("y")
+        commands.remove_items(self.lib, u"", False, True, False)
         items = self.lib.items()
         self.assertEqual(len(list(items)), 0)
         self.assertFalse(os.path.exists(self.i.path))
 
     def test_remove_items_with_force_no_delete(self):
-        commands.remove_items(self.lib, u'', False, False, True)
+        commands.remove_items(self.lib, u"", False, False, True)
         items = self.lib.items()
         self.assertEqual(len(list(items)), 0)
         self.assertTrue(os.path.exists(self.i.path))
 
     def test_remove_items_with_force_delete(self):
-        commands.remove_items(self.lib, u'', False, True, True)
+        commands.remove_items(self.lib, u"", False, True, True)
         items = self.lib.items()
         self.assertEqual(len(list(items)), 0)
         self.assertFalse(os.path.exists(self.i.path))
 
 
 class ModifyTest(unittest.TestCase, TestHelper):
-
     def setUp(self):
         self.setup_beets()
         self.album = self.add_album_fixture()
@@ -166,29 +166,29 @@ class ModifyTest(unittest.TestCase, TestHelper):
 
     def modify_inp(self, inp, *args):
         with control_stdin(inp):
-            self.run_command('modify', *args)
+            self.run_command("modify", *args)
 
     def modify(self, *args):
-        self.modify_inp('y', *args)
+        self.modify_inp("y", *args)
 
     # Item tests
 
     def test_modify_item(self):
         self.modify(u"title=newTitle")
         item = self.lib.items().get()
-        self.assertEqual(item.title, u'newTitle')
+        self.assertEqual(item.title, u"newTitle")
 
     def test_modify_item_abort(self):
         item = self.lib.items().get()
         title = item.title
-        self.modify_inp('n', u"title=newTitle")
+        self.modify_inp("n", u"title=newTitle")
         item = self.lib.items().get()
         self.assertEqual(item.title, title)
 
     def test_modify_item_no_change(self):
         title = u"Tracktitle"
         item = self.add_item_fixture(title=title)
-        self.modify_inp('y', u"title", u"title={0}".format(title))
+        self.modify_inp("y", u"title", u"title={0}".format(title))
         item = self.lib.items(title).get()
         self.assertEqual(item.title, title)
 
@@ -196,30 +196,30 @@ class ModifyTest(unittest.TestCase, TestHelper):
         self.modify(u"title=newTitle")
         item = self.lib.items().get()
         item.read()
-        self.assertEqual(item.title, u'newTitle')
+        self.assertEqual(item.title, u"newTitle")
 
     def test_modify_dont_write_tags(self):
         self.modify(u"--nowrite", u"title=newTitle")
         item = self.lib.items().get()
         item.read()
-        self.assertNotEqual(item.title, 'newTitle')
+        self.assertNotEqual(item.title, "newTitle")
 
     def test_move(self):
         self.modify(u"title=newTitle")
         item = self.lib.items().get()
-        self.assertIn(b'newTitle', item.path)
+        self.assertIn(b"newTitle", item.path)
 
     def test_not_move(self):
         self.modify(u"--nomove", u"title=newTitle")
         item = self.lib.items().get()
-        self.assertNotIn(b'newTitle', item.path)
+        self.assertNotIn(b"newTitle", item.path)
 
     def test_no_write_no_move(self):
         self.modify(u"--nomove", u"--nowrite", u"title=newTitle")
         item = self.lib.items().get()
         item.read()
-        self.assertNotIn(b'newTitle', item.path)
-        self.assertNotEqual(item.title, u'newTitle')
+        self.assertNotIn(b"newTitle", item.path)
+        self.assertNotEqual(item.title, u"newTitle")
 
     def test_update_mtime(self):
         item = self.item
@@ -243,11 +243,16 @@ class ModifyTest(unittest.TestCase, TestHelper):
         original_artist = u"composer"
         new_artist = u"coverArtist"
         for i in range(0, 10):
-            self.add_item_fixture(title=u"{0}{1}".format(title, i),
-                                  artist=original_artist,
-                                  album=album)
-        self.modify_inp('s\ny\ny\ny\nn\nn\ny\ny\ny\ny\nn',
-                        title, u"artist={0}".format(new_artist))
+            self.add_item_fixture(
+                title=u"{0}{1}".format(title, i),
+                artist=original_artist,
+                album=album,
+            )
+        self.modify_inp(
+            "s\ny\ny\ny\nn\nn\ny\ny\ny\ny\nn",
+            title,
+            u"artist={0}".format(new_artist),
+        )
         original_items = self.lib.items(u"artist:{0}".format(original_artist))
         new_items = self.lib.items(u"artist:{0}".format(new_artist))
         self.assertEqual(len(list(original_items)), 3)
@@ -258,31 +263,31 @@ class ModifyTest(unittest.TestCase, TestHelper):
     def test_modify_album(self):
         self.modify(u"--album", u"album=newAlbum")
         album = self.lib.albums().get()
-        self.assertEqual(album.album, u'newAlbum')
+        self.assertEqual(album.album, u"newAlbum")
 
     def test_modify_album_write_tags(self):
         self.modify(u"--album", u"album=newAlbum")
         item = self.lib.items().get()
         item.read()
-        self.assertEqual(item.album, u'newAlbum')
+        self.assertEqual(item.album, u"newAlbum")
 
     def test_modify_album_dont_write_tags(self):
         self.modify(u"--album", u"--nowrite", u"album=newAlbum")
         item = self.lib.items().get()
         item.read()
-        self.assertEqual(item.album, u'the album')
+        self.assertEqual(item.album, u"the album")
 
     def test_album_move(self):
         self.modify(u"--album", u"album=newAlbum")
         item = self.lib.items().get()
         item.read()
-        self.assertIn(b'newAlbum', item.path)
+        self.assertIn(b"newAlbum", item.path)
 
     def test_album_not_move(self):
         self.modify(u"--nomove", u"--album", u"album=newAlbum")
         item = self.lib.items().get()
         item.read()
-        self.assertNotIn(b'newAlbum', item.path)
+        self.assertNotIn(b"newAlbum", item.path)
 
     # Misc
 
@@ -290,63 +295,66 @@ class ModifyTest(unittest.TestCase, TestHelper):
         self.modify(u"initial_key=C#m")
         item = self.lib.items().get()
         mediafile = MediaFile(syspath(item.path))
-        self.assertEqual(mediafile.initial_key, u'C#m')
+        self.assertEqual(mediafile.initial_key, u"C#m")
 
     def test_set_flexattr(self):
         self.modify(u"flexattr=testAttr")
         item = self.lib.items().get()
-        self.assertEqual(item.flexattr, u'testAttr')
+        self.assertEqual(item.flexattr, u"testAttr")
 
     def test_remove_flexattr(self):
         item = self.lib.items().get()
-        item.flexattr = u'testAttr'
+        item.flexattr = u"testAttr"
         item.store()
 
         self.modify(u"flexattr!")
         item = self.lib.items().get()
         self.assertNotIn(u"flexattr", item)
 
-    @unittest.skip(u'not yet implemented')
+    @unittest.skip(u"not yet implemented")
     def test_delete_initial_key_tag(self):
         item = self.lib.items().get()
-        item.initial_key = u'C#m'
+        item.initial_key = u"C#m"
         item.write()
         item.store()
 
         mediafile = MediaFile(syspath(item.path))
-        self.assertEqual(mediafile.initial_key, u'C#m')
+        self.assertEqual(mediafile.initial_key, u"C#m")
 
         self.modify(u"initial_key!")
         mediafile = MediaFile(syspath(item.path))
         self.assertIsNone(mediafile.initial_key)
 
     def test_arg_parsing_colon_query(self):
-        (query, mods, dels) = commands.modify_parse_args([u"title:oldTitle",
-                                                          u"title=newTitle"])
+        (query, mods, dels) = commands.modify_parse_args(
+            [u"title:oldTitle", u"title=newTitle"]
+        )
         self.assertEqual(query, [u"title:oldTitle"])
         self.assertEqual(mods, {"title": u"newTitle"})
 
     def test_arg_parsing_delete(self):
-        (query, mods, dels) = commands.modify_parse_args([u"title:oldTitle",
-                                                          u"title!"])
+        (query, mods, dels) = commands.modify_parse_args(
+            [u"title:oldTitle", u"title!"]
+        )
         self.assertEqual(query, [u"title:oldTitle"])
         self.assertEqual(dels, ["title"])
 
     def test_arg_parsing_query_with_exclaimation(self):
-        (query, mods, dels) = commands.modify_parse_args([u"title:oldTitle!",
-                                                          u"title=newTitle!"])
+        (query, mods, dels) = commands.modify_parse_args(
+            [u"title:oldTitle!", u"title=newTitle!"]
+        )
         self.assertEqual(query, [u"title:oldTitle!"])
         self.assertEqual(mods, {"title": u"newTitle!"})
 
     def test_arg_parsing_equals_in_value(self):
-        (query, mods, dels) = commands.modify_parse_args([u"title:foo=bar",
-                                                          u"title=newTitle"])
+        (query, mods, dels) = commands.modify_parse_args(
+            [u"title:foo=bar", u"title=newTitle"]
+        )
         self.assertEqual(query, [u"title:foo=bar"])
         self.assertEqual(mods, {"title": u"newTitle"})
 
 
 class WriteTest(unittest.TestCase, TestHelper):
-
     def setUp(self):
         self.setup_beets()
 
@@ -354,11 +362,11 @@ class WriteTest(unittest.TestCase, TestHelper):
         self.teardown_beets()
 
     def write_cmd(self, *args):
-        return self.run_with_output('write', *args)
+        return self.run_with_output("write", *args)
 
     def test_update_mtime(self):
         item = self.add_item_fixture()
-        item['title'] = u'a new title'
+        item["title"] = u"a new title"
         item.store()
 
         item = self.lib.items().get()
@@ -382,20 +390,19 @@ class WriteTest(unittest.TestCase, TestHelper):
 
         output = self.write_cmd()
 
-        self.assertEqual(output, '')
+        self.assertEqual(output, "")
 
     def test_write_metadata_field(self):
         item = self.add_item_fixture()
         item.read()
         old_title = item.title
 
-        item.title = u'new title'
+        item.title = u"new title"
         item.store()
 
         output = self.write_cmd()
 
-        self.assertTrue(u'{0} -> new title'.format(old_title)
-                        in output)
+        self.assertTrue(u"{0} -> new title".format(old_title) in output)
 
 
 class MoveTest(_common.TestCase):
@@ -404,77 +411,85 @@ class MoveTest(_common.TestCase):
 
         self.io.install()
 
-        self.libdir = os.path.join(self.temp_dir, b'testlibdir')
+        self.libdir = os.path.join(self.temp_dir, b"testlibdir")
         os.mkdir(self.libdir)
 
-        self.itempath = os.path.join(self.libdir, b'srcfile')
-        shutil.copy(os.path.join(_common.RSRC, b'full.mp3'), self.itempath)
+        self.itempath = os.path.join(self.libdir, b"srcfile")
+        shutil.copy(os.path.join(_common.RSRC, b"full.mp3"), self.itempath)
 
         # Add a file to the library but don't copy it in yet.
-        self.lib = library.Library(':memory:', self.libdir)
+        self.lib = library.Library(":memory:", self.libdir)
         self.i = library.Item.from_path(self.itempath)
         self.lib.add(self.i)
         self.album = self.lib.add_album([self.i])
 
         # Alternate destination directory.
-        self.otherdir = os.path.join(self.temp_dir, b'testotherdir')
+        self.otherdir = os.path.join(self.temp_dir, b"testotherdir")
 
-    def _move(self, query=(), dest=None, copy=False, album=False,
-              pretend=False, export=False):
-        commands.move_items(self.lib, dest, query, copy, album, pretend,
-                            export=export)
+    def _move(
+        self,
+        query=(),
+        dest=None,
+        copy=False,
+        album=False,
+        pretend=False,
+        export=False,
+    ):
+        commands.move_items(
+            self.lib, dest, query, copy, album, pretend, export=export
+        )
 
     def test_move_item(self):
         self._move()
         self.i.load()
-        self.assertTrue(b'testlibdir' in self.i.path)
+        self.assertTrue(b"testlibdir" in self.i.path)
         self.assertExists(self.i.path)
         self.assertNotExists(self.itempath)
 
     def test_copy_item(self):
         self._move(copy=True)
         self.i.load()
-        self.assertTrue(b'testlibdir' in self.i.path)
+        self.assertTrue(b"testlibdir" in self.i.path)
         self.assertExists(self.i.path)
         self.assertExists(self.itempath)
 
     def test_move_album(self):
         self._move(album=True)
         self.i.load()
-        self.assertTrue(b'testlibdir' in self.i.path)
+        self.assertTrue(b"testlibdir" in self.i.path)
         self.assertExists(self.i.path)
         self.assertNotExists(self.itempath)
 
     def test_copy_album(self):
         self._move(copy=True, album=True)
         self.i.load()
-        self.assertTrue(b'testlibdir' in self.i.path)
+        self.assertTrue(b"testlibdir" in self.i.path)
         self.assertExists(self.i.path)
         self.assertExists(self.itempath)
 
     def test_move_item_custom_dir(self):
         self._move(dest=self.otherdir)
         self.i.load()
-        self.assertTrue(b'testotherdir' in self.i.path)
+        self.assertTrue(b"testotherdir" in self.i.path)
         self.assertExists(self.i.path)
         self.assertNotExists(self.itempath)
 
     def test_move_album_custom_dir(self):
         self._move(dest=self.otherdir, album=True)
         self.i.load()
-        self.assertTrue(b'testotherdir' in self.i.path)
+        self.assertTrue(b"testotherdir" in self.i.path)
         self.assertExists(self.i.path)
         self.assertNotExists(self.itempath)
 
     def test_pretend_move_item(self):
         self._move(dest=self.otherdir, pretend=True)
         self.i.load()
-        self.assertIn(b'srcfile', self.i.path)
+        self.assertIn(b"srcfile", self.i.path)
 
     def test_pretend_move_album(self):
         self._move(album=True, pretend=True)
         self.i.load()
-        self.assertIn(b'srcfile', self.i.path)
+        self.assertIn(b"srcfile", self.i.path)
 
     def test_export_item_custom_dir(self):
         self._move(dest=self.otherdir, export=True)
@@ -491,7 +506,7 @@ class MoveTest(_common.TestCase):
     def test_pretend_export_item(self):
         self._move(dest=self.otherdir, pretend=True, export=True)
         self.i.load()
-        self.assertIn(b'srcfile', self.i.path)
+        self.assertIn(b"srcfile", self.i.path)
         self.assertNotExists(self.otherdir)
 
 
@@ -501,12 +516,12 @@ class UpdateTest(_common.TestCase):
 
         self.io.install()
 
-        self.libdir = os.path.join(self.temp_dir, b'testlibdir')
+        self.libdir = os.path.join(self.temp_dir, b"testlibdir")
 
         # Copy a file into the library.
-        self.lib = library.Library(':memory:', self.libdir)
-        item_path = os.path.join(_common.RSRC, b'full.mp3')
-        item_path_two = os.path.join(_common.RSRC, b'full.flac')
+        self.lib = library.Library(":memory:", self.libdir)
+        item_path = os.path.join(_common.RSRC, b"full.mp3")
+        item_path_two = os.path.join(_common.RSRC, b"full.flac")
         self.i = library.Item.from_path(item_path)
         self.i2 = library.Item.from_path(item_path_two)
         self.lib.add(self.i)
@@ -516,20 +531,22 @@ class UpdateTest(_common.TestCase):
         self.album = self.lib.add_album([self.i, self.i2])
 
         # Album art.
-        artfile = os.path.join(self.temp_dir, b'testart.jpg')
+        artfile = os.path.join(self.temp_dir, b"testart.jpg")
         _common.touch(artfile)
         self.album.set_art(artfile)
         self.album.store()
         os.remove(artfile)
 
-    def _update(self, query=(), album=False, move=False, reset_mtime=True,
-                fields=None):
-        self.io.addinput('y')
+    def _update(
+        self, query=(), album=False, move=False, reset_mtime=True, fields=None
+    ):
+        self.io.addinput("y")
         if reset_mtime:
             self.i.mtime = 0
             self.i.store()
-        commands.update_items(self.lib, query, album, move, False,
-                              fields=fields)
+        commands.update_items(
+            self.lib, query, album, move, False, fields=fields
+        )
 
     def test_delete_removes_item(self):
         self.assertTrue(list(self.lib.items()))
@@ -555,60 +572,60 @@ class UpdateTest(_common.TestCase):
 
     def test_modified_metadata_detected(self):
         mf = MediaFile(syspath(self.i.path))
-        mf.title = u'differentTitle'
+        mf.title = u"differentTitle"
         mf.save()
         self._update()
         item = self.lib.items().get()
-        self.assertEqual(item.title, u'differentTitle')
+        self.assertEqual(item.title, u"differentTitle")
 
     def test_modified_metadata_moved(self):
         mf = MediaFile(syspath(self.i.path))
-        mf.title = u'differentTitle'
+        mf.title = u"differentTitle"
         mf.save()
         self._update(move=True)
         item = self.lib.items().get()
-        self.assertTrue(b'differentTitle' in item.path)
+        self.assertTrue(b"differentTitle" in item.path)
 
     def test_modified_metadata_not_moved(self):
         mf = MediaFile(syspath(self.i.path))
-        mf.title = u'differentTitle'
+        mf.title = u"differentTitle"
         mf.save()
         self._update(move=False)
         item = self.lib.items().get()
-        self.assertTrue(b'differentTitle' not in item.path)
+        self.assertTrue(b"differentTitle" not in item.path)
 
     def test_selective_modified_metadata_moved(self):
         mf = MediaFile(syspath(self.i.path))
-        mf.title = u'differentTitle'
-        mf.genre = u'differentGenre'
+        mf.title = u"differentTitle"
+        mf.genre = u"differentGenre"
         mf.save()
-        self._update(move=True, fields=['title'])
+        self._update(move=True, fields=["title"])
         item = self.lib.items().get()
-        self.assertTrue(b'differentTitle' in item.path)
-        self.assertNotEqual(item.genre, u'differentGenre')
+        self.assertTrue(b"differentTitle" in item.path)
+        self.assertNotEqual(item.genre, u"differentGenre")
 
     def test_selective_modified_metadata_not_moved(self):
         mf = MediaFile(syspath(self.i.path))
-        mf.title = u'differentTitle'
-        mf.genre = u'differentGenre'
+        mf.title = u"differentTitle"
+        mf.genre = u"differentGenre"
         mf.save()
-        self._update(move=False, fields=['title'])
+        self._update(move=False, fields=["title"])
         item = self.lib.items().get()
-        self.assertTrue(b'differentTitle' not in item.path)
-        self.assertNotEqual(item.genre, u'differentGenre')
+        self.assertTrue(b"differentTitle" not in item.path)
+        self.assertNotEqual(item.genre, u"differentGenre")
 
     def test_modified_album_metadata_moved(self):
         mf = MediaFile(syspath(self.i.path))
-        mf.album = u'differentAlbum'
+        mf.album = u"differentAlbum"
         mf.save()
         self._update(move=True)
         item = self.lib.items().get()
-        self.assertTrue(b'differentAlbum' in item.path)
+        self.assertTrue(b"differentAlbum" in item.path)
 
     def test_modified_album_metadata_art_moved(self):
         artpath = self.album.artpath
         mf = MediaFile(syspath(self.i.path))
-        mf.album = u'differentAlbum'
+        mf.album = u"differentAlbum"
         mf.save()
         self._update(move=True)
         album = self.lib.albums()[0]
@@ -617,27 +634,27 @@ class UpdateTest(_common.TestCase):
 
     def test_selective_modified_album_metadata_moved(self):
         mf = MediaFile(syspath(self.i.path))
-        mf.album = u'differentAlbum'
-        mf.genre = u'differentGenre'
+        mf.album = u"differentAlbum"
+        mf.genre = u"differentGenre"
         mf.save()
-        self._update(move=True, fields=['album'])
+        self._update(move=True, fields=["album"])
         item = self.lib.items().get()
-        self.assertTrue(b'differentAlbum' in item.path)
-        self.assertNotEqual(item.genre, u'differentGenre')
+        self.assertTrue(b"differentAlbum" in item.path)
+        self.assertNotEqual(item.genre, u"differentGenre")
 
     def test_selective_modified_album_metadata_not_moved(self):
         mf = MediaFile(syspath(self.i.path))
-        mf.album = u'differentAlbum'
-        mf.genre = u'differentGenre'
+        mf.album = u"differentAlbum"
+        mf.genre = u"differentGenre"
         mf.save()
-        self._update(move=True, fields=['genre'])
+        self._update(move=True, fields=["genre"])
         item = self.lib.items().get()
-        self.assertTrue(b'differentAlbum' not in item.path)
-        self.assertEqual(item.genre, u'differentGenre')
+        self.assertTrue(b"differentAlbum" not in item.path)
+        self.assertEqual(item.genre, u"differentGenre")
 
     def test_mtime_match_skips_update(self):
         mf = MediaFile(syspath(self.i.path))
-        mf.title = u'differentTitle'
+        mf.title = u"differentTitle"
         mf.save()
 
         # Make in-memory mtime match on-disk mtime.
@@ -646,7 +663,7 @@ class UpdateTest(_common.TestCase):
 
         self._update(reset_mtime=False)
         item = self.lib.items().get()
-        self.assertEqual(item.title, u'full')
+        self.assertEqual(item.title, u"full")
 
 
 class PrintTest(_common.TestCase):
@@ -655,45 +672,44 @@ class PrintTest(_common.TestCase):
         self.io.install()
 
     def test_print_without_locale(self):
-        lang = os.environ.get('LANG')
+        lang = os.environ.get("LANG")
         if lang:
-            del os.environ['LANG']
+            del os.environ["LANG"]
 
         try:
-            ui.print_(u'something')
+            ui.print_(u"something")
         except TypeError:
-            self.fail(u'TypeError during print')
+            self.fail(u"TypeError during print")
         finally:
             if lang:
-                os.environ['LANG'] = lang
+                os.environ["LANG"] = lang
 
     def test_print_with_invalid_locale(self):
-        old_lang = os.environ.get('LANG')
-        os.environ['LANG'] = ''
-        old_ctype = os.environ.get('LC_CTYPE')
-        os.environ['LC_CTYPE'] = 'UTF-8'
+        old_lang = os.environ.get("LANG")
+        os.environ["LANG"] = ""
+        old_ctype = os.environ.get("LC_CTYPE")
+        os.environ["LC_CTYPE"] = "UTF-8"
 
         try:
-            ui.print_(u'something')
+            ui.print_(u"something")
         except ValueError:
-            self.fail(u'ValueError during print')
+            self.fail(u"ValueError during print")
         finally:
             if old_lang:
-                os.environ['LANG'] = old_lang
+                os.environ["LANG"] = old_lang
             else:
-                del os.environ['LANG']
+                del os.environ["LANG"]
             if old_ctype:
-                os.environ['LC_CTYPE'] = old_ctype
+                os.environ["LC_CTYPE"] = old_ctype
             else:
-                del os.environ['LC_CTYPE']
+                del os.environ["LC_CTYPE"]
 
 
 class ImportTest(_common.TestCase):
     def test_quiet_timid_disallowed(self):
-        config['import']['quiet'] = True
-        config['import']['timid'] = True
-        self.assertRaises(ui.UserError, commands.import_files, None, [],
-                          None)
+        config["import"]["quiet"] = True
+        config["import"]["timid"] = True
+        self.assertRaises(ui.UserError, commands.import_files, None, [], None)
 
 
 @_common.slow_test()
@@ -703,34 +719,36 @@ class ConfigTest(unittest.TestCase, TestHelper, _common.Assertions):
 
         # Don't use the BEETSDIR from `helper`. Instead, we point the home
         # directory there. Some tests will set `BEETSDIR` themselves.
-        del os.environ['BEETSDIR']
-        self._old_home = os.environ.get('HOME')
-        os.environ['HOME'] = util.py3_path(self.temp_dir)
+        del os.environ["BEETSDIR"]
+        self._old_home = os.environ.get("HOME")
+        os.environ["HOME"] = util.py3_path(self.temp_dir)
 
         # Also set APPDATA, the Windows equivalent of setting $HOME.
-        self._old_appdata = os.environ.get('APPDATA')
-        os.environ['APPDATA'] = \
-            util.py3_path(os.path.join(self.temp_dir, b'AppData', b'Roaming'))
+        self._old_appdata = os.environ.get("APPDATA")
+        os.environ["APPDATA"] = util.py3_path(
+            os.path.join(self.temp_dir, b"AppData", b"Roaming")
+        )
 
         self._orig_cwd = os.getcwd()
         self.test_cmd = self._make_test_cmd()
         commands.default_commands.append(self.test_cmd)
 
         # Default user configuration
-        if platform.system() == 'Windows':
+        if platform.system() == "Windows":
             self.user_config_dir = os.path.join(
-                self.temp_dir, b'AppData', b'Roaming', b'beets'
+                self.temp_dir, b"AppData", b"Roaming", b"beets"
             )
         else:
             self.user_config_dir = os.path.join(
-                self.temp_dir, b'.config', b'beets'
+                self.temp_dir, b".config", b"beets"
             )
         os.makedirs(self.user_config_dir)
-        self.user_config_path = os.path.join(self.user_config_dir,
-                                             b'config.yaml')
+        self.user_config_path = os.path.join(
+            self.user_config_dir, b"config.yaml"
+        )
 
         # Custom BEETSDIR
-        self.beetsdir = os.path.join(self.temp_dir, b'beetsdir')
+        self.beetsdir = os.path.join(self.temp_dir, b"beetsdir")
         os.makedirs(self.beetsdir)
 
         self._reset_config()
@@ -739,15 +757,15 @@ class ConfigTest(unittest.TestCase, TestHelper, _common.Assertions):
         commands.default_commands.pop()
         os.chdir(self._orig_cwd)
         if self._old_home is not None:
-            os.environ['HOME'] = self._old_home
+            os.environ["HOME"] = self._old_home
         if self._old_appdata is None:
-            del os.environ['APPDATA']
+            del os.environ["APPDATA"]
         else:
-            os.environ['APPDATA'] = self._old_appdata
+            os.environ["APPDATA"] = self._old_appdata
         self.teardown_beets()
 
     def _make_test_cmd(self):
-        test_cmd = ui.Subcommand('test', help=u'test')
+        test_cmd = ui.Subcommand("test", help=u"test")
 
         def run(lib, options, args):
             test_cmd.lib = lib
@@ -763,229 +781,227 @@ class ConfigTest(unittest.TestCase, TestHelper, _common.Assertions):
         config._materialized = False
 
     def write_config_file(self):
-        return open(self.user_config_path, 'w')
+        return open(self.user_config_path, "w")
 
     def test_paths_section_respected(self):
         with self.write_config_file() as config:
-            config.write('paths: {x: y}')
+            config.write("paths: {x: y}")
 
-        self.run_command('test', lib=None)
+        self.run_command("test", lib=None)
         key, template = self.test_cmd.lib.path_formats[0]
-        self.assertEqual(key, 'x')
-        self.assertEqual(template.original, 'y')
+        self.assertEqual(key, "x")
+        self.assertEqual(template.original, "y")
 
     def test_default_paths_preserved(self):
         default_formats = ui.get_path_formats()
 
         self._reset_config()
         with self.write_config_file() as config:
-            config.write('paths: {x: y}')
-        self.run_command('test', lib=None)
+            config.write("paths: {x: y}")
+        self.run_command("test", lib=None)
         key, template = self.test_cmd.lib.path_formats[0]
-        self.assertEqual(key, 'x')
-        self.assertEqual(template.original, 'y')
-        self.assertEqual(self.test_cmd.lib.path_formats[1:],
-                         default_formats)
+        self.assertEqual(key, "x")
+        self.assertEqual(template.original, "y")
+        self.assertEqual(self.test_cmd.lib.path_formats[1:], default_formats)
 
     def test_nonexistant_db(self):
         with self.write_config_file() as config:
-            config.write('library: /xxx/yyy/not/a/real/path')
+            config.write("library: /xxx/yyy/not/a/real/path")
 
         with self.assertRaises(ui.UserError):
-            self.run_command('test', lib=None)
+            self.run_command("test", lib=None)
 
     def test_user_config_file(self):
         with self.write_config_file() as file:
-            file.write('anoption: value')
+            file.write("anoption: value")
 
-        self.run_command('test', lib=None)
-        self.assertEqual(config['anoption'].get(), 'value')
+        self.run_command("test", lib=None)
+        self.assertEqual(config["anoption"].get(), "value")
 
     def test_replacements_parsed(self):
         with self.write_config_file() as config:
             config.write("replace: {'[xy]': z}")
 
-        self.run_command('test', lib=None)
+        self.run_command("test", lib=None)
         replacements = self.test_cmd.lib.replacements
         repls = [(p.pattern, s) for p, s in replacements]  # Compare patterns.
-        self.assertEqual(repls, [(u'[xy]', 'z')])
+        self.assertEqual(repls, [(u"[xy]", "z")])
 
     def test_multiple_replacements_parsed(self):
         with self.write_config_file() as config:
             config.write("replace: {'[xy]': z, foo: bar}")
-        self.run_command('test', lib=None)
+        self.run_command("test", lib=None)
         replacements = self.test_cmd.lib.replacements
         repls = [(p.pattern, s) for p, s in replacements]
-        self.assertEqual(repls, [
-            (u'[xy]', u'z'),
-            (u'foo', u'bar'),
-        ])
+        self.assertEqual(repls, [(u"[xy]", u"z"), (u"foo", u"bar"),])
 
     def test_cli_config_option(self):
-        config_path = os.path.join(self.temp_dir, b'config.yaml')
-        with open(config_path, 'w') as file:
-            file.write('anoption: value')
-        self.run_command('--config', config_path, 'test', lib=None)
-        self.assertEqual(config['anoption'].get(), 'value')
+        config_path = os.path.join(self.temp_dir, b"config.yaml")
+        with open(config_path, "w") as file:
+            file.write("anoption: value")
+        self.run_command("--config", config_path, "test", lib=None)
+        self.assertEqual(config["anoption"].get(), "value")
 
     def test_cli_config_file_overwrites_user_defaults(self):
-        with open(self.user_config_path, 'w') as file:
-            file.write('anoption: value')
+        with open(self.user_config_path, "w") as file:
+            file.write("anoption: value")
 
-        cli_config_path = os.path.join(self.temp_dir, b'config.yaml')
-        with open(cli_config_path, 'w') as file:
-            file.write('anoption: cli overwrite')
-        self.run_command('--config', cli_config_path, 'test', lib=None)
-        self.assertEqual(config['anoption'].get(), 'cli overwrite')
+        cli_config_path = os.path.join(self.temp_dir, b"config.yaml")
+        with open(cli_config_path, "w") as file:
+            file.write("anoption: cli overwrite")
+        self.run_command("--config", cli_config_path, "test", lib=None)
+        self.assertEqual(config["anoption"].get(), "cli overwrite")
 
     def test_cli_config_file_overwrites_beetsdir_defaults(self):
-        os.environ['BEETSDIR'] = util.py3_path(self.beetsdir)
-        env_config_path = os.path.join(self.beetsdir, b'config.yaml')
-        with open(env_config_path, 'w') as file:
-            file.write('anoption: value')
+        os.environ["BEETSDIR"] = util.py3_path(self.beetsdir)
+        env_config_path = os.path.join(self.beetsdir, b"config.yaml")
+        with open(env_config_path, "w") as file:
+            file.write("anoption: value")
 
-        cli_config_path = os.path.join(self.temp_dir, b'config.yaml')
-        with open(cli_config_path, 'w') as file:
-            file.write('anoption: cli overwrite')
-        self.run_command('--config', cli_config_path, 'test', lib=None)
-        self.assertEqual(config['anoption'].get(), 'cli overwrite')
+        cli_config_path = os.path.join(self.temp_dir, b"config.yaml")
+        with open(cli_config_path, "w") as file:
+            file.write("anoption: cli overwrite")
+        self.run_command("--config", cli_config_path, "test", lib=None)
+        self.assertEqual(config["anoption"].get(), "cli overwrite")
 
-#    @unittest.skip('Difficult to implement with optparse')
-#    def test_multiple_cli_config_files(self):
-#        cli_config_path_1 = os.path.join(self.temp_dir, b'config.yaml')
-#        cli_config_path_2 = os.path.join(self.temp_dir, b'config_2.yaml')
-#
-#        with open(cli_config_path_1, 'w') as file:
-#            file.write('first: value')
-#
-#        with open(cli_config_path_2, 'w') as file:
-#            file.write('second: value')
-#
-#        self.run_command('--config', cli_config_path_1,
-#                      '--config', cli_config_path_2, 'test', lib=None)
-#        self.assertEqual(config['first'].get(), 'value')
-#        self.assertEqual(config['second'].get(), 'value')
-#
-#    @unittest.skip('Difficult to implement with optparse')
-#    def test_multiple_cli_config_overwrite(self):
-#        cli_config_path = os.path.join(self.temp_dir, b'config.yaml')
-#        cli_overwrite_config_path = os.path.join(self.temp_dir,
-#                                                 b'overwrite_config.yaml')
-#
-#        with open(cli_config_path, 'w') as file:
-#            file.write('anoption: value')
-#
-#        with open(cli_overwrite_config_path, 'w') as file:
-#            file.write('anoption: overwrite')
-#
-#        self.run_command('--config', cli_config_path,
-#                      '--config', cli_overwrite_config_path, 'test')
-#        self.assertEqual(config['anoption'].get(), 'cli overwrite')
+    #    @unittest.skip('Difficult to implement with optparse')
+    #    def test_multiple_cli_config_files(self):
+    #        cli_config_path_1 = os.path.join(self.temp_dir, b'config.yaml')
+    #        cli_config_path_2 = os.path.join(self.temp_dir, b'config_2.yaml')
+    #
+    #        with open(cli_config_path_1, 'w') as file:
+    #            file.write('first: value')
+    #
+    #        with open(cli_config_path_2, 'w') as file:
+    #            file.write('second: value')
+    #
+    #        self.run_command('--config', cli_config_path_1,
+    #                      '--config', cli_config_path_2, 'test', lib=None)
+    #        self.assertEqual(config['first'].get(), 'value')
+    #        self.assertEqual(config['second'].get(), 'value')
+    #
+    #    @unittest.skip('Difficult to implement with optparse')
+    #    def test_multiple_cli_config_overwrite(self):
+    #        cli_config_path = os.path.join(self.temp_dir, b'config.yaml')
+    #        cli_overwrite_config_path = os.path.join(self.temp_dir,
+    #                                                 b'overwrite_config.yaml')
+    #
+    #        with open(cli_config_path, 'w') as file:
+    #            file.write('anoption: value')
+    #
+    #        with open(cli_overwrite_config_path, 'w') as file:
+    #            file.write('anoption: overwrite')
+    #
+    #        self.run_command('--config', cli_config_path,
+    #                      '--config', cli_overwrite_config_path, 'test')
+    #        self.assertEqual(config['anoption'].get(), 'cli overwrite')
 
     def test_cli_config_paths_resolve_relative_to_user_dir(self):
-        cli_config_path = os.path.join(self.temp_dir, b'config.yaml')
-        with open(cli_config_path, 'w') as file:
-            file.write('library: beets.db\n')
-            file.write('statefile: state')
+        cli_config_path = os.path.join(self.temp_dir, b"config.yaml")
+        with open(cli_config_path, "w") as file:
+            file.write("library: beets.db\n")
+            file.write("statefile: state")
 
-        self.run_command('--config', cli_config_path, 'test', lib=None)
+        self.run_command("--config", cli_config_path, "test", lib=None)
         self.assert_equal_path(
-            util.bytestring_path(config['library'].as_filename()),
-            os.path.join(self.user_config_dir, b'beets.db')
+            util.bytestring_path(config["library"].as_filename()),
+            os.path.join(self.user_config_dir, b"beets.db"),
         )
         self.assert_equal_path(
-            util.bytestring_path(config['statefile'].as_filename()),
-            os.path.join(self.user_config_dir, b'state')
+            util.bytestring_path(config["statefile"].as_filename()),
+            os.path.join(self.user_config_dir, b"state"),
         )
 
     def test_cli_config_paths_resolve_relative_to_beetsdir(self):
-        os.environ['BEETSDIR'] = util.py3_path(self.beetsdir)
+        os.environ["BEETSDIR"] = util.py3_path(self.beetsdir)
 
-        cli_config_path = os.path.join(self.temp_dir, b'config.yaml')
-        with open(cli_config_path, 'w') as file:
-            file.write('library: beets.db\n')
-            file.write('statefile: state')
+        cli_config_path = os.path.join(self.temp_dir, b"config.yaml")
+        with open(cli_config_path, "w") as file:
+            file.write("library: beets.db\n")
+            file.write("statefile: state")
 
-        self.run_command('--config', cli_config_path, 'test', lib=None)
+        self.run_command("--config", cli_config_path, "test", lib=None)
         self.assert_equal_path(
-            util.bytestring_path(config['library'].as_filename()),
-            os.path.join(self.beetsdir, b'beets.db')
+            util.bytestring_path(config["library"].as_filename()),
+            os.path.join(self.beetsdir, b"beets.db"),
         )
         self.assert_equal_path(
-            util.bytestring_path(config['statefile'].as_filename()),
-            os.path.join(self.beetsdir, b'state')
+            util.bytestring_path(config["statefile"].as_filename()),
+            os.path.join(self.beetsdir, b"state"),
         )
 
     def test_command_line_option_relative_to_working_dir(self):
         config.read()
         os.chdir(self.temp_dir)
-        self.run_command('--library', 'foo.db', 'test', lib=None)
-        self.assert_equal_path(config['library'].as_filename(),
-                               os.path.join(os.getcwd(), 'foo.db'))
+        self.run_command("--library", "foo.db", "test", lib=None)
+        self.assert_equal_path(
+            config["library"].as_filename(),
+            os.path.join(os.getcwd(), "foo.db"),
+        )
 
     def test_cli_config_file_loads_plugin_commands(self):
-        cli_config_path = os.path.join(self.temp_dir, b'config.yaml')
-        with open(cli_config_path, 'w') as file:
-            file.write('pluginpath: %s\n' % _common.PLUGINPATH)
-            file.write('plugins: test')
+        cli_config_path = os.path.join(self.temp_dir, b"config.yaml")
+        with open(cli_config_path, "w") as file:
+            file.write("pluginpath: %s\n" % _common.PLUGINPATH)
+            file.write("plugins: test")
 
-        self.run_command('--config', cli_config_path, 'plugin', lib=None)
+        self.run_command("--config", cli_config_path, "plugin", lib=None)
         self.assertTrue(plugins.find_plugins()[0].is_test_plugin)
 
     def test_beetsdir_config(self):
-        os.environ['BEETSDIR'] = util.py3_path(self.beetsdir)
+        os.environ["BEETSDIR"] = util.py3_path(self.beetsdir)
 
-        env_config_path = os.path.join(self.beetsdir, b'config.yaml')
-        with open(env_config_path, 'w') as file:
-            file.write('anoption: overwrite')
+        env_config_path = os.path.join(self.beetsdir, b"config.yaml")
+        with open(env_config_path, "w") as file:
+            file.write("anoption: overwrite")
 
         config.read()
-        self.assertEqual(config['anoption'].get(), 'overwrite')
+        self.assertEqual(config["anoption"].get(), "overwrite")
 
     def test_beetsdir_points_to_file_error(self):
-        beetsdir = os.path.join(self.temp_dir, b'beetsfile')
-        open(beetsdir, 'a').close()
-        os.environ['BEETSDIR'] = util.py3_path(beetsdir)
-        self.assertRaises(ConfigError, self.run_command, 'test')
+        beetsdir = os.path.join(self.temp_dir, b"beetsfile")
+        open(beetsdir, "a").close()
+        os.environ["BEETSDIR"] = util.py3_path(beetsdir)
+        self.assertRaises(ConfigError, self.run_command, "test")
 
     def test_beetsdir_config_does_not_load_default_user_config(self):
-        os.environ['BEETSDIR'] = util.py3_path(self.beetsdir)
+        os.environ["BEETSDIR"] = util.py3_path(self.beetsdir)
 
-        with open(self.user_config_path, 'w') as file:
-            file.write('anoption: value')
+        with open(self.user_config_path, "w") as file:
+            file.write("anoption: value")
 
         config.read()
-        self.assertFalse(config['anoption'].exists())
+        self.assertFalse(config["anoption"].exists())
 
     def test_default_config_paths_resolve_relative_to_beetsdir(self):
-        os.environ['BEETSDIR'] = util.py3_path(self.beetsdir)
+        os.environ["BEETSDIR"] = util.py3_path(self.beetsdir)
 
         config.read()
         self.assert_equal_path(
-            util.bytestring_path(config['library'].as_filename()),
-            os.path.join(self.beetsdir, b'library.db')
+            util.bytestring_path(config["library"].as_filename()),
+            os.path.join(self.beetsdir, b"library.db"),
         )
         self.assert_equal_path(
-            util.bytestring_path(config['statefile'].as_filename()),
-            os.path.join(self.beetsdir, b'state.pickle')
+            util.bytestring_path(config["statefile"].as_filename()),
+            os.path.join(self.beetsdir, b"state.pickle"),
         )
 
     def test_beetsdir_config_paths_resolve_relative_to_beetsdir(self):
-        os.environ['BEETSDIR'] = util.py3_path(self.beetsdir)
+        os.environ["BEETSDIR"] = util.py3_path(self.beetsdir)
 
-        env_config_path = os.path.join(self.beetsdir, b'config.yaml')
-        with open(env_config_path, 'w') as file:
-            file.write('library: beets.db\n')
-            file.write('statefile: state')
+        env_config_path = os.path.join(self.beetsdir, b"config.yaml")
+        with open(env_config_path, "w") as file:
+            file.write("library: beets.db\n")
+            file.write("statefile: state")
 
         config.read()
         self.assert_equal_path(
-            util.bytestring_path(config['library'].as_filename()),
-            os.path.join(self.beetsdir, b'beets.db')
+            util.bytestring_path(config["library"].as_filename()),
+            os.path.join(self.beetsdir, b"beets.db"),
         )
         self.assert_equal_path(
-            util.bytestring_path(config['statefile'].as_filename()),
-            os.path.join(self.beetsdir, b'state')
+            util.bytestring_path(config["statefile"].as_filename()),
+            os.path.join(self.beetsdir, b"state"),
         )
 
 
@@ -1005,40 +1021,40 @@ class ShowModelChangeTest(_common.TestCase):
     def test_identical(self):
         change, out = self._show()
         self.assertFalse(change)
-        self.assertEqual(out, '')
+        self.assertEqual(out, "")
 
     def test_string_fixed_field_change(self):
-        self.b.title = 'x'
+        self.b.title = "x"
         change, out = self._show()
         self.assertTrue(change)
-        self.assertTrue(u'title' in out)
+        self.assertTrue(u"title" in out)
 
     def test_int_fixed_field_change(self):
         self.b.track = 9
         change, out = self._show()
         self.assertTrue(change)
-        self.assertTrue(u'track' in out)
+        self.assertTrue(u"track" in out)
 
     def test_floats_close_to_identical(self):
         self.a.length = 1.00001
         self.b.length = 1.00005
         change, out = self._show()
         self.assertFalse(change)
-        self.assertEqual(out, u'')
+        self.assertEqual(out, u"")
 
     def test_floats_different(self):
         self.a.length = 1.00001
         self.b.length = 2.00001
         change, out = self._show()
         self.assertTrue(change)
-        self.assertTrue(u'length' in out)
+        self.assertTrue(u"length" in out)
 
     def test_both_values_shown(self):
-        self.a.title = u'foo'
-        self.b.title = u'bar'
+        self.a.title = u"foo"
+        self.b.title = u"bar"
         change, out = self._show()
-        self.assertTrue(u'foo' in out)
-        self.assertTrue(u'bar' in out)
+        self.assertTrue(u"foo" in out)
+        self.assertTrue(u"bar" in out)
 
 
 class ShowChangeTest(_common.TestCase):
@@ -1048,25 +1064,34 @@ class ShowChangeTest(_common.TestCase):
 
         self.items = [_common.item()]
         self.items[0].track = 1
-        self.items[0].path = b'/path/to/file.mp3'
+        self.items[0].path = b"/path/to/file.mp3"
         self.info = autotag.AlbumInfo(
-            album=u'the album', album_id=u'album id', artist=u'the artist',
-            artist_id=u'artist id', tracks=[
-                autotag.TrackInfo(title=u'the title', track_id=u'track id',
-                                  index=1)
-            ]
+            album=u"the album",
+            album_id=u"album id",
+            artist=u"the artist",
+            artist_id=u"artist id",
+            tracks=[
+                autotag.TrackInfo(
+                    title=u"the title", track_id=u"track id", index=1
+                )
+            ],
         )
 
-    def _show_change(self, items=None, info=None,
-                     cur_artist=u'the artist', cur_album=u'the album',
-                     dist=0.1):
+    def _show_change(
+        self,
+        items=None,
+        info=None,
+        cur_artist=u"the artist",
+        cur_album=u"the album",
+        dist=0.1,
+    ):
         """Return an unicode string representing the changes"""
         items = items or self.items
         info = info or self.info
         mapping = dict(zip(items, info.tracks))
-        config['ui']['color'] = False
+        config["ui"]["color"] = False
         album_dist = distance(items, info, mapping)
-        album_dist._penalties = {'album': [dist]}
+        album_dist._penalties = {"album": [dist]}
         commands.show_change(
             cur_artist,
             cur_album,
@@ -1077,43 +1102,46 @@ class ShowChangeTest(_common.TestCase):
 
     def test_null_change(self):
         msg = self._show_change()
-        self.assertTrue('similarity: 90' in msg)
-        self.assertTrue('tagging:' in msg)
+        self.assertTrue("similarity: 90" in msg)
+        self.assertTrue("tagging:" in msg)
 
     def test_album_data_change(self):
-        msg = self._show_change(cur_artist='another artist',
-                                cur_album='another album')
-        self.assertTrue('correcting tags from:' in msg)
+        msg = self._show_change(
+            cur_artist="another artist", cur_album="another album"
+        )
+        self.assertTrue("correcting tags from:" in msg)
 
     def test_item_data_change(self):
-        self.items[0].title = u'different'
+        self.items[0].title = u"different"
         msg = self._show_change()
-        self.assertTrue('different -> the title' in msg)
+        self.assertTrue("different -> the title" in msg)
 
     def test_item_data_change_with_unicode(self):
-        self.items[0].title = u'caf\xe9'
+        self.items[0].title = u"caf\xe9"
         msg = self._show_change()
-        self.assertTrue(u'caf\xe9 -> the title' in msg)
+        self.assertTrue(u"caf\xe9 -> the title" in msg)
 
     def test_album_data_change_with_unicode(self):
-        msg = self._show_change(cur_artist=u'caf\xe9',
-                                cur_album=u'another album')
-        self.assertTrue(u'correcting tags from:' in msg)
+        msg = self._show_change(
+            cur_artist=u"caf\xe9", cur_album=u"another album"
+        )
+        self.assertTrue(u"correcting tags from:" in msg)
 
     def test_item_data_change_title_missing(self):
-        self.items[0].title = u''
-        msg = re.sub(r'  +', ' ', self._show_change())
-        self.assertTrue(u'file.mp3 -> the title' in msg)
+        self.items[0].title = u""
+        msg = re.sub(r"  +", " ", self._show_change())
+        self.assertTrue(u"file.mp3 -> the title" in msg)
 
     def test_item_data_change_title_missing_with_unicode_filename(self):
-        self.items[0].title = u''
-        self.items[0].path = u'/path/to/caf\xe9.mp3'.encode('utf-8')
-        msg = re.sub(r'  +', ' ', self._show_change())
-        self.assertTrue(u'caf\xe9.mp3 -> the title' in msg or
-                        u'caf.mp3 ->' in msg)
+        self.items[0].title = u""
+        self.items[0].path = u"/path/to/caf\xe9.mp3".encode("utf-8")
+        msg = re.sub(r"  +", " ", self._show_change())
+        self.assertTrue(
+            u"caf\xe9.mp3 -> the title" in msg or u"caf.mp3 ->" in msg
+        )
 
 
-@patch('beets.library.Item.try_filesize', Mock(return_value=987))
+@patch("beets.library.Item.try_filesize", Mock(return_value=987))
 class SummarizeItemsTest(_common.TestCase):
     def setUp(self):
         super(SummarizeItemsTest, self).setUp()
@@ -1155,41 +1183,42 @@ class PathFormatTest(_common.TestCase):
     def test_custom_paths_prepend(self):
         default_formats = ui.get_path_formats()
 
-        config['paths'] = {u'foo': u'bar'}
+        config["paths"] = {u"foo": u"bar"}
         pf = ui.get_path_formats()
         key, tmpl = pf[0]
-        self.assertEqual(key, u'foo')
-        self.assertEqual(tmpl.original, u'bar')
+        self.assertEqual(key, u"foo")
+        self.assertEqual(tmpl.original, u"bar")
         self.assertEqual(pf[1:], default_formats)
 
 
 @_common.slow_test()
 class PluginTest(_common.TestCase, TestHelper):
     def test_plugin_command_from_pluginpath(self):
-        config['pluginpath'] = [_common.PLUGINPATH]
-        config['plugins'] = ['test']
-        self.run_command('test', lib=None)
+        config["pluginpath"] = [_common.PLUGINPATH]
+        config["plugins"] = ["test"]
+        self.run_command("test", lib=None)
 
 
 @_common.slow_test()
 class CompletionTest(_common.TestCase, TestHelper):
     def test_completion(self):
         # Load plugin commands
-        config['pluginpath'] = [_common.PLUGINPATH]
-        config['plugins'] = ['test']
+        config["pluginpath"] = [_common.PLUGINPATH]
+        config["plugins"] = ["test"]
 
         # Do not load any other bash completion scripts on the system.
         env = dict(os.environ)
-        env['BASH_COMPLETION_DIR'] = os.devnull
-        env['BASH_COMPLETION_COMPAT_DIR'] = os.devnull
+        env["BASH_COMPLETION_DIR"] = os.devnull
+        env["BASH_COMPLETION_COMPAT_DIR"] = os.devnull
 
         # Open a `bash` process to run the tests in. We'll pipe in bash
         # commands via stdin.
-        cmd = os.environ.get('BEETS_TEST_SHELL', '/bin/bash --norc').split()
+        cmd = os.environ.get("BEETS_TEST_SHELL", "/bin/bash --norc").split()
         if not has_program(cmd[0]):
-            self.skipTest(u'bash not available')
-        tester = subprocess.Popen(cmd, stdin=subprocess.PIPE,
-                                  stdout=subprocess.PIPE, env=env)
+            self.skipTest(u"bash not available")
+        tester = subprocess.Popen(
+            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, env=env
+        )
 
         # Load bash_completion library.
         for path in commands.BASH_COMPLETION_PATHS:
@@ -1197,38 +1226,39 @@ class CompletionTest(_common.TestCase, TestHelper):
                 bash_completion = path
                 break
         else:
-            self.skipTest(u'bash-completion script not found')
+            self.skipTest(u"bash-completion script not found")
         try:
-            with open(util.syspath(bash_completion), 'rb') as f:
+            with open(util.syspath(bash_completion), "rb") as f:
                 tester.stdin.writelines(f)
         except IOError:
-            self.skipTest(u'could not read bash-completion script')
+            self.skipTest(u"could not read bash-completion script")
 
         # Load completion script.
         self.io.install()
-        self.run_command('completion', lib=None)
-        completion_script = self.io.getoutput().encode('utf-8')
+        self.run_command("completion", lib=None)
+        completion_script = self.io.getoutput().encode("utf-8")
         self.io.restore()
         tester.stdin.writelines(completion_script.splitlines(True))
 
         # Load test suite.
-        test_script_name = os.path.join(_common.RSRC, b'test_completion.sh')
-        with open(test_script_name, 'rb') as test_script_file:
+        test_script_name = os.path.join(_common.RSRC, b"test_completion.sh")
+        with open(test_script_name, "rb") as test_script_file:
             tester.stdin.writelines(test_script_file)
         out, err = tester.communicate()
-        if tester.returncode != 0 or out != b'completion tests passed\n':
-            print(out.decode('utf-8'))
-            self.fail(u'test/test_completion.sh did not execute properly')
+        if tester.returncode != 0 or out != b"completion tests passed\n":
+            print(out.decode("utf-8"))
+            self.fail(u"test/test_completion.sh did not execute properly")
 
 
 class CommonOptionsParserCliTest(unittest.TestCase, TestHelper):
     """Test CommonOptionsParser and formatting LibModel formatting on 'list'
     command.
     """
+
     def setUp(self):
         self.setup_beets()
         self.item = _common.item()
-        self.item.path = b'xxx/yyy'
+        self.item.path = b"xxx/yyy"
         self.lib.add(self.item)
         self.lib.add_album([self.item])
         self.load_plugins()
@@ -1238,63 +1268,70 @@ class CommonOptionsParserCliTest(unittest.TestCase, TestHelper):
         self.teardown_beets()
 
     def test_base(self):
-        l = self.run_with_output(u'ls')
-        self.assertEqual(l, u'the artist - the album - the title\n')
+        l = self.run_with_output(u"ls")
+        self.assertEqual(l, u"the artist - the album - the title\n")
 
-        l = self.run_with_output(u'ls', u'-a')
-        self.assertEqual(l, u'the album artist - the album\n')
+        l = self.run_with_output(u"ls", u"-a")
+        self.assertEqual(l, u"the album artist - the album\n")
 
     def test_path_option(self):
-        l = self.run_with_output(u'ls', u'-p')
-        self.assertEqual(l, u'xxx/yyy\n')
+        l = self.run_with_output(u"ls", u"-p")
+        self.assertEqual(l, u"xxx/yyy\n")
 
-        l = self.run_with_output(u'ls', u'-a', u'-p')
-        self.assertEqual(l, u'xxx\n')
+        l = self.run_with_output(u"ls", u"-a", u"-p")
+        self.assertEqual(l, u"xxx\n")
 
     def test_format_option(self):
-        l = self.run_with_output(u'ls', u'-f', u'$artist')
-        self.assertEqual(l, u'the artist\n')
+        l = self.run_with_output(u"ls", u"-f", u"$artist")
+        self.assertEqual(l, u"the artist\n")
 
-        l = self.run_with_output(u'ls', u'-a', u'-f', u'$albumartist')
-        self.assertEqual(l, u'the album artist\n')
+        l = self.run_with_output(u"ls", u"-a", u"-f", u"$albumartist")
+        self.assertEqual(l, u"the album artist\n")
 
     def test_format_option_unicode(self):
-        l = self.run_with_output(b'ls', b'-f',
-                                 u'caf\xe9'.encode(util.arg_encoding()))
-        self.assertEqual(l, u'caf\xe9\n')
+        l = self.run_with_output(
+            b"ls", b"-f", u"caf\xe9".encode(util.arg_encoding())
+        )
+        self.assertEqual(l, u"caf\xe9\n")
 
     def test_root_format_option(self):
-        l = self.run_with_output(u'--format-item', u'$artist',
-                                 u'--format-album', u'foo', u'ls')
-        self.assertEqual(l, u'the artist\n')
+        l = self.run_with_output(
+            u"--format-item", u"$artist", u"--format-album", u"foo", u"ls"
+        )
+        self.assertEqual(l, u"the artist\n")
 
-        l = self.run_with_output(u'--format-item', u'foo',
-                                 u'--format-album', u'$albumartist',
-                                 u'ls', u'-a')
-        self.assertEqual(l, u'the album artist\n')
+        l = self.run_with_output(
+            u"--format-item",
+            u"foo",
+            u"--format-album",
+            u"$albumartist",
+            u"ls",
+            u"-a",
+        )
+        self.assertEqual(l, u"the album artist\n")
 
     def test_help(self):
-        l = self.run_with_output(u'help')
-        self.assertIn(u'Usage:', l)
+        l = self.run_with_output(u"help")
+        self.assertIn(u"Usage:", l)
 
-        l = self.run_with_output(u'help', u'list')
-        self.assertIn(u'Usage:', l)
+        l = self.run_with_output(u"help", u"list")
+        self.assertIn(u"Usage:", l)
 
         with self.assertRaises(ui.UserError):
-            self.run_command(u'help', u'this.is.not.a.real.command')
+            self.run_command(u"help", u"this.is.not.a.real.command")
 
     def test_stats(self):
-        l = self.run_with_output(u'stats')
-        self.assertIn(u'Approximate total size:', l)
+        l = self.run_with_output(u"stats")
+        self.assertIn(u"Approximate total size:", l)
 
         # # Need to have more realistic library setup for this to work
         # l = self.run_with_output('stats', '-e')
         # self.assertIn('Total size:', l)
 
     def test_version(self):
-        l = self.run_with_output(u'version')
-        self.assertIn(u'Python version', l)
-        self.assertIn(u'no plugins loaded', l)
+        l = self.run_with_output(u"version")
+        self.assertIn(u"Python version", l)
+        self.assertIn(u"no plugins loaded", l)
 
         # # Need to have plugin loaded
         # l = self.run_with_output('version')
@@ -1314,85 +1351,96 @@ class CommonOptionsParserTest(unittest.TestCase, TestHelper):
         parser.add_album_option()
         self.assertTrue(bool(parser._album_flags))
 
-        self.assertEqual(parser.parse_args([]), ({'album': None}, []))
-        self.assertEqual(parser.parse_args([u'-a']), ({'album': True}, []))
-        self.assertEqual(parser.parse_args([u'--album']),
-                         ({'album': True}, []))
+        self.assertEqual(parser.parse_args([]), ({"album": None}, []))
+        self.assertEqual(parser.parse_args([u"-a"]), ({"album": True}, []))
+        self.assertEqual(
+            parser.parse_args([u"--album"]), ({"album": True}, [])
+        )
 
     def test_path_option(self):
         parser = ui.CommonOptionsParser()
         parser.add_path_option()
         self.assertFalse(parser._album_flags)
 
-        config['format_item'].set('$foo')
-        self.assertEqual(parser.parse_args([]), ({'path': None}, []))
-        self.assertEqual(config['format_item'].as_str(), u'$foo')
+        config["format_item"].set("$foo")
+        self.assertEqual(parser.parse_args([]), ({"path": None}, []))
+        self.assertEqual(config["format_item"].as_str(), u"$foo")
 
-        self.assertEqual(parser.parse_args([u'-p']),
-                         ({'path': True, 'format': u'$path'}, []))
-        self.assertEqual(parser.parse_args(['--path']),
-                         ({'path': True, 'format': u'$path'}, []))
+        self.assertEqual(
+            parser.parse_args([u"-p"]),
+            ({"path": True, "format": u"$path"}, []),
+        )
+        self.assertEqual(
+            parser.parse_args(["--path"]),
+            ({"path": True, "format": u"$path"}, []),
+        )
 
-        self.assertEqual(config['format_item'].as_str(), u'$path')
-        self.assertEqual(config['format_album'].as_str(), u'$path')
+        self.assertEqual(config["format_item"].as_str(), u"$path")
+        self.assertEqual(config["format_album"].as_str(), u"$path")
 
     def test_format_option(self):
         parser = ui.CommonOptionsParser()
         parser.add_format_option()
         self.assertFalse(parser._album_flags)
 
-        config['format_item'].set('$foo')
-        self.assertEqual(parser.parse_args([]), ({'format': None}, []))
-        self.assertEqual(config['format_item'].as_str(), u'$foo')
+        config["format_item"].set("$foo")
+        self.assertEqual(parser.parse_args([]), ({"format": None}, []))
+        self.assertEqual(config["format_item"].as_str(), u"$foo")
 
-        self.assertEqual(parser.parse_args([u'-f', u'$bar']),
-                         ({'format': u'$bar'}, []))
-        self.assertEqual(parser.parse_args([u'--format', u'$baz']),
-                         ({'format': u'$baz'}, []))
+        self.assertEqual(
+            parser.parse_args([u"-f", u"$bar"]), ({"format": u"$bar"}, [])
+        )
+        self.assertEqual(
+            parser.parse_args([u"--format", u"$baz"]),
+            ({"format": u"$baz"}, []),
+        )
 
-        self.assertEqual(config['format_item'].as_str(), u'$baz')
-        self.assertEqual(config['format_album'].as_str(), u'$baz')
+        self.assertEqual(config["format_item"].as_str(), u"$baz")
+        self.assertEqual(config["format_album"].as_str(), u"$baz")
 
     def test_format_option_with_target(self):
         with self.assertRaises(KeyError):
-            ui.CommonOptionsParser().add_format_option(target='thingy')
+            ui.CommonOptionsParser().add_format_option(target="thingy")
 
         parser = ui.CommonOptionsParser()
-        parser.add_format_option(target='item')
+        parser.add_format_option(target="item")
 
-        config['format_item'].set('$item')
-        config['format_album'].set('$album')
+        config["format_item"].set("$item")
+        config["format_album"].set("$album")
 
-        self.assertEqual(parser.parse_args([u'-f', u'$bar']),
-                         ({'format': u'$bar'}, []))
+        self.assertEqual(
+            parser.parse_args([u"-f", u"$bar"]), ({"format": u"$bar"}, [])
+        )
 
-        self.assertEqual(config['format_item'].as_str(), u'$bar')
-        self.assertEqual(config['format_album'].as_str(), u'$album')
+        self.assertEqual(config["format_item"].as_str(), u"$bar")
+        self.assertEqual(config["format_album"].as_str(), u"$album")
 
     def test_format_option_with_album(self):
         parser = ui.CommonOptionsParser()
         parser.add_album_option()
         parser.add_format_option()
 
-        config['format_item'].set('$item')
-        config['format_album'].set('$album')
+        config["format_item"].set("$item")
+        config["format_album"].set("$album")
 
-        parser.parse_args([u'-f', u'$bar'])
-        self.assertEqual(config['format_item'].as_str(), u'$bar')
-        self.assertEqual(config['format_album'].as_str(), u'$album')
+        parser.parse_args([u"-f", u"$bar"])
+        self.assertEqual(config["format_item"].as_str(), u"$bar")
+        self.assertEqual(config["format_album"].as_str(), u"$album")
 
-        parser.parse_args([u'-a', u'-f', u'$foo'])
-        self.assertEqual(config['format_item'].as_str(), u'$bar')
-        self.assertEqual(config['format_album'].as_str(), u'$foo')
+        parser.parse_args([u"-a", u"-f", u"$foo"])
+        self.assertEqual(config["format_item"].as_str(), u"$bar")
+        self.assertEqual(config["format_album"].as_str(), u"$foo")
 
-        parser.parse_args([u'-f', u'$foo2', u'-a'])
-        self.assertEqual(config['format_album'].as_str(), u'$foo2')
+        parser.parse_args([u"-f", u"$foo2", u"-a"])
+        self.assertEqual(config["format_album"].as_str(), u"$foo2")
 
     def test_add_all_common_options(self):
         parser = ui.CommonOptionsParser()
         parser.add_all_common_options()
-        self.assertEqual(parser.parse_args([]),
-                         ({'album': None, 'path': None, 'format': None}, []))
+        self.assertEqual(
+            parser.parse_args([]),
+            ({"album": None, "path": None, "format": None}, []),
+        )
 
 
 class EncodingTest(_common.TestCase):
@@ -1401,26 +1449,27 @@ class EncodingTest(_common.TestCase):
     """
 
     def out_encoding_overridden(self):
-        config['terminal_encoding'] = 'fake_encoding'
-        self.assertEqual(ui._out_encoding(), 'fake_encoding')
+        config["terminal_encoding"] = "fake_encoding"
+        self.assertEqual(ui._out_encoding(), "fake_encoding")
 
     def in_encoding_overridden(self):
-        config['terminal_encoding'] = 'fake_encoding'
-        self.assertEqual(ui._in_encoding(), 'fake_encoding')
+        config["terminal_encoding"] = "fake_encoding"
+        self.assertEqual(ui._in_encoding(), "fake_encoding")
 
     def out_encoding_default_utf8(self):
-        with patch('sys.stdout') as stdout:
+        with patch("sys.stdout") as stdout:
             stdout.encoding = None
-            self.assertEqual(ui._out_encoding(), 'utf-8')
+            self.assertEqual(ui._out_encoding(), "utf-8")
 
     def in_encoding_default_utf8(self):
-        with patch('sys.stdin') as stdin:
+        with patch("sys.stdin") as stdin:
             stdin.encoding = None
-            self.assertEqual(ui._in_encoding(), 'utf-8')
+            self.assertEqual(ui._in_encoding(), "utf-8")
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_ui_commands.py
+++ b/test/test_ui_commands.py
@@ -33,16 +33,16 @@ class QueryTest(_common.TestCase):
     def setUp(self):
         super(QueryTest, self).setUp()
 
-        self.libdir = os.path.join(self.temp_dir, b'testlibdir')
+        self.libdir = os.path.join(self.temp_dir, b"testlibdir")
         os.mkdir(self.libdir)
 
         # Add a file to the library but don't copy it in yet.
-        self.lib = library.Library(':memory:', self.libdir)
+        self.lib = library.Library(":memory:", self.libdir)
 
         # Alternate destination directory.
-        self.otherdir = os.path.join(self.temp_dir, b'testotherdir')
+        self.otherdir = os.path.join(self.temp_dir, b"testotherdir")
 
-    def add_item(self, filename=b'srcfile', templatefile=b'full.mp3'):
+    def add_item(self, filename=b"srcfile", templatefile=b"full.mp3"):
         itempath = os.path.join(self.libdir, filename)
         shutil.copy(os.path.join(_common.RSRC, templatefile), itempath)
         item = library.Item.from_path(itempath)
@@ -53,10 +53,10 @@ class QueryTest(_common.TestCase):
         album = self.lib.add_album(items)
         return album
 
-    def check_do_query(self, num_items, num_albums,
-                       q=(), album=False, also_items=True):
-        items, albums = commands._do_query(
-            self.lib, q, album, also_items)
+    def check_do_query(
+        self, num_items, num_albums, q=(), album=False, also_items=True
+    ):
+        items, albums = commands._do_query(self.lib, q, album, also_items)
         self.assertEqual(len(items), num_items)
         self.assertEqual(len(albums), num_albums)
 
@@ -119,5 +119,6 @@ class FieldsTest(_common.LibTestCase):
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_ui_importer.py
+++ b/test/test_ui_importer.py
@@ -31,9 +31,8 @@ import six
 
 
 class TerminalImportSessionFixture(TerminalImportSession):
-
     def __init__(self, *args, **kwargs):
-        self.io = kwargs.pop('io')
+        self.io = kwargs.pop("io")
         super(TerminalImportSessionFixture, self).__init__(*args, **kwargs)
         self._choices = []
 
@@ -60,95 +59,113 @@ class TerminalImportSessionFixture(TerminalImportSession):
             choice = self.default_choice
 
         if choice == importer.action.APPLY:
-            self.io.addinput(u'A')
+            self.io.addinput(u"A")
         elif choice == importer.action.ASIS:
-            self.io.addinput(u'U')
+            self.io.addinput(u"U")
         elif choice == importer.action.ALBUMS:
-            self.io.addinput(u'G')
+            self.io.addinput(u"G")
         elif choice == importer.action.TRACKS:
-            self.io.addinput(u'T')
+            self.io.addinput(u"T")
         elif choice == importer.action.SKIP:
-            self.io.addinput(u'S')
+            self.io.addinput(u"S")
         elif isinstance(choice, int):
-            self.io.addinput(u'M')
+            self.io.addinput(u"M")
             self.io.addinput(six.text_type(choice))
             self._add_choice_input()
         else:
-            raise Exception(u'Unknown choice %s' % choice)
+            raise Exception(u"Unknown choice %s" % choice)
 
 
 class TerminalImportSessionSetup(object):
     """Overwrites test_importer.ImportHelper to provide a terminal importer
     """
 
-    def _setup_import_session(self, import_dir=None, delete=False,
-                              threaded=False, copy=True, singletons=False,
-                              move=False, autotag=True):
-        config['import']['copy'] = copy
-        config['import']['delete'] = delete
-        config['import']['timid'] = True
-        config['threaded'] = False
-        config['import']['singletons'] = singletons
-        config['import']['move'] = move
-        config['import']['autotag'] = autotag
-        config['import']['resume'] = False
+    def _setup_import_session(
+        self,
+        import_dir=None,
+        delete=False,
+        threaded=False,
+        copy=True,
+        singletons=False,
+        move=False,
+        autotag=True,
+    ):
+        config["import"]["copy"] = copy
+        config["import"]["delete"] = delete
+        config["import"]["timid"] = True
+        config["threaded"] = False
+        config["import"]["singletons"] = singletons
+        config["import"]["move"] = move
+        config["import"]["autotag"] = autotag
+        config["import"]["resume"] = False
 
-        if not hasattr(self, 'io'):
+        if not hasattr(self, "io"):
             self.io = DummyIO()
         self.io.install()
         self.importer = TerminalImportSessionFixture(
-            self.lib, loghandler=None, query=None, io=self.io,
+            self.lib,
+            loghandler=None,
+            query=None,
+            io=self.io,
             paths=[import_dir or self.import_dir],
         )
 
 
-class NonAutotaggedImportTest(TerminalImportSessionSetup,
-                              test_importer.NonAutotaggedImportTest):
+class NonAutotaggedImportTest(
+    TerminalImportSessionSetup, test_importer.NonAutotaggedImportTest
+):
     pass
 
 
-class ImportTest(TerminalImportSessionSetup,
-                 test_importer.ImportTest):
+class ImportTest(TerminalImportSessionSetup, test_importer.ImportTest):
     pass
 
 
-class ImportSingletonTest(TerminalImportSessionSetup,
-                          test_importer.ImportSingletonTest):
+class ImportSingletonTest(
+    TerminalImportSessionSetup, test_importer.ImportSingletonTest
+):
     pass
 
 
-class ImportTracksTest(TerminalImportSessionSetup,
-                       test_importer.ImportTracksTest):
+class ImportTracksTest(
+    TerminalImportSessionSetup, test_importer.ImportTracksTest
+):
     pass
 
 
-class ImportCompilationTest(TerminalImportSessionSetup,
-                            test_importer.ImportCompilationTest):
+class ImportCompilationTest(
+    TerminalImportSessionSetup, test_importer.ImportCompilationTest
+):
     pass
 
 
-class ImportExistingTest(TerminalImportSessionSetup,
-                         test_importer.ImportExistingTest):
+class ImportExistingTest(
+    TerminalImportSessionSetup, test_importer.ImportExistingTest
+):
     pass
 
 
-class ChooseCandidateTest(TerminalImportSessionSetup,
-                          test_importer.ChooseCandidateTest):
+class ChooseCandidateTest(
+    TerminalImportSessionSetup, test_importer.ChooseCandidateTest
+):
     pass
 
 
-class GroupAlbumsImportTest(TerminalImportSessionSetup,
-                            test_importer.GroupAlbumsImportTest):
+class GroupAlbumsImportTest(
+    TerminalImportSessionSetup, test_importer.GroupAlbumsImportTest
+):
     pass
 
 
-class GlobalGroupAlbumsImportTest(TerminalImportSessionSetup,
-                                  test_importer.GlobalGroupAlbumsImportTest):
+class GlobalGroupAlbumsImportTest(
+    TerminalImportSessionSetup, test_importer.GlobalGroupAlbumsImportTest
+):
     pass
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_ui_init.py
+++ b/test/test_ui_init.py
@@ -36,52 +36,56 @@ class InputMethodsTest(_common.TestCase):
         print(prefix, s)
 
     def test_input_select_objects(self):
-        full_items = ['1', '2', '3', '4', '5']
+        full_items = ["1", "2", "3", "4", "5"]
 
         # Test no
-        self.io.addinput('n')
+        self.io.addinput("n")
         items = ui.input_select_objects(
-            "Prompt", full_items, self._print_helper)
+            "Prompt", full_items, self._print_helper
+        )
         self.assertEqual(items, [])
 
         # Test yes
-        self.io.addinput('y')
+        self.io.addinput("y")
         items = ui.input_select_objects(
-            "Prompt", full_items, self._print_helper)
+            "Prompt", full_items, self._print_helper
+        )
         self.assertEqual(items, full_items)
 
         # Test selective 1
-        self.io.addinput('s')
-        self.io.addinput('n')
-        self.io.addinput('y')
-        self.io.addinput('n')
-        self.io.addinput('y')
-        self.io.addinput('n')
+        self.io.addinput("s")
+        self.io.addinput("n")
+        self.io.addinput("y")
+        self.io.addinput("n")
+        self.io.addinput("y")
+        self.io.addinput("n")
         items = ui.input_select_objects(
-            "Prompt", full_items, self._print_helper)
-        self.assertEqual(items, ['2', '4'])
+            "Prompt", full_items, self._print_helper
+        )
+        self.assertEqual(items, ["2", "4"])
 
         # Test selective 2
-        self.io.addinput('s')
-        self.io.addinput('y')
-        self.io.addinput('y')
-        self.io.addinput('n')
-        self.io.addinput('y')
-        self.io.addinput('n')
+        self.io.addinput("s")
+        self.io.addinput("y")
+        self.io.addinput("y")
+        self.io.addinput("n")
+        self.io.addinput("y")
+        self.io.addinput("n")
         items = ui.input_select_objects(
-            "Prompt", full_items,
-            lambda s: self._print_helper2(s, "Prefix"))
-        self.assertEqual(items, ['1', '2', '4'])
+            "Prompt", full_items, lambda s: self._print_helper2(s, "Prefix")
+        )
+        self.assertEqual(items, ["1", "2", "4"])
 
         # Test selective 3
-        self.io.addinput('s')
-        self.io.addinput('y')
-        self.io.addinput('n')
-        self.io.addinput('y')
-        self.io.addinput('q')
+        self.io.addinput("s")
+        self.io.addinput("y")
+        self.io.addinput("n")
+        self.io.addinput("y")
+        self.io.addinput("q")
         items = ui.input_select_objects(
-            "Prompt", full_items, self._print_helper)
-        self.assertEqual(items, ['1', '3'])
+            "Prompt", full_items, self._print_helper
+        )
+        self.assertEqual(items, ["1", "3"])
 
 
 class InitTest(_common.LibTestCase):
@@ -90,34 +94,34 @@ class InitTest(_common.LibTestCase):
 
     def test_human_bytes(self):
         tests = [
-            (0, '0.0 B'),
-            (30, '30.0 B'),
-            (pow(2, 10), '1.0 KiB'),
-            (pow(2, 20), '1.0 MiB'),
-            (pow(2, 30), '1.0 GiB'),
-            (pow(2, 40), '1.0 TiB'),
-            (pow(2, 50), '1.0 PiB'),
-            (pow(2, 60), '1.0 EiB'),
-            (pow(2, 70), '1.0 ZiB'),
-            (pow(2, 80), '1.0 YiB'),
-            (pow(2, 90), '1.0 HiB'),
-            (pow(2, 100), 'big'),
+            (0, "0.0 B"),
+            (30, "30.0 B"),
+            (pow(2, 10), "1.0 KiB"),
+            (pow(2, 20), "1.0 MiB"),
+            (pow(2, 30), "1.0 GiB"),
+            (pow(2, 40), "1.0 TiB"),
+            (pow(2, 50), "1.0 PiB"),
+            (pow(2, 60), "1.0 EiB"),
+            (pow(2, 70), "1.0 ZiB"),
+            (pow(2, 80), "1.0 YiB"),
+            (pow(2, 90), "1.0 HiB"),
+            (pow(2, 100), "big"),
         ]
         for i, h in tests:
             self.assertEqual(h, ui.human_bytes(i))
 
     def test_human_seconds(self):
         tests = [
-            (0, '0.0 seconds'),
-            (30, '30.0 seconds'),
-            (60, '1.0 minutes'),
-            (90, '1.5 minutes'),
-            (125, '2.1 minutes'),
-            (3600, '1.0 hours'),
-            (86400, '1.0 days'),
-            (604800, '1.0 weeks'),
-            (31449600, '1.0 years'),
-            (314496000, '1.0 decades'),
+            (0, "0.0 seconds"),
+            (30, "30.0 seconds"),
+            (60, "1.0 minutes"),
+            (90, "1.5 minutes"),
+            (125, "2.1 minutes"),
+            (3600, "1.0 hours"),
+            (86400, "1.0 days"),
+            (604800, "1.0 weeks"),
+            (31449600, "1.0 years"),
+            (314496000, "1.0 decades"),
         ]
         for i, h in tests:
             self.assertEqual(h, ui.human_seconds(i))
@@ -126,5 +130,6 @@ class InitTest(_common.LibTestCase):
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -31,128 +31,124 @@ import six
 
 class UtilTest(unittest.TestCase):
     def test_open_anything(self):
-        with _common.system_mock('Windows'):
-            self.assertEqual(util.open_anything(), 'start')
+        with _common.system_mock("Windows"):
+            self.assertEqual(util.open_anything(), "start")
 
-        with _common.system_mock('Darwin'):
-            self.assertEqual(util.open_anything(), 'open')
+        with _common.system_mock("Darwin"):
+            self.assertEqual(util.open_anything(), "open")
 
-        with _common.system_mock('Tagada'):
-            self.assertEqual(util.open_anything(), 'xdg-open')
+        with _common.system_mock("Tagada"):
+            self.assertEqual(util.open_anything(), "xdg-open")
 
-    @patch('os.execlp')
-    @patch('beets.util.open_anything')
+    @patch("os.execlp")
+    @patch("beets.util.open_anything")
     def test_interactive_open(self, mock_open, mock_execlp):
-        mock_open.return_value = u'tagada'
-        util.interactive_open(['foo'], util.open_anything())
-        mock_execlp.assert_called_once_with(u'tagada', u'tagada', u'foo')
+        mock_open.return_value = u"tagada"
+        util.interactive_open(["foo"], util.open_anything())
+        mock_execlp.assert_called_once_with(u"tagada", u"tagada", u"foo")
         mock_execlp.reset_mock()
 
-        util.interactive_open(['foo'], u'bar')
-        mock_execlp.assert_called_once_with(u'bar', u'bar', u'foo')
+        util.interactive_open(["foo"], u"bar")
+        mock_execlp.assert_called_once_with(u"bar", u"bar", u"foo")
 
     def test_sanitize_unix_replaces_leading_dot(self):
         with _common.platform_posix():
-            p = util.sanitize_path(u'one/.two/three')
-        self.assertFalse(u'.' in p)
+            p = util.sanitize_path(u"one/.two/three")
+        self.assertFalse(u"." in p)
 
     def test_sanitize_windows_replaces_trailing_dot(self):
         with _common.platform_windows():
-            p = util.sanitize_path(u'one/two./three')
-        self.assertFalse(u'.' in p)
+            p = util.sanitize_path(u"one/two./three")
+        self.assertFalse(u"." in p)
 
     def test_sanitize_windows_replaces_illegal_chars(self):
         with _common.platform_windows():
             p = util.sanitize_path(u':*?"<>|')
-        self.assertFalse(u':' in p)
-        self.assertFalse(u'*' in p)
-        self.assertFalse(u'?' in p)
+        self.assertFalse(u":" in p)
+        self.assertFalse(u"*" in p)
+        self.assertFalse(u"?" in p)
         self.assertFalse(u'"' in p)
-        self.assertFalse(u'<' in p)
-        self.assertFalse(u'>' in p)
-        self.assertFalse(u'|' in p)
+        self.assertFalse(u"<" in p)
+        self.assertFalse(u">" in p)
+        self.assertFalse(u"|" in p)
 
     def test_sanitize_windows_replaces_trailing_space(self):
         with _common.platform_windows():
-            p = util.sanitize_path(u'one/two /three')
-        self.assertFalse(u' ' in p)
+            p = util.sanitize_path(u"one/two /three")
+        self.assertFalse(u" " in p)
 
     def test_sanitize_path_works_on_empty_string(self):
         with _common.platform_posix():
-            p = util.sanitize_path(u'')
-        self.assertEqual(p, u'')
+            p = util.sanitize_path(u"")
+        self.assertEqual(p, u"")
 
     def test_sanitize_with_custom_replace_overrides_built_in_sub(self):
         with _common.platform_posix():
-            p = util.sanitize_path(u'a/.?/b', [
-                (re.compile(r'foo'), u'bar'),
-            ])
-        self.assertEqual(p, u'a/.?/b')
+            p = util.sanitize_path(u"a/.?/b", [(re.compile(r"foo"), u"bar"),])
+        self.assertEqual(p, u"a/.?/b")
 
     def test_sanitize_with_custom_replace_adds_replacements(self):
         with _common.platform_posix():
-            p = util.sanitize_path(u'foo/bar', [
-                (re.compile(r'foo'), u'bar'),
-            ])
-        self.assertEqual(p, u'bar/bar')
+            p = util.sanitize_path(u"foo/bar", [(re.compile(r"foo"), u"bar"),])
+        self.assertEqual(p, u"bar/bar")
 
-    @unittest.skip(u'unimplemented: #359')
+    @unittest.skip(u"unimplemented: #359")
     def test_sanitize_empty_component(self):
         with _common.platform_posix():
-            p = util.sanitize_path(u'foo//bar', [
-                (re.compile(r'^$'), u'_'),
-            ])
-        self.assertEqual(p, u'foo/_/bar')
+            p = util.sanitize_path(u"foo//bar", [(re.compile(r"^$"), u"_"),])
+        self.assertEqual(p, u"foo/_/bar")
 
-    @unittest.skipIf(six.PY2, 'surrogateescape error handler not available'
-                     'on Python 2')
+    @unittest.skipIf(
+        six.PY2, "surrogateescape error handler not available" "on Python 2"
+    )
     def test_convert_command_args_keeps_undecodeable_bytes(self):
-        arg = b'\x82'  # non-ascii bytes
+        arg = b"\x82"  # non-ascii bytes
         cmd_args = util.convert_command_args([arg])
 
-        self.assertEqual(cmd_args[0],
-                         arg.decode(util.arg_encoding(), 'surrogateescape'))
+        self.assertEqual(
+            cmd_args[0], arg.decode(util.arg_encoding(), "surrogateescape")
+        )
 
-    @patch('beets.util.subprocess.Popen')
+    @patch("beets.util.subprocess.Popen")
     def test_command_output(self, mock_popen):
         def popen_fail(*args, **kwargs):
             m = Mock(returncode=1)
-            m.communicate.return_value = u'foo', u'bar'
+            m.communicate.return_value = u"foo", u"bar"
             return m
 
         mock_popen.side_effect = popen_fail
         with self.assertRaises(subprocess.CalledProcessError) as exc_context:
-            util.command_output(['taga', '\xc3\xa9'])
+            util.command_output(["taga", "\xc3\xa9"])
         self.assertEqual(exc_context.exception.returncode, 1)
-        self.assertEqual(exc_context.exception.cmd, 'taga \xc3\xa9')
+        self.assertEqual(exc_context.exception.cmd, "taga \xc3\xa9")
 
 
 class PathConversionTest(_common.TestCase):
     def test_syspath_windows_format(self):
         with _common.platform_windows():
-            path = os.path.join(u'a', u'b', u'c')
+            path = os.path.join(u"a", u"b", u"c")
             outpath = util.syspath(path)
         self.assertTrue(isinstance(outpath, six.text_type))
-        self.assertTrue(outpath.startswith(u'\\\\?\\'))
+        self.assertTrue(outpath.startswith(u"\\\\?\\"))
 
     def test_syspath_windows_format_unc_path(self):
         # The \\?\ prefix on Windows behaves differently with UNC
         # (network share) paths.
-        path = '\\\\server\\share\\file.mp3'
+        path = "\\\\server\\share\\file.mp3"
         with _common.platform_windows():
             outpath = util.syspath(path)
         self.assertTrue(isinstance(outpath, six.text_type))
-        self.assertEqual(outpath, u'\\\\?\\UNC\\server\\share\\file.mp3')
+        self.assertEqual(outpath, u"\\\\?\\UNC\\server\\share\\file.mp3")
 
     def test_syspath_posix_unchanged(self):
         with _common.platform_posix():
-            path = os.path.join(u'a', u'b', u'c')
+            path = os.path.join(u"a", u"b", u"c")
             outpath = util.syspath(path)
         self.assertEqual(path, outpath)
 
     def _windows_bytestring_path(self, path):
         old_gfse = sys.getfilesystemencoding
-        sys.getfilesystemencoding = lambda: 'mbcs'
+        sys.getfilesystemencoding = lambda: "mbcs"
         try:
             with _common.platform_windows():
                 return util.bytestring_path(path)
@@ -160,35 +156,36 @@ class PathConversionTest(_common.TestCase):
             sys.getfilesystemencoding = old_gfse
 
     def test_bytestring_path_windows_encodes_utf8(self):
-        path = u'caf\xe9'
+        path = u"caf\xe9"
         outpath = self._windows_bytestring_path(path)
-        self.assertEqual(path, outpath.decode('utf-8'))
+        self.assertEqual(path, outpath.decode("utf-8"))
 
     def test_bytesting_path_windows_removes_magic_prefix(self):
-        path = u'\\\\?\\C:\\caf\xe9'
+        path = u"\\\\?\\C:\\caf\xe9"
         outpath = self._windows_bytestring_path(path)
-        self.assertEqual(outpath, u'C:\\caf\xe9'.encode('utf-8'))
+        self.assertEqual(outpath, u"C:\\caf\xe9".encode("utf-8"))
 
 
 class PathTruncationTest(_common.TestCase):
     def test_truncate_bytestring(self):
         with _common.platform_posix():
-            p = util.truncate_path(b'abcde/fgh', 4)
-        self.assertEqual(p, b'abcd/fgh')
+            p = util.truncate_path(b"abcde/fgh", 4)
+        self.assertEqual(p, b"abcd/fgh")
 
     def test_truncate_unicode(self):
         with _common.platform_posix():
-            p = util.truncate_path(u'abcde/fgh', 4)
-        self.assertEqual(p, u'abcd/fgh')
+            p = util.truncate_path(u"abcde/fgh", 4)
+        self.assertEqual(p, u"abcd/fgh")
 
     def test_truncate_preserves_extension(self):
         with _common.platform_posix():
-            p = util.truncate_path(u'abcde/fgh.ext', 5)
-        self.assertEqual(p, u'abcde/f.ext')
+            p = util.truncate_path(u"abcde/fgh.ext", 5)
+        self.assertEqual(p, u"abcde/f.ext")
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_vfs.py
+++ b/test/test_vfs.py
@@ -25,25 +25,31 @@ from beets import vfs
 class VFSTest(_common.TestCase):
     def setUp(self):
         super(VFSTest, self).setUp()
-        self.lib = library.Library(':memory:', path_formats=[
-            (u'default', u'albums/$album/$title'),
-            (u'singleton:true', u'tracks/$artist/$title'),
-        ])
+        self.lib = library.Library(
+            ":memory:",
+            path_formats=[
+                (u"default", u"albums/$album/$title"),
+                (u"singleton:true", u"tracks/$artist/$title"),
+            ],
+        )
         self.lib.add(_common.item())
         self.lib.add_album([_common.item()])
         self.tree = vfs.libtree(self.lib)
 
     def test_singleton_item(self):
-        self.assertEqual(self.tree.dirs['tracks'].dirs['the artist'].
-                         files['the title'], 1)
+        self.assertEqual(
+            self.tree.dirs["tracks"].dirs["the artist"].files["the title"], 1
+        )
 
     def test_album_item(self):
-        self.assertEqual(self.tree.dirs['albums'].dirs['the album'].
-                         files['the title'], 2)
+        self.assertEqual(
+            self.tree.dirs["albums"].dirs["the album"].files["the title"], 2
+        )
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -15,134 +15,133 @@ from beetsplug import web
 
 
 class WebPluginTest(_common.LibTestCase):
-
     def setUp(self):
         super(WebPluginTest, self).setUp()
 
         # Add fixtures
         for track in self.lib.items():
             track.remove()
-        self.lib.add(Item(title=u'title', path='/path_1', id=1))
-        self.lib.add(Item(title=u'another title', path='/path_2', id=2))
-        self.lib.add(Album(album=u'album', id=3))
-        self.lib.add(Album(album=u'another album', id=4))
+        self.lib.add(Item(title=u"title", path="/path_1", id=1))
+        self.lib.add(Item(title=u"another title", path="/path_2", id=2))
+        self.lib.add(Album(album=u"album", id=3))
+        self.lib.add(Album(album=u"another album", id=4))
 
-        web.app.config['TESTING'] = True
-        web.app.config['lib'] = self.lib
-        web.app.config['INCLUDE_PATHS'] = False
+        web.app.config["TESTING"] = True
+        web.app.config["lib"] = self.lib
+        web.app.config["INCLUDE_PATHS"] = False
         self.client = web.app.test_client()
 
     def test_config_include_paths_true(self):
-        web.app.config['INCLUDE_PATHS'] = True
-        response = self.client.get('/item/1')
-        res_json = json.loads(response.data.decode('utf-8'))
+        web.app.config["INCLUDE_PATHS"] = True
+        response = self.client.get("/item/1")
+        res_json = json.loads(response.data.decode("utf-8"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(res_json['path'], u'/path_1')
+        self.assertEqual(res_json["path"], u"/path_1")
 
     def test_config_include_paths_false(self):
-        web.app.config['INCLUDE_PATHS'] = False
-        response = self.client.get('/item/1')
-        res_json = json.loads(response.data.decode('utf-8'))
+        web.app.config["INCLUDE_PATHS"] = False
+        response = self.client.get("/item/1")
+        res_json = json.loads(response.data.decode("utf-8"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn('path', res_json)
+        self.assertNotIn("path", res_json)
 
     def test_get_all_items(self):
-        response = self.client.get('/item/')
-        res_json = json.loads(response.data.decode('utf-8'))
+        response = self.client.get("/item/")
+        res_json = json.loads(response.data.decode("utf-8"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(res_json['items']), 2)
+        self.assertEqual(len(res_json["items"]), 2)
 
     def test_get_single_item_by_id(self):
-        response = self.client.get('/item/1')
-        res_json = json.loads(response.data.decode('utf-8'))
+        response = self.client.get("/item/1")
+        res_json = json.loads(response.data.decode("utf-8"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(res_json['id'], 1)
-        self.assertEqual(res_json['title'], u'title')
+        self.assertEqual(res_json["id"], 1)
+        self.assertEqual(res_json["title"], u"title")
 
     def test_get_multiple_items_by_id(self):
-        response = self.client.get('/item/1,2')
-        res_json = json.loads(response.data.decode('utf-8'))
+        response = self.client.get("/item/1,2")
+        res_json = json.loads(response.data.decode("utf-8"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(res_json['items']), 2)
-        response_titles = [item['title'] for item in res_json['items']]
-        assertCountEqual(self, response_titles, [u'title', u'another title'])
+        self.assertEqual(len(res_json["items"]), 2)
+        response_titles = [item["title"] for item in res_json["items"]]
+        assertCountEqual(self, response_titles, [u"title", u"another title"])
 
     def test_get_single_item_not_found(self):
-        response = self.client.get('/item/3')
+        response = self.client.get("/item/3")
         self.assertEqual(response.status_code, 404)
 
     def test_get_single_item_by_path(self):
-        data_path = os.path.join(_common.RSRC, b'full.mp3')
+        data_path = os.path.join(_common.RSRC, b"full.mp3")
         self.lib.add(Item.from_path(data_path))
-        response = self.client.get('/item/path/' + data_path.decode('utf-8'))
-        res_json = json.loads(response.data.decode('utf-8'))
+        response = self.client.get("/item/path/" + data_path.decode("utf-8"))
+        res_json = json.loads(response.data.decode("utf-8"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(res_json['title'], u'full')
+        self.assertEqual(res_json["title"], u"full")
 
     def test_get_single_item_by_path_not_found_if_not_in_library(self):
-        data_path = os.path.join(_common.RSRC, b'full.mp3')
+        data_path = os.path.join(_common.RSRC, b"full.mp3")
         # data_path points to a valid file, but we have not added the file
         # to the library.
-        response = self.client.get('/item/path/' + data_path.decode('utf-8'))
+        response = self.client.get("/item/path/" + data_path.decode("utf-8"))
 
         self.assertEqual(response.status_code, 404)
 
     def test_get_item_empty_query(self):
-        response = self.client.get('/item/query/')
-        res_json = json.loads(response.data.decode('utf-8'))
+        response = self.client.get("/item/query/")
+        res_json = json.loads(response.data.decode("utf-8"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(res_json['items']), 2)
+        self.assertEqual(len(res_json["items"]), 2)
 
     def test_get_simple_item_query(self):
-        response = self.client.get('/item/query/another')
-        res_json = json.loads(response.data.decode('utf-8'))
+        response = self.client.get("/item/query/another")
+        res_json = json.loads(response.data.decode("utf-8"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(res_json['results']), 1)
-        self.assertEqual(res_json['results'][0]['title'],
-                         u'another title')
+        self.assertEqual(len(res_json["results"]), 1)
+        self.assertEqual(res_json["results"][0]["title"], u"another title")
 
     def test_get_all_albums(self):
-        response = self.client.get('/album/')
-        res_json = json.loads(response.data.decode('utf-8'))
+        response = self.client.get("/album/")
+        res_json = json.loads(response.data.decode("utf-8"))
 
         self.assertEqual(response.status_code, 200)
-        response_albums = [album['album'] for album in res_json['albums']]
-        assertCountEqual(self, response_albums, [u'album', u'another album'])
+        response_albums = [album["album"] for album in res_json["albums"]]
+        assertCountEqual(self, response_albums, [u"album", u"another album"])
 
     def test_get_single_album_by_id(self):
-        response = self.client.get('/album/2')
-        res_json = json.loads(response.data.decode('utf-8'))
+        response = self.client.get("/album/2")
+        res_json = json.loads(response.data.decode("utf-8"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(res_json['id'], 2)
-        self.assertEqual(res_json['album'], u'another album')
+        self.assertEqual(res_json["id"], 2)
+        self.assertEqual(res_json["album"], u"another album")
 
     def test_get_multiple_albums_by_id(self):
-        response = self.client.get('/album/1,2')
-        res_json = json.loads(response.data.decode('utf-8'))
+        response = self.client.get("/album/1,2")
+        res_json = json.loads(response.data.decode("utf-8"))
 
         self.assertEqual(response.status_code, 200)
-        response_albums = [album['album'] for album in res_json['albums']]
-        assertCountEqual(self, response_albums, [u'album', u'another album'])
+        response_albums = [album["album"] for album in res_json["albums"]]
+        assertCountEqual(self, response_albums, [u"album", u"another album"])
 
     def test_get_album_empty_query(self):
-        response = self.client.get('/album/query/')
-        res_json = json.loads(response.data.decode('utf-8'))
+        response = self.client.get("/album/query/")
+        res_json = json.loads(response.data.decode("utf-8"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(res_json['albums']), 2)
+        self.assertEqual(len(res_json["albums"]), 2)
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/test_zero.py
+++ b/test/test_zero.py
@@ -16,10 +16,10 @@ from beets.util import syspath
 class ZeroPluginTest(unittest.TestCase, TestHelper):
     def setUp(self):
         self.setup_beets()
-        self.config['zero'] = {
-            'fields': [],
-            'keep_fields': [],
-            'update_database': False,
+        self.config["zero"] = {
+            "fields": [],
+            "keep_fields": [],
+            "update_database": False,
         }
 
     def tearDown(self):
@@ -28,166 +28,154 @@ class ZeroPluginTest(unittest.TestCase, TestHelper):
         self.unload_plugins()
 
     def test_no_patterns(self):
-        self.config['zero']['fields'] = ['comments', 'month']
+        self.config["zero"]["fields"] = ["comments", "month"]
 
         item = self.add_item_fixture(
-            comments=u'test comment',
-            title=u'Title',
-            month=1,
-            year=2000,
+            comments=u"test comment", title=u"Title", month=1, year=2000,
         )
         item.write()
 
-        self.load_plugins('zero')
+        self.load_plugins("zero")
         item.write()
 
         mf = MediaFile(syspath(item.path))
         self.assertIsNone(mf.comments)
         self.assertIsNone(mf.month)
-        self.assertEqual(mf.title, u'Title')
+        self.assertEqual(mf.title, u"Title")
         self.assertEqual(mf.year, 2000)
 
     def test_pattern_match(self):
-        self.config['zero']['fields'] = ['comments']
-        self.config['zero']['comments'] = [u'encoded by']
+        self.config["zero"]["fields"] = ["comments"]
+        self.config["zero"]["comments"] = [u"encoded by"]
 
-        item = self.add_item_fixture(comments=u'encoded by encoder')
+        item = self.add_item_fixture(comments=u"encoded by encoder")
         item.write()
 
-        self.load_plugins('zero')
+        self.load_plugins("zero")
         item.write()
 
         mf = MediaFile(syspath(item.path))
         self.assertIsNone(mf.comments)
 
     def test_pattern_nomatch(self):
-        self.config['zero']['fields'] = ['comments']
-        self.config['zero']['comments'] = [u'encoded by']
+        self.config["zero"]["fields"] = ["comments"]
+        self.config["zero"]["comments"] = [u"encoded by"]
 
-        item = self.add_item_fixture(comments=u'recorded at place')
+        item = self.add_item_fixture(comments=u"recorded at place")
         item.write()
 
-        self.load_plugins('zero')
+        self.load_plugins("zero")
         item.write()
 
         mf = MediaFile(syspath(item.path))
-        self.assertEqual(mf.comments, u'recorded at place')
+        self.assertEqual(mf.comments, u"recorded at place")
 
     def test_do_not_change_database(self):
-        self.config['zero']['fields'] = ['year']
+        self.config["zero"]["fields"] = ["year"]
 
         item = self.add_item_fixture(year=2000)
         item.write()
 
-        self.load_plugins('zero')
+        self.load_plugins("zero")
         item.write()
 
-        self.assertEqual(item['year'], 2000)
+        self.assertEqual(item["year"], 2000)
 
     def test_change_database(self):
-        self.config['zero']['fields'] = ['year']
-        self.config['zero']['update_database'] = True
+        self.config["zero"]["fields"] = ["year"]
+        self.config["zero"]["update_database"] = True
 
         item = self.add_item_fixture(year=2000)
         item.write()
 
-        self.load_plugins('zero')
+        self.load_plugins("zero")
         item.write()
 
-        self.assertEqual(item['year'], 0)
+        self.assertEqual(item["year"], 0)
 
     def test_album_art(self):
-        self.config['zero']['fields'] = ['images']
+        self.config["zero"]["fields"] = ["images"]
 
-        path = self.create_mediafile_fixture(images=['jpg'])
+        path = self.create_mediafile_fixture(images=["jpg"])
         item = Item.from_path(path)
 
-        self.load_plugins('zero')
+        self.load_plugins("zero")
         item.write()
 
         mf = MediaFile(syspath(path))
         self.assertEqual(0, len(mf.images))
 
     def test_auto_false(self):
-        self.config['zero']['fields'] = ['year']
-        self.config['zero']['update_database'] = True
-        self.config['zero']['auto'] = False
+        self.config["zero"]["fields"] = ["year"]
+        self.config["zero"]["update_database"] = True
+        self.config["zero"]["auto"] = False
 
         item = self.add_item_fixture(year=2000)
         item.write()
 
-        self.load_plugins('zero')
+        self.load_plugins("zero")
         item.write()
 
-        self.assertEqual(item['year'], 2000)
+        self.assertEqual(item["year"], 2000)
 
     def test_subcommand_update_database_true(self):
         item = self.add_item_fixture(
-            year=2016,
-            day=13,
-            month=3,
-            comments=u'test comment'
+            year=2016, day=13, month=3, comments=u"test comment"
         )
         item.write()
         item_id = item.id
-        self.config['zero']['fields'] = ['comments']
-        self.config['zero']['update_database'] = True
-        self.config['zero']['auto'] = False
+        self.config["zero"]["fields"] = ["comments"]
+        self.config["zero"]["update_database"] = True
+        self.config["zero"]["auto"] = False
 
-        self.load_plugins('zero')
-        with control_stdin('y'):
-            self.run_command('zero')
+        self.load_plugins("zero")
+        with control_stdin("y"):
+            self.run_command("zero")
 
         mf = MediaFile(syspath(item.path))
         item = self.lib.get_item(item_id)
 
-        self.assertEqual(item['year'], 2016)
+        self.assertEqual(item["year"], 2016)
         self.assertEqual(mf.year, 2016)
         self.assertEqual(mf.comments, None)
-        self.assertEqual(item['comments'], u'')
+        self.assertEqual(item["comments"], u"")
 
     def test_subcommand_update_database_false(self):
         item = self.add_item_fixture(
-            year=2016,
-            day=13,
-            month=3,
-            comments=u'test comment'
+            year=2016, day=13, month=3, comments=u"test comment"
         )
         item.write()
         item_id = item.id
 
-        self.config['zero']['fields'] = ['comments']
-        self.config['zero']['update_database'] = False
-        self.config['zero']['auto'] = False
+        self.config["zero"]["fields"] = ["comments"]
+        self.config["zero"]["update_database"] = False
+        self.config["zero"]["auto"] = False
 
-        self.load_plugins('zero')
-        with control_stdin('y'):
-            self.run_command('zero')
+        self.load_plugins("zero")
+        with control_stdin("y"):
+            self.run_command("zero")
 
         mf = MediaFile(syspath(item.path))
         item = self.lib.get_item(item_id)
 
-        self.assertEqual(item['year'], 2016)
+        self.assertEqual(item["year"], 2016)
         self.assertEqual(mf.year, 2016)
-        self.assertEqual(item['comments'], u'test comment')
+        self.assertEqual(item["comments"], u"test comment")
         self.assertEqual(mf.comments, None)
 
     def test_subcommand_query_include(self):
         item = self.add_item_fixture(
-            year=2016,
-            day=13,
-            month=3,
-            comments=u'test comment'
+            year=2016, day=13, month=3, comments=u"test comment"
         )
 
         item.write()
 
-        self.config['zero']['fields'] = ['comments']
-        self.config['zero']['update_database'] = False
-        self.config['zero']['auto'] = False
+        self.config["zero"]["fields"] = ["comments"]
+        self.config["zero"]["update_database"] = False
+        self.config["zero"]["auto"] = False
 
-        self.load_plugins('zero')
-        self.run_command('zero', 'year: 2016')
+        self.load_plugins("zero")
+        self.run_command("zero", "year: 2016")
 
         mf = MediaFile(syspath(item.path))
 
@@ -196,25 +184,22 @@ class ZeroPluginTest(unittest.TestCase, TestHelper):
 
     def test_subcommand_query_exclude(self):
         item = self.add_item_fixture(
-            year=2016,
-            day=13,
-            month=3,
-            comments=u'test comment'
+            year=2016, day=13, month=3, comments=u"test comment"
         )
 
         item.write()
 
-        self.config['zero']['fields'] = ['comments']
-        self.config['zero']['update_database'] = False
-        self.config['zero']['auto'] = False
+        self.config["zero"]["fields"] = ["comments"]
+        self.config["zero"]["update_database"] = False
+        self.config["zero"]["auto"] = False
 
-        self.load_plugins('zero')
-        self.run_command('zero', 'year: 0000')
+        self.load_plugins("zero")
+        self.run_command("zero", "year: 0000")
 
         mf = MediaFile(syspath(item.path))
 
         self.assertEqual(mf.year, 2016)
-        self.assertEqual(mf.comments, u'test comment')
+        self.assertEqual(mf.comments, u"test comment")
 
     def test_no_fields(self):
         item = self.add_item_fixture(year=2016)
@@ -224,13 +209,13 @@ class ZeroPluginTest(unittest.TestCase, TestHelper):
 
         item_id = item.id
 
-        self.load_plugins('zero')
-        with control_stdin('y'):
-            self.run_command('zero')
+        self.load_plugins("zero")
+        with control_stdin("y"):
+            self.run_command("zero")
 
         item = self.lib.get_item(item_id)
 
-        self.assertEqual(item['year'], 2016)
+        self.assertEqual(item["year"], 2016)
         self.assertEqual(mediafile.year, 2016)
 
     def test_whitelist_and_blacklist(self):
@@ -240,80 +225,78 @@ class ZeroPluginTest(unittest.TestCase, TestHelper):
         self.assertEqual(mf.year, 2016)
 
         item_id = item.id
-        self.config['zero']['fields'] = [u'year']
-        self.config['zero']['keep_fields'] = [u'comments']
+        self.config["zero"]["fields"] = [u"year"]
+        self.config["zero"]["keep_fields"] = [u"comments"]
 
-        self.load_plugins('zero')
-        with control_stdin('y'):
-            self.run_command('zero')
+        self.load_plugins("zero")
+        with control_stdin("y"):
+            self.run_command("zero")
 
         item = self.lib.get_item(item_id)
 
-        self.assertEqual(item['year'], 2016)
+        self.assertEqual(item["year"], 2016)
         self.assertEqual(mf.year, 2016)
 
     def test_keep_fields(self):
-        item = self.add_item_fixture(year=2016, comments=u'test comment')
-        self.config['zero']['keep_fields'] = [u'year']
-        self.config['zero']['fields'] = None
-        self.config['zero']['update_database'] = True
+        item = self.add_item_fixture(year=2016, comments=u"test comment")
+        self.config["zero"]["keep_fields"] = [u"year"]
+        self.config["zero"]["fields"] = None
+        self.config["zero"]["update_database"] = True
 
         tags = {
-            'comments': u'test comment',
-            'year': 2016,
+            "comments": u"test comment",
+            "year": 2016,
         }
-        self.load_plugins('zero')
+        self.load_plugins("zero")
 
         z = ZeroPlugin()
         z.write_event(item, item.path, tags)
-        self.assertEqual(tags['comments'], None)
-        self.assertEqual(tags['year'], 2016)
+        self.assertEqual(tags["comments"], None)
+        self.assertEqual(tags["year"], 2016)
 
     def test_keep_fields_removes_preserved_tags(self):
-        self.config['zero']['keep_fields'] = [u'year']
-        self.config['zero']['fields'] = None
-        self.config['zero']['update_database'] = True
+        self.config["zero"]["keep_fields"] = [u"year"]
+        self.config["zero"]["fields"] = None
+        self.config["zero"]["update_database"] = True
 
         z = ZeroPlugin()
 
-        self.assertNotIn('id', z.fields_to_progs)
+        self.assertNotIn("id", z.fields_to_progs)
 
     def test_fields_removes_preserved_tags(self):
-        self.config['zero']['fields'] = [u'year id']
-        self.config['zero']['update_database'] = True
+        self.config["zero"]["fields"] = [u"year id"]
+        self.config["zero"]["update_database"] = True
 
         z = ZeroPlugin()
 
-        self.assertNotIn('id', z.fields_to_progs)
+        self.assertNotIn("id", z.fields_to_progs)
 
     def test_empty_query_n_response_no_changes(self):
         item = self.add_item_fixture(
-            year=2016,
-            day=13,
-            month=3,
-            comments=u'test comment'
+            year=2016, day=13, month=3, comments=u"test comment"
         )
         item.write()
         item_id = item.id
-        self.config['zero']['fields'] = ['comments']
-        self.config['zero']['update_database'] = True
-        self.config['zero']['auto'] = False
+        self.config["zero"]["fields"] = ["comments"]
+        self.config["zero"]["update_database"] = True
+        self.config["zero"]["auto"] = False
 
-        self.load_plugins('zero')
-        with control_stdin('n'):
-            self.run_command('zero')
+        self.load_plugins("zero")
+        with control_stdin("n"):
+            self.run_command("zero")
 
         mf = MediaFile(syspath(item.path))
         item = self.lib.get_item(item_id)
 
-        self.assertEqual(item['year'], 2016)
+        self.assertEqual(item["year"], 2016)
         self.assertEqual(mf.year, 2016)
-        self.assertEqual(mf.comments, u'test comment')
-        self.assertEqual(item['comments'], u'test comment')
+        self.assertEqual(mf.comments, u"test comment")
+        self.assertEqual(item["comments"], u"test comment")
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/test/testall.py
+++ b/test/testall.py
@@ -22,7 +22,7 @@ import re
 import sys
 import unittest
 
-pkgpath = os.path.dirname(os.path.dirname(os.path.realpath(__file__))) or '..'
+pkgpath = os.path.dirname(os.path.dirname(os.path.realpath(__file__))) or ".."
 sys.path.insert(0, pkgpath)
 
 
@@ -30,13 +30,13 @@ def suite():
     s = unittest.TestSuite()
     # Get the suite() of every module in this directory beginning with
     # "test_".
-    for fname in os.listdir(os.path.join(pkgpath, 'test')):
-        match = re.match(r'(test_\S+)\.py$', fname)
+    for fname in os.listdir(os.path.join(pkgpath, "test")):
+        match = re.match(r"(test_\S+)\.py$", fname)
         if match:
             modname = match.group(1)
             s.addTest(__import__(modname).suite())
     return s
 
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='suite')
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ deps = .[test]
 
 [_lint]
 deps = .[lint]
-files = beets beetsplug beet test setup.py docs
 
 [testenv]
 deps =
@@ -20,7 +19,7 @@ deps =
 commands =
     test: python -bb -m pytest {posargs}
     cov: coverage run -m pytest {posargs}
-    lint: python -m flake8 {posargs} {[_lint]files}
+    lint: pre-commit run -a
 
 [testenv:docs]
 basepython = python2.7


### PR DESCRIPTION
## Description

[See discussion](https://discourse.beets.io/t/switching-to-using-a-universal-code-formatter/1431/5)

* Adds black a universal and automatic code formatter
* black is now enforced via an optional pre-commit hook (see below)
* flake8 is now included in that hook
* `tox -e lint` now runs `pre-commit run -a` (see below)

To add this to your workflow, I recommend creating a [git hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) with [pre-commit](https://pre-commit.com/). Note that this is optional and you can just run the checks as normal with `tox -e lint` if you don't want the hooks in your git workflow. Another option, if you don't want to run the hooks for some reason on any particular commit, you can use `git commit -n [--no-verify]`

To install the hook run `pre-commit install`. This will now enforce black and flake8 prior to completing the commit. It will only check files that were commited, so the performance hit isn't an issue.

Example workflow for a compliant commit:
```bash
$ git commit
black....................................................................Passed
flake8...................................................................Passed
[black 0ab1ef45] good commit
 1 file changed, 1 insertion(+), 1 deletion(-)
```

Example for a commit that is not compliant with the lint checks:
```bash
$ git commit
black....................................................................Failed
- hook id: black
- files were modified by this hook

reformatted setup.py
All done! ✨ 🍰 ✨
1 file reformatted.

flake8...................................................................Passed
```
Note that since it was a formatting issue, black will automatically apply the changes. However, you will need to re-stage and attempt the commit again. These checks will occur prior to writing the commit message if you don't use `git commit -m`.


To run the linting commands normally on all files (does not require the `pre-commit install` command) run `pre-commit run -a`. This is now exactly what `tox -e lint` will do.

Edit: this would also significantly affect https://github.com/beetbox/beets/pull/3673 as a lot of those changes would no longer be required.
 

## To Do

- [ ] Documentation - add info to CONTRIBUTING.rst
