### PR TITLE
Obtain Spotify track (popularity and audio features) attributes

### DIFF
--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -160,7 +160,7 @@ class SpotifySyncPlugin(BeetsPlugin):
                 audio_features = self.track_audio_features(item.spotify_track_id)
                 for key in audio_features.keys():
                     self._log.info('key: {}',SPOTIFY_AUDIO_FEATURES[key][0])
-                    self._log.info('audio feature: {}',audio_features[key])
+                    self._log.info('audio feature: {} for {}',audio_features[key], item)
                     item[SPOTIFY_AUDIO_FEATURES[key][0]] = audio_features[key]
                 # item['spotify_track_acousticness'] = audio_features["acousticness"]
                 # item['spotify_track_danceability'] = audio_features["danceability"]

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -168,6 +168,7 @@ class SpotifySyncPlugin(BeetsPlugin):
 
     def _handle_response(self, request_type, url, params=None):
         """Send a request, reauthenticating if necessary.
+        
         :param request_type: Type of :class:`Request` constructor,
             e.g. ``requests.get``, ``requests.post``, etc.
         :type request_type: function

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -126,14 +126,14 @@ class SpotifySyncPlugin(BeetsPlugin):
         """
         for item in items:
             time.sleep(.5)
-            self._log.info('getting data for: {}', item)
+            self._log.debug('getting data for: {}', item)
             try:
                 # If we're not forcing re-downloading for all tracks, check
                 # whether the popularity data is already present
                 if not force:
                     spotify_track_popularity = item.get('spotify_track_popularity', '')
                     if spotify_track_popularity:
-                        self._log.error('data already present for: {}', item)
+                        self._log.debug('data already present for: {}', item)
                         continue
 
                 self._log.info('getting data for: {}', item)
@@ -147,6 +147,7 @@ class SpotifySyncPlugin(BeetsPlugin):
                 if write:
                     item.try_write()
             except AttributeError:
+                self._log.debug('No track_id present for: {}', item)
                 pass
 
 
@@ -198,11 +199,10 @@ class SpotifySyncPlugin(BeetsPlugin):
         :return: TrackInfo object for track
         :rtype: beets.autotag.hooks.TrackInfo or None
         """
-        self._log.error('spotify_track_id: {}',track_id)
         track_data = self._handle_response(
             requests.get, self.track_url + track_id
         )
-        self._log.error('track_data: {}',track_data['popularity'])
+        self._log.debug('track_data: {}',track_data['popularity'])
         track_popularity=track_data['popularity']
         return track_popularity
 

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -140,7 +140,7 @@ class SpotifySyncPlugin(BeetsPlugin):
                     continue
 
             self._log.info('getting data for: {}', item)
-            data = self.track_for_id(item.spotify_track_id)
+            data = self.track_popularity(item.spotify_track_id)
             if data:
                 self._log.debug('data = {}', data)
             else:
@@ -185,7 +185,7 @@ class SpotifySyncPlugin(BeetsPlugin):
                 )
         return response.json()
 
-    def track_for_id(self, track_id=None):
+    def track_popularity(self, track_id=None):
         """Fetch a track by its Spotify ID or URL and return a
         TrackInfo object or None if the track is not found.
 
@@ -203,8 +203,8 @@ class SpotifySyncPlugin(BeetsPlugin):
             requests.get, self.track_url + track_id
         )
         self._log.error('track_data: {}',track_data['popularity'])
-        track = self._get_track(track_data)
-        return track
+        track_popularity=track_data['popularity']
+        return track_popularity
 
     def _get_track(self, track_data):
         """Convert a Spotify track object dict to a TrackInfo object.

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -202,7 +202,7 @@ class SpotifySyncPlugin(BeetsPlugin):
         track_data = self._handle_response(
             requests.get, self.track_url + track_id
         )
-        self._log.error('track_data: {}',track_data)
+        self._log.error('track_data: {}',track_data['popularity'])
         track = self._get_track(track_data)
         return track
 

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -121,6 +121,7 @@ class SpotifySyncPlugin(BeetsPlugin):
 
     def _fetch_info(self, items, write, force):
         SPOTIFY_AUDIO_FEATURES = {
+            'acousticness': ['spotify_track_acousticness'],
             'danceability': ['spotify_track_danceability'],
             'energy': ['spotify_track_energy'],
             'instrumentalness': ['spotify_track_instrumentalness'],

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -198,7 +198,7 @@ class SpotifySyncPlugin(BeetsPlugin):
         :return: TrackInfo object for track
         :rtype: beets.autotag.hooks.TrackInfo or None
         """
-        self._log.error('{}',item)
+        self._log.error('{}',track_id)
         spotify_id = self._get_id('track', spotify_track_id)
         if spotify_id is None:
             return None

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -134,17 +134,16 @@ class SpotifySyncPlugin(BeetsPlugin):
                 # If we're not forcing re-downloading for all tracks, check
                 # whether the popularity data is already present
                 if not force:
-                    self._log.info('Force 1')
                     spotify_track_popularity = item.get('spotify_track_popularity', '')
                     if spotify_track_popularity:
-                        self._log.info('Popularity already present for: {}', item)
+                        self._log.debug('Popularity already present for: {}', item)
                         continue
 
                 data = self.track_popularity(item.spotify_track_id)
                 if data:
-                    self._log.info('data = {}', data)
+                    self._log.debug('data = {}', data)
                 else:
