### PR TITLE
Extend mbsubmit plugin to run after initial import

### DIFF
--- a/beetsplug/mbsubmit.py
+++ b/beetsplug/mbsubmit.py
@@ -22,9 +22,11 @@ implemented by MusicBrainz yet.
 """
 
 
+from beets import ui
 from beets.autotag import Recommendation
 from beets.plugins import BeetsPlugin
 from beets.ui.commands import PromptChoice
+
 from beetsplug.info import print_data
 
 
@@ -54,4 +56,23 @@ class MBSubmitPlugin(BeetsPlugin):
 
     def print_tracks(self, session, task):
         for i in sorted(task.items, key=lambda i: i.track):
+            print_data(None, i, self.config['format'].as_str())
+
+    def commands(self):
+        """Add beet UI commands to interact with Plex."""
+        mbsubmit_cmd = ui.Subcommand(
+            'mbsubmit', help=f'Submit Tracks to MusicBrainz')
+
+        def func(lib, opts, args):
+            self._mbsubmit()
+
+        mbsubmit_cmd.func = func
+
+        return [mbsubmit_cmd]
+
+    def _mbsubmit(self, items):
+        """Print track list to be submitted to MB."""
+        self._log.debug('Total {} tracks', len(items))
+
+        for i in sorted(items, key=lambda i: i.track):
             print_data(None, i, self.config['format'].as_str())

--- a/beetsplug/mbsubmit.py
+++ b/beetsplug/mbsubmit.py
@@ -64,7 +64,8 @@ class MBSubmitPlugin(BeetsPlugin):
             'mbsubmit', help=f'Submit Tracks to MusicBrainz')
 
         def func(lib, opts, args):
-            self._mbsubmit()
+            items = lib.items(ui.decargs(args))
+            self._mbsubmit(items)
 
         mbsubmit_cmd.func = func
 

--- a/beetsplug/mbsubmit.py
+++ b/beetsplug/mbsubmit.py
@@ -61,7 +61,7 @@ class MBSubmitPlugin(BeetsPlugin):
     def commands(self):
         """Add beet UI commands for mbsubmit."""
         mbsubmit_cmd = ui.Subcommand(
-            'mbsubmit', help=f'Submit Tracks to MusicBrainz')
+            'mbsubmit', help='Submit Tracks to MusicBrainz')
 
         def func(lib, opts, args):
             items = lib.items(ui.decargs(args))

--- a/beetsplug/mbsubmit.py
+++ b/beetsplug/mbsubmit.py
@@ -59,7 +59,7 @@ class MBSubmitPlugin(BeetsPlugin):
             print_data(None, i, self.config['format'].as_str())
 
     def commands(self):
-        """Add beet UI commands to interact with Plex."""
+        """Add beet UI commands for mbsubmit."""
         mbsubmit_cmd = ui.Subcommand(
             'mbsubmit', help=f'Submit Tracks to MusicBrainz')
 
@@ -72,8 +72,6 @@ class MBSubmitPlugin(BeetsPlugin):
         return [mbsubmit_cmd]
 
     def _mbsubmit(self, items):
-        """Print track list to be submitted to MB."""
-        self._log.debug('Total {} tracks', len(items))
-
+        """Print track information to be submitted to MusicBrainz."""
         for i in sorted(items, key=lambda i: i.track):
             print_data(None, i, self.config['format'].as_str())

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,8 @@ Changelog goes here!
 
 New features:
 
+* Added `mbsubmit` command to print track information to be submitted to MusicBrainz after initial import.
+  :bug:`4455`
 * Added `spotify_updated` field to track when the information was last updated.
 * We now import and tag the `album` information when importing singletons using Spotify source.
   :bug:`4398`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ Changelog goes here!
 
 New features:
 
-* Added `mbsubmit` command to print track information to be submitted to MusicBrainz after initial import.
+* :doc:`/plugins/mbsubmit`: Added a new `mbsubmit` command to print track information to be submitted to MusicBrainz after initial import.
   :bug:`4455`
 * Added `spotify_updated` field to track when the information was last updated.
 * We now import and tag the `album` information when importing singletons using Spotify source.

--- a/docs/plugins/mbsubmit.rst
+++ b/docs/plugins/mbsubmit.rst
@@ -2,8 +2,7 @@ MusicBrainz Submit Plugin
 =========================
 
 The ``mbsubmit`` plugin provides an extra prompt choice during an import
-session that prints the tracks of the current album in a format that is
-parseable by MusicBrainz's `track parser`_.
+session and a ``mbsubmit`` command that prints the tracks of the current album in a format that is parseable by MusicBrainz's `track parser`_.
 
 .. _track parser: https://wiki.musicbrainz.org/History:How_To_Parse_Track_Listings
 
@@ -26,6 +25,13 @@ strong recommendations are found for the album::
     For help, see: https://beets.readthedocs.org/en/latest/faq.html#nomatch
     [U]se as-is, as Tracks, Group albums, Skip, Enter search, enter Id, aBort,
     Print tracks?
+
+You can also run ``beet mbsubmit QUERY`` to print the track information for any album::
+
+    $ beet mbsubmit album:"An Obscure Album".
+    01. An Obscure Track - An Obscure Artist (3:37)
+    02. Another Obscure Track - An Obscure Artist (2:05)
+    03. The Third Track - Another Obscure Artist (3:02)
 
 As MusicBrainz currently does not support submitting albums programmatically,
 the recommended workflow is to copy the output of the ``Print tracks`` choice

--- a/docs/plugins/mbsubmit.rst
+++ b/docs/plugins/mbsubmit.rst
@@ -2,7 +2,8 @@ MusicBrainz Submit Plugin
 =========================
 
 The ``mbsubmit`` plugin provides an extra prompt choice during an import
-session and a ``mbsubmit`` command that prints the tracks of the current album in a format that is parseable by MusicBrainz's `track parser`_.
+session and a ``mbsubmit`` command that prints the tracks of the current
+album in a format that is parseable by MusicBrainz's `track parser`_.
 
 .. _track parser: https://wiki.musicbrainz.org/History:How_To_Parse_Track_Listings
 

--- a/docs/plugins/mbsubmit.rst
+++ b/docs/plugins/mbsubmit.rst
@@ -29,7 +29,7 @@ strong recommendations are found for the album::
 
 You can also run ``beet mbsubmit QUERY`` to print the track information for any album::
 
-    $ beet mbsubmit album:"An Obscure Album".
+    $ beet mbsubmit album:"An Obscure Album"
     01. An Obscure Track - An Obscure Artist (3:37)
     02. Another Obscure Track - An Obscure Artist (2:05)
     03. The Third Track - Another Obscure Artist (3:02)


### PR DESCRIPTION
## Description

Adds a command `mbsubmit` to run even after the initial import. The command accepts queries and prints the tracklist to be submitted to MB. Users can now run something like `beet mbsubmit album:"Atrangi Re"` to generate the track listing (see output below). 

```
arsaboo@ubuntuvm2:~/beets$ beet mbsubmit album:"Atrangi Re"
01. Garda - A.R. Rahman, Daler Mehndi (3:44)
02. Chaka Chak - A.R. Rahman, Shreya Ghoshal (4:31)
03. Tere Rang - A.R. Rahman, Haricharan, Shreya Ghoshal (4:34)
04. Little Little - A.R. Rahman, Dhanush, Hiral Viradia (4:18)
05. Tumhein Mohabbat - A.R. Rahman, Arijit Singh (3:07)
06. Rait Zara Si - A.R. Rahman, Arijit Singh, Shashaa Tirupati (4:51)
07. Toofan Si Kudi - A.R. Rahman, Rashid Ali (3:37)
```
Fixes #4455 

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
