### PR TITLE
feat: discogs: allow style to be appended to genre

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -57,6 +57,7 @@ class DiscogsPlugin(BeetsPlugin):
             'user_token': '',
             'separator': ', ',
             'index_tracks': False,
+            'append_style_genre': False,
         })
         self.config['apikey'].redact = True
         self.config['apisecret'].redact = True
@@ -318,7 +319,13 @@ class DiscogsPlugin(BeetsPlugin):
         country = result.data.get('country')
         data_url = result.data.get('uri')
         style = self.format(result.data.get('styles'))
-        genre = self.format(result.data.get('genres'))
+
+        if self.config['append_style_genre'] and style:
+            genre = self.config['separator'].as_str() \
+                .join([self.format(result.data.get('genres')), style])
+        else:
+            genre = self.format(result.data.get('genres'))
+
         discogs_albumid = self.extract_release_id(result.data.get('uri'))
 
         # Extract information for the optional AlbumInfo fields that are

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ New features:
   :bug:`4101`
 * Add the item fields ``bitrate_mode``, ``encoder_info`` and ``encoder_settings``.
 * Add query prefixes ``=`` and ``~``.
+* :doc:`/plugins/discogs`: Permit appending style to genre
 
 Bug fixes:
 

--- a/docs/plugins/discogs.rst
+++ b/docs/plugins/discogs.rst
@@ -76,6 +76,12 @@ whereas with ``index_tracks`` disabled you'd get::
 
 This option is useful when importing classical music.
 
+Other configurations available under ``discogs:`` are:
+
+- **append_style_genre**: Appends the style (if found) to the genre tag, useful if you would like more granular genre styles added to music file tags
+  Default: ``false``
+
+
 Troubleshooting
 ---------------
 

--- a/test/test_discogs.py
+++ b/test/test_discogs.py
@@ -20,6 +20,8 @@ from test import _common
 from test._common import Bag
 from test.helper import capture_log
 
+from beets import config
+
 from beetsplug.discogs import DiscogsPlugin
 
 
@@ -372,6 +374,33 @@ class DGAlbumInfoTest(_common.TestCase):
             if not match:
                 match = ''
             self.assertEqual(match, expected)
+
+    def test_default_genre_style_settings(self):
+        """Test genre default settings, genres to genre, styles to style"""
+        release = self._make_release_from_positions(['1', '2'])
+
+        d = DiscogsPlugin().get_album_info(release)
+        self.assertEqual(d.genre, 'GENRE1, GENRE2')
+        self.assertEqual(d.style, 'STYLE1, STYLE2')
+
+    def test_append_style_to_genre(self):
+        """Test appending style to genre if config enabled"""
+        config['discogs']['append_style_genre'] = True
+        release = self._make_release_from_positions(['1', '2'])
+
+        d = DiscogsPlugin().get_album_info(release)
+        self.assertEqual(d.genre, 'GENRE1, GENRE2, STYLE1, STYLE2')
+        self.assertEqual(d.style, 'STYLE1, STYLE2')
+
+    def test_append_style_to_genre_no_style(self):
+        """Test nothing appended to genre if style is empty"""
+        config['discogs']['append_style_genre'] = True
+        release = self._make_release_from_positions(['1', '2'])
+        release.data['styles'] = []
+
+        d = DiscogsPlugin().get_album_info(release)
+        self.assertEqual(d.genre, 'GENRE1, GENRE2')
+        self.assertEqual(d.style, None)
 
 
 def suite():


### PR DESCRIPTION

## Description

- Adds a configuration that, when enabled, will append the style to genre
- Rationale is to have more verbose genres in genre tag of players that only support genre
- [Discussed here](https://github.com/beetbox/beets/discussions/4301)

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
