### PR TITLE
Add wave to lossless formats

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -41,7 +41,7 @@ ALIASES = {
     'vorbis': 'ogg',
 }
 
-LOSSLESS_FORMATS = ['ape', 'flac', 'alac', 'wav', 'aiff']
+LOSSLESS_FORMATS = ['ape', 'flac', 'alac', 'wav', 'wave', 'aiff']
 
 
 def replace_ext(path, ext):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -52,6 +52,7 @@ New features:
 * :doc:`/plugins/fromfilename`:  Add debug log messages that inform when the
   plugin replaced bad (missing) artist, title or tracknumber metadata.
   :bug:`4561` :bug:`4600`
+* :doc:`/plugins/convert`: Add ``wave`` to the list of lossless formats.
 
 Bug fixes:
 


### PR DESCRIPTION
## Description

My `.wav` files were reported as `wave`-formatted files, this change adds them to the lossless files list.

I left 'wav' in there in case some systems *do* refer to this format in this way.

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
