### PR TITLE
Notify Zulip chat on integration test failure

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -39,6 +39,6 @@ jobs:
           curl -X POST https://beets.zulipchat.com/api/v1/messages \
             -u "${ZULIP_BOT_CREDENTIALS}" \
             -d "type=stream" \
-            -d "to=general" \
+            -d "to=github" \
             -d "subject=${GITHUB_WORKFLOW} - $(date -u +%Y-%m-%d)" \
             -d "content=[${GITHUB_WORKFLOW}#${GITHUB_RUN_NUMBER}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) failed."

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -25,3 +25,20 @@ jobs:
       - name: Test with tox
         run: |
           tox -e int
+
+      - name: Notify on failure
+        if: ${{ failure() }}
+        env:
+          ZULIP_BOT_CREDENTIALS: ${{ secrets.ZULIP_BOT_CREDENTIALS }}
+        run: |
+          if [ -z "${ZULIP_BOT_CREDENTIALS}" ]; then
+            echo "Skipping notify, ZULIP_BOT_CREDENTIALS is unset"
+            exit 0
+          fi
+
+          curl -X POST https://beets.zulipchat.com/api/v1/messages \
+            -u "${ZULIP_BOT_CREDENTIALS}" \
+            -d "type=stream" \
+            -d "to=general" \
+            -d "subject=${GITHUB_WORKFLOW} - $(date -u +%Y-%m-%d)" \
+            -d "content=[${GITHUB_WORKFLOW}#${GITHUB_RUN_NUMBER}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) failed."


### PR DESCRIPTION
## Description

This PR adds a step to our integration tests to send a message to our Zulip instance if the tests fail:

![Zulip screenshot](https://user-images.githubusercontent.com/1843197/89124990-0e389a80-d4d3-11ea-9ed9-2161f28d0cf9.png)

I've currently configured the step to post to #general, but @jtpavlock has suggested we create a new #github stream for this instead (which sounds good to me).

To set up this bot properly, someone on our Zulip instance (preferably @sampsyo) will need to create a bot by going to `Settings → Your bots`, and then set the `ZULIP_BOT_CREDENTIALS` GitHub secret to `bot email:api key`.

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
