### PR TITLE
Skip Genius integration test on GitHub actions

### DIFF
--- a/test/test_lyrics.py
+++ b/test/test_lyrics.py
@@ -330,7 +330,12 @@ class LyricsPluginSourcesTest(LyricsGoogleBaseTest):
         """Test default backends with songs known to exist in respective databases.
         """
         errors = []
-        for s in self.DEFAULT_SOURCES:
+        # GitHub actions seems to be on a Cloudflare blacklist, so we can't
+        # contact genius.
+        sources = [s for s in self.DEFAULT_SOURCES if
+                   s['backend'] != lyrics.Genius or
+                   os.environ.get('GITHUB_ACTIONS') != 'true']
+        for s in sources:
             res = s['backend'](self.plugin.config, self.plugin._log).fetch(
                 s['artist'], s['title'])
             if not is_lyrics_content_ok(s['title'], res):

--- a/tox.ini
+++ b/tox.ini
@@ -30,4 +30,5 @@ commands = sphinx-build -W -q -b html docs {envtmpdir}/html {posargs}
 [testenv:int]
 deps = {[_test]deps}
 setenv = INTEGRATION_TEST = 1
+passenv = GITHUB_ACTIONS
 commands = python -bb -m pytest {posargs}


### PR DESCRIPTION
## Description

Genius seems to be using Cloudflare, which blocks requests from GitHub actions. I've disabled Genius on GitHub actions in this PR, which allows our integration tests to pass.

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
