### PR TITLE
Ability to optionally disable the musicbrainz metadata source

### DIFF
--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -598,7 +598,7 @@ def tracks_for_id(track_id):
             yield t
 
 
-def handle_exc(call_func, *args):
+def invoke_mb(call_func, *args):
     if not config["musicbrainz"]["enabled"]:
         return ()
 
@@ -622,11 +622,11 @@ def album_candidates(items, artist, album, va_likely, extra_tags):
     common_args = [album, len(items), extra_tags]
     # Base candidates if we have album and artist to match.
     if artist and album:
-        yield from handle_exc(mb.match_album, artist, *common_args)
+        yield from invoke_mb(mb.match_album, artist, *common_args)
 
     # Also add VA matches from MusicBrainz where appropriate.
     if va_likely and album:
-        yield from handle_exc(mb.match_album, None, *common_args)
+        yield from invoke_mb(mb.match_album, None, *common_args)
 
     # Candidates from plugins.
     yield from plugins.candidates(items, artist, album, va_likely, extra_tags)
@@ -641,7 +641,7 @@ def item_candidates(item, artist, title):
 
     # MusicBrainz candidates.
     if artist and title:
-        yield from handle_exc(mb.match_track, artist, title)
+        yield from invoke_mb(mb.match_track, artist, title)
 
     # Plugin candidates.
     yield from plugins.item_candidates(item, artist, title)

--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -606,6 +606,7 @@ def invoke_mb(call_func, *args):
         return call_func(*args)
     except mb.MusicBrainzAPIError as exc:
         exc.log(log)
+        return ()
 
 
 @plugins.notify_info_yielded('albuminfo_received')

--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -599,9 +599,6 @@ def tracks_for_id(track_id):
 
 
 def invoke_mb(call_func, *args):
-    if not config["musicbrainz"]["enabled"]:
-        return ()
-
     try:
         return call_func(*args)
     except mb.MusicBrainzAPIError as exc:
@@ -620,15 +617,16 @@ def album_candidates(items, artist, album, va_likely, extra_tags):
     constrain the search.
     """
 
-    # Base candidates if we have album and artist to match.
-    if artist and album:
-        yield from invoke_mb(mb.match_album, artist, album, len(items),
-                             extra_tags)
+    if config["musicbrainz"]["enabled"]:
+        # Base candidates if we have album and artist to match.
+        if artist and album:
+            yield from invoke_mb(mb.match_album, artist, album, len(items),
+                                 extra_tags)
 
-    # Also add VA matches from MusicBrainz where appropriate.
-    if va_likely and album:
-        yield from invoke_mb(mb.match_album, None, album, len(items),
-                             extra_tags)
+        # Also add VA matches from MusicBrainz where appropriate.
+        if va_likely and album:
+            yield from invoke_mb(mb.match_album, None, album, len(items),
+                                 extra_tags)
 
     # Candidates from plugins.
     yield from plugins.candidates(items, artist, album, va_likely, extra_tags)
@@ -642,7 +640,7 @@ def item_candidates(item, artist, title):
     """
 
     # MusicBrainz candidates.
-    if artist and title:
+    if config["musicbrainz"]["enabled"] and artist and title:
         yield from invoke_mb(mb.match_track, artist, title)
 
     # Plugin candidates.

--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -620,14 +620,15 @@ def album_candidates(items, artist, album, va_likely, extra_tags):
     constrain the search.
     """
 
-    common_args = [album, len(items), extra_tags]
     # Base candidates if we have album and artist to match.
     if artist and album:
-        yield from invoke_mb(mb.match_album, artist, *common_args)
+        yield from invoke_mb(mb.match_album, artist, album, len(items),
+                             extra_tags)
 
     # Also add VA matches from MusicBrainz where appropriate.
     if va_likely and album:
-        yield from invoke_mb(mb.match_album, None, *common_args)
+        yield from invoke_mb(mb.match_album, None, album, len(items),
+                             extra_tags)
 
     # Candidates from plugins.
     yield from plugins.candidates(items, artist, album, va_likely, extra_tags)

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -482,6 +482,9 @@ def match_album(artist, album, tracks=None, extra_tags=None):
     The query consists of an artist name, an album name, and,
     optionally, a number of tracks on the album and any other extra tags.
     """
+    if not config["musicbrainz"]["enabled"].get(bool):
+        return None
+
     # Build search criteria.
     criteria = {'release': album.lower().strip()}
     if artist is not None:
