### PR TITLE
Optimise FormattedMapping when querying a specific set of fields

### DIFF
--- a/beetsplug/export.py
+++ b/beetsplug/export.py
@@ -26,8 +26,9 @@ from xml.etree import ElementTree
 from datetime import datetime, date
 from beets.plugins import BeetsPlugin
 from beets import ui
+from beets import util
 import mediafile
-from beetsplug.info import make_key_filter, library_data, tag_data
+from beetsplug.info import library_data, tag_data
 
 
 class ExportEncoder(json.JSONEncoder):
@@ -129,16 +130,18 @@ class ExportPlugin(BeetsPlugin):
         for keys in opts.included_keys:
             included_keys.extend(keys.split(','))
 
-        key_filter = make_key_filter(included_keys)
-
         for data_emitter in data_collector(lib, ui.decargs(args)):
             try:
-                data, item = data_emitter()
+                data, item = data_emitter(included_keys or '*')
             except (mediafile.UnreadableFileError, IOError) as ex:
                 self._log.error(u'cannot read file: {0}', ex)
                 continue
 
-            data = key_filter(data)
+            for key, value in data.items():
+                if isinstance(value, bytes):
+                    data[key] = util.displayable_path(value)
+
+            items += [data]
 
             if file_format_is_line_based:
                 export_format.export(data, **format_options)

--- a/beetsplug/info.py
+++ b/beetsplug/info.py
@@ -19,7 +19,6 @@
 from __future__ import division, absolute_import, print_function
 
 import os
-import re
 
 from beets.plugins import BeetsPlugin
 from beets import ui
@@ -42,15 +41,29 @@ def tag_data(lib, args):
             yield tag_data_emitter(item.path)
 
 
+def tag_fields():
+    fields = set(mediafile.MediaFile.readable_fields())
+    fields.add('art')
+    return fields
+
+
 def tag_data_emitter(path):
-    def emitter():
-        fields = list(mediafile.MediaFile.readable_fields())
-        fields.remove('images')
+    def emitter(included_keys):
+        if included_keys == '*':
+            fields = tag_fields()
+        else:
+            fields = included_keys
+        if 'images' in fields:
+            # We can't serialize the image data.
+            fields.remove('images')
         mf = mediafile.MediaFile(syspath(path))
         tags = {}
         for field in fields:
-            tags[field] = getattr(mf, field)
-        tags['art'] = mf.art is not None
+            if field == 'art':
+                tags[field] = mf.art is not None
+            else:
+                tags[field] = getattr(mf, field, None)
+
         # create a temporary Item to take advantage of __format__
         item = Item.from_path(syspath(path))
 
@@ -64,8 +77,8 @@ def library_data(lib, args):
 
 
 def library_data_emitter(item):
-    def emitter():
-        data = dict(item.formatted())
+    def emitter(included_keys):
+        data = dict(item.formatted(included_keys=included_keys))
 
         return data, item
     return emitter
@@ -185,18 +198,16 @@ class InfoPlugin(BeetsPlugin):
             included_keys.extend(keys.split(','))
         # Drop path even if user provides it multiple times
         included_keys = [k for k in included_keys if k != 'path']
-        key_filter = make_key_filter(included_keys)
 
         first = True
         summary = {}
         for data_emitter in data_collector(lib, ui.decargs(args)):
             try:
-                data, item = data_emitter()
+                data, item = data_emitter(included_keys or '*')
             except (mediafile.UnreadableFileError, IOError) as ex:
                 self._log.error(u'cannot read file: {0}', ex)
                 continue
 
-            data = key_filter(data)
             if opts.summarize:
                 update_summary(summary, data)
             else:
@@ -211,34 +222,3 @@ class InfoPlugin(BeetsPlugin):
 
         if opts.summarize:
             print_data(summary)
