### PR TITLE
fetchart: revert a cleanup from #4774 that could break plugins

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -977,6 +977,12 @@ class Spotify(RemoteArtSource):
             return
 # Try each source in turn.
 
+# Note that SOURCES_ALL is redundant (and presently unused). However, we keep
+# it around nn order not break plugins that "register" (a.k.a. monkey-patch)
+# their own fetchart sources.
+SOURCES_ALL = ['filesystem', 'coverart', 'itunes', 'amazon', 'albumart',
+               'wikipedia', 'google', 'fanarttv', 'lastfm', 'spotify']
+
 ART_SOURCES = {
     'filesystem': FileSystem,
     'coverart': CoverArtArchive,


### PR DESCRIPTION
cf. @arogl's comment https://github.com/beetbox/beets/commit/254bb297c894c0323174012ff27500867416d02b#commitcomment-111922347

> Now that this has been merged, external plugins that add to the fetchart plugin now fail with:
>
> ```AttributeError: module 'beetsplug.fetchart' has no attribute 'SOURCES_ALL'``