### PR TITLE
Fixes #3834: Submitting AcoustID information for tracks which already have a fingerprint

### DIFF
--- a/beetsplug/chroma.py
+++ b/beetsplug/chroma.py
@@ -329,7 +329,7 @@ def fingerprint_item(log, item, write=False):
         else:
             log.info(u'{0}: using existing fingerprint',
                      util.displayable_path(item.path))
-            return item.acoustid_fingerprint
+        return item.acoustid_fingerprint
     else:
         log.info(u'{0}: fingerprinting',
                  util.displayable_path(item.path))

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 
 New features:
 
+* Submitting acoustID information on tracks which already have a fingerprint
+  :bug:`3834`
 * conversion uses par_map to parallelize conversion jobs in python3
 * Add ``title_case`` config option to lastgenre to make TitleCasing optional.
 * When config is printed with no available configuration a new message is printed.


### PR DESCRIPTION
## Description

Fixes #3834

Tracks which have already been fingerprinted do not return to be used by `beet submit` (part of the Chroma plugin). This results in  submission errors, as the fingerprint is omitted from the resultant payload sent to acoustID.

## To Do

- [X] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
