### PR TITLE
Play plugin: allow generation of playlist with M3U extensions (comments)

### DIFF
--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -195,7 +195,7 @@ class PlayPlugin(BeetsPlugin):
 
         if extended_m3u:
             m3u.write(b'#EXTM3U\n')
-        
+
         for item in paths_list:
             m3u.write(item + b'\n')
         m3u.close()

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -65,6 +65,7 @@ class PlayPlugin(BeetsPlugin):
             'raw': False,
             'warning_threshold': 100,
             'bom': False,
+            'extended_m3u': True,
         })
 
         self.register_listener('before_choose_candidate',
@@ -186,11 +187,15 @@ class PlayPlugin(BeetsPlugin):
         """Create a temporary .m3u file. Return the filename.
         """
         utf8_bom = config['play']['bom'].get(bool)
+        extended_m3u = config['play']['extended_m3u'].get(bool)
         m3u = NamedTemporaryFile('wb', suffix='.m3u', delete=False)
 
         if utf8_bom:
             m3u.write(b'\xEF\xBB\xBF')
 
+        if extended_m3u:
+            m3u.write(b'#EXTM3U\n')
+        
         for item in paths_list:
             m3u.write(item + b'\n')
         m3u.close()

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,7 @@ New features:
   :bug:`1840` :bug:`4302`
 * Added a ``-P`` (or ``--disable-plugins``) flag to specify one/multiple plugin(s) to be
   disabled at startup.
+* :doc:`/plugins/play`: Allow m3u extensions in the temporary playlist.
 
 Bug fixes:
 

--- a/docs/plugins/play.rst
+++ b/docs/plugins/play.rst
@@ -65,6 +65,9 @@ configuration file. The available options are:
 - **bom**: Set whether or not a UTF-8 Byte Order Mark should be emitted into
   the m3u file. If you're using foobar2000 or Winamp, this is needed.
   Default: ``no``.
+- **extended_m3u**: Set whether or not the plugin will add M3U extensions
+  (or comments) to the m3u file.
+  Default: ``yes``.
 
 Optional Arguments
 ------------------


### PR DESCRIPTION
These commits modify the play plugin to create m3u playlists with the #EXTM3U comment.

- [x] Documentation. 
- [x] Changelog.
