### PR TITLE
Fix exception handling in tests

### DIFF
--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -175,7 +175,7 @@ class ConcurrentEventsTest(TestCase, helper.TestHelper):
             self.lock1 = threading.Lock()
             self.lock2 = threading.Lock()
             self.test_case = test_case
-            self.exc_info = None
+            self.exc = None
             self.t1_step = self.t2_step = 0
 
         def log_all(self, name):
@@ -190,9 +190,8 @@ class ConcurrentEventsTest(TestCase, helper.TestHelper):
                 self.lock1.acquire()
                 self.test_case.assertEqual(self._log.level, log.INFO)
                 self.t1_step = 2
-            except Exception:
-                import sys
-                self.exc_info = sys.exc_info()
+            except Exception as e:
+                self.exc = e
 
         def listener2(self):
             try:
@@ -201,9 +200,8 @@ class ConcurrentEventsTest(TestCase, helper.TestHelper):
                 self.lock2.acquire()
                 self.test_case.assertEqual(self._log.level, log.DEBUG)
                 self.t2_step = 2
-            except Exception:
-                import sys
-                self.exc_info = sys.exc_info()
+            except Exception as e:
+                self.exc = e
 
     def setUp(self):
         self.setup_beets(disk=True)
@@ -215,8 +213,8 @@ class ConcurrentEventsTest(TestCase, helper.TestHelper):
         dp = self.DummyPlugin(self)
 
         def check_dp_exc():
-            if dp.exc_info:
-                raise None.with_traceback(dp.exc_info[2])
+            if dp.exc:
+                raise dp.exc
 
         try:
             dp.lock1.acquire()

--- a/test/test_replaygain.py
+++ b/test/test_replaygain.py
@@ -55,18 +55,8 @@ class ReplayGainCliTestBase(TestHelper):
         try:
             self.load_plugins('replaygain')
         except Exception:
-            import sys
-            # store exception info so an error in teardown does not swallow it
-            exc_info = sys.exc_info()
-            try:
-                self.teardown_beets()
-                self.unload_plugins()
-            except Exception:
-                # if load_plugins() failed then setup is incomplete and
-                # teardown operations may fail. In particular # {Item,Album}
-                # may not have the _original_types attribute in unload_plugins
-                pass
-            raise None.with_traceback(exc_info[2])
+            self.teardown_beets()
+            self.unload_plugins()
 
         album = self.add_album_fixture(2)
         for item in album.items():


### PR DESCRIPTION
Apparently we haven't hit these exceptions in a while; see the commit messages for details.

tl;dr: `raise e0, None, e2` was incorrectly translated to `None.with_traceback(e2)`, but clearly, `None` has no such attribute ( `BaseException` has). `e0.with_traceback(e2)` would be correct, but we need here can be expressed in a simpler way on Python 3.