### PR TITLE
Always use syspath conversions (#3690 split up, part 3)

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -392,7 +392,8 @@ class ImportSession:
         """Mark paths and directories as merged for future reimport tasks.
         """
         self._merged_items.update(paths)
-        dirs = {os.path.dirname(path) if os.path.isfile(path) else path
+        dirs = {os.path.dirname(path)
+                if os.path.isfile(syspath(path)) else path
                 for path in paths}
         self._merged_dirs.update(dirs)
 
@@ -921,7 +922,7 @@ class ImportTask(BaseImportTask):
         the file still exists, no pruning is performed, so it's safe to
         call when the file in question may not have been removed.
         """
-        if self.toppath and not os.path.exists(filename):
+        if self.toppath and not os.path.exists(syspath(filename)):
             util.prune_dirs(os.path.dirname(filename),
                             self.toppath,
                             clutter=config['clutter'].as_str_seq())
@@ -1131,7 +1132,7 @@ class ArchiveImportTask(SentinelImportTask):
         if self.extracted:
             log.debug('Removing extracted directory: {0}',
                       displayable_path(self.toppath))
-            shutil.rmtree(self.toppath)
+            shutil.rmtree(syspath(self.toppath))
 
     def extract(self):
         """Extracts the archive to a temporary directory and sets

--- a/beets/library.py
+++ b/beets/library.py
@@ -1215,7 +1215,7 @@ class Album(LibModel):
         if not old_art:
             return
 
-        if not os.path.exists(old_art):
+        if not os.path.exists(syspath(old_art)):
             log.error('removing reference to missing album art file {}',
                       util.displayable_path(old_art))
             self.artpath = None

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1272,7 +1272,7 @@ def update_items(lib, query, album, move, pretend, fields):
 
 def update_func(lib, opts, args):
     # Verify that the library folder exists to prevent accidental wipes.
-    if not os.path.isdir(lib.directory):
+    if not os.path.isdir(syspath(lib.directory)):
         ui.print_("Library path is unavailable or does not exist.")
         ui.print_(lib.directory)
         if not ui.input_yn("Are you sure you want to continue (y/n)?", True):
@@ -1666,8 +1666,10 @@ def move_func(lib, opts, args):
     dest = opts.dest
     if dest is not None:
         dest = normpath(dest)
-        if not os.path.isdir(dest):
-            raise ui.UserError('no such directory: %s' % dest)
+        if not os.path.isdir(syspath(dest)):
+            raise ui.UserError('no such directory: {}'.format(
+                displayable_path(dest)
+            ))
 
     move_items(lib, dest, decargs(args), opts.copy, opts.album, opts.pretend,
                opts.timid, opts.export)


### PR DESCRIPTION
Follow-up to https://github.com/beetbox/beets/pull/4830 and #4848:

> I've had https://github.com/beetbox/beets/pull/3690 in the pipeline for a long time; and it has grown too big to look at in one piece. This is just the first commit rebased on master. It is still quite big, but only touches test code, so should be safe (assuming CI is green).

This is part 3, with some changes to beets' core. Thus, this is probably the most sensitive PR in the series.