### PR TITLE
Always use syspath conversions (#3690 split up, part 2)

### DIFF
--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -460,11 +460,11 @@ class PILBackend(LocalBackend):
 
         # FIXME: Detect and handle other file types (currently, the only user
         # is the thumbnails plugin, which generates PNG images).
-        im = Image.open(file)
+        im = Image.open(syspath(file))
         meta = PngImagePlugin.PngInfo()
         for k, v in metadata.items():
             meta.add_text(k, v, 0)
-        im.save(file, "PNG", pnginfo=meta)
+        im.save(py3_path(file), "PNG", pnginfo=meta)
 
 
 class Shareable(type):

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -553,7 +553,7 @@ class ConvertPlugin(BeetsPlugin):
     def _cleanup(self, task, session):
         for path in task.old_paths:
             if path in _temp_files:
-                if os.path.isfile(path):
+                if os.path.isfile(util.syspath(path)):
                     util.remove(path)
                 _temp_files.remove(path)
 

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -226,8 +226,8 @@ class EmbedCoverArtPlugin(BeetsPlugin):
         appropriate configuration option is enabled).
         """
         if self.config['remove_art_file'] and album.artpath:
-            if os.path.isfile(album.artpath):
+            if os.path.isfile(syspath(album.artpath)):
                 self._log.debug('Removing album art file for {0}', album)
-                os.remove(album.artpath)
+                os.remove(syspath(album.artpath))
                 album.artpath = None
                 album.store()

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -1133,7 +1133,8 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
     def fetch_art(self, session, task):
         """Find art for the album being imported."""
         if task.is_album:  # Only fetch art for full albums.
-            if task.album.artpath and os.path.isfile(task.album.artpath):
+            if (task.album.artpath
+                    and os.path.isfile(syspath(task.album.artpath))):
                 # Album already has art (probably a re-import); skip it.
                 return
             if task.choice_flag == importer.action.ASIS:
@@ -1237,7 +1238,8 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         fetchart CLI command.
         """
         for album in albums:
-            if album.artpath and not force and os.path.isfile(album.artpath):
+            if (album.artpath and not force
+                    and os.path.isfile(syspath(album.artpath))):
                 if not quiet:
                     message = ui.colorize('text_highlight_minor',
                                           'has album art')

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -17,6 +17,7 @@
 
 from beets import ui, util, library, config
 from beets.plugins import BeetsPlugin
+from beets.util import syspath
 
 import subprocess
 import shutil
@@ -172,7 +173,10 @@ class IPFSPlugin(BeetsPlugin):
         imp = ui.commands.TerminalImportSession(lib, loghandler=None,
                                                 query=None, paths=[_hash])
         imp.run()
-        shutil.rmtree(_hash)
+        # This uses a relative path, hence we cannot use util.syspath(_hash,
+        # prefix=True). However, that should be fine since the hash will not
+        # exceed MAX_PATH.
+        shutil.rmtree(syspath(_hash, prefix=False))
 
     def ipfs_publish(self, lib):
         with tempfile.NamedTemporaryFile() as tmp:

--- a/beetsplug/metasync/itunes.py
+++ b/beetsplug/metasync/itunes.py
@@ -28,19 +28,20 @@ from time import mktime
 from beets import util
 from beets.dbcore import types
 from beets.library import DateType
+from beets.util import bytestring_path, syspath
 from confuse import ConfigValueError
 from beetsplug.metasync import MetaSource
 
 
 @contextmanager
 def create_temporary_copy(path):
-    temp_dir = tempfile.mkdtemp()
-    temp_path = os.path.join(temp_dir, 'temp_itunes_lib')
-    shutil.copyfile(path, temp_path)
+    temp_dir = bytestring_path(tempfile.mkdtemp())
+    temp_path = os.path.join(temp_dir, b'temp_itunes_lib')
+    shutil.copyfile(syspath(path), syspath(temp_path))
     try:
         yield temp_path
     finally:
-        shutil.rmtree(temp_dir)
+        shutil.rmtree(syspath(temp_dir))
 
 
 def _norm_itunes_path(path):

