### PR TITLE
Add documentation for `path_sep_replace`

### DIFF
--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -159,7 +159,7 @@ path_sep_replace
 A string that replaces the path separator (for example, the forward slash
 ``/`` on Linux and MacOS, and the backward slash ``\\`` on Windows) when
 generating filenames with beets.
-This option is related to ::ref:`replace`, but is distict from it for
+This option is related to :ref:`replace`, but is distict from it for
 technical reasons.
 
 .. warning::


### PR DESCRIPTION
## Description

Fixes https://github.com/beetbox/beets/issues/323 (probably).

This PR adds documentation for `path_sep_replace` configuration option, which is not yet present in the official docs.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
