### PR TITLE
Improve config cmd

### DIFF
--- a/beets/__init__.py
+++ b/beets/__init__.py
@@ -30,7 +30,7 @@ class IncludeLazyConfig(confuse.LazyConfig):
 
         path = self.user_config_path()
         if not os.path.isfile(path):
-            with open(path,'w+') as file:
+            with open(path, 'w+') as file:
                 file.write(self.dump())
 
         try:

--- a/beets/__init__.py
+++ b/beets/__init__.py
@@ -14,6 +14,7 @@
 
 
 import confuse
+import os
 from sys import stderr
 
 __version__ = '1.5.1'
@@ -26,6 +27,11 @@ class IncludeLazyConfig(confuse.LazyConfig):
     """
     def read(self, user=True, defaults=True):
         super().read(user, defaults)
+
+        path = self.user_config_path()
+        if not os.path.isfile(path):
+            with open(path,'w+') as file:
+                file.write(self.dump())
 
         try:
             for view in self['include']:

--- a/beets/__init__.py
+++ b/beets/__init__.py
@@ -14,7 +14,6 @@
 
 
 import confuse
-import os
 from sys import stderr
 
 __version__ = '1.5.1'
@@ -27,11 +26,6 @@ class IncludeLazyConfig(confuse.LazyConfig):
     """
     def read(self, user=True, defaults=True):
         super().read(user, defaults)
-
-        path = self.user_config_path()
-        if not os.path.isfile(path):
-            with open(path, 'w+') as file:
-                file.write(self.dump())
 
         try:
             for view in self['include']:

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -1253,9 +1253,9 @@ def _raw_main(args, lib=None):
     # that an invalid configuration does not prevent the editor from
     # starting.
     if subargs and subargs[0] == 'config' \
-       and ('-e' in subargs or '--edit' in subargs):
-        from beets.ui.commands import config_edit
-        return config_edit()
+       and ('-o' in subargs or '--open' in subargs):
+        from beets.ui.commands import config_open
+        return config_open()
 
     test_lib = bool(lib)
     subcommands, plugins, lib = _setup(options, lib)

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -1253,7 +1253,7 @@ def _raw_main(args, lib=None):
     # that an invalid configuration does not prevent the editor from
     # starting.
     if subargs and subargs[0] == 'config' \
-       and ('-o' in subargs or '--open' in subargs):
+       and ('-e' in subargs or '--edit' in subargs):
         from beets.ui.commands import config_open
         return config_open()
 


### PR DESCRIPTION
## Description

Add two major things:
* Generate a default configuration file if one does not exist
* New command to change the options from command-line
 

Changed the config edit flag as follow:
```shell
beet config --edit -> beet config --open
beet config -e -> beet config -o
```
New flag for editing settings from command-line. Edit flag accept the path of setting, the key must be present in the file.
It's impossible to modify option type (like string to integer). This command support boolean, string, integer and float and other type will be ignored.
```shell
beets config --edit=import.write --value=true
```

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
