### PR TITLE
Added option to embedart using an image URL [small PR]

### DIFF
--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -84,7 +84,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                                     help='the image file to embed')
         embed_cmd.parser.add_option("-y", "--yes", action="store_true",
                                     help="skip confirmation")
-        embed_cmd.parser.add_option('-u', '--url', metavar='URL',
+        embed_cmd.parser.add_option('-u', '--url',
                                     help='the URL of the image file to embed')
 
         maxwidth = self.config['maxwidth'].get(int)

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -122,8 +122,12 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                 except OSError as e:
                     self._log.error("Error: {}".format(e))
                 if img.format:
-                    with open('temp.jpg', 'wb') as f:
-                        f.write(response.content)
+                    try:
+                        with open('temp.jpg', 'wb') as f:
+                            f.write(response.content)
+                    except Exception as e:
+                        self._log.error(f"Error writing file: {e}"
+                                        )
                     opts.file = 'temp.jpg'
                     items = lib.items(decargs(args))
                     # Confirm with user.

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -119,6 +119,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                     with open('temp.jpg', 'wb') as f:
                         f.write(response.content)
                     opts.file = 'temp.jpg'
+                    items = lib.items(decargs(args))
                     # Confirm with user.
                     if not opts.yes and not _confirm(items, not opts.url):
                         return

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -116,7 +116,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                     response = requests.get(opts.url, timeout=5)
                     response.raise_for_status()
                 except requests.exceptions.RequestException as e:
-                    self._log.error("Error: {}".format(e))
+                    self._log.error("{}".format(e))
                     return
                 extension = guess_extension(response.headers
                                             ['Content-Type'])

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -118,28 +118,24 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                     response.raise_for_status()
                 except requests.exceptions.RequestException as e:
                     self._log.error("Error: {}".format(e))
+                    return
                 try:
                     img = Image.open(BytesIO(response.content))
                 except OSError as e:
                     self._log.error("Error: {}".format(e))
+                    return
                 if img.format:
-                    try:
-                        with open('temp.jpg', 'wb') as f:
-                            f.write(response.content)
-                    except OSError as exc:
-                        raise util.FilesystemError(exc, 'write',
-                                                   bytestring_path('temp.jpg'),
-                                                   traceback.format_exc())
-                    opts.file = 'temp.jpg'
+                    img.save('temp.jpg', format='JPEG')
+                    tempimg = 'temp.jpg'
                     items = lib.items(decargs(args))
                     # Confirm with user.
                     if not opts.yes and not _confirm(items, not opts.url):
                         return
                     for item in items:
-                        art.embed_item(self._log, item, opts.file, maxwidth,
+                        art.embed_item(self._log, item, tempimg, maxwidth,
                                        None, compare_threshold, ifempty,
                                        quality=quality)
-                    os.remove(opts.file)
+                    os.remove(tempimg)
                 else:
                     self._log.error('Invalid image file')
                     return

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -84,7 +84,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                                     help='the image file to embed')
         embed_cmd.parser.add_option("-y", "--yes", action="store_true",
                                     help="skip confirmation")
-        embed_cmd.parser.add_option('-u', '--url',
+        embed_cmd.parser.add_option('-u', '--url', action="store_true",
                                     help='the URL of the image file to embed')
 
         maxwidth = self.config['maxwidth'].get(int)

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -123,7 +123,6 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                     self._log.error('Invalid image file')
                     return
                 tempimg = f'image{extension}'
-                self._log.error(tempimg)
                 try:
                     with open(tempimg, 'wb') as f:
                         f.write(response.content)

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -124,8 +124,8 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                     self._log.error("Error: {}".format(e))
                     return
                 if img.format:
-                    img.save('temp.jpg', format='JPEG')
-                    tempimg = 'temp.jpg'
+                    img.save('temp.png', format='PNG')
+                    tempimg = 'temp.png'
                     items = lib.items(decargs(args))
                     # Confirm with user.
                     if not opts.yes and not _confirm(items, not opts.url):

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -19,7 +19,7 @@ from io import BytesIO
 
 import requests
 
-from beets import art, config, ui
+from beets import art, config, ui, util
 from beets.plugins import BeetsPlugin
 from beets.ui import decargs, print_
 from beets.util import bytestring_path, displayable_path, normpath, syspath
@@ -125,9 +125,8 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                     try:
                         with open('temp.jpg', 'wb') as f:
                             f.write(response.content)
-                    except Exception as e:
-                        self._log.error(f"Error writing file: {e}"
-                                        )
+                    except util.FilesystemError as exc:
+                        self._log.error('Error writing file: {}', exc)
                     opts.file = 'temp.jpg'
                     items = lib.items(decargs(args))
                     # Confirm with user.

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -125,7 +125,6 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                     return
                 file = f'image{extension}'
                 tempimg = os.path.join(tempfile.gettempdir(), file)
-                print(tempimg)
                 try:
                     with open(tempimg, 'wb') as f:
                         f.write(response.content)

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -82,8 +82,10 @@ class EmbedCoverArtPlugin(BeetsPlugin):
         )
         embed_cmd.parser.add_option('-f', '--file', metavar='PATH',
                                     help='the image file to embed')
+
         embed_cmd.parser.add_option("-y", "--yes", action="store_true",
                                     help="skip confirmation")
+
         embed_cmd.parser.add_option('-u', '--url', action="store_true",
                                     help='the URL of the image file to embed')
 

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -76,16 +76,15 @@ class EmbedCoverArtPlugin(BeetsPlugin):
 
     def commands(self):
         # Embed command.
-        embed_cmd = ui.Subcommand(
-            'embedart', help='embed image files into file metadata'
-        )
+        embed_cmd = ui.Subcommand('embedart',
+                                  help='embed image files into file metadata')
         embed_cmd.parser.add_option('-f', '--file', metavar='PATH',
                                     help='the image file to embed')
 
         embed_cmd.parser.add_option("-y", "--yes", action="store_true",
                                     help="skip confirmation")
 
-        embed_cmd.parser.add_option('-u', '--url', metavar='URL',
+        embed_cmd.parser.add_option('-u', '--url', action="store_true",
                                     help='the URL of the image file to embed')
 
         maxwidth = self.config['maxwidth'].get(int)

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -15,6 +15,7 @@
 """Allows beets to embed album art into file metadata."""
 
 import os.path
+import tempfile
 from mimetypes import guess_extension
 
 import requests
@@ -122,7 +123,9 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                 if extension is None:
                     self._log.error('Invalid image file')
                     return
-                tempimg = f'image{extension}'
+                file = f'image{extension}'
+                tempimg = os.path.join(tempfile.gettempdir(), file)
+                print(tempimg)
                 try:
                     with open(tempimg, 'wb') as f:
                         f.write(response.content)
@@ -132,6 +135,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                 items = lib.items(decargs(args))
                 # Confirm with user.
                 if not opts.yes and not _confirm(items, not opts.url):
+                    os.remove(tempimg)
                     return
                 for item in items:
                     art.embed_item(self._log, item, tempimg, maxwidth,

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -15,7 +15,7 @@
 """Allows beets to embed album art into file metadata."""
 
 import os.path
-from io import BytesIO
+from mimetypes import guess_extension
 
 import requests
 
@@ -111,37 +111,34 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                                    None, compare_threshold, ifempty,
                                    quality=quality)
             elif opts.url:
-                from PIL import Image
                 try:
                     response = requests.get(opts.url, timeout=5)
                     response.raise_for_status()
                 except requests.exceptions.RequestException as e:
                     self._log.error("Error: {}".format(e))
                     return
-                try:
-                    img = Image.open(BytesIO(response.content))
-                except OSError as e:
-                    self._log.error("Error: {}".format(e))
-                    return
-                if img.format:
-                    try:
-                        img.save('temp.png', format='PNG')
-                    except IOError as e:
-                        self._log.error("Cannot save image: {}".format(e))
-                        return
-                    tempimg = 'temp.png'
-                    items = lib.items(decargs(args))
-                    # Confirm with user.
-                    if not opts.yes and not _confirm(items, not opts.url):
-                        return
-                    for item in items:
-                        art.embed_item(self._log, item, tempimg, maxwidth,
-                                       None, compare_threshold, ifempty,
-                                       quality=quality)
-                    os.remove(tempimg)
-                else:
+                extension = guess_extension(response.headers
+                                            ['Content-Type'])
+                if extension is None:
                     self._log.error('Invalid image file')
                     return
+                tempimg = f'image{extension}'
+                self._log.error(tempimg)
+                try:
+                    with open(tempimg, 'wb') as f:
+                        f.write(response.content)
+                except Exception as e:
+                    self._log.error("Unable to save image: {}".format(e))
+                    return
+                items = lib.items(decargs(args))
+                # Confirm with user.
+                if not opts.yes and not _confirm(items, not opts.url):
+                    return
+                for item in items:
+                    art.embed_item(self._log, item, tempimg, maxwidth,
+                                    None, compare_threshold, ifempty,
+                                    quality=quality)
+                os.remove(tempimg)
             else:
                 albums = lib.albums(decargs(args))
                 # Confirm with user.

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -86,7 +86,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
         embed_cmd.parser.add_option("-y", "--yes", action="store_true",
                                     help="skip confirmation")
 
-        embed_cmd.parser.add_option('-u', '--url', action="store_true",
+        embed_cmd.parser.add_option('-u', '--url', metavar='URL',
                                     help='the URL of the image file to embed')
 
         maxwidth = self.config['maxwidth'].get(int)

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -124,7 +124,11 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                     self._log.error("Error: {}".format(e))
                     return
                 if img.format:
-                    img.save('temp.png', format='PNG')
+                    try:
+                        img.save('temp.png', format='PNG')
+                    except IOError as e:
+                        self._log.error("Cannot save image: {}".format(e))
+                        return
                     tempimg = 'temp.png'
                     items = lib.items(decargs(args))
                     # Confirm with user.

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -136,8 +136,8 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                     return
                 for item in items:
                     art.embed_item(self._log, item, tempimg, maxwidth,
-                                    None, compare_threshold, ifempty,
-                                    quality=quality)
+                                   None, compare_threshold, ifempty,
+                                   quality=quality)
                 os.remove(tempimg)
             else:
                 albums = lib.albums(decargs(args))

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -112,8 +112,15 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                                    quality=quality)
             elif opts.url:
                 from PIL import Image
-                response = requests.get(opts.url)
-                img = Image.open(BytesIO(response.content))
+                try:
+                    response = requests.get(opts.url, timeout=5)
+                    response.raise_for_status()
+                except requests.exceptions.RequestException as e:
+                    self._log.error("Error: {}".format(e))
+                try:
+                    img = Image.open(BytesIO(response.content))
+                except OSError as e:
+                    self._log.error("Error: {}".format(e))
                 if img.format:
                     with open('temp.jpg', 'wb') as f:
                         f.write(response.content)

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -15,6 +15,7 @@
 """Allows beets to embed album art into file metadata."""
 
 import os.path
+import traceback
 from io import BytesIO
 
 import requests
@@ -84,7 +85,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
         embed_cmd.parser.add_option("-y", "--yes", action="store_true",
                                     help="skip confirmation")
 
-        embed_cmd.parser.add_option('-u', '--url', action="store_true",
+        embed_cmd.parser.add_option('-u', '--url', metavar='URL',
                                     help='the URL of the image file to embed')
 
         maxwidth = self.config['maxwidth'].get(int)
@@ -125,8 +126,10 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                     try:
                         with open('temp.jpg', 'wb') as f:
                             f.write(response.content)
-                    except util.FilesystemError as exc:
-                        self._log.error('Error writing file: {}', exc)
+                    except OSError as exc:
+                        raise util.FilesystemError(exc, 'write',
+                                                   bytestring_path('temp.jpg'),
+                                                   traceback.format_exc())
                     opts.file = 'temp.jpg'
                     items = lib.items(decargs(args))
                     # Confirm with user.

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -15,12 +15,11 @@
 """Allows beets to embed album art into file metadata."""
 
 import os.path
-import traceback
 from io import BytesIO
 
 import requests
 
-from beets import art, config, ui, util
+from beets import art, config, ui
 from beets.plugins import BeetsPlugin
 from beets.ui import decargs, print_
 from beets.util import bytestring_path, displayable_path, normpath, syspath

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -18,7 +18,6 @@ import os.path
 from io import BytesIO
 
 import requests
-from PIL import Image
 
 from beets import art, config, ui
 from beets.plugins import BeetsPlugin
@@ -113,6 +112,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                                    None, compare_threshold, ifempty,
                                    quality=quality)
             elif opts.url:
+                from PIL import Image
                 response = requests.get(opts.url)
                 img = Image.open(BytesIO(response.content))
                 if img.format:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,8 @@ for Python 3.6).
 
 New features:
 
