### PR TITLE
escape ? in fish completion

### DIFF
--- a/beetsplug/fish.py
+++ b/beetsplug/fish.py
@@ -132,6 +132,7 @@ class FishPlugin(BeetsPlugin):
         with open(completion_file_path, 'w') as fish_file:
             fish_file.write(totstring)
 
+
 def _escape(name):
     # Escape ? in fish
     if name == "?":

--- a/beetsplug/fish.py
+++ b/beetsplug/fish.py
@@ -201,6 +201,10 @@ def get_subcommands(cmd_name_and_help, nobasicfields, extravalues):
     # Formatting for Fish to complete our fields/values
     word = ""
     for cmdname, cmdhelp in cmd_name_and_help:
+        # Escape ? in fish
+        if cmdname == "?":
+            cmdname = "\\" + cmdname
+
         word += "\n" + "# ------ {} -------".format(
             "fieldsetups for  " + cmdname) + "\n"
         word += (
@@ -232,6 +236,10 @@ def get_all_commands(beetcmds):
         names = [alias for alias in cmd.aliases]
         names.append(cmd.name)
         for name in names:
+            # Escape ? in fish
+            if name == "?":
+                name = "\\" + name
+
             word += "\n"
             word += ("\n" * 2) + "# ====== {} =====".format(
                 "completions for  " + name) + "\n"

--- a/beetsplug/fish.py
+++ b/beetsplug/fish.py
@@ -132,6 +132,11 @@ class FishPlugin(BeetsPlugin):
         with open(completion_file_path, 'w') as fish_file:
             fish_file.write(totstring)
 
+def _escape(name):
+    # Escape ? in fish
+    if name == "?":
+        name = "\\" + name
+
 
 def get_cmds_list(cmds_names):
     # Make a list of all Beets core & plugin commands
@@ -201,9 +206,7 @@ def get_subcommands(cmd_name_and_help, nobasicfields, extravalues):
     # Formatting for Fish to complete our fields/values
     word = ""
     for cmdname, cmdhelp in cmd_name_and_help:
-        # Escape ? in fish
-        if cmdname == "?":
-            cmdname = "\\" + cmdname
+        cmdname = _escape(cmdname)
 
         word += "\n" + "# ------ {} -------".format(
             "fieldsetups for  " + cmdname) + "\n"
@@ -236,9 +239,7 @@ def get_all_commands(beetcmds):
         names = [alias for alias in cmd.aliases]
         names.append(cmd.name)
         for name in names:
-            # Escape ? in fish
-            if name == "?":
-                name = "\\" + name
+            name = _escape(name)
 
             word += "\n"
             word += ("\n" * 2) + "# ====== {} =====".format(


### PR DESCRIPTION
## Description

Change the fish plugin to escape "?" in the completions file, without escping ? is interpreted as a regex and creates lots of errors that interfere with the actual useful completions.
This PR introduces changes to escape "?" in the command names in fish.py to ensure working completions.

## To Do

- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)

EDIT: I am not sure whether this should go into the changelog as the fish plugin is not even included in the latest release.