### PR TITLE
Clarify config docs for `per_disc_numbering`

### DIFF
--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -285,6 +285,10 @@ use a path format like this::
     paths:
         default: $albumartist/$album%aunique{}/$disc-$track $title
 
+but note that this adds disc numbers to all tracks. To add disc numbers only
+to multi-disc tracks, use the :doc:`/plugins/inline` (in particular, see the
+``$disc_and_track`` example).
+
 When this option is off (the default), even "pregap" hidden tracks are
 numbered from one, not zero, so other track numbers may appear to be bumped up
 by one. When it is on, the pregap track for each disc can be numbered zero.


### PR DESCRIPTION
## Description

Originally I found the `per_disc_numbering` docs lacking since the path format suggested adds disc numbers to all tracks, even single-disc tracks.

I then found out about the inline plugin which even had a nice `$disc_and_track` example which I thought should be referenced in the section about `per_disc_numbering`.

## To Do

Does this require a changelog entry? If so, happy to add one.