### PR TITLE
Use config option for Spotify

### DIFF
--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -61,8 +61,8 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
                 'track_field': 'title',
                 'region_filter': None,
                 'regex': [],
-                'client_id': '4e414367a1d14c75a5c5129a627fcab8',
-                'client_secret': 'f82bdc09b2254f1a8286815d02fd46dc',
+                'client_id': config['spotify']['client_id'].as_str(),
+                'client_secret': config['spotify']['client_secret'].as_str(),
                 'tokenfile': 'spotify_token.json',
             }
         )

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -27,6 +27,7 @@ import requests
 import confuse
 
 from beets import ui
+from beets import config
 from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.plugins import MetadataSourcePlugin, BeetsPlugin
 


### PR DESCRIPTION
## Description

Partially Fixes #4347.  <!-- Insert issue number here if applicable. -->

Use config option for Spotify. Tested with the following configs and both work:
```
spotify:
    source_weight: 0
    client_id: REDACTED
    client_secret: REDACTED
```

```
spotify:
    client_id: REDACTED
    client_secret: REDACTED
```

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
