### PR TITLE
Define SingletonQuery to perform filtering through SQL

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -45,6 +45,15 @@ log = logging.getLogger('beets')
 # Library-specific query types.
 
 class SingletonQuery(dbcore.FieldQuery):
+    """This query is responsible for the 'singleton' lookup.
+
+    It is based on the FieldQuery and constructs a SQL clause
+    'album_id is NULL' which yields the same result as the previous filter
+    in Python but is more performant since it's done in SQL.
+
+    Using util.str2bool ensures that lookups like singleton:true, singleton:1
+    and singleton:false, singleton:0 are handled consistently.
+    """
     def __new__(cls, field, value, *args, **kwargs):
         query = dbcore.query.NoneQuery('album_id')
         if util.str2bool(value):

--- a/beets/library.py
+++ b/beets/library.py
@@ -44,6 +44,14 @@ log = logging.getLogger('beets')
 
 # Library-specific query types.
 
+class SingletonQuery(dbcore.FieldQuery):
+    def __new__(cls, field, value, *args, **kwargs):
+        query = dbcore.query.NoneQuery('album_id')
+        if util.str2bool(value):
+            return query
+        return dbcore.query.NotQuery(query)
+
+
 class PathQuery(dbcore.FieldQuery):
     """A query that matches all items under a given path.
 
@@ -568,6 +576,8 @@ class Item(LibModel):
     _formatter = FormattedItemMapping
 
     _sorts = {'artist': SmartArtistSort}
+
+    _queries = {'singleton': SingletonQuery}
 
     _format_config_key = 'format_item'
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,8 @@ for Python 3.6).
 
 New features:
 
+* :ref:`list-cmd` `singleton:true` queries have been made faster
+* :ref:`list-cmd` `singleton:1` and `singleton:0` can now alternatively be used in queries, same as `comp`
 * --from-logfile now parses log files using a UTF-8 encoding in `beets/beets/ui/commands.py`.
   :bug:`4693` 
 * Added additional error handling for `spotify` plugin.

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -290,8 +290,18 @@ class GetTest(DummyDataTestCase):
         results = self.lib.items(q)
         self.assert_items_matched(results, ['beets 4 eva'])
 
+    def test_singleton_1(self):
+        q = 'singleton:1'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, ['beets 4 eva'])
+
     def test_singleton_false(self):
         q = 'singleton:false'
+        results = self.lib.items(q)
+        self.assert_items_matched(results, ['foo bar', 'baz qux'])
+
+    def test_singleton_0(self):
+        q = 'singleton:0'
         results = self.lib.items(q)
         self.assert_items_matched(results, ['foo bar', 'baz qux'])
 


### PR DESCRIPTION
## Description

Added `SingletonQuery` which queries 
* `album_id is NULL` for `singleton:true`
* `not (album_id is NULL)` for `singleton:false`

As a result
* A nice speed-up of the `singleton:true` query 
* `singleton:1` and `singleton:0` now work fine!

This is ultimately building towards replacing python-only queries with SQL equivalents.

### Timings
Tested with default config on my ~7K items library that has 350 singletons. Numbers represent seconds, and each command was run 10 times.

![image](https://user-images.githubusercontent.com/16212750/230704604-e95e700d-12cf-4e4d-96e3-716906d0e8f4.png)


## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
