### PR TITLE
Better parallelism - Don't review yet, only for CI

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -1522,12 +1522,16 @@ def plugin_stage(session, func, task):
     if task.skip:
         return
 
-    func(session, task)
+    # While this is expected to be a mutator stage, it may return a future,
+    # which we need to pass on.
+    result = func(session, task)
 
     # Stage may modify DB, so re-load cached item data.
     # FIXME Importer plugins should not modify the database but instead
     # the albums and items attached to tasks.
     task.reload()
+
+    return result
 
 
 @pipeline.stage

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -25,7 +25,6 @@ import shutil
 import fnmatch
 import functools
 from collections import Counter, namedtuple
-from multiprocessing.pool import ThreadPool
 import traceback
 import subprocess
 import platform
@@ -1064,27 +1063,6 @@ def asciify_path(path, sep_replace):
                 sep_replace
             )
     return os.sep.join(path_components)
-
-
-def par_map(transform, items):
-    """Apply the function `transform` to all the elements in the
-    iterable `items`, like `map(transform, items)` but with no return
-    value. The map *might* happen in parallel: it's parallel on Python 3
-    and sequential on Python 2.
-
-    The parallelism uses threads (not processes), so this is only useful
-    for IO-bound `transform`s.
-    """
-    if sys.version_info[0] < 3:
-        # multiprocessing.pool.ThreadPool does not seem to work on
-        # Python 2. We could consider switching to futures instead.
-        for item in items:
-            transform(item)
-    else:
-        pool = ThreadPool()
-        pool.map(transform, items)
-        pool.close()
-        pool.join()
 
 
 def lazy_property(func):

--- a/beets/util/concurrency.py
+++ b/beets/util/concurrency.py
@@ -13,9 +13,12 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
-"""Provides a global thread pool that can be shared among beets' core and
-plugins. Every piece of work that is CPU-intensive (e.g. calling a subprocess
-which performs the actual work) should block a thread on the pool.
+"""Provides a global shared thread pool.
+
+The common pool should be used both by beets' core and plugins. Every piece of
+work that is CPU-intensive (e.g. calling a subprocess which performs the actual
+work) should block a thread on the pool in order to ensure that different
+tasks don't fight over resources too much.
 """
 
 from __future__ import division, absolute_import, print_function

--- a/beets/util/concurrency.py
+++ b/beets/util/concurrency.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+# This file is part of beets.
+# Copyright 2021, @wisp3rwind
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""Provides a global thread pool that can be shared among beets' core and
+plugins. Every piece of work that is CPU-intensive (e.g. calling a subprocess
+which performs the actual work) should block a thread on the pool.
+"""
+
+from __future__ import division, absolute_import, print_function
+
+from concurrent.futures import ThreadPoolExecutor
+import signal
+from beets import logging
+from beets.util import cpu_count
+
+__all__ = ["pool"]
+
+# Global logger.
+log = logging.getLogger('beets')
+
+pool = None
+
+
+def _sigint_handler(signal, frame):
+    global pool
+
+    if pool is not None:
+        pool.close(wait=True, abort=True)
+
+
+signal.signal(signal.SIGINT, _sigint_handler)
+
+
+class _Pool():
+    def __init__(self):
+        self._pool = None
+
+    def _open(self):
+        """Open the global thread pool instance lazily."""
+        if self._pool is None:
+            self._pool = ThreadPoolExecutor(
+                max_workers=cpu_count() + 2,
+                # thread_name_prefix="worker"  # not available in Python < 3.6
+            )
+
+    # FIXME: Cleanly shutdown when beets is shutting down
+    # FIXME: abort on uncaught exceptions
+    def close(self, wait=False, abort=False):
+        """Shutdown the thread pool.
+
+        If `abort` is `True`, all tasks that have not been started will be
+        cancelled. Tasks that are already running will not be interrupted.
+        """
+        if self._pool is not None:
+            self._pool.shutdown(wait=wait, cancel_futures=abort)
+            self._pool = None
+
+    def submit(self, transform, item):
+        self._open()
+
+        return self._pool.submit(transform, item)
+
+    def map_iter_nowait(self, transform, items):
+        """Map `transform` over `items`, yielding `Future`s.
+
+        Apply the function `transform` to all the elements in the
+        iterable `items`, like `map(transform, items)`, but in parallel.
+
+        The parallelism uses threads (not processes), so this is only useful
+        for IO-bound `transform`s.
+
+        This yields the submitted `Future`s directly.
+        """
+        self._open()
+
+        for i in items:
+            yield self.submit(transform, i)
+
+    def map_iter(self, transform, items, cancel_on_error=True):
+        """Map `transform` over `items`, yielding the results.
+
+        Apply the function `transform` to all the elements in the
+        iterable `items`, like `map(transform, items)`, but in parallel.
+
+        The parallelism uses threads (not processes), so this is only useful
+        for IO-bound `transform`s.
+
+        This yields the result of each transform as it completes.
+        """
+        self._open()
+
+        # FIXME: When dropping Python 2, convert to `yield from`
+        for fut in self._pool.map(transform, items):
+            yield fut
+
+    def map(self, transform, items, wait=True):
+        """Map `transform` over `items`, discarding the results.
+
+        Wrapper around `map_iter` which exhausts the iterator such that
+        exceptions from threads are propagated, but discards the results.
+        """
+        for result in self.map_iter(transform, items, wait):
+            pass
+
+
+pool = _Pool()

