### PR TITLE
docs: add link to Beets-audible plugin

### DIFF
--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -279,6 +279,9 @@ Here are a few of the plugins written by the beets community:
 
 * `beets-autofix`_ automates repetitive tasks to keep your library in order.
 
+* `beets-audible`_ adds Audible as a tagger data source and provides 
+  other features for managing audiobook collections.
+
 * `beets-barcode`_ lets you scan or enter barcodes for physical media to
   search for their metadata.
 
@@ -370,3 +373,4 @@ Here are a few of the plugins written by the beets community:
 .. _beets-bpmanalyser: https://github.com/adamjakab/BeetsPluginBpmAnalyser
 .. _beets-originquery: https://github.com/x1ppy/beets-originquery
 .. _drop2beets: https://github.com/martinkirch/drop2beets
+.. _beets-audible: https://github.com/Neurrone/beets-audible


### PR DESCRIPTION
## Description

Adds a link to the [beets-audible plugin](https://github.com/Neurrone/beets-audible)

(...)

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
