### PR TITLE
AURA: Add aura plugin and docs

### DIFF
--- a/beetsplug/aura.py
+++ b/beetsplug/aura.py
@@ -116,7 +116,7 @@ ARTIST_ATTR_MAP = {
     # Required
     "name": "artist",
     # Optional
-    "artist_mbid": "mb_artistid",
+    "artist-mbid": "mb_artistid",
 }
 
 

--- a/beetsplug/aura.py
+++ b/beetsplug/aura.py
@@ -896,6 +896,16 @@ def image_file(image_id):
 
 def create_app():
     """An application factory for use by a WSGI server."""
+    config["aura"].add(
+        {
+            "host": u"127.0.0.1",
+            "port": 8337,
+            "cors": [],
+            "cors_supports_credentials": False,
+            "page_limit": 500,
+        }
+    )
+
     app = Flask(__name__)
     # Register AURA blueprint view functions under a URL prefix
     app.register_blueprint(aura_bp, url_prefix="/aura")
@@ -935,15 +945,6 @@ class AURAPlugin(BeetsPlugin):
     def __init__(self):
         """Add configuration options for the AURA plugin."""
         super(AURAPlugin, self).__init__()
-        self.config.add(
-            {
-                "host": u"127.0.0.1",
-                "port": 8337,
-                "cors": [],
-                "cors_supports_credentials": False,
-                "page_limit": 500,
-            }
-        )
 
     def commands(self):
         """Add subcommand used to run the AURA server."""

