### PR TITLE
[Lyrics] Genius uses query param not body

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -377,7 +377,7 @@ class Genius(Backend):
         data = {'q': title + " " + artist.lower()}
         try:
             response = requests.get(
-                search_url, data=data, headers=self.headers)
+                search_url, params=data, headers=self.headers)
         except requests.RequestException as exc:
             self._log.debug('Genius API request failed: {0}', exc)
             return None

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,10 @@ Changelog
 
 Changelog goes here!
 
+Bug fixes:
+
+* :doc:`/plugins/lyrics`: Fix Genius search by using query params instead of body.
+
 For packagers:
 
 * We fixed a version for the dependency on the `Confuse`_ library.


### PR DESCRIPTION
## Description

Currently, the Genius lyrics search does not work.
It throws the following error for all files I tried:
```
lyrics: Genius failed to find a matching artist for <artist>
```
I tested it locally and I now see:
```
lyrics: got lyrics from backend: Genius
lyrics: fetched lyrics: <song>
```

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
