### PR TITLE
Fix data_source not updated on re-import and refactor `reimport_metadata`

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -50,6 +50,11 @@ QUEUE_SIZE = 128
 SINGLE_ARTIST_THRESH = 0.25
 PROGRESS_KEY = 'tagprogress'
 HISTORY_KEY = 'taghistory'
+# Album and item flexble attrbutes that should not be preserved on reimports.
+REIMPORT_FRESH_FIELDS_ALBUM = ['data_source']
+REIMPORT_FRESH_FIELDS_ITEM = ['data_source', 'bandcamp_album_id',
+                              'spotify_album_id', 'deezer_album_id',
+                              'beatport_album_id']
 
 # Global logger.
 log = logging.getLogger('beets')
@@ -811,17 +816,12 @@ class ImportTask(BaseImportTask):
         """For reimports, preserves metadata for reimported items and
         albums.
         """
-        # Album and item flex attrs that should not be preserved on reimports.
-        dont_preserve_album_flex = ['data_source']
-        dont_preserve_item_flex = ['data_source', 'bandcamp_album_id',
-                                   'spotify_album_id', 'deezer_album_id',
-                                   'beatport_album_id']
         if self.is_album:
             replaced_album = self.replaced_albums.get(self.album.path)
             if replaced_album:
                 preserved_album_attrs = dict(replaced_album._values_flex)
 
-                for attr in dont_preserve_album_flex:
+                for attr in REIMPORT_FRESH_FIELDS_ALBUM:
                     if not self.album.get(attr):
                         continue
                     new_val = self.album.get(attr)
@@ -860,7 +860,7 @@ class ImportTask(BaseImportTask):
                         item.id, dup_item.id, displayable_path(item.path))
 
                 preserved_item_attrs = dict(dup_item._values_flex)
-                for attr in dont_preserve_item_flex:
+                for attr in REIMPORT_FRESH_FIELDS_ITEM:
                     if not item.get(attr):
                         continue
                     new_val = item.get(attr)

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -819,32 +819,35 @@ class ImportTask(BaseImportTask):
         if self.is_album:
             replaced_album = self.replaced_albums.get(self.album.path)
             if replaced_album:
-                self.album.added = replaced_album.added
                 preserved_album_attrs = dict(replaced_album._values_flex)
 
                 for attr in dont_preserve_album_flex:
-                    if self.album.get(attr):
-                        new_val = self.album.get(attr)
-                        old_val = replaced_album.get(attr)
-                        if new_val != old_val:
-                            preserved_album_attrs.pop(attr, None)
-                            log.debug(
-                                'Setting album flexible attribute '
-                                '{0}: {1} for {2}, {3}',
-                                attr, new_val, self.album.id,
-                                displayable_path(self.album.path))
+                    if not self.album.get(attr):
+                        continue
+                    new_val = self.album.get(attr)
+                    old_val = replaced_album.get(attr)
+                    if new_val != old_val:
+                        preserved_album_attrs.pop(attr, None)
+                        log.debug(
+                            'Not reimported album {} flexible attribute: {}. '
+                            'New value: {}, Path: {}',
+                            self.album.id, attr, new_val,
+                            displayable_path(self.album.path))
 
+                self.album.added = replaced_album.added
                 self.album.update(preserved_album_attrs)
                 self.album.artpath = replaced_album.artpath
                 self.album.store()
                 log.debug(
-                    'Reimported album: added {0}, flexible '
-                    'attributes {1} from album {2} for {3}',
-                    self.album.added,
-                    list(preserved_album_attrs.keys()),
-                    replaced_album.id,
-                    displayable_path(self.album.path)
-                )
+                    "Reimported album {} attribute: ['added'] from album {}, "
+                    "Path: {}",
+                    self.album.id, replaced_album.id,
+                    displayable_path(self.album.path))
+                log.debug(
+                    'Reimported album {} flexible attributes: {} '
+                    'from album {}, Path:{}',
+                    self.album.id, list(preserved_album_attrs.keys()),
+                    replaced_album.id, displayable_path(self.album.path))
 
         for item in self.imported_items():
             dup_items = self.replaced_items[item]
