### PR TITLE
Fetchart: use cover_art_url flex attr as a cover art source

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -837,7 +837,7 @@ class CoverArtUrl(RemoteArtSource):
 
     def get(self, album, plugin, paths):
         try:
-            url = album.item().get().cover_art_url
+            url = album.items().get().cover_art_url
             print(url)
         except ValueError:
             self._log.debug('Cover art URL not found for {0}', album)

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -956,9 +956,6 @@ class Spotify(RemoteArtSource):
         return HAS_BEAUTIFUL_SOUP
 
     def get(self, album, plugin, paths):
-        if not len(album.mb_albumid) == 22:
-            self._log.debug("Invalid Spotify album_id: {}", album.mb_albumid)
-            return
         url = self.SPOTIFY_ALBUM_URL + album.mb_albumid
         try:
             response = requests.get(url)

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -983,13 +983,14 @@ class CoverArtUrl(RemoteArtSource):
         image_url = None
         try:
             image_url = album.items().get().cover_art_url
+            self._log.debug(f'Cover art URL {image_url} found for {album}')
         except (AttributeError, TypeError):
-            self._log.debug('Cover art URL not found for {0}', album)
+            self._log.debug(f'Cover art URL not found for {album}')
             return
         if image_url:
             yield self._candidate(url=image_url, match=Candidate.MATCH_EXACT)
         else:
-            self._log.debug('Cover art URL not found for {0}', album)
+            self._log.debug(f'Cover art URL not found for {album}')
             return
 
 

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -837,7 +837,7 @@ class CoverArtUrl(RemoteArtSource):
 
     def get(self, album, plugin, paths):
         try:
-            url = album.cover_art_url
+            url = album.item().get().cover_art_url
             print(url)
         except ValueError:
             self._log.debug('Cover art URL not found for {0}', album)

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -977,7 +977,7 @@ class Spotify(RemoteArtSource):
 
 
 class CoverArtUrl(RemoteArtSource):
-    # This source is intended to be used with the plugin that sets the
+    # This source is intended to be used with a plugin that sets the
     # cover_art_url field on albums or tracks. Users can also manually update
     # the cover_art_url field using the "set" command. This source will then
     # use that URL to fetch the image.

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -839,7 +839,7 @@ class CoverArtUrl(RemoteArtSource):
         image_url = None
         try:
             image_url = album.items().get().cover_art_url
-        except ValueError:
+        except AttributeError:
             self._log.debug('Cover art URL not found for {0}', album)
             return
         if image_url:

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -838,7 +838,6 @@ class CoverArtUrl(RemoteArtSource):
     def get(self, album, plugin, paths):
         try:
             url = album.items().get().cover_art_url
-            print(url)
         except ValueError:
             self._log.debug('Cover art URL not found for {0}', album)
             return
@@ -855,7 +854,6 @@ class CoverArtUrl(RemoteArtSource):
             return
         file = f'image{extension}'
         tempimg = os.path.join(tempfile.gettempdir(), file)
-        print(tempimg)
         try:
             with open(tempimg, 'wb') as f:
                 f.write(response.content)

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -977,12 +977,21 @@ class Spotify(RemoteArtSource):
 
 
 class CoverArtUrl(RemoteArtSource):
+    # This source is intended to be used with the plugin that sets the
+    # cover_art_url field on albums or tracks. Users can also manually update
+    # the cover_art_url field using the "set" command. This source will then
+    # use that URL to fetch the image.
+
     NAME = "Cover Art URL"
 
     def get(self, album, plugin, paths):
         image_url = None
         try:
-            image_url = album.items().get().cover_art_url
+            # look for cover_art_url on album or first track
+            if album.cover_art_url:
+                image_url = album.cover_art_url
+            else:
+                image_url = album.items().get().cover_art_url
             self._log.debug(f'Cover art URL {image_url} found for {album}')
         except (AttributeError, TypeError):
             self._log.debug(f'Cover art URL not found for {album}')

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -901,6 +901,9 @@ class Spotify(RemoteArtSource):
     SPOTIFY_ALBUM_URL = 'https://open.spotify.com/album/'
 
     def get(self, album, plugin, paths):
