### PR TITLE
Fix some CI breakage due to backwards-incompatible flake8 changes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,21 +5,27 @@ docstring-convention = google
 # errors we ignore; see https://www.flake8rules.com/ for more info
 ignore =
     # pycodestyle errors
-    E121,  # continuation line under-indented for hanging indent
-    E123,  # closing bracket does not match indentation of opening bracket's line
-    E126,  # continuation line over-indented for hangin indent
-    E241,  # multiple spaces after non-arithmetic operators (for vertical alignment)
-    E305,  # expected 2 blank lines after end of function or class
-    E731,  # do not assign a lamba expression, use a def
-    E741,  # do not use variables name 'I', 'O', or 'l'
-    # pycodestyle warnings
-    W503,  # line break occurred before a binary operator
-    W504,  # line break occurred after a binary operator
-    # pyflakes errors
-    F405,  # name be undefined, or defined from star imports: module
-    # mccabe error
-    C901,  # function is too complex
-    N818,  # Exception subclasses should be named with an Error suffix
+    # continuation line under-indented for hanging indent
+    E121,
+    # closing bracket does not match indentation of opening bracket's line
+    E123,
+    # continuation line over-indented for hanging indent
+    E126,
+    # multiple spaces after non-arithmetic operators (for vertical alignment)
+    E241,
+    # expected 2 blank lines after end of function or class
+    E305,
+    # do not assign a lambda expression, use a def
+    E731,
+    # do not use variables name 'I', 'O', or 'l'
+    E741,
+    # pycodestyle warnings: line breaks around binary operators
+    W503,
+    W504,
+    # mccabe errors: function is too complex
+    C901,
+    # Exception subclasses should be named with an Error suffix
+    N818,
 per-file-ignores =
     ./beet:D
     ./docs/conf.py:D


### PR DESCRIPTION
The primary change here is to adapt to adapt to the issue described in https://github.com/PyCQA/flake8/issues/1689#issuecomment-1326319235, wherein a recent change to flake8 required reformatting of `setup.cfg`.

I also took the opportunity to remove one particularly suspicious flake8 "ignore" override, for `from _ import *` wildcard imports. There was one place we were relying on this that didn't really seem necessary.