### PR TITLE
Fix escape helper in fish completion plugin

### DIFF
--- a/beetsplug/fish.py
+++ b/beetsplug/fish.py
@@ -137,6 +137,7 @@ def _escape(name):
     # Escape ? in fish
     if name == "?":
         name = "\\" + name
+    return name
 
 
 def get_cmds_list(cmds_names):


### PR DESCRIPTION
## Description

The `_escape` helper was introduced in https://github.com/beetbox/beets/pull/3792, specifically 57a1b3aca86253d130848fdfcd2accbed861b5ee, but the omission of a `return` statement means that the function always incorrectly returns `None`. This causes `beet fish` to error when it eventually attempts to concatenate the value with a string:

```
Traceback (most recent call last):
  File "/home/linuxbrew/.linuxbrew/bin/beet", line 8, in <module>
    sys.exit(main())
  File "/home/linuxbrew/.linuxbrew/opt/python@3.9/lib/python3.9/site-packages/beets/ui/__init__.py", line 1278, in main
    _raw_main(args)
  File "/home/linuxbrew/.linuxbrew/opt/python@3.9/lib/python3.9/site-packages/beets/ui/__init__.py", line 1265, in _raw_main
    subcommand.func(lib, suboptions, subargs)
  File "/home/linuxbrew/.linuxbrew/opt/python@3.9/lib/python3.9/site-packages/beetsplug/fish.py", line 127, in run
    totstring += get_subcommands(
  File "/home/linuxbrew/.linuxbrew/opt/python@3.9/lib/python3.9/site-packages/beetsplug/fish.py", line 213, in get_subcommands
    "fieldsetups for  " + cmdname) + "\n"
TypeError: can only concatenate str (not "NoneType") to str
```

This PR adds the missing `return` statement.

IMO a changelog entry isn't necessarily because it's such a simple fix, but let me know if you disagree.

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
