### PR TITLE
Disable replaygain parallelism during import

### DIFF
--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -1234,6 +1234,7 @@ class ReplayGainPlugin(BeetsPlugin):
             'auto': True,
             'backend': u'command',
             'threads': cpu_count(),
+            'parallel_on_import': False,
             'per_disc': False,
             'peak': 'true',
             'targetlevel': 89,
@@ -1553,8 +1554,10 @@ class ReplayGainPlugin(BeetsPlugin):
     def import_begin(self, session):
         """Handle `import_begin` event -> open pool
         """
-        if self.config['auto']:
-            self.open_pool(self.config['threads'].get(int))
+        threads = self.config['threads'].get(int)
+
+        if self.config['parallel_on_import'] and threads:
+            self.open_pool(threads)
 
     def import_end(self, paths):
         """Handle `import` event -> close pool

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -1556,7 +1556,9 @@ class ReplayGainPlugin(BeetsPlugin):
         """
         threads = self.config['threads'].get(int)
 
-        if self.config['parallel_on_import'] and threads:
+        if self.config['parallel_on_import'] \
+                and self.config['auto'] \
+                and threads:
             self.open_pool(threads)
 
     def import_end(self, paths):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -289,7 +289,7 @@ Fixes:
 * :doc:`plugins/keyfinder`: Catch output from ``keyfinder-cli`` that is missing key.
   :bug:`2242`
 * :doc:`plugins/replaygain`: Disable parallel analysis on import by default.
-
+  :bug:`3819`
 
 For plugin developers:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -288,6 +288,8 @@ Fixes:
   :bug:`3743`
 * :doc:`plugins/keyfinder`: Catch output from ``keyfinder-cli`` that is missing key.
   :bug:`2242`
+* :doc:`plugins/replaygain`: Disable parallel analysis on import by default.
+
 
 For plugin developers:
 

--- a/docs/plugins/replaygain.rst
+++ b/docs/plugins/replaygain.rst
@@ -103,6 +103,12 @@ configuration file. The available options are:
 - **threads**: The number of parallel threads to run the analysis in. Overridden
   by ``--threads`` at the command line.
   Default: # of logical CPU cores
+- **parallel_on_import**: Whether to enable parallel analysis during import.
+  As of now this ReplayGain data is not written to files properly, so this option
+  is disabled by default.
+  If you wish to enable it, remember to run ``beet write`` after importing to
+  actually write to the imported files.
+  Default: ``no``
 - **backend**: The analysis backend; either ``gstreamer``, ``command``, ``audiotools``
   or ``ffmpeg``.
   Default: ``command``.


### PR DESCRIPTION
## Description

Add an additional config parameter to enable parallelism on import. Defaults to `False` because this functionality is unpredictable and should be opt-in for now.
