### PR TITLE
Fix PIL image quality

### DIFF
--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -77,6 +77,11 @@ def pil_resize(maxwidth, path_in, path_out=None, quality=0):
         im = Image.open(util.syspath(path_in))
         size = maxwidth, maxwidth
         im.thumbnail(size, Image.ANTIALIAS)
+
+        if quality == 0:
+            # Use PIL's default quality.
+            quality = -1
+
         im.save(util.py3_path(path_out), quality=quality)
         return path_out
     except IOError:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -265,6 +265,8 @@ Fixes:
   the current track in the queue.
   Thanks to :user:`aereaux`.
   :bug:`3722`
+* Fix a bug causing PIL to generate poor quality JPEGs when resizing artwork.
+  :bug:`3743`
 
 For plugin developers:
 


### PR DESCRIPTION
## Description

Fixes #3743.

It seems like specifying an image quality of 0 to PIL when saving a JPEG generates an image with the lowest possible quality, instead of using PIL's default quality of 75.

```Python
from PIL import Image

im = Image.open("./beet.jpg")
im.save("./beet_modified.jpg", quality=0)
```

<table>
<thead>
<tr>
<th>
<code>beet.jpg</code>
</th>
<th>
<code>beet_modified.jpg</code>
</th>
</thead>
<tbody>
<tr>
<td width="50%">
<img src="https://user-images.githubusercontent.com/1843197/97112860-9e573c00-16de-11eb-973a-05426302105d.jpg">
</td>
<td width="50%">
<img src="https://user-images.githubusercontent.com/1843197/97112868-a7e0a400-16de-11eb-9331-a99a8b6bbdd9.jpg">
</td>
</tr>
</tbody>
</table>

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
