### PR TITLE
Improved test coverage for web plugin JSON API

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -186,6 +186,7 @@ New features:
 
 Fixes:
 
+* Small improvement to ``web`` plugin test coverage (for `expand` and `stats` features)
 * :bug:`/plugins/discogs`: Fixed a bug with ``index_tracks`` options that
   sometimes caused the index to be discarded. Also remove the extra semicolon
   that was added when there is no index track.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -186,7 +186,6 @@ New features:
 
 Fixes:
 
-* Small improvement to ``web`` plugin test coverage (for `expand` and `stats` features)
 * :bug:`/plugins/discogs`: Fixed a bug with ``index_tracks`` options that
   sometimes caused the index to be discarded. Also remove the extra semicolon
   that was added when there is no index track.

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -26,11 +26,11 @@ class WebPluginTest(_common.LibTestCase):
         # Add library elements. Note that self.lib.add overrides any "id=<n>" and assigns
         # the next free id number.
         # The following adds will create items #1 and #2
-        self.lib.add(Item(title=u'title', path='/path_1'))
-        self.lib.add(Item(title=u'another title', path='/path_2', album_id=2))
+        self.lib.add(Item(title=u'title', path='/path_1', album_id=2))
+        self.lib.add(Item(title=u'another title', path='/path_2'))
         # The following adds will create albums #1 and #2
         self.lib.add(Album(album=u'album'))
-        self.lib.add(Album(album=u'another album'))
+        self.lib.add(Album(album=u'other album'))
 
         web.app.config['TESTING'] = True
         web.app.config['lib'] = self.lib
@@ -120,7 +120,7 @@ class WebPluginTest(_common.LibTestCase):
 
         self.assertEqual(response.status_code, 200)
         response_albums = [album['album'] for album in res_json['albums']]
-        assertCountEqual(self, response_albums, [u'album', u'another album'])
+        assertCountEqual(self, response_albums, [u'album', u'other album'])
 
     def test_get_single_album_by_id(self):
         response = self.client.get('/album/2')
@@ -128,7 +128,7 @@ class WebPluginTest(_common.LibTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(res_json['id'], 2)
-        self.assertEqual(res_json['album'], u'another album')
+        self.assertEqual(res_json['album'], u'other album')
 
     def test_get_multiple_albums_by_id(self):
         response = self.client.get('/album/1,2')
@@ -136,7 +136,7 @@ class WebPluginTest(_common.LibTestCase):
 
         self.assertEqual(response.status_code, 200)
         response_albums = [album['album'] for album in res_json['albums']]
-        assertCountEqual(self, response_albums, [u'album', u'another album'])
+        assertCountEqual(self, response_albums, [u'album', u'other album'])
 
     def test_get_album_empty_query(self):
         response = self.client.get('/album/query/')
@@ -146,14 +146,24 @@ class WebPluginTest(_common.LibTestCase):
         self.assertEqual(len(res_json['albums']), 2)
 
     def test_get_simple_album_query(self):
-        response = self.client.get('/album/query/another')
+        response = self.client.get('/album/query/other')
         res_json = json.loads(response.data.decode('utf-8'))
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(res_json['results']), 1)
         self.assertEqual(res_json['results'][0]['album'],
-                         u'another album')
+                         u'other album')
         self.assertEqual(res_json['results'][0]['id'], 2)
