### PR TITLE
Update Beatport plugin to use API v4

### DIFF
--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -1,5 +1,6 @@
 # This file is part of beets.
 # Copyright 2016, Adrian Sampson.
+# Copyright 2022, Szymon "Samik" Tarasiński.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -17,20 +18,20 @@
 
 import json
 import re
-from datetime import datetime, timedelta
+import time
+from datetime import timedelta, datetime
+from json import JSONDecodeError
+from urllib.parse import urlencode
 
-from requests_oauthlib import OAuth1Session
-from requests_oauthlib.oauth1_session import (TokenRequestDenied, TokenMissing,
-                                              VerifierMissing)
+from beets.library import MusicalKey
 
 import beets
 import beets.ui
+import requests
 from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.plugins import BeetsPlugin, MetadataSourcePlugin, get_distance
 import confuse
 
-
-AUTH_ERRORS = (TokenRequestDenied, TokenMissing, VerifierMissing)
 USER_AGENT = f'beets/{beets.__version__} +https://beets.io/'
 
 
@@ -38,84 +39,213 @@ class BeatportAPIError(Exception):
     pass
 
 
-class BeatportObject:
+class BeatportOAuthToken:
     def __init__(self, data):
-        self.beatport_id = data['id']
+        self.access_token = str(data['access_token'])
+        if 'expires_at' in data:
+            self.expires_at = data['expires_at']
+        else:
+            self.expires_at = time.time() + int(data['expires_in'])
+        self.refresh_token = str(data['refresh_token'])
+
+    def is_expired(self):
+        """ Checks if token is expired
+        """
+        return time.time() + 30 >= self.expires_at
+
+    def encode(self):
+        """ Encodes the class into json serializable object
+        """
+        return {
+            'access_token': self.access_token,
+            'expires_at': self.expires_at,
+            'refresh_token': self.refresh_token
+        }
+
+
+class BeatportLabel:
+    def __init__(self, data):
+        self.id = str(data['id'])
         self.name = str(data['name'])
-        if 'releaseDate' in data:
-            self.release_date = datetime.strptime(data['releaseDate'],
-                                                  '%Y-%m-%d')
+
+    def __str__(self):
+        return "<BeatportLabel: {}>".format(self.name)
+
+    def __repr__(self):
+        return str(self)
+
+
+class BeatportArtist:
+    def __init__(self, data):
+        self.id = str(data['id'])
+        self.name = str(data['name'])
+
+    def __str__(self):
+        return "<BeatportArtist: {}>".format(self.name)
+
+    def __repr__(self):
+        return str(self)
+
+
+class BeatportRelease:
+    def __init__(self, data):
+        self.id = str(data['id'])
+        self.name = str(data['name'])
+        self.artists = []
+        self.tracks = []
+        self.type = None
         if 'artists' in data:
-            self.artists = [(x['id'], str(x['name']))
-                            for x in data['artists']]
-        if 'genres' in data:
-            self.genres = [str(x['name'])
-                           for x in data['genres']]
+            self.artists = [BeatportArtist(x) for x in data['artists']]
+        if 'label' in data:
+            self.label = BeatportLabel(data['label'])
+        if 'catalog_number' in data:
+            self.catalog_number = str(data['catalog_number'])
+        if 'slug' in data:
+            self.url = "https://beatport.com/release/{}/{}" \
+                .format(data['slug'], data['id'])
+        if 'type' in data:
+            self.type = data['type']['name']
+        if 'publish_date' in data:
+            self.publish_date = datetime.strptime(
+                data['publish_date'], '%Y-%m-%d')
+
+    def __str__(self):
+        if len(self.artists) < 4:
+            artist_str = ", ".join(x.name for x in self.artists)
+        else:
+            artist_str = "Various Artists"
+        return "<BeatportRelease: {} - {} ({})>" \
+            .format(artist_str, self.name, self.catalog_number)
+
+    def __repr__(self):
+        return str(self)
 
 
-class BeatportClient:
-    _api_base = 'https://oauth-api.beatport.com'
+class BeatportTrack:
+    def __init__(self, data):
+        self.id = str(data['id'])
+        self.name = str(data['name'])
+        self.artists = [BeatportArtist(x) for x in data['artists']]
+        self.length = timedelta(milliseconds=data.get('length_ms', 0) or 0)
+        self.number = None
+        self.initial_key = None
+        self.url = None
+        self.bpm = None
+        self.genre = None
+        if not self.length:
+            try:
+                min, sec = data.get('length', '0:0').split(':')
+                self.length = timedelta(minutes=int(min), seconds=int(sec))
+            except ValueError:
+                pass
+        if data.get('key') and data['key']['name']:
+            self.initial_key = self._normalize_key(str(data['key']['name']))
+        if data.get('bpm'):
+            self.bpm = int(data['bpm'])
+        if 'sub_genre' in data and data['sub_genre']:
+            self.genre = str(data['sub_genre']['name'])
+        elif 'genre' in data and data['genre']:
+            self.genre = str(data['genre']['name'])
+        if 'mix_name' in data:
+            self.mix_name = data['mix_name']
+        if 'number' in data:
+            self.number = data['number']
+        if 'release' in data:
+            self.release = BeatportRelease(data['release'])
+        if 'remixers' in data:
+            self.remixers = data['remixers']
+        if 'slug' in data:
+            self.url = "https://beatport.com/track/{}/{}" \
+                .format(data['slug'], data['id'])
 
