### PR TITLE
beetsplug/web: fix translation of query path

### DIFF
--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -261,7 +261,7 @@ class QueryConverter(PathConverter):
                 for query in queries]
 
     def to_url(self, value):
-        return ','.join([v.replace(os.sep, '\\') for v in value])
+        return '/'.join([v.replace(os.sep, '\\') for v in value])
 
 
 class EverythingConverter(PathConverter):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,9 @@ Bug fixes:
   ``r128_album_gain`` fields was changed from integer to float to fix loss of
   precision due to truncation.
   :bug:`4169`
+* :doc:`plugins/web`: Fix handling of "query" requests. Previously queries
+  consisting of more than one token (separated by a slash) always returned an
+  empty result.
 
 For packagers:
 


### PR DESCRIPTION
The routing map translator `QueryConverter` was misconfigured:
* decoding (parsing a path): splitting with "/" as tokenizer
* encoding (translating back to a path): joining items with "," as separator

Instead the encoding should have used the same delimiter (the slash) for the backward conversion.

How to reproduce:
* query: `/album/query/albumartist::%5Efoo%24/original_year%2B/year%2B/album%2B`
* resulting content in parsed argument `queries` in the `album_query` function:
    * previous (wrong): `['albumartist::^foo$,original_year+,year+,album+']`
    * new (correct): `['albumartist::^foo$', 'original_year+', 'year+', 'album+']`

I am not sure, why the issue was not noticed before. Maybe `werkzeug`s handling of routing maps has changed.