### PR TITLE
Remove Tekstowo extraneous text from `lyricstext.yaml` to fix `test_lyrics`

### DIFF
--- a/test/rsrc/lyricstext.yaml
+++ b/test/rsrc/lyricstext.yaml
@@ -57,6 +57,6 @@ Black_magic_woman: |
 u_n_eye: |
     let see cool bed for sometimes are place told in yeah or ride open hide blame knee your my borders
     perfect i of laying lies they love the night all out saying fast things said that on face hit hell
-    no low not bullets bullet fly time maybe over is roof a it know now airplane where tekst and tonight
-    brakes just waste we go an to you was going eye start need insane cross gotta historia mood life with
-    hurts too whoa me fight little every oh would thousand but high tekstu lay space do down private edycji
+    no low not bullets bullet fly time maybe over is roof a it know now airplane where and tonight
+    brakes just waste we go an to you was going eye start need insane cross gotta mood life with
+    hurts too whoa me fight little every oh would thousand but high lay space do down private


### PR DESCRIPTION
## Description

Fixes #4334 

https://github.com/beetbox/beets/commit/3f896ab28117cd9032a0d9fcc8fc5c871f954324 fixed the plugin `lyrics` for Tekstowo. However the current test suite _expects_ the extraneous text, which is why it's [failing](https://github.com/beetbox/beets/runs/5706550224?check_suite_focus=true). 

This PR removes the extraneous text from this particular song's definition.

https://github.com/beetbox/beets/blob/e52b5980164edb23d5549fd31793b6c6287cf91e/test/rsrc/lyricstext.yaml#L57-L62

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
