### PR TITLE
discogs plugin: fix index_track option

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -499,7 +499,7 @@ class DiscogsPlugin(BeetsPlugin):
                 else:
                     # Promote the subtracks to real tracks, discarding the
                     # index track, assuming the subtracks are physical tracks.
-                    index_track = tracklist.pop()
+                    index_track = tracklist[-1]
                     # Fix artists when they are specified on the index track.
                     if index_track.get('artists'):
                         for subtrack in subtracks:

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -557,7 +557,8 @@ class DiscogsPlugin(BeetsPlugin):
         title = track['title']
         if self.config['index_tracks']:
             prefix = ', '.join(divisions)
-            title = ': '.join([prefix, title])
+            if prefix != '':
+                title = ': '.join([prefix, title])
         track_id = None
         medium, medium_index, _ = self.get_track_index(track['position'])
         artist, artist_id = MetadataSourcePlugin.get_artist(

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -563,8 +563,8 @@ class DiscogsPlugin(BeetsPlugin):
         title = track['title']
         if self.config['index_tracks']:
             prefix = ', '.join(divisions)
-            if prefix != '':
-                title = ': '.join([prefix, title])
+            if prefix:
+                title = '{}: {}'.format(prefix, title)
         track_id = None
         medium, medium_index, _ = self.get_track_index(track['position'])
         artist, artist_id = MetadataSourcePlugin.get_artist(

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -499,12 +499,18 @@ class DiscogsPlugin(BeetsPlugin):
                 else:
                     # Promote the subtracks to real tracks, discarding the
                     # index track, assuming the subtracks are physical tracks.
-                    index_track = tracklist[-1]
+                    index_track = tracklist.pop()
                     # Fix artists when they are specified on the index track.
                     if index_track.get('artists'):
                         for subtrack in subtracks:
                             if not subtrack.get('artists'):
                                 subtrack['artists'] = index_track['artists']
+                    # Concatenate index with track title when index_tracks
+                    # option is set
+                    if self.config['index_tracks']:
+                        for subtrack in subtracks:
+                            subtrack['title'] = '{}: {}'.format(
+                                    index_track['title'], subtrack['title'])
                     tracklist.extend(subtracks)
             else:
                 # Merge the subtracks, pick a title, and append the new track.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -176,6 +176,9 @@ New features:
 
 Fixes:
 
+* :bug:`/plugins/discogs`: Fixed a bug with ``index_tracks`` options that
+  sometimes caused the index to be discarded. Also remove the extra semicolon
+  that was added when there is no index track.
 * :doc:`/plugins/subsonicupdate`: REST was using `POST` method rather `GET` method.
   Also includes better exception handling, response parsing, and tests.
 * :doc:`/plugins/the`: Fixed incorrect regex for 'the' that matched any


### PR DESCRIPTION
This PR fixes the behavior of the ``index_track`` option of the discogs plugin.

Currently, it only works when index tracks are of type "heading" in the discogs listing (like in https://www.discogs.com/Handel-Sutherland-Kirkby-Kwella-Nelson-Watkinson-Bowman-Rolfe-Johnson-Elliott-Partridge-Thomas-The-A/release/2026070), but not when they are of type "index" (like in https://www.discogs.com/fr/Glenn-Gould-Columbia-Symphony-Orchestra-Vladimir-Golschmann-Bach-The-Concertos-For-KeyboardClavier-S/release/10142332).
This is because index tracks are removed in function ``coalesce_tracks``. The fix is simply to keep them when there is no subtrack merging.

This also removes the semicolon when there is no index track. Currently, when the option is on, every track title will start with " : " when there is no index track.