### PR TITLE
smartplaylist: change option --extm3u to --output

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -148,7 +148,7 @@ New features:
   `synced` option to prefer synced lyrics over plain lyrics.
 * :ref:`import-cmd`: Expose import.quiet_fallback as CLI option.
 * :ref:`import-cmd`: Expose `import.incremental_skip_later` as CLI option.
-* :doc:`/plugins/smartplaylist`: Add new config option `smartplaylist.extm3u`.
+* :doc:`/plugins/smartplaylist`: Add new config option `smartplaylist.output`.
 * :doc:`/plugins/smartplaylist`: Expose config options as CLI options.
 
 Bug fixes:

--- a/docs/plugins/smartplaylist.rst
+++ b/docs/plugins/smartplaylist.rst
@@ -118,9 +118,9 @@ other configuration options are:
 - **urlencode**: URL-encode all paths. Default: ``no``.
 - **pretend_paths**: When running with ``--pretend``, show the actual file
   paths that will be written to the m3u file. Default: ``false``.
-- **extm3u**: Generate extm3u/m3u8 playlists. Default ``ǹo``.
+- **output**: Specify the playlist format: m3u|m3u8. Default ``m3u``.
 
 For many configuration options, there is a corresponding CLI option, e.g.
 ``--playlist-dir``, ``--relative-to``, ``--prefix``, ``--forward-slash``,
-``--urlencode``, ``--extm3u``, ``--pretend-paths``.
+``--urlencode``, ``--output``, ``--pretend-paths``.
 CLI options take precedence over those specified within the configuration file.

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -191,7 +191,7 @@ class SmartPlaylistTest(_common.TestCase):
 
         self.assertEqual(content, b"/tagada.mp3\n")
 
-    def test_playlist_update_extm3u(self):
+    def test_playlist_update_output_m3u8(self):
         spl = SmartPlaylistPlugin()
 
         i = MagicMock()
@@ -215,7 +215,7 @@ class SmartPlaylistTest(_common.TestCase):
         spl._matched_playlists = [pl]
 
         dir = bytestring_path(mkdtemp())
-        config["smartplaylist"]["extm3u"] = True
+        config["smartplaylist"]["output"] = "m3u8"
         config["smartplaylist"]["prefix"] = "http://beets:8337/files"
         config["smartplaylist"]["relative_to"] = False
         config["smartplaylist"]["playlist_dir"] = py3_path(dir)


### PR DESCRIPTION
The boolean flags `--extm3u` and `--no-extm3u` are replaced with a string option `--output=m3u|m3u8`.
This reduces the amount of options and allows to evolve the CLI to support more playlist output formats in the future (e.g. JSON) without polluting the CLI at that point.

This is a follow-up of #5046.
Relates to #5048.

## To Do

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
