### PR TITLE
In test I/O utility, restore the old `stdin`/`stdout` instead of the "true" I/O streams

### DIFF
--- a/test/_common.py
+++ b/test/_common.py
@@ -332,6 +332,7 @@ class DummyIO:
     def __init__(self):
         self.stdout = DummyOut()
         self.stdin = DummyIn(self.stdout)
+        self.installed = False
 
     def addinput(self, s):
         self.stdin.add(s)
@@ -345,12 +346,18 @@ class DummyIO:
         return self.stdin.reads
 
     def install(self):
+        self.installed = True
+
+        self.orig_stdin = sys.stdin
+        self.orig_stdout = sys.stdout
+
         sys.stdin = self.stdin
         sys.stdout = self.stdout
 
     def restore(self):
-        sys.stdin = sys.__stdin__
-        sys.stdout = sys.__stdout__
+        if self.installed:
+            sys.stdin = self.orig_stdin
+            sys.stdout = self.orig_stdout
 
 
 # Utility.


### PR DESCRIPTION
I got a little bit nerdsniped by the problems observed in #5027. In short, my high-level diagnosis in https://github.com/beetbox/beets/pull/5027#issuecomment-1857953929 seems to have been correct: other tests were suppressing the legitimate failure of a flaky test.

I found the problem by running other tests before the problem test, like this:

```
$ pytest -k 'test_nonexistant_db or test_delete_removes_item' test/test_ui.py
```

When running `test_nonexistant_db` alone, it fails. When running it like this with another test that goes first, it passes. That's the problem.

However, `test_delete_removes_item` is just one example that works to make this problem happen. It appeared that _any_ test in a class that used our `_common.TestCase` base class had this power. I tracked down the issue to our `DummyIO` utility, which was having an unintentional effect even when it was never actually used.

Here's the solution. Instead of restoring `sys.stdin` to `sys.__stdin__`, we now restore it to whatever it was before we installed out dummy I/O hooks. This is relevant in pytest, for example, which installs its *own* `sys.stdin`, which we were then clobbering. This was leading to the suppression of test failures observed in #5021 and addressed in #5027.

The CI will fail for this PR because it now (correctly) exposes a failing test. Hopefully by combining this with the fixes in the works in #5027, we'll be back to a passing test suite. :smiley: @Phil305, could you perhaps help validate that hypothesis?