-    def __init__(self, c_key, c_secret, auth_key=None, auth_secret=None):
-        """ Initiate the client with OAuth information.
+    def __str__(self):
+        artist_str = ", ".join(x.name for x in self.artists)
+        return "<BeatportTrack: {} - {} ({})>" \
+            .format(artist_str, self.name, self.mix_name)
 
-        For the initial authentication with the backend `auth_key` and
-        `auth_secret` can be `None`. Use `get_authorize_url` and
-        `get_access_token` to obtain them for subsequent uses of the API.
+    def __repr__(self):
+        return str(self)
 
-        :param c_key:       OAuth1 client key
-        :param c_secret:    OAuth1 client secret
-        :param auth_key:    OAuth1 resource owner key
-        :param auth_secret: OAuth1 resource owner secret
+    def _normalize_key(self, key):
+        """ Normalize new Beatport key name format (e.g "Eb Major, C# Minor)
+         for backwards compatibility
+
+        :param key:    Key name
         """
-        self.api = OAuth1Session(
-            client_key=c_key, client_secret=c_secret,
-            resource_owner_key=auth_key,
-            resource_owner_secret=auth_secret,
-            callback_uri='oob')
-        self.api.headers = {'User-Agent': USER_AGENT}
+        (letter_sign, chord) = key.split(" ")
+        return MusicalKey().normalize((letter_sign + chord.lower())[:-2])
 
-    def get_authorize_url(self):
-        """ Generate the URL for the user to authorize the application.
 
-        Retrieves a request token from the Beatport API and returns the
-        corresponding authorization URL on their end that the user has
-        to visit.
+class BeatportMyAccount:
+    def __init__(self, data):
+        self.id = str(data['id'])
+        self.email = str(data['email'])
+        self.username = str(data['username'])
 
-        This is the first step of the initial authorization process with the
-        API. Once the user has visited the URL, call
-        :py:method:`get_access_token` with the displayed data to complete
-        the process.
+    def __str__(self):
+        return "<BeatportMyAccount: {} <{}>>" \
+            .format(self.username, self.email)
 
-        :returns:   Authorization URL for the user to visit
-        :rtype:     unicode
+    def __repr__(self):
+        return str(self)
+
+
+class Beatport4Client:
+    def __init__(self, log, beatport_token=None):
+        """ Initiate the client and make sure it is correctly authorized
+        If beatport_token is passed, it is used to make a call to
+        /my/account endpoint to check if the token is access_token is valid
+
+        :param beatport_token:    BeatportOAuthToken
         """
-        self.api.fetch_request_token(
-            self._make_url('/identity/1/oauth/request-token'))
-        return self.api.authorization_url(
-            self._make_url('/identity/1/oauth/authorize'))
+        self._api_base = 'https://api.beatport.com/v4'
+        self._beatport_client_id = '0GIvkCltVIuPkkwSJHp6NDb3s0potTjLBQr388Dd'
+        self._beatport_redirect_uri = '{}/auth/o/post-message/' \
+            .format(self._api_base)
+        self.beatport_token = beatport_token
+        self._log = log
 
-    def get_access_token(self, auth_data):
-        """ Obtain the final access token and secret for the API.
+        # Token from the file passed
+        if self.beatport_token and not self.beatport_token.is_expired():
+            self._log.debug('Trying beatport token loaded from file')
+            try:
+                my_account = self.get_my_account()
+                self._log.debug(
+                    'Beatport authorized with stored token as {0} <{1}>',
+                    my_account.username, my_account.email)
+            except BeatportAPIError as e:
+                # Token from the file could be invalid, authorize and fetch new
+                self._log.debug('Beatport token loaded from file invalid')
 
-        :param auth_data:   URL-encoded authorization data as displayed at
-                            the authorization url (obtained via
-                            :py:meth:`get_authorize_url`) after signing in
-        :type auth_data:    unicode
-        :returns:           OAuth resource owner key and secret
-        :rtype:             (unicode, unicode) tuple
+                # TODO: uncomment when authorizing is possible
+                # self.beatport_token = self._authorize()
+                raise e
+        else:
+            raise BeatportAPIError('Token missing or expired')
+
+    def _authorize(self):
+        """ Authorize client and fetch access token.
+
+        :returns:               Beatport OAuth token
+        :rtype:                 :py:class:`BeatportOAuthToken`
         """
-        self.api.parse_authorization_response(
-            "https://beets.io/auth?" + auth_data)
-        access_data = self.api.fetch_access_token(
-            self._make_url('/identity/1/oauth/access-token'))
-        return access_data['oauth_token'], access_data['oauth_token_secret']
+        # TODO: implement  when Beatport opens public authorization
+        pass
 
-    def search(self, query, release_type='release', details=True):
+    def get_my_account(self):
+        """ Get information about current account.
+
+        :returns:               The user account information
+        :rtype:                 :py:class:`BeatportMyAccount`
+        """
+        response = self._get('/my/account')
+        return BeatportMyAccount(response)
+
+    def search(self, query, model='releases', details=True):
         """ Perform a search of the Beatport catalogue.
 
         :param query:           Query string
-        :param release_type:    Type of releases to search for, can be
+        :param model:           Type of releases to search for, can be
                                 'release' or 'track'
         :param details:         Retrieve additional information about the
                                 search results. Currently this will fetch
@@ -126,18 +256,18 @@ class BeatportClient:
                                 py:class:`BeatportRelease` or
                                 :py:class:`BeatportTrack`
         """
-        response = self._get('catalog/3/search',
-                             query=query, perPage=5,
-                             facets=[f'fieldType:{release_type}'])
-        for item in response:
-            if release_type == 'release':
+        response = self._get('catalog/search', q=query, per_page=5, type=model)
+        if model == 'releases':
+            for release in response['releases']:
                 if details:
-                    release = self.get_release(item['id'])
-                else:
-                    release = BeatportRelease(item)
-                yield release
-            elif release_type == 'track':
-                yield BeatportTrack(item)
+                    release = self.get_release(release['id'])
+                    if release:
+                        yield release
+                    continue
+                yield BeatportRelease(release)
+        elif model == 'tracks':
+            for track in response['tracks']:
+                yield BeatportTrack(track)
 
     def get_release(self, beatport_id):
         """ Get information about a single release.
@@ -146,9 +276,13 @@ class BeatportClient:
         :returns:               The matching release
         :rtype:                 :py:class:`BeatportRelease`
         """
-        response = self._get('/catalog/3/releases', id=beatport_id)
+        try:
+            response = self._get(f'/catalog/releases/{beatport_id}/')
+        except BeatportAPIError as e:
+            self._log.debug((str(e)))
+            return None
         if response:
-            release = BeatportRelease(response[0])
+            release = BeatportRelease(response)
             release.tracks = self.get_release_tracks(beatport_id)
             return release
         return None
@@ -160,9 +294,14 @@ class BeatportClient:
         :returns:               Tracks in the matching release
         :rtype:                 list of :py:class:`BeatportTrack`
         """
-        response = self._get('/catalog/3/tracks', releaseId=beatport_id,
-                             perPage=100)
-        return [BeatportTrack(t) for t in response]
+        try:
+            response = self._get(f'/catalog/releases/{beatport_id}/tracks/',
+                                 perPage=100)
+        except BeatportAPIError as e:
+            self._log.debug((str(e)))
+            return []
+        # we are not using BeatportTrack(t) because "number" field is missing
+        return [self.get_track(t['id']) for t in response]
 
     def get_track(self, beatport_id):
         """ Get information about a single track.
@@ -171,13 +310,19 @@ class BeatportClient:
         :returns:               The matching track
         :rtype:                 :py:class:`BeatportTrack`
         """
-        response = self._get('/catalog/3/tracks', id=beatport_id)
-        return BeatportTrack(response[0])
+        try:
+            response = self._get(f'/catalog/tracks/{beatport_id}/')
+        except BeatportAPIError as e:
+            self._log.debug(str(e))
+            return None
+        return BeatportTrack(response)
 
-    def _make_url(self, endpoint):
+    def _make_url(self, endpoint, query=None):
         """ Get complete URL for a given API endpoint. """
         if not endpoint.startswith('/'):
             endpoint = '/' + endpoint
+        if query:
+            return self._api_base + endpoint + '?' + urlencode(query)
         return self._api_base + endpoint
 
     def _get(self, endpoint, **kwargs):
@@ -187,143 +332,89 @@ class BeatportClient:
         exceptions into :py:class:`BeatportAPIError` objects.
         """
         try:
-            response = self.api.get(self._make_url(endpoint), params=kwargs)
+            headers = {
+                'Authorization': 'Bearer {}'
+                .format(self.beatport_token.access_token),
+                'User-Agent': USER_AGENT
+            }
+            response = requests.get(self._make_url(endpoint),
+                                    params=kwargs,
+                                    headers=headers)
         except Exception as e:
-            raise BeatportAPIError("Error connecting to Beatport API: {}"
-                                   .format(e))
+            raise BeatportAPIError(
+                "Error connecting to Beatport API: {}"
+                .format(e)
+            )
         if not response:
             raise BeatportAPIError(
                 "Error {0.status_code} for '{0.request.path_url}"
-                .format(response))
-        return response.json()['results']
+                .format(response)
+            )
+
+        json_response = response.json()
+
+        # Handle both list and single entity responses
+        if 'results' in json_response:
+            return json_response['results']
+        return json_response
 
 
-class BeatportRelease(BeatportObject):
-    def __str__(self):
-        if len(self.artists) < 4:
-            artist_str = ", ".join(x[1] for x in self.artists)
-        else:
-            artist_str = "Various Artists"
-        return "<BeatportRelease: {} - {} ({})>".format(
-            artist_str,
-            self.name,
-            self.catalog_number,
-        )
-
-    def __repr__(self):
-        return str(self).encode('utf-8')
-
-    def __init__(self, data):
-        BeatportObject.__init__(self, data)
-        if 'catalogNumber' in data:
-            self.catalog_number = data['catalogNumber']
-        if 'label' in data:
-            self.label_name = data['label']['name']
-        if 'category' in data:
-            self.category = data['category']
-        if 'slug' in data:
-            self.url = "https://beatport.com/release/{}/{}".format(
-                data['slug'], data['id'])
-        self.genre = data.get('genre')
-
-
-class BeatportTrack(BeatportObject):
-    def __str__(self):
-        artist_str = ", ".join(x[1] for x in self.artists)
-        return ("<BeatportTrack: {} - {} ({})>"
-                .format(artist_str, self.name, self.mix_name))
-
-    def __repr__(self):
-        return str(self).encode('utf-8')
-
-    def __init__(self, data):
-        BeatportObject.__init__(self, data)
-        if 'title' in data:
-            self.title = str(data['title'])
-        if 'mixName' in data:
-            self.mix_name = str(data['mixName'])
-        self.length = timedelta(milliseconds=data.get('lengthMs', 0) or 0)
-        if not self.length:
-            try:
-                min, sec = data.get('length', '0:0').split(':')
-                self.length = timedelta(minutes=int(min), seconds=int(sec))
-            except ValueError:
-                pass
-        if 'slug' in data:
-            self.url = "https://beatport.com/track/{}/{}" \
-                .format(data['slug'], data['id'])
-        self.track_number = data.get('trackNumber')
-        self.bpm = data.get('bpm')
-        self.initial_key = str(
-            (data.get('key') or {}).get('shortName')
-        )
-
-        # Use 'subgenre' and if not present, 'genre' as a fallback.
-        if data.get('subGenres'):
-            self.genre = str(data['subGenres'][0].get('name'))
-        elif data.get('genres'):
-            self.genre = str(data['genres'][0].get('name'))
-
-
-class BeatportPlugin(BeetsPlugin):
+class Beatport4Plugin(BeetsPlugin):
     data_source = 'Beatport'
 
     def __init__(self):
         super().__init__()
         self.config.add({
-            'apikey': '57713c3906af6f5def151b33601389176b37b429',
-            'apisecret': 'b3fe08c93c80aefd749fe871a16cd2bb32e2b954',
             'tokenfile': 'beatport_token.json',
             'source_weight': 0.5,
         })
-        self.config['apikey'].redact = True
-        self.config['apisecret'].redact = True
         self.client = None
         self.register_listener('import_begin', self.setup)
 
-    def setup(self, session=None):
-        c_key = self.config['apikey'].as_str()
-        c_secret = self.config['apisecret'].as_str()
-
-        # Get the OAuth token from a file or log in.
+    def setup(self):
+        """Loads access token from the file, initializes the client
+        and writes the token to the file if new one is fetched during
+        client authorization
+        """
+        beatport_token = None
+        # Get the OAuth token from a file
         try:
             with open(self._tokenfile()) as f:
-                tokendata = json.load(f)
-        except OSError:
-            # No token yet. Generate one.
-            token, secret = self.authenticate(c_key, c_secret)
-        else:
-            token = tokendata['token']
-            secret = tokendata['secret']
+                beatport_token = BeatportOAuthToken(json.load(f))
 
-        self.client = BeatportClient(c_key, c_secret, token, secret)
+        except (OSError, AttributeError, JSONDecodeError):
+            # File does not exist, or has invalid format
+            pass
 
-    def authenticate(self, c_key, c_secret):
-        # Get the link for the OAuth page.
-        auth_client = BeatportClient(c_key, c_secret)
         try:
-            url = auth_client.get_authorize_url()
-        except AUTH_ERRORS as e:
-            self._log.debug('authentication error: {0}', e)
-            raise beets.ui.UserError('communication with Beatport failed')
+            self.client = Beatport4Client(
+                log=self._log,
+                beatport_token=beatport_token
+            )
+        except BeatportAPIError as e:
+            # Invalid token
+            beets.ui.print_(str(e))
 
-        beets.ui.print_("To authenticate with Beatport, visit:")
-        beets.ui.print_(url)
+            # Retry manually
+            token = self._prompt_for_token()
 
-        # Ask for the verifier data and validate it.
-        data = beets.ui.input_("Enter the string displayed in your browser:")
-        try:
-            token, secret = auth_client.get_access_token(data)
-        except AUTH_ERRORS as e:
-            self._log.debug('authentication error: {0}', e)
-            raise beets.ui.UserError('Beatport token request failed')
+            self.client = Beatport4Client(
+                log=self._log,
+                beatport_token=token
+            )
 
-        # Save the token for later use.
-        self._log.debug('Beatport token {0}, secret {1}', token, secret)
         with open(self._tokenfile(), 'w') as f:
-            json.dump({'token': token, 'secret': secret}, f)
+            json.dump(self.client.beatport_token.encode(), f)
 
-        return token, secret
+    def _prompt_for_token(self):
+        """Prompts user to paste the OAuth token in the console and
+        writes the contents to the beatport_token.json file.
+        Returns parsed JSON.
+        """
+        data = json.loads(beets.ui.input_("Paste the Beatport OAuth access "
+                                          "token:"))
+
+        return BeatportOAuthToken(data)
 
     def _tokenfile(self):
         """Get the path to the JSON file for storing the OAuth token.
@@ -390,8 +481,9 @@ class BeatportPlugin(BeetsPlugin):
         return None
 
     def track_for_id(self, track_id):
-        """Fetches a track by its Beatport ID and returns a TrackInfo object
-        or None if the track is not a valid Beatport ID or track is not found.
+        """Fetches a track by its Beatport ID and returns a
+        TrackInfo object or None if the track is not a valid
+        Beatport ID or track is not found.
         """
         self._log.debug('Searching for track {0}', track_id)
         match = re.search(r'(^|beatport\.com/track/.+/)(\d+)$', track_id)
@@ -422,21 +514,23 @@ class BeatportPlugin(BeetsPlugin):
         """Returns an AlbumInfo object for a Beatport Release object.
         """
         va = len(release.artists) > 3
-        artist, artist_id = self._get_artist(release.artists)
+        artist, artist_id = self._get_artist(
+            ((artist.id, artist.name) for artist in release.artists)
+        )
         if va:
             artist = "Various Artists"
         tracks = [self._get_track_info(x) for x in release.tracks]
 
-        return AlbumInfo(album=release.name, album_id=release.beatport_id,
+        return AlbumInfo(album=release.name, album_id=release.id,
                          artist=artist, artist_id=artist_id, tracks=tracks,
-                         albumtype=release.category, va=va,
-                         year=release.release_date.year,
-                         month=release.release_date.month,
-                         day=release.release_date.day,
-                         label=release.label_name,
+                         albumtype=release.type, va=va,
+                         year=release.publish_date.year,
+                         month=release.publish_date.month,
+                         day=release.publish_date.day,
+                         label=release.label.name,
                          catalognum=release.catalog_number, media='Digital',
                          data_source=self.data_source, data_url=release.url,
-                         genre=release.genre)
+                         genre=None)
 
     def _get_track_info(self, track):
         """Returns a TrackInfo object for a Beatport Track object.
@@ -444,12 +538,14 @@ class BeatportPlugin(BeetsPlugin):
         title = track.name
         if track.mix_name != "Original Mix":
             title += f" ({track.mix_name})"
-        artist, artist_id = self._get_artist(track.artists)
+        artist, artist_id = self._get_artist(
+            ((artist.id, artist.name) for artist in track.artists)
+        )
         length = track.length.total_seconds()
-        return TrackInfo(title=title, track_id=track.beatport_id,
+        return TrackInfo(title=title, track_id=track.id,
                          artist=artist, artist_id=artist_id,
-                         length=length, index=track.track_number,
-                         medium_index=track.track_number,
+                         length=length, index=track.number,
+                         medium_index=track.number,
                          data_source=self.data_source, data_url=track.url,
                          bpm=track.bpm, initial_key=track.initial_key,
                          genre=track.genre)
@@ -465,6 +561,6 @@ class BeatportPlugin(BeetsPlugin):
     def _get_tracks(self, query):
         """Returns a list of TrackInfo objects for a Beatport query.
         """
-        bp_tracks = self.client.search(query, release_type='track')
+        bp_tracks = self.client.search(query, model='tracks')
         tracks = [self._get_track_info(x) for x in bp_tracks]
         return tracks

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -296,7 +296,7 @@ class Beatport4Client:
         """
         try:
             response = self._get(f'/catalog/releases/{beatport_id}/tracks/',
-                                 perPage=100)
+                                 per_page=100)
         except BeatportAPIError as e:
             self._log.debug((str(e)))
             return []

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -52,6 +52,8 @@ New features:
 * :doc:`/plugins/fromfilename`:  Add debug log messages that inform when the
   plugin replaced bad (missing) artist, title or tracknumber metadata.
   :bug:`4561` :bug:`4600`
+* :doc:`/plugins/beatport` The plugin now supports Beatport API v4 using access token provided by the user
+  :bug:`3862`
 
 Bug fixes:
 
@@ -60,7 +62,7 @@ Bug fixes:
   base when the MetadataSourcePlugin abstract class was introduced in PR's
   #3335 and #3371.
   :bug:`4401`
-* :doc:`/plugins/convert`: Set default ``max_bitrate`` value to ``None`` to 
+* :doc:`/plugins/convert`: Set default ``max_bitrate`` value to ``None`` to
   avoid transcoding when this parameter is not set. :bug:`4472`
 * :doc:`/plugins/replaygain`: Avoid a crash when errors occur in the analysis
   backend.

--- a/docs/plugins/beatport.rst
+++ b/docs/plugins/beatport.rst
@@ -12,20 +12,33 @@ Installation
 ------------
 
 To use the ``beatport`` plugin, first enable it in your configuration (see
-:ref:`using-plugins`). Then, install the `requests`_ and `requests_oauthlib`_
-libraries (which we need for querying and authorizing with the Beatport API)
-by typing::
+:ref:`using-plugins`). Then, install the `requests`_ library
+(which we need for querying the Beatport API) by typing::
 
-    pip install requests requests_oauthlib
+    pip install requests
 
 You will also need to register for a `Beatport`_ account. The first time you
 run the :ref:`import-cmd` command after enabling the plugin, it will ask you
-to authorize with Beatport by visiting the site in a browser. On the site
-you will be asked to enter your username and password to authorize beets
-to query the Beatport API. You will then be displayed with a single line of
-text that you should paste as a whole into your terminal. This will store the
-authentication data for subsequent runs and you will not be required to repeat
-the above steps.
+to provide the Beatport API access token to authorize beets to query
+the Beatport API. User OAuth token structure looks like this:
+
+.. code-block:: json
+
+    {
+      "access_token": "XXX",
+      "expires_in": 36000,
+      "token_type": "Bearer",
+      "scope": "XXX",
+      "refresh_token": "XXX"
+    }
+
+Copy the whole JSON and paste it into the terminal (or directly into
+``beatport_token.json`` file in the directory next to your beets config).
+This will store the authentication data for subsequent runs,
+but after the token expires, you will have to repeat the above.
+
+Usage
+-----
 
 Matches from Beatport should now show up alongside matches
 from MusicBrainz and other sources.
@@ -38,9 +51,8 @@ also search for an id like so::
 
 Configuration
 -------------
-
-This plugin can be configured like other metadata source plugins as described in :ref:`metadata-source-plugin-configuration`.
+This plugin can be configured like other metadata source
+plugins as described in :ref:`metadata-source-plugin-configuration`.
 
 .. _requests: https://requests.readthedocs.io/en/master/
-.. _requests_oauthlib: https://github.com/requests/requests-oauthlib
 .. _Beatport: https://www.beatport.com/

--- a/test/test_beatport.py
+++ b/test/test_beatport.py
@@ -1,5 +1,6 @@
 # This file is part of beets.
 # Copyright 2016, Adrian Sampson.
+# Copyright 2022, Szymon "Samik" Tarasiński.
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -29,382 +30,373 @@ class BeatportTest(_common.TestCase, TestHelper):
         """Returns a dict that mimics a response from the beatport API.
 
         The results were retrieved from:
-        https://oauth-api.beatport.com/catalog/3/releases?id=1742984
+        https://api.beatport.com/v4/docs/catalog/releases/1742984/
         The list of elements on the returned dict is incomplete, including just
         those required for the tests on this class.
         """
-        results = {
-          "id": 1742984,
-          "type": "release",
-          "name": "Charade",
-          "slug": "charade",
-          "releaseDate": "2016-04-11",
-          "publishDate": "2016-04-11",
-          "audioFormat": "",
-          "category": "Release",
-          "currentStatus": "General Content",
-          "catalogNumber": "GR089",
-          "description": "",
-          "label": {
-            "id": 24539,
-            "name": "Gravitas Recordings",
-            "type": "label",
-            "slug": "gravitas-recordings"
-          },
-          "artists": [{
-            "id": 326158,
-            "name": "Supersillyus",
-            "slug": "supersillyus",
-            "type": "artist"
-          }],
-          "genres": [{
-            "id": 9,
-            "name": "Breaks",
-            "slug": "breaks",
-            "type": "genre"
-          }],
+        result = {
+            "artists": [
+                {
+                    "id": 326158,
+                    "name": "Supersillyus",
+                    "slug": "supersillyus",
+                }
+            ],
+            "catalog_number": "GR089",
+            "id": 1742984,
+            "label": {
+                "id": 24539,
+                "name": "Gravitas Recordings",
+                "slug": "gravitas-recordings"
+            },
+            "name": "Charade",
+            "new_release_date": "2016-04-11",
+            "publish_date": "2016-04-11",
+            "remixers": [],
+            "slug": "charade",
+            "track_count": 6,
+            "type": {
+                "id": 1,
+                "name": "Release"
+            },
         }
-        return results
+        return result
 
     def _make_tracks_response(self):
         """Return a list that mimics a response from the beatport API.
 
         The results were retrieved from:
-        https://oauth-api.beatport.com/catalog/3/tracks?releaseId=1742984
+        https://api.beatport.com/v4/docs/catalog/releases/1742984/tracks/
         The list of elements on the returned list is incomplete, including just
         those required for the tests on this class.
         """
-        results = [{
-          "id": 7817567,
-          "type": "track",
-          "sku": "track-7817567",
-          "name": "Mirage a Trois",
-          "trackNumber": 1,
-          "mixName": "Original Mix",
-          "title": "Mirage a Trois (Original Mix)",
-          "slug": "mirage-a-trois-original-mix",
-          "releaseDate": "2016-04-11",
-          "publishDate": "2016-04-11",
-          "currentStatus": "General Content",
-          "length": "7:05",
-          "lengthMs": 425421,
-          "bpm": 90,
-          "key": {
-            "standard": {
-              "letter": "G",
-              "sharp": False,
-              "flat": False,
-              "chord": "minor"
-            },
-            "shortName": "Gmin"
-          },
-          "artists": [{
-            "id": 326158,
-            "name": "Supersillyus",
-            "slug": "supersillyus",
-            "type": "artist"
-          }],
-          "genres": [{
-            "id": 9,
-            "name": "Breaks",
-            "slug": "breaks",
-            "type": "genre"
-          }],
-          "subGenres": [{
-            "id": 209,
-            "name": "Glitch Hop",
-            "slug": "glitch-hop",
-            "type": "subgenre"
-          }],
-          "release": {
-            "id": 1742984,
-            "name": "Charade",
-            "type": "release",
-            "slug": "charade"
-          },
-          "label": {
-            "id": 24539,
-            "name": "Gravitas Recordings",
-            "type": "label",
-            "slug": "gravitas-recordings",
-            "status": True
-          }
-        }, {
-          "id": 7817568,
-          "type": "track",
-          "sku": "track-7817568",
-          "name": "Aeon Bahamut",
-          "trackNumber": 2,
-          "mixName": "Original Mix",
-          "title": "Aeon Bahamut (Original Mix)",
-          "slug": "aeon-bahamut-original-mix",
-          "releaseDate": "2016-04-11",
-          "publishDate": "2016-04-11",
-          "currentStatus": "General Content",
-          "length": "7:38",
-          "lengthMs": 458000,
-          "bpm": 100,
-          "key": {
-            "standard": {
-              "letter": "G",
-              "sharp": False,
-              "flat": False,
-              "chord": "major"
-            },
-            "shortName": "Gmaj"
-          },
-          "artists": [{
-            "id": 326158,
-            "name": "Supersillyus",
-            "slug": "supersillyus",
-            "type": "artist"
-          }],
-          "genres": [{
-            "id": 9,
-            "name": "Breaks",
-            "slug": "breaks",
-            "type": "genre"
-          }],
-          "subGenres": [{
-            "id": 209,
-            "name": "Glitch Hop",
-            "slug": "glitch-hop",
-            "type": "subgenre"
-          }],
-          "release": {
-            "id": 1742984,
-            "name": "Charade",
-            "type": "release",
-            "slug": "charade"
-          },
-          "label": {
-            "id": 24539,
-            "name": "Gravitas Recordings",
-            "type": "label",
-            "slug": "gravitas-recordings",
-            "status": True
-          }
-        }, {
-          "id": 7817569,
-          "type": "track",
-          "sku": "track-7817569",
-          "name": "Trancendental Medication",
-          "trackNumber": 3,
-          "mixName": "Original Mix",
-          "title": "Trancendental Medication (Original Mix)",
-          "slug": "trancendental-medication-original-mix",
-          "releaseDate": "2016-04-11",
-          "publishDate": "2016-04-11",
-          "currentStatus": "General Content",
-          "length": "1:08",
-          "lengthMs": 68571,
-          "bpm": 141,
-          "key": {
-            "standard": {
-              "letter": "F",
-              "sharp": False,
-              "flat": False,
-              "chord": "major"
-            },
-            "shortName": "Fmaj"
-          },
-          "artists": [{
-            "id": 326158,
-            "name": "Supersillyus",
-            "slug": "supersillyus",
-            "type": "artist"
-          }],
-          "genres": [{
-            "id": 9,
-            "name": "Breaks",
-            "slug": "breaks",
-            "type": "genre"
-          }],
-          "subGenres": [{
-            "id": 209,
-            "name": "Glitch Hop",
-            "slug": "glitch-hop",
-            "type": "subgenre"
-          }],
-          "release": {
-            "id": 1742984,
-            "name": "Charade",
-            "type": "release",
-            "slug": "charade"
-          },
-          "label": {
-            "id": 24539,
-            "name": "Gravitas Recordings",
-            "type": "label",
-            "slug": "gravitas-recordings",
-            "status": True
-          }
-        }, {
-          "id": 7817570,
-          "type": "track",
-          "sku": "track-7817570",
-          "name": "A List of Instructions for When I'm Human",
-          "trackNumber": 4,
-          "mixName": "Original Mix",
-          "title": "A List of Instructions for When I'm Human (Original Mix)",
-          "slug": "a-list-of-instructions-for-when-im-human-original-mix",
-          "releaseDate": "2016-04-11",
-          "publishDate": "2016-04-11",
-          "currentStatus": "General Content",
-          "length": "6:57",
-          "lengthMs": 417913,
-          "bpm": 88,
-          "key": {
-            "standard": {
-              "letter": "A",
-              "sharp": False,
-              "flat": False,
-              "chord": "minor"
-            },
-            "shortName": "Amin"
-          },
-          "artists": [{
-            "id": 326158,
-            "name": "Supersillyus",
-            "slug": "supersillyus",
-            "type": "artist"
-          }],
-          "genres": [{
-            "id": 9,
-            "name": "Breaks",
-            "slug": "breaks",
-            "type": "genre"
-          }],
-          "subGenres": [{
-            "id": 209,
-            "name": "Glitch Hop",
-            "slug": "glitch-hop",
-            "type": "subgenre"
-          }],
-          "release": {
-            "id": 1742984,
-            "name": "Charade",
-            "type": "release",
-            "slug": "charade"
-          },
-          "label": {
-            "id": 24539,
-            "name": "Gravitas Recordings",
-            "type": "label",
-            "slug": "gravitas-recordings",
-            "status": True
-          }
-        }, {
-          "id": 7817571,
-          "type": "track",
-          "sku": "track-7817571",
-          "name": "The Great Shenanigan",
-          "trackNumber": 5,
-          "mixName": "Original Mix",
-          "title": "The Great Shenanigan (Original Mix)",
-          "slug": "the-great-shenanigan-original-mix",
-          "releaseDate": "2016-04-11",
-          "publishDate": "2016-04-11",
-          "currentStatus": "General Content",
-          "length": "9:49",
-          "lengthMs": 589875,
-          "bpm": 123,
-          "key": {
-            "standard": {
-              "letter": "E",
-              "sharp": False,
-              "flat": True,
-              "chord": "major"
-            },
-            "shortName": "E&#9837;maj"
-          },
-          "artists": [{
-            "id": 326158,
-            "name": "Supersillyus",
-            "slug": "supersillyus",
-            "type": "artist"
-          }],
-          "genres": [{
-            "id": 9,
-            "name": "Breaks",
-            "slug": "breaks",
-            "type": "genre"
-          }],
-          "subGenres": [{
-            "id": 209,
-            "name": "Glitch Hop",
-            "slug": "glitch-hop",
-            "type": "subgenre"
-          }],
-          "release": {
-            "id": 1742984,
-            "name": "Charade",
-            "type": "release",
-            "slug": "charade"
-          },
-          "label": {
-            "id": 24539,
-            "name": "Gravitas Recordings",
-            "type": "label",
-            "slug": "gravitas-recordings",
-            "status": True
-          }
-        }, {
-          "id": 7817572,
-          "type": "track",
-          "sku": "track-7817572",
-          "name": "Charade",
-          "trackNumber": 6,
-          "mixName": "Original Mix",
-          "title": "Charade (Original Mix)",
-          "slug": "charade-original-mix",
-          "releaseDate": "2016-04-11",
-          "publishDate": "2016-04-11",
-          "currentStatus": "General Content",
-          "length": "7:05",
-          "lengthMs": 425423,
-          "bpm": 123,
-          "key": {
-            "standard": {
-              "letter": "A",
-              "sharp": False,
-              "flat": False,
-              "chord": "major"
-            },
-            "shortName": "Amaj"
-          },
-          "artists": [{
-            "id": 326158,
-            "name": "Supersillyus",
-            "slug": "supersillyus",
-            "type": "artist"
-          }],
-          "genres": [{
-            "id": 9,
-            "name": "Breaks",
-            "slug": "breaks",
-            "type": "genre"
-          }],
-          "subGenres": [{
-            "id": 209,
-            "name": "Glitch Hop",
-            "slug": "glitch-hop",
-            "type": "subgenre"
-          }],
-          "release": {
-            "id": 1742984,
-            "name": "Charade",
-            "type": "release",
-            "slug": "charade"
-          },
-          "label": {
-            "id": 24539,
-            "name": "Gravitas Recordings",
-            "type": "label",
-            "slug": "gravitas-recordings",
-            "status": True
-          }
-        }]
+        results = {
+            "next": None,
+            "previous": None,
+            "count": 6,
+            "page": "1/1",
+            "per_page": 10,
+            "results": [
+                {
+                    "artists": [
+                        {
+                            "id": 326158,
+                            "name": "Supersillyus",
+                            "slug": "supersillyus",
+                        }
+                    ],
+                    "bpm": 90,
+                    "catalog_number": "GR089",
+                    "genre": {
+                        "id": 9,
+                        "name": "Breaks / Breakbeat / UK Bass",
+                        "slug": "breaks-breakbeat-uk-bass",
+                    },
+                    "id": 7817567,
+                    "key": {
+                        "camelot_number": 6,
+                        "camelot_letter": "A",
+                        "chord_type": {
+                            "id": 1,
+                            "name": "Minor",
+                        },
+                        "id": 6,
+                        "is_sharp": False,
+                        "is_flat": False,
+                        "letter": "G",
+                        "name": "G Minor",
+                    },
+                    "length": "7:05",
+                    "length_ms": 425421,
+                    "mix_name": "Original Mix",
+                    "name": "Mirage a Trois",
+                    "new_release_date": "2016-04-11",
+                    "publish_date": "2016-04-11",
+                    "release": {
+                        "id": 1742984,
+                        "name": "Charade",
+                        "label": {
+                            "id": 24539,
+                            "name": "Gravitas Recordings",
+                            "slug": "gravitas-recordings"
+                        },
+                        "slug": "charade"
+                    },
+                    "remixers": [],
+                    "slug": "mirage-a-trois",
+                    "sub_genre": {
+                        "id": 209,
+                        "name": "Glitch Hop",
+                        "slug": "glitch-hop",
+                    },
+                },
+                {
+                    "artists": [
+                        {
+                            "id": 326158,
+                            "name": "Supersillyus",
+                            "slug": "supersillyus",
+                        }
+                    ],
+                    "bpm": 100,
+                    "catalog_number": "GR089",
+                    "genre": {
+                        "id": 9,
+                        "name": "Breaks / Breakbeat / UK Bass",
+                        "slug": "breaks-breakbeat-uk-bass",
+                    },
+                    "id": 7817568,
+                    "key": {
+                        "camelot_number": 9,
+                        "camelot_letter": "B",
+                        "chord_type": {
+                            "id": 2,
+                            "name": "Major",
+                        },
+                        "id": 21,
+                        "is_sharp": False,
+                        "is_flat": False,
+                        "letter": "G",
+                        "name": "G Major",
+                    },
+                    "length": "7:38",
+                    "length_ms": 458000,
+                    "mix_name": "Original Mix",
+                    "name": "Aeon Bahamut",
+                    "new_release_date": "2016-04-11",
+                    "publish_date": "2016-04-11",
+                    "release": {
+                        "id": 1742984,
+                        "name": "Charade",
+                        "label": {
+                            "id": 24539,
+                            "name": "Gravitas Recordings",
+                            "slug": "gravitas-recordings"
+                        },
+                        "slug": "charade"
+                    },
+                    "remixers": [],
+                    "slug": "aeon-bahamut",
+                    "sub_genre": {
+                        "id": 209,
+                        "name": "Glitch Hop",
+                        "slug": "glitch-hop",
+                    },
+                },
+                {
+                    "artists": [
+                        {
+                            "id": 326158,
+                            "name": "Supersillyus",
+                            "slug": "supersillyus",
+                        }
+                    ],
+                    "bpm": 141,
+                    "catalog_number": "GR089",
+                    "genre": {
+                        "id": 9,
+                        "name": "Breaks / Breakbeat / UK Bass",
+                        "slug": "breaks-breakbeat-uk-bass",
+                    },
+                    "id": 7817569,
+                    "key": {
+                        "camelot_number": 7,
+                        "camelot_letter": "B",
+                        "chord_type": {
+                            "id": 2,
+                            "name": "Major",
+                        },
+                        "id": 19,
+                        "is_sharp": False,
+                        "is_flat": False,
+                        "letter": "F",
+                        "name": "F Major",
+                    },
+                    "length": "1:08",
+                    "length_ms": 68571,
+                    "mix_name": "Original Mix",
+                    "name": "Trancendental Medication",
+                    "new_release_date": "2016-04-11",
+                    "publish_date": "2016-04-11",
+                    "release": {
+                        "id": 1742984,
+                        "name": "Charade",
+                        "label": {
+                            "id": 24539,
+                            "name": "Gravitas Recordings",
+                            "slug": "gravitas-recordings"
+                        },
+                        "slug": "charade"
+                    },
+                    "remixers": [],
+                    "slug": "trancendental-medication",
+                    "sub_genre": {
+                        "id": 209,
+                        "name": "Glitch Hop",
+                        "slug": "glitch-hop",
+                    },
+                },
+                {
+                    "artists": [
+                        {
+                            "id": 326158,
+                            "name": "Supersillyus",
+                            "slug": "supersillyus",
+                        }
+                    ],
+                    "bpm": 88,
+                    "catalog_number": "GR089",
+                    "genre": {
+                        "id": 9,
+                        "name": "Breaks / Breakbeat / UK Bass",
+                        "slug": "breaks-breakbeat-uk-bass",
+                    },
+                    "id": 7817570,
+                    "key": {
+                        "camelot_number": 8,
+                        "camelot_letter": "A",
+                        "chord_type": {
+                            "id": 1,
+                            "name": "Minor",
+                        },
+                        "id": 8,
+                        "is_sharp": False,
+                        "is_flat": False,
+                        "letter": "A",
+                        "name": "A Minor",
+                    },
+                    "length": "6:57",
+                    "length_ms": 417913,
+                    "mix_name": "Original Mix",
+                    "name": "A List of Instructions for When I'm Human",
+                    "new_release_date": "2016-04-11",
+                    "publish_date": "2016-04-11",
+                    "release": {
+                        "id": 1742984,
+                        "name": "Charade",
+                        "label": {
+                            "id": 24539,
+                            "name": "Gravitas Recordings",
+                            "slug": "gravitas-recordings"
+                        },
+                        "slug": "charade"
+                    },
+                    "remixers": [],
+                    "slug": "a-list-of-instructions-for-when-im-human",
+                    "sub_genre": {
+                        "id": 209,
+                        "name": "Glitch Hop",
+                        "slug": "glitch-hop",
+                    },
+                },
+                {
+                    "artists": [
+                        {
+                            "id": 326158,
+                            "name": "Supersillyus",
+                            "slug": "supersillyus",
+                        }
+                    ],
+                    "bpm": 123,
+                    "catalog_number": "GR089",
+                    "genre": {
+                        "id": 9,
+                        "name": "Breaks / Breakbeat / UK Bass",
+                        "slug": "breaks-breakbeat-uk-bass",
+                    },
+                    "id": 7817571,
+                    "key": {
+                        "camelot_number": 5,
+                        "camelot_letter": "B",
+                        "chord_type": {
+                            "id": 2,
+                            "name": "Major",
+                        },
+                        "id": 17,
+                        "is_sharp": False,
+                        "is_flat": True,
+                        "letter": "E",
+                        "name": "Eb Major",
+                    },
+                    "length": "9:49",
+                    "length_ms": 589875,
+                    "mix_name": "Original Mix",
+                    "name": "The Great Shenanigan",
+                    "new_release_date": "2016-04-11",
+                    "publish_date": "2016-04-11",
+                    "release": {
+                        "id": 1742984,
+                        "name": "Charade",
+                        "label": {
+                            "id": 24539,
+                            "name": "Gravitas Recordings",
+                            "slug": "gravitas-recordings"
+                        },
+                        "slug": "charade"
+                    },
+                    "remixers": [],
+                    "slug": "the-great-shenanigan",
+                    "sub_genre": {
+                        "id": 209,
+                        "name": "Glitch Hop",
+                        "slug": "glitch-hop",
+                    },
+                },
+                {
+                    "artists": [
+                        {
+                            "id": 326158,
+                            "name": "Supersillyus",
+                            "slug": "supersillyus",
+                        }
+                    ],
+                    "bpm": 123,
+                    "catalog_number": "GR089",
+                    "genre": {
+                        "id": 9,
+                        "name": "Breaks / Breakbeat / UK Bass",
+                        "slug": "breaks-breakbeat-uk-bass",
+                    },
+                    "id": 7817572,
+                    "key": {
+                        "camelot_number": 11,
+                        "camelot_letter": "B",
+                        "chord_type": {
+                            "id": 2,
+                            "name": "Major",
+                        },
+                        "id": 23,
+                        "is_sharp": False,
+                        "is_flat": False,
+                        "letter": "A",
+                        "name": "A Major",
+                    },
+                    "length": "7:05",
+                    "length_ms": 425423,
+                    "mix_name": "Original Mix",
+                    "name": "Charade",
+                    "new_release_date": "2016-04-11",
+                    "publish_date": "2016-04-11",
+                    "release": {
+                        "id": 1742984,
+                        "name": "Charade",
+                        "label": {
+                            "id": 24539,
+                            "name": "Gravitas Recordings",
+                            "slug": "gravitas-recordings"
+                        },
+                        "slug": "charade"
+                    },
+                    "remixers": [],
+                    "slug": "charade",
+                    "sub_genre": {
+                        "id": 209,
+                        "name": "Glitch Hop",
+                        "slug": "glitch-hop",
+                    },
+                }
+            ]
+        }
         return results
 
     def setUp(self):
@@ -418,7 +410,8 @@ class BeatportTest(_common.TestCase, TestHelper):
 
         # Set up 'tracks'.
         response_tracks = self._make_tracks_response()
-        self.tracks = [beatport.BeatportTrack(t) for t in response_tracks]
+        self.tracks = [beatport.BeatportTrack(t)
+                       for t in response_tracks['results']]
 
         # Set up 'test_album'.
         self.test_album = self.mk_test_album()
@@ -460,12 +453,12 @@ class BeatportTest(_common.TestCase, TestHelper):
         items[4].length = timedelta(minutes=9, seconds=49).total_seconds()
         items[5].length = timedelta(minutes=7, seconds=5).total_seconds()
 
-        items[0].url = 'mirage-a-trois-original-mix'
-        items[1].url = 'aeon-bahamut-original-mix'
-        items[2].url = 'trancendental-medication-original-mix'
-        items[3].url = 'a-list-of-instructions-for-when-im-human-original-mix'
-        items[4].url = 'the-great-shenanigan-original-mix'
-        items[5].url = 'charade-original-mix'
+        items[0].url = 'mirage-a-trois'
+        items[1].url = 'aeon-bahamut'
+        items[2].url = 'trancendental-medication'
+        items[3].url = 'a-list-of-instructions-for-when-im-human'
+        items[4].url = 'the-great-shenanigan'
+        items[5].url = 'charade'
 
         counter = 0
         for item in items:
@@ -483,7 +476,7 @@ class BeatportTest(_common.TestCase, TestHelper):
         items[1].initial_key = 'Gmaj'
         items[2].initial_key = 'Fmaj'
         items[3].initial_key = 'Amin'
-        items[4].initial_key = 'E&#9837;maj'
+        items[4].initial_key = 'Ebmaj'
         items[5].initial_key = 'Amaj'
 
         for item in items:
@@ -503,10 +496,10 @@ class BeatportTest(_common.TestCase, TestHelper):
                          self.test_album['catalognum'])
 
     def test_label_applied(self):
-        self.assertEqual(self.album.label_name, self.test_album['label'])
+        self.assertEqual(self.album.label.name, self.test_album['label'])
 
     def test_category_applied(self):
-        self.assertEqual(self.album.category, 'Release')
+        self.assertEqual(self.album.type, 'Release')
 
     def test_album_url_applied(self):
         self.assertEqual(self.album.url,
@@ -540,7 +533,7 @@ class BeatportTest(_common.TestCase, TestHelper):
         for track, test_track, id in zip(self.tracks, self.test_tracks, ids):
             self.assertEqual(
                 track.url, 'https://beatport.com/track/' +
-                test_track.url + '/' + str(id))
+                           test_track.url + '/' + str(id))
 
     def test_bpm_applied(self):
         for track, test_track in zip(self.tracks, self.test_tracks):
@@ -557,22 +550,68 @@ class BeatportTest(_common.TestCase, TestHelper):
 
 class BeatportResponseEmptyTest(_common.TestCase, TestHelper):
     def _make_tracks_response(self):
-        results = [{
-            "id": 7817567,
-            "name": "Mirage a Trois",
-            "genres": [{
-              "id": 9,
-              "name": "Breaks",
-              "slug": "breaks",
-              "type": "genre"
-            }],
-            "subGenres": [{
-              "id": 209,
-              "name": "Glitch Hop",
-              "slug": "glitch-hop",
-              "type": "subgenre"
-            }],
-        }]
+        results = {
+            "next": None,
+            "previous": None,
+            "count": 1,
+            "page": "1/1",
+            "per_page": 10,
+            "results": [
+                {
+                    "artists": [
+                        {
+                            "id": 326158,
+                            "name": "Supersillyus",
+                            "slug": "supersillyus",
+                        }
+                    ],
+                    "bpm": 90,
+                    "catalog_number": "GR089",
+                    "genre": {
+                        "id": 9,
+                        "name": "Breaks / Breakbeat / UK Bass",
+                        "slug": "breaks-breakbeat-uk-bass",
+                    },
+                    "id": 7817567,
+                    "key": {
+                        "camelot_number": 6,
+                        "camelot_letter": "A",
+                        "chord_type": {
+                            "id": 1,
+                            "name": "Minor",
+                        },
+                        "id": 6,
+                        "is_sharp": False,
+                        "is_flat": False,
+                        "letter": "G",
+                        "name": "G Minor",
+                    },
+                    "length": "7:05",
+                    "length_ms": 425421,
+                    "mix_name": "Original Mix",
+                    "name": "Mirage a Trois",
+                    "new_release_date": "2016-04-11",
+                    "publish_date": "2016-04-11",
+                    "release": {
+                        "id": 1742984,
+                        "name": "Charade",
+                        "label": {
+                            "id": 24539,
+                            "name": "Gravitas Recordings",
+                            "slug": "gravitas-recordings"
+                        },
+                        "slug": "charade"
+                    },
+                    "remixers": [],
+                    "slug": "mirage-a-trois",
+                    "sub_genre": {
+                        "id": 209,
+                        "name": "Glitch Hop",
+                        "slug": "glitch-hop",
+                    },
+                },
+            ]
+        }
         return results
 
     def setUp(self):
@@ -582,7 +621,8 @@ class BeatportResponseEmptyTest(_common.TestCase, TestHelper):
 
         # Set up 'tracks'.
         self.response_tracks = self._make_tracks_response()
-        self.tracks = [beatport.BeatportTrack(t) for t in self.response_tracks]
+        self.tracks = [beatport.BeatportTrack(t)
+                       for t in self.response_tracks['results']]
 
         # Make alias to be congruent with class `BeatportTest`.
         self.test_tracks = self.response_tracks
@@ -599,24 +639,22 @@ class BeatportResponseEmptyTest(_common.TestCase, TestHelper):
     def test_sub_genre_empty_fallback(self):
         """No 'sub_genre' is provided. Test if fallback to 'genre' works.
         """
-        self.response_tracks[0]['subGenres'] = []
-        tracks = [beatport.BeatportTrack(t) for t in self.response_tracks]
-
-        self.test_tracks[0]['subGenres'] = []
+        del self.response_tracks['results'][0]['sub_genre']
+        tracks = [beatport.BeatportTrack(t)
+                  for t in self.response_tracks['results']]
 
         self.assertEqual(tracks[0].genre,
-                         self.test_tracks[0]['genres'][0]['name'])
+                         self.test_tracks['results'][0]['genre']['name'])
 
     def test_genre_empty(self):
         """No 'genre' is provided. Test if 'sub_genre' is applied.
         """
-        self.response_tracks[0]['genres'] = []
-        tracks = [beatport.BeatportTrack(t) for t in self.response_tracks]
-
-        self.test_tracks[0]['genres'] = []
+        del self.response_tracks['results'][0]['genre']
+        tracks = [beatport.BeatportTrack(t)
+                  for t in self.response_tracks['results']]
 
         self.assertEqual(tracks[0].genre,
-                         self.test_tracks[0]['subGenres'][0]['name'])
+                         self.test_tracks['results'][0]['sub_genre']['name'])
 
 
 def suite():


### PR DESCRIPTION
## Description

Fixes #3862 

As Beatport had killed their API v3, the stock beatport plugin does not work anymore. It is also currently not possible to request the access to the API "normal" way (by using your client credentials or API token generated by Beatport, see the linked issue #3862). I have found a workaround and was able to update the code to use the new specification of API v4.

Currently, to use the plugin, you need to obtain the access token yourself. As soon as Beatport allows official way of the authorization, I am willing to update the code to use it, whether it be `client_credentials` grant or any other OAuth2 flow they are now presenting in the API docs.

I have also created a `beatport4` plugin that uses the above code and added there an unoficcial way of acquiring the token (not part of this PR). To see more details, please see the plugin repository: https://github.com/Samik081/beets-beatport4

## Beatport Authorization

Steps:

1. Add `beatport` plugin to your `beets/config.yaml` plugins list
2. When the first import with plugin enabled happens, you will be prompted to paste the access token JSON
3. Obtain a token (currently rather not possible official way, see the description above) in a following format (those two fields are required):
  
  ```json
  {
    "access_token": "XXX",
    "expires_in": 36000,
    ...
  }
  ```
  
4. Paste it to the terminal (or `beatport_token.json` file next to your `beets/config.yaml` - you can check the path by running `beet config --paths` command)

P.S I am not a daily python developer, so don't hesitate to point out anything you think looks ugly :)

## EDIT 10.09.2022

Removed authorization part that uses user credentials, Beatport swagger-ui client ID and `authorization_code` flow, see the comments.

## EDIT 16.09.2022

Edited PR description so it reflects the current code (removed part about Beatport unofficial authorization).