### PR TITLE
Resolve some deprecation warnings

### DIFF
--- a/beets/util/pipeline.py
+++ b/beets/util/pipeline.py
@@ -75,8 +75,8 @@ def _invalidate_queue(q, val=None, sync=True):
         q._qsize = _qsize
         q._put = _put
         q._get = _get
-        q.not_empty.notifyAll()
-        q.not_full.notifyAll()
+        q.not_empty.notify_all()
+        q.not_full.notify_all()
 
     finally:
         if sync:

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -560,7 +560,8 @@ def scrape_lyrics_from_html(html):
     html = _scrape_merge_paragraphs(html)
 
     # extract all long text blocks that are not code
-    soup = try_parse_html(html, parse_only=SoupStrainer(text=is_text_notcode))
+    soup = try_parse_html(html,
+                          parse_only=SoupStrainer(string=is_text_notcode))
     if not soup:
         return None
 

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -336,8 +336,7 @@ class AAOTest(UseThePlugin):
         super().run(*args, **kwargs)
 
     def mock_response(self, url, body):
-        responses.add(responses.GET, url, body=body, content_type='text/html',
-                      match_querystring=True)
+        responses.add(responses.GET, url, body=body, content_type='text/html')
 
     def test_aao_scraper_finds_image(self):
         body = """

--- a/test/test_player.py
+++ b/test/test_player.py
@@ -35,8 +35,10 @@ import confuse
 
 # Mock GstPlayer so that the forked process doesn't attempt to import gi:
 from unittest import mock
-import imp
-gstplayer = imp.new_module("beetsplug.bpd.gstplayer")
+import importlib.util
+gstplayer = importlib.util.module_from_spec(
+    importlib.util.find_spec("beetsplug.bpd.gstplayer")
+)
 def _gstplayer_play(*_):  # noqa: 42
     bpd.gstplayer._GstPlayer.playing = True
     return mock.DEFAULT


### PR DESCRIPTION
I found a few deprecations because [pytest](https://docs.pytest.org/) surfaces warnings by default (unlike nose). Fortunately, they were all pretty easy to fix.