### PR TITLE
keyfinder: Catch output from keyfinder-cli with no key

### DIFF
--- a/beetsplug/keyfinder.py
+++ b/beetsplug/keyfinder.py
@@ -79,8 +79,8 @@ class KeyFinderPlugin(BeetsPlugin):
             try:
                 key_raw = output.rsplit(None, 1)[-1]
             except IndexError:
-                # Sometimes keyfinder-cli returns 0 but with no key, usually when
-                # the file is silent or corrupt, so we log and skip.
+                # Sometimes keyfinder-cli returns 0 but with no key, usually
+                # when the file is silent or corrupt, so we log and skip.
                 self._log.error(u'no key returned for path: {0}', item.path)
                 continue
 

--- a/beetsplug/keyfinder.py
+++ b/beetsplug/keyfinder.py
@@ -76,7 +76,14 @@ class KeyFinderPlugin(BeetsPlugin):
                                 item.path)
                 continue
 
-            key_raw = output.rsplit(None, 1)[-1]
+            try:
+                key_raw = output.rsplit(None, 1)[-1]
+            except IndexError:
+                # Sometimes keyfinder-cli returns 0 but with no key, usually when
+                # the file is silent or corrupt, so we log and skip.
+                self._log.error(u'no key returned for path: {0}', item.path)
+                continue
+
             try:
                 key = util.text_string(key_raw)
             except UnicodeDecodeError:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -282,6 +282,8 @@ Fixes:
   :bug:`3773` :bug:`3774`
 * Fix a bug causing PIL to generate poor quality JPEGs when resizing artwork.
   :bug:`3743`
+* :doc:`plugins/keyfinder`: Catch output from ``keyfinder-cli`` that is missing key.
+  :bug:`2242`
 
 For plugin developers:
 

--- a/test/test_keyfinder.py
+++ b/test/test_keyfinder.py
@@ -76,6 +76,16 @@ class KeyFinderTest(unittest.TestCase, TestHelper):
         item.load()
         self.assertEqual(item['initial_key'], 'F')
 
+    def test_no_key(self, command_output):
+        item = Item(path='/file')
+        item.add(self.lib)
+
+        command_output.return_value = util.CommandOutput(b"", b"")
+        self.run_command('keyfinder')
+
+        item.load()
+        self.assertEqual(item['initial_key'], None)
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)


### PR DESCRIPTION
## Description

Fixes #2242 

When you run `keyfinder-cli` on some files (in my testing, files that are either corrupted or silent in some way), it will exit with 0 but return an empty output for the key. This caused an IndexError when attempting to access an index in the resulting empty array.

This PR adds exception handling for this case, where it just logs that it happened and continues. It also adds a unit test for this case.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
