### PR TITLE
Add a `import.ignored_alias_types` option to ignore alias types.

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -117,11 +117,20 @@ def _preferred_alias(aliases):
     # Only consider aliases that have locales set.
     aliases = [a for a in aliases if 'locale' in a]
 
+    # Get any ignored alias types and lower case them to prevent case issues
+    ignored_alias_types = config['import']['ignored_alias_types'].as_str_seq()
+    ignored_alias_types = [a.lower() for a in ignored_alias_types]
+
     # Search configured locales in order.
     for locale in config['import']['languages'].as_str_seq():
-        # Find matching primary aliases for this locale.
-        matches = [a for a in aliases
-                   if a['locale'] == locale and 'primary' in a]
+        # Find matching primary aliases for this locale that are not
+        # being ignored
+        matches = []
+        for a in aliases:
+            if a['locale'] == locale and 'primary' in a and \
+               a.get('type', '').lower() not in ignored_alias_types:
+                matches.append(a)
+
         # Skip to the next locale if we have no matches
         if not matches:
             continue

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -33,6 +33,7 @@ import:
     duplicate_action: ask
     bell: no
     set_fields: {}
+    ignored_alias_types: []
 
 clutter: ["Thumbs.DB", ".DS_Store"]
 ignore: [".*", "*~", "System Volume Information", "lost+found"]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -45,6 +45,8 @@ New features:
   :bug:`4379` :bug:`4387`
 * Add :ref:`%sunique{} <sunique>` template to disambiguate between singletons.
   :bug:`4438`
+* Add a new ``import.ignored_alias_types`` config option to allow for
+  specific alias types to be skipped over when importing items/albums.
 
 Bug fixes:
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -652,6 +652,17 @@ MusicBrainz. You can use a space-separated list of language abbreviations, like
 ``en jp es``, to specify a preference order. Defaults to an empty list, meaning 
 that no language is preferred.
 
+.. _ignored_alias_types:
+
+ignored_alias_types
+~~~~~~~~~~~~~~~~~~~
+
+A list of alias types to be ignored when importing new items.
+
+See the `MusicBrainz Documentation` for more information on aliases.
+
+.._MusicBrainz Documentation: https://musicbrainz.org/doc/Aliases
+
 .. _detail:
 
 detail


### PR DESCRIPTION
Sometimes a user may want to use an artist's locale-specific alias but *not* want to use their legal name, for example.

## Description

A good example of this would be the artist [Qeight](https://musicbrainz.org/artist/9888f61e-3ec8-4dcd-ae11-3115da898f0a). On MusicBrainz, their `en` locale is set to their legal name. While technically correct for the data in MusicBrainz, this probably isn't what a user expects when using beets.

(No tests yet but I can add them if this PR is going to be merged)

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
