### PR TITLE
Add a basic "--album" flag to "beet info"

### DIFF
--- a/beetsplug/export.py
+++ b/beetsplug/export.py
@@ -149,8 +149,6 @@ class ExportPlugin(BeetsPlugin):
                 if isinstance(value, bytes):
                     data[key] = util.displayable_path(value)
 
-            items += [data]
-
             if file_format_is_line_based:
                 export_format.export(data, **format_options)
             else:

--- a/beetsplug/export.py
+++ b/beetsplug/export.py
@@ -88,6 +88,10 @@ class ExportPlugin(BeetsPlugin):
             help='show library fields instead of tags',
         )
         cmd.parser.add_option(
+            '-a', '--album', action='store_true',
+            help='show album fields instead of tracks (implies "--library")',
+        )
+        cmd.parser.add_option(
             '--append', action='store_true', default=False,
             help='if should append data to the file',
         )
@@ -121,14 +125,20 @@ class ExportPlugin(BeetsPlugin):
             }
         )
 
-        items = []
-        data_collector = library_data if opts.library else tag_data
+        if opts.library or opts.album:
+            data_collector = library_data
+        else:
+            data_collector = tag_data
 
         included_keys = []
         for keys in opts.included_keys:
             included_keys.extend(keys.split(','))
 
-        for data_emitter in data_collector(lib, ui.decargs(args)):
+        items = []
+        for data_emitter in data_collector(
+                lib, ui.decargs(args),
+                album=opts.album,
+        ):
             try:
                 data, item = data_emitter(included_keys or '*')
             except (mediafile.UnreadableFileError, OSError) as ex:

--- a/beetsplug/info.py
+++ b/beetsplug/info.py
@@ -25,7 +25,7 @@ from beets.library import Item
 from beets.util import displayable_path, normpath, syspath
 
 
-def tag_data(opts, lib, args):
+def tag_data(lib, args, album=False):
     query = []
     for arg in args:
         path = normpath(arg)
@@ -69,8 +69,8 @@ def tag_data_emitter(path):
     return emitter
 
 
-def library_data(opts, lib, args):
-    for item in lib.albums(args) if opts.album else lib.items(args):
+def library_data(lib, args, album=False):
+    for item in lib.albums(args) if album else lib.items(args):
         yield library_data_emitter(item)
 
 
@@ -203,7 +203,10 @@ class InfoPlugin(BeetsPlugin):
 
         first = True
         summary = {}
-        for data_emitter in data_collector(opts, lib, ui.decargs(args)):
+        for data_emitter in data_collector(
+                lib, ui.decargs(args),
+                album=opts.album,
+        ):
             try:
                 data, item = data_emitter(included_keys or '*')
             except (mediafile.UnreadableFileError, OSError) as ex:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -36,6 +36,7 @@ Other new things:
 * :doc:`/plugins/unimported`: Support excluding specific
   subdirectories in library.
 * :doc:`/plugins/info`: Support ``--album`` flag.
+* :doc:`/plugins/export`: Support ``--album`` flag.
 
 Bug fixes:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -49,6 +49,8 @@ Bug fixes:
 * :doc:`/plugins/discogs`: Remove requests ratel imit code from plugin in favor of discogs library built-in capability
   :bug: `4108`
 
+* :doc:`/plugins/export`: Fix duplicated output.
+
 1.5.0 (August 19, 2021)
 -----------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,7 @@ Other new things:
 * Permissions plugin now sets cover art permissions to the file permissions.
 * :doc:`/plugins/unimported`: Support excluding specific
   subdirectories in library.
+* :doc:`/plugins/info`: Support ``--album`` flag.
 
 Bug fixes:
 

--- a/docs/plugins/export.rst
+++ b/docs/plugins/export.rst
@@ -34,6 +34,9 @@ The ``export`` command has these command-line options:
 * ``--library`` or ``-l``: Show data from the library database instead of the
   files' tags.
 
+* ``--album`` or ``-a``: Show data from albums instead of tracks (implies
+  ``--library``).
+
 * ``--output`` or ``-o``: Path for an output file. If not informed, will print
   the data in the console.
 

--- a/docs/plugins/info.rst
+++ b/docs/plugins/info.rst
@@ -31,6 +31,8 @@ Additional command-line options include:
 
 * ``--library`` or ``-l``: Show data from the library database instead of the
   files' tags.
+* ``--album`` or ``-a``: Show data from albums instead of tracks (implies
+  ``--library``).
 * ``--summarize`` or ``-s``: Merge all the information from multiple files
   into a single list of values. If the tags differ across the files, print
   ``[various]``.


### PR DESCRIPTION
This currently implies `--library` because I'm not sure what `album info` of the tags of individual files would mean. 😅

(Honestly it's felt really off that `beet info` shows details of the tags by default when every other command shows information from the beet database by default, but looking at the code I learned it could be used directly on unimported files, so I guess that makes some sense. :innocent:)

I've tested this successfully in my own `pluginpath` directory, although admittedly haven't done much more than `beet info --album` (haven't tested the combination with other flags, but from the code I don't see any reasons for them not to work).

I'm happy to adjust, rebase, amend, etc, although I'll probably need some specific guidance if you want code changes because I don't write a lot of Python. :sweat_smile:

Fixes #2134.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)