### PR TITLE
Streamline album attributes modification behaviour and allow override via CLI

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -1369,7 +1369,7 @@ class Album(LibModel):
 
         plugins.send('art_set', album=self)
 
-    def store(self, fields=None):
+    def store(self, fields=None, inherit=True):
         """Update the database with the album information.
 
         The album's tracks are also updated.
@@ -1381,11 +1381,11 @@ class Album(LibModel):
         track_updates = {}
         track_deletes = set()
         for key in self._dirty:
-            if key in self.item_keys:
+            if key in self.item_keys and inherit:
                 track_updates[key] = self[key]
-            elif key not in self:
+            elif key not in self and inherit:
                 track_deletes.add(key)
-            else:  # Must be a flex attr
+            elif inherit:  # Must be a flex attr
                 track_updates[key] = self[key]
 
         with self._db.transaction():
@@ -1402,7 +1402,7 @@ class Album(LibModel):
                             del item[key]
                     item.store()
 
-    def try_sync(self, write, move):
+    def try_sync(self, write, move, inherit=True):
         """Synchronize the album and its items with the database.
         Optionally, also write any new tags into the files and update
         their paths.
@@ -1411,7 +1411,7 @@ class Album(LibModel):
         `move` controls whether files (both audio and album art) are
         moved.
         """
-        self.store()
+        self.store(inherit=inherit)
         for item in self.items():
             item.try_sync(write, move)
 

--- a/beets/library.py
+++ b/beets/library.py
@@ -1385,7 +1385,7 @@ class Album(LibModel):
                 track_updates[key] = self[key]
             elif key not in self and inherit:
                 track_deletes.add(key)
-            elif inherit:  # Must be a flex attr
+            elif key != 'id' and inherit:  # Could be a flex attr or id
                 track_updates[key] = self[key]
 
         with self._db.transaction():

--- a/beets/library.py
+++ b/beets/library.py
@@ -1385,6 +1385,8 @@ class Album(LibModel):
                 track_updates[key] = self[key]
             elif key not in self:
                 track_deletes.add(key)
+            else:  # Must be a flex attr
+                track_updates[key] = self[key]
 
         with self._db.transaction():
             super().store(fields)

--- a/beets/library.py
+++ b/beets/library.py
@@ -1383,12 +1383,13 @@ class Album(LibModel):
         track_updates = {}
         track_deletes = set()
         for key in self._dirty:
-            if key in self.item_keys and inherit:  # Fixed attr
-                track_updates[key] = self[key]
-            elif key not in self and inherit:  # Fixed or flex attr
-                track_deletes.add(key)
-            elif key != 'id' and inherit:  # Could be a flex attr or id (fixed)
-                track_updates[key] = self[key]
+            if inherit:
+                if key in self.item_keys:  # is a fixed attribute
+                    track_updates[key] = self[key]
+                elif key not in self:  # is a fixed or a flexible attribute
+                    track_deletes.add(key)
+                elif key != 'id':  # is a flexible attribute
+                    track_updates[key] = self[key]
 
         with self._db.transaction():
             super().store(fields)

--- a/beets/library.py
+++ b/beets/library.py
@@ -1372,20 +1372,22 @@ class Album(LibModel):
     def store(self, fields=None, inherit=True):
         """Update the database with the album information.
 
-        The album's tracks are also updated.
-
         `fields` represents the fields to be stored. If not specified,
         all fields will be.
+
+        The album's tracks are also updated when the `inherit` flag is enabled.
+        This applies to fixed attributes as well as flexible ones. The `id`
+        attribute of the album will never be inherited.
         """
         # Get modified track fields.
         track_updates = {}
         track_deletes = set()
         for key in self._dirty:
-            if key in self.item_keys and inherit:
+            if key in self.item_keys and inherit:  # Fixed attr
                 track_updates[key] = self[key]
-            elif key not in self and inherit:
+            elif key not in self and inherit:  # Fixed or flex attr
                 track_deletes.add(key)
-            elif key != 'id' and inherit:  # Could be a flex attr or id
+            elif key != 'id' and inherit:  # Could be a flex attr or id (fixed)
                 track_updates[key] = self[key]
 
         with self._db.transaction():

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1489,7 +1489,7 @@ default_commands.append(version_cmd)
 
 # modify: Declaratively change metadata.
 
-def modify_items(lib, mods, dels, query, write, move, album, confirm):
+def modify_items(lib, mods, dels, query, write, move, album, confirm, inherit):
     """Modifies matching items according to user-specified assignments and
     deletions.
 
@@ -1542,7 +1542,7 @@ def modify_items(lib, mods, dels, query, write, move, album, confirm):
     # Apply changes to database and files
     with lib.transaction():
         for obj in changed:
-            obj.try_sync(write, move)
+            obj.try_sync(write, move, inherit)
 
 
 def print_and_modify(obj, mods, dels):
