### PR TITLE
Add reference to an external beetcamp autotagger in the docs

### DIFF
--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -165,7 +165,7 @@ Metadata
 * :doc:`metasync`: Fetch metadata from local or remote sources
 * :doc:`mpdstats`: Connect to `MPD`_ and update the beets library with play
   statistics (last_played, play_count, skip_count, rating).
-* :doc:`parentwork`: Fetch work titles and works they are part of. 
+* :doc:`parentwork`: Fetch work titles and works they are part of.
 * :doc:`replaygain`: Calculate volume normalization for players that support it.
 * :doc:`scrub`: Clean extraneous metadata from music files.
 * :doc:`zero`: Nullify fields by pattern or unconditionally.
@@ -268,66 +268,66 @@ line in your config file.
 
 Here are a few of the plugins written by the beets community:
 
-* `beetFs`_ is a FUSE filesystem for browsing the music in your beets library.
-  (Might be out of date.)
+* `beets-alternatives`_ manages external files.
 
-* `A cmus plugin`_ integrates with the `cmus`_ console music player.
+* `beet-amazon`_ adds Amazon.com as a tagger data source.
 
 * `beets-artistcountry`_ fetches the artist's country of origin from
   MusicBrainz.
 
-* `dsedivec`_ has two plugins: ``edit`` and ``moveall``.
-
-* `beet-amazon`_ adds Amazon.com as a tagger data source.
-
-* `beets-copyartifacts`_ helps bring non-music files along during import.
-
-* `beets-check`_ automatically checksums your files to detect corruption.
-
-* `beets-alternatives`_ manages external files.
-
-* `beets-follow`_ lets you check for new albums from artists you like.
-
-* `beets-ibroadcast`_ uploads tracks to the `iBroadcast`_ cloud service.
-
-* `beets-setlister`_ generate playlists from the setlists of a given artist.
-
-* `beets-noimport`_ adds and removes directories from the incremental import skip list.
-
-* `whatlastgenre`_ fetches genres from various music sites.
-
-* `beets-usertag`_ lets you use keywords to tag and organize your music.
-
-* `beets-popularity`_ fetches popularity values from Spotify.
+* `beets-autofix`_ automates repetitive tasks to keep your library in order.
 
 * `beets-barcode`_ lets you scan or enter barcodes for physical media to
   search for their metadata.
 
-* `beets-ydl`_ downloads audio from youtube-dl sources and import into beets.
-
-* `beet-summarize`_ can compute lots of counts and statistics about your music
-  library.
-
-* `beets-mosaic`_ generates a montage of a mosaic from cover art.
-
-* `beets-goingrunning`_ generates playlists to go with your running sessions.
-
-* `beets-xtractor`_ extracts low- and high-level musical information from your songs.
-
-* `beets-yearfixer`_ attempts to fix all missing ``original_year`` and ``year`` fields.
-
-* `beets-autofix`_ automates repetitive tasks to keep your library in order.
-
-* `beets-describe`_ gives you the full picture of a single attribute of your library items.
-
 * `beets-bpmanalyser`_ analyses songs and calculates their tempo (BPM).
 
-* `beets-originquery`_ augments MusicBrainz queries with locally-sourced data
-  to improve autotagger results.
+* `beets-check`_ automatically checksums your files to detect corruption.
+
+* `A cmus plugin`_ integrates with the `cmus`_ console music player.
+
+* `beets-copyartifacts`_ helps bring non-music files along during import.
+
+* `beets-describe`_ gives you the full picture of a single attribute of your library items.
 
 * `drop2beets`_ automatically imports singles as soon as they are dropped in a
   folder (using Linux's ``inotify``). You can also set a sub-folders
   hierarchy to set flexible attributes by the way.
+
+* `dsedivec`_ has two plugins: ``edit`` and ``moveall``.
+
+* `beets-follow`_ lets you check for new albums from artists you like.
+
+* `beetFs`_ is a FUSE filesystem for browsing the music in your beets library.
+  (Might be out of date.)
+
+* `beets-goingrunning`_ generates playlists to go with your running sessions.
+
+* `beets-ibroadcast`_ uploads tracks to the `iBroadcast`_ cloud service.
+
+* `beets-mosaic`_ generates a montage of a mosaic from cover art.
+
+* `beets-noimport`_ adds and removes directories from the incremental import skip list.
+
+* `beets-originquery`_ augments MusicBrainz queries with locally-sourced data
+  to improve autotagger results.
+
+* `beets-popularity`_ fetches popularity values from Spotify.
+
+* `beets-setlister`_ generate playlists from the setlists of a given artist.
+
+* `beet-summarize`_ can compute lots of counts and statistics about your music
+  library.
+
+* `beets-usertag`_ lets you use keywords to tag and organize your music.
+
+* `whatlastgenre`_ fetches genres from various music sites.
+
+* `beets-xtractor`_ extracts low- and high-level musical information from your songs.
+
+* `beets-ydl`_ downloads audio from youtube-dl sources and import into beets.
+
+* `beets-yearfixer`_ attempts to fix all missing ``original_year`` and ``year`` fields.
 
 .. _beets-barcode: https://github.com/8h2a/beets-barcode
 .. _beets-check: https://github.com/geigerzaehler/beets-check

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -280,6 +280,8 @@ Here are a few of the plugins written by the beets community:
 * `beets-barcode`_ lets you scan or enter barcodes for physical media to
   search for their metadata.
 
+* `beetcamp`_ enables **bandcamp.com** autotagger with a fairly extensive amount of metadata.
+
 * `beets-bpmanalyser`_ analyses songs and calculates their tempo (BPM).
 
 * `beets-check`_ automatically checksums your files to detect corruption.
@@ -330,6 +332,7 @@ Here are a few of the plugins written by the beets community:
 * `beets-yearfixer`_ attempts to fix all missing ``original_year`` and ``year`` fields.
 
 .. _beets-barcode: https://github.com/8h2a/beets-barcode
+.. _beetcamp: https://github.com/snejus/beetcamp
 .. _beets-check: https://github.com/geigerzaehler/beets-check
 .. _beets-copyartifacts: https://github.com/adammillerio/beets-copyartifacts
 .. _dsedivec: https://github.com/dsedivec/beets-plugins


### PR DESCRIPTION
## Description

As briefly mentioned in #3793, this PR adds a reference to the up-to-date bandcamp autotagger.

I additionally ordered the external plugins list alphabetically to make it a bit easier to
navigate.

## To Do

- [x] (Only) documentation. (If you've added a new commanrd-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
