### PR TITLE
Add mypy to tox and CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,15 @@ jobs:
         run: |
           tox -vv -e py-cov
 
+      - name: Test latest Python version with tox and mypy
+        if: matrix.python-version == '3.10'
+        # continue-on-error is not ideal since it doesn't give a visible
+        # warning, but there doesn't seem to be anything better:
+        # https://github.com/actions/toolkit/issues/399
+        continue-on-error: true
+        run: |
+          tox -vv -e py-mypy
+
       - name: Test nightly Python version with tox
         if: matrix.python-version == '3.11-dev'
         # continue-on-error is not ideal since it doesn't give a visible

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+# FIXME: Would be better to actually type the libraries (if under our control),
+# or write our own stubs. For now, silence errors
+ignore_missing_imports = True
+

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,15 @@ setup(
             'flake8-docstrings',
             'pep8-naming',
         ],
+        'mypy': [
+            'mypy',
+            'types-Pillow',
+            'types-urllib3',
+            'types-beautifulsoup4',
+            'types-PyYAML',
+            'types-requests',
+            'types-Flask-Cors',
+        ],
 
         # Plugin (optional) dependencies:
         'absubmit': ['requests'],

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py38-{cov,lint}, docs
+envlist = py38-{cov,lint,mypy}, docs
 
 [_test]
 deps = .[test]
@@ -13,15 +13,23 @@ deps = .[test]
 deps = .[lint]
 files = beets beetsplug beet test setup.py docs
 
+[_mypy]
+deps =
+    .[mypy]
+    .[test]
+
 [testenv]
 deps =
     {test,cov}: {[_test]deps}
     lint: {[_lint]deps}
+    mypy: {[_mypy]deps}
 passenv = INTEGRATION_TEST
 commands =
     test: python -bb -m pytest -rs {posargs}
     cov: coverage run -m pytest -rs {posargs}
     lint: python -m flake8 {posargs} {[_lint]files}
+    mypy: mypy -p beets -p beetsplug
+    mypy: mypy test
 
 [testenv:docs]
 basepython = python3.10


### PR DESCRIPTION
Add mypy to tox and CI configurations, and add a few type stubs to the dependencies. This allows failures, similar to the nightly Python tests. Unsurprisingly, mypy does fail currently.

cf. https://github.com/beetbox/beets/pull/4495#issuecomment-1356458837