### PR TITLE
Use definition lists with the plugins' names in the documentation

### DIFF
--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -132,13 +132,21 @@ following to your configuration::
 Autotagger Extensions
 ---------------------
 
-* :doc:`chroma`: Use acoustic fingerprinting to identify audio files with
-  missing or incorrect metadata.
-* :doc:`discogs`: Search for releases in the `Discogs`_ database.
-* :doc:`spotify`: Search for releases in the `Spotify`_ database.
-* :doc:`deezer`: Search for releases in the `Deezer`_ database.
-* :doc:`fromfilename`: Guess metadata for untagged tracks from their
-  filenames.
+:doc:`chroma <chroma>`
+   Use acoustic fingerprinting to identify audio files with
+   missing or incorrect metadata.
+
+:doc:`discogs <discogs>`
+  Search for releases in the `Discogs`_ database.
+
+:doc:`spotify <spotify>`
+   Search for releases in the `Spotify`_ database.
+
+:doc:`deezer <deezer>`
+   Search for releases in the `Deezer`_ database.
+
+:doc:`fromfilename <fromfilename>`
+   Guess metadata for untagged tracks from their filenames.
 
 .. _Discogs: https://www.discogs.com/
 .. _Spotify: https://www.spotify.com
@@ -147,30 +155,69 @@ Autotagger Extensions
 Metadata
 --------
 
-* :doc:`absubmit`: Analyse audio with the `streaming_extractor_music`_ program and submit the metadata to the AcousticBrainz server
-* :doc:`acousticbrainz`: Fetch various AcousticBrainz metadata
-* :doc:`bpm`: Measure tempo using keystrokes.
-* :doc:`bpsync`: Fetch updated metadata from Beatport.
-* :doc:`edit`: Edit metadata from a text editor.
-* :doc:`embedart`: Embed album art images into files' metadata.
-* :doc:`fetchart`: Fetch album cover art from various sources.
-* :doc:`ftintitle`: Move "featured" artists from the artist field to the title
-  field.
-* :doc:`keyfinder`: Use the `KeyFinder`_ program to detect the musical
+:doc:`absubmit <absubmit>`
+   Analyse audio with the `streaming_extractor_music`_ program and submit the metadata to the AcousticBrainz server
+
+:doc:`acousticbrainz <acousticbrainz>`
+   Fetch various AcousticBrainz metadata
+
+:doc:`bpm <bpm>`
+   Measure tempo using keystrokes.
+
+:doc:`bpsync <bpsync>`
+   Fetch updated metadata from Beatport.
+
+:doc:`edit <edit>`
+   Edit metadata from a text editor.
+
+:doc:`embedart <embedart>`
+   Embed album art images into files' metadata.
+
+:doc:`fetchart <fetchart>`
+   Fetch album cover art from various sources.
+
+:doc:`ftintitle <ftintitle>`
+   Move "featured" artists from the artist field to the title
+   field.
+
+:doc:`keyfinder <keyfinder>`
+   Use the `KeyFinder`_ program to detect the musical
   key from the audio.
