### PR TITLE
Fix embedart with compare_threshold on ImageMagick 7

### DIFF
--- a/beets/art.py
+++ b/beets/art.py
@@ -51,14 +51,17 @@ def embed_item(log, item, imagepath, maxwidth=None, itempath=None,
                quality=0):
     """Embed an image into the item's media file.
     """
-    # Conditions and filters.
+    # Conditions.
     if compare_threshold:
         if not check_art_similarity(log, item, imagepath, compare_threshold):
             log.info('Image not similar; skipping.')
             return
+
     if ifempty and get_art(log, item):
         log.info('media file already contained art')
         return
+
+    # Filters.
     if maxwidth and not as_album:
         imagepath = resize_image(log, imagepath, maxwidth, quality)
 

--- a/beets/art.py
+++ b/beets/art.py
@@ -53,7 +53,12 @@ def embed_item(log, item, imagepath, maxwidth=None, itempath=None,
     """
     # Conditions.
     if compare_threshold:
-        if not check_art_similarity(log, item, imagepath, compare_threshold):
+        is_similar = check_art_similarity(
+            log, item, imagepath, compare_threshold)
+        if is_similar is None:
+            log.warning('Error while checking art similarity; skipping.')
+            return
+        elif not is_similar:
             log.info('Image not similar; skipping.')
             return
 
@@ -119,7 +124,8 @@ def resize_image(log, imagepath, maxwidth, quality):
 def check_art_similarity(log, item, imagepath, compare_threshold):
     """A boolean indicating if an image is similar to embedded item art.
 
-    If no embedded art exists, always return `True`.
+    If no embedded art exists, always return `True`. If the comparison fails
+    for some reason, the return value is `None`.
 
     This must only be called if `ArtResizer.shared.can_compare` is `True`.
     """

--- a/beets/art.py
+++ b/beets/art.py
@@ -121,7 +121,13 @@ def resize_image(log, imagepath, maxwidth, quality):
     return imagepath
 
 
-def check_art_similarity(log, item, imagepath, compare_threshold):
+def check_art_similarity(
+    log,
+    item,
+    imagepath,
+    compare_threshold,
+    artresizer=None,
+):
     """A boolean indicating if an image is similar to embedded item art.
 
     If no embedded art exists, always return `True`. If the comparison fails
@@ -135,7 +141,10 @@ def check_art_similarity(log, item, imagepath, compare_threshold):
         if not art:
             return True
 
-        return ArtResizer.shared.compare(art, imagepath, compare_threshold)
+        if artresizer is None:
+            artresizer = ArtResizer.shared
+
+        return artresizer.compare(art, imagepath, compare_threshold)
 
 
 def extract(log, outpath, item):

--- a/beets/art.py
+++ b/beets/art.py
@@ -115,6 +115,10 @@ def resize_image(log, imagepath, maxwidth, quality):
 
 def check_art_similarity(log, item, imagepath, compare_threshold):
     """A boolean indicating if an image is similar to embedded item art.
+
+    If no embedded art exists, always return `True`.
+
+    This must only be called if `ArtResizer.shared.can_compare` is `True`.
     """
     with NamedTemporaryFile(delete=True) as f:
         art = extract(log, f.name, item)

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -329,7 +329,6 @@ class ArtResizer(metaclass=Shareable):
         """
         self.method = self._check_method()
         log.debug("artresizer: method is {0}", self.method)
-        self.can_compare = self._can_compare()
 
         # Use ImageMagick's magick binary when it's available. If it's
         # not, fall back to the older, separate convert and identify
@@ -430,7 +429,8 @@ class ArtResizer(metaclass=Shareable):
                 os.unlink(path_in)
         return result_path
 
-    def _can_compare(self):
+    @property
+    def can_compare(self):
         """A boolean indicating whether image comparison is available"""
 
         return self.method[0] == IMAGEMAGICK and self.method[1] > (6, 8, 7)

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -177,6 +177,7 @@ def pil_getsize(artresizer, path_in):
     except OSError as exc:
         log.error("PIL could not read file {}: {}",
                   displayable_path(path_in), exc)
+        return None
 
 
 def im_getsize(artresizer, path_in):
@@ -192,11 +193,12 @@ def im_getsize(artresizer, path_in):
             'getting size with command {}:\n{}',
             exc.returncode, cmd, exc.output.strip()
         )
-        return
+        return None
     try:
         return tuple(map(int, out.split(b' ')))
     except IndexError:
         log.warning('Could not understand IM output: {0!r}', out)
+        return None
 
 
 BACKEND_GET_SIZE = {
@@ -347,7 +349,7 @@ def im_compare(artresizer, im1, im2, compare_threshold):
             convert_proc.returncode,
             convert_stderr,
         )
-        return
+        return None
 
     # Check the compare output.
     stdout, stderr = compare_proc.communicate()
@@ -355,7 +357,7 @@ def im_compare(artresizer, im1, im2, compare_threshold):
         if compare_proc.returncode != 1:
             log.debug('ImageMagick compare failed: {0}, {1}',
                       displayable_path(im2), displayable_path(im1))
-            return
+            return None
         out_str = stderr
     else:
         out_str = stdout
@@ -364,7 +366,7 @@ def im_compare(artresizer, im1, im2, compare_threshold):
         phash_diff = float(out_str)
     except ValueError:
         log.debug('IM output is not a number: {0!r}', out_str)
-        return
+        return None
 
     log.debug('ImageMagick compare score: {0}', phash_diff)
     return phash_diff <= compare_threshold
@@ -471,6 +473,7 @@ class ArtResizer(metaclass=Shareable):
         if self.local:
             func = BACKEND_GET_SIZE[self.method[0]]
             return func(self, path_in)
+        return None
 
     def get_format(self, path_in):
         """Returns the format of the image as a string.
@@ -480,6 +483,7 @@ class ArtResizer(metaclass=Shareable):
         if self.local:
             func = BACKEND_GET_FORMAT[self.method[0]]
             return func(self, path_in)
+        return None
 
     def reformat(self, path_in, new_format, deinterlaced=True):
         """Converts image to desired format, updating its extension, but
@@ -524,6 +528,7 @@ class ArtResizer(metaclass=Shareable):
         if self.local:
             func = BACKEND_COMPARE[self.method[0]]
             return func(self, im1, im2, compare_threshold)
+        return None
 
     @staticmethod
     def _check_method():

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -310,10 +310,13 @@ def im_compare(im1, im2, compare_threshold):
     # to grayscale and then pipe them into the `compare` command.
     # On Windows, ImageMagick doesn't support the magic \\?\ prefix
     # on paths, so we pass `prefix=False` to `syspath`.
-    convert_cmd = ['convert', syspath(im2, prefix=False),
-                   syspath(im1, prefix=False),
-                   '-colorspace', 'gray', 'MIFF:-']
-    compare_cmd = ['compare', '-metric', 'PHASH', '-', 'null:']
+    convert_cmd = ArtResizer.shared.im_convert_cmd + [
+        syspath(im2, prefix=False), syspath(im1, prefix=False),
+        '-colorspace', 'gray', 'MIFF:-'
+    ]
+    compare_cmd = ArtResizer.shared.im_compare_cmd + [
+        '-metric', 'PHASH', '-', 'null:',
+    ]
     log.debug('comparing images with pipeline {} | {}',
               convert_cmd, compare_cmd)
     convert_proc = subprocess.Popen(
@@ -412,9 +415,11 @@ class ArtResizer(metaclass=Shareable):
             if self.im_legacy:
                 self.im_convert_cmd = ['convert']
                 self.im_identify_cmd = ['identify']
+                self.im_compare_cmd = ['compare']
             else:
                 self.im_convert_cmd = ['magick']
                 self.im_identify_cmd = ['magick', 'identify']
+                self.im_compare_cmd = ['magick', 'compare']
 
     def resize(
         self, maxwidth, path_in, path_out=None, quality=0, max_filesize=0

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -19,6 +19,7 @@ public resizing proxy if neither is available.
 import subprocess
 import os
 import os.path
+import platform
 import re
 from tempfile import NamedTemporaryFile
 from urllib.parse import urlencode
@@ -301,6 +302,79 @@ BACKEND_CONVERT_IMAGE_FORMAT = {
     IMAGEMAGICK: im_convert_format,
 }
 
+def im_compare(im1, im2, compare_threshold):
+    is_windows = platform.system() == "Windows"
+
+    # Converting images to grayscale tends to minimize the weight
+    # of colors in the diff score. So we first convert both images
+    # to grayscale and then pipe them into the `compare` command.
+    # On Windows, ImageMagick doesn't support the magic \\?\ prefix
+    # on paths, so we pass `prefix=False` to `syspath`.
+    convert_cmd = ['convert', syspath(im2, prefix=False),
+                   syspath(im1, prefix=False),
+                   '-colorspace', 'gray', 'MIFF:-']
+    compare_cmd = ['compare', '-metric', 'PHASH', '-', 'null:']
+    log.debug('comparing images with pipeline {} | {}',
+              convert_cmd, compare_cmd)
+    convert_proc = subprocess.Popen(
+        convert_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        close_fds=not is_windows,
+    )
+    compare_proc = subprocess.Popen(
+        compare_cmd,
+        stdin=convert_proc.stdout,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        close_fds=not is_windows,
+    )
+
+    # Check the convert output. We're not interested in the
+    # standard output; that gets piped to the next stage.
+    convert_proc.stdout.close()
+    convert_stderr = convert_proc.stderr.read()
+    convert_proc.stderr.close()
+    convert_proc.wait()
+    if convert_proc.returncode:
+        log.debug(
+            'ImageMagick convert failed with status {}: {!r}',
+            convert_proc.returncode,
+            convert_stderr,
+        )
+        return
+
+    # Check the compare output.
+    stdout, stderr = compare_proc.communicate()
+    if compare_proc.returncode:
+        if compare_proc.returncode != 1:
+            log.debug('ImageMagick compare failed: {0}, {1}',
+                      displayable_path(im2), displayable_path(im1))
+            return
+        out_str = stderr
+    else:
+        out_str = stdout
+
+    try:
+        phash_diff = float(out_str)
+    except ValueError:
+        log.debug('IM output is not a number: {0!r}', out_str)
+        return
+
+    log.debug('ImageMagick compare score: {0}', phash_diff)
+    return phash_diff <= compare_threshold
+
+
+def pil_compare(im1, im2, compare_threshold):
+    # It is an error to call this when ArtResizer.can_compare is not True.
+    raise NotImplementedError()
+
+
+BACKEND_COMPARE = {
+    PIL: pil_compare,
+    IMAGEMAGICK: im_compare,
+}
+
 
 class Shareable(type):
     """A pseudo-singleton metaclass that allows both shared and
@@ -434,6 +508,15 @@ class ArtResizer(metaclass=Shareable):
         """A boolean indicating whether image comparison is available"""
 
         return self.method[0] == IMAGEMAGICK and self.method[1] > (6, 8, 7)
+
+    def compare(self, im1, im2, compare_threshold):
+        """Return a boolean indicating whether two images are similar.
+
+        Only available locally.
+        """
+        if self.local:
+            func = BACKEND_COMPARE[self.method[0]]
+            return func(im1, im2, compare_threshold)
 
     @staticmethod
     def _check_method():

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -62,7 +62,7 @@ def temp_file_for(path):
 
 
 def pil_resize(artresizer, maxwidth, path_in, path_out=None, quality=0,
-        max_filesize=0):
+               max_filesize=0):
     """Resize using Python Imaging Library (PIL).  Return the output path
     of resized image.
     """
