### PR TITLE
Fix error while opening config on Windows (with beet config -e command)

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -949,11 +949,20 @@ def interactive_open(targets, command):
     """
     assert command
 
-    # Split the command string into its arguments.
-    try:
-        args = shlex.split(command)
-    except ValueError:  # Malformed shell tokens.
-        args = [command]
+    if os.name == 'nt':
+        if command == 'start':
+            args = ['cmd.exe']
+            targets = ['/C start ' + targets[0]]
+        else:
+            args = [command]
+    else:
+        # Split the command string into its arguments.
+        try:
+            # Doesn't work well with Windows
+            # (removes all the '\' from path resulting in an invalid path)
+            args = shlex.split(command)
+        except ValueError:  # Malformed shell tokens.
+            args = [command]
 
     args.insert(0, args[0])  # for argv[0]
 

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -921,7 +921,7 @@ def open_anything():
     if sys_name == 'Darwin':
         base_cmd = 'open'
     elif sys_name == 'Windows':
-        base_cmd = 'start'
+        base_cmd = 'cmd.exe'
     else:  # Assume Unix
         base_cmd = 'xdg-open'
     return base_cmd
@@ -950,11 +950,11 @@ def interactive_open(targets, command):
     assert command
 
     if os.name == 'nt':
-        if command == 'start':
-            args = ['cmd.exe']
+        args = [command]
+
+        if command == 'cmd.exe':
             targets = ['/C start ' + targets[0]]
-        else:
-            args = [command]
+
     else:
         # Split the command string into its arguments.
         try:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,8 @@ New features:
 
 Bug fixes:
 
+* Fix error while opening config on Windows (with beet config -e command)
+  :bug:`2847`
 * :doc:`/plugins/convert`: Resize album art when embedding
   :bug:`2116`
 * :doc:`/plugins/deezer`: Fix auto tagger pagination issues (fetch beyond the

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -29,7 +29,7 @@ from beets import util
 class UtilTest(unittest.TestCase):
     def test_open_anything(self):
         with _common.system_mock('Windows'):
-            self.assertEqual(util.open_anything(), 'start')
+            self.assertEqual(util.open_anything(), 'cmd.exe')
 
         with _common.system_mock('Darwin'):
             self.assertEqual(util.open_anything(), 'open')


### PR DESCRIPTION
## Description

Fixes #2847

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
