### PR TITLE
Limit plugin

### DIFF
--- a/beetsplug/limit.py
+++ b/beetsplug/limit.py
@@ -11,6 +11,15 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
+"""Adds head/tail functionality to list/ls.
+
+1. Implemented as `lslimit` command with `--head` and `--tail` options. This is
+   the idiomatic way to use this plugin.
+2. Implemented as query prefix `<` for head functionality only. This is the
+   composable way to use the plugin (plays nicely with anything that uses the
+   query language).
+"""
+
 from beets.dbcore import FieldQuery
 from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand, decargs, print_

--- a/beetsplug/limit.py
+++ b/beetsplug/limit.py
@@ -28,7 +28,7 @@ from itertools import islice
 
 
 def lslimit(lib, opts, args):
-    """Query command with head/tail"""
+    """Query command with head/tail."""
 
     if (opts.head is not None) and (opts.tail is not None):
         raise ValueError("Only use one of --head and --tail")
@@ -56,15 +56,15 @@ lslimit_cmd = Subcommand(
 )
 
 lslimit_cmd.parser.add_option(
-    '--head',
-    action='store',
+    "--head",
+    action="store",
     type="int",
     default=None
 )
 
 lslimit_cmd.parser.add_option(
-    '--tail',
-    action='store',
+    "--tail",
+    action="store",
     type="int",
     default=None
 )
@@ -74,28 +74,25 @@ lslimit_cmd.func = lslimit
 
 
 class LimitPlugin(BeetsPlugin):
-    """Query limit functionality via command and query prefix
-    """
+    """Query limit functionality via command and query prefix."""
 
     def commands(self):
+        """Expose `lslimit` subcommand."""
         return [lslimit_cmd]
 
     def queries(self):
 
         class HeadQuery(FieldQuery):
-            """This inner class pattern allows the query to track state
-            """
+            """This inner class pattern allows the query to track state."""
             n = 0
             N = None
 
             @classmethod
             def value_match(cls, pattern, value):
-
                 if cls.N is None:
                     cls.N = int(pattern)
                     if cls.N < 0:
                         raise ValueError("Limit value must be non-negative")
-
                 cls.n += 1
                 return cls.n <= cls.N
 

--- a/beetsplug/limit.py
+++ b/beetsplug/limit.py
@@ -1,0 +1,95 @@
+# This file is part of beets.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+from beets.dbcore import FieldQuery
+from beets.plugins import BeetsPlugin
+from beets.ui import Subcommand, decargs, print_
+from collections import deque
+from itertools import islice
+
+
+def lslimit(lib, opts, args):
+    """Query command with head/tail"""
+    
+    head = opts.head
+    tail = opts.tail
+
+    if head and tail:
+        raise RuntimeError("Only use one of --head and --tail")
+    
+    query = decargs(args)
+    if opts.album:
+        objs = lib.albums(query)
+    else:
+        objs = lib.items(query)
+    
+    if head:
+        objs = islice(objs, head)
+    elif tail:
+        objs = deque(objs, tail)
+
+    for obj in objs:
+        print_(format(obj))
+
+
+lslimit_cmd = Subcommand(
+    "lslimit", 
+    help="query with optional head or tail"
+)
+
+lslimit_cmd.parser.add_option(
+    '--head', 
+    action='store', 
+    type="int",
+    default=None
+)
+
+lslimit_cmd.parser.add_option(
+    '--tail',
+    action='store', 
+    type="int",
+    default=None
+)
+
+lslimit_cmd.parser.add_all_common_options()
+lslimit_cmd.func = lslimit
+
+
+class LsLimitPlugin(BeetsPlugin):
+    def commands(self):
+        return [lslimit_cmd]
+
+
+class HeadPlugin(BeetsPlugin):
+    """Head of an arbitrary query.
+    
+    This allows a user to limit the results of any query to the first
+    `pattern` rows. Example usage: return first 10 tracks `beet ls '<10'`.
+    """
+    
+    def queries(self):
+
+        class HeadQuery(FieldQuery):
+            """Singleton query implementation that tracks result count."""
+            n = 0
+            include = True
+            @classmethod
+            def value_match(cls, pattern, value):
+                cls.n += 1
+                if cls.include:
+                    cls.include = cls.n <= int(pattern)
+                return cls.include
+        
+        return {
+            "<": HeadQuery
+        }

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,10 @@ For packagers:
 * We fixed a version for the dependency on the `Confuse`_ library.
   :bug:`4167`
 
