### PR TITLE
Fix for Musixmatch multi-part lyrics

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -292,15 +292,11 @@ class MusiXmatch(Backend):
                               % url)
             return
         html_parts = html.split('<p class="mxm-lyrics__content')
-        # Sometimes lyrics come in 2 parts
-        if len(html_parts) > 1:
-            html_part1 = html_parts[-2]
-            lyrics_part1 = extract_text_between(html_part1, '>', '</p>')
-        else:
-            lyrics_part1 = ''
-        html_part2 = html_parts[-1]
-        lyrics_part2 = extract_text_between(html_part2, '>', '</p>')
-        lyrics = lyrics_part1 + '\n' + lyrics_part2
+        # Sometimes lyrics come in 2 or more parts
+        lyrics_parts = []
+        for html_part in html_parts:
+            lyrics_parts.append(extract_text_between(html_part, '>', '</p>'))
+        lyrics = '\n'.join(lyrics_parts)
         lyrics = lyrics.strip(',"').replace('\\n', '\n')
         # another odd case: sometimes only that string remains, for
         # missing songs. this seems to happen after being blocked
@@ -308,7 +304,7 @@ class MusiXmatch(Backend):
         if "Instant lyrics for all your music." in lyrics:
             return
         # sometimes there are non-existent lyrics with some content
-        if 'Think is wrong? You can always add the lyrics' in lyrics:
+        if 'Lyrics | Musixmatch' in lyrics:
             return
         return lyrics
 

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -291,13 +291,24 @@ class MusiXmatch(Backend):
             self._log.warning(u'we are blocked at MusixMatch: url %s failed'
                               % url)
             return
-        html_part = html.split('<p class="mxm-lyrics__content')[-1]
-        lyrics = extract_text_between(html_part, '>', '</p>')
+        html_parts = html.split('<p class="mxm-lyrics__content')
+        # Sometimes lyrics come in 2 parts
+        if len(html_parts) > 1:
+            html_part1 = html_parts[-2]
+            lyrics_part1 = extract_text_between(html_part1, '>', '</p>')
+        else:
+            lyrics_part1 = ''
+        html_part2 = html_parts[-1]
+        lyrics_part2 = extract_text_between(html_part2, '>', '</p>')
+        lyrics = lyrics_part1 + '\n' + lyrics_part2
         lyrics = lyrics.strip(',"').replace('\\n', '\n')
         # another odd case: sometimes only that string remains, for
         # missing songs. this seems to happen after being blocked
         # above, when filling in the CAPTCHA.
         if "Instant lyrics for all your music." in lyrics:
+            return
+        # sometimes there are non-existent lyrics with some content
+        if 'Think is wrong? You can always add the lyrics' in lyrics:
             return
         return lyrics
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -215,6 +215,8 @@ Other new things:
 
 Fixes:
 
+* :bug:`/plugins/lyrics`: Fixed Musixmatch fetch lyrics divided into multiple elements on the web-page
+* :bug:`/plugins/lyrics`: Fixed Musixmatch fetch for non-existing lyrics
 * :bug:`/plugins/web`: Allow use of backslash in regex web queries.
   :bug:`3867`
 * :bug:`/plugins/web`: Fixed a small bug which caused album artpath to be


### PR DESCRIPTION
## Description

Sometimes Musixmatch lyrics come in 2 parts.
Also, sometime non-existent lyrics return some content

## Changelog
### Lyrics: Improve Musixmatch backend
* Fix for lyrics that divided into 2 or more <div> elements.
* Ignore "fake" lyrics when lyrics not found but some content still being retrieved.

