### PR TITLE
Use short-circuit evaluation in AndQuery and OrQuery (fix #4145)

### DIFF
--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -443,7 +443,7 @@ class AndQuery(MutableCollectionQuery):
         return self.clause_with_joiner('and')
 
     def match(self, item):
-        return all([q.match(item) for q in self.subqueries])
+        return all(q.match(item) for q in self.subqueries)
 
 
 class OrQuery(MutableCollectionQuery):
@@ -453,7 +453,7 @@ class OrQuery(MutableCollectionQuery):
         return self.clause_with_joiner('or')
 
     def match(self, item):
-        return any([q.match(item) for q in self.subqueries])
+        return any(q.match(item) for q in self.subqueries)
 
 
 class NotQuery(Query):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -73,6 +73,9 @@ Bug fixes:
 * :doc:`/dev/library`: Use slow queries for flexible attributes in aunique.
   :bug:`2678` :bug:`3553`
 
+* :doc:`/reference/query`: Use short-circuit evaluation in AndQuery and OrQuery
+  :bug:`4145`
+
 1.5.0 (August 19, 2021)
 -----------------------
 


### PR DESCRIPTION
## Description

This improves the performance of `dbcore.AndQuery.match` and `dbcore.OrQuery.match`.
They would evaluate all queries and construct a list of all query results and then pass that list to `all` / `any`.
This modification passes a generator to `all` / `any`, which allows to stop querying at the first false / true result (short-circuit evaluation).
I guess we could also code the whole loops so that we do not run into the same issue accidentally.

Fixes #4145
Related to #2388 ?

## To Do

- [x] Documentation: not applicable
- [x] Changelog.
- [ ] Tests: I did not find any test case related to query behavior...