--- a/beetsplug/aura.py
+++ b/beetsplug/aura.py
@@ -394,7 +394,7 @@ class TrackDocument(AURADocument):
             return self.error(
                 "404 Not Found",
                 "No track with the requested id.",
-                ("There is no track with an id of {} in the library.").format(
+                "There is no track with an id of {} in the library.".format(
                     track_id
                 ),
             )
@@ -492,7 +492,7 @@ class AlbumDocument(AURADocument):
             return self.error(
                 "404 Not Found",
                 "No album with the requested id.",
-                ("There is no album with an id of {} in the library.").format(
+                "There is no album with an id of {} in the library.".format(
                     album_id
                 ),
             )
@@ -591,7 +591,7 @@ class ArtistDocument(AURADocument):
             return self.error(
                 "404 Not Found",
                 "No artist with the requested id.",
-                ("There is no artist with an id of {} in the library.").format(
+                "There is no artist with an id of {} in the library.".format(
                     artist_id
                 ),
             )
@@ -696,7 +696,7 @@ class ImageDocument(AURADocument):
             return self.error(
                 "404 Not Found",
                 "No image with the requested id.",
-                ("There is no image with an id of {} in the library.").format(
+                "There is no image with an id of {} in the library.".format(
                     image_id
                 ),
             )
@@ -746,7 +746,7 @@ def audio_file(track_id):
         return AURADocument.error(
             "404 Not Found",
             "No track with the requested id.",
-            ("There is no track with an id of {} in the library.").format(
+            "There is no track with an id of {} in the library.".format(
                 track_id
             ),
         )
@@ -768,7 +768,7 @@ def audio_file(track_id):
             "Requested audio file has an unknown mimetype.",
             (
                 "The audio file for track {} has an unknown mimetype. "
-                "It's file extension is {}."
+                "Its file extension is {}."
             ).format(track_id, path.split(".")[-1]),
         )
 
@@ -872,7 +872,7 @@ def image_file(image_id):
         return AURADocument.error(
             "404 Not Found",
             "No image with the requested id.",
-            ("There is no image with an id of {} in the library").format(
+            "There is no image with an id of {} in the library".format(
                 image_id
             ),
         )

--- a/beetsplug/aura.py
+++ b/beetsplug/aura.py
@@ -1,0 +1,847 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of beets.
+# Copyright 2020, Callum Brown.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""An AURA server using Flask.
+"""
+
+from __future__ import division, absolute_import, print_function
+
+from mimetypes import guess_type
+import re
+from os.path import isfile, getsize
+
+from beets.plugins import BeetsPlugin
+from beets.ui import Subcommand, _open_library
+from beets import config
+from beets.util import displayable_path
+from beets.library import Item, Album
+from beets.dbcore.query import (
+    MatchQuery,
+    NotQuery,
+    RegexpQuery,
+    AndQuery,
+    FixedFieldSort,
+    SlowFieldSort,
+    MultipleSort,
+)
+
+from flask import (
+    Blueprint,
+    Flask,
+    current_app,
+    send_file,
+    make_response,
+    request,
+)
+
+
+# Constants
+
+# AURA server information
+# TODO: Add version information
+SERVER_INFO = {
+    "aura-version": "0",
+    "server": "beets-aura",
+    "server-version": "0",
+    "auth-required": False,
+    "features": ["albums", "artists", "images"],
+}
+
+# Maps AURA Track attribute to beets Item attribute
+TRACK_ATTR_MAP = {
+    # Required
+    "title": "title",
+    "artist": "artist",
+    # Optional
+    "album": "album",
+    "track": "track",  # Track number on album
+    "tracktotal": "tracktotal",
+    "disc": "disc",
+    "disctotal": "disctotal",
+    "year": "year",
+    "month": "month",
+    "day": "day",
+    "bpm": "bpm",
+    "genre": "genre",
+    "recording-mbid": "mb_trackid",  # beets trackid is MB recording
+    "track-mbid": "mb_releasetrackid",
+    "composer": "composer",
+    "albumartist": "albumartist",
+    "comments": "comments",
+    # Optional for Audio Metadata
+    # TODO: Support the mimetype attribute, format != mime type
+    # "mimetype": track.format,
+    "duration": "length",
+    "framerate": "samplerate",
+    # I don't think beets has a framecount field
+    # "framecount": ???,
+    "channels": "channels",
+    "bitrate": "bitrate",
+    "bitdepth": "bitdepth",
+    "size": "filesize",
+}
+
+# Maps AURA Album attribute to beets Album attribute
+ALBUM_ATTR_MAP = {
+    # Required
+    "title": "album",
+    "artist": "albumartist",
+    # Optional
+    "tracktotal": "albumtotal",
+    "disctotal": "disctotal",
+    "year": "year",
+    "month": "month",
+    "day": "day",
+    "genre": "genre",
+    "release-mbid": "mb_albumid",
+    "release-group-mbid": "mb_releasegroupid",
+}
+
+# Maps AURA Artist attribute to beets Item field
+# Artists are not first-class in beets, so information is extracted from
+# beets Items.
+ARTIST_ATTR_MAP = {
+    # Required
+    "name": "artist",
+    # Optional
+    "artist_mbid": "mb_artistid",
+}
+
+
+class AURADocument:
+    """Base class for building AURA documents."""
+
+    @staticmethod
+    def error(status, title, detail):
+        """Make a response for an error following the JSON:API spec."""
+        document = {
+            "errors": [{"status": status, "title": title, "detail": detail}]
+        }
+        return make_response(document, status)
+
+    def translate_attribute(self, aura_attr):
+        """Translate AURA attribute name to beets attribute name."""
+        try:
+            return self.attribute_map[aura_attr]
+        except KeyError:
+            # Assume native beets attribute
+            return aura_attr
+
+    def translate_filters(self):
+        """Translate filters from request arguments to a beets Query."""
+        # The format of each filter key in the request parameter is:
+        # filter[<attribute>]. This regex extracts <attribute>.
+        pattern = re.compile(r"filter\[(?P<attribute>\w+)\]")
+        queries = []
+        for key, value in request.args.items():
+            match = pattern.match(key)
+            if match is not None:
+                # Extract attribute name from key
+                aura_attr = match.group("attribute")
+                # Get the beets version of the attribute name
+                beets_attr = self.translate_attribute(aura_attr)
+                converter = self.get_attribute_converter(beets_attr)
+                value = converter(value)
+                # Add exact match query to list
+                # Use a slow query so it works with all fields
+                queries.append(MatchQuery(beets_attr, value, fast=False))
+        # NOTE: AURA doesn't officially support multiple queries
+        return AndQuery(queries)
+
+    def translate_sorts(self, sort_arg):
+        """Translate an AURA sort parameter into a beets Sort."""
+        # Change HTTP query parameter to a list
+        aura_sorts = sort_arg.strip(",").split(",")
+        sorts = []
+        for aura_attr in aura_sorts:
+            if aura_attr[0] == "-":
+                ascending = False
+                # Remove leading "-"
+                aura_attr = aura_attr[1:]
+            else:
+                # JSON:API default
+                ascending = True
+            # Get the beets version of the attribute name
+            beets_attr = self.translate_attribute(aura_attr)
+            # Use slow sort so it works with all fields (inc. computed)
+            sorts.append(SlowFieldSort(beets_attr, ascending=ascending))
+        return MultipleSort(sorts)
+
+    def paginate(self, collection):
+        """Get a page of the collection and the URL to the next page."""
+        # Pages start from zero
+        page = request.args.get("page", 0, int)
+        # Use page limit defined in config by default.
+        default_limit = config["aura"]["page_limit"].get(int)
+        limit = request.args.get("limit", default_limit, int)
+        # start = offset of first item to return
+        start = page * limit
+        # end = offset of last item + 1
+        end = start + limit
+        if end > len(collection):
+            end = len(collection)
+            next_url = None
+        else:
+            # Not the last page so work out links.next url
+            if len(request.args) == 0:
+                # No existing arguments, so current page is 0
+                next_url = request.url + "?page=1"
+            elif request.args.get("page", None) is None:
+                # No existing page argument, so add one to the end
+                next_url = request.url + "&page=1"
+            else:
+                # Increment page token by 1
+                next_url = request.url.replace(
+                    "page={}".format(page), "page={}".format(page + 1)
+                )
+        # Get only the items in the page range
+        data = [self.resource_object(collection[i]) for i in range(start, end)]
+        return data, next_url
+
+    def get_included(self, data, include_str):
+        """Build a list of resource objects for inclusion.
+
+        :param data: Array of dicts in the form of resource objects
+        :param include_str: Comma separated list of resources to include
+        """
+        # Change HTTP query parameter to a list
+        to_include = include_str.strip(",").split(",")
+        # Build a list of unique type and id combinations
+        # For each resource object in the primary data, iterate over it's
+        # relationships. If a relationship matches one of the types
+        # requested for inclusion (e.g. "albums") then add each type-id pair
+        # under the "data" key to unique_identifiers, checking first that
+        # it has not already been added. This ensures that no resources are
+        # included more than once.
+        unique_identifiers = []
+        for res_obj in data:
+            for rel_name, rel_obj in res_obj["relationships"].items():
+                if rel_name in to_include:
+                    # NOTE: Assumes relationship is to-many
+                    for identifier in rel_obj["data"]:
+                        if identifier not in unique_identifiers:
+                            unique_identifiers.append(identifier)
+        # TODO: I think this could be improved
+        included = []
+        for identifier in unique_identifiers:
+            res_type = identifier["type"]
+            if res_type == "track":
+                track_id = int(identifier["id"])
+                track = current_app.config["lib"].get_item(track_id)
+                included.append(TrackDocument.resource_object(track))
+            elif res_type == "album":
+                album_id = int(identifier["id"])
+                album = current_app.config["lib"].get_album(album_id)
+                included.append(AlbumDocument.resource_object(album))
+            elif res_type == "artist":
+                artist_id = identifier["id"]
+                included.append(ArtistDocument.resource_object(artist_id))
+            elif res_type == "image":
+                image_id = identifier["id"]
+                included.append(ImageDocument.resource_object(image_id))
+            else:
+                raise ValueError("Invalid resource type: {}".format(res_type))
+        return included
+
+    def all_resources(self):
+        """Build document for /tracks, /albums or /artists."""
+        query = self.translate_filters()
+        sort_arg = request.args.get("sort", None)
+        if sort_arg is not None:
+            sort = self.translate_sorts(sort_arg)
+            # For each sort field add a query which ensures all results
+            # have a non-empty, non-zero value for that field.
+            for s in sort.sorts:
+                query.subqueries.append(
+                    NotQuery(
+                        # Match empty fields (^$) or zero fields, (^0$)
+                        RegexpQuery(s.field, "(^$|^0$)", fast=False)
+                    )
+                )
+        else:
+            sort = None
+        # Get information from the library
+        collection = self.get_collection(query=query, sort=sort)
+        # Convert info to AURA form and paginate it
+        data, next_url = self.paginate(collection)
+        document = {"data": data}
+        # If there are more pages then provide a way to access them
+        if next_url is not None:
+            document["links"] = {"next": next_url}
+        # Include related resources for each element in "data"
+        include_str = request.args.get("include", None)
+        if include_str is not None:
+            document["included"] = self.get_included(data, include_str)
+        return document
+
+    def single_resource_document(self, resource_object):
+        """Build document for a specific requested resource."""
+        document = {"data": resource_object}
+        include_str = request.args.get("include", None)
+        if include_str is not None:
+            # [document["data"]] is because arg needs to be list
+            document["included"] = self.get_included(
+                [document["data"]], include_str
+            )
+        return document
+
+
+class TrackDocument(AURADocument):
+    """Class for building documents for /tracks endpoints."""
+
+    attribute_map = TRACK_ATTR_MAP
+
+    def get_collection(self, query=None, sort=None):
+        """Get Item objects from the library."""
+        return current_app.config["lib"].items(query, sort)
+
+    def get_attribute_converter(self, beets_attr):
+        """Work out what data type an attribute should be for beets."""
+        # filesize is a special field (read from disk not db?)
+        if beets_attr == "filesize":
+            converter = int
+        else:
+            try:
+                # Look for field in list of Item fields
+                # and get python type of database type.
+                # See beets.library.Item and beets.dbcore.types
+                converter = Item._fields[beets_attr].model_type
+            except KeyError:
+                # Fall back to string (NOTE: probably not good)
+                converter = str
+        return converter
+
+    @staticmethod
+    def resource_object(track):
+        """Construct a JSON:API resource object from a beets Item."""
+        attributes = {}
+        # Use aura => beets attribute map, e.g. size => filesize
+        for aura_attr, beets_attr in TRACK_ATTR_MAP.items():
+            a = getattr(track, beets_attr)
+            # Only set attribute if it's not None, 0, "", etc.
+            # NOTE: This could result in required attributes not being set
+            if a:
+                attributes[aura_attr] = a
+
+        # JSON:API one-to-many relationship to parent album
+        relationships = {
+            "artists": {"data": [{"type": "artist", "id": track.artist}]}
+        }
+        # Only add album relationship if not singleton
+        if not track.singleton:
+            relationships["albums"] = {
+                "data": [{"type": "album", "id": str(track.album_id)}]
+            }
+
+        return {
+            "type": "track",
+            "id": str(track.id),
+            "attributes": attributes,
+            "relationships": relationships,
+        }
+
+    def single_resource(self, track_id):
+        """Get track from the library and build a document."""
+        track = current_app.config["lib"].get_item(track_id)
+        if track is None:
+            return self.error(
+                "404 Not Found",
+                "No track with the requested id.",
+                ("There is no track with an id of {} in the library.").format(
+                    track_id
+                ),
+            )
+        return self.single_resource_document(self.resource_object(track))
+
+
+class AlbumDocument(AURADocument):
+    """Class for building documents for /albums endpoints."""
+
+    attribute_map = ALBUM_ATTR_MAP
+
+    def get_collection(self, query=None, sort=None):
+        """Get Album objects from the library."""
+        return current_app.config["lib"].albums(query, sort)
+
+    def get_attribute_converter(self, beets_attr):
+        """Work out what data type an attribute should be for beets."""
+        # filesize is a special field (read from disk not db?)
+        try:
+            # Look for field in list of Album fields
+            # and get python type of database type.
+            # See beets.library.Album and beets.dbcore.types
+            converter = Album._fields[beets_attr].model_type
+        except KeyError:
+            # Fall back to string (NOTE: probably not good)
+            converter = str
+        return converter
+
+    @staticmethod
+    def resource_object(album):
+        """Construct a JSON:API resource object from a beets Album."""
+        attributes = {}
+        # Use aura => beets attribute name map
+        for aura_attr, beets_attr in ALBUM_ATTR_MAP.items():
+            a = getattr(album, beets_attr)
+            # Only set attribute if it's not None, 0, "", etc.
+            # NOTE: This could mean required attributes are not set
+            if a:
+                attributes[aura_attr] = a
+
+        # Get beets Item objects for all tracks in the album sorted by
+        # track number. Sorting is not required but it's nice.
+        query = MatchQuery("album_id", album.id)
+        sort = FixedFieldSort("track", ascending=True)
+        tracks = current_app.config["lib"].items(query, sort)
+        # JSON:API one-to-many relationship to tracks on the album
+        relationships = {
+            "tracks": {
+                "data": [{"type": "track", "id": str(t.id)} for t in tracks]
+            }
+        }
+        # Add images relationship if album has associated images
+        if album.artpath is not None:
+            path = displayable_path(album.artpath)
+            filename = path.split("/")[-1]
+            image_id = "album-{}-{}".format(album.id, filename)
+            relationships["images"] = {
+                "data": [{"type": "image", "id": image_id}]
+            }
+        # Add artist relationship if artist name is same on tracks
+        # Tracks are used to define artists so don't albumartist
+        # Check for all tracks in case some have featured artists
+        if album.albumartist in [t.artist for t in tracks]:
+            relationships["artists"] = {
+                "data": [{"type": "artist", "id": album.albumartist}]
+            }
+
+        return {
+            "type": "album",
+            "id": str(album.id),
+            "attributes": attributes,
+            "relationships": relationships,
+        }
+
+    def single_resource(self, album_id):
+        """Get album from the library and build a document."""
+        album = current_app.config["lib"].get_album(album_id)
+        if album is None:
+            return self.error(
+                "404 Not Found",
+                "No album with the requested id.",
+                ("There is no album with an id of {} in the library.").format(
+                    album_id
+                ),
+            )
+        return self.single_resource_document(self.resource_object(album))
+
+
+class ArtistDocument(AURADocument):
+    """Class for building documents for /artists endpoints."""
+
+    attribute_map = ARTIST_ATTR_MAP
+
+    def get_collection(self, query=None, sort=None):
+        """Get a list of artist names from the library."""
+        # Gets only tracks with matching artist information
+        tracks = current_app.config["lib"].items(query, sort)
+        collection = []
+        for track in tracks:
+            # Do not add duplicates
+            if track.artist not in collection:
+                collection.append(track.artist)
+        return collection
+
+    def get_attribute_converter(self, beets_attr):
+        """Work out what data type an attribute should be for beets."""
+        try:
+            # Look for field in list of Item fields
+            # and get python type of database type.
+            # See beets.library.Item and beets.dbcore.types
+            converter = Item._fields[beets_attr].model_type
+        except KeyError:
+            # Fall back to string (NOTE: probably not good)
+            converter = str
+        return converter
+
+    @staticmethod
+    def resource_object(artist_id):
+        """Construct a JSON:API resource object for the given artist."""
+        # Get tracks where artist field exactly matches artist_id
+        query = MatchQuery("artist", artist_id)
+        tracks = current_app.config["lib"].items(query)
+        if len(tracks) == 0:
+            return None
+
+        # Get artist information from the first track
+        # NOTE: It could be that the first track doesn't have a
+        # MusicBrainz id but later tracks do, which isn't ideal.
+        attributes = {}
+        # Use aura => beets attribute map, e.g. artist => name
+        for aura_attr, beets_attr in ARTIST_ATTR_MAP.items():
+            a = getattr(tracks[0], beets_attr)
+            # Only set attribute if it's not None, 0, "", etc.
+            # NOTE: This could mean required attributes are not set
+            if a:
+                attributes[aura_attr] = a
+
+        relationships = {
+            "tracks": {
+                "data": [{"type": "track", "id": str(t.id)} for t in tracks]
+            }
+        }
+        album_query = MatchQuery("albumartist", artist_id)
+        albums = current_app.config["lib"].albums(query=album_query)
+        if len(albums) != 0:
+            relationships["albums"] = {
+                "data": [{"type": "album", "id": str(a.id)} for a in albums]
+            }
+
+        return {
+            "type": "artist",
+            "id": artist_id,
+            "attributes": attributes,
+            "relationships": relationships,
+        }
+
+    def single_resource(self, artist_id):
+        """Get info for the requested artist and build a document."""
+        artist_resource = self.resource_object(artist_id)
+        if artist_resource is None:
+            return self.error(
+                "404 Not Found",
+                "No artist with the requested id.",
+                ("There is no artist with an id of {} in the library.").format(
+                    artist_id
+                ),
+            )
+        return self.single_resource_document(artist_resource)
+
+
+class ImageDocument(AURADocument):
+    """Class for building documents for /images/(id) endpoints."""
+
+    @staticmethod
+    def get_image_path(image_id):
+        """Works out the full path to the image with the given id.
+
+        Returns None if there is no such image.
+        image_id is in the form <parent_type>-<parent_id>-<img_filename>
+        """
+        # Split image_id into its constituent parts
+        id_split = image_id.split("-")
+        if len(id_split) < 3:
+            # image_id is not in the required format
+            return None
+        parent_type = id_split[0]
+        parent_id = id_split[1]
+        img_filename = "-".join(id_split[2:])
+
+        # Get the path to the directory parent's images are in
+        if parent_type == "album":
+            album = current_app.config["lib"].get_album(int(parent_id))
+            if album is None or album.artpath is None:
+                return None
+            # Cut the filename off of artpath
+            # This is in preparation for supporting images in the same
+            # directory that are not tracked by beets.
+            artpath = displayable_path(album.artpath)
+            dir_path = "/".join(artpath.split("/")[:-1])
+        else:
+            # Images for other resource types are not supported
+            return None
+
+        img_path = dir_path + "/" + img_filename
+        # Check the image actually exists
+        if isfile(img_path):
+            return img_path
+        else:
+            return None
+
+    @staticmethod
+    def resource_object(image_id):
+        """Construct a JSON:API resource object for the given image."""
+        # Could be called as a static method, so can't use
+        # self.get_image_path()
+        image_path = ImageDocument.get_image_path(image_id)
+        if image_path is None:
+            return None
+
+        attributes = {
+            "role": "cover",
+            "mimetype": guess_type(image_path)[0],
+            "size": getsize(image_path),
+        }
+        try:
+            from PIL import Image
+        except ImportError:
+            pass
+        else:
+            im = Image.open(image_path)
+            attributes["width"] = im.width
+            attributes["height"] = im.height
+
+        relationships = {}
+        # Split id into [parent_type, parent_id, filename]
+        id_split = image_id.split("-")
+        relationships[id_split[0] + "s"] = {
+            "data": [{"type": id_split[0], "id": id_split[1]}]
+        }
+
+        return {
+            "id": image_id,
+            "type": "image",
+            # Remove attributes that are None, 0, "", etc.
+            "attributes": {k: v for k, v in attributes.items() if v},
+            "relationships": relationships,
+        }
+
+    def single_resource(self, image_id):
+        """Get info for the requested image and build a document."""
+        image_resource = self.resource_object(image_id)
+        if image_resource is None:
+            return self.error(
+                "404 Not Found",
+                "No image with the requested id.",
+                ("There is no image with an id of {} in the library.").format(
+                    image_id
+                ),
+            )
+        return self.single_resource_document(image_resource)
+
+
+# Initialise flask blueprint
+aura_bp = Blueprint("aura_bp", __name__)
+
+
+@aura_bp.route("/server")
+def server_info():
+    """Respond with info about the server."""
+    return {"data": {"type": "server", "id": "0", "attributes": SERVER_INFO}}
+
+
+# Track endpoints
+
+
+@aura_bp.route("/tracks")
+def all_tracks():
+    """Respond with a list of all tracks and related information."""
+    doc = TrackDocument()
+    return doc.all_resources()
+
+
+@aura_bp.route("/tracks/<int:track_id>")
+def single_track(track_id):
+    """Respond with info about the specified track."""
+    doc = TrackDocument()
+    return doc.single_resource(track_id)
+
+
+@aura_bp.route("/tracks/<track_id>/audio")
+def audio_file(track_id):
+    """Supply an audio file for the specified track."""
+    track = current_app.config["lib"].get_item(track_id)
+    if track is None:
+        return AURADocument.error(
+            "404 Not Found",
+            "No track with the requested id.",
+            ("There is no track with an id of {} in the library.").format(
+                track_id
+            ),
+        )
+
+    path = displayable_path(track.destination())
+    if not isfile(path):
+        return AURADocument.error(
+            "404 Not Found",
+            "No audio file for the requested track.",
+            (
+                "There is no audio file for track {} at the expected location"
+            ).format(track_id),
+        )
+
+    file_mimetype = guess_type(path)[0]
+    if file_mimetype is None:
+        return AURADocument.error(
+            "500 Internal Server Error",
+            "Requested audio file has an unknown mimetype.",
+            (
+                "The audio file for track {} has an unknown mimetype. "
+                "It's file extension is {}."
+            ).format(track_id, path.split(".")[-1]),
+        )
+
+    # Check that the Accept header contains the file's mimetype
+    # Takes into account */* and audio/*
+    # Adding support for the bitrate parameter would require some effort so I
+    # left it out. This means the client could be sent an error even if the
+    # audio doesn't need transcoding.
+    if request.accept_mimetypes.best_match([file_mimetype]) is None:
+        return AURADocument.error(
+            "406 Not Acceptable",
+            "Unsupported MIME type or bitrate parameter in Accept header.",
+            (
+                "The audio file for track {} is only available as {} and "
+                "bitrate parameters are not supported."
+            ).format(track_id, file_mimetype),
+        )
+
+    return send_file(
+        path,
+        mimetype=file_mimetype,
+        # Handles filename in Content-Disposition header
+        as_attachment=True,
+        # Tries to upgrade the stream to support range requests
+        conditional=True,
+    )
+
+
+# Album endpoints
+
+
+@aura_bp.route("/albums")
+def all_albums():
+    """Respond with a list of all albums and related information."""
+    doc = AlbumDocument()
+    return doc.all_resources()
+
+
+@aura_bp.route("/albums/<int:album_id>")
+def single_album(album_id):
+    """Respond with info about the specified album."""
+    doc = AlbumDocument()
+    return doc.single_resource(album_id)
+
+
+# Artist endpoints
+# Artist ids are their names
+
+
+@aura_bp.route("/artists")
+def all_artists():
+    """Respond with a list of all artists and related information."""
+    doc = ArtistDocument()
+    return doc.all_resources()
+
+
+# Using the path converter allows slashes in artist_id
+@aura_bp.route("/artists/<path:artist_id>")
+def single_artist(artist_id):
+    """Respond with info about the specified artist."""
+    doc = ArtistDocument()
+    return doc.single_resource(artist_id)
+
+
+# Image endpoints
+# Image ids are in the form <parent_type>-<parent_id>-<img_filename>
+# For example: album-13-cover.jpg
+
+
+@aura_bp.route("/images/<string:image_id>")
+def single_image(image_id):
+    """Respond with info about the specified image."""
+    doc = ImageDocument()
+    return doc.single_resource(image_id)
+
+
+@aura_bp.route("/images/<string:image_id>/file")
+def image_file(image_id):
+    """Supply an image file for the specified image."""
+    img_path = ImageDocument.get_image_path(image_id)
+    if img_path is None:
+        return AURADocument.error(
+            "404 Not Found",
+            "No image with the requested id.",
+            ("There is no image with an id of {} in the library").format(
+                image_id
+            ),
+        )
+    return send_file(img_path)
+
+
+# WSGI app
+
+
+def create_app():
+    """An application factory for use by a WSGI server."""
+    app = Flask(__name__)
+    # Register AURA blueprint view functions under a URL prefix
+    app.register_blueprint(aura_bp, url_prefix="/aura")
+    # AURA specifies mimetype MUST be this
+    app.config["JSONIFY_MIMETYPE"] = "application/vnd.api+json"
+    # Disable auto-sorting of JSON keys
+    app.config["JSON_SORT_KEYS"] = False
+    # Provide a way to access the beets library
+    # The normal method of using the Library and config provided in the
+    # command function is not used because create_app() could be called
+    # by an external WSGI server.
+    # NOTE: this uses a 'private' function from beets.ui.__init__
+    app.config["lib"] = _open_library(config)
+
+    # Enable CORS if required
+    cors = config["aura"]["cors"].get(list)
+    if cors:
+        from flask_cors import CORS
+
+        # "Accept" is the only header clients use
+        app.config["CORS_ALLOW_HEADERS"] = "Accept"
+        app.config["CORS_RESOURCES"] = {r"/aura/*": {"origins": cors}}
+        app.config["CORS_SUPPORTS_CREDENTIALS"] = config["aura"][
+            "cors_supports_credentials"
+        ].get(bool)
+        CORS(app)
+
+    return app
+
+
+# Beets Plugin Hook
+
+
+class AURAPlugin(BeetsPlugin):
+    def __init__(self):
+        super(AURAPlugin, self).__init__()
+        self.config.add(
+            {
+                "host": u"127.0.0.1",
+                "port": 8337,
+                "cors": [],
+                "cors_supports_credentials": False,
+                "page_limit": 500,
+            }
+        )
+
+    def commands(self):
+        def run_aura(lib, opts, args):
+            """Run the application using Flask's built in-server."""
+            app = create_app()
+            # Start the built-in server (not intended for production)
+            app.run(
+                host=self.config["host"].get(str),
+                port=self.config["port"].get(int),
+                debug=opts.debug,
+                threaded=True,
+            )
+
+        run_aura_cmd = Subcommand("aura", help=u"run an AURA server")
+        run_aura_cmd.parser.add_option(
+            u"-d",
+            u"--debug",
+            action="store_true",
+            default=False,
+            help=u"use Flask debug mode",
+        )
+        run_aura_cmd.func = run_aura
+        return [run_aura_cmd]

--- a/beetsplug/aura.py
+++ b/beetsplug/aura.py
@@ -54,7 +54,7 @@ from flask import (
 SERVER_INFO = {
     "aura-version": "0",
     "server": "beets-aura",
-    "server-version": "0",
+    "server-version": "0.1",
     "auth-required": False,
     "features": ["albums", "artists", "images"],
 }

--- a/beetsplug/aura.py
+++ b/beetsplug/aura.py
@@ -14,8 +14,7 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
-"""An AURA server using Flask.
-"""
+"""An AURA server using Flask."""
 
 from __future__ import division, absolute_import, print_function
 
@@ -811,7 +810,10 @@ def create_app():
 
 
 class AURAPlugin(BeetsPlugin):
+    """The BeetsPlugin subclass for the AURA server plugin."""
+
     def __init__(self):
+        """Add configuration options for the AURA plugin."""
         super(AURAPlugin, self).__init__()
         self.config.add(
             {
@@ -824,6 +826,8 @@ class AURAPlugin(BeetsPlugin):
         )
 
     def commands(self):
+        """Add subcommand used to run the AURA server."""
+
         def run_aura(lib, opts, args):
             """Run the application using Flask's built in-server."""
             app = create_app()

--- a/beetsplug/aura.py
+++ b/beetsplug/aura.py
@@ -138,18 +138,6 @@ class AURADocument:
         }
         return make_response(document, status)
 
-    def translate_attribute(self, aura_attr):
-        """Translate AURA attribute name to beets attribute name.
-
-        Args:
-            aura_attr: The attribute name to convert, e.g. "title".
-        """
-        try:
-            return self.attribute_map[aura_attr]
-        except KeyError:
-            # Assume native beets attribute
-            return aura_attr
-
     def translate_filters(self):
         """Translate filters from request arguments to a beets Query."""
         # The format of each filter key in the request parameter is:
@@ -162,7 +150,7 @@ class AURADocument:
                 # Extract attribute name from key
                 aura_attr = match.group("attribute")
                 # Get the beets version of the attribute name
-                beets_attr = self.translate_attribute(aura_attr)
+                beets_attr = self.attribute_map.get(aura_attr, aura_attr)
                 converter = self.get_attribute_converter(beets_attr)
                 value = converter(value)
                 # Add exact match query to list
@@ -191,7 +179,7 @@ class AURADocument:
                 # JSON:API default
                 ascending = True
             # Get the beets version of the attribute name
-            beets_attr = self.translate_attribute(aura_attr)
+            beets_attr = self.attribute_map.get(aura_attr, aura_attr)
             # Use slow sort so it works with all fields (inc. computed)
             sorts.append(SlowFieldSort(beets_attr, ascending=ascending))
         return MultipleSort(sorts)

--- a/beetsplug/aura.py
+++ b/beetsplug/aura.py
@@ -25,7 +25,7 @@ from os.path import isfile, getsize
 from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand, _open_library
 from beets import config
-from beets.util import displayable_path
+from beets.util import py3_path
 from beets.library import Item, Album
 from beets.dbcore.query import (
     MatchQuery,
@@ -460,7 +460,7 @@ class AlbumDocument(AURADocument):
         }
         # Add images relationship if album has associated images
         if album.artpath:
-            path = displayable_path(album.artpath)
+            path = py3_path(album.artpath)
             filename = path.split("/")[-1]
             image_id = "album-{}-{}".format(album.id, filename)
             relationships["images"] = {
@@ -628,7 +628,7 @@ class ImageDocument(AURADocument):
             # Cut the filename off of artpath
             # This is in preparation for supporting images in the same
             # directory that are not tracked by beets.
-            artpath = displayable_path(album.artpath)
+            artpath = py3_path(album.artpath)
             dir_path = "/".join(artpath.split("/")[:-1])
         else:
             # Images for other resource types are not supported
@@ -751,7 +751,7 @@ def audio_file(track_id):
             ),
         )
 
-    path = displayable_path(track.destination())
+    path = py3_path(track.path)
     if not isfile(path):
         return AURADocument.error(
             "404 Not Found",

--- a/beetsplug/aura.py
+++ b/beetsplug/aura.py
@@ -142,7 +142,7 @@ class AURADocument:
         """Translate filters from request arguments to a beets Query."""
         # The format of each filter key in the request parameter is:
         # filter[<attribute>]. This regex extracts <attribute>.
-        pattern = re.compile(r"filter\[(?P<attribute>\w+)\]")
+        pattern = re.compile(r"filter\[(?P<attribute>[a-zA-Z0-9_-]+)\]")
         queries = []
         for key, value in request.args.items():
             match = pattern.match(key)

--- a/beetsplug/aura.py
+++ b/beetsplug/aura.py
@@ -909,7 +909,7 @@ def create_app():
     app.config["lib"] = _open_library(config)
 
     # Enable CORS if required
-    cors = config["aura"]["cors"].get(list)
+    cors = config["aura"]["cors"].as_str_seq(list)
     if cors:
         from flask_cors import CORS
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -183,6 +183,7 @@ New features:
 * Added ``trackdisambig`` which stores the recording disambiguation from
   MusicBrainz for each track.
   :bug:`1904`
+* The :doc:`/plugins/aura` has arrived!
 
 Fixes:
 

--- a/docs/plugins/aura.rst
+++ b/docs/plugins/aura.rst
@@ -1,0 +1,195 @@
+AURA Plugin
+===========
+
+This plugin is a server implementation of the `AURA`_ specification using the
+`Flask`_ framework. AURA is still a work in progress and doesn't yet have a
+stable version, but this server should be kept up to date. You are advised to
+read the :ref:`aura-issues` section.
+
+.. _AURA: https://auraspec.readthedocs.io
+.. _Flask: https://palletsprojects.com/p/flask/
+
+Install
+-------
+
+The ``aura`` plugin depends on `Flask`_, which can be installed using
+``python -m pip install flask``. Then you can enable the ``aura`` plugin in
+your configuration (see :ref:`using-plugins`).
+
+It is likely that you will need to enable :ref:`aura-cors`, which introduces
+an additional dependency: `flask-cors`_. This can be installed with
+``python -m pip install flask-cors``.
+
+If `Pillow`_ is installed (``python -m pip install Pillow``) then the optional
+``width`` and ``height`` attributes are included in image resource objects.
+
+.. _flask-cors: https://flask-cors.readthedocs.io
+.. _Pillow: https://pillow.readthedocs.io
+
+
+Usage
+-----
+
+Use ``beet aura`` to start the AURA server.
+By default Flask's built-in server is used, which will give a warning about
+using it in a production environment. It is safe to ignore this warning if the
+server will have only a few users.
+
+Alternatively, you can use ``beet aura -d`` to start the server in
+`development mode`_, which will reload the server every time the AURA plugin
+file is changed.
+
+You can specify the hostname and port number used by the server in your
+:doc:`configuration file </reference/config>`. For more detail see the
+:ref:`configuration` section below.
+
+If you would prefer to use a different WSGI server, such as gunicorn or uWSGI,
+then see :ref:`aura-external-server`.
+
+AURA is designed to separate the client and server functionality. This plugin
+provides the server but not the client, so unless you like looking at JSON you
+will need a separate client. Unfortunately there are no AURA clients yet
+(discounting the broken and outdated reference implementation).
+
+By default the API is served under http://127.0.0.1:8337/aura/. For example
+information about the track with an id of 3 can be obtained at
+http://127.0.0.1:8337/aura/tracks/3.
+
+**Note the absence of a trailing slash**:
+http://127.0.0.1:8337/aura/tracks/3/ returns a ``404 Not Found`` error.
+
+.. _development mode: https://flask.palletsprojects.com/en/1.1.x/server
+
+
+.. _configuration:
+
+Configuration
+-------------
+
+To configure the plugin, make an ``aura:`` section in your
+configuration file. The available options are:
+
+- **host**: The server hostname. Set this to 0.0.0.0 to bind to all interfaces.
+  Default: ``127.0.0.1``.
+- **port**: The server port.
+  Default: ``8337``.
+- **cors**: A YAML list of origins to allow CORS requests from (see
+  :ref:`aura-cors`, below).
+  Default: disabled.
+- **cors_supports_credentials**: Allow authenticated requests when using CORS.
+  Default: disabled.
+- **page_limit**: The number of items responses should be truncated to if the
+  client does not specify. Default ``500``.
+
+
+.. _aura-cors:
+
+Cross-Origin Resource Sharing (CORS)
+------------------------------------
+
+`CORS`_ allows browser clients to make requests to the AURA server. You should
+set the ``cors`` configuration option to a YAML list of allowed origins.
+
+For example::
+
+    aura:
+        cors:
+            - http://www.example.com
+            - https://aura.example.org
+
+Alternatively you can set it to ``'*'`` to enable access from all origins.
+Note that there are security implications if you set the origin to ``'*'``,
+so please research this before using it. Note the use of quote marks when
+allowing all origins. Quote marks are also required when the origin is
+``null``, for example when using ``file:///``.
+
+If the server is behind a proxy that uses credentials, you might want to set
+the ``cors_supports_credentials`` configuration option to true to let
+in-browser clients log in. Note that this option has not been tested, so it
+may not work.
+
+.. _CORS: https://en.wikipedia.org/wiki/Cross-origin_resource_sharing
+
+
+.. _aura-external-server:
+
+Using an External WSGI Server
+-----------------------------
+
+If you would like to use a different WSGI server (not Flask's built-in one),
+then you can! The ``beetsplug.aura`` module provides a WSGI callable called
+``create_app()`` which can be used by many WSGI servers.
+
+For example to run the AURA server using `gunicorn`_ use
+``gunicorn 'beetsplug.aura:create_app()'``, or for `uWSGI`_ use
+``uwsgi --http :9090 --module 'beetsplug.aura:create_app()'``.
+Note that these commands just show how to use the AURA app and you would
+probably use something a bit different in a production environment. Read the
+relevant server's documentation to figure out what you need.
+
+.. _gunicorn: https://gunicorn.org
+.. _uWSGI: https://uwsgi-docs.readthedocs.io
+
+
+Reverse Proxy Support
+---------------------
+
+The plugin should work behind a reverse proxy without further configuration,
+however this has not been tested extensively. For details of what headers must
+be rewritten and a sample NGINX configuration see `Flask proxy setups`_.
+
+It may be possibly to run the application under a URL prefix (for example so
+you could have ``/foo/aura/server`` rather than ``/aura/server``), but it is
+likely this would require changes in the code.
+
+Do not add a trailing slash (``/``) to the URL where the application is
+running, otherwise you will get a 404. For example with NGINX you should use
+``proxy_pass http://127.0.0.1:8000;`` rather than
+``proxy_pass http://127.0.0.1:8000/;``.
+
+.. _Flask proxy setups: https://flask.palletsprojects.com/en/1.1.x/deploying/wsgi-standalone/#proxy-setups
+
+
+.. _aura-issues:
+
+Issues
+------
+
+As of writing there are some differences between the specification and this
+implementation:
+
+- Compound filters are not specified in AURA, but this server interprets
+  multiple ``filter`` parameters as AND. See `issue #19`_ for discussion.
+- The ``bitrate`` parameter used for content negotiation is not supported.
+  Adding support for this is doable, but the way Flask handles acceptable MIME
+  types means it's a lot easier not to bother with it. This means an error
+  could be returned even if no transcoding was required.
+
+It is possible that some attributes required by AURA could be absent from the
+server's response if beets does not have a saved value for them. However, this
+has not happened so far.
+
+The ``mimetype`` and ``framecount`` attributes for track resources are not
+supported. The first is due to beets storing the file type (e.g. ``MP3``), so
+it is hard to filter by MIME type. The second is because there is no
+corresponding beets field.
+
+Artists are defined by the ``artist`` field on beets Items, which means some
+albums have no ``artists`` relationship. Albums only have related artists
+when their beets ``albumartist`` field is the same as the ``artist`` field on
+at least one of it's constituent tracks.
+
+The only art tracked by beets is a single cover image, so only albums have
+related images at the moment. This could be expanded to looking in the same
+directory for other images, and relating tracks to their album's image.
+
+There are likely to be some performance issues, especially with larger
+libraries. Pagination and inclusion (most notably of images) are probably two
+of the main offenders. On a related note, the program attempts to import Pillow
+every time it constructs an image resource object, which is not very good.
+
+The beets library is accessed using a so called private function (with a single
+leading underscore) ``beets.ui.__init__._open_library()``. This shouldn't cause
+any issues but it is probably not best practice.
+
+.. _issue #19: https://github.com/beetbox/aura/issues/19

--- a/docs/plugins/aura.rst
+++ b/docs/plugins/aura.rst
@@ -69,8 +69,8 @@ Configuration
 To configure the plugin, make an ``aura:`` section in your
 configuration file. The available options are:
 
-- **host**: The server hostname. Set this to 0.0.0.0 to bind to all interfaces.
-  Default: ``127.0.0.1``.
+- **host**: The server hostname. Set this to ``0.0.0.0`` to bind to all
+  interfaces. Default: ``127.0.0.1``.
 - **port**: The server port.
   Default: ``8337``.
 - **cors**: A YAML list of origins to allow CORS requests from (see
@@ -122,7 +122,7 @@ then you can! The ``beetsplug.aura`` module provides a WSGI callable called
 
 For example to run the AURA server using `gunicorn`_ use
 ``gunicorn 'beetsplug.aura:create_app()'``, or for `uWSGI`_ use
-``uwsgi --http :9090 --module 'beetsplug.aura:create_app()'``.
+``uwsgi --http :8337 --module 'beetsplug.aura:create_app()'``.
 Note that these commands just show how to use the AURA app and you would
 probably use something a bit different in a production environment. Read the
 relevant server's documentation to figure out what you need.
@@ -144,8 +144,8 @@ likely this would require changes in the code.
 
 Do not add a trailing slash (``/``) to the URL where the application is
 running, otherwise you will get a 404. For example with NGINX you should use
-``proxy_pass http://127.0.0.1:8000;`` rather than
-``proxy_pass http://127.0.0.1:8000/;``.
+``proxy_pass http://127.0.0.1:8337;`` rather than
+``proxy_pass http://127.0.0.1:8337/;``.
 
 .. _Flask proxy setups: https://flask.palletsprojects.com/en/1.1.x/deploying/wsgi-standalone/#proxy-setups
 
@@ -184,9 +184,9 @@ related images at the moment. This could be expanded to looking in the same
 directory for other images, and relating tracks to their album's image.
 
 There are likely to be some performance issues, especially with larger
-libraries. Pagination and inclusion (most notably of images) are probably two
-of the main offenders. On a related note, the program attempts to import Pillow
-every time it constructs an image resource object, which is not very good.
+libraries. Sorting, pagination and inclusion (most notably of images) are
+probably the main offenders. On a related note, the program attempts to import
+Pillow every time it constructs an image resource object, which is not good.
 
 The beets library is accessed using a so called private function (with a single
 leading underscore) ``beets.ui.__init__._open_library()``. This shouldn't cause

--- a/docs/plugins/aura.rst
+++ b/docs/plugins/aura.rst
@@ -48,8 +48,7 @@ then see :ref:`aura-external-server`.
 
 AURA is designed to separate the client and server functionality. This plugin
 provides the server but not the client, so unless you like looking at JSON you
-will need a separate client. Unfortunately there are no AURA clients yet
-(discounting the broken and outdated reference implementation).
+will need a separate client. Currently the only client is `AURA Web Client`_.
 
 By default the API is served under http://127.0.0.1:8337/aura/. For example
 information about the track with an id of 3 can be obtained at
@@ -59,6 +58,7 @@ http://127.0.0.1:8337/aura/tracks/3.
 http://127.0.0.1:8337/aura/tracks/3/ returns a ``404 Not Found`` error.
 
 .. _development mode: https://flask.palletsprojects.com/en/1.1.x/server
+.. _AURA Web Client: https://sr.ht/~callum/aura-web-client/
 
 
 .. _configuration:
@@ -167,6 +167,10 @@ implementation:
 It is possible that some attributes required by AURA could be absent from the
 server's response if beets does not have a saved value for them. However, this
 has not happened so far.
+
+Beets fields (including flexible fields) that do not have an AURA equivalent
+are not provided in any resource's attributes section, however these fields may
+be used for filtering.
 
 The ``mimetype`` and ``framecount`` attributes for track resources are not
 supported. The first is due to beets storing the file type (e.g. ``MP3``), so

--- a/docs/plugins/aura.rst
+++ b/docs/plugins/aura.rst
@@ -138,14 +138,13 @@ The plugin should work behind a reverse proxy without further configuration,
 however this has not been tested extensively. For details of what headers must
 be rewritten and a sample NGINX configuration see `Flask proxy setups`_.
 
-It may be possibly to run the application under a URL prefix (for example so
-you could have ``/foo/aura/server`` rather than ``/aura/server``), but it is
-likely this would require changes in the code.
+It is (reportedly) possible to run the application under a URL prefix (for
+example so you could have ``/foo/aura/server`` rather than ``/aura/server``),
+but you'll have to work it out for yourself :-)
 
-Do not add a trailing slash (``/``) to the URL where the application is
-running, otherwise you will get a 404. For example with NGINX you should use
-``proxy_pass http://127.0.0.1:8337;`` rather than
-``proxy_pass http://127.0.0.1:8337/;``.
+If using NGINX, do **not** add a trailing slash (``/``) to the URL where the
+application is running, otherwise you will get a 404. However if you are using
+Apache then you **should** add a trailing slash.
 
 .. _Flask proxy setups: https://flask.palletsprojects.com/en/1.1.x/deploying/wsgi-standalone/#proxy-setups
 

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -61,6 +61,7 @@ following to your configuration::
 
    absubmit
    acousticbrainz
+   aura
    badfiles
    beatport
    bpd
@@ -184,6 +185,7 @@ Path Formats
 Interoperability
 ----------------
 
+* :doc:`aura`: A server implementation of the `AURA`_ specification.
 * :doc:`badfiles`: Check audio file integrity.
 * :doc:`embyupdate`: Automatically notifies `Emby`_ whenever the beets library changes.
 * :doc:`fish`: Adds `Fish shell`_ tab autocompletion to ``beet`` commands.
@@ -205,6 +207,7 @@ Interoperability
   library changes.
 
 
+.. _AURA: https://auraspec.readthedocs.io
 .. _Emby: https://emby.media
 .. _Fish shell: https://fishshell.com/
 .. _Plex: https://plex.tv


### PR DESCRIPTION
This is a server implementation of an [AURA](http://https://auraspec.readthedocs.io) server.
``tox -e lint`` fails (see [here](https://github.com/beetbox/beets/runs/1145869325)), which would be easy enough to fix but puzzles me because no other plugins with the same "problems" cause an error. Does anyone know what's up with that?