### PR TITLE
convert: New feature "Write m3u playlist to destination folder"

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -124,13 +124,6 @@ class FilesystemError(HumanReadableException):
         return f'{self._reasonstr()} {clause}'
 
 
-class EmptyPlaylistError(Exception):
-    """An error that should be raised when a playlist file without media files
-    is saved or loaded.
-    """
-    pass
-
-
 class MoveOperation(Enum):
     """The file operations that e.g. various move functions can carry out.
     """
@@ -140,60 +133,6 @@ class MoveOperation(Enum):
     HARDLINK = 3
     REFLINK = 4
     REFLINK_AUTO = 5
-
-
-class M3UFile():
-    def __init__(self, path):
-        """Reads and writes m3u or m3u8 playlist files.
-
-        ``path`` is the full path to the playlist file.
-
-        The playlist file type, m3u or m3u8 is determined by 1) the ending
-        being m3u8 and 2) the file paths contained in the list being utf-8
-        encoded. Since the list is passed from the outside, this is currently
-        out of control of this class.
-        """
-        self.path = path
-        self.extm3u = False
-        self.media_list = []
-
-    def load(self):
-        """Reads the m3u file from disk and sets the object's attributes.
-        """
-        with open(self.path, "r") as playlist_file:
-            raw_contents = playlist_file.readlines()
-        self.extm3u = True if raw_contents[0] == "#EXTM3U\n" else False
-        for line in raw_contents[1:]:
-            if line.startswith("#"):
-                # Some EXTM3U comment, do something. FIXME
-                continue
-            self.media_list.append(line)
-        if not self.media_list:
-            raise EmptyPlaylistError
-
-    def set_contents(self, media_list, extm3u=True):
-        """Sets self.media_list to a list of media file paths,
-
-        and sets additional flags, changing the final m3u-file's format.
-
-        ``media_list`` is a list of paths to media files that should be added
-        to the playlist (relative or absolute paths, that's the responsibility
-        of the caller). By default the ``extm3u`` flag is set, to ensure a
-        save-operation writes an m3u-extended playlist (comment "#EXTM3U" at
-        the top of the file).
-        """
-        self.media_list = media_list
-        self.extm3u = extm3u
-
-    def write(self):
-        """Writes the m3u file to disk."""
-        header = ["#EXTM3U"] if self.extm3u else []
-        if not self.media_list:
-            raise EmptyPlaylistError
-        contents = header + self.media_list
-        with open(self.path, "w") as playlist_file:
-            playlist_file.writelines('\n'.join(contents))
-            playlist_file.write('\n')  # Final linefeed to prevent noeol file.
 
 
 def normpath(path):

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -153,7 +153,7 @@ class M3UFile():
     def load(self):
         """Reads the m3u file from disk and sets the object's attributes.
         """
-        with open(self.name, "r") as playlist_file:
+        with open(self.path, "r") as playlist_file:
             raw_contents = playlist_file.readlines()
         self.extm3u = True if raw_contents[0] == "#EXTM3U" else False
         for line in raw_contents[1:]:

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -409,11 +409,17 @@ def syspath(path, prefix=True):
         # reported as the FS encoding by Windows. Try both.
         try:
             path = path.decode('utf-8')
+            print("syspath: this is path:")
+            print(path)
         except UnicodeError:
             # The encoding should always be MBCS, Windows' broken
             # Unicode representation.
             encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
             path = path.decode(encoding, 'replace')
+            print("syspath: this is encoding:")
+            print(encoding)
+            print("syspath: this is path:")
+            print(path)
 
     # Add the magic prefix if it isn't already there.
     # https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247.aspx

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -162,7 +162,7 @@ class M3UFile():
         """
         with open(self.path, "r") as playlist_file:
             raw_contents = playlist_file.readlines()
-        self.extm3u = True if raw_contents[0] == "#EXTM3U" else False
+        self.extm3u = True if raw_contents[0] == "#EXTM3U\n" else False
         for line in raw_contents[1:]:
             if line.startswith("#"):
                 # Some EXTM3U comment, do something. FIXME

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -409,17 +409,11 @@ def syspath(path, prefix=True):
         # reported as the FS encoding by Windows. Try both.
         try:
             path = path.decode('utf-8')
-            print("syspath: this is path:")
-            print(path)
         except UnicodeError:
             # The encoding should always be MBCS, Windows' broken
             # Unicode representation.
             encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
             path = path.decode(encoding, 'replace')
-            print("syspath: this is encoding:")
-            print(encoding)
-            print("syspath: this is path:")
-            print(path)
 
     # Add the magic prefix if it isn't already there.
     # https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247.aspx

--- a/beets/util/m3u.py
+++ b/beets/util/m3u.py
@@ -46,7 +46,7 @@ class M3UFile():
             if line.startswith("#"):
                 # Some EXTM3U comment, do something. FIXME
                 continue
-            self.media_list.append(line)
+            self.media_list.append(syspath(line))
         if not self.media_list:
             raise EmptyPlaylistError
 

--- a/beets/util/m3u.py
+++ b/beets/util/m3u.py
@@ -39,7 +39,7 @@ class M3UFile():
 
     def load(self):
         """Reads the m3u file from disk and sets the object's attributes."""
-        with open(syspath(self.path), "r") as playlist_file:
+        with open(syspath(self.path), "r", encoding="utf-8") as playlist_file:
             raw_contents = playlist_file.readlines()
         self.extm3u = True if raw_contents[0] == "#EXTM3U\n" else False
         for line in raw_contents[1:]:
@@ -70,6 +70,6 @@ class M3UFile():
         if not self.media_list:
             raise EmptyPlaylistError
         contents = header + self.media_list
-        with open(syspath(self.path), "w") as playlist_file:
+        with open(syspath(self.path), "w", encoding="utf-8") as playlist_file:
             playlist_file.writelines('\n'.join(contents))
             playlist_file.write('\n')  # Final linefeed to prevent noeol file.

--- a/beets/util/m3u.py
+++ b/beets/util/m3u.py
@@ -12,7 +12,7 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
-"""Provides utilities to read, write an manipulate m3u playlist files."""
+"""Provides utilities to read, write and manipulate m3u playlist files."""
 
 
 from beets.util import syspath, normpath

--- a/beets/util/m3u.py
+++ b/beets/util/m3u.py
@@ -16,6 +16,9 @@
 """
 
 
+from beets.util import syspath
+
+
 class EmptyPlaylistError(Exception):
     """An error that should be raised when a playlist file without media files
     is saved or loaded.
@@ -41,7 +44,7 @@ class M3UFile():
     def load(self):
         """Reads the m3u file from disk and sets the object's attributes.
         """
-        with open(self.path, "r") as playlist_file:
+        with open(syspath(self.path), "r") as playlist_file:
             raw_contents = playlist_file.readlines()
         self.extm3u = True if raw_contents[0] == "#EXTM3U\n" else False
         for line in raw_contents[1:]:
