### PR TITLE
add basic e2e test for lastimport

### DIFF
--- a/test/test_lastimport.py
+++ b/test/test_lastimport.py
@@ -1,0 +1,43 @@
+"""Tests for the 'lastimport' plugin"""
+
+import unittest
+
+
+from beets.library import Item
+
+from beets import config
+from beetsplug import lastimport
+from test import helper, _common
+
+
+class LastImportPluginTest(_common.TestCase, helper.TestHelper):
+    def setUp(self):
+        config.clear()
+        self.setup_beets()
+
+        config["lastfm"].add({"user": "asdfg"})
+        config["lastimport"].add({"per_page": 1})
+
+        self.lastimport = lastimport.LastImportPlugin()
+
+    def tearDown(self):
+        self.teardown_beets()
+
+    def test_e2e(self):
+        item = Item(
+            artist="Morcheeba",
+            title="Public Displays of Affection",
+        )
+        id = self.lib.add(item)
+        self.assertIsNone(self.lib.get_item(id).get("play_count"))
+
+        lastimport.import_lastfm(self.lib, self.lastimport._log)
+        self.assertEqual(self.lib.get_item(id).get("play_count"), "1")
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromName(__name__)
+
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")


### PR DESCRIPTION
## Description

The lastimport plugin does not currently have any tests. This is a good starter for such a test suite. Mocking with RESPX is a WIP.

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
- [ ] Mock pylast with RESPX 
