### PR TITLE
Remove Musixmatch from default enabled sources

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -743,7 +743,9 @@ class LyricsPlugin(plugins.BeetsPlugin):
             'fallback': None,
             'force': False,
             'local': False,
-            'sources': self.SOURCES,
+            # Musixmatch is disabled by default as they are currently blocking
+            # requests with the beets user agent.
+            'sources': [s for s in self.SOURCES if s != "musixmatch"],
             'dist_thresh': 0.1,
         })
         self.config['bing_client_secret'].redact = True

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -129,11 +129,14 @@ For packagers:
   :bug:`4167`
 * The minimum required version of :pypi:`mediafile` is now 0.9.0.
 
-Other new things:
+Other changes:
 
 * :doc:`/plugins/limit`: Limit query results to head or tail (``lslimit``
   command only)
 * :doc:`/plugins/fish`: Add ``--output`` option.
+* :doc:`/plugins/lyrics`: Remove Musixmatch from default enabled sources as
+  they are currently blocking requests from the beets user agent.
+  :bug:`4585`
 
 1.6.0 (November 27, 2021)
 -------------------------

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -2,10 +2,9 @@ Lyrics Plugin
 =============
 
 The ``lyrics`` plugin fetches and stores song lyrics from databases on the Web.
-Namely, the current version of the plugin uses `Musixmatch`_, `Genius.com`_,
-`Tekstowo.pl`_, and, optionally, the Google custom search API.
+Namely, the current version of the plugin uses `Genius.com`_, `Tekstowo.pl`_,
+and, optionally, the Google custom search API.
 
-.. _Musixmatch: https://www.musixmatch.com/
 .. _Genius.com: https://genius.com/
 .. _Tekstowo.pl: https://www.tekstowo.pl/
 
@@ -59,9 +58,9 @@ configuration file. The available options are:
   sources known to be scrapeable.
 - **sources**: List of sources to search for lyrics. An asterisk ``*`` expands
   to all available sources.
-  Default: ``google musixmatch genius tekstowo``, i.e., all the
-  available sources. The ``google`` source will be automatically
-  deactivated if no ``google_API_key`` is setup.
+  Default: ``google genius tekstowo``, i.e., all the available sources. The
+  ``google`` source will be automatically deactivated if no ``google_API_key``
+  is setup.
   The ``google``, ``genius``, and ``tekstowo`` sources will only be enabled if
   BeautifulSoup is installed.
 
@@ -139,8 +138,7 @@ configuration option to your key.
 Then add ``google`` to the list of sources in your configuration (or use
 default list, which includes it as long as you have an API key).
 If you use default ``google_engine_ID``, we recommend limiting the sources to
-``musixmatch google`` as the other sources are already included in the Google
-results.
+``google`` as the other sources are already included in the Google results.
 
 .. _register for a Google API key: https://console.developers.google.com/
 


### PR DESCRIPTION
## Description

Musixmatch are currently blocking all requests with the beets user agent. This MR removes Musixmatch from the default enabled sources and documentation.

Fixes #4585.  <!-- Insert issue number here if applicable. -->

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