@@ -72,6 +75,6 @@ class M3UFile():
         if not self.media_list:
             raise EmptyPlaylistError
         contents = header + self.media_list
-        with open(self.path, "w") as playlist_file:
+        with open(syspath(self.path), "w") as playlist_file:
             playlist_file.writelines('\n'.join(contents))
             playlist_file.write('\n')  # Final linefeed to prevent noeol file.

--- a/beets/util/m3u.py
+++ b/beets/util/m3u.py
@@ -76,7 +76,7 @@ class M3UFile():
 
         Handles the creation of potential parent directories.
         """
-        header = ["#EXTM3U"] if self.extm3u else []
+        header = [b"#EXTM3U"] if self.extm3u else []
         if not self.media_list:
             raise EmptyPlaylistError
         contents = header + self.media_list
@@ -84,9 +84,10 @@ class M3UFile():
         mkdirall(pl_normpath)
 
         try:
-            with open(syspath(pl_normpath), "w", encoding="utf-8") as pl_file:
-                pl_file.writelines('\n'.join(contents))
-                pl_file.write('\n')  # Final linefeed to prevent noeol file.
+            with open(syspath(pl_normpath), "wb") as pl_file:
+                for line in contents:
+                    pl_file.write(line + b'\n')
+                pl_file.write(b'\n')  # Final linefeed to prevent noeol file.
         except OSError as exc:
             raise FilesystemError(exc, 'create', (pl_normpath, ),
                                   traceback.format_exc())

--- a/beets/util/m3u.py
+++ b/beets/util/m3u.py
@@ -15,7 +15,7 @@
 """Provides utilities to read, write an manipulate m3u playlist files."""
 
 
-from beets.util import syspath
+from beets.util import syspath, normpath
 
 
 class EmptyPlaylistError(Exception):
@@ -70,6 +70,6 @@ class M3UFile():
         if not self.media_list:
             raise EmptyPlaylistError
         contents = header + self.media_list
-        with open(syspath(self.path), "w", encoding="utf-8") as playlist_file:
+        with open(syspath(normpath(self.path)), "w", encoding="utf-8") as playlist_file:
             playlist_file.writelines('\n'.join(contents))
             playlist_file.write('\n')  # Final linefeed to prevent noeol file.

--- a/beets/util/m3u.py
+++ b/beets/util/m3u.py
@@ -42,18 +42,18 @@ class M3UFile():
         """Reads the m3u file from disk and sets the object's attributes."""
         pl_normpath = normpath(self.path)
         try:
-            with open(syspath(pl_normpath), "r", encoding="utf-8") as pl_file:
+            with open(syspath(pl_normpath), "rb") as pl_file:
                 raw_contents = pl_file.readlines()
         except OSError as exc:
             raise FilesystemError(exc, 'read', (pl_normpath, ),
                                   traceback.format_exc())
 
-        self.extm3u = True if raw_contents[0] == "#EXTM3U\n" else False
+        self.extm3u = True if raw_contents[0].rstrip() == b"#EXTM3U" else False
         for line in raw_contents[1:]:
-            if line.startswith("#"):
-                # Some EXTM3U comment, do something. FIXME
+            if line.startswith(b"#"):
+                # Support for specific EXTM3U comments could be added here.
                 continue
-            self.media_list.append(syspath(line, prefix=False))
+            self.media_list.append(normpath(line.rstrip()))
         if not self.media_list:
             raise EmptyPlaylistError
 

--- a/beets/util/m3u.py
+++ b/beets/util/m3u.py
@@ -46,7 +46,7 @@ class M3UFile():
             if line.startswith("#"):
                 # Some EXTM3U comment, do something. FIXME
                 continue
-            self.media_list.append(syspath(line))
+            self.media_list.append(syspath(line, prefix=False))
         if not self.media_list:
             raise EmptyPlaylistError
 

--- a/beets/util/m3u.py
+++ b/beets/util/m3u.py
@@ -12,25 +12,21 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
-"""Provides utilities to read, write an manipulate m3u playlist files.
-"""
+"""Provides utilities to read, write an manipulate m3u playlist files."""
 
 
 from beets.util import syspath
 
 
 class EmptyPlaylistError(Exception):
-    """An error that should be raised when a playlist file without media files
-    is saved or loaded.
-    """
+    """Raised when a playlist file without media files is saved or loaded."""
     pass
 
 
 class M3UFile():
+    """Reads and writes m3u or m3u8 playlist files."""
     def __init__(self, path):
-        """Reads and writes m3u or m3u8 playlist files.
-
-        ``path`` is the full path to the playlist file.
+        """``path`` is the absolute path to the playlist file.
 
         The playlist file type, m3u or m3u8 is determined by 1) the ending
         being m3u8 and 2) the file paths contained in the list being utf-8
@@ -42,8 +38,7 @@ class M3UFile():
         self.media_list = []
 
     def load(self):
-        """Reads the m3u file from disk and sets the object's attributes.
-        """
+        """Reads the m3u file from disk and sets the object's attributes."""
         with open(syspath(self.path), "r") as playlist_file:
             raw_contents = playlist_file.readlines()
         self.extm3u = True if raw_contents[0] == "#EXTM3U\n" else False
@@ -56,9 +51,9 @@ class M3UFile():
             raise EmptyPlaylistError
 
     def set_contents(self, media_list, extm3u=True):
-        """Sets self.media_list to a list of media file paths,
+        """Sets self.media_list to a list of media file paths.
 
