### PR TITLE
Perform regex and `bareasc` lookups using SQL

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -975,6 +975,7 @@ class Database:
         conn = sqlite3.connect(
             py3_path(self.path), timeout=self.timeout
         )
+        self.add_functions(conn)
 
         if self.supports_extensions:
             conn.enable_load_extension(True)
@@ -986,6 +987,14 @@ class Database:
         # Access SELECT results like dictionaries.
         conn.row_factory = sqlite3.Row
         return conn
+
+    def add_functions(self, conn):
+        def regexp(value, pattern):
+            if isinstance(value, bytes):
+                value = value.decode()
+            return re.search(pattern, str(value)) is not None
+
+        conn.create_function("regexp", 2, regexp)
 
     def _close(self):
         """Close the all connections to the underlying SQLite database

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -23,6 +23,8 @@ import threading
 import sqlite3
 import contextlib
 
+from unidecode import unidecode
+
 import beets
 from beets.util import functemplate
 from beets.util import py3_path
@@ -995,6 +997,7 @@ class Database:
             return re.search(pattern, str(value)) is not None
 
         conn.create_function("regexp", 2, regexp)
+        conn.create_function("unidecode", 1, unidecode)
 
     def _close(self):
         """Close the all connections to the underlying SQLite database

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -231,6 +231,9 @@ class RegexpQuery(StringFieldQuery):
                                                  "a regular expression",
                                                  format(exc))
 
+    def col_clause(self):
+        return f" regexp({self.field}, ?)", [self.pattern.pattern]
+
     @staticmethod
     def _normalize(s):
         """Normalize a Unicode string's representation (used on both

--- a/beetsplug/bareasc.py
+++ b/beetsplug/bareasc.py
@@ -42,6 +42,14 @@ class BareascQuery(StringFieldQuery):
         val = unidecode(val)
         return pattern in val
 
+    def col_clause(self):
+        """Compare ascii version of the pattern."""
+        clause = f"unidecode({self.field})"
+        if self.pattern.islower():
+            clause = f"lower({clause})"
+
+        return rf"{clause} LIKE ? ESCAPE '\'", [f"%{unidecode(self.pattern)}%"]
+
 
 class BareascPlugin(BeetsPlugin):
     """Plugin to provide bare-ASCII option for beets matching."""

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ New features:
 
 * --from-logfile now parses log files using a UTF-8 encoding in `beets/beets/ui/commands.py`.
   :bug:`4693` 
+* :ref:`list-cmd` lookups using the pattern operator `::` have been made faster
 * Added additional error handling for `spotify` plugin.
   :bug:`4686`
 * We now import the remixer field from Musicbrainz into the library.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ New features:
 
 * --from-logfile now parses log files using a UTF-8 encoding in `beets/beets/ui/commands.py`.
   :bug:`4693` 
+* :doc:`/plugins/bareasc` lookups have been made faster
 * :ref:`list-cmd` lookups using the pattern operator `::` have been made faster
 * Added additional error handling for `spotify` plugin.
   :bug:`4686`


### PR DESCRIPTION
## Description

* Define a custom function which performs regex lookups natively in SQL. This improves
performance of lookups like `beet list path::hello`.
* Define a function which runs `unidecode` for the `bareasc` lookups

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
