### PR TITLE
Added flac-specific samplerate-bitdepth reporting for duplicate imports

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -465,9 +465,13 @@ def summarize_items(items, singleton):
 
     if items:
         average_bitrate = sum([item.bitrate for item in items]) / len(items)
+        if items[0].format == "FLAC":
+            sample_bits = u'{}kHz/{} bit'.format(items[0].samplerate, items[0].bitdepth)
         total_duration = sum([item.length for item in items])
         total_filesize = sum([item.filesize for item in items])
         summary_parts.append(u'{0}kbps'.format(int(average_bitrate / 1000)))
+        if items[0].format == "FLAC":
+            summary_parts.append(sample_bits)
         summary_parts.append(ui.human_seconds_short(total_duration))
         summary_parts.append(ui.human_bytes(total_filesize))
 

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -465,13 +465,12 @@ def summarize_items(items, singleton):
 
     if items:
         average_bitrate = sum([item.bitrate for item in items]) / len(items)
-        if items[0].format == "FLAC":
-            sample_bits = u'{}kHz/{} bit'.format(
-                round(int(items[0].samplerate) / 1000, 1), items[0].bitdepth)
         total_duration = sum([item.length for item in items])
         total_filesize = sum([item.filesize for item in items])
         summary_parts.append(u'{0}kbps'.format(int(average_bitrate / 1000)))
         if items[0].format == "FLAC":
+            sample_bits = u'{}kHz/{} bit'.format(
+                round(int(items[0].samplerate) / 1000, 1), items[0].bitdepth)
             summary_parts.append(sample_bits)
         summary_parts.append(ui.human_seconds_short(total_duration))
         summary_parts.append(ui.human_bytes(total_filesize))

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -466,7 +466,8 @@ def summarize_items(items, singleton):
     if items:
         average_bitrate = sum([item.bitrate for item in items]) / len(items)
         if items[0].format == "FLAC":
-            sample_bits = u'{}kHz/{} bit'.format(items[0].samplerate, items[0].bitdepth)
+            sample_bits = u'{}kHz/{} bit'.format(
+                round(int(items[0].samplerate) / 1000, 1), items[0].bitdepth)
         total_duration = sum([item.length for item in items])
         total_filesize = sum([item.filesize for item in items])
         summary_parts.append(u'{0}kbps'.format(int(average_bitrate / 1000)))

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -147,6 +147,7 @@ New features:
   be deleted after importing.
   Thanks to :user:`logan-arens`.
   :bug:`2947`
+* Added flac-specific reporting of samplerate and bitrate when importing duplicates.
 
 Fixes:
 


### PR DESCRIPTION
## Description
When importing duplicate flac files, it is often less important what the bitrate is and more important the sample rate and bit depth. My change adds this for flac files for convenience

## To Do

- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
