### PR TITLE
Refactoring of the replaygain plugin

### DIFF
--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -1145,8 +1145,9 @@ class ReplayGainPlugin(BeetsPlugin):
             self._log.info('Skipping album {0}', album)
             return
 
-        if (any([self.should_use_r128(item) for item in album.items()]) and not
-                all([self.should_use_r128(item) for item in album.items()])):
+        items_iter = iter(album.items())
+        use_r128 = self.should_use_r128(next(items_iter))
+        if any(use_r128 != self.should_use_r128(i) for i in items_iter):
             self._log.error(
                 "Cannot calculate gain for album {0} (incompatible formats)",
                 album)

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -109,6 +109,7 @@ class Backend:
     """An abstract class representing engine for calculating RG values.
     """
 
+    NAME = ""
     do_parallel = False
 
     def __init__(self, config, log):
@@ -135,6 +136,7 @@ class FfmpegBackend(Backend):
     """A replaygain backend using ffmpeg's ebur128 filter.
     """
 
+    NAME = "ffmpeg"
     do_parallel = True
 
     def __init__(self, config, log):
@@ -379,6 +381,7 @@ class FfmpegBackend(Backend):
 
 # mpgain/aacgain CLI tool backend.
 class CommandBackend(Backend):
+    NAME = "command"
     do_parallel = True
 
     def __init__(self, config, log):
@@ -508,6 +511,8 @@ class CommandBackend(Backend):
 # GStreamer-based backend.
 
 class GStreamerBackend(Backend):
+    NAME = "gstreamer"
+
     def __init__(self, config, log):
         super().__init__(config, log)
         self._import_gst()
@@ -779,6 +784,7 @@ class AudioToolsBackend(Backend):
     <http://audiotools.sourceforge.net/>`_ and its capabilities to read more
     file formats and compute ReplayGain values using it replaygain module.
     """
+    NAME = "audiotools"
 
     def __init__(self, config, log):
         super().__init__(config, log)
@@ -956,16 +962,18 @@ class ExceptionWatcher(Thread):
 
 # Main plugin logic.
 
+BACKEND_CLASSES = [
+    CommandBackend,
+    GStreamerBackend,
+    AudioToolsBackend,
+    FfmpegBackend,
+]
+BACKENDS = {b.NAME: b for b in BACKEND_CLASSES}
+
+
 class ReplayGainPlugin(BeetsPlugin):
     """Provides ReplayGain analysis.
     """
-
-    backends = {
-        "command": CommandBackend,
-        "gstreamer": GStreamerBackend,
-        "audiotools": AudioToolsBackend,
-        "ffmpeg": FfmpegBackend,
-    }
 
     peak_methods = {
         "true": Peak.true,
@@ -997,12 +1005,12 @@ class ReplayGainPlugin(BeetsPlugin):
         # Remember which backend is used for CLI feedback
         self.backend_name = self.config['backend'].as_str()
 
-        if self.backend_name not in self.backends:
+        if self.backend_name not in BACKENDS:
             raise ui.UserError(
                 "Selected ReplayGain backend {} is not supported. "
                 "Please select one of: {}".format(
                     self.backend_name,
-                    ', '.join(self.backends.keys())
+                    ', '.join(BACKENDS.keys())
                 )
             )
         peak_method = self.config["peak"].as_str()
@@ -1026,7 +1034,7 @@ class ReplayGainPlugin(BeetsPlugin):
         self.r128_whitelist = self.config['r128'].as_str_seq()
 
         try:
-            self.backend_instance = self.backends[self.backend_name](
+            self.backend_instance = BACKENDS[self.backend_name](
                 self.config, self._log
             )
         except (ReplayGainError, FatalReplayGainError) as e:

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -1110,13 +1110,13 @@ class ReplayGainPlugin(BeetsPlugin):
         self._log.debug('applied r128 album gain {0} LU',
                         item.r128_album_gain)
 
-    def tag_specific_values(self, items):
+    def tag_specific_values(self, use_r128):
         """Return some tag specific values.
 
         Returns a tuple (store_track_gain, store_album_gain, target_level,
         peak_method).
         """
-        if any([self.should_use_r128(item) for item in items]):
+        if use_r128:
             store_track_gain = self.store_track_r128_gain
             store_album_gain = self.store_album_r128_gain
             target_level = self.config['r128_targetlevel'].as_number()
@@ -1151,7 +1151,7 @@ class ReplayGainPlugin(BeetsPlugin):
 
         self._log.info('analyzing {0}', album)
 
-        tag_vals = self.tag_specific_values(album.items())
+        tag_vals = self.tag_specific_values(use_r128)
         store_track_gain, store_album_gain, target_level, peak = tag_vals
 
         discs = {}
@@ -1210,7 +1210,8 @@ class ReplayGainPlugin(BeetsPlugin):
             self._log.info('Skipping track {0}', item)
             return
 
-        tag_vals = self.tag_specific_values([item])
+        use_r128 = self.should_use_r128(item)
+        tag_vals = self.tag_specific_values(use_r128)
         store_track_gain, store_album_gain, target_level, peak = tag_vals
 
         def _store_track(track_gains):

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -102,6 +102,15 @@ class PeakMethod(enum.Enum):
 
 
 class RgTask():
+    """State and methods for a single replaygain calculation (rg version).
+
+    Bundles the state (parameters and results) of a single replaygain
+    calculation (either for one item, one disk, or one full album).
+
+    This class provides methods to store the resulting gains and peaks as plain
+    old rg tags.
+    """
+
     def __init__(self, items, album, target_level, peak_method, backend_name,
                  log):
         self.items = items
@@ -114,6 +123,8 @@ class RgTask():
         self.track_gains = None
 
     def _store_track_gain(self, item, track_gain):
+        """Store track gain for a single item in the database.
+        """
         item.rg_track_gain = track_gain.gain
         item.rg_track_peak = track_gain.peak
         item.store()
@@ -121,7 +132,7 @@ class RgTask():
                         item.rg_track_gain, item.rg_track_peak)
 
     def _store_album_gain(self, item):
-        """
+        """Store album gain for a single item in the database.
 
         The caller needs to ensure that `self.album_gain is not None`.
         """
