### PR TITLE
Fix importadded plugin with reflink

### DIFF
--- a/beetsplug/importadded.py
+++ b/beetsplug/importadded.py
@@ -34,6 +34,7 @@ class ImportAddedPlugin(BeetsPlugin):
         register('item_copied', self.record_import_mtime)
         register('item_linked', self.record_import_mtime)
         register('item_hardlinked', self.record_import_mtime)
+        register('item_reflinked', self.record_import_mtime)
         register('album_imported', self.update_album_times)
         register('item_imported', self.update_item_times)
         register('after_write', self.update_after_write_time)
@@ -49,7 +50,8 @@ class ImportAddedPlugin(BeetsPlugin):
 
     def record_if_inplace(self, task, session):
         if not (session.config['copy'] or session.config['move'] or
-                session.config['link'] or session.config['hardlink']):
+                session.config['link'] or session.config['hardlink'] or
+                session.config['reflink']):
             self._log.debug("In place import detected, recording mtimes from "
                             "source paths")
             items = [task.item] \

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -82,6 +82,9 @@ Bug fixes:
   :bug:`4272`
 * :doc:`plugins/lyrics`: Fixed issue with Genius header being included in lyrics,
   added test case of up-to-date Genius html
+* :doc:`plugins/importadded`: Fix a bug with recently added reflink import option
+  that casues a crash when ImportAdded plugin enabled.
+  :bug:`4389`
 
 For packagers:
 


### PR DESCRIPTION
## Description

Fixes #4389
It seems to me that this issue may be fixed in a similar way to previously fixed importadded issue #1107 and hardlink option #2445.

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
