### PR TITLE
Refactor: ArtResizer backends are classes

### DIFF
--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -612,9 +612,6 @@ class ArtResizer(metaclass=Shareable):
             result_path = self.local_method.convert_format(
                 path_in, path_new, deinterlaced
             )
-        except Exception:
-            # FIXME: Should probably issue a warning?
-            pass
         finally:
             if result_path != path_in:
                 os.unlink(path_in)

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -207,7 +207,7 @@ class IMBackend(LocalBackend):
             util.command_output(cmd)
             return path_out
         except subprocess.CalledProcessError:
-            # FIXME: add a warning
+            # FIXME: Should probably issue a warning?
             return path_in
 
     def get_format(self, filepath):
@@ -219,6 +219,7 @@ class IMBackend(LocalBackend):
         try:
             return util.command_output(cmd).stdout
         except subprocess.CalledProcessError:
+            # FIXME: Should probably issue a warning?
             return None
 
     def convert_format(self, source, target, deinterlaced):
@@ -236,6 +237,7 @@ class IMBackend(LocalBackend):
             )
             return target
         except subprocess.CalledProcessError:
+            # FIXME: Should probably issue a warning?
             return source
 
     @property
@@ -404,6 +406,7 @@ class PILBackend(LocalBackend):
             im.save(py3_path(path_out), progressive=False)
             return path_out
         except IOError:
+            # FIXME: Should probably issue a warning?
             return path_in
 
     def get_format(self, filepath):
@@ -574,6 +577,9 @@ class ArtResizer(metaclass=Shareable):
             result_path = self.local_method.convert_format(
                 path_in, path_new, deinterlaced
             )
+        except Exception:
+            # FIXME: Should probably issue a warning?
+            pass
         finally:
             if result_path != path_in:
                 os.unlink(path_in)

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -238,6 +238,10 @@ class IMBackend(LocalBackend):
         except subprocess.CalledProcessError:
             return source
 
+    @property
+    def can_compare(self):
+        return self.version() > (6, 8, 7)
+
     def compare(self, im1, im2, compare_threshold):
         is_windows = platform.system() == "Windows"
 
@@ -425,6 +429,10 @@ class PILBackend(LocalBackend):
             log.exception("failed to convert image {} -> {}", source, target)
             return source
 
+    @property
+    def can_compare(self):
+        return False
+
     def compare(self, im1, im2, compare_threshold):
         # It is an error to call this when ArtResizer.can_compare is not True.
         raise NotImplementedError()
@@ -563,11 +571,10 @@ class ArtResizer(metaclass=Shareable):
     def can_compare(self):
         """A boolean indicating whether image comparison is available"""
 
-        return (
-            self.local
-            and self.local_method.ID == IMAGEMAGICK
-            and self.local_method.version() > (6, 8, 7)
-        )
+        if self.local:
+            return self.local_method.can_compare
+        else:
+            return False
 
     def compare(self, im1, im2, compare_threshold):
         """Return a boolean indicating whether two images are similar.

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -592,7 +592,7 @@ class ArtResizer(metaclass=Shareable):
 
         Only available locally.
         """
-        if self.local:
+        if not self.local:
             # FIXME: Should probably issue a warning?
             return path_in
 

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -439,13 +439,19 @@ class ArtResizer(metaclass=Shareable):
             return func(self, maxwidth, path_in, path_out,
                         quality=quality, max_filesize=max_filesize)
         else:
+            # Handled by `proxy_url` already.
             return path_in
 
     def deinterlace(self, path_in, path_out=None):
+        """Deinterlace an image.
+
+        Only available locally.
+        """
         if self.local:
             func = DEINTERLACE_FUNCS[self.method[0]]
             return func(self, path_in, path_out)
         else:
+            # FIXME: Should probably issue a warning?
             return path_in
 
     def proxy_url(self, maxwidth, url, quality=0):
