### PR TITLE
lastgenre: Make TitleCasing optional

### DIFF
--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -111,6 +111,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
             'auto': True,
             'separator': u', ',
             'prefer_specific': False,
+            'title_case': True,
         })
 
         self.setup()
@@ -224,11 +225,16 @@ class LastGenrePlugin(plugins.BeetsPlugin):
 
         # c14n only adds allowed genres but we may have had forbidden genres in
         # the original tags list
-        tags = [x.title() for x in tags if self._is_allowed(x)]
+        tags = [self._format_tag(x) for x in tags if self._is_allowed(x)]
 
         return self.config['separator'].as_str().join(
             tags[:self.config['count'].get(int)]
         )
+
+    def _format_tag(self, tag):
+        if self.config["title_case"]:
+            return tag.title()
+        return tag
 
     def fetch_genre(self, lastfm_obj):
         """Return the genre for a pylast entity or None if no suitable genre

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 
 New features:
 
+* Add ``title_case`` config option to lastgenre to make TitleCasing optional.
 * When config is printed with no available configuration a new message is printed.
   :bug:`3779`
 * When importing a duplicate album it ask if it should "Keep all" instead of "Keep both".

--- a/docs/plugins/lastgenre.rst
+++ b/docs/plugins/lastgenre.rst
@@ -146,6 +146,8 @@ configuration file. The available options are:
 - **whitelist**: The filename of a custom genre list, ``yes`` to use
   the internal whitelist, or ``no`` to consider all genres valid.
   Default: ``yes``.
+- **title_case**: Convert the new tags to TitleCase before saving.
+  Default: ``yes``.
 
 Running Manually
 ----------------


### PR DESCRIPTION
## Description

This makes the `lastgenre`'s title casing behaviour optional to stay truer to the whitelist tag formatting

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