+        if not len(album.mb_albumid) == 22:
+            self._log.debug("Invalid Spotify album_id: {}", album.mb_albumid)
+            return
         url = self.SPOTIFY_ALBUM_URL + album.mb_albumid
         try:
             response = requests.get(url)

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -926,7 +926,7 @@ class LastFM(RemoteArtSource):
 # Try each source in turn.
 
 SOURCES_ALL = ['filesystem', 'coverart', 'itunes', 'amazon', 'albumart',
-               'wikipedia', 'google', 'fanarttv', 'lastfm']
+               'wikipedia', 'google', 'fanarttv', 'lastfm', 'cover_art_url']
 
 ART_SOURCES = {
     'filesystem': FileSystem,

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -986,7 +986,7 @@ class CoverArtUrl(RemoteArtSource):
         image_url = None
         try:
             image_url = album.items().get().cover_art_url
-        except AttributeError:
+        except (AttributeError, TypeError):
             self._log.debug('Cover art URL not found for {0}', album)
             return
         if image_url:

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -23,11 +23,10 @@ from tempfile import NamedTemporaryFile
 
 import confuse
 import requests
-from mediafile import image_mime_type
-
 from beets import config, importer, plugins, ui, util
 from beets.util import bytestring_path, py3_path, sorted_walk, syspath
 from beets.util.artresizer import ArtResizer
+from mediafile import image_mime_type
 
 try:
     from bs4 import BeautifulSoup
@@ -837,23 +836,6 @@ class FileSystem(LocalArtSource):
                                       match=Candidate.MATCH_FALLBACK)
 
 
-class CoverArtUrl(RemoteArtSource):
-    NAME = "Cover Art URL"
-
-    def get(self, album, plugin, paths):
-        image_url = None
-        try:
-            image_url = album.items().get().cover_art_url
-        except AttributeError:
-            self._log.debug('Cover art URL not found for {0}', album)
-            return
-        if image_url:
-            yield self._candidate(url=image_url, match=Candidate.MATCH_EXACT)
-        else:
-            self._log.debug('Cover art URL not found for {0}', album)
-            return
-
-
 class LastFM(RemoteArtSource):
     NAME = "Last.fm"
 
@@ -937,6 +919,25 @@ class Spotify(RemoteArtSource):
             self._log.debug('Spotify: error loading response: {}'
                             .format(response.text))
             return
+
+
+class CoverArtUrl(RemoteArtSource):
+    NAME = "Cover Art URL"
+
+    def get(self, album, plugin, paths):
+        image_url = None
+        try:
+            image_url = album.items().get().cover_art_url
+        except AttributeError:
+            self._log.debug('Cover art URL not found for {0}', album)
+            return
+        if image_url:
+            yield self._candidate(url=image_url, match=Candidate.MATCH_EXACT)
+        else:
+            self._log.debug('Cover art URL not found for {0}', album)
+            return
+
+
 # Try each source in turn.
 
 SOURCES_ALL = ['filesystem', 'coverart', 'itunes', 'amazon', 'albumart',
@@ -952,8 +953,8 @@ ART_SOURCES = {
     'google': GoogleImages,
     'fanarttv': FanartTV,
     'lastfm': LastFM,
-    'cover_art_url': CoverArtUrl,
     'spotify': Spotify,
+    'cover_art_url': CoverArtUrl,
 }
 SOURCE_NAMES = {v: k for k, v in ART_SOURCES.items()}
 

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -836,31 +836,17 @@ class CoverArtUrl(RemoteArtSource):
     NAME = "Cover Art URL"
 
     def get(self, album, plugin, paths):
+        image_url = None
         try:
-            url = album.items().get().cover_art_url
+            image_url = album.items().get().cover_art_url
         except ValueError:
             self._log.debug('Cover art URL not found for {0}', album)
             return
-        try:
-            response = requests.get(url, timeout=5)
-            response.raise_for_status()
-        except requests.RequestException as e:
-            self._log.error("{}".format(e))
+        if image_url:
+            yield self._candidate(url=image_url, match=Candidate.MATCH_EXACT)
+        else:
+            self._log.debug('Cover art URL not found for {0}', album)
             return
-        extension = guess_extension(response.headers
-                                    ['Content-Type'])
-        if extension is None:
-            self._log.error('Invalid image file')
-            return
-        file = f'image{extension}'
-        tempimg = os.path.join(tempfile.gettempdir(), file)
-        try:
-            with open(tempimg, 'wb') as f:
-                f.write(response.content)
-        except Exception as e:
-            self._log.error("Unable to save image: {}".format(e))
-            return
-        yield self._candidate(path=tempimg, match=Candidate.MATCH_EXACT)
 
 
 class LastFM(RemoteArtSource):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,8 @@ for Python 3.6).
 
 New features:
 
