### PR TITLE
Add m3u per session feature to importfeeds plugin

### DIFF
--- a/beetsplug/importfeeds.py
+++ b/beetsplug/importfeeds.py
@@ -28,10 +28,21 @@ from beets import config
 M3U_DEFAULT_NAME = 'imported.m3u'
 
 
+def _build_m3u_session_filename(basename):
+    """Builds unique m3u filename by putting current date between given
+    basename and file ending."""
+    date = datetime.datetime.now().strftime("%Y%m%d_%Hh%M")
+    basename = re.sub(r"(\.m3u|\.M3U)", '', basename)
+    path = normpath(os.path.join(
+        config['importfeeds']['dir'].as_filename(),
+        basename + '_' + date + '.m3u'
+    ))
+    return path
+
+
 def _build_m3u_filename(basename):
     """Builds unique m3u filename by appending given basename to current
     date."""
-
     basename = re.sub(r"[\s,/\\'\"]", '_', basename)
     date = datetime.datetime.now().strftime("%Y%m%d_%Hh%M")
     path = normpath(os.path.join(
@@ -70,6 +81,7 @@ class ImportFeedsPlugin(BeetsPlugin):
 
         self.register_listener('album_imported', self.album_imported)
         self.register_listener('item_imported', self.item_imported)
+        self.register_listener('import_begin', self.import_begin)
 
     def get_feeds_dir(self):
         feeds_dir = self.config['dir'].get()
@@ -105,6 +117,10 @@ class ImportFeedsPlugin(BeetsPlugin):
             m3u_path = os.path.join(feedsdir, m3u_basename)
             _write_m3u(m3u_path, paths)
 
+        if 'm3u_session' in formats:
+            m3u_path = os.path.join(feedsdir, self.m3u_session)
+            _write_m3u(m3u_path, paths)
+
         if 'm3u_multi' in formats:
             m3u_path = _build_m3u_filename(basename)
             _write_m3u(m3u_path, paths)
@@ -125,3 +141,9 @@ class ImportFeedsPlugin(BeetsPlugin):
 
     def item_imported(self, lib, item):
         self._record_items(lib, item.title, [item])
+
+    def import_begin(self, session):
+        formats = self.config['formats'].as_str_seq()
+        if 'm3u_session' in formats:
+            self.m3u_session = _build_m3u_session_filename(
+                self.config['m3u_name'].as_str())

--- a/beetsplug/importfeeds.py
+++ b/beetsplug/importfeeds.py
@@ -35,7 +35,7 @@ def _build_m3u_session_filename(basename):
     basename = re.sub(r"(\.m3u|\.M3U)", '', basename)
     path = normpath(os.path.join(
         config['importfeeds']['dir'].as_filename(),
-        basename + '_' + date + '.m3u'
+        f'{basename}_{date}.m3u'
     ))
     return path
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -104,6 +104,9 @@ New features:
 * :doc:`plugins/subsonicupdate`: Updates are now triggered whenever either the
   beets database is changed or a smart playlist is created/updated.
   :bug: `4862`
+* :doc:`plugins/importfeeds`: Add a new output format allowing to save a
+  playlist once per import session.
+  :bug: `4863`
 
 Bug fixes:
 

--- a/docs/plugins/importfeeds.rst
+++ b/docs/plugins/importfeeds.rst
@@ -22,6 +22,9 @@ configuration file. The available options are:
    - **m3u**: Catalog the imports in a centralized playlist.
    - **m3u_multi**: Create a new playlist for each import (uniquely named by
      appending the date and track/album name).
+   - **m3u_session**: Create a new playlist for each import session. The file
+     is named as ``m3u_name`` appending the date and time the import session
+     was started.
    - **link**: Create a symlink for each imported item. This is the
      recommended setting to propagate beets imports to your iTunes library:
      just drag and drop the ``dir`` folder on the iTunes dock icon.
@@ -29,7 +32,8 @@ configuration file. The available options are:
      file paths to the terminal.
 
   Default: None.
-- **m3u_name**: Playlist name used by the ``m3u`` format.
+- **m3u_name**: Playlist name used by the ``m3u`` format and as a prefix used
+  by the ``m3u_session`` format.
   Default: ``imported.m3u``.
 - **relative_to**: Make the m3u paths relative to another
   folder than where the playlist is being written. If you're using importfeeds

--- a/test/test_importfeeds.py
+++ b/test/test_importfeeds.py
@@ -3,6 +3,7 @@ import os.path
 import tempfile
 import shutil
 import unittest
+import datetime
 
 from beets import config
 from beets.library import Item, Album, Library
@@ -53,6 +54,23 @@ class ImportfeedsTestTest(unittest.TestCase):
         playlist_subdir = os.path.dirname(playlist)
         self.assertTrue(os.path.isdir(playlist_subdir))
         self.assertTrue(os.path.isfile(playlist))
+
+    def test_playlist_per_session(self):
+        config['importfeeds']['formats'] = 'm3u_session'
+        config['importfeeds']['m3u_name'] = 'imports.m3u'
+        album = Album(album='album/name', id=1)
+        item_path = os.path.join('path', 'to', 'item')
+        item = Item(title='song', album_id=1, path=item_path)
+        self.lib.add(album)
+        self.lib.add(item)
+
+        self.importfeeds.import_begin(self)
+        self.importfeeds.album_imported(self.lib, album)
+        date = datetime.datetime.now().strftime("%Y%m%d_%Hh%M")
+        playlist = os.path.join(self.feeds_dir, 'imports_' + date + '.m3u')
+        self.assertTrue(os.path.isfile(playlist))
+        with open(playlist) as playlist_contents:
+            self.assertIn(item_path, playlist_contents.read())
 
 
 def suite():


### PR DESCRIPTION
## Description

Adds a new output format named `m3u_session` that saves a playlist named `<m3u_name>_<import_begin_datetime>` on each run of `beets import ....`



## To Do

- [x] Documentation. 
- [x] Changelog.
- [x] Tests.
