### PR TITLE
Fix compatibility with pillow 10

### DIFF
--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -353,7 +353,7 @@ class PILBackend(LocalBackend):
         try:
             im = Image.open(syspath(path_in))
             size = maxwidth, maxwidth
-            im.thumbnail(size, Image.ANTIALIAS)
+            im.thumbnail(size, Image.Resampling.LANCZOS)
 
             if quality == 0:
                 # Use PIL's default quality.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -107,6 +107,8 @@ New features:
 * :doc:`plugins/importfeeds`: Add a new output format allowing to save a
   playlist once per import session.
   :bug: `4863`
+* Make ArtResizer work with :pypi:`PIL`/:pypi:`pillow` 10.0.0 removals.
+  :bug:`4869`
 
 Bug fixes:
 


### PR DESCRIPTION
The `ANTIALIAS` attribute has long been deprecated, and was finally removed in pillow 10.0.

The recommendation is to migrate to `Resampling.LANCZOS` instead.

https://pillow.readthedocs.io/en/stable/deprecations.html#constants

## Description

Fixes #X.  <!-- Insert issue number here if applicable. -->

(...)

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
