### PR TITLE
Add trackdisambig from musicbrainz.

### DIFF
--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -163,7 +163,7 @@ class TrackInfo(AttrDict):
                  composer=None, composer_sort=None, arranger=None,
                  track_alt=None, work=None, mb_workid=None,
                  work_disambig=None, bpm=None, initial_key=None, genre=None,
-                 **kwargs):
+                 trackdisambig=None, **kwargs):
         self.title = title
         self.track_id = track_id
         self.release_track_id = release_track_id
@@ -191,6 +191,7 @@ class TrackInfo(AttrDict):
         self.bpm = bpm
         self.initial_key = initial_key
         self.genre = genre
+        self.trackdisambig = trackdisambig
         self.update(kwargs)
 
     # As above, work around a bug in python-musicbrainz-ngs.

--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -163,7 +163,7 @@ class TrackInfo(AttrDict):
                  composer=None, composer_sort=None, arranger=None,
                  track_alt=None, work=None, mb_workid=None,
                  work_disambig=None, bpm=None, initial_key=None, genre=None,
-                 trackdisambig=None, **kwargs):
+                 **kwargs):
         self.title = title
         self.track_id = track_id
         self.release_track_id = release_track_id
@@ -191,7 +191,6 @@ class TrackInfo(AttrDict):
         self.bpm = bpm
         self.initial_key = initial_key
         self.genre = genre
-        self.trackdisambig = trackdisambig
         self.update(kwargs)
 
     # As above, work around a bug in python-musicbrainz-ngs.

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -223,7 +223,7 @@ def track_info(recording, index=None, medium=None, medium_index=None,
     if recording.get('length'):
         info.length = int(recording['length']) / (1000.0)
 
-    info.trackdisambig = recording.get('disambiguation', None)
+    info.trackdisambig = recording.get('disambiguation')
 
     lyricist = []
     composer = []

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -223,6 +223,9 @@ def track_info(recording, index=None, medium=None, medium_index=None,
     if recording.get('length'):
         info.length = int(recording['length']) / (1000.0)
 
+    if recording.get('disambiguation'):
+        info.trackdisambig = recording.get('disambiguation')
+
     lyricist = []
     composer = []
     composer_sort = []

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -223,8 +223,7 @@ def track_info(recording, index=None, medium=None, medium_index=None,
     if recording.get('length'):
         info.length = int(recording['length']) / (1000.0)
 
-    if recording.get('disambiguation'):
-        info.trackdisambig = recording.get('disambiguation')
+    info.trackdisambig = recording.get('disambiguation', None)
 
     lyricist = []
     composer = []

--- a/beets/library.py
+++ b/beets/library.py
@@ -477,6 +477,7 @@ class Item(LibModel):
         'mb_artistid':          types.STRING,
         'mb_albumartistid':     types.STRING,
         'mb_releasetrackid':    types.STRING,
+        'trackdisambig':        types.STRING,
         'albumtype':            types.STRING,
         'label':                types.STRING,
         'acoustid_fingerprint': types.STRING,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -178,6 +178,9 @@ New features:
   :bug:`3478`
 * Removes usage of the bs1770gain replaygain backend.
   Thanks to :user:`SamuelCook`.
+* Added ``trackdisambig`` which stores the recording disambiguation from
+  musicbrainz for each track.
+  :bug:`1904`
 
 Fixes:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -179,7 +179,7 @@ New features:
 * Removes usage of the bs1770gain replaygain backend.
   Thanks to :user:`SamuelCook`.
 * Added ``trackdisambig`` which stores the recording disambiguation from
-  musicbrainz for each track.
+  MusicBrainz for each track.
   :bug:`1904`
 
 Fixes:

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -111,7 +111,8 @@ class MBAlbumInfoTest(_common.TestCase):
         })
         return release
 
-    def _make_track(self, title, tr_id, duration, artist=False, video=False):
+    def _make_track(self, title, tr_id, duration, artist=False, video=False,
+                    disambiguation=None):
         track = {
             'title': title,
             'id': tr_id,
@@ -131,6 +132,8 @@ class MBAlbumInfoTest(_common.TestCase):
             ]
         if video:
             track['video'] = 'true'
+        if disambiguation:
+            track['disambiguation'] = disambiguation
         return track
 
     def test_parse_release_with_year(self):
@@ -444,6 +447,18 @@ class MBAlbumInfoTest(_common.TestCase):
         self.assertEqual(d.tracks[0].title, 'TITLE ONE')
         self.assertEqual(d.tracks[1].title, 'TITLE TWO')
         self.assertEqual(d.tracks[2].title, 'TITLE VIDEO')
+
+    def test_track_disambiguation(self):
+        tracks = [self._make_track('TITLE ONE', 'ID ONE', 100.0 * 1000.0),
+                  self._make_track('TITLE TWO', 'ID TWO', 200.0 * 1000.0,
+                                   disambiguation="SECOND TRACK")]
+        release = self._make_release(tracks=tracks)
+
+        d = mb.album_info(release)
+        t = d.tracks
+        self.assertEqual(len(t), 2)
+        self.assertEqual(t[0].trackdisambig, None)
+        self.assertEqual(t[1].trackdisambig, "SECOND TRACK")
 
 
 class ParseIDTest(_common.TestCase):


### PR DESCRIPTION
fixes beetbox/beets#1904

## Description

Fixes #1904.

(...)

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
