### PR TITLE
Handle missing release-relation-list field during pseudo-release lookup

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -678,7 +678,10 @@ def _is_translation(r):
 
 def _find_actual_release_from_pseudo_release(pseudo_rel: Dict) \
         -> Optional[Dict]:
-    relations = pseudo_rel['release']["release-relation-list"]
+    try:
+        relations = pseudo_rel['release']["release-relation-list"]
+    except KeyError:
+        return None
 
     # currently we only support trans(liter)ation's
     translations = [r for r in relations if _is_translation(r)]

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -724,7 +724,7 @@ class MBLibraryTest(unittest.TestCase):
             album = mb.album_for_id('d2a6f856-b553-40a0-ac54-a321e8e2da02')
             self.assertEqual(album.country, 'COUNTRY')
 
-    def test_pseudo_releases_without_links(self):
+    def test_pseudo_releases_with_empty_links(self):
         side_effect = [{
                     'release': {
                         'title': 'pseudo',
@@ -753,6 +753,43 @@ class MBLibraryTest(unittest.TestCase):
                             'id': 'another-id',
                         },
                         'release-relation-list': []
+                    }
+                },
+        ]
+
+        with mock.patch('musicbrainzngs.get_release_by_id') as gp:
+            gp.side_effect = side_effect
+            album = mb.album_for_id('d2a6f856-b553-40a0-ac54-a321e8e2da02')
+            self.assertEqual(album.country, None)
+
+    def test_pseudo_releases_without_links(self):
+        side_effect = [{
+                    'release': {
+                        'title': 'pseudo',
+                        'id': 'd2a6f856-b553-40a0-ac54-a321e8e2da02',
+                        'status': 'Pseudo-Release',
+                        'medium-list': [{
+                            'track-list': [{
+                                'id': 'baz',
+                                'recording': {
+                                    'title': 'translated title',
+                                    'id': 'bar',
+                                    'length': 42,
+                                },
+                                'position': 9,
+                                'number': 'A1',
+                            }],
+                            'position': 5,
+                        }],
+                        'artist-credit': [{
+                            'artist': {
+                                'name': 'some-artist',
+                                'id': 'some-id',
+                            },
+                        }],
+                        'release-group': {
+                            'id': 'another-id',
+                        },
                     }
                 },
         ]


### PR DESCRIPTION
## Description
Some pseudo-releases (erroneously) lack the relation to the actual release which previously would've caused a crash.

Examples:
- https://musicbrainz.org/release/5642e194-51ee-4012-bc4e-36b1cbd7bc06
- https://musicbrainz.org/release/f8f0c58a-b40a-4334-9294-14a5fd1300ab

Related to #4714.
cc @TypicalFence.