@@ -132,6 +143,8 @@ class RgTask():
                         item.rg_album_gain, item.rg_album_peak)
 
     def _store_track(self, write):
+        """Store track gain for the first track of the task in the database.
+        """
         item = self.items[0]
         if self.track_gains is None or len(self.track_gains) != 1:
             # In some cases, backends fail to produce a valid
@@ -148,6 +161,8 @@ class RgTask():
         self._log.debug('done analyzing {0}', item)
 
     def _store_album(self, write):
+        """Store track/album gains for all tracks of the task in the database.
+        """
         if (self.album_gain is None or self.track_gains is None
                 or len(self.track_gains) != len(self.items)):
             # In some cases, backends fail to produce a valid
@@ -166,6 +181,8 @@ class RgTask():
             self._log.debug('done analyzing {0}', item)
 
     def store(self, write):
+        """Store computed gains for the items of this task in the database.
+        """
         if self.album is not None:
             self._store_album(write)
         else:
@@ -173,6 +190,15 @@ class RgTask():
 
 
 class R128Task(RgTask):
+    """State and methods for a single replaygain calculation (r128 version).
+
+    Bundles the state (parameters and results) of a single replaygain
+    calculation (either for one item, one disk, or one full album).
+
+    This class provides methods to store the resulting gains and peaks as R128
+    tags.
+    """
+
     def __init__(self, items, album, target_level, backend_name, log):
         # R128_* tags do not store the track/album peak
         super().__init__(items, album, target_level, None, backend_name,

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -989,7 +989,9 @@ class ReplayGainPlugin(BeetsPlugin):
             'r128_targetlevel': lufs_to_db(-23),
         })
 
-        self.overwrite = self.config['overwrite'].get(bool)
+        # FIXME: Consider renaming the configuration option and deprecating the
+        # old name 'overwrite'.
+        self.force_on_import = self.config['overwrite'].get(bool)
         self.per_disc = self.config['per_disc'].get(bool)
 
         # Remember which backend is used for CLI feedback
@@ -1047,9 +1049,6 @@ class ReplayGainPlugin(BeetsPlugin):
                 and item.rg_track_peak is not None)
 
     def track_requires_gain(self, item):
