### PR TITLE
Remove duplicate "Trip-hop" genre

### DIFF
--- a/beetsplug/lastgenre/genres.txt
+++ b/beetsplug/lastgenre/genres.txt
@@ -1459,7 +1459,6 @@ tribal house
 trikitixa
 trip hop
 trip rock
-trip-hop
 tropicalia
 tropicalismo
 tropipop

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -112,6 +112,9 @@ Bug fixes:
   :bug:`4389`
 * :doc:`plugins/convert`: Fix a bug with the `wma` format alias.
 * :doc:`/plugins/web`: Fix get file from item.
+* :doc:`/plugins/lastgenre`: Fix a duplicated entry for trip hop in the
+  default genre list.
+  :bug:`4510`
 
 For packagers:
 


### PR DESCRIPTION
## Description

Remove "Trip-hop" because it's duplicate (the other one is "Trip hop").
For more information see https://github.com/beetbox/beets/discussions/4503#discussioncomment-3781639

(...)

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
