### PR TITLE
replaygain: Fix error handling for parallel runs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -48,6 +48,9 @@ New features:
 
 Bug fixes:
 
+* :doc:`/plugins/replaygain`: Avoid a crash when errors occur in the analysis
+  backend.
+  :bug:`4506`
 * We now respect the Spotify API's rate limiting, which avoids crashing when the API reports code 429 (too many requests).
   :bug:`4370`
 * Fix implicit paths OR queries (e.g. ``beet list /path/ , /other-path/``)


### PR DESCRIPTION
This is a second fix to errors that have been cropping up in CI lately. Put this one into the bucket labeled "I don't know why this ever worked," but it's causing problems only on the Windows CI builds.

The parallelism strategy in #3478, in retrospect, used a pretty funky way to deal with exceptions in the asynchronous work—since `apply_async` has an `error_callback` parameter that's meant for exactly this. The problem is that the wrapped function would correctly log the exception *and then return `None`*, confusing any downstream code. Instead of just adding `None`-awareness to the callback, let's just avoid running the callback altogether in the case of an error.
