### PR TITLE
Improved fix for Unicode mistakes in atomic move

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -496,8 +496,9 @@ def move(path, dest, replace=False):
         os.replace(path, dest)
     except OSError:
         # Copy the file to a temporary destination.
+        base = os.path.basename(bytestring_path(dest))
         tmp = tempfile.NamedTemporaryFile(suffix=b'.beets',
-                                          prefix=b'.' + os.path.basename(dest),
+                                          prefix=b'.' + base,
                                           dir=os.path.dirname(dest),
                                           delete=False)
         try:

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -479,9 +479,9 @@ def move(path, dest, replace=False):
     instead, in which case metadata will *not* be preserved. Paths are
     translated to system paths.
     """
-    if os.path.isdir(path):
+    if os.path.isdir(syspath(path)):
         raise FilesystemError(u'source is directory', 'move', (path, dest))
-    if os.path.isdir(dest):
+    if os.path.isdir(syspath(dest)):
         raise FilesystemError(u'destination is directory', 'move',
                               (path, dest))
     if samefile(path, dest):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,9 @@ Bug fixes:
   ``r128_album_gain`` fields was changed from integer to float to fix loss of
   precision due to truncation.
   :bug:`4169`
+* Fix a regression in the previous release that caused a `TypeError` when
+  moving files across filesystems.
+  :bug:`4168`
 
 For packagers:
 


### PR DESCRIPTION
The original problem was that this implementation of atomic moves, in #4060, used bytestrings incorrectly to invoke `mktemp`. This caused a regression that crashed beets when it tried to move files across filesystems (which, of course, actually involves a copy).

However, `mktemp` is deprecated, so this PR just avoids it altogether. Fortunately, the non-deprecated APIs in `tempfile` support all-bytes arguments.

Fixes #4168. Also closes #4192, which it supersedes.
