### PR TITLE
Improve "Changelog goes here note" in changelog.rst

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 1.6.1 (in development)
 ----------------------
 
-Changelog goes here!
+Changelog goes here! Please add your entry to the bottom of one of the lists below!
 
 With this release, beets now requires Python 3.7 or later (it removes support
 for Python 3.6).


### PR DESCRIPTION
## Description

Added a note to the very top of the changelog.rst that editors should add there "new things" to the bottom to the list. Some people add it to the top, some to the bottom. Basically it doesn't really matter in the end where a feature/fix is placed in the final release notes, but since we constantly have to resolve merge conflicts within this file I think it would reduce confusion at least a little if we know that "news" are at the bottom _always_.

