### PR TITLE
ci: scope ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,11 @@
 name: ci
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
   test:
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
## Description

Changes `ci` workflow to only run when:

- A push to `master` happens
- A pull request gets opened and it's base is `master`
	- This will also kick of sequential `ci` runs if the branch is updated (synchronized: GitHub's terminology)

This makes for deduping the checks ran.