### PR TITLE
Web readonly

### DIFF
--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -442,6 +442,7 @@ class WebPlugin(BeetsPlugin):
             'cors_supports_credentials': False,
             'reverse_proxy': False,
             'include_paths': False,
+            'readonly': True,
         })
 
     def commands(self):
@@ -461,6 +462,7 @@ class WebPlugin(BeetsPlugin):
             app.config['JSONIFY_PRETTYPRINT_REGULAR'] = False
 
             app.config['INCLUDE_PATHS'] = self.config['include_paths']
+            app.config['READONLY'] = self.config['readonly']
 
             # Enable CORS if required.
             if self.config['cors']:

--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -116,6 +116,7 @@ def resource(name, patchable=False):
             entities = [entity for entity in entities if entity]
 
             if get_method() == "DELETE":
+
                 if app.config.get('READONLY', True):
                     return flask.abort(405)
 
@@ -168,6 +169,7 @@ def resource_query(name, patchable=False):
             entities = query_func(queries)
 
             if get_method() == "DELETE":
+
                 if app.config.get('READONLY', True):
                     return flask.abort(405)
 

--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -116,12 +116,18 @@ def resource(name, patchable=False):
             entities = [entity for entity in entities if entity]
 
             if get_method() == "DELETE":
+                if app.config.get('READONLY', True):
+                    return flask.abort(405)
+
                 for entity in entities:
                     entity.remove(delete=is_delete())
 
                 return flask.make_response(jsonify({'deleted': True}), 200)
 
             elif get_method() == "PATCH" and patchable:
+                if app.config.get('READONLY', True):
+                    return flask.abort(405)
+
                 for entity in entities:
                     entity.update(flask.request.get_json())
                     entity.try_sync(True, False)  # write, don't move
@@ -162,12 +168,18 @@ def resource_query(name, patchable=False):
             entities = query_func(queries)
 
             if get_method() == "DELETE":
+                if app.config.get('READONLY', True):
+                    return flask.abort(405)
+
                 for entity in entities:
                     entity.remove(delete=is_delete())
 
                 return flask.make_response(jsonify({'deleted': True}), 200)
 
             elif get_method() == "PATCH" and patchable:
+                if app.config.get('READONLY', True):
+                    return flask.abort(405)
+
                 for entity in entities:
                     entity.update(flask.request.get_json())
                     entity.try_sync(True, False)  # write, don't move

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -335,6 +335,9 @@ Fixes:
 * :doc:`/plugins/chroma`: Fixed submitting AcoustID information for tracks
   that already have a fingerprint.
   :bug:`3834`
+* :doc:`/plugins/web`: DELETE and PATCH methods are disallowed by default.
+  Set ``readonly: no`` web config option to enable them.
+  :bug:`3870`
 
 For plugin developers:
 

--- a/docs/plugins/web.rst
+++ b/docs/plugins/web.rst
@@ -66,6 +66,8 @@ configuration file. The available options are:
   Default: false.
 - **include_paths**: If true, includes paths in item objects.
   Default: false.
+- **readonly**: If true, DELETE and PATCH operations are not allowed. Only GET is permitted.
+  Default: true.
 
 Implementation
 --------------
@@ -189,6 +191,8 @@ code.
 Removes the item with id *6* from the beets library. If the *?delete* query string is included,
 the matching file will be deleted from disk.
 
+Only allowed if ``readonly`` configuration option is set to ``no``.
+
 ``PATCH /item/6``
 ++++++++++++++++++
 
@@ -202,6 +206,8 @@ Returns the updated JSON representation. ::
       "title": "A Song",
       ...
     }
+
+Only allowed if ``readonly`` configuration option is set to ``no``.
 
 ``GET /item/6,12,13``
 +++++++++++++++++++++
@@ -279,6 +285,7 @@ or ``/album/5,7``. In addition we can request the cover art of an album with
 ``GET /album/5/art``.
 You can also add the '?expand' flag to get the individual items of an album.
 