-* :doc:`importadded`: Use file modification times for guessing the value for
-  the `added` field in the database.
-* :doc:`lastgenre`: Fetch genres based on Last.fm tags.
-* :doc:`lastimport`: Collect play counts from Last.fm.
-* :doc:`lyrics`: Automatically fetch song lyrics.
-* :doc:`mbsync`: Fetch updated metadata from MusicBrainz.
-* :doc:`metasync`: Fetch metadata from local or remote sources
-* :doc:`mpdstats`: Connect to `MPD`_ and update the beets library with play
-  statistics (last_played, play_count, skip_count, rating).
-* :doc:`parentwork`: Fetch work titles and works they are part of.
-* :doc:`replaygain`: Calculate volume normalization for players that support it.
-* :doc:`scrub`: Clean extraneous metadata from music files.
-* :doc:`zero`: Nullify fields by pattern or unconditionally.
+
+:doc:`importadded <importadded>`
+   Use file modification times for guessing the value for
+   the `added` field in the database.
+
+:doc:`lastgenre <lastgenre>`
+   Fetch genres based on Last.fm tags.
+
+:doc:`lastimport <lastimport>`
+   Collect play counts from Last.fm.
+
+:doc:`lyrics <lyrics>`
+   Automatically fetch song lyrics.
+
+:doc:`mbsync <mbsync>`
+   Fetch updated metadata from MusicBrainz.
+
+:doc:`metasync <metasync>`
+   Fetch metadata from local or remote sources
+
+:doc:`mpdstats <mpdstats>`
+   Connect to `MPD`_ and update the beets library with play
+   statistics (last_played, play_count, skip_count, rating).
+
+:doc:`parentwork <parentwork>`
+   Fetch work titles and works they are part of.
+
+:doc:`replaygain <replaygain>`
+   Calculate volume normalization for players that support it.
+
+:doc:`scrub <scrub>`
+   Clean extraneous metadata from music files.
+
+:doc:`zero <zero>`
+   Nullify fields by pattern or unconditionally.
 
 .. _KeyFinder: http://www.ibrahimshaath.co.uk/keyfinder/
 .. _streaming_extractor_music: https://acousticbrainz.org/download
@@ -178,37 +225,75 @@ Metadata
 Path Formats
 ------------
 
-* :doc:`albumtypes`: Format album type in path formats.
-* :doc:`bucket`: Group your files into bucket directories that cover different
-  field values ranges.
-* :doc:`inline`: Use Python snippets to customize path format strings.
-* :doc:`rewrite`: Substitute values in path formats.
-* :doc:`the`: Move patterns in path formats (i.e., move "a" and "the" to the
-  end).
+:doc:`albumtypes <albumtypes>`
+   Format album type in path formats.
+
+:doc:`bucket <bucket>`
+   Group your files into bucket directories that cover different
+   field values ranges.
+
+:doc:`inline <inline>`
+   Use Python snippets to customize path format strings.
+
+:doc:`rewrite <rewrite>`
+   Substitute values in path formats.
+
+:doc:`the <the>`
+   Move patterns in path formats (i.e., move "a" and "the" to the
+   end).
 
 Interoperability
 ----------------
 
