### PR TITLE
convert: uses new par_map to work in parallel

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -26,7 +26,6 @@ import shlex
 import six
 from string import Template
 import platform
-from itertools import repeat
 
 from beets import ui, util, plugins, config
 from beets.plugins import BeetsPlugin
@@ -185,8 +184,8 @@ class ConvertPlugin(BeetsPlugin):
 
     def auto_convert(self, config, task):
         if self.config['auto']:
-            par_map(lambda item: self.convert_on_import(config.lib, item), task.imported_items())
-
+            par_map(lambda item: self.convert_on_import(config.lib, item),
+                    task.imported_items())
 
     # Utilities converted from functions to methods on logging overhaul
 

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -185,8 +185,8 @@ class ConvertPlugin(BeetsPlugin):
 
     def auto_convert(self, config, task):
         if self.config['auto']:
-            items = zip(repeat(config.lib), list(task.imported_items()))
-            par_map(self.convert_on_import, items)
+            par_map(lambda item: self.convert_on_import(config.lib, item), task.imported_items())
+
 
     # Utilities converted from functions to methods on logging overhaul
 
@@ -510,12 +510,10 @@ class ConvertPlugin(BeetsPlugin):
         pipe = util.pipeline.Pipeline([iter(items), convert])
         pipe.run_parallel()
 
-    def convert_on_import(self, lib_item_pair):
+    def convert_on_import(self, lib, item):
         """Transcode a file automatically after it is imported into the
         library.
         """
-        lib = lib_item_pair[0]
-        item = lib_item_pair[1]
         fmt = self.config['format'].as_str().lower()
         if should_transcode(item, fmt):
             command, ext = get_format()

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -185,9 +185,8 @@ class ConvertPlugin(BeetsPlugin):
 
     def auto_convert(self, config, task):
         if self.config['auto']:
-            items = zip(repeat(config.lib),list(task.imported_items()))
-            par_map(self.convert_on_import, items )
-
+            items = zip(repeat(config.lib), list(task.imported_items()))
+            par_map(self.convert_on_import, items)
 
     # Utilities converted from functions to methods on logging overhaul
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 
 New features:
 
+* conversion uses par_map to parallelize conversion jobs in python3
 * Add ``title_case`` config option to lastgenre to make TitleCasing optional.
 * When config is printed with no available configuration a new message is printed.
   :bug:`3779`


### PR DESCRIPTION
## Description

Builds on  #3153 
parallelizes convert using par_map on python3

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
