### PR TITLE
Save Spotify album_id and track_id as flexible attributes

### DIFF
--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -244,7 +244,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
         return TrackInfo(
             title=track_data['name'],
             track_id=track_data['id'],
-            spotify_track_id=track_id,
+            spotify_track_id=track_data['id'],
             artist=artist,
             artist_id=artist_id,
             spotify_artist_id=artist_id,

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -214,8 +214,10 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
         return AlbumInfo(
             album=album_data['name'],
             album_id=spotify_id,
+            spotify_album_id=spotify_id,
             artist=artist,
             artist_id=artist_id,
+            spotify_artist_id=artist_id,
             tracks=tracks,
             albumtype=album_data['album_type'],
             va=len(album_data['artists']) == 1
@@ -242,8 +244,10 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
         return TrackInfo(
             title=track_data['name'],
             track_id=track_data['id'],
+            spotify_track_id=track_id,
             artist=artist,
             artist_id=artist_id,
+            spotify_artist_id=artist_id,
             length=track_data['duration_ms'] / 1000,
             index=track_data['track_number'],
             medium=track_data['disc_number'],

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,9 @@ Changelog goes here!
 
 New features:
 
-* Save Spotify `album_id`, `artist_id`, and `track_id` information
+* :doc:`/pluings/spotify`: The plugin now records Spotify-specific IDs in the
+  `spotify_album_id`, `spotify_artist_id`, and `spotify_track_id` fields.
+  :bug:`4348`
 * Create the parental directories for database if they do not exist.
   :bug:`3808` :bug:`4327`
 * :ref:`musicbrainz-config`: a new :ref:`musicbrainz.enabled` option allows disabling

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ Changelog goes here!
 
 New features:
 
-* Save Spotify `album_id`, `artist_id` and `track_id` information. Partial fix for `4347`.
+* Save Spotify `album_id`, `artist_id`, and `track_id` information
 * Create the parental directories for database if they do not exist.
   :bug:`3808` :bug:`4327`
 * :ref:`musicbrainz-config`: a new :ref:`musicbrainz.enabled` option allows disabling

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 Changelog goes here!
 
 New features:
+
 * Save Spotify `album_id`, `artist_id` and `track_id` information. Partial fix for `4347`.
 * Create the parental directories for database if they do not exist.
   :bug:`3808` :bug:`4327`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,10 +7,10 @@ Changelog
 Changelog goes here!
 
 New features:
-
+* Save Spotify `album_id`, `artist_id` and `track_id` information. Partial fix for `4347`.
 * Create the parental directories for database if they do not exist.
   :bug:`3808` :bug:`4327`
-* :ref:`musicbrainz-config`: a new :ref:`musicbrainz.enabled` option allows disabling 
+* :ref:`musicbrainz-config`: a new :ref:`musicbrainz.enabled` option allows disabling
   the MusicBrainz metadata source during the autotagging process
 * :doc:`/plugins/kodiupdate`: Now supports multiple kodi instances
   :bug:`4101`
@@ -20,7 +20,7 @@ New features:
 * :doc:`/plugins/convert`: Add a new `auto_keep` option that automatically
   converts files but keeps the *originals* in the library.
   :bug:`1840` :bug:`4302`
-* Added a ``-P`` (or ``--disable-plugins``) flag to specify one/multiple plugin(s) to be 
+* Added a ``-P`` (or ``--disable-plugins``) flag to specify one/multiple plugin(s) to be
   disabled at startup.
 
 Bug fixes:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ Changelog goes here!
 
 New features:
 
-* :doc:`/pluings/spotify`: The plugin now records Spotify-specific IDs in the
+* :doc:`/plugins/spotify`: The plugin now records Spotify-specific IDs in the
   `spotify_album_id`, `spotify_artist_id`, and `spotify_track_id` fields.
   :bug:`4348`
 * Create the parental directories for database if they do not exist.


### PR DESCRIPTION
## Description

Partially Fixes #4347.  <!-- Insert issue number here if applicable. -->

Added additional keys to save Spotify `track_id` and `album_id` as flexible attributes. 

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
