### PR TITLE
OLD Support providing album information on singleton imports

### DIFF
--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -547,10 +547,10 @@ def tag_item(
     if trackids:
         for trackid in trackids:
             log.debug('Searching for track ID: {0}', trackid)
-            for track_info in hooks.tracks_for_id(trackid):
+            for track_info, album_info in hooks.tracks_for_id(trackid):
                 dist = track_distance(item, track_info, incl_artist=True)
                 candidates[track_info.track_id] = \
-                    hooks.TrackMatch(dist, track_info)
+                    hooks.TrackMatch(dist, track_info, album_info)
                 # If this is a good match, then don't keep searching.
                 rec = _recommendation(_sort_candidates(candidates.values()))
                 if rec == Recommendation.strong and \

--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -572,9 +572,11 @@ def tag_item(
     log.debug('Item search terms: {0} - {1}', search_artist, search_title)
 
     # Get and evaluate candidate metadata.
-    for track_info in hooks.item_candidates(item, search_artist, search_title):
+    for track_info, album_info in hooks.item_candidates(item, search_artist,
+                                                        search_title):
         dist = track_distance(item, track_info, incl_artist=True)
-        candidates[track_info.track_id] = hooks.TrackMatch(dist, track_info)
+        candidates[track_info.track_id] = hooks.TrackMatch(dist, track_info,
+                                                           album_info)
 
     # Sort by distance and return with recommendation.
     log.debug('Found {0} candidates.', len(candidates))

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -953,7 +953,17 @@ class SingletonImportTask(ImportTask):
         return [self.item]
 
     def apply_metadata(self):
-        autotag.apply_item_metadata(self.item, self.match.info)
+        if (self.match.album_info):
+            # Match optionally provides album info,
+            # in which case this is not a singleton!
+            self.item.album = self.match.album_info.album
+            self.item.album_id = self.match.album_info.album_id
+            # Apply track and album metadata
+            autotag.apply_metadata(
+                self.match.album_info, {self.item: self.match.info})
+        else:
+            # Apply track metadata only.
+            autotag.apply_item_metadata(self.item, self.match.info)
 
     def _emit_imported(self, lib):
         for item in self.imported_items():

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -954,10 +954,10 @@ class SingletonImportTask(ImportTask):
 
     def apply_metadata(self):
         if (self.match.album_info):
-            # Match optionally provides album info,
-            # in which case this is not a singleton!
+            # The match might provide album info, in which case we apply the
+            # album name. The item still is a singleton, it does not have an
+            # album_id!
             self.item.album = self.match.album_info.album
-            self.item.album_id = self.match.album_info.album_id
             # Apply track and album metadata
             autotag.apply_metadata(
                 self.match.album_info, {self.item: self.match.info})

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -215,6 +215,12 @@ def disambig_string(info):
         if info.albumstatus == 'Pseudo-Release':
             disambig.append(info.albumstatus)
 
+    if isinstance(info, hooks.TrackInfo):
+        if info.index:
+            disambig.append("Index {}".format(str(info.index)))
+        if info.track_alt:
+            disambig.append("Track {} ".format(info.track_alt))
+
     if disambig:
         return ', '.join(disambig)
 

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -450,18 +450,25 @@ def show_item_change(item, match):
     """
     cur_artist, new_artist = item.artist, match.info.artist
     cur_title, new_title = item.title, match.info.title
+    cur_album = item.album if item.album else ""
+    new_album = match.album_info.album if match.album_info else ""
 
-    if cur_artist != new_artist or cur_title != new_title:
+    if (cur_artist != new_artist or cur_title != new_title
+            or cur_album != new_album):
         cur_artist, new_artist = ui.colordiff(cur_artist, new_artist)
         cur_title, new_title = ui.colordiff(cur_title, new_title)
+        cur_album, new_album = ui.colordiff(cur_album, new_album)
 
         print_("Correcting track tags from:")
         print_(f"    {cur_artist} - {cur_title}")
+        print_(f"    Album: {cur_album}") if cur_album else None
         print_("To:")
         print_(f"    {new_artist} - {new_title}")
+        print_(f"    Album: {new_album}") if new_album else None
 
     else:
         print_(f"Tagging track: {cur_artist} - {cur_title}")
+        print_(f"               Album: {new_album}") if cur_album else None
 
     # Data URL.
     if match.info.data_url:

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -244,6 +244,7 @@ class DiscogsPlugin(BeetsPlugin):
         if not artist and not title:
             self._log.debug('Skipping Discogs query. File missing artist and '
                             'title tags.')
+            return
 
         query = f'{artist} {title}'
         try:

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -267,8 +267,7 @@ class DiscogsPlugin(BeetsPlugin):
             )
             if track_result:
                 candidates.append(track_result)
-        # first 10 results, don't overwhelm with options
-        return candidates[:10]
+        return candidates
 
     def album_for_id(self, album_id):
         """Fetches an album by its Discogs ID and returns an AlbumInfo object

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -311,7 +311,7 @@ class DiscogsPlugin(BeetsPlugin):
         query = re.sub(r'(?u)\W+', ' ', query)
         # Strip medium information from query, Things like "CD1" and "disk 1"
         # can also negate an otherwise positive result.
-        query = re.sub(r'(?i)\b(CD|disc)\s*\d+', '', query)
+        query = re.sub(r'(?i)\b(CD|disc|vinyl)\s*\d+', '', query)
 
         try:
             releases = self.discogs_client.search(query,


### PR DESCRIPTION
## Description

Implements a way to allow supplying album information on singleton imports and makes use of it in the Discogs metadata source plugin.

Resolves #4716

## To Do

- [ ] Documentation.
- [ ] Changelog.
- [ ] Tests.