-
-
-def make_key_filter(include):
-    """Return a function that filters a dictionary.
-
-    The returned filter takes a dictionary and returns another
-    dictionary that only includes the key-value pairs where the key
-    glob-matches one of the keys in `include`.
-    """
-    # By default, if no field inclusions are specified, include
-    # everything but `path`.
-    if not include:
-        def filter_(data):
-            return {k: v for k, v in data.items()
-                    if k != 'path'}
-        return filter_
-
-    matchers = []
-    for key in include:
-        key = re.escape(key)
-        key = key.replace(r'\*', '.*')
-        matchers.append(re.compile(key + '$'))
-
-    def filter_(data):
-        filtered = {}
-        for key, value in data.items():
-            if any([m.match(key) for m in matchers]):
-                filtered[key] = value
-        return filtered
-
-    return filter_

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -212,6 +212,8 @@ Other new things:
   used to target a maximum image filesize.
 * :doc:`/plugins/badfiles`: Checkers can now be run during import with the
   ``check_on_import`` config option.
+* :doc:`/plugins/export`: big speedups when `--include-keys` option is used
+  Thanks to :user:`ssssam`.
 
 Fixes:
 

--- a/docs/plugins/info.rst
+++ b/docs/plugins/info.rst
@@ -20,14 +20,12 @@ your library::
 
 If you just want to see specific properties you can use the
 ``--include-keys`` option to filter them. The argument is a
-comma-separated list of simple glob patterns where ``*`` matches any
-string. For example::
+comma-separated list of field names. For example::
 
-    $ beet info -i 'title,mb*' beatles
+    $ beet info -i 'title,mb_artistid' beatles
 
-Will only show the ``title`` property and all properties starting with
-``mb``. You can add the ``-i`` option multiple times to the command
-line.
+Will only show the ``title`` and ``mb_artistid`` properties.  You can add the
+``-i`` option multiple times to the command line.
 
 Additional command-line options include:
 

--- a/test/test_info.py
+++ b/test/test_info.py
@@ -92,17 +92,6 @@ class InfoTest(unittest.TestCase, TestHelper):
         self.assertIn(u'title: [various]', out)
         self.remove_mediafile_fixtures()
 
-    def test_include_pattern(self):
-        item, = self.add_item_fixtures()
-        item.album = 'xxxx'
-        item.store()
-
-        out = self.run_with_output('info', '--library', 'album:xxxx',
-                                   '--include-keys', '*lbu*')
-        self.assertIn(displayable_path(item.path), out)
-        self.assertNotIn(u'title:', out)
-        self.assertIn(u'album: xxxx', out)
-
     def test_custom_format(self):
         self.add_item_fixtures()
         out = self.run_with_output('info', '--library', '--format',


### PR DESCRIPTION
## Description

This changes greatly improves the speed of `beet export` and `beet info`
when the `--include-keys` option is used.

Listing all fields for an item requires querying the database to find
any flex attributes. This is slow when done for every item being
exported. We already have a way for the user to specify a fixed set
of keys, but we previously queried everything and filtered it afterwards.
The new approach is more efficient.

Code that iterates through all fields now have to handle invalid field
names. The export and info plugins output invalid fields as None.

Timings before:

    > /usr/bin/time beet export -i title,path,artist -l  Bob Dylan
    13.26user 20.22system 0:34.01elapsed 98%CPU (0avgtext+0avgdata 52544maxresident)k

    > /usr/bin/time beet export -l  Bob Dylan
    12.93user 20.15system 0:33.58elapsed 98%CPU (0avgtext+0avgdata 53632maxresident)k

Timings after:

    > /usr/bin/time beet export -l  Bob Dylan
    13.33user 20.17system 0:34.02elapsed 98%CPU (0avgtext+0avgdata 53500maxresident)k

    > /usr/bin/time beet export -i title,path,artist -l  Bob Dylan
    0.49user 0.07system 0:00.56elapsed 98%CPU (0avgtext+0avgdata 50496maxresident)k

Notice the dramatic speedup in the last example!

Fixes https://github.com/beetbox/beets/issues/3108

## To Do

- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
