### PR TITLE
convert: Revert some recent changes to convert-on-import path

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,8 +32,6 @@ Bug fixes:
 * Fix a regression in the previous release that caused a `TypeError` when
   moving files across filesystems.
   :bug:`4168`
-* :doc:`/plugins/convert`: Files are no longer converted when running import in
-  ``--pretend`` mode.
 * :doc:`/plugins/convert`: Deleting the original files during conversion no
   longer logs output when the ``quiet`` flag is enabled.
 * :doc:`plugins/web`: Fix handling of "query" requests. Previously queries

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -127,16 +127,6 @@ class ImportConvertTest(unittest.TestCase, TestHelper):
                                  'Non-empty import directory {}'
                                  .format(util.displayable_path(path)))
 
-    def test_delete_originals_keeps_originals_when_pretend_enabled(self):
-        import_file_count = self.get_count_of_import_files()
-
-        self.config['convert']['delete_originals'] = True
-        self.config['convert']['pretend'] = True
-        self.importer.run()
-
-        self.assertEqual(self.get_count_of_import_files(), import_file_count,
-                         'Count of files differs after running import')
-
     def get_count_of_import_files(self):
         import_file_count = 0
 


### PR DESCRIPTION
This rectifies a couple of things in #4226, as pointed in https://github.com/beetbox/beets/pull/4226#issuecomment-1011499620:

- Undo the `pretend` sensitivity in the import path, because it's not clear how this setting could ever be true.
- Preserve the log message in debug mode, even when quiet.