### PR TITLE
Adapt to some recent flake8/pycodestyle changes

### DIFF
--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from collections import namedtuple
 from functools import total_ordering
 import re
-from typing import Dict, List, Tuple, Iterator, Union, Any, Optional,\
+from typing import Dict, List, Tuple, Iterator, Union, Any, Optional, \
     Iterable, Callable, cast
 
 from beets import logging

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -108,7 +108,7 @@ class Query(ABC):
         return f"{self.__class__.__name__}()"
 
     def __eq__(self, other) -> bool:
-        return type(self) == type(other)
+        return type(self) is type(other)
 
     def __hash__(self) -> int:
         """Minimalistic default implementation of a hash.
@@ -868,7 +868,7 @@ class Sort:
         return 0
 
     def __eq__(self, other) -> bool:
-        return type(self) == type(other)
+        return type(self) is type(other)
 
 
 class MultipleSort(Sort):
@@ -1014,7 +1014,7 @@ class NullSort(Sort):
         return False
 
     def __eq__(self, other) -> bool:
-        return type(self) == type(other) or other is None
+        return type(self) is type(other) or other is None
 
     def __hash__(self) -> int:
         return 0

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -1363,7 +1363,7 @@ def _freshen_items(items):
 
 def _extend_pipeline(tasks, *stages):
     # Return pipeline extension for stages with list of tasks
-    if type(tasks) is list:
+    if isinstance(tasks, list):
         task_iter = iter(tasks)
     else:
         task_iter = tasks

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -1363,7 +1363,7 @@ def _freshen_items(items):
 
 def _extend_pipeline(tasks, *stages):
     # Return pipeline extension for stages with list of tasks
-    if type(tasks) == list:
+    if type(tasks) is list:
         task_iter = iter(tasks)
     else:
         task_iter = tasks

--- a/beetsplug/acousticbrainz.py
+++ b/beetsplug/acousticbrainz.py
@@ -323,11 +323,11 @@ class AcousticPlugin(plugins.BeetsPlugin):
         """
         for k, v in subscheme.items():
             if k in subdata:
-                if type(v) == dict:
+                if isinstance(v, dict):
                     yield from self._data_to_scheme_child(subdata[k],
                                                           v,
                                                           composites)
-                elif type(v) == tuple:
+                elif isinstance(v, tuple):
                     composite_attribute, part_number = v
                     attribute_parts = composites[composite_attribute]
                     # Parts are not guaranteed to be inserted in order

--- a/test/test_datequery.py
+++ b/test/test_datequery.py
@@ -19,7 +19,7 @@ from test import _common
 from datetime import datetime, timedelta
 import unittest
 import time
-from beets.dbcore.query import _parse_periods, DateInterval, DateQuery,\
+from beets.dbcore.query import _parse_periods, DateInterval, DateQuery, \
     InvalidQueryArgumentValueError
 
 

--- a/test/test_mbsync.py
+++ b/test/test_mbsync.py
@@ -16,7 +16,7 @@
 import unittest
 from unittest.mock import patch
 
-from test.helper import TestHelper,\
+from test.helper import TestHelper, \
     generate_album_info, \
     generate_track_info, \
     capture_log


### PR DESCRIPTION
It's pretty common for updates to flake8 & pycodestyle to add new style-related lint warnings. There are a few of these surfaced in this recent CI run:
https://github.com/beetbox/beets/actions/runs/5716141601/job/15486984755?pr=4866

These all look like perfectly reasonable improvements that are unlikely to break anything.