### PR TITLE
tests: add a (xfailing) test for issue #4528

### DIFF
--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -701,6 +701,28 @@ class UpdateTest(_common.TestCase):
         item = self.lib.items().get()
         self.assertEqual(item.title, 'full')
 
+    @unittest.expectedFailure
+    def test_multivalued_albumtype_roundtrip(self):
+        # https://github.com/beetbox/beets/issues/4528
+
+        # albumtypes is empty for our test fixtures, so populate it first
+        album = self.album
+        # setting albumtypes does not set albumtype currently...
+        # FIXME: When actually fixing the issue 4528, consider whether this
+        # should be set to "album" or ["album"]
+        album.albumtype = "album"
+        album.albumtypes = "album"
+        album.try_sync(write=True, move=False)
+
+        album.load()
+        albumtype_before = album.albumtype
+        self.assertEqual(albumtype_before, "album")
+
+        self._update()
+
+        album.load()
+        self.assertEqual(albumtype_before, album.albumtype)
+
 
 class PrintTest(_common.TestCase):
     def setUp(self):


### PR DESCRIPTION
From #4582 (@jpluscplusm)

> I strongly suggest that this only be merged after tests are added that would have caught this problem before 1.6.0 was released. I've added no tests in this PR as the relevant parts of the Beets test suite quickly put me out of my depth. I really think it's worth getting a failing test in place, before merging this (I'll happily rebase, or anything else needed) as I /believe/ this bug will be causing any Beets user on 1.6.0+ to be re-tagging much/all of their library on each write.

This PR should do the trick.

I'm not up to speed on the issue and the history of the `albumtype[s]` fields, this is only a quick test made from the description of the problem. So, I can't really comment on the solution and an automated database fix that the next beets version might do. I do feel urged to point out that the interaction between the `albumtype` and `albumtypes` fields is completely unclear to me.
