### PR TITLE
Fix failing test: test_nonexistant_db

### DIFF
--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -937,7 +937,8 @@ class ConfigTest(unittest.TestCase, TestHelper, _common.Assertions):
             config.write("library: /xxx/yyy/not/a/real/path")
 
         with self.assertRaises(ui.UserError):
-            self.run_command("test", lib=None)
+            with control_stdin("n"):
+                self.run_command("test", lib=None)
 
     def test_user_config_file(self):
         with self.write_config_file() as file:


### PR DESCRIPTION
## Description

Fixes #5021

The `test_nonexistant_db` test in `test_ui` would attempt to read from `stdin` under certain conditions (particularly when run directly, i.e. `pytest -k nonex test/test_ui.py`).

This diff fixes the issue.

**note:** I didn't **really** figure out what the root cause of the initial issue was (since the tests could sometimes pass when run with the entire test-suite), but if this works on other folks machines, then hey, good enough I suppose...