### PR TITLE
Fix some docs links

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -24,7 +24,7 @@ We love to get contributions from our community—you! There are many ways
 to contribute, whether you’re a programmer or not.
 
 The first thing to do, regardless of how you'd like to contribute to the
-project, is to check out our :doc:`Code of Conduct </code_of_conduct>` and to
+project, is to check out our :doc:`Code of Conduct <code_of_conduct>` and to
 keep that in mind while interacting with other contributors and users.
 
 Non-Programming

--- a/README.rst
+++ b/README.rst
@@ -100,11 +100,11 @@ programmer or not, you should be able to find all the info you need at
 Read More
 ---------
 
-Learn more about beets at `its Web site`_. Follow `@b33ts`_ on Twitter for
+Learn more about beets at `its Web site`_. Follow `@b33ts`_ on Mastodon for
 news and updates.
 
 .. _its Web site: https://beets.io/
-.. _@b33ts: https://twitter.com/b33ts/
+.. _@b33ts: https://fosstodon.org/@beets
 
 Contact
 -------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -289,7 +289,7 @@ Other changes:
   :bug:`4585`
 * :doc:`/faq`: :ref:`multidisc`: Elaborated the multi-disc FAQ :bug:`4806`
 * :doc:`/faq`: :ref:`src`: Removed some long lines.
-* :doc:`README`: Update contact information
+* :doc:`README.rst`: Update contact information
 
 1.6.0 (November 27, 2021)
 -------------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -289,6 +289,7 @@ Other changes:
   :bug:`4585`
 * :doc:`/faq`: :ref:`multidisc`: Elaborated the multi-disc FAQ :bug:`4806`
 * :doc:`/faq`: :ref:`src`: Removed some long lines.
+* :doc:`README`: Update contact information
 
 1.6.0 (November 27, 2021)
 -------------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -290,6 +290,7 @@ Other changes:
 * :doc:`/faq`: :ref:`multidisc`: Elaborated the multi-disc FAQ :bug:`4806`
 * :doc:`/faq`: :ref:`src`: Removed some long lines.
 * :doc:`README.rst`: Update contact information
+* :doc:`CONTRIBUTING.rst`: Fix link typo
 
 1.6.0 (November 27, 2021)
 -------------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -289,8 +289,6 @@ Other changes:
   :bug:`4585`
 * :doc:`/faq`: :ref:`multidisc`: Elaborated the multi-disc FAQ :bug:`4806`
 * :doc:`/faq`: :ref:`src`: Removed some long lines.
-* :doc:`README.rst`: Update contact information
-* :doc:`CONTRIBUTING.rst`: Fix link typo
 
 1.6.0 (November 27, 2021)
 -------------------------


### PR DESCRIPTION
## Description

This is just a small doc fix: update the Twitter link in README to point to the Mastodon account (the pinned forwarding address on X isn't accessible to non-logged-in users anymore), and fix a typo that broke the link to the code of conduct in CONTRIBUTING.

## To Do

- [x] ~~Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)~~
- [x] ~~Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)~~
- [x] ~~Tests. (Very much encouraged but not strictly required.)~~