+
+    def test_get_album_details(self):
+        response = self.client.get('/album/2?expand=1')
+        res_json = json.loads(response.data.decode('utf-8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(res_json['items']), 1)
+        self.assertEqual(res_json['items'][0]['album'],
+                         u'other album')
+        self.assertEqual(res_json['items'][0]['id'], 1)
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -22,10 +22,15 @@ class WebPluginTest(_common.LibTestCase):
         # Add fixtures
         for track in self.lib.items():
             track.remove()
-        self.lib.add(Item(title=u'title', path='/path_1', id=1))
-        self.lib.add(Item(title=u'another title', path='/path_2', id=2))
-        self.lib.add(Album(album=u'album', id=3))
-        self.lib.add(Album(album=u'another album', id=4))
+
+        # Add library elements. Note that self.lib.add overrides any "id=<n>" and assigns
+        # the next free id number.
+        # The following adds will create items #1 and #2
+        self.lib.add(Item(title=u'title', path='/path_1'))
+        self.lib.add(Item(title=u'another title', path='/path_2', album_id=2))
+        # The following adds will create albums #1 and #2
+        self.lib.add(Album(album=u'album'))
+        self.lib.add(Album(album=u'another album'))
 
         web.app.config['TESTING'] = True
         web.app.config['lib'] = self.lib
@@ -140,6 +145,15 @@ class WebPluginTest(_common.LibTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(res_json['albums']), 2)
 
+    def test_get_simple_album_query(self):
+        response = self.client.get('/album/query/another')
+        res_json = json.loads(response.data.decode('utf-8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(res_json['results']), 1)
+        self.assertEqual(res_json['results'][0]['album'],
+                         u'another album')
+        self.assertEqual(res_json['results'][0]['id'], 2)
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -156,7 +156,7 @@ class WebPluginTest(_common.LibTestCase):
         self.assertEqual(res_json['results'][0]['id'], 2)
 
     def test_get_album_details(self):
-        response = self.client.get('/album/2?expand=1')
+        response = self.client.get('/album/2?expand')
         res_json = json.loads(response.data.decode('utf-8'))
 
         self.assertEqual(response.status_code, 200)

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -23,8 +23,8 @@ class WebPluginTest(_common.LibTestCase):
         for track in self.lib.items():
             track.remove()
 
-        # Add library elements. Note that self.lib.add overrides any "id=<n>" and assigns
-        # the next free id number.
+        # Add library elements. Note that self.lib.add overrides any "id=<n>"
+        # and assigns the next free id number.
         # The following adds will create items #1, #2 and #3
         self.lib.add(Item(title=u'title', path='/path_1', album_id=2))
         self.lib.add(Item(title=u'another title', path='/path_2'))
@@ -173,6 +173,7 @@ class WebPluginTest(_common.LibTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(res_json['items'], 3)
         self.assertEqual(res_json['albums'], 2)
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -25,9 +25,10 @@ class WebPluginTest(_common.LibTestCase):
 
         # Add library elements. Note that self.lib.add overrides any "id=<n>" and assigns
         # the next free id number.
-        # The following adds will create items #1 and #2
+        # The following adds will create items #1, #2 and #3
         self.lib.add(Item(title=u'title', path='/path_1', album_id=2))
         self.lib.add(Item(title=u'another title', path='/path_2'))
+        self.lib.add(Item(title=u'and a third'))
         # The following adds will create albums #1 and #2
         self.lib.add(Album(album=u'album'))
         self.lib.add(Album(album=u'other album'))
@@ -58,7 +59,7 @@ class WebPluginTest(_common.LibTestCase):
         res_json = json.loads(response.data.decode('utf-8'))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(res_json['items']), 2)
+        self.assertEqual(len(res_json['items']), 3)
 
     def test_get_single_item_by_id(self):
         response = self.client.get('/item/1')
@@ -78,7 +79,7 @@ class WebPluginTest(_common.LibTestCase):
         assertCountEqual(self, response_titles, [u'title', u'another title'])
 
     def test_get_single_item_not_found(self):
-        response = self.client.get('/item/3')
+        response = self.client.get('/item/4')
         self.assertEqual(response.status_code, 404)
 
     def test_get_single_item_by_path(self):
@@ -103,7 +104,7 @@ class WebPluginTest(_common.LibTestCase):
         res_json = json.loads(response.data.decode('utf-8'))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(res_json['items']), 2)
+        self.assertEqual(len(res_json['items']), 3)
 
     def test_get_simple_item_query(self):
         response = self.client.get('/item/query/another')
@@ -164,6 +165,14 @@ class WebPluginTest(_common.LibTestCase):
         self.assertEqual(res_json['items'][0]['album'],
                          u'other album')
         self.assertEqual(res_json['items'][0]['id'], 1)
+
+    def test_get_stats(self):
+        response = self.client.get('/stats')
+        res_json = json.loads(response.data.decode('utf-8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(res_json['items'], 3)
+        self.assertEqual(res_json['albums'], 2)
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)


### PR DESCRIPTION
## Description

Adds a few tests for parts of the web plugin API not previously covered. In particular, for the
`/album/<n>?expand` request and the `/stats` request.

No new features or documentation required. changelog updated.

Signed-off-by: Graham R. Cobb <g+beets@cobb.uk.net>
