### PR TITLE
Add default for unimported.ignore_subdirectories

### DIFF
--- a/beetsplug/unimported.py
+++ b/beetsplug/unimported.py
@@ -32,7 +32,8 @@ class Unimported(BeetsPlugin):
         super().__init__()
         self.config.add(
             {
-                'ignore_extensions': []
+                'ignore_extensions': [],
+                'ignore_subdirectories': []
             }
         )
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,8 +9,8 @@ Changelog goes here!
 Bug fixes:
 
 * :doc:`/plugins/lyrics`: Fix Genius search by using query params instead of body.
-* :doc:`/plugins/unimported`: The new configuration option added in 1.6.0 now has
-  a default value if it hasn't been set.
+* :doc:`/plugins/unimported`: The new ``ignore_subdirectories`` configuration
+  option added in 1.6.0 now has a default value if it hasn't been set.
 
 For packagers:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,8 @@ Changelog goes here!
 Bug fixes:
 
 * :doc:`/plugins/lyrics`: Fix Genius search by using query params instead of body.
+* :doc:`/plugins/unimported`: The new configuration option added in 1.6.0 now has
+  a default value if it hasn't been set.
 
 For packagers:
 


### PR DESCRIPTION
## Description

Adds a default value for the new option introduced in #4086 . Without this, the plugin requires you to set it:

```
$ beet -vv unimported
user configuration: /home/sjung/.config/beets/config.yaml
data directory: /home/sjung/.config/beets
plugin paths:
inline: adding item field disc_track_padded
Sending event: pluginload
library database: /home/sjung/music/beets.db
library directory: /home/sjung/music
Sending event: library_opened
configuration error: unimported.ignore_subdirectories not found
```