### PR TITLE
Add additional asciify documentation

### DIFF
--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -165,6 +165,10 @@ take place before applying the :ref:`replace` configuration and are roughly
 equivalent to wrapping all your path templates in the ``%asciify{}``
 :ref:`template function <template-functions>`.
 
+This uses the `unidecode module`_ which is language agnostic, so some 
+characters may be transliterated from a different language than expected. 
+For example, Japanese kanji will usually use their Chinese readings.
+
 Default: ``no``.
 
 .. _unidecode module: https://pypi.org/project/Unidecode


### PR DESCRIPTION
## Description

Fixes #929.

This was proposed but never dealt with, so after going through some confusion around this myself I figured it's about time.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)