### PR TITLE
Fix for all folders using aunique when a non-standard key is used

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -1832,7 +1832,7 @@ class DefaultTemplateFunctions:
 
         # If there's only one item to matching these details, then do
         # nothing.
-        if len(ambigous_items) == 1:
+        if len(ambigous_items) <= 1:
             self.lib._memotable[memokey] = ''
             return ''
 


### PR DESCRIPTION
## Description

This is a tentative quick and dirty fix for an error that I've come across. When attempting to add the key `composer` to the keys of the `aunique` function in the configuration file, a strange error occurs: every folder and file will trigger the `aunique` function (so that the `aunique` string is included in the folder name). This happens even when there are no conceivable duplicates, or even any other items in the library at all.

Going through the code, this seems to be because, when searching for the `composer` field, the album object *at that point* returns no value for the `composer` field. It does before hand but that information is dropped along the way inside the `wrapper_func` function. Because of that, the final key field used to create the query at [this line](https://github.com/beetbox/beets/blob/dcba529827124d5b2cdbc84073a23388fb4ed28d/beets/library.py#L1794) is empty, and so beets thinks the album needs disambiguation because the length of `ambiguous_items` is 0, instead of 1.

So, my fix is just to include 0 and negative numbers in that if statement. It's a quick and dirty fix and works but I think the better solution would be to find out why the other fields for the album information have been dropped and to fix that. Any hints for where to go or help would be much appreciated!

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
