### PR TITLE
kodiupdate: Support multiple instances

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 
 Changelog goes here!
 
+New features:
+
+* :doc:`/plugins/kodiupdate`: Now supports multiple kodi instances
+  :bug:`4101`
+
 Bug fixes:
 
 * :doc:`/plugins/lyrics`: Fix Genius search by using query params instead of body.

--- a/docs/plugins/kodiupdate.rst
+++ b/docs/plugins/kodiupdate.rst
@@ -16,6 +16,19 @@ which looks like this::
         user: kodi
         pwd: kodi
 
+To update multiple Kodi instances, specify them as an array::
+
+    kodi:
+      - host: x.x.x.x
+        port: 8080
+        user: kodi
+        pwd: kodi
+      - host: y.y.y.y
+        port: 8081
+        user: kodi2
+        pwd: kodi2
+
+
 To use the ``kodiupdate`` plugin you need to install the `requests`_ library with::
 
     pip install requests


### PR DESCRIPTION
## Description

Fixes #4101

* Read `kodi` configuration as an array and handle all configured instances.
* Backwards compatible with previous config (non-array single instance)
* When failing to connect to/update an instance, log and move on to the next one instead of bailing at the first failure

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
