### PR TITLE
Add prefix option to relative_to paths in smartplaylist plugin

### DIFF
--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -35,6 +35,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
         super(SmartPlaylistPlugin, self).__init__()
         self.config.add({
             'relative_to': None,
+            'relative_to_prefix': None,
             'playlist_dir': u'.',
             'auto': True,
             'playlists': [],
@@ -172,6 +173,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
         relative_to = self.config['relative_to'].get()
         if relative_to:
             relative_to = normpath(relative_to)
+        prefix = self.config['relative_to_prefix'].get()
 
         # Maps playlist filenames to lists of track filenames.
         m3us = {}
@@ -197,6 +199,8 @@ class SmartPlaylistPlugin(BeetsPlugin):
                 item_path = item.path
                 if relative_to:
                     item_path = os.path.relpath(item.path, relative_to)
+                    if prefix:
+                        item_path = bytes(prefix.encode('utf-8')) + item_path
                 if item_path not in m3us[m3u_name]:
                     m3us[m3u_name].append(item_path)
 


### PR DESCRIPTION
Perhaps I misunderstood the `relative_to` option and what I want to achieve could have been done without this modification but I didn't easily find it. I needed a way to append a prefix to each line when using the `relative_to` option. Perhaps this `relative_to_prefix` option could be used without `relative_to` in some sort of valid use case but I'm uncertain, at which point we could rename the option to something different.

**My Problem**
When using `relative_to` the `normpath` function kept removing the `../` at the beginning of my defined relative path. Then without it or using whatever variations I could the `normpath` call would sometimes prepend the path to the file as accessed from my WSL shell where I use beets so I would end up with `/home/xxx/music/path/to/file`. However this would mean the playlist won't work outside of WSL where I want it on Windows for playback. My music library is also on an external media and so I didn't want to have to reference a static prefix such as `E:\\beets\\library\\` since then when I move my hard drive to another machine it would break the m3u file.

Let me know if there is a different way to handle this use case. And for clarity my beets setup on the external media is like the following:

```
- beets/
    |-- library/
    |-- playlists/
    |-- config.yaml
```

## Description

Fixes #X.  <!-- Insert issue number here if applicable. -->

(...)

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
