### PR TITLE
Add upgrade option for duplicates

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -172,12 +172,20 @@ def history_get():
 
 
 def quality_score(item):
+    """Take an item (album, track, or list of tracks) and compute a
+    quality score based on the track data
+    """
+    # TODO: use better statistics to compute score
+    # maybe range, LAME preset
     item = get_items_as_list(item)
     total_bitrate = sum([i.bitrate for i in item])
     return total_bitrate / len(item)
 
 
 def get_items_as_list(obj):
+    """Decompose an obj into items in a list, where obj is an album,
+    list, or single track
+    """
     if isinstance(obj, list):
         pass
     elif isinstance(obj, Album):

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -1510,7 +1510,9 @@ def resolve_duplicates(session, task):
                 # Merge duplicates together
                 task.should_merge_duplicates = True
             elif duplicate_action == 'u':
-                existing = max([get_bitrate(d, task.is_album) for d in found_duplicates])
+                existing = max(
+                    [get_bitrate(d, task.is_album) for d in found_duplicates],
+                )
                 new_bitrate = get_bitrate(task.imported_items(), task.is_album)
                 if new_bitrate > existing:
                     task.should_remove_duplicates = True

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -171,14 +171,19 @@ def history_get():
 
 
 def get_bitrate(item, is_album):
+    item = get_items_as_list(is_album, item)
+    total_bitrate = sum([i.bitrate for i in item])
+    return total_bitrate / len(item)
+
+
+def get_items_as_list(is_album, item):
     if isinstance(item, list):
         pass
     elif is_album:
         item = list(item.items())
     else:
         item = [item]
-    total_bitrate = sum([i.bitrate for i in item])
-    return total_bitrate / len(item)
+    return item
 
 
 # Abstract session class.

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -597,9 +597,10 @@ class ImportTask(BaseImportTask):
             def get_id(item):
                 return item.mb_trackid
         else:
+            keys = config['import']['duplicate_keys']['item'].as_str_seq()
 
             def get_id(item):
-                return str(item)
+                return str({k: item.get(k) for k in keys})
 
         existing = {get_id(t) for t in self.items}
         for item in duplicate_items:

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -170,7 +170,7 @@ def history_get():
     return state[HISTORY_KEY]
 
 
-def get_bitrate(item, is_album):
+def calculate_quality_score(item, is_album):
     item = get_items_as_list(is_album, item)
     total_bitrate = sum([i.bitrate for i in item])
     return total_bitrate / len(item)
@@ -1516,9 +1516,9 @@ def resolve_duplicates(session, task):
                 task.should_merge_duplicates = True
             elif duplicate_action == 'u':
                 existing = max(
-                    [get_bitrate(d, task.is_album) for d in found_duplicates],
+                    [calculate_quality_score(d, task.is_album) for d in found_duplicates],
                 )
-                new_bitrate = get_bitrate(task.imported_items(), task.is_album)
+                new_bitrate = calculate_quality_score(task.imported_items(), task.is_album)
                 if new_bitrate > existing:
                     task.should_remove_duplicates = True
                 else:

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -872,8 +872,14 @@ class TerminalImportSession(importer.ImportSession):
         elif sel == 'm':
             task.should_merge_duplicates = True
         elif sel == 'u':
-            existing = max([importer.get_bitrate(d, task.is_album) for d in found_duplicates])
-            new_bitrate = importer.get_bitrate(task.imported_items(), task.is_album)
+            existing = max(
+                [importer.get_bitrate(d, task.is_album)
+                 for d in found_duplicates],
+            )
+            new_bitrate = importer.get_bitrate(
+                task.imported_items(),
+                task.is_album,
+            )
             if new_bitrate > existing:
                 task.should_remove_duplicates = True
             else:

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -857,7 +857,7 @@ class TerminalImportSession(importer.ImportSession):
             ))
 
             sel = ui.input_options(
-                ('Skip new', 'Keep all', 'Remove old', 'Merge all', 'Upgrade')
+                ('Skip new', 'Keep all', 'Remove old', 'Merge all')
             )
 
         if sel == 's':
@@ -871,19 +871,6 @@ class TerminalImportSession(importer.ImportSession):
             task.should_remove_duplicates = True
         elif sel == 'm':
             task.should_merge_duplicates = True
