### PR TITLE
Update lyrics.py to make unescape is more robust

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -127,13 +127,15 @@ def unescape(text):
     """Resolve &#xxx; HTML entities (and some others)."""
     if isinstance(text, bytes):
         text = text.decode('utf-8', 'ignore')
-    out = text.replace(u'&nbsp;', u' ')
+    if text:
+        out = text.replace(u'&nbsp;', u' ')
 
-    def replchar(m):
-        num = m.group(1)
-        return unichar(int(num))
-    out = re.sub(u"&#(\\d+);", replchar, out)
-    return out
+        def replchar(m):
+            num = m.group(1)
+            return unichar(int(num))
+        out = re.sub(u"&#(\\d+);", replchar, out)
+        return out
+    return None
 
 
 def extract_text_between(html, start_marker, end_marker):


### PR DESCRIPTION

## Description
I have noted that in some cases text is undefined. the lyrics plugin just fails if this the case.

This patch allows the plugin to proceed Instead of failing here, it ensures that unescape function returns None, so that other lyrics backends can get a chance to fetch lyrics instead

No bugreport was filed before this fix.