### PR TITLE
Fix get item file in web plugin

### DIFF
--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -324,7 +324,7 @@ def item_file(item_id):
     response = flask.send_file(
         item_path,
         as_attachment=True,
-        attachment_filename=safe_filename
+        download_name=safe_filename
     )
     response.headers['Content-Length'] = os.path.getsize(item_path)
     return response

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -92,6 +92,7 @@ Bug fixes:
   that casues a crash when ImportAdded plugin enabled.
   :bug:`4389`
 * :doc:`plugins/convert`: Fix a bug with the `wma` format alias.
+* :doc:`/plugins/web`: Fix get file from item.
 
 For packagers:
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -667,6 +667,16 @@ class WebPluginTest(_common.LibTestCase):
         # Remove the item
         self.lib.get_item(item_id).remove()
 
+    def test_get_item_file(self):
+        ipath = os.path.join(self.temp_dir, b'testfile2.mp3')
+        shutil.copy(os.path.join(_common.RSRC, b'full.mp3'), ipath)
+        self.assertTrue(os.path.exists(ipath))
+        item_id = self.lib.add(Item.from_path(ipath))
+
+        response = self.client.get('/item/' + str(item_id) + '/file')
+
+        self.assertEqual(response.status_code, 200)
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)


### PR DESCRIPTION
## Description

Hi! In the last version of Flask, the `attach_filename` parameter was removed of the `send_file` function, used by the web plugin to stream the file. So thing change broke the web plugin. [Flask changelog](https://flask.palletsprojects.com/en/2.2.0/changes/#version-2-2-0)

Also, I added a test for that feature.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
