### PR TITLE
aura: Sanitize filenames in image IDs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,11 @@ Other new things:
 
 * Permissions plugin now sets cover art permissions to the file permissions.
 
+Fixes:
+
+* :doc:`/plugins/aura`: Fix a potential security hole when serving image
+  files. :bug:`4160`
+
 1.5.0 (August 19, 2021)
 -----------------------
 


### PR DESCRIPTION
When constructing paths to image files to serve, we previously spliced strings from URL requests directly into the path to be opened. This is theoretically worrisome because it could allow clients to read other files that they are not supposed to read.

I'm not actually sure this is a real security problem because Flask's URL parsing should probably rule out IDs that have `/` in them anyway. But out of an abundance of caution, this now prevents paths from showing up in IDs at all—and also prevents `.` and `..` from being valid names.

Closes #4111.