@@ -454,6 +460,7 @@ class ArtResizer(metaclass=Shareable):
         Otherwise, the URL is returned unmodified.
         """
         if self.local:
+            # Going to be handled by `resize()`.
             return url
         else:
             return resize_url(url, maxwidth, quality)
@@ -474,7 +481,9 @@ class ArtResizer(metaclass=Shareable):
         if self.local:
             func = BACKEND_GET_SIZE[self.method[0]]
             return func(self, path_in)
-        return None
+        else:
+            # FIXME: Should probably issue a warning?
+            return None
 
     def get_format(self, path_in):
         """Returns the format of the image as a string.
@@ -484,7 +493,9 @@ class ArtResizer(metaclass=Shareable):
         if self.local:
             func = BACKEND_GET_FORMAT[self.method[0]]
             return func(self, path_in)
-        return None
+        else:
+            # FIXME: Should probably issue a warning?
+            return None
 
     def reformat(self, path_in, new_format, deinterlaced=True):
         """Converts image to desired format, updating its extension, but
@@ -493,6 +504,7 @@ class ArtResizer(metaclass=Shareable):
         Only available locally.
         """
         if not self.local:
+            # FIXME: Should probably issue a warning?
             return path_in
 
         new_format = new_format.lower()
@@ -529,7 +541,9 @@ class ArtResizer(metaclass=Shareable):
         if self.local:
             func = BACKEND_COMPARE[self.method[0]]
             return func(self, im1, im2, compare_threshold)
-        return None
+        else:
+            # FIXME: Should probably issue a warning?
+            return None
 
     @staticmethod
     def _check_method():

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -76,6 +76,10 @@ class LocalBackend:
 
 class IMBackend(LocalBackend):
     NAME = "ImageMagick"
+
+    # These fields are used as a cache for `version()`. `_legacy` indicates
+    # whether the modern `magick` binary is available or whether to fall back
+    # to the old-style `convert`, `identify`, etc. commands.
     _version = None
     _legacy = None
 

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -27,11 +27,6 @@ from beets import logging
 from beets import util
 from beets.util import bytestring_path, displayable_path, py3_path, syspath
 
-# Resizing methods
-PIL = 1
-IMAGEMAGICK = 2
-WEBPROXY = 3
-
 PROXY_URL = 'https://images.weserv.nl/'
 
 log = logging.getLogger('beets')
@@ -80,7 +75,6 @@ class LocalBackend:
 
 class IMBackend(LocalBackend):
     NAME="ImageMagick"
-    ID=IMAGEMAGICK
     _version = None
     _legacy = None
 
@@ -312,7 +306,6 @@ class IMBackend(LocalBackend):
 
 class PILBackend(LocalBackend):
     NAME="PIL"
-    ID=PIL
 
     @classmethod
     def version(cls):

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -74,7 +74,7 @@ class LocalBackend:
 
 
 class IMBackend(LocalBackend):
-    NAME="ImageMagick"
+    NAME = "ImageMagick"
     _version = None
     _legacy = None
 
@@ -97,8 +97,8 @@ class IMBackend(LocalBackend):
                         match = re.search(pattern, out)
                         if match:
                             cls._version = (int(match.group(1)),
-                                       int(match.group(2)),
-                                       int(match.group(3)))
+                                            int(match.group(2)),
+                                            int(match.group(3)))
                             cls._legacy = legacy
 
         if cls._version is _NOT_AVAILABLE:
