### PR TITLE
Spotify: Add album name for singleton imports

### DIFF
--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -160,7 +160,7 @@ class TrackInfo(AttrDict):
                  artist_sort=None, disctitle=None, artist_credit=None,
                  data_source=None, data_url=None, media=None, lyricist=None,
                  composer=None, composer_sort=None, arranger=None,
-                 track_alt=None, work=None, mb_workid=None,
+                 track_alt=None, work=None, mb_workid=None,album=None,
                  work_disambig=None, bpm=None, initial_key=None, genre=None,
                  **kwargs):
         self.title = title
@@ -172,6 +172,7 @@ class TrackInfo(AttrDict):
         self.index = index
         self.media = media
         self.medium = medium
+        self.album=album
         self.medium_index = medium_index
         self.medium_total = medium_total
         self.artist_sort = artist_sort

--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -160,7 +160,7 @@ class TrackInfo(AttrDict):
                  artist_sort=None, disctitle=None, artist_credit=None,
                  data_source=None, data_url=None, media=None, lyricist=None,
                  composer=None, composer_sort=None, arranger=None,
-                 track_alt=None, work=None, mb_workid=None,album=None,
+                 track_alt=None, work=None, mb_workid=None,
                  work_disambig=None, bpm=None, initial_key=None, genre=None,
                  **kwargs):
         self.title = title
@@ -172,7 +172,6 @@ class TrackInfo(AttrDict):
         self.index = index
         self.media = media
         self.medium = medium
-        self.album=album
         self.medium_index = medium_index
         self.medium_total = medium_total
         self.artist_sort = artist_sort

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -297,7 +297,6 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
             album = track_data['album']['name']
         except KeyError:
             album = None
-            pass
         return TrackInfo(
             title=track_data['name'],
             track_id=track_data['id'],

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -291,11 +291,19 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
         :rtype: beets.autotag.hooks.TrackInfo
         """
         artist, artist_id = self.get_artist(track_data['artists'])
+
+        # Get album information for spotify tracks
+        try:
+            album=track_data['album']['name']
+        except KeyError:
+            album=None
+            pass
         return TrackInfo(
             title=track_data['name'],
             track_id=track_data['id'],
             spotify_track_id=track_data['id'],
             artist=artist,
+            album=album,
             artist_id=artist_id,
             spotify_artist_id=artist_id,
             length=track_data['duration_ms'] / 1000,

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -294,9 +294,9 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
 
         # Get album information for spotify tracks
         try:
-            album=track_data['album']['name']
+            album = track_data['album']['name']
         except KeyError:
-            album=None
+            album = None
             pass
         return TrackInfo(
             title=track_data['name'],

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,8 @@ Changelog goes here!
 
 New features:
 
+* We now import and tag the `album` information when importing singletons using Spotify source.
+  :bug:`4398
 * :doc:`/plugins/spotify`: The plugin now provides an additional command
   `spotifysync` that allows getting track popularity and audio features
   information from Spotify.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,7 +9,7 @@ Changelog goes here!
 New features:
 
 * We now import and tag the `album` information when importing singletons using Spotify source.
-  :bug:`4398
+  :bug:`4398`
 * :doc:`/plugins/spotify`: The plugin now provides an additional command
   `spotifysync` that allows getting track popularity and audio features
   information from Spotify.


### PR DESCRIPTION
As discussed in #4398, this PR adds the Spotify album information when importing tracks. I understand there are unresolved issues about which album to import for other taggers (e.g., MB). Thus, this PR only works for Spotify taggers. The behavior is unchanged for other sources. 


## To Do

- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
