### PR TITLE
fix spotify pagination

### DIFF
--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -194,9 +194,16 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
                 )
             )
 
+        tracks_data = album_data['tracks']
+        tracks_items = tracks_data['items']
+        while tracks_data['next']:
+            tracks_data = self._handle_response(requests.get,
+                                                tracks_data['next'])
+            tracks_items.extend(tracks_data['items'])
+
         tracks = []
         medium_totals = collections.defaultdict(int)
-        for i, track_data in enumerate(album_data['tracks']['items'], start=1):
+        for i, track_data in enumerate(tracks_items, start=1):
             track = self._get_track(track_data)
             track.index = i
             medium_totals[track.medium] += 1

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,8 @@ New features:
 
 Bug fixes:
 
+* :doc:`/plugins/spotify`: Fix auto tagger pagination issues (fetch beyond the
+  first 50 tracks of a release).
 * :doc:`/plugins/lyrics`: Fix Genius search by using query params instead of body.
 * :doc:`/plugins/unimported`: The new ``ignore_subdirectories`` configuration
   option added in 1.6.0 now has a default value if it hasn't been set.


### PR DESCRIPTION
Basically, keep fetching tracks until there are no more available for
the specified album.

Fixes #4180 .

I tested this by locally importing some albums, but please let me know if you want more extended tests. I am not sure how to write them, though.

EDIT: Fix issue number.