### PR TITLE
acousticbrainz: Write tags to file

### DIFF
--- a/beetsplug/acousticbrainz.py
+++ b/beetsplug/acousticbrainz.py
@@ -210,11 +210,13 @@ class AcousticPlugin(plugins.BeetsPlugin):
 
             # We can only fetch data for tracks with MBIDs.
             if not item.mb_trackid:
+                self._log.info('no MusicBrainz ID found for: {}', item)
                 continue
 
             self._log.info('getting data for: {}', item)
             data = self._get_data(item.mb_trackid)
             if data:
+                tags_to_write = {}
                 for attr, val in self._map_data_to_scheme(data, ABSCHEME):
                     if not tags or attr in tags:
                         self._log.debug('attribute {} of {} set to {}',
@@ -222,6 +224,7 @@ class AcousticPlugin(plugins.BeetsPlugin):
                                         item,
                                         val)
                         setattr(item, attr, val)
+                        tags_to_write[attr] = val
                     else:
                         self._log.debug('skipping attribute {} of {}'
                                         ' (value {}) due to config',
@@ -230,7 +233,7 @@ class AcousticPlugin(plugins.BeetsPlugin):
                                         val)
                 item.store()
                 if write:
-                    item.try_write()
+                    item.try_write(tags=tags_to_write)
 
     def _map_data_to_scheme(self, data, scheme):
         """Given `data` as a structure of nested dictionaries, and `scheme` as a

--- a/beetsplug/acousticbrainz.py
+++ b/beetsplug/acousticbrainz.py
@@ -16,14 +16,12 @@
 """
 
 from collections import defaultdict
-
 import requests
 
 from beets import plugins, ui
 from beets.dbcore import types
 from mediafile import MediaField, StorageStyle, ASFStorageStyle
 from mediafile import MP3DescStorageStyle, MP4StorageStyle
-
 
 ACOUSTIC_BASE = "https://acousticbrainz.org/"
 LEVELS = ["/low-level", "/high-level"]
@@ -362,7 +360,6 @@ class AcousticPlugin(plugins.BeetsPlugin):
             ),
             out_type=float
         ))
