### PR TITLE
Add sphinx problem matcher

### DIFF
--- a/.github/sphinx-problem-matcher.json
+++ b/.github/sphinx-problem-matcher.json
@@ -1,0 +1,18 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "sphinx",
+            "pattern": [
+                {
+                    "regexp": "^Warning, treated as error:$"
+                },
+                {
+                    "regexp": "^(.*?):(\\d+):(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "message": 3
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,9 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install tox sphinx
 
+      - name: Add problem matcher
+        run: echo "::add-matcher::.github/sphinx-problem-matcher.json"
+
       - name: Build and check docs using tox
         run: tox -e docs
 


### PR DESCRIPTION
## Description

Fixes #3614. This PR implements the remaining sphinx half of #3614 using another problem matcher, giving us more nice inline errors like this on PRs:

![inline error](https://user-images.githubusercontent.com/1843197/89182346-777ce400-d58d-11ea-9e78-683860f6227b.png)

Oddly enough, it seems like the errors reported by sphinx are for the first line of the paragraph containing the error, instead of the actual line of the error:

![weird error positioning](https://user-images.githubusercontent.com/1843197/89182457-ac893680-d58d-11ea-806a-42ea996ca68e.png)

I don't know if there's much we can do about this, as it looks like it's a problem with sphinx itself.

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
