### PR TITLE
Fix: Crash when search encounters a 404 error 

### DIFF
--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -749,7 +749,10 @@ class MetadataSourcePlugin(metaclass=abc.ABCMeta):
         tracks = self._search_api(
             query_type='track', keywords=title, filters={'artist': artist}
         )
-        return [self.track_for_id(track_data=track) for track in tracks]
+        if tracks is not None:
+            return [self.track_for_id(track_data=track) for track in tracks]
+        else:
+            return None
 
     def album_distance(self, items, album_info, mapping):
         return get_distance(

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -389,7 +389,8 @@ def item_candidates(item, artist, title):
     """Gets MusicBrainz candidates for an item from the plugins.
     """
     for plugin in find_plugins():
-        yield from plugin.item_candidates(item, artist, title)
+        if plugin.item_candidates(item, artist, title) is not None:
+            yield from plugin.item_candidates(item, artist, title)
 
 
 def album_for_id(album_id):

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -733,6 +733,8 @@ class MetadataSourcePlugin(metaclass=abc.ABCMeta):
         results = self._search_api(query_type='album', filters=query_filters)
         if results is not None:
             albums = [self.album_for_id(album_id=r['id']) for r in results]
+        else:
+            albums = None
         return [a for a in albums if a is not None]
 
     def item_candidates(self, item, artist, title):

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -384,7 +384,7 @@ def candidates(items, artist, album, va_likely, extra_tags=None):
         if plugin.candidates(items, artist, album, va_likely,
                              extra_tags) is not None:
             yield from plugin.candidates(items, artist, album, va_likely,
-                                     extra_tags)
+                                         extra_tags)
 
 
 def item_candidates(item, artist, title):

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -733,9 +733,9 @@ class MetadataSourcePlugin(metaclass=abc.ABCMeta):
         results = self._search_api(query_type='album', filters=query_filters)
         if results is not None:
             albums = [self.album_for_id(album_id=r['id']) for r in results]
+            return [a for a in albums if a is not None]
         else:
-            albums = None
-        return [a for a in albums if a is not None]
+            return None
 
     def item_candidates(self, item, artist, title):
         """Returns a list of TrackInfo objects for Search API results

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -381,7 +381,9 @@ def candidates(items, artist, album, va_likely, extra_tags=None):
     """Gets MusicBrainz candidates for an album from each plugin.
     """
     for plugin in find_plugins():
-        yield from plugin.candidates(items, artist, album, va_likely,
+        if plugin.candidates(items, artist, album, va_likely,
+                             extra_tags) is not None:
+            yield from plugin.candidates(items, artist, album, va_likely,
                                      extra_tags)
 
 

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -731,7 +731,8 @@ class MetadataSourcePlugin(metaclass=abc.ABCMeta):
         if not va_likely:
             query_filters['artist'] = artist
         results = self._search_api(query_type='album', filters=query_filters)
-        albums = [self.album_for_id(album_id=r['id']) for r in results]
+        if results is not None:
+            albums = [self.album_for_id(album_id=r['id']) for r in results]
         return [a for a in albums if a is not None]
 
     def item_candidates(self, item, artist, title):

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -381,18 +381,15 @@ def candidates(items, artist, album, va_likely, extra_tags=None):
     """Gets MusicBrainz candidates for an album from each plugin.
     """
     for plugin in find_plugins():
-        if plugin.candidates(items, artist, album, va_likely,
-                             extra_tags) is not None:
-            yield from plugin.candidates(items, artist, album, va_likely,
-                                         extra_tags)
+        yield from plugin.candidates(items, artist, album, va_likely,
+                                     extra_tags)
 
 
 def item_candidates(item, artist, title):
     """Gets MusicBrainz candidates for an item from the plugins.
     """
     for plugin in find_plugins():
-        if plugin.item_candidates(item, artist, title) is not None:
-            yield from plugin.item_candidates(item, artist, title)
+        yield from plugin.item_candidates(item, artist, title)
 
 
 def album_for_id(album_id):
@@ -733,11 +730,8 @@ class MetadataSourcePlugin(metaclass=abc.ABCMeta):
         if not va_likely:
             query_filters['artist'] = artist
         results = self._search_api(query_type='album', filters=query_filters)
-        if results is not None:
-            albums = [self.album_for_id(album_id=r['id']) for r in results]
-            return [a for a in albums if a is not None]
-        else:
-            return None
+        albums = [self.album_for_id(album_id=r['id']) for r in results]
+        return [a for a in albums if a is not None]
 
     def item_candidates(self, item, artist, title):
         """Returns a list of TrackInfo objects for Search API results
@@ -755,10 +749,7 @@ class MetadataSourcePlugin(metaclass=abc.ABCMeta):
         tracks = self._search_api(
             query_type='track', keywords=title, filters={'artist': artist}
         )