-
 
     def commands(self):
         cmd = ui.Subcommand('acousticbrainz',

--- a/beetsplug/acousticbrainz.py
+++ b/beetsplug/acousticbrainz.py
@@ -432,7 +432,6 @@ class AcousticPlugin(plugins.BeetsPlugin):
             self._log.info('getting data for: {}', item)
             data = self._get_data(item.mb_trackid)
             if data:
-                tags_to_write = {}
                 for attr, val in self._map_data_to_scheme(data, ABSCHEME):
                     if not tags or attr in tags:
                         self._log.debug('attribute {} of {} set to {}',
@@ -440,7 +439,6 @@ class AcousticPlugin(plugins.BeetsPlugin):
                                         item,
                                         val)
                         setattr(item, attr, val)
-                        tags_to_write[attr] = val
                     else:
                         self._log.debug('skipping attribute {} of {}'
                                         ' (value {}) due to config',
@@ -449,7 +447,7 @@ class AcousticPlugin(plugins.BeetsPlugin):
                                         val)
                 item.store()
                 if write:
-                    item.try_write(tags=tags_to_write)
+                    item.try_write()
 
     def _map_data_to_scheme(self, data, scheme):
         """Given `data` as a structure of nested dictionaries, and `scheme` as a

--- a/beetsplug/acousticbrainz.py
+++ b/beetsplug/acousticbrainz.py
@@ -21,6 +21,9 @@ import requests
 
 from beets import plugins, ui
 from beets.dbcore import types
+from mediafile import MediaField, StorageStyle, ASFStorageStyle
+from mediafile import MP3DescStorageStyle, MP4StorageStyle
+
 
 ACOUSTIC_BASE = "https://acousticbrainz.org/"
 LEVELS = ["/low-level", "/high-level"]
@@ -147,6 +150,219 @@ class AcousticPlugin(plugins.BeetsPlugin):
         if self.config['auto']:
             self.register_listener('import_task_files',
                                    self.import_task_files)
+
+        self.add_media_field('danceable', MediaField(
+            StorageStyle('ESSENTIA_AB_DANCEABLE', float_places=12),
+            MP3DescStorageStyle(u'Essentia_ab Danceable', float_places=12),
+            ASFStorageStyle('Essentia_ab/Danceable', float_places=12),
+            MP4StorageStyle(
+                '----:com.apple.iTunes:Essentia_ab Danceable',
+                float_places=12
+            ),
+            out_type=float
+        ))
+        self.add_media_field('gender', MediaField(
+            StorageStyle('ESSENTIA_AB_GENDER'),
+            MP3DescStorageStyle(u'Essentia_ab Gender'),
+            ASFStorageStyle('Essentia_ab/Gender'),
+            MP4StorageStyle('----:com.apple.iTunes:Essentia_ab Gender'),
+        ))
+        self.add_media_field('genre_rosamerica', MediaField(
+            StorageStyle('ESSENTIA_AB_GENRE_ROSAMERICA'),
+            MP3DescStorageStyle(u'Essentia_ab Genre Rosamerica'),
+            ASFStorageStyle(u'Essentia_ab/Genre Rosamerica'),
+            MP4StorageStyle(
+                '----:com.apple.iTunes:Essentia_ab Genre Rosamerica'
+            ),
+        ))
+        self.add_media_field('tonal', MediaField(
+            StorageStyle('ESSENTIA_AB_TONAL', float_places=12),
+            MP3DescStorageStyle(u'Essentia_ab Tonal', float_places=12),
+            ASFStorageStyle(u'Essentia_ab/Tonal', float_places=12),
+            MP4StorageStyle(
+                '----:com.apple.iTunes:Essentia_ab Tonal',
+                float_places=12
+            ),
+            out_type=float
+        ))
+        self.add_media_field('mood_acoustic', MediaField(
+            StorageStyle('ESSENTIA_AB_MOOD_ACOUSTIC', float_places=12),
+            MP3DescStorageStyle(u'Essentia_ab Mood Acoustic', float_places=12),
+            ASFStorageStyle(u'Essentia_ab/Mood Acoustic', float_places=12),
+            MP4StorageStyle(
+                '----:com.apple.iTunes:Essentia_ab Mood Acoustic',
+                float_places=12
+            ),
+            out_type=float
+        ))
+        self.add_media_field('mood_aggressive', MediaField(
+            StorageStyle('ESSENTIA_AB_MOOD_AGGRESSIVE', float_places=12),
+            MP3DescStorageStyle(
+                u'Essentia_ab Mood Aggressive', float_places=12
+            ),
+            ASFStorageStyle(
+                u'Essentia_ab/Mood Aggressive', float_places=12
+            ),
+            MP4StorageStyle(
+                '----:com.apple.iTunes:Essentia_ab Mood Aggressive',
+                float_places=12
+            ),
+            out_type=float
+        ))
+        self.add_media_field('mood_electronic', MediaField(
+            StorageStyle('ESSENTIA_AB_MOOD_ELECTRONIC', float_places=12),
+            MP3DescStorageStyle(
+                u'Essentia_ab Mood Electronic',
+                float_places=12
+            ),
+            ASFStorageStyle(
+                u'Essentia_ab/Mood Electronic',
+                float_places=12
+            ),
+            MP4StorageStyle(
+                '----:com.apple.iTunes:Essentia_ab Mood Electronic',
+                float_places=12
+            ),
+            out_type=float
+        ))
+        self.add_media_field('mood_happy', MediaField(
+            StorageStyle('ESSENTIA_AB_MOOD_HAPPY', float_places=12),
+            MP3DescStorageStyle(u'Essentia_ab Mood Happy', float_places=12),
+            ASFStorageStyle(u'Essentia_ab/Mood Happy', float_places=12),
+            MP4StorageStyle(
+                '----:com.apple.iTunes:Essentia_ab Mood Happy',
+                float_places=12
+            ),
+            out_type=float
+        ))
+        self.add_media_field('mood_party', MediaField(
+            StorageStyle('ESSENTIA_AB_MOOD_PARTY', float_places=12),
+            MP3DescStorageStyle(u'Essentia_ab Mood Party', float_places=12),
+            ASFStorageStyle(u'Essentia_ab/Mood Party', float_places=12),
+            MP4StorageStyle(
+                '----:com.apple.iTunes:Essentia_ab Mood Party',
+                float_places=12
+            ),
+            out_type=float
+        ))
+        self.add_media_field('mood_relaxed', MediaField(
+            StorageStyle('ESSENTIA_AB_MOOD_RELAXED', float_places=12),
+            MP3DescStorageStyle(u'Essentia_ab Mood Relaxed', float_places=12),
+            ASFStorageStyle(u'Essentia_ab/Mood Relaxed', float_places=12),
+            MP4StorageStyle(
+                '----:com.apple.iTunes:Essentia_ab Mood Relaxed',
+                float_places=12
+            ),
+            out_type=float
+        ))
+        self.add_media_field('mood_sad', MediaField(
+            StorageStyle('ESSENTIA_AB_MOOD_SAD', float_places=12),
+            MP3DescStorageStyle(u'Essentia_ab Mood Sad', float_places=12),
+            ASFStorageStyle(u'Essentia_ab/Mood Sad', float_places=12),
+            MP4StorageStyle(
+                '----:com.apple.iTunes:Essentia_ab Mood Sad',
+                float_places=12
+            ),
+            out_type=float
+        ))
+        self.add_media_field('moods_mirex', MediaField(
+            StorageStyle('ESSENTIA_AB_MOODS_MIREX'),
+            MP3DescStorageStyle(u'Essentia_ab Moods Mirex'),
+            ASFStorageStyle(u'Essentia_ab/Moods Mirex'),
+            MP4StorageStyle('----:com.apple.iTunes:Essentia_ab Moods Mirex'),
+        ))
+        self.add_media_field('rhythm', MediaField(
+            StorageStyle('ESSENTIA_AB_ISMIR04_RHYTHM'),
+            MP3DescStorageStyle(u'Essentia_ab Ismir04 Rhythm'),
+            ASFStorageStyle(u'Essentia_ab/Ismir04 Rhythm'),
+            MP4StorageStyle(
+                '----:com.apple.iTunes:Essentia_ab Ismir04 Rhythm'
+            ),
+        ))
+        self.add_media_field('timbre', MediaField(
+            StorageStyle('ESSENTIA_AB_TIMBRE'),
+            MP3DescStorageStyle(u'Essentia_ab Timbre'),
+            ASFStorageStyle(u'Essentia_ab/Timbre'),
+            MP4StorageStyle('----:com.apple.iTunes:Essentia_ab Timbre'),
+        ))
+        self.add_media_field('voice_instrumental', MediaField(
+            StorageStyle('ESSENTIA_AB_VOICE_INSTRUMENTAL'),
+            MP3DescStorageStyle(u'Essentia_ab Voice Instrumental'),
+            MP4StorageStyle(
+                '----:com.apple.iTunes:Essentia_ab Voice Instrumental'
+            ),
+        ))
+
+        # AcousticBrainz low-level fields.
+        self.add_media_field('average_loudness', MediaField(
+            StorageStyle('ESSENTIA_AB_AVERAGE_LOUDNESS', float_places=12),
+            MP3DescStorageStyle(
+                u'Essentia_ab Average Loudness', float_places=12
+            ),
+            ASFStorageStyle(
+                u'Essentia_ab/Average Loudness', float_places=12
+            ),
+            MP4StorageStyle(
+                '----:com.apple.iTunes:Essentia_ab Average Loudness',
+                float_places=12
+            ),
+            out_type=float
+        ))
+        self.add_media_field('chords_changes_rate', MediaField(
+            StorageStyle('ESSENTIA_AB_CHORDS_CHANGES_RATE', float_places=12),
+            MP3DescStorageStyle(
+                u'Essentia_ab Chords Changes Rate',
+                float_places=12
+            ),
+            ASFStorageStyle(
+                u'Essentia_ab/Chords Changes Rate',
+                float_places=12
+            ),
+            MP4StorageStyle(
+                '----:com.apple.iTunes:Essentia_ab Chords Changes Rate',
+                float_places=12
+            ),
+            out_type=float
+        ))
+        self.add_media_field('chords_key', MediaField(
+            StorageStyle('ESSENTIA_AB_CHORDS_KEY'),
+            MP3DescStorageStyle(u'Essentia_ab Chords Key'),
+            ASFStorageStyle(u'Essentia_ab/Chords Key'),
+            MP4StorageStyle('----:com.apple.iTunes:Essentia_ab Chords Key'),
+        ))
+        self.add_media_field('chords_number_rate', MediaField(
+            StorageStyle('ESSENTIA_AB_CHORDS_NUMBER_RATE', float_places=12),
+            MP3DescStorageStyle(
+                u'Essentia_ab Chords Number Rate',
+                float_places=12
+            ),
+            ASFStorageStyle(
+                u'Essentia_ab/Chords Number Rate',
+                float_places=12
+            ),
+            MP4StorageStyle(
+                '----:com.apple.iTunes:Essentia_ab Chords Number Rate',
+                float_places=12
+            ),
+            out_type=float
+        ))
+        self.add_media_field('chords_scale', MediaField(
+            StorageStyle('ESSENTIA_AB_CHORDS_SCALE'),
+            MP3DescStorageStyle(u'Essentia_ab Chords Scale'),
+            ASFStorageStyle(u'Essentia_ab/Chords Scale'),
+            MP4StorageStyle('----:com.apple.iTunes:Essentia_ab Chords Scale'),
+        ))
+        self.add_media_field('key_strength', MediaField(
+            StorageStyle('ESSENTIA_AB_KEY_STRENGTH', float_places=12),
+            MP3DescStorageStyle(u'Essentia_ab Key Strength', float_places=12),
+            ASFStorageStyle(u'Essentia_ab/Key Strength', float_places=12),
+            MP4StorageStyle(
+                '----:com.apple.iTunes:Essentia_ab Key Strength',
+                float_places=12,
+            ),
+            out_type=float
+        ))
+
 
     def commands(self):
         cmd = ui.Subcommand('acousticbrainz',

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,10 @@ New features:
 
 Bug fixes:
 
+* :doc:`/plugins/acousticbrainz`: Fix writing fetched data to media files.
+  Previously the docs stated that metadata is written to files but that was not
+  the case anymore.
+  :bug:`3928`
 * The Discogs release ID is now populated correctly to the discogs_albumid
   field again (it was no longer working after Discogs changed their release URL
   format).

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,7 +21,7 @@ Bug fixes:
 
 * :doc:`/plugins/acousticbrainz`: Fix writing fetched data to media files.
   Previously the docs stated that metadata is written to files but that was not
-  the case anymore.
+  the case anymore. All on-disk tags are named with a prefix of Essentia_ab.
   :bug:`3928`
 * The Discogs release ID is now populated correctly to the discogs_albumid
   field again (it was no longer working after Discogs changed their release URL

--- a/docs/plugins/acousticbrainz.rst
+++ b/docs/plugins/acousticbrainz.rst
@@ -11,7 +11,7 @@ Enable the ``acousticbrainz`` plugin in your configuration (see :ref:`using-plug
     $ beet acousticbrainz [-f] [QUERY]
 
 By default, the command will only look for AcousticBrainz data when the tracks
-doesn't already have it; the ``-f`` or ``--force`` switch makes it re-download
+don't already have it; the ``-f`` or ``--force`` switch makes it re-download
 data even when it already exists. If you specify a query, only matching tracks
 will be processed; otherwise, the command processes every track in your
 library.
@@ -43,6 +43,34 @@ these fields:
 * ``timbre``
 * ``tonal``
 * ``voice_instrumental``
+
+The metadata written to files follows the tag naming scheme of MusicBrainz
+Picard's AcousticBrainz plugin. Here's an example:
+
+    ab:lo:average_loudness=0.887623310089
+    ab:lo:tonal:chords_changes_rate=0.082755811512
+    ab:lo:tonal:chords_key=A#
+    ab:lo:tonal:chords_number_rate=0.002038320526
+    ab:lo:tonal:chords_scale=minor
+    ab:hi:danceability:danceable=0.000000000000
+    ab:hi:gender=female
+    ab:hi:genre_rosamerica=rhy
+    ab:lo:tonal:key_strength=0.654201686382
+    ab:hi:mood_acoustic:acoustic=0.081802986562
+    ab:hi:mood_aggressive:aggressive=0.000000000000
+    ab:hi:mood_electronic:electronic=0.979390621185
+    ab:hi:mood_happy:happy=0.085078120232
+    ab:hi:mood_party:party=0.000015778420
+    ab:hi:mood_relaxed:relaxed=0.808817088604
+    ab:hi:mood_sad:sad=0.109234951437
+    ab:hi:moods_mirex=Cluster5
+    ab:hi:ismir04_rhythm=ChaChaCha
+    ab:hi:timbre=dark
+    ab:hi:tonal_atonal:tonal=0.002889123978
+    ab:hi:voice_instrumental=instrumental
+
+For musical key and BPM information the default metadata fields ``initial_key``
+and ``bpm`` are used.
 
 Automatic Tagging
 -----------------

--- a/docs/plugins/acousticbrainz.rst
+++ b/docs/plugins/acousticbrainz.rst
@@ -44,30 +44,29 @@ these fields:
 * ``tonal``
 * ``voice_instrumental``
 
-The metadata written to files follows the tag naming scheme of MusicBrainz
-Picard's AcousticBrainz plugin. Here's an example:
+Here's an example of how the metadata will look like when written to mp3 files:
 
-    ab:lo:average_loudness=0.887623310089
-    ab:lo:tonal:chords_changes_rate=0.082755811512
-    ab:lo:tonal:chords_key=A#
-    ab:lo:tonal:chords_number_rate=0.002038320526
-    ab:lo:tonal:chords_scale=minor
-    ab:hi:danceability:danceable=0.000000000000
-    ab:hi:gender=female
-    ab:hi:genre_rosamerica=rhy
-    ab:lo:tonal:key_strength=0.654201686382
-    ab:hi:mood_acoustic:acoustic=0.081802986562
-    ab:hi:mood_aggressive:aggressive=0.000000000000
-    ab:hi:mood_electronic:electronic=0.979390621185
-    ab:hi:mood_happy:happy=0.085078120232
-    ab:hi:mood_party:party=0.000015778420
-    ab:hi:mood_relaxed:relaxed=0.808817088604
-    ab:hi:mood_sad:sad=0.109234951437
-    ab:hi:moods_mirex=Cluster5
-    ab:hi:ismir04_rhythm=ChaChaCha
-    ab:hi:timbre=dark
-    ab:hi:tonal_atonal:tonal=0.002889123978
-    ab:hi:voice_instrumental=instrumental
+   Essentia_ab Average Loudness=0.523903489113
+   Essentia_ab Chords Changes Rate=0.040707375854
+   Essentia_ab Chords Key=C
+   Essentia_ab Chords Number Rate=0.001668335055
+   Essentia_ab Chords Scale=minor
+   Essentia_ab Danceable=0.500000000000
+   Essentia_ab Gender=male
+   Essentia_ab Genre Rosamerica=rhy
+   Essentia_ab Ismir04 Rhythm=0.00
+   Essentia_ab Key Strength=0.677906572819
+   Essentia_ab Mood Acoustic=0.227068513632
+   Essentia_ab Mood Aggressive=0.074388481677
+   Essentia_ab Mood Electronic=0.938988804817
+   Essentia_ab Mood Happy=0.070650450885
+   Essentia_ab Mood Party=0.265368700027
+   Essentia_ab Mood Relaxed=0.943796038628
+   Essentia_ab Mood Sad=0.398043692112
+   Essentia_ab Moods Mirex=Cluster5
+   Essentia_ab Timbre=dark
+   Essentia_ab Tonal=0.506820321083
+   Essentia_ab Voice Instrumental=instrumental
 
 For musical key and BPM information the default metadata fields ``initial_key``
 and ``bpm`` are used.


### PR DESCRIPTION
## Description

- Fixes #3928
- Adds the ability to write to actual file tags using the acousticbrainz plugin.
- ~Requires https://github.com/beetbox/mediafile/pull/59~
- Adds an info log statement when AcousticBrainz data could not be fetched due to simply not having an MBID.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- ~[ ] Tests. (Encouraged but not strictly required.)~
