### PR TITLE
Save external ID's via MusicBrainz

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -29,7 +29,9 @@ from beets import util
 from beets import config
 from collections import Counter
 from urllib.parse import urljoin
-from beets.util.id_extractors import extract_discogs_id_regex
+from beets.util.id_extractors import extract_discogs_id_regex, \
+    spotify_id_regex, deezer_id_regex, beatport_id_regex
+from beets.plugins import MetadataSourcePlugin
 
 VARIOUS_ARTISTS_ID = '89ad4ac3-39f7-470e-963a-56509c546377'
 
@@ -512,14 +514,41 @@ def album_info(release: Dict) -> beets.autotag.hooks.AlbumInfo:
             in sorted(genres.items(), key=lambda g: -g[1])
         )
 
-    # We might find URLs to external sources (Discogs, Spotify, ...)
+    # We might find links to external sources (Discogs, Bandcamp, ...)
     if release.get('url-relation-list'):
-        discogs_url = None
+        discogs_url, bandcamp_url, spotify_url = None, None, None
+        deezer_url, beatport_url = None, None
+
         for url in release['url-relation-list']:
             if url['type'] == 'discogs':
                 log.debug('Found link to Discogs release via MusicBrainz')
                 discogs_url = url['target']
-        info.discogs_albumid = extract_release_id_regex(discogs_url)
+            if 'bandcamp.com' in url['target']:
+                log.debug('Found link to Bandcamp release via MusicBrainz')
+                bandcamp_url = url['target']
+            if 'spotify.com' in url['target']:
+                log.debug('Found link to Spotify album via MusicBrainz')
+                spotify_url = url['target']
+            if 'deezer.com' in url['target']:
+                log.debug('Found link to Deezer album via MusicBrainz')
+                deezer_url = url['target']
+            if 'beatport.com' in url['target']:
+                log.debug('Found link to Beatport release via MusicBrainz')
+                beatport_url = url['target']
+
+        if discogs_url:
+            info.discogs_albumid = extract_discogs_id_regex(discogs_url)
+        if bandcamp_url:
+            info.bandcamp_album_id = bandcamp_url
+        if spotify_url:
+            info.spotify_album_id = MetadataSourcePlugin._get_id(
+                'album', spotify_url, spotify_id_regex)
+        if deezer_url:
+            info.deezer_album_id = MetadataSourcePlugin._get_id(
+                'album', deezer_url, deezer_id_regex)
+        if beatport_url:
+            info.beatport_album_id = MetadataSourcePlugin._get_id(
+                'album', beatport_url, beatport_id_regex)
 
     extra_albumdatas = plugins.send('mb_album_extract', data=release)
     for extra_albumdata in extra_albumdatas:

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -515,24 +515,38 @@ def album_info(release: Dict) -> beets.autotag.hooks.AlbumInfo:
         )
 
     # We might find links to external sources (Discogs, Bandcamp, ...)
-    if release.get('url-relation-list'):
+    if (any(config['musicbrainz']['external_ids'].get().values())
+            and release.get('url-relation-list')):
         discogs_url, bandcamp_url, spotify_url = None, None, None
         deezer_url, beatport_url = None, None
+        fetch_discogs, fetch_bandcamp, fetch_spotify = False, False, False
+        fetch_deezer, fetch_beatport = False, False
+
+        if config['musicbrainz']['external_ids']['discogs'].get():
+            fetch_discogs = True
+        if config['musicbrainz']['external_ids']['bandcamp'].get():
+            fetch_bandcamp = True
+        if config['musicbrainz']['external_ids']['spotify'].get():
+            fetch_spotify = True
+        if config['musicbrainz']['external_ids']['deezer'].get():
+            fetch_deezer = True
+        if config['musicbrainz']['external_ids']['beatport'].get():
+            fetch_beatport = True
 
         for url in release['url-relation-list']:
-            if url['type'] == 'discogs':
+            if fetch_discogs and url['type'] == 'discogs':
                 log.debug('Found link to Discogs release via MusicBrainz')
                 discogs_url = url['target']
-            if 'bandcamp.com' in url['target']:
+            if fetch_bandcamp and 'bandcamp.com' in url['target']:
                 log.debug('Found link to Bandcamp release via MusicBrainz')
                 bandcamp_url = url['target']
-            if 'spotify.com' in url['target']:
+            if fetch_spotify and 'spotify.com' in url['target']:
                 log.debug('Found link to Spotify album via MusicBrainz')
                 spotify_url = url['target']
-            if 'deezer.com' in url['target']:
+            if fetch_deezer and 'deezer.com' in url['target']:
                 log.debug('Found link to Deezer album via MusicBrainz')
                 deezer_url = url['target']
-            if 'beatport.com' in url['target']:
+            if fetch_beatport and 'beatport.com' in url['target']:
                 log.debug('Found link to Beatport release via MusicBrainz')
                 beatport_url = url['target']
 

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -128,6 +128,12 @@ musicbrainz:
     searchlimit: 5
     extra_tags: []
     genres: no
