### PR TITLE
Add additional example to convert plugin 

### DIFF
--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -96,7 +96,7 @@ file. The available options are:
   Default: none.
 - **no_convert**: Does not transcode items matching the query string provided
   (see :doc:`/reference/query`). For example, to not convert AAC or WMA formats, you can use ``format:AAC, format:WMA`` or
-  ``path::\.(m4a|wma)$``. If you only want to transcode WMA format, you can use the query term negation to not convert all the other formats except wma, e.g., ``^path::\.(wma)$``.
+  ``path::\.(m4a|wma)$``. If you only want to transcode WMA format, you can use a negative query, e.g., ``^path::\.(wma)$``, to not convert any other format except WMA.
 - **never_convert_lossy_files**: Cross-conversions between lossy codecs---such
   as mp3, ogg vorbis, etc.---makes little sense as they will decrease quality
   even further. If set to ``yes``, lossy files are always copied.

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -94,9 +94,9 @@ file. The available options are:
   output.  Note that this does not guarantee that all converted files will have
   a lower bitrate---that depends on the encoder and its configuration.
   Default: none.
-- **no_convert**: Does not transcode items matching provided query string
-  (see :doc:`/reference/query`). (i.e. ``format:AAC, format:WMA`` or
-  ``path::\.(m4a|wma)$``)
+- **no_convert**: Does not transcode items matching the query string provided
+  (see :doc:`/reference/query`). For example, to not convert AAC or WMA formats, you can use ``format:AAC, format:WMA`` or
+  ``path::\.(m4a|wma)$``. If you only want to transcode WMA format, you can use the query term negation to not convert all the other formats except wma, e.g., ``^path::\.(wma)$``.
 - **never_convert_lossy_files**: Cross-conversions between lossy codecs---such
   as mp3, ogg vorbis, etc.---makes little sense as they will decrease quality
   even further. If set to ``yes``, lossy files are always copied.


### PR DESCRIPTION
## Description

Fixes https://github.com/beetbox/beets/issues/4711

Add another example to `convert` plugin to allow specifying a format to convert. 