### PR TITLE
Add retry logic for Spotify 

### DIFF
--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -196,17 +196,16 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
                 raise SpotifyAPIError(f'API Error: {e.response.status_code}\n'
                                       f'URL: {url}\nparams: {params}')
             elif e.response.status_code == 429:
-                if retry_count < max_retries:
-                    seconds = response.headers.get('Retry-After',
-                                                   DEFAULT_WAITING_TIME)
-                    self._log.debug(f'Too many API requests. Retrying after '
-                                    f'{seconds} seconds.')
-                    time.sleep(int(seconds) + 1)
-                    return self._handle_response(request_type, url,
-                                                 params=params,
-                                                 retry_count=retry_count + 1)
-                else:
+                if retry_count >= max_retries:
                     raise SpotifyAPIError('Maximum retries reached.')
+                seconds = response.headers.get('Retry-After',
+                                               DEFAULT_WAITING_TIME)
+                self._log.debug(f'Too many API requests. Retrying after '
+                                f'{seconds} seconds.')
+                time.sleep(int(seconds) + 1)
+                return self._handle_response(request_type, url,
+                                             params=params,
+                                             retry_count=retry_count + 1)
             elif e.response.status_code == 503:
                 self._log.error('Service Unavailable.')
                 raise SpotifyAPIError('Service Unavailable.')

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -142,7 +142,7 @@ New features:
 
 Bug fixes:
 
-* Fix retry-logic for Spotify plugin.
+* :doc:`/plugins/spotify`: Add a limit of 3 retries, instead of retrying endlessly when the API is not available.
 * Fix a crash when the Spotify API timeouts or does not return a `Retry-After` interval.
   :bug:`4942`
 * :doc:`/plugins/scrub`: Fixed the import behavior where scrubbed database tags

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -142,6 +142,7 @@ New features:
 
 Bug fixes:
 
+* Fix retry-logic for Spotify plugin.
 * Fix a crash when the Spotify API timeouts or does not return a `Retry-After` interval.
   :bug:`4942`
 * :doc:`/plugins/scrub`: Fixed the import behavior where scrubbed database tags


### PR DESCRIPTION
## Description

Part 2 of the PR - #4943 

Currently, the plugin will endlessly keep retrying. I added the max-retries so that it stops after three retries. 

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
