### PR TITLE
Add path template "sunique" to disambiguate between singleton tracks

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -55,6 +55,11 @@ aunique:
     disambiguators: albumtype year label catalognum albumdisambig releasegroupdisambig
     bracket: '[]'
 
+sunique:
+    keys: artist title
+    disambiguators: year trackdisambig
+    bracket: '[]'
+
 overwrite_null:
   album: []
   track: []

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,8 @@ New features:
 * :ref:`import-options`: Add support for re-running the importer on paths in
   log files that were created with the ``-l`` (or ``--logfile``) argument.
   :bug:`4379` :bug:`4387`
+* Add :ref:`%sunique{} <sunique>` template to disambiguate between singletons.
+  :bug:`4438`
 
 Bug fixes:
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -326,6 +326,23 @@ The defaults look like this::
 
 See :ref:`aunique` for more details.
 
+.. _config-sunique:
+
+sunique
+~~~~~~~
+
+These options are used to generate a string that is guaranteed to be unique
+among all singletons in the library who share the same set of keys.
+
+The defaults look like this::
+
+    sunique:
+        keys: artist title
+        disambiguators: year trackdisambig
+        bracket: '[]'
+
+See :ref:`sunique` for more details.
+
 
 .. _terminal_encoding:
 

--- a/docs/reference/pathformat.rst
+++ b/docs/reference/pathformat.rst
@@ -73,6 +73,8 @@ These functions are built in to beets:
   option.
 * ``%aunique{identifiers,disambiguators,brackets}``: Provides a unique string
   to disambiguate similar albums in the database. See :ref:`aunique`, below.
+* ``%sunique{identifiers,disambiguators,brackets}``: Provides a unique string
+  to disambiguate similar singletons in the database. See :ref:`sunique`, below.
 * ``%time{date_time,format}``: Return the date and time in any format accepted
   by `strftime`_. For example, to get the year some music was added to your
   library, use ``%time{$added,%Y}``.
@@ -145,6 +147,18 @@ its import time. Only the second album will receive a disambiguation string. If
 you want to add the disambiguation string to both albums, just run ``beet move``
 (possibly restricted by a query) to update the paths for the albums.
 
+.. _sunique:
+
+Singleton Disambiguation
+------------------------
+
+It is also possible to have singleton tracks with the same name and the same
+artist. Beets provides the ``%sunique{}`` template to avoid having the same
+file path.
+
+It has the same arguments as the :ref:`%aunique <aunique>` template, but the default
+values are different. The default identifiers are ``artist title`` and the
+default disambiguators are ``year trackdisambig``.
 
 Syntax Details
 --------------

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -805,6 +805,91 @@ class DisambiguationTest(_common.TestCase, PathFormattingMixin):
         self._assert_dest(b'/base/foo/the title', self.i1)
 
 
+class SingletonDisambiguationTest(_common.TestCase, PathFormattingMixin):
+    def setUp(self):
+        super().setUp()
+        self.lib = beets.library.Library(':memory:')
+        self.lib.directory = b'/base'
+        self.lib.path_formats = [('default', 'path')]
+
+        self.i1 = item()
+        self.i1.year = 2001
+        self.lib.add(self.i1)
+        self.i2 = item()
+        self.i2.year = 2002
+        self.lib.add(self.i2)
+        self.lib._connection().commit()
+
+        self._setf('foo/$title%sunique{artist title,year}')
+
+    def tearDown(self):
+        super().tearDown()
+        self.lib._connection().close()
+
+    def test_sunique_expands_to_disambiguating_year(self):
+        self._assert_dest(b'/base/foo/the title [2001]', self.i1)
+
+    def test_sunique_with_default_arguments_uses_trackdisambig(self):
+        self.i1.trackdisambig = 'live version'
+        self.i1.year = self.i2.year
+        self.i1.store()
+        self._setf('foo/$title%sunique{}')
+        self._assert_dest(b'/base/foo/the title [live version]', self.i1)
+
+    def test_sunique_expands_to_nothing_for_distinct_singletons(self):
+        self.i2.title = 'different track'
+        self.i2.store()
+
+        self._assert_dest(b'/base/foo/the title', self.i1)
+
+    def test_sunique_does_not_match_album(self):
+        self.lib.add_album([self.i2])
+        self._assert_dest(b'/base/foo/the title', self.i1)
+
+    def test_sunique_use_fallback_numbers_when_identical(self):
+        self.i2.year = self.i1.year
+        self.i2.store()
+
+        self._assert_dest(b'/base/foo/the title [1]', self.i1)
+        self._assert_dest(b'/base/foo/the title [2]', self.i2)
+
+    def test_sunique_falls_back_to_second_distinguishing_field(self):
+        self._setf('foo/$title%sunique{albumartist album,month year}')
+        self._assert_dest(b'/base/foo/the title [2001]', self.i1)
+
+    def test_sunique_sanitized(self):
+        self.i2.year = self.i1.year
+        self.i1.trackdisambig = 'foo/bar'
+        self.i2.store()
+        self.i1.store()
+        self._setf('foo/$title%sunique{artist title,trackdisambig}')
+        self._assert_dest(b'/base/foo/the title [foo_bar]', self.i1)
+
+    def test_drop_empty_disambig_string(self):
+        self.i1.trackdisambig = None
+        self.i2.trackdisambig = 'foo'
+        self.i1.store()
+        self.i2.store()
+        self._setf('foo/$title%sunique{albumartist album,trackdisambig}')
+        self._assert_dest(b'/base/foo/the title', self.i1)
+
+    def test_change_brackets(self):
+        self._setf('foo/$title%sunique{artist title,year,()}')
+        self._assert_dest(b'/base/foo/the title (2001)', self.i1)
+
+    def test_remove_brackets(self):
+        self._setf('foo/$title%sunique{artist title,year,}')
+        self._assert_dest(b'/base/foo/the title 2001', self.i1)
+
+    def test_key_flexible_attribute(self):
+        self.i1.flex = 'flex1'
+        self.i2.flex = 'flex2'
+        self.i1.store()
+        self.i2.store()
+        self._setf('foo/$title%sunique{artist title flex,year}')
+        self._assert_dest(b'/base/foo/the title', self.i1)
+
+
 class PluginDestinationTest(_common.TestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Solution for https://github.com/beetbox/beets/discussions/4436. It is mostly copied from the `aunique` template. I don't know if there could be better defaults for the `disambiguators`.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [X] Tests. (Encouraged but not strictly required.)
