### PR TITLE
Fix old alias

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -37,7 +37,7 @@ _temp_files = []  # Keep track of temporary transcoded files for deletion.
 
 # Some convenient alternate names for formats.
 ALIASES = {
-    'wma': 'windows media',
+    'windows media': 'wma',
     'vorbis': 'ogg',
 }
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -90,6 +90,7 @@ Bug fixes:
 * :doc:`plugins/importadded`: Fix a bug with recently added reflink import option
   that casues a crash when ImportAdded plugin enabled.
   :bug:`4389`
+* :doc:`plugins/convert`: Fix a bug with the `wma` format alias.
 
 For packagers:
 

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -165,7 +165,7 @@ command to use to transcode audio. The tokens ``$source`` and ``$dest`` in the
 command are replaced with the paths to the existing and new file.
 
 The plugin in comes with default commands for the most common audio
-formats: `mp3`, `alac`, `flac`, `aac`, `opus`, `ogg`, `wmv`. For
+formats: `mp3`, `alac`, `flac`, `aac`, `opus`, `ogg`, `wma`. For
 details have a look at the output of ``beet config -d``.
 
 For a one-command-fits-all solution use the ``convert.command`` and


### PR DESCRIPTION
It looks like the convert option for wma used to be called windows media.  We could just remove this alias, but might be good to keep for backwards compatibility.

## Description

Fixes error when trying to use wma format in convert.

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
