### PR TITLE
4326 scrub should not restore on import if "write" is disabled

### DIFF
--- a/beetsplug/scrub.py
+++ b/beetsplug/scrub.py
@@ -109,7 +109,7 @@ class ScrubPlugin(BeetsPlugin):
                 self._log.error('could not scrub {0}: {1}',
                                 util.displayable_path(path), exc)
 
-    def _scrub_item(self, item, restore=True):
+    def _scrub_item(self, item, restore):
         """Remove tags from an Item's associated file and, if `restore`
         is enabled, write the database's tags back to the file.
         """
@@ -146,4 +146,4 @@ class ScrubPlugin(BeetsPlugin):
         for item in task.imported_items():
             self._log.debug('auto-scrubbing {0}',
                             util.displayable_path(item.path))
-            self._scrub_item(item)
+            self._scrub_item(item, ui.should_write())

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -118,6 +118,10 @@ New features:
 
 Bug fixes:
 
+* :doc:`/plugins/scrub`: Fixed the import behavior where scrubbed database tags 
+  were restored to newly imported tracks with config settings ``scrub.auto: yes`` 
+  and ``import.write: no``.
+  :bug:`4326`
 * :doc:`/plugins/deezer`: Fixed the error where Deezer plugin would crash if non-Deezer id is passed during import.  
 * :doc:`/plugins/fetchart`: Fix fetching from Cover Art Archive when the
   `maxwidth` option is set to one of the supported Cover Art Archive widths.

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -257,29 +257,44 @@ class ScrubbedImportTest(_common.TestCase, ImportHelper):
     def test_tags_not_scrubbed(self):
         config['plugins'] = ['scrub']
         config['scrub']['auto'] = False
-        config['import']['write'] = False
+        config['import']['write'] = True
+        for mediafile in self.import_media:
+            self.assertEqual(mediafile.artist, 'Tag Artist')
+            self.assertEqual(mediafile.album, 'Tag Album')
         self.importer.run()
-        albums = self.lib.albums()
-        self.assertEqual(len(albums), 1)
-        self.assertEqual(albums[0].albumartist, 'Tag Artist')
+        for item in self.lib.items():
+            imported_file = os.path.join(item.path)
+            imported_file = MediaFile(imported_file)
+            self.assertEqual(imported_file.artist, 'Tag Artist')
+            self.assertEqual(imported_file.album, 'Tag Album')
 
     def test_tags_restored(self):
         config['plugins'] = ['scrub']
         config['scrub']['auto'] = True
         config['import']['write'] = True
+        for mediafile in self.import_media:
+            self.assertEqual(mediafile.artist, 'Tag Artist')
+            self.assertEqual(mediafile.album, 'Tag Album')
         self.importer.run()
-        albums = self.lib.albums()
-        self.assertEqual(len(albums), 1)
-        self.assertEqual(albums[0].albumartist, 'Tag Artist')
+        for item in self.lib.items():
+            imported_file = os.path.join(item.path)
+            imported_file = MediaFile(imported_file)
+            self.assertEqual(imported_file.artist, 'Tag Artist')
+            self.assertEqual(imported_file.album, 'Tag Album')
 
     def test_tags_not_restored(self):
         config['plugins'] = ['scrub']
         config['scrub']['auto'] = True
         config['import']['write'] = False
+        for mediafile in self.import_media:
+            self.assertEqual(mediafile.artist, 'Tag Artist')
+            self.assertEqual(mediafile.album, 'Tag Album')
         self.importer.run()
-        albums = self.lib.albums()
-        self.assertEqual(len(albums), 1)
-        self.assertEqual(albums[0].albumartist, 'Tag Artist')
+        for item in self.lib.items():
+            imported_file = os.path.join(item.path)
+            imported_file = MediaFile(imported_file)
+            self.assertEqual(imported_file.artist, None)
+            self.assertEqual(imported_file.album, None)
 
 
 @_common.slow_test()

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -252,6 +252,7 @@ class ScrubbedImportTest(_common.TestCase, ImportHelper):
         self._setup_import_session(autotag=False)
 
     def tearDown(self):
+        self.unload_plugins()
         self.teardown_beets()
 
     def test_tags_not_scrubbed(self):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -244,6 +244,44 @@ class ImportHelper(TestHelper):
         self.assertEqual(len(os.listdir(syspath(self.libdir))), 0)
 
 
+class ScrubbedImportTest(_common.TestCase, ImportHelper):
+    def setUp(self):
+        self.setup_beets(disk=True)
+        self.load_plugins('scrub')
+        self._create_import_dir(2)
+        self._setup_import_session(autotag=False)
+
+    def tearDown(self):
+        self.teardown_beets()
+
+    def test_tags_not_scrubbed(self):
+        config['plugins'] = ['scrub']
+        config['scrub']['auto'] = False
+        config['import']['write'] = False
+        self.importer.run()
+        albums = self.lib.albums()
+        self.assertEqual(len(albums), 1)
+        self.assertEqual(albums[0].albumartist, 'Tag Artist')
+
+    def test_tags_restored(self):
+        config['plugins'] = ['scrub']
+        config['scrub']['auto'] = True
+        config['import']['write'] = True
+        self.importer.run()
+        albums = self.lib.albums()
+        self.assertEqual(len(albums), 1)
+        self.assertEqual(albums[0].albumartist, 'Tag Artist')
+
+    def test_tags_not_restored(self):
+        config['plugins'] = ['scrub']
+        config['scrub']['auto'] = True
+        config['import']['write'] = False
+        self.importer.run()
+        albums = self.lib.albums()
+        self.assertEqual(len(albums), 1)
+        self.assertEqual(albums[0].albumartist, 'Tag Artist')
+
+
 @_common.slow_test()
 class NonAutotaggedImportTest(_common.TestCase, ImportHelper):
     def setUp(self):


### PR DESCRIPTION
## Description

Fixes #4326.

`scrub.py:import_task_files` now passes `ui.should_write()` to `_scrub_item` to control restoring tags.
I also added a few tests to `test_importer.py`.

## To Do

- [x] Documentation. (fixes discrepancy between documentation and behavior)
- [x] Changelog.
- [x] Tests.
