### PR TITLE
Add an 'album_removed' event.

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -878,7 +878,6 @@ class Item(LibModel):
             album = self.get_album()
             if album and not album.items():
                 album.remove(delete, False)
-                plugins.send('album_removed', album=album)
 
         # Send a 'item_removed' signal to plugins
         plugins.send('item_removed', item=self)
@@ -1142,6 +1141,9 @@ class Album(LibModel):
         Set with_items to False to avoid removing the album's items.
         """
         super().remove()
+
+        # Send a 'album_removed' signal to plugins
+        plugins.send('album_removed', album=self)
 
         # Delete art file.
         if delete:

--- a/beets/library.py
+++ b/beets/library.py
@@ -878,6 +878,7 @@ class Item(LibModel):
             album = self.get_album()
             if album and not album.items():
                 album.remove(delete, False)
+                plugins.send('album_removed', album=album)
 
         # Send a 'item_removed' signal to plugins
         plugins.send('item_removed', item=self)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -51,6 +51,8 @@ Other new things:
   yes`` in your configuration to enable.
 * :doc:`/plugins/fetchart`: A new option to change cover art format. Useful for
   DAPs that do not support some image formats.
+* New plugin event: ``album_removed``. Called when an album is removed from the
+  library (even when its file is not deleted from disk).
 
 For plugin developers:
 

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -143,6 +143,9 @@ The events currently available are:
   command finishes adding an album to the library. Parameters: ``lib``,
   ``album``
 
+* `album_removed`: called with an ``Album`` object every time an album is
+  removed from the library (even when its file is not deleted from disk).
+
 * `item_copied`: called with an ``Item`` object whenever its file is copied.
   Parameters: ``item``, ``source`` path, ``destination`` path
 


### PR DESCRIPTION
## Description

This works similarly to the existing 'item_removed' event but is called with an `Album` object.

My primary goal for writing this is to scratch my own itch. I'd like to update the `mbcollection` plugin to support automatically removing albums when an album is removed from the library. There was no easy way to do this (e.g. you have to use the `item_removed` event and keep track of all the items in an album) so here we are 😄 

It's been a while since I've had a look at the code so please feel free to let me know if this is the correct way to approach this.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
