### PR TITLE
play plugin: $playlist marker for precise control where the playlist …

### DIFF
--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -30,6 +30,11 @@ import shlex
 # If this is missing, they're placed at the end.
 ARGS_MARKER = '$args'
 
+# Indicate where the playlist file (with absolute path) should be inserted into
+# the command string. If this is missing, its placed at the end, but before
+# arguments.
+PLS_MARKER = '$playlist'
+
 
 def play(command_str, selection, paths, open_args, log, item_type='track',
          keep_open=False):
@@ -128,6 +133,15 @@ class PlayPlugin(BeetsPlugin):
 
         open_args = self._playlist_or_paths(paths)
         command_str = self._command_str(opts.args)
+
+        if PLS_MARKER in command_str:
+            if not config['play']['raw']:
+                ui.print_(ui.colorize('text_warning', 'DEBUG: ' + command_str))
+                command_str = command_str.replace(PLS_MARKER, ''.join(open_args))
+                ui.print_(ui.colorize('text_warning', 'DEBUG: ' + command_str))
+                open_args = []
+            else:
+                command_str = command_str.replace(PLS_MARKER, " ")
 
         # Check if the selection exceeds configured threshold. If True,
         # cancel, otherwise proceed with play command.

--- a/docs/plugins/play.rst
+++ b/docs/plugins/play.rst
@@ -48,8 +48,14 @@ To configure the plugin, make a ``play:`` section in your
 configuration file. The available options are:
 
 - **command**: The command used to open the playlist.
-  Default: ``open`` on OS X, ``xdg-open`` on other Unixes and ``start`` on
-  Windows. Insert ``$args`` to use the ``--args`` feature.
+
+  - Default: ``open`` on OS X, ``xdg-open`` on other Unixes and ``start`` on
+    Windows.
+  - Insert ``$args`` to use the ``--args`` feature.
+  - Insert ``$playlist`` to specify precisely where the playlist path should
+    appear in the command; only works if a playlist is generated, that is when
+    **raw** = ``no`` is configured.
+
 - **relative_to**: If set, emit paths relative to this directory.
   Default: None.
 - **use_folders**: When using the ``-a`` option, the m3u will contain the
@@ -97,6 +103,13 @@ example::
 
 indicates that you need to insert extra arguments before specifying the
 playlist.
+
+The above example, however, does not work with current ``mpv`` because the
+``--playlist`` argument wants a different syntax. To satisfy this, the optional
+``$playlist`` can be used to meet that::
+
+    play:
+        command: mpv $args --playlist=$playlist
 
 The ``--yes`` (or ``-y``) flag to the ``play`` command will skip the warning
 message if you choose to play more items than the **warning_threshold** 


### PR DESCRIPTION
…file is placed in the command

## Description

see included doc; placing the playlist filename at the end of command just isn't working for all players

I have this in use with `mpv`

## To Do

- [ ] Documentation. (done, let me know if more is needed)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (let me know if needed)
