### PR TITLE
Remove reference to rarfile version in link

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -359,6 +359,7 @@ Fixes:
   :bug:`2984`
 * :doc:`/plugins/lyrics`: Fix crashes for Tekstowo false positives
   :bug:`3904`
+* :doc`/reference/cli`: Remove reference to rarfile version in link
 
 For plugin developers:
 

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -151,7 +151,7 @@ Optional command flags:
 
     beet import --set genre="Alternative Rock" --set mood="emotional"
 
-.. _rarfile: https://pypi.python.org/pypi/rarfile/2.2
+.. _rarfile: https://pypi.python.org/pypi/rarfile/
 
 .. only:: html
 


### PR DESCRIPTION
## Description

Remove reference to rarfile version in pypi link in `cli.rst`



## To Do

- [X] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