+* Added option to specify a URL in the `embedart` plugin.
+  :bug:`83`
 * Added additional error handling for `spotify` plugin.
   :bug:`4686`
 * We now import the remixer field from Musicbrainz into the library.

--- a/docs/plugins/embedart.rst
+++ b/docs/plugins/embedart.rst
@@ -85,7 +85,7 @@ Manually Embedding and Extracting Art
 The ``embedart`` plugin provides a couple of commands for manually managing
 embedded album art:
 
-* ``beet embedart [-f IMAGE] QUERY``: embed images into the every track on the
+* ``beet embedart [-f IMAGE] QUERY``: embed images in every track of the
   albums matching the query. If the ``-f`` (``--file``) option is given, then
   use a specific image file from the filesystem; otherwise, each album embeds
   its own currently associated album art. The command prompts for confirmation

--- a/docs/plugins/embedart.rst
+++ b/docs/plugins/embedart.rst
@@ -91,6 +91,9 @@ embedded album art:
   its own currently associated album art. The command prompts for confirmation
   before making the change unless you specify the ``-y`` (``--yes``) option.
 
+* ``beet embedart [-u IMAGE_URL] QUERY``: embed image specified in the URL
+  into every track of the albums matching the query. The ``-u`` (``--url``) option can be used to specify the URL of the image to be used. The command prompts for confirmation before making the change unless you specify the ``-y`` (``--yes``) option.
+
 * ``beet extractart [-a] [-n FILE] QUERY``: extracts the images for all albums
   matching the query. The images are placed inside the album folder. You can
   specify the destination file name using the ``-n`` option, but leave off the