-        if self.overwrite:
-            return True
-
         if self.should_use_r128(item):
             if not self.has_r128_track_data(item):
                 return True
@@ -1074,9 +1073,6 @@ class ReplayGainPlugin(BeetsPlugin):
         # recalculation. This way, if any file among an album's tracks
         # needs recalculation, we still get an accurate album gain
         # value.
-        if self.overwrite:
-            return True
-
         for item in album.items():
             if self.should_use_r128(item):
                 if not self.has_r128_album_data(item):
@@ -1340,9 +1336,9 @@ class ReplayGainPlugin(BeetsPlugin):
         """
         if self.config['auto']:
             if task.is_album:
-                self.handle_album(task.album, False)
+                self.handle_album(task.album, False, self.force_on_import)
             else:
-                self.handle_track(task.item, False)
+                self.handle_track(task.item, False, self.force_on_import)
 
     def command_func(self, lib, opts, args):
         try:

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -99,10 +99,61 @@ Gain = collections.namedtuple("Gain", "gain peak")
 AlbumGain = collections.namedtuple("AlbumGain", "album_gain track_gains")
 
 
-class Peak(enum.Enum):
-    none = 0
-    true = 1
-    sample = 2
+ALL_PEAK_METHODS = ["true", "sample"]
+Peak = enum.Enum("Peak", ["none"] + ALL_PEAK_METHODS)
+
+
+class GainHandler():
+    def __init__(self, config, peak, log):
+        self.config = config
+        self.peak = peak
+        self._log = log
+
+    @property
+    def target_level(self):
+        """This currently needs to reloaded from the config since the tests
+        modify its value on-the-fly.
+        """
+        return self.config['targetlevel'].as_number()
+
+    def store_track_gain(self, item, track_gain):
+        item.rg_track_gain = track_gain.gain
+        item.rg_track_peak = track_gain.peak
+        item.store()
+        self._log.debug('applied track gain {0} LU, peak {1} of FS',
+                        item.rg_track_gain, item.rg_track_peak)
+
+    def store_album_gain(self, item, album_gain):
+        item.rg_album_gain = album_gain.gain
+        item.rg_album_peak = album_gain.peak
+        item.store()
+        self._log.debug('applied album gain {0} LU, peak {1} of FS',
+                        item.rg_album_gain, item.rg_album_peak)
+
+
+class R128GainHandler(GainHandler):
+    def __init__(self, config, log):
+        # R128_* tags do not store the track/album peak
+        super().__init__(config, Peak.none, log)
+
+    @property
+    def target_level(self):
+        """This currently needs to reloaded from the config since the tests
+        modify its value on-the-fly.
+        """
+        return self.config['r128_targetlevel'].as_number()
+
+    def store_track_gain(self, item, track_gain):
+        item.r128_track_gain = track_gain.gain
+        item.store()
+        self._log.debug('applied r128 track gain {0} LU',
+                        item.r128_track_gain)
+
+    def store_album_gain(self, item, album_gain):
+        item.r128_album_gain = album_gain.gain
+        item.store()
+        self._log.debug('applied r128 album gain {0} LU',
+                        item.r128_album_gain)
 
 
 class Backend:
@@ -975,11 +1026,6 @@ class ReplayGainPlugin(BeetsPlugin):
     """Provides ReplayGain analysis.
     """
 
-    peak_methods = {
-        "true": Peak.true,
-        "sample": Peak.sample,
-    }
-
     def __init__(self):
         super().__init__()
 
@@ -1013,16 +1059,29 @@ class ReplayGainPlugin(BeetsPlugin):
                     ', '.join(BACKENDS.keys())
                 )
             )
+
         peak_method = self.config["peak"].as_str()
-        if peak_method not in self.peak_methods:
+        if peak_method not in ALL_PEAK_METHODS:
             raise ui.UserError(
                 "Selected ReplayGain peak method {} is not supported. "
                 "Please select one of: {}".format(
                     peak_method,
-                    ', '.join(self.peak_methods.keys())
+                    ', '.join(ALL_PEAK_METHODS)
                 )
             )
-        self._peak_method = self.peak_methods[peak_method]
+
+        # The key in this dict is the `use_r128` flag.
+        self.gain_handlers = {
+            True: R128GainHandler(
+                self.config,
+                self._log,
+            ),
+            False: GainHandler(
+                self.config,
+                Peak[peak_method],
+                self._log,
+            ),
+        }
 
         # On-import analysis.
         if self.config['auto']:
@@ -1091,52 +1150,6 @@ class ReplayGainPlugin(BeetsPlugin):
 
         return False
 
-    def store_track_gain(self, item, track_gain):
-        item.rg_track_gain = track_gain.gain
-        item.rg_track_peak = track_gain.peak
-        item.store()
-        self._log.debug('applied track gain {0} LU, peak {1} of FS',
-                        item.rg_track_gain, item.rg_track_peak)
-
-    def store_album_gain(self, item, album_gain):
-        item.rg_album_gain = album_gain.gain
-        item.rg_album_peak = album_gain.peak
-        item.store()
-        self._log.debug('applied album gain {0} LU, peak {1} of FS',
-                        item.rg_album_gain, item.rg_album_peak)
-
-    def store_track_r128_gain(self, item, track_gain):
-        item.r128_track_gain = track_gain.gain
-        item.store()
-
-        self._log.debug('applied r128 track gain {0} LU',
-                        item.r128_track_gain)
-
-    def store_album_r128_gain(self, item, album_gain):
-        item.r128_album_gain = album_gain.gain
-        item.store()
-        self._log.debug('applied r128 album gain {0} LU',
-                        item.r128_album_gain)
-
-    def tag_specific_values(self, use_r128):
-        """Return some tag specific values.
-
-        Returns a tuple (store_track_gain, store_album_gain, target_level,
-        peak_method).
-        """
-        if use_r128:
-            store_track_gain = self.store_track_r128_gain
-            store_album_gain = self.store_album_r128_gain
-            target_level = self.config['r128_targetlevel'].as_number()
-            peak = Peak.none  # R128_* tags do not store the track/album peak
-        else:
-            store_track_gain = self.store_track_gain
-            store_album_gain = self.store_album_gain
-            target_level = self.config['targetlevel'].as_number()
-            peak = self._peak_method
-
-        return store_track_gain, store_album_gain, target_level, peak
-
     def handle_album(self, album, write, force=False):
         """Compute album and track replay gain store it in all of the
         album's items.
