### PR TITLE
Update beetcamp URL in id_extractors

### DIFF
--- a/beets/util/id_extractors.py
+++ b/beets/util/id_extractors.py
@@ -35,7 +35,7 @@ beatport_id_regex = {
 
 # A note on Bandcamp: There is no such thing as a Bandcamp album or artist ID,
 # the URL can be used as the identifier. The Bandcamp metadata source plugin
-# works that way - https://github.com/unrblt/beets-bandcamp. Bandcamp album
+# works that way - https://github.com/snejus/beetcamp. Bandcamp album
 # URLs usually look like: https://nameofartist.bandcamp.com/album/nameofalbum
 
 


### PR DESCRIPTION
## Description

A tiny beetcamp URL fixup

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