@@ -121,7 +121,7 @@ def pil_resize(artresizer, maxwidth, path_in, path_out=None, quality=0,
 
 
 def im_resize(artresizer, maxwidth, path_in, path_out=None, quality=0,
-        max_filesize=0):
+              max_filesize=0):
     """Resize using ImageMagick.
 
     Use the ``magick`` program or ``convert`` on older versions. Return
@@ -305,6 +305,7 @@ BACKEND_CONVERT_IMAGE_FORMAT = {
     PIL: pil_convert_format,
     IMAGEMAGICK: im_convert_format,
 }
+
 
 def im_compare(artresizer, im1, im2, compare_threshold):
     is_windows = platform.system() == "Windows"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -46,6 +46,9 @@ Bug fixes:
 * :doc:`plugins/replaygain`: Correctly handle the ``overwrite`` config option,
   which forces recomputing ReplayGain values on import even for tracks
   that already have the tags.
+* :doc:`plugins/embedart`: Fix a crash when using recent versions of
+  ImageMagick and the ``compare_threshold`` option.
+  :bug:`4272`
 
 For packagers:
 

--- a/test/test_art_resize.py
+++ b/test/test_art_resize.py
@@ -50,6 +50,7 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
         """Test resizing based on file size, given a resize_func."""
         # Check quality setting unaffected by new parameter
         im_95_qual = resize_func(
+            ArtResizer.shared,
             225,
             self.IMG_225x225,
             quality=95,
@@ -60,6 +61,7 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
 
         # Attempt a lower filesize with same quality
         im_a = resize_func(
+            ArtResizer.shared,
             225,
             self.IMG_225x225,
             quality=95,
@@ -72,6 +74,7 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
 
         # Attempt with lower initial quality
         im_75_qual = resize_func(
+            ArtResizer.shared,
             225,
             self.IMG_225x225,
             quality=75,
@@ -80,6 +83,7 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
         self.assertExists(im_75_qual)
 
         im_b = resize_func(
+            ArtResizer.shared,
             225,
             self.IMG_225x225,
             quality=95,
@@ -107,7 +111,7 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
         Check if pil_deinterlace function returns images
         that are non-progressive
         """
-        path = pil_deinterlace(self.IMG_225x225)
+        path = pil_deinterlace(ArtResizer.shared, self.IMG_225x225)
         from PIL import Image
         with Image.open(path) as img:
             self.assertFalse('progression' in img.info)
@@ -119,7 +123,7 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
         Check if im_deinterlace function returns images
         that are non-progressive.
         """
-        path = im_deinterlace(self.IMG_225x225)
+        path = im_deinterlace(ArtResizer.shared, self.IMG_225x225)
         cmd = ArtResizer.shared.im_identify_cmd + [
             '-format', '%[interlace]', syspath(path, prefix=False),
         ]

--- a/test/test_embedart.py
+++ b/test/test_embedart.py
@@ -216,7 +216,7 @@ class EmbedartCliTest(_common.TestCase, TestHelper):
         self.assertEqual(mediafile.images[0].data, self.image_data)
 
 
-@patch('beets.art.subprocess')
+@patch('beets.util.artresizer.subprocess')
 @patch('beets.art.extract')
 class ArtSimilarityTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #4272. In the process, I found that I didn't like some details of the code for checking art similarity and `ArtResizer` in general, so this includes a fair bit of refactoring. For review, best read the commits individually and look at the commit messages.
