### PR TITLE
Get genres from both musicbrainz releases and release-groups.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,12 @@ For packagers:
   be necessary.
   :bug:`4037` :bug:`4038`
 
+Major new features:
+
+* Include the genre tags from the release group when the musicbrainz genre
+  option is set, and sort them by the number of votes.  Thanks to
+  :user:`aereaux`.
+
 
 1.5.0 (August 19, 2021)
 -----------------------

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -753,9 +753,10 @@ Default: ``[]``
 genres
 ~~~~~~
 
-Use MusicBrainz genre tags to populate the ``genre`` tag.  This will make it a
-semicolon-separated list of all the genres tagged for the release on
-MusicBrainz.
+Use MusicBrainz genre tags to populate (and replace if it's already set) the
+``genre`` tag.  This will make it a list of all the genres tagged for the
+release and the release-group on MusicBrainz, separated by "; " and sorted by
+the total number of votes.
 
 Default: ``no``
 


### PR DESCRIPTION
## Description

This adds the votes from each.

This also changes the behavior to reset genre tags if the genre option is
enabled and no tags are received from musicbrainz.

This also sorts genres by the number of votes.

This is typically more useful because release-groups are usually better tagged, and now the %first function can be used to get the most popular genre tag.  Let me know if there are any other improvements I could make here.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
