### PR TITLE
fix youtube video when using https

### DIFF
--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -9,7 +9,7 @@
         <link href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" rel="stylesheet">
         <link rel="stylesheet" href="/beets.css">
         {% if page.section == 'main' %}
-        <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
         <script type="text/javascript" src="beets.js"></script>
         {% endif %}
 
@@ -48,7 +48,7 @@
                 <div class="col-md-8 screen" id="{{ page.section }}">
 {% if page.section == 'main' %}
 <div class="embed">
-    <iframe width="560" height="345" src="http://www.youtube.com/embed/ZaqJmjM23D0" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
+    <iframe width="560" height="345" src="https://www.youtube.com/embed/ZaqJmjM23D0" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>
 </div>
 {% endif %}
 {{ content }}
@@ -71,7 +71,7 @@ or <a href="http://news.ycombinator.com/submitlink?u={{ site.url | cgi_escape }}
 <h3><a href="/">This is Beets</a></h3>
 <p>
     Beets is the media library management system for obsessive music
-    geeks. <a href="http://www.youtube.com/watch?v=ZaqJmjM23D0">Watch a
+    geeks. <a href="https://www.youtube.com/watch?v=ZaqJmjM23D0">Watch a
         screencast</a> to learn more.
 </p>
 </section>


### PR DESCRIPTION
## Description

Should fix youtube video now shown on github.io page when using https due to using http within https

https://beets.io/

vs

http://beets.io/

(...)

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