--- a/beets/util/queue.py
+++ b/beets/util/queue.py
@@ -1,0 +1,258 @@
+# -*- coding: utf-8 -*-
+# This file is part of beets.
+# Copyright 2021, @wisp3rwind
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+# The queue implementation is based on queue.Queue from Python 3.7, which is
+# licensed under the PSF (), and
+#
+# Copyright © 2001-2018 Python Software Foundation; All Rights Reserved
+#
+# All functionality that is not required has been stripped. Facilities for
+# counting threads that feed into a queue and for invalidating the queue have
+# been added.
+
+"""Custom queue for communication between pipeline stages."""
+
+from __future__ import division, absolute_import, print_function
+
+from collections import deque
+import threading
+
+
+__all__ = ["CountedInvalidatingQueue"]
+
+
+class Reservation():
+    def __init__(self, queue):
+        self._queue = queue
+
+    def put(self, item):
+        self._queue._put_reservation(self, item)
+
+    def discard(self):
+        self._queue._discard_reservation(self)
+
+
+class CountedInvalidatingQueue():
+    """A simple thread-safe queue derived from Python's `queue.Queue`.
+
+    Implements additional methods for
+
+    - tracking when all producers are done putting items into the queue,
+    - invalidating the queue, i.e. immediatly unblocking all threads that are
+      waiting to `put()` or `get()`.
+    """
+
+    def __init__(self, maxsize=0, on_finished=None):
+        """Create a queue object with a given maximum size.
+
+        If `maxsize` is <= 0, the queue size is infinite.
+
+        After all threads have released the queue it will be invalidated with
+        the value of `on_finished`.
+        """
+        self._maxsize = maxsize
+        self._on_finished = on_finished
+
+        self._queue = deque()
+        self._invalidated = False
+        self._finished = False
+        self._nthreads = 0
+        self._reservations = set()
+
+        # _mutex must be held whenever the queue is mutating.  All methods
+        # that acquire _mutex must release it before returning.  _mutex
+        # is shared between the three conditions, so acquiring and
+        # releasing the conditions also acquires and releases _mutex.
+        self._mutex = threading.Lock()
+
+        # Notify not_empty whenever an item is added to the queue; a
+        # thread waiting to get is notified then.
+        self.not_empty = threading.Condition(self._mutex)
+
+        # Notify not_full whenever an item is removed from the queue;
+        # a thread waiting to put is notified then.
+        self.not_full = threading.Condition(self._mutex)
+
+    def acquire(self):
+        """Indicate that a thread will start putting into this queue.
+
+        Must not be called after the queue is already finished.
+        """
+        with self._mutex:
+            assert not self._finished
+            self._nthreads += 1
+
+    def release(self):
+        """Indicate that a thread that was putting into this queue has exited.
+
+        If this is the last thread using the queue, the queue is finished.
+        """
+        with self._mutex:
+            assert self._nthreads > 0
+            self._nthreads -= 1
+            if self._nthreads == 0:
+                # All threads are done adding to this queue. Poison it
+                # when it becomes empty.
+                self._finished = True
+                self.not_empty.notify_all()
+
+    def _invalidate(self, value):
+        """Internal method implementing invalidation, see `invalidate()`.
+
+        The caller must hold `self._mutex`.
+        """
+        self._invalid_value = value
+        if not self._invalidated:
+            self._invalidated = True
+            self.not_full.notifyAll()
+            self.not_empty.notifyAll()
+
+    def invalidate(self, value):
+        """Invalidate the queue with the given `value`.
+
+        When invalidated, the Queue will accept more items beyond its maxsize
+        and only ever return the `value`. Thus, it will never block, and wake
+        up all threads that are blocked in `put()` or `get()`.
+        While invalidated, the queue will not 'lose' any items such that it is
+        possible to `resume()` operation at a later point.
+
+        It is safe to call this multiple times, subsequent calls after the
+        first will do nothing expcpet for updating the value.
+        """
+        with self._mutex:
+            self._invalidate(value)
+
+    def resume(self):
+        """Resume operation after the queue has been invalidated.
+
+        It is an error to call `resume()` when the queue is not actually
+        invalidated.
+
+        This method is not currently tested or used anywhere. It was added in
+        preparation for better error handling during import sessions.
+        """
+        with self._mutex:
+            assert self._invalidated
+            if not self._finished:
+                self._invalidated = False
+                self._invalid_value = None
+                self.not_empty.notifyAll()
+                self.not_full.notifyAll()
+            else:
+                # FIXME: maybe allow resumptions in this case? That might be
+                # useful when a pipeline is almost done when the queue is
+                # invalidated.
+                assert not self._queue and not self._reservations
+
+    def _is_full(self):
+        """Predicate factored out to increase readability of `put()`.
+
+        For internal use only, `self._mutex` must be held.
+        """
+        return (self._maxsize > 0
+                and (len(self._queue) + len(self._reservations)
+                     >= self._maxsize))
+
+    def put(self, item):
+        """Put an item into the queue.
+
+        Blocks if the queue is full, unless the queue is invalidated. In that
+        case, store the item anyway even if `seld.maxsize` will be exceeded and
+        return immediately.
+        """
+        with self.not_full:
+            while not self._invalidated and self._is_full():
+                self.not_full.wait()
+
+            self._queue.append(item)
+            if not self._invalidated:
+                self.not_empty.notify()
+
+    def get(self):
+        """Remove and return an item from the queue.
+
+        Blocks if the queue is empty, unless the queue is invalidated. In that
+        case, the value specified on invalidation will be returned immediately.
+        """
+        with self.not_empty:
+            while True:
+                if self._invalidated:
+                    return self._invalid_value
+
+                if self._queue:
+                    item = self._queue.popleft()
+                    self.not_full.notify()
+                    return item
+
+                # When this code is reached, the queue is currently empty, so
+                # check whether we're done.
+                if self._finished and not self._reservations:
+                    self._invalidate(self._on_finished)
+                    return self._on_finished
+
+                self.not_empty.wait()
+
+    def reserve(self):
+        """Reserve the space to put an item into the queue.
+
+        Returns a `Reservation` object which must be used to actually submit
+        the item. Essentially, this splits `put()` into two steps, `reserve()`
+        and `Reservation.put()` where the latter is guaranteed to succeed
+        immediately.
+
+        Blocks if the queue is full, unless the queue is invalidated. In that
+        case, retuan a `Reservation` immediately anyway even if `seld.maxsize`
+        might be exceeded when using it.
+        """
+        with self.not_full:
+            while not self._invalidated and self._is_full():
+                self.not_full.wait()
+
+            res = Reservation(self)
+            self._reservations.add(res)
+            return res
+
+    def _put_reservation(self, res, item):
+        """Put an item into the queue, consuming the reserved space.
+
+        For internal use (by `Reservation.put()`)only.
+        """
+        with self._mutex:
+            # It is an error to use a reservation twice!
+            self._reservations.remove(res)
+
+            self._queue.append(item)
+            if not self._invalidated:
+                self.not_empty.notify()
+
+    def _discard_reservation(self, res):
+        """Discard a reservation, freeing the reserved space.
+
+        For internal use (by `Reservation.discard()`)only.
+        """
+        with self._mutex:
+            self._reservations.remove(res)
+
+            # We might be done now, if there are no more items or reservations:
+            if self._finished and not self._queue and not self._reservations:
+                self._invalidate(self._on_finished)
+                return self._on_finished
+
+            # Otherwise, notify waiters of the free space. That's clearly only
+            # necessary when the queue isn't invalidated; if it is there can't
+            # be any more waiters since they have been notified already and
+            # returned `self._invalid_value`.
+            if not self._invalidated:
+                self.not_full.notify()

