### PR TITLE
Avoid writing a user-configurable set of file tags

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -30,6 +30,7 @@ import:
     duplicate_action: ask
     bell: no
     set_fields: {}
+    autotag_exclude_fields: []
 
 clutter: ["Thumbs.DB", ".DS_Store"]
 ignore: [".*", "*~", "System Volume Information", "lost+found"]

--- a/beets/library.py
+++ b/beets/library.py
@@ -753,9 +753,13 @@ class Item(LibModel):
             id3v23 = beets.config['id3v23'].get(bool)
 
         # Get the data to write to the file.
+        exclude = beets.config['import']['autotag_exclude_fields'].as_str_seq()
         item_tags = dict(self)
         item_tags = {k: v for k, v in item_tags.items()
-                     if k in self._media_fields}  # Only write media fields.
+                     if k in self._media_fields  # Only write media fields
+                     and not k in exclude}  # and respect excluded fields.
+
+        log.debug('Excluding tags from write: {0}', ' '.join(exclude))
         if tags is not None:
             item_tags.update(tags)
         plugins.send('write', item=self, path=path, tags=item_tags)


### PR DESCRIPTION
## Description

- Adds a configuration option(import.autotag_exclude_fields) that let's a user decide which file tags should never be written by beets.
- Fixes parts of #4087

## To Do

- [ ] Documentation
- [ ] Changelog
- [ ] Tests