@@ -127,7 +127,7 @@ class IMBackend(LocalBackend):
             self.compare_cmd = ['magick', 'compare']
 
     def resize(self, maxwidth, path_in, path_out=None, quality=0,
-                  max_filesize=0):
+               max_filesize=0):
         """Resize using ImageMagick.
 
         Use the ``magick`` program or ``convert`` on older versions. Return
@@ -140,8 +140,8 @@ class IMBackend(LocalBackend):
         # "-resize WIDTHx>" shrinks images with the width larger
         # than the given width while maintaining the aspect ratio
         # with regards to the height.
-        # ImageMagick already seems to default to no interlace, but we include it
-        # here for the sake of explicitness.
+        # ImageMagick already seems to default to no interlace, but we include
+        # it here for the sake of explicitness.
         cmd = self.convert_cmd + [
             syspath(path_in, prefix=False),
             '-resize', f'{maxwidth}x>',
@@ -151,8 +151,8 @@ class IMBackend(LocalBackend):
         if quality > 0:
             cmd += ['-quality', f'{quality}']
 
-        # "-define jpeg:extent=SIZEb" sets the target filesize for imagemagick to
-        # SIZE in bytes.
+        # "-define jpeg:extent=SIZEb" sets the target filesize for imagemagick
+        # to SIZE in bytes.
         if max_filesize > 0:
             cmd += ['-define', f'jpeg:extent={max_filesize}b']
 
@@ -305,7 +305,7 @@ class IMBackend(LocalBackend):
 
 
 class PILBackend(LocalBackend):
-    NAME="PIL"
+    NAME = "PIL"
 
     @classmethod
     def version(cls):
@@ -322,7 +322,7 @@ class PILBackend(LocalBackend):
         self.version()
 
     def resize(self, maxwidth, path_in, path_out=None, quality=0,
-                   max_filesize=0):
+               max_filesize=0):
         """Resize using Python Imaging Library (PIL).  Return the output path
         of resized image.
         """
@@ -346,8 +346,8 @@ class PILBackend(LocalBackend):
             im.save(py3_path(path_out), quality=quality, progressive=False)
 
             if max_filesize > 0:
-                # If maximum filesize is set, we attempt to lower the quality of
-                # jpeg conversion by a proportional amount, up to 3 attempts
+                # If maximum filesize is set, we attempt to lower the quality
+                # of jpeg conversion by a proportional amount, up to 3 attempts
                 # First, set the maximum quality to either provided, or 95
                 if quality > 0:
                     lower_qual = quality
@@ -408,10 +408,10 @@ class PILBackend(LocalBackend):
         try:
             with Image.open(syspath(filepath)) as im:
                 return im.format
-        except (ValueError, TypeError, UnidentifiedImageError, FileNotFoundError):
+        except (ValueError, TypeError, UnidentifiedImageError,
+                FileNotFoundError):
             log.exception("failed to detect image format for {}", filepath)
             return None
-
 
     def convert_format(self, source, target, deinterlaced):
         from PIL import Image, UnidentifiedImageError
@@ -420,8 +420,8 @@ class PILBackend(LocalBackend):
             with Image.open(syspath(source)) as im:
                 im.save(py3_path(target), progressive=not deinterlaced)
                 return target
-        except (ValueError, TypeError, UnidentifiedImageError, FileNotFoundError,
-                OSError):
+        except (ValueError, TypeError, UnidentifiedImageError,
+                FileNotFoundError, OSError):
             log.exception("failed to convert image {} -> {}", source, target)
             return source
 
@@ -457,6 +457,7 @@ BACKEND_CLASSES = [
     PILBackend,
 ]
 
+
 class ArtResizer(metaclass=Shareable):
     """A singleton class that performs image resizes.
     """
@@ -486,8 +487,10 @@ class ArtResizer(metaclass=Shareable):
         For WEBPROXY, returns `path_in` unmodified.
         """
         if self.local:
-            return self.local_method.resize(maxwidth, path_in, path_out,
-                        quality=quality, max_filesize=max_filesize)
+            return self.local_method.resize(
+                maxwidth, path_in, path_out,
+                quality=quality, max_filesize=max_filesize
+            )
         else:
             # Handled by `proxy_url` already.
             return path_in
@@ -597,4 +600,3 @@ class ArtResizer(metaclass=Shareable):
         else:
             # FIXME: Should probably issue a warning?
             return None
-

--- a/beetsplug/thumbnails.py
+++ b/beetsplug/thumbnails.py
@@ -22,7 +22,6 @@ Spec: standards.freedesktop.org/thumbnail-spec/latest/index.html
 from hashlib import md5
 import os
 import shutil
-from itertools import chain
 from pathlib import PurePosixPath
 import ctypes
 import ctypes.util
