### PR TITLE
Rewrite plugin: Prioritize explicit albumartist rules

### DIFF
--- a/beetsplug/rewrite.py
+++ b/beetsplug/rewrite.py
@@ -60,10 +60,11 @@ class RewritePlugin(BeetsPlugin):
             self._log.debug('adding template field {0}', key)
             pattern = re.compile(pattern.lower())
             rules[fieldname].append((pattern, value))
-            if fieldname == 'artist':
-                # Special case for the artist field: apply the same
-                # rewrite for "albumartist" as well.
-                rules['albumartist'].append((pattern, value))
+
+        # Special case for the "artist" field: apply the same rewrite for
+        # "albumartist" as well (only if no other "albumartist" rule matches)
+        if 'artist' in rules:
+            rules['albumartist'] += rules['artist']
 
         # Replace each template field with the new rewriter function.
         for fieldname, fieldrules in rules.items():


### PR DESCRIPTION
## Description

The `rewrite` plugin applies patterns for 'artist' to 'albumartist' too.

However, this means you didn't know that the patterns are checked in
order, you might write something like this:

    rewrite:
        artist .*jimi hendrix.*: The Jimi Hendrix Experience
        albumartist .*jimi hendrix.*: Jimi Hendrix

..and be sad when your alubumartist becomes The Jimi Hendrix Experience.

This change always prioritizes explicit 'albumartist' rules over those
inherited from 'artist', regardless of which order they're defined.

## Caveats

I'm not sure if this is a good idea, since it reduces power/flexibility. Before, if you *wanted* to have an artist rule selectively override an albumartist rule, you could put it in front. Now you can't. My main motivation was getting my feet wet in the beets code base, so I don't mind if this is not merged :)

Maybe a better solution is just to document the ordering— I wasn't aware that the keys in yaml dictionaries were ordered (maybe they're not supposed to be and this is an implementation quirk?). Either way, this is not ready for merge, so I'll leave it as a draft for now.

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)