-                    self._log.info('skipping popularity')
+                    self._log.debug('skipping popularity')
                 item['spotify_track_popularity'] = data
                 item.store()
                 if write:

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -126,7 +126,7 @@ class SpotifySyncPlugin(BeetsPlugin):
         """
         for item in items:
             time.sleep(.5)
-            self._log.debug('getting data for: {}', item)
+            self._log.info('getting data for: {}', item)
             try:
                 # If we're not forcing re-downloading for all tracks, check
                 # whether the popularity data is already present
@@ -136,7 +136,7 @@ class SpotifySyncPlugin(BeetsPlugin):
                         self._log.debug('data already present for: {}', item)
                         continue
 
-                self._log.debug('getting data for2: {}', item)
+                self._log.info('getting data for2: {}', item)
                 data = self.track_popularity(item.spotify_track_id)
                 if data:
                     self._log.debug('data = {}', data)

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -129,7 +129,7 @@ class SpotifySyncPlugin(BeetsPlugin):
 
         for index, item in enumerate(items, start=1):
             time.sleep(.5)
-            self._log.info('Processing {}/{} tracks', index, no_items)
+            self._log.info('Processing {}/{} tracks - {} ', index, no_items, item)
             try:
                 # If we're not forcing re-downloading for all tracks, check
                 # whether the popularity data is already present
@@ -139,7 +139,6 @@ class SpotifySyncPlugin(BeetsPlugin):
                         self._log.debug('data already present for: {}', item)
                         continue
 
-                self._log.info('getting data for2: {}', item)
                 data = self.track_popularity(item.spotify_track_id)
                 if data:
                     self._log.debug('data = {}', data)

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -136,29 +136,32 @@ class SpotifySyncPlugin(BeetsPlugin):
         no_items = len(items)
         self._log.info('Total {} tracks', no_items)
 
-        for index, item in enumerate(items, start=1):
+        for (index, item) in enumerate(items, start=1):
             time.sleep(.5)
-            self._log.info('Processing {}/{} tracks - {} ',
-                           index, no_items, item)
+            self._log.info('Processing {}/{} tracks - {} ', index,
+                           no_items, item)
             try:
+
                 # If we're not forcing re-downloading for all tracks, check
                 # whether the popularity data is already present
+
                 if not force:
-                    spotify_track_popularity = (
-                      item.get('spotify_track_popularity', ''))
+                    spotify_track_popularity = \
+                        item.get('spotify_track_popularity', '')
                     if spotify_track_popularity:
-                        self._log.debug('Popularity already present for: {}',
-                        item)
+                        self._log.debug('Popularity already present for: {}'
+                                , item)
                         continue
 
-                popularity = self.track_popularity(item.spotify_track_id)
+                popularity = \
+                    self.track_popularity(item.spotify_track_id)
                 item['spotify_track_popularity'] = popularity
-                audio_features = self.track_audio_features(item.spotify_track_id)
+                audio_features = \
+                    self.track_audio_features(item.spotify_track_id)
                 for feature in audio_features.keys():
                     if feature in spotify_audio_features.keys():
-                        item[spotify_audio_features[feature][0]] =
-                        audio_features[feature]
-                item.store()
+                        item[spotify_audio_features[feature][0]] = \
+                            audio_features[feature]
                 if write:
                     item.try_write()
             except AttributeError:

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -41,7 +41,6 @@ class SpotifySyncPlugin(BeetsPlugin):
     search_url = 'https://api.spotify.com/v1/search'
     album_url = 'https://api.spotify.com/v1/albums/'
     track_url = 'https://api.spotify.com/v1/tracks/'
-    track_url_new = 'https://api.spotify.com/v1/track/'
 
     def __init__(self):
         super().__init__()
@@ -201,7 +200,7 @@ class SpotifySyncPlugin(BeetsPlugin):
         """
         self._log.error('spotify_track_id: {}',track_id)
         track_data = self._handle_response(
-            requests.get, self.track_url_new + track_id
+            requests.get, self.track_url + track_id
         )
         self._log.error('track_data: {}',track_data)
         track = self._get_track(track_data)

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -136,7 +136,7 @@ class SpotifySyncPlugin(BeetsPlugin):
                         self._log.debug('data already present for: {}', item)
                         continue
 
-                self._log.info('getting data for: {}', item)
+                self._log.debug('getting data for2: {}', item)
                 data = self.track_popularity(item.spotify_track_id)
                 if data:
                     self._log.debug('data = {}', data)

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -184,7 +184,7 @@ class SpotifySyncPlugin(MetadataSourcePlugin, BeetsPlugin):
                 )
         return response.json()
 
-    def track_for_id(self, track_id=None, track_data=None):
+    def track_for_id(self, track_id=None):
         """Fetch a track by its Spotify ID or URL and return a
         TrackInfo object or None if the track is not found.
 
@@ -197,15 +197,15 @@ class SpotifySyncPlugin(MetadataSourcePlugin, BeetsPlugin):
         :return: TrackInfo object for track
         :rtype: beets.autotag.hooks.TrackInfo or None
         """
+        self._log.error('{}',item)
         if not item.spotify_track_id:
             continue
-        if track_data is None:
-            spotify_id = self._get_id('track', spotify_track_id)
-            if spotify_id is None:
-                return None
-            track_data = self._handle_response(
-                requests.get, self.track_url + spotify_id
-            )
+        spotify_id = self._get_id('track', spotify_track_id)
+        if spotify_id is None:
+            return None
+        track_data = self._handle_response(
+            requests.get, self.track_url + spotify_id
+        )
         track = self._get_track(track_data)
         return track
 

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -156,8 +156,8 @@ class SpotifySyncPlugin(BeetsPlugin):
                 audio_features = self.track_audio_features(item.spotify_track_id)
                 for feature in audio_features.keys():
                     if feature in spotify_audio_features.keys():
-                        item[spotify_audio_features[feature][0]] =
-                        audio_features[feature]
+                        item[spotify_audio_features[feature][0]] = \
+                            audio_features[feature]
                 item.store()
                 if write:
                     item.try_write()

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -132,8 +132,8 @@ class SpotifySyncPlugin(MetadataSourcePlugin, BeetsPlugin):
             # representative field name to check for previously fetched
             # data.
             # We can only fetch data for tracks with MBIDs.
-            # if not item.spotify_track_id:
-            #     continue
+            if not item.spotify_track_id:
+                continue
 
             if not force:
                 spotify_track_popularity = item.get('spotify_track_popularity', '')
