### PR TITLE
mpdstats: Don't record a skip when stopping MPD.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -245,6 +245,10 @@ Fixes:
 * Fix a bug that caused metadata starting with something resembling a drive
   letter to be incorrectly split into an extra directory after the colon.
   :bug:`3685`
+* :doc:`/plugins/mpdstats`: Don't record a skip when stopping MPD, as MPD keeps
+  the current track in the queue.
+  Thanks to :user:`aereaux`.
+  :bug:`3722`
 
 For plugin developers:
 

--- a/test/test_mpdstats.py
+++ b/test/test_mpdstats.py
@@ -62,10 +62,11 @@ class MPDStatsTest(unittest.TestCase, TestHelper):
                 {'state': u'stop'}]
     EVENTS = [["player"]] * (len(STATUSES) - 1) + [KeyboardInterrupt]
     item_path = util.normpath('/foo/bar.flac')
+    songid = 1
 
     @patch("beetsplug.mpdstats.MPDClientWrapper", return_value=Mock(**{
         "events.side_effect": EVENTS, "status.side_effect": STATUSES,
-        "currentsong.return_value": item_path}))
+        "currentsong.return_value": (item_path, songid)}))
     def test_run_mpdstats(self, mpd_mock):
         item = Item(title=u'title', path=self.item_path, id=1)
         item.add(self.lib)


### PR DESCRIPTION
## Description

MPD keeps the current track in the queue when stopping, so it's not
really like a skip, and I use it so that I can stop the music, and later
start at the beginning of a track.

I do this by keeping track of the current song id, and then comparing
them when we receive a stop signal.

Fixes #3722 .  <!-- Insert issue number here if applicable. -->

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