@@ -1159,8 +1172,7 @@ class ReplayGainPlugin(BeetsPlugin):
 
         self._log.info('analyzing {0}', album)
 
-        tag_vals = self.tag_specific_values(use_r128)
-        store_track_gain, store_album_gain, target_level, peak = tag_vals
+        handler = self.gain_handlers[use_r128]
 
         discs = {}
         if self.per_disc:
@@ -1185,8 +1197,8 @@ class ReplayGainPlugin(BeetsPlugin):
                     )
                 for item, track_gain in zip(items,
                                             album_gain.track_gains):
-                    store_track_gain(item, track_gain)
-                    store_album_gain(item, album_gain.album_gain)
+                    handler.store_track_gain(item, track_gain)
+                    handler.store_album_gain(item, album_gain.album_gain)
                     if write:
                         item.try_write()
                     self._log.debug('done analyzing {0}', item)
@@ -1196,8 +1208,8 @@ class ReplayGainPlugin(BeetsPlugin):
                     self.backend_instance.compute_album_gain, args=(),
                     kwds={
                         "items": list(items),
-                        "target_level": target_level,
-                        "peak": peak
+                        "target_level": handler.target_level,
+                        "peak": handler.peak,
                     },
                     callback=_store_album
                 )
@@ -1219,8 +1231,7 @@ class ReplayGainPlugin(BeetsPlugin):
             return
 
         use_r128 = self.should_use_r128(item)
-        tag_vals = self.tag_specific_values(use_r128)
-        store_track_gain, store_album_gain, target_level, peak = tag_vals
+        handler = self.gain_handlers[use_r128]
 
         def _store_track(track_gains):
             if not track_gains or len(track_gains) != 1:
@@ -1232,7 +1243,7 @@ class ReplayGainPlugin(BeetsPlugin):
                     .format(self.backend_name, item)
                 )
 