-* :doc:`aura`: A server implementation of the `AURA`_ specification.
-* :doc:`badfiles`: Check audio file integrity.
-* :doc:`embyupdate`: Automatically notifies `Emby`_ whenever the beets library changes.
-* :doc:`fish`: Adds `Fish shell`_ tab autocompletion to ``beet`` commands.
-* :doc:`importfeeds`: Keep track of imported files via ``.m3u`` playlist file(s) or symlinks.
-* :doc:`ipfs`: Import libraries from friends and get albums from them via ipfs.
-* :doc:`kodiupdate`: Automatically notifies `Kodi`_ whenever the beets library
-  changes.
-* :doc:`mpdupdate`: Automatically notifies `MPD`_ whenever the beets library
-  changes.
-* :doc:`play`: Play beets queries in your music player.
-* :doc:`playlist`: Use M3U playlists to query the beets library.
-* :doc:`plexupdate`: Automatically notifies `Plex`_ whenever the beets library
-  changes.
-* :doc:`smartplaylist`: Generate smart playlists based on beets queries.
-* :doc:`sonosupdate`: Automatically notifies `Sonos`_ whenever the beets library
-  changes.
-* :doc:`thumbnails`: Get thumbnails with the cover art on your album folders.
-* :doc:`subsonicupdate`: Automatically notifies `Subsonic`_ whenever the beets
-  library changes.
+:doc:`aura <aura>`
+   A server implementation of the `AURA`_ specification.
+
+:doc:`badfiles <badfiles>`
+   Check audio file integrity.
+
+:doc:`embyupdate <embyupdate>`
+   Automatically notifies `Emby`_ whenever the beets library changes.
+
+:doc:`fish <fish>`
+   Adds `Fish shell`_ tab autocompletion to ``beet`` commands.
+
+:doc:`importfeeds <importfeeds>`
+   Keep track of imported files via ``.m3u`` playlist file(s) or symlinks.
+
+:doc:`ipfs <ipfs>`
+   Import libraries from friends and get albums from them via ipfs.
+
+:doc:`kodiupdate <kodiupdate>`
+   Automatically notifies `Kodi`_ whenever the beets library
+   changes.
+
+:doc:`mpdupdate <mpdupdate>`
+   Automatically notifies `MPD`_ whenever the beets library
+   changes.
+
+:doc:`play <play>`
+   Play beets queries in your music player.
+
+:doc:`playlist <playlist>`
+   Use M3U playlists to query the beets library.
+
+:doc:`plexupdate <plexupdate>`
+   Automatically notifies `Plex`_ whenever the beets library
+   changes.
+
+:doc:`smartplaylist <smartplaylist>`
+   Generate smart playlists based on beets queries.
+
+:doc:`sonosupdate <sonosupdate>`
+   Automatically notifies `Sonos`_ whenever the beets library
+   changes.
+
+:doc:`thumbnails <thumbnails>`
+   Get thumbnails with the cover art on your album folders.
+
+:doc:`subsonicupdate <subsonicupdate>`
+   Automatically notifies `Subsonic`_ whenever the beets
+   library changes.
 
 
 .. _AURA: https://auraspec.readthedocs.io
@@ -222,28 +307,65 @@ Interoperability
 Miscellaneous
 -------------
 
-* :doc:`bareasc`: Search albums and tracks with bare ASCII string matching.
-* :doc:`bpd`: A music player for your beets library that emulates `MPD`_ and is
-  compatible with `MPD clients`_.
-* :doc:`convert`: Transcode music and embed album art while exporting to
-  a different directory.
-* :doc:`duplicates`: List duplicate tracks or albums.
-* :doc:`export`: Export data from queries to a format.
-* :doc:`filefilter`: Automatically skip files during the import process based
-  on regular expressions.
-* :doc:`fuzzy`: Search albums and tracks with fuzzy string matching.
-* :doc:`hook`: Run a command when an event is emitted by beets.
-* :doc:`ihate`: Automatically skip albums and tracks during the import process.
-* :doc:`info`: Print music files' tags to the console.
-* :doc:`loadext`: Load SQLite extensions.
-* :doc:`mbcollection`: Maintain your MusicBrainz collection list.
-* :doc:`mbsubmit`: Print an album's tracks in a MusicBrainz-friendly format.
-* :doc:`missing`: List missing tracks.
-* `mstream`_: A music streaming server + webapp that can be used alongside beets.
-* :doc:`random`: Randomly choose albums and tracks from your library.
-* :doc:`spotify`: Create Spotify playlists from the Beets library.
-* :doc:`types`: Declare types for flexible attributes.
-* :doc:`web`: An experimental Web-based GUI for beets.
+:doc:`bareasc <bareasc>`
+   Search albums and tracks with bare ASCII string matching.
+
+:doc:`bpd <bpd>`
+   A music player for your beets library that emulates `MPD`_ and is
+   compatible with `MPD clients`_.
+
+:doc:`convert <convert>`
+   Transcode music and embed album art while exporting to
+   a different directory.
+
+:doc:`duplicates <duplicates>`
+   List duplicate tracks or albums.
+
+:doc:`export <export>`
+   Export data from queries to a format.
+
+:doc:`filefilter <filefilter>`
+   Automatically skip files during the import process based
+   on regular expressions.
+
+:doc:`fuzzy <fuzzy>`
+   Search albums and tracks with fuzzy string matching.
+
+:doc:`hook <hook>`
+   Run a command when an event is emitted by beets.
+
+:doc:`ihate <ihate>`
+   Automatically skip albums and tracks during the import process.
+
+:doc:`info <info>`
+   Print music files' tags to the console.
+
+:doc:`loadext <loadext>`
+   Load SQLite extensions.
+
+:doc:`mbcollection <mbcollection>`
+   Maintain your MusicBrainz collection list.
+
+:doc:`mbsubmit <mbsubmit>`
+   Print an album's tracks in a MusicBrainz-friendly format.
+
+:doc:`missing <missing>`
+   List missing tracks.
+
+`mstream`_
+   A music streaming server + webapp that can be used alongside beets.
+
+:doc:`random <random>`
+   Randomly choose albums and tracks from your library.
+
+:doc:`spotify <spotify>`
+   Create Spotify playlists from the Beets library.
+
+:doc:`types <types>`
+   Declare types for flexible attributes.
+
+:doc:`web <web>`
+   An experimental Web-based GUI for beets.
 
 .. _MPD: https://www.musicpd.org/
 .. _MPD clients: https://mpd.wikia.com/wiki/Clients