@@ -1585,7 +1585,8 @@ def modify_func(lib, opts, args):
     if not mods and not dels:
         raise ui.UserError('no modifications specified')
     modify_items(lib, mods, dels, query, ui.should_write(opts.write),
-                 ui.should_move(opts.move), opts.album, not opts.yes)
+                 ui.should_move(opts.move), opts.album, not opts.yes,
+                 opts.inherit)
 
 
 modify_cmd = ui.Subcommand(
@@ -1612,6 +1613,10 @@ modify_cmd.parser.add_format_option(target='item')
 modify_cmd.parser.add_option(
     '-y', '--yes', action='store_true',
     help='skip confirmation'
+)
+modify_cmd.parser.add_option(
+    '-I', '--noinherit', action='store_false', dest='inherit', default=True,
+    help="Don't inherit album-changes to tracks"
 )
 modify_cmd.func = modify_func
 default_commands.append(modify_cmd)

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1616,7 +1616,7 @@ modify_cmd.parser.add_option(
 )
 modify_cmd.parser.add_option(
     '-I', '--noinherit', action='store_false', dest='inherit', default=True,
-    help="Don't inherit album-changes to tracks"
+    help="when modifying albums, don't also change item data"
 )
 modify_cmd.func = modify_func
 default_commands.append(modify_cmd)

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -296,4 +296,4 @@ class IPFSPlugin(BeetsPlugin):
         self._log.info("Adding '{0}' to temporary library", album)
         new_album = tmplib.add_album(items)
         new_album.ipfs = album.ipfs
-        new_album.store()
+        new_album.store(inherit=False)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -211,6 +211,11 @@ Bug fixes:
   the highest number of likes
 * :doc:`/plugins/lyrics`: Fix a crash with the Google backend when processing
   some web pages. :bug:`4875`
+* Modifying flexible attributes of albums now cascade to the individual album
+  tracks, similar to how fixed album attributes have been cascading to tracks
+  already. A new option ``--noinherit/-I`` to :ref:`modify <modify-cmd>`
+  allows changing this behaviour.
+  :bug:`4822`
 
 For packagers:
 

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -283,7 +283,7 @@ to avoid a confusing situation where the data for individual tracks conflicts
 with the data for the whole album.
 
 Modifications issued using ``-a`` by default cascade to individual tracks. To
-prevent this behaviour, ``-I/--noinherit`` can be used.
+prevent this behavior, use ``-I``/``--noinherit``.
 
 Items will automatically be moved around when necessary if they're in your
 library directory, but you can disable that with  ``-M``. Tags will be written

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -257,7 +257,7 @@ modify
 ``````
 ::
 
-    beet modify [-MWay] [-f FORMAT] QUERY [FIELD=VALUE...] [FIELD!...]
+    beet modify [-IMWay] [-f FORMAT] QUERY [FIELD=VALUE...] [FIELD!...]
 
 Change the metadata for items or albums in the database.
 
@@ -274,12 +274,16 @@ name into the artist field for all your tracks,
 and ``beet modify title='$track $title'`` will add track numbers to their
 title metadata.
 
-The ``-a`` switch also operates on albums in addition to the individual tracks.
+The ``-a`` option changes to querying album fields instead of track fields and
+also enables to operate on albums in addition to the individual tracks.
 Without this flag, the command will only change *track-level* data, even if all
 the tracks belong to the same album. If you want to change an *album-level*
 field, such as ``year`` or ``albumartist``, you'll want to use the ``-a`` flag
 to avoid a confusing situation where the data for individual tracks conflicts
 with the data for the whole album.
+
+Modifications issued using ``-a`` by default cascade to individual tracks. To
+prevent this behaviour, ``-I/--noinherit`` can be used.
 
 Items will automatically be moved around when necessary if they're in your
 library directory, but you can disable that with  ``-M``. Tags will be written

--- a/test/test_ipfs.py
+++ b/test/test_ipfs.py
@@ -87,7 +87,7 @@ class IPFSPluginTest(unittest.TestCase, TestHelper):
 
         album = self.lib.add_album(items)
         album.ipfs = "QmfM9ic5LJj7V6ecozFx1MkSoaaiq3PXfhJoFvyqzpLXSf"
-        album.store()
+        album.store(inherit=False)
 
         return album
 

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1022,10 +1022,17 @@ class AlbumInfoTest(_common.TestCase):
         self.assertEqual(i.albumartist, 'myNewArtist')
         self.assertNotEqual(i.artist, 'myNewArtist')
 
+    def test_albuminfo_change_artist_does_change_items(self):
+        ai = self.lib.get_album(self.i)
+        ai.artist = 'myNewArtist'
+        ai.store(inherit=True)
+        i = self.lib.items()[0]
+        self.assertEqual(i.artist, 'myNewArtist')
+
     def test_albuminfo_change_artist_does_not_change_items(self):
         ai = self.lib.get_album(self.i)
         ai.artist = 'myNewArtist'
-        ai.store()
+        ai.store(inherit=False)
         i = self.lib.items()[0]
         self.assertNotEqual(i.artist, 'myNewArtist')
 


### PR DESCRIPTION
## Description

- Fixes #4822
- Keeps the default behaviour of inheriting album (fixed) attributes modifications to album tracks.
- Fixes album modifications of flexible attributes to be inherited to album-tracks as well.
- Adds a new CLI option `--noinherit/-I` that prevents inheriting to album-tracks, which allows changing fixed/flexible attributes on an album only.


## To Do

- [x] Documentation.
- [x] Changelog.
- [x] Tests. 
