### PR TITLE
Add --plugins flag

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -35,6 +35,12 @@ Here's a link to the music files that trigger the bug (if relevant):
 * beets version: 
 * Turning off plugins made problem go away (yes/no): 
 
+<!--
+You can turn off plugins temporarily by passing --plugins= on the command line:
+
+$ beet --plugins= version
+-->
+
 My configuration (output of `beet config`) is:
 
 ```yaml

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -1102,8 +1102,8 @@ optparse.Option.ALWAYS_TYPED_ACTIONS += ('callback',)
 
 # The main entry point and bootstrapping.
 
-def _load_plugins(config):
-    """Load the plugins specified in the configuration.
+def _load_plugins(options, config):
+    """Load the plugins specified on the command line or in the configuration.
     """
     paths = config['pluginpath'].as_str_seq(split=False)
     paths = [util.normpath(p) for p in paths]
@@ -1120,7 +1120,14 @@ def _load_plugins(config):
     # *contain* a `beetsplug` package.
     sys.path += paths
 
-    plugins.load_plugins(config['plugins'].as_str_seq())
+    # If we were given any plugins on the command line, use those.
+    if options.plugins is not None:
+        plugin_list = (options.plugins.split(',')
+                       if len(options.plugins) > 0 else [])
+    else:
+        plugin_list = config['plugins'].as_str_seq()
+
+    plugins.load_plugins(plugin_list)
     plugins.send("pluginload")
     return plugins
 
@@ -1135,7 +1142,7 @@ def _setup(options, lib=None):
 
     config = _configure(options)
 
-    plugins = _load_plugins(config)
+    plugins = _load_plugins(options, config)
 
     # Get the default subcommands.
     from beets.ui.commands import default_commands
@@ -1233,6 +1240,8 @@ def _raw_main(args, lib=None):
                       help=u'log more details (use twice for even more)')
     parser.add_option('-c', '--config', dest='config',
                       help=u'path to configuration file')
+    parser.add_option('-p', '--plugins', dest='plugins',
+                      help=u'a comma-separated list of plugins to load')
     parser.add_option('-h', '--help', dest='help', action='store_true',
                       help=u'show this help message and exit')
     parser.add_option('--version', dest='version', action='store_true',

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -154,6 +154,7 @@ New features:
   similar to ``beet modify``
 * :doc:`/plugins/web`: add DELETE and PATCH methods for modifying items
 * :doc:`/plugins/lyrics`: Removed LyricWiki source (shut down on 21/09/2020).
+* Added a ``--plugins`` (or ``-p``) flag to specify a list of plugins at startup.
 
 Fixes:
 

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -440,6 +440,10 @@ import ...``.
   configuration options entirely, the two are merged. Any individual options set
   in this config file will override the corresponding settings in your base
   configuration.
+* ``-p plugins``: specify a comma-separated list of plugins to enable. If
+  specified, the plugin list in your configuration is ignored. The long form
+  of this argument also allows specifying no plugins, effectively disabling
+  all plugins: ``--plugins=``.
 
 Beets also uses the ``BEETSDIR`` environment variable to look for
 configuration and data.


### PR DESCRIPTION
## Description

This PR adds a `--plugins` flag to beets, allowing enabling/disabling of plugins without adding them to the user's configuration.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
