### PR TITLE
Remove reference to detox

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -282,8 +282,8 @@ Running the Tests
 
 To run the tests for multiple Python versions, compile the docs, and
 check style, use `tox`_. Just type ``tox`` or use something like
-``tox -e py27`` to test a specific configuration. `detox`_ makes this go
-faster.
+``tox -e py27`` to test a specific configuration. You can use the
+``--parallel`` flag to make this go faster. 
 
 You can disable a hand-selected set of "slow" tests by setting the
 environment variable SKIP_SLOW_TESTS before running them.
@@ -359,7 +359,6 @@ others. See `unittest.mock`_ for more info.
 .. _Codecov: https://codecov.io/github/beetbox/beets
 .. _pytest-random: https://github.com/klrmn/pytest-random
 .. _tox: https://tox.readthedocs.io/en/latest/
-.. _detox: https://pypi.org/project/detox/
 .. _pytest: https://docs.pytest.org/en/stable/
 .. _Linux: https://github.com/beetbox/beets/actions
 .. _Windows: https://ci.appveyor.com/project/beetbox/beets/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -283,7 +283,7 @@ Running the Tests
 To run the tests for multiple Python versions, compile the docs, and
 check style, use `tox`_. Just type ``tox`` or use something like
 ``tox -e py27`` to test a specific configuration. You can use the
-``--parallel`` flag to make this go faster. 
+``--parallel`` flag to make this go faster.
 
 You can disable a hand-selected set of "slow" tests by setting the
 environment variable SKIP_SLOW_TESTS before running them.


### PR DESCRIPTION
`detox` has been superceded by a native option in `tox`, so it is no longer maintained. 

See: https://github.com/tox-dev/detox