--- a/test/test_thumbnails.py
+++ b/test/test_thumbnails.py
@@ -51,8 +51,7 @@ class ThumbnailsTest(unittest.TestCase, TestHelper):
             b"/path/to/thumbnail",
             metadata,
         )
-        # FIXME: Plugin should use syspath
-        mock_stat.assert_called_once_with(album.artpath)
+        mock_stat.assert_called_once_with(syspath(album.artpath))
 
     @patch('beetsplug.thumbnails.os')
     @patch('beetsplug.thumbnails.ArtResizer')
@@ -69,17 +68,14 @@ class ThumbnailsTest(unittest.TestCase, TestHelper):
         mock_artresizer.shared.can_write_metadata = True
 
         def exists(path):
-            # FIXME: Plugin should use syspath
-            if path == NORMAL_DIR:
+            if path == syspath(NORMAL_DIR):
                 return False
-            # FIXME: Plugin should use syspath
-            if path == LARGE_DIR:
+            if path == syspath(LARGE_DIR):
                 return True
             raise ValueError(f"unexpected path {path!r}")
         mock_os.path.exists = exists
         plugin = ThumbnailsPlugin()
-        # FIXME: Plugin should use syspath
-        mock_os.makedirs.assert_called_once_with(NORMAL_DIR)
+        mock_os.makedirs.assert_called_once_with(syspath(NORMAL_DIR))
         self.assertTrue(plugin._check_local_ok())
 
         # test metadata writer function
@@ -125,11 +121,9 @@ class ThumbnailsTest(unittest.TestCase, TestHelper):
         mock_os.path.exists.return_value = False
 
         def os_stat(target):
-            # FIXME: Plugin should use syspath
-            if target == md5_file:
+            if target == syspath(md5_file):
                 return Mock(st_mtime=1)
-            # FIXME: Plugin should use syspath
-            elif target == path_to_art:
+            elif target == syspath(path_to_art):
                 return Mock(st_mtime=2)
             else:
                 raise ValueError(f"invalid target {target}")
@@ -140,17 +134,15 @@ class ThumbnailsTest(unittest.TestCase, TestHelper):
 
         plugin.make_cover_thumbnail(album, 12345, thumbnail_dir)
 
-        # FIXME: Plugin should use syspath
-        mock_os.path.exists.assert_called_once_with(md5_file)
+        mock_os.path.exists.assert_called_once_with(syspath(md5_file))
         mock_os.stat.has_calls([call(syspath(md5_file)),
                                 call(syspath(path_to_art))],
                                any_order=True)
 
         mock_resize.assert_called_once_with(12345, path_to_art, md5_file)
         plugin.add_tags.assert_called_once_with(album, path_to_resized_art)
-        # FIXME: Plugin should use syspath
-        mock_shutils.move.assert_called_once_with(path_to_resized_art,
-                                                  md5_file)
+        mock_shutils.move.assert_called_once_with(syspath(path_to_resized_art),
+                                                  syspath(md5_file))
 
         # now test with recent thumbnail & with force
         mock_os.path.exists.return_value = True
@@ -158,11 +150,9 @@ class ThumbnailsTest(unittest.TestCase, TestHelper):
         mock_resize.reset_mock()
 
         def os_stat(target):
-            # FIXME: Plugin should use syspath
-            if target == md5_file:
+            if target == syspath(md5_file):
                 return Mock(st_mtime=3)
-            # FIXME: Plugin should use syspath
-            elif target == path_to_art:
+            elif target == syspath(path_to_art):
                 return Mock(st_mtime=2)
             else:
                 raise ValueError(f"invalid target {target}")


### PR DESCRIPTION
Follow-up to #4830:

> I've had https://github.com/beetbox/beets/pull/3690 in the pipeline for a long time; and it has grown too big to look at in one piece. This is just the first commit rebased on master. It is still quite big, but only touches test code, so should be safe (assuming CI is green).

This is part 2, which mostly concerns plugins (except for a small fix to the `artresizer` module such that it's internally consistent).