### PR TITLE
 Sort and categorize config_default.yaml

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -160,9 +160,6 @@ sort_case_insensitive: yes
 
 # --------------- Autotagger ---------------
 
-# FIXME undocumented feature
-# https://github.com/beetbox/beets/blob/c15ccb16bf3bceadfdf50268818dd64f04de25f8/beets/autotag/__init__.py#L219
-
 overwrite_null:
   album: []
   track: []

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -145,7 +145,8 @@ New features:
   plugin which allows to replace fields based on a given library query.
 * :doc:`/plugins/lyrics`: Add LRCLIB as a new lyrics provider and a new
   `synced` option to prefer synced lyrics over plain lyrics.
-* Sorted the default configuration file :ref: into categories.
+* Sorted the default configuration file into categories.
+  :bug:`4987`
 
 Bug fixes:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -145,6 +145,7 @@ New features:
   plugin which allows to replace fields based on a given library query.
 * :doc:`/plugins/lyrics`: Add LRCLIB as a new lyrics provider and a new
   `synced` option to prefer synced lyrics over plain lyrics.
+* Sorted the default configuration file :ref: into categories.
 
 Bug fixes:
 


### PR DESCRIPTION
## Description

Sorted the default config into categories, more or less. Added a FIXME and URL for an undocumented feature but otherwise it just re-arranges the existing config. No changes to substance.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)~
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] ~Tests. (Very much encouraged but not strictly required.)~
