### PR TITLE
fetchart: Improve Cover Art Archive source.

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -319,7 +319,7 @@ class CoverArtArchive(RemoteArtSource):
         using album MusicBrainz release ID and release group ID.
         """
 
-        def get_image_url(url, size_suffix=None):
+        def get_image_urls(url, size_suffix=None):
             try:
                 response = self.request(url)
             except requests.RequestException:
@@ -340,9 +340,9 @@ class CoverArtArchive(RemoteArtSource):
                         continue
 
                     if size_suffix:
-                        return item['thumbnails'][size_suffix]
-
-                    return item['image']
+                        yield item['thumbnails'][size_suffix]
+                    else:
+                        yield item['image']
 
         release_url = self.URL.format(mbid=album.mb_albumid)
         release_group_url = self.GROUP_URL.format(mbid=album.mb_releasegroupid)
@@ -356,12 +356,12 @@ class CoverArtArchive(RemoteArtSource):
             size_suffix = "-" + str(plugin.maxwidth)
 
         if 'release' in self.match_by and album.mb_albumid:
-            url = get_image_url(release_url, size_suffix)
-            yield self._candidate(url=url, match=Candidate.MATCH_EXACT)
+            for url in get_image_urls(release_url, size_suffix):
+                yield self._candidate(url=url, match=Candidate.MATCH_EXACT)
 
         if 'releasegroup' in self.match_by and album.mb_releasegroupid:
-            url = get_image_url(release_group_url)
-            yield self._candidate(url=url, match=Candidate.MATCH_FALLBACK)
+            for url in get_image_urls(release_group_url):
+                yield self._candidate(url=url, match=Candidate.MATCH_FALLBACK)
 
 
 class Amazon(RemoteArtSource):

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -336,7 +336,7 @@ class CoverArtArchive(RemoteArtSource):
 
             if 'images' in data.keys():
                 for item in data['images']:
-                    if not item['front']:
+                    if 'Front' not in item['types']:
                         continue
 
                     if size_suffix:

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -334,8 +334,8 @@ class CoverArtArchive(RemoteArtSource):
                                 .format(self.NAME, response.text))
                 return
 
-            if 'images' in data.keys():
-                for item in data['images']:
+            for item in data.get('images', []):
+                try:
                     if 'Front' not in item['types']:
                         continue
 
@@ -343,6 +343,8 @@ class CoverArtArchive(RemoteArtSource):
                         yield item['thumbnails'][size_suffix]
                     else:
                         yield item['image']
+                except KeyError:
+                    pass
 
         release_url = self.URL.format(mbid=album.mb_albumid)
         release_group_url = self.GROUP_URL.format(mbid=album.mb_releasegroupid)

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -344,7 +344,6 @@ class CoverArtArchive(RemoteArtSource):
 
                     return item['image']
 
-
         release_url = self.URL.format(mbid=album.mb_albumid)
         release_group_url = self.GROUP_URL.format(mbid=album.mb_releasegroupid)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -148,6 +148,8 @@ New features:
   Thanks to :user:`logan-arens`.
   :bug:`2947`
 * Added flac-specific reporting of samplerate and bitrate when importing duplicates.
+* :doc:`/plugins/fetchart`: Cover Art Archive source now iterates over
+  all front images instead of blindly selecting the first one.
 
 Fixes:
 

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -404,9 +404,9 @@ class GoogleImageTest(UseThePlugin):
 class CoverArtArchiveTest(UseThePlugin):
     MBID = 'rid'
     RELEASE_URL = 'coverartarchive.org/release/{0}' \
-              .format(MBID)
+                  .format(MBID)
     GROUP_URL = 'coverartarchive.org/release-group/{0}' \
-              .format(MBID)
+                .format(MBID)
     RESPONSE_RELEASE = """{
     "images": [
       {
@@ -487,7 +487,6 @@ class CoverArtArchiveTest(UseThePlugin):
             self.RELEASE_URL = "http://" + self.RELEASE_URL
             self.GROUP_URL = "http://" + self.GROUP_URL
 
-
     @responses.activate
     def run(self, *args, **kwargs):
         super(CoverArtArchiveTest, self).run(*args, **kwargs)
@@ -501,7 +500,8 @@ class CoverArtArchiveTest(UseThePlugin):
         self.mock_response(self.RELEASE_URL, self.RESPONSE_RELEASE)
         self.mock_response(self.GROUP_URL, self.RESPONSE_GROUP)
         candidate = next(self.source.get(album, self.settings, []))
-        self.assertEqual(candidate.url, 'http://coverartarchive.org/release/rid/12345.gif')
+        self.assertEqual(candidate.url,
+                         'http://coverartarchive.org/release/rid/12345.gif')
 
 
 class FanartTVTest(UseThePlugin):

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -402,11 +402,12 @@ class GoogleImageTest(UseThePlugin):
 
 
 class CoverArtArchiveTest(UseThePlugin):
-    MBID = 'rid'
+    MBID_RELASE = 'rid'
+    MBID_GROUP = 'rgid'
     RELEASE_URL = 'coverartarchive.org/release/{0}' \
-                  .format(MBID)
+                  .format(MBID_RELASE)
     GROUP_URL = 'coverartarchive.org/release-group/{0}' \
-                .format(MBID)
+                .format(MBID_GROUP)
     RESPONSE_RELEASE = """{
     "images": [
       {
@@ -496,7 +497,8 @@ class CoverArtArchiveTest(UseThePlugin):
                       content_type='application/json')
 
     def test_caa_finds_image(self):
-        album = _common.Bag(mb_albumid=self.MBID, mb_releasegroupid=self.MBID)
+        album = _common.Bag(mb_albumid=self.MBID_RELASE,
+                            mb_releasegroupid=self.MBID_GROUP)
         self.mock_response(self.RELEASE_URL, self.RESPONSE_RELEASE)
         self.mock_response(self.GROUP_URL, self.RESPONSE_GROUP)
         candidate = next(self.source.get(album, self.settings, []))

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -76,6 +76,96 @@ class FetchImageHelper(_common.TestCase):
                           file_type, b'').ljust(32, b'\x00'))
 
 
+class CAAHelper():
+    """Helper mixin for mocking requests to the Cover Art Archive."""
+    MBID_RELASE = 'rid'
+    MBID_GROUP = 'rgid'
+
+    RELEASE_URL = 'coverartarchive.org/release/{0}' \
+                  .format(MBID_RELASE)
+    GROUP_URL = 'coverartarchive.org/release-group/{0}' \
+                .format(MBID_GROUP)
+
+    if util.SNI_SUPPORTED:
+        RELEASE_URL = "https://" + RELEASE_URL
+        GROUP_URL = "https://" + GROUP_URL
+    else:
+        RELEASE_URL = "http://" + RELEASE_URL
+        GROUP_URL = "http://" + GROUP_URL
+
+    RESPONSE_RELEASE = """{
+    "images": [
+      {
+        "approved": false,
+        "back": false,
+        "comment": "GIF",
+        "edit": 12345,
+        "front": true,
+        "id": 12345,
+        "image": "http://coverartarchive.org/release/rid/12345.gif",
+        "thumbnails": {
+          "1200": "http://coverartarchive.org/release/rid/12345-1200.jpg",
+          "250": "http://coverartarchive.org/release/rid/12345-250.jpg",
+          "500": "http://coverartarchive.org/release/rid/12345-500.jpg",
+          "large": "http://coverartarchive.org/release/rid/12345-500.jpg",
+          "small": "http://coverartarchive.org/release/rid/12345-250.jpg"
+        },
+        "types": [
+          "Front"
+        ]
+      },
+      {
+        "approved": false,
+        "back": false,
+        "comment": "",
+        "edit": 12345,
+        "front": false,
+        "id": 12345,
+        "image": "http://coverartarchive.org/release/rid/12345.jpg",
+        "thumbnails": {
+          "1200": "http://coverartarchive.org/release/rid/12345-1200.jpg",
+          "250": "http://coverartarchive.org/release/rid/12345-250.jpg",
+          "500": "http://coverartarchive.org/release/rid/12345-500.jpg",
+          "large": "http://coverartarchive.org/release/rid/12345-500.jpg",
+          "small": "http://coverartarchive.org/release/rid/12345-250.jpg"
+        },
+        "types": [
+          "Front"
+        ]
+      }
+    ],
+    "release": "https://musicbrainz.org/release/releaseid"
+}"""
+    RESPONSE_GROUP = """{
+        "images": [
+          {
+            "approved": false,
+            "back": false,
+            "comment": "",
+            "edit": 12345,
+            "front": true,
+            "id": 12345,
+            "image": "http://coverartarchive.org/release/releaseid/12345.jpg",
+            "thumbnails": {
+              "1200": "http://coverartarchive.org/release/rgid/12345-1200.jpg",
+              "250": "http://coverartarchive.org/release/rgid/12345-250.jpg",
+              "500": "http://coverartarchive.org/release/rgid/12345-500.jpg",
+              "large": "http://coverartarchive.org/release/rgid/12345-500.jpg",
+              "small": "http://coverartarchive.org/release/rgid/12345-250.jpg"
+            },
+            "types": [
+              "Front"
+            ]
+          }
+        ],
+        "release": "https://musicbrainz.org/release/release-id"
+    }"""
+
+    def mock_caa_response(self, url, json):
+        responses.add(responses.GET, url, body=json,
+                      content_type='application/json')
+
+
 class FetchImageTest(FetchImageHelper, UseThePlugin):
     URL = 'http://example.com/test.jpg'
 
@@ -156,7 +246,7 @@ class FSArtTest(UseThePlugin):
         self.assertEqual(candidates, paths)
 
 
-class CombinedTest(FetchImageHelper, UseThePlugin):
+class CombinedTest(FetchImageHelper, UseThePlugin, CAAHelper):
     ASIN = 'xxxx'
     MBID = 'releaseid'
     AMAZON_URL = 'https://images.amazon.com/images/P/{0}.01.LZZZZZZZ.jpg' \
@@ -207,6 +297,21 @@ class CombinedTest(FetchImageHelper, UseThePlugin):
         album = _common.Bag(asin=self.ASIN)
         self.plugin.art_for_album(album, [self.dpath])
         self.assertEqual(responses.calls[-1].request.url, self.AAO_URL)
+
+    def test_main_interface_uses_caa_when_mbid_available(self):
+        self.mock_caa_response(self.RELEASE_URL, self.RESPONSE_RELEASE)
+        self.mock_caa_response(self.GROUP_URL, self.RESPONSE_GROUP)
+        self.mock_response('http://coverartarchive.org/release/rid/12345.gif',
+                           content_type='image/gif')
+        self.mock_response('http://coverartarchive.org/release/rid/12345.jpg',
+                           content_type='image/jpeg')
+        album = _common.Bag(mb_albumid=self.MBID_RELASE,
+                            mb_releasegroupid=self.MBID_GROUP,
+                            asin=self.ASIN)
+        candidate = self.plugin.art_for_album(album, None)
+        self.assertIsNotNone(candidate)
+        self.assertEqual(len(responses.calls), 3)
+        self.assertEqual(responses.calls[0].request.url, self.RELEASE_URL)
 
     def test_local_only_does_not_access_network(self):
         album = _common.Bag(mb_albumid=self.MBID, asin=self.ASIN)
@@ -401,106 +506,22 @@ class GoogleImageTest(UseThePlugin):
             next(self.source.get(album, self.settings, []))
 
 
-class CoverArtArchiveTest(UseThePlugin):
-    MBID_RELASE = 'rid'
-    MBID_GROUP = 'rgid'
-    RELEASE_URL = 'coverartarchive.org/release/{0}' \
-                  .format(MBID_RELASE)
-    GROUP_URL = 'coverartarchive.org/release-group/{0}' \
-                .format(MBID_GROUP)
-    RESPONSE_RELEASE = """{
-    "images": [
-      {
-        "approved": false,
-        "back": false,
-        "comment": "GIF",
-        "edit": 12345,
-        "front": true,
-        "id": 12345,
-        "image": "http://coverartarchive.org/release/rid/12345.gif",
-        "thumbnails": {
-          "1200": "http://coverartarchive.org/release/rid/12345-1200.jpg",
-          "250": "http://coverartarchive.org/release/rid/12345-250.jpg",
-          "500": "http://coverartarchive.org/release/rid/12345-500.jpg",
-          "large": "http://coverartarchive.org/release/rid/12345-500.jpg",
-          "small": "http://coverartarchive.org/release/rid/12345-250.jpg"
-        },
-        "types": [
-          "Front"
-        ]
-      },
-      {
-        "approved": false,
-        "back": false,
-        "comment": "",
-        "edit": 12345,
-        "front": false,
-        "id": 12345,
-        "image": "http://coverartarchive.org/release/rid/12345.jpg",
-        "thumbnails": {
-          "1200": "http://coverartarchive.org/release/rid/12345-1200.jpg",
-          "250": "http://coverartarchive.org/release/rid/12345-250.jpg",
-          "500": "http://coverartarchive.org/release/rid/12345-500.jpg",
-          "large": "http://coverartarchive.org/release/rid/12345-500.jpg",
-          "small": "http://coverartarchive.org/release/rid/12345-250.jpg"
-        },
-        "types": [
-          "Front"
-        ]
-      }
-    ],
-    "release": "https://musicbrainz.org/release/releaseid"
-}"""
-    RESPONSE_GROUP = """{
-        "images": [
-          {
-            "approved": false,
-            "back": false,
-            "comment": "",
-            "edit": 12345,
-            "front": true,
-            "id": 12345,
-            "image": "http://coverartarchive.org/release/releaseid/12345.jpg",
-            "thumbnails": {
-              "1200": "http://coverartarchive.org/release/rgid/12345-1200.jpg",
-              "250": "http://coverartarchive.org/release/rgid/12345-250.jpg",
-              "500": "http://coverartarchive.org/release/rgid/12345-500.jpg",
-              "large": "http://coverartarchive.org/release/rgid/12345-500.jpg",
-              "small": "http://coverartarchive.org/release/rgid/12345-250.jpg"
-            },
-            "types": [
-              "Front"
-            ]
-          }
-        ],
-        "release": "https://musicbrainz.org/release/release-id"
-    }"""
+class CoverArtArchiveTest(UseThePlugin, CAAHelper):
 
     def setUp(self):
         super(CoverArtArchiveTest, self).setUp()
         self.source = fetchart.CoverArtArchive(logger, self.plugin.config)
         self.settings = Settings(maxwidth=0)
 
-        if util.SNI_SUPPORTED:
-            self.RELEASE_URL = "https://" + self.RELEASE_URL
-            self.GROUP_URL = "https://" + self.GROUP_URL
-        else:
-            self.RELEASE_URL = "http://" + self.RELEASE_URL
-            self.GROUP_URL = "http://" + self.GROUP_URL
-
     @responses.activate
     def run(self, *args, **kwargs):
         super(CoverArtArchiveTest, self).run(*args, **kwargs)
 
-    def mock_response(self, url, json):
-        responses.add(responses.GET, url, body=json,
-                      content_type='application/json')
-
     def test_caa_finds_image(self):
         album = _common.Bag(mb_albumid=self.MBID_RELASE,
                             mb_releasegroupid=self.MBID_GROUP)
-        self.mock_response(self.RELEASE_URL, self.RESPONSE_RELEASE)
-        self.mock_response(self.GROUP_URL, self.RESPONSE_GROUP)
+        self.mock_caa_response(self.RELEASE_URL, self.RESPONSE_RELEASE)
+        self.mock_caa_response(self.GROUP_URL, self.RESPONSE_GROUP)
         candidate = next(self.source.get(album, self.settings, []))
         self.assertIsNotNone(candidate)
         self.assertEqual(candidate.url,

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -500,8 +500,11 @@ class CoverArtArchiveTest(UseThePlugin):
         self.mock_response(self.RELEASE_URL, self.RESPONSE_RELEASE)
         self.mock_response(self.GROUP_URL, self.RESPONSE_GROUP)
         candidate = next(self.source.get(album, self.settings, []))
+        self.assertIsNotNone(candidate)
         self.assertEqual(candidate.url,
                          'http://coverartarchive.org/release/rid/12345.gif')
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(responses.calls[0].request.url, self.RELEASE_URL)
 
 
 class FanartTVTest(UseThePlugin):

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -522,11 +522,9 @@ class CoverArtArchiveTest(UseThePlugin, CAAHelper):
                             mb_releasegroupid=self.MBID_GROUP)
         self.mock_caa_response(self.RELEASE_URL, self.RESPONSE_RELEASE)
         self.mock_caa_response(self.GROUP_URL, self.RESPONSE_GROUP)
-        candidate = next(self.source.get(album, self.settings, []))
-        self.assertIsNotNone(candidate)
-        self.assertEqual(candidate.url,
-                         'http://coverartarchive.org/release/rid/12345.gif')
-        self.assertEqual(len(responses.calls), 1)
+        candidates = list(self.source.get(album, self.settings, []))
+        self.assertEqual(len(candidates), 3)
+        self.assertEqual(len(responses.calls), 2)
         self.assertEqual(responses.calls[0].request.url, self.RELEASE_URL)
 
 


### PR DESCRIPTION
Instead of blindly selecting the first image, we now treat all "front" images as candidates.

This is useful where some digital releases have both an animated cover and a still image and the animated image is the first image returned from the API.

Example release: https://musicbrainz.org/release/dc20e054-0177-4652-b6e7-fe0c193ea8dd