### PR TITLE
Support excluding fields with update command

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1196,7 +1196,7 @@ default_commands.append(list_cmd)
 
 # update: Update library contents according to on-disk tags.
 
-def update_items(lib, query, album, move, pretend, fields, exclude_fields):
+def update_items(lib, query, album, move, pretend, fields, exclude_fields=None):
     """For all the items matched by the query, update the library to
     reflect the item's embedded tags.
     :param fields: The fields to be stored. If not specified, all fields will

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1196,13 +1196,14 @@ default_commands.append(list_cmd)
 
 # update: Update library contents according to on-disk tags.
 
-def update_items(lib, query, album, move, pretend, fields, exclude_fields=None):
+def update_items(lib, query, album, move, pretend, fields,
+                 exclude_fields=None):
     """For all the items matched by the query, update the library to
     reflect the item's embedded tags.
     :param fields: The fields to be stored. If not specified, all fields will
     be.
-    :param exclude_fields: The fields to not be stored. If not specified, all fields will
-    be.
+    :param exclude_fields: The fields to not be stored. If not specified, all
+    fields will be.
     """
     with lib.transaction():
         if move and fields is not None and 'path' not in fields:
@@ -1339,7 +1340,8 @@ update_cmd.parser.add_option(
     help='list of fields to update'
 )
 update_cmd.parser.add_option(
-    '-e', '--exclude-field', default=None, action='append', dest='exclude_fields',
+    '-e', '--exclude-field', default=None, action='append',
+    dest='exclude_fields',
     help='list of fields to exclude from updates'
 )
 update_cmd.func = update_func

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1338,10 +1338,10 @@ update_cmd.parser.add_option(
     '-F', '--field', default=None, action='append', dest='fields',
     help='list of fields to update'
 )
-update_cmd.parser.add_option(
-    '-f', '--exclude-field', default=None, action='append', dest='exclude_fields',
-    help='list of fields to exclude from updates'
-)
+# update_cmd.parser.add_option(
+#     '-f', '--exclude-field', default=None, action='append', dest='exclude_fields',
+#     help='list of fields to exclude from updates'
+# )
 update_cmd.func = update_func
 default_commands.append(update_cmd)
 

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1338,10 +1338,10 @@ update_cmd.parser.add_option(
     '-F', '--field', default=None, action='append', dest='fields',
     help='list of fields to update'
 )
-# update_cmd.parser.add_option(
-#     '-f', '--exclude-field', default=None, action='append', dest='exclude_fields',
-#     help='list of fields to exclude from updates'
-# )
+update_cmd.parser.add_option(
+    '-e', '--exclude-field', default=None, action='append', dest='exclude_fields',
+    help='list of fields to exclude from updates'
+)
 update_cmd.func = update_func
 default_commands.append(update_cmd)
 

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1213,7 +1213,7 @@ def update_items(lib, query, album, move, pretend, fields,
             fields.append('path')
         items, _ = _do_query(lib, query, album)
 
-        item_fields = fields or library.Item._media_fields
+        item_fields = fields or library.Item._fields.keys()
         album_fields = fields or library.Album._fields.keys()
         if exclude_fields:
             item_fields = [f for f in item_fields if f not in exclude_fields]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ for Python 3.6).
 
 New features:
 
+* :ref:`update-cmd`: added ```-e``` flag for excluding fields from being updated.
 * :doc:`/plugins/deezer`: Import rank and other attributes from Deezer during import and add a function to update the rank of existing items.
   :bug:`4841`
 * resolve transl-tracklisting relations for pseudo releases and merge data with the actual release

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -329,7 +329,7 @@ update
 ``````
 ::
 
-    beet update [-F] FIELD [-aM] QUERY
+    beet update [-F] FIELD [-e] EXCLUDE_FIELD [-aM] QUERY
 
 Update the library (and, by default, move files) to reflect out-of-band metadata
 changes and file deletions.
@@ -347,8 +347,9 @@ on disk.
 
 By default, all the changed metadata will be populated back to the database.
 If you only want certain fields to be written, specify them with the ```-F```
-flags (which can be used multiple times). For the list of supported fields,
-please see ```beet fields```.
+flags (which can be used multiple times). Alternatively, specify fields to *not*
+write with ```-e``` flags (which can be used multiple times). For the list of 
+supported fields, please see ```beet fields```.
 
 When an updated track is part of an album, the album-level fields of *all*
 tracks from the album are also updated. (Specifically, the command copies

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -579,13 +579,13 @@ class UpdateTest(_common.TestCase):
         util.remove(artfile)
 
     def _update(self, query=(), album=False, move=False, reset_mtime=True,
-                fields=None, excluded_fields=None):
+                fields=None, exclude_fields=None):
         self.io.addinput('y')
         if reset_mtime:
             self.i.mtime = 0
             self.i.store()
         commands.update_items(self.lib, query, album, move, False,
-                              fields=fields, exclude_fields=excluded_fields)
+                              fields=fields, exclude_fields=exclude_fields)
 
     def test_delete_removes_item(self):
         self.assertTrue(list(self.lib.items()))
@@ -733,7 +733,7 @@ class UpdateTest(_common.TestCase):
         mf = MediaFile(syspath(self.i.path))
         mf.lyrics = 'new lyrics'
         mf.save()
-        self._update(excluded_fields=['lyrics'])
+        self._update(exclude_fields=['lyrics'])
         item = self.lib.items().get()
         self.assertNotEqual(item.lyrics, 'new lyrics')
 

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -585,7 +585,7 @@ class UpdateTest(_common.TestCase):
             self.i.mtime = 0
             self.i.store()
         commands.update_items(self.lib, query, album, move, False,
-                              fields=fields, excluded_fields=excluded_fields)
+                              fields=fields, exclude_fields=excluded_fields)
 
     def test_delete_removes_item(self):
         self.assertTrue(list(self.lib.items()))

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -579,13 +579,13 @@ class UpdateTest(_common.TestCase):
         util.remove(artfile)
 
     def _update(self, query=(), album=False, move=False, reset_mtime=True,
-                fields=None):
+                fields=None, excluded_fields=None):
         self.io.addinput('y')
         if reset_mtime:
             self.i.mtime = 0
             self.i.store()
         commands.update_items(self.lib, query, album, move, False,
-                              fields=fields)
+                              fields=fields, excluded_fields=excluded_fields)
 
     def test_delete_removes_item(self):
         self.assertTrue(list(self.lib.items()))
@@ -728,6 +728,14 @@ class UpdateTest(_common.TestCase):
         album.load()
         self.assertEqual(album.albumtype,  correct_albumtype)
         self.assertEqual(album.albumtypes, correct_albumtypes)
+
+    def test_modified_metadata_excluded(self):
+        mf = MediaFile(syspath(self.i.path))
+        mf.lyrics = 'new lyrics'
+        mf.save()
+        self._update(excluded_fields=['lyrics'])
+        item = self.lib.items().get()
+        self.assertNotEqual(item.lyrics, 'new lyrics')
 
 
 class PrintTest(_common.TestCase):


### PR DESCRIPTION
## Description

Adds `-e`, `–exclude-field` for selecting fields to _not_ update.

## To Do

- [x] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
