### PR TITLE
release.py: fix version regex (remove u'' string prefix)

### DIFF
--- a/extra/release.py
+++ b/extra/release.py
@@ -34,7 +34,7 @@ VERSION_LOCS = [
         os.path.join(BASE, 'beets', '__init__.py'),
         [
             (
-                r'__version__\s*=\s*u[\'"]([0-9\.]+)[\'"]',
+                r'__version__\s*=\s*[\'"]([0-9\.]+)[\'"]',
                 "__version__ = '{version}'",
             )
         ]


### PR DESCRIPTION
Fixes the issue noted in #4395

> Thanks! Not sure how this one didn't get bumped when the other occurrences did.

_Originally posted by @sampsyo in https://github.com/beetbox/beets/issues/4395#issuecomment-1172913377_