### PR TITLE
Add missing test data for tekstowo

### DIFF
--- a/test/rsrc/lyricstext.yaml
+++ b/test/rsrc/lyricstext.yaml
@@ -54,3 +54,9 @@ Black_magic_woman: |
     you might me woman turning spell stop baby with 'round a on stone messin' magic i of 
     tricks up leave turn bad so pick she's my can't
 
+u_n_eye: |
+    let see cool bed for sometimes are place told in yeah or ride open hide blame knee your my borders
+    perfect i of laying lies they love the night all out saying fast things said that on face hit hell
+    no low not bullets bullet fly time maybe over is roof a it know now airplane where tekst and tonight
+    brakes just waste we go an to you was going eye start need insane cross gotta historia mood life with
+    hurts too whoa me fight little every oh would thousand but high tekstu lay space do down private edycji


### PR DESCRIPTION
## Description

Fixes integration test failures caused by missing tekstowo test data (https://github.com/beetbox/beets/runs/2647894205).

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
