### PR TITLE
Extend Spotify plugin to obtain (popularity and audio features) track attributes

### DIFF
--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -251,6 +251,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
             artist=artist,
             artist_id=artist_id,
             spotify_artist_id=artist_id,
+            spotify_track_popularity=track_data['popularity'],
             length=track_data['duration_ms'] / 1000,
             index=track_data['track_number'],
             medium=track_data['disc_number'],

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -251,6 +251,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
             artist=artist,
             artist_id=artist_id,
             spotify_artist_id=artist_id,
+            spotify_track_popularity=track_data['tracks']['popularity'],
             length=track_data['duration_ms'] / 1000,
             index=track_data['track_number'],
             medium=track_data['disc_number'],

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -413,8 +413,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
 
         def func(lib, opts, args):
             items = lib.items(ui.decargs(args))
-            self._fetch_info(items, ui.should_write(),
-                             opts.force_refetch or self.config['force'])
+            self._fetch_info(items, ui.should_write(), opts.force_refetch)
 
         sync_cmd.func = func
         return [spotify_cmd, sync_cmd]

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -597,8 +597,6 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
                     self.track_audio_features(item.spotify_track_id)
                 for feature in audio_features.keys():
                     if feature in spotify_audio_features.keys():
-                        self._log.info('feature: {}',
-                                       audio_features[feature])
                         item[spotify_audio_features[feature][0]] = \
                             audio_features[feature]
                 item.store()

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -586,9 +586,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
                 # If we're not forcing re-downloading for all tracks, check
                 # whether the popularity data is already present
                 if not force:
-                    spotify_track_popularity = \
-                        item.get('spotify_track_popularity', '')
-                    if spotify_track_popularity:
+                    if 'spotify_track_popularity' in item:
                         self._log.debug('Popularity already present for: {}',
                                         item)
                         continue

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -612,8 +612,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
             requests.get, self.track_url + track_id
         )
         self._log.debug('track_data: {}', track_data['popularity'])
-        track_popularity = track_data['popularity']
-        return track_popularity
+        return track_data['popularity']
 
     def track_audio_features(self, track_id=None):
         """Fetch track audio features by its Spotify ID."""

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -251,7 +251,6 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
             artist=artist,
             artist_id=artist_id,
             spotify_artist_id=artist_id,
-            spotify_track_popularity=track_data['tracks']['popularity'],
             length=track_data['duration_ms'] / 1000,
             index=track_data['track_number'],
             medium=track_data['disc_number'],

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -1,5 +1,6 @@
 # This file is part of beets.
 # Copyright 2019, Rahul Ahuja.
+# Copyright 2022, Alok Saboo.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -606,16 +606,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
                 pass
 
     def track_popularity(self, track_id=None):
-        """Fetch a track popularity by its Spotify ID.
-        :param track_id: (Optional) Spotify ID or URL for the track. Either
-            ``track_id`` or ``track_data`` must be provided.
-        :type track_id: str
-        :param track_data: (Optional) Simplified track object dict. May be
-            provided instead of ``track_id`` to avoid unnecessary API calls.
-        :type track_data: dict
-        :return: TrackInfo object for track
-        :rtype: beets.autotag.hooks.TrackInfo or None
-        """
+        """Fetch a track popularity by its Spotify ID."""
         track_data = self._handle_response(
             requests.get, self.track_url + track_id
         )
@@ -624,16 +615,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
         return track_popularity
 
     def track_audio_features(self, track_id=None):
-        """Fetch track features by its Spotify ID.
-        :param track_id: (Optional) Spotify ID or URL for the track. Either
-            ``track_id`` or ``track_data`` must be provided.
-        :type track_id: str
-        :param track_data: (Optional) Simplified track object dict. May be
-            provided instead of ``track_id`` to avoid unnecessary API calls.
-        :type track_data: dict
-        :return: TrackInfo object for track
-        :rtype: beets.autotag.hooks.TrackInfo or None
-        """
+        """Fetch track audio features by its Spotify ID."""
         track_data = self._handle_response(
             requests.get, self.audio_features_url + track_id
         )

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -597,6 +597,8 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
                     self.track_audio_features(item.spotify_track_id)
                 for feature in audio_features.keys():
                     if feature in spotify_audio_features.keys():
+                        self._log.info('feature: {}',
+                                       audio_features[feature])
                         item[spotify_audio_features[feature][0]] = \
                             audio_features[feature]
                 item.store()

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -578,6 +578,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
 
         for index, item in enumerate(items, start=1):
             # Added sleep to avoid API rate limit
