### PR TITLE
Fix cover art archive fetching

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -367,7 +367,7 @@ class CoverArtArchive(RemoteArtSource):
         ID.
         """
 
-        def get_image_urls(url, size_suffix=None):
+        def get_image_urls(url, preferred_width=None):
             try:
                 response = self.request(url)
             except requests.RequestException:
@@ -387,8 +387,8 @@ class CoverArtArchive(RemoteArtSource):
                     if 'Front' not in item['types']:
                         continue
 
-                    if size_suffix:
-                        yield item['thumbnails'][size_suffix]
+                    if preferred_width:
+                        yield item['thumbnails'][preferred_width]
                     else:
                         yield item['image']
                 except KeyError:
@@ -401,12 +401,12 @@ class CoverArtArchive(RemoteArtSource):
         # If the maxwidth config matches one of the already available sizes
         # fetch it directly intead of fetching the full sized image and
         # resizing it.
-        size_suffix = None
+        preferred_width = None
         if plugin.maxwidth in self.VALID_THUMBNAIL_SIZES:
-            size_suffix = "-" + str(plugin.maxwidth)
+            preferred_width = str(plugin.maxwidth)
 
         if 'release' in self.match_by and album.mb_albumid:
-            for url in get_image_urls(release_url, size_suffix):
+            for url in get_image_urls(release_url, preferred_width):
                 yield self._candidate(url=url, match=Candidate.MATCH_EXACT)
 
         if 'releasegroup' in self.match_by and album.mb_releasegroupid:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -60,6 +60,8 @@ New features:
 
 Bug fixes:
 
+* :doc:`/plugins/fetchart`: Fix fetching from Cover Art Archive when the
+  `maxwidth` option is set to one of the supported Cover Art Archive widths.
 * :doc:`/plugins/discogs`: Fix "Discogs plugin replacing Feat. or Ft. with
   a comma" by fixing an oversight that removed a functionality from the code
   base when the MetadataSourcePlugin abstract class was introduced in PR's


### PR DESCRIPTION
## Description

PR #3748 changed the way cover art is fetched from the cover art archive, but the manual addition of a `-` to the width suffix that was needed when the image URI was being constructed manually was not removed. Because of this the plugin would try to look up the property under `thumbnails` that didn't exist (for example `-1200` instead of `1200`), which would fail.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
