### PR TITLE
Make sure raw_words is nonempty before accessing its first element

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -858,7 +858,7 @@ def split_into_lines(string, width_tuple):
                     m.group("esc") + raw_word + RESET_COLOR
                     for raw_word in raw_words
                 ]
-            else:
+            elif len(raw_words) >= 1:
                 # Pretext stops mid-word
                 if m.group("esc") != RESET_COLOR:
                     # Add the rest of the current word, with a reset after it


### PR DESCRIPTION
## Description

Fix a crash that can happen with multiline escaped text. I encountered a crash while importing that turned out to be caused by text rendering. In `split_into_lines` in `beets/ui/__init__.py`, if the interior of an escape sequence has no non-whitespace characters, then the access to `raw_words[0]` is invalid.

This seems rare -- I encountered it on a 10-CD album with many multiline track titles mixing English and Japanese text. Adding a check for an empty interior and skipping the escape sequence in that case fixed the issue.

<details>

<summary>Stack trace of the original crash</summary>

```
Traceback (most recent call last):
  File "/opt/homebrew/bin/beet", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/fae/code/local/beets/beets/ui/__init__.py", line 1865, in main
    _raw_main(args)
  File "/Users/fae/code/local/beets/beets/ui/__init__.py", line 1852, in _raw_main
    subcommand.func(lib, suboptions, subargs)
  File "/Users/fae/code/local/beets/beets/ui/commands.py", line 1387, in import_func
    import_files(lib, paths, query)
  File "/Users/fae/code/local/beets/beets/ui/commands.py", line 1318, in import_files
    session.run()
  File "/Users/fae/code/local/beets/beets/importer.py", line 360, in run
    pl.run_parallel(QUEUE_SIZE)
  File "/Users/fae/code/local/beets/beets/util/pipeline.py", line 447, in run_parallel
    raise exc_info[1].with_traceback(exc_info[2])
  File "/Users/fae/code/local/beets/beets/util/pipeline.py", line 312, in run
    out = self.coro.send(msg)
          ^^^^^^^^^^^^^^^^^^^
  File "/Users/fae/code/local/beets/beets/util/pipeline.py", line 171, in coro
    task = func(*(args + (task,)))
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/fae/code/local/beets/beets/importer.py", line 1521, in user_query
    task.choose_match(session)
  File "/Users/fae/code/local/beets/beets/importer.py", line 949, in choose_match
    choice = session.choose_match(self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/fae/code/local/beets/beets/ui/commands.py", line 1070, in choose_match
    choice = choose_candidate(
             ^^^^^^^^^^^^^^^^^
  File "/Users/fae/code/local/beets/beets/ui/commands.py", line 955, in choose_candidate
    show_change(cur_artist, cur_album, match)
  File "/Users/fae/code/local/beets/beets/ui/commands.py", line 741, in show_change
    change.show_match_tracks()
  File "/Users/fae/code/local/beets/beets/ui/commands.py", line 690, in show_match_tracks
    self.print_tracklist(lines)
  File "/Users/fae/code/local/beets/beets/ui/commands.py", line 644, in print_tracklist
    self.print_layout(self.indent_tracklist, left, right)
  File "/Users/fae/code/local/beets/beets/ui/commands.py", line 346, in print_layout
    print_column_layout(indent, left, right, separator, max_width)
  File "/Users/fae/code/local/beets/beets/ui/__init__.py", line 994, in print_column_layout
    left_split = split_into_lines(left["contents"], left_width_tuple)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/fae/code/local/beets/beets/ui/__init__.py", line 865, in split_into_lines
    words[-1] += m.group("esc") + raw_words[0] + RESET_COLOR
                                  ~~~~~~~~~^^^
IndexError: list index out of range
```
</details>


## To Do

This is a pretty targeted fix so I'm guessing the to-do items don't apply, but let me know if I should change anything.

- [x] ~~Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)~~
- [x] ~~Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)~~
- [x] ~~Tests. (Very much encouraged but not strictly required.)~~
