### PR TITLE
Document Libera.Chat as the new official IRC home

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,9 @@ dependencies---packagers, please take note.
 Finally, this is the last version of beets where we intend to support Python
 2.x and 3.5; future releases will soon require Python 3.6.
 
+One non-technical change includes that we moved our official ``#beets`` home
+on IRC from freenode to Libera.Chat.
+
 Major new features:
 
 * A new :ref:`reflink` config option instructs the importer to create fast,
@@ -46,6 +49,7 @@ Major new features:
 
 Other new things:
 
+* Document Libera.Chat as the new official IRC home. Thanks to :user:`Freso`.
 * Enable HTTPS for MusicBrainz by default and add configuration option
   `https` for custom servers.
 * :doc:`/plugins/mpdstats`: Add a new `strip_path` option to help build the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,9 +13,9 @@ Then you can get a more detailed look at beets' features in the
 be interested in exploring the :doc:`plugins </plugins/index>`.
 
 If you still need help, your can drop by the ``#beets`` IRC channel on
-Freenode, drop by `the discussion board`_, send email to `the mailing list`_,
-or `file a bug`_ in the issue tracker. Please let us know where you think this
-documentation can be improved.
+Libera.Chat, drop by `the discussion board`_, send email to
+`the mailing list`_, or `file a bug`_ in the issue tracker. Please let us know
+where you think this documentation can be improved.
 
 .. _beets: https://beets.io/
 .. _the mailing list: https://groups.google.com/group/beets-users


### PR DESCRIPTION
## Description

Resolves https://github.com/beetbox/beets/discussions/3953

freenode has had a hostile takeover (see [DWF CVE-2021-1000189](https://github.com/distributedweaknessfiling/dwflist/blob/main/2021/1000xxx/CVE-2021-1000189.json)) and the network is no longer safe. This PR sets out to document Libera.Chat as our new home on IRC.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)

(Nothing to test.)