@@ -32,7 +31,7 @@ from xdg import BaseDirectory
 from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand, decargs
 from beets import util
-from beets.util.artresizer import ArtResizer, IMBackend, PILBackend
+from beets.util.artresizer import ArtResizer
 
 
 BASE_DIR = os.path.join(BaseDirectory.xdg_cache_home, "thumbnails")
@@ -49,7 +48,6 @@ class ThumbnailsPlugin(BeetsPlugin):
             'dolphin': False,
         })
 
-        self.write_metadata = None
         if self.config['auto'] and self._check_local_ok():
             self.register_listener('art_set', self.process_album)
 
@@ -90,18 +88,12 @@ class ThumbnailsPlugin(BeetsPlugin):
             if not os.path.exists(dir):
                 os.makedirs(dir)
 
-        # FIXME: Should we have our own backend instance?
-        self.backend = ArtResizer.shared.local_method
-        if isinstance(self.backend, IMBackend):
-            self.write_metadata = write_metadata_im
-        elif isinstance(self.backend, PILBackend):
-            self.write_metadata = write_metadata_pil
-        else:
-            # since we're local
+        if not ArtResizer.shared.can_write_metadata:
             raise RuntimeError(
-                f"Thumbnails: Unexpected ArtResizer backend {self.backend!r}."
+                f"Thumbnails: ArtResizer backend {ArtResizer.shared.method}"
+                f" unexpectedly cannot write image metadata."
             )
-        self._log.debug(f"using {self.backend.NAME} to write metadata")
+        self._log.debug(f"using {ArtResizer.shared.method} to write metadata")
 
         uri_getter = GioURI()
         if not uri_getter.available:
@@ -175,7 +167,7 @@ class ThumbnailsPlugin(BeetsPlugin):
         metadata = {"Thumb::URI": self.get_uri(album.artpath),
                     "Thumb::MTime": str(mtime)}
         try:
-            self.write_metadata(self.backend, image_path, metadata)
+            ArtResizer.shared.write_metadata(image_path, metadata)
         except Exception:
             self._log.exception("could not write metadata to {0}",
                                 util.displayable_path(image_path))
@@ -190,26 +182,6 @@ class ThumbnailsPlugin(BeetsPlugin):
             f.write('Icon=./{}'.format(artfile.decode('utf-8')))
             f.close()
         self._log.debug("Wrote file {0}", util.displayable_path(outfilename))
-
-
-def write_metadata_im(im_backend, file, metadata):
-    """Enrich the file metadata with `metadata` dict thanks to IM."""
-    command = im_backend.convert_cmd + [file] + \
-        list(chain.from_iterable(('-set', k, v)
-                                 for k, v in metadata.items())) + [file]
-    util.command_output(command)
-    return True
-
-
-def write_metadata_pil(pil_backend, file, metadata):
-    """Enrich the file metadata with `metadata` dict thanks to PIL."""
-    from PIL import Image, PngImagePlugin
-    im = Image.open(file)
-    meta = PngImagePlugin.PngInfo()
-    for k, v in metadata.items():
-        meta.add_text(k, v, 0)
-    im.save(file, "PNG", pnginfo=meta)
-    return True
 
 
 class URIGetter:

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -31,7 +31,7 @@ from beets import library
 from beets import importer
 from beets import logging
 from beets import util
-from beets.util.artresizer import ArtResizer, WEBPROXY
+from beets.util.artresizer import ArtResizer
 import confuse
 
 
@@ -787,7 +787,7 @@ class ArtForAlbumTest(UseThePlugin):
         """Skip the test if the art resizer doesn't have ImageMagick or
         PIL (so comparisons and measurements are unavailable).
         """
-        if ArtResizer.shared.method[0] == WEBPROXY:
+        if not ArtResizer.shared.local:
             self.skipTest("ArtResizer has no local imaging backend available")
 
     def test_respect_minwidth(self):