@@ -201,8 +201,6 @@ class SpotifySyncPlugin(MetadataSourcePlugin, BeetsPlugin):
         :rtype: beets.autotag.hooks.TrackInfo or None
         """
         self._log.error('{}',item)
-        if not item.spotify_track_id:
-            continue
         spotify_id = self._get_id('track', spotify_track_id)
         if spotify_id is None:
             return None

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -12,9 +12,7 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
-"""Adds Spotify sync function to import track popularity and audio features
-information.
-"""
+"""Adds Spotify sync function to import track features."""
 
 import json
 import base64
@@ -40,7 +38,6 @@ class SpotifySyncPlugin(BeetsPlugin):
 
     def __init__(self):
         """Initialize the SpotifySync Plugin."""
-
         super().__init__()
         self.config.add(
             {
@@ -57,7 +54,6 @@ class SpotifySyncPlugin(BeetsPlugin):
 
     def setup(self):
         """Retrieve previously saved OAuth token or generate a new one."""
-
         try:
             with open(self.tokenfile) as f:
                 token_data = json.load(f)
@@ -67,8 +63,7 @@ class SpotifySyncPlugin(BeetsPlugin):
             self.access_token = token_data['access_token']
 
     def _authenticate(self):
-        """Request an access token via the Client Credentials Flow. """
-
+        """Request an access token via the Client Credentials Flow."""
         headers = {
             'Authorization': 'Basic {}'.format(
                 base64.b64encode(
@@ -121,7 +116,6 @@ class SpotifySyncPlugin(BeetsPlugin):
 
     def _fetch_info(self, items, write, force):
         """Obtain track information from Spotify."""
-
         spotify_audio_features = {
             'acousticness': ['spotify_track_acousticness'],
             'danceability': ['spotify_track_danceability'],
@@ -144,7 +138,8 @@ class SpotifySyncPlugin(BeetsPlugin):
 
         for index, item in enumerate(items, start=1):
             time.sleep(.5)
-            self._log.info('Processing {}/{} tracks - {} ', index, no_items, item)
+            self._log.info('Processing {}/{} tracks - {} ',
+                            index, no_items, item)
             try:
                 # If we're not forcing re-downloading for all tracks, check
                 # whether the popularity data is already present

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -126,14 +126,14 @@ class SpotifySyncPlugin(MetadataSourcePlugin, BeetsPlugin):
         """Fetch popularity information from Spotify for the item.
         """
         for item in items:
-            self._log.error('getting data for: {}', item)
+            self._log.error('getting data for: {}', item.spotify_track_id)
             # If we're not forcing re-downloading for all tracks, check
             # whether the data is already present. We use one
             # representative field name to check for previously fetched
             # data.
             # We can only fetch data for tracks with MBIDs.
-            if not item.spotify_track_id:
-                continue
+            # if not item.spotify_track_id:
+            #     continue
 
             if not force:
                 spotify_track_popularity = item.get('spotify_track_popularity', '')

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -148,12 +148,13 @@ class SpotifySyncPlugin(BeetsPlugin):
                         item.get('spotify_track_popularity', '')
                     if spotify_track_popularity:
                         self._log.debug('Popularity already present for: {}',
-                        item)
+                                        item)
                         continue
 
                 popularity = self.track_popularity(item.spotify_track_id)
                 item['spotify_track_popularity'] = popularity
-                audio_features = self.track_audio_features(item.spotify_track_id)
+                audio_features = \
+                    self.track_audio_features(item.spotify_track_id)
                 for feature in audio_features.keys():
                     if feature in spotify_audio_features.keys():
                         item[spotify_audio_features[feature][0]] = \

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -114,8 +114,6 @@ class SpotifySyncPlugin(BeetsPlugin):
 
         def func(lib, opts, args):
             items = lib.items(ui.decargs(args))
-            self._log.error('items {}, write {}, force {}', items, ui.should_write(),
-                             opts.force_refetch or self.config['force'])
             self._fetch_info(items, ui.should_write(),
                              opts.force_refetch or self.config['force'])
 
@@ -126,7 +124,7 @@ class SpotifySyncPlugin(BeetsPlugin):
         """Fetch popularity information from Spotify for the item.
         """
         for item in items:
-            self._log.error('getting data for: {}', item.spotify_track_id)
+            self._log.error('getting data for: {}', item)
             # If we're not forcing re-downloading for all tracks, check
             # whether the data is already present. We use one
             # representative field name to check for previously fetched

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -162,22 +162,7 @@ class SpotifySyncPlugin(BeetsPlugin):
                 for feature in audio_features.keys():
                     if feature in [ "analysis_url", "duration_ms", "id", "track_href", "type", "audio_features", "uri"]:
                         continue
-                    self._log.info('features: {}',feature)
-                    self._log.info('key: {}',SPOTIFY_AUDIO_FEATURES[feature][0])
-                    self._log.info('audio feature: {} for {}',audio_features[feature], item)
                     item[SPOTIFY_AUDIO_FEATURES[feature][0]] = audio_features[feature]
-                # item['spotify_track_acousticness'] = audio_features["acousticness"]
-                # item['spotify_track_danceability'] = audio_features["danceability"]
-                # item['spotify_track_energy'] = audio_features["energy"]
-                # item['spotify_track_instrumentalness'] = audio_features["instrumentalness"]
-                # item['spotify_track_key'] = audio_features["key"]
-                # item['spotify_track_liveness'] = audio_features["liveness"]
-                # item['spotify_track_loudness'] = audio_features["loudness"]
-                # item['spotify_track_mode'] = audio_features["mode"]
-                # item['spotify_track_speechiness'] = audio_features["speechiness"]
-                # item['spotify_track_tempo'] = audio_features["tempo"]
-                # item['spotify_track_time_sig'] = audio_features["time_signature"]
-                # item['spotify_track_valence'] = audio_features["valence"]
                 item.store()
                 if write:
                     item.try_write()

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -216,7 +216,7 @@ class SpotifySyncPlugin(BeetsPlugin):
         track_data = self._handle_response(
             requests.get, self.track_url + track_id
         )
-        self._log.debug('track_data: {}', strack_data['popularity'])
+        self._log.debug('track_data: {}', track_data['popularity'])
         track_popularity = track_data['popularity']
         return track_popularity
 

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -166,7 +166,6 @@ class SpotifySyncPlugin(BeetsPlugin):
                 self._log.debug('No track_id present for: {}', item)
                 pass
 
-
     def _handle_response(self, request_type, url, params=None):
         """Send a request, reauthenticating if necessary.
         :param request_type: Type of :class:`Request` constructor,

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -121,27 +121,23 @@ class SpotifySyncPlugin(BeetsPlugin):
         return [cmd]
 
     def _fetch_info(self, items, write, force):
+        import time
         """Fetch popularity information from Spotify for the item.
         """
         for item in items:
-            self._log.error('getting data for: {}', item)
-            # If we're not forcing re-downloading for all tracks, check
-            # whether the data is already present. We use one
-            # representative field name to check for previously fetched
-            # data.
-            # We can only fetch data for tracks with MBIDs.
-            # if not item.spotify_track_id:
-            #     continue
+            time.sleep(.5)
+            self._log.info('getting data for: {}', item)
             try:
+                # If we're not forcing re-downloading for all tracks, check
+                # whether the popularity data is already present
                 if not force:
                     spotify_track_popularity = item.get('spotify_track_popularity', '')
                     if spotify_track_popularity:
-                        self._log.error('data already present for: {}', item)
+                        self._log.debug('data already present for: {}', item)
                         continue
 
                 self._log.info('getting data for: {}', item)
                 data = self.track_popularity(item.spotify_track_id)
-                self._log.info('data1: {}', data)
                 if data:
                     self._log.debug('data = {}', data)
                 else:

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -146,6 +146,7 @@ class SpotifySyncPlugin(BeetsPlugin):
                 self._log.debug('data = {}', data)
             else:
                 self._log.debug('skipping popularity')
+            item['spotify_track_popularity'] = data
             item.store()
             if write:
                 item.try_write()

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -160,9 +160,8 @@ class SpotifySyncPlugin(BeetsPlugin):
                 item['spotify_track_popularity'] = data
                 audio_features = self.track_audio_features(item.spotify_track_id)
                 for feature in audio_features.keys():
