### PR TITLE
Implement item_candidates for Discogs plugin

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -218,7 +218,8 @@ class DiscogsPlugin(BeetsPlugin):
             candidates += track_list
         for candidate in candidates:
             candidate.data_source = 'Discogs'
-        return candidates
+        # first 10 results, don't overwhelm with options
+        return candidates[:10] 
 
     def get_tracks_from_album(self, album_info):
         """Return a list of tracks in the release

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -214,27 +214,11 @@ class DiscogsPlugin(BeetsPlugin):
         candidates = []
         for album_cur in albums:
             self._log.debug(u'searching within album {0}', album_cur.album)
-            track_list = self.get_tracks_from_album(album_cur)
-            candidates += track_list
+            candidates += album_cur.tracks
         for candidate in candidates:
             candidate.data_source = 'Discogs'
         # first 10 results, don't overwhelm with options
-        return candidates[:10] 
-
-    def get_tracks_from_album(self, album_info):
-        """Return a list of tracks in the release
-        """
-        if not album_info:
-            return []
-
-        result = []
-        for track_info in album_info.tracks:
-            # attach artist info if not provided
-            if not track_info['artist']:
-                track_info['artist'] = album_info.artist
-                track_info['artist_id'] = album_info.artist_id
-            result.append(track_info)
-        return result
+        return candidates[:10]
 
     @staticmethod
     def extract_release_id_regex(album_id):
@@ -407,9 +391,13 @@ class DiscogsPlugin(BeetsPlugin):
         for track in tracks:
             track.media = media
             track.medium_total = mediums.count(track.medium)
+            # artist info will be identical for all tracks until #3353 fixed
+            track.artist = artist
+            track.artist_id = artist_id
             # Discogs does not have track IDs. Invent our own IDs as proposed
             # in #2336.
             track.track_id = str(album_id) + "-" + track.track_alt
+            track.data_url = data_url
 
         # Retrieve master release id (returns None if there isn't one).
         master_id = result.data.get('master_id')

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -195,6 +195,10 @@ class DiscogsPlugin(BeetsPlugin):
         if not self.discogs_client:
             return
 
+        if not artist and not title:
+            self._log.debug('Skipping Discogs query. File missing artist and '
+                            'title tags.')
+
         query = f'{artist} {title}'
         try:
             albums = self.get_albums(query)
@@ -212,12 +216,14 @@ class DiscogsPlugin(BeetsPlugin):
             self._log.debug(u'searching within album {0}', album_cur.album)
             track_list = self.get_tracks_from_album(album_cur)
             candidates += track_list
+        for candidate in candidates:
+            candidate.data_source = 'Discogs'
         return candidates
 
     def get_tracks_from_album(self, album_info):
         """Return a list of tracks in the release
         """
-        if not album_info: 
+        if not album_info:
             return []
 
         result = []

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -215,8 +215,6 @@ class DiscogsPlugin(BeetsPlugin):
         for album_cur in albums:
             self._log.debug(u'searching within album {0}', album_cur.album)
             candidates += album_cur.tracks
-        for candidate in candidates:
-            candidate.data_source = 'Discogs'
         # first 10 results, don't overwhelm with options
         return candidates[:10]
 
@@ -391,13 +389,15 @@ class DiscogsPlugin(BeetsPlugin):
         for track in tracks:
             track.media = media
             track.medium_total = mediums.count(track.medium)
-            # artist info will be identical for all tracks until #3353 fixed
-            track.artist = artist
-            track.artist_id = artist_id
+            if not track.artist:  # get_track_info often fails to find artist
+                track.artist = artist
+            if not track.artist_id:
+                track.artist_id = artist_id
             # Discogs does not have track IDs. Invent our own IDs as proposed
             # in #2336.
             track.track_id = str(album_id) + "-" + track.track_alt
             track.data_url = data_url
+            track.data_source = 'Discogs'
 
         # Retrieve master release id (returns None if there isn't one).
         master_id = result.data.get('master_id')

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -37,6 +37,7 @@ New features:
   ``=~``.
   :bug:`4251`
 * :doc:`/plugins/discogs`: Permit appending style to genre
+* :doc:`plugins/discogs`: Implement item_candidates for matching singletons
 * :doc:`/plugins/convert`: Add a new `auto_keep` option that automatically
   converts files but keeps the *originals* in the library.
   :bug:`1840` :bug:`4302`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -36,8 +36,8 @@ New features:
 * Add :ref:`exact match <exact-match>` queries, using the prefixes ``=`` and
   ``=~``.
   :bug:`4251`
-* :doc:`/plugins/discogs`: Permit appending style to genre
-* :doc:`plugins/discogs`: Implement item_candidates for matching singletons
+* :doc:`/plugins/discogs`: Permit appending style to genre.
+* :doc:`plugins/discogs`: Implement item_candidates for matching singletons.
 * :doc:`/plugins/convert`: Add a new `auto_keep` option that automatically
   converts files but keeps the *originals* in the library.
   :bug:`1840` :bug:`4302`

--- a/docs/plugins/discogs.rst
+++ b/docs/plugins/discogs.rst
@@ -2,8 +2,7 @@ Discogs Plugin
 ==============
 
 The ``discogs`` plugin extends the autotagger's search capabilities to
-include matches from the `Discogs`_ database when importing albums.
-(The plugin does not yet support matching singleton tracks.)
+include matches from the `Discogs`_ database.
 
 .. _Discogs: https://discogs.com
 
@@ -100,8 +99,7 @@ Here are two things you can try:
 * Make sure that your system clock is accurate. The Discogs servers can reject
   your request if your clock is too out of sync.
 
-The plugin can only match albums, so no Discogs matches will be
-reported when importing singletons using ``-s``. One possible
-workaround is to use the ``--group-albums`` option.
+Support for matching singleton tracks using ``-s`` is in progress.
+If this is not working well, try the ``--group-albums`` option in album import mode.
 
 .. _python3-discogs-client: https://github.com/joalla/discogs_client

--- a/docs/plugins/discogs.rst
+++ b/docs/plugins/discogs.rst
@@ -99,7 +99,7 @@ Here are two things you can try:
 * Make sure that your system clock is accurate. The Discogs servers can reject
   your request if your clock is too out of sync.
 
-Support for matching singleton tracks using ``-s`` is in progress.
-If this is not working well, try the ``--group-albums`` option in album import mode.
+Matching tracks by Discogs ID is not yet supported. The ``--group-albums``
+option in album import mode provides an alternative to singleton mode for autotagging tracks that are not in album-related folders.
 
 .. _python3-discogs-client: https://github.com/joalla/discogs_client


### PR DESCRIPTION
## Description

Implements `item_candidates` for the Discogs plugin, which begins to address #2544 and #3574.
Continues staled PR #3682 by implementing a subset of its provided features as requested by @sampsyo.

**Major change from  #3682**: no longer using string distance to narrow matches before returning candidates. This additional narrowing seems reasonable but it slowed down `item_candidates` (though marginally compared to the API call) and more importantly used a string match tolerance that users had no obvious way to control as far as I could tell. It seems preferable for as much pruning/matching to happen in a single unified function which would take all candidates returned by `item_candidates` as input; hardcoded matching in a separate function could result in harder to control and debug behavior.

**Known fragility**: results can be quite sensitive to the Discogs query, which is of the form  of string `<artist> <track>`, for example a difference of a single word in only the title can result in no results. In general this behavior seems to be known and documented in a few places, but I figured I'd mention it.

```
Ameega Funkysize My Baby  // wrong title, no results
Ameega Funkysize Now Baby // correct artist and title, query finds proper album
```

Querying only `<artist>` then using the first few album results performed significantly worse empirically, so `<artist> <track>` was used as the query usually returns the exact album containing the track if all data is correct.

## To Do

I will address these To Dos, but would like some feedback on the first draft first if possible.
@JOJ0 If you can give any feedback that would be great! One thing I'm currently worried about is testing. I run `tox`, but it doesn't take that long (about 10 seconds), and many things seem to be skipping. My best guess is that my version of Python (3.9.9) is too new, so maybe I'll have to set up an environment with 3.8 and `beets`, but for now I'm posting the code it can be discussed and tested via CI.

- [x] Documentation.
- [x] Changelog.
- [x] Tests.