+* Added option use `cover_art_arl` as an album art source in the `fetchart` plugin.
+  :bug:`4707`
 * :doc:`/plugins/fetchart`: The plugin can now get album art from `spotify`.
 * Added option to specify a URL in the `embedart` plugin.
   :bug:`83`

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -267,7 +267,7 @@ Spotify backend is enabled by default and will update album art if a valid Spoti
 .. _BeautifulSoup: https://www.crummy.com/software/BeautifulSoup/bs4/doc/
 
 Cover Art URL
-'''''''
+'''''''''''''
 
 The `fetchart` plugin can also use a flexible attribute field ``cover_art_url`` where you can manually specify the image URL to be used as cover art. Any custom plugin can use this field to provide the cover art and ``fetchart`` will use it as a source. Just add ``cover_art_url`` to the list of sources in your configuration to enable this source.
 

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -269,7 +269,7 @@ Spotify backend is enabled by default and will update album art if a valid Spoti
 Cover Art URL
 '''''''''''''
 
-The `fetchart` plugin can also use a flexible attribute field ``cover_art_url`` where you can manually specify the image URL to be used as cover art. Any custom plugin can use this field to provide the cover art and ``fetchart`` will use it as a source. Just add ``cover_art_url`` to the list of sources in your configuration to enable this source.
+The `fetchart` plugin can also use a flexible attribute field ``cover_art_url`` where you can manually specify the image URL to be used as cover art. Any custom plugin can use this field to provide the cover art and ``fetchart`` will use it as a source.
 
 Storing the Artwork's Source
 ----------------------------

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -269,7 +269,7 @@ Spotify backend is enabled by default and will update album art if a valid Spoti
 Cover Art URL
 '''''''
 
-The `fetchart` plugin can also use a flexible attribute field `cover_art_url` where you can manually specify the image URL to be used as cover art. Any custom plugin can use this field to provide the cover art and `fetchart` will use it as a source. Just add `cover_art_url` to the list of sources in your configuration to enable this source.
+The `fetchart` plugin can also use a flexible attribute field ``cover_art_url`` where you can manually specify the image URL to be used as cover art. Any custom plugin can use this field to provide the cover art and ``fetchart`` will use it as a source. Just add ``cover_art_url`` to the list of sources in your configuration to enable this source.
 
 Storing the Artwork's Source
 ----------------------------

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -266,6 +266,11 @@ Spotify backend is enabled by default and will update album art if a valid Spoti
 .. _pip: https://pip.pypa.io
 .. _BeautifulSoup: https://www.crummy.com/software/BeautifulSoup/bs4/doc/
 
+Cover Art URL
+'''''''
+
+The `fetchart` plugin can also use a flexible attribute field `cover_art_url` where you can manually specify the image URL to be used as cover art. Any custom plugin can use this field to provide the cover art and `fetchart` will use it as a source. Just add `cover_art_url` to the list of sources in your configuration to enable this source.
+
 Storing the Artwork's Source
 ----------------------------
 


### PR DESCRIPTION
## Description

Fixes #4707 

It turned out to be a lot simpler than I thought. As discussed in #4707, this PR creates a generic function that will use the image URL from `cover_art_url` field and update the album art. The idea was discussed in the linked issue to allow any plugin to save the cover art link to a flexible field `cover_art_url` and then `fetchart` should be able to use that field. Users can also manually update this field to specify a covert art image. 

Tested this with the [JioSaavn](https://github.com/arsaboo/beets-jiosaavn) plugin and it works perfectly. 

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
