### PR TITLE
plugins: add markunmatched

### DIFF
--- a/beetsplug/markunmatched.py
+++ b/beetsplug/markunmatched.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import subprocess
+import shlex
+
+from beets.autotag.match import Recommendation
+from confuse import NotFoundError as ConfigParmNotFound
+from beets.plugins import BeetsPlugin
+from beets.ui.commands import PromptChoice
+from beets.importer import action
+
+
+class MarkUnmatched(BeetsPlugin):
+    def __init__(self):
+        super(MarkUnmatched, self).__init__()
+        self.register_listener('before_choose_candidate',
+                               self.before_choose_candidate_event)
+
+    def before_choose_candidate_event(self, session, task):
+        if task.rec == Recommendation.strong:
+            self._log.info("recommendation is strong, not notifying")
+            return
+        notify_command = ""
+        try:
+            notify_command = shlex.split(str(self.config['notify-command']))
+        except ConfigParmNotFound:
+            self._log.info("no notify-command was configured")
+        if notify_command:
+            self._log.info("notifying no-match via command configured: %s",
+                           self.config['notify-command'])
+            print_cmd = [
+                "printf", "%s",
+                "failed to find match for paths:\n",
+                "\n".join([path.decode('utf-8') for path in task.paths])
+            ]
+            p_msg = subprocess.Popen(print_cmd, stdout=subprocess.PIPE)
+            p_out = subprocess.Popen(notify_command, stdin=p_msg.stdout, stdout=subprocess.PIPE)
+            (stdout, stderr) = p_out.communicate()
+            if stderr:
+                print("'notify-command' printed errors:")
+                print(stderr.decode('utf-8'), end='')
+            if stdout:
+                print("'notify-command' printed:")
+                print(stdout.decode('utf-8'), end='')
+        return [PromptChoice(
+            'f',
+            'create a \'beets-unmatched\' File and skip',
+            self.touch_unmatched
+        )]
+
+    def touch_unmatched(self, session, task):
+        for path in task.paths:
+            Path(path.decode('utf-8') + "/beets-unmatched").touch()
+        return action.SKIP

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -101,6 +101,7 @@ following to your configuration::
    limit
    loadext
    lyrics
+   markunmatched
    mbcollection
    mbsubmit
    mbsync

--- a/docs/plugins/markunmatched.rst
+++ b/docs/plugins/markunmatched.rst
@@ -1,0 +1,38 @@
+MarkUnmatched Plugin
+==================
+
+The ``markunmatched`` plugin is a simple plugin that adds a prompt choice when
+beets fails to find accurate enough matches when importing a directory (see
+:doc:`usage`). It also includes an option to notify you via a custom command
+when an import has encountered a too weak recommendation.
+
+To use the ``markunmatched`` plugin, enable it in your configuration (see
+:ref:`using-plugins`).
+
+Usage
+-----
+
+When importing many directories in a bulk, you may want to skip a directory but
+mark yourself to take care of it later - for example add that album to
+musicbrainz later, and not now during the bulk import.
+
+The prompt looks like this::
+
+    Apply, More candidates, Skip, Use as-is, as Tracks, Group albums,
+    Enter search, enter Id, aBort, create a 'beets-unmatched' File and skip,
+    Print tracks, eDit, edit Candidates?
+
+The `beets-unmatched` file can be used to later to reiterate the unmatched
+albums.
+
+Configuration:
+--------------
+
+By default, no notification is made when a match is not found in an import
+procedure. To configure such notification, use (e.g)::
+
+    markunmatched:
+        notify-command: "gotify push --title 'Beets Music importer' --priority 4"
+
+Beets pipes to stdin of the above command the message mentioning the unmatched
+paths.

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,6 +86,7 @@ per-file-ignores =
     ./beetsplug/bpsync.py:D
     ./beetsplug/__init__.py:D
     ./beetsplug/edit.py:D
+    ./beetsplug/markunmatched.py:D
     ./beetsplug/types.py:D
     ./beetsplug/embedart.py:D
     ./beetsplug/mpdupdate.py:D


### PR DESCRIPTION
## Description

Add a plugin useful for bulk importers.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
