### PR TITLE
update irc link: freenode -> libera

### DIFF
--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -100,9 +100,8 @@ or <a href="http://news.ycombinator.com/submitlink?u={{ site.url | cgi_escape }}
     <li><a href="http://groups.google.com/group/beets-users">mailing
         list</a></li>
     <li><a href="/blog/">blog</a>, <a href="/blog/atom.xml">atom</a></li>
-    <li><a href="irc://irc.freenode.net/beets">#beets on
-        freenode</a>,
-        <a href="https://botbot.me/freenode/beets/">log</a></li>
+    <li><a href="irc://irc.libera.chat/beets">#beets on
+        libera.chat</a></li>
     <li><a href="/donate.html">donate</a></li>
 </ul>
 </section>


### PR DESCRIPTION
The website still pointed to freenode. Do we have a log bot around? (@Freso ?) For now, I've removed the link since `botbot.me` appears to be defunct.