### PR TITLE
pipeline: remove duplicate code from previous refactoring

### DIFF
--- a/beets/util/pipeline.py
+++ b/beets/util/pipeline.py
@@ -247,9 +247,6 @@ class FirstPipelineThread(PipelineThread):
         self.out_queue = out_queue
         self.out_queue.acquire()
 
-        self.abort_lock = Lock()
-        self.abort_flag = False
-
     def run(self):
         try:
             while True:


### PR DESCRIPTION
`PipelineThread.__init__()` already initializes this lock:

https://github.com/beetbox/beets/blob/109b547f7a85f5403a63d63d18d8bcb4ca815dc8/beets/util/pipeline.py#L211-L218