### PR TITLE
Change the prefix for exact match queries

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -1387,7 +1387,7 @@ def parse_query_parts(parts, model_cls):
     # Get query types and their prefix characters.
     prefixes = {
         ':': dbcore.query.RegexpQuery,
-        '~': dbcore.query.StringQuery,
+        '=~': dbcore.query.StringQuery,
         '=': dbcore.query.MatchQuery,
     }
     prefixes.update(plugins.queries())

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,7 +25,9 @@ New features:
 * :doc:`/plugins/kodiupdate`: Now supports multiple kodi instances
   :bug:`4101`
 * Add the item fields ``bitrate_mode``, ``encoder_info`` and ``encoder_settings``.
-* Add query prefixes ``=`` and ``~``.
+* Add :ref:`exact match <exact-match>` queries, using the prefixes ``=`` and
+  ``=~``.
+  :bug:`4251`
 * :doc:`/plugins/discogs`: Permit appending style to genre
 * :doc:`/plugins/convert`: Add a new `auto_keep` option that automatically
   converts files but keeps the *originals* in the library.

--- a/docs/reference/query.rst
+++ b/docs/reference/query.rst
@@ -93,15 +93,17 @@ backslashes are not part of beets' syntax; I'm just using the escaping
 functionality of my shell (bash or zsh, for instance) to pass ``the rebel`` as a
 single argument instead of two.
 
+.. _exact-match:
+
 Exact Matches
 -------------
 
 While ordinary queries perform *substring* matches, beets can also match whole
-strings by adding either ``=`` (case-sensitive) or ``~`` (ignore case) after the
-field name's colon and before the expression::
+strings by adding either ``=`` (case-sensitive) or ``=~`` (ignore case) after
+the field name's colon and before the expression::
 
     $ beet list artist:air
-    $ beet list artist:~air
+    $ beet list artist:=~air
     $ beet list artist:=AIR
 
 The first query is a simple substring one that returns tracks by Air, AIR, and
@@ -112,16 +114,16 @@ returns tracks by AIR only.
 
 Exact matches may be performed on phrases as well::
 
-    $ beet list artist:~"dave matthews"
+    $ beet list artist:=~"dave matthews"
     $ beet list artist:="Dave Matthews"
 
 Both of these queries return tracks by Dave Matthews, but not by Dave Matthews
 Band.
 
 To search for exact matches across *all* fields, just prefix the expression with
-a single ``=`` or ``~``::
+a single ``=`` or ``=~``::
 
-    $ beet list ~crash
+    $ beet list =~crash
     $ beet list ="American Football"
 
 .. _regex:

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -150,7 +150,7 @@ class GetTest(DummyDataTestCase):
         self.assert_items_matched(results, ['beets 4 eva'])
 
     def test_get_one_keyed_exact_nocase(self):
-        q = 'genre:~"hard rock"'
+        q = 'genre:=~"hard rock"'
         results = self.lib.items(q)
         self.assert_items_matched(results, ['beets 4 eva'])
 
@@ -220,7 +220,7 @@ class GetTest(DummyDataTestCase):
         self.assert_items_matched(results, ['beets 4 eva'])
 
     def test_keyed_matches_exact_nocase(self):
-        q = 'genre:~rock'
+        q = 'genre:=~rock'
         results = self.lib.items(q)
         self.assert_items_matched(results, [
             'foo bar',

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -170,7 +170,7 @@ class GetTest(DummyDataTestCase):
         self.assert_items_matched(results, ['foo bar'])
 
     def test_get_one_unkeyed_exact_nocase(self):
-        q = '~"hard rock"'
+        q = '=~"hard rock"'
         results = self.lib.items(q)
         self.assert_items_matched(results, ['beets 4 eva'])
 


### PR DESCRIPTION
#4251 added exact match queries, which are great, but it was subsequently pointed out in https://github.com/beetbox/beets/pull/4251#issuecomment-1069455483  that the `~` query prefix was already in use.

So this changes the prefix from `~` to `=~`. A little longer, but hopefully it makes the relationship to the similarly-new `=` prefix obvious.