### PR TITLE
Revert line change behaviour when importing tracks

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -680,10 +680,13 @@ class AlbumChange(ChangeRepresentation):
                 # Save new medium details for future comparison.
                 medium, disctitle = track_info.medium, track_info.disctitle
 
-            if config["import"]["detail"]:
-                # Construct the line tuple for the track.
-                left, right = self.make_line(item, track_info)
+            # Construct the line tuple for the track.
+            left, right = self.make_line(item, track_info)
+            if left != right:
                 lines.append((left, right))
+            else:
+                if config["import"]["detail"]:
+                    lines.append((left, right))
         self.print_tracklist(lines)
 
         # Missing and unmatched tracks.

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -682,7 +682,7 @@ class AlbumChange(ChangeRepresentation):
 
             # Construct the line tuple for the track.
             left, right = self.make_line(item, track_info)
-            if left != right:
+            if right["contents"] != "":
                 lines.append((left, right))
             else:
                 if config["import"]["detail"]:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -263,6 +263,8 @@ Bug fixes:
   a null path that can't be removed.
 * Fix bug where empty artist and title fields would return None instead of an
   empty list in the discord plugin. :bug:`4973`
+* Fix bug regarding displaying tracks that have been changed not being
+  displayed unless the detail configuration is enabled.
 
 For packagers:
 


### PR DESCRIPTION
Fixes https://github.com/beetbox/beets/issues/4980

When importing, the old behaviour before the UI upgrade was that changed tracks were always displayed. After the update was merged, this was changed to showing no tracks at all unless the detail configuration was enabled, in which case all tracks are shown. This changes the behaviour back to what it should be.