### PR TITLE
config.rst: Remove extraneous for

### DIFF
--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -135,7 +135,7 @@ unexpected behavior on all popular platforms::
 
 These substitutions remove forward and back slashes, leading dots, and
 control characters—all of which is a good idea on any OS. The fourth line
-removes the Windows "reserved characters" (useful even on Unix for for
+removes the Windows "reserved characters" (useful even on Unix for
 compatibility with Windows-influenced network filesystems like Samba).
 Trailing dots and trailing whitespace, which can cause problems on Windows
 clients, are also removed.


### PR DESCRIPTION
## Description

This fixes a simple grammatical error in config.rst. I'm not sure if a changelog entry is needed here, so I didn't add it.
 
## To Do

- [] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
