### PR TITLE
README.md: HTTP => HTTPS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ shockingly simple if you know a little Python.
 .. _writing your own plugin:
     https://beets.readthedocs.org/page/dev/plugins.html
 .. _HTML5 Audio:
-    https://www.w3.org/TR/html-markup/audio.html
+    https://html.spec.whatwg.org/multipage/media.html#the-audio-element
 .. _albums that are missing tracks:
     https://beets.readthedocs.org/page/plugins/missing.html
 .. _duplicate tracks and albums:

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ shockingly simple if you know a little Python.
 .. _writing your own plugin:
     https://beets.readthedocs.org/page/dev/plugins.html
 .. _HTML5 Audio:
-    http://www.w3.org/TR/html-markup/audio.html
+    https://www.w3.org/TR/html-markup/audio.html
 .. _albums that are missing tracks:
     https://beets.readthedocs.org/page/plugins/missing.html
 .. _duplicate tracks and albums:

--- a/README_kr.rst
+++ b/README_kr.rst
@@ -54,7 +54,7 @@ Beets는 라이브러리로 디자인 되었기 때문에, 당신이 음악들�
 .. _writing your own plugin:
     https://beets.readthedocs.org/page/dev/plugins.html
 .. _HTML5 Audio:
-    https://www.w3.org/TR/html-markup/audio.html
+    https://html.spec.whatwg.org/multipage/media.html#the-audio-element
 .. _albums that are missing tracks:
     https://beets.readthedocs.org/page/plugins/missing.html
 .. _duplicate tracks and albums:

--- a/README_kr.rst
+++ b/README_kr.rst
@@ -54,7 +54,7 @@ Beets는 라이브러리로 디자인 되었기 때문에, 당신이 음악들�
 .. _writing your own plugin:
     https://beets.readthedocs.org/page/dev/plugins.html
 .. _HTML5 Audio:
-    http://www.w3.org/TR/html-markup/audio.html
+    https://www.w3.org/TR/html-markup/audio.html
 .. _albums that are missing tracks:
     https://beets.readthedocs.org/page/plugins/missing.html
 .. _duplicate tracks and albums:


### PR DESCRIPTION
## Description

Hi beets, long time no see 👋

Just a tiny change today, checked the link and made it HTTPS, skipping the redirect HTTP => HTTPS this way 0:-)

As [the link](https://www.w3.org/TR/html-markup/audio.html) is being redirected and most likely not showing what was intended before it potentially could even be replaced, for example with either of
- https://en.wikipedia.org/wiki/HTML5_audio
- https://html.spec.whatwg.org/multipage/media.html#the-audio-element
- https://caniuse.com/audio

I even went back and checked where the link originally pointed at: https://web.archive.org/web/20161125120800/http://www.w3.org/TR/html-markup/audio.html

Just say the word if I should change something :)

## To Do

- N/A Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- N/A Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- N/A Tests. (Encouraged but not strictly required.)