+``DELETE`` is only allowed if ``readonly`` configuration option is set to ``no``.
 
 ``GET /stats``
 ++++++++++++++

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -66,7 +66,7 @@ class WebPluginTest(_common.LibTestCase):
         web.app.config['TESTING'] = True
         web.app.config['lib'] = self.lib
         web.app.config['INCLUDE_PATHS'] = False
-        # Default value of READONLY is True
+        web.app.config['READONLY'] = True
         self.client = web.app.test_client()
 
     def test_config_include_paths_true(self):
@@ -312,7 +312,6 @@ class WebPluginTest(_common.LibTestCase):
 
     def test_delete_item_id(self):
 
-        # Default value of READONLY is True
         web.app.config['READONLY'] = False
 
         # Create a temporary item
@@ -338,7 +337,6 @@ class WebPluginTest(_common.LibTestCase):
 
     def test_delete_item_without_file(self):
 
-        # Default value of READONLY is True
         web.app.config['READONLY'] = False
 
         # Create an item with a file
@@ -368,7 +366,6 @@ class WebPluginTest(_common.LibTestCase):
 
     def test_delete_item_with_file(self):
 
-        # Default value of READONLY is True
         web.app.config['READONLY'] = False
 
         # Create an item with a file
@@ -397,7 +394,6 @@ class WebPluginTest(_common.LibTestCase):
 
     def test_delete_item_query(self):
 
-        # Default value of READONLY is True
         web.app.config['READONLY'] = False
 
         # Create a temporary item
@@ -424,7 +420,6 @@ class WebPluginTest(_common.LibTestCase):
     def test_delete_item_all_fails(self):
         """ DELETE is not supported for list all """
 
-        # Default value of READONLY is True
         web.app.config['READONLY'] = False
 
         # Delete all items
@@ -436,8 +431,7 @@ class WebPluginTest(_common.LibTestCase):
 
     def test_delete_item_id_readonly(self):
 
