### PR TITLE
docs: fix links that were failing sphinx' linkcheck

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -102,8 +102,8 @@ Code Contribution Ideas
    places to think about performance optimization (see
    `Optimization <https://github.com/beetbox/beets/wiki/Optimization>`__).
 -  Not all of our code is up to our coding conventions. In particular,
-   the `API
-   documentation <https://beets.readthedocs.io/en/stable/dev/api.html>`__
+   the `library API
+   documentation <https://beets.readthedocs.io/en/stable/dev/library.html>`__
    are currently quite sparse. You can help by adding to the docstrings
    in the code and to the documentation pages themselves. beets follows
    `PEP-257 <https://www.python.org/dev/peps/pep-0257/>`__ for
@@ -159,9 +159,9 @@ documentation, and the changelog entry. Thank you for contributing!
 The Code
 ========
 
-The documentation has an `API
-section <https://beets.readthedocs.io/en/stable/dev/api.html>`__ that
-serves as an introduction to beets’ design.
+The documentation has a section on the
+`library API <https://beets.readthedocs.io/en/stable/dev/library.html>`__
+that serves as an introduction to beets’ design.
 
 Coding Conventions
 ==================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,7 @@ linkcheck_ignore = [
     r'https://github.com/beetbox/beets/issues/',
     r'https://github.com/[^/]+$',  # ignore user pages
     r'.*localhost.*',
+    r'https?://127\.0\.0\.1',
     r'https://www.musixmatch.com/',  # blocks requests
     r'https://genius.com/',  # blocks requests
 ]

--- a/docs/plugins/spotify.rst
+++ b/docs/plugins/spotify.rst
@@ -8,9 +8,9 @@ Also, the plugin can use the Spotify `Album`_ and `Track`_ APIs to provide
 metadata matches for the importer.
 
 .. _Spotify: https://www.spotify.com/
-.. _Spotify Search API: https://developer.spotify.com/documentation/web-api/reference/search/search/
-.. _Album: https://developer.spotify.com/documentation/web-api/reference/albums/get-album/
-.. _Track: https://developer.spotify.com/documentation/web-api/reference/tracks/get-track/
+.. _Spotify Search API: https://developer.spotify.com/documentation/web-api/reference/#category-search
+.. _Album: https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-an-album
+.. _Track: https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-track
 
 Why Use This Plugin?
 --------------------


### PR DESCRIPTION
As the integration tests show, some of our links are rotting...

...also, sphinx is trying to access AURA at 127.0.0.1.