### PR TITLE
Add support for 256 colors

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -534,9 +534,9 @@ def _colorize(color, text):
         # 38 == foreground color, but attributes as well as background
         # color can be specified in the same string if desired, i.e:
         # 38;5;196;1;3;4;5;7;48;5;220m
-        COLOR_ESCAPE = "\x1b[38;5"
+        COLOR_ESCAPE = "\x1b[38;5;"
         RESET_COLOR  = "\x1b[m"
-        escape = COLOR_ESCAPE + "%sm" (MORE_COLORS[color])
+        escape = COLOR_ESCAPE + MORE_COLORS[color] + "m"
     else:
         raise ValueError(u'no such color %s', color)
     return escape + text + RESET_COLOR

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -505,6 +505,13 @@ LIGHT_COLORS = {
     "cyan": 6,
     "white": 7
 }
+MORE_COLORS = { }
+# Generate color index mappings for 256 colors since there's no good way
+# to create meaningful names for them.
+for index in range(0, 256):
+    index = str(index)
+    MORE_COLORS[index] = index
+
 RESET_COLOR = COLOR_ESCAPE + "39;49;00m"
 
 # These abstract COLOR_NAMES are lazily mapped on to the actual color in COLORS
@@ -523,6 +530,13 @@ def _colorize(color, text):
         escape = COLOR_ESCAPE + "%im" % (DARK_COLORS[color] + 30)
     elif color in LIGHT_COLORS:
         escape = COLOR_ESCAPE + "%i;01m" % (LIGHT_COLORS[color] + 30)
+    elif color in MORE_COLORS:
+        # 38 == foreground color, but attributes as well as background
+        # color can be specified in the same string if desired, i.e:
+        # 38;5;196;1;3;4;5;7;48;5;220m
+        COLOR_ESCAPE = "\x1b[38;5"
+        RESET_COLOR  = "\x1b[m"
+        escape = COLOR_ESCAPE + "%sm" (MORE_COLORS[color])
     else:
         raise ValueError(u'no such color %s', color)
     return escape + text + RESET_COLOR

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -52,6 +52,8 @@ Major new features:
 
 Other new things:
 
+* Support for 256 colors. Can be accessed by referencing color index 0-255 as
+  color name in the configuration file.
 * Enable HTTPS for MusicBrainz by default and add configuration option
   `https` for custom servers. See :ref:`musicbrainz-config` for more details.
 * :doc:`/plugins/mpdstats`: Add a new `strip_path` option to help build the


### PR DESCRIPTION
## Description

Adds support for 256 colors in the ui. Color index is used as a name, like so:
```
ui:
  color: yes
  colors:
    text_success:         '40'
    text_warning:         '137'
    text_error:           '160'
    text_highlight:       '106'
    text_highlight_minor: '108'
    action_default:       '197'
    action:               '210'
```
![256colors](https://www.japh.se/assets/beets_256colors_000.png)

## To Do

It would be nice to be able to specify (different) attributes on (different) COLOR_NAMES, like:
```yaml

text_success: 'bold 40'
text_warning: 'bold italic reverse 32'
```

but I'm unsure how to implement that right now. Feels like a waste to create more *_COLORS dictionaries, one for each attribute, like how DARK_COLORS and LIGHT_COLORS work right now for ANSI colors. Furthermore, attributes can be nested:  

```bash
printf "\033[38;5;196;1;3;4;7;48;5;220mfoobar\e[m" # perfectly legal
```

One _could_ allow the user to specify the relevant portion of the escape sequence themselves, like so:
```yaml
text_success: '40;1'      # bold 40
text_warning: '32;1;3;7' # bold italic reverse 32