### PR TITLE
Adapt tests to latest Unidecode version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
     },
 
     install_requires=[
-        'unidecode',
+        'unidecode>=1.3.6',
         'musicbrainzngs>=0.4',
         'pyyaml',
         'mediafile>=0.9.0',

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -441,7 +441,7 @@ class DestinationTest(_common.TestCase):
         self.lib.directory = b'lib'
         self.lib.path_formats = [('default', '$title')]
         self.i.title = 'ab\xa2\xbdd'
-        self.assertEqual(self.i.destination(), np('lib/abC_ 1_2 d'))
+        self.assertEqual(self.i.destination(), np('lib/abC_ 1_2d'))
 
     def test_destination_with_replacements(self):
         self.lib.directory = b'base'
@@ -637,7 +637,7 @@ class DestinationFunctionTest(_common.TestCase, PathFormattingMixin):
 
     def test_asciify_variable(self):
         self._setf('%asciify{ab\xa2\xbdd}')
-        self._assert_dest(b'/base/abC_ 1_2 d')
+        self._assert_dest(b'/base/abC_ 1_2d')
 
     def test_left_variable(self):
         self._setf('%left{$title, 3}')


### PR DESCRIPTION
Unidecode 1.3.5 (a yanked PyPI version) [changed the behavior](https://github.com/avian2/unidecode/blob/414199246e4871669896756279e3460ff0364839/ChangeLog#L5) for some specific characters:

> Remove trailing space in replacements for vulgar fractions.

As luck would have it, our tests used the 1/2 character specifically to test the behavior when these characters decoded to contain slashes. We now pin a sufficiently recent version of Unidecode and adapt the tests to match the new behavior.
