### PR TITLE
Add more detail to option about terminal width in the docs

### DIFF
--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -466,7 +466,9 @@ example ``blue`` will become ``['blue']``.
 terminal_width
 ~~~~~~~~~~~~~~
 
-Controls line wrapping. Defaults to ``80`` characters::
+Controls line wrapping on non-Unix systems. On Unix systems, the width of the
+terminal is detected automatically. If this fails, or on non-Unix systems, the
+specified value is used as a fallback. Defaults to ``80`` characters::
 
     ui:
         terminal_width: 80


### PR DESCRIPTION
I was going through the code, preparing to do a PR that makes it find the terminal width dynamically, but to my surprise that is already the case. So this is a short thing that just adds that information to the docs.