### PR TITLE
Log smart playlist create msg as info log

### DIFF
--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -192,7 +192,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
             if pretend:
                 self._log.info('Results for playlist {}:', name)
             else:
-                self._log.debug("Creating playlist {0}", name)
+                self._log.info("Creating playlist {0}", name)
             items = []
 
             if query:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -97,6 +97,10 @@ New features:
 * :doc:`plugins/discogs`: Add support for applying album information on
   singleton imports.
   :bug: `4716`
+* :doc:`/plugins/smartplaylist`: During explicit runs of the ``splupdate``
+  command, the log message "Creating playlist ..."" is now displayed instead of
+  hidden in the debug log, which states some form of progress through the UI.
+  :bug:`4861`
 
 Bug fixes:
 


### PR DESCRIPTION
Log the creation of a smart playlist as info instead of debug log level. 

## Description

In an explicit run (not while importing) it doesn't hurt to get some progress to the UI since creating/updating smart playlists can take a singinficant amount of time.


## To Do

- [x] ~Documentation.~
- [x] Changelog.
- [x] ~Tests.~