+            # https://developer.spotify.com/documentation/web-api/guides/rate-limits/
             time.sleep(.5)
             self._log.info('Processing {}/{} tracks - {} ',
                            index, len(items), item)

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -251,7 +251,6 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
             artist=artist,
             artist_id=artist_id,
             spotify_artist_id=artist_id,
-            spotify_track_popularity=track_data['popularity'],
             length=track_data['duration_ms'] / 1000,
             index=track_data['track_number'],
             medium=track_data['disc_number'],

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -66,6 +66,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
                 'client_id': '4e414367a1d14c75a5c5129a627fcab8',
                 'client_secret': 'f82bdc09b2254f1a8286815d02fd46dc',
                 'tokenfile': 'spotify_token.json',
+                'force': False,
             }
         )
         self.config['client_secret'].redact = True

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -41,6 +41,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
     search_url = 'https://api.spotify.com/v1/search'
     album_url = 'https://api.spotify.com/v1/albums/'
     track_url = 'https://api.spotify.com/v1/tracks/'
+    audio_features_url = 'https://api.spotify.com/v1/audio-features/'
 
     # Spotify IDs consist of 22 alphanumeric characters
     # (zero-left-padded base62 representation of randomly generated UUID4)

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -577,6 +577,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
         self._log.debug('Total {} tracks', len(items))
 
         for index, item in enumerate(items, start=1):
+            # Added sleep to avoid API rate limit
             time.sleep(.5)
             self._log.info('Processing {}/{} tracks - {} ',
                            index, len(items), item)

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -53,18 +53,18 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
     }
 
     spotify_audio_features = {
-        'acousticness': 'spotify_track_acousticness',
-        'danceability': 'spotify_track_danceability',
-        'energy': 'spotify_track_energy',
-        'instrumentalness': 'spotify_track_instrumentalness',
-        'key': 'spotify_track_key',
-        'liveness': 'spotify_track_liveness',
-        'loudness': 'spotify_track_loudness',
-        'mode': 'spotify_track_mode',
-        'speechiness': 'spotify_track_speechiness',
-        'tempo': 'spotify_track_tempo',
-        'time_signature': 'spotify_track_time_sig',
-        'valence': 'spotify_track_valence',
+        'acousticness': 'spotify_acousticness',
+        'danceability': 'spotify_danceability',
+        'energy': 'spotify_energy',
+        'instrumentalness': 'spotify_instrumentalness',
+        'key': 'spotify_key',
+        'liveness': 'spotify_liveness',
+        'loudness': 'spotify_loudness',
+        'mode': 'spotify_mode',
+        'speechiness': 'spotify_speechiness',
+        'tempo': 'spotify_tempo',
+        'time_signature': 'spotify_time_signature',
+        'valence': 'spotify_valence',
     }
 
     def __init__(self):

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -620,5 +620,4 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
         track_data = self._handle_response(
             requests.get, self.audio_features_url + track_id
         )
-        audio_features = track_data
-        return audio_features
+        return track_data

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -590,20 +590,22 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
                                     item)
                     continue
             try:
-                popularity = self.track_popularity(item.spotify_track_id)
-                item['spotify_track_popularity'] = popularity
-                audio_features = \
-                    self.track_audio_features(item.spotify_track_id)
-                for feature in audio_features.keys():
-                    if feature in self.spotify_audio_features.keys():
-                        item[self.spotify_audio_features[feature]] = \
-                            audio_features[feature]
-                item.store()
-                if write:
-                    item.try_write()
+                spotify_track_id = item.spotify_track_id
             except AttributeError:
                 self._log.debug('No track_id present for: {}', item)
-                pass
+                continue
+
+            popularity = self.track_popularity(spotify_track_id)
+            item['spotify_track_popularity'] = popularity
+            audio_features = \
+                self.track_audio_features(spotify_track_id)
+            for feature in audio_features.keys():
+                if feature in self.spotify_audio_features.keys():
+                    item[self.spotify_audio_features[feature]] = \
+                        audio_features[feature]
+            item.store()
+            if write:
+                item.try_write()
 
     def track_popularity(self, track_id=None):
         """Fetch a track popularity by its Spotify ID."""

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,10 @@ Changelog goes here!
 
 New features:
 
+* :doc:`/plugins/spotify`: The plugin now provides an additional command
+  `spotifysync` that allows getting track popularity and audio features
+  information from Spotify.
+  :bug:`4094`
 * :doc:`/plugins/spotify`: The plugin now records Spotify-specific IDs in the
   `spotify_album_id`, `spotify_artist_id`, and `spotify_track_id` fields.
   :bug:`4348`