-        and sets additional flags, changing the final m3u-file's format.
+        Also sets additional flags, changing the final m3u-file's format.
 
         ``media_list`` is a list of paths to media files that should be added
         to the playlist (relative or absolute paths, that's the responsibility

--- a/beets/util/m3u.py
+++ b/beets/util/m3u.py
@@ -1,0 +1,77 @@
+# This file is part of beets.
+# Copyright 2022, J0J0 Todos.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""Provides utilities to read, write an manipulate m3u playlist files.
+"""
+
+
+class EmptyPlaylistError(Exception):
+    """An error that should be raised when a playlist file without media files
+    is saved or loaded.
+    """
+    pass
+
+
+class M3UFile():
+    def __init__(self, path):
+        """Reads and writes m3u or m3u8 playlist files.
+
+        ``path`` is the full path to the playlist file.
+
+        The playlist file type, m3u or m3u8 is determined by 1) the ending
+        being m3u8 and 2) the file paths contained in the list being utf-8
+        encoded. Since the list is passed from the outside, this is currently
+        out of control of this class.
+        """
+        self.path = path
+        self.extm3u = False
+        self.media_list = []
+
+    def load(self):
+        """Reads the m3u file from disk and sets the object's attributes.
+        """
+        with open(self.path, "r") as playlist_file:
+            raw_contents = playlist_file.readlines()
+        self.extm3u = True if raw_contents[0] == "#EXTM3U\n" else False
+        for line in raw_contents[1:]:
+            if line.startswith("#"):
+                # Some EXTM3U comment, do something. FIXME
+                continue
+            self.media_list.append(line)
+        if not self.media_list:
+            raise EmptyPlaylistError
+
+    def set_contents(self, media_list, extm3u=True):
+        """Sets self.media_list to a list of media file paths,
+
+        and sets additional flags, changing the final m3u-file's format.
+
+        ``media_list`` is a list of paths to media files that should be added
+        to the playlist (relative or absolute paths, that's the responsibility
+        of the caller). By default the ``extm3u`` flag is set, to ensure a
+        save-operation writes an m3u-extended playlist (comment "#EXTM3U" at
+        the top of the file).
+        """
+        self.media_list = media_list
+        self.extm3u = extm3u
+
+    def write(self):
+        """Writes the m3u file to disk."""
+        header = ["#EXTM3U"] if self.extm3u else []
+        if not self.media_list:
+            raise EmptyPlaylistError
+        contents = header + self.media_list
+        with open(self.path, "w") as playlist_file:
+            playlist_file.writelines('\n'.join(contents))
+            playlist_file.write('\n')  # Final linefeed to prevent noeol file.

--- a/beets/util/m3u.py
+++ b/beets/util/m3u.py
@@ -15,7 +15,7 @@
 """Provides utilities to read, write and manipulate m3u playlist files."""
 
 
-from beets.util import syspath, normpath
+from beets.util import syspath, normpath, mkdirall
 
 
 class EmptyPlaylistError(Exception):
@@ -65,11 +65,17 @@ class M3UFile():
         self.extm3u = extm3u
 
     def write(self):
-        """Writes the m3u file to disk."""
+        """Writes the m3u file to disk.
+
+        Handles the creation of potential parent directories.
+        """
         header = ["#EXTM3U"] if self.extm3u else []
         if not self.media_list:
             raise EmptyPlaylistError
         contents = header + self.media_list
-        with open(syspath(normpath(self.path)), "w", encoding="utf-8") as playlist_file:
+        pl_normpath = normpath(self.path)
+        mkdirall(pl_normpath)
+
+        with open(syspath(pl_normpath), "w", encoding="utf-8") as playlist_file:
             playlist_file.writelines('\n'.join(contents))
             playlist_file.write('\n')  # Final linefeed to prevent noeol file.

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -494,7 +494,7 @@ class ConvertPlugin(BeetsPlugin):
         if playlist:
             self._log.info("Creating playlist file: {0}", playlist)
             if not pretend:
-                with open(os.path.join(dest, playlist), "w") as playlist_file:
+                with open(playlist, "w") as playlist_file:
                     playlist_file.write("#EXTM3U" + "\n")
 
         self._parallel_convert(dest, opts.keep_new, path_formats, fmt, pretend,

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -299,11 +299,16 @@ class ConvertPlugin(BeetsPlugin):
                     "Appending to playlist file {0}",
                     util.displayable_path(playlist)
                 )
+                # The classic m3u format doesn't support special characters in
+                # media file paths, thus we use the m3u8 format which requires
+                # media file paths to be unicode. Additionally we use relative
+                # paths to ensure readability of the playlist on remote
+                # computers.
+                dest_relative = util.displayable_path(dest).replace(
+                    util.displayable_path(dest_dir) + os.sep, ""
+                )
                 with open(playlist, "a") as playlist_file:
-                    # The classic m3u format doesn't support special characters
-                    # in media file paths, thus we use the m3u8 format which
-                    # requires media file paths to be unicode.
-                    playlist_file.write(util.displayable_path(dest) + "\n")
+                    playlist_file.write(dest_relative + "\n")
 
             # Ensure that only one thread tries to create directories at a
             # time. (The existence check is not atomic with the directory

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -31,7 +31,7 @@ from beets import art
 from beets.util.artresizer import ArtResizer
 from beets.library import parse_query_string
 from beets.library import Item
-from beets.util import M3UFile
+from beets.util.m3u import M3UFile
 
 _fs_lock = threading.Lock()
 _temp_files = []  # Keep track of temporary transcoded files for deletion.

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -304,8 +304,10 @@ class ConvertPlugin(BeetsPlugin):
                 # media file paths to be unicode. Additionally we use relative
                 # paths to ensure readability of the playlist on remote
                 # computers.
-                dest_relative = util.displayable_path(dest).replace(
-                    util.displayable_path(dest_dir) + os.sep, ""
+                dest_relative = item.destination(
+                    basedir=dest_dir,
+                    path_formats=path_formats,
+                    fragment=True
                 )
                 with open(playlist, "a") as playlist_file:
                     playlist_file.write(dest_relative + "\n")

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -476,16 +476,13 @@ class ConvertPlugin(BeetsPlugin):
                                link, hardlink, threads, items)
 
         if playlist:
-            # When playlist arg is passed create an m3u8 file in dest folder.
-            #
-            # The classic m3u format doesn't support special characters in
-            # media file paths, thus we use the m3u8 format which requires
-            # media file paths to be unicode. Additionally we use relative
-            # paths to ensure readability of the playlist on remote
-            # computers.
+            # Playlist paths are understood as relative to the dest directory.
             pl_normpath = util.normpath(playlist)
             pl_dir = os.path.dirname(pl_normpath)
             self._log.info("Creating playlist file {0}", pl_normpath)
+            # Generates a list of paths to media files, ensures the paths are
+            # relative to the playlist's location and translates the unicode
+            # strings we get from item.destination to bytes.
             items_paths = [
                 os.path.relpath(util.bytestring_path(item.destination(
                     basedir=dest, path_formats=path_formats, fragment=False

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -485,9 +485,9 @@ class ConvertPlugin(BeetsPlugin):
             # computers.
             self._log.info("Creating playlist file: {0}", playlist)
             items_paths = [
-                item.destination(
+                util.syspath(item.destination(
                     basedir=dest, path_formats=path_formats, fragment=True
-                ) for item in items
+                )) for item in items
             ]
             if not pretend:
                 m3ufile = M3UFile(playlist)

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -483,12 +483,13 @@ class ConvertPlugin(BeetsPlugin):
             # media file paths to be unicode. Additionally we use relative
             # paths to ensure readability of the playlist on remote
             # computers.
-            self._log.info("Creating playlist file: {0}",
-                           util.normpath(playlist))
+            pl_normpath = util.normpath(playlist)
+            pl_dir = os.path.dirname(pl_normpath)
+            self._log.info("Creating playlist file {0}", pl_normpath)
             items_paths = [
-                util.bytestring_path(item.destination(
-                    basedir=dest, path_formats=path_formats, fragment=True
-                )) for item in items
+                os.path.relpath(util.bytestring_path(item.destination(
+                    basedir=dest, path_formats=path_formats, fragment=False
+                )), pl_dir) for item in items
             ]
             if not pretend:
                 m3ufile = M3UFile(playlist)

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -472,6 +472,9 @@ class ConvertPlugin(BeetsPlugin):
                 self.copy_album_art(album, dest, path_formats, pretend,
                                     link, hardlink)
 
+        self._parallel_convert(dest, opts.keep_new, path_formats, fmt, pretend,
+                               link, hardlink, threads, items)
+
         if playlist:
             # When playlist arg is passed create an m3u8 file in dest folder.
             #
@@ -490,9 +493,6 @@ class ConvertPlugin(BeetsPlugin):
                 m3ufile = M3UFile(playlist)
                 m3ufile.set_contents(items_paths)
                 m3ufile.write()
-
-        self._parallel_convert(dest, opts.keep_new, path_formats, fmt, pretend,
-                               link, hardlink, threads, items)
 
     def convert_on_import(self, lib, item):
         """Transcode a file automatically after it is imported into the

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -486,7 +486,7 @@ class ConvertPlugin(BeetsPlugin):
             self._log.info("Creating playlist file: {0}",
                            util.normpath(playlist))
             items_paths = [
-                util.syspath(item.destination(
+                util.bytestring_path(item.destination(
                     basedir=dest, path_formats=path_formats, fragment=True
                 )) for item in items
             ]

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -490,8 +490,8 @@ class ConvertPlugin(BeetsPlugin):
                 with open(os.path.join(dest, playlist), "w") as playlist_file:
                     playlist_file.write("#EXTM3U" + "\n")
 
-        self._parallel_convert(dest, opts.keep_new, path_formats, fmt,
-                               pretend, link, hardlink, threads, items, playlist)
+        self._parallel_convert(dest, opts.keep_new, path_formats, fmt, pretend,
+                               link, hardlink, threads, items, playlist)
 
     def convert_on_import(self, lib, item):
         """Transcode a file automatically after it is imported into the
@@ -592,8 +592,8 @@ class ConvertPlugin(BeetsPlugin):
             hardlink = self.config['hardlink'].get(bool)
             link = self.config['link'].get(bool)
 
-
-        return dest, threads, path_formats, fmt, pretend, hardlink, link, playlist
+        return (dest, threads, path_formats, fmt, pretend, hardlink, link,
+                playlist)
 
     def _parallel_convert(self, dest, keep_new, path_formats, fmt,
                           pretend, link, hardlink, threads, items, playlist):

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -180,14 +180,14 @@ class ConvertPlugin(BeetsPlugin):
                               help='hardlink files that do not \
                               need transcoding. Overrides --link.')
         cmd.parser.add_option('-m', '--playlist', action='store',
-                              help='''the name of an m3u8 playlist file to
-                              be created in the root of the destination folder.
-                              The m3u8 format ensures special characters
-                              support by using unicode to save media file
-                              paths. Relative paths are used to point to media
-                              files ensuring a working playlist when
-                              transferred to a different computer (eg. when
-                              opened from an external drive).''')
+                              help='''create an m3u8 playlist file containing
+                              the converted files. The playlist file will be
+                              saved below the destination directory, thus
+                              PLAYLIST could be a file name or a relative path.
+                              To ensure a working playlist when transferred to
+                              a different computer, or opened from an external
+                              drive, relative paths pointing to media files
+                              will be used.''')
         cmd.parser.add_album_option()
         cmd.func = self.convert_func
         return [cmd]

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -31,6 +31,7 @@ from beets import art
 from beets.util.artresizer import ArtResizer
 from beets.library import parse_query_string
 from beets.library import Item
+from beets.util import M3UFile
 
 _fs_lock = threading.Lock()
 _temp_files = []  # Keep track of temporary transcoded files for deletion.
@@ -485,10 +486,10 @@ class ConvertPlugin(BeetsPlugin):
                     basedir=dest, path_formats=path_formats, fragment=True
                 ) for item in items
             ]
-            items_paths = ["#EXTM3U"] + items_paths
             if not pretend:
-                with open(playlist, "w") as playlist_file:
-                    playlist_file.writelines('\n'.join(items_paths))
+                m3ufile = M3UFile(playlist)
+                m3ufile.set_contents(items_paths)
+                m3ufile.write()
 
         self._parallel_convert(dest, opts.keep_new, path_formats, fmt, pretend,
                                link, hardlink, threads, items)

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -483,7 +483,8 @@ class ConvertPlugin(BeetsPlugin):
             # media file paths to be unicode. Additionally we use relative
             # paths to ensure readability of the playlist on remote
             # computers.
-            self._log.info("Creating playlist file: {0}", playlist)
+            self._log.info("Creating playlist file: {0}",
+                           util.normpath(playlist))
             items_paths = [
                 util.syspath(item.destination(
                     basedir=dest, path_formats=path_formats, fragment=True

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -68,6 +68,9 @@ New features:
   enabled via the :ref:`musicbrainz.external_ids` options, release ID's will be
   extracted from those URL's and imported to the library.
   :bug:`4220`
+* :doc:`/plugins/convert`: Add support for generating m3u8 playlists together
+  with converted media files.
+  :bug:`4373`
 
 Bug fixes:
 

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -65,7 +65,7 @@ to the ``playlist`` option below.
 
 Note that the classic m3u format doesn't support special characters in media
 file paths, thus the m3u8 format which requires media file paths to be unicode,
-is used. Typically a playlist file would be named *.m3u8. The name of the file
+is used. Typically a playlist file would be named `*.m3u8`. The name of the file
 can be freely chosen by the user though. Since it is always ensured that paths
 to media files are written as defined by the ``path`` configuration, a
 generated playlist potentially could contain unicode characters no matter what

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -4,7 +4,8 @@ Convert Plugin
 The ``convert`` plugin lets you convert parts of your collection to a
 directory of your choice, transcoding audio and embedding album art along the
 way. It can transcode to and from any format using a configurable command
-line.
+line. Optionally an m3u playlist file containing all the converted files can be
+saved to the destination path.
 
 
 Installation
@@ -54,6 +55,21 @@ instead, passing ``-H`` (``--hardlink``) creates hard links.
 Note that album art embedding is disabled for files that are linked.
 Refer to the ``link`` and ``hardlink`` options below.
 
+The ``-m`` (or ``--playlist``) option enables the plugin to create an m3u8
+playlist file in the destination folder given by the ``-d`` (``--dest``) option
+or the ``dest`` configuration. Either a simple filename or a relative path plus
+a filename can be passed. The generated playlist will always use relative paths
+to the contained media files to ensure compatibility when read from external
+drives or on computers other than the one used for the conversion. Also refer
+to the ``playlist`` option below.
+
+Note that the classic m3u format doesn't support special characters in media
+file paths, thus the m3u8 format which requires media file paths to be unicode,
+is used. Typically a playlist file would be named *.m3u8. The name of the file
+can be freely chosen by the user though. Since it is always ensured that paths
+to media files are written as defined by the ``path`` configuration, a
+generated playlist potentially could contain unicode characters no matter what
+file ending was chosen.
 
 Configuration
 -------------
@@ -124,6 +140,12 @@ file. The available options are:
   Default: ``false``.
 - **delete_originals**: Transcoded files will be copied or moved to their destination, depending on the import configuration. By default, the original files are not modified by the plugin. This option deletes the original files after the transcoding step has completed.
   Default: ``false``.
+- **playlist**: The name of a playlist file that should be written on each run
+  of the plugin. A relative file path (e.g `playlists/mylist.m3u8`) is allowed
+  as well. The final destination of the playlist file will always be relative
+  to the destination path (``dest``, ``--dest``, ``-d``). This configuration is
+  overridden by the ``-m`` (``--playlist``) command line option.
+  Default: none.
 
 You can also configure the format to use for transcoding (see the next
 section):

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -57,19 +57,16 @@ Refer to the ``link`` and ``hardlink`` options below.
 
 The ``-m`` (or ``--playlist``) option enables the plugin to create an m3u8
 playlist file in the destination folder given by the ``-d`` (``--dest``) option
-or the ``dest`` configuration. Either a simple filename or a relative path plus
-a filename can be passed. The generated playlist will always use relative paths
-to the contained media files to ensure compatibility when read from external
-drives or on computers other than the one used for the conversion. Also refer
-to the ``playlist`` option below.
+or the ``dest`` configuration. The path to the playlist file can either be
+absolute or relative to the ``dest`` directory. The contents will always be
+relative paths to media files, which tries to ensure compatibility when read
+from external drives or on computers other than the one used for the
+conversion. There is one caveat though: A list generated on Unix/macOS can't be
+read on Windows and vice versa.
 
-Note that the classic m3u format doesn't support special characters in media
-file paths, thus the m3u8 format which requires media file paths to be unicode,
-is used. Typically a playlist file would be named `*.m3u8`. The name of the file
-can be freely chosen by the user though. Since it is always ensured that paths
-to media files are written as defined by the ``path`` configuration, a
-generated playlist potentially could contain unicode characters no matter what
-file ending was chosen.
+Depending on the beets user's settings a generated playlist potentially could
+contain unicode characters. This is supported, playlists are written in [m3u8
+format](https://en.wikipedia.org/wiki/M3U#M3U8).
 
 Configuration
 -------------

--- a/test/rsrc/playlist.m3u
+++ b/test/rsrc/playlist.m3u
@@ -1,0 +1,3 @@
+#EXTM3U
+/This/is/a/path/to_a_file.mp3
+/This/is/another/path/to_a_file.mp3

--- a/test/rsrc/playlist.m3u8
+++ b/test/rsrc/playlist.m3u8
@@ -1,0 +1,3 @@
+#EXTM3U
+/This/is/å/path/to_a_file.mp3
+/This/is/another/path/tö_a_file.mp3

--- a/test/rsrc/playlist_non_ext.m3u
+++ b/test/rsrc/playlist_non_ext.m3u
@@ -1,0 +1,2 @@
+/This/is/a/path/to_a_file.mp3
+/This/is/another/path/to_a_file.mp3

--- a/test/rsrc/playlist_windows.m3u8
+++ b/test/rsrc/playlist_windows.m3u8
@@ -1,0 +1,3 @@
+#EXTM3U
+\\\\?\\/This/is/å/path/to_a_file.mp3
+\\\\?\\/This/is/another/path/tö_a_file.mp3

--- a/test/rsrc/playlist_windows.m3u8
+++ b/test/rsrc/playlist_windows.m3u8
@@ -1,3 +1,3 @@
 #EXTM3U
-\\\\?\\/This/is/å/path/to_a_file.mp3
-\\\\?\\/This/is/another/path/tö_a_file.mp3
+x:\This\is\å\path\to_a_file.mp3
+x:\This\is\another\path\tö_a_file.mp3

--- a/test/rsrc/playlist_windows.m3u8
+++ b/test/rsrc/playlist_windows.m3u8
@@ -1,3 +1,3 @@
-#EXTM3U
+﻿#EXTM3U
 x:\This\is\å\path\to_a_file.mp3
 x:\This\is\another\path\tö_a_file.mp3

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -184,9 +184,8 @@ class ConvertCliTest(unittest.TestCase, TestHelper, ConvertCommand):
         }
 
     def tearDown(self):
-        pass
-        #self.unload_plugins()
-        #self.teardown_beets()
+        self.unload_plugins()
+        self.teardown_beets()
 
     def test_convert(self):
         with control_stdin('y'):
@@ -297,8 +296,6 @@ class ConvertCliTest(unittest.TestCase, TestHelper, ConvertCommand):
     def test_playlist(self):
         with control_stdin('y'):
             self.run_convert('--playlist', 'playlist.m3u8')
-            converted = os.path.join(self.convert_dest, b'converted.mp3')
-            self.assertFileTag(converted, 'mp3')
             m3u_created = os.path.join(self.convert_dest, b'playlist.m3u8')
         self.assertTrue(os.path.exists(m3u_created))
 

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -184,8 +184,9 @@ class ConvertCliTest(unittest.TestCase, TestHelper, ConvertCommand):
         }
 
     def tearDown(self):
-        self.unload_plugins()
-        self.teardown_beets()
+        pass
+        #self.unload_plugins()
+        #self.teardown_beets()
 
     def test_convert(self):
         with control_stdin('y'):
@@ -292,6 +293,19 @@ class ConvertCliTest(unittest.TestCase, TestHelper, ConvertCommand):
             self.run_convert()
         converted = os.path.join(self.convert_dest, b'converted.ogg')
         self.assertNoFileTag(converted, 'ogg')
+
+    def test_playlist(self):
+        with control_stdin('y'):
+            self.run_convert('--playlist', 'playlist.m3u8')
+            converted = os.path.join(self.convert_dest, b'converted.mp3')
+            self.assertFileTag(converted, 'mp3')
+            m3u_created = os.path.join(self.convert_dest, b'playlist.m3u8')
+        self.assertTrue(os.path.exists(m3u_created))
+
+    def test_playlist_pretend(self):
+        self.run_convert('--playlist', 'playlist.m3u8', '--pretend')
+        m3u_created = os.path.join(self.convert_dest, b'playlist.m3u8')
+        self.assertFalse(os.path.exists(m3u_created))
 
 
 @_common.slow_test()

--- a/test/test_m3ufile.py
+++ b/test/test_m3ufile.py
@@ -90,13 +90,14 @@ class M3UFileTest(unittest.TestCase):
         )
         rmtree(tempdir)
 
+    @unittest.skipIf(sys.platform == 'win32', 'win32')
     def test_playlist_load_ascii(self):
         """Test loading ascii paths from a playlist file."""
         the_playlist_file = path.join(RSRC, b'playlist.m3u')
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.load()
         self.assertEqual(m3ufile.media_list[0],
-                         '/This/is/a/path/to_a_file.mp3\n')
+                         bytestring_path('/This/is/a/path/to_a_file.mp3'))
 
     @unittest.skipIf(sys.platform == 'win32', 'win32')
     def test_playlist_load_unicode(self):
@@ -105,18 +106,19 @@ class M3UFileTest(unittest.TestCase):
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.load()
         self.assertEqual(m3ufile.media_list[0],
-                         '/This/is/å/path/to_a_file.mp3\n')
+                         bytestring_path('/This/is/å/path/to_a_file.mp3'))
 
     @unittest.skipUnless(sys.platform == 'win32', 'win32')
     def test_playlist_load_unicode_windows(self):
         """Test loading unicode paths from a playlist file."""
         the_playlist_file = path.join(RSRC, b'playlist_windows.m3u8')
-        winpath = path.join('x:\\', 'This', 'is', 'å', 'path', 'to_a_file.mp3')
+        winpath = bytestring_path(path.join(
+            'x:\\', 'This', 'is', 'å', 'path', 'to_a_file.mp3'))
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.load()
         self.assertEqual(
             m3ufile.media_list[0],
-            winpath + '\n'
+            winpath
         )
 
     def test_playlist_load_extm3u(self):

--- a/test/test_m3ufile.py
+++ b/test/test_m3ufile.py
@@ -84,6 +84,8 @@ class M3UFileTest(unittest.TestCase):
         """Test loading unicode paths from a playlist file."""
         the_playlist_file = path.join(RSRC, b'playlist_windows.m3u8')
         winpath = path.join('x:', 'This', 'is', 'å', 'path', 'to_a_file.mp3')
+        print("this is winpath:")
+        print(winpath)
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.load()
         self.assertEqual(

--- a/test/test_m3ufile.py
+++ b/test/test_m3ufile.py
@@ -62,6 +62,32 @@ class M3UFileTest(unittest.TestCase):
         self.assertTrue(path.exists(the_playlist_file))
         rmtree(tempdir)
 
+    @unittest.skipUnless(sys.platform == 'win32', 'win32')
+    def test_playlist_write_and_read_unicode_windows(self):
+        """Test saving unicode paths to a playlist file on Windows."""
+        tempdir = bytestring_path(mkdtemp())
+        the_playlist_file = path.join(tempdir,
+                                      b'playlist_write_and_read_windows.m3u8')
+        m3ufile = M3UFile(the_playlist_file)
+        m3ufile.set_contents([
+            r"x:\This\is\å\path\to_a_file.mp3",
+            r"x:\This\is\another\path\tö_a_file.mp3"
+        ])
+        m3ufile.write()
+        self.assertTrue(path.exists(the_playlist_file))
+        m3ufile_read = M3UFile(the_playlist_file)
+        m3ufile_read.load()
+        self.assertEquals(
+            m3ufile.media_list[0],
+            path.join('x:\\', 'This', 'is', 'å', 'path', 'to_a_file.mp3')
+        )
+        self.assertEquals(
+            m3ufile.media_list[1],
+            r"x:\This\is\another\path\tö_a_file.mp3",
+            path.join('x:\\', 'This', 'is', 'another', 'path', 'tö_a_file.mp3')
+        )
+        rmtree(tempdir)
+
     def test_playlist_load_ascii(self):
         """Test loading ascii paths from a playlist file."""
         the_playlist_file = path.join(RSRC, b'playlist.m3u')

--- a/test/test_m3ufile.py
+++ b/test/test_m3ufile.py
@@ -83,7 +83,7 @@ class M3UFileTest(unittest.TestCase):
     def test_playlist_load_unicode_windows(self):
         """Test loading unicode paths from a playlist file."""
         the_playlist_file = path.join(RSRC, b'playlist_windows.m3u8')
-        winpath = path.join('x:', 'This', 'is', 'å', 'path', 'to_a_file.mp3')
+        winpath = path.join('x:\\', 'This', 'is', 'å', 'path', 'to_a_file.mp3')
         print("this is winpath:")
         print(winpath)
         m3ufile = M3UFile(the_playlist_file)

--- a/test/test_m3ufile.py
+++ b/test/test_m3ufile.py
@@ -20,7 +20,7 @@ import unittest
 
 # from unittest.mock import Mock, MagicMock
 
-from beets.util import M3UFile
+from beets.util import M3UFile, EmptyPlaylistError
 from beets.util import syspath, bytestring_path, py3_path, CHAR_REPLACE
 from test._common import RSRC
 
@@ -30,8 +30,8 @@ class M3UFileTest(unittest.TestCase):
         tempdir = bytestring_path(mkdtemp())
         the_playlist_file = path.join(tempdir, b'playlist.m3u8')
         m3ufile = M3UFile(the_playlist_file)
-        m3ufile.write()
-        self.assertFalse(path.exists(the_playlist_file))
+        with self.assertRaises(EmptyPlaylistError):
+            m3ufile.write()
         rmtree(tempdir)
 
     def test_playlist_write(self):

--- a/test/test_m3ufile.py
+++ b/test/test_m3ufile.py
@@ -86,7 +86,7 @@ class M3UFileTest(unittest.TestCase):
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.load()
         self.assertEqual(m3ufile.media_list[0],
-                         '\\\\?\\/This/is/å/path/to_a_file.mp3\n')
+                         'x:\This\is\å\path\to_a_file.mp3\n')
 
     def test_playlist_load_extm3u(self):
         """Test loading a playlist with an #EXTM3U header."""

--- a/test/test_m3ufile.py
+++ b/test/test_m3ufile.py
@@ -18,6 +18,7 @@ from os import path
 from tempfile import mkdtemp
 from shutil import rmtree
 import unittest
+import sys
 
 from beets.util import bytestring_path
 from beets.util.m3u import M3UFile, EmptyPlaylistError
@@ -69,6 +70,7 @@ class M3UFileTest(unittest.TestCase):
         self.assertEqual(m3ufile.media_list[0],
                          '/This/is/a/path/to_a_file.mp3\n')
 
+    @unittest.skipIf(sys.platform == 'win32', 'win32')
     def test_playlist_load_unicode(self):
         """Test loading unicode paths from a playlist file."""
         the_playlist_file = path.join(RSRC, b'playlist.m3u8')
@@ -76,6 +78,15 @@ class M3UFileTest(unittest.TestCase):
         m3ufile.load()
         self.assertEqual(m3ufile.media_list[0],
                          '/This/is/å/path/to_a_file.mp3\n')
+
+    @unittest.skipUnless(sys.platform == 'win32', 'win32')
+    def test_playlist_load_unicode_windows(self):
+        """Test loading unicode paths from a playlist file."""
+        the_playlist_file = path.join(RSRC, b'playlist_windows.m3u8')
+        m3ufile = M3UFile(the_playlist_file)
+        m3ufile.load()
+        self.assertEqual(m3ufile.media_list[0],
+                         '\\\\?\\/This/is/å/path/to_a_file.mp3\n')
 
     def test_playlist_load_extm3u(self):
         """Test loading a playlist with an #EXTM3U header."""

--- a/test/test_m3ufile.py
+++ b/test/test_m3ufile.py
@@ -85,8 +85,10 @@ class M3UFileTest(unittest.TestCase):
         the_playlist_file = path.join(RSRC, b'playlist_windows.m3u8')
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.load()
-        self.assertEqual(m3ufile.media_list[0],
-                         'x:\This\is\å\path\to_a_file.mp3\n')
+        self.assertEqual(
+            m3ufile.media_list[0],
+            path.join('x:', 'This', 'is', 'å', 'path', 'to_a_file.mp3') + '\n'
+        )
 
     def test_playlist_load_extm3u(self):
         """Test loading a playlist with an #EXTM3U header."""

--- a/test/test_m3ufile.py
+++ b/test/test_m3ufile.py
@@ -83,11 +83,12 @@ class M3UFileTest(unittest.TestCase):
     def test_playlist_load_unicode_windows(self):
         """Test loading unicode paths from a playlist file."""
         the_playlist_file = path.join(RSRC, b'playlist_windows.m3u8')
+        winpath = path.join('x:', 'This', 'is', 'å', 'path', 'to_a_file.mp3')
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.load()
         self.assertEqual(
             m3ufile.media_list[0],
-            path.join('x:', 'This', 'is', 'å', 'path', 'to_a_file.mp3') + '\n'
+            winpath + '\n'
         )
 
     def test_playlist_load_extm3u(self):

--- a/test/test_m3ufile.py
+++ b/test/test_m3ufile.py
@@ -1,0 +1,81 @@
+# This file is part of beets.
+# Copyright 2016, Johannes Tiefenbacher.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+
+from os import path, remove
+from tempfile import mkdtemp
+from shutil import rmtree
+import unittest
+
+# from unittest.mock import Mock, MagicMock
+
+from beets.util import M3UFile
+from beets.util import syspath, bytestring_path, py3_path, CHAR_REPLACE
+from test._common import RSRC
+
+
+class M3UFileTest(unittest.TestCase):
+    def test_playlist_write_empty(self):
+        tempdir = bytestring_path(mkdtemp())
+        the_playlist_file = path.join(tempdir, b'playlist.m3u8')
+        m3ufile = M3UFile(the_playlist_file)
+        m3ufile.write()
+        self.assertFalse(path.exists(the_playlist_file))
+        rmtree(tempdir)
+
+    def test_playlist_write(self):
+        tempdir = bytestring_path(mkdtemp())
+        the_playlist_file = path.join(tempdir, b'playlist.m3u')
+        m3ufile = M3UFile(the_playlist_file)
+        m3ufile.set_contents([
+            '/This/is/a/path/to_a_file.mp3',
+            '/This/is/another/path/to_a_file.mp3',
+        ])
+        m3ufile.write()
+        self.assertTrue(path.exists(the_playlist_file))
+        rmtree(tempdir)
+
+    def test_playlist_write_unicode(self):
+        tempdir = bytestring_path(mkdtemp())
+        the_playlist_file = path.join(tempdir, b'playlist.m3u8')
+        m3ufile = M3UFile(the_playlist_file)
+        m3ufile.set_contents([
+            '/This/is/å/path/to_a_file.mp3',
+            '/This/is/another/path/tö_a_file.mp3',
+        ])
+        m3ufile.write()
+        self.assertTrue(path.exists(the_playlist_file))
+        rmtree(tempdir)
+
+    def test_playlist_load_ascii(self):
+        the_playlist_file = path.join(RSRC, b'playlist.m3u')
+        m3ufile = M3UFile(the_playlist_file)
+        m3ufile.load()
+        self.assertEqual(m3ufile.media_list[0],
+                         '/This/is/a/path/to_a_file.mp3\n')
+
+    def test_playlist_load_unicode(self):
+        the_playlist_file = path.join(RSRC, b'playlist.m3u8')
+        m3ufile = M3UFile(the_playlist_file)
+        m3ufile.load()
+        self.assertEqual(m3ufile.media_list[0],
+                         '/This/is/å/path/to_a_file.mp3\n')
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromName(__name__)
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/test/test_m3ufile.py
+++ b/test/test_m3ufile.py
@@ -42,8 +42,8 @@ class M3UFileTest(unittest.TestCase):
         the_playlist_file = path.join(tempdir, b'playlist.m3u')
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.set_contents([
-            '/This/is/a/path/to_a_file.mp3',
-            '/This/is/another/path/to_a_file.mp3',
+            bytestring_path('/This/is/a/path/to_a_file.mp3'),
+            bytestring_path('/This/is/another/path/to_a_file.mp3')
         ])
         m3ufile.write()
         self.assertTrue(path.exists(the_playlist_file))
@@ -55,8 +55,8 @@ class M3UFileTest(unittest.TestCase):
         the_playlist_file = path.join(tempdir, b'playlist.m3u8')
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.set_contents([
-            '/This/is/å/path/to_a_file.mp3',
-            '/This/is/another/path/tö_a_file.mp3',
+            bytestring_path('/This/is/å/path/to_a_file.mp3'),
+            bytestring_path('/This/is/another/path/tö_a_file.mp3')
         ])
         m3ufile.write()
         self.assertTrue(path.exists(the_playlist_file))
@@ -70,8 +70,8 @@ class M3UFileTest(unittest.TestCase):
                                       b'playlist_write_and_read_windows.m3u8')
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.set_contents([
-            r"x:\This\is\å\path\to_a_file.mp3",
-            r"x:\This\is\another\path\tö_a_file.mp3"
+            bytestring_path(r"x:\This\is\å\path\to_a_file.mp3"),
+            bytestring_path(r"x:\This\is\another\path\tö_a_file.mp3")
         ])
         m3ufile.write()
         self.assertTrue(path.exists(the_playlist_file))
@@ -79,12 +79,14 @@ class M3UFileTest(unittest.TestCase):
         m3ufile_read.load()
         self.assertEquals(
             m3ufile.media_list[0],
-            path.join('x:\\', 'This', 'is', 'å', 'path', 'to_a_file.mp3')
+            bytestring_path(
+                path.join('x:\\', 'This', 'is', 'å', 'path', 'to_a_file.mp3'))
         )
         self.assertEquals(
             m3ufile.media_list[1],
-            r"x:\This\is\another\path\tö_a_file.mp3",
-            path.join('x:\\', 'This', 'is', 'another', 'path', 'tö_a_file.mp3')
+            bytestring_path(r"x:\This\is\another\path\tö_a_file.mp3"),
+            bytestring_path(path.join(
+                'x:\\', 'This', 'is', 'another', 'path', 'tö_a_file.mp3'))
         )
         rmtree(tempdir)
 

--- a/test/test_m3ufile.py
+++ b/test/test_m3ufile.py
@@ -1,5 +1,5 @@
 # This file is part of beets.
-# Copyright 2016, Johannes Tiefenbacher.
+# Copyright 2016, J0J0 Todos.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -11,22 +11,23 @@
 #
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
+"""Testsuite for the M3UFile class."""
 
 
-from os import path, remove
+from os import path
 from tempfile import mkdtemp
 from shutil import rmtree
 import unittest
 
-# from unittest.mock import Mock, MagicMock
-
-from beets.util import M3UFile, EmptyPlaylistError
-from beets.util import syspath, bytestring_path, py3_path, CHAR_REPLACE
+from beets.util import bytestring_path
+from beets.util.m3u import M3UFile, EmptyPlaylistError
 from test._common import RSRC
 
 
 class M3UFileTest(unittest.TestCase):
+    """Tests the M3UFile class."""
     def test_playlist_write_empty(self):
+        """Test whether saving an empty playlist file raises an error."""
         tempdir = bytestring_path(mkdtemp())
         the_playlist_file = path.join(tempdir, b'playlist.m3u8')
         m3ufile = M3UFile(the_playlist_file)
@@ -35,6 +36,7 @@ class M3UFileTest(unittest.TestCase):
         rmtree(tempdir)
 
     def test_playlist_write(self):
+        """Test saving ascii paths to a playlist file."""
         tempdir = bytestring_path(mkdtemp())
         the_playlist_file = path.join(tempdir, b'playlist.m3u')
         m3ufile = M3UFile(the_playlist_file)
@@ -47,6 +49,7 @@ class M3UFileTest(unittest.TestCase):
         rmtree(tempdir)
 
     def test_playlist_write_unicode(self):
+        """Test saving unicode paths to a playlist file."""
         tempdir = bytestring_path(mkdtemp())
         the_playlist_file = path.join(tempdir, b'playlist.m3u8')
         m3ufile = M3UFile(the_playlist_file)
@@ -59,6 +62,7 @@ class M3UFileTest(unittest.TestCase):
         rmtree(tempdir)
 
     def test_playlist_load_ascii(self):
+        """Test loading ascii paths from a playlist file."""
         the_playlist_file = path.join(RSRC, b'playlist.m3u')
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.load()
@@ -66,6 +70,7 @@ class M3UFileTest(unittest.TestCase):
                          '/This/is/a/path/to_a_file.mp3\n')
 
     def test_playlist_load_unicode(self):
