### PR TITLE
MusicbrainzNGS replacement

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1240,6 +1240,28 @@ files = [
 ]
 
 [[package]]
+name = "mbzero"
+version = "0.4"
+description = "Python bindings for the MusicBrainz and the Cover Art Archive webservices"
+optional = false
+python-versions = "<4,>=3.8"
+files = [
+    {file = "mbzero-0.4-py3-none-any.whl", hash = "sha256:92b0f7e235fc2f1e25e79b22717282f71d555d2743d755f6f249a54aef073002"},
+    {file = "mbzero-0.4.tar.gz", hash = "sha256:e19957d9d4d35c5dd9739bd4ca6792fb7bd777bf88067038b4db2f54a363f992"},
+]
+
+[package.dependencies]
+pytest = "*"
+requests = "*"
+requests-oauthlib = "*"
+
+[package.extras]
+cov = ["pytest-cov"]
+docs = ["sphinx (>=7.1.2)", "sphinx-rtd-theme (>=2.0.0)"]
+lint = ["flake8 (>=3.5.0)", "flake8-simplify"]
+test = ["pytest (>=4.6)"]
+
+[[package]]
 name = "mccabe"
 version = "0.7.0"
 description = "McCabe checker, plugin for flake8"
@@ -2720,4 +2742,4 @@ web = ["flask", "flask-cors"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "48fba7c7149c8cb7824f96329bd469a9e9c84b13d233f957889b8b1d7076392f"
+content-hash = "4466182a29f75943dbb09c76c531cc426eabe84f36fe19113a418676f9578aa5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ jellyfish = "*"
 mediafile = ">=0.12.0"
 munkres = ">=1.0.0"
 musicbrainzngs = ">=0.4"
+mbzero = ">=0.3"
 pyyaml = "*"
 typing_extensions = { version = "*", python = "<=3.10" }
 unidecode = ">=1.3.6"

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1922,28 +1922,26 @@ def mocked_get_recording_by_id(
     }
 
     return {
-        "recording": {
-            "title": releases[id_][0],
-            "id": id_,
-            "length": 59,
-            "artist-credit": [
-                {
-                    "artist": {
-                        "name": releases[id_][1],
-                        "id": "some-id",
-                    },
-                }
-            ],
-        }
+        "title": releases[id_][0],
+        "id": id_,
+        "length": 59,
+        "artist-credit": [
+            {
+                "artist": {
+                    "name": releases[id_][1],
+                    "id": "some-id",
+                },
+            }
+        ],
     }
 
 
 @patch(
-    "musicbrainzngs.get_recording_by_id",
+    "beets.autotag.mb.MbInterface.get_recording_by_id",
     Mock(side_effect=mocked_get_recording_by_id),
 )
 @patch(
-    "musicbrainzngs.get_release_by_id",
+    "beets.autotag.mb.MbInterface.get_release_by_id",
     Mock(side_effect=mocked_get_release_by_id),
 )
 class ImportMusicBrainzIdTest(_common.TestCase, ImportHelper):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1868,39 +1868,37 @@ def mocked_get_release_by_id(
     }
 
     return {
-        "release": {
-            "title": releases[id_][0],
-            "id": id_,
-            "medium-list": [
-                {
-                    "track-list": [
-                        {
-                            "id": "baz",
-                            "recording": {
-                                "title": "foo",
-                                "id": "bar",
-                                "length": 59,
-                            },
-                            "position": 9,
-                            "number": "A2",
-                        }
-                    ],
-                    "position": 5,
-                }
-            ],
-            "artist-credit": [
-                {
-                    "artist": {
-                        "name": releases[id_][1],
-                        "id": "some-id",
-                    },
-                }
-            ],
-            "release-group": {
-                "id": "another-id",
-            },
-            "status": "Official",
-        }
+        "title": releases[id_][0],
+        "id": id_,
+        "media": [
+            {
+                "tracks": [
+                    {
+                        "id": "baz",
+                        "recording": {
+                            "title": "foo",
+                            "id": "bar",
+                            "length": 59,
+                        },
+                        "position": 9,
+                        "number": "A2",
+                    }
+                ],
+                "position": 5,
+            }
+        ],
+        "artist-credit": [
+            {
+                "artist": {
+                    "name": releases[id_][1],
+                    "id": "some-id",
+                },
+            }
+        ],
+        "release-group": {
+            "id": "another-id",
+        },
+        "status": "Official",
     }
 
 

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -56,8 +56,8 @@ class MBAlbumInfoTest(_common.TestCase):
                 }
             ],
             "date": "3001",
