### PR TITLE
duplicates: fix crash on empty query

### DIFF
--- a/beetsplug/duplicates.py
+++ b/beetsplug/duplicates.py
@@ -136,6 +136,11 @@ class DuplicatesPlugin(BeetsPlugin):
                     keys = ['mb_trackid', 'mb_albumid']
                 items = lib.items(decargs(args))
 
+            # If there's nothing to do, return early. The code below assumes
+            # `items` to be non-empty.
+            if not items:
+                return
+
             if path:
                 fmt = u'$path'
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -383,6 +383,9 @@ Fixes:
 * :doc:`/plugins/lyrics`: Fix crashes when a website could not be retrieved,
   affecting at least the Genius source
   :bug:`3970`
+* :doc:`/plugins/duplicates`: Fix a crash when running the ``dup`` command with
+  a query that returns no results.
+  :bug:`3943`
 
 For plugin developers:
 


### PR DESCRIPTION
Fixes the remainder of https://github.com/beetbox/beets/issues/3943 now that #3930 was merged.

Fixes #3943