### PR TITLE
Add instructions to install directly from Github.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ shockingly simple if you know a little Python.
 Install
 -------
 
-You can install beets by typing ``pip install beets`` or directly from Github (see details [here](https://beets.readthedocs.io/en/stable/faq.html#run-the-latest-source-version-of-beets)).
+You can install beets by typing ``pip install beets`` or directly from Github (see details [here](https://beets.readthedocs.io/en/latest/faq.html#run-the-latest-source-version-of-beets)).
 Beets has also been packaged in the `software repositories`_ of several
 distributions. Check out the `Getting Started`_ guide for more information.
 

--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ shockingly simple if you know a little Python.
 Install
 -------
 
-You can install beets by typing ``pip install beets`` or directly from github using ``python -m pip install git+https://github.com/beetbox/beets.git``. command.
+You can install beets by typing ``pip install beets`` or directly from Github (see details [here](https://beets.readthedocs.io/en/stable/faq.html#run-the-latest-source-version-of-beets)).
 Beets has also been packaged in the `software repositories`_ of several
 distributions. Check out the `Getting Started`_ guide for more information.
 

--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ shockingly simple if you know a little Python.
 Install
 -------
 
-You can install beets by typing ``pip install beets``.
+You can install beets by typing ``pip install beets`` or directly from github using ``python -m pip install git+https://github.com/beetbox/beets.git``. command.
 Beets has also been packaged in the `software repositories`_ of several
 distributions. Check out the `Getting Started`_ guide for more information.
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -137,7 +137,7 @@ it's helpful to run on the "bleeding edge". To run the latest source:
    ``pip uninstall beets``.
 2. Install from source. Choose one of these methods:
 
-   -  Directly from github using
+   -  Directly from GitHub using
       ``python -m pip install git+https://github.com/beetbox/beets.git`` command. Depending on your system, you may need to use ``pip3`` and ``python3`` instead of ``pip`` and ``python`` respectively.
    -  Use ``pip`` to install the latest snapshot tarball. Type:
       ``pip install https://github.com/beetbox/beets/tarball/master``

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -137,6 +137,8 @@ it's helpful to run on the "bleeding edge". To run the latest source:
    ``pip uninstall beets``.
 2. Install from source. Choose one of these methods:
 
+   -  Directly from github using
+      ``python -m pip install git+https://github.com/beetbox/beets.git`` command. Depending on your system, you may need to use ``pip3`` and ``python3`` instead of ``pip`` and ``python`` respectively.
    -  Use ``pip`` to install the latest snapshot tarball. Type:
       ``pip install https://github.com/beetbox/beets/tarball/master``
    -  Grab the source using git. First, clone the repository:


### PR DESCRIPTION
Since the release is getting delayed, I think it may be worthwhile to add installation instructions directly from GitHub. 