### PR TITLE
Add `-l` flag to `list` command to limit query results

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -1078,7 +1078,7 @@ class Database:
 
     # Querying.
 
-    def _fetch(self, model_cls, query=None, sort=None):
+    def _fetch(self, model_cls, query=None, sort=None, limit=None):
         """Fetch the objects of type `model_cls` matching the given
         query. The query may be given as a string, string sequence, a
         Query object, or None (to fetch everything). `sort` is an
@@ -1089,10 +1089,11 @@ class Database:
         where, subvals = query.clause()
         order_by = sort.order_clause()
 
-        sql = ("SELECT * FROM {} WHERE {} {}").format(
+        sql = ("SELECT * FROM {} WHERE {} {} {}").format(
             model_cls._table,
             where or '1',
             f"ORDER BY {order_by}" if order_by else '',
+            f"LIMIT {limit}" if limit else '',
         )
 
         # Fetch flexible attributes for items matching the main query.

--- a/beets/library.py
+++ b/beets/library.py
@@ -1512,7 +1512,7 @@ class Library(dbcore.Database):
 
     # Querying.
 
-    def _fetch(self, model_cls, query, sort=None):
+    def _fetch(self, model_cls, query, sort=None, limit=None):
         """Parse a query and fetch.
 
         If an order specification is present in the query string
@@ -1533,9 +1533,7 @@ class Library(dbcore.Database):
         if parsed_sort and not isinstance(parsed_sort, dbcore.query.NullSort):
             sort = parsed_sort
 
-        return super()._fetch(
-            model_cls, query, sort
-        )
+        return super()._fetch(model_cls, query, sort, limit)
 
     @staticmethod
     def get_default_album_sort():
@@ -1549,13 +1547,15 @@ class Library(dbcore.Database):
         return dbcore.sort_from_strings(
             Item, beets.config['sort_item'].as_str_seq())
 
-    def albums(self, query=None, sort=None):
+    def albums(self, query=None, sort=None, limit=None):
         """Get :class:`Album` objects matching the query."""
-        return self._fetch(Album, query, sort or self.get_default_album_sort())
+        sort = sort or self.get_default_album_sort()
+        return self._fetch(Album, query, sort, limit)
 
-    def items(self, query=None, sort=None):
+    def items(self, query=None, sort=None, limit=None):
         """Get :class:`Item` objects matching the query."""
-        return self._fetch(Item, query, sort or self.get_default_item_sort())
+        sort = sort or self.get_default_item_sort()
+        return self._fetch(Item, query, sort, limit)
 
     # Convenience accessors.
 

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1139,26 +1139,28 @@ default_commands.append(import_cmd)
 
 # list: Query and show library contents.
 
-def list_items(lib, query, album, fmt=''):
+def list_items(lib, query, album, limit, fmt=''):
     """Print out items in lib matching query. If album, then search for
     albums instead of single items.
     """
     if album:
-        for album in lib.albums(query):
+        for album in lib.albums(query, limit=limit):
             ui.print_(format(album, fmt))
     else:
-        for item in lib.items(query):
+        for item in lib.items(query, limit=limit):
             ui.print_(format(item, fmt))
 
 
 def list_func(lib, opts, args):
-    list_items(lib, decargs(args), opts.album)
+    list_items(lib, decargs(args), opts.album, opts.limit)
 
 
 list_cmd = ui.Subcommand('list', help='query the library', aliases=('ls',))
-list_cmd.parser.usage += "\n" \
-    'Example: %prog -f \'$album: $title\' artist:beatles'
+list_cmd.parser.usage += """
+Example: %prog -f '$album: $title' artist:beatles"""
 list_cmd.parser.add_all_common_options()
+list_cmd.parser.add_option('-l', '--limit', type=int,
+                           help='limit query results')
 list_cmd.func = list_func
 default_commands.append(list_cmd)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ for Python 3.6).
 
 New features:
 
+* :ref:`list-cmd` Add ``-l / --limit LIMIT`` flag to the ``list`` command to limit query results
 * Added additional error handling for `spotify` plugin.
   :bug:`4686`
 * We now import the remixer field from Musicbrainz into the library.

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -198,7 +198,7 @@ list
 ````
 ::
 
-    beet list [-apf] QUERY
+    beet list [-apf] [-l LIMIT] QUERY
 
 :doc:`Queries <query>` the database for music.
 
@@ -212,6 +212,9 @@ In this case, the queries you use are restricted to album-level fields: for
 example, you can search for ``year:1969`` but query parts for item-level fields
 like ``title:foo`` will be ignored. Remember that ``artist`` is an item-level
 field; ``albumartist`` is the corresponding album field.
+
+Use the ``-l LIMIT`` (``--limit=LIMIT``) flag when you want to cap the maximum
+number of items that are returned.
 
 The ``-p`` option makes beets print out filenames of matched items, which might
 be useful for piping into other Unix commands (such as `xargs`_). Similarly, the

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -47,10 +47,13 @@ class ListTest(unittest.TestCase):
         self.item.path = 'xxx/yyy'
         self.lib.add(self.item)
         self.lib.add_album([self.item])
+        self.another_item = _common.item()
+        self.another_item.path = "another/path"
+        self.lib.add(self.another_item)
 
-    def _run_list(self, query='', album=False, path=False, fmt=''):
+    def _run_list(self, query='', album=False, path=False, fmt='', limit=None):
         with capture_stdout() as stdout:
-            commands.list_items(self.lib, query, album, fmt)
+            commands.list_items(self.lib, query, album, limit, fmt)
         return stdout
 
     def test_list_outputs_item(self):
@@ -68,7 +71,7 @@ class ListTest(unittest.TestCase):
 
     def test_list_item_path(self):
         stdout = self._run_list(fmt='$path')
-        self.assertEqual(stdout.getvalue().strip(), 'xxx/yyy')
+        self.assertEqual(stdout.getvalue().strip().splitlines()[0], 'xxx/yyy')
 
     def test_list_album_outputs_something(self):
         stdout = self._run_list(album=True)
@@ -99,12 +102,18 @@ class ListTest(unittest.TestCase):
     def test_list_item_format_multiple(self):
         stdout = self._run_list(fmt='$artist - $album - $year')
         self.assertEqual('the artist - the album - 0001',
-                         stdout.getvalue().strip())
+                         stdout.getvalue().strip().splitlines()[0])
 
     def test_list_album_format(self):
         stdout = self._run_list(album=True, fmt='$genre')
         self.assertIn('the genre', stdout.getvalue())
         self.assertNotIn('the album', stdout.getvalue())
+
+    def test_limit_query_results(self):
+        stdout = self._run_list()
+        self.assertEqual(2, len(stdout.getvalue().strip().splitlines()))
+        stdout = self._run_list(limit=1)
+        self.assertEqual(1, len(stdout.getvalue().strip().splitlines()))
 
 
 class RemoveTest(_common.TestCase, TestHelper):


### PR DESCRIPTION
## Description

I'm slowly coming back #4362: splitting the `--limit` flag into a separate PR is something that I promised I'd do!

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
