### PR TITLE
Add log message on verbose, when beets renames destination file during move.

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -856,7 +856,13 @@ class Item(LibModel):
         `operation` should be an instance of `util.MoveOperation`.
         """
         if not util.samefile(self.path, dest):
+            old_dest = dest
             dest = util.unique_path(dest)
+            log.debug(
+                'File already exists at dest, changing final path slightly, '
+                "to be unique, from '{}', to '{}'.",
+                old_dest, dest
+            )
         if operation == MoveOperation.MOVE:
             plugins.send("before_item_moved", item=self, source=self.path,
                          destination=dest)

--- a/beets/library.py
+++ b/beets/library.py
@@ -859,9 +859,8 @@ class Item(LibModel):
             old_dest = dest
             dest = util.unique_path(dest)
             log.debug(
-                'File already exists at dest, changing final path slightly, '
-                "to be unique, from '{}', to '{}'.",
-                old_dest, dest
+                'File exists at {}. Avoiding conflict with new name: {}',
+                util.displayable_path(old_dest), util.displayable_path(dest)
             )
         if operation == MoveOperation.MOVE:
             plugins.send("before_item_moved", item=self, source=self.path,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -122,6 +122,8 @@ New features:
   :bug:`2786`
 * Add support for ``artists`` and ``albumartists`` multi-valued tags.
   :bug:`505`
+* Add log message on verbose, when beets renames destination file during move.
+  :bug:`2895`
 
 Bug fixes:
 


### PR DESCRIPTION
## Description

First step in fix of #2895.  Add log message on verbose, when beets renames destination file during move.  The issue says it may be trickier than it looks.  It did not seem tricky, so only doing the first step suggested, to see if I missed something.

## To Do

- [x] Documentation is not needed since functional behavior is not changing.
- [x] Changelog
- [x] Tests are not needed because there are already tests in test/test_files.py that exercise the code path that pass.
