### PR TITLE
add cl formatting to beatport plugin docs

### DIFF
--- a/docs/plugins/beatport.rst
+++ b/docs/plugins/beatport.rst
@@ -32,7 +32,7 @@ from MusicBrainz and other sources.
 
 If you have a Beatport ID or a URL for a release or track you want to tag, you
 can just enter one of the two at the "enter Id" prompt in the importer. You can
-also search for an id like so:
+also search for an id like so::
 
     beet import path/to/music/library --search-id id
 


### PR DESCRIPTION
## Description

Fixes the command line formatting for the Beatport plugin page in the Documentation.

