### PR TITLE
Allow `mb_track_extract` to have the final say for all fields

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -395,7 +395,8 @@ def album_info(release):
                 ti.length = int(track['length']) / (1000.0)
 
             # Supplementary fields provided by plugins
-            extra_trackdatas = plugins.send('mb_track_extract', data=track)
+            extra_trackdatas = plugins.send(
+                'mb_track_extract', data=track['recording'])
             for extra_trackdata in extra_trackdatas:
                 ti.update(extra_trackdata)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog goes here!
 
 New features:
 
+* Fixed ``mb_track_extract`` value overrides when called from ``album_info`` :bug:`4512`
 * :doc:`/plugins/mbsubmit`: Added a new `mbsubmit` command to print track information to be submitted to MusicBrainz after initial import.
   :bug:`4455`
 * Added `spotify_updated` field to track when the information was last updated.
@@ -50,7 +51,7 @@ New features:
 
 Bug fixes:
 
-* :doc:`/plugins/convert`: Set default ``max_bitrate`` value to ``None`` to 
+* :doc:`/plugins/convert`: Set default ``max_bitrate`` value to ``None`` to
   avoid transcoding when this parameter is not set. :bug:`4472`
 * :doc:`/plugins/replaygain`: Avoid a crash when errors occur in the analysis
   backend.

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -492,7 +492,7 @@ class MBHookTest(
 
     def test_no_hooks_sanity(self):
         track = self._make_track('RELEASE TITLE', 'id', 100.0 * 1000.0)
-        album = self._make_release(tracks=[track], track_title='track title')
+        album = self._make_release(tracks=[track], track_title='HONORED')
 
         track_info = mb.track_info(track)
         self.assertEqual(track_info.title, 'RELEASE TITLE')
@@ -503,33 +503,33 @@ class MBHookTest(
         # "recording". album_info overrides certain properties
         # of a release with properties of a "track" which may
         # only be present in the response for an album request
-        self.assertEqual(album_info.tracks[0].title, 'track title')
+        self.assertEqual(album_info.tracks[0].title, 'HONORED')
 
     def test_hooks_modify_results(self):
         track_hook_calls = [0, 0]
 
         def track_extract(data):
             track_hook_calls[0] += 1
-            return {'title': 'new title'}
+            return {'title': 'new {}'.format(data['title'].lower())}
         self.register_listener('mb_track_extract', track_extract)
 
         def album_extract(data):
             track_hook_calls[1] += 1
-            return {'album': 'new album'}
+            return {'album': 'new {}'.format(data['title'].lower())}
         self.register_listener('mb_album_extract', album_extract)
 
         track = self._make_track('TRACK TITLE', 'id', 100.0 * 1000.0)
-        album = self._make_release(tracks=[track], track_title='track title')
+        album = self._make_release(tracks=[track], track_title='IGNORED')
 
         track_info = mb.track_info(track)
-        self.assertEqual(track_info.title, 'new title')
+        self.assertEqual(track_info.title, 'new track title')
 
         album_info = mb.album_info(album)
-        self.assertEqual(album_info.album, 'new album')
-        self.assertEqual(album_info.tracks[0].title, 'new title')
+        self.assertEqual(album_info.album, 'new album title')
+        self.assertEqual(album_info.tracks[0].title, 'new track title')
 
-        # track_extract is called once from mb.track_info and once from mb.album_info
-        # it should not be called twice from mb.album_info
+        # track_extract is called once from mb.track_info and once from
+        # mb.album_info it should not be called twice from mb.album_info
         self.assertEqual(track_hook_calls, [2, 1])
 
 


### PR DESCRIPTION
## Description
In the source, the `mb.album_info` function calls track_info for each recording in a release... but then overrides certain values such as `title`, `artist`, and `length`. This unexpectedly causes hooks for `mb_track_extract` that return values for these fields to not have those values honored.

This PR defers calling the hook when `mb.track_info` is called from `mb.album_info` until after these album-context modifications have been made, thus allowing plugins to have the final say on the values for any fields.

Fixes #4512.  <!-- Insert issue number here if applicable. -->

## To Do

- [n/a] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