-            store_track_gain(item, track_gains[0])
+            handler.store_track_gain(item, track_gains[0])
             if write:
                 item.try_write()
             self._log.debug('done analyzing {0}', item)
@@ -1242,8 +1253,8 @@ class ReplayGainPlugin(BeetsPlugin):
                 self.backend_instance.compute_track_gain, args=(),
                 kwds={
                     "items": [item],
-                    "target_level": target_level,
-                    "peak": peak,
+                    "target_level": handler.target_level,
+                    "peak": handler.peak,
                 },
                 callback=_store_track
             )

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -1096,7 +1096,6 @@ class ReplayGainPlugin(BeetsPlugin):
         # FIXME: Consider renaming the configuration option and deprecating the
         # old name 'overwrite'.
         self.force_on_import = self.config['overwrite'].get(bool)
-        self.per_disc = self.config['per_disc'].get(bool)
 
         # Remember which backend is used for CLI feedback
         self.backend_name = self.config['backend'].as_str()
@@ -1234,7 +1233,7 @@ class ReplayGainPlugin(BeetsPlugin):
         self._log.info('analyzing {0}', album)
 
         discs = {}
-        if self.per_disc:
+        if self.config['per_disc'].get(bool):
             for item in album.items():
                 if discs.get(item.disc) is None:
                     discs[item.disc] = []

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -1200,7 +1200,7 @@ class ReplayGainPlugin(BeetsPlugin):
             discs[1] = album.items()
 
         for discnumber, items in discs.items():
-            def _store_album(task):
+            def _store_album(task, write):
                 if (task.album_gain is None or task.track_gains is None
                         or len(task.track_gains) != len(task.items)):
                     # In some cases, backends fail to produce a valid
@@ -1223,7 +1223,7 @@ class ReplayGainPlugin(BeetsPlugin):
                 self._apply(
                     self.backend_instance.compute_album_gain,
                     args=[task], kwds={},
-                    callback=_store_album
+                    callback=lambda task: _store_album(task, write)
                 )
             except ReplayGainError as e:
                 self._log.info("ReplayGain error: {0}", e)
@@ -1244,7 +1244,7 @@ class ReplayGainPlugin(BeetsPlugin):
 
         use_r128 = self.should_use_r128(item)
 
-        def _store_track(task):
+        def _store_track(task, write):
             if task.track_gains is None or len(task.track_gains) != 1:
                 # In some cases, backends fail to produce a valid
                 # `track_gains` without throwing FatalReplayGainError
@@ -1264,7 +1264,7 @@ class ReplayGainPlugin(BeetsPlugin):
             self._apply(
                 self.backend_instance.compute_track_gain,
                 args=[task], kwds={},
-                callback=_store_track
+                callback=lambda task: _store_track(task, write)
             )
         except ReplayGainError as e:
             self._log.info("ReplayGain error: {0}", e)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -44,6 +44,9 @@ Bug fixes:
 * :doc:`plugins/lyrics`: Fixed issues with the Tekstowo.pl and Genius
   backends where some non-lyrics content got included in the lyrics
 * :doc:`plugins/limit`: Better header formatting to improve index
+* :doc:`plugins/replaygain`: Correctly handle the ``overwrite`` config option,
+  which forces recomputing ReplayGain values on import even for tracks
+  that already have the tags.
 
 For packagers:
 

--- a/docs/plugins/replaygain.rst
+++ b/docs/plugins/replaygain.rst
@@ -112,7 +112,10 @@ configuration file. The available options are:
 - **backend**: The analysis backend; either ``gstreamer``, ``command``, ``audiotools``
   or ``ffmpeg``.
   Default: ``command``.
-- **overwrite**: Re-analyze files that already have ReplayGain tags.
+- **overwrite**: On import, re-analyze files that already have ReplayGain tags.
+  Note that, for historical reasons, the name of this option is somewhat
+  unfortunate: It does not decide whether tags are written to the files (which
+  is controlled by the :ref:`import.write <config-import-write>` option).
   Default: ``no``.
 - **targetlevel**: A number of decibels for the target loudness level for files
   using ``REPLAYGAIN_`` tags.

