### PR TITLE
Add template functionality in rewrite plugin

### DIFF
--- a/beetsplug/rewrite.py
+++ b/beetsplug/rewrite.py
@@ -49,10 +49,12 @@ def rewriter(field, rules, og_templ_funcs):
         return value
     return fieldfunc
 
+
 def og_getters(prev_templs, new_getters):
     def blankfield(item):
         return ""
-    return { k: prev_templs.get(k, blankfield) for k in new_getters.keys() }
+    return {k: prev_templs.get(k, blankfield) for k in new_getters.keys()}
+
 
 class RewritePlugin(BeetsPlugin):
     def __init__(self):


### PR DESCRIPTION
## Description

Amongst other things, the goal is to be able to prevent overriding the `albumartist` just because you want to override the `album`. E.g.:

```yaml
rewrite:
    albumartist: $albumartist
    artist .*jimi hendrix.*: Jimi Hendrix
```

It also moves the `rewrite` plugin closer to the `inline` plugin in terms of functionality. So the example from the docs,

> ```yaml
> rewrite:
>     artist .*jimi hendrix.*: Jimi Hendrix
> ```

can be replaced with

```yaml
rewrite:
    artist .*: %ifdef{$artist_override,$artist_override,$artist}
```
Followed by `beet modify artist_override="Jimi Hendrix" artist::'.*jimi hendrix.*'`. This allows much more fine-grained canonicalizations, since you can select individual tracks or albums to modify by adding custom attributes. Or you can just write more fine-grained rewrite rules, like only modifying the artist on *some* albums.

## Status

Currently templates work as long as there's no (infinite) recursion, and crash if there is any recursion, despite my attempts to avoid this. I'm out of energy to bang my head against this for now. `Template.substitute()` must be independently fetching the list of template fields somewhere, since the one I pass in is definitely overridden with the previous, non-recursive, template.

@sampsyo If you're interested in me getting this good-enough to merge, I'd appreciate any guidance on what I'd need to touch in order to prevent the infinite recursion (following things around the call stack has been making my head spin a little…).

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (~~Encouraged but not strictly required.~~ Definitely required for this one :P)
