### PR TITLE
Move files to trash instead of deleting via new config option

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -69,6 +69,7 @@ terminal_encoding:
 original_date: no
 artist_credit: no
 id3v23: no
+remove_command: "trash"
 va_name: "Various Artists"
 
 ui:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -41,6 +41,11 @@ Major new features:
 
 Other new things:
 
+* File removal operations are performed by the command specified in the new
+  :ref:`remove_command` configuration option (default: ``trash``), allowing
+  users to optionally install and use safer file removal tools.
+  Thanks to :user:`justinmayer`.
+  :bug:`3796`
 * :doc:`/plugins/mpdstats`: Add a new `strip_path` option to help build the
   right local path from MPD information.
 * :doc:`/plugins/convert`: Conversion can now parallelize conversion jobs on

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -347,6 +347,16 @@ By default, beets writes MP3 tags using the ID3v2.4 standard, the latest
 version of ID3. Enable this option to instead use the older ID3v2.3 standard,
 which is preferred by certain older software such as Windows Media Player.
 
+.. _remove_command:
+
+remove_command
+~~~~~~~~~~~~~~
+
+If Beets finds the specified executable on ``$PATH`` (default: ``"trash"``),
+file removal operations will be performed via that command. If this setting
+is set to ``""`` or to a value that does not appear to be an executable file,
+to-be-removed files will be deleted immediately via ``os.remove()``.
+
 .. _va_name:
 
 va_name


### PR DESCRIPTION
## Description

While it doesn't happen often, some folks have had experiences in which Beets unexpectedly deletes a song. All software has bugs, and data loss sometimes happens. But as someone who once lost an entire music collection due to data loss (not Beets-related), I think we should do everything we can to prevent unexpected file deletion, regardless of whether that happens via bugs or user mistakes. 

This pull request enhances the `util.remove()` function to move the specified file to the trash by default **if** there is a `trash` executable on `$PATH`. Otherwise, the file is deleted. This approach provides the option for a safer user experience without adding yet another Python dependency to the project.

The executable to be used for these safer file removal operations (default: `trash`) is configurable via a new `remove_command` configuration option.

Fixes #149 #2499 