### PR TITLE
Switch to python 3.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10.0-rc.2]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     env:
       PY_COLORS: 1


### PR DESCRIPTION
## Description

Python 3.10 was released for a month. Let add it to CI.
