### PR TITLE
Improve lyrics tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ files = beets beetsplug beet test setup.py docs
 deps =
     {test,cov}: {[_test]deps}
     lint: {[_lint]deps}
+passenv = INTEGRATION_TEST
 commands =
     test: python -bb -m pytest -rs {posargs}
     cov: coverage run -m pytest -rs {posargs}


### PR DESCRIPTION
## Description

Inspired by the recurring test failures of the kind seen in https://github.com/beetbox/beets/runs/4993930755?check_suite_focus=true

Generate more useful output on failed assertion in the lyrics integration tests, in particular provides more details for the failures in https://github.com/beetbox/beets/runs/4993930755?check_suite_focus=true

In addition, `subTest` is used to better separate tests of different backends, and avoids aborting the entire test function if one backend fails.


## To Do

Nothing, this is only improves the tests.
