### PR TITLE
Fix fanarttv sorting

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -590,7 +590,7 @@ class FanartTV(RemoteArtSource):
                 self._log.debug('fanart.tv: unexpected mb_releasegroupid in '
                                 'response!')
 
-        matches.sort(key=lambda x: x['likes'], reverse=True)
+        matches.sort(key=lambda x: int(x['likes']), reverse=True)
         for item in matches:
             # fanart.tv has a strict size requirement for album art to be
             # uploaded

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -185,6 +185,8 @@ Bug fixes:
 * Fix updating "data_source" on re-imports and improve logging when flexible
   attributes are being re-imported.
   :bug:`4726`
+* :doc:`/plugins/fetchart`: Correctly select the cover art from fanart.tv with
+  the highest number of likes
 
 For packagers:
 


### PR DESCRIPTION
## Description

fanart.tv uses a string to output the number of likes (see https://fanart.tv/api-docs/api-v3/). In order to sort numerically we need to convert the string into an int.

This was tested locally with `http://webservice.fanart.tv/v3/music/albums/1cbc1a5a-5512-3f8e-997b-d9281b83722b?api_key=...`

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