-                    if feature in [ "analysis_url", "duration_ms", "id", "track_href", "type", "audio_features", "uri"]:
-                        continue
-                    item[SPOTIFY_AUDIO_FEATURES[feature][0]] = audio_features[feature]
+                    if feature in SPOTIFY_AUDIO_FEATURES.keys():
+                        item[SPOTIFY_AUDIO_FEATURES[feature][0]] = audio_features[feature]
                 item.store()
                 if write:
                     item.try_write()

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -1,0 +1,223 @@
+# This file is part of beets.
+# Copyright 2019, Rahul Ahuja.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""Adds Spotify release and track search support to the autotagger, along with
+Spotify playlist construction.
+"""
+
+import re
+import json
+import base64
+import webbrowser
+import collections
+
+import unidecode
+import requests
+import confuse
+
+from beets import ui
+from beets.autotag.hooks import AlbumInfo, TrackInfo
+from beets.plugins import MetadataSourcePlugin, BeetsPlugin
+
+
+class SpotifySyncPlugin(MetadataSourcePlugin, BeetsPlugin):
+    data_source = 'Spotify'
+
+    # Base URLs for the Spotify API
+    # Documentation: https://developer.spotify.com/web-api
+    oauth_token_url = 'https://accounts.spotify.com/api/token'
+    open_track_url = 'https://open.spotify.com/track/'
+    search_url = 'https://api.spotify.com/v1/search'
+    album_url = 'https://api.spotify.com/v1/albums/'
+    track_url = 'https://api.spotify.com/v1/tracks/'
+
+    def __init__(self):
+        super().__init__()
+        self.config.add(
+            {
+                'show_failures': False,
+                'tokenfile': 'spotify_token.json',
+            }
+        )
+        self.config['client_secret'].redact = True
+
+        self.tokenfile = self.config['tokenfile'].get(
+            confuse.Filename(in_app_dir=True)
+        )  # Path to the JSON file for storing the OAuth access token.
+        self.setup()
+
+    def setup(self):
+        """Retrieve previously saved OAuth token or generate a new one."""
+        try:
+            with open(self.tokenfile) as f:
+                token_data = json.load(f)
+        except OSError:
+            self._authenticate()
+        else:
+            self.access_token = token_data['access_token']
+
+    def _authenticate(self):
+        """Request an access token via the Client Credentials Flow:
+        https://developer.spotify.com/documentation/general/guides/authorization-guide/#client-credentials-flow
+        """
+        headers = {
+            'Authorization': 'Basic {}'.format(
+                base64.b64encode(
+                    ':'.join(
+                        self.config[k].as_str()
+                        for k in ('client_id', 'client_secret')
+                    ).encode()
+                ).decode()
+            )
+        }
+        response = requests.post(
+            self.oauth_token_url,
+            data={'grant_type': 'client_credentials'},
+            headers=headers,
+        )
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            raise ui.UserError(
+                'Spotify authorization failed: {}\n{}'.format(
+                    e, response.text
+                )
+            )
+        self.access_token = response.json()['access_token']
+
+        # Save the token for later use.
+        self._log.debug(
+            '{} access token: {}', self.data_source, self.access_token
+        )
+        with open(self.tokenfile, 'w') as f:
+            json.dump({'access_token': self.access_token}, f)
+
+    def commands(self):
+        cmd = ui.Subcommand('spotifysync',
+                            help="fetch track attributes from Spotify")
+        cmd.parser.add_option(
+            '-f', '--force', dest='force_refetch',
+            action='store_true', default=False,
+            help='re-download data when already present'
+        )
+
+        def func(lib, opts, args):
+            items = lib.items(ui.decargs(args))
+            self._fetch_info(items, ui.should_write(),
+                             opts.force_refetch or self.config['force'])
+
+        cmd.func = func
+        return [cmd]
+
+    def _fetch_info(self, items, write, force):
+        """Fetch popularity information from Spotify for the item.
+        """
+        for item in items:
+            # If we're not forcing re-downloading for all tracks, check
+            # whether the data is already present. We use one
+            # representative field name to check for previously fetched
+            # data.
+            if not force:
+                spotify_track_popularity = item.get('spotify_track_popularity', '')
+                if spotify_track_popularity:
+                    self._log.info('data already present for: {}', item)
+                    continue
+
+            # We can only fetch data for tracks with MBIDs.
+            if not item.spotify_track_id:
+                continue
+
+            self._log.info('getting data for: {}', item)
+            data = self.track_for_id(item.spotify_track_id)
+            if data:
+                self._log.debug('data = {}', data)
+            else:
+                self._log.debug('skipping popularity')
+            item.store()
+            if write:
+                item.try_write()
+
+
+    def _handle_response(self, request_type, url, params=None):
+        """Send a request, reauthenticating if necessary.
+
+        :param request_type: Type of :class:`Request` constructor,
+            e.g. ``requests.get``, ``requests.post``, etc.
+        :type request_type: function
+        :param url: URL for the new :class:`Request` object.
+        :type url: str
+        :param params: (optional) list of tuples or bytes to send
+            in the query string for the :class:`Request`.
+        :type params: dict
+        :return: JSON data for the class:`Response <Response>` object.
+        :rtype: dict
+        """
+        response = request_type(
+            url,
+            headers={'Authorization': f'Bearer {self.access_token}'},
+            params=params,
+        )
+        if response.status_code != 200:
+            if 'token expired' in response.text:
+                self._log.debug(
+                    '{} access token has expired. Reauthenticating.',
+                    self.data_source,
+                )
+                self._authenticate()
+                return self._handle_response(request_type, url, params=params)
+            else:
+                raise ui.UserError(
+                    '{} API error:\n{}\nURL:\n{}\nparams:\n{}'.format(
+                        self.data_source, response.text, url, params
+                    )
+                )
+        return response.json()
+
+    def track_for_id(self, track_id=None, track_data=None):
+        """Fetch a track by its Spotify ID or URL and return a
+        TrackInfo object or None if the track is not found.
+
+        :param track_id: (Optional) Spotify ID or URL for the track. Either
+            ``track_id`` or ``track_data`` must be provided.
+        :type track_id: str
+        :param track_data: (Optional) Simplified track object dict. May be
+            provided instead of ``track_id`` to avoid unnecessary API calls.
+        :type track_data: dict
+        :return: TrackInfo object for track
+        :rtype: beets.autotag.hooks.TrackInfo or None
+        """
+        if not item.spotify_track_id:
+            continue
+        if track_data is None:
+            spotify_id = self._get_id('track', spotify_track_id)
+            if spotify_id is None:
+                return None
+            track_data = self._handle_response(
+                requests.get, self.track_url + spotify_id
+            )
+        track = self._get_track(track_data)
+        return track
+
+    def _get_track(self, track_data):
+        """Convert a Spotify track object dict to a TrackInfo object.
+
+        :param track_data: Simplified track object
+            (https://developer.spotify.com/documentation/web-api/reference/object-model/#track-object-simplified)
+        :type track_data: dict
+        :return: TrackInfo object for track
+        :rtype: beets.autotag.hooks.TrackInfo
+        """
+        return TrackInfo(
+            spotify_track_popularity=track_data['popularity'],
+        )

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -31,7 +31,7 @@ from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.plugins import MetadataSourcePlugin, BeetsPlugin
 
 
-class SpotifySyncPlugin(MetadataSourcePlugin, BeetsPlugin):
+class SpotifySyncPlugin(plugins.BeetsPlugin):
     data_source = 'Spotify'
 
     # Base URLs for the Spotify API

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -168,7 +168,7 @@ class SpotifySyncPlugin(BeetsPlugin):
 
     def _handle_response(self, request_type, url, params=None):
         """Send a request, reauthenticating if necessary.
-        
+
         :param request_type: Type of :class:`Request` constructor,
             e.g. ``requests.get``, ``requests.post``, etc.
         :type request_type: function
@@ -202,8 +202,7 @@ class SpotifySyncPlugin(BeetsPlugin):
         return response.json()
 
     def track_popularity(self, track_id=None):
-        """Fetch a track by its Spotify ID or URL and return a
-        TrackInfo object or None if the track is not found.
+        """Fetch a track popularity by its Spotify ID.
 
         :param track_id: (Optional) Spotify ID or URL for the track. Either
             ``track_id`` or ``track_data`` must be provided.

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -159,10 +159,11 @@ class SpotifySyncPlugin(BeetsPlugin):
                     self._log.debug('skipping popularity')
                 item['spotify_track_popularity'] = data
                 audio_features = self.track_audio_features(item.spotify_track_id)
-                for key in audio_features.keys():
-                    self._log.info('key: {}',SPOTIFY_AUDIO_FEATURES[key][0])
-                    self._log.info('audio feature: {} for {}',audio_features[key], item)
-                    item[SPOTIFY_AUDIO_FEATURES[key][0]] = audio_features[key]
+                for feature in audio_features.keys():
+                    self._log.info('features: {}',feature)
+                    self._log.info('key: {}',SPOTIFY_AUDIO_FEATURES[feature][0])
+                    self._log.info('audio feature: {} for {}',audio_features[feature], item)
+                    item[SPOTIFY_AUDIO_FEATURES[feature][0]] = audio_features[feature]
                 # item['spotify_track_acousticness'] = audio_features["acousticness"]
                 # item['spotify_track_danceability'] = audio_features["danceability"]
                 # item['spotify_track_energy'] = audio_features["energy"]

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -114,6 +114,8 @@ class SpotifySyncPlugin(MetadataSourcePlugin, BeetsPlugin):
 
         def func(lib, opts, args):
             items = lib.items(ui.decargs(args))
+            self._log.error('items {}, write {}, force {}', items, ui.should_write(),
+                             opts.force_refetch or self.config['force'])
             self._fetch_info(items, ui.should_write(),
                              opts.force_refetch or self.config['force'])
 
@@ -124,19 +126,20 @@ class SpotifySyncPlugin(MetadataSourcePlugin, BeetsPlugin):
         """Fetch popularity information from Spotify for the item.
         """
         for item in items:
+            self._log.error('getting data for: {}', item)
             # If we're not forcing re-downloading for all tracks, check
             # whether the data is already present. We use one
             # representative field name to check for previously fetched
             # data.
-            if not force:
-                spotify_track_popularity = item.get('spotify_track_popularity', '')
-                if spotify_track_popularity:
-                    self._log.info('data already present for: {}', item)
-                    continue
-
             # We can only fetch data for tracks with MBIDs.
             if not item.spotify_track_id:
                 continue
+
+            if not force:
+                spotify_track_popularity = item.get('spotify_track_popularity', '')
+                if spotify_track_popularity:
+                    self._log.error('data already present for: {}', item)
+                    continue
 
             self._log.info('getting data for: {}', item)
             data = self.track_for_id(item.spotify_track_id)

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -139,14 +139,16 @@ class SpotifySyncPlugin(BeetsPlugin):
         for index, item in enumerate(items, start=1):
             time.sleep(.5)
             self._log.info('Processing {}/{} tracks - {} ',
-                            index, no_items, item)
+                           index, no_items, item)
             try:
                 # If we're not forcing re-downloading for all tracks, check
                 # whether the popularity data is already present
                 if not force:
