### PR TITLE
Add query prefixes :~ and :=

### DIFF
--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -191,7 +191,7 @@ class StringQuery(StringFieldQuery):
 
     @classmethod
     def string_match(cls, pattern, value):
-        return pattern == value
+        return pattern.lower() == value.lower()
 
 
 class SubstringQuery(StringFieldQuery):

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -177,6 +177,23 @@ class StringFieldQuery(FieldQuery):
         raise NotImplementedError()
 
 
+class StringQuery(StringFieldQuery):
+    """A query that matches a whole string in a specific item field."""
+
+    def col_clause(self):
+        search = (self.pattern
+                  .replace('\\', '\\\\')
+                  .replace('%', '\\%')
+                  .replace('_', '\\_'))
+        clause = self.field + " like ? escape '\\'"
+        subvals = [search]
+        return clause, subvals
+
+    @classmethod
+    def string_match(cls, pattern, value):
+        return pattern == value
+
+
 class SubstringQuery(StringFieldQuery):
     """A query that matches a substring in a specific item field."""
 

--- a/beets/library.py
+++ b/beets/library.py
@@ -1385,7 +1385,11 @@ def parse_query_parts(parts, model_cls):
     special path query detection.
     """
     # Get query types and their prefix characters.
-    prefixes = {':': dbcore.query.RegexpQuery}
+    prefixes = {
+        ':': dbcore.query.RegexpQuery,
+        '~': dbcore.query.StringQuery,
+        '=': dbcore.query.MatchQuery,
+    }
     prefixes.update(plugins.queries())
 
     # Special-case path-like queries, which are non-field queries

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ New features:
 * :doc:`/plugins/kodiupdate`: Now supports multiple kodi instances
   :bug:`4101`
 * Add the item fields ``bitrate_mode``, ``encoder_info`` and ``encoder_settings``.
+* Add query prefixes ``=`` and ``~``.
 
 Bug fixes:
 

--- a/docs/reference/query.rst
+++ b/docs/reference/query.rst
@@ -93,14 +93,45 @@ backslashes are not part of beets' syntax; I'm just using the escaping
 functionality of my shell (bash or zsh, for instance) to pass ``the rebel`` as a
 single argument instead of two.
 
+Exact Matches
+-------------
+
+While ordinary queries perform *substring* matches, beets can also match whole
+strings by adding either ``=`` (case-sensitive) or ``~`` (ignore case) after the
+field name's colon and before the expression::
+
+    $ beet list artist:air
+    $ beet list artist:~air
+    $ beet list artist:=AIR
+
+The first query is a simple substring one that returns tracks by Air, AIR, and
+Air Supply.  The second query returns tracks by Air and AIR, since both are a
+case-insensitive match for the entire expression, but does not return anything
+by Air Supply.  The third query, which requires a case-sensitive exact match,
+returns tracks by AIR only.
+
+Exact matches may be performed on phrases as well::
+
+    $ beet list artist:~"dave matthews"
+    $ beet list artist:="Dave Matthews"
+
+Both of these queries return tracks by Dave Matthews, but not by Dave Matthews
+Band.
+
+To search for exact matches across *all* fields, just prefix the expression with
+a single ``=`` or ``~``::
+
+    $ beet list ~crash
+    $ beet list ="American Football"
+
 .. _regex:
 
 Regular Expressions
 -------------------
 
-While ordinary keywords perform simple substring matches, beets also supports
-regular expression matching for more advanced queries. To run a regex query, use
-an additional ``:`` between the field name and the expression::
+In addition to simple substring and exact matches, beets also supports regular
+expression matching for more advanced queries. To run a regex query, use an
+additional ``:`` between the field name and the expression::
 
     $ beet list "artist::Ann(a|ie)"
 

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -395,11 +395,11 @@ class MatchTest(_common.TestCase):
     def test_exact_match_nocase_positive(self):
         q = dbcore.query.StringQuery('genre', 'the genre')
         self.assertTrue(q.match(self.item))
+        q = dbcore.query.StringQuery('genre', 'THE GENRE')
+        self.assertTrue(q.match(self.item))
 
     def test_exact_match_nocase_negative(self):
         q = dbcore.query.StringQuery('genre', 'genre')
-        self.assertFalse(q.match(self.item))
-        q = dbcore.query.StringQuery('genre', 'THE GENRE')
         self.assertFalse(q.match(self.item))
 
     def test_year_match_positive(self):

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -94,16 +94,19 @@ class DummyDataTestCase(_common.TestCase, AssertsMixin):
         items[0].album = 'baz'
         items[0].year = 2001
         items[0].comp = True
+        items[0].genre = 'rock'
         items[1].title = 'baz qux'
         items[1].artist = 'two'
         items[1].album = 'baz'
         items[1].year = 2002
         items[1].comp = True
+        items[1].genre = 'Rock'
         items[2].title = 'beets 4 eva'
         items[2].artist = 'three'
         items[2].album = 'foo'
         items[2].year = 2003
         items[2].comp = False
+        items[2].genre = 'Hard Rock'
         for item in items:
             self.lib.add(item)
         self.album = self.lib.add_album(items[:2])
@@ -132,6 +135,22 @@ class GetTest(DummyDataTestCase):
         results = self.lib.items(q)
         self.assert_items_matched(results, ['baz qux'])
 
+    def test_get_one_keyed_exact(self):
+        q = 'genre:=rock'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, ['foo bar'])
+        q = 'genre:=Rock'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, ['baz qux'])
+        q = 'genre:="Hard Rock"'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, ['beets 4 eva'])
+
+    def test_get_one_keyed_exact_nocase(self):
+        q = 'genre:~"hard rock"'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, ['beets 4 eva'])
+
     def test_get_one_keyed_regexp(self):
         q = 'artist::t.+r'
         results = self.lib.items(q)
@@ -139,6 +158,16 @@ class GetTest(DummyDataTestCase):
 
     def test_get_one_unkeyed_term(self):
         q = 'three'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, ['beets 4 eva'])
+
+    def test_get_one_unkeyed_exact(self):
+        q = '=rock'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, ['foo bar'])
+
+    def test_get_one_unkeyed_exact_nocase(self):
+        q = '~"hard rock"'
         results = self.lib.items(q)
         self.assert_items_matched(results, ['beets 4 eva'])
 
@@ -157,6 +186,11 @@ class GetTest(DummyDataTestCase):
         results = self.lib.items(q)
         # Matches nothing since the flexattr is not present on the
         # objects.
+        self.assert_items_matched(results, [])
+
+    def test_get_no_matches_exact(self):
+        q = 'genre:="hard rock"'
+        results = self.lib.items(q)
         self.assert_items_matched(results, [])
 
     def test_term_case_insensitive(self):
@@ -181,6 +215,14 @@ class GetTest(DummyDataTestCase):
         q = 'ArTiST:three'
         results = self.lib.items(q)
         self.assert_items_matched(results, ['beets 4 eva'])
+
+    def test_keyed_matches_exact_nocase(self):
+        q = 'genre:~rock'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, [
+            'foo bar',
+            'baz qux',
+        ])
 
     def test_unkeyed_term_matches_multiple_columns(self):
         q = 'baz'
@@ -349,6 +391,16 @@ class MatchTest(_common.TestCase):
     def test_substring_match_non_string_value(self):
         q = dbcore.query.SubstringQuery('disc', '6')
         self.assertTrue(q.match(self.item))
+
+    def test_exact_match_nocase_positive(self):
+        q = dbcore.query.StringQuery('genre', 'the genre')
+        self.assertTrue(q.match(self.item))
+
+    def test_exact_match_nocase_negative(self):
+        q = dbcore.query.StringQuery('genre', 'genre')
+        self.assertFalse(q.match(self.item))
+        q = dbcore.query.StringQuery('genre', 'THE GENRE')
+        self.assertFalse(q.match(self.item))
 
     def test_year_match_positive(self):
         q = dbcore.query.NumericQuery('year', '1')


### PR DESCRIPTION
## Description

Adds 2 new query prefixes to specify exact matches for strings; `=` for case-sensitive matches and `~` for case-insensitive.  For example, the queries `~braid` and `=Braid` both match "Braid" but not "Braids".

I have often wished for a way to do this without having to write a regex on the command line.  Perhaps there is a better way than what I am suggesting in this PR, but I wanted to get the ball rolling on this (imo) handy feature.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
