### PR TITLE
Change the option 'Remove old' -> 'Replace old' in the importer CLI

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -1473,7 +1473,7 @@ def resolve_duplicates(session, task):
                 # Keep both. Do nothing; leave the choice intact.
                 pass
             elif duplicate_action == 'r':
-                # Remove old.
+                # Replace old.
                 task.should_remove_duplicates = True
             elif duplicate_action == 'm':
                 # Merge duplicates together

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -857,7 +857,7 @@ class TerminalImportSession(importer.ImportSession):
             ))
 
             sel = ui.input_options(
-                ('Skip new', 'Keep all', 'Remove old', 'Merge all')
+                ('Skip new', 'Keep all', 'Replace old', 'Merge all')
             )
 
         if sel == 's':
@@ -867,7 +867,7 @@ class TerminalImportSession(importer.ImportSession):
             # Keep both. Do nothing; leave the choice intact.
             pass
         elif sel == 'r':
-            # Remove old.
+            # Replace old.
             task.should_remove_duplicates = True
         elif sel == 'm':
             task.should_merge_duplicates = True

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -102,6 +102,7 @@ Other new things:
 * :doc:`/plugins/limit`: Limit query results to head or tail (``lslimit``
   command only)
 * :doc:`/plugins/fish`: Add ``--output`` option.
+* Change ``Remove old`` to ``Replace old`` in the importer.
 
 1.6.0 (November 27, 2021)
 -------------------------

--- a/docs/guides/tagger.rst
+++ b/docs/guides/tagger.rst
@@ -237,17 +237,16 @@ If beets finds an album or item in your library that seems to be the same as the
 one you're importing, you may see a prompt like this::
 
     This album is already in the library!
-    [S]kip new, Keep all, Remove old, Merge all?
+    [S]kip new, Keep all, Replace old, Merge all?
 
 Beets wants to keep you safe from duplicates, which can be a real pain, so you
 have four choices in this situation. You can skip importing the new music,
 choosing to keep the stuff you already have in your library; you can keep both
-the old and the new music; you can remove the existing music and choose the
+the old and the new music; you can replace the existing music with the
 new stuff; or you can merge all the new and old tracks into a single album.
-If you choose that "remove" option, any duplicates will be
-removed from your library database---and, if the corresponding files are located
-inside of your beets library directory, the files themselves will be deleted as
-well.
+If you choose that "replace" option, any duplicates will be removed from your 
+library database---and, if the corresponding files are located inside of your
+beets library directory, the files themselves will be deleted as well.
 
 If you choose "merge", beets will try re-importing the existing and new tracks
 as one bundle together.


### PR DESCRIPTION
## Description

The CLI currently provides the following options to handle adding a duplicate album:

```
[S]kip new, Keep all, Remove old, Merge all?
```

This PR replaces the word `Remove` with `Replace`:

```
[S]kip new, Keep all, Replace old, Merge all?
```

In my opinion, this more accurately reflects what the operation does.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
