### PR TITLE
Add two events ```extracting_trackdata``` and ```extracting_albumdata```

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -23,6 +23,7 @@ import traceback
 from six.moves.urllib.parse import urljoin
 
 from beets import logging
+from beets import plugins
 import beets.autotag.hooks
 import beets
 from beets import util
@@ -259,6 +260,12 @@ def track_info(recording, index=None, medium=None, medium_index=None,
     if arranger:
         info.arranger = u', '.join(arranger)
 
+    # supplementary tags provided by plugins
+    extra_trackdatas = plugins.send('extracting_trackdata', info=recording)
+    for extra_trackdata in extra_trackdatas:
+        for key in extra_trackdata:
+            info[key] = extra_trackdata[key]
+
     info.decode()
     return info
 
@@ -446,6 +453,12 @@ def album_info(release):
     genres = release.get('genre-list')
     if config['musicbrainz']['genres'] and genres:
         info.genre = ';'.join(g['name'] for g in genres)
+
+    # supplementary tags provided by plugins
+    extra_albumdatas = plugins.send('extracting_albumdata', info=release)
+    for extra_albumdata in extra_albumdatas:
+        for key in extra_albumdata:
+            info[key] = extra_albumdata[key]
 
     info.decode()
     return info

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -94,7 +94,7 @@ New features:
   Windows.
   Thanks to :user:`MartyLake`.
   :bug:`3331` :bug:`3334`
-* The 'data_source' field is now also applied as an album-level flexible
+* The ``data_source`` field is now also applied as an album-level flexible
   attribute during imports, allowing for more refined album level searches.
   :bug:`3350` :bug:`1693`
 * :doc:`/plugins/deezer`: Added Deezer plugin as an import metadata provider:
@@ -173,7 +173,8 @@ New features:
 * :doc:`/plugins/replaygain` now does its analysis in parallel when using
   the ``command``, ``ffmpeg`` or ``bs1770gain`` backends.
   :bug:`3478`
-
+* Add ``extracting_albumdata`` and ``extracting_trackdata`` hooks to allow
+  plugins to add new fields based on MusicBrainz data. Thanks to :user:`dosoe`.
 Fixes:
 
 * :bug:`/plugins/discogs`: Fixed a bug with ``index_tracks`` options that
@@ -1929,7 +1930,7 @@ Major new features and bigger changes:
   search results you wish to see when looking up releases at MusicBrainz
   during import. :bug:`1245`
 * The importer now records the data source for a match in a new
-  flexible attribute `data_source` on items and albums. :bug:`1311`
+  flexible attribute ``data_source`` on items and albums. :bug:`1311`
 * The colors used in the terminal interface are now configurable via the new
   config option ``colors``, nested under the option ``ui``. (Also, the `color`
   config option has been moved from top-level to under ``ui``. Beets will

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -238,6 +238,11 @@ The events currently available are:
   during a ``beet import`` interactive session. Plugins can use this event for
   :ref:`appending choices to the prompt <append_prompt_choices>` by returning a
   list of ``PromptChoices``. Parameters: ``task`` and ``session``.
+  
+* `extracting_trackdata` and `extracting_albumdata`: called after the metadata
+  is obtained from MusicBrainz. The parameter is a ``dict`` containing the data
+  retrieved from MusicBrainz for a track or an album.
+  Allows to add additional tags.
 
 The included ``mpdupdate`` plugin provides an example use case for event listeners.
 


### PR DESCRIPTION
## Description

Only the events as discussed in https://github.com/beetbox/beets/pull/3589

## To Do

- [X] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [X] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
