### PR TITLE
Prevent reimporting album if an album is permanently removed from Spotify

### DIFF
--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -219,6 +219,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
         album_data = self._handle_response(
             requests.get, self.album_url + spotify_id
         )
+        self._log.debug('Album data: {}', album_data)
         artist, artist_id = self.get_artist(album_data['artists'])
 
         date_parts = [

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -219,7 +219,9 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
         album_data = self._handle_response(
             requests.get, self.album_url + spotify_id
         )
-        self._log.debug('Album data: {}', album_data)
+        if album_data['name'] == "":
+            self._log.debug("Album removed from Spotify: {}", album_id)
+            return None
         artist, artist_id = self.get_artist(album_data['artists'])
 
         date_parts = [

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,8 @@ for Python 3.6).
 
 New features:
 
+* Prevent reimporting album if it is permanently removed from Spotify
+  :bug:`4800`
 * Added option use `cover_art_arl` as an album art source in the `fetchart` plugin.
   :bug:`4707`
 * :doc:`/plugins/fetchart`: The plugin can now get album art from `spotify`.


### PR DESCRIPTION
## Description

Fixes #4800

(...)

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [X] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