@@ -558,6 +561,9 @@ def album_for_id(releaseid):
     object or None if the album is not found. May raise a
     MusicBrainzAPIError.
     """
+    if not config["musicbrainz"]["enabled"].get(bool):
+        return None
+
     log.debug('Requesting MusicBrainz release {}', releaseid)
     albumid = _parse_id(releaseid)
     if not albumid:
@@ -579,6 +585,9 @@ def track_for_id(releaseid):
     """Fetches a track by its MusicBrainz ID. Returns a TrackInfo object
     or None if no track is found. May raise a MusicBrainzAPIError.
     """
+    if not config["musicbrainz"]["enabled"].get(bool):
+        return None
+
     trackid = _parse_id(releaseid)
     if not trackid:
         log.debug('Invalid MBID ({0}).', releaseid)

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -482,9 +482,6 @@ def match_album(artist, album, tracks=None, extra_tags=None):
     The query consists of an artist name, an album name, and,
     optionally, a number of tracks on the album and any other extra tags.
     """
-    if not config["musicbrainz"]["enabled"].get(bool):
-        return None
-
     # Build search criteria.
     criteria = {'release': album.lower().strip()}
     if artist is not None:
@@ -561,9 +558,6 @@ def album_for_id(releaseid):
     object or None if the album is not found. May raise a
     MusicBrainzAPIError.
     """
-    if not config["musicbrainz"]["enabled"].get(bool):
-        return None
-
     log.debug('Requesting MusicBrainz release {}', releaseid)
     albumid = _parse_id(releaseid)
     if not albumid:
@@ -585,9 +579,6 @@ def track_for_id(releaseid):
     """Fetches a track by its MusicBrainz ID. Returns a TrackInfo object
     or None if no track is found. May raise a MusicBrainzAPIError.
     """
-    if not config["musicbrainz"]["enabled"].get(bool):
-        return None
-
     trackid = _parse_id(releaseid)
     if not trackid:
         log.debug('Invalid MBID ({0}).', releaseid)

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -101,6 +101,7 @@ paths:
 statefile: state.pickle
 
 musicbrainz:
+    enabled: yes
     host: musicbrainz.org
     https: no
     ratelimit: 1
@@ -108,7 +109,6 @@ musicbrainz:
     searchlimit: 5
     extra_tags: []
     genres: no
-    enabled: yes
 
 match:
     strong_rec_thresh: 0.04

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -108,6 +108,7 @@ musicbrainz:
     searchlimit: 5
     extra_tags: []
     genres: no
+    enabled: yes
 
 match:
     strong_rec_thresh: 0.04

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,8 @@ Changelog goes here!
 
 New features:
 
+* :ref:`musicbrainz-config`: a new :ref:`musicbrainz.enabled` option allows disabling 
+  the MusicBrainz metadata source during the autotagging process
 * :doc:`/plugins/kodiupdate`: Now supports multiple kodi instances
   :bug:`4101`
 * Add the item fields ``bitrate_mode``, ``encoder_info`` and ``encoder_settings``.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -728,7 +728,7 @@ Default configuration::
         extra_tags: []
         genres: no
 
-.. _enabled:
+.. _musicbrainz.enabled:
 
 enabled
 ~~~~~~~

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -716,17 +716,6 @@ Default: ``{}`` (empty).
 MusicBrainz Options
 -------------------
 
-.. _musicbrainz.enabled:
-
-enabled
-~~~~~~~
-
-This option allows you to disable using MusicBrainz as a metadata source. This applies
-if you use plugins that fetch data from alternative sources and should make the import
-process quicker.
-
-Default: ``yes``.
-
 You can instruct beets to use `your own MusicBrainz database`_ instead of
 the `main server`_. Use the ``host``, ``https`` and ``ratelimit`` options
 under a ``musicbrainz:`` header, like so::
@@ -751,6 +740,17 @@ to one request per second.
 .. _main server: https://musicbrainz.org/
 .. _limited: https://musicbrainz.org/doc/XML_Web_Service/Rate_Limiting
 .. _Building search indexes: https://musicbrainz.org/doc/Development/Search_server_setup
+
+.. _musicbrainz.enabled:
+
+enabled
+~~~~~~~
+
+This option allows you to disable using MusicBrainz as a metadata source. This applies
+if you use plugins that fetch data from alternative sources and should make the import
+process quicker.
+
+Default: ``yes``.
 
 .. _searchlimit:
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -716,18 +716,6 @@ Default: ``{}`` (empty).
 MusicBrainz Options
 -------------------
 
-Default configuration::
-
-    musicbrainz:
-        enabled: yes
-        host: musicbrainz.org
-        https: no
-        ratelimit: 1
-        ratelimit_interval: 1.0
-        searchlimit: 5
-        extra_tags: []
-        genres: no
-
 .. _musicbrainz.enabled:
 
 enabled
@@ -739,16 +727,6 @@ process quicker.
 
 Default: ``yes``.
 
-.. _host:
-
-host
-~~~~
-
-The ``host`` key, of course, controls the Web server hostname (and port,
-optionally) that will be contacted by beets.
-
-Default: ``musicbrainz.org``
-
 You can instruct beets to use `your own MusicBrainz database`_ instead of
 the `main server`_. Use the ``host``, ``https`` and ``ratelimit`` options
 under a ``musicbrainz:`` header, like so::
@@ -758,27 +736,16 @@ under a ``musicbrainz:`` header, like so::
         https: no
         ratelimit: 100
 
-.. _https:
-
-https
-~~~~~
-
+The ``host`` key, of course, controls the Web server hostname (and port,
+optionally) that will be contacted by beets (default: musicbrainz.org).
 The ``https`` key makes the client use HTTPS instead of HTTP. This setting applies
-only to custom servers. The official MusicBrainz server always uses HTTPS.
+only to custom servers. The official MusicBrainz server always uses HTTPS. (Default: no.)
 The server must have search indices enabled (see `Building search indexes`_).
 
-Default: ``no``
-
-.. _ratelimit and ratelimit_interval:
-
-ratelimit and ratelimit_interval
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-``ratelimit`` many requests will be sent per ``ratelimit_interval`` by the Web service.
-**Do not change these settings** if you're using the main MusicBrainz
-server - on this public server, you're `limited`_ to one request per second.
-
-Default: ``1`` and ``1.0``
+The ``ratelimit`` option, an integer, controls the number of Web service requests
+per second (default: 1). **Do not change the rate limit setting** if you're
+using the main MusicBrainz server---on this public server, you're `limited`_
+to one request per second.
 
 .. _your own MusicBrainz database: https://musicbrainz.org/doc/MusicBrainz_Server/Setup
 .. _main server: https://musicbrainz.org/
@@ -824,7 +791,6 @@ Use MusicBrainz genre tags to populate (and replace if it's already set) the
 ``genre`` tag.  This will make it a list of all the genres tagged for the
 release and the release-group on MusicBrainz, separated by "; " and sorted by
 the total number of votes.
-
 Default: ``no``
 
 .. _match-config:

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -716,6 +716,39 @@ Default: ``{}`` (empty).
 MusicBrainz Options
 -------------------
 
+Default configuration::
+
+    musicbrainz:
+        enabled: yes
+        host: musicbrainz.org
+        https: no
+        ratelimit: 1
+        ratelimit_interval: 1.0
+        searchlimit: 5
+        extra_tags: []
+        genres: no
+
+.. _enabled:
+
+enabled
+~~~~~~~
+
+This option allows you to disable using MusicBrainz as a metadata source. This applies
+if you use plugins that fetch data from alternative sources and should make the import
+process quicker.
+
+Default: ``yes``.
+
+.. _host:
+
+host
+~~~~
+
+The ``host`` key, of course, controls the Web server hostname (and port,
+optionally) that will be contacted by beets.
+
+Default: ``musicbrainz.org``
+
 You can instruct beets to use `your own MusicBrainz database`_ instead of
 the `main server`_. Use the ``host``, ``https`` and ``ratelimit`` options
 under a ``musicbrainz:`` header, like so::
@@ -725,16 +758,27 @@ under a ``musicbrainz:`` header, like so::
         https: no
         ratelimit: 100
 
-The ``host`` key, of course, controls the Web server hostname (and port,
-optionally) that will be contacted by beets (default: musicbrainz.org).
+.. _https:
+
+https
+~~~~~
+
 The ``https`` key makes the client use HTTPS instead of HTTP. This setting applies
-only to custom servers. The official MusicBrainz server always uses HTTPS. (Default: no.)
+only to custom servers. The official MusicBrainz server always uses HTTPS.
 The server must have search indices enabled (see `Building search indexes`_).
 
-The ``ratelimit`` option, an integer, controls the number of Web service requests
-per second (default: 1). **Do not change the rate limit setting** if you're
-using the main MusicBrainz server---on this public server, you're `limited`_
-to one request per second.
+Default: ``no``
+
+.. _ratelimit and ratelimit_interval:
+
+ratelimit and ratelimit_interval
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``ratelimit`` many requests will be sent per ``ratelimit_interval`` by the Web service.
+**Do not change these settings** if you're using the main MusicBrainz
+server - on this public server, you're `limited`_ to one request per second.
+
+Default: ``1`` and ``1.0``
 
 .. _your own MusicBrainz database: https://musicbrainz.org/doc/MusicBrainz_Server/Setup
 .. _main server: https://musicbrainz.org/
@@ -780,6 +824,7 @@ Use MusicBrainz genre tags to populate (and replace if it's already set) the
 ``genre`` tag.  This will make it a list of all the genres tagged for the
 release and the release-group on MusicBrainz, separated by "; " and sorted by
 the total number of votes.
+
 Default: ``no``
 
 .. _match-config:


### PR DESCRIPTION
## Description

Fixes #400.  <!-- Insert issue number here if applicable. -->
Related to #2686

As I mentioned in https://github.com/beetbox/beets/issues/400#issuecomment-1067666254, this adds a patch that allows to disable the MusicBrainz metadata source during the import process.

I had a little go at making the `MusicBrainz Options` section in the docs a little bit more consistent, and copied over the entire default config section for clarity.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
