### PR TITLE
FetchArt : fix an error with CAA where the pre-sized thumbs of release groups would be ignored

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -399,10 +399,15 @@ class CoverArtArchive(RemoteArtSource):
                     if 'Front' not in item['types']:
                         continue
 
-                    if preferred_width:
-                        yield item['thumbnails'][preferred_width]
-                    else:
-                        yield item['image']
+                    # If there is a pre-sized thumbnail of the desired size
+                    # we select it. Otherwise, we return the raw image.
+                    image_url: str = item["image"]
+                    if preferred_width is not None:
+                        if isinstance(item.get("thumbnails"), dict):
+                            image_url = item["thumbnails"].get(
+                                preferred_width, image_url
+                            )
+                    yield image_url
                 except KeyError:
                     pass
 

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -422,7 +422,7 @@ class CoverArtArchive(RemoteArtSource):
                 yield self._candidate(url=url, match=Candidate.MATCH_EXACT)
 
         if 'releasegroup' in self.match_by and album.mb_releasegroupid:
-            for url in get_image_urls(release_group_url):
+            for url in get_image_urls(release_group_url, preferred_width):
                 yield self._candidate(url=url, match=Candidate.MATCH_FALLBACK)
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -125,6 +125,9 @@ New features:
 * :doc:`/plugins/autobpm`: Add the `autobpm` plugin which uses Librosa to
   calculate the BPM of the audio.
   :bug:`3856`
+* :doc:`/plugins/fetchart`: Fix the error with CoverArtArchive where the
+  `maxwidth` option would not be used to download a pre-sized thumbnail for
+  release groups, as is already done with releases.
 
 Bug fixes:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -128,6 +128,9 @@ New features:
 * :doc:`/plugins/fetchart`: Fix the error with CoverArtArchive where the
   `maxwidth` option would not be used to download a pre-sized thumbnail for
   release groups, as is already done with releases.
+* :doc:`/plugins/fetchart`: Fix the error with CoverArtArchive where no cover
+  would be found when the `maxwidth` option matches a pre-sized thumbnail size,
+  but no thumbnail is provided by CAA. We now fallback to the raw image.
 
 Bug fixes:
 

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -41,7 +41,10 @@ file. The available options are:
   considered as valid album art candidates. Default: 0.
 - **maxwidth**: A maximum image width to downscale fetched images if they are
   too big. The resize operation reduces image width to at most ``maxwidth``
-  pixels. The height is recomputed so that the aspect ratio is preserved.
+  pixels. The height is recomputed so that the aspect ratio is preserved. See
+  the section on :ref:`cover-art-archive-maxwidth` below for additional
+  information regarding the Cover Art Archive source.
+  Default: 0 (no maximum is enforced).
 - **quality**: The JPEG quality level to use when compressing images (when
   ``maxwidth`` is set). This should be either a number from 1 to 100 or 0 to
   use the default quality. 65–75 is usually a good starting point. The default
@@ -269,7 +272,21 @@ Spotify backend is enabled by default and will update album art if a valid Spoti
 Cover Art URL
 '''''''''''''
 
