### PR TITLE
Fix recent bug that would not transcode when format was wrong

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -102,10 +102,9 @@ def should_transcode(item, fmt):
             not (item.format.lower() in LOSSLESS_FORMATS):
         return False
     maxbr = config['convert']['max_bitrate'].get(Optional(int))
-    if maxbr is None:
-        return False
-    return fmt.lower() != item.format.lower() or \
-        item.bitrate >= 1000 * maxbr
+    if maxbr is not None and item.bitrate >= 1000 * maxbr:
+        return True
+    return fmt.lower() != item.format.lower()
 
 
 class ConvertPlugin(BeetsPlugin):

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -88,10 +88,11 @@ file. The available options are:
 - **embed**: Embed album art in converted items. Default: ``yes``.
 - **id3v23**: Can be used to override the global ``id3v23`` option. Default:
   ``inherit``.
-- **max_bitrate**: All lossy files with a higher bitrate will be
-  transcoded and those with a lower bitrate will simply be copied. Note that
-  this does not guarantee that all converted files will have a lower
-  bitrate---that depends on the encoder and its configuration.
+- **max_bitrate**: By default, the plugin does not transcode files that are
+  already in the destination format. This option instead also transcodes files
+  with high bitrates, even if they are already in the same format as the
+  output.  Note that this does not guarantee that all converted files will have
+  a lower bitrate---that depends on the encoder and its configuration.
   Default: none.
 - **no_convert**: Does not transcode items matching provided query string
   (see :doc:`/reference/query`). (i.e. ``format:AAC, format:WMA`` or


### PR DESCRIPTION
## Description

Bug introduced in c6d623241b578d1c409affaa2cef27c4f27cb02c, should_transcode would return False even when the format was different.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
