### PR TITLE
Configure `sphinx_rtd_theme`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,8 @@ Changelog goes here!
 
 New features:
 
+* Recolor the Sphinx documentation header to use the Beets' logo color
+* Configure Sphinx so that it uses ``sphinx_rtd_theme`` locally
 * We now import the remixer field from Musicbrainz into the library.
   :bug:`4428`
 * :doc:`/plugins/mbsubmit`: Added a new `mbsubmit` command to print track information to be submitted to MusicBrainz after initial import.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,7 @@ linkcheck_ignore = [
 ]
 
 # Options for HTML output
+html_theme = 'sphinx_rtd_theme'
 htmlhelp_basename = 'beetsdoc'
 
 # Options for LaTeX output

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,9 @@ linkcheck_ignore = [
 
 # Options for HTML output
 html_theme = 'sphinx_rtd_theme'
+html_theme_options = {
+    "style_nav_header_background": "#a23632",
+}
 htmlhelp_basename = 'beetsdoc'
 
 # Options for LaTeX output


### PR DESCRIPTION
## Description

This PR makes the documentation build locally with `sphinx_rtd_theme` instead of the default theme, matching [how the documentation is displayed on Read the Docs](https://beets.readthedocs.io/en/stable/).

Additionally, this configures the theme to use the Beets logo color as the background of the nav header, customizing the documentation page for the project.

![A screenshot of the locally built docs after the changes. The page now uses `sphinx_rtd_theme`. The background of the header containing the project's name and the searc bar is dark red.](https://user-images.githubusercontent.com/1540885/213697146-b1d10c7e-2a20-42ce-91b7-b927c6f27363.png "A screenshot of the locally built docs after the changes. The page now uses `sphinx_rtd_theme`. The background of the header containing the project's name and the searc bar is dark red.")

## To Do

- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
