### PR TITLE
discogs: Fix discogs_albumid extraction

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -194,16 +194,17 @@ class DiscogsPlugin(BeetsPlugin):
         # patterns.
         # Regex has been tested here https://regex101.com/r/wyLdB4/2
 
-        for pattern in [
-                r'^\[?r?(?P<id>\d+)\]?$',
-                r'discogs\.com/release/(?P<id>\d+)-',
-                r'discogs\.com/[^/]+/release/(?P<id>\d+)',
-        ]:
-            match = re.search(pattern, album_id)
-            if match:
-                return int(match.group('id'))
-
-        return None
+        if album_id:
+            for pattern in [
+                    r'^\[?r?(?P<id>\d+)\]?$',
+                    r'discogs\.com/release/(?P<id>\d+)-',
+                    r'discogs\.com/[^/]+/release/(?P<id>\d+)',
+            ]:
+                match = re.search(pattern, album_id)
+                if match:
+                    return int(match.group('id'))
+        else:
+            return None
 
     def album_for_id(self, album_id):
         """Fetches an album by its Discogs ID and returns an AlbumInfo object

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -326,7 +326,7 @@ class DiscogsPlugin(BeetsPlugin):
         else:
             genre = base_genre
 
-        discogs_albumid = self.extract_release_id(result.data.get('uri'))
+        discogs_albumid = self.extract_release_id_regex(result.data.get('uri'))
 
         # Extract information for the optional AlbumInfo fields that are
         # contained on nested discogs fields.
@@ -375,12 +375,6 @@ class DiscogsPlugin(BeetsPlugin):
         if classification:
             return self.config['separator'].as_str() \
                 .join(sorted(classification))
-        else:
-            return None
-
-    def extract_release_id(self, uri):
-        if uri:
-            return uri.split("/")[-1]
         else:
             return None
 

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -194,17 +194,16 @@ class DiscogsPlugin(BeetsPlugin):
         # patterns.
         # Regex has been tested here https://regex101.com/r/wyLdB4/2
 
-        if album_id:
-            for pattern in [
-                    r'^\[?r?(?P<id>\d+)\]?$',
-                    r'discogs\.com/release/(?P<id>\d+)-',
-                    r'discogs\.com/[^/]+/release/(?P<id>\d+)',
-            ]:
-                match = re.search(pattern, album_id)
-                if match:
-                    return int(match.group('id'))
-        else:
-            return None
+        for pattern in [
+                r'^\[?r?(?P<id>\d+)\]?$',
+                r'discogs\.com/release/(?P<id>\d+)-',
+                r'discogs\.com/[^/]+/release/(?P<id>\d+)',
+        ]:
+            match = re.search(pattern, album_id)
+            if match:
+                return int(match.group('id'))
+
+        return None
 
     def album_for_id(self, album_id):
         """Fetches an album by its Discogs ID and returns an AlbumInfo object

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,10 @@ New features:
 
 Bug fixes:
 
+* The Discogs release ID is now populated correctly to the discogs_albumid
+  field again (it was no longer working after Discogs changed their release URL
+  format).
+  :bug:`4225`
 * The autotagger no longer considers all matches without a MusicBrainz ID as
   duplicates of each other.
   :bug:`4299`

--- a/test/test_discogs.py
+++ b/test/test_discogs.py
@@ -337,6 +337,7 @@ class DGAlbumInfoTest(_common.TestCase):
     def test_parse_minimal_release(self):
         """Test parsing of a release with the minimal amount of information."""
         data = {'id': 123,
+                'uri': 'https://www.discogs.com/release/123456-something',
                 'tracklist': [self._make_track('A', '1', '01:01')],
                 'artists': [{'name': 'ARTIST NAME', 'id': 321, 'join': ''}],
                 'title': 'TITLE'}


### PR DESCRIPTION
## Description

- Fixes #4225
- Discogs changed their release URL format. This fixes the albumid extraction by using an improved extraction method.

## To Do

- [x] ~Documentation.~ 
- [x] Changelog.
- [x] Tests.