### PR TITLE
mediafile: Improve deprecation warning

### DIFF
--- a/beets/mediafile.py
+++ b/beets/mediafile.py
@@ -16,11 +16,18 @@
 import mediafile
 
 import warnings
-warnings.warn("beets.mediafile is deprecated; use mediafile instead")
+warnings.warn(
+    "beets.mediafile is deprecated; use mediafile instead",
+    # Show the location of the `import mediafile` statement as the warning's
+    # source, rather than this file, such that the offending module can be
+    # identified easily.
+    stacklevel=2,
+)
 
 # Import everything from the mediafile module into this module.
 for key, value in mediafile.__dict__.items():
     if key not in ['__name__']:
         globals()[key] = value
 
+# Cleanup namespace.
 del key, value, warnings, mediafile


### PR DESCRIPTION
This is for mediafile what cc8c3529fbf528da8eadadf2ff61389db9adf767 was for confit, cf. https://github.com/beetbox/beets/pull/4263.

Spotted in the top post of https://github.com/beetbox/beets/issues/4330