### PR TITLE
Use caching in plugins.find_plugins()

### DIFF
--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -301,6 +301,11 @@ def find_plugins():
     currently loaded beets plugins. Loads the default plugin set
     first.
     """
+    if _instances:
+        # After the first call, use cached instances for performance reasons.
+        # See https://github.com/beetbox/beets/pull/3810
+        return list(_instances.values())
+
     load_plugins()
     plugins = []
     for cls in _classes:


### PR DESCRIPTION
This function is called from library.Item._getters(), making it a hot
path when exporting data. We cache plugin instances but previously we
reran `import` for each module on each call. We now return the cached
values providing a speed boost for `beet export`.

This has a small effect on `beet ls` speed: for me it went 11.00s ->
10.40.

It had a significant effect on `beet export` speed when combined with
https://github.com/beetbox/beets/pull/3762/.

Before:

    $ time /home/sam/.local/bin/beet 'export' '--library' '--format' 'jsonlines' '--include-keys' 'artist,title,path,mb_artistid,mb_trackid' 'artist+ title+' > /dev/null
    Executed in   25.13 secs

After:

    $ time /home/sam/.local/bin/beet 'export' '--library' '--format' 'jsonlines' '--include-keys' 'artist,title,path,mb_artistid,mb_trackid' 'artist+ title+' > /dev/null
    Executed in   10.49 secs

## To Do

- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
