### PR TITLE
fix: dont deduplicate matches if musicbrainz ID is not set for album matches

### DIFF
--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -357,8 +357,8 @@ def _add_candidate(items, results, info):
         log.debug('No tracks.')
         return
 
-    # Don't duplicate.
-    if info.album_id in results:
+    # Prevent duplicates
+    if info.album_id and info.album_id in results:
         log.debug('Duplicate.')
         return
 

--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -357,7 +357,7 @@ def _add_candidate(items, results, info):
         log.debug('No tracks.')
         return
 
-    # Prevent duplicates
+    # Prevent duplicates.
     if info.album_id and info.album_id in results:
         log.debug('Duplicate.')
         return

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ New features:
 
 Bug fixes:
 
+* Fix autotagger marking all albums without a musicbrainz id as a duplicate
 * :doc:`/plugins/convert`: Resize album art when embedding
   :bug:`2116`
 * :doc:`/plugins/deezer`: Fix auto tagger pagination issues (fetch beyond the

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,9 @@ New features:
 
 Bug fixes:
 
-* Fix autotagger marking all albums without a musicbrainz id as a duplicate
+* The autotagger no longer considers all matches without a MusicBrainz ID as
+  duplicates of each other.
+  :bug:`4299`
 * :doc:`/plugins/convert`: Resize album art when embedding
   :bug:`2116`
 * :doc:`/plugins/deezer`: Fix auto tagger pagination issues (fetch beyond the


### PR DESCRIPTION
First discussed in https://github.com/beetbox/beets/discussions/4269#discussioncomment-2251701

## Description

Fixes album candidates being treated as duplicates when the album id (assumed to be musicbrainz id) is not set.

(...)

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
