### PR TITLE
change copyartifact doc

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -169,6 +169,7 @@ New features:
 
 Fixes:
 
+* :doc:`/plugins/index`: Change beets-copyartifacts to maintained repo.
 * :doc:`/plugins/subsonicupdate`: REST was using `POST` method rather `GET` method.
   Also includes better exception handling, response parsing, and tests.
 * :doc:`/plugins/the`: Fixed incorrect regex for 'the' that matched any

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -169,7 +169,6 @@ New features:
 
 Fixes:
 
-* :doc:`/plugins/index`: Change beets-copyartifacts to maintained repo.
 * :doc:`/plugins/subsonicupdate`: REST was using `POST` method rather `GET` method.
   Also includes better exception handling, response parsing, and tests.
 * :doc:`/plugins/the`: Fixed incorrect regex for 'the' that matched any

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -275,7 +275,7 @@ Here are a few of the plugins written by the beets community:
 
 * `beet-amazon`_ adds Amazon.com as a tagger data source.
 
-* `copyartifacts`_ helps bring non-music files along during import.
+* `beets-copyartifacts`_ helps bring non-music files along during import.
 
 * `beets-check`_ automatically checksums your files to detect corruption.
 
@@ -326,7 +326,7 @@ Here are a few of the plugins written by the beets community:
 
 .. _beets-barcode: https://github.com/8h2a/beets-barcode
 .. _beets-check: https://github.com/geigerzaehler/beets-check
-.. _copyartifacts: https://github.com/sbarakat/beets-copyartifacts
+.. _beets-copyartifacts: https://github.com/adammillerio/beets-copyartifacts
 .. _dsedivec: https://github.com/dsedivec/beets-plugins
 .. _beets-artistcountry: https://github.com/agrausem/beets-artistcountry
 .. _beetFs: https://github.com/jbaiter/beetfs


### PR DESCRIPTION
## Description

based on https://github.com/sbarakat/beets-copyartifacts/commit/63776efebe4da38c31d9583110614ca2bf402f3d sbarakat/beets-copyartifacts is no longer maintained. The repo suggest 2 beets plugins alternative, https://github.com/adammillerio/beets-copyartifacts, a fork of the repo and https://github.com/Holzhaus/beets-extrafiles another plugin to manage files. i choose the fork to replace the old repo and change the link name.

i can also add Holzhaus/beets-extrafiles if required.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- Tests. (Encouraged but not strictly required.)
