### PR TITLE
Fix falso positive lyric pages for Tekstowo

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -416,15 +416,11 @@ class Tekstowo(Backend):
 
     def fetch(self, artist, title):
         url = self.build_url(title, artist)
-        print(url)
         search_results = self.fetch_url(url)
         song_page_url = self.parse_search_results(search_results)
 
         if not song_page_url:
             return None
-
-        print('--------------------')
-        print(song_page_url)
 
         song_page_html = self.fetch_url(song_page_url)
         return self.extract_lyrics(song_page_html)
@@ -445,7 +441,7 @@ class Tekstowo(Backend):
             find("div", class_="card"). \
             find_all("div", class_="box-przeboje")
 
-        if len(song_rows) < 1:
+        if not song_rows:
             return None
 
         song_row = song_rows[0]

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -416,11 +416,15 @@ class Tekstowo(Backend):
 
     def fetch(self, artist, title):
         url = self.build_url(title, artist)
+        print(url)
         search_results = self.fetch_url(url)
         song_page_url = self.parse_search_results(search_results)
 
         if not song_page_url:
             return None
+
+        print('--------------------')
+        print(song_page_url)
 
         song_page_html = self.fetch_url(song_page_url)
         return self.extract_lyrics(song_page_html)
@@ -437,8 +441,14 @@ class Tekstowo(Backend):
         except HTMLParseError:
             return None
 
-        song_row = html.find("div", class_="content"). \
-            find_all("div", class_="box-przeboje")[0]
+        song_rows = html.find("div", class_="content"). \
+            find("div", class_="card"). \
+            find_all("div", class_="box-przeboje")
+
+        if len(song_rows) < 1:
+            return None
+
+        song_row = song_rows[0]
 
         if not song_row:
             return None

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -353,6 +353,8 @@ Fixes:
   :bug:`3870`
 * Allow equals within ``--set`` value when importing.
   :bug:`2984`
+* :doc:`/plugins/lyrics`: Fix crashes for Tekstowo false positives
+  :bug:`3904`
 
 For plugin developers:
 


### PR DESCRIPTION
## Description

Fixes #3904 

Did mange to reproduce the specific error the user saw

* Fixed cases where false positives occurred for certain searches such as https://www.tekstowo.pl/szukaj,wykonawca,Boy+In+Space,tytul,Hsafjsahfkjsahfkl.html
* Fixed additional edge-case found while testing

## To Do

- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