@@ -852,33 +855,30 @@ class ImportTask(BaseImportTask):
                 if dup_item.added and dup_item.added != item.added:
                     item.added = dup_item.added
                     log.debug(
-                        'Reimported item added {0} '
-                        'from item {1} for {2}',
-                        item.added,
-                        dup_item.id,
-                        displayable_path(item.path)
-                    )
+                        "Reimported item {} attribute: ['added'] "
+                        "from item {}, Path: {}",
+                        item.id, dup_item.id, displayable_path(item.path))
 
                 preserved_item_attrs = dict(dup_item._values_flex)
                 for attr in dont_preserve_item_flex:
-                    if item.get(attr):
-                        new_val = item.get(attr)
-                        old_val = dup_item.get(attr)
-                        if new_val != old_val:
-                            preserved_item_attrs.pop(attr)
-                            log.debug(
-                                'Setting item flexible attribute '
-                                '{0}: {1} for item {2}, {3}', attr, new_val,
-                                item.id, displayable_path(item.path))
+                    if not item.get(attr):
+                        continue
+                    new_val = item.get(attr)
+                    old_val = dup_item.get(attr)
+                    if new_val != old_val:
+                        preserved_item_attrs.pop(attr)
+                        log.debug(
+                            'Not reimported item {} flexible attribute: {}'
+                            'New value: {}, Path: {}',
+                            item.id, attr, new_val,
+                            displayable_path(item.path))
 
                 item.update(preserved_item_attrs)
                 log.debug(
-                    'Reimported item flexible attributes {0} '
-                    'from item {1} for {2}',
-                    list(preserved_item_attrs.keys()),
-                    dup_item.id,
-                    displayable_path(item.path)
-                )
+                    'Reimported item {} flexible attributes: {} '
+                    'from item {}, Path: {}',
+                    item.id, list(preserved_item_attrs.keys()), dup_item.id,
+                    displayable_path(item.path))
                 item.store()
 
     def remove_replaced(self, lib):

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -822,7 +822,7 @@ class ImportTask(BaseImportTask):
             entries that should not be preserved and returns a dict containing
             those fields left to actually be preserved.
             """
-            noun = 'album' if self.is_album else 'item'
+            noun = 'album' if isinstance(new_obj, library.Album) else 'item'
             existing_fields = dict(existing_fields)
             overwritten_fields = [k for k in existing_fields
                                   if k in overwrite_keys

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -817,11 +817,10 @@ class ImportTask(BaseImportTask):
         albums.
         """
         def _reduce_and_log(new_obj, existing_fields, overwrite_keys):
