### PR TITLE
Add itunes_dateadded to metasync plugin

### DIFF
--- a/beetsplug/metasync/itunes.py
+++ b/beetsplug/metasync/itunes.py
@@ -69,6 +69,7 @@ class Itunes(MetaSource):
         'itunes_skipcount':   types.INTEGER,
         'itunes_lastplayed':  DateType(),
         'itunes_lastskipped': DateType(),
+        'itunes_dateadded':   DateType(),
     }
 
     def __init__(self, config, log):
@@ -117,10 +118,11 @@ class Itunes(MetaSource):
         item.itunes_playcount = result.get('Play Count')
         item.itunes_skipcount = result.get('Skip Count')
 
-        if result.get('Play Date UTC'):
-            item.itunes_lastplayed = mktime(
-                result.get('Play Date UTC').timetuple())
+        if (result_playdateutc := result.get("Play Date UTC")) :
+            item.itunes_lastplayed = mktime(result_playdateutc.timetuple())
 
-        if result.get('Skip Date'):
-            item.itunes_lastskipped = mktime(
-                result.get('Skip Date').timetuple())
+        if (result_skipdate := result.get("Skip Date")) :
+            item.itunes_lastskipped = mktime(result_skipdate.timetuple())
+
+        if (result_dateadded := result.get("Date Added")) :
+            item.itunes_dateadded = mktime(result_dateadded.timetuple())

--- a/beetsplug/metasync/itunes.py
+++ b/beetsplug/metasync/itunes.py
@@ -118,11 +118,14 @@ class Itunes(MetaSource):
         item.itunes_playcount = result.get('Play Count')
         item.itunes_skipcount = result.get('Skip Count')
 
-        if (result_playdateutc := result.get("Play Date UTC")) :
-            item.itunes_lastplayed = mktime(result_playdateutc.timetuple())
+        if result.get('Play Date UTC'):
+            item.itunes_lastplayed = mktime(
+                result.get('Play Date UTC').timetuple())
 
-        if (result_skipdate := result.get("Skip Date")) :
-            item.itunes_lastskipped = mktime(result_skipdate.timetuple())
+        if result.get('Skip Date'):
+            item.itunes_lastskipped = mktime(
+                result.get('Skip Date').timetuple())
 
-        if (result_dateadded := result.get("Date Added")) :
-            item.itunes_dateadded = mktime(result_dateadded.timetuple())
+        if result.get('Date Added'):
+            item.itunes_dateadded = mktime(
+                result.get('Date Added').timetuple())

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -222,6 +222,7 @@ Other new things:
   Thanks to :user:`arogl`.  :bug:`3906`
 * Get ISRC identifiers from musicbrainz
   Thanks to :user:`aereaux`.
+* :doc:`/plugins/metasync`: The ``metasync`` plugin now also fetches the ``Date Added`` field from iTunes databases and stores it in the``itunes_dateadded`` field.Thanks to :user:`sandersantema`.
 
   .. _py7zr: https://pypi.org/project/py7zr/
 

--- a/test/test_metasync.py
+++ b/test/test_metasync.py
@@ -100,6 +100,7 @@ class MetaSyncTest(_common.TestCase, TestHelper):
         self.assertIn('itunes_skipcount: 3', out)
         self.assertIn('itunes_lastplayed: 2015-05-04 12:20:51', out)
         self.assertIn('itunes_lastskipped: 2015-02-05 15:41:04', out)
+        self.assertIn('itunes_dateadded: 2014-04-24 09:28:38', out)
         self.assertEqual(self.lib.items()[0].itunes_rating, 60)
 
     def test_sync_from_itunes(self):
@@ -111,12 +112,16 @@ class MetaSyncTest(_common.TestCase, TestHelper):
         self.assertFalse(hasattr(self.lib.items()[0], 'itunes_lastplayed'))
         self.assertEqual(self.lib.items()[0].itunes_lastskipped,
                          _parsetime('2015-02-05 15:41:04'))
+        self.assertEqual(self.lib.items()[0].itunes_dateadded,
+                         _parsetime('2014-04-24 09:28:38'))
 
         self.assertEqual(self.lib.items()[1].itunes_rating, 100)
         self.assertEqual(self.lib.items()[1].itunes_playcount, 31)
         self.assertEqual(self.lib.items()[1].itunes_skipcount, 0)
         self.assertEqual(self.lib.items()[1].itunes_lastplayed,
                          _parsetime('2015-05-04 12:20:51'))
+        self.assertEqual(self.lib.items()[1].itunes_dateadded,
+                         _parsetime('2014-04-24 09:28:38'))
         self.assertFalse(hasattr(self.lib.items()[1], 'itunes_lastskipped'))
 
 


### PR DESCRIPTION
## Description

This adds `itunes_dateadded` to the metasync plugin.

## To Do

- [x] Documentation: I believe this isn't required.
- [ ] Changelog: is "Add itunes_dateadded to metasync plugin" sufficient?
- [x] Tests: might need to be checked given that I've never really wrote tests before.