--- a/test/helper.py
+++ b/test/helper.py
@@ -373,21 +373,23 @@ class TestHelper:
             items.append(item)
         return items
 
-    def add_album_fixture(self, track_count=1, ext='mp3'):
+    def add_album_fixture(self, track_count=1, ext='mp3', disc_count=1):
         """Add an album with files to the database.
         """
         items = []
         path = os.path.join(_common.RSRC, util.bytestring_path('full.' + ext))
-        for i in range(track_count):
-            item = Item.from_path(path)
-            item.album = '\u00e4lbum'  # Check unicode paths
-            item.title = f't\u00eftle {i}'
-            # mtime needs to be set last since other assignments reset it.
-            item.mtime = 12345
-            item.add(self.lib)
-            item.move(operation=MoveOperation.COPY)
-            item.store()
-            items.append(item)
+        for discnumber in range(1, disc_count + 1):
+            for i in range(track_count):
+                item = Item.from_path(path)
+                item.album = '\u00e4lbum'  # Check unicode paths
+                item.title = f't\u00eftle {i}'
+                item.disc = discnumber
+                # mtime needs to be set last since other assignments reset it.
+                item.mtime = 12345
+                item.add(self.lib)
+                item.move(operation=MoveOperation.COPY)
+                item.store()
+                items.append(item)
         return self.lib.add_album(items)
 
     def create_mediafile_fixture(self, ext='mp3', images=[]):

--- a/test/test_replaygain.py
+++ b/test/test_replaygain.py
@@ -169,6 +169,18 @@ class ReplayGainCliTestBase(TestHelper):
 
         self.assertNotEqual(gain_relative_to_84, gain_relative_to_89)
 
+    def test_per_disc(self):
+        # Use the per_disc option and add a little more concurrency.
+        album = self._add_album(track_count=4, disc_count=3)
+        self.config['replaygain']['per_disc'] = True
+        self.run_command('replaygain', '-a')
+
+        # FIXME: Add fixtures with known track/album gain (within a suitable
+        # tolerance) so that we can actually check per-disc operation here.
+        for item in album.items():
+            self.assertIsNotNone(item.rg_track_gain)
+            self.assertIsNotNone(item.rg_album_gain)
+
 
 @unittest.skipIf(not GST_AVAILABLE, 'gstreamer cannot be found')
 class ReplayGainGstCliTest(ReplayGainCliTestBase, unittest.TestCase):

--- a/test/test_replaygain.py
+++ b/test/test_replaygain.py
@@ -58,15 +58,20 @@ class ReplayGainCliTestBase(TestHelper):
             self.teardown_beets()
             self.unload_plugins()
 
-        album = self.add_album_fixture(2)
+    def _add_album(self, *args, **kwargs):
+        album = self.add_album_fixture(*args, **kwargs)
         for item in album.items():
             reset_replaygain(item)
+
+        return album
 
     def tearDown(self):
         self.teardown_beets()
         self.unload_plugins()
 
     def test_cli_saves_track_gain(self):
+        self._add_album(2)
+
         for item in self.lib.items():
             self.assertIsNone(item.rg_track_peak)
             self.assertIsNone(item.rg_track_gain)
@@ -92,6 +97,8 @@ class ReplayGainCliTestBase(TestHelper):
                 mediafile.rg_track_gain, item.rg_track_gain, places=2)
 
     def test_cli_skips_calculated_tracks(self):
+        self._add_album(2)
+
         self.run_command('replaygain')
         item = self.lib.items()[0]
         peak = item.rg_track_peak
@@ -101,6 +108,8 @@ class ReplayGainCliTestBase(TestHelper):
         self.assertEqual(item.rg_track_peak, peak)
 
     def test_cli_saves_album_gain_to_file(self):
+        self._add_album(2)
+
         for item in self.lib.items():
             mediafile = MediaFile(item.path)
             self.assertIsNone(mediafile.rg_album_peak)
@@ -127,9 +136,7 @@ class ReplayGainCliTestBase(TestHelper):
             # opus not supported by command backend
             return
 
-        album = self.add_album_fixture(2, ext="opus")
-        for item in album.items():
-            reset_replaygain(item)
+        album = self._add_album(2, ext="opus")
 
         self.run_command('replaygain', '-a')
 
