### PR TITLE
Define colorspaces for imagemagick comparison

### DIFF
--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -256,7 +256,8 @@ class IMBackend(LocalBackend):
             '-colorspace', 'gray', 'MIFF:-'
         ]
         compare_cmd = self.compare_cmd + [
-            '-define', 'phash:colorspaces=sRGB,HCLp', '-metric', 'PHASH', '-', 'null:',
+            '-define', 'phash:colorspaces=sRGB,HCLp',
+            '-metric', 'PHASH', '-', 'null:',
         ]
         log.debug('comparing images with pipeline {} | {}',
                   convert_cmd, compare_cmd)

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -256,7 +256,7 @@ class IMBackend(LocalBackend):
             '-colorspace', 'gray', 'MIFF:-'
         ]
         compare_cmd = self.compare_cmd + [
-            '-metric', 'PHASH', '-', 'null:',
+            '-define', 'phash:colorspaces=sRGB,HCLp', '-metric', 'PHASH', '-', 'null:',
         ]
         log.debug('comparing images with pipeline {} | {}',
                   convert_cmd, compare_cmd)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -172,6 +172,8 @@ Bug fixes:
 * :doc:`plugins/lyrics`: Fixed issue with Tekstowo backend not actually checking
   if the found song matches.
   :bug:`4406`
+* :doc:`plugins/embedart`: Add support for ImageMagick 7.1.1-12
+  :bug:`4836`
 * :doc:`/plugins/fromfilename`: Fix failed detection of <track> <title>
   filename patterns.
   :bug:`4561` :bug:`4600`


### PR DESCRIPTION

## Description

Fixes #4836

ImageMagick 7.1.1-12 changed the default colorspaces used by the PHASH
compare function from sRGB,HCLp to xyY,HSB. This breaks the current code
for comparisons, so let's define the colorspaces ourselves.

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
