### PR TITLE
[fetchart] Add retry with exponential backoff

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -141,7 +141,9 @@ New features:
   plugin which allows to replace fields based on a given library query.
 
 Bug fixes:
-
+* :doc:`/plugins/fetchart`: Add retry with exponential backoff to all requests to
+  work around iTunes rate limiting.
+  :bug:`3827`
 * :doc:`/plugins/scrub`: Fixed the import behavior where scrubbed database tags
   were restored to newly imported tracks with config settings ``scrub.auto: yes``
   and ``import.write: no``.


### PR DESCRIPTION
## Description

The iTunes source returns 403 as a basic form of rate limiting. To get around this, we add a retry with exponential backoff to all requests made by `_logged_get()`. We also include some other generic error codes to retry.

Fixes #3827, which was closed with no fix. Without this change, two different runs of `beet fetchart -f` will download different sets of album art because the iTunes has art available but will fail some requests with 403.

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
