### PR TITLE
when iterating over item keys, do not return duplicates

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -623,7 +623,9 @@ class Item(LibModel):
         """
         keys = super(Item, self).keys(computed=computed)
         if with_album and self._cached_album:
-            keys += self._cached_album.keys(computed=computed)
+            keys = set(keys)
+            keys.update(self._cached_album.keys(computed=computed))
+            keys = list(keys)
         return keys
 
     def get(self, key, default=None, with_album=True):


### PR DESCRIPTION
... for keys that exist both as Item and Album fields

## Description

Fixes #3880

## To Do

- [ ] <del>Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)</del> Probably no need for this, the regression wasn't in a release.
