### PR TITLE
Allow fetchart to reformat JPEGs as baseline.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -215,6 +215,8 @@ Other new things:
 * :doc:`/plugins/lyrics`: Added Tekstowo.pl lyrics provider. Thanks to various
   people for the implementation and for reporting issues with the initial version.
   :bug:`3344` :bug:`3904` :bug:`3905` :bug:`3994`
+* :doc:`/plugins/fetchart`: Album art can now be forced into JPEG baseline
+  format.
 
   .. _py7zr: https://pypi.org/project/py7zr/
 

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -86,6 +86,8 @@ file. The available options are:
 - **high_resolution**: If enabled, fetchart retrieves artwork in the highest
   resolution it can find (warning: image files can sometimes reach >20MB).
   Default: ``no``.
+- **jpg_always_baseline**: If enabled, forces fetchart to reencode all
+  progressive JPEGs to baseline. This requires `Pillow`_.
 
 Note: ``maxwidth`` and ``enforce_ratio`` options require either `ImageMagick`_
 or `Pillow`_.


### PR DESCRIPTION
## Description
Prior discussion happened on IRC. This change allows fetchart to, after downloading, reformat JPEGs to baseline JPEGs if need be.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)

A few caveats exist in the current implementation: this is probably done way too early in the process (before `ArtResize` kicks in), it strictly requires pillow (no `convert` fallback), and it breaks the current convention of the `CANDIDATE_*` values. I was not sure how to introduce the last bit into the current codebase, and I figured opening a PR is a good place to start in filing down the sharp edges.