### PR TITLE
Add flake8 problem matcher

### DIFF
--- a/.github/flake8-problem-matcher.json
+++ b/.github/flake8-problem-matcher.json
@@ -4,12 +4,11 @@
             "owner": "flake8",
             "pattern": [
                 {
-                    "regexp": "^(.*?):(\\d+):(\\d+): ([^ ]+) (.*)$",
+                    "regexp": "^(.*?):(\\d+):(\\d+): (.*)$",
                     "file": 1,
                     "line": 2,
                     "column": 3,
-                    "code": 4,
-                    "message": 5
+                    "message": 4
                 }
             ]
         }

--- a/.github/flake8-problem-matcher.json
+++ b/.github/flake8-problem-matcher.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "flake8",
+            "pattern": [
+                {
+                    "regexp": "^(.*?):(\\d+):(\\d+): ([^ ]+) (.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "code": 4,
+                    "message": 5
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,9 +65,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
-    env:
-      PY_COLORS: 1
-
     steps:
       - uses: actions/checkout@v2
 
@@ -80,6 +77,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install tox sphinx
+
+      - name: Add problem matcher
+        run: echo "::add-matcher::.github/flake8-problem-matcher.json"
 
       - name: Lint with flake8
         run: tox -e py-lint


### PR DESCRIPTION
## Description

This PR implements the flake8 half of #3614 using a [problem matcher](https://github.com/actions/toolkit/blob/1cc56db0ff126f4d65aeb83798852e02a2c180c3/docs/problem-matchers.md), giving us nice inline errors like this on PRs:

![inline error](https://user-images.githubusercontent.com/1843197/89132697-e6b2f380-d50d-11ea-8a97-97357d0f8969.png)

I've had to disable `PY_COLORS` here, as the ANSI escape sequences were tripping up the regex used in the matcher.

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
