### PR TITLE
ci: install ffmpeg for replaygain tests; show skipped tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,10 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install tox sphinx
 
+      - name: Install optional dependencies
+        run: |
+          sudo apt-get install ffmpeg  # For replaygain
+
       - name: Test with tox
         if: matrix.python-version != '3.9'
         run: |

--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,8 @@ deps =
     {test,cov}: {[_test]deps}
     lint: {[_lint]deps}
 commands =
-    test: python -bb -m pytest {posargs}
-    cov: coverage run -m pytest {posargs}
+    test: python -bb -m pytest -rs {posargs}
+    cov: coverage run -m pytest -rs {posargs}
     lint: python -m flake8 {posargs} {[_lint]files}
 
 [testenv:docs]


### PR DESCRIPTION
We lost the ability to show skipped tests when transitioning to gh actions. As it turns out, all of the replaygain tests were being skipped, so as a start, try to install at least one backend.

Let's see whether installing ffmpeg actually works, I don't really know what I'm doing regarding Github actions.