### PR TITLE
docs: fix simple typo, seperated -> separated

### DIFF
--- a/beetsplug/web/static/jquery.js
+++ b/beetsplug/web/static/jquery.js
@@ -2278,7 +2278,7 @@ jQuery.fn.extend({
 					classNames = value.split( rspace );
 
 				while ( (className = classNames[ i++ ]) ) {
-					// check each className given, space seperated list
+					// check each className given, space separated list
 					state = isBool ? state : !self.hasClass( className );
 					self[ state ? "addClass" : "removeClass" ]( className );
 				}


### PR DESCRIPTION
There is a small typo in beetsplug/web/static/jquery.js.

Should read `separated` rather than `seperated`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md