### PR TITLE
Catch when items have no path

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1232,7 +1232,7 @@ def update_items(lib, query, album, move, pretend, fields,
         affected_albums = set()
         for item in items:
             # Item deleted?
-            if not os.path.exists(syspath(item.path)):
+            if not item.path or not os.path.exists(syspath(item.path)):
                 ui.print_(format(item))
                 ui.print_(ui.colorize('text_error', '  deleted'))
                 if not pretend:

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -452,12 +452,12 @@ def samefile(p1: bytes, p2: bytes) -> bool:
     return shutil._samefile(syspath(p1), syspath(p2))
 
 
-def remove(path: bytes, soft: bool = True):
+def remove(path: Optional[bytes], soft: bool = True):
     """Remove the file. If `soft`, then no error will be raised if the
     file does not exist.
     """
     path = syspath(path)
-    if soft and not os.path.exists(path):
+    if not path or (soft and not os.path.exists(path)):
         return
     try:
         os.remove(path)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -229,7 +229,8 @@ Bug fixes:
   already. A new option ``--noinherit/-I`` to :ref:`modify <modify-cmd>`
   allows changing this behaviour.
   :bug:`4822`
-* Fix bug where an interrupted import process poisons the database.
+* Fix bug where an interrupted import process poisons the database, causing
+  a null path that can't be removed.
 
 For packagers:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -229,6 +229,7 @@ Bug fixes:
   already. A new option ``--noinherit/-I`` to :ref:`modify <modify-cmd>`
   allows changing this behaviour.
   :bug:`4822`
+* Fix bug where an interrupted import process poisons the database.
 
 For packagers:
 


### PR DESCRIPTION
## Description

When importing things using beets, by pure chance, it is apparently possible to have an item inserted into the database that does not have a path registered. Because the database returns `None` for the items' paths, cascading errors cause most library-wide operations to fail. Update, write, etc, all fail.

This effectively poisons the database and there's no way to remove it other than manually editing the database file. 

This PR just changes two lines and a typing so that the `update` command can still be used. The other commands will still fail but this seems to be a pretty rare edge case so I've only changed the `update` command. Now the logic, when there is no path associated with an entry, will consider it to be the same as a deleted file and purge it from the database.

## To Do

- [X] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
