### PR TITLE
smartplaylist: expose config as CLI options

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -149,6 +149,7 @@ New features:
 * :ref:`import-cmd`: Expose import.quiet_fallback as CLI option.
 * :ref:`import-cmd`: Expose `import.incremental_skip_later` as CLI option.
 * :doc:`/plugins/smartplaylist`: Add new config option `smartplaylist.extm3u`.
+* :doc:`/plugins/smartplaylist`: Expose config options as CLI options.
 
 Bug fixes:
 

--- a/docs/plugins/smartplaylist.rst
+++ b/docs/plugins/smartplaylist.rst
@@ -115,7 +115,12 @@ other configuration options are:
 - **prefix**: Prepend this string to every path in the playlist file. For
   example, you could use the URL for a server where the music is stored.
   Default: empty string.
-- **urlencoded**: URL-encode all paths. Default: ``no``.
+- **urlencode**: URL-encode all paths. Default: ``no``.
 - **pretend_paths**: When running with ``--pretend``, show the actual file
   paths that will be written to the m3u file. Default: ``false``.
 - **extm3u**: Generate extm3u/m3u8 playlists. Default ``ǹo``.
+
+For many configuration options, there is a corresponding CLI option, e.g.
+``--playlist-dir``, ``--relative-to``, ``--prefix``, ``--forward-slash``,
+``--urlencode``, ``--extm3u``, ``--pretend-paths``.
+CLI options take precedence over those specified within the configuration file.


### PR DESCRIPTION
## Description

Add CLI options to `splupdate` command:
* `--playlist-dir`, `-d`
* `--relative-to`
* `--prefix`
* `--urlencode`
* `--forward-slash`
* `--pretend-paths`

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] ~~Tests~~. (Very much encouraged but not strictly required.)
