### PR TITLE
Optional more verbose duplicates prompt

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -31,6 +31,7 @@ import:
         album: albumartist album
         item: artist title
     duplicate_action: ask
+    duplicate_verbose_prompt: no
     bell: no
     set_fields: {}
     ignored_alias_types: []

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -873,8 +873,11 @@ class TerminalImportSession(importer.ImportSession):
                     not task.is_album,
                 ))
                 if config['import']['duplicate_verbose_prompt']:
-                    for dup in duplicate.items():
-                        print(f"  {dup}")
+                    if task.is_album:
+                        for dup in duplicate.items():
+                            print(f"  {dup}")
+                    else:
+                        print(f"  {duplicate}")
 
             print_("New: " + summarize_items(
                 task.imported_items(),

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -872,15 +872,17 @@ class TerminalImportSession(importer.ImportSession):
                     list(duplicate.items()) if task.is_album else [duplicate],
                     not task.is_album,
                 ))
-                for dup in duplicate.items():
-                    print(f"  {dup}")
+                if config['import']['duplicate_verbose_prompt']:
+                    for dup in duplicate.items():
+                        print(f"  {dup}")
 
             print_("New: " + summarize_items(
                 task.imported_items(),
                 not task.is_album,
             ))
-            for item in task.imported_items():
-                print(f"  {item}")
+            if config['import']['duplicate_verbose_prompt']:
+                for item in task.imported_items():
+                    print(f"  {item}")
 
             sel = ui.input_options(
                 ('Skip new', 'Keep all', 'Remove old', 'Merge all')

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -872,11 +872,15 @@ class TerminalImportSession(importer.ImportSession):
                     list(duplicate.items()) if task.is_album else [duplicate],
                     not task.is_album,
                 ))
+                for dup in duplicate.items():
+                    print(f"  {dup}")
 
             print_("New: " + summarize_items(
                 task.imported_items(),
                 not task.is_album,
             ))
+            for item in task.imported_items():
+                print(f"  {item}")
 
             sel = ui.input_options(
                 ('Skip new', 'Keep all', 'Remove old', 'Merge all')

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -109,6 +109,9 @@ New features:
   :bug: `4863`
 * Make ArtResizer work with :pypi:`PIL`/:pypi:`pillow` 10.0.0 removals.
   :bug:`4869`
+* A new configuration option, :ref:`duplicate_verbose_prompt`, allows changing
+  how duplicates are presented during import.
+  :bug: `4866`
 
 Bug fixes:
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -728,6 +728,29 @@ Controls how duplicates are treated in import task.
 item; "merge" means merge into one album; "ask" means the user 
 should be prompted for the action each time. The default is ``ask``.
 
+.. _duplicate_verbose_prompt:
+
+duplicate_verbose_prompt
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Usually when duplicates are detected during import, information about the
+existing and the newly imported album is summarized. Enabling this option also
+lists details on individual tracks. The :ref:`format_item setting
+<format_item>` is applied, which would, considering the default, look like
+this:
+
+.. code-block:: console
+
+    This item is already in the library!
+    Old: 1 items, MP3, 320kbps, 5:56, 13.6 MiB
+      Artist Name - Album Name - Third Track Title
+    New: 2 items, MP3, 320kbps, 7:18, 17.1 MiB
+      Artist Name - Album Name - First Track Title
+      Artist Name - Album Name - Second Track Title
+    [S]kip new, Keep all, Remove old, Merge all?
+
+Default: ``no``.
+
 .. _bell:
 
 bell


### PR DESCRIPTION
## Description

A new config option allows to enable a more detailed view when a duplicate is detected during import of an album or singleton.

- New `import` config option:

```
import:
    duplicate_verbose_prompt: no
```
- Disabled by default.

## To Do

- [x] Documentation.
- [x] Changelog. 
- [x] ~Tests.~