-The `fetchart` plugin can also use a flexible attribute field ``cover_art_url`` where you can manually specify the image URL to be used as cover art. Any custom plugin can use this field to provide the cover art and ``fetchart`` will use it as a source.
+The `fetchart` plugin can also use a flexible attribute field ``cover_art_url``
+where you can manually specify the image URL to be used as cover art. Any custom
+plugin can use this field to provide the cover art and ``fetchart`` will use it
+as a source.
+
+.. _cover-art-archive-maxwidth:
+
+Cover Art Archive Pre-sized Thumbnails
+--------------------------------------
+
+The CAA provides pre-sized thumbnails of width 250, 500, and 1200 pixels. If you
+set the `maxwidth` option to one of these values, the corresponding image will
+be downloaded, saving `beets` the need to scale down the image. It can also
+speed up the downloading process, as some cover arts can sometimes be very
+large.
 
 Storing the Artwork's Source
 ----------------------------

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -131,6 +131,39 @@ class CAAHelper():
     ],
     "release": "https://musicbrainz.org/release/releaseid"
 }"""
+    RESPONSE_RELEASE_WITHOUT_THUMBNAILS = """{
+    "images": [
+      {
+        "approved": false,
+        "back": false,
+        "comment": "GIF",
+        "edit": 12345,
+        "front": true,
+        "id": 12345,
+        "image": "http://coverartarchive.org/release/rid/12345.gif",
+        "types": [
+          "Front"
+        ]
+      },
+      {
+        "approved": false,
+        "back": false,
+        "comment": "",
+        "edit": 12345,
+        "front": false,
+        "id": 12345,
+        "image": "http://coverartarchive.org/release/rid/12345.jpg",
+        "thumbnails": {
+            "large": "http://coverartarchive.org/release/rgid/12345-500.jpg",
+            "small": "http://coverartarchive.org/release/rgid/12345-250.jpg"
+        },
+        "types": [
+          "Front"
+        ]
+      }
+    ],
+    "release": "https://musicbrainz.org/release/releaseid"
+}"""
     RESPONSE_GROUP = """{
         "images": [
           {
@@ -148,6 +181,23 @@ class CAAHelper():
               "large": "http://coverartarchive.org/release/rgid/12345-500.jpg",
               "small": "http://coverartarchive.org/release/rgid/12345-250.jpg"
             },
+            "types": [
+              "Front"
+            ]
+          }
+        ],
+        "release": "https://musicbrainz.org/release/release-id"
+    }"""
+    RESPONSE_GROUP_WITHOUT_THUMBNAILS = """{
+        "images": [
+          {
+            "approved": false,
+            "back": false,
+            "comment": "",
+            "edit": 12345,
+            "front": true,
+            "id": 12345,
+            "image": "http://coverartarchive.org/release/releaseid/12345.jpg",
             "types": [
               "Front"
             ]
@@ -536,6 +586,26 @@ class CoverArtArchiveTest(UseThePlugin, CAAHelper):
         self.assertEqual(len(candidates), 3)
         for candidate in candidates:
             self.assertTrue(f"-{maxwidth}.jpg" in candidate.url)
+
+    def test_caa_finds_image_if_maxwidth_is_set_and_thumbnails_is_empty(self):
+        # CAA provides pre-sized thumbnails of width 250px, 500px, and 1200px
+        # We only test with one of them here
+        maxwidth = 1200
+        self.settings = Settings(maxwidth=maxwidth)
+
+        album = _common.Bag(
+            mb_albumid=self.MBID_RELASE, mb_releasegroupid=self.MBID_GROUP
+        )
+        self.mock_caa_response(
+            self.RELEASE_URL, self.RESPONSE_RELEASE_WITHOUT_THUMBNAILS
+        )
+        self.mock_caa_response(
+            self.GROUP_URL, self.RESPONSE_GROUP_WITHOUT_THUMBNAILS,
+        )
+        candidates = list(self.source.get(album, self.settings, []))
+        self.assertEqual(len(candidates), 3)
+        for candidate in candidates:
+            self.assertFalse(f"-{maxwidth}.jpg" in candidate.url)
 
 
 class FanartTVTest(UseThePlugin):

--- a/test/test_art.py
+++ b/test/test_art.py
@@ -521,6 +521,22 @@ class CoverArtArchiveTest(UseThePlugin, CAAHelper):
         self.assertEqual(len(responses.calls), 2)
         self.assertEqual(responses.calls[0].request.url, self.RELEASE_URL)
 
+    def test_fetchart_uses_caa_pre_sized_maxwidth_thumbs(self):
+        # CAA provides pre-sized thumbnails of width 250px, 500px, and 1200px
+        # We only test with one of them here
+        maxwidth = 1200
+        self.settings = Settings(maxwidth=maxwidth)
+
+        album = _common.Bag(
+            mb_albumid=self.MBID_RELASE, mb_releasegroupid=self.MBID_GROUP
+        )
+        self.mock_caa_response(self.RELEASE_URL, self.RESPONSE_RELEASE)
+        self.mock_caa_response(self.GROUP_URL, self.RESPONSE_GROUP)
+        candidates = list(self.source.get(album, self.settings, []))
+        self.assertEqual(len(candidates), 3)
+        for candidate in candidates:
+            self.assertTrue(f"-{maxwidth}.jpg" in candidate.url)
+
 
 class FanartTVTest(UseThePlugin):
     RESPONSE_MULTIPLE = """{


### PR DESCRIPTION
## Description

This patch fixes two bugs with the Cover Art Archive provider of the `FetchArt` plugin:

-  the pre-sized thumbnails of the release group of an album would be ignored when the `maxwidth` option matches one of the available sizes (250, 500, and 1200 pixels).
    - This allows the release group to behave exactly like the release itself (which does take the pre-sized thumbnails into account).
- no cover would be found and downloaded when the `maxsize` option is defined, is in the pre-sized thumbnails list, but CAA does not provide thumbnails for this release/release group

This patch can significantly speed up the fetching process of some albums, as the default size of some cover arts can be quite large (e.g. [this cover ](https://coverartarchive.org/release-group/1cd77af1-5fe8-45ac-9953-710315c85604) is 56 MB and 7300 pixels wide, while the 1200px version is 450KB).

This patch also add a section in the `FetchArt` plugin documentation, detailing this behavior.

## To Do

- [X] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [X] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [X] Tests. (Encouraged but not strictly required.)
