### PR TITLE
Enforced utf-8 encoding on imported files

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -958,7 +958,7 @@ def import_files(lib, paths, query):
     if config['import']['log'].get() is not None:
         logpath = syspath(config['import']['log'].as_filename())
         try:
-            loghandler = logging.FileHandler(logpath)
+            loghandler = logging.FileHandler(logpath, encoding='utf-8')
         except OSError:
             raise ui.UserError("could not open log file for writing: "
                                "{}".format(displayable_path(logpath)))

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,8 @@ for Python 3.6).
 
 New features:
 
+* Added UTF-8 encoding enforcement to imported files in `beets/beets/ui/commands.py`.
+  :bug:`4693` 
 * Added additional error handling for `spotify` plugin.
   :bug:`4686`
 * We now import the remixer field from Musicbrainz into the library.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,7 +11,7 @@ for Python 3.6).
 
 New features:
 
-* Added UTF-8 encoding enforcement to imported files in `beets/beets/ui/commands.py`.
+* --from-logfile now parses log files using a UTF-8 encoding in `beets/beets/ui/commands.py`.
   :bug:`4693` 
 * Added additional error handling for `spotify` plugin.
   :bug:`4686`

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -172,7 +172,7 @@ Optional command flags:
 
     Just point the ``beet import`` command at a directory of files that are
     already catalogged in your library. Beets will automatically detect this
-    situation and avoid duplicating any items. A UTF-8 encoding will be enforced on your imported file. In this situation, the "copy
+    situation and avoid duplicating any items. In this situation, the "copy
     files" option (``-c``/``-C`` on the command line or ``copy`` in the
     config file) has slightly different behavior: it causes files to be *moved*,
     rather than duplicated, if they're already in your library. (The same is

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -172,7 +172,7 @@ Optional command flags:
 
     Just point the ``beet import`` command at a directory of files that are
     already catalogged in your library. Beets will automatically detect this
-    situation and avoid duplicating any items. In this situation, the "copy
+    situation and avoid duplicating any items. A UTF-8 encoding will be enforced on your imported file. In this situation, the "copy
     files" option (``-c``/``-C`` on the command line or ``copy`` in the
     config file) has slightly different behavior: it causes files to be *moved*,
     rather than duplicated, if they're already in your library. (The same is


### PR DESCRIPTION
## Description

Fixes #4693. 
To address the bug outlined in issue #4693, we added a utf-8 encoding argument to the import_files function in the commands.py file.


## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
