### PR TITLE
fish plugin: Add --output option

### DIFF
--- a/beetsplug/fish.py
+++ b/beetsplug/fish.py
@@ -85,7 +85,8 @@ class FishPlugin(BeetsPlugin):
             '-o',
             '--output',
             default=None,
-            help='save the script to a specific file, by default it will be saved to ~/.config/fish/completions')
+            help='save the script to a specific file, by default it will be'
+                 'saved to ~/.config/fish/completions')
         return [cmd]
 
     def run(self, lib, opts, args):

--- a/beetsplug/fish.py
+++ b/beetsplug/fish.py
@@ -105,11 +105,7 @@ class FishPlugin(BeetsPlugin):
             completion_file_path = os.path.join(completion_dir, 'beet.fish')
 
         if completion_dir != '':
-            try:
-                os.makedirs(completion_dir)
-            except OSError:
-                if not os.path.isdir(completion_dir):
-                    raise
+            os.makedirs(completion_dir, exist_ok=True)
 
         nobasicfields = opts.noFields  # Do not complete for album/track fields
         extravalues = opts.extravalues  # e.g., Also complete artists names

--- a/beetsplug/fish.py
+++ b/beetsplug/fish.py
@@ -84,7 +84,7 @@ class FishPlugin(BeetsPlugin):
         cmd.parser.add_option(
             '-o',
             '--output',
-            default=None,
+            default='~/.config/fish/completions/beet.fish',
             help='save the script to a specific file, by default it will be'
                  'saved to ~/.config/fish/completions')
         return [cmd]
@@ -96,13 +96,8 @@ class FishPlugin(BeetsPlugin):
         # Make a giant string of all the above, formatted in a way that
         # allows Fish to do tab completion for the `beet` command.
 
-        completion_file_path = opts.output
-        if completion_file_path is not None:
-            completion_dir = os.path.dirname(completion_file_path)
-        else:
-            home_dir = os.path.expanduser("~")
-            completion_dir = os.path.join(home_dir, '.config/fish/completions')
-            completion_file_path = os.path.join(completion_dir, 'beet.fish')
+        completion_file_path = os.path.expanduser(opts.output)
+        completion_dir = os.path.dirname(completion_file_path)
 
         if completion_dir != '':
             os.makedirs(completion_dir, exist_ok=True)

--- a/beetsplug/fish.py
+++ b/beetsplug/fish.py
@@ -81,6 +81,11 @@ class FishPlugin(BeetsPlugin):
             choices=library.Item.all_keys() +
             library.Album.all_keys(),
             help='include specified field *values* in completions')
+        cmd.parser.add_option(
+            '-o',
+            '--output',
+            default=None,
+            help='save the script to a specific file, by default it will be saved to ~/.config/fish/completions')
         return [cmd]
 
     def run(self, lib, opts, args):
@@ -89,14 +94,22 @@ class FishPlugin(BeetsPlugin):
         # If specified, also collect the values for these fields.
         # Make a giant string of all the above, formatted in a way that
         # allows Fish to do tab completion for the `beet` command.
-        home_dir = os.path.expanduser("~")
-        completion_dir = os.path.join(home_dir, '.config/fish/completions')
-        try:
-            os.makedirs(completion_dir)
-        except OSError:
-            if not os.path.isdir(completion_dir):
-                raise
-        completion_file_path = os.path.join(completion_dir, 'beet.fish')
+
+        completion_file_path = opts.output
+        if completion_file_path is not None:
+            completion_dir = os.path.dirname(completion_file_path)
+        else:
+            home_dir = os.path.expanduser("~")
+            completion_dir = os.path.join(home_dir, '.config/fish/completions')
+            completion_file_path = os.path.join(completion_dir, 'beet.fish')
+
+        if completion_dir != '':
+            try:
+                os.makedirs(completion_dir)
+            except OSError:
+                if not os.path.isdir(completion_dir):
+                    raise
+
         nobasicfields = opts.noFields  # Do not complete for album/track fields
         extravalues = opts.extravalues  # e.g., Also complete artists names
         beetcmds = sorted(

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -59,6 +59,7 @@ Other new things:
 
 * :doc:`/plugins/limit`: Limit query results to head or tail (``lslimit`` 
   command only)
+* :doc:`/plugins/fish`: Add ``--output`` option.
 
 1.6.0 (November 27, 2021)
 -------------------------

--- a/docs/plugins/fish.rst
+++ b/docs/plugins/fish.rst
@@ -50,3 +50,6 @@ with care when specified fields contain a large number of values. Libraries with
 for example, very large numbers of genres/artists may result in higher memory
 utilization, completion latency, et cetera. This option is not meant to replace
 database queries altogether.
+
+By default the completion file will be generated at ``~/.config/fish/completions/``,
+if you want to save it somewhere else you can use the ``-o`` or ``--output``.

--- a/docs/plugins/fish.rst
+++ b/docs/plugins/fish.rst
@@ -51,5 +51,5 @@ for example, very large numbers of genres/artists may result in higher memory
 utilization, completion latency, et cetera. This option is not meant to replace
 database queries altogether.
 
-By default the completion file will be generated at ``~/.config/fish/completions/``,
-if you want to save it somewhere else you can use the ``-o`` or ``--output``.
+By default the completion file will be generated at ``~/.config/fish/completions/``.
+If you want to save it somewhere else you can use the ``-o`` or ``--output``.


### PR DESCRIPTION
I find it useful because it would allow us to generate the completion script when creating an .rpm package.

## To Do

- [X] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [X] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
