### PR TITLE
expose import.quiet_fallback as cli option

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1461,6 +1461,12 @@ import_cmd.parser.add_option(
     help="never prompt for input: skip albums instead",
 )
 import_cmd.parser.add_option(
+    "--quiet-fallback",
+    type="string",
+    dest="quiet_fallback",
+    help="decision in quiet mode when no strong match: skip or asis",
+)
+import_cmd.parser.add_option(
     "-l",
     "--log",
     dest="log",

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -145,6 +145,7 @@ New features:
   plugin which allows to replace fields based on a given library query.
 * :doc:`/plugins/lyrics`: Add LRCLIB as a new lyrics provider and a new
   `synced` option to prefer synced lyrics over plain lyrics.
+* :ref:`import-cmd`: Expose import.quiet_fallback as CLI option.
 
 Bug fixes:
 

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -93,8 +93,10 @@ Optional command flags:
 * Relatedly, the ``-q`` (quiet) option can help with large imports by
   autotagging without ever bothering to ask for user input. Whenever the
   normal autotagger mode would ask for confirmation, the quiet mode
-  pessimistically skips the album. The quiet mode also disables the tagger's
-  ability to resume interrupted imports.
+  performs a fallback action that can be configured using the
+  ``quiet_fallback`` configuration or ``--quiet-fallback`` CLI option.
+  By default it pessimistically ``skip``s the file.
+  Alternatively, it can be used as is, by configuring ``asis``.
 
 * Speaking of resuming interrupted imports, the tagger will prompt you if it
   seems like the last import of the directory was interrupted (by you or by


### PR DESCRIPTION
## Description

Exposes the configuration option `import.quiet_fallback` as CLI option.

Relates to #4958.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] ~~Tests~~. (Very much encouraged but not strictly required.)
