### PR TITLE
Correcting pip specific version install from "=" to "==" in Contributing.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -288,7 +288,7 @@ Other ways to run the tests:
 You can also see the latest test results on `Linux`_ and on `Windows`_.
 
 Note, if you are on Windows and are seeing errors running tox, it may be related to `this issue`_,
-in which case you may have to install tox v3.8.3 e.g. ``python -m pip install tox=3.8.3``
+in which case you may have to install tox v3.8.3 e.g. ``python -m pip install tox==3.8.3``
 
 .. _this issue: https://github.com/tox-dev/tox/issues/1550
 


### PR DESCRIPTION
## Description

Changed line 291 from  ``python -m pip install tox=3.8.3`` to  ``python -m pip install tox==3.8.3`` as shown in the 7th example: https://pip.pypa.io/en/stable/cli/pip_install/#examples, this is the correct way to install specific versions.