--- a/docs/plugins/spotify.rst
+++ b/docs/plugins/spotify.rst
@@ -19,6 +19,7 @@ Why Use This Plugin?
 * You have playlists or albums you'd like to make available in Spotify from Beets without having to search for each artist/album/track.
 * You want to check which tracks in your library are available on Spotify.
 * You want to autotag music with metadata from the Spotify API.
+* You want to obtain track popularity and audio features (e.g., danceability)
 
 Basic Usage
 -----------
@@ -58,7 +59,7 @@ configuration options are provided.
 The default options should work as-is, but there are some options you can put
 in config.yaml under the ``spotify:`` section:
 
-- **mode**: One of the following:  
+- **mode**: One of the following:
 
    - ``list``: Print out the playlist as a list of links. This list can then
      be pasted in to a new or existing Spotify playlist.
@@ -105,3 +106,19 @@ Here's an example::
             }
         ]
 
+Obtaining Track Popularity and Audio Features from Spotify
+----------------------------------------------------------
+
+Spotify provides track `popularity`_ and audio `features`_ that be used to
+create better playlists.
+
+.. _popularity: https://developer.spotify.com/documentation/web-api/reference/#/operations/get-track
+.. _features: https://developer.spotify.com/documentation/web-api/reference/#/operations/get-audio-features
+
+The ``spotify`` plugin provides an additional command ``spotifysync`` to obtain
+these track attributes from Spotify:
+
+* ``beet spotifysync [-f]``: obtain popularity and audio features information
+  for every track in the library. By default, ``spotifysync`` will skip tracks
+  that already have this information populated. Using the ``-f`` or ``-force``
+  option will download the data even for tracks that already have it.

--- a/docs/plugins/spotify.rst
+++ b/docs/plugins/spotify.rst
@@ -109,10 +109,11 @@ Here's an example::
 Obtaining Track Popularity and Audio Features from Spotify
 ----------------------------------------------------------
 
-Spotify provides track `popularity`_ and audio `features`_ that be used to
-create better playlists.
+Spotify provides information on track `popularity`_ and audio `features`_ that
+can be used for music discovery.
 
 .. _popularity: https://developer.spotify.com/documentation/web-api/reference/#/operations/get-track
+
 .. _features: https://developer.spotify.com/documentation/web-api/reference/#/operations/get-audio-features
 
 The ``spotify`` plugin provides an additional command ``spotifysync`` to obtain
@@ -126,3 +127,19 @@ these track attributes from Spotify:
   identifiers. So run ``spotifysync`` only after importing your music, during
   which Spotify identifiers will be added for tracks where Spotify is chosen as
   the tag source.
+
+  In addition to ``popularity``, the command currently sets these audio features
+  for all tracks with a Spotify track ID:
+
+  * ``acousticness``
+  * ``danceability``
+  * ``energy``
+  * ``instrumentalness``
+  * ``key``
+  * ``liveness``
+  * ``loudness``
+  * ``mode``
+  * ``speechiness``
+  * ``tempo``
+  * ``time_signature``
+  * ``valence``

--- a/docs/plugins/spotify.rst
+++ b/docs/plugins/spotify.rst
@@ -121,4 +121,8 @@ these track attributes from Spotify:
 * ``beet spotifysync [-f]``: obtain popularity and audio features information
   for every track in the library. By default, ``spotifysync`` will skip tracks
   that already have this information populated. Using the ``-f`` or ``-force``
-  option will download the data even for tracks that already have it.
+  option will download the data even for tracks that already have it. Please
+  note that ``spotifysync`` works on tracks that have the Spotify track
+  identifiers. So run ``spotifysync`` only after importing your music, during
+  which Spotify identifiers will be added for tracks where Spotify is chosen as
+  the tag source.


### PR DESCRIPTION
This PR extends the `spotify` plugin to add another command `beet spotifysync` to obtain all the audio features available for a track. This includes the `popularity` information and `audio_features`. The following `audio_features` are included: acousticness, danceability, energy, instrumentalness, key, liveness, loudness, mode, speechiness, tempo, time_signature, valence. See details [here](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-audio-features). 

This command only processes tracks that already have the `spotify_track_id` (which was introduced in #4348). So, the workflow will be to run `beet import` to obtain the `spotify_track_id`. This information can then be used to run `beet spotifysync`. 

Fixes #4347 #3578 #4094

optional config:

```
spotify:
    client_id: SPOTIFY_CLIENT_ID
    client_secret: SPOTIFY_CLIENT_SECRET
```

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