@@ -270,76 +392,106 @@ line in your config file.
 
 Here are a few of the plugins written by the beets community:
 
-* `beets-alternatives`_ manages external files.
+`beets-alternatives`_
+   Manages external files.
 
-* `beet-amazon`_ adds Amazon.com as a tagger data source.
+`beet-amazon`_
+   Adds Amazon.com as a tagger data source.
 
-* `beets-artistcountry`_ fetches the artist's country of origin from
-  MusicBrainz.
+`beets-artistcountry`_
+   Fetches the artist's country of origin from MusicBrainz.
 
-* `beets-autofix`_ automates repetitive tasks to keep your library in order.
+`beets-autofix`_
+   Automates repetitive tasks to keep your library in order.
 
-* `beets-audible`_ adds Audible as a tagger data source and provides 
-  other features for managing audiobook collections.
+`beets-audible`_
+   Adds Audible as a tagger data source and provides
+   other features for managing audiobook collections.
 
-* `beets-barcode`_ lets you scan or enter barcodes for physical media to
-  search for their metadata.
+`beets-barcode`_
+   Lets you scan or enter barcodes for physical media to
+   search for their metadata.
 
-* `beetcamp`_ enables **bandcamp.com** autotagger with a fairly extensive amount of metadata.
+`beetcamp`_
+   Enables **bandcamp.com** autotagger with a fairly extensive amount of metadata.
 
-* `beetstream`_ is server implementation of the `SubSonic API`_ specification, allowing you to stream your music on a multitude of clients.
+`beetstream`_
+   Is server implementation of the `SubSonic API`_ specification, allowing you to stream your music on a multitude of clients.
 
-* `beets-bpmanalyser`_ analyses songs and calculates their tempo (BPM).
+`beets-bpmanalyser`_
+   Analyses songs and calculates their tempo (BPM).
 
-* `beets-check`_ automatically checksums your files to detect corruption.
+`beets-check`_
+   Automatically checksums your files to detect corruption.
 
-* `A cmus plugin`_ integrates with the `cmus`_ console music player.
+`A cmus plugin`_
+   Integrates with the `cmus`_ console music player.
 
-* `beets-copyartifacts`_ helps bring non-music files along during import.
+`beets-copyartifacts`_
+   Helps bring non-music files along during import.
 
-* `beets-describe`_ gives you the full picture of a single attribute of your library items.
+`beets-describe`_
+   Gives you the full picture of a single attribute of your library items.
 
