### PR TITLE
Minor fixes to lyrics scrapers

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -488,11 +488,11 @@ class Tekstowo(Backend):
         if not soup:
             return None
 
-        lyrics_div = soup.find("div", class_="song-text")
+        lyrics_div = soup.select("div.song-text > div.inner-text")
         if not lyrics_div:
             return None
 
-        return lyrics_div.get_text()
+        return lyrics_div[0].get_text()
 
 
 def remove_credits(text):

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -419,10 +419,16 @@ class Genius(Backend):
             lyrics_div = verse_div.parent
             for br in lyrics_div.find_all("br"):
                 br.replace_with("\n")
+
             ads = lyrics_div.find_all("div",
                                       class_=re.compile("InreadAd__Container"))
             for ad in ads:
                 ad.replace_with("\n")
+
+            footers = lyrics_div.find_all("div",
+                                          class_=re.compile("Lyrics__Footer"))
+            for footer in footers:
+                footer.replace_with("")
 
         return lyrics_div.get_text()
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,8 +35,8 @@ Bug fixes:
 * :doc:`plugins/web`: Fix handling of "query" requests. Previously queries
   consisting of more than one token (separated by a slash) always returned an
   empty result.
-* :doc:`plugins/lyrics`: Fixed an issue with the Tekstowo.pl scraper where some
-  non-lyrics content got included in the lyrics
+* :doc:`plugins/lyrics`: Fixed issues with the Tekstowo.pl and Genius
+  backends where some non-lyrics content got included in the lyrics
 
 For packagers:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,8 @@ Bug fixes:
 * :doc:`plugins/web`: Fix handling of "query" requests. Previously queries
   consisting of more than one token (separated by a slash) always returned an
   empty result.
+* :doc:`plugins/lyrics`: Fixed an issue with the Tekstowo.pl scraper where some
+  non-lyrics content got included in the lyrics
 
 For packagers:
 


### PR DESCRIPTION
## Description

Fixes #4228, #4161

Used to include some non-lyrics content in the lyrics, see e.g. https://www.tekstowo.pl/piosenka,au_revoir_simone,crazy.html

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
