### PR TITLE
Fetchart: Use the right field to obtain Spotify album id

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -956,7 +956,11 @@ class Spotify(RemoteArtSource):
         return HAS_BEAUTIFUL_SOUP
 
     def get(self, album, plugin, paths):
-        url = self.SPOTIFY_ALBUM_URL + album.items().get().spotify_album_id
+        try:
+            url = self.SPOTIFY_ALBUM_URL + album.items().get().spotify_album_id
+        except AttributeError:
+            self._log.debug('Fetchart: no Spotify album ID found')
+            return
         try:
             response = requests.get(url)
             response.raise_for_status()

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -956,7 +956,7 @@ class Spotify(RemoteArtSource):
         return HAS_BEAUTIFUL_SOUP
 
     def get(self, album, plugin, paths):
-        url = self.SPOTIFY_ALBUM_URL + album.mb_albumid
+        url = self.SPOTIFY_ALBUM_URL + album.items().get().spotify_album_id
         try:
             response = requests.get(url)
             response.raise_for_status()

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,8 @@ for Python 3.6).
 
 New features:
 
+* Fetchart: Use the right field (`spotify_album_id`) to obtain the Spotify album id
+  :bug:`4803`
 * Prevent reimporting album if it is permanently removed from Spotify
   :bug:`4800`
 * Added option use `cover_art_arl` as an album art source in the `fetchart` plugin.


### PR DESCRIPTION
## Description

Use `spotify_album_id` instead of `mb_albumid` to always obtain the right values. 

Fixes #4803

## To Do

- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
