### PR TITLE
Unload plugins in UI config test

### DIFF
--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -770,6 +770,7 @@ class ConfigTest(unittest.TestCase, TestHelper, _common.Assertions):
         os.makedirs(self.beetsdir)
 
         self._reset_config()
+        self.load_plugins()
 
     def tearDown(self):
         commands.default_commands.pop()
@@ -780,6 +781,7 @@ class ConfigTest(unittest.TestCase, TestHelper, _common.Assertions):
             del os.environ['APPDATA']
         else:
             os.environ['APPDATA'] = self._old_appdata
+        self.unload_plugins()
         self.teardown_beets()
 
     def _make_test_cmd(self):


### PR DESCRIPTION
## Description

Fixes #4037.

The `test_cli_config_file_loads_plugin_commands` test uses beets' normal plugin loader to load a test plugin, however it never tidies up after itself. This leads to any future plugin loads being ignored until the next `unload_plugins` call.

I'm not entirely sure why or how this is passing on our CI at the moment (or on my local machine when running all tests), as it looks like this would have been broken for a while. I'm also not sure why it only affects this test - others should also be impacted by the fact that the `zero` plugin is not loaded.

This PR changes the config tests so that we always call `load_plugins` on setup (to store the default beets state) and `unload_plugins` on teardown (to restore the previously stored state).

You can reproduce the failure by just running these two tests:

```Text
$ tox -e py-test test/test_ui.py::ConfigTest::test_cli_config_file_loads_plugin_commands test/test_zero.py::ZeroPluginTest::test_album_art
GLOB sdist-make: /beets/setup.py
py-test inst-nodeps: /beets/.tox/.tmp/package/1/beets-1.5.1.zip
py-test installed: attrs==21.2.0,bcj-cffi==0.5.1,beautifulsoup4==4.9.3,beets @ file:///beets/.tox/.tmp/package/1/beets-1.5.1.zip,Brotli==1.0.9,certifi==2021.5.30,cffi==1.14.6,charset-normalizer==2.0.4,click==8.0.1,confuse==1.5.0,coverage==5.5,Flask==2.0.1,idna==3.2,iniconfig==1.1.1,itsdangerous==2.0.1,jellyfish==0.8.8,Jinja2==3.0.1,MarkupSafe==2.0.1,mediafile==0.7.0,mock==4.0.3,multivolumefile==0.2.3,munkres==1.1.4,musicbrainzngs==0.7.1,mutagen==1.45.1,oauthlib==3.1.1,packaging==21.0,pluggy==1.0.0,py==1.10.0,py7zr==0.16.1,pycparser==2.20,pycryptodomex==3.10.1,pylast==4.2.1,pyparsing==2.4.7,pyppmd==0.16.1,pytest==6.2.5,python-dateutil==2.8.2,python-mpd2==3.0.4,python3-discogs-client==2.3.12,pyxdg==0.27,PyYAML==5.4.1,pyzstd==0.14.4,rarfile==4.0,reflink==0.2.1,requests==2.26.0,requests-oauthlib==1.3.0,responses==0.13.4,six==1.16.0,soupsieve==2.2.1,texttable==1.6.4,toml==0.10.2,Unidecode==1.2.0,urllib3==1.26.6,Werkzeug==2.0.1
py-test run-test-pre: PYTHONHASHSEED='2180953874'
py-test run-test: commands[0] | python -bb -m pytest -rs test/test_ui.py::ConfigTest::test_cli_config_file_loads_plugin_commands test/test_zero.py::ZeroPluginTest::test_album_art
========================================= test session starts =========================================
platform darwin -- Python 3.9.6, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
cachedir: .tox/py-test/.pytest_cache
rootdir: /beets
collected 2 items                                                                                     

test/test_ui.py .                                                                               [ 50%]
test/test_zero.py F                                                                             [100%]

============================================== FAILURES ===============================================
____________________________________ ZeroPluginTest.test_album_art ____________________________________

self = <test.test_zero.ZeroPluginTest testMethod=test_album_art>

    def test_album_art(self):
        self.config['zero']['fields'] = ['images']
    
        path = self.create_mediafile_fixture(images=['jpg'])
        item = Item.from_path(path)
    
        self.load_plugins('zero')
        item.write()
    
        mf = MediaFile(syspath(path))
>       self.assertEqual(0, len(mf.images))
E       AssertionError: 0 != 1

test/test_zero.py:109: AssertionError
===================================== 1 failed, 1 passed in 0.81s =====================================
ERROR: InvocationError for command /beets/.tox/py-test/bin/python -bb -m pytest -rs test/test_ui.py::ConfigTest::test_cli_config_file_loads_plugin_commands test/test_zero.py::ZeroPluginTest::test_album_art (exited with code 1)
_______________________________________________ summary _______________________________________________
ERROR:   py-test: commands failed
```

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
