### PR TITLE
Fix #3608: Replace discogs-client with python3-discogs-client

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -14,7 +14,7 @@
 # included in all copies or substantial portions of the Software.
 
 """Adds Discogs album search support to the autotagger. Requires the
-discogs-client library.
+python3-discogs-client library.
 """
 from __future__ import division, absolute_import, print_function
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -302,6 +302,8 @@ Fixes:
   :bug:`3798`
 * Fix :bug:`3308` by using browsing for big releases to retrieve additional
   information. Thanks to :user:`dosoe`.
+* :doc:`/plugins/discogs`: Replace deprecated discogs-client library with community
+  supported python3-discogs-client library. :bug:`3608`
 
 For plugin developers:
 

--- a/docs/plugins/discogs.rst
+++ b/docs/plugins/discogs.rst
@@ -10,9 +10,9 @@ Installation
 ------------
 
 To use the ``discogs`` plugin, first enable it in your configuration (see
-:ref:`using-plugins`). Then, install the `discogs-client`_ library by typing::
+:ref:`using-plugins`). Then, install the `python3-discogs-client`_ library by typing::
 
-    pip install discogs-client
+    pip install python3-discogs-client
 
 You will also need to register for a `Discogs`_ account, and provide
 authentication credentials via a personal access token or an OAuth2
@@ -36,7 +36,7 @@ Authentication via Personal Access Token
 
 As an alternative to OAuth, you can get a token from Discogs and add it to
 your configuration.
-To get a personal access token (called a "user token" in the `discogs-client`_
+To get a personal access token (called a "user token" in the `python3-discogs-client`_
 documentation), login to `Discogs`_, and visit the
 `Developer settings page
 <https://www.discogs.com/settings/developers>`_. Press the ``Generate new
@@ -89,4 +89,4 @@ Here are two things you can try:
 * Make sure that your system clock is accurate. The Discogs servers can reject
   your request if your clock is too out of sync.
 
-.. _discogs-client: https://github.com/discogs/discogs_client
+.. _python3-discogs-client: https://github.com/joalla/discogs_client

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,6 @@ setup(
         'test': [
             'beautifulsoup4',
             'coverage',
-            'discogs-client',
             'flask',
             'mock',
             'pylast',
@@ -128,6 +127,9 @@ setup(
             ['pathlib'] if (sys.version_info < (3, 4, 0)) else []
         ) + [
             'rarfile<4' if sys.version_info < (3, 6, 0) else 'rarfile',
+        ] + [
+            'discogs-client' if (sys.version_info < (3, 0, 0))
+            else 'python3-discogs-client'
         ],
         'lint': [
             'flake8',
@@ -144,7 +146,10 @@ setup(
         'embyupdate': ['requests'],
         'chroma': ['pyacoustid'],
         'gmusic': ['gmusicapi'],
-        'discogs': ['discogs-client>=2.2.1'],
+        'discogs': (
+            ['discogs-client' if (sys.version_info < (3, 0, 0))
+                else 'python3-discogs-client']
+        ),
         'beatport': ['requests-oauthlib>=0.6.1'],
         'kodiupdate': ['requests'],
         'lastgenre': ['pylast'],


### PR DESCRIPTION
discogs-client has been deprecated since June 2020, the replacement
is actively developed by the community and does not have any breaking
API changes.

Signed-off-by: George Rawlinson <george@rawlinson.net.nz>

## Description

Fixes #3608.