### PR TITLE
discogs: Skip Discogs query on insufficiently tagged files

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -157,6 +157,11 @@ class DiscogsPlugin(BeetsPlugin):
         if not self.discogs_client:
             return
 
+        if not album and not artist:
+            self._log.debug('Skipping Discogs query. Files missing album and '
+                            'artist tags.')
+            return []
+
         if va_likely:
             query = album
         else:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,7 +22,7 @@ Bug fixes:
 * :doc:`/plugins/unimported`: The new ``ignore_subdirectories`` configuration
   option added in 1.6.0 now has a default value if it hasn't been set.
 * :doc:`/plugins/deezer`: Tolerate missing fields when searching for singleton
-  tracks
+  tracks.
   :bug:`4116`
 * :doc:`/plugins/replaygain`: The type of the internal ``r128_track_gain`` and
   ``r128_album_gain`` fields was changed from integer to float to fix loss of
@@ -35,6 +35,9 @@ Bug fixes:
 * :doc:`plugins/web`: Fix handling of "query" requests. Previously queries
   consisting of more than one token (separated by a slash) always returned an
   empty result.
+* :doc:`/plugins/discogs`: Skip Discogs query on insufficiently tagged files
+  (artist and album tags missing) to prevent arbitrary candidate results.
+  :bug:`4227`
 
 For packagers:
 

--- a/docs/plugins/discogs.rst
+++ b/docs/plugins/discogs.rst
@@ -19,7 +19,8 @@ authentication credentials via a personal access token or an OAuth2
 authorization.
 
 Matches from Discogs will now show up during import alongside matches from
-MusicBrainz.
+MusicBrainz. The search terms sent to the Discogs API are based on the artist
+and album tags of your tracks. If those are empty no query will be issued.
 
 If you have a Discogs ID for an album you want to tag, you can also enter it
 at the "enter Id" prompt in the importer.


### PR DESCRIPTION
## Description

Fixes #4222.

- When files are missing both, album and artist tags, the Discogs metadata
  plugin sends empty information to the Discogs API which returns arbitrary
  query results. The resulting "Candidates" are not affiliated with the release being searched for at all and thus are more confusing than helpful to the beets user.
- This patch catches this case and states it in beets import verbose output.
- An example output of such arbitrary results with untagged files can be found here: https://github.com/beetbox/beets/discussions/4222#discussion-3769077

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.) -> Should I add a short note to the Discogs plugin chapter?
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.) -> Will do that after this PR is approved. Currently I think the "Bug fixes:" section would be the right one to add to.
- [ ] Tests. (Encouraged but not strictly required.) -> I can add a test if you think it is useful but haven't looked into the testsuite yet.

## Notes

- There might be a similar issue in other metadata source plugins as well (amazon, beetport, ...) but I haven't looked into them since I don't use them (yet).
- There might be a better place to fix this than in the in the candidates method, please point me there / let's discuss. Thanks in advance!