### PR TITLE
Allow multiple plugins to provide getters for one field

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -430,8 +430,12 @@ class Model(ABC):
         """
         getters = self._getters()
         if key in getters:  # Computed.
-            return getters[key](self)
-        elif key in self._fields:  # Fixed.
+            # Use the result of the first getter that returns a value.
+            for getter in getters[key]:
+                result = getter(self)
+                if result is not None:
+                    return result
+        if key in self._fields:  # Fixed.
             if key in self._values_fixed:
                 return self._values_fixed[key]
             else:

--- a/beets/library.py
+++ b/beets/library.py
@@ -662,8 +662,8 @@ class Item(LibModel):
     @classmethod
     def _getters(cls):
         getters = plugins.item_field_getters()
-        getters["singleton"] = lambda i: i.album_id is None
-        getters["filesize"] = Item.try_filesize  # In bytes.
+        getters["singleton"] = [lambda i: i.album_id is None]
+        getters["filesize"] = [Item.try_filesize]  # In bytes.
         return getters
 
     @classmethod
@@ -1242,8 +1242,8 @@ class Album(LibModel):
         # In addition to plugin-provided computed fields, also expose
         # the album's directory as `path`.
         getters = plugins.album_field_getters()
-        getters["path"] = Album.item_dir
-        getters["albumtotal"] = Album._albumtotal
+        getters["path"] = [Album.item_dir]
+        getters["albumtotal"] = [Album._albumtotal]
         return getters
 
     def items(self):

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -305,8 +305,9 @@ def find_plugins():
         return list(_instances.values())
 
     load_plugins()
+    classes = sorted(_classes, key=lambda _class: _class.__name__)
     plugins = []
-    for cls in _classes:
+    for cls in classes:
         # Only instantiate each plugin class once.
         if cls not in _instances:
             _instances[cls] = cls()

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -26,6 +26,7 @@ import mediafile
 
 import beets
 from beets import logging
+from beets.util.dict_utils import merge_list_dicts
 
 PLUGIN_NAMESPACE = "beetsplug"
 
@@ -452,7 +453,7 @@ def item_field_getters():
     funcs = {}
     for plugin in find_plugins():
         if plugin.template_fields:
-            funcs.update(plugin.template_fields)
+            merge_list_dicts(plugin.template_fields, funcs)
     return funcs
 
 
@@ -461,7 +462,7 @@ def album_field_getters():
     funcs = {}
     for plugin in find_plugins():
         if plugin.album_template_fields:
-            funcs.update(plugin.album_template_fields)
+            merge_list_dicts(plugin.album_template_fields, funcs)
     return funcs
 
 

--- a/beets/util/dict_utils.py
+++ b/beets/util/dict_utils.py
@@ -1,0 +1,15 @@
+"""Utility functions for working with dictionaries."""
+
+
+def merge_list_dicts(source, target):
+    """Merges the value or list from the source dict into target dict list.
+
+    If a list already exists for a given key in the target dict,
+    the new item is appended or the two lists are merged.
+    """
+    for key, value in source.items():
+        value_list = value if isinstance(value, list) else [value]
+        if key in target:
+            target[key] = target[key] + value_list
+        else:
+            target[key] = value_list

--- a/beetsplug/advancedrewrite.py
+++ b/beetsplug/advancedrewrite.py
@@ -34,13 +34,12 @@ def rewriter(field, rules):
     """
 
     def fieldfunc(item):
-        value = item._values_fixed[field]
         for query, replacement in rules:
             if query.match(item):
                 # Rewrite activated.
                 return replacement
-        # Not activated; return original value.
-        return value
+        # Not activated; return None.
+        return None
 
     return fieldfunc
 

--- a/beetsplug/rewrite.py
+++ b/beetsplug/rewrite.py
@@ -35,8 +35,8 @@ def rewriter(field, rules):
             if pattern.match(value.lower()):
                 # Rewrite activated.
                 return replacement
-        # Not activated; return original value.
-        return value
+        # Not activated; return None.
+        return None
 
     return fieldfunc
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -263,6 +263,11 @@ Bug fixes:
   a null path that can't be removed.
 * Fix bug where empty artist and title fields would return None instead of an
   empty list in the discord plugin. :bug:`4973`
+* Fix a bug where it wasn't possible for multiple plugins to define replacement
+  functions for the same field.
+  For example, it wasn't possible to have both `rewrite` and `advancedrewrite`
+  rules for the same field.
+  :bug:`5002`
 
 For packagers:
 

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -146,7 +146,7 @@ class DatabaseFixtureTwoModels(dbcore.Database):
 class ModelFixtureWithGetters(dbcore.Model):
     @classmethod
     def _getters(cls):
-        return {"aComputedField": (lambda s: "thing")}
+        return {"aComputedField": [lambda s: "thing"]}
 
     def _template_funcs(self):
         return {}

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -917,7 +917,7 @@ class PluginDestinationTest(_common.TestCase):
         def field_getters():
             getters = {}
             for key, value in self._tv_map.items():
-                getters[key] = lambda _: value
+                getters[key] = [lambda _: value]
             return getters
 
         self.old_field_getters = plugins.item_field_getters


### PR DESCRIPTION
Fixes a bug where it wasn't possible for multiple plugins to define replacement functions for the same field. See #5002 for more details.

Closes #5002.