### PR TITLE
unimported: ignore_subdirectories works recursively

### DIFF
--- a/beetsplug/unimported.py
+++ b/beetsplug/unimported.py
@@ -53,7 +53,7 @@ class Unimported(BeetsPlugin):
                 for file in f
                 if not any(
                     [file.endswith(ext) for ext in ignore_exts]
-                    + [r in ignore_dirs]
+                    + [r.startswith(ignore_dir) for ignore_dir in ignore_dirs]
                 )
             }
             in_library = {x.path for x in lib.items()}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Changelog goes here!
 
 New features:
 
+* :doc:`/plugins/unimported`: Ignored subdirectories are now ignored recursively.
 * We now import the remixer field from Musicbrainz into the library.
   :bug:`4428`
 * :doc:`/plugins/mbsubmit`: Added a new `mbsubmit` command to print track information to be submitted to MusicBrainz after initial import.


### PR DESCRIPTION
The `ignore_subdirectories` option for the unimported plugin does not ignore directories recursively; that is, if there are directories under the ignored directory, they are not ignored. I believe this is a bug, and this commit corrects that behaviour.

I store my music in a folder checked into git (using [git-annex](https://git-annex.branchable.com/)). This means that there are many, many subdirectories under the .git folder and I am unable to list them individually in the config file ahead of time. I expected this config option to behave for the entire tree under the ignored directory, but it does not. I considered whether other people might find this change in behaviour surprising, but I can't think of a good use-case for the existing behaviour, and I don't think it goes against [the intention of the original feature request](https://github.com/beetbox/beets/issues/4025).

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [X] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