--- a/test/test_art_resize.py
+++ b/test/test_art_resize.py
@@ -24,8 +24,6 @@ from beets.util import command_output, syspath
 from beets.util.artresizer import (
     IMBackend,
     PILBackend,
-    pil_resize,
-    im_resize,
     pil_deinterlace,
     im_deinterlace,
 )
@@ -64,11 +62,10 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
         """Called after each test, unloading all plugins."""
         self.teardown_beets()
 
-    def _test_img_resize(self, backend, resize_func):
+    def _test_img_resize(self, backend):
         """Test resizing based on file size, given a resize_func."""
         # Check quality setting unaffected by new parameter
-        im_95_qual = resize_func(
-            backend,
+        im_95_qual = backend.resize(
             225,
             self.IMG_225x225,
             quality=95,
@@ -78,8 +75,7 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
         self.assertExists(im_95_qual)
 
         # Attempt a lower filesize with same quality
-        im_a = resize_func(
-            backend,
+        im_a = backend.resize(
             225,
             self.IMG_225x225,
             quality=95,
@@ -91,8 +87,7 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
                         os.stat(syspath(im_95_qual)).st_size)
 
         # Attempt with lower initial quality
-        im_75_qual = resize_func(
-            backend,
+        im_75_qual = backend.resize(
             225,
             self.IMG_225x225,
             quality=75,
@@ -100,8 +95,7 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
         )
         self.assertExists(im_75_qual)
 
-        im_b = resize_func(
-            backend,
+        im_b = backend.resize(
             225,
             self.IMG_225x225,
             quality=95,
@@ -115,12 +109,12 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
     @unittest.skipUnless(PILBackend.available(), "PIL not available")
     def test_pil_file_resize(self):
         """Test PIL resize function is lowering file size."""
-        self._test_img_resize(PILBackend(), pil_resize)
+        self._test_img_resize(PILBackend())
 
     @unittest.skipUnless(IMBackend.available(), "ImageMagick not available")
     def test_im_file_resize(self):
         """Test IM resize function is lowering file size."""
-        self._test_img_resize(IMBackend(), im_resize)
+        self._test_img_resize(IMBackend())
 
     @unittest.skipUnless(PILBackend.available(), "PIL not available")
     def test_pil_file_deinterlace(self):

--- a/test/test_art_resize.py
+++ b/test/test_art_resize.py
@@ -22,14 +22,32 @@ from test import _common
 from test.helper import TestHelper
 from beets.util import command_output, syspath
 from beets.util.artresizer import (
+    IMBackend,
+    PILBackend,
     pil_resize,
     im_resize,
-    get_im_version,
-    get_pil_version,
     pil_deinterlace,
     im_deinterlace,
-    ArtResizer,
 )
+
+
+class DummyIMBackend(IMBackend):
+    """An `IMBackend` which pretends that ImageMagick is available, and has
+    a sufficiently recent version to support image comparison.
+    """
+    def __init__(self):
+        self.version = (7, 0, 0)
+        self.legacy = False
+        self.convert_cmd = ['magick']
+        self.identify_cmd = ['magick', 'identify']
+        self.compare_cmd = ['magick', 'compare']
+
+
+class DummyPILBackend(PILBackend):
+    """An `PILBackend` which pretends that PIL is available.
+    """
+    def __init__(self):
+        pass
 
 
 class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
@@ -46,11 +64,11 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
         """Called after each test, unloading all plugins."""
         self.teardown_beets()
 
-    def _test_img_resize(self, resize_func):
+    def _test_img_resize(self, backend, resize_func):
         """Test resizing based on file size, given a resize_func."""
         # Check quality setting unaffected by new parameter
         im_95_qual = resize_func(
-            ArtResizer.shared,
+            backend,
             225,
             self.IMG_225x225,
             quality=95,
@@ -61,7 +79,7 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
 
         # Attempt a lower filesize with same quality
         im_a = resize_func(
-            ArtResizer.shared,
+            backend,
             225,
             self.IMG_225x225,
             quality=95,
@@ -74,7 +92,7 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
 
         # Attempt with lower initial quality
         im_75_qual = resize_func(
-            ArtResizer.shared,
+            backend,
             225,
             self.IMG_225x225,
             quality=75,
@@ -83,7 +101,7 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
         self.assertExists(im_75_qual)
 
         im_b = resize_func(
-            ArtResizer.shared,
+            backend,
             225,
             self.IMG_225x225,
             quality=95,
@@ -94,37 +112,38 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
         self.assertLess(os.stat(syspath(im_b)).st_size,
                         os.stat(syspath(im_75_qual)).st_size)
 
-    @unittest.skipUnless(get_pil_version(), "PIL not available")
+    @unittest.skipUnless(PILBackend.available(), "PIL not available")
     def test_pil_file_resize(self):
         """Test PIL resize function is lowering file size."""
-        self._test_img_resize(pil_resize)
+        self._test_img_resize(PILBackend(), pil_resize)
 
-    @unittest.skipUnless(get_im_version(), "ImageMagick not available")
+    @unittest.skipUnless(IMBackend.available(), "ImageMagick not available")
     def test_im_file_resize(self):
         """Test IM resize function is lowering file size."""
-        self._test_img_resize(im_resize)
+        self._test_img_resize(IMBackend(), im_resize)
 
-    @unittest.skipUnless(get_pil_version(), "PIL not available")
+    @unittest.skipUnless(PILBackend.available(), "PIL not available")
     def test_pil_file_deinterlace(self):
         """Test PIL deinterlace function.
 
         Check if pil_deinterlace function returns images
         that are non-progressive
         """
-        path = pil_deinterlace(ArtResizer.shared, self.IMG_225x225)
+        path = pil_deinterlace(PILBackend(), self.IMG_225x225)
         from PIL import Image
         with Image.open(path) as img:
             self.assertFalse('progression' in img.info)
 
-    @unittest.skipUnless(get_im_version(), "ImageMagick not available")
+    @unittest.skipUnless(IMBackend.available(), "ImageMagick not available")
     def test_im_file_deinterlace(self):
         """Test ImageMagick deinterlace function.
 
         Check if im_deinterlace function returns images
         that are non-progressive.
         """
-        path = im_deinterlace(ArtResizer.shared, self.IMG_225x225)
-        cmd = ArtResizer.shared.im_identify_cmd + [
+        im = IMBackend()
+        path = im_deinterlace(im, self.IMG_225x225)
+        cmd = im.identify_cmd + [
             '-format', '%[interlace]', syspath(path, prefix=False),
         ]
         out = command_output(cmd).stdout

--- a/test/test_art_resize.py
+++ b/test/test_art_resize.py
@@ -16,6 +16,7 @@
 
 
 import unittest
+from unittest.mock import patch
 import os
 
 from test import _common
@@ -141,6 +142,19 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
         ]
         out = command_output(cmd).stdout
         self.assertTrue(out == b'None')
+
+    @patch('beets.util.artresizer.util')
+    def test_write_metadata_im(self, mock_util):
+        """Test writing image metadata."""
+        metadata = {"a": "A", "b": "B"}
+        im = DummyIMBackend()
+        im.write_metadata("foo", metadata)
+        try:
+            command = im.convert_cmd + "foo -set a A -set b B foo".split()
+            mock_util.command_output.assert_called_once_with(command)
+        except AssertionError:
+            command = im.convert_cmd + "foo -set b B -set a A foo".split()
+            mock_util.command_output.assert_called_once_with(command)
 
 
 def suite():

--- a/test/test_art_resize.py
+++ b/test/test_art_resize.py
@@ -24,8 +24,6 @@ from beets.util import command_output, syspath
 from beets.util.artresizer import (
     IMBackend,
     PILBackend,
-    pil_deinterlace,
-    im_deinterlace,
 )
 
 
@@ -120,10 +118,10 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
     def test_pil_file_deinterlace(self):
         """Test PIL deinterlace function.
 
-        Check if pil_deinterlace function returns images
+        Check if the `PILBackend.deinterlace()` function returns images
         that are non-progressive
         """
-        path = pil_deinterlace(PILBackend(), self.IMG_225x225)
+        path = PILBackend().deinterlace(self.IMG_225x225)
         from PIL import Image
         with Image.open(path) as img:
             self.assertFalse('progression' in img.info)
@@ -132,11 +130,11 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
     def test_im_file_deinterlace(self):
         """Test ImageMagick deinterlace function.
 
-        Check if im_deinterlace function returns images
+        Check if the `IMBackend.deinterlace()` function returns images
         that are non-progressive.
         """
         im = IMBackend()
-        path = im_deinterlace(im, self.IMG_225x225)
+        path = im.deinterlace(self.IMG_225x225)
         cmd = im.identify_cmd + [
             '-format', '%[interlace]', syspath(path, prefix=False),
         ]

--- a/test/test_art_resize.py
+++ b/test/test_art_resize.py
@@ -21,17 +21,17 @@ import os
 from test import _common
 from test.helper import TestHelper
 from beets.util import command_output, syspath
-from beets.util.artresizer import (
-    IMBackend,
-    PILBackend,
-)
+from beets.util.artresizer import IMBackend, PILBackend
 
 
 class DummyIMBackend(IMBackend):
-    """An `IMBackend` which pretends that ImageMagick is available, and has
-    a sufficiently recent version to support image comparison.
+    """An `IMBackend` which pretends that ImageMagick is available.
+
+    The version is sufficiently recent to support image comparison.
     """
+
     def __init__(self):
+        """Init a dummy backend class for mocked ImageMagick tests."""
         self.version = (7, 0, 0)
         self.legacy = False
         self.convert_cmd = ['magick']
@@ -40,9 +40,10 @@ class DummyIMBackend(IMBackend):
 
 
 class DummyPILBackend(PILBackend):
-    """An `PILBackend` which pretends that PIL is available.
-    """
+    """An `PILBackend` which pretends that PIL is available."""
+
     def __init__(self):
+        """Init a dummy backend class for mocked PIL tests."""
         pass
 
 

--- a/test/test_embedart.py
+++ b/test/test_embedart.py
@@ -25,7 +25,7 @@ from test.test_art_resize import DummyIMBackend
 
 from mediafile import MediaFile
 from beets import config, logging, ui
-from beets.util import artresizer, syspath, displayable_path
+from beets.util import syspath, displayable_path
 from beets.util.artresizer import ArtResizer
 from beets import art
 

--- a/test/test_embedart.py
+++ b/test/test_embedart.py
@@ -21,6 +21,7 @@ import unittest
 
 from test import _common
 from test.helper import TestHelper
+from test.test_art_resize import DummyIMBackend
 
 from mediafile import MediaFile
 from beets import config, logging, ui
@@ -220,9 +221,8 @@ class DummyArtResizer(ArtResizer):
     """An `ArtResizer` which pretends that ImageMagick is available, and has
     a sufficiently recent version to support image comparison.
     """
-    @staticmethod
-    def _check_method():
-        return artresizer.IMAGEMAGICK, (7, 0, 0), True
+    def __init__(self):
+        self.local_method = DummyIMBackend()
 
 
 @patch('beets.util.artresizer.subprocess')


### PR DESCRIPTION
A follow-up to https://github.com/beetbox/beets/pull/4275. Previously, `ArtResizer` had several backend -> method mappings, which seems to be a poor substitute for proper classes given that the `ArtResizer` has outgrown its name and supports many methods these days. This also allows for a cleaner separation of backend-specific concerns such as handling the modern/legacy ImageMagick invocations.

Some patterns in this code still feel a little clunky (such as the repeated checks for local/proxy backend), but in my opinion, this is at least a small improvement. Do you agree? In particular, I'd be interested if the last commit in this series, which moves some code from the thumbnails plugin to `ArtResizer`, seems sensible. Or is this not really universal enough to warrant moving to beets' core?

No functional changes, so no documentation/changelog/test updates should be required. As usual, this is best reviewed commit-by-commit: All commits should pass the tests, and only move limited amounts of code around such that the diff is still readable.