### PR TITLE
Create third-party tutorials section

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog goes here!
 
 New features:
 
+* :blog:`/_posts/2022-06-21-walkthrough.md` Create a guided walkthrough for getting started with beets
 * :doc:`/plugins/spotify`: The plugin now provides an additional command
   `spotifysync` that allows getting track popularity and audio features
   information from Spotify.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ Changelog goes here!
 
 New features:
 
-* :blog:`/_posts/2022-06-21-walkthrough.md` Create a guided walkthrough for getting started with beets
+* Create a new guided walkthrough blog post for getting started with beets
 * :doc:`/plugins/spotify`: The plugin now provides an additional command
   `spotifysync` that allows getting track popularity and audio features
   information from Spotify.

--- a/docs/guides/main.rst
+++ b/docs/guides/main.rst
@@ -301,6 +301,12 @@ import`` gives more specific help about the ``import`` command.
 Please let me know what you think of beets via `the discussion board`_ or
 `Twitter`_.
 
+Third-party Tutorials
+---------------------
+
+* **Beets Blog** `Guided walkthrough`_
+
 .. _the mailing list: https://groups.google.com/group/beets-users
 .. _the discussion board: https://discourse.beets.io
 .. _twitter: https://twitter.com/b33ts
+.. _Guided Walkthrough: https://beets.io/blog/walkthrough.html


### PR DESCRIPTION
## Description

References #4361 / #4381, and #4363 and follows the suggestion of @wisp3rwind to link additional tutorials at the end of the Getting Started guide.

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
