### PR TITLE
Draft: Allow plugins to inhibit file operations via hooks

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -747,14 +747,14 @@ class ImportTask(BaseImportTask):
                 if (operation != MoveOperation.MOVE
                         and self.replaced_items[item]
                         and session.lib.directory in util.ancestry(old_path)):
-                    item.move()
-                    # We moved the item, so remove the
-                    # now-nonexistent file from old_paths.
-                    self.old_paths.remove(old_path)
+                    if item.try_move():
+                        # We moved the item, so remove the
+                        # now-nonexistent file from old_paths.
+                        self.old_paths.remove(old_path)
                 else:
                     # A normal import. Just copy files and keep track of
                     # old paths.
-                    item.move(operation)
+                    item.try_move(operation)
 
             if write and (self.apply or self.choice_flag == action.RETAG):
                 item.try_write()


### PR DESCRIPTION
This reflects the `try_write` approach will handles write failures
elegantly, by logging the error and continuing. We do the same with
`move`, `art_set` and `move_art`.

We also handle exceptions on `before_item_moved` and `art_set` plugins
hooks, the latter of which is moved *before* the file operations to
remain consistent with other hook configurations.

That might be a mistake and API-breaking change, another approach
would be to have a new `before_art_set` hook instead.

We also introduce a new hook (`move_art`) for those operations as
well.

The point of this patch is to make it possible for plugins to send a
signal (through the already FileOperationError exception) to callers
that it should skip a specific item or artwork.

This is essential to allow beets to better integrate with other
utilities like bittorrent clients which may rewrite those files. The
rationale here is that some music collections will have *parts* of
them managed by such clients in which case we should be careful not to
overwrite or move those files.

Operations like copy or hardlink are not handled by this, for that
reason. We may also want to do proper error handling for those as
well, that said, but that seems out of scope for this specific
issue (#2617).

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