-        if tracks is not None:
-            return [self.track_for_id(track_data=track) for track in tracks]
-        else:
-            return None
+        return [self.track_for_id(track_data=track) for track in tracks]
 
     def album_distance(self, items, album_info, mapping):
         return get_distance(

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -658,9 +658,8 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
     def track_audio_features(self, track_id=None):
         """Fetch track audio features by its Spotify ID."""
         try:
-            track_features = self._handle_response(
+            return self._handle_response(
                 requests.get, self.audio_features_url + track_id)
         except SpotifyAPIError as e:
             self._log.debug('Spotify API error: {}', e)
-            track_features = None
-        return track_features
+            return None

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -404,6 +404,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
             )
         except SpotifyAPIError as e:
             self._log.debug('Spotify API error: {}', e)
+            return None
         response_data = (response
                          .get(query_type + 's', {})
                          .get('items', [])

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -36,7 +36,7 @@ DEFAULT_WAITING_TIME = 5
 
 
 class SpotifyAPIError(Exception):
-    pass
+    continue
 
 
 class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -195,7 +195,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
                 return self._handle_response(request_type, url, params=params)
             elif response.status_code == 404:
                 raise SpotifyAPIError("API Error {0.status_code} for {1} and \
-                    params = {2}".format(response, url, params=params))
+                    params = {2}".format(response, url, params))
             else:
                 raise ui.UserError(
                     '{} API error:\n{}\nURL:\n{}\nparams:\n{}'.format(

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -405,10 +405,8 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
         except SpotifyAPIError as e:
             self._log.debug('Spotify API error: {}', e)
             return None
-        response_data = (response
-                         .get(query_type + 's', {})
-                         .get('items', [])
-                        )
+        response_data = (response.get(query_type + 's', {})
+                         .get('items', []))
         self._log.debug(
             "Found {} result(s) from {} for '{}'",
             len(response_data),

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -658,8 +658,9 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
     def track_audio_features(self, track_id=None):
         """Fetch track audio features by its Spotify ID."""
         try:
-            return self._handle_response(
+            track_features = self._handle_response(
                 requests.get, self.audio_features_url + track_id)
         except SpotifyAPIError as e:
             self._log.debug('Spotify API error: {}', e)
-            return None
+            track_features = None
+        return track_features

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -36,7 +36,7 @@ DEFAULT_WAITING_TIME = 5
 
 
 class SpotifyAPIError(Exception):
-    continue
+    pass
 
 
 class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -396,15 +396,18 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
         self._log.debug(
             f"Searching {self.data_source} for '{query}'"
         )
-        response_data = (
-            self._handle_response(
+        try:
+            response = self._handle_response(
                 requests.get,
                 self.search_url,
                 params={'q': query, 'type': query_type},
             )
-            .get(query_type + 's', {})
-            .get('items', [])
-        )
+        except SpotifyAPIError as e:
+            self._log.debug('Spotify API error: {}', e)
+        response_data = (response
+                         .get(query_type + 's', {})
+                         .get('items', [])
+                        )
         self._log.debug(
             "Found {} result(s) from {} for '{}'",
             len(response_data),

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -194,8 +194,8 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
                 time.sleep(int(seconds) + 1)
                 return self._handle_response(request_type, url, params=params)
             elif response.status_code == 404:
-                raise SpotifyAPIError("API Error {0.status_code} for {1}"
-                                      .format(response, url))
+                raise SpotifyAPIError("API Error {0.status_code} for {1} and \
+                    params = {2}".format(response, url, params=params))
             else:
                 raise ui.UserError(
                     '{} API error:\n{}\nURL:\n{}\nparams:\n{}'.format(

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -404,7 +404,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
             )
         except SpotifyAPIError as e:
             self._log.debug('Spotify API error: {}', e)
-            return None
+            return []
         response_data = (response.get(query_type + 's', {})
                          .get('items', []))
         self._log.debug(

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -194,8 +194,9 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
                 time.sleep(int(seconds) + 1)
                 return self._handle_response(request_type, url, params=params)
             elif response.status_code == 404:
-                raise SpotifyAPIError("API Error {} for {} and params = {}".
-                                      format(response.status_code, url, params))
+                raise SpotifyAPIError("API Error: {}\nURL: {}\nparams: {}".
+                                      format(response.status_code, url,
+                                             params))
             else:
                 raise ui.UserError(
                     '{} API error:\n{}\nURL:\n{}\nparams:\n{}'.format(

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -194,8 +194,8 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
                 time.sleep(int(seconds) + 1)
                 return self._handle_response(request_type, url, params=params)
             elif response.status_code == 404:
-                raise SpotifyAPIError("API Error {0.status_code} for {1} and \
-                    params = {2}".format(response, url, params))
+                raise SpotifyAPIError("API Error {} for {} and params = {}".
+                                      format(response.status_code, url, params))
             else:
                 raise ui.UserError(
                     '{} API error:\n{}\nURL:\n{}\nparams:\n{}'.format(


### PR DESCRIPTION
Fixes #4411

I had to add a few additional guard clauses to prevent errors. 

Tested this fix with the same track with both Spotify and MB match and it works fine. 
