### PR TITLE
Web artpath fix

### DIFF
--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -59,7 +59,10 @@ def _rep(obj, expand=False):
         return out
 
     elif isinstance(obj, beets.library.Album):
-        del out['artpath']
+        if app.config.get('INCLUDE_PATHS', False):
+            out['artpath'] = util.displayable_path(out['artpath'])
+        else:
+            del out['artpath']
         if expand:
             out['items'] = [_rep(item) for item in obj.items()]
         return out

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -186,6 +186,9 @@ New features:
 
 Fixes:
 
+* :bug:`/plugins/web`: Fixed a small bug which caused album artpath to be
+  redacted even when ``include_paths`` option is set.
+  :bug:`3866`
 * :bug:`/plugins/discogs`: Fixed a bug with ``index_tracks`` options that
   sometimes caused the index to be discarded. Also remove the extra semicolon
   that was added when there is no index track.

--- a/docs/plugins/web.rst
+++ b/docs/plugins/web.rst
@@ -261,6 +261,8 @@ For albums, the following endpoints are provided:
 
 * ``GET /album/5``
 
+* ``GET /album/5/art``
+
 * ``DELETE /album/5``
 
 * ``GET /album/5,7``

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -31,7 +31,7 @@ class WebPluginTest(_common.LibTestCase):
         self.lib.add(Item(title=u'and a third'))
         # The following adds will create albums #1 and #2
         self.lib.add(Album(album=u'album'))
-        self.lib.add(Album(album=u'other album'))
+        self.lib.add(Album(album=u'other album', artpath='/art_path_2'))
 
         web.app.config['TESTING'] = True
         web.app.config['lib'] = self.lib
@@ -46,6 +46,14 @@ class WebPluginTest(_common.LibTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(res_json['path'], u'/path_1')
 
+    def test_config_include_artpaths_true(self):
+        web.app.config['INCLUDE_PATHS'] = True
+        response = self.client.get('/album/2')
+        res_json = json.loads(response.data.decode('utf-8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(res_json['artpath'], u'/art_path_2')
+
     def test_config_include_paths_false(self):
         web.app.config['INCLUDE_PATHS'] = False
         response = self.client.get('/item/1')
@@ -53,6 +61,14 @@ class WebPluginTest(_common.LibTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertNotIn('path', res_json)
+
+    def test_config_include_artpaths_false(self):
+        web.app.config['INCLUDE_PATHS'] = False
+        response = self.client.get('/album/2')
+        res_json = json.loads(response.data.decode('utf-8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('artpath', res_json)
 
     def test_get_all_items(self):
         response = self.client.get('/item/')


### PR DESCRIPTION
## Description

Fixes #3866.  

Change web/__init__.py to only remove `artpath` if `include_paths` is false.

## To Do

- [X] Documentation. No substantive change but made /art clearer.
- [X] Changelog. Added to bugs list.
- [X] Tests. Tests added.
