### PR TITLE
Pin Sphinx <4.4.0 in CI to work around new warning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,7 +86,7 @@ jobs:
       - name: Install base dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install tox 'sphinx<4.4.0'
+          python -m pip install tox sphinx
 
       - name: Add problem matcher
         run: echo "::add-matcher::.github/sphinx-problem-matcher.json"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,7 +86,7 @@ jobs:
       - name: Install base dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install tox sphinx
+          python -m pip install tox 'sphinx<4.4.0'
 
       - name: Add problem matcher
         run: echo "::add-matcher::.github/sphinx-problem-matcher.json"

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands =
 
 [testenv:docs]
 basepython = python3.9
-deps = sphinx
+deps = sphinx<4.4.0
 commands = sphinx-build -W -q -b html docs {envtmpdir}/html {posargs}
 
 # checks all links in the docs


### PR DESCRIPTION
A recent change in Sphinx, as covered in https://github.com/sphinx-doc/sphinx/issues/10112, introduced a new warning about missed extlink opportunities. These warnings are causing spurious CI failures. Some of these suggestions are good but many of them are not, and there is not currently a way to disable the warning (globally or locally). So the only workable solution currently seems to be to pin an old version of Sphinx in CI for now. Hopefully there will be an option to disable this in 4.4.1, at which point we can unpin.

