### PR TITLE
Remove completed TODO item

### DIFF
--- a/beetsplug/export.py
+++ b/beetsplug/export.py
@@ -79,8 +79,6 @@ class ExportPlugin(BeetsPlugin):
         })
 
     def commands(self):
-        # TODO: Add option to use albums
-
         cmd = ui.Subcommand('export', help='export data from beets')
         cmd.func = self.run
         cmd.parser.add_option(


### PR DESCRIPTION
## Description

Removes a `TODO` comment that was completed in #4124 (but I didn't notice the comment in the code until after it was merged and I was looking at the file again later :facepalm:).

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
