### PR TITLE
Change "first" and "second" in test_lyrics output to "expected" and "result"

### DIFF
--- a/test/test_lyrics.py
+++ b/test/test_lyrics.py
@@ -245,8 +245,8 @@ class LyricsAssertions:
         if not keywords <= words:
             details = (
                 f"{keywords!r} is not a subset of {words!r}."
-                f" Words only in first {keywords - words!r},"
-                f" Words only in second {words - keywords!r}."
+                f" Words only in expected set {keywords - words!r},"
+                f" Words only in result set {words - keywords!r}."
             )
             self.fail(f"{details} : {msg}")
 


### PR DESCRIPTION
## Description

As per https://github.com/beetbox/beets/pull/4344#issuecomment-1119098074, this updates "first" and "second" in the test_lyrics output to "expected set" and "result set" to make it clearer which is which.

Thanks for maintaining beets, I've been using it for years now :)

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