-        # Default value of READONLY is True
-        del web.app.config['READONLY']
+        web.app.config['READONLY'] = True
 
         # Create a temporary item
         item_id = self.lib.add(Item(title=u'test_delete_item_id_ro',
@@ -464,8 +458,7 @@ class WebPluginTest(_common.LibTestCase):
 
     def test_delete_item_query_readonly(self):
 
-        # Default value of READONLY is True
-        del web.app.config['READONLY']
+        web.app.config['READONLY'] = True
 
         # Create a temporary item
         item_id = self.lib.add(Item(title=u'test_delete_item_q_ro',
@@ -492,7 +485,6 @@ class WebPluginTest(_common.LibTestCase):
 
     def test_delete_album_id(self):
 
-        # Default value of READONLY is True
         web.app.config['READONLY'] = False
 
         # Create a temporary album
@@ -518,7 +510,6 @@ class WebPluginTest(_common.LibTestCase):
 
     def test_delete_album_query(self):
 
-        # Default value of READONLY is True
         web.app.config['READONLY'] = False
 
         # Create a temporary album
@@ -545,7 +536,6 @@ class WebPluginTest(_common.LibTestCase):
     def test_delete_album_all_fails(self):
         """ DELETE is not supported for list all """
 
-        # Default value of READONLY is True
         web.app.config['READONLY'] = False
 
         # Delete all albums
@@ -557,8 +547,7 @@ class WebPluginTest(_common.LibTestCase):
 
     def test_delete_album_id_readonly(self):
 
-        # Default value of READONLY is True
-        del web.app.config['READONLY']
+        web.app.config['READONLY'] = True
 
         # Create a temporary album
         album_id = self.lib.add(Album(album=u'test_delete_album_id_ro',
@@ -585,8 +574,7 @@ class WebPluginTest(_common.LibTestCase):
 
     def test_delete_album_query_readonly(self):
 
-        # Default value of READONLY is True
-        del web.app.config['READONLY']
+        web.app.config['READONLY'] = True
 
         # Create a temporary album
         album_id = self.lib.add(Album(album=u'test_delete_album_query_ro',
@@ -616,7 +604,6 @@ class WebPluginTest(_common.LibTestCase):
     def test_patch_item_id(self):
         # Note: PATCH is currently only implemented for track items, not albums
 
-        # Default value of READONLY is True
         web.app.config['READONLY'] = False
 
         # Create a temporary item
@@ -659,8 +646,7 @@ class WebPluginTest(_common.LibTestCase):
     def test_patch_item_id_readonly(self):
         # Note: PATCH is currently only implemented for track items, not albums
 
-        # Default value of READONLY is True
-        del web.app.config['READONLY']
+        web.app.config['READONLY'] = True
 
         # Create a temporary item
         item_id = self.lib.add(Item(title=u'test_patch_item_id_ro',

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -613,6 +613,78 @@ class WebPluginTest(_common.LibTestCase):
         # Remove it
         self.lib.get_album(album_id).remove()
 
+    def test_patch_item_id(self):
+        # Note: PATCH is currently only implemented for track items, not albums
+
+        # Default value of READONLY is True
+        web.app.config['READONLY'] = False
+
+        # Create a temporary item
+        item_id = self.lib.add(Item(title=u'test_patch_item_id',
+                                    test_patch_f1=1,
+                                    test_patch_f2="Old"))
+
+        # Check we can find the temporary item we just created
+        response = self.client.get('/item/' + str(item_id))
+        res_json = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(res_json['id'], item_id)
+        self.assertEqual(
+            [res_json['test_patch_f1'], res_json['test_patch_f2']],
+            ['1', 'Old'])
+
+        # Patch item by id
+        # patch_json = json.JSONEncoder().encode({"test_patch_f2": "New"}]})
+        response = self.client.patch('/item/' + str(item_id),
+                                     json={"test_patch_f2": "New"})
+        res_json = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(res_json['id'], item_id)
+        self.assertEqual(
+            [res_json['test_patch_f1'], res_json['test_patch_f2']],
+            ['1', 'New'])
+
+        # Check the update has really worked
+        response = self.client.get('/item/' + str(item_id))
+        res_json = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(res_json['id'], item_id)
+        self.assertEqual(
+            [res_json['test_patch_f1'], res_json['test_patch_f2']],
+            ['1', 'New'])
+
+        # Remove the item
+        self.lib.get_item(item_id).remove()
+
+    def test_patch_item_id_readonly(self):
+        # Note: PATCH is currently only implemented for track items, not albums
+
+        # Default value of READONLY is True
+        del web.app.config['READONLY']
+
+        # Create a temporary item
+        item_id = self.lib.add(Item(title=u'test_patch_item_id_ro',
+                                    test_patch_f1=2,
+                                    test_patch_f2="Old"))
+
+        # Check we can find the temporary item we just created
+        response = self.client.get('/item/' + str(item_id))
+        res_json = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(res_json['id'], item_id)
+        self.assertEqual(
+            [res_json['test_patch_f1'], res_json['test_patch_f2']],
+            ['2', 'Old'])
+
+        # Patch item by id
+        # patch_json = json.JSONEncoder().encode({"test_patch_f2": "New"})
+        response = self.client.patch('/item/' + str(item_id),
+                                     json={"test_patch_f2": "New"})
+        self.assertEqual(response.status_code, 405)
+
+        # Remove the item
+        self.lib.get_item(item_id).remove()
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)


### PR DESCRIPTION
## Description

Fixes #3870

This PR adds a new web configuration option ``readonly``. If ``readonly`` is true (the default)
only _GET_ operations are allowed. ``readonly`` must be false to allow _DELETE_ or _PATCH_ operations.

**NOTE**: this is a change, which may break existing users of the _DELETE_ or _PATCH_ operations, but after discussion in #3870 it was decided that the default has to be read only. Re-enabling them is just a matter of adding ``readonly: no`` to the web configuration.

## To Do

- [X] Documentation. Documentation added for new rules and the ``readonly`` config option.
- [X] Changelog. Added
- [X] Tests. Many tests for _DELETE_ and _PATCH_ operations (with and without ``readonly``) have been added.