+        """Test loading unicode paths from a playlist file."""
         the_playlist_file = path.join(RSRC, b'playlist.m3u8')
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.load()
@@ -73,12 +78,14 @@ class M3UFileTest(unittest.TestCase):
                          '/This/is/å/path/to_a_file.mp3\n')
 
     def test_playlist_load_extm3u(self):
+        """Test loading a playlist with an #EXTM3U header."""
         the_playlist_file = path.join(RSRC, b'playlist.m3u')
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.load()
         self.assertTrue(m3ufile.extm3u)
 
     def test_playlist_load_non_extm3u(self):
+        """Test loading a playlist without an #EXTM3U header."""
         the_playlist_file = path.join(RSRC, b'playlist_non_ext.m3u')
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.load()
@@ -86,6 +93,7 @@ class M3UFileTest(unittest.TestCase):
 
 
 def suite():
+    """This testsuite's main function."""
     return unittest.TestLoader().loadTestsFromName(__name__)
 
 

--- a/test/test_m3ufile.py
+++ b/test/test_m3ufile.py
@@ -1,5 +1,5 @@
 # This file is part of beets.
-# Copyright 2016, J0J0 Todos.
+# Copyright 2022, J0J0 Todos.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the

--- a/test/test_m3ufile.py
+++ b/test/test_m3ufile.py
@@ -110,8 +110,6 @@ class M3UFileTest(unittest.TestCase):
         """Test loading unicode paths from a playlist file."""
         the_playlist_file = path.join(RSRC, b'playlist_windows.m3u8')
         winpath = path.join('x:\\', 'This', 'is', 'å', 'path', 'to_a_file.mp3')
