### PR TITLE
Transition to pathlib

### DIFF
--- a/beets/util/path.py
+++ b/beets/util/path.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-  # noqa: FI
+# This file is part of beets.
+# Copyright 2016, Adrian Sampson.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""Utility functions for paths."""


### PR DESCRIPTION
## Description

Works towards implementing pathlib everywhere https://github.com/beetbox/beets/issues/1409

An in progress pathlib implementation. My goal for this is to incrementally transition modules/plugins to using pathlib and the new path module over current methods. I don't expect pathlib to be used "everywhere" by the time this PR is able to be merged. This code should live alongside the existing path logic until all modules are fully transitioned.

The idea is also to create separate pull requests for each transition case to try and split up the review process. This branch should serve as a base for pathlib related code that has already been reviewed.

Implementation/Design Notes:

* I initially thought of just subclassing pathlib.Path and pathlib.PurePath to extend for relevant beets logic. This actually isn't easy(/possible?) due to the complex relationships inside the pathlib module. https://bugs.python.org/issue24132
* My current plan is to pass pathlib.PurePath objects around everywhere, converting to pathlib.Path objects if actual file operations are needed, and converting the objects to and from bytes for the database

## To Do

- [ ] Proof of concept - transition first module/plugin to pathlib and thoroughly test
- [ ] Documentation - advise new convention to use the path module and pathlib over current methods
- [ ] Tests

This pull request can be merged once python 2.7, 3.4, and 3.5 support are dropped (with v1.5.0) and the above checks are completed.
