### PR TITLE
Fix album store method to cascade flex field deletions to items

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -1360,7 +1360,7 @@ class Album(LibModel):
             if key in self.item_keys:
                 track_updates[key] = self[key]
             elif key not in self:
-                track_deletes.add(key);
+                track_deletes.add(key)
 
         with self._db.transaction():
             super().store(fields)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -133,6 +133,8 @@ Bug fixes:
 * :doc:`/plugins/fromfilename`: Fix failed detection of <track> <title>
   filename patterns.
   :bug:`4561` :bug:`4600`
+* Fix issue where deletion of flexible fields on an album doesn't cascade to items
+  :bug:`4662`
 
 For packagers:
 

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -77,6 +77,19 @@ class StoreTest(_common.LibTestCase):
         self.i.store()
         self.assertTrue('composer' not in self.i._dirty)
 
+    def test_store_album_cascades_flex_deletes(self):
+        album = _common.album()
+        album.flex1="Flex-1"
+        self.lib.add(album)
+        item = _common.item()
+        item.album_id = album.id
+        item.flex1="Flex-1"
+        self.lib.add(item)
+        del album.flex1
+        album.store()
+        self.assertNotIn('flex1', album)
+        self.assertNotIn('flex1', album.items()[0])
+
 
 class AddTest(_common.TestCase):
     def setUp(self):

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -79,11 +79,11 @@ class StoreTest(_common.LibTestCase):
 
     def test_store_album_cascades_flex_deletes(self):
         album = _common.album()
-        album.flex1="Flex-1"
+        album.flex1 = "Flex-1"
         self.lib.add(album)
         item = _common.item()
         item.album_id = album.id
-        item.flex1="Flex-1"
+        item.flex1 = "Flex-1"
         self.lib.add(item)
         del album.flex1
         album.store()


### PR DESCRIPTION
## Description

Fixes #4662.

## To Do

- [ ] N/A ~Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)~
- [X] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [X] Tests. (Encouraged but not strictly required.)