-            "medium-list": [],
-            "label-info-list": [
+            "media": [],
+            "label-info": [
                 {
                     "catalog-number": "CATALOG NUMBER",
                     "label": {"name": "LABEL NAME"},
@@ -138,11 +138,11 @@ class MBAlbumInfoTest(_common.TestCase):
                     "number": "A1",
                 }
                 data_track_list.append(data_track)
-        release["medium-list"].append(
+        release["media"].append(
             {
                 "position": "1",
-                "track-list": track_list,
-                "data-track-list": data_track_list,
+                "tracks": track_list,
+                "data-tracks": data_track_list,
                 "format": medium_format,
                 "title": "MEDIUM TITLE",
             }
@@ -190,7 +190,7 @@ class MBAlbumInfoTest(_common.TestCase):
                     }
                 )
         if remixer:
-            track["artist-relation-list"] = [
+            track["artist-relations"] = [
                 {
                     "type": "remixer",
                     "type-id": "RELATION TYPE ID",
@@ -291,10 +291,10 @@ class MBAlbumInfoTest(_common.TestCase):
                 "number": "A1",
             }
         ]
-        release["medium-list"].append(
+        release["media"].append(
             {
                 "position": "2",
-                "track-list": second_track_list,
+                "tracks": second_track_list,
             }
         )
 
@@ -698,9 +698,9 @@ class ArtistFlatteningTest(_common.TestCase):
         }
         if primary:
             alias["primary"] = "primary"
-        if "alias-list" not in credit_dict["artist"]:
-            credit_dict["artist"]["alias-list"] = []
-        credit_dict["artist"]["alias-list"].append(alias)
+        if "aliases" not in credit_dict["artist"]:
+            credit_dict["artist"]["aliases"] = []
+        credit_dict["artist"]["aliases"].append(alias)
 
     def test_single_artist(self):
         credit = [self._credit_dict()]
@@ -771,7 +771,7 @@ class MBLibraryTest(unittest.TestCase):
     def test_match_track(self):
         with mock.patch("musicbrainzngs.search_recordings") as p:
             p.return_value = {
-                "recording-list": [
+                "recordings": [
                     {
                         "title": "foo",
                         "id": "bar",
@@ -796,7 +796,7 @@ class MBLibraryTest(unittest.TestCase):
         mbid = "d2a6f856-b553-40a0-ac54-a321e8e2da99"
         with mock.patch("musicbrainzngs.search_releases") as sp:
             sp.return_value = {
-                "release-list": [
+                "releases": [
                     {
                         "id": mbid,
                     }
@@ -804,39 +804,37 @@ class MBLibraryTest(unittest.TestCase):
             }
             with mock.patch("musicbrainzngs.get_release_by_id") as gp:
                 gp.return_value = {
-                    "release": {
-                        "title": "hi",
-                        "id": mbid,
-                        "status": "status",
-                        "medium-list": [
-                            {
-                                "track-list": [
-                                    {
-                                        "id": "baz",
-                                        "recording": {
-                                            "title": "foo",
-                                            "id": "bar",
-                                            "length": 42,
-                                        },
-                                        "position": 9,
-                                        "number": "A1",
-                                    }
-                                ],
-                                "position": 5,
-                            }
-                        ],
-                        "artist-credit": [
-                            {
-                                "artist": {
-                                    "name": "some-artist",
-                                    "id": "some-id",
-                                },
-                            }
-                        ],
-                        "release-group": {
-                            "id": "another-id",
-                        },
-                    }
+                    "title": "hi",
+                    "id": mbid,
+                    "status": "status",
+                    "media": [
+                        {
+                            "tracks": [
+                                {
+                                    "id": "baz",
+                                    "recording": {
+                                        "title": "foo",
+                                        "id": "bar",
+                                        "length": 42,
+                                    },
+                                    "position": 9,
+                                    "number": "A1",
+                                }
+                            ],
+                            "position": 5,
+                        }
+                    ],
+                    "artist-credit": [
+                        {
+                            "artist": {
+                                "name": "some-artist",
+                                "id": "some-id",
+                            },
+                        }
+                    ],
+                    "release-group": {
+                        "id": "another-id",
+                    },
                 }
 
                 ai = list(mb.match_album("hello", "there"))[0]
@@ -870,82 +868,78 @@ class MBLibraryTest(unittest.TestCase):
     def test_follow_pseudo_releases(self):
         side_effect = [
             {
-                "release": {
-                    "title": "pseudo",
-                    "id": "d2a6f856-b553-40a0-ac54-a321e8e2da02",
-                    "status": "Pseudo-Release",
-                    "medium-list": [
-                        {
-                            "track-list": [
-                                {
-                                    "id": "baz",
-                                    "recording": {
-                                        "title": "translated title",
-                                        "id": "bar",
-                                        "length": 42,
-                                    },
-                                    "position": 9,
-                                    "number": "A1",
-                                }
-                            ],
-                            "position": 5,
-                        }
-                    ],
-                    "artist-credit": [
-                        {
-                            "artist": {
-                                "name": "some-artist",
-                                "id": "some-id",
-                            },
-                        }
-                    ],
-                    "release-group": {
-                        "id": "another-id",
-                    },
-                    "release-relation-list": [
-                        {
-                            "type": "transl-tracklisting",
-                            "target": "d2a6f856-b553-40a0-ac54-a321e8e2da01",
-                            "direction": "backward",
-                        }
-                    ],
-                }
+                "title": "pseudo",
+                "id": "d2a6f856-b553-40a0-ac54-a321e8e2da02",
+                "status": "Pseudo-Release",
+                "media": [
+                    {
+                        "tracks": [
+                            {
+                                "id": "baz",
+                                "recording": {
+                                    "title": "translated title",
+                                    "id": "bar",
+                                    "length": 42,
+                                },
+                                "position": 9,
+                                "number": "A1",
+                            }
+                        ],
+                        "position": 5,
+                    }
+                ],
+                "artist-credit": [
+                    {
+                        "artist": {
+                            "name": "some-artist",
+                            "id": "some-id",
+                        },
+                    }
+                ],
+                "release-group": {
+                    "id": "another-id",
+                },
+                "release-relations": [
+                    {
+                        "type": "transl-tracklisting",
+                        "target": "d2a6f856-b553-40a0-ac54-a321e8e2da01",
+                        "direction": "backward",
+                    }
+                ],
             },
             {
-                "release": {
-                    "title": "actual",
-                    "id": "d2a6f856-b553-40a0-ac54-a321e8e2da01",
-                    "status": "Official",
-                    "medium-list": [
-                        {
-                            "track-list": [
-                                {
-                                    "id": "baz",
-                                    "recording": {
-                                        "title": "original title",
-                                        "id": "bar",
-                                        "length": 42,
-                                    },
-                                    "position": 9,
-                                    "number": "A1",
-                                }
-                            ],
-                            "position": 5,
-                        }
-                    ],
-                    "artist-credit": [
-                        {
-                            "artist": {
-                                "name": "some-artist",
-                                "id": "some-id",
-                            },
-                        }
-                    ],
-                    "release-group": {
-                        "id": "another-id",
-                    },
-                    "country": "COUNTRY",
-                }
+                "title": "actual",
+                "id": "d2a6f856-b553-40a0-ac54-a321e8e2da01",
+                "status": "Official",
+                "media": [
+                    {
+                        "tracks": [
+                            {
+                                "id": "baz",
+                                "recording": {
+                                    "title": "original title",
+                                    "id": "bar",
+                                    "length": 42,
+                                },
+                                "position": 9,
+                                "number": "A1",
+                            }
+                        ],
+                        "position": 5,
+                    }
+                ],
+                "artist-credit": [
+                    {
+                        "artist": {
+                            "name": "some-artist",
+                            "id": "some-id",
+                        },
+                    }
+                ],
+                "release-group": {
+                    "id": "another-id",
+                },
+                "country": "COUNTRY",
             },
         ]
 
@@ -957,40 +951,38 @@ class MBLibraryTest(unittest.TestCase):
     def test_pseudo_releases_with_empty_links(self):
         side_effect = [
             {
-                "release": {
-                    "title": "pseudo",
-                    "id": "d2a6f856-b553-40a0-ac54-a321e8e2da02",
-                    "status": "Pseudo-Release",
-                    "medium-list": [
-                        {
-                            "track-list": [
-                                {
-                                    "id": "baz",
-                                    "recording": {
-                                        "title": "translated title",
-                                        "id": "bar",
-                                        "length": 42,
-                                    },
-                                    "position": 9,
-                                    "number": "A1",
-                                }
-                            ],
-                            "position": 5,
-                        }
-                    ],
-                    "artist-credit": [
-                        {
-                            "artist": {
-                                "name": "some-artist",
-                                "id": "some-id",
-                            },
-                        }
-                    ],
-                    "release-group": {
-                        "id": "another-id",
-                    },
-                    "release-relation-list": [],
-                }
+                "title": "pseudo",
+                "id": "d2a6f856-b553-40a0-ac54-a321e8e2da02",
+                "status": "Pseudo-Release",
+                "media": [
+                    {
+                        "tracks": [
+                            {
+                                "id": "baz",
+                                "recording": {
+                                    "title": "translated title",
+                                    "id": "bar",
+                                    "length": 42,
+                                },
+                                "position": 9,
+                                "number": "A1",
+                            }
+                        ],
+                        "position": 5,
+                    }
+                ],
+                "artist-credit": [
+                    {
+                        "artist": {
+                            "name": "some-artist",
+                            "id": "some-id",
+                        },
+                    }
+                ],
+                "release-group": {
+                    "id": "another-id",
+                },
+                "release-relations": [],
             },
         ]
 
@@ -1002,39 +994,37 @@ class MBLibraryTest(unittest.TestCase):
     def test_pseudo_releases_without_links(self):
         side_effect = [
             {
-                "release": {
-                    "title": "pseudo",
-                    "id": "d2a6f856-b553-40a0-ac54-a321e8e2da02",
-                    "status": "Pseudo-Release",
-                    "medium-list": [
-                        {
-                            "track-list": [
-                                {
-                                    "id": "baz",
-                                    "recording": {
-                                        "title": "translated title",
-                                        "id": "bar",
-                                        "length": 42,
-                                    },
-                                    "position": 9,
-                                    "number": "A1",
-                                }
-                            ],
-                            "position": 5,
-                        }
-                    ],
-                    "artist-credit": [
-                        {
-                            "artist": {
-                                "name": "some-artist",
-                                "id": "some-id",
-                            },
-                        }
-                    ],
-                    "release-group": {
-                        "id": "another-id",
-                    },
-                }
+                "title": "pseudo",
+                "id": "d2a6f856-b553-40a0-ac54-a321e8e2da02",
+                "status": "Pseudo-Release",
+                "media": [
+                    {
+                        "tracks": [
+                            {
+                                "id": "baz",
+                                "recording": {
+                                    "title": "translated title",
+                                    "id": "bar",
+                                    "length": 42,
+                                },
+                                "position": 9,
+                                "number": "A1",
+                            }
+                        ],
+                        "position": 5,
+                    }
+                ],
+                "artist-credit": [
+                    {
+                        "artist": {
+                            "name": "some-artist",
+                            "id": "some-id",
+                        },
+                    }
+                ],
+                "release-group": {
+                    "id": "another-id",
+                },
             },
         ]
 
@@ -1046,46 +1036,44 @@ class MBLibraryTest(unittest.TestCase):
     def test_pseudo_releases_with_unsupported_links(self):
         side_effect = [
             {
-                "release": {
-                    "title": "pseudo",
-                    "id": "d2a6f856-b553-40a0-ac54-a321e8e2da02",
-                    "status": "Pseudo-Release",
-                    "medium-list": [
-                        {
-                            "track-list": [
-                                {
-                                    "id": "baz",
-                                    "recording": {
-                                        "title": "translated title",
-                                        "id": "bar",
-                                        "length": 42,
-                                    },
-                                    "position": 9,
-                                    "number": "A1",
-                                }
-                            ],
-                            "position": 5,
-                        }
-                    ],
-                    "artist-credit": [
-                        {
-                            "artist": {
-                                "name": "some-artist",
-                                "id": "some-id",
-                            },
-                        }
-                    ],
-                    "release-group": {
-                        "id": "another-id",
-                    },
-                    "release-relation-list": [
-                        {
-                            "type": "remaster",
-                            "target": "d2a6f856-b553-40a0-ac54-a321e8e2da01",
-                            "direction": "backward",
-                        }
-                    ],
-                }
+                "title": "pseudo",
+                "id": "d2a6f856-b553-40a0-ac54-a321e8e2da02",
+                "status": "Pseudo-Release",
+                "media": [
+                    {
+                        "tracks": [
+                            {
+                                "id": "baz",
+                                "recording": {
+                                    "title": "translated title",
+                                    "id": "bar",
+                                    "length": 42,
+                                },
+                                "position": 9,
+                                "number": "A1",
+                            }
+                        ],
+                        "position": 5,
+                    }
+                ],
+                "artist-credit": [
+                    {
+                        "artist": {
+                            "name": "some-artist",
+                            "id": "some-id",
+                        },
+                    }
+                ],
+                "release-group": {
+                    "id": "another-id",
+                },
+                "release-relations": [
+                    {
+                        "type": "remaster",
+                        "target": "d2a6f856-b553-40a0-ac54-a321e8e2da01",
+                        "direction": "backward",
+                    }
+                ],
             },
         ]
 

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -781,7 +781,14 @@ class MBLibraryTest(unittest.TestCase):
             }
             ti = list(mb.match_track("hello", "there"))[0]
 
-            p.assert_called_with(artist="hello", recording="there", limit=5)
+            p.assert_called_with(
+                query="",
+                limit=5,
+                offset=None,
+                strict=False,
+                artist="hello",
+                recording="there",
+            )
             self.assertEqual(ti.title, "foo")
             self.assertEqual(ti.track_id, "bar")
 
@@ -834,8 +841,17 @@ class MBLibraryTest(unittest.TestCase):
 
                 ai = list(mb.match_album("hello", "there"))[0]
 
-                sp.assert_called_with(artist="hello", release="there", limit=5)
-                gp.assert_called_with(mbid, mock.ANY)
+                sp.assert_called_with(
+                    query="",
+                    limit=5,
+                    offset=None,
+                    strict=False,
+                    artist="hello",
+                    release="there",
+                )
+                gp.assert_called_with(
+                    mbid, includes=mock.ANY, release_status=[], release_type=[]
+                )
                 self.assertEqual(ai.tracks[0].title, "foo")
                 self.assertEqual(ai.album, "hi")
 

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -769,7 +769,7 @@ class ArtistFlatteningTest(_common.TestCase):
 
 class MBLibraryTest(unittest.TestCase):
     def test_match_track(self):
-        with mock.patch("musicbrainzngs.search_recordings") as p:
+        with mock.patch("beets.autotag.mb.MbInterface.search_recordings") as p:
             p.return_value = {
                 "recordings": [
                     {
@@ -781,20 +781,13 @@ class MBLibraryTest(unittest.TestCase):
             }
             ti = list(mb.match_track("hello", "there"))[0]
 
-            p.assert_called_with(
-                query="",
-                limit=5,
-                offset=None,
-                strict=False,
-                artist="hello",
-                recording="there",
-            )
+            p.assert_called_with(limit=5, artist="hello", recording="there")
             self.assertEqual(ti.title, "foo")
             self.assertEqual(ti.track_id, "bar")
 
     def test_match_album(self):
         mbid = "d2a6f856-b553-40a0-ac54-a321e8e2da99"
-        with mock.patch("musicbrainzngs.search_releases") as sp:
+        with mock.patch("beets.autotag.mb.MbInterface.search_releases") as sp:
             sp.return_value = {
                 "releases": [
                     {
@@ -802,7 +795,9 @@ class MBLibraryTest(unittest.TestCase):
                     }
                 ],
             }
-            with mock.patch("musicbrainzngs.get_release_by_id") as gp:
+            with mock.patch(
+                "beets.autotag.mb.MbInterface.get_release_by_id"
+            ) as gp:
                 gp.return_value = {
                     "title": "hi",
                     "id": mbid,
@@ -839,28 +834,19 @@ class MBLibraryTest(unittest.TestCase):
 
                 ai = list(mb.match_album("hello", "there"))[0]
 
-                sp.assert_called_with(
-                    query="",
-                    limit=5,
-                    offset=None,
-                    strict=False,
-                    artist="hello",
-                    release="there",
-                )
-                gp.assert_called_with(
-                    mbid, includes=mock.ANY, release_status=[], release_type=[]
-                )
+                sp.assert_called_with(limit=5, artist="hello", release="there")
+                gp.assert_called_with(mbid, includes=mock.ANY)
                 self.assertEqual(ai.tracks[0].title, "foo")
                 self.assertEqual(ai.album, "hi")
 
     def test_match_track_empty(self):
-        with mock.patch("musicbrainzngs.search_recordings") as p:
+        with mock.patch("beets.autotag.mb.MbInterface.search_recordings") as p:
             til = list(mb.match_track(" ", " "))
             self.assertFalse(p.called)
             self.assertEqual(til, [])
 
     def test_match_album_empty(self):
-        with mock.patch("musicbrainzngs.search_releases") as p:
+        with mock.patch("beets.autotag.mb.MbInterface.search_releases") as p:
             ail = list(mb.match_album(" ", " "))
             self.assertFalse(p.called)
             self.assertEqual(ail, [])
@@ -942,8 +928,7 @@ class MBLibraryTest(unittest.TestCase):
                 "country": "COUNTRY",
             },
         ]
-
-        with mock.patch("musicbrainzngs.get_release_by_id") as gp:
+        with mock.patch("beets.autotag.mb.MbInterface.get_release_by_id") as gp:
             gp.side_effect = side_effect
             album = mb.album_for_id("d2a6f856-b553-40a0-ac54-a321e8e2da02")
             self.assertEqual(album.country, "COUNTRY")
@@ -986,7 +971,7 @@ class MBLibraryTest(unittest.TestCase):
             },
         ]
 
-        with mock.patch("musicbrainzngs.get_release_by_id") as gp:
+        with mock.patch("beets.autotag.mb.MbInterface.get_release_by_id") as gp:
             gp.side_effect = side_effect
             album = mb.album_for_id("d2a6f856-b553-40a0-ac54-a321e8e2da02")
             self.assertIsNone(album.country)
@@ -1028,7 +1013,7 @@ class MBLibraryTest(unittest.TestCase):
             },
         ]
 
-        with mock.patch("musicbrainzngs.get_release_by_id") as gp:
+        with mock.patch("beets.autotag.mb.MbInterface.get_release_by_id") as gp:
             gp.side_effect = side_effect
             album = mb.album_for_id("d2a6f856-b553-40a0-ac54-a321e8e2da02")
             self.assertIsNone(album.country)
@@ -1077,7 +1062,7 @@ class MBLibraryTest(unittest.TestCase):
             },
         ]
 
-        with mock.patch("musicbrainzngs.get_release_by_id") as gp:
+        with mock.patch("beets.autotag.mb.MbInterface.get_release_by_id") as gp:
             gp.side_effect = side_effect
             album = mb.album_for_id("d2a6f856-b553-40a0-ac54-a321e8e2da02")
             self.assertIsNone(album.country)


### PR DESCRIPTION
## Description

Suggestion for musicbrainz substitution in relation with discussion  #4660 

Tests have been ran with command `tox -e py311-test`

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [x] Tests. (Encouraged but not strictly required.)