@@ -143,7 +150,8 @@ class ReplayGainCliTestBase(TestHelper):
             self.assertIsNotNone(mediafile.r128_album_gain)
 
     def test_target_level_has_effect(self):
-        item = self.lib.items()[0]
+        album = self._add_album(1)
+        item = album.items()[0]
 
         def analyse(target_level):
             self.config['replaygain']['targetlevel'] = target_level

--- a/test/test_replaygain.py
+++ b/test/test_replaygain.py
@@ -255,23 +255,37 @@ class ReplayGainCliTestBase(TestHelper):
             self.assertIsNotNone(mediafile.r128_track_gain)
             self.assertIsNotNone(mediafile.r128_album_gain)
 
-    def test_target_level_has_effect(self):
+    def test_targetlevel_has_effect(self):
         album = self._add_album(1)
         item = album.items()[0]
 
         def analyse(target_level):
             self.config['replaygain']['targetlevel'] = target_level
-            reset_replaygain(item)
             self.run_command('replaygain', '-f')
-            mediafile = MediaFile(item.path)
-            return mediafile.rg_track_gain
+            item.load()
+            return item.rg_track_gain
 
         gain_relative_to_84 = analyse(84)
         gain_relative_to_89 = analyse(89)
 
-        # check that second calculation did work
-        if gain_relative_to_84 is not None:
-            self.assertIsNotNone(gain_relative_to_89)
+        self.assertNotEqual(gain_relative_to_84, gain_relative_to_89)
+
+    def test_r128_targetlevel_has_effect(self):
+        if not self.has_r128_support:
+            self.skipTest("r128 tags for opus not supported on backend {}"
+                          .format(self.backend))
+
+        album = self._add_album(1, ext="opus")
+        item = album.items()[0]
+
+        def analyse(target_level):
+            self.config['replaygain']['r128_targetlevel'] = target_level
+            self.run_command('replaygain', '-f')
+            item.load()
+            return item.r128_track_gain
+
+        gain_relative_to_84 = analyse(84)
+        gain_relative_to_89 = analyse(89)
 
         self.assertNotEqual(gain_relative_to_84, gain_relative_to_89)
 

--- a/test/test_replaygain.py
+++ b/test/test_replaygain.py
@@ -137,15 +137,81 @@ class ReplayGainCliTestBase(TestHelper):
                 mediafile.rg_track_gain, item.rg_track_gain, places=2)
 
     def test_cli_skips_calculated_tracks(self):
-        self._add_album(2)
+        album_rg = self._add_album(1)
+        item_rg = album_rg.items()[0]
+
+        if self.has_r128_support:
+            album_r128 = self._add_album(1, ext="opus")
+            item_r128 = album_r128.items()[0]
 
         self.run_command('replaygain')
-        item = self.lib.items()[0]
-        peak = item.rg_track_peak
-        item.rg_track_gain = 0.0
+
+        item_rg.load()
+        self.assertIsNotNone(item_rg.rg_track_gain)
+        self.assertIsNotNone(item_rg.rg_track_peak)
+        self.assertIsNone(item_rg.r128_track_gain)
+
+        item_rg.rg_track_gain += 1.0
+        item_rg.rg_track_peak += 1.0
+        item_rg.store()
+        rg_track_gain = item_rg.rg_track_gain
+        rg_track_peak = item_rg.rg_track_peak
+
+        if self.has_r128_support:
+            item_r128.load()
+            self.assertIsNotNone(item_r128.r128_track_gain)
+            self.assertIsNone(item_r128.rg_track_gain)
+            self.assertIsNone(item_r128.rg_track_peak)
+
+            item_r128.r128_track_gain += 1.0
+            item_r128.store()
+            r128_track_gain = item_r128.r128_track_gain
+
         self.run_command('replaygain')
