### PR TITLE
typings: Fixes and improvements for dbcore.query

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -385,7 +385,7 @@ class Model:
         """
         return cls._fields.get(key) or cls._types.get(key) or types.DEFAULT
 
-    def _get(self, key, default: bool = None, raise_: bool = False):
+    def _get(self, key, default: Any = None, raise_: bool = False):
         """Get the value for a field, or `default`. Alternatively,
         raise a KeyError if the field is not available.
         """

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -265,15 +265,16 @@ class RegexpQuery(StringFieldQuery):
     """
 
     def __init__(self, field: str, pattern: str, fast: bool = True):
-        super().__init__(field, pattern, fast)
         pattern = self._normalize(pattern)
         try:
-            self.pattern = re.compile(self.pattern)
+            pattern_re = re.compile(pattern)
         except re.error as exc:
             # Invalid regular expression.
             raise InvalidQueryArgumentValueError(pattern,
                                                  "a regular expression",
                                                  format(exc))
+
+        super().__init__(field, pattern_re, fast)
 
     def col_clause(self):
         return f" regexp({self.field}, ?)", [self.pattern.pattern]


### PR DESCRIPTION
The next iteration of introducing typings into dbcore. This is splitting out only `dbcore.query`; with some additional changes, I have clean mypy on `dbcore`, but that'd be a bit too much for a single PR.