-                    spotify_track_popularity = item.get('spotify_track_popularity', '')
+                    spotify_track_popularity =
+                    item.get('spotify_track_popularity', '')
                     if spotify_track_popularity:
-                        self._log.debug('Popularity already present for: {}', item)
+                        self._log.debug('Popularity already present for: {}',
+                        item)
                         continue
 
                 popularity = self.track_popularity(item.spotify_track_id)
@@ -154,7 +156,8 @@ class SpotifySyncPlugin(BeetsPlugin):
                 audio_features = self.track_audio_features(item.spotify_track_id)
                 for feature in audio_features.keys():
                     if feature in spotify_audio_features.keys():
-                        item[spotify_audio_features[feature][0]] = audio_features[feature]
+                        item[spotify_audio_features[feature][0]] =
+                        audio_features[feature]
                 item.store()
                 if write:
                     item.try_write()

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -216,13 +216,12 @@ class SpotifySyncPlugin(BeetsPlugin):
         track_data = self._handle_response(
             requests.get, self.track_url + track_id
         )
-        self._log.debug('track_data: {}',track_data['popularity'])
-        track_popularity=track_data['popularity']
+        self._log.debug('track_data: {}', strack_data['popularity'])
+        track_popularity = track_data['popularity']
         return track_popularity
 
     def track_audio_features(self, track_id=None):
-        """Fetch track features by its Spotify ID or URL and return a
-        TrackInfo object or None if the track is not found.
+        """Fetch track features by its Spotify ID.
 
         :param track_id: (Optional) Spotify ID or URL for the track. Either
             ``track_id`` or ``track_data`` must be provided.
@@ -236,5 +235,5 @@ class SpotifySyncPlugin(BeetsPlugin):
         track_data = self._handle_response(
             requests.get, self.audio_features_url + track_id
         )
-        audio_features=track_data
+        audio_features = track_data
         return audio_features

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -30,8 +30,21 @@ from beets import ui
 from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.plugins import MetadataSourcePlugin, BeetsPlugin
 
-
 class SpotifySyncPlugin(BeetsPlugin):
+
+    SPOTIFY_AUDIO_FEATURES = {
+        'danceability': ['spotify_track_danceability'],
+        'energy': ['spotify_track_energy'],
+        'instrumentalness': ['spotify_track_instrumentalness'],
+        'key': ['spotify_track_key'],
+        'liveness': ['spotify_track_liveness'],
+        'loudness': ['spotify_track_loudness'],
+        'mode': ['spotify_track_mode'],
+        'speechiness': ['spotify_track_speechiness'],
+        'tempo': ['spotify_track_tempo'],
+        'time_signature': ['spotify_track_time_sig'],
+        'valence': ['spotify_track_valence'],
+    }
     data_source = 'Spotify'
 
     # Base URLs for the Spotify API
@@ -145,18 +158,21 @@ class SpotifySyncPlugin(BeetsPlugin):
                     self._log.debug('skipping popularity')
                 item['spotify_track_popularity'] = data
                 audio_features = self.track_audio_features(item.spotify_track_id)
