### PR TITLE
Fix typo in deezer.py

### DIFF
--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -23,7 +23,7 @@ import requests
 from beets import ui
 from beets.autotag import AlbumInfo, TrackInfo
 from beets.plugins import MetadataSourcePlugin, BeetsPlugin
-from betts.utils.id_extractors import deezer_id_regex
+from beets.utils.id_extractors import deezer_id_regex
 
 
 class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):


### PR DESCRIPTION
## Description

```
** error loading plugin deezer:
Traceback (most recent call last):
  File "\git\beets\beets\plugins.py", line 268, in load_plugins
    namespace = __import__(modname, None, None)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "e:\git\beets\beetsplug\deezer.py", line 26, in <module>
    from betts.utils.id_extractors import deezer_id_regex
ModuleNotFoundError: No module named 'betts'
```
(...)

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