--- a/test/test_embedart.py
+++ b/test/test_embedart.py
@@ -246,7 +246,7 @@ class EmbedartCliTest(TestHelper, FetchImageHelper):
         self._setup_data()
         album = self.add_album_fixture()
         item = album.items()[0]
-        self.mock_response('http://example.com/test.txt', 'text/html')
+        self.mock_response('http://example.com/test.html', 'text/html')
         self.run_command('embedart', '-y', '-u', 'http://example.com/test.txt')
         mediafile = MediaFile(syspath(item.path))
         self.assertFalse(mediafile.images)

--- a/test/test_embedart.py
+++ b/test/test_embedart.py
@@ -75,42 +75,6 @@ class EmbedartCliTest(TestHelper, FetchImageHelper):
         mediafile = MediaFile(syspath(item.path))
         self.assertEqual(mediafile.images[0].data, self.image_data)
 
-    def test_embed_art_from_url_with_yes_input(self):
-        self._setup_data()
-        album = self.add_album_fixture()
-        item = album.items()[0]
-        self.mock_response('http://example.com/test.jpg', 'image/jpeg')
-        self.io.addinput('y')
-        self.run_command('embedart', '-u', 'http://example.com/test.jpg')
-        mediafile = MediaFile(syspath(item.path))
-        self.assertEqual(
-            mediafile.images[0].data,
-            self.IMAGEHEADER.get('image/jpeg').ljust(32, b'\x00')
-        )
-
-    def test_embed_art_png_from_file_with_yes_input(self):
-        self._setup_data()
-        album = self.add_album_fixture()
-        item = album.items()[0]
-        self.mock_response('http://example.com/test.png', 'image/png')
-        self.io.addinput('y')
-        self.run_command('embedart', '-u', 'http://example.com/test.png')
-        mediafile = MediaFile(syspath(item.path))
-        self.assertEqual(
-            mediafile.images[0].data,
-            self.IMAGEHEADER.get('image/png').ljust(32, b'\x00'))
-
-    # test embedart with url that does not have a valid image
-    def test_embed_art_from_url_with_yes_input_not_image(self):
-        self._setup_data()
-        album = self.add_album_fixture()
-        item = album.items()[0]
-        self.mock_response('http://example.com/test.txt', 'text/html')
-        self.io.addinput('y')
-        self.run_command('embedart', '-u', 'http://example.com/test.txt')
-        mediafile = MediaFile(syspath(item.path))
-        self.assertFalse(mediafile.images)
-
     def test_embed_art_from_file_with_no_input(self):
         self._setup_data()
         album = self.add_album_fixture()