-* `drop2beets`_ automatically imports singles as soon as they are dropped in a
-  folder (using Linux's ``inotify``). You can also set a sub-folders
-  hierarchy to set flexible attributes by the way.
+`drop2beets`_
+   Automatically imports singles as soon as they are dropped in a
+   folder (using Linux's ``inotify``). You can also set a sub-folders
+   hierarchy to set flexible attributes by the way.
 
-* `dsedivec`_ has two plugins: ``edit`` and ``moveall``.
+`dsedivec`_
+   Has two plugins: ``edit`` and ``moveall``.
 
-* `beets-follow`_ lets you check for new albums from artists you like.
+`beets-follow`_
+   Lets you check for new albums from artists you like.
 
-* `beetFs`_ is a FUSE filesystem for browsing the music in your beets library.
-  (Might be out of date.)
+`beetFs`_
+   Is a FUSE filesystem for browsing the music in your beets library.
+   (Might be out of date.)
 
-* `beets-goingrunning`_ generates playlists to go with your running sessions.
+`beets-goingrunning`_
+   Generates playlists to go with your running sessions.
 
-* `beets-ibroadcast`_ uploads tracks to the `iBroadcast`_ cloud service.
+`beets-ibroadcast`_
+   Uploads tracks to the `iBroadcast`_ cloud service.
 
-* `beets-importreplace`_ lets you perform regex replacements on incoming
-  metadata.
+`beets-importreplace`_
+   Lets you perform regex replacements on incoming
+   metadata.
 
-* `beets-mosaic`_ generates a montage of a mosaic from cover art.
+`beets-mosaic`_
+   Generates a montage of a mosaic from cover art.
 
-* `beets-noimport`_ adds and removes directories from the incremental import skip list.
+`beets-noimport`_
+   Adds and removes directories from the incremental import skip list.
 
-* `beets-originquery`_ augments MusicBrainz queries with locally-sourced data
-  to improve autotagger results.
+`beets-originquery`_
+   Augments MusicBrainz queries with locally-sourced data
+   to improve autotagger results.
 
-* `beets-popularity`_ fetches popularity values from Deezer.
+`beets-popularity`_
+   Fetches popularity values from Deezer.
 
-* `beets-setlister`_ generate playlists from the setlists of a given artist.
+`beets-setlister`_
+   Generate playlists from the setlists of a given artist.
 
-* `beet-summarize`_ can compute lots of counts and statistics about your music
-  library.
+`beet-summarize`_
+   Can compute lots of counts and statistics about your music
+   library.
 
-* `beets-usertag`_ lets you use keywords to tag and organize your music.
+`beets-usertag`_
+   Lets you use keywords to tag and organize your music.
 
-* `whatlastgenre`_ fetches genres from various music sites.
+`whatlastgenre`_
+   Fetches genres from various music sites.
 
-* `beets-xtractor`_ extracts low- and high-level musical information from your songs.
+`beets-xtractor`_
+   Extracts low- and high-level musical information from your songs.
 
-* `beets-ydl`_ downloads audio from youtube-dl sources and import into beets.
+`beets-ydl`_
+   Downloads audio from youtube-dl sources and import into beets.
 
-* `beets-yearfixer`_ attempts to fix all missing ``original_year`` and ``year`` fields.
+`beets-yearfixer`_
+   Attempts to fix all missing ``original_year`` and ``year`` fields.
 
 .. _beets-barcode: https://github.com/8h2a/beets-barcode
 .. _beetcamp: https://github.com/snejus/beetcamp

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -182,7 +182,7 @@ Metadata
 
 :doc:`keyfinder <keyfinder>`
    Use the `KeyFinder`_ program to detect the musical
-  key from the audio.
+   key from the audio.
 
 :doc:`importadded <importadded>`
    Use file modification times for guessing the value for


### PR DESCRIPTION
## Description

This PR changes the list of plugins in the documentation:

* it converts the *unordered lists* of plugins into *definition lists*, more appropriate for this kind of listing
* it changes the terms of the lists from the documentation page name to the relative plugin's id, allowing easier search when the exact plugin name is known

## To Do

_None of the checkboxes seems applicable to this pull request._
