### PR TITLE
Add HTTPS support/configuration option for Musicbrainz

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -97,8 +97,11 @@ def configure():
     from the beets configuration. This should be called at startup.
     """
     hostname = config['musicbrainz']['host'].as_str()
-    use_https = config['musicbrainz']['use_https'].get(bool)
-    musicbrainzngs.set_hostname(hostname, use_https)
+    https = config['musicbrainz']['https'].get(bool)
+    # Only call set_hostname when a custom server is configured. Since
+    # musicbrainz-ngs connects to musicbrainz.org with HTTPS by default
+    if hostname != "musicbrainz.org":
+        musicbrainzngs.set_hostname(hostname, https)
     musicbrainzngs.set_rate_limit(
         config['musicbrainz']['ratelimit_interval'].as_number(),
         config['musicbrainz']['ratelimit'].get(int),

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -97,7 +97,8 @@ def configure():
     from the beets configuration. This should be called at startup.
     """
     hostname = config['musicbrainz']['host'].as_str()
-    musicbrainzngs.set_hostname(hostname)
+    use_https = config['musicbrainz']['use_https'].get(bool)
+    musicbrainzngs.set_hostname(hostname, use_https)
     musicbrainzngs.set_rate_limit(
         config['musicbrainz']['ratelimit_interval'].as_number(),
         config['musicbrainz']['ratelimit'].get(int),

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -102,6 +102,7 @@ statefile: state.pickle
 
 musicbrainz:
     host: musicbrainz.org
+    use_https: yes
     ratelimit: 1
     ratelimit_interval: 1.0
     searchlimit: 5

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -102,7 +102,7 @@ statefile: state.pickle
 
 musicbrainz:
     host: musicbrainz.org
-    use_https: yes
+    https: no
     ratelimit: 1
     ratelimit_interval: 1.0
     searchlimit: 5

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -46,6 +46,8 @@ Major new features:
 
 Other new things:
 
+* Enable HTTPS support to Musicbrainz by default and add configuration option
+  `use_https`.
 * :doc:`/plugins/mpdstats`: Add a new `strip_path` option to help build the
   right local path from MPD information.
 * :doc:`/plugins/convert`: Conversion can now parallelize conversion jobs on

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -47,7 +47,7 @@ Major new features:
 Other new things:
 
 * Enable HTTPS support to Musicbrainz by default and add configuration option
-  `use_https`.
+  `https` for custom servers.
 * :doc:`/plugins/mpdstats`: Add a new `strip_path` option to help build the
   right local path from MPD information.
 * :doc:`/plugins/convert`: Conversion can now parallelize conversion jobs on

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -46,7 +46,7 @@ Major new features:
 
 Other new things:
 
-* Enable HTTPS support to Musicbrainz by default and add configuration option
+* Enable HTTPS for MusicBrainz by default and add configuration option
   `https` for custom servers.
 * :doc:`/plugins/mpdstats`: Add a new `strip_path` option to help build the
   right local path from MPD information.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -701,8 +701,8 @@ under a ``musicbrainz:`` header, like so::
 
 The ``host`` key, of course, controls the Web server hostname (and port,
 optionally) that will be contacted by beets (default: musicbrainz.org).
-The ``https`` key makes the client use https instead of http, this setting applies
-only to custom servers. The official musicbrainz server always uses HTTPS (default: no).
+The ``https`` key makes the client use HTTPS instead of HTTP. This setting applies
+only to custom servers. The official MusicBrainz server always uses HTTPS. (Default: no.)
 The server must have search indices enabled (see `Building search indexes`_).
 
 The ``ratelimit`` option, an integer, controls the number of Web service requests

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -691,15 +691,17 @@ MusicBrainz Options
 -------------------
 
 You can instruct beets to use `your own MusicBrainz database`_ instead of
-the `main server`_. Use the ``host`` and ``ratelimit`` options under a
-``musicbrainz:`` header, like so::
+the `main server`_. Use the ``host``, ``use_https`` and ``ratelimit`` options
+under a ``musicbrainz:`` header, like so::
 
     musicbrainz:
         host: localhost:5000
+        use_https: no
         ratelimit: 100
 
 The ``host`` key, of course, controls the Web server hostname (and port,
 optionally) that will be contacted by beets (default: musicbrainz.org).
+The ``use_https`` key makes the client use https instead of http (default: yes).
 The server must have search indices enabled (see `Building search indexes`_).
 
 The ``ratelimit`` option, an integer, controls the number of Web service requests

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -691,17 +691,18 @@ MusicBrainz Options
 -------------------
 
 You can instruct beets to use `your own MusicBrainz database`_ instead of
-the `main server`_. Use the ``host``, ``use_https`` and ``ratelimit`` options
+the `main server`_. Use the ``host``, ``https`` and ``ratelimit`` options
 under a ``musicbrainz:`` header, like so::
 
     musicbrainz:
         host: localhost:5000
-        use_https: no
+        https: no
         ratelimit: 100
 
 The ``host`` key, of course, controls the Web server hostname (and port,
 optionally) that will be contacted by beets (default: musicbrainz.org).
-The ``use_https`` key makes the client use https instead of http (default: yes).
+The ``https`` key makes the client use https instead of http, this setting applies
+only to custom servers. The official musicbrainz server always uses HTTPS (default: no).
 The server must have search indices enabled (see `Building search indexes`_).
 
 The ``ratelimit`` option, an integer, controls the number of Web service requests


### PR DESCRIPTION
## Description

Enable HTTPS for musicbrainz.org API access by default. I noticed that beets was using HTTP with no way for the user to change this.

This patch does change default behavior since the use_https configuration option is set to yes by default. Setting this to no by default might be more appropriate.

## To Do

- [ ] Tests. I can't really think of a good way to write a test for this. I have verified that setting use_https works correctly by viewing a packet capture.
