### PR TITLE
chore(ci): add informational Codecov status checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,7 @@
 comment: off
 
 # Sets non-blocking status checks
+# https://docs.codecov.com/docs/commit-status#informational
 coverage:
   status:
     project:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,13 @@
 # Don't post a comment on pull requests.
 comment: off
 
-# I think this disables commit statuses?
+# Sets non-blocking status checks
 coverage:
-    status:
-        project: no
-        patch: no
-        changes: no
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+    changes: no


### PR DESCRIPTION
## Description
Hi, Tom from Codecov here. I noticed that you were using Codecov but weren't actually getting any notifications on pull requests. I figured it would be useful to get some idea if code being changed is being tested, but also not blocking CI/merging. Let me know if this makes sense or if we can do something that would be helpful.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
