### PR TITLE
Add genre support using musicbrainz tags.

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -74,6 +74,8 @@ RELEASE_INCLUDES = ['artists', 'media', 'recordings', 'release-groups',
 TRACK_INCLUDES = ['artists', 'aliases']
 if 'work-level-rels' in musicbrainzngs.VALID_INCLUDES['recording']:
     TRACK_INCLUDES += ['work-level-rels', 'artist-rels']
+if 'genres' in musicbrainzngs.VALID_INCLUDES['recording']:
+    RELEASE_INCLUDES += ['genres']
 
 
 def track_url(trackid):
@@ -414,6 +416,9 @@ def album_info(release):
     if release['medium-list']:
         first_medium = release['medium-list'][0]
         info.media = first_medium.get('format')
+
+    if release.get('genre-list'):
+        info.genre = ';'.join(g['name'] for g in release['genre-list'])
 
     info.decode()
     return info

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -417,8 +417,9 @@ def album_info(release):
         first_medium = release['medium-list'][0]
         info.media = first_medium.get('format')
 
-    if release.get('genre-list'):
-        info.genre = ';'.join(g['name'] for g in release['genre-list'])
+    genres = release.get('genre-list')
+    if genres:
+        info.genre = ';'.join(g['name'] for g in genres)
 
     info.decode()
     return info

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -159,6 +159,11 @@ New features:
 * :doc:`/plugins/web`: add DELETE and PATCH methods for modifying items
 * :doc:`/plugins/lyrics`: Removed LyricWiki source (shut down on 21/09/2020).
 * Added a ``--plugins`` (or ``-p``) flag to specify a list of plugins at startup.
+* Use musicbrainz genre tag api to get genre information.  This currently
+  depends on functionality that is currently unreleased in musicbrainzngs.
+  See https://github.com/alastair/python-musicbrainzngs/pull/247 and
+  https://github.com/alastair/python-musicbrainzngs/pull/266 .
+  Thanks to :user:`aereaux`.
 
 Fixes:
 


### PR DESCRIPTION
## Description

Fixes #3053.

This used musicbrainz tags to populate the genre album tag.  This is still a WIP, and it requires this PR (https://github.com/alastair/python-musicbrainzngs/pull/266).  Let me know if anyone has any ideas on how this could work better.  Currently I just take the most-voted-for genre tag, breaking ties arbitrarily.

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
