### PR TITLE
Add Spotify 429 (too many requests) API error handling

### DIFF
--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -170,7 +170,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
                                                DEFAULT_WAITING_TIME)
                 self._log.debug('Too many API requests. Retrying after {} \
                     seconds.', seconds)
-                time.sleep(int(seconds))
+                time.sleep(int(seconds) + 1)
                 return self._handle_response(request_type, url, params=params)
             else:
                 raise ui.UserError(

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -167,8 +167,8 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
             elif response.status_code == 429:
                 seconds = response.headers['Retry-After']
                 time.sleep(int(seconds))
-                self._log.info('Too many API requests. Retrying after {} seconds.',
-                               seconds)
+                self._log.info('Too many API requests. Retrying after {} \
+                    seconds.', seconds)
                 return self._handle_response(request_type, url, params=params)
             else:
                 raise ui.UserError(

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -17,20 +17,19 @@
 Spotify playlist construction.
 """
 
-import re
-import json
 import base64
+import collections
+import json
+import re
 import time
 import webbrowser
-import collections
 
-import unidecode
-import requests
 import confuse
-
+import requests
+import unidecode
 from beets import ui
 from beets.autotag.hooks import AlbumInfo, TrackInfo
-from beets.plugins import MetadataSourcePlugin, BeetsPlugin
+from beets.plugins import BeetsPlugin, MetadataSourcePlugin
 
 DEFAULT_WAITING_TIME = 5
 

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -164,6 +164,11 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
                 )
                 self._authenticate()
                 return self._handle_response(request_type, url, params=params)
+            elif response.status_code == 429:
+                seconds = response.headers['Retry-After']
+                time.sleep(int(seconds))
+                self._log.info('Too many API requests. Retrying after {} seconds.', seconds)
+                return self._handle_response(request_type, url, params=params)
             else:
                 raise ui.UserError(
                     '{} API error:\n{}\nURL:\n{}\nparams:\n{}'.format(

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -32,6 +32,7 @@ from beets import ui
 from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.plugins import MetadataSourcePlugin, BeetsPlugin
 
+DEFAULT_WAITING_TIME = 5
 
 class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
     data_source = 'Spotify'
@@ -165,10 +166,11 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
                 self._authenticate()
                 return self._handle_response(request_type, url, params=params)
             elif response.status_code == 429:
-                seconds = response.headers['Retry-After']
-                time.sleep(int(seconds))
-                self._log.info('Too many API requests. Retrying after {} \
+                seconds = response.headers.get('Retry-After',
+                                               DEFAULT_WAITING_TIME)
+                self._log.debug('Too many API requests. Retrying after {} \
                     seconds.', seconds)
+                time.sleep(int(seconds))
                 return self._handle_response(request_type, url, params=params)
             else:
                 raise ui.UserError(

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -34,6 +34,7 @@ from beets.plugins import MetadataSourcePlugin, BeetsPlugin
 
 DEFAULT_WAITING_TIME = 5
 
+
 class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
     data_source = 'Spotify'
 

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -585,9 +585,6 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
         self._log.debug('Total {} tracks', len(items))
 
         for index, item in enumerate(items, start=1):
-            # Added sleep to avoid API rate limit
-            # https://developer.spotify.com/documentation/web-api/guides/rate-limits/
-            time.sleep(.5)
             self._log.info('Processing {}/{} tracks - {} ',
                            index, len(items), item)
             # If we're not forcing re-downloading for all tracks, check

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -167,7 +167,8 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
             elif response.status_code == 429:
                 seconds = response.headers['Retry-After']
                 time.sleep(int(seconds))
-                self._log.info('Too many API requests. Retrying after {} seconds.', seconds)
+                self._log.info('Too many API requests. Retrying after {} seconds.',
+                               seconds)
                 return self._handle_response(request_type, url, params=params)
             else:
                 raise ui.UserError(

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -168,7 +168,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
             elif response.status_code == 429:
                 seconds = response.headers.get('Retry-After',
                                                DEFAULT_WAITING_TIME)
-                self._log.debug('Too many API requests. Retrying after {} \
+                self._log.info('Too many API requests. Retrying after {} \
                     seconds.', seconds)
                 time.sleep(int(seconds) + 1)
                 return self._handle_response(request_type, url, params=params)

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -168,7 +168,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
             elif response.status_code == 429:
                 seconds = response.headers.get('Retry-After',
                                                DEFAULT_WAITING_TIME)
-                self._log.info('Too many API requests. Retrying after {} \
+                self._log.debug('Too many API requests. Retrying after {} \
                     seconds.', seconds)
                 time.sleep(int(seconds) + 1)
                 return self._handle_response(request_type, url, params=params)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,7 +32,9 @@ New features:
 
 Bug fixes:
 
-* Fix implicit paths OR queries (e.g. ``beet list /path/ , /other-path/``) 
+* Added Spotify 429 (too many requests) API error handling
+  :bug:`4370`
+* Fix implicit paths OR queries (e.g. ``beet list /path/ , /other-path/``)
   which have previously been returning the entire library.
   :bug:`1865`
 * The Discogs release ID is now populated correctly to the discogs_albumid

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,7 +32,7 @@ New features:
 
 Bug fixes:
 
-* Added Spotify 429 (too many requests) API error handling
+* We now respect the Spotify API's rate limiting, which avoids crashing when the API reports code 429 (too many requests).
   :bug:`4370`
 * Fix implicit paths OR queries (e.g. ``beet list /path/ , /other-path/``)
   which have previously been returning the entire library.


### PR DESCRIPTION
## Description
Added ability to handle API error (too many requests). 

Fixes #4369 


## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