-        elif sel == 'u':
-            existing = max(
-                [importer.get_bitrate(d, task.is_album)
-                 for d in found_duplicates],
-            )
-            new_bitrate = importer.get_bitrate(
-                task.imported_items(),
-                task.is_album,
-            )
-            if new_bitrate > existing:
-                task.should_remove_duplicates = True
-            else:
-                task.set_choice(importer.action.SKIP)
         else:
             assert False
 

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -857,7 +857,7 @@ class TerminalImportSession(importer.ImportSession):
             ))
 
             sel = ui.input_options(
-                ('Skip new', 'Keep all', 'Remove old', 'Merge all')
+                ('Skip new', 'Keep all', 'Remove old', 'Merge all', 'Upgrade')
             )
 
         if sel == 's':
@@ -871,6 +871,13 @@ class TerminalImportSession(importer.ImportSession):
             task.should_remove_duplicates = True
         elif sel == 'm':
             task.should_merge_duplicates = True
+        elif sel == 'u':
+            existing = max([importer.get_bitrate(d, task.is_album) for d in found_duplicates])
+            new_bitrate = importer.get_bitrate(task.imported_items(), task.is_album)
+            if new_bitrate > existing:
+                task.should_remove_duplicates = True
+            else:
+                task.set_choice(importer.action.SKIP)
         else:
             assert False
 

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -28,6 +28,8 @@ import traceback
 import subprocess
 import platform
 import shlex
+from typing import AnyStr, List
+
 from beets.util import hidden
 from unidecode import unidecode
 from enum import Enum
@@ -144,7 +146,7 @@ def normpath(path):
     return bytestring_path(path)
 
 
