### PR TITLE
[Small PR] Add spotify_lastupdatedat field

### DIFF
--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -58,7 +58,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
         'spotify_tempo': types.FLOAT,
         'spotify_time_signature': types.INTEGER,
         'spotify_valence': types.FLOAT,
-        'spotify_lastupdatedat': DateType(),
+        'spotify_updated': DateType(),
     }
 
     # Base URLs for the Spotify API
@@ -648,7 +648,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
                 if feature in self.spotify_audio_features.keys():
                     item[self.spotify_audio_features[feature]] = \
                         audio_features[feature]
-            item['spotify_lastupdatedat'] = datetime.datetime.now()
+            item['spotify_updated'] = datetime.datetime.now()
             item.store()
             if write:
                 item.try_write()

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -19,6 +19,7 @@ Spotify playlist construction.
 
 import base64
 import collections
+import datetime
 import json
 import re
 import time
@@ -30,6 +31,7 @@ import unidecode
 from beets import ui
 from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.dbcore import types
+from beets.library import DateType
 from beets.plugins import BeetsPlugin, MetadataSourcePlugin
 
 DEFAULT_WAITING_TIME = 5
@@ -56,6 +58,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
         'spotify_tempo': types.FLOAT,
         'spotify_time_signature': types.INTEGER,
         'spotify_valence': types.FLOAT,
+        'spotify_lastupdatedat': DateType(),
     }
 
     # Base URLs for the Spotify API
@@ -645,6 +648,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
                 if feature in self.spotify_audio_features.keys():
                     item[self.spotify_audio_features[feature]] = \
                         audio_features[feature]
+            item['spotify_lastupdatedat'] = datetime.datetime.now()
             item.store()
             if write:
                 item.try_write()

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog goes here!
 
 New features:
 
+* Added `spotify_updated` field to track when the information was last updated.
 * We now import and tag the `album` information when importing singletons using Spotify source.
   :bug:`4398`
 * :doc:`/plugins/spotify`: The plugin now provides an additional command


### PR DESCRIPTION
## Description
Added `spotify_lastupdatedat` field that can be used to economize on the API calls. For example, we can use this field to update only those tracks that have not been updated in the last 6 months. 

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
