### PR TITLE
web: fix/add range request support

### DIFF
--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -336,7 +336,6 @@ def item_file(item_id):
     response = flask.send_file(
         item_path, as_attachment=True, download_name=safe_filename
     )
-    response.headers["Content-Length"] = os.path.getsize(item_path)
     return response
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -279,6 +279,8 @@ Bug fixes:
   :bug:`4973`
 * Fix bug regarding displaying tracks that have been changed not being
   displayed unless the detail configuration is enabled.
+* :doc:`/plugins/web`: Fix range request support, allowing to play large audio/
+  opus files using e.g. a browser/firefox or gstreamer/mopidy directly.
 
 For plugin developers:
 


### PR DESCRIPTION
## Description
Do not let the web plugin overwrite the Content-Length header with the full file length since flask/werkzeug [sets the requested range's/chunk's length](https://github.com/pallets/werkzeug/blob/eafbed0ce2a6bdf60e62de82bf4a8365188ac334/src/werkzeug/wrappers/response.py#L702) when handling a range request.
This is to allow playing large audio/opus files using e.g. a browser/firefox or gstreamer/mopidy without making a reverse-proxy/nginx emulate range request support and hide range-related headers from the backend.

I tested the fix successfully using firefox and gstreamer (mopidy-beets).

## Workaround
Previously (before beets 1.6.1), range requests had to be workedaround explicitly using a reverse-proxy such as nginx. A corresponding nginx server configuration could look as follows:
```
server {
    listen 8080;
    server_name localhost;
    root   /data/music;

    location / {
        # Reverse-proxy beets web API.
        proxy_pass http://localhost:8337;
        # Make nginx emulate range requests.
        proxy_force_ranges on;
        # Prevent beets from handling range requests, making it always return the entire file.
        proxy_set_header "Range" "";
    }
}
```

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~~Documentation~~. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] ~~Tests~~. (Very much encouraged but not strictly required.)