-        print("this is winpath:")
-        print(winpath)
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.load()
         self.assertEqual(

--- a/test/test_m3ufile.py
+++ b/test/test_m3ufile.py
@@ -72,6 +72,18 @@ class M3UFileTest(unittest.TestCase):
         self.assertEqual(m3ufile.media_list[0],
                          '/This/is/å/path/to_a_file.mp3\n')
 
+    def test_playlist_load_extm3u(self):
+        the_playlist_file = path.join(RSRC, b'playlist.m3u')
+        m3ufile = M3UFile(the_playlist_file)
+        m3ufile.load()
+        self.assertTrue(m3ufile.extm3u)
+
+    def test_playlist_load_non_extm3u(self):
+        the_playlist_file = path.join(RSRC, b'playlist_non_ext.m3u')
+        m3ufile = M3UFile(the_playlist_file)
+        m3ufile.load()
+        self.assertFalse(m3ufile.extm3u)
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)


### PR DESCRIPTION
## Description

- Enables the functionality proposed in https://github.com/beetbox/beets/discussions/4373
- The convert plugin is suitable to be used as a media file exporter already.
- Thus it makes sense to add a feature to save a playlist file into the export folder containing all exported media files in the order they were exported/converted.
- Since with the convert plugin all sorts of "beets queries" could be exported/converted, the feature uses a more general approach than described in the initial proposal (above linked discussion). To achieve exactly what's described in the discussion, additionally the beets `playlist` feature can be used.
- Relative paths should be used to make the playlist file portable, e.g used on another computer.
- The classic m3u format does not do well with special characters in media file names. Since the beets "path" variables could be used to write all sorts of characters, the m3u8 format which requires unicode for all media file entries, is required.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests.
  - [x] convert plugin tests.
  - [x] M3UFile class tests (macOS/Unix/General).
  - [x] M3UFile class tests (Windows).
- [x] Currently there is an issue with VLC media player not reading the generated files correctly. It seems to still have a problem with special characters (e.g square brackets: []). -> Fixed, it was a bug in VLC 3.0.16, it works with 3.0.17.3, see https://forum.videolan.org/viewtopic.php?f=2&t=158920&p=529284#p529284
- [x] It seems that there is another bug (?) in the current VLC version 3.0.17.3 that files containing the # character are not opening, also see same post: https://forum.videolan.org/viewtopic.php?f=2&t=158920&p=529284#p529284
        I'm not considering this a problem with my implementation here. Let's see what happens on that forum post, but for now I check this task as done.
- [x] Test correct reading of the files in other software. So far working fine (all tested on macOS 10.15.3 Catalina):
    - [x] iTunes (latest on Catalina)
    - [x] Traktor Scratch Pro 2 (latest, 2.11.3.17)
    - [x] VLC (3.0.17.3)
- [x] ~Ensure cross-platform compatibility~Ensure compatibility of playlists generated _on_ an OS _for_ an OS. For example, lists generated on Windows should work on Windows.


