### PR TITLE
convert plugin: add destination directory pruning

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog goes here!
 
 New features:
 
+* :doc:`/plugins/convert`: Add optional destination directory pruning.
 * :doc:`/plugins/kodiupdate`: Now supports multiple kodi instances
   :bug:`4101`
 * Add the item fields ``bitrate_mode``, ``encoder_info`` and ``encoder_settings``.

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -54,6 +54,11 @@ instead, passing ``-H`` (``--hardlink``) creates hard links.
 Note that album art embedding is disabled for files that are linked.
 Refer to the ``link`` and ``hardlink`` options below.
 
+by default, any extra files in the destination directory are left untouched. To
+remove any files that have no matching library file after converting, use the
+``-P`` (``--prune``) option or the corresponding ``prune`` configuration
+option.
+
 
 Configuration
 -------------
@@ -112,6 +117,8 @@ file. The available options are:
   on the same filesystem as the library.
   Default: ``false``.
 - **delete_originals**: Transcoded files will be copied or moved to their destination, depending on the import configuration. By default, the original files are not modified by the plugin. This option deletes the original files after the transcoding step has completed.
+  Default: ``false``.
+- **prune**: Delete any extra files in the destination directory after converting.
   Default: ``false``.
 
 You can also configure the format to use for transcoding (see the next

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -258,6 +258,33 @@ class ConvertCliTest(unittest.TestCase, TestHelper, ConvertCommand):
             self.run_convert('An impossible query')
         self.assertEqual(logs[0], 'convert: Empty query result.')
 
+    def test_no_prune_destination_directory(self):
+        self.config['convert']['prune'] = False
+        prune_path = os.path.join(self.convert_dest, b'keep.me')
+        self.touch(prune_path)
+        [item] = self.add_item_fixtures()
+        with control_stdin('y'):
+            self.run_convert_path(item.path)
+        self.assertTrue(os.path.exists(prune_path))
+
+    def test_prune_destination_directory_confirm_no(self):
+        self.config['convert']['prune'] = True
+        prune_path = os.path.join(self.convert_dest, b'keep.me')
+        self.touch(prune_path)
+        [item] = self.add_item_fixtures()
+        with control_stdin('\n'.join('yn')):
+            self.run_convert_path(item.path)
+        self.assertTrue(os.path.exists(prune_path))
+
+    def test_prune_destination_directory_confirm_yes(self):
+        self.config['convert']['prune'] = True
+        prune_path = os.path.join(self.convert_dest, b'remove.me')
+        self.touch(prune_path)
+        [item] = self.add_item_fixtures()
+        with control_stdin('\n'.join('yy')):
+            self.run_convert_path(item.path)
+        self.assertFalse(os.path.exists(prune_path))
+
 
 @_common.slow_test()
 class NeverConvertLossyFilesTest(unittest.TestCase, TestHelper,


### PR DESCRIPTION
## Description

This adds `-P`/`--prune` to delete any extra files in the destination directory after converting.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
