### PR TITLE
ci: also run on latest Python alpha, but allow failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10-dev]
 
     env:
       PY_COLORS: 1
@@ -28,15 +28,24 @@ jobs:
         run: |
           sudo apt-get install ffmpeg  # For replaygain
 
-      - name: Test with tox
-        if: matrix.python-version != '3.9'
+      - name: Test older Python versions with tox
+        if: matrix.python-version != '3.9' && matrix.python-version != '3.10-dev'
         run: |
           tox -e py-test
 
-      - name: Test with tox and get coverage
+      - name: Test latest Python version with tox and get coverage
         if: matrix.python-version == '3.9'
         run: |
           tox -vv -e py-cov
+
+      - name: Test nightly Python version with tox
+        if: matrix.python-version == '3.10-dev'
+        # continue-on-error is not ideal since it doesn't give a visible
+        # warning, but there doesn't seem to be anything better:
+        # https://github.com/actions/toolkit/issues/399
+        continue-on-error: true
+        run: |
+          tox -e py-test
 
       - name: Upload code coverage
         if: matrix.python-version == '3.9'


### PR DESCRIPTION
Hopefully, this helps to spot breaking changes early. Unfortunately, the UI appears to be somewhat lacking: https://github.com/actions/toolkit/issues/399