### PR TITLE
Resize album art when embedding (convert plugin)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,8 @@ New features:
 
 Bug fixes:
 
+* :doc:`/plugins/convert`: Resize album art when embedding
+  :bug:`2116`
 * :doc:`/plugins/deezer`: Fix auto tagger pagination issues (fetch beyond the
   first 25 tracks of a release).
 * :doc:`/plugins/spotify`: Fix auto tagger pagination issues (fetch beyond the

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -72,7 +72,8 @@ file. The available options are:
   using the ``-a`` option. Default: ``no``.
 - **album_art_maxwidth**: Downscale album art if it's too big. The resize
   operation reduces image width to at most ``maxwidth`` pixels while
-  preserving the aspect ratio.
+  preserving the aspect ratio. The specified image size will apply to both
+  embedded album art and external image files.
 - **dest**: The directory where the files will be converted (or copied) to.
   Default: none.
 - **embed**: Embed album art in converted items. Default: ``yes``.


### PR DESCRIPTION
## Description

Fixes #2116 

Prior to this PR, the convert plugin didn't resize album art when embedding it into the file, even when a maximum art size was set in the config file for the plugin. I discovered this to be a serious issue when every ~2.5 MB Opus file in an album got bloated to over 20MB because of some scanned hi-res art from a vinyl album.

This PR refactors the handling of album art resizing slightly to avoid code duplication.

A useful next step would be to add "force_jpg" and "quality" options to the config file for the convert plugin. Even when resizing the embedded art to something reasonable like 1080x1080, PNG art can still end up quite large. The art resizing code already supports converting to JPEG and setting the quality parameter.

## To Do

- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
