### PR TITLE
Add strip_path to mpdstats

### DIFF
--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -127,8 +127,9 @@ class MPDClientWrapper(object):
         entry = self.get('currentsong')
         if 'file' in entry:
             if not is_url(entry['file']):
-                file = entry['file'].replace(self.strip_path, '', count=1)
-                result = os.path.join(self.music_directory, file)
+                if entry.startswith(self.strip_path):
+                    entry = entry[len(self.strip_path):]
+                result = os.path.join(self.music_directory, entry)
             else:
                 result = entry['file']
         return result, entry.get('id')

--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -127,9 +127,10 @@ class MPDClientWrapper(object):
         entry = self.get('currentsong')
         if 'file' in entry:
             if not is_url(entry['file']):
-                if entry.startswith(self.strip_path):
-                    entry = entry[len(self.strip_path):]
-                result = os.path.join(self.music_directory, entry)
+                file = entry['file']
+                if file.startswith(self.strip_path):
+                    file = file[len(self.strip_path):]
+                result = os.path.join(self.music_directory, file)
             else:
                 result = entry['file']
         return result, entry.get('id')

--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -53,6 +53,13 @@ class MPDClientWrapper(object):
         self.music_directory = mpd_config['music_directory'].as_str()
         self.strip_path = mpd_config['strip_path'].as_str()
 
+        # Ensure strip_path end with '/'
+        if not self.strip_path.endswith('/'):
+            self.strip_path += '/'
+
+        self._log.debug('music_directory: {0}', self.music_directory)
+        self._log.debug('strip_path: {0}', self.strip_path)
+
         if sys.version_info < (3, 0):
             # On Python 2, use_unicode will enable the utf-8 mode for
             # python-mpd2
@@ -132,6 +139,7 @@ class MPDClientWrapper(object):
                 result = os.path.join(self.music_directory, file)
             else:
                 result = entry['file']
+        self._log.debug('returning: {0}', result)
         return result, entry.get('id')
 
     def status(self):

--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -50,9 +50,8 @@ class MPDClientWrapper(object):
     def __init__(self, log):
         self._log = log
 
-        self.music_directory = (mpd_config['music_directory'].as_str())
-
-        self.strip_path = (mpd_config['strip_path'].as_str())
+        self.music_directory = mpd_config['music_directory'].as_str()
+        self.strip_path = mpd_config['strip_path'].as_str()
 
         if sys.version_info < (3, 0):
             # On Python 2, use_unicode will enable the utf-8 mode for

--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -53,6 +53,9 @@ class MPDClientWrapper(object):
         self.music_directory = (
             mpd_config['music_directory'].as_str())
 
+        self.strip_path = (
+            mpd_config['strip_path'].as_str())
+
         if sys.version_info < (3, 0):
             # On Python 2, use_unicode will enable the utf-8 mode for
             # python-mpd2
@@ -118,12 +121,16 @@ class MPDClientWrapper(object):
         """Return the path to the currently playing song, along with its
         songid.  Prefixes paths with the music_directory, to get the absolute
         path.
+        In some cases, we need to remove the local path from MPD server,
+        we replace 'strip_path' with ''.
+        `strip_path` defaults to ''.
         """
         result = None
         entry = self.get('currentsong')
         if 'file' in entry:
             if not is_url(entry['file']):
-                result = os.path.join(self.music_directory, entry['file'])
+                file = entry['file'].replace(self.strip_path, '')
+                result = os.path.join(self.music_directory, file)
             else:
                 result = entry['file']
         return result, entry.get('id')
@@ -334,6 +341,7 @@ class MPDStatsPlugin(plugins.BeetsPlugin):
         super(MPDStatsPlugin, self).__init__()
         mpd_config.add({
             'music_directory': config['directory'].as_filename(),
+            'strip_path':      u'',
             'rating':          True,
             'rating_mix':      0.75,
             'host':            os.environ.get('MPD_HOST', u'localhost'),

--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -127,7 +127,7 @@ class MPDClientWrapper(object):
         entry = self.get('currentsong')
         if 'file' in entry:
             if not is_url(entry['file']):
-                file = entry['file'].replace(self.strip_path, '')
+                file = entry['file'].replace(self.strip_path, '', count=1)
                 result = os.path.join(self.music_directory, file)
             else:
                 result = entry['file']

--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -50,11 +50,9 @@ class MPDClientWrapper(object):
     def __init__(self, log):
         self._log = log
 
-        self.music_directory = (
-            mpd_config['music_directory'].as_str())
+        self.music_directory = (mpd_config['music_directory'].as_str())
 
-        self.strip_path = (
-            mpd_config['strip_path'].as_str())
+        self.strip_path = (mpd_config['strip_path'].as_str())
 
         if sys.version_info < (3, 0):
             # On Python 2, use_unicode will enable the utf-8 mode for

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 
 New features:
 
+* :doc:`/plugins/mpdstats`: Add strip_path option to help build the right local path
+  from MPD information
 * Submitting acoustID information on tracks which already have a fingerprint
   :bug:`3834`
 * conversion uses par_map to parallelize conversion jobs in python3

--- a/docs/plugins/mpdstats.rst
+++ b/docs/plugins/mpdstats.rst
@@ -53,6 +53,9 @@ configuration file. The available options are:
 - **music_directory**: If your MPD library is at a different location from the
   beets library (e.g., because one is mounted on a NFS share), specify the path
   here.
+- **strip_path**: If your MPD library contains local path, specify the part to remove
+  here. Combining this with **music_directory** you can mangle MPD path to match the 
+  **beets library** one.
   Default: The beets library directory.
 - **rating**: Enable rating updates.
   Default: ``yes``.

--- a/docs/plugins/mpdstats.rst
+++ b/docs/plugins/mpdstats.rst
@@ -55,7 +55,7 @@ configuration file. The available options are:
   here.
 - **strip_path**: If your MPD library contains local path, specify the part to remove
   here. Combining this with **music_directory** you can mangle MPD path to match the 
-  **beets library** one.
+  beets library one.
   Default: The beets library directory.
 - **rating**: Enable rating updates.
   Default: ``yes``.


### PR DESCRIPTION
## Description

Add `strip_path` option to mpdstats plugin. Combined with `music_directory` option it can help mangling the path received from MPD daemon to match beets library one.

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
