### PR TITLE
WIP tests: Render ui output to HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ htmlcov/
 coverage.xml
 *,cover
 .hypothesis/
+ui_render/
 
 # Flask stuff:
 instance/

--- a/extra/render-test-outputs.py
+++ b/extra/render-test-outputs.py
@@ -1,0 +1,83 @@
+#! /usr/bin/env python3
+
+from ansi2html import Ansi2HTMLConverter
+from jinja2 import Template
+import json
+from pathlib import Path
+import re
+
+outdir = Path("ui_render")
+outdir.mkdir(exist_ok=True)
+
+outputs = []
+
+template = Template(
+"""<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .terminal {
+            width: 800px;
+        }
+        .test {
+            margin-top: 0px;
+            margin-bottom: 40px;
+        }
+        .sep {
+            color: grey;
+        }
+        .test-name {
+            font-family: Consolas,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New, monospace;
+        }
+    </style>
+    {{ headers }}
+</head>
+    <body>
+        {{ content }}
+    </body>
+</html>
+"""
+)
+
+term_template = Template(
+"""
+<div class="test">
+    <h2 class="test-name">{{ file }}<span class="sep"> :: </span>{{ cls }}<span class="sep"> :: </span>{{ func }}</h2>
+    <div class="body_foreground body_background terminal">
+        <pre class="ansi2html-content">{{ content }}</pre>
+    </div>
+</div>
+"""
+)
+
+name_pattern = re.compile(
+    "^test/(?P<file>test_[^:]+\.py)::(?P<cls>[^:]+)::(?P<func>[^:]+)$"
+)
+
+with open(outdir / "log.json") as f:
+    for line in f:
+        report = json.loads(line)
+        if report.get("when") != "call" or "sections" not in report:
+            continue
+
+        name = report["nodeid"]
+        name_parts = name_pattern.match(name)
+        for section, content in report["sections"]:
+            if "stdout" in section and content:
+                conv = Ansi2HTMLConverter()
+                html = conv.convert(content, full=False)
+                outputs.append(
+                    term_template.render(
+                        file=name_parts.group("file"),
+                        cls=name_parts.group("cls"),
+                        func=name_parts.group("func"),
+                        content=html
+                    )
+                )
+
+with open(outdir / "index.html", "w") as fhtml:
+    html = template.render(
+        headers = conv.produce_headers(),
+        content="\n".join(outputs),
+    )
+    fhtml.write(html)

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,11 @@ setup(
             'flake8-docstrings',
             'pep8-naming',
         ],
+        'render_ui': [
+            'ansi2html',
+            'jinja2',
+            'pytest-reportlog',
+        ],
 
         # Plugin (optional) dependencies:
         'absubmit': ['requests'],

--- a/tox.ini
+++ b/tox.ini
@@ -13,15 +13,22 @@ deps = .[test]
 deps = .[lint]
 files = beets beetsplug beet test setup.py docs
 
+[_render_ui]
+deps = .[test,render_ui]
+
 [testenv]
 deps =
     {test,cov}: {[_test]deps}
     lint: {[_lint]deps}
+    render_ui: {[_render_ui]deps}
 passenv = INTEGRATION_TEST
 commands =
     test: python -bb -m pytest -rs {posargs}
     cov: coverage run -m pytest -rs {posargs}
     lint: python -m flake8 {posargs} {[_lint]files}
+    render_ui: python -bb -m pytest -rs --report-log=ui_render/log.json {posargs}
+commands_post =
+    render_ui: python extra/render-test-outputs.py
 
 [testenv:docs]
 basepython = python3.10


### PR DESCRIPTION
This is a bare-bones implementation of an idea I've had in mind for a while: Record unit test output and render it to HTML to ease development and review regarding our UI.

Does that sound like a useful tool (@davidswarbrick)? Any other thoughts?

Commit message:
> experiment to help with development of the commandline user interface. The idea is to record representative output from tests, instead of needing to manually run some beet commands to get feedback. This works by
>
> - recording pytest output in a new tox run (tox -e py310-render_ui)
> - parsing stdout in the tox commands_post, and turning it into a basic html document with ansi2html
>
> To be useful, a bunch of new tests should be written that showcase most of the ui and enable color. (It might also be useful to only run this script for those specific tests, instead of the entire test suite.)
