### PR TITLE
resolve transl-tracklisting relations for pseudo releases

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -73,7 +73,8 @@ log = logging.getLogger('beets')
 RELEASE_INCLUDES = ['artists', 'media', 'recordings', 'release-groups',
                     'labels', 'artist-credits', 'aliases',
                     'recording-level-rels', 'work-rels',
-                    'work-level-rels', 'artist-rels', 'isrcs', 'url-rels', 'release-rels']
+                    'work-level-rels', 'artist-rels', 'isrcs',
+                    'url-rels', 'release-rels']
 BROWSE_INCLUDES = ['artist-credits', 'work-rels',
                    'artist-rels', 'recording-rels', 'release-rels']
 if "work-level-rels" in musicbrainzngs.VALID_BROWSE_INCLUDES['recording']:

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -211,7 +211,7 @@ def disambig_string(info):
             disambig.append(info.catalognum)
         if info.albumdisambig:
             disambig.append(info.albumdisambig)
-        # pseudo releases can't be differentiated from real release otherwise
+        # Let the user differentiate between pseudo and actual releases.
         if info.albumstatus == 'Pseudo-Release':
             disambig.append(info.albumstatus)
 

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -211,6 +211,9 @@ def disambig_string(info):
             disambig.append(info.catalognum)
         if info.albumdisambig:
             disambig.append(info.albumdisambig)
+        # pseudo releases can't be differentiated from real release otherwise
+        if info.albumstatus == 'Pseudo-Release':
+            disambig.append(info.albumstatus)
 
     if disambig:
         return ', '.join(disambig)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,8 @@ for Python 3.6).
 
 New features:
 
+* resolve transl-tracklisting relations for pseudo releases and merge data with the actual release
+  :bug:`654`
 * Fetchart: Use the right field (`spotify_album_id`) to obtain the Spotify album id
   :bug:`4803`
 * Prevent reimporting album if it is permanently removed from Spotify

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1931,7 +1931,8 @@ def mocked_get_release_by_id(id_, includes=[], release_status=[],
             }],
             'release-group': {
                 'id': 'another-id',
-            }
+            },
+            'status': 'Official',
         }
     }
 


### PR DESCRIPTION
## Description

Fixes #654 

As in the issue suggested I implemented the "easiest/most obvious approach".

It fetches release relations and "follows" the ones for the type [transl-tracklisting](https://musicbrainz.org/relationship/fc399d47-23a7-4c28-bfcf-0607a562b644) for pseudo releases. The additional data gets merged with the pseudo-release. I am not 100% sure if I included all applicable fields for the merge. I left the pseudo-releases id's as is.

This change makes it near impossible to differentiate the pseudo releases from the actual releases in the ui, so I added that to `disambig_string`.  Are there any unwanted side effects from that change?

A small screenshot for reference:
<img width="1137" alt="Screenshot 2023-03-15 at 22 42 24" src="https://user-images.githubusercontent.com/15641615/225450376-61c43fdd-f02d-4790-8f6c-67eaf3360c7c.png">

This implementation has almost the same approach as the [plugin](https://github.com/TypicalFence/beets-resolve-pesudo-releases) I wrote recently. Said plugin hasn't caused any issues for me yet. This PR handles things much cleaner tho (it doesn't have to fetch pseudo-releases twice for instance).

I feel like my code ended up being a bit awkward, I haven't written any serious python in a long while and pep8 feels a bit tedious. 

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
- [ ] Add a Setting for people who really don't care about this?
