### PR TITLE
Remove ascii encode step

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -239,13 +239,10 @@ class DiscogsPlugin(BeetsPlugin):
         # cause a query to return no results, even if they match the artist or
         # album title. Use `re.UNICODE` flag to avoid stripping non-english
         # word characters.
-        # FIXME: Encode as ASCII to work around a bug:
-        # https://github.com/beetbox/beets/issues/1051
-        # When the library is fixed, we should encode as UTF-8.
-        query = re.sub(r'(?u)\W+', ' ', query).encode('ascii', "replace")
+        query = re.sub(r'(?u)\W+', ' ', query)
         # Strip medium information from query, Things like "CD1" and "disk 1"
         # can also negate an otherwise positive result.
-        query = re.sub(br'(?i)\b(CD|disc)\s*\d+', b'', query)
+        query = re.sub(r'(?i)\b(CD|disc)\s*\d+', '', query)
 
         self.request_start()
         try:


### PR DESCRIPTION
## Description

Fixes https://github.com/beetbox/beets/issues/1051 (and maybe a reoccurrence of https://github.com/beetbox/beets/issues/2387)

As described in [this comment](https://github.com/beetbox/beets/issues/1051#issuecomment-800584218) I encountered a `TypeError: sequence item 0: expected str instance, bytes found` error, and it seems the step to encode to ascii is no longer required. Removing it resolved this issue for me.

## To Do

- [ ] ~~Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)~~
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] ~~Tests. (Encouraged but not strictly required.)~~
