### PR TITLE
Fix typos

### DIFF
--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -48,7 +48,7 @@ REPLACE = {
 
 
 def deduplicate(seq):
-    """Remove duplicates from sequence wile preserving order.
+    """Remove duplicates from sequence while preserving order.
     """
     seen = set()
     return [x for x in seq if x not in seen and not seen.add(x)]

--- a/beetsplug/substitute.py
+++ b/beetsplug/substitute.py
@@ -24,7 +24,7 @@ from beets.plugins import BeetsPlugin
 class Substitute(BeetsPlugin):
     """The substitute plugin class.
 
-    Create a template field function that subsitute the given field with the
+    Create a template field function that substitute the given field with the
     given substitution rules. ``rules`` must be a list of (pattern,
     replacement) pairs.
     """

--- a/beetsplug/web/static/backbone.js
+++ b/beetsplug/web/static/backbone.js
@@ -274,7 +274,7 @@
     },
 
     // Fetch the model from the server. If the server's representation of the
-    // model differs from its current attributes, they will be overriden,
+    // model differs from its current attributes, they will be overridden,
     // triggering a `"change"` event.
     fetch : function(options) {
       options || (options = {});
@@ -885,7 +885,7 @@
   };
 
   // Element lookup, scoped to DOM elements within the current view.
-  // This should be prefered to global lookups, if you're dealing with
+  // This should be preferred to global lookups, if you're dealing with
   // a specific view.
   var selectorDelegate = function(selector) {
     return $(selector, this.el);
@@ -984,7 +984,7 @@
     // Ensure that the View has a DOM element to render into.
     // If `this.el` is a string, pass it through `$()`, take the first
     // matching element, and re-assign it to `el`. Otherwise, create
-    // an element from the `id`, `className` and `tagName` proeprties.
+    // an element from the `id`, `className` and `tagName` properties.
     _ensureElement : function() {
       if (!this.el) {
         var attrs = this.attributes || {};

--- a/beetsplug/web/static/jquery.js
+++ b/beetsplug/web/static/jquery.js
@@ -2278,7 +2278,7 @@ jQuery.fn.extend({
 					classNames = value.split( rspace );
 
 				while ( (className = classNames[ i++ ]) ) {
-					// check each className given, space seperated list
+					// check each className given, space separated list
 					state = isBool ? state : !self.hasClass( className );
 					self[ state ? "addClass" : "removeClass" ]( className );
 				}
@@ -3868,7 +3868,7 @@ var chunker = /((?:\((?:\([^()]+\)|[^()]+)+\)|\[(?:\[[^\[\]]*\]|['"][^'"]*['"]|[
 	rNonWord = /\W/;
 
 // Here we check if the JavaScript engine is using some sort of
-// optimization where it does not always call our comparision
+// optimization where it does not always call our comparison
 // function. If that is the case, discard the hasDuplicate value.
 //   Thus far that includes Google Chrome.
 [0, 0].sort(function() {
@@ -4180,7 +4180,7 @@ Sizzle.error = function( msg ) {
 };
 
 /**
- * Utility function for retreiving the text value of an array of DOM nodes
+ * Utility function for retrieving the text value of an array of DOM nodes
  * @param {Array|Element} elem
  */
 var getText = Sizzle.getText = function( elem ) {
@@ -8111,7 +8111,7 @@ if ( jQuery.support.ajax ) {
 							xml;
 
 						// Firefox throws exceptions when accessing properties
-						// of an xhr when a network error occured
+						// of an xhr when a network error occurred
 						// http://helpful.knobs-dials.com/index.php/Component_returned_failure_code:_0x80040111_(NS_ERROR_NOT_AVAILABLE)
 						try {
 

--- a/docs/plugins/substitute.rst
+++ b/docs/plugins/substitute.rst
@@ -6,7 +6,7 @@ path formats. Specifically, it is intended to let you *canonicalize* names
 such as artists: For example, perhaps you want albums from The Jimi Hendrix
 Experience to be sorted into the same folder as solo Hendrix albums.
 
-This plugin is intented as a replacement for the ``rewrite`` plugin. While
+This plugin is intended as a replacement for the ``rewrite`` plugin. While
 the ``rewrite`` plugin modifies the metadata, this plugin does not.
 
 Enable the ``substitute`` plugin (see :ref:`using-plugins`), then make a ``substitute:`` section in your config file to contain your rules.

--- a/extra/_beet
+++ b/extra/_beet
@@ -12,7 +12,7 @@ zstyle ":completion:${curcontext}:" cache-policy _beet_check_cache
 _beet_check_cache () {
     local cachefile="$(basename ${1})"
     if [[ ! -a "${1}" ]] || [[ "${1}" -ot =beet ]]; then
-	# always update the cache if it doesnt exist, or if the beet executable changes
+	# always update the cache if it doesn't exist, or if the beet executable changes
 	return 0
     fi
     case cachefile; in


### PR DESCRIPTION
## Description

Fix typos found via `codespell -S ./test/rsrc,genres.txt -L
caf,fo,ue,searchin,crashers,crasher,te,skool,egal,nothin`

(...)

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
