### PR TITLE
Add customisable disambiguation strings for importer

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -176,3 +176,5 @@ match:
     ignore_video_tracks: yes
     track_length_grace: 10
     track_length_max: 30
+    album_disambig_fields: data_source media year country label catalognum albumdisambig albumrelease
+    singleton_disambig_fields: data_source index track_alt album


### PR DESCRIPTION
## Description

This adds configurable disambiguation strings when importing. The defaults I've provided are what is currently in place but there are a number of limitations.

- When used with the `beets-audible` plugin, sometimes there are 'None' values that are printed, I haven't managed to narrow down the cause of that yet, but it may be limited to something that that plugin does.
- Values that may be printed can contain comma-separated values, which is how the disambiguation string is printed. This makes it appear as though there are more fields than there are, because it is CSVs nested in CSVs.
- This modification does not allow for any computation or formatting of values. Note that I've had to leave the medium and disc-number parsing in place, because my solution does not allow for formatting the variables in this manner.

If you have any solutions for these, I'd love to hear them! I'll leave it as a draft PR for now since this is very much a work in progress.

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
