### PR TITLE
Docs: improve formatting of the Getting Started guide

### DIFF
--- a/docs/guides/main.rst
+++ b/docs/guides/main.rst
@@ -40,9 +40,7 @@ Beets works on Python 3.6 or later.
 
 * For **Slackware**, there's a `SlackBuild`_ available.
 
-* On **Fedora** 22 or later, there is a `DNF package`_::
-
-      $ sudo dnf install beets beets-plugins beets-doc
+* On **Fedora** 22 or later, there's a `DNF package`_ you can install with ``sudo dnf install beets beets-plugins beets-doc``.
 
 * On **Solus**, run ``eopkg install beets``.
 


### PR DESCRIPTION
## Description

Make sure all installation instructions have similar formatting.

Previously, the Fedora instructions stood out.

## To Do

_Not sure any of the below are applicable?_ 🤔 

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