+    external_ids:
+        discogs: no
+        bandcamp: no
+        spotify: no
+        deezer: no
+        beatport: no
 
 match:
     strong_rec_thresh: 0.04

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -839,6 +839,19 @@ class ImportTask(BaseImportTask):
                         dup_item.id,
                         displayable_path(item.path)
                     )
+                # We exclude certain flexible attributes from the preserving
+                # process since they might have been fetched from MusicBrainz
+                # and been set in beets.autotag.apply_metadata().
+                # discogs_albumid might also have been set but is not a
+                # flexible attribute, thus no exclude is required.
+                if item.get('bandcamp_album_id'):
+                    dup_item.bandcamp_album_id = item.bandcamp_album_id
+                if item.get('spotify_album_id'):
+                    dup_item.spotify_album_id = item.spotify_album_id
+                if item.get('deezer_album_id'):
+                    dup_item.deezer_album_id = item.deezer_album_id
+                if item.get('beatport_album_id'):
+                    dup_item.beatport_album_id = item.beatport_album_id
                 item.update(dup_item._values_flex)
                 log.debug(
                     'Reimported item flexible attributes {0} '

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -432,6 +432,7 @@ class BeatportPlugin(BeetsPlugin):
         tracks = [self._get_track_info(x) for x in release.tracks]
 
         return AlbumInfo(album=release.name, album_id=release.beatport_id,
+                         beatport_album_id=release.beatport_id,
                          artist=artist, artist_id=artist_id, tracks=tracks,
                          albumtype=release.category, va=va,
                          year=release.release_date.year,

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -98,6 +98,7 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
         return AlbumInfo(
             album=album_data['title'],
             album_id=deezer_id,
+            deezer_album_id=deezer_id,
             artist=artist,
             artist_credit=self.get_artist([album_data['artist']])[0],
             artist_id=artist_id,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -63,6 +63,11 @@ New features:
 * :doc:`/plugins/fromfilename`:  Add debug log messages that inform when the
   plugin replaced bad (missing) artist, title or tracknumber metadata.
   :bug:`4561` :bug:`4600`
+* :ref:`musicbrainz-config`: MusicBrainz release pages often link to related
+  metadata sources like Discogs, Bandcamp, Spotify, Deezer and Beatport. When
+  enabled via the :ref:`musicbrainz.external_ids` options, release ID's will be
+  extracted from those URL's and imported to the library.
+  :bug:`4220`
 
 Bug fixes:
 

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -129,6 +129,8 @@ following to your configuration::
    web
    zero
 
+.. _autotagger_extensions:
+
 Autotagger Extensions
 ---------------------
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -842,6 +842,32 @@ release and the release-group on MusicBrainz, separated by "; " and sorted by
 the total number of votes.
 Default: ``no``
 
+.. _musicbrainz.external_ids:
+
+external_ids
+~~~~~~~~~~~~
+
+Set any of the ``external_ids`` options to ``yes`` to enable the MusicBrainz
+importer to look for links to related metadata sources. If such a link is
+available the release ID will be extracted from the URL provided and imported
+to the beets library.
+
+    musicbrainz:
+        external_ids:
+            discogs: yes
+            spotify: yes
+            bandcamp: yes
+            beatport: yes
+            deezer: yes
+
+
+The library fields of the corresponding :ref:`autotagger_extensions` are used
+to save the data (``discogs_albumid``, ``bandcamp_album_id``,
+``spotify_album_id``, ``beatport_album_id``, ``deezer_album_id``). On
+re-imports existing data will be overwritten.
+
+The default of all options is ``no``.
+
 .. _match-config:
 
 Autotagger Matching Options


### PR DESCRIPTION
## Description

MusicBrainz provides links to related websites via the "External links" section , usually found at the bottom right of a release page:

![image](https://user-images.githubusercontent.com/2733783/224732315-07cd91ec-2a8e-47d6-a8ba-8b3f5d548a7d.png)

Fortunately this information is available via the MusicBrainz API. This PR adds the fetching of these URL's, extracts the "metadata source ID's" from those and saves them in the corresponding fields in the Beets library. 

Currently the following sources are supported: Discogs, Bandcamp, Spotify, Deezer, Beatport. Typically **a link to a Discogs release is very likely** to be provided and seems to be considered a "quasi standard" for MusicBrainz editors. It seems worth for Beets to access this information and use it with  future features. The rest of the supported external sources are not that likely to be found.

- Fixes #4220
- Is required for future feature ideas:
  - #4707


Note: This is a replacement for #4474, which was split into two separate pull requests. The first one which was a prerequesite, was merged already: #4633 




## To Do

- [x] Documentation. 
- [x] Changelog.
- [x] ~Tests~.