-        self.assertEqual(item.rg_track_gain, 0.0)
-        self.assertEqual(item.rg_track_peak, peak)
+
+        item_rg.load()
+        self.assertEqual(item_rg.rg_track_gain, rg_track_gain)
+        self.assertEqual(item_rg.rg_track_peak, rg_track_peak)
+
+        if self.has_r128_support:
+            item_r128.load()
+            self.assertEqual(item_r128.r128_track_gain, r128_track_gain)
+
+    def test_cli_does_not_skip_wrong_tag_type(self):
+        """Check that items that have tags of the wrong type won't be skipped.
+        """
+        if not self.has_r128_support:
+            # This test is a lot less interesting if the backend cannot write
+            # both tag types.
+            self.skipTest("r128 tags for opus not supported on backend {}"
+                          .format(self.backend))
+
+        album_rg = self._add_album(1)
+        item_rg = album_rg.items()[0]
+
+        album_r128 = self._add_album(1, ext="opus")
+        item_r128 = album_r128.items()[0]
+
+        item_rg.r128_track_gain = 0.0
+        item_rg.store()
+
+        item_r128.rg_track_gain = 0.0
+        item_r128.rg_track_peak = 42.0
+        item_r128.store()
+
+        self.run_command('replaygain')
+        item_rg.load()
+        item_r128.load()
+
+        self.assertIsNotNone(item_rg.rg_track_gain)
+        self.assertIsNotNone(item_rg.rg_track_peak)
+        # FIXME: Should the plugin null this field?
+        # self.assertIsNone(item_rg.r128_track_gain)
+
+        self.assertIsNotNone(item_r128.r128_track_gain)
+        # FIXME: Should the plugin null these fields?
+        # self.assertIsNone(item_r128.rg_track_gain)
+        # self.assertIsNone(item_r128.rg_track_peak)
 
     def test_cli_saves_album_gain_to_file(self):
         self._add_album(2)

--- a/test/test_replaygain.py
+++ b/test/test_replaygain.py
@@ -41,6 +41,8 @@ def reset_replaygain(item):
     item['rg_track_gain'] = None
     item['rg_album_gain'] = None
     item['rg_album_gain'] = None
+    item['r128_track_gain'] = None
+    item['r128_album_gain'] = None
     item.write()
     item.store()
 
@@ -63,16 +65,6 @@ class ReplayGainCliTestBase(TestHelper):
     def tearDown(self):
         self.teardown_beets()
         self.unload_plugins()
-
-    def _reset_replaygain(self, item):
-        item['rg_track_peak'] = None
-        item['rg_track_gain'] = None
-        item['rg_album_peak'] = None
-        item['rg_album_gain'] = None
-        item['r128_track_gain'] = None
-        item['r128_album_gain'] = None
-        item.write()
-        item.store()
 
     def test_cli_saves_track_gain(self):
         for item in self.lib.items():
@@ -137,7 +129,7 @@ class ReplayGainCliTestBase(TestHelper):
 
         album = self.add_album_fixture(2, ext="opus")
         for item in album.items():
-            self._reset_replaygain(item)
+            reset_replaygain(item)
 
         self.run_command('replaygain', '-a')
 
@@ -155,7 +147,7 @@ class ReplayGainCliTestBase(TestHelper):
 
         def analyse(target_level):
             self.config['replaygain']['targetlevel'] = target_level
-            self._reset_replaygain(item)
+            reset_replaygain(item)
             self.run_command('replaygain', '-f')
             mediafile = MediaFile(item.path)
             return mediafile.rg_track_gain

--- a/test/test_replaygain.py
+++ b/test/test_replaygain.py
@@ -43,8 +43,6 @@ def reset_replaygain(item):
     item['rg_album_gain'] = None
     item.write()
     item.store()
-    item.store()
-    item.store()
 
 
 class ReplayGainCliTestBase(TestHelper):


### PR DESCRIPTION
## Description

Part of #3893: While working on improved parallelism, I did quite a bit of refactoring of the replaygain plugin to make the code easier to understand and modify (to me, at least). This also adds a few new tests for previously uncovered codepaths.  There's also a bugfix in one of the commits (`replaygain: clarify docs for overwrite/force and actually respect it correctly`). None of the other commits should change the behaviour of the plugin, though.

If someone dares to review (sorry! - this is quite extensive), best look at the individual commits and their commit messages, I've tried to split this into small-ish changes.

## To Do

- [ ] Wait for CI.
- [ ] Changelog (probably not necessary, except maybe for the `overwrite` flag)
