### PR TITLE
Allow prefix behavior to depend on the field's type

### DIFF
--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -262,8 +262,8 @@ class BytesQuery(MatchQuery):
     `MatchQuery` when matching on BLOB values.
     """
 
-    def __init__(self, field, pattern):
-        super().__init__(field, pattern)
+    def __init__(self, field, pattern, fast=True):
+        super().__init__(field, pattern, fast)
 
         # Use a buffer/memoryview representation of the pattern for SQLite
         # matching. This instructs SQLite to treat the blob as binary

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -90,8 +90,16 @@ def parse_query_part(part, query_classes={}, prefixes={},
 
     # Check whether there's a prefix in the query and use the
     # corresponding query type.
-    for pre, query_class in prefixes.items():
+    for pre, config in prefixes.items():
         if term.startswith(pre):
+            if (isinstance(config, type) and issubclass(config, query.Query)):
+                # The query class for prefix is specified as a single class.
+                query_class = config
+            else:
+                # The query class for prefix depends on the key's non-prefixed
+                # query class. A default class may be provided via defaultdict.
+                non_prefixed_class = query_classes.get(key, default_class)
+                query_class = config[non_prefixed_class]
             return key, term[len(pre):], query_class, negate
 
     # No matching prefix, so use either the query class determined by

--- a/beets/library.py
+++ b/beets/library.py
@@ -22,6 +22,7 @@ import time
 import re
 import string
 import shlex
+from collections import defaultdict
 
 from beets import logging
 from mediafile import MediaFile, UnreadableFileError
@@ -1405,7 +1406,9 @@ def parse_query_parts(parts, model_cls):
     prefixes = {
         ':': dbcore.query.RegexpQuery,
         '=~': dbcore.query.StringQuery,
-        '=': dbcore.query.MatchQuery,
+        '=': defaultdict(lambda: dbcore.query.MatchQuery, {
+            PathQuery: dbcore.query.BytesQuery,
+        }),
     }
     prefixes.update(plugins.queries())
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,13 +32,14 @@ New features:
 * :doc:`/plugins/kodiupdate`: Now supports multiple kodi instances
   :bug:`4101`
 * Add the item fields ``bitrate_mode``, ``encoder_info`` and ``encoder_settings``.
-* Add query prefixes ``=`` and ``~``.
 * A new configuration option, :ref:`duplicate_keys`, lets you change which
   fields the beets importer uses to identify duplicates.
   :bug:`1133` :bug:`4199`
 * Add :ref:`exact match <exact-match>` queries, using the prefixes ``=`` and
   ``=~``.
   :bug:`4251`
+* Allow the Query type for a prefix to depend on its key's non-prefixed Query
+  type via a lookup table.
 * :doc:`/plugins/discogs`: Permit appending style to genre.
 * :doc:`plugins/discogs`: Implement item_candidates for matching singletons.
 * :doc:`/plugins/convert`: Add a new `auto_keep` option that automatically

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -507,6 +507,27 @@ plugin will be used if we issue a command like ``beet ls @something`` or
                 '@': ExactMatchQuery
             }
 
+If the behavior of your query prefix depends on the type of the field being
+searched, you may assign a prefix string to a dictionary instead of a single
+Query class. That dictionary should map the un-prefixed query class for each
+supported field to the query classes your prefix should use; a default Query
+class can be specified with a defaultdict::
+
+    from collections import defaultdict
+    from beets.dbcore import query
+    from beets import library
+
+    class PathSafeExactMatchPlugin(BeetsPlugin):
+        def queries(self):
+            return {
+                '@': defaultdict(lambda: ExactMatchQuery, {
+                    library.PathQuery: query.BytesQuery,
+                })
+            }
+
+The ``PathSafeExactMatchPlugin`` above will use your new ``ExactMatchQuery``
+class for ``@``-prefixed searches on all fields except for those which would
+use the ``PathQuery`` type in non-prefixed searches.
 
 Flexible Field Types
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/reference/query.rst
+++ b/docs/reference/query.rst
@@ -324,6 +324,13 @@ ones you've already added to your beets library.
 Path queries are case sensitive if the queried path is on a case-sensitive
 filesystem.
 
+Regardless of the underlying filesystem, :ref:`exact match <exact-match>`
+queries always perform either case-sensitive (``=``) or case-insensitive
+(``=~``) matches on whole file paths for both albums and items::
+
+    $ beet list path:='/my/music/directory/AIR/Clouds Up.mp3'
+    $ beet list path:=~'/my/music/directory/air/CLOUDS UP.mp3'
+
 .. _query-sort:
 
 Sort Order

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -471,6 +471,12 @@ class PathQueryTest(_common.LibTestCase, TestHelper, AssertsMixin):
         results = self.lib.albums(q)
         self.assert_albums_matched(results, [])
 
+    def test_item_exact_match_trailing_slash(self):
+        # NOTE: This test documents the current, unexpected behavior.
+        q = 'path:/a/b/c.mp3/'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, ['path item'])
+
     # FIXME: fails on windows
     @unittest.skipIf(sys.platform == 'win32', 'win32')
     def test_parent_directory_no_slash(self):
@@ -556,6 +562,92 @@ class PathQueryTest(_common.LibTestCase, TestHelper, AssertsMixin):
         q = 'path::b'
         results = self.lib.albums(q)
         self.assert_albums_matched(results, ['path album'])
+
+    def test_item_exact_prefix_match(self):
+        q = 'path:=/a/b/c.mp3'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, ['path item'])
+
+    def test_album_exact_prefix_match(self):
+        q = 'path:=/a/b'
+        results = self.lib.albums(q)
+        self.assert_albums_matched(results, ['path album'])
+
+    def test_item_exact_nocase_prefix_match(self):
+        q = 'path:=~/a/b/c.mp3'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, ['path item'])
+
+        q = 'path:=~/A/b/c.MP3'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, ['path item'])
+
+    def test_album_exact_nocase_prefix_match(self):
+        q = 'path:=~/a/b'
+        results = self.lib.albums(q)
+        self.assert_albums_matched(results, ['path album'])
+
+        q = 'path:=~/A/B'
+        results = self.lib.albums(q)
+        self.assert_albums_matched(results, ['path album'])
+
+    def test_item_exact_prefix_no_match(self):
+        q = 'path:=/'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, [])
+
+        q = 'path:=/a'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, [])
+
+        q = 'path:=/a/'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, [])
+
+        q = 'path:=/a/b'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, [])
+
+        q = 'path:=/a/b/'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, [])
+
+        q = 'path:=/a/b/c'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, [])
+
+        q = 'path:=/a/b/c/'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, [])
+
+        q = 'path:=/a/b/c.mp3/'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, [])
+
+        q = 'path:=/A/B/C.MP3'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, [])
+
+    def test_album_exact_prefix_no_match(self):
+        q = 'path:=/'
+        results = self.lib.albums(q)
+        self.assert_albums_matched(results, [])
+
+        q = 'path:=/a'
+        results = self.lib.albums(q)
+        self.assert_albums_matched(results, [])
+
+        q = 'path:=/a/'
+        results = self.lib.albums(q)
+        self.assert_albums_matched(results, [])
+
+        q = 'path:=/a/b/c'
+        results = self.lib.albums(q)
+        self.assert_albums_matched(results, [])
+
+        q = 'path:=/A/B'
+        results = self.lib.albums(q)
+        self.assert_albums_matched(results, [])
 
     def test_escape_underscore(self):
         self.add_album(path=b'/a/_/title.mp3', title='with underscore',


### PR DESCRIPTION
## Description

I helped add the exact match query feature last year, but the exact-match prefix `=` does not seem to work for `PathQuery`.  After stepping through this code for a while tonight, I believe this because `MatchQuery` does not know to convert its pattern to a `memoryview`.

The proposed solution here tweaks the way prefixes work, allowing any prefix string to be assigned to a dictionary mapping the field's un-prefixed query type to the prefix's desired query type (use a defaultdict to provide a default query class, if desired).

I thought this made sense (vs simply checking for the field name 'path') to support plugins that may want to use this functionality for their own ends.  But is there a better, more straightforward approach that I could have used?

(...)

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
