### PR TITLE
Support providing album information on singleton imports via Discogs

### DIFF
--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -212,6 +212,7 @@ class TrackInfo(AttrDict):
             bpm: Optional[str] = None,
             initial_key: Optional[str] = None,
             genre: Optional[str] = None,
+            album: Optional[str] = None,
             **kwargs,
     ):
         self.title = title
@@ -241,6 +242,7 @@ class TrackInfo(AttrDict):
         self.bpm = bpm
         self.initial_key = initial_key
         self.genre = genre
+        self.album = album
         self.update(kwargs)
 
     # As above, work around a bug in python-musicbrainz-ngs.

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -34,6 +34,7 @@ import:
     bell: no
     set_fields: {}
     ignored_alias_types: []
+    singleton_album_disambig: yes
 
 clutter: ["Thumbs.DB", ".DS_Store"]
 ignore: [".*", "*~", "System Volume Information", "lost+found"]

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -220,6 +220,9 @@ def disambig_string(info):
             disambig.append("Index {}".format(str(info.index)))
         if info.track_alt:
             disambig.append("Track {}".format(info.track_alt))
+        if (config['import']['singleton_album_disambig'].get()
+                and info.get('album')):
+            disambig.append("[{}]".format(info.album))
 
     if disambig:
         return ', '.join(disambig)

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -450,18 +450,25 @@ def show_item_change(item, match):
     """
     cur_artist, new_artist = item.artist, match.info.artist
     cur_title, new_title = item.title, match.info.title
+    cur_album = item.album if item.album else ""
+    new_album = match.info.album if match.info.album else ""
 
-    if cur_artist != new_artist or cur_title != new_title:
+    if (cur_artist != new_artist or cur_title != new_title
+            or cur_album != new_album):
         cur_artist, new_artist = ui.colordiff(cur_artist, new_artist)
         cur_title, new_title = ui.colordiff(cur_title, new_title)
+        cur_album, new_album = ui.colordiff(cur_album, new_album)
 
         print_("Correcting track tags from:")
         print_(f"    {cur_artist} - {cur_title}")
+        print_(f"    Album: {cur_album}") if cur_album else None
         print_("To:")
         print_(f"    {new_artist} - {new_title}")
+        print_(f"    Album: {new_album}") if new_album else None
 
     else:
         print_(f"Tagging track: {cur_artist} - {cur_title}")
+        print_(f"               Album: {new_album}") if cur_album else None
 
     # Data URL.
     if match.info.data_url:

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -461,14 +461,17 @@ def show_item_change(item, match):
 
         print_("Correcting track tags from:")
         print_(f"    {cur_artist} - {cur_title}")
-        print_(f"    Album: {cur_album}") if cur_album else None
+        if cur_album:
+            print_(f"    Album: {cur_album}")
         print_("To:")
         print_(f"    {new_artist} - {new_title}")
-        print_(f"    Album: {new_album}") if new_album else None
+        if new_album:
+            print_(f"    Album: {new_album}")
 
     else:
         print_(f"Tagging track: {cur_artist} - {cur_title}")
-        print_(f"               Album: {new_album}") if cur_album else None
+        if cur_album:
+            print_(f"               Album: {new_album}")
 
     # Data URL.
     if match.info.data_url:

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -215,6 +215,12 @@ def disambig_string(info):
         if info.albumstatus == 'Pseudo-Release':
             disambig.append(info.albumstatus)
 
+    if isinstance(info, hooks.TrackInfo):
+        if info.index:
+            disambig.append("Index {}".format(str(info.index)))
+        if info.track_alt:
+            disambig.append("Track {}".format(info.track_alt))
+
     if disambig:
         return ', '.join(disambig)
 

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -277,7 +277,7 @@ class DiscogsPlugin(BeetsPlugin):
         query = re.sub(r'(?u)\W+', ' ', query)
         # Strip medium information from query, Things like "CD1" and "disk 1"
         # can also negate an otherwise positive result.
-        query = re.sub(r'(?i)\b(CD|disc)\s*\d+', '', query)
+        query = re.sub(r'(?i)\b(CD|disc|vinyl)\s*\d+', '', query)
 
         try:
             releases = self.discogs_client.search(query,

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -214,6 +214,7 @@ class DiscogsPlugin(BeetsPlugin):
         if not artist and not title:
             self._log.debug('Skipping Discogs query. File missing artist and '
                             'title tags.')
+            return
 
         query = f'{artist} {title}'
         try:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -94,6 +94,9 @@ New features:
   :bug:`4373`
 * Fetch the ``release_group_title`` field from MusicBrainz.
   :bug: `4809`
+* :doc:`plugins/discogs`: Add support for applying album information on
+  singleton imports.
+  :bug: `4716`
 
 Bug fixes:
 

--- a/docs/plugins/discogs.rst
+++ b/docs/plugins/discogs.rst
@@ -4,6 +4,11 @@ Discogs Plugin
 The ``discogs`` plugin extends the autotagger's search capabilities to
 include matches from the `Discogs`_ database.
 
+Files can be imported as albums or as singletons. Since `Discogs`_ matches are
+always based on `Discogs`_ releases, the album tag is written even to
+singletons.  This enhances the importers results when reimporting as (full or
+partial) albums later on.
+
 .. _Discogs: https://discogs.com
 
 Installation

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -760,6 +760,19 @@ Fields are persisted to the media files of each track.
 
 Default: ``{}`` (empty).
 
+.. _singleton_album_disambig:
+
+singleton_album_disambig
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+During singleton imports and if the metadata source provides it, album names
+are appended to the disambiguation string of matching track candidates. For
+example: ``The Artist - The Title (Discogs, Index 3, Track B1, [The Album]``.
+This feature is currently supported by the :doc:`/plugins/discogs` and the
+:doc:`/plugins/spotify`.
+
+Default: ``yes``.
+
 .. _musicbrainz-config:
 
 MusicBrainz Options


### PR DESCRIPTION
## Description

The Discogs metadata plugin now saves album information when importing singletons.

- Fixes #4716
- Is a refactored / simplified version of #4717
- Presents album information in the singleton importer UI as:

```
# selection (default 1), Skip, Use as-is, Enter search, enter Id, aBort,
eDit, edit Candidates? 4
Tagging track: Portishead - Numb
               Album: Numb
URL:
    https://www.discogs.com/release/1385011-Portishead-Numb
(Similarity: 100.0%) (Discogs, Index 1, Track A1)
Apply, More candidates, Skip, Use as-is, Enter search, enter Id, aBort,
eDit, edit Candidates? 
```

- Additionally this PR extends the "disambiguation string" for _all_ singleton imports with track index and alternative name (track_alt field):

```
Candidates:
1. Portishead - Numb (100.0%) (Spotify, Index 7)
2. Portishead - Numb (100.0%) (Spotify, Index 1)
3. Portishead - Numb (100.0%) (Spotify, Index 27)
4. Portishead - Numb (100.0%) (Discogs, Index 1, Track A1)
5. Portishead - Numb (100.0%) (Discogs, Index 1, Track A1)
6. Portishead - Numb (100.0%) (Discogs, Index 1, Track 1)
7. Portishead - Numb (100.0%) (Discogs, Index 1, Track 1)
8. Portishead - Numb (100.0%) (Discogs, Index 1, Track 1)
```
- Furthermore if an album name is found, it's appended to the end of the disambiguation string.  This is currently supported by the Discogs and the Spotify plugin:

```
Candidates:
1. Portishead - Numb (100.0%) (Discogs, Index 1, Track A1, [Numb])
2. Portishead - Numb (100.0%) (Discogs, Index 1, Track A1, [Numb])
3. Portishead - Numb (100.0%) (Discogs, Index 1, Track 1, [Numb])
4. Portishead - Numb (100.0%) (Discogs, Index 1, Track 1, [Numb])
5. Portishead - Numb (100.0%) (Discogs, Index 1, Track 1, [Numb])
6. Portishead - Numb (100.0%) (Spotify, Index 7, [Dummy])
7. Portishead - Numb (100.0%) (Spotify, Index 1, [Numb])
8. Portishead - Numb (100.0%) (Spotify, Index 27, [Crazy Mix 5])
9. Portishead - Numbed In Moscow (64.3%) (title) (Spotify, Index 2, [Numb])
```
- This feature is enabled by default but if such a long disambiguation string is not desired by the user, displaying of `[Album]` can be turned off using a new configuration option:
```
import:
    singleton_album_disambig: no
```

## To Do

- [x] Documentation. 
- [x] Changelog.
- [x] ~Tests.~
