### PR TITLE
Allow importing Tidal album id from MusicBrainz

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -518,9 +518,9 @@ def album_info(release: Dict) -> beets.autotag.hooks.AlbumInfo:
     if (any(config['musicbrainz']['external_ids'].get().values())
             and release.get('url-relation-list')):
         discogs_url, bandcamp_url, spotify_url = None, None, None
-        deezer_url, beatport_url = None, None
+        deezer_url, beatport_url, tidal_url = None, None, None
         fetch_discogs, fetch_bandcamp, fetch_spotify = False, False, False
-        fetch_deezer, fetch_beatport = False, False
+        fetch_deezer, fetch_beatport, fetch_tidal = False, False, False
 
         if config['musicbrainz']['external_ids']['discogs'].get():
             fetch_discogs = True
@@ -532,6 +532,8 @@ def album_info(release: Dict) -> beets.autotag.hooks.AlbumInfo:
             fetch_deezer = True
         if config['musicbrainz']['external_ids']['beatport'].get():
             fetch_beatport = True
+        if config['musicbrainz']['external_ids']['tidal'].get():
+            fetch_tidal = True
 
         for url in release['url-relation-list']:
             if fetch_discogs and url['type'] == 'discogs':
@@ -549,6 +551,9 @@ def album_info(release: Dict) -> beets.autotag.hooks.AlbumInfo:
             if fetch_beatport and 'beatport.com' in url['target']:
                 log.debug('Found link to Beatport release via MusicBrainz')
                 beatport_url = url['target']
+            if fetch_tidal and 'tidal.com' in url['target']:
+                log.debug('Found link to Tidal release via MusicBrainz')
+                tidal_url = url['target']
 
         if discogs_url:
             info.discogs_albumid = extract_discogs_id_regex(discogs_url)
@@ -563,6 +568,8 @@ def album_info(release: Dict) -> beets.autotag.hooks.AlbumInfo:
         if beatport_url:
             info.beatport_album_id = MetadataSourcePlugin._get_id(
                 'album', beatport_url, beatport_id_regex)
+        if tidal_url:
+            info.tidal_album_id = tidal_url.split('/')[-1]
 
     extra_albumdatas = plugins.send('mb_album_extract', data=release)
     for extra_albumdata in extra_albumdatas:

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -134,6 +134,7 @@ musicbrainz:
         spotify: no
         deezer: no
         beatport: no
+        tidal: no
 
 match:
     strong_rec_thresh: 0.04

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -54,7 +54,7 @@ HISTORY_KEY = 'taghistory'
 REIMPORT_FRESH_FIELDS_ALBUM = ['data_source']
 REIMPORT_FRESH_FIELDS_ITEM = ['data_source', 'bandcamp_album_id',
                               'spotify_album_id', 'deezer_album_id',
-                              'beatport_album_id']
+                              'beatport_album_id', 'tidal_album_id']
 
 # Global logger.
 log = logging.getLogger('beets')

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,7 @@ With this release, beets now requires Python 3.7 or later (it removes support
 for Python 3.6).
 
 New features:
-
+* Allow importing Tidal album id from MusicBrainz release page if the information is available. 
 * Prevent reimporting album if it is permanently removed from Spotify
   :bug:`4800`
 * Added option use `cover_art_arl` as an album art source in the `fetchart` plugin.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,7 @@ With this release, beets now requires Python 3.7 or later (it removes support
 for Python 3.6).
 
 New features:
-* Allow importing Tidal album id from MusicBrainz release page if the information is available.
+* Allow importing Tidal album id from MusicBrainz release page.
 * Prevent reimporting album if it is permanently removed from Spotify
   :bug:`4800`
 * Added option use `cover_art_arl` as an album art source in the `fetchart` plugin.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,7 @@ With this release, beets now requires Python 3.7 or later (it removes support
 for Python 3.6).
 
 New features:
-* Allow importing Tidal album id from MusicBrainz release page.
+
 * Prevent reimporting album if it is permanently removed from Spotify
   :bug:`4800`
 * Added option use `cover_art_arl` as an album art source in the `fetchart` plugin.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,7 +10,7 @@ With this release, beets now requires Python 3.7 or later (it removes support
 for Python 3.6).
 
 New features:
-* Allow importing Tidal album id from MusicBrainz release page if the information is available. 
+* Allow importing Tidal album id from MusicBrainz release page if the information is available.
 * Prevent reimporting album if it is permanently removed from Spotify
   :bug:`4800`
 * Added option use `cover_art_arl` as an album art source in the `fetchart` plugin.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -859,12 +859,13 @@ to the beets library.
             bandcamp: yes
             beatport: yes
             deezer: yes
+            tidal: yes
 
 
 The library fields of the corresponding :ref:`autotagger_extensions` are used
 to save the data (``discogs_albumid``, ``bandcamp_album_id``,
-``spotify_album_id``, ``beatport_album_id``, ``deezer_album_id``). On
-re-imports existing data will be overwritten.
+``spotify_album_id``, ``beatport_album_id``, ``deezer_album_id``,
+``tidal_album_id``). On re-imports existing data will be overwritten.
 
 The default of all options is ``no``.
 


### PR DESCRIPTION
Following #4708, this PR adds the ability to also import Tidal album id, which is also sometimes available on the release pages. 

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
