### PR TITLE
musicbrainz: Support extra_tag discogs_catalog

### DIFF
--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -72,7 +72,7 @@ def current_metadata(items):
     consensus = {}
     fields = ['artist', 'album', 'albumartist', 'year', 'disctotal',
               'mb_albumid', 'label', 'catalognum', 'country', 'media',
-              'albumdisambig']
+              'albumdisambig', 'discogs_catalog']
     for field in fields:
         values = [item[field] for item in items if item]
         likelies[field], freq = plurality(values)
@@ -231,6 +231,11 @@ def distance(items, album_info, mapping):
     # Catalog number.
     if likelies['catalognum'] and album_info.catalognum:
         dist.add_string('catalognum', likelies['catalognum'],
+                        album_info.catalognum)
+
+    # Discogs Catalog number.
+    if likelies['discogs_catalog'] and album_info.catalognum:
+        dist.add_string('catalognum', likelies['discogs_catalog'],
                         album_info.catalognum)
 
     # Disambiguation.

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -36,6 +36,7 @@ SKIPPED_TRACKS = ['[data track]']
 
 FIELDS_TO_MB_KEYS = {
     'catalognum': 'catno',
+    'discogs_catalog': 'catno',
     'country': 'country',
     'label': 'label',
     'media': 'format',

--- a/beets/library.py
+++ b/beets/library.py
@@ -475,6 +475,7 @@ class Item(LibModel):
         'discogs_albumid': types.INTEGER,
         'discogs_artistid': types.INTEGER,
         'discogs_labelid': types.INTEGER,
+        'discogs_catalog': types.STRING,
         'lyricist': types.STRING,
         'composer': types.STRING,
         'composer_sort': types.STRING,


### PR DESCRIPTION
## Description

- Some tagging software saves a tag named `discogs_catalog` when pulling metadata from Discogs.
  - Eg. mp3tag does that when using the "Discogs web sources file"
  - Also a quick code search on github reveals it appears to be "a thing":
    https://github.com/search?q=discogs_catalog&type=code
- This tag could be used to more precisely search for matches on MusicBrainz and get better distance scores for a candidate.


## To Do

- [ ] Documentation. FIXME add discogs_catalog to set of available extra_fields.
- [ ] Changelog.
- [ ] Tests.
