### PR TITLE
Use "colordiff" to highlight "beet move" path differences

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -757,15 +757,21 @@ def show_path_changes(path_changes):
     if max_width > col_width:
         # Print every change over two lines
         for source, dest in zip(sources, destinations):
-            log.info('{0} \n  -> {1}', source, dest)
+            color_source, color_dest = colordiff(source, dest)
+            print_('{0} \n  -> {1}'.format(color_source, color_dest))
     else:
         # Print every change on a single line, and add a header
         title_pad = max_width - len('Source ') + len(' -> ')
 
-        log.info('Source {0} Destination', ' ' * title_pad)
+        print_('Source {0} Destination'.format(' ' * title_pad))
         for source, dest in zip(sources, destinations):
             pad = max_width - len(source)
-            log.info('{0} {1} -> {2}', source, ' ' * pad, dest)
+            color_source, color_dest = colordiff(source, dest)
+            print_('{0} {1} -> {2}'.format(
+                color_source,
+                ' ' * pad,
+                color_dest,
+            ))
 
 
 # Helper functions for option parsing.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -37,6 +37,7 @@ Other new things:
   subdirectories in library.
 * :doc:`/plugins/info`: Support ``--album`` flag.
 * :doc:`/plugins/export`: Support ``--album`` flag.
+* ``beet move`` path differences are now highlighted in color (when enabled).
 
 For plugin developers:
 


### PR DESCRIPTION
## Description

This uses the common `colordiff` function such that path pairs shown by `beet move` have their differences highlighted, which makes them _way_ easier to scan through visually (more so if they were lined up better or if the added vs subtracted colors were different, but this makes a huge difference by itself).

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
