### PR TITLE
Add --exclude flag

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -1127,6 +1127,10 @@ def _load_plugins(options, config):
                        if len(options.plugins) > 0 else [])
     else:
         plugin_list = config['plugins'].as_str_seq()
+    
+    # Exclude any plugins that were specified on the command line
+    if options.exclude is not None:
+        plugin_list = [p for p in plugin_list if p not in options.exclude.split(',')]
 
     plugins.load_plugins(plugin_list)
     return plugins
@@ -1261,6 +1265,8 @@ def _raw_main(args, lib=None):
                       help='path to configuration file')
     parser.add_option('-p', '--plugins', dest='plugins',
                       help='a comma-separated list of plugins to load')
+    parser.add_option('-x', '--exclude', dest='exclude',
+                      help='a comma-separated list of plugins to disable')
     parser.add_option('-h', '--help', dest='help', action='store_true',
                       help='show this help message and exit')
     parser.add_option('--version', dest='version', action='store_true',

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,8 @@ New features:
 * :doc:`/plugins/convert`: Add a new `auto_keep` option that automatically
   converts files but keeps the *originals* in the library.
   :bug:`1840` :bug:`4302`
+* Added a ``-x`` (or ``--exclude``) flag to specify one/multiple plugin(s) to be 
+  disabled at startup.
 
 Bug fixes:
 

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -445,6 +445,10 @@ import ...``.
   specified, the plugin list in your configuration is ignored. The long form
   of this argument also allows specifying no plugins, effectively disabling
   all plugins: ``--plugins=``.
+* ``-x EXCLUDE``: specify a comma-separated list of plugins to disable in a
+  specific beets run. If specified, it will exclude plugins from your configuration
+  and/or plugins specified using the ``-p`` flag. To disable ALL plugins, use
+  ``--plugins=`` instead.
 
 Beets also uses the ``BEETSDIR`` environment variable to look for
 configuration and data.


### PR DESCRIPTION
## Description

Add a `--exclude` (or `-x`) flag to allow disabling of one/multiple plugin(s). Related issue: #4325 

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
