### PR TITLE
Docs: Add a link to the walkthrough from the main tutorial guide

### DIFF
--- a/docs/guides/main.rst
+++ b/docs/guides/main.rst
@@ -298,9 +298,9 @@ You can always get help using the ``beet help`` command. The plain ``beet help``
 command lists all the available commands; then, for example, ``beet help
 import`` gives more specific help about the ``import`` command.
 
-Please let me know what you think of beets via `the discussion board`_ or
-`Twitter`_.
+Please let us know what you think of beets via `the discussion board`_ or
+`Mastodon`_.
 
 .. _the mailing list: https://groups.google.com/group/beets-users
-.. _the discussion board: https://discourse.beets.io
-.. _twitter: https://twitter.com/b33ts
+.. _the discussion board: https://github.com/beetbox/beets/discussions
+.. _mastodon: https://fosstodon.org/@beets

--- a/docs/guides/main.rst
+++ b/docs/guides/main.rst
@@ -298,6 +298,9 @@ You can always get help using the ``beet help`` command. The plain ``beet help``
 command lists all the available commands; then, for example, ``beet help
 import`` gives more specific help about the ``import`` command.
 
+If you need more of a walkthrough, you can read an illustrated one `on the
+beets blog <https://beets.io/blog/walkthrough.html>`_.
+
 Please let us know what you think of beets via `the discussion board`_ or
 `Mastodon`_.
 


### PR DESCRIPTION
Supersedes #4382, with a somewhat simpler set of context around the link. Also fixes a link to Twitter (we're on Mastodon now).