<details>
<summary>For posterity, here is the full set of warnings when I ran this a moment ago.</summary>
<pre>
/Users/asampson/Documents/code/beets/docs/changelog.rst:50: WARNING: hardcoded link 'https://github.com/beetbox/confuse' could be replaced by an extlink (try using ':user:`beetbox/confuse`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:143: WARNING: hardcoded link 'https://pypi.org/project/six/' could be replaced by an extlink (try using ':pypi:`six`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:153: WARNING: hardcoded link 'https://github.com/beetbox/mediafile' could be replaced by an extlink (try using ':user:`beetbox/mediafile`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:153: WARNING: hardcoded link 'https://github.com/beetbox/confuse' could be replaced by an extlink (try using ':user:`beetbox/confuse`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:246: WARNING: hardcoded link 'https://github.com/EvanPurkhiser/keyfinder-cli' could be replaced by an extlink (try using ':user:`EvanPurkhiser/keyfinder-cli`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:326: WARNING: hardcoded link 'https://pypi.org/project/py7zr/' could be replaced by an extlink (try using ':pypi:`py7zr`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:338: WARNING: hardcoded link 'https://github.com/alastair/python-musicbrainzngs' could be replaced by an extlink (try using ':user:`alastair/python-musicbrainzngs`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:338: WARNING: hardcoded link 'https://github.com/alastair/python-musicbrainzngs/pull/266' could be replaced by an extlink (try using ':user:`alastair/python-musicbrainzngs/pull/266`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:501: WARNING: hardcoded link 'https://github.com/joalla/discogs_client' could be replaced by an extlink (try using ':user:`joalla/discogs_client`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:548: WARNING: hardcoded link 'https://github.com/beetbox/mediafile' could be replaced by an extlink (try using ':user:`beetbox/mediafile`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:553: WARNING: hardcoded link 'https://github.com/beetbox/confuse' could be replaced by an extlink (try using ':user:`beetbox/confuse`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:591: WARNING: hardcoded link 'https://github.com/beetbox/mediafile' could be replaced by an extlink (try using ':user:`beetbox/mediafile`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:596: WARNING: hardcoded link 'https://github.com/beetbox/confuse' could be replaced by an extlink (try using ':user:`beetbox/confuse`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:1380: WARNING: hardcoded link 'https://github.com/ocelma/python-itunes' could be replaced by an extlink (try using ':user:`ocelma/python-itunes`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:1400: WARNING: hardcoded link 'https://github.com/alastair/python-musicbrainzngs' could be replaced by an extlink (try using ':user:`alastair/python-musicbrainzngs`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:1493: WARNING: hardcoded link 'https://pypi.org/project/six/' could be replaced by an extlink (try using ':pypi:`six`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:1494: WARNING: hardcoded link 'https://github.com/quodlibet/mutagen' could be replaced by an extlink (try using ':user:`quodlibet/mutagen`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:1726: WARNING: hardcoded link 'https://github.com/beetbox' could be replaced by an extlink (try using ':user:`beetbox`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:1998: WARNING: hardcoded link 'https://github.com/alastair/python-musicbrainzngs' could be replaced by an extlink (try using ':user:`alastair/python-musicbrainzngs`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:2082: WARNING: hardcoded link 'https://github.com/sunlightlabs/jellyfish' could be replaced by an extlink (try using ':user:`sunlightlabs/jellyfish`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:2096: WARNING: hardcoded link 'https://github.com/sunlightlabs/jellyfish' could be replaced by an extlink (try using ':user:`sunlightlabs/jellyfish`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:2106: WARNING: hardcoded link 'https://github.com/sunlightlabs/jellyfish' could be replaced by an extlink (try using ':user:`sunlightlabs/jellyfish`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:2583: WARNING: hardcoded link 'https://github.com/discogs/discogs_client' could be replaced by an extlink (try using ':user:`discogs/discogs_client`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:2634: WARNING: hardcoded link 'https://github.com/quodlibet/mutagen' could be replaced by an extlink (try using ':user:`quodlibet/mutagen`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:2657: WARNING: hardcoded link 'https://github.com/quodlibet/mutagen' could be replaced by an extlink (try using ':user:`quodlibet/mutagen`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:3108: WARNING: hardcoded link 'https://github.com/Verrus' could be replaced by an extlink (try using ':user:`Verrus`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:3433: WARNING: hardcoded link 'https://github.com/tomahawk-player/tomahawk' could be replaced by an extlink (try using ':user:`tomahawk-player/tomahawk`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:3452: WARNING: hardcoded link 'https://github.com/alastair/python-musicbrainzngs' could be replaced by an extlink (try using ':user:`alastair/python-musicbrainzngs`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:3930: WARNING: hardcoded link 'https://github.com/beetbox/pyacoustid' could be replaced by an extlink (try using ':user:`beetbox/pyacoustid`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:3993: WARNING: hardcoded link 'https://github.com/Lugoues' could be replaced by an extlink (try using ':user:`Lugoues`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:4118: WARNING: hardcoded link 'https://github.com/alastair/python-musicbrainzngs' could be replaced by an extlink (try using ':user:`alastair/python-musicbrainzngs`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:4131: WARNING: hardcoded link 'https://github.com/laarmen' could be replaced by an extlink (try using ':user:`laarmen`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:4134: WARNING: hardcoded link 'https://github.com/KraYmer' could be replaced by an extlink (try using ':user:`KraYmer`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:4137: WARNING: hardcoded link 'https://github.com/Lugoues' could be replaced by an extlink (try using ':user:`Lugoues`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:4493: WARNING: hardcoded link 'https://github.com/quodlibet/mutagen/issues/7' could be replaced by an extlink (try using ':user:`quodlibet/mutagen/issues/7`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:4498: WARNING: hardcoded link 'https://github.com/sampsyo/bluelet' could be replaced by an extlink (try using ':user:`sampsyo/bluelet`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:4705: WARNING: hardcoded link 'https://github.com/google-code-export/beets/issues/69' could be replaced by an extlink (try using ':user:`google-code-export/beets/issues/69`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:4716: WARNING: hardcoded link 'https://github.com/beetbox/beets/tree/master/beetsplug' could be replaced by an extlink (try using ':user:`beetbox/beets/tree/master/beetsplug`' instead)
/Users/asampson/Documents/code/beets/docs/changelog.rst:4747: WARNING: hardcoded link 'https://github.com/jbaiter/beetfs' could be replaced by an extlink (try using ':user:`jbaiter/beetfs`' instead)
../CONTRIBUTING.rst:92: WARNING: hardcoded link 'https://github.com/beetbox/beets/labels/bitesize' could be replaced by an extlink (try using ':user:`beetbox/beets/labels/bitesize`' instead)
../CONTRIBUTING.rst:96: WARNING: hardcoded link 'https://github.com/beetbox/beets/labels/testing' could be replaced by an extlink (try using ':user:`beetbox/beets/labels/testing`' instead)
../CONTRIBUTING.rst:101: WARNING: hardcoded link 'https://github.com/beetbox/beets/wiki/Optimization' could be replaced by an extlink (try using ':user:`beetbox/beets/wiki/Optimization`' instead)
../CONTRIBUTING.rst:124: WARNING: hardcoded link 'https://github.com/beetbox/beets/issues?q=is%3Aopen+is%3Aissue+label%3A%22first+timers+only%22' could be replaced by an extlink (try using ':user:`beetbox/beets/issues?q=is%3Aopen+is%3Aissue+label%3A%22first+timers+only%22`' instead)
../CONTRIBUTING.rst:262: WARNING: hardcoded link 'https://github.com/mitsuhiko/vim-python-combined' could be replaced by an extlink (try using ':user:`mitsuhiko/vim-python-combined`' instead)
../CONTRIBUTING.rst:262: WARNING: hardcoded link 'https://github.com/neomake/neomake' could be replaced by an extlink (try using ':user:`neomake/neomake`' instead)
../CONTRIBUTING.rst:275: WARNING: hardcoded link 'https://pypi.org/project/detox/' could be replaced by an extlink (try using ':pypi:`detox`' instead)
../CONTRIBUTING.rst:289: WARNING: hardcoded link 'https://github.com/beetbox/beets/actions' could be replaced by an extlink (try using ':user:`beetbox/beets/actions`' instead)
../CONTRIBUTING.rst:291: WARNING: hardcoded link 'https://github.com/tox-dev/tox/issues/1550' could be replaced by an extlink (try using ':user:`tox-dev/tox/issues/1550`' instead)
../CONTRIBUTING.rst:305: WARNING: hardcoded link 'https://github.com/klrmn/pytest-random' could be replaced by an extlink (try using ':user:`klrmn/pytest-random`' instead)
../CONTRIBUTING.rst:312: WARNING: hardcoded link 'https://github.com/beetbox/beets/blob/master/setup.py' could be replaced by an extlink (try using ':user:`beetbox/beets/blob/master/setup.py`' instead)
../CONTRIBUTING.rst:325: WARNING: hardcoded link 'https://github.com/beetbox/beets/tree/master/test' could be replaced by an extlink (try using ':user:`beetbox/beets/tree/master/test`' instead)
../CONTRIBUTING.rst:325: WARNING: hardcoded link 'https://github.com/beetbox/beets/blob/master/test/test_template.py#L224' could be replaced by an extlink (try using ':user:`beetbox/beets/blob/master/test/test_template.py#L224`' instead)
../CONTRIBUTING.rst:331: WARNING: hardcoded link 'https://github.com/beetbox/beets/actions?query=workflow%3A%22integration+tests%22' could be replaced by an extlink (try using ':user:`beetbox/beets/actions?query=workflow%3A%22integration+tests%22`' instead)
../CONTRIBUTING.rst:343: WARNING: hardcoded link 'https://docs.python.org/3/library/unittest.mock.html' could be replaced by an extlink (try using ':stdlib:`unittest.mock`' instead)
/Users/asampson/Documents/code/beets/docs/faq.rst:166: WARNING: hardcoded link 'https://github.com/beetbox/beets/issues' could be replaced by an extlink (try using ':user:`beetbox/beets/issues`' instead)
/Users/asampson/Documents/code/beets/docs/faq.rst:166: WARNING: hardcoded link 'https://github.com/beetbox/beets/issues/new' could be replaced by an extlink (try using ':bug:`new`' instead)
/Users/asampson/Documents/code/beets/docs/faq.rst:166: WARNING: hardcoded link 'https://github.com/beetbox/beets/issues/new' could be replaced by an extlink (try using ':user:`beetbox/beets/issues/new`' instead)
/Users/asampson/Documents/code/beets/docs/faq.rst:335: WARNING: hardcoded link 'https://github.com/beetbox/beets/issues/new' could be replaced by an extlink (try using ':bug:`new`' instead)
/Users/asampson/Documents/code/beets/docs/faq.rst:335: WARNING: hardcoded link 'https://github.com/beetbox/beets/issues/new' could be replaced by an extlink (try using ':user:`beetbox/beets/issues/new`' instead)
/Users/asampson/Documents/code/beets/docs/faq.rst:335: WARNING: hardcoded link 'https://github.com/quodlibet/mutagen' could be replaced by an extlink (try using ':user:`quodlibet/mutagen`' instead)
/Users/asampson/Documents/code/beets/docs/guides/main.rst:47: WARNING: hardcoded link 'https://github.com/NixOS/nixpkgs/tree/master/pkgs/tools/audio/beets' could be replaced by an extlink (try using ':user:`NixOS/nixpkgs/tree/master/pkgs/tools/audio/beets`' instead)
/Users/asampson/Documents/code/beets/docs/guides/main.rst:63: WARNING: hardcoded link 'https://pypi.org/project/beets/#files' could be replaced by an extlink (try using ':pypi:`beets`' instead)
/Users/asampson/Documents/code/beets/docs/guides/main.rst:114: WARNING: hardcoded link 'https://github.com/beetbox/beets/blob/master/extra/beets.reg' could be replaced by an extlink (try using ':user:`beetbox/beets/blob/master/extra/beets.reg`' instead)
/Users/asampson/Documents/code/beets/docs/guides/tagger.rst:75: WARNING: hardcoded link 'https://github.com/beetbox/beets/issues/new' could be replaced by an extlink (try using ':bug:`new`' instead)
/Users/asampson/Documents/code/beets/docs/guides/tagger.rst:75: WARNING: hardcoded link 'https://github.com/beetbox/beets/issues/new' could be replaced by an extlink (try using ':user:`beetbox/beets/issues/new`' instead)
/Users/asampson/Documents/code/beets/docs/guides/tagger.rst:297: WARNING: hardcoded link 'https://github.com/beetbox/beets/issues' could be replaced by an extlink (try using ':user:`beetbox/beets/issues`' instead)
/Users/asampson/Documents/code/beets/docs/index.rst:15: WARNING: hardcoded link 'https://github.com/beetbox/beets/issues' could be replaced by an extlink (try using ':user:`beetbox/beets/issues`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/absubmit.rst:10: WARNING: hardcoded link 'https://github.com/MTG/essentia' could be replaced by an extlink (try using ':user:`MTG/essentia`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/aura.rst:160: WARNING: hardcoded link 'https://github.com/beetbox/aura/issues/19' could be replaced by an extlink (try using ':user:`beetbox/aura/issues/19`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/bareasc.rst:66: WARNING: hardcoded link 'https://pypi.org/project/Unidecode/' could be replaced by an extlink (try using ':pypi:`Unidecode`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/beatport.rst:14: WARNING: hardcoded link 'https://github.com/requests/requests-oauthlib' could be replaced by an extlink (try using ':user:`requests/requests-oauthlib`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/bpd.rst:4: WARNING: hardcoded link 'https://github.com/TheStalwart/Theremin' could be replaced by an extlink (try using ':user:`TheStalwart/Theremin`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/bpd.rst:48: WARNING: hardcoded link 'https://github.com/TheStalwart/Theremin' could be replaced by an extlink (try using ':user:`TheStalwart/Theremin`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/chroma.rst:26: WARNING: hardcoded link 'https://github.com/beetbox/pyacoustid' could be replaced by an extlink (try using ':user:`beetbox/pyacoustid`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/chroma.rst:61: WARNING: hardcoded link 'https://github.com/beetbox/audioread' could be replaced by an extlink (try using ':user:`beetbox/audioread`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/discogs.rst:12: WARNING: hardcoded link 'https://github.com/joalla/discogs_client' could be replaced by an extlink (try using ':user:`joalla/discogs_client`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/discogs.rst:38: WARNING: hardcoded link 'https://github.com/joalla/discogs_client' could be replaced by an extlink (try using ':user:`joalla/discogs_client`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/discogs.rst:82: WARNING: hardcoded link 'https://github.com/beetbox/beets/issues?utf8=%E2%9C%93&q=is%3Aissue+discogs' could be replaced by an extlink (try using ':user:`beetbox/beets/issues?utf8=%E2%9C%93&q=is%3Aissue+discogs`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/duplicates.rst:107: WARNING: hardcoded link 'https://github.com/holman/spark' could be replaced by an extlink (try using ':user:`holman/spark`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/embedart.rst:75: WARNING: hardcoded link 'https://github.com/python-pillow/Pillow' could be replaced by an extlink (try using ':user:`python-pillow/Pillow`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/export.rst:67: WARNING: hardcoded link 'https://docs.python.org/3/library/csv.html#csv-fmt-params' could be replaced by an extlink (try using ':stdlib:`csv`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/fetchart.rst:89: WARNING: hardcoded link 'https://github.com/python-pillow/Pillow' could be replaced by an extlink (try using ':user:`python-pillow/Pillow`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/fetchart.rst:98: WARNING: hardcoded link 'https://github.com/python-pillow/Pillow' could be replaced by an extlink (try using ':user:`python-pillow/Pillow`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/fetchart.rst:159: WARNING: hardcoded link 'https://github.com/python-pillow/Pillow' could be replaced by an extlink (try using ':user:`python-pillow/Pillow`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:242: WARNING: hardcoded link 'https://github.com/IrosTheBeggar/mStream' could be replaced by an extlink (try using ':user:`IrosTheBeggar/mStream`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:273: WARNING: hardcoded link 'https://github.com/geigerzaehler/beets-alternatives' could be replaced by an extlink (try using ':user:`geigerzaehler/beets-alternatives`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:275: WARNING: hardcoded link 'https://github.com/jmwatte/beet-amazon' could be replaced by an extlink (try using ':user:`jmwatte/beet-amazon`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:277: WARNING: hardcoded link 'https://github.com/agrausem/beets-artistcountry' could be replaced by an extlink (try using ':user:`agrausem/beets-artistcountry`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:280: WARNING: hardcoded link 'https://github.com/adamjakab/BeetsPluginAutofix' could be replaced by an extlink (try using ':user:`adamjakab/BeetsPluginAutofix`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:282: WARNING: hardcoded link 'https://github.com/8h2a/beets-barcode' could be replaced by an extlink (try using ':user:`8h2a/beets-barcode`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:285: WARNING: hardcoded link 'https://github.com/snejus/beetcamp' could be replaced by an extlink (try using ':user:`snejus/beetcamp`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:287: WARNING: hardcoded link 'https://github.com/adamjakab/BeetsPluginBpmAnalyser' could be replaced by an extlink (try using ':user:`adamjakab/BeetsPluginBpmAnalyser`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:289: WARNING: hardcoded link 'https://github.com/geigerzaehler/beets-check' could be replaced by an extlink (try using ':user:`geigerzaehler/beets-check`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:291: WARNING: hardcoded link 'https://github.com/coolkehon/beets/blob/master/beetsplug/cmus.py' could be replaced by an extlink (try using ':user:`coolkehon/beets/blob/master/beetsplug/cmus.py`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:293: WARNING: hardcoded link 'https://github.com/adammillerio/beets-copyartifacts' could be replaced by an extlink (try using ':user:`adammillerio/beets-copyartifacts`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:295: WARNING: hardcoded link 'https://github.com/adamjakab/BeetsPluginDescribe' could be replaced by an extlink (try using ':user:`adamjakab/BeetsPluginDescribe`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:297: WARNING: hardcoded link 'https://github.com/martinkirch/drop2beets' could be replaced by an extlink (try using ':user:`martinkirch/drop2beets`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:301: WARNING: hardcoded link 'https://github.com/dsedivec/beets-plugins' could be replaced by an extlink (try using ':user:`dsedivec/beets-plugins`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:303: WARNING: hardcoded link 'https://github.com/nolsto/beets-follow' could be replaced by an extlink (try using ':user:`nolsto/beets-follow`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:305: WARNING: hardcoded link 'https://github.com/jbaiter/beetfs' could be replaced by an extlink (try using ':user:`jbaiter/beetfs`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:310: WARNING: hardcoded link 'https://github.com/ctrueden/beets-ibroadcast' could be replaced by an extlink (try using ':user:`ctrueden/beets-ibroadcast`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:312: WARNING: hardcoded link 'https://github.com/edgars-supe/beets-importreplace' could be replaced by an extlink (try using ':user:`edgars-supe/beets-importreplace`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:315: WARNING: hardcoded link 'https://github.com/SusannaMaria/beets-mosaic' could be replaced by an extlink (try using ':user:`SusannaMaria/beets-mosaic`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:319: WARNING: hardcoded link 'https://github.com/x1ppy/beets-originquery' could be replaced by an extlink (try using ':user:`x1ppy/beets-originquery`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:322: WARNING: hardcoded link 'https://github.com/abba23/beets-popularity' could be replaced by an extlink (try using ':user:`abba23/beets-popularity`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:324: WARNING: hardcoded link 'https://github.com/tomjaspers/beets-setlister' could be replaced by an extlink (try using ':user:`tomjaspers/beets-setlister`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:326: WARNING: hardcoded link 'https://github.com/steven-murray/beet-summarize' could be replaced by an extlink (try using ':user:`steven-murray/beet-summarize`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:329: WARNING: hardcoded link 'https://github.com/igordertigor/beets-usertag' could be replaced by an extlink (try using ':user:`igordertigor/beets-usertag`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:331: WARNING: hardcoded link 'https://github.com/YetAnotherNerd/whatlastgenre/tree/master/plugin/beets' could be replaced by an extlink (try using ':user:`YetAnotherNerd/whatlastgenre/tree/master/plugin/beets`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:333: WARNING: hardcoded link 'https://github.com/adamjakab/BeetsPluginXtractor' could be replaced by an extlink (try using ':user:`adamjakab/BeetsPluginXtractor`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:335: WARNING: hardcoded link 'https://github.com/vmassuchetto/beets-ydl' could be replaced by an extlink (try using ':user:`vmassuchetto/beets-ydl`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/index.rst:337: WARNING: hardcoded link 'https://github.com/adamjakab/BeetsPluginYearFixer' could be replaced by an extlink (try using ':user:`adamjakab/BeetsPluginYearFixer`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/ipfs.rst:12: WARNING: hardcoded link 'https://github.com/ipfs/go-ipfs' could be replaced by an extlink (try using ':user:`ipfs/go-ipfs`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/keyfinder.rst:4: WARNING: hardcoded link 'https://github.com/EvanPurkhiser/keyfinder-cli/' could be replaced by an extlink (try using ':user:`EvanPurkhiser/keyfinder-cli/`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/keyfinder.rst:23: WARNING: hardcoded link 'https://github.com/EvanPurkhiser/keyfinder-cli/' could be replaced by an extlink (try using ':user:`EvanPurkhiser/keyfinder-cli/`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/keyfinder.rst:23: WARNING: hardcoded link 'https://github.com/EvanPurkhiser/keyfinder-cli/' could be replaced by an extlink (try using ':user:`EvanPurkhiser/keyfinder-cli/`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/lastgenre.rst:13: WARNING: hardcoded link 'https://github.com/pylast/pylast' could be replaced by an extlink (try using ':user:`pylast/pylast`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/lastimport.rst:14: WARNING: hardcoded link 'https://github.com/pylast/pylast' could be replaced by an extlink (try using ':user:`pylast/pylast`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/missing.rst:75: WARNING: hardcoded link 'https://github.com/holman/spark' could be replaced by an extlink (try using ':user:`holman/spark`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/mpdstats.rst:104: WARNING: hardcoded link 'https://github.com/beetbox/beets/issues' could be replaced by an extlink (try using ':user:`beetbox/beets/issues`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/thumbnails.rst:12: WARNING: hardcoded link 'https://github.com/python-pillow/Pillow' could be replaced by an extlink (try using ':user:`python-pillow/Pillow`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/web.rst:22: WARNING: hardcoded link 'https://github.com/CoryDolphin/flask-cors' could be replaced by an extlink (try using ':user:`CoryDolphin/flask-cors`' instead)
/Users/asampson/Documents/code/beets/docs/plugins/web.rst:103: WARNING: hardcoded link 'https://github.com/CoryDolphin/flask-cors' could be replaced by an extlink (try using ':user:`CoryDolphin/flask-cors`' instead)
/Users/asampson/Documents/code/beets/docs/reference/cli.rst:25: WARNING: hardcoded link 'https://github.com/beetbox/beets/blob/master/extra/_beet' could be replaced by an extlink (try using ':user:`beetbox/beets/blob/master/extra/_beet`' instead)
/Users/asampson/Documents/code/beets/docs/reference/cli.rst:64: WARNING: hardcoded link 'https://pypi.org/project/py7zr/' could be replaced by an extlink (try using ':pypi:`py7zr`' instead)
/Users/asampson/Documents/code/beets/docs/reference/cli.rst:467: WARNING: hardcoded link 'https://github.com/scop/bash-completion' could be replaced by an extlink (try using ':user:`scop/bash-completion`' instead)
/Users/asampson/Documents/code/beets/docs/reference/cli.rst:494: WARNING: hardcoded link 'https://github.com/beetbox/beets/blob/master/extra/_beet' could be replaced by an extlink (try using ':user:`beetbox/beets/blob/master/extra/_beet`' instead)
/Users/asampson/Documents/code/beets/docs/reference/pathformat.rst:76: WARNING: hardcoded link 'https://docs.python.org/3/library/time.html#time.strftime' could be replaced by an extlink (try using ':stdlib:`time`' instead)
</pre>
</details>
