### PR TITLE
Fix various typos

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -237,7 +237,7 @@ guidelines to follow:
 -  If you have a Unicode path or you’re not sure whether something is
    Unicode or not, pass it through ``bytestring_path`` function in the
    ``beets.util`` module to convert it to bytes.
--  Pass every path name trough the ``syspath`` function (also in
+-  Pass every path name through the ``syspath`` function (also in
    ``beets.util``) before sending it to any *operating system* file
    operation (``open``, for example). This is necessary to use long
    filenames (which, maddeningly, must be Unicode) on Windows. This

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -708,7 +708,7 @@ def _merge_pseudo_and_actual_album(
     According to the ticket PICARD-145, the main release id should be used.
     But the ticket has been in limbo since over a decade now.
     It also suggests the introduction of the tag `musicbrainz_pseudoreleaseid`,
-    but as of this field can't be found in any offical Picard docs,
+    but as of this field can't be found in any official Picard docs,
     hence why we did not implement that for now.
     """
     merged = pseudo.copy()

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 
 
 class ParsingError(ValueError):
-    """Abstract class for any unparseable user-requested album/query
+    """Abstract class for any unparsable user-requested album/query
     specification.
     """
 
@@ -549,7 +549,7 @@ class OrQuery(MutableCollectionQuery):
 
 
 class NotQuery(Query):
-    """A query that matches the negation of its `subquery`, as a shorcut for
+    """A query that matches the negation of its `subquery`, as a shortcut for
     performing `not(subquery)` without using regular expressions.
     """
 

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -1456,7 +1456,7 @@ def user_query(session, task):
     and the processed task is yielded.
 
     It emits the ``import_task_choice`` event for plugins. Plugins have
-    acces to the choice via the ``taks.choice_flag`` property and may
+    access to the choice via the ``task.choice_flag`` property and may
     choose to change it.
     """
     if task.skip:

--- a/beets/library.py
+++ b/beets/library.py
@@ -1790,7 +1790,7 @@ class DefaultTemplateFunctions:
         should return an empty string.
 
         "initial_subqueries" is a list of subqueries that should be included
-        in the query to find the ambigous items.
+        in the query to find the ambiguous items.
         """
         memokey = self._tmpl_unique_memokey(name, keys, disam, item_id)
         memoval = self.lib._memotable.get(memokey)

--- a/beets/ui/completion_base.sh
+++ b/beets/ui/completion_base.sh
@@ -31,7 +31,7 @@
 # plugins dynamically
 #
 # Currently, only Bash 3.2 and newer is supported and the
-# `bash-completion` package is requied.
+# `bash-completion` package is required.
 #
 # TODO
 # ----

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -187,7 +187,7 @@ def sorted_walk(
     pattern in `ignore` are skipped. If `logger` is provided, then
     warning messages are logged there when a directory cannot be listed.
     """
-    # Make sure the pathes aren't Unicode strings.
+    # Make sure the paths aren't Unicode strings.
     path = bytestring_path(path)
     ignore = [bytestring_path(i) for i in ignore]
 

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -372,7 +372,7 @@ class PILBackend(LocalBackend):
                 else:
                     lower_qual = 95
                 for i in range(5):
-                    # 5 attempts is an abitrary choice
+                    # 5 attempts is an arbitrary choice
                     filesize = os.stat(syspath(path_out)).st_size
                     log.debug("PIL Pass {0} : Output size: {1}B", i, filesize)
                     if filesize <= max_filesize:
@@ -498,7 +498,7 @@ class ArtResizer(metaclass=Shareable):
     def __init__(self):
         """Create a resizer object with an inferred method.
         """
-        # Check if a local backend is availabe, and store an instance of the
+        # Check if a local backend is available, and store an instance of the
         # backend class. Otherwise, fallback to the web proxy.
         for backend_cls in BACKEND_CLASSES:
             try:

--- a/beets/util/hidden.py
+++ b/beets/util/hidden.py
@@ -46,7 +46,7 @@ def _is_hidden_win(path):
     # Retrieve the attributes for the file.
     attrs = ctypes.windll.kernel32.GetFileAttributesW(beets.util.syspath(path))
 
-    # Ensure we have valid attribues and compare them against the mask.
+    # Ensure we have valid attributes and compare them against the mask.
     return attrs >= 0 and attrs & hidden_mask
 
 

--- a/beetsplug/absubmit.py
+++ b/beetsplug/absubmit.py
@@ -68,7 +68,7 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
         self.extractor = self.config['extractor'].as_str()
         if self.extractor:
             self.extractor = util.normpath(self.extractor)
-            # Expicit path to extractor
+            # Explicit path to extractor
             if not os.path.isfile(self.extractor):
                 raise ui.UserError(
                     'Extractor command does not exist: {0}.'.

--- a/beetsplug/export.py
+++ b/beetsplug/export.py
@@ -64,9 +64,9 @@ class ExportPlugin(BeetsPlugin):
             'csv': {
                 # CSV module formatting options.
                 'formatting': {
-                    # The delimiter used to seperate columns.
+                    # The delimiter used to separate columns.
                     'delimiter': ',',
-                    # The dialect to use when formating the file output.
+                    # The dialect to use when formatting the file output.
                     'dialect': 'excel'
                 }
             },

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -411,7 +411,7 @@ class CoverArtArchive(RemoteArtSource):
 
         # Cover Art Archive API offers pre-resized thumbnails at several sizes.
         # If the maxwidth config matches one of the already available sizes
-        # fetch it directly intead of fetching the full sized image and
+        # fetch it directly instead of fetching the full sized image and
         # resizing it.
         preferred_width = None
         if plugin.maxwidth in self.VALID_THUMBNAIL_SIZES:

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -345,7 +345,7 @@ class Genius(Backend):
     def fetch(self, artist, title):
         """Fetch lyrics from genius.com
 
-        Because genius doesn't allow accesssing lyrics via the api,
+        Because genius doesn't allow accessing lyrics via the api,
         we first query the api for a url matching our artist & title,
         then attempt to scrape that url for the lyrics.
         """

--- a/beetsplug/sonosupdate.py
+++ b/beetsplug/sonosupdate.py
@@ -31,7 +31,7 @@ class SonosUpdate(BeetsPlugin):
 
     def update(self, lib):
         """When the client exists try to send refresh request to a Sonos
-        controler.
+        controller.
         """
         self._log.info('Requesting a Sonos library update...')
 

--- a/beetsplug/thumbnails.py
+++ b/beetsplug/thumbnails.py
@@ -74,7 +74,7 @@ class ThumbnailsPlugin(BeetsPlugin):
                 self.process_album(album)
 
     def _check_local_ok(self):
-        """Check that's everythings ready:
+        """Check that everything is ready:
             - local capability to resize images
             - thumbnail dirs exist (create them if needed)
             - detect whether we'll use PIL or IM

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -178,7 +178,7 @@ Bug fixes:
 * :doc:`plugins/lyrics`: Fixed issue with Genius header being included in lyrics,
   added test case of up-to-date Genius html
 * :doc:`plugins/importadded`: Fix a bug with recently added reflink import option
-  that casues a crash when ImportAdded plugin enabled.
+  that causes a crash when ImportAdded plugin enabled.
   :bug:`4389`
 * :doc:`plugins/convert`: Fix a bug with the `wma` format alias.
 * :doc:`/plugins/web`: Fix get file from item.
@@ -195,7 +195,7 @@ Bug fixes:
   :bug:`4561` :bug:`4600`
 * Fix issue where deletion of flexible fields on an album doesn't cascade to items
   :bug:`4662`
-* Fix issue where ``beet write`` continuosly retags the ``albumtypes`` metadata
+* Fix issue where ``beet write`` continuously retags the ``albumtypes`` metadata
   field in files. Additionally broken data could have been added to the library
   when the tag was read from file back into the library using ``beet update``.
   It is required for all users to **check if such broken data is present in the
@@ -2764,7 +2764,7 @@ Still more fixes and little improvements:
   title were found.
 * Fix a crash when reading some files with missing tags.
 * :doc:`/plugins/discogs`: Compatibility with the new 2.0 version of the
-  `discogs_client`_ Python library. If you were using the old version, you wil
+  `discogs_client`_ Python library. If you were using the old version, you will
   need to upgrade to the latest version of the library to use the
   correspondingly new version of the plugin (e.g., with
   ``pip install -U discogs-client``). Thanks to Andriy Kohut.
@@ -4832,7 +4832,7 @@ Here's the detailed list of changes:
   (This means it might fail if that album can't be found.) Also, you can now
   abort the tagging process by entering ``b`` (for aBort) at any of the prompts.
 
-* Overhauled methods for handling fileystem paths to allow filenames that have
+* Overhauled methods for handling filesystem paths to allow filenames that have
   badly encoded special characters. These changes are pretty fragile, so please
   report any bugs involving ``UnicodeError`` or SQLite ``ProgrammingError``
   messages in this version.

--- a/docs/plugins/absubmit.rst
+++ b/docs/plugins/absubmit.rst
@@ -38,7 +38,7 @@ To run the analysis program and upload its results, type::
 
 By default, the command will only look for AcousticBrainz data when the tracks
 don't already have it; the ``-f`` or ``--force`` switch makes it refetch
-data even when it already exists. You can use the ``-d`` or ``--dry`` swtich
+data even when it already exists. You can use the ``-d`` or ``--dry`` switch
 to check which files will be analyzed, before you start a longer period
 of processing.
 

--- a/docs/plugins/aura.rst
+++ b/docs/plugins/aura.rst
@@ -99,7 +99,7 @@ For example::
             - https://aura.example.org
 
 In order to use the plugin with a local browser client accessed using
-``file:///`` you must inclue ``'null'`` in the list of allowed origins
+``file:///`` you must include ``'null'`` in the list of allowed origins
 (including quote marks)::
 
     aura:

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -250,7 +250,7 @@ Last.fm
 
 To use the Last.fm backend, you need to `register for a Last.fm API key`_. Set
 the ``lastfm_key`` configuration option to your API key, then add ``lastfm`` to
-the list of sources in your configutation.
+the list of sources in your configuration.
 
 .. _register for a Last.fm API key: https://www.last.fm/api/account/create
 

--- a/docs/plugins/limit.rst
+++ b/docs/plugins/limit.rst
@@ -3,7 +3,7 @@ Limit Query Plugin
 
 ``limit`` is a plugin to limit a query to the first or last set of 
 results. We also provide a query prefix ``'<n'`` to inline the same 
-behavior in the ``list`` command. They are analagous to piping results:
+behavior in the ``list`` command. They are analogous to piping results:
 
     $ beet [list|ls] [QUERY] | [head|tail] -n n
 

--- a/docs/plugins/replaygain.rst
+++ b/docs/plugins/replaygain.rst
@@ -19,7 +19,7 @@ Once installed, this plugin analyzes all files during the import process. This
 can be a slow process; to instead analyze after the fact, disable automatic
 analysis and use the ``beet replaygain`` command (see below).
 
-To speed up analysis with some of the avalaible backends, this plugin processes
+To speed up analysis with some of the available backends, this plugin processes
 tracks or albums (when using the ``-a`` option) in parallel. By default,
 a single thread is used per logical core of your CPU.
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -159,7 +159,7 @@ path_sep_replace
 A string that replaces the path separator (for example, the forward slash
 ``/`` on Linux and MacOS, and the backward slash ``\\`` on Windows) when
 generating filenames with beets.
-This option is related to :ref:`replace`, but is distict from it for
+This option is related to :ref:`replace`, but is distinct from it for
 technical reasons.
 
 .. warning::

--- a/test/helper.py
+++ b/test/helper.py
@@ -293,7 +293,7 @@ class TestHelper:
         The item receives its attributes from `**values` paratmeter. The
         `title`, `artist`, `album`, `track`, `format` and `path`
         attributes have defaults if they are not given as parameters.
-        The `title` attribute is formated with a running item count to
+        The `title` attribute is formatted with a running item count to
         prevent duplicates. The default for the `path` attribute
         respects the `format` value.
 

--- a/test/test_lyrics.py
+++ b/test/test_lyrics.py
@@ -509,7 +509,7 @@ class GeniusFetchTest(GeniusBaseTest):
             mock_fetch_url.assert_called_once_with("blackbear_url")
             mock_scrape.assert_called_once_with(True)
 
-            # genius uses the hypen minus (\u002D) as their dash
+            # genius uses the hyphen minus (\u002D) as their dash
             self.assertIsNotNone(genius.fetch('El-p', 'Idfc'))
             mock_fetch_url.assert_called_with('El-p_url')
             mock_scrape.assert_called_with(True)
@@ -628,7 +628,7 @@ class TekstowoIntegrationTest(TekstowoBaseTest, LyricsAssertions):
         self.assertEqual(lyrics, None)
 
 
-# test utilties
+# test utilities
 
 class SlugTests(unittest.TestCase):
 

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -691,7 +691,7 @@ class MBLibraryTest(unittest.TestCase):
                     'release': {
                         'title': 'actual',
                         'id': 'd2a6f856-b553-40a0-ac54-a321e8e2da01',
-                        'status': 'Offical',
+                        'status': 'Official',
                         'medium-list': [{
                             'track-list': [{
                                 'id': 'baz',

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -375,7 +375,7 @@ class ListenersTest(unittest.TestCase, TestHelper):
             def dummy5(self, bar):
                 test.assertFalse(True)
 
-            # more complex exmaples
+            # more complex examples
 
             def dummy6(self, foo, bar=None):
                 test.assertEqual(foo, 5)

--- a/test/test_ui_init.py
+++ b/test/test_ui_init.py
@@ -131,7 +131,7 @@ class ParentalDirCreation(_common.TestCase):
         non_exist_path = _common.util.py3_path(os.path.join(
             self.temp_dir, b'nonexist', str(random()).encode()))
         # Deepcopy instead of recovering because exceptions might
-        # occcur; wish I can use a golang defer here.
+        # occur; wish I can use a golang defer here.
         test_config = deepcopy(config)
         test_config['library'] = non_exist_path
         with control_stdin('y'):

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -423,7 +423,7 @@ class WebPluginTest(_common.LibTestCase):
         self.assertEqual(response.status_code, 405)
 
         # Note: if this fails, all items have gone and rest of
-        # tests wil fail!
+        # tests will fail!
 
     def test_delete_item_id_readonly(self):
 
@@ -539,7 +539,7 @@ class WebPluginTest(_common.LibTestCase):
         self.assertEqual(response.status_code, 405)
 
         # Note: if this fails, all albums have gone and rest of
-        # tests wil fail!
+        # tests will fail!
 
     def test_delete_album_id_readonly(self):
 


### PR DESCRIPTION
## Description

Fixes various user-facing and non-user-facing typos

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