@@ -252,6 +216,40 @@ class EmbedartCliTest(TestHelper, FetchImageHelper):
         self.run_command('clearart')
         mediafile = MediaFile(syspath(item.path))
         self.assertEqual(mediafile.images[0].data, self.image_data)
+
+    def test_embed_art_from_url_with_yes_input(self):
+        self._setup_data()
+        album = self.add_album_fixture()
+        item = album.items()[0]
+        self.mock_response('http://example.com/test.jpg', 'image/jpeg')
+        self.io.addinput('y')
+        self.run_command('embedart', '-u', 'http://example.com/test.jpg')
+        mediafile = MediaFile(syspath(item.path))
+        self.assertEqual(
+            mediafile.images[0].data,
+            self.IMAGEHEADER.get('image/jpeg').ljust(32, b'\x00')
+        )
+
+    def test_embed_art_from_url_png(self):
+        self._setup_data()
+        album = self.add_album_fixture()
+        item = album.items()[0]
+        self.mock_response('http://example.com/test.png', 'image/png')
+        self.run_command('embedart', '-y', '-u', 'http://example.com/test.png')
+        mediafile = MediaFile(syspath(item.path))
+        self.assertEqual(
+            mediafile.images[0].data,
+            self.IMAGEHEADER.get('image/png').ljust(32, b'\x00')
+        )
+
+    def test_embed_art_from_url_not_image(self):
+        self._setup_data()
+        album = self.add_album_fixture()
+        item = album.items()[0]
+        self.mock_response('http://example.com/test.txt', 'text/html')
+        self.run_command('embedart', '-y', '-u', 'http://example.com/test.txt')
+        mediafile = MediaFile(syspath(item.path))
+        self.assertFalse(mediafile.images)
 
 
 class DummyArtResizer(ArtResizer):

