### PR TITLE
Trigger subsonicupdate on database and smart playlist changes

### DIFF
--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -17,6 +17,7 @@
 
 
 from beets.plugins import BeetsPlugin
+from beets.plugins import send as send_event
 from beets import ui
 from beets.util import (mkdirall, normpath, sanitize_path, syspath,
                         bytestring_path, path_as_posix, displayable_path)
@@ -232,6 +233,8 @@ class SmartPlaylistPlugin(BeetsPlugin):
                         if self.config['urlencode']:
                             path = bytestring_path(pathname2url(path))
                         f.write(prefix + path + b'\n')
+            # Send an event when playlists were updated.
+            send_event("smartplaylist_update")
 
         if pretend:
             self._log.info("Displayed results for {0} playlists",

--- a/beetsplug/subsonicupdate.py
+++ b/beetsplug/subsonicupdate.py
@@ -53,7 +53,14 @@ class SubsonicUpdate(BeetsPlugin):
             'auth': 'token',
         })
         config['subsonic']['pass'].redact = True
-        self.register_listener('import', self.start_scan)
+        self.register_listener('database_change', self.db_change)
+        self.register_listener('smartplaylist_update', self.spl_update)
+
+    def db_change(self, lib, model):
+        self.register_listener('cli_exit', self.start_scan)
+
+    def spl_update(self):
+        self.register_listener('cli_exit', self.start_scan)
 
     @staticmethod
     def __create_token():

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -101,6 +101,9 @@ New features:
   command, the log message "Creating playlist ..."" is now displayed instead of
   hidden in the debug log, which states some form of progress through the UI.
   :bug:`4861`
+* :doc:`plugins/subsonicupdate`: Updates are now triggered whenever either the
+  beets database is changed or a smart playlist is created/updated.
+  :bug: `4862`
 
 Bug fixes:
 

--- a/docs/plugins/subsonicupdate.rst
+++ b/docs/plugins/subsonicupdate.rst
@@ -18,11 +18,18 @@ which looks like this::
         pass: password
         auth: token
 
-With that all in place, beets will send a Rest API to your Subsonic
-server every time you import new music.
-Due to a current limitation of the API, all libraries visible to that user will be scanned.
+With that all in place, this plugin will send a REST API call to your Subsonic
+server every time you change your beets library. Due to a current limitation
+of the API, all libraries visible to that user will be scanned.
 
-This plugin requires Subsonic with an active Premium license (or active trial).
+If the :doc:`/plugins/smartplaylist` is used, creating or changing any
+playlist will trigger a Subsonic update as well.
+
+This plugin requires Subsonic with an active Premium license (or active trial)
+or any other `Subsonic API compatible`_ server implementing the ``startScan``
+endpoint.
+
+.. _Subsonic API compatible: http://www.subsonic.org/pages/api.jsp
 
 Configuration
 -------------


### PR DESCRIPTION
## Description

- Fixes triggering subsonicupdate on a database_change event instead of only at an import event.
- Sends a new event from the smartplaylist plugin whenever lists are updated/created and has subsonicupdate plugin listen to it.
- Both events register new listeners that launch the actual Subsonic library update _at the very end of a beets run_ (cli_exit) instead of being triggered by each change (similar to how the mpdupdate plugin does it).
- It doesn't hurt if Subsonic is informed on subsequent changes of smart playlists (while the user is heavily experimenting with them) since once a subsonic-rescan is triggered, it keeps running and doesn't restart from scratch.


## To Do

- [x] Documentation.
- [x] Changelog.
- [x] ~Tests.~
