### PR TITLE
Update file metadata after generating fingerprints through the `submit` command.

### DIFF
--- a/beetsplug/chroma.py
+++ b/beetsplug/chroma.py
@@ -279,7 +279,7 @@ def submit_items(log, userkey, items, chunksize=64):
         del data[:]
 
     for item in items:
-        fp = fingerprint_item(log, item)
+        fp = fingerprint_item(log, item, write=ui.should_write())
 
         # Construct a submission dictionary for this item.
         item_data = {

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 
 New features:
 
+* :doc:`/plugins/chroma`: Update file metadata after generating fingerprints through the `submit` command.
 * :doc:`/plugins/lastgenre`: Added more heavy metal genres: https://en.wikipedia.org/wiki/Heavy_metal_genres to genres.txt and genres-tree.yaml
 * :doc:`/plugins/subsonicplaylist`: import playlist from a subsonic server.
 * A new :ref:`extra_tags` configuration option allows more tagged metadata


### PR DESCRIPTION
This should be pretty self-explanatory.
I noticed that the file metadata was only updated when I used the `fingerprint` command, but not if I used the `submit` command and it generated the fingerprints while doing so. In the latter case, the database was updated, but the files were only updated after I ran `write` afterwards.
I must admit that I'm not fully sure if this is the intended behavior or not, but I thought creating this Pull Request shouldn't hurt, seeing as I fully expected its behavior to stay the same (i.e. to update the file after updating the database), regardless of whether it was triggered directly by `fingerprint` or indirectly via `submit`.

This PR makes the third argument match [this one](https://github.com/beetbox/beets/blob/06e7453a6066813edc68f888aab0e3e5806b6db7/beetsplug/chroma.py#L236).