### PR TITLE
Fetch data for releases with more than 500 tracks

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -74,6 +74,7 @@ RELEASE_INCLUDES = ['artists', 'media', 'recordings', 'release-groups',
 BROWSE_INCLUDES = ['artist-credits', 'work-rels',
                    'artist-rels', 'recording-rels', 'release-rels']
 BROWSE_CHUNKSIZE = 100
+v = 500
 TRACK_INCLUDES = ['artists', 'aliases']
 if 'work-level-rels' in musicbrainzngs.VALID_INCLUDES['recording']:
     TRACK_INCLUDES += ['work-level-rels', 'artist-rels']
@@ -293,7 +294,7 @@ def album_info(release):
     # The MusicBrainz API omits 'artist-relation-list' and 'work-relation-list'
     # when the release has more than 500 tracks. So we use browse_recordings
     # on chunks of tracks to recover the same information in this case.
-    if ntracks > 500:
+    if ntracks > BROWSE_MAXTRACKS:
         recording_list = []
         for i in range(0, ntracks, BROWSE_CHUNKSIZE):
             recording_list.extend(musicbrainzngs.browse_recordings(

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -73,7 +73,6 @@ RELEASE_INCLUDES = ['artists', 'media', 'recordings', 'release-groups',
                     'work-level-rels', 'artist-rels']
 BROWSE_INCLUDES = ['artist-credits', 'work-rels',
                    'artist-rels', 'recording-rels', 'release-rels']
-
 TRACK_INCLUDES = ['artists', 'aliases']
 if 'work-level-rels' in musicbrainzngs.VALID_INCLUDES['recording']:
     TRACK_INCLUDES += ['work-level-rels', 'artist-rels']

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -288,9 +288,7 @@ def album_info(release):
     artist_name, artist_sort_name, artist_credit_name = \
         _flatten_artist_credit(release['artist-credit'])
 
-    ntracks = 0
-    for medium in release['medium-list']:
-        ntracks += len(medium['track-list'])
+    ntracks = sum(len(m['track-list']) for m in release['medium-list'])
 
     # The MusicBrainz API omits 'artist-relation-list' and 'work-relation-list'
     # when the release has more than 500 tracks. So we use browse_recordings

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -295,7 +295,7 @@ def album_info(release):
     # when the release has more than 500 tracks. So we use browse_recordings
     # on chunks of tracks to recover the same information in this case.
     if ntracks > BROWSE_MAXTRACKS:
-        log.info(u'Album ' + str(release['id']) + u' has too many tracks')
+        log.debug(u'Album {} has too many tracks', release['id'])
         log.info(u'Fetching recordings in batches of ' + str(BROWSE_CHUNKSIZE))
         recording_list = []
         for i in range(0, ntracks, BROWSE_CHUNKSIZE):

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -295,6 +295,8 @@ def album_info(release):
     # when the release has more than 500 tracks. So we use browse_recordings
     # on chunks of tracks to recover the same information in this case.
     if ntracks > BROWSE_MAXTRACKS:
+        log.info(u'Album '+str(trackid)+u' has too many tracks')
+        log.info(u'Fetching recordings in batches of '+str(BROWSE_CHUNKSIZE))
         recording_list = []
         for i in range(0, ntracks, BROWSE_CHUNKSIZE):
             recording_list.extend(musicbrainzngs.browse_recordings(
@@ -540,6 +542,7 @@ def album_for_id(releaseid):
     try:
         res = musicbrainzngs.get_release_by_id(albumid,
                                                RELEASE_INCLUDES)
+        log.info(u'Album '+str(trackid)+u' fetched from MusicBrainz')
     except musicbrainzngs.ResponseError:
         log.debug(u'Album ID match failed.')
         return None
@@ -559,6 +562,7 @@ def track_for_id(releaseid):
         return
     try:
         res = musicbrainzngs.get_recording_by_id(trackid, TRACK_INCLUDES)
+        log.info(u'Track '+str(trackid)+u' fetched from MusicBrainz')
     except musicbrainzngs.ResponseError:
         log.debug(u'Track ID match failed.')
         return None

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -305,9 +305,7 @@ def album_info(release):
                     release=release['id'], limit=BROWSE_CHUNKSIZE,
                     includes=BROWSE_INCLUDES,
                     offset=i)['recording-list'])
-        track_map = {}
-        for recording in recording_list:
-            track_map[recording['id']] = recording
+        track_map = {r['id']: r for r in recording_list}
         for medium in release['medium-list']:
             for recording in medium['track-list']:
                 recording_info = track_map[recording['recording']['id']]

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -74,7 +74,7 @@ RELEASE_INCLUDES = ['artists', 'media', 'recordings', 'release-groups',
 BROWSE_INCLUDES = ['artist-credits', 'work-rels',
                    'artist-rels', 'recording-rels', 'release-rels']
 BROWSE_CHUNKSIZE = 100
-v = 500
+BROWSE_MAXTRACKS = 500
 TRACK_INCLUDES = ['artists', 'aliases']
 if 'work-level-rels' in musicbrainzngs.VALID_INCLUDES['recording']:
     TRACK_INCLUDES += ['work-level-rels', 'artist-rels']

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -73,6 +73,8 @@ RELEASE_INCLUDES = ['artists', 'media', 'recordings', 'release-groups',
                     'work-level-rels', 'artist-rels']
 BROWSE_INCLUDES = ['artist-credits', 'work-rels',
                    'artist-rels', 'recording-rels', 'release-rels']
+if "work-level-rels" in musicbrainzngs.VALID_BROWSE_INCLUDES['recording']:
+    BROWSE_INCLUDES.append("work-level-rels")
 BROWSE_CHUNKSIZE = 100
 BROWSE_MAXTRACKS = 500
 TRACK_INCLUDES = ['artists', 'aliases']

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -294,10 +294,10 @@ def album_info(release):
     # for albums with more than 500 tracks
     if ntracks > 500:
         recording_list = []
-        for i in range((ntracks//100)+1):
+        for i in range((ntracks // 100) + 1):
             recording_list.extend(musicbrainzngs.browse_recordings(
                     release=release['id'], limit=100, includes=BROWSE_INCLUDES,
-                    offset=100*i)['recording-list'])
+                    offset=100 * i)['recording-list'])
         for medium in release['medium-list']:
             for recording in medium['track-list']:
                 recording_info = list(filter(lambda track: track['id'] ==

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -295,8 +295,8 @@ def album_info(release):
     # when the release has more than 500 tracks. So we use browse_recordings
     # on chunks of tracks to recover the same information in this case.
     if ntracks > BROWSE_MAXTRACKS:
-        log.info(u'Album '+str(trackid)+u' has too many tracks')
-        log.info(u'Fetching recordings in batches of '+str(BROWSE_CHUNKSIZE))
+        log.info(u'Album ' + str(release['id']) + u' has too many tracks')
+        log.info(u'Fetching recordings in batches of ' + str(BROWSE_CHUNKSIZE))
         recording_list = []
         for i in range(0, ntracks, BROWSE_CHUNKSIZE):
             recording_list.extend(musicbrainzngs.browse_recordings(
@@ -542,7 +542,7 @@ def album_for_id(releaseid):
     try:
         res = musicbrainzngs.get_release_by_id(albumid,
                                                RELEASE_INCLUDES)
-        log.info(u'Album '+str(trackid)+u' fetched from MusicBrainz')
+        log.info(u'Album ' + str(releaseid) + u' fetched from MusicBrainz')
     except musicbrainzngs.ResponseError:
         log.debug(u'Album ID match failed.')
         return None
@@ -562,7 +562,7 @@ def track_for_id(releaseid):
         return
     try:
         res = musicbrainzngs.get_recording_by_id(trackid, TRACK_INCLUDES)
-        log.info(u'Track '+str(trackid)+u' fetched from MusicBrainz')
+        log.info(u'Track ' + str(releaseid) + u' fetched from MusicBrainz')
     except musicbrainzngs.ResponseError:
         log.debug(u'Track ID match failed.')
         return None

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -71,6 +71,9 @@ RELEASE_INCLUDES = ['artists', 'media', 'recordings', 'release-groups',
                     'labels', 'artist-credits', 'aliases',
                     'recording-level-rels', 'work-rels',
                     'work-level-rels', 'artist-rels']
+BROWSE_INCLUDES = ['artist-credits', 'work-rels',
+                   'artist-rels', 'recording-rels', 'release-rels']
+
 TRACK_INCLUDES = ['artists', 'aliases']
 if 'work-level-rels' in musicbrainzngs.VALID_INCLUDES['recording']:
     TRACK_INCLUDES += ['work-level-rels', 'artist-rels']
@@ -284,6 +287,24 @@ def album_info(release):
     # Get artist name using join phrases.
     artist_name, artist_sort_name, artist_credit_name = \
         _flatten_artist_credit(release['artist-credit'])
+
+    ntracks = 0
+    for medium in release['medium-list']:
+        ntracks += len(medium['track-list'])
+
+    # for albums with more than 500 tracks
+    if ntracks > 500:
+        recording_list = []
+        for i in range((ntracks//100)+1):
+            recording_list.extend(musicbrainzngs.browse_recordings(
+                    release=release['id'], limit=100, includes=BROWSE_INCLUDES,
+                    offset=100*i)['recording-list'])
+        for medium in release['medium-list']:
+            for recording in medium['track-list']:
+                recording_info = list(filter(lambda track: track['id'] ==
+                                             recording['recording']['id'],
+                                             recording_list))[0]
+                recording['recording'] = recording_info
 
     # Basic info.
     track_infos = []

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -290,6 +290,8 @@ Fixes:
   :bug:`2242`
 * :doc:`plugins/replaygain`: Disable parallel analysis on import by default.
   :bug:`3819`
+* Fix :bug:`3308` by using browsing for big releases to retrieve additional
+  information. Thanks to :user:`dosoe`.
 
 For plugin developers:
 


### PR DESCRIPTION
## Description

Fixes #3308. 
```musicbrainzngs.get_release_by_id``` doesn't provide all data beets asks for when a release has more than 500 tracks. I use ```musicbrainzngs.browse_recordings``` as a complement to ```musicbrainzngs.get_release_by_id``` for releases with more than 500 tracks to get the missing data. It doesn't work perfectly yet, mainly because ```musicbrainzngs.browse_recordings``` does not allow to fetch quite the same data than  ```musicbrainzngs.get_release_by_id``` (notably, ```work_level_rels``` and ```aliases``` are missing for reasons I don't quite understand) but it's already much better and on the day ```musicbrainzngs.browse_recordings``` does fetch this data, the update should be trivial. 

## To Do

- [X] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (What should I test? Create a mock release with more than 500 tracks?)
