### PR TITLE
Stream-friendly smart playlists

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2166,6 +2166,9 @@ And many little fixes and improvements:
 * When there's a parse error in a query (for example, when you type a
   malformed date in a :ref:`date query <datequery>`), beets now stops with an
   error instead of silently ignoring the query component.
+* :doc:`/plugins/smartplaylist`: Stream-friendly smart playlists.
+  The ``splupdate`` command can now also add a URL-encodable prefix to every
+  path in the playlist file.
 
 For developers:
 

--- a/docs/plugins/smartplaylist.rst
+++ b/docs/plugins/smartplaylist.rst
@@ -101,3 +101,7 @@ other configuration options are:
   If you intend to use this plugin to generate playlists for MPD on
   Windows, set this to yes.
   Default: Use system separator.
+- **prefix**: Prepend this string to every path in the playlist file. For
+  example, you could use the URL for a server where the music is stored.
+  Default: empty string.
+- **urlencoded**: URL-encode all paths. Default: ``no``.


### PR DESCRIPTION
## Description

This commit introduced a way to generate a stream-frienldy playlists.

This is that I've missed to make me very happy at #3847

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
- [x] ~figured out that to do with complex unicode strings.~

## ~Unicode-related issue~

~Right now current code encodes at least at python `3.8.7` a string `Ayọ` as `Ayo%CC%A3` when it should be `Ay%E1%BB%8D`.~

~Until it is fixed I ask to don't merge it. @sampsyo if you have any idea how to fix it I'll be appreciated.~