### PR TITLE
Import additional fields from Deezer and add function to update rank

### DIFF
--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -76,7 +76,7 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
             return None
 
         album_data = requests.get(self.album_url + deezer_id).json()
-        artist, artist_id = self.get_artist(album_data['contributors'])
+        artist, artist_id = self.get_artist(album_data.get('contributors'))
 
         release_date = album_data['release_date']
         date_parts = [int(part) for part in release_date.split('-')]

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -192,6 +192,10 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
             if deezer_id is None:
                 return None
             track_data = requests.get(self.track_url + deezer_id).json()
+            if 'error' in track_data:
+                self._log.debug(f"Error fetching track {track_id}: "
+                                f"{track_data['error']['message']}")
+                return None
         track = self._get_track(track_data)
 
         # Get album's tracks to set `track.index` (position on the entire

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -268,7 +268,7 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
                 continue
             try:
                 rank = requests.get(
-                    self.track_url + deezer_track_id).json().get('rank')
+                    f"{self.track_url}{deezer_track_id}").json().get('rank')
                 self._log.debug('Deezer track: {} has {} rank',
                                 deezer_track_id, rank)
             except Exception as e:

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -76,7 +76,11 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
             return None
 
         album_data = requests.get(self.album_url + deezer_id).json()
-        artist, artist_id = self.get_artist(album_data.get('contributors'))
+        contributors = album_data.get('contributors')
+        if contributors is not None:
+            artist, artist_id = self.get_artist(contributors)
+        else:
+            artist, artist_id = None, None
 
         release_date = album_data['release_date']
         date_parts = [int(part) for part in release_date.split('-')]

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -16,6 +16,7 @@
 """
 
 import collections
+import time
 
 import requests
 import unidecode
@@ -23,6 +24,7 @@ import unidecode
 from beets import ui
 from beets.autotag import AlbumInfo, TrackInfo
 from beets.dbcore import types
+from beets.library import DateType
 from beets.plugins import BeetsPlugin, MetadataSourcePlugin
 from beets.util.id_extractors import deezer_id_regex
 
@@ -33,6 +35,7 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
     item_types = {
         'deezer_track_rank': types.INTEGER,
         'deezer_track_id': types.INTEGER,
+        'deezer_updated': DateType(),
     }
 
     # Base URLs for the Deezer API
@@ -160,6 +163,7 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
             medium_index=track_data.get('track_position'),
             data_source=self.data_source,
             data_url=track_data['link'],
+            deezer_updated=time.time(),
         )
 
     def track_for_id(self, track_id=None, track_data=None):
@@ -276,5 +280,6 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
                 continue
             item.deezer_track_rank = int(rank)
             item.store()
+            item.deezer_updated = time.time()
             if write:
                 item.try_write()

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -17,17 +17,23 @@
 
 import collections
 
-import unidecode
 import requests
+import unidecode
 
 from beets import ui
 from beets.autotag import AlbumInfo, TrackInfo
-from beets.plugins import MetadataSourcePlugin, BeetsPlugin
+from beets.dbcore import types
+from beets.plugins import BeetsPlugin, MetadataSourcePlugin
 from beets.util.id_extractors import deezer_id_regex
 
 
 class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
     data_source = 'Deezer'
+
+    item_types = {
+        'deezer_track_rank': types.INTEGER,
+        'deezer_track_id': types.INTEGER,
+    }
 
     # Base URLs for the Deezer API
     # Documentation: https://developers.deezer.com/api/
@@ -113,6 +119,7 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
             mediums=max(medium_totals.keys()),
             data_source=self.data_source,
             data_url=album_data['link'],
+            cover_art_url=album_data['cover_xl'],
         )
 
     def _get_track(self, track_data):
@@ -129,11 +136,14 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
         return TrackInfo(
             title=track_data['title'],
             track_id=track_data['id'],
+            deezer_track_id=track_data['id'],
+            isrc=track_data.get('isrc'),
             artist=artist,
             artist_id=artist_id,
             length=track_data['duration'],
             index=track_data.get('track_position'),
             medium=track_data.get('disk_number'),
+            deezer_track_rank=track_data.get('rank'),
             medium_index=track_data.get('track_position'),
             data_source=self.data_source,
             data_url=track_data['link'],

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -16,7 +16,6 @@
 """
 
 import collections
-import re
 import time
 
 import requests

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -72,7 +72,8 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
         :rtype: beets.autotag.hooks.AlbumInfo or None
         """
         deezer_id = self._get_id('album', album_id, self.id_regex)
-        if deezer_id is None:
+        if deezer_id is None or not self.id_regex.match(deezer_id):
+            self._log.debug("Invalid Deezer ID found: %s", deezer_id)
             return None
 
         album_data = requests.get(self.album_url + deezer_id).json()
@@ -81,6 +82,7 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
             artist, artist_id = self.get_artist(contributors)
         else:
             artist, artist_id = None, None
+
 
         release_date = album_data['release_date']
         date_parts = [int(part) for part in release_date.split('-')]

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -119,7 +119,7 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
             mediums=max(medium_totals.keys()),
             data_source=self.data_source,
             data_url=album_data['link'],
-            cover_art_url=album_data['cover_xl'],
+            cover_art_url=album_data.get('cover_xl'),
         )
 
     def _get_track(self, track_data):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,7 +11,7 @@ for Python 3.6).
 
 New features:
 
-* Deezer: Import rank and other attributes from Deezer during import and add a function to update the rank of existing items.
+* :doc:`/plugins/deezer`: Import rank and other attributes from Deezer during import and add a function to update the rank of existing items.
   :bug:`4841`
 * resolve transl-tracklisting relations for pseudo releases and merge data with the actual release
   :bug:`654`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -97,6 +97,7 @@ New features:
 
 Bug fixes:
 
+* :doc:`/plugins/deezer`: Fixed the error where Deezer plugin would crash if non-Deezer id is passed during import.  
 * :doc:`/plugins/fetchart`: Fix fetching from Cover Art Archive when the
   `maxwidth` option is set to one of the supported Cover Art Archive widths.
 * :doc:`/plugins/discogs`: Fix "Discogs plugin replacing Feat. or Ft. with

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,8 @@ for Python 3.6).
 
 New features:
 
+* Deezer: Import rank and other attributes from Deezer during import and add a function to update the rank of existing items.
+  :bug:`4841`
 * resolve transl-tracklisting relations for pseudo releases and merge data with the actual release
   :bug:`654`
 * Fetchart: Use the right field (`spotify_album_id`) to obtain the Spotify album id

--- a/docs/plugins/deezer.rst
+++ b/docs/plugins/deezer.rst
@@ -23,3 +23,5 @@ Configuration
 -------------
 
 This plugin can be configured like other metadata source plugins as described in :ref:`metadata-source-plugin-configuration`.
+
+The ``deezer`` plugin provides an additional command ``deezerupdate`` to update the ``rank`` information from Deezer. The ``rank`` (ranges from 0 to 1M) is a global indicator of a song's popularity on Deezer that is updated daily based on streams. The higher the ``rank``, the more popular the track is.


### PR DESCRIPTION
## Description

Fixes #4841 
Imports few other fields provided by Deezer. 

In addition, I added a function `deezerupdate` that updates the rank information without going through the import process. The rank information is updated daily and users may want to refresh the rank information periodically. 

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
