### PR TITLE
Add beets-more to community plugins

### DIFF
--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -543,4 +543,4 @@ Here are a few of the plugins written by the beets community:
 .. _beets-originquery: https://github.com/x1ppy/beets-originquery
 .. _drop2beets: https://github.com/martinkirch/drop2beets
 .. _beets-audible: https://github.com/Neurrone/beets-audible
-.. _beets-more: https://forgejo.sny.sh/sun/beetsplug
+.. _beets-more: https://forgejo.sny.sh/sun/beetsplug/src/branch/main/more

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -463,6 +463,9 @@ Here are a few of the plugins written by the beets community:
 `beets-jiosaavn`_
    Adds JioSaavn.com as a tagger data source.
 
+`beets-more`_
+   Finds versions of indexed releases with more tracks, like deluxe and anniversary editions.
+
 `beets-mosaic`_
    Generates a montage of a mosaic from cover art.
 
@@ -540,3 +543,4 @@ Here are a few of the plugins written by the beets community:
 .. _beets-originquery: https://github.com/x1ppy/beets-originquery
 .. _drop2beets: https://github.com/martinkirch/drop2beets
 .. _beets-audible: https://github.com/Neurrone/beets-audible
+.. _beets-more: https://forgejo.sny.sh/sun/beetsplug


### PR DESCRIPTION
I wrote a plugin that scans MusicBrainz and Discogs for versions of releases that have more tracks than the ones in the user's database, such as deluxe, expanded or anniversary editions. For example:

```
beet more "Electric Light Orchestra"
```

```
more: Electric Light Orchestra - Discovery
more:     Fetching data from MusicBrainz...
more:     Version with 12 tracks found (have 9).
more:     See https://musicbrainz.org/release/23bf913d-3709-4f84-a3df-f19d3928cb2b​.
more: Electric Light Orchestra - Out of the Blue
more:     Fetching data from MusicBrainz...
more:     Version with 20 tracks found (have 17).
more:     See https://musicbrainz.org/release/9a86feb3-66db-3946-a477-67312641cc93​.
```

This PR adds it to the community plugins list.