### PR TITLE
Correct headers in limit plugin documentation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -43,6 +43,7 @@ Bug fixes:
   :bug:`4227`
 * :doc:`plugins/lyrics`: Fixed issues with the Tekstowo.pl and Genius
   backends where some non-lyrics content got included in the lyrics
+* :doc:`plugins/limit`: Better header formatting to improve index
 
 For packagers:
 

--- a/docs/plugins/limit.rst
+++ b/docs/plugins/limit.rst
@@ -32,13 +32,13 @@ you can use the query prefix in ``smartplaylist``
 playlist for applications like most played and recently added.
 
 Configuration
-=============
+-------------
 
 Enable the ``limit`` plugin in your configuration (see
 :ref:`using-plugins`).
 
 Examples
-========
+--------
 
 First 10 tracks
 


### PR DESCRIPTION
## Description
The index in the plugins looked weird and this was due to wrong headers in the limit plugin description:

![grafik](https://user-images.githubusercontent.com/37914724/149593068-6f1ebb67-ab41-4b09-b15e-090c5cc7bb83.png)


## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
