### PR TITLE
Fixed check for pseudo-release.

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -746,7 +746,7 @@ def album_for_id(releaseid: str) -> Optional[beets.autotag.hooks.AlbumInfo]:
         # resolve linked release relations
         actual_res = None
 
-        if res['release']['status'] == 'Pseudo-Release':
+        if res['release'].get('status') == 'Pseudo-Release':
             actual_res = _find_actual_release_from_pseudo_release(res)
 
     except musicbrainzngs.ResponseError:


### PR DESCRIPTION
The 'status' field is potentially null, and in this case the dictionary key is not returned by the API. Using get will return null in this case. Tested locally and this solves the issue!

## Description

Fixes #4832.
