### PR TITLE
discogs_client version check

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -69,9 +69,9 @@ class DiscogsPlugin(BeetsPlugin):
         self.register_listener('import_begin', self.setup)
 
     def check_discogs_client(self):
-        """Ensure python3-discogs-client version >= 2.3.10
+        """Ensure python3-discogs-client version >= 2.3.15
         """
-        dc_min_version = [2, 3, 10]
+        dc_min_version = [2, 3, 15]
         dc_version = [int(elem) for elem in dc_string.split('.')]
         min_len = min(len(dc_version), len(dc_min_version))
         gt_min = [(elem > elem_min) for elem, elem_min in
@@ -79,7 +79,7 @@ class DiscogsPlugin(BeetsPlugin):
                       dc_min_version[:min_len])]
         if True not in gt_min:
             self._log.warning(('python3-discogs-client version should be '
-                               '>= 2.3.10'))
+                               '>= 2.3.15'))
 
     def setup(self, session=None):
         """Create the `discogs_client` field. Authenticate if necessary.

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -71,14 +71,15 @@ class DiscogsPlugin(BeetsPlugin):
     def check_discogs_client(self):
         """Ensure python3-discogs-client version >= 2.3.10
         """
-        dc_min_version = [2,3,10]
+        dc_min_version = [2, 3, 10]
         dc_version = [int(elem) for elem in dc_string.split('.')]
-        min_len = min(len(dc_version),len(dc_min_version))
+        min_len = min(len(dc_version), len(dc_min_version))
         gt_min = [(elem > elem_min) for elem, elem_min in
                   zip(dc_version[:min_len],
                       dc_min_version[:min_len])]
         if True not in gt_min:
-            self._log.warning("python3-discogs-client version should be >= 2.3.10")
+            self._log.warning(('python3-discogs-client version should be '
+                               '>= 2.3.10'))
 
     def setup(self, session=None):
         """Create the `discogs_client` field. Authenticate if necessary.

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -22,6 +22,7 @@ from beets.util.id_extractors import extract_discogs_id_regex
 from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.plugins import MetadataSourcePlugin, BeetsPlugin, get_distance
 import confuse
+from discogs_client import __version__ as dc_string
 from discogs_client import Release, Master, Client
 from discogs_client.exceptions import DiscogsAPIError
 from requests.exceptions import ConnectionError
@@ -50,6 +51,7 @@ class DiscogsPlugin(BeetsPlugin):
 
     def __init__(self):
         super().__init__()
+        self.check_discogs_client()
         self.config.add({
             'apikey': API_KEY,
             'apisecret': API_SECRET,
@@ -65,6 +67,18 @@ class DiscogsPlugin(BeetsPlugin):
         self.config['user_token'].redact = True
         self.discogs_client = None
         self.register_listener('import_begin', self.setup)
+
+    def check_discogs_client(self):
+        """Ensure python3-discogs-client version >= 2.3.10
+        """
+        dc_min_version = [2,3,10]
+        dc_version = [int(elem) for elem in dc_string.split('.')]
+        min_len = min(len(dc_version),len(dc_min_version))
+        gt_min = [(elem > elem_min) for elem, elem_min in
+                  zip(dc_version[:min_len],
+                      dc_min_version[:min_len])]
+        if True not in gt_min:
+            self._log.warning("python3-discogs-client version should be >= 2.3.10")
 
     def setup(self, session=None):
         """Create the `discogs_client` field. Authenticate if necessary.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -43,6 +43,7 @@ New features:
   :bug:`4251`
 * :doc:`/plugins/discogs`: Permit appending style to genre.
 * :doc:`plugins/discogs`: Implement item_candidates for matching singletons.
+* :doc:`plugins/discogs`: Check for compliant discogs_client module.
 * :doc:`/plugins/convert`: Add a new `auto_keep` option that automatically
   converts files but keeps the *originals* in the library.
   :bug:`1840` :bug:`4302`

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ setup(
             'requests_oauthlib',
             'reflink',
             'rarfile',
-            'python3-discogs-client',
+            'python3-discogs-client>=2.3.15',
             'py7zr',
         ],
         'lint': [
@@ -139,7 +139,7 @@ setup(
         'embedart': ['Pillow'],
         'embyupdate': ['requests'],
         'chroma': ['pyacoustid'],
-        'discogs': ['python3-discogs-client>=2.3.10'],
+        'discogs': ['python3-discogs-client>=2.3.15'],
         'beatport': ['requests-oauthlib>=0.6.1'],
         'kodiupdate': ['requests'],
         'lastgenre': ['pylast'],


### PR DESCRIPTION
## Description

Addresses #4691, providing a warning if the user attempts to use a non-compliant version of `discogs_client` (any version of the abandoned package `discogs-client` or `python3-discogs-client` < 2.3.10). These non-compliant versions give no error when running `beet import`, but instead manifest as a large number of `No matching records found` due to rate limiting (which is expected to be implemented by `discogs_client`).

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
