### PR TITLE
Use slow queries for flexible attributes in aunique (fix #2678, close #3553)

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -1690,7 +1690,9 @@ class DefaultTemplateFunctions:
         subqueries = []
         for key in keys:
             value = album.get(key, '')
-            subqueries.append(dbcore.MatchQuery(key, value))
+            # Use slow queries for flexible attributes.
+            fast = key in album.item_keys
+            subqueries.append(dbcore.MatchQuery(key, value, fast))
         albums = self.lib.albums(dbcore.AndQuery(subqueries))
 
         # If there's only one album to matching these details, then do

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -70,6 +70,9 @@ Bug fixes:
 
 * :doc:`/plugins/export`: Fix duplicated output.
 
+* :doc:`/dev/library`: Use slow queries for flexible attributes in aunique.
+  :bug:`2678` :bug:`3553`
+
 1.5.0 (August 19, 2021)
 -----------------------
 

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -791,6 +791,16 @@ class DisambiguationTest(_common.TestCase, PathFormattingMixin):
         self._setf('foo%aunique{albumartist album,year,}/$title')
         self._assert_dest(b'/base/foo 2001/the title', self.i1)
 
+    def test_key_flexible_attribute(self):
+        album1 = self.lib.get_album(self.i1)
+        album1.flex = 'flex1'
+        album2 = self.lib.get_album(self.i2)
+        album2.flex = 'flex2'
+        album1.store()
+        album2.store()
+        self._setf('foo%aunique{albumartist album flex,year}/$title')
+        self._assert_dest(b'/base/foo/the title', self.i1)
+
 
 class PluginDestinationTest(_common.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Description

This allows to use flexible attributes as aunique keys.

Example: `foo%aunique{albumartist album,flex}`
Result using fast query: `foo_no such column_ flex_`
Result using slow query: `foo [flex1]`

Fixes #2678
Fixes #3553

## To Do

- [x] Documentation: not applicable
- [x] Changelog
- [x] Tests
