### PR TITLE
CI: update python versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11-dev']
+        python-version: ['3.7', '3.8', '3.9', '3.x', '3.12-dev']
 
     env:
       PY_COLORS: 1
@@ -45,17 +45,17 @@ jobs:
           sudo apt install ffmpeg  # For replaygain
 
       - name: Test older Python versions with tox
-        if: matrix.python-version != '3.10' && matrix.python-version != '3.11-dev'
+        if: matrix.python-version != '3.x' && matrix.python-version != '3.12-dev'
         run: |
           tox -e py-test
 
       - name: Test latest Python version with tox and get coverage
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.x'
         run: |
           tox -vv -e py-cov
 
       - name: Test latest Python version with tox and mypy
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.x'
         # continue-on-error is not ideal since it doesn't give a visible
         # warning, but there doesn't seem to be anything better:
         # https://github.com/actions/toolkit/issues/399
@@ -64,7 +64,7 @@ jobs:
           tox -vv -e py-mypy
 
       - name: Test nightly Python version with tox
-        if: matrix.python-version == '3.11-dev'
+        if: matrix.python-version == '3.12-dev'
         # continue-on-error is not ideal since it doesn't give a visible
         # warning, but there doesn't seem to be anything better:
         # https://github.com/actions/toolkit/issues/399
@@ -73,7 +73,7 @@ jobs:
           tox -e py-test
 
       - name: Upload code coverage
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.x'
         run: |
           pip install codecov || true
           codecov || true
@@ -87,10 +87,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.x
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.x'
 
       - name: Install base dependencies
         run: |
@@ -109,10 +109,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.x
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.x'
 
       - name: Install base dependencies
         run: |

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -923,6 +923,11 @@ class Database:
     """
 
     def __init__(self, path, timeout=5.0):
+        if sqlite3.threadsafety == 0:
+            raise RuntimeError(
+                "sqlite3 must be compiled with multi-threading support"
+            )
+
         self.path = path
         self.timeout = timeout
 

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -171,6 +171,7 @@ class MigrationTest(unittest.TestCase):
             'insert into test (field_one, field_two) values (4, 2)'
         )
         old_lib._connection().commit()
+        old_lib._connection().close()
         del old_lib
 
     @classmethod
@@ -190,6 +191,7 @@ class MigrationTest(unittest.TestCase):
         c = new_lib._connection().cursor()
         c.execute("select * from test")
         row = c.fetchone()
+        c.connection.close()
         self.assertEqual(len(row.keys()), len(ModelFixture2._fields))
 
     def test_open_with_new_field_adds_column(self):
@@ -197,6 +199,7 @@ class MigrationTest(unittest.TestCase):
         c = new_lib._connection().cursor()
         c.execute("select * from test")
         row = c.fetchone()
+        c.connection.close()
         self.assertEqual(len(row.keys()), len(ModelFixture3._fields))
 
     def test_open_with_fewer_fields_leaves_untouched(self):
@@ -204,6 +207,7 @@ class MigrationTest(unittest.TestCase):
         c = new_lib._connection().cursor()
         c.execute("select * from test")
         row = c.fetchone()
+        c.connection.close()
         self.assertEqual(len(row.keys()), len(ModelFixture2._fields))
 
     def test_open_with_multiple_new_fields(self):
@@ -211,12 +215,15 @@ class MigrationTest(unittest.TestCase):
         c = new_lib._connection().cursor()
         c.execute("select * from test")
         row = c.fetchone()
+        c.connection.close()
         self.assertEqual(len(row.keys()), len(ModelFixture4._fields))
 
     def test_extra_model_adds_table(self):
         new_lib = DatabaseFixtureTwoModels(self.libfile)
         try:
-            new_lib._connection().execute("select * from another")
+            c = new_lib._connection()
+            c.execute("select * from another")
+            c.close()
         except sqlite3.OperationalError:
             self.fail("select failed")
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1221,7 +1221,7 @@ class InferAlbumDataTest(_common.TestCase):
         self.assertFalse(self.items[0].comp)
 
 
-def test_album_info(*args, **kwargs):
+def match_album_mock(*args, **kwargs):
     """Create an AlbumInfo object for testing.
     """
     track_info = TrackInfo(
@@ -1240,7 +1240,7 @@ def test_album_info(*args, **kwargs):
     return iter([album_info])
 
 
-@patch('beets.autotag.mb.match_album', Mock(side_effect=test_album_info))
+@patch('beets.autotag.mb.match_album', Mock(side_effect=match_album_mock))
 class ImportDuplicateAlbumTest(unittest.TestCase, TestHelper,
                                _common.Assertions):
 
@@ -1349,13 +1349,13 @@ class ImportDuplicateAlbumTest(unittest.TestCase, TestHelper,
         return album
 
 
-def test_track_info(*args, **kwargs):
+def match_track_mock(*args, **kwargs):
     return iter([TrackInfo(
         artist='artist', title='title',
         track_id='new trackid', index=0,)])
 
 
-@patch('beets.autotag.mb.match_track', Mock(side_effect=test_track_info))
+@patch('beets.autotag.mb.match_track', Mock(side_effect=match_track_mock))
 class ImportDuplicateSingletonTest(unittest.TestCase, TestHelper,
                                    _common.Assertions):
 

--- a/test/test_m3ufile.py
+++ b/test/test_m3ufile.py
@@ -77,12 +77,12 @@ class M3UFileTest(unittest.TestCase):
         self.assertTrue(path.exists(the_playlist_file))
         m3ufile_read = M3UFile(the_playlist_file)
         m3ufile_read.load()
-        self.assertEquals(
+        self.assertEqual(
             m3ufile.media_list[0],
             bytestring_path(
                 path.join('x:\\', 'This', 'is', 'å', 'path', 'to_a_file.mp3'))
         )
-        self.assertEquals(
+        self.assertEqual(
             m3ufile.media_list[1],
             bytestring_path(r"x:\This\is\another\path\tö_a_file.mp3"),
             bytestring_path(path.join(

--- a/test/test_ui_init.py
+++ b/test/test_ui_init.py
@@ -135,7 +135,8 @@ class ParentalDirCreation(_common.TestCase):
         test_config = deepcopy(config)
         test_config['library'] = non_exist_path
         with control_stdin('y'):
-            ui._open_library(test_config)
+            lib = ui._open_library(test_config)
+        lib._close()
 
     def test_create_no(self):
         non_exist_path_parent = _common.util.py3_path(
@@ -147,12 +148,14 @@ class ParentalDirCreation(_common.TestCase):
 
         with control_stdin('n'):
             try:
-                ui._open_library(test_config)
+                lib = ui._open_library(test_config)
             except ui.UserError:
                 if os.path.exists(non_exist_path_parent):
                     shutil.rmtree(non_exist_path_parent)
                     raise OSError("Parent directories should not be created.")
             else:
+                if lib:
+                    lib._close()
                 raise OSError("Parent directories should not be created.")
 
 


### PR DESCRIPTION
Given that Python 3.11 is released, we've not been testing the most recent versions anymore. Thus, (try to) use semver x-ranges in order to avoid needing manual updates of this in the future.

~~Don't merge yet, I'm not sure that the range specification for `-dev` versions is actually valid as I used it here.~~
Unfortunately, [semver intentionally doesn't give a way to specify `3.x-dev`](https://github.com/npm/node-semver#prerelease-tags) to always get the latest development version. Thus, the 3.12 specification will still need to be updated manually.