--- a/beetsplug/absubmit.py
+++ b/beetsplug/absubmit.py
@@ -30,6 +30,7 @@ import requests
 
 from beets import plugins
 from beets import util
+from beets.util.concurrency import pool
 from beets import ui
 
 # We use this field to check whether AcousticBrainz info is present.
@@ -123,7 +124,9 @@ only files which would be processed'
         # Get items from arguments
         items = lib.items(ui.decargs(args))
         self.opts = opts
-        util.par_map(self.analyze_submit, items)
+        # FIXME: analysis should be on the limited threadpool, but what about
+        # submission parallelism?
+        pool.map(self.analyze_submit, items)
 
     def analyze_submit(self, item):
         analysis = self._get_analysis(item)

--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -28,7 +28,8 @@ import six
 import confuse
 from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand
-from beets.util import displayable_path, par_map
+from beets.util import displayable_path
+from beets.util.concurrency import pool
 from beets import ui
 
 
@@ -148,7 +149,7 @@ class BadFiles(BeetsPlugin):
         # Get items from arguments
         items = lib.items(ui.decargs(args))
         self.verbose = opts.verbose
-        par_map(self.check_item, items)
+        pool.map(self.check_item, items)
 
     def commands(self):
         bad_command = Subcommand('bad',

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -16,7 +16,6 @@
 """Converts tracks or albums to external directory
 """
 from __future__ import division, absolute_import, print_function
-from beets.util import par_map
 
 import os
 import threading
@@ -32,6 +31,7 @@ from beets.plugins import BeetsPlugin
 from confuse import ConfigTypeError
 from beets import art
 from beets.util.artresizer import ArtResizer
+from beets.util.concurrency import pool
 from beets.library import parse_query_string
 from beets.library import Item
 
@@ -184,8 +184,8 @@ class ConvertPlugin(BeetsPlugin):
 
     def auto_convert(self, config, task):
         if self.config['auto']:
-            par_map(lambda item: self.convert_on_import(config.lib, item),
-                    task.imported_items())
+            pool.map(lambda item: self.convert_on_import(config.lib, item),
+                     task.imported_items())
 
     # Utilities converted from functions to methods on logging overhaul
 

--- a/docs/plugins/replaygain.rst
+++ b/docs/plugins/replaygain.rst
@@ -112,7 +112,8 @@ configuration file. The available options are:
 - **backend**: The analysis backend; either ``gstreamer``, ``command``, ``audiotools``
   or ``ffmpeg``.
   Default: ``command``.
-- **overwrite**: Re-analyze files that already have ReplayGain tags.
+- **overwrite**: Re-analyze files that already have ReplayGain tags during
+  import.
   Default: ``no``.
 - **targetlevel**: A number of decibels for the target loudness level for files
   using ``REPLAYGAIN_`` tags.

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,7 @@ setup(
             'mock',
             'pylast',
             'pytest',
+            'pytest-timeout',
             'python-mpd2',
             'pyxdg',
             'responses>=0.3.0',

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,8 @@ setup(
     ) + (
         # Support for ANSI console colors on Windows.
         ['colorama'] if (sys.platform == 'win32') else []
+    ) + (
+            ['futures'] if sys.version_info[:2] == (2, 7) else []
     ),
 
     extras_require={

--- a/test/helper.py
+++ b/test/helper.py
@@ -385,21 +385,23 @@ class TestHelper(object):
             items.append(item)
         return items
 
-    def add_album_fixture(self, track_count=1, ext='mp3'):
+    def add_album_fixture(self, track_count=1, ext='mp3', disc_count=1):
         """Add an album with files to the database.
         """
         items = []
         path = os.path.join(_common.RSRC, util.bytestring_path('full.' + ext))
-        for i in range(track_count):
-            item = Item.from_path(path)
-            item.album = u'\u00e4lbum'  # Check unicode paths
-            item.title = u't\u00eftle {0}'.format(i)
-            # mtime needs to be set last since other assignments reset it.
-            item.mtime = 12345
-            item.add(self.lib)
-            item.move(operation=MoveOperation.COPY)
-            item.store()
-            items.append(item)
+        for discnumber in range(1, disc_count + 1):
+            for i in range(track_count):
+                item = Item.from_path(path)
+                item.album = u'\u00e4lbum'  # Check unicode paths
+                item.title = u't\u00eftle {0}'.format(i)
+                item.disc = discnumber
+                # mtime needs to be set last since other assignments reset it.
+                item.mtime = 12345
+                item.add(self.lib)
+                item.move(operation=MoveOperation.COPY)
+                item.store()
+                items.append(item)
         return self.lib.add_album(items)
 
     def create_mediafile_fixture(self, ext='mp3', images=[]):

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -17,10 +17,18 @@
 """
 from __future__ import division, absolute_import, print_function
 
+from concurrent.futures import ThreadPoolExecutor
+import pytest
 import six
+import time
 import unittest
 
 from beets.util import pipeline
+
+
+# Large value to prevent failures on CI, set to something smaller for more
+# convenient local debugging.
+TIMEOUT = 60
 
 
 # Some simple pipeline stages for testing.
@@ -56,6 +64,29 @@ def _exc_work(num=3):
         i *= 2
 
 
+# This cannot be a nested function in _work_futures because we need to
+# establish a new scope to properly capture i
+# https://stackoverflow.com/questions/2295290/what-do-lambda-function-closures-capture
+def _do_work(i, pool, exc_at, spike_at):
+    def func():
+        if i == spike_at:
+            time.sleep(.2)
+        else:
+            time.sleep(.001)
+        if i == exc_at:
+            raise ExceptionFixture()
+        return i * 2
+
+    return pool.submit(func)
+
+
+def _work_futures(pool, exc_at=-1, spike_at=-1):
+    fut = None
+    while True:
+        i = yield fut
+        fut = _do_work(i, pool, exc_at, spike_at)
+
+
 # A worker that yields a bubble.
 def _bub_work(num=3):
     i = None
@@ -75,6 +106,7 @@ def _multi_work():
         i = pipeline.multiple([i, -i])
 
 
+@pytest.mark.timeout(TIMEOUT)
 class SimplePipelineTest(unittest.TestCase):
     def setUp(self):
         self.l = []
@@ -98,6 +130,7 @@ class SimplePipelineTest(unittest.TestCase):
         self.assertEqual(list(pl2.pull()), [0, 4, 8, 12, 16])
 
 
+@pytest.mark.timeout(TIMEOUT)
 class ParallelStageTest(unittest.TestCase):
     def setUp(self):
         self.l = []
@@ -119,6 +152,7 @@ class ParallelStageTest(unittest.TestCase):
         self.assertEqual(list(pl.pull()), [0, 2, 4, 6, 8])
 
 
+@pytest.mark.timeout(TIMEOUT)
 class ExceptionTest(unittest.TestCase):
     def setUp(self):
         self.l = []
@@ -142,6 +176,7 @@ class ExceptionTest(unittest.TestCase):
             self.assertRaises(ExceptionFixture, pull.__next__)
 
 
+@pytest.mark.timeout(TIMEOUT)
 class ParallelExceptionTest(unittest.TestCase):
     def setUp(self):
         self.l = []
@@ -153,6 +188,7 @@ class ParallelExceptionTest(unittest.TestCase):
         self.assertRaises(ExceptionFixture, self.pl.run_parallel)
 
 
+@pytest.mark.timeout(TIMEOUT)
 class ConstrainedThreadedPipelineTest(unittest.TestCase):
     def test_constrained(self):
         l = []
@@ -177,6 +213,7 @@ class ConstrainedThreadedPipelineTest(unittest.TestCase):
         self.assertEqual(set(l), set(i * 2 for i in range(1000)))
 
 
+@pytest.mark.timeout(TIMEOUT)
 class BubbleTest(unittest.TestCase):
     def setUp(self):
         self.l = []
@@ -196,6 +233,7 @@ class BubbleTest(unittest.TestCase):
         self.assertEqual(list(pl.pull()), [0, 2, 4, 8])
 
 
+@pytest.mark.timeout(TIMEOUT)
 class MultiMessageTest(unittest.TestCase):
     def setUp(self):
         self.l = []
@@ -216,6 +254,7 @@ class MultiMessageTest(unittest.TestCase):
         self.assertEqual(list(pl.pull()), [0, 0, 1, -1, 2, -2, 3, -3, 4, -4])
 
 
+@pytest.mark.timeout(TIMEOUT)
 class StageDecoratorTest(unittest.TestCase):
 
     def test_stage_decorator(self):
@@ -240,6 +279,119 @@ class StageDecoratorTest(unittest.TestCase):
         ])
         self.assertEqual(list(pl.pull()),
                          [{'x': True}, {'a': False, 'x': True}])
+
+
+@pytest.mark.timeout(TIMEOUT)
+class SimpleFuturesTest(unittest.TestCase):
+    def setUp(self):
+        self.pool = ThreadPoolExecutor()
+        self.l = []
+        self.pl = pipeline.Pipeline((
+            _produce(),
+            _work_futures(self.pool),
+            _consume(self.l),
+        ))
+
+    def tearDown(self):
+        self.pool.shutdown()
+
+    def test_run_sequential(self):
+        self.pl.run_sequential()
+        self.assertEqual(set(self.l), set([0, 2, 4, 6, 8]))
+
+    def test_run_parallel(self):
+        self.pl.run_parallel()
+        self.assertEqual(set(self.l), set([0, 2, 4, 6, 8]))
+
+    def test_spike(self):
+        pl = pipeline.Pipeline((
+            _produce(),
+            _work_futures(self.pool, spike_at=4),
+            _consume(self.l),
+        ))
+        pl.run_parallel()
+        self.assertEqual(set(self.l), set([0, 2, 4, 6, 8]))
+
+    def test_spike_and_exc(self):
+        # Check that the pipeline doesn't lock up when an exception occurs and
+        # there are pending futures.
+        pl = pipeline.Pipeline((
+            _produce(),
+            _work_futures(self.pool, spike_at=3, exc_at=3),
+            _consume(self.l),
+        ))
+        self.assertRaises(ExceptionFixture, pl.run_parallel)
+
+    def test_spike_then_exc(self):
+        # Check that the pipeline doesn't lock up when an exception occurs and
+        # there are pending futures.
+        pl = pipeline.Pipeline((
+            _produce(),
+            _work_futures(self.pool, spike_at=2, exc_at=3),
+            _consume(self.l),
+        ))
+        self.assertRaises(ExceptionFixture, pl.run_parallel)
+
+    def test_pull(self):
+        pl = pipeline.Pipeline((_produce(), _work_futures(self.pool)))
+        self.assertEqual(set(pl.pull()), set([0, 2, 4, 6, 8]))
+
+    def test_pull_chain(self):
+        pl = pipeline.Pipeline((_produce(), _work_futures(self.pool)))
+        pl2 = pipeline.Pipeline((pl.pull(), _work_futures(self.pool)))
+        self.assertEqual(set(pl2.pull()), set([0, 4, 8, 12, 16]))
+
+
+@pytest.mark.timeout(TIMEOUT)
+class ConstrainedThreadedPipelineFuturesTest(unittest.TestCase):
+    def setUp(self):
+        self.pool = ThreadPoolExecutor()
+
+    def tearDown(self):
+        self.pool.shutdown()
+
+    def test_constrained(self):
+        l = []
+        # Do a "significant" amount of work...
+        pl = pipeline.Pipeline((
+            _produce(1000),
+            _work_futures(self.pool),
+            _consume(l),
+        ))
+        # ... with only a single queue slot.
+        pl.run_parallel(1)
+        self.assertEqual(set(l), set(i * 2 for i in range(1000)))
+
+    def test_constrained_exception(self):
+        # Raise an exception in a constrained pipeline.
+        l = []
+        pl = pipeline.Pipeline((
+            _produce(1000),
+            _work_futures(self.pool, exc_at=300),
+            _consume(l),
+        ))
+        self.assertRaises(ExceptionFixture, pl.run_parallel, 1)
+
+    def test_constrained_spike(self):
+        # One task takes a lot longer than others.
+        l = []
+        pl = pipeline.Pipeline((
+            _produce(1000),
+            _work_futures(self.pool, spike_at=999),
+            _consume(l),
+        ))
+        pl.run_parallel(1)
+        self.assertEqual(set(l), set(i * 2 for i in range(1000)))
+
+    def test_constrained_parallel(self):
+        l = []
+        pl = pipeline.Pipeline((
+            _produce(1000),
+            (_work_futures(self.pool), _work_futures(self.pool)),
+            _consume(l),
+        ))
+        pl.run_parallel(1)
+        self.assertEqual(set(l), set(i * 2 for i in range(1000)))
 
 
 def suite():

--- a/test/test_replaygain.py
+++ b/test/test_replaygain.py
@@ -45,14 +45,54 @@ def reset_replaygain(item):
     item['rg_track_gain'] = None
     item['rg_album_gain'] = None
     item['rg_album_gain'] = None
+    item['r128_track_gain'] = None
+    item['r128_album_gain'] = None
     item.write()
     item.store()
-    item.store()
-    item.store()
+
+
+class GstBackendMixin():
+    backend = u'gstreamer'
+    has_r128_support = True
+
+    def test_backend(self):
+        """Check whether the backend actually has all required functionality.
+        """
+        try:
+            # Check if required plugins can be loaded by instantiating a
+            # GStreamerBackend (via its .__init__).
+            config['replaygain']['targetlevel'] = 89
+            GStreamerBackend(config['replaygain'], None)
+        except FatalGstreamerPluginReplayGainError as e:
+            # Skip the test if plugins could not be loaded.
+            self.skipTest(str(e))
+
+
+class CmdBackendMixin():
+    backend = u'command'
+    has_r128_support = False
+
+    def test_backend(self):
+        """Check whether the backend actually has all required functionality.
+        """
+        pass
+
+
+class FfmpegBackendMixin():
+    backend = u'ffmpeg'
+    has_r128_support = True
+
+    def test_backend(self):
+        """Check whether the backend actually has all required functionality.
+        """
+        pass
 
 
 class ReplayGainCliTestBase(TestHelper):
     def setUp(self):
+        # Implemented by Mixins, see above. This may decide to skip the test.
+        self.test_backend()
+
         self.setup_beets(disk=True)
         self.config['replaygain']['backend'] = self.backend
 
@@ -72,25 +112,20 @@ class ReplayGainCliTestBase(TestHelper):
                 pass
             six.reraise(exc_info[1], None, exc_info[2])
 
-        album = self.add_album_fixture(2)
+    def _add_album(self, *args, **kwargs):
+        album = self.add_album_fixture(*args, **kwargs)
         for item in album.items():
             reset_replaygain(item)
+
+        return album
 
     def tearDown(self):
         self.teardown_beets()
         self.unload_plugins()
 
-    def _reset_replaygain(self, item):
-        item['rg_track_peak'] = None
-        item['rg_track_gain'] = None
-        item['rg_album_peak'] = None
-        item['rg_album_gain'] = None
-        item['r128_track_gain'] = None
-        item['r128_album_gain'] = None
-        item.write()
-        item.store()
-
     def test_cli_saves_track_gain(self):
+        self._add_album(2)
+
         for item in self.lib.items():
             self.assertIsNone(item.rg_track_peak)
             self.assertIsNone(item.rg_track_gain)
@@ -116,15 +151,85 @@ class ReplayGainCliTestBase(TestHelper):
                 mediafile.rg_track_gain, item.rg_track_gain, places=2)
 
     def test_cli_skips_calculated_tracks(self):
+        album_rg = self._add_album(1)
+        item_rg = album_rg.items()[0]
+
+        if self.has_r128_support:
+            album_r128 = self._add_album(1, ext="opus")
+            item_r128 = album_r128.items()[0]
+
         self.run_command(u'replaygain')
-        item = self.lib.items()[0]
-        peak = item.rg_track_peak
-        item.rg_track_gain = 0.0
+
+        item_rg.load()
+        self.assertIsNotNone(item_rg.rg_track_gain)
+        self.assertIsNotNone(item_rg.rg_track_peak)
+        self.assertIsNone(item_rg.r128_track_gain)
+
+        item_rg.rg_track_gain += 1.0
+        item_rg.rg_track_peak += 1.0
+        item_rg.store()
+        rg_track_gain = item_rg.rg_track_gain
+        rg_track_peak = item_rg.rg_track_peak
+
+        if self.has_r128_support:
+            item_r128.load()
+            self.assertIsNotNone(item_r128.r128_track_gain)
+            self.assertIsNone(item_r128.rg_track_gain)
+            self.assertIsNone(item_r128.rg_track_peak)
+
+            item_r128.r128_track_gain += 1.0
+            item_r128.store()
+            r128_track_gain = item_r128.r128_track_gain
+
         self.run_command(u'replaygain')
-        self.assertEqual(item.rg_track_gain, 0.0)
-        self.assertEqual(item.rg_track_peak, peak)
+
+        item_rg.load()
+        self.assertEqual(item_rg.rg_track_gain, rg_track_gain)
+        self.assertEqual(item_rg.rg_track_peak, rg_track_peak)
+
+        if self.has_r128_support:
+            item_r128.load()
+            self.assertEqual(item_r128.r128_track_gain, r128_track_gain)
+
+    def test_cli_does_not_skip_wrong_tag_type(self):
+        """Check that items that have tags of the wrong type won't be skipped.
+        """
+        if not self.has_r128_support:
+            # This test is a lot less interesting if the backend cannot write
+            # both tag types.
+            self.skipTest("r128 tags for opus not supported on backend {}"
+                          .format(self.backend))
+
+        album_rg = self._add_album(1)
+        item_rg = album_rg.items()[0]
+
+        album_r128 = self._add_album(1, ext="opus")
+        item_r128 = album_r128.items()[0]
+
+        item_rg.r128_track_gain = 0.0
+        item_rg.store()
+
+        item_r128.rg_track_gain = 0.0
+        item_r128.rg_track_peak = 42.0
+        item_r128.store()
+
+        self.run_command(u'replaygain')
+        item_rg.load()
+        item_r128.load()
+
+        self.assertIsNotNone(item_rg.rg_track_gain)
+        self.assertIsNotNone(item_rg.rg_track_peak)
+        # FIXME: Should the plugin null this field?
+        # self.assertIsNone(item_rg.r128_track_gain)
+
+        self.assertIsNotNone(item_r128.r128_track_gain)
+        # FIXME: Should the plugin null these fields?
+        # self.assertIsNone(item_r128.rg_track_gain)
+        # self.assertIsNone(item_r128.rg_track_peak)
 
     def test_cli_saves_album_gain_to_file(self):
+        self._add_album(2)
+
         for item in self.lib.items():
             mediafile = MediaFile(item.path)
             self.assertIsNone(mediafile.rg_album_peak)
@@ -147,13 +252,11 @@ class ReplayGainCliTestBase(TestHelper):
         self.assertNotEqual(max(peaks), 0.0)
 
     def test_cli_writes_only_r128_tags(self):
-        if self.backend == "command":
-            # opus not supported by command backend
-            return
+        if not self.has_r128_support:
+            self.skipTest("r128 tags for opus not supported on backend {}"
+                          .format(self.backend))
 
-        album = self.add_album_fixture(2, ext="opus")
-        for item in album.items():
-            self._reset_replaygain(item)
+        album = self._add_album(2, ext="opus")
 
         self.run_command(u'replaygain', u'-a')
 
@@ -166,51 +269,137 @@ class ReplayGainCliTestBase(TestHelper):
             self.assertIsNotNone(mediafile.r128_track_gain)
             self.assertIsNotNone(mediafile.r128_album_gain)
 
-    def test_target_level_has_effect(self):
-        item = self.lib.items()[0]
+    def test_targetlevel_has_effect(self):
+        album = self._add_album(1)
+        item = album.items()[0]
 
         def analyse(target_level):
             self.config['replaygain']['targetlevel'] = target_level
-            self._reset_replaygain(item)
             self.run_command(u'replaygain', '-f')
-            mediafile = MediaFile(item.path)
-            return mediafile.rg_track_gain
+            item.load()
+            return item.rg_track_gain
 
         gain_relative_to_84 = analyse(84)
         gain_relative_to_89 = analyse(89)
 
-        # check that second calculation did work
-        if gain_relative_to_84 is not None:
-            self.assertIsNotNone(gain_relative_to_89)
+        self.assertNotEqual(gain_relative_to_84, gain_relative_to_89)
+
+    def test_r128_targetlevel_has_effect(self):
+        if not self.has_r128_support:
+            self.skipTest("r128 tags for opus not supported on backend {}"
+                          .format(self.backend))
+
+        album = self._add_album(1, ext="opus")
+        item = album.items()[0]
+
+        def analyse(target_level):
+            self.config['replaygain']['r128_targetlevel'] = target_level
+            self.run_command(u'replaygain', '-f')
+            item.load()
+            return item.r128_track_gain
+
+        gain_relative_to_84 = analyse(84)
+        gain_relative_to_89 = analyse(89)
 
         self.assertNotEqual(gain_relative_to_84, gain_relative_to_89)
 
+    def test_per_disc(self):
+        # Use the per_disc option and add a little more concurrency.
+        album = self._add_album(track_count=4, disc_count=3)
+        self.config['replaygain']['per_disc'] = True
+        self.run_command(u'replaygain', '-a')
+
+        # FIXME: Add fixtures with known track/album gain so that we can
+        # actually check per-disc operation here.
+        for item in album.items():
+            self.assertIsNotNone(item.rg_track_gain)
+            self.assertIsNotNone(item.rg_album_gain)
+
 
 @unittest.skipIf(not GST_AVAILABLE, u'gstreamer cannot be found')
-class ReplayGainGstCliTest(ReplayGainCliTestBase, unittest.TestCase):
-    backend = u'gstreamer'
-
-    def setUp(self):
-        try:
-            # Check if required plugins can be loaded by instantiating a
-            # GStreamerBackend (via its .__init__).
-            config['replaygain']['targetlevel'] = 89
-            GStreamerBackend(config['replaygain'], None)
-        except FatalGstreamerPluginReplayGainError as e:
-            # Skip the test if plugins could not be loaded.
-            self.skipTest(str(e))
-
-        super(ReplayGainGstCliTest, self).setUp()
+class ReplayGainGstCliTest(ReplayGainCliTestBase, unittest.TestCase,
+                           GstBackendMixin):
+    pass
 
 
 @unittest.skipIf(not GAIN_PROG_AVAILABLE, u'no *gain command found')
-class ReplayGainCmdCliTest(ReplayGainCliTestBase, unittest.TestCase):
-    backend = u'command'
+class ReplayGainCmdCliTest(ReplayGainCliTestBase, unittest.TestCase,
+                           CmdBackendMixin):
+    pass
 
 
 @unittest.skipIf(not FFMPEG_AVAILABLE, u'ffmpeg cannot be found')
-class ReplayGainFfmpegTest(ReplayGainCliTestBase, unittest.TestCase):
-    backend = u'ffmpeg'
+class ReplayGainFfmpegCliTest(ReplayGainCliTestBase, unittest.TestCase,
+                              FfmpegBackendMixin):
+    pass
+
+
+class ImportTest(TestHelper):
+    threaded = False
+
+    def setUp(self):
+        # Implemented by Mixins, see above. This may decide to skip the test.
+        self.test_backend()
+
+        self.setup_beets(disk=True)
+        self.config['threaded'] = self.threaded
+        self.config['replaygain'] = {
+                'backend': self.backend,
+        }
+
+        try:
+            self.load_plugins('replaygain')
+        except Exception:
+            import sys
+            # store exception info so an error in teardown does not swallow it
+            exc_info = sys.exc_info()
+            try:
+                self.teardown_beets()
+                self.unload_plugins()
+            except Exception:
+                # if load_plugins() failed then setup is incomplete and
+                # teardown operations may fail. In particular # {Item,Album}
+                # may not have the _original_types attribute in unload_plugins
+                pass
+            six.reraise(exc_info[1], None, exc_info[2])
+
+        self.importer = self.create_importer()
+
+    def tearDown(self):
+        self.unload_plugins()
+        self.teardown_beets()
+
+    def test_import_converted(self):
+        self.importer.run()
+        for item in self.lib.items():
+            # FIXME: Add fixtures with known track/album gain so that we can
+            # actually check correct operation here.
+            self.assertIsNotNone(item.rg_track_gain)
+            self.assertIsNotNone(item.rg_album_gain)
+
+
+@unittest.skipIf(not GST_AVAILABLE, u'gstreamer cannot be found')
+class ReplayGainGstImportTest(ImportTest, unittest.TestCase,
+                              GstBackendMixin):
+    pass
+
+
+@unittest.skipIf(not GAIN_PROG_AVAILABLE, u'no *gain command found')
+class ReplayGainCmdImportTest(ImportTest, unittest.TestCase,
+                              CmdBackendMixin):
+    pass
+
+
+@unittest.skipIf(not FFMPEG_AVAILABLE, u'ffmpeg cannot be found')
+class ReplayGainFfmpegImportTest(ImportTest, unittest.TestCase,
+                                 FfmpegBackendMixin):
+    pass
+
+
+@unittest.skipIf(not FFMPEG_AVAILABLE, u'ffmpeg cannot be found')
+class ReplayGainFfmpegThreadedImportTest(ImportTest, unittest.TestCase,
+                                         FfmpegBackendMixin):
+    threaded = True
 
 
 def suite():


### PR DESCRIPTION
This PR is just for running CI - don't spend your time on reviewing it yet.

I've been toying around with pipeline/queue restructuring for some time already, and I think I've now come up with a design that actually works out. This introduces a generic framework for import stages and plugins to submit work items to a shared threadpool, and communicate the results through futures. As a result, both replaygain and convert should now be able to work completely in parallel, even during imports.

When this is actually ready, I'll submit several individual PRs which should be more focused and easier to review.