### PR TITLE
Add lib64 to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ downloads/
 eggs/
 .eggs/
 lib/
-lib64/
+lib64
 parts/
 sdist/
 var/


### PR DESCRIPTION
lib64/ was already included, but sometimes lib64 is a symlink to lib/