### PR TITLE
Fix linkcheck on GitHub actions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ linkcheck_ignore = [
     r'https://github.com/[^/]+$',  # ignore user pages
     r'.*localhost.*',
     r'https://www.musixmatch.com/',  # blocks requests
+    r'https://genius.com/',  # blocks requests
 ]
 
 # Options for HTML output

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ extlinks = {
 
 linkcheck_ignore = [
     r'https://github.com/beetbox/beets/issues/',
-    r'https://github.com/\w+$',  # ignore user pages
+    r'https://github.com/[^/]+$',  # ignore user pages
     r'.*localhost.*',
     r'https://www.musixmatch.com/',  # blocks requests
 ]


### PR DESCRIPTION
It looks like the existing GitHub user page regex wasn't quite right - I've updated this to match anything at the top-level of GitHub (it was missing usernames containing hyphens before).

I've added genius to the link ignore list too, as they're still blocking GitHub actions (see #3713).

Here's hoping this is the final nail in the integration test failure coffin 💪 