-                item['spotify_track_acousticness'] = audio_features["acousticness"]
-                item['spotify_track_danceability'] = audio_features["danceability"]
-                item['spotify_track_energy'] = audio_features["energy"]
-                item['spotify_track_instrumentalness'] = audio_features["instrumentalness"]
-                item['spotify_track_key'] = audio_features["key"]
-                item['spotify_track_liveness'] = audio_features["liveness"]
-                item['spotify_track_loudness'] = audio_features["loudness"]
-                item['spotify_track_mode'] = audio_features["mode"]
-                item['spotify_track_speechiness'] = audio_features["speechiness"]
-                item['spotify_track_tempo'] = audio_features["tempo"]
-                item['spotify_track_time_sig'] = audio_features["time_signature"]
-                item['spotify_track_valence'] = audio_features["valence"]
+                for key in audio_features.keys():
+                    self._log.info('key: {}',SPOTIFY_AUDIO_FEATURES[key][0])
+                    item[SPOTIFY_AUDIO_FEATURES[key][0]] = audio_features[key]
+                # item['spotify_track_acousticness'] = audio_features["acousticness"]
+                # item['spotify_track_danceability'] = audio_features["danceability"]
+                # item['spotify_track_energy'] = audio_features["energy"]
+                # item['spotify_track_instrumentalness'] = audio_features["instrumentalness"]
+                # item['spotify_track_key'] = audio_features["key"]
+                # item['spotify_track_liveness'] = audio_features["liveness"]
+                # item['spotify_track_loudness'] = audio_features["loudness"]
+                # item['spotify_track_mode'] = audio_features["mode"]
+                # item['spotify_track_speechiness'] = audio_features["speechiness"]
+                # item['spotify_track_tempo'] = audio_features["tempo"]
+                # item['spotify_track_time_sig'] = audio_features["time_signature"]
+                # item['spotify_track_valence'] = audio_features["valence"]
                 item.store()
                 if write:
                     item.try_write()

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -1,5 +1,5 @@
 # This file is part of beets.
-# Copyright 2019, Rahul Ahuja.
+# Copyright 2019, Alok Saboo
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -160,6 +160,8 @@ class SpotifySyncPlugin(BeetsPlugin):
                 item['spotify_track_popularity'] = data
                 audio_features = self.track_audio_features(item.spotify_track_id)
                 for feature in audio_features.keys():
+                    if feature in [ "analysis_url", "duration_ms", "id", "track_href", "type", "audio_features", "uri"]:
+                        continue
                     self._log.info('features: {}',feature)
                     self._log.info('key: {}',SPOTIFY_AUDIO_FEATURES[feature][0])
                     self._log.info('audio feature: {} for {}',audio_features[feature], item)

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -124,9 +124,12 @@ class SpotifySyncPlugin(BeetsPlugin):
         import time
         """Fetch popularity information from Spotify for the item.
         """
-        for item in items:
+        no_items = len(items)
+        self._log.info('Total {} tracks', no_items)
+
+        for index, item in enumerate(items, start=1):
             time.sleep(.5)
-            self._log.info('getting data for: {}', item)
+            self._log.info('Processing {}/{} tracks', index, no_items)
             try:
                 # If we're not forcing re-downloading for all tracks, check
                 # whether the popularity data is already present

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -134,9 +134,10 @@ class SpotifySyncPlugin(BeetsPlugin):
                 # If we're not forcing re-downloading for all tracks, check
                 # whether the popularity data is already present
                 if not force:
+                    self._log.info('Force 1')
                     spotify_track_popularity = item.get('spotify_track_popularity', '')
                     if spotify_track_popularity:
-                        self._log.debug('data already present for: {}', item)
+                        self._log.info('Popularity already present for: {}', item)
                         continue
 
                 data = self.track_popularity(item.spotify_track_id)

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -169,7 +169,6 @@ class SpotifySyncPlugin(BeetsPlugin):
 
     def _handle_response(self, request_type, url, params=None):
         """Send a request, reauthenticating if necessary.
-
         :param request_type: Type of :class:`Request` constructor,
             e.g. ``requests.get``, ``requests.post``, etc.
         :type request_type: function

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -198,10 +198,11 @@ class SpotifySyncPlugin(BeetsPlugin):
         :return: TrackInfo object for track
         :rtype: beets.autotag.hooks.TrackInfo or None
         """
-        self._log.error('{}',track_id)
+        self._log.error('spotify_track_id: {}',track_id)
         track_data = self._handle_response(
-            requests.get, self.track_url + spotify_id
+            requests.get, self.track_url + track_id
         )
