### PR TITLE
Add option to convert cover art file format.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -49,6 +49,8 @@ Other new things:
 * :doc:`/plugins/fetchart`: A new option to store cover art as non-progressive
   image. Useful for DAPs that support progressive images. Set ``deinterlace:
   yes`` in your configuration to enable.
+* :doc:`/plugins/fetchart`: A new option to change cover art format. Useful for
+  DAPs that do not support some image formats.
 
 For plugin developers:
 

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -90,6 +90,10 @@ file. The available options are:
   instructed to store cover art as non-progressive JPEG. You might need this if
   you use DAPs that don't support progressive images.
   Default: ``no``.
+- **cover_format**: If enabled, forced the cover image into the specified
+  format. Most often, this will be either ``JPEG`` or ``PNG`` [#imgformats]_.
+  Also respects ``deinterlace``.
+  Default: None (leave unchanged).
 
 Note: ``maxwidth`` and ``enforce_ratio`` options require either `ImageMagick`_
 or `Pillow`_.
@@ -105,6 +109,12 @@ or `Pillow`_.
 .. _beets custom search engine: https://cse.google.com.au:443/cse/publicurl?cx=001442825323518660753:hrh5ch1gjzm
 .. _Pillow: https://github.com/python-pillow/Pillow
 .. _ImageMagick: https://www.imagemagick.org/
+.. [#imgformats] Other image formats are available, though the full list
+   depends on your system and what backend you are using. If you're using the
+   ImageMagick backend, you can use ``magick identify -list format`` to get a
+   full list of all supported formats, and you can use the Python function
+   PIL.features.pilinfo() to print a list of all supported formats in Pillow
+   (``python3 -c 'import PIL.features as f; f.pilinfo()'``).
 
 Here's an example that makes plugin select only images that contain ``front`` or
 ``back`` keywords in their filenames and prioritizes the iTunes source over


### PR DESCRIPTION
## Description

Introduces an option to force an image format, as some IEMs (notably, Rockbox) might lack support for some image formats.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)

I want to do tests, but I am unsure as to how to implement a test that changes the resulting cover file name.

PS: there might be a bug in cleanup of the temporary files here, however, my `/tmp` is too polluted to test, so consider this a call for help. I also don't have Windows anywhere to test on.