### PR TITLE
Send the pluginload event after types and queries are available

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -1129,7 +1129,6 @@ def _load_plugins(options, config):
         plugin_list = config['plugins'].as_str_seq()
 
     plugins.load_plugins(plugin_list)
-    plugins.send("pluginload")
     return plugins
 
 
@@ -1145,16 +1144,6 @@ def _setup(options, lib=None):
 
     plugins = _load_plugins(options, config)
 
-    # Get the default subcommands.
-    from beets.ui.commands import default_commands
-
-    subcommands = list(default_commands)
-    subcommands.extend(plugins.commands())
-
-    if lib is None:
-        lib = _open_library(config)
-        plugins.send("library_opened", lib=lib)
-
     # Add types and queries defined by plugins.
     plugin_types_album = plugins.types(library.Album)
     library.Album._types.update(plugin_types_album)
@@ -1165,6 +1154,18 @@ def _setup(options, lib=None):
 
     library.Item._queries.update(plugins.named_queries(library.Item))
     library.Album._queries.update(plugins.named_queries(library.Album))
+
+    plugins.send("pluginload")
+
+    # Get the default subcommands.
+    from beets.ui.commands import default_commands
+
+    subcommands = list(default_commands)
+    subcommands.extend(plugins.commands())
+
+    if lib is None:
+        lib = _open_library(config)
+        plugins.send("library_opened", lib=lib)
 
     return subcommands, plugins, lib
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -56,6 +56,7 @@ For plugin developers:
 
 * :py:meth:`beets.library.Item.destination` now accepts a `replacements`
   argument to be used in favor of the default.
+* Send the `pluginload` event after plugin types and queries are available, not before.
 
 Bug fixes:
 


### PR DESCRIPTION
## Description

Making these types and queries available is part of fully loading the plugins,
so the event should not be sent until this work is done. This allows plugins
to make use of those types and queries in a pluginload listener.

## To Do

- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