+Other new things:
+
+* :doc:`/plugins/limit`: Limit query results to head or tail (``lslimit`` 
+  command only)
 
 1.6.0 (November 27, 2021)
 -------------------------

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -98,6 +98,7 @@ following to your configuration::
    kodiupdate
    lastgenre
    lastimport
+   limit
    loadext
    lyrics
    mbcollection

--- a/docs/plugins/limit.rst
+++ b/docs/plugins/limit.rst
@@ -3,7 +3,7 @@ Limit Query Plugin
 
 ``limit`` is a plugin to limit a query to the first or last set of 
 results. We also provide a query prefix ``'<n'`` to inline the same 
-behavior in the ``list`` command. They are analagous to piping results: 
+behavior in the ``list`` command. They are analagous to piping results:
 
     $ beet [list|ls] [QUERY] | [head|tail] -n n
 
@@ -34,7 +34,7 @@ applications like most played and recently added.
 Configuration
 =============
 
-Enable the ``last`` plugin in your configuration (see 
+Enable the ``limit`` plugin in your configuration (see
 :ref:`using-plugins`).
 
 Examples
@@ -46,7 +46,13 @@ First 10 tracks
     $ beet lslimit --head 10
     $ beet ls '<10'
 
+Last 10 tracks
+
+    $ beet ls | tail -n 10
+    $ beet lslimit --tail 10
+
 100 mostly recently released tracks
 
-    $ beet lslimit --tail 100 year+ month+ day+
+    $ beet lslimit --head 100 year- month- day-
     $ beet ls year- month- day- '<100'
+    $ beet lslimit --tail 100 year+ month+ day+

--- a/docs/plugins/limit.rst
+++ b/docs/plugins/limit.rst
@@ -27,9 +27,9 @@ singleton-based implementation.
 
 So why does the query prefix exist? Because it composes with any other 
 query-based API or plugin (see :doc:`/reference/query`). For example, 
-you can use the query prefix in ``smartplaylists`` (see :doc:`/plugins/
-smartplaylists`) to limit the number of tracks in a smart playlist for 
-applications like most played and recently added.
+you can use the query prefix in ``smartplaylists``
+(see :doc:`/plugins/smartplaylists`) to limit the number of tracks in a smart
+playlist for applications like most played and recently added.
 
 Configuration
 =============

--- a/docs/plugins/limit.rst
+++ b/docs/plugins/limit.rst
@@ -27,8 +27,8 @@ singleton-based implementation.
 
 So why does the query prefix exist? Because it composes with any other 
 query-based API or plugin (see :doc:`/reference/query`). For example, 
-you can use the query prefix in ``smartplaylists``
-(see :doc:`/plugins/smartplaylists`) to limit the number of tracks in a smart
+you can use the query prefix in ``smartplaylist``
+(see :doc:`/plugins/smartplaylist`) to limit the number of tracks in a smart
 playlist for applications like most played and recently added.
 
 Configuration

--- a/docs/plugins/limit.rst
+++ b/docs/plugins/limit.rst
@@ -1,0 +1,52 @@
+Limit Query Plugin
+==================
+
+``limit`` is a plugin to limit a query to the first or last set of 
+results. We also provide a query prefix ``'<n'`` to inline the same 
+behavior in the ``list`` command. They are analagous to piping results: 
+
+    $ beet [list|ls] [QUERY] | [head|tail] -n n
+
+There are two provided interfaces:
+
+1. ``beet lslimit [--head n | --tail n] [QUERY]`` returns the head or 
+tail of a query
+
+2. ``beet [list|ls] [QUERY] '<n'`` returns the head of a query
+
+There are two differences in behavior: 
+
+1. The query prefix does not support tail.
+
+2. The query prefix could appear anywhere in the query but will only 
+have the same behavior as the ``lslimit`` command and piping to ``head`` 
+when it appears last.
+
+Performance for the query previx is much worse due to the current  
+singleton-based implementation. 
+
+So why does the query prefix exist? Because it composes with any other 
+query-based API or plugin (see :doc:`/reference/query`). For example, 
+you can use the query prefix in ``smartplaylists`` (see :doc:`/plugins/
+smartplaylists`) to limit the number of tracks in a smart playlist for 
+applications like most played and recently added.
+
+Configuration
+=============
+
+Enable the ``last`` plugin in your configuration (see 
+:ref:`using-plugins`).
+
+Examples
+========
+
+First 10 tracks
+
+    $ beet ls | head -n 10
+    $ beet lslimit --head 10
+    $ beet ls '<10'
+
+100 mostly recently released tracks
+
+    $ beet lslimit --tail 100 year+ month+ day+
+    $ beet ls year- month- day- '<100'

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,7 @@ per-file-ignores =
     ./beetsplug/permissions.py:D
     ./beetsplug/spotify.py:D
     ./beetsplug/lastgenre/__init__.py:D
+    ./beetsplug/limit.py:D
     ./beetsplug/mbcollection.py:D
     ./beetsplug/metasync/amarok.py:D
     ./beetsplug/metasync/itunes.py:D

--- a/setup.cfg
+++ b/setup.cfg
@@ -162,6 +162,7 @@ per-file-ignores =
     ./test/test_library.py:D
     ./test/test_ui_commands.py:D
     ./test/test_lyrics.py:D
+    ./test/test_limit.py:D
     ./test/test_beatport.py:D
     ./test/test_random.py:D
     ./test/test_embyupdate.py:D

--- a/test/test_limit.py
+++ b/test/test_limit.py
@@ -1,0 +1,80 @@
+# This file is part of beets.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""Tests for the 'limit' plugin."""
+
+import unittest
+
+from test import _common
+from beetsplug import limit
+from beets import config
+
+from test.helper import TestHelper
+
+
+class LsLimitPluginTest(unittest.TestCase, TestHelper):
+
+    def setUp(self):
+        self.setup_beets()
+        self.load_plugins("limit")
+        self.num_test_items = 10
+        assert self.num_test_items % 2 == 0
+        self.num_limit = self.num_test_items / 2
+        self.num_limit_prefix = "'<" + str(self.num_limit) + "'"
+        self.track_head_range = "track:.." + str(self.num_limit)
+        self.track_tail_range = "track:" + str(self.num_limit + 1) + ".."
+        for item_no, item in enumerate(self.add_item_fixtures(count=self.num_test_items)):
+            item.track = item_no + 1
+            item.store()
+
+    def tearDown(self):
+        self.teardown_beets()
+
+    def test_no_limit(self):
+        result = self.run_with_output("lslimit")
+        self.assertEqual(result.count("\n"), self.num_test_items)
+    
+    def test_lslimit_head(self):
+        result = self.run_with_output("lslimit", "--head", str(self.num_limit))
+        self.assertEqual(result.count("\n"), self.num_limit)
+    
+    def test_lslimit_tail(self):
+        result = self.run_with_output("lslimit", "--tail", str(self.num_limit))
+        self.assertEqual(result.count("\n"), self.num_limit)
+    
+    def test_lslimit_head_invariant(self):
+        result = self.run_with_output("lslimit", "--head", str(self.num_limit), self.track_tail_range)
+        self.assertEqual(result.count("\n"), self.num_limit)
+    
+    def test_lslimit_tail_invariant(self):
+        result = self.run_with_output("lslimit", "--tail", str(self.num_limit), self.track_head_range)
+        self.assertEqual(result.count("\n"), self.num_limit)
+
+    def test_prefix(self):
+        result = self.run_with_output("ls", self.num_limit_prefix)
+        self.assertEqual(result.count("\n"), self.num_limit)
+
+    def test_prefix_when_correctly_ordered(self):
+        result = self.run_with_output("ls", self.track_tail_range, self.num_limit_prefix)
+        self.assertEqual(result.count("\n"), self.num_limit)
+
+    def test_prefix_when_incorrectly_ordred(self):
+        result = self.run_with_output("ls", self.num_limit_prefix, self.track_tail_range)
+        self.assertEqual(result.count("\n"), 0)
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromName(__name__)
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/test/test_limit.py
+++ b/test/test_limit.py
@@ -18,60 +18,83 @@ import unittest
 from test.helper import TestHelper
 
 
-class LsLimitPluginTest(unittest.TestCase, TestHelper):
+class LimitPluginTest(unittest.TestCase, TestHelper):
+    """Unit tests for LimitPlugin
+
+    Note: query prefix tests do not work correctly with `run_with_output`.
+    """
 
     def setUp(self):
+
         self.setup_beets()
         self.load_plugins("limit")
+
+        # we'll create an even number of tracks in the library
         self.num_test_items = 10
         assert self.num_test_items % 2 == 0
-        self.num_limit = self.num_test_items // 2
-        self.num_limit_prefix = "'<" + str(self.num_limit) + "'"
-        self.track_head_range = "track:.." + str(self.num_limit)
-        self.track_tail_range = "track:" + str(self.num_limit + 1) + ".."
         for item_no, item in \
                 enumerate(self.add_item_fixtures(count=self.num_test_items)):
             item.track = item_no + 1
             item.store()
 
+        # our limit tests will use half of this number
+        self.num_limit = self.num_test_items // 2
+        self.num_limit_prefix = "".join(["'", "<", str(self.num_limit), "'"])
+
+        # a subset of tests has only `num_limit` results, identified by a
+        # range filter on the track number
+        self.track_head_range = "track:.." + str(self.num_limit)
+        self.track_tail_range = "track:" + str(self.num_limit + 1) + ".."
+
     def tearDown(self):
+        self.unload_plugins()
         self.teardown_beets()
 
     def test_no_limit(self):
+        """Returns all when there is no limit or filter."""
         result = self.run_with_output("lslimit")
         self.assertEqual(result.count("\n"), self.num_test_items)
 
     def test_lslimit_head(self):
+        """Returns the expected number with `lslimit --head`."""
         result = self.run_with_output("lslimit", "--head", str(self.num_limit))
         self.assertEqual(result.count("\n"), self.num_limit)
 
     def test_lslimit_tail(self):
+        """Returns the expected number with `lslimit --tail`."""
         result = self.run_with_output("lslimit", "--tail", str(self.num_limit))
         self.assertEqual(result.count("\n"), self.num_limit)
 
     def test_lslimit_head_invariant(self):
+        """Returns the expected number with `lslimit --head` and a filter."""
         result = self.run_with_output(
             "lslimit", "--head", str(self.num_limit), self.track_tail_range)
         self.assertEqual(result.count("\n"), self.num_limit)
 
     def test_lslimit_tail_invariant(self):
+        """Returns the expected number with `lslimit --tail` and a filter."""
         result = self.run_with_output(
             "lslimit", "--tail", str(self.num_limit), self.track_head_range)
         self.assertEqual(result.count("\n"), self.num_limit)
 
     def test_prefix(self):
-        result = self.run_with_output("ls", self.num_limit_prefix)
-        self.assertEqual(result.count("\n"), self.num_limit)
+        """Returns the expected number with the query prefix."""
+        result = self.lib.items(self.num_limit_prefix)
+        self.assertEqual(len(result), self.num_limit)
 
     def test_prefix_when_correctly_ordered(self):
-        result = self.run_with_output(
-            "ls", self.track_tail_range, self.num_limit_prefix)
-        self.assertEqual(result.count("\n"), self.num_limit)
+        """Returns the expected number with the query prefix and filter when
+        the prefix portion (correctly) appears last."""
+        correct_order = self.track_tail_range + " " + self.num_limit_prefix
+        result = self.lib.items(correct_order)
+        self.assertEqual(len(result), self.num_limit)
 
     def test_prefix_when_incorrectly_ordred(self):
-        result = self.run_with_output(
-            "ls", self.num_limit_prefix, self.track_tail_range)
-        self.assertEqual(result.count("\n"), 0)
+        """Returns no results with the query prefix and filter when the prefix
+        portion (incorrectly) appears first."""
+        incorrect_order = self.num_limit_prefix + " " + self.track_tail_range
+        result = self.lib.items(incorrect_order)
+        self.assertEqual(len(result), 0)
 
 
 def suite():

--- a/test/test_limit.py
+++ b/test/test_limit.py
@@ -15,10 +15,6 @@
 
 import unittest
 
-from test import _common
-from beetsplug import limit
-from beets import config
-
 from test.helper import TestHelper
 
 
@@ -29,11 +25,12 @@ class LsLimitPluginTest(unittest.TestCase, TestHelper):
         self.load_plugins("limit")
         self.num_test_items = 10
         assert self.num_test_items % 2 == 0
-        self.num_limit = self.num_test_items / 2
+        self.num_limit = self.num_test_items // 2
         self.num_limit_prefix = "'<" + str(self.num_limit) + "'"
         self.track_head_range = "track:.." + str(self.num_limit)
         self.track_tail_range = "track:" + str(self.num_limit + 1) + ".."
-        for item_no, item in enumerate(self.add_item_fixtures(count=self.num_test_items)):
+        for item_no, item in \
+                enumerate(self.add_item_fixtures(count=self.num_test_items)):
             item.track = item_no + 1
             item.store()
 
@@ -43,21 +40,23 @@ class LsLimitPluginTest(unittest.TestCase, TestHelper):
     def test_no_limit(self):
         result = self.run_with_output("lslimit")
         self.assertEqual(result.count("\n"), self.num_test_items)
-    
+
     def test_lslimit_head(self):
         result = self.run_with_output("lslimit", "--head", str(self.num_limit))
         self.assertEqual(result.count("\n"), self.num_limit)
-    
+
     def test_lslimit_tail(self):
         result = self.run_with_output("lslimit", "--tail", str(self.num_limit))
         self.assertEqual(result.count("\n"), self.num_limit)
-    
+
     def test_lslimit_head_invariant(self):
-        result = self.run_with_output("lslimit", "--head", str(self.num_limit), self.track_tail_range)
+        result = self.run_with_output(
+            "lslimit", "--head", str(self.num_limit), self.track_tail_range)
         self.assertEqual(result.count("\n"), self.num_limit)
-    
+
     def test_lslimit_tail_invariant(self):
-        result = self.run_with_output("lslimit", "--tail", str(self.num_limit), self.track_head_range)
+        result = self.run_with_output(
+            "lslimit", "--tail", str(self.num_limit), self.track_head_range)
         self.assertEqual(result.count("\n"), self.num_limit)
 
     def test_prefix(self):
@@ -65,16 +64,19 @@ class LsLimitPluginTest(unittest.TestCase, TestHelper):
         self.assertEqual(result.count("\n"), self.num_limit)
 
     def test_prefix_when_correctly_ordered(self):
-        result = self.run_with_output("ls", self.track_tail_range, self.num_limit_prefix)
+        result = self.run_with_output(
+            "ls", self.track_tail_range, self.num_limit_prefix)
         self.assertEqual(result.count("\n"), self.num_limit)
 
     def test_prefix_when_incorrectly_ordred(self):
-        result = self.run_with_output("ls", self.num_limit_prefix, self.track_tail_range)
+        result = self.run_with_output(
+            "ls", self.num_limit_prefix, self.track_tail_range)
         self.assertEqual(result.count("\n"), 0)
 
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)
+
 
 if __name__ == '__main__':
     unittest.main(defaultTest='suite')


### PR DESCRIPTION
## Description

The `limit` plugin adds the command `lslimit` and the query prefix `<` for limiting query results to the head or tail. (Tail is supported by command only.) 

The impetus for this change was for `smartplaylists` with size limits. Such a feature has been requested before and there looks to have long been talk about this behavior through pagination (see #750). 