+        self._log.error('track_data: {}',track_data)
         track = self._get_track(track_data)
         return track
 

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -199,9 +199,6 @@ class SpotifySyncPlugin(BeetsPlugin):
         :rtype: beets.autotag.hooks.TrackInfo or None
         """
         self._log.error('{}',track_id)
-        spotify_id = self._get_id('track', spotify_track_id)
-        if spotify_id is None:
-            return None
         track_data = self._handle_response(
             requests.get, self.track_url + spotify_id
         )

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -130,26 +130,28 @@ class SpotifySyncPlugin(BeetsPlugin):
             # representative field name to check for previously fetched
             # data.
             # We can only fetch data for tracks with MBIDs.
-            if not item.spotify_track_id:
-                continue
+            # if not item.spotify_track_id:
+            #     continue
+            try:
+                if not force:
+                    spotify_track_popularity = item.get('spotify_track_popularity', '')
+                    if spotify_track_popularity:
+                        self._log.error('data already present for: {}', item)
+                        continue
 
-            if not force:
-                spotify_track_popularity = item.get('spotify_track_popularity', '')
-                if spotify_track_popularity:
-                    self._log.error('data already present for: {}', item)
-                    continue
-
-            self._log.info('getting data for: {}', item)
-            data = self.track_popularity(item.spotify_track_id)
-            self._log.info('data1: {}', data)
-            if data:
-                self._log.debug('data = {}', data)
-            else:
-                self._log.debug('skipping popularity')
-            item['spotify_track_popularity'] = data
-            item.store()
-            if write:
-                item.try_write()
+                self._log.info('getting data for: {}', item)
+                data = self.track_popularity(item.spotify_track_id)
+                self._log.info('data1: {}', data)
+                if data:
+                    self._log.debug('data = {}', data)
+                else:
+                    self._log.debug('skipping popularity')
+                item['spotify_track_popularity'] = data
+                item.store()
+                if write:
+                    item.try_write()
+            except AttributeError:
+                pass
 
 
     def _handle_response(self, request_type, url, params=None):

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -32,19 +32,6 @@ from beets.plugins import MetadataSourcePlugin, BeetsPlugin
 
 class SpotifySyncPlugin(BeetsPlugin):
 
-    SPOTIFY_AUDIO_FEATURES = {
-        'danceability': ['spotify_track_danceability'],
-        'energy': ['spotify_track_energy'],
-        'instrumentalness': ['spotify_track_instrumentalness'],
-        'key': ['spotify_track_key'],
-        'liveness': ['spotify_track_liveness'],
-        'loudness': ['spotify_track_loudness'],
-        'mode': ['spotify_track_mode'],
-        'speechiness': ['spotify_track_speechiness'],
-        'tempo': ['spotify_track_tempo'],
-        'time_signature': ['spotify_track_time_sig'],
-        'valence': ['spotify_track_valence'],
-    }
     data_source = 'Spotify'
 
     # Base URLs for the Spotify API
@@ -133,6 +120,19 @@ class SpotifySyncPlugin(BeetsPlugin):
         return [cmd]
 
     def _fetch_info(self, items, write, force):
+        SPOTIFY_AUDIO_FEATURES = {
+            'danceability': ['spotify_track_danceability'],
+            'energy': ['spotify_track_energy'],
+            'instrumentalness': ['spotify_track_instrumentalness'],
+            'key': ['spotify_track_key'],
+            'liveness': ['spotify_track_liveness'],
+            'loudness': ['spotify_track_loudness'],
+            'mode': ['spotify_track_mode'],
+            'speechiness': ['spotify_track_speechiness'],
+            'tempo': ['spotify_track_tempo'],
+            'time_signature': ['spotify_track_time_sig'],
+            'valence': ['spotify_track_valence'],
+        }
         import time
         """Fetch popularity information from Spotify for the item.
         """

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -1,5 +1,5 @@
 # This file is part of beets.
-# Copyright 2019, Alok Saboo
+# Copyright 2022, Alok Saboo
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -144,8 +144,8 @@ class SpotifySyncPlugin(BeetsPlugin):
                 # If we're not forcing re-downloading for all tracks, check
                 # whether the popularity data is already present
                 if not force:
-                    spotify_track_popularity =
-                    item.get('spotify_track_popularity', '')
+                    spotify_track_popularity = (
+                      item.get('spotify_track_popularity', ''))
                     if spotify_track_popularity:
                         self._log.debug('Popularity already present for: {}',
                         item)

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -41,6 +41,7 @@ class SpotifySyncPlugin(BeetsPlugin):
     search_url = 'https://api.spotify.com/v1/search'
     album_url = 'https://api.spotify.com/v1/albums/'
     track_url = 'https://api.spotify.com/v1/tracks/'
+    track_url_new = 'https://api.spotify.com/v1/track/'
 
     def __init__(self):
         super().__init__()
@@ -200,7 +201,7 @@ class SpotifySyncPlugin(BeetsPlugin):
         """
         self._log.error('spotify_track_id: {}',track_id)
         track_data = self._handle_response(
-            requests.get, self.track_url + track_id
+            requests.get, self.track_url_new + track_id
         )
         self._log.error('track_data: {}',track_data)
         track = self._get_track(track_data)

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -241,6 +241,5 @@ class SpotifySyncPlugin(BeetsPlugin):
         track_data = self._handle_response(
             requests.get, self.audio_features_url + track_id
         )
-        self._log.info('track_data: {}',track_data['acousticness'])
         audio_features=track_data
         return audio_features

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -141,6 +141,7 @@ class SpotifySyncPlugin(BeetsPlugin):
 
             self._log.info('getting data for: {}', item)
             data = self.track_popularity(item.spotify_track_id)
+            self._log.info('data1: {}', data)
             if data:
                 self._log.debug('data = {}', data)
             else:

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -16,16 +16,14 @@
 Spotify playlist construction.
 """
 
-import re
 import json
 import base64
 
-import unidecode
 import requests
 import confuse
 
 from beets import ui
-from beets.plugins import MetadataSourcePlugin, BeetsPlugin
+from beets.plugins import  BeetsPlugin
 
 class SpotifySyncPlugin(BeetsPlugin):
 
@@ -100,6 +98,7 @@ class SpotifySyncPlugin(BeetsPlugin):
             json.dump({'access_token': self.access_token}, f)
 
     def commands(self):
+        """Setup spotifysync command."""
         cmd = ui.Subcommand('spotifysync',
                             help="fetch track attributes from Spotify")
         cmd.parser.add_option(
@@ -117,6 +116,8 @@ class SpotifySyncPlugin(BeetsPlugin):
         return [cmd]
 
     def _fetch_info(self, items, write, force):
+        """Obtain track information from Spotify.
+        """
         SPOTIFY_AUDIO_FEATURES = {
             'acousticness': ['spotify_track_acousticness'],
             'danceability': ['spotify_track_danceability'],

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -133,7 +133,7 @@ class SpotifySyncPlugin(BeetsPlugin):
                 if not force:
                     spotify_track_popularity = item.get('spotify_track_popularity', '')
                     if spotify_track_popularity:
-                        self._log.debug('data already present for: {}', item)
+                        self._log.error('data already present for: {}', item)
                         continue
 
                 self._log.info('getting data for: {}', item)

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -12,6 +12,10 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
+"""Adds Spotify sync function to import track popularity and audio features
+information.
+"""
+
 import json
 import base64
 
@@ -21,9 +25,9 @@ import confuse
 from beets import ui
 from beets.plugins import BeetsPlugin
 
+
 class SpotifySyncPlugin(BeetsPlugin):
     """Setup the SpotifySync Plugin."""
-
 
     data_source = 'Spotify'
 
@@ -35,6 +39,8 @@ class SpotifySyncPlugin(BeetsPlugin):
     audio_features_url = 'https://api.spotify.com/v1/audio-features/'
 
     def __init__(self):
+        """Initialize the SpotifySync Plugin."""
+
         super().__init__()
         self.config.add(
             {
@@ -51,6 +57,7 @@ class SpotifySyncPlugin(BeetsPlugin):
 
     def setup(self):
         """Retrieve previously saved OAuth token or generate a new one."""
+
         try:
             with open(self.tokenfile) as f:
                 token_data = json.load(f)
@@ -60,9 +67,7 @@ class SpotifySyncPlugin(BeetsPlugin):
             self.access_token = token_data['access_token']
 
     def _authenticate(self):
-        """Request an access token via the Client Credentials Flow.
-        https://developer.spotify.com/documentation/general/guides/authorization-guide/#client-credentials-flow
-        """
+        """Request an access token via the Client Credentials Flow. """
 
         headers = {
             'Authorization': 'Basic {}'.format(

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -19,15 +19,12 @@ Spotify playlist construction.
 import re
 import json
 import base64
-import webbrowser
-import collections
 
 import unidecode
 import requests
 import confuse
 
 from beets import ui
-from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.plugins import MetadataSourcePlugin, BeetsPlugin
 
 class SpotifySyncPlugin(BeetsPlugin):
@@ -152,12 +149,8 @@ class SpotifySyncPlugin(BeetsPlugin):
                         self._log.debug('Popularity already present for: {}', item)
                         continue
 
-                data = self.track_popularity(item.spotify_track_id)
-                if data:
-                    self._log.debug('data = {}', data)
-                else:
-                    self._log.debug('skipping popularity')
-                item['spotify_track_popularity'] = data
+                popularity = self.track_popularity(item.spotify_track_id)
+                item['spotify_track_popularity'] = popularity
                 audio_features = self.track_audio_features(item.spotify_track_id)
                 for feature in audio_features.keys():
                     if feature in SPOTIFY_AUDIO_FEATURES.keys():

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -160,6 +160,7 @@ class SpotifySyncPlugin(BeetsPlugin):
                 audio_features = self.track_audio_features(item.spotify_track_id)
                 for key in audio_features.keys():
                     self._log.info('key: {}',SPOTIFY_AUDIO_FEATURES[key][0])
+                    self._log.info('audio feature: {}',audio_features[key])
                     item[SPOTIFY_AUDIO_FEATURES[key][0]] = audio_features[key]
                 # item['spotify_track_acousticness'] = audio_features["acousticness"]
                 # item['spotify_track_danceability'] = audio_features["danceability"]

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -31,7 +31,7 @@ from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.plugins import MetadataSourcePlugin, BeetsPlugin
 
 
-class SpotifySyncPlugin(plugins.BeetsPlugin):
+class SpotifySyncPlugin(BeetsPlugin):
     data_source = 'Spotify'
 
     # Base URLs for the Spotify API

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -136,32 +136,29 @@ class SpotifySyncPlugin(BeetsPlugin):
         no_items = len(items)
         self._log.info('Total {} tracks', no_items)
 
-        for (index, item) in enumerate(items, start=1):
+        for index, item in enumerate(items, start=1):
             time.sleep(.5)
-            self._log.info('Processing {}/{} tracks - {} ', index,
-                           no_items, item)
+            self._log.info('Processing {}/{} tracks - {} ',
+                           index, no_items, item)
             try:
-
                 # If we're not forcing re-downloading for all tracks, check
                 # whether the popularity data is already present
-
                 if not force:
                     spotify_track_popularity = \
                         item.get('spotify_track_popularity', '')
                     if spotify_track_popularity:
-                        self._log.debug('Popularity already present for: {}'
-                                , item)
+                        self._log.debug('Popularity already present for: {}',
+                        item)
                         continue
 
-                popularity = \
-                    self.track_popularity(item.spotify_track_id)
+                popularity = self.track_popularity(item.spotify_track_id)
                 item['spotify_track_popularity'] = popularity
-                audio_features = \
-                    self.track_audio_features(item.spotify_track_id)
+                audio_features = self.track_audio_features(item.spotify_track_id)
                 for feature in audio_features.keys():
                     if feature in spotify_audio_features.keys():
-                        item[spotify_audio_features[feature][0]] = \
-                            audio_features[feature]
+                        item[spotify_audio_features[feature][0]] =
+                        audio_features[feature]
+                item.store()
                 if write:
                     item.try_write()
             except AttributeError:

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -12,10 +12,6 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
-"""Adds Spotify release and track search support to the autotagger, along with
-Spotify playlist construction.
-"""
-
 import json
 import base64
 
@@ -23,9 +19,11 @@ import requests
 import confuse
 
 from beets import ui
-from beets.plugins import  BeetsPlugin
+from beets.plugins import BeetsPlugin
 
 class SpotifySyncPlugin(BeetsPlugin):
+    """Setup the SpotifySync Plugin."""
+
 
     data_source = 'Spotify'
 
@@ -62,9 +60,10 @@ class SpotifySyncPlugin(BeetsPlugin):
             self.access_token = token_data['access_token']
 
     def _authenticate(self):
-        """Request an access token via the Client Credentials Flow:
+        """Request an access token via the Client Credentials Flow.
         https://developer.spotify.com/documentation/general/guides/authorization-guide/#client-credentials-flow
         """
+
         headers = {
             'Authorization': 'Basic {}'.format(
                 base64.b64encode(
@@ -116,9 +115,9 @@ class SpotifySyncPlugin(BeetsPlugin):
         return [cmd]
 
     def _fetch_info(self, items, write, force):
-        """Obtain track information from Spotify.
-        """
-        SPOTIFY_AUDIO_FEATURES = {
+        """Obtain track information from Spotify."""
+
+        spotify_audio_features = {
             'acousticness': ['spotify_track_acousticness'],
             'danceability': ['spotify_track_danceability'],
             'energy': ['spotify_track_energy'],
@@ -133,8 +132,8 @@ class SpotifySyncPlugin(BeetsPlugin):
             'valence': ['spotify_track_valence'],
         }
         import time
-        """Fetch popularity information from Spotify for the item.
-        """
+        """Fetch popularity information from Spotify for the item."""
+
         no_items = len(items)
         self._log.info('Total {} tracks', no_items)
 
@@ -154,8 +153,8 @@ class SpotifySyncPlugin(BeetsPlugin):
                 item['spotify_track_popularity'] = popularity
                 audio_features = self.track_audio_features(item.spotify_track_id)
                 for feature in audio_features.keys():
-                    if feature in SPOTIFY_AUDIO_FEATURES.keys():
-                        item[SPOTIFY_AUDIO_FEATURES[feature][0]] = audio_features[feature]
+                    if feature in spotify_audio_features.keys():
+                        item[spotify_audio_features[feature][0]] = audio_features[feature]
                 item.store()
                 if write:
                     item.try_write()

--- a/beetsplug/spotifysync.py
+++ b/beetsplug/spotifysync.py
@@ -142,9 +142,9 @@ class SpotifySyncPlugin(BeetsPlugin):
 
                 data = self.track_popularity(item.spotify_track_id)
                 if data:
-                    self._log.debug('data = {}', data)
+                    self._log.info('data = {}', data)
                 else:
-                    self._log.debug('skipping popularity')
+                    self._log.info('skipping popularity')
                 item['spotify_track_popularity'] = data
                 item.store()
                 if write:


### PR DESCRIPTION
This PR introduces a new command `beet spotifysync` to obtain all the audio features available for a track. This includes the `popularity` information and `audio_features`. The following `audio_features` are included: acousticness, danceability, energy, instrumentalness, key, liveness, loudness, mode, speechiness, tempo, time_signature, valence. See details [here](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-audio-features). 

This features only processes tracks that already have the spotify_track_id (which was introduced in #4348). So, the workflow will be to run `beet import` which will populate the `spotify_track_id`. This information can then be used to run `beet spotifysync`. 

Fixes #4347 #3578 #4094

Config required:

```
spotifysync:
    client_id: SPOTIFY_CLIENT_ID
    client_secret: SPOTIFY_CLIENT_SECRET
    force: no
```

My hope is that we get the initial PR so that folks can start using it and improve upon it. 

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
