### PR TITLE
fixup noqa after black auto-formatting

### DIFF
--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -72,8 +72,8 @@ class ModifyFileMocker:
 class EditMixin:
     """Helper containing some common functionality used for the Edit tests."""
 
-    def assertItemFieldsModified(
-        self, library_items, items, fields=[], allowed=["path"]  # noqa
+    def assertItemFieldsModified(  # noqa
+        self, library_items, items, fields=[], allowed=["path"]
     ):
         """Assert that items in the library (`lib_items`) have different values
         on the specified `fields` (and *only* on those fields), compared to
@@ -135,11 +135,11 @@ class EditCommandTest(unittest.TestCase, TestHelper, EditMixin):
         self.teardown_beets()
         self.unload_plugins()
 
-    def assertCounts(
+    def assertCounts(  # noqa
         self,
         mock_write,
         album_count=ALBUM_COUNT,
-        track_count=TRACK_COUNT,  # noqa
+        track_count=TRACK_COUNT,
         write_call_count=TRACK_COUNT,
         title_starts_with="",
     ):

--- a/test/test_autotag.py
+++ b/test/test_autotag.py
@@ -1078,9 +1078,9 @@ class EnumTest(_common.TestCase):
     """
 
     def test_ordered_enum(self):
-        OrderedEnumClass = match.OrderedEnum(
+        OrderedEnumClass = match.OrderedEnum(  # noqa
             "OrderedEnumTest", ["a", "b", "c"]
-        )  # noqa
+        )
         self.assertLess(OrderedEnumClass.a, OrderedEnumClass.b)
         self.assertLess(OrderedEnumClass.a, OrderedEnumClass.c)
         self.assertLess(OrderedEnumClass.b, OrderedEnumClass.c)

--- a/test/test_datequery.py
+++ b/test/test_datequery.py
@@ -132,9 +132,9 @@ class DateIntervalTest(unittest.TestCase):
         self.assertContains("..", date=datetime.min)
         self.assertContains("..", "1000-01-01T00:00:00")
 
-    def assertContains(
+    def assertContains(  # noqa
         self, interval_pattern, date_pattern=None, date=None
-    ):  # noqa
+    ):
         if date is None:
             date = _date(date_pattern)
         (start, end) = _parse_periods(interval_pattern)


### PR DESCRIPTION
The black conversion moved some `# noqa` statements to the wrong lines, leading to lint failures. This moves them back to the offending lines.