### PR TITLE
Added remixer field

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -202,6 +202,19 @@ def _flatten_artist_credit(credit):
     )
 
 
+def _get_remixer_names(relations):
+    """ Given a list representing the artist relationships extract the names of
+    the remixers and concatenate them.
+    """
+    remixers = []
+
+    for relation in relations:
+        if relation['type'] == 'remixer':
+            remixers.append(relation['artist']['name'])
+
+    return ', '.join(remixers)
+
+
 def track_info(recording, index=None, medium=None, medium_index=None,
                medium_total=None):
     """Translates a MusicBrainz recording result dictionary into a beets
@@ -230,6 +243,9 @@ def track_info(recording, index=None, medium=None, medium_index=None,
         # Get the ID and sort name of the first artist.
         artist = recording['artist-credit'][0]['artist']
         info.artist_id = artist['id']
+
+    if recording.get('artist-relation-list'):
+        info.remixer = _get_remixer_names(recording['artist-relation-list'])
 
     if recording.get('length'):
         info.length = int(recording['length']) / (1000.0)

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -202,17 +202,17 @@ def _flatten_artist_credit(credit):
     )
 
 
-def _get_remixer_names(relations):
-    """ Given a list representing the artist relationships extract the names of
+def _get_related_artist_names(relations, relation_type):
+    """Given a list representing the artist relationships extract the names of
     the remixers and concatenate them.
     """
-    remixers = []
+    related_artists = []
 
     for relation in relations:
-        if relation['type'] == 'remixer':
-            remixers.append(relation['artist']['name'])
+        if relation['type'] == relation_type:
+            related_artists.append(relation['artist']['name'])
 
-    return ', '.join(remixers)
+    return ', '.join(related_artists)
 
 
 def track_info(recording, index=None, medium=None, medium_index=None,
@@ -245,7 +245,10 @@ def track_info(recording, index=None, medium=None, medium_index=None,
         info.artist_id = artist['id']
 
     if recording.get('artist-relation-list'):
-        info.remixer = _get_remixer_names(recording['artist-relation-list'])
+        info.remixer = _get_related_artist_names(
+            recording['artist-relation-list'],
+            relation_type='remixer'
+        )
 
     if recording.get('length'):
         info.length = int(recording['length']) / (1000.0)

--- a/beets/library.py
+++ b/beets/library.py
@@ -466,6 +466,7 @@ class Item(LibModel):
         'artist': types.STRING,
         'artist_sort': types.STRING,
         'artist_credit': types.STRING,
+        'remixer': types.STRING,
         'album': types.STRING,
         'albumartist': types.STRING,
         'albumartist_sort': types.STRING,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,8 @@ Changelog goes here!
 
 New features:
 
+* We now import the remixer field from Musicbrainz into the library.
+  :bug:`4428`
 * :doc:`/plugins/mbsubmit`: Added a new `mbsubmit` command to print track information to be submitted to MusicBrainz after initial import.
   :bug:`4455`
 * Added `spotify_updated` field to track when the information was last updated.

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -109,8 +109,8 @@ class MBAlbumInfoTest(_common.TestCase):
         })
         return release
 
-    def _make_track(self, title, tr_id, duration, artist=False, video=False,
-                    disambiguation=None):
+    def _make_track(self, title, tr_id, duration, artist=False, remixer=False,
+                    video=False, disambiguation=None):
         track = {
             'title': title,
             'id': tr_id,
@@ -126,6 +126,22 @@ class MBAlbumInfoTest(_common.TestCase):
                         'sort-name': 'RECORDING ARTIST SORT NAME',
                     },
                     'name': 'RECORDING ARTIST CREDIT',
+                }
+            ]
+        if remixer:
+            track['artist-relation-list'] = [
+                {
+                    'type': 'remixer',
+                    'type-id': 'RELATION TYPE ID',
+                    'target': 'RECORDING REMIXER ARTIST ID',
+                    'direction': 'RECORDING RELATION DIRECTION',
+                    'artist': 
+                        {
+                            'id': 'RECORDING REMIXER ARTIST ID',
+                            'type': 'RECORDING REMIXER ARTIST TYPE',
+                            'name': 'RECORDING REMIXER ARTIST NAME',
+                            'sort-name': 'RECORDING REMIXER ARTIST SORT NAME'
+                        }
                 }
             ]
         if video:
@@ -338,6 +354,12 @@ class MBAlbumInfoTest(_common.TestCase):
         self.assertEqual(track.artist_id, 'TRACK ARTIST ID')
         self.assertEqual(track.artist_sort, 'TRACK ARTIST SORT NAME')
         self.assertEqual(track.artist_credit, 'TRACK ARTIST CREDIT')
+
+    def test_parse_recording_remixer(self):
+        tracks = [self._make_track('a', 'b', 1, remixer=True)]
+        release = self._make_release(None, tracks=tracks)
+        track = mb.album_info(release).tracks[0]
+        self.assertEqual(track.remixer, 'RECORDING REMIXER ARTIST NAME')
 
     def test_data_source(self):
         release = self._make_release()

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -109,8 +109,8 @@ class MBAlbumInfoTest(_common.TestCase):
         })
         return release
 
-    def _make_track(self, title, tr_id, duration, artist=False, remixer=False,
-                    video=False, disambiguation=None):
+    def _make_track(self, title, tr_id, duration, artist=False,
+                    video=False, disambiguation=None, remixer=False):
         track = {
             'title': title,
             'id': tr_id,
@@ -135,7 +135,7 @@ class MBAlbumInfoTest(_common.TestCase):
                     'type-id': 'RELATION TYPE ID',
                     'target': 'RECORDING REMIXER ARTIST ID',
                     'direction': 'RECORDING RELATION DIRECTION',
-                    'artist': 
+                    'artist':
                         {
                             'id': 'RECORDING REMIXER ARTIST ID',
                             'type': 'RECORDING REMIXER ARTIST TYPE',


### PR DESCRIPTION
## Description

Fixes #4428

Adds the remixer field from the musicbrainz database to the beets library. I haven't added any documentation since I didn't know if it is necessary for the changes I made.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
