### PR TITLE
Add popularity tag

### DIFF
--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -161,9 +161,8 @@ class TrackInfo(AttrDict):
                  data_source=None, data_url=None, media=None, lyricist=None,
                  composer=None, composer_sort=None, arranger=None,
                  track_alt=None, work=None, mb_workid=None,
-                 spotify_popularity=None, work_disambig=None,
-                 bpm=None, initial_key=None, genre=None,
-                 **kwargs):
+                 work_disambig=None, bpm=None, initial_key=None,
+                 genre=None, **kwargs):
         self.title = title
         self.track_id = track_id
         self.release_track_id = release_track_id
@@ -187,7 +186,6 @@ class TrackInfo(AttrDict):
         self.track_alt = track_alt
         self.work = work
         self.mb_workid = mb_workid
-        self.spotify_popularity = spotify_popularity
         self.work_disambig = work_disambig
         self.bpm = bpm
         self.initial_key = initial_key

--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -160,8 +160,8 @@ class TrackInfo(AttrDict):
                  artist_sort=None, disctitle=None, artist_credit=None,
                  data_source=None, data_url=None, media=None, lyricist=None,
                  composer=None, composer_sort=None, arranger=None,
-                 track_alt=None, work=None, mb_workid=None, 
-                 spotify_popularity=None, work_disambig=None, 
+                 track_alt=None, work=None, mb_workid=None,
+                 spotify_popularity=None, work_disambig=None,
                  bpm=None, initial_key=None, genre=None,
                  **kwargs):
         self.title = title

--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -160,8 +160,9 @@ class TrackInfo(AttrDict):
                  artist_sort=None, disctitle=None, artist_credit=None,
                  data_source=None, data_url=None, media=None, lyricist=None,
                  composer=None, composer_sort=None, arranger=None,
-                 track_alt=None, work=None, mb_workid=None,
-                 work_disambig=None, bpm=None, initial_key=None, genre=None,
+                 track_alt=None, work=None, mb_workid=None, 
+                 spotify_popularity=None, work_disambig=None, 
+                 bpm=None, initial_key=None, genre=None,
                  **kwargs):
         self.title = title
         self.track_id = track_id
@@ -186,6 +187,7 @@ class TrackInfo(AttrDict):
         self.track_alt = track_alt
         self.work = work
         self.mb_workid = mb_workid
+        self.spotify_popularity = spotify_popularity
         self.work_disambig = work_disambig
         self.bpm = bpm
         self.initial_key = initial_key

--- a/beets/library.py
+++ b/beets/library.py
@@ -511,7 +511,6 @@ class Item(LibModel):
         'releasegroupdisambig': types.STRING,
         'disctitle': types.STRING,
         'encoder': types.STRING,
-        'spotify_popularity': types.INTEGER,
         'rg_track_gain': types.NULL_FLOAT,
         'rg_track_peak': types.NULL_FLOAT,
         'rg_album_gain': types.NULL_FLOAT,

--- a/beets/library.py
+++ b/beets/library.py
@@ -511,6 +511,7 @@ class Item(LibModel):
         'releasegroupdisambig': types.STRING,
         'disctitle': types.STRING,
         'encoder': types.STRING,
+        'popularity': types.INTEGER,
         'rg_track_gain': types.NULL_FLOAT,
         'rg_track_peak': types.NULL_FLOAT,
         'rg_album_gain': types.NULL_FLOAT,

--- a/beets/library.py
+++ b/beets/library.py
@@ -511,7 +511,7 @@ class Item(LibModel):
         'releasegroupdisambig': types.STRING,
         'disctitle': types.STRING,
         'encoder': types.STRING,
-        'popularity': types.INTEGER,
+        'spotify_popularity': types.INTEGER,
         'rg_track_gain': types.NULL_FLOAT,
         'rg_track_peak': types.NULL_FLOAT,
         'rg_album_gain': types.NULL_FLOAT,

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -197,6 +197,9 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
         tracks = []
         medium_totals = collections.defaultdict(int)
         for i, track_data in enumerate(album_data['tracks']['items'], start=1):
+            track_data = self._handle_response(
+                requests.get, track_data["href"]
+            )
             track = self._get_track(track_data)
             track.index = i
             medium_totals[track.medium] += 1

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -243,6 +243,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
             medium_index=track_data['track_number'],
             data_source=self.data_source,
             data_url=track_data['external_urls']['spotify'],
+            popularity=track_data['popularity'],
         )
 
     def track_for_id(self, track_id=None, track_data=None):

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -243,7 +243,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
             medium_index=track_data['track_number'],
             data_source=self.data_source,
             data_url=track_data['external_urls']['spotify'],
-            popularity=track_data['popularity'],
+            spotify_popularity=track_data['popularity'],
         )
 
     def track_for_id(self, track_id=None, track_data=None):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,7 @@ Other new things:
 * Permissions plugin now sets cover art permissions to the file permissions.
 * :doc:`/plugins/unimported`: Support excluding specific
   subdirectories in library.
+* Added spotify_popularity label.
 
 Bug fixes:
 


### PR DESCRIPTION
## Get popularity tag for tracks from track api in Spotify plugin 

Fixes #4094 .  <!--4094 -->

Makes use of the popularity information for tracks

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
