### PR TITLE
return None for lyrics if Tekstowo fails to extract lyrics

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -483,7 +483,10 @@ class Tekstowo(Backend):
         if not soup:
             return None
 
-        return soup.find("div", class_="song-text").get_text()
+        c = soup.find("div", class_="song-text")
+        if c:
+            return c.get_text()
+        return None
 
 
 def remove_credits(text):


### PR DESCRIPTION
## Description
I experienced a failure to parse Tekstowo for song lyrics. 

This patch allowed the lyrics plugin to fetch the lyrics from another provider as opposed to failing.

No bug was reported before this patch was generated