### PR TITLE
Add embyupdate `userid` config option

### DIFF
--- a/beetsplug/embyupdate.py
+++ b/beetsplug/embyupdate.py
@@ -167,6 +167,7 @@ class EmbyUpdate(BeetsPlugin):
         port = config['emby']['port'].get()
         username = config['emby']['username'].get()
         password = config['emby']['password'].get()
+        userid = config['emby']['userid'].get()
         token = config['emby']['apikey'].get()
 
         # Check if at least a apikey or password is given.
@@ -174,16 +175,18 @@ class EmbyUpdate(BeetsPlugin):
             self._log.warning('Provide at least Emby password or apikey.')
             return
 
-        # Get user information from the Emby API.
-        user = get_user(host, port, username)
-        if not user:
-            self._log.warning(f'User {username} could not be found.')
-            return
+        if not userid:
+            # Get user information from the Emby API.
+            user = get_user(host, port, username)
+            if not user:
+                self._log.warning(f'User {username} could not be found.')
+                return
+            userid = user[0]['Id']
 
         if not token:
             # Create Authentication data and headers.
             auth_data = password_data(username, password)
-            headers = create_headers(user[0]['Id'])
+            headers = create_headers(userid)
 
             # Get authentication token.
             token = get_token(host, port, headers, auth_data)
@@ -194,7 +197,7 @@ class EmbyUpdate(BeetsPlugin):
                 return
 
         # Recreate headers with a token.
-        headers = create_headers(user[0]['Id'], token=token)
+        headers = create_headers(userid, token=token)
 
         # Trigger the Update.
         url = api_url(host, port, '/Library/Refresh')

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -112,6 +112,9 @@ New features:
 * A new configuration option, :ref:`duplicate_verbose_prompt`, allows changing
   how duplicates are presented during import.
   :bug: `4866`
+* :doc:`/plugins/embyupdate`: Add handling for private users by adding
+  ``userid`` config option.
+  :bug:`4402`
 
 Bug fixes:
 

--- a/docs/plugins/embyupdate.rst
+++ b/docs/plugins/embyupdate.rst
@@ -29,7 +29,10 @@ The available options under the ``emby:`` section are:
   Default: ``localhost``
 - **port**: The Emby server port.
   Default: 8096
-- **username**: A username of a Emby user that is allowed to refresh the library.
+- **username**: A username of an Emby user that is allowed to refresh the library.
+- **userid**: A user ID of an Emby user that is allowed to refresh the library.
+  (This is only necessary for private users i.e. when the user is hidden from
+  login screens)
 - **apikey**: An Emby API key for the user.
 - **password**: The password for the user. (This is only necessary if no API
   key is provided.)


### PR DESCRIPTION
## Description

Fixes #4402.  <!-- Insert issue number here if applicable. -->

Adds a `userid` config option for the `embyupdate` plugin. When the
`userid` is provided, the Emby user lookup is bypassed. This avoids a
failure to get the user ID for private users.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
