### PR TITLE
Add Python version check for mpdstats

### DIFF
--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -18,6 +18,7 @@ from __future__ import division, absolute_import, print_function
 import mpd
 import socket
 import select
+import sys
 import time
 import os
 
@@ -52,7 +53,13 @@ class MPDClientWrapper(object):
         self.music_directory = (
             mpd_config['music_directory'].as_str())
 
-        self.client = mpd.MPDClient(use_unicode=True)
+        if sys.version_info < (3, 0):
+            # On Python 2, use_unicode will enable the utf-8 mode for
+            # python-mpd2
+            self.client = mpd.MPDClient(use_unicode=True)
+        else:
+            # On Python 3, python-mpd2 always uses Unicode
+            self.client = mpd.MPDClient()
 
     def connect(self):
         """Connect to the MPD.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -293,6 +293,8 @@ Fixes:
   :bug:`2242`
 * :doc:`plugins/replaygain`: Disable parallel analysis on import by default.
   :bug:`3819`
+* :doc:`/plugins/mpdstats`: Fix Python 2/3 compatibility
+  :bug:`3798`
 
 For plugin developers:
 


### PR DESCRIPTION
## Description

Fixes #3798.

Adds a check for Python 2/3 as to pass the correct init arguments to MPDClientWrapper. This removes the warning:
```
test/test_mpdstats.py::MPDStatsTest::test_update_rating
  /home/andrew/Documents/beets/beetsplug/mpdstats.py:55: DeprecationWarning: use_unicode parameter to ``MPDClient`` constructor is deprecated
    self.client = mpd.MPDClient(use_unicode=True)
```

~~Do the dependency constraints for python-mpd2 in setup.py need to be adjusted at all? Could there be a scenario where a user is using some version of Python 3 along with python-mpd2<2.0.0 that could cause issues?~~

## To Do

- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] ~~Update dependency version constraints? (See question in description)~~
