### PR TITLE
Fix beets#4472 - set 'max_bitrate' default param to none

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -26,7 +26,7 @@ import logging
 
 from beets import ui, util, plugins, config
 from beets.plugins import BeetsPlugin
-from confuse import ConfigTypeError
+from confuse import ConfigTypeError, Optional
 from beets import art
 from beets.util.artresizer import ArtResizer
 from beets.library import parse_query_string
@@ -101,7 +101,9 @@ def should_transcode(item, fmt):
     if config['convert']['never_convert_lossy_files'] and \
             not (item.format.lower() in LOSSLESS_FORMATS):
         return False
-    maxbr = config['convert']['max_bitrate'].get(int)
+    maxbr = config['convert']['max_bitrate'].get(Optional(int))
+    if maxbr is None:
+        return False
     return fmt.lower() != item.format.lower() or \
         item.bitrate >= 1000 * maxbr
 
@@ -136,7 +138,7 @@ class ConvertPlugin(BeetsPlugin):
                 'wma':
                     'ffmpeg -i $source -y -vn -acodec wmav2 -vn $dest',
             },
-            'max_bitrate': 500,
+            'max_bitrate': None,
             'auto': False,
             'auto_keep': False,
             'tmpdir': None,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -48,6 +48,7 @@ New features:
 
 Bug fixes:
 
+* :doc:`/plugins/convert`: Set default ``max_bitrate`` value to ``None`` to avoid transcoding when this parameter is not set. :bug:`4472`
 * We now respect the Spotify API's rate limiting, which avoids crashing when the API reports code 429 (too many requests).
   :bug:`4370`
 * Fix implicit paths OR queries (e.g. ``beet list /path/ , /other-path/``)

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -171,6 +171,8 @@ class ConvertCliTest(unittest.TestCase, TestHelper, ConvertCommand):
         )
         self.config['convert'] = {
             'dest': self.convert_dest,
+            # Enforce running convert
+            'max_bitrate': 1,
             'paths': {'default': 'converted'},
             'format': 'mp3',
             'formats': {
@@ -249,6 +251,13 @@ class ConvertCliTest(unittest.TestCase, TestHelper, ConvertCommand):
             self.run_convert('An impossible query')
         self.assertEqual(logs[0], 'convert: Empty query result.')
 
+    def test_no_transcode_when_max_bitrate_set_to_none(self):
+        self.config['convert']['max_bitrate'] = None
+        with control_stdin('y'):
+            self.run_convert()
+        converted = os.path.join(self.convert_dest, b'converted.ogg')
+        self.assertNoFileTag(converted, 'mp3')
+
 
 @_common.slow_test()
 class NeverConvertLossyFilesTest(unittest.TestCase, TestHelper,
@@ -263,6 +272,8 @@ class NeverConvertLossyFilesTest(unittest.TestCase, TestHelper,
         self.convert_dest = os.path.join(self.temp_dir, b'convert_dest')
         self.config['convert'] = {
             'dest': self.convert_dest,
+            # Enforce running convert
+            'max_bitrate': 1,
             'paths': {'default': 'converted'},
             'never_convert_lossy_files': True,
             'format': 'mp3',


### PR DESCRIPTION
## Description

Fixes #4472.

## To Do

- [ ] Documentation. N/A because the documentation was already correct.
- [X] Changelog.
- [X] Tests.