-            """Some flexible attributes should be overwritten (and not
-            preserved) on reimports which this function handles. Copies
-            existing_fields, logs and removes entries that should not be
-            preserved and returns a dict containing those fields left to
-            actually be preserved
+            """Some flexible attributes should be overwritten (rather than
+            preserved) on reimports; Copies existing_fields, logs and removes
+            entries that should not be preserved and returns a dict containing
+            those fields left to actually be preserved.
             """
             noun = 'album' if self.is_album else 'item'
             existing_fields = dict(existing_fields)
@@ -829,9 +828,11 @@ class ImportTask(BaseImportTask):
                                   if k in overwrite_keys
                                   and existing_fields.get(k) != new_obj.get(k)]
             if overwritten_fields:
-                log.debug('Not preserving {} {} flexible attributes: {}. '
-                          'Path: {}', noun, new_obj.id, overwritten_fields,
-                          displayable_path(new_obj.path))
+                log.debug(
+                    'Reimported {} {}. Not preserving flexible attributes {}. '
+                    'Path: {}',
+                    noun, new_obj.id, overwritten_fields,
+                    displayable_path(new_obj.path))
                 for key in overwritten_fields:
                     del existing_fields[key]
             return existing_fields
@@ -847,15 +848,14 @@ class ImportTask(BaseImportTask):
                 self.album.artpath = replaced_album.artpath
                 self.album.store()
                 log.debug(
-                    "Reimported album {} attribute: ['added'] from album {}, "
+                    "Reimported album {}. Preserving attribute ['added']. "
                     "Path: {}",
-                    self.album.id, replaced_album.id,
-                    displayable_path(self.album.path))
+                    self.album.id, displayable_path(self.album.path))
                 log.debug(
-                    'Reimported album {} flexible attributes: {} '
-                    'from album {}, Path:{}',
+                    'Reimported album {}. Preserving flexible attributes {}. '
+                    'Path: {}',
                     self.album.id, list(album_fields.keys()),
-                    replaced_album.id, displayable_path(self.album.path))
+                    displayable_path(self.album.path))
 
         for item in self.imported_items():
             dup_items = self.replaced_items[item]
@@ -863,16 +863,16 @@ class ImportTask(BaseImportTask):
                 if dup_item.added and dup_item.added != item.added:
                     item.added = dup_item.added
                     log.debug(
-                        "Reimported item {} attribute: ['added'] "
-                        "from item {}, Path: {}",
-                        item.id, dup_item.id, displayable_path(item.path))
+                        "Reimported item {}. Preserving attribute ['added']. "
+                        "Path: {}",
+                        item.id, displayable_path(item.path))
                 item_fields = _reduce_and_log(item, dup_item._values_flex,
                                               REIMPORT_FRESH_FIELDS_ITEM)
                 item.update(item_fields)
                 log.debug(
-                    'Reimported item {} flexible attributes: {} '
-                    'from item {}, Path: {}',
-                    item.id, list(item_fields.keys()), dup_item.id,
+                    'Reimported item {}. Preserving flexible attributes {}. '
+                    'Path: {}',
+                    item.id, list(item_fields.keys()),
                     displayable_path(item.path))
                 item.store()
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -171,6 +171,9 @@ Bug fixes:
   library**. Following the instructions `described here
   <https://github.com/beetbox/beets/pull/4582#issuecomment-1445023493>`_, a
   sanity check and potential fix is easily possible. :bug:`4528`
+* Fix updating "data_source" on re-imports and improve logging when flexible
+  attributes are being re-imported.
+  :bug:`4726`
 
 For packagers:
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -139,7 +139,8 @@ class AutotagStub:
             va=False,
             album_id='albumid' + id,
             artist_id='artistid' + id,
-            albumtype='soundtrack'
+            albumtype='soundtrack',
+            data_source='match_source'
         )
 
 
@@ -1723,6 +1724,7 @@ class ReimportTest(unittest.TestCase, ImportHelper, _common.Assertions):
         album = self.add_album_fixture()
         album.added = 4242.0
         album.foo = 'bar'  # Some flexible attribute.
+        album.data_source = 'original_source'
         album.store()
         item = album.items().get()
         item.baz = 'qux'
@@ -1803,6 +1805,12 @@ class ReimportTest(unittest.TestCase, ImportHelper, _common.Assertions):
         self.assertExists(new_artpath)
         if new_artpath != old_artpath:
             self.assertNotExists(old_artpath)
+
+    def test_reimported_album_not_preserves_flexattr(self):
+        self._setup_session()
+        self.assertEqual(self._album().data_source, 'original_source')
+        self.importer.run()
+        self.assertEqual(self._album().data_source, 'match_source')
 
 
 class ImportPretendTest(_common.TestCase, ImportHelper):


### PR DESCRIPTION
## Description

- Fixes #4726 
- Refactors preserving of flexible attributes in the importer's `reimport_metadata()` method.
- New logging message when flexible attributes are excluded from the preserving process and _actually_ set to a new value.
- Reformats all existing logging messages and streamline their looks.
- Adds a new unittest that checks if the data_source album field is _not_ reset to its original value on a reimport.

## To Do

- [X] ~Documentation.~
- [X] Changelog.
- [X] Tests.