--- a/test/test_embedart.py
+++ b/test/test_embedart.py
@@ -28,6 +28,7 @@ from beets import config, logging, ui
 from beets.util import syspath, displayable_path
 from beets.util.artresizer import ArtResizer
 from beets import art
+from test.test_art import FetchImageHelper
 
 
 def require_artresizer_compare(test):
@@ -42,7 +43,7 @@ def require_artresizer_compare(test):
     return wrapper
 
 
-class EmbedartCliTest(_common.TestCase, TestHelper):
+class EmbedartCliTest(TestHelper, FetchImageHelper):
 
     small_artpath = os.path.join(_common.RSRC, b'image-2x3.jpg')
     abbey_artpath = os.path.join(_common.RSRC, b'abbey.jpg')
@@ -73,6 +74,19 @@ class EmbedartCliTest(_common.TestCase, TestHelper):
         self.run_command('embedart', '-f', self.small_artpath)
         mediafile = MediaFile(syspath(item.path))
         self.assertEqual(mediafile.images[0].data, self.image_data)
+
+    def test_embed_art_from_url_with_yes_input(self):
+        self._setup_data()
+        album = self.add_album_fixture()
+        item = album.items()[0]
+        self.mock_response('http://example.com/test.jpg', 'image/jpeg')
+        self.io.addinput('y')
+        self.run_command('embedart', '-u', 'http://example.com/test.jpg')
+        mediafile = MediaFile(syspath(item.path))
+        self.assertEqual(
+            mediafile.images[0].data,
+            self.IMAGEHEADER.get('image/jpeg').ljust(32, b'\x00')
+        )
 
     def test_embed_art_from_file_with_no_input(self):
         self._setup_data()

--- a/test/test_embedart.py
+++ b/test/test_embedart.py
@@ -100,6 +100,17 @@ class EmbedartCliTest(TestHelper, FetchImageHelper):
             mediafile.images[0].data,
             self.IMAGEHEADER.get('image/png').ljust(32, b'\x00'))
 
+    # test embedart with url that does not have a valid image
+    def test_embed_art_from_url_with_yes_input_not_image(self):
+        self._setup_data()
+        album = self.add_album_fixture()
+        item = album.items()[0]
+        self.mock_response('http://example.com/test.txt', 'text/html')
+        self.io.addinput('y')
+        self.run_command('embedart', '-u', 'http://example.com/test.txt')
+        mediafile = MediaFile(syspath(item.path))
+        self.assertFalse(mediafile.images)
+
     def test_embed_art_from_file_with_no_input(self):
         self._setup_data()
         album = self.add_album_fixture()

--- a/test/test_embedart.py
+++ b/test/test_embedart.py
@@ -88,6 +88,18 @@ class EmbedartCliTest(TestHelper, FetchImageHelper):
             self.IMAGEHEADER.get('image/jpeg').ljust(32, b'\x00')
         )
 
+    def test_embed_art_png_from_file_with_yes_input(self):
+        self._setup_data()
+        album = self.add_album_fixture()
+        item = album.items()[0]
+        self.mock_response('http://example.com/test.png', 'image/png')
+        self.io.addinput('y')
+        self.run_command('embedart', '-u', 'http://example.com/test.png')
+        mediafile = MediaFile(syspath(item.path))
+        self.assertEqual(
+            mediafile.images[0].data,
+            self.IMAGEHEADER.get('image/png').ljust(32, b'\x00'))
+
     def test_embed_art_from_file_with_no_input(self):
         self._setup_data()
         album = self.add_album_fixture()


### PR DESCRIPTION
## Description

Fixes [#83](https://github.com/beetbox/beets/issues/831)

Added another option `-u` to provide an image URL. The plugin can now download the image, check if it is valid, and then embed the picture as cover art. 

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