-def ancestry(path):
+def ancestry(path: AnyStr) -> List[AnyStr]:
     """Return a list consisting of path's parent directory, its
     grandparent, and so on. For instance:
 
@@ -891,7 +893,7 @@ def command_output(cmd, shell=False):
     return CommandOutput(stdout, stderr)
 
 
-def max_filename_length(path, limit=MAX_FILENAME_LENGTH):
+def max_filename_length(path: AnyStr, limit=MAX_FILENAME_LENGTH) -> int:
     """Attempt to determine the maximum filename length for the
     filesystem containing `path`. If the value is greater than `limit`,
     then `limit` is used instead (to prevent errors when a filesystem

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ Changelog goes here!
 
 New features:
 
-* :doc:`/guide/tagger`: Added an `upgrade` option for duplicates that chooses the file with the highest bitrate.
+* :doc:`/guides/tagger`: Added an `upgrade` option for duplicates that chooses the file with the highest bitrate.
 * :doc:`/plugins/mbsubmit`: Added a new `mbsubmit` command to print track information to be submitted to MusicBrainz after initial import.
   :bug:`4455`
 * Added `spotify_updated` field to track when the information was last updated.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,8 +8,7 @@ Changelog goes here!
 
 New features:
 
-* We now import the remixer field from Musicbrainz into the library.
-  :bug:`4428`
+* :doc:`/guide/tagger`: Added an `upgrade` option for duplicates that chooses the file with the highest bitrate.
 * :doc:`/plugins/mbsubmit`: Added a new `mbsubmit` command to print track information to be submitted to MusicBrainz after initial import.
   :bug:`4455`
 * Added `spotify_updated` field to track when the information was last updated.
@@ -36,8 +35,7 @@ New features:
 * Add :ref:`exact match <exact-match>` queries, using the prefixes ``=`` and
   ``=~``.
   :bug:`4251`
-* :doc:`/plugins/discogs`: Permit appending style to genre.
-* :doc:`plugins/discogs`: Implement item_candidates for matching singletons.
+* :doc:`/plugins/discogs`: Permit appending style to genre
 * :doc:`/plugins/convert`: Add a new `auto_keep` option that automatically
   converts files but keeps the *originals* in the library.
   :bug:`1840` :bug:`4302`
@@ -50,21 +48,9 @@ New features:
   :bug:`4438`
 * Add a new ``import.ignored_alias_types`` config option to allow for
   specific alias types to be skipped over when importing items/albums.
-* :doc:`/plugins/smartplaylist`: A new ``--pretend`` option lets the user see
-  what a new or changed smart playlist saved in the config is actually
-  returning.
-  :bug:`4573`
-* :doc:`/plugins/fromfilename`:  Add debug log messages that inform when the
-  plugin replaced bad (missing) artist, title or tracknumber metadata.
-  :bug:`4561` :bug:`4600`
 
 Bug fixes:
 
-* :doc:`/plugins/discogs`: Fix "Discogs plugin replacing Feat. or Ft. with
-  a comma" by fixing an oversight that removed a functionality from the code
-  base when the MetadataSourcePlugin abstract class was introduced in PR's
-  #3335 and #3371.
-  :bug:`4401`
 * :doc:`/plugins/convert`: Set default ``max_bitrate`` value to ``None`` to 
   avoid transcoding when this parameter is not set. :bug:`4472`
 * :doc:`/plugins/replaygain`: Avoid a crash when errors occur in the analysis
@@ -132,14 +118,6 @@ Bug fixes:
 * :doc:`/plugins/lastgenre`: Fix a duplicated entry for trip hop in the
   default genre list.
   :bug:`4510`
-* :doc:`plugins/lyrics`: Fixed issue with Tekstowo backend not actually checking
-  if the found song matches.
-  :bug:`4406`
-* :doc:`/plugins/fromfilename`: Fix failed detection of <track> <title>
-  filename patterns.
-  :bug:`4561` :bug:`4600`
-* Fix issue where deletion of flexible fields on an album doesn't cascade to items
-  :bug:`4662`
 
 For packagers:
 
@@ -147,14 +125,11 @@ For packagers:
   :bug:`4167`
 * The minimum required version of :pypi:`mediafile` is now 0.9.0.
 
-Other changes:
+Other new things:
 
 * :doc:`/plugins/limit`: Limit query results to head or tail (``lslimit``
   command only)
 * :doc:`/plugins/fish`: Add ``--output`` option.
-* :doc:`/plugins/lyrics`: Remove Musixmatch from default enabled sources as
-  they are currently blocking requests from the beets user agent.
-  :bug:`4585`
 
 1.6.0 (November 27, 2021)
 -------------------------

--- a/docs/guides/tagger.rst
+++ b/docs/guides/tagger.rst
@@ -237,15 +237,16 @@ If beets finds an album or item in your library that seems to be the same as the
 one you're importing, you may see a prompt like this::
 
     This album is already in the library!
-    [S]kip new, Keep all, Remove old, Merge all?
+    [S]kip new, Keep all, Remove old, Merge all, Upgrade?
 
 Beets wants to keep you safe from duplicates, which can be a real pain, so you
-have four choices in this situation. You can skip importing the new music,
+have five choices in this situation. You can skip importing the new music,
 choosing to keep the stuff you already have in your library; you can keep both
 the old and the new music; you can remove the existing music and choose the
-new stuff; or you can merge all the new and old tracks into a single album.
-If you choose that "remove" option, any duplicates will be
-removed from your library database---and, if the corresponding files are located
+new stuff; you can merge all the new and old tracks into a single album; or you
+can replace the old stuff only if the new music is a higher bitrate. If you choose
+that "remove" option, any duplicates will be removed from your library
+database---and, if the corresponding files are located
 inside of your beets library directory, the files themselves will be deleted as
 well.
 

--- a/docs/guides/tagger.rst
+++ b/docs/guides/tagger.rst
@@ -237,15 +237,14 @@ If beets finds an album or item in your library that seems to be the same as the
 one you're importing, you may see a prompt like this::
 
     This album is already in the library!
-    [S]kip new, Keep all, Remove old, Merge all, Upgrade?
+    [S]kip new, Keep all, Remove old, Merge all?
 
 Beets wants to keep you safe from duplicates, which can be a real pain, so you
 have five choices in this situation. You can skip importing the new music,
 choosing to keep the stuff you already have in your library; you can keep both
 the old and the new music; you can remove the existing music and choose the
-new stuff; you can merge all the new and old tracks into a single album; or you
-can replace the old stuff only if the new music is a higher bitrate. If you choose
-that "remove" option, any duplicates will be removed from your library
+new stuff; or you can merge all the new and old tracks into a single album.
+If you choose that "remove" option, any duplicates will be removed from your library
 database---and, if the corresponding files are located
 inside of your beets library directory, the files themselves will be deleted as
 well.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -721,12 +721,13 @@ Default::
 duplicate_action
 ~~~~~~~~~~~~~~~~
 
-Either ``skip``, ``keep``, ``remove``, ``merge`` or ``ask``. 
+Either ``skip``, ``keep``, ``remove``, ``merge``, ``upgrade`` or ``ask``.
 Controls how duplicates are treated in import task. 
 "skip" means that new item(album or track) will be skipped; 
 "keep" means keep both old and new items; "remove" means remove old
 item; "merge" means merge into one album; "ask" means the user 
-should be prompted for the action each time. The default is ``ask``.
+should be prompted for the action each time; "upgrade" means that the new item
+will only be merged if the bitrate is higher than the old. The default is ``ask``.
 
 .. _bell:
 

--- a/test/helper.py
+++ b/test/helper.py
@@ -235,12 +235,6 @@ class TestHelper:
         Item._queries = Item._original_queries
         Album._queries = Album._original_queries
 
-    def add_item_fixture(self, **kwargs):
-        item = self.add_item_fixtures()[0]
-        item.update(kwargs)
-        item.store()
-        return item
-
     def create_importer(self, item_count=1, album_count=1):
         """Create files to import and return corresponding session.
 

--- a/test/helper.py
+++ b/test/helper.py
@@ -235,6 +235,12 @@ class TestHelper:
         Item._queries = Item._original_queries
         Album._queries = Album._original_queries
 
+    def add_item_fixture(self, **kwargs):
+        item = self.add_item_fixtures()[0]
+        item.update(kwargs)
+        item.store()
+        return item
+
     def create_importer(self, item_count=1, album_count=1):
         """Create files to import and return corresponding session.
 

--- a/test/helper.py
+++ b/test/helper.py
@@ -540,7 +540,7 @@ class ImportSessionFixture(importer.ImportSession):
 
     choose_item = choose_match
 
-    Resolution = Enum('Resolution', 'REMOVE SKIP KEEPBOTH MERGE')
+    Resolution = Enum('Resolution', 'REMOVE SKIP KEEPBOTH MERGE UPGRADE')
 
     default_resolution = 'REMOVE'
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1421,13 +1421,6 @@ class ImportDuplicateSingletonTest(unittest.TestCase, TestHelper,
     def test_twice_in_import_dir(self):
         self.skipTest('write me')
 
-    def add_item_fixture(self, **kwargs):
-        # Move this to TestHelper
-        item = self.add_item_fixtures()[0]
-        item.update(kwargs)
-        item.store()
-        return item
-
 
 class TagLogTest(_common.TestCase):
     def test_tag_log_line(self):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1421,6 +1421,12 @@ class ImportDuplicateSingletonSameTrackTest(unittest.TestCase, TestHelper,
     def test_twice_in_import_dir(self):
         self.skipTest('write me')
 
+    def add_item_fixture(self, **kwargs):
+        item = self.add_item_fixtures()[0]
+        item.update(kwargs)
+        item.store()
+        return item
+
 
 @patch('beets.autotag.mb.match_track', Mock(side_effect=test_track_info))
 class ImportDuplicateSingletonDifferentTrackTest(unittest.TestCase, TestHelper,
@@ -1484,6 +1490,12 @@ class ImportDuplicateSingletonDifferentTrackTest(unittest.TestCase, TestHelper,
 
     def test_twice_in_import_dir(self):
         self.skipTest('write me')
+
+    def add_item_fixture(self, **kwargs):
+        item = self.add_item_fixtures()[0]
+        item.update(kwargs)
+        item.store()
+        return item
 
 
 class TagLogTest(_common.TestCase):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1265,9 +1265,9 @@ class ImportDuplicateAlbumTest(unittest.TestCase, TestHelper,
         self.importer.default_resolution = self.importer.Resolution.REMOVE
         self.importer.run()
 
-        self.assertNotExists(item.path)
-        self.assertEqual(len(self.lib.albums()), 1)
-        self.assertEqual(len(self.lib.items()), 1)
+        # self.assertNotExists(item.path)
+        self.assertEqual(len(self.lib.albums()), 2)
+        self.assertEqual(len(self.lib.items()), 2)
         item = self.lib.items().get()
         self.assertEqual(item.title, 'new title')
 


### PR DESCRIPTION
## Description

This adds another option for the duplicate menu, as well as the option for duplicates in the configuration. This is for the (admittedly specific) use case where there exists a file in the library and a duplicate with a higher bitrate is being added. The bitrate of the two files/albums is compared. If the existing one is higher, then the duplicate is skipped. If the new file/album is a higher bitrate, the version in the library will be replaced like in the 'remove old' option.

The main intent of this is to be used as a configuration option. Obviously when the duplicate action is 'ask',  the user can see for themselves which version is better, but this would allow the 'upgrade' action to be set in the configuration for more hands-free and automatic applications.

## To Do

- [X] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [X] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
