### PR TITLE
Handle "join keyword" in `MetadataSourcePlugin.get_artist()`

### DIFF
--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -684,9 +684,8 @@ class MetadataSourcePlugin(metaclass=abc.ABCMeta):
         :rtype: str
         """
         artist_id = None
-        artist_names = []
-        joined = False
-        for artist in artists:
+        artist_string = ""
+        for idx, artist in enumerate(artists):
             if not artist_id:
                 artist_id = artist[id_key]
             name = artist[name_key]
@@ -695,17 +694,14 @@ class MetadataSourcePlugin(metaclass=abc.ABCMeta):
             # Move articles to the front.
             name = re.sub(r'^(.*?), (a|an|the)$', r'\2 \1', name, flags=re.I)
             # Use a join keyword if requested and available.
-            if join_key and artist.get(join_key, None):
-                name += " " + artist[join_key]
-                joined = True
-            artist_names.append(name)
-        # Concat using spaces only if join_key was passed and the join_key was
-        # ever found. Otherwise join comma-separated.
-        if join_key and joined is True:
-            artist = ' '.join(artist_names) or None
-        else:
-            artist = ', '.join(artist_names).replace(' ,', ',') or None
-        return artist, artist_id
+            if idx < (len(artists) - 1):  # Skip joining on last.
+                if join_key and artist.get(join_key, None):
+                    name += f" {artist[join_key]} "
+                else:
+                    name += ', '
+            artist_string += name
+
+        return artist_string, artist_id
 
     def _get_id(self, url_type, id_):
         """Parse an ID from its URL if necessary.

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -685,6 +685,8 @@ class MetadataSourcePlugin(metaclass=abc.ABCMeta):
         """
         artist_id = None
         artist_string = ""
+        artists = list(artists)  # In case a generator was passed.
+        total = len(artists)
         for idx, artist in enumerate(artists):
             if not artist_id:
                 artist_id = artist[id_key]
@@ -694,7 +696,7 @@ class MetadataSourcePlugin(metaclass=abc.ABCMeta):
             # Move articles to the front.
             name = re.sub(r'^(.*?), (a|an|the)$', r'\2 \1', name, flags=re.I)
             # Use a join keyword if requested and available.
-            if idx < (len(artists) - 1):  # Skip joining on last.
+            if idx < (total - 1):  # Skip joining on last.
                 if join_key and artist.get(join_key, None):
                     name += f" {artist[join_key]} "
                 else:

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -655,7 +655,7 @@ class MetadataSourcePlugin(metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     @staticmethod
-    def get_artist(artists, id_key='id', name_key='name'):
+    def get_artist(artists, id_key='id', name_key='name', join_key=None):
         """Returns an artist string (all artists) and an artist_id (the main
         artist) for a list of artist object dicts.
 
@@ -663,6 +663,8 @@ class MetadataSourcePlugin(metaclass=abc.ABCMeta):
         and 'the') to the front and strips trailing disambiguation numbers. It
         returns a tuple containing the comma-separated string of all
         normalized artists and the ``id`` of the main/first artist.
+        Alternatively a keyword can be used to combine artists together into a
+        single string by passing the join_key argument.
 
         :param artists: Iterable of artist dicts or lists returned by API.
         :type artists: list[dict] or list[list]
@@ -673,11 +675,17 @@ class MetadataSourcePlugin(metaclass=abc.ABCMeta):
             to concatenate for the artist string (containing all artists).
             Defaults to 'name'.
         :type name_key: str or int
+        :param join_key: Key or index corresponding to a field containing a
+            keyword to use for combining artists into a single string, for
+            example "Feat.", "Vs.", "And" or similar. The default is None
+            which keeps the default behaviour (comma-separated).
+        :type join_key: str or int
         :return: Normalized artist string.
         :rtype: str
         """
         artist_id = None
         artist_names = []
+        joined = False
         for artist in artists:
             if not artist_id:
                 artist_id = artist[id_key]
@@ -686,8 +694,17 @@ class MetadataSourcePlugin(metaclass=abc.ABCMeta):
             name = re.sub(r' \(\d+\)$', '', name)
             # Move articles to the front.
             name = re.sub(r'^(.*?), (a|an|the)$', r'\2 \1', name, flags=re.I)
+            # Use a join keyword if requested and available.
+            if join_key and artist.get(join_key, None):
+                name += " " + artist[join_key]
+                joined = True
             artist_names.append(name)
-        artist = ', '.join(artist_names).replace(' ,', ',') or None
+        # Concat using spaces only if join_key was passed and the join_key was
+        # ever found. Otherwise join comma-separated.
+        if join_key and joined is True:
+            artist = ' '.join(artist_names) or None
+        else:
+            artist = ', '.join(artist_names).replace(' ,', ',') or None
         return artist, artist_id
 
     def _get_id(self, url_type, id_):

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -302,7 +302,8 @@ class DiscogsPlugin(BeetsPlugin):
             return None
 
         artist, artist_id = MetadataSourcePlugin.get_artist(
-            [a.data for a in result.artists]
+            [a.data for a in result.artists],
+            join_key='join'
         )
         album = re.sub(r' +', ' ', result.title)
         album_id = result.data['id']
@@ -566,7 +567,8 @@ class DiscogsPlugin(BeetsPlugin):
         track_id = None
         medium, medium_index, _ = self.get_track_index(track['position'])
         artist, artist_id = MetadataSourcePlugin.get_artist(
-            track.get('artists', [])
+            track.get('artists', []),
+            join_key='join'
         )
         length = self.get_track_length(track['duration'])
         return TrackInfo(title=title, track_id=track_id, artist=artist,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -52,6 +52,11 @@ New features:
 
 Bug fixes:
 
+* :doc:`/plugins/discogs`: Fix "Discogs plugin replacing Feat. or Ft. with
+  a comma" by fixing an oversight that removed a functionality from the code
+  base when the MetadataSourcePlugin abstract class was introduced in PR's
+  #3335 and #3371.
+  :bug:`4401`
 * :doc:`/plugins/convert`: Set default ``max_bitrate`` value to ``None`` to 
   avoid transcoding when this parameter is not set. :bug:`4472`
 * :doc:`/plugins/replaygain`: Avoid a crash when errors occur in the analysis


### PR DESCRIPTION
## Description

- Handle "join keyword" in MetadataSourcePlugin.get_artist() and make use of the new functionality in the Discogs source plugin.
- Fixes #4401 (Note that despite being discussed here, no version bump of python3-discogs-client is required since the `data` attribute being used, contains the required "join" field already.)

## To Do

- [x] ~Documentation.~
- [x] Changelog.
- [x] ~Tests.~

