### PR TITLE
Update badfiles.py

### DIFF
--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -178,19 +178,12 @@ class BadFiles(BeetsPlugin):
                 for error_line in error:
                     ui.print_(error_line)
 
-            ui.print_()
-            ui.print_('What would you like to do?')
-
-            sel = ui.input_options(['aBort', 'skip', 'continue'])
-
-            if sel == 's':
-                return importer.action.SKIP
-            elif sel == 'c':
+             if self.config['skip_import_if_badfile'].get(False):
+                print("according to config option do not import a bad file")
                 return None
-            elif sel == 'b':
-                raise importer.ImportAbort()
-            else:
-                raise Exception(f'Unexpected selection: {sel}')
+             else:
+                print("according to config option import a bad file")
+                return importer.action.SKIP
 
     def command(self, lib, opts, args):
         # Get items from arguments


### PR DESCRIPTION
untested as I need to figure out how to dev locally, but someone in the team may look at this and just think, yeah that's fine as it's a small change.

add a config option that allows the import of the file to be skipped if the file is bad.  By default it should import even if bad.

This has only been done to remove the prompt/nag.  There is never a reason to stop on a badfile imo, you either want to import it, or not globally.

## Description

Fixes 4736

(https://github.com/beetbox/beets/issues/4736)](https://github.com/beetbox/beets/issues/4736)

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
