### PR TITLE
Added ftintitle_mb plugin

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -527,6 +527,7 @@ def match_album(artist, album, tracks=None, extra_tags=None):
         # so we just use the ID and fetch the rest of the information.
         albuminfo = album_for_id(release['id'])
         if albuminfo is not None:
+            plugins.send('mb_album_by_search_received', info=release)
             yield albuminfo
 
 
@@ -549,6 +550,7 @@ def match_track(artist, title):
         raise MusicBrainzAPIError(exc, 'recording search', criteria,
                                   traceback.format_exc())
     for recording in res['recording-list']:
+        plugins.send('mb_track_by_search_received', info=recording)
         yield track_info(recording)
 
 
@@ -581,6 +583,7 @@ def album_for_id(releaseid):
     except musicbrainzngs.MusicBrainzError as exc:
         raise MusicBrainzAPIError(exc, 'get release by ID', albumid,
                                   traceback.format_exc())
+    plugins.send('mb_album_by_id_received', info=res['release'])
     return album_info(res['release'])
 
 
@@ -600,4 +603,5 @@ def track_for_id(releaseid):
     except musicbrainzngs.MusicBrainzError as exc:
         raise MusicBrainzAPIError(exc, 'get recording by ID', trackid,
                                   traceback.format_exc())
+    plugins.send('mb_track_by_id_received', info=res['recording'])
     return track_info(res['recording'])

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -657,6 +657,7 @@ def choose_candidate(candidates, singleton, rec, cur_artist=None,
 
         # Exact match => tag automatically if we're not in timid mode.
         if rec == Recommendation.strong and not config['import']['timid']:
+            plugins.send('matchinfo_received', match=match)
             return match
 
         # Ask for confirmation.
@@ -674,6 +675,7 @@ def choose_candidate(candidates, singleton, rec, cur_artist=None,
         sel = ui.input_options(('Apply', 'More candidates') + choice_opts,
                                require=require, default=default)
         if sel == 'a':
+            plugins.send('matchinfo_received', match=match)
             return match
         elif sel in choice_actions:
             return choice_actions[sel]

--- a/beetsplug/ftintitle_mb.py
+++ b/beetsplug/ftintitle_mb.py
@@ -1,0 +1,133 @@
+# This file is part of beets.
+# Copyright 2022, dvcky <https://col.ee/>
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""Moves "featured" artists to the title from the artist field using MusicBrainz
+data for potentially better results.
+"""
+
+from beets import plugins
+from beets import ui
+
+import musicbrainzngs
+
+mb_candidates = []
+
+class FtInTitleMBPlugin(plugins.BeetsPlugin):
+    def __init__(self):
+        super().__init__()
+
+        self.config.add({
+            'feat_format': "(feat. {0})",
+            'collab_cases': [", ", " & ", " vs ", " x ", " × "],
+        })
+
+        self.register_listener('matchinfo_received', self.ftintitle_mb)
+        self.register_listener('mb_album_by_id_received', self.collect)
+        self.register_listener('mb_track_by_id_received', self.collect)
+        self.register_listener('mb_track_by_search_received', self.collect)
+
+    # appends info to the array we will be checking later using find_mb_match
+    def collect(self, info):
+        mb_candidates.append(info)
+
+    # finds the "raw" MusicBrainz data for the user's selection by iterating
+    # through an array of possible candidates until one is found that has an
+    # identical ID to the Match object passed
+    def find_mb_match(self, match):
+        found = {}
+        # iterate through each possible match
+        for candidate in mb_candidates:
+            # if it has the attribute "album_id", it is an album. check if 
+            if hasattr(match.info, "album_id") and (match.info.album_id == candidate['id']):
+                found = candidate
+                break
+            elif hasattr(match.info, "track_id") and (match.info.track_id == candidate['id']):
+                found = candidate
+                break
+        # somehow beets saves results (even if they aren't used in the current
+        # import) and will use them if a match comes up later. I have no idea
+        # how they do that without using loads of memory, so we will just
+        # manually fetch the data if it ends up being a repeated result. in most
+        # cases this shouldn't be an issue
+        if not found:
+            if hasattr(match.info, "album_id"):
+               found = musicbrainzngs.get_release_by_id(match.info.album_id, ['recordings', 'artist-credits'])['release']
+            elif hasattr(match.info, "track_id"):
+                found = musicbrainzngs.get_recording_by_id(match.info.track_id, ['artist-credits'])['recording']
+        # wipe array to save memory
+        mb_candidates.clear()
+        return found
+
+    # iterates through the `collab_cases` array to see if the current
+    # featuretype is one of them
+    def is_collab_case(self, featuretype):
+        for case in self.config['collab_cases'].as_str_seq():
+            if featuretype == case:
+                return True
+        return False
+
+    # this is technically a misinformative title, but it ends up with the same
+    # effect. this is the meat of the ftintitle, and translates the MusicBrainz
+    # data into something that can be put into our Match object. later on the
+    # Match object will create a file based on info stored in it.
+    def update_metadata(self, match, mb_track):
+        # initializing some variables:
+        # artistbuilder: our artist building variable
+        # featurebuilder: our feature building variable
+        # featuretypes: stores all the feature types in-between artists
+        # featureartists: stores the artists that will be placed in the feature
+        # multiartist: are we still be appending artists to the artistbuilder?
+        artistbuilder=""
+        featurebuilder=""
+        featuretypes=[]
+        featureartists=[]
+        multiartist = True
+
+        # iterate through each credit (can be artist, feat type, or feat artist)
+        # this will distribute items to their respective arrays
+        for credit in mb_track['artist-credit']:
+            if not isinstance(credit, str):
+                if multiartist:
+                    artistbuilder += credit['artist']['name']
+                else:
+                    featureartists.append(credit['artist']['name'])
+            elif multiartist and self.is_collab_case(credit):
+                artistbuilder += credit
+            else:
+                multiartist = False
+                featuretypes.append(credit)
+        # time to build our feature!
+        for x in range(len(featuretypes)):
+            # we dont include first feature type, user defines that
+            if x != 0:
+                featurebuilder += featuretypes[x]
+            featurebuilder += featureartists[x]
+        # we dont want to add a space and formatting if there is no feature!
+        if len(featuretypes) > 0:
+            featurebuilder = \
+            " " + self.config['feat_format'].get(str).format(featurebuilder)
+        # apply our changes to the Match object
+        match['title'] = mb_track['title'] + featurebuilder
+        match['artist'] = artistbuilder
+
+    def ftintitle_mb(self, match):
+        # get MusicBrainz data for respective Match object
+        mb_match = self.find_mb_match(match)
+        # if it is an album, make sure we iterate through bits of the data like
+        # a track, rather than the whole thing
+        if hasattr(match.info, "album_id"):
+            for track, mb_track in zip(match.info['tracks'], mb_match['medium-list'][0]['track-list']):
+                self.update_metadata(track, mb_track['recording'])
+        else:
+            self.update_metadata(match.info, mb_match)

--- a/beetsplug/ftintitle_mb.py
+++ b/beetsplug/ftintitle_mb.py
@@ -12,7 +12,9 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 """Moves "featured" artists to the title from the artist field.
-Uses MusicBrainz data for potentially better results.
+
+Works similarly to regular ftintitle, but uses data from
+MusicBrainz to produce potentially better results.
 """
 
 from beets import plugins
@@ -22,11 +24,10 @@ mb_candidates = []
 
 
 class FtInTitleMBPlugin(plugins.BeetsPlugin):
-    """Class for ftintitle_mb plugin.
-    """
+    """Class for ftintitle_mb plugin."""
+
     def __init__(self):
-        """Initialize plugin.
-        """
+        """Initialize plugin."""
         super().__init__()
 
         self.config.add({
@@ -40,17 +41,14 @@ class FtInTitleMBPlugin(plugins.BeetsPlugin):
         self.register_listener('mb_track_by_search_received', self.collect)
 
     def collect(self, info):
-        """Appends information to the array to be used later by find_mb_match.
-        """
+        """Append information to the array to be used by find_mb_match."""
         mb_candidates.append(info)
 
     # finds the "raw" MusicBrainz data for the user's selection by iterating
     # through an array of possible candidates until one is found that has an
     # identical ID to the Match object passed
     def find_mb_match(self, match):
-        """Finds "raw" MusicBrainz data for user's selection.
-        Looks for a matching ID between the Match and the raw data.
-        """
+        """Find "raw" MusicBrainz data for user's selection."""
         found = {}
         # iterate through each possible match
         for candidate in mb_candidates:
@@ -59,8 +57,8 @@ class FtInTitleMBPlugin(plugins.BeetsPlugin):
             (match.info.album_id == candidate['id']):
                 found = candidate
                 break
-            elif hasattr(match.info, "track_id") \
-            and(match.info.track_id == candidate['id']):
+            elif hasattr(match.info, "track_id") and \
+            (match.info.track_id == candidate['id']):
                 found = candidate
                 break
         # somehow beets saves results (even if they aren't used in the current
@@ -70,8 +68,8 @@ class FtInTitleMBPlugin(plugins.BeetsPlugin):
         # most cases this shouldn't be an issue
         if not found:
             if hasattr(match.info, "album_id"):
-               found = musicbrainzngs.get_release_by_id(match.info.album_id, \
-               ['recordings', 'artist-credits'])['release']
+                found = musicbrainzngs.get_release_by_id(match.info.album_id, \
+                ['recordings', 'artist-credits'])['release']
             elif hasattr(match.info, "track_id"):
                 found = musicbrainzngs.get_recording_by_id( \
                 match.info.track_id, ['artist-credits'])['recording']
@@ -98,10 +96,10 @@ class FtInTitleMBPlugin(plugins.BeetsPlugin):
         # featuretypes: stores all the feature types in-between artists
         # featureartists: stores the artists that will be placed in the feature
         # multiartist: are we still be appending artists to the artistbuilder?
-        artistbuilder=""
-        featurebuilder=""
-        featuretypes=[]
-        featureartists=[]
+        artistbuilder = ""
+        featurebuilder = ""
+        featuretypes = []
+        featureartists = []
         multiartist = True
 
         # iterate through each credit (can be artist, feat type, or feat

--- a/beetsplug/ftintitle_mb.py
+++ b/beetsplug/ftintitle_mb.py
@@ -133,7 +133,7 @@ class FtInTitleMBPlugin(plugins.BeetsPlugin):
         match['artist'] = artistbuilder
 
     def ftintitle_mb(self, match):
-        """get MusicBrainz data for respective Match object"""
+        """Get MusicBrainz data for respective Match object."""
         mb_match = self.find_mb_match(match)
         # if it is an album, make sure we iterate through bits of the data like
         # a track, rather than the whole thing

--- a/beetsplug/ftintitle_mb.py
+++ b/beetsplug/ftintitle_mb.py
@@ -54,11 +54,11 @@ class FtInTitleMBPlugin(plugins.BeetsPlugin):
         for candidate in mb_candidates:
             # if it has the attribute "album_id", it is an album.
             if hasattr(match.info, "album_id") and \
-            (match.info.album_id == candidate['id']):
+                        (match.info.album_id == candidate['id']):
                 found = candidate
                 break
             elif hasattr(match.info, "track_id") and \
-            (match.info.track_id == candidate['id']):
+                        (match.info.track_id == candidate['id']):
                 found = candidate
                 break
         # somehow beets saves results (even if they aren't used in the current
@@ -68,11 +68,12 @@ class FtInTitleMBPlugin(plugins.BeetsPlugin):
         # most cases this shouldn't be an issue
         if not found:
             if hasattr(match.info, "album_id"):
-                found = musicbrainzngs.get_release_by_id(match.info.album_id, \
-                ['recordings', 'artist-credits'])['release']
+                found = musicbrainzngs.get_release_by_id(
+                    match.info.album_id,
+                    ['recordings', 'artist-credits'])['release']
             elif hasattr(match.info, "track_id"):
-                found = musicbrainzngs.get_recording_by_id( \
-                match.info.track_id, ['artist-credits'])['recording']
+                found = musicbrainzngs.get_recording_by_id(
+                    match.info.track_id, ['artist-credits'])['recording']
         # wipe array to save memory
         mb_candidates.clear()
         return found
@@ -80,6 +81,7 @@ class FtInTitleMBPlugin(plugins.BeetsPlugin):
     # iterates through the `collab_cases` array to see if the current
     # featuretype is one of them
     def is_collab_case(self, featuretype):
+        """Check if current case is one of the collab cases."""
         for case in self.config['collab_cases'].as_str_seq():
             if featuretype == case:
                 return True
@@ -90,6 +92,7 @@ class FtInTitleMBPlugin(plugins.BeetsPlugin):
     # data into something that can be put into our Match object. later on the
     # Match object will create a file based on info stored in it.
     def update_metadata(self, match, mb_track):
+        """Update metadata for Match based on information found."""
         # initializing some variables:
         # artistbuilder: our artist building variable
         # featurebuilder: our feature building variable
@@ -123,20 +126,21 @@ class FtInTitleMBPlugin(plugins.BeetsPlugin):
             featurebuilder += featureartists[x]
         # we dont want to add a space and formatting if there is no feature!
         if len(featuretypes) > 0:
-            featurebuilder = \
-            " " + self.config['feat_format'].get(str).format(featurebuilder)
+            featurebuilder = " " + \
+                self.config['feat_format'].get(str).format(featurebuilder)
         # apply our changes to the Match object
         match['title'] = mb_track['title'] + featurebuilder
         match['artist'] = artistbuilder
 
     def ftintitle_mb(self, match):
-        # get MusicBrainz data for respective Match object
+        """get MusicBrainz data for respective Match object"""
         mb_match = self.find_mb_match(match)
         # if it is an album, make sure we iterate through bits of the data like
         # a track, rather than the whole thing
         if hasattr(match.info, "album_id"):
-            for track, mb_track in zip( \
-            match.info['tracks'], mb_match['medium-list'][0]['track-list']):
+            for track, mb_track \
+                              in zip(match.info['tracks'],
+                                     mb_match['medium-list'][0]['track-list']):
                 self.update_metadata(track, mb_track['recording'])
         else:
             self.update_metadata(match.info, mb_match)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,8 @@ Changelog goes here!
 
 New features:
 
+* Added `ftintitle_mb`: A plugin aimed at producing better results in
+  "feature splitting", specifically when utilizing data from MusicBrainz.
 * :doc:`/plugins/mbsubmit`: Added a new `mbsubmit` command to print track information to be submitted to MusicBrainz after initial import.
   :bug:`4455`
 * Added `spotify_updated` field to track when the information was last updated.

--- a/test/test_ftintitle_mb.py
+++ b/test/test_ftintitle_mb.py
@@ -1,0 +1,89 @@
+# This file is part of beets.
+# Copyright 2022, dvcky.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""Tests for the 'ftintitle_mb' plugin."""
+
+import unittest
+import musicbrainzngs
+from beets.autotag import AlbumInfo, TrackInfo, match
+from beetsplug import ftintitle_mb
+from test.helper import TestHelper
+
+# used for fetching data with musicbrainzngs
+RELEASE_INCLUDES = ['artists', 'media', 'recordings', 'release-groups',
+                    'labels', 'artist-credits', 'aliases',
+                    'recording-level-rels', 'work-rels',
+                    'work-level-rels', 'artist-rels', 'isrcs']
+
+
+class FtInTitleMBPluginTest(unittest.TestCase, TestHelper):
+
+    def setUp(self):
+        """Set up configuration"""
+        self.setup_beets()
+        self.load_plugins('ftintitle_mb')
+
+    def tearDown(self):
+        self.unload_plugins()
+        self.teardown_beets()
+
+    def ftmb_config(self):
+        self.config['ftintitle_mb']['feat_format'] = "(feat. {0})"
+        self.config['ftintitle_mb']['collab_cases'] = [" & "]
+
+    def ftmb_track(self, albumid, expected_title, expected_artist):
+        """Test first track in an album"""
+        match_test = match.match_by_id([AlbumInfo(mb_albumid=albumid,
+                                        tracks=[TrackInfo()])])
+        raw_test = \
+            musicbrainzngs.get_release_by_id(albumid,
+                                             RELEASE_INCLUDES)['release']
+
+        ftintitle_mb.FtInTitleMBPlugin().update_metadata(
+            match_test['tracks'][0],
+            raw_test['medium-list'][0]['track-list'][0]['recording'])
+        self.assertEqual(match_test['tracks'][0]['title'],
+                         expected_title)
+        self.assertEqual(match_test['tracks'][0]['artist'],
+                         expected_artist)
+
+    def test_ftintitle_mb(self):
+        """Main test function"""
+
+        # Apply testing config
+        self.ftmb_config()
+
+        # Test an artist with "&" in their name to show that it won't be
+        # split like it would be using the normal ftintitle plugin.
+        self.ftmb_track('3b675b27-c087-49e9-9e50-1875d88bf78c',
+                        'Tompkins Square Park', 'Mumford & Sons')
+
+        # TODO: Test an artist with & to show that it won't be split since we
+        # have that in our collab_cases.
+        #self.ftmb_track('3b675b27-c087-49e9-9e50-1875d88bf78c',
+        #                'Tompkins Square Park', 'Mumford & Sons')
+
+        # Finally, test an artist with a feature type not listed in
+        # collab_cases. This should move that artist to the title using
+        # our selected format.
+        self.ftmb_track('71289422-f99c-47a9-ad2b-8f0969500dd0',
+                        'Dig (feat. Sonny Rollins)', 'Miles Davis')
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromName(__name__)
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')


### PR DESCRIPTION
## Added `ftintitle_mb` plugin

After conversing and thinking over my original idea of [(overhauling ftintitle)](https://github.com/beetbox/beets/pull/4509) with @sampsyo, I decided it would make more sense to have this be an entirely different plugin.

### Description
This plugin moves "featured" artists to the title from the artist field. Unlike the previous ftintitle, ftintitle_mb uses MusicBrainz data to determine where the featured artist lies. It also uses new hooks that reduce redundancy in fetching MusicBrainz data.

### Additional notes
Configuration variables:
- `feat_format`: Determines how to format the feature at the end of the title.
Default value: `"(feat. {0})"`
- `collab_cases`: Allows certain "feature types" to be added to the artist before switching to the title.
Default value: `[", ", " & ", " vs ", " x ", " × "]`

The new hooks added:
- `matchinfo_received`: returns user-selected Match object _(match)_
- `mb_album_by_id_received`: returns unmodified MusicBrainz album data _(info)_
- `mb_track_by_id_received`: returns unmodified MusicBrainz track data _(info)_
- `mb_album_by_search_received`: returns unmodified MusicBrainz search data for albums _(info)_
- `mb_track_by_search_received`: returns unmodified MusicBrainz search data for tracks _(info)_

~~### Also:
For some reason, I can't pass a custom `collab_cases` through my user config. I have the default value in the plugin set to something I believe is a reasonable default, but I do want it to be customizable to the user's preference. I thought bringing this to the pull request might draw some attention and get a fresh set of eyes to look at and give tips on the code. Any help would be greatly appreciated!~~ I can't type, that's the unfortunate reason for this issue. It's fixed now, and everything is working great as far as I can tell! Should be ready for merge!