### PR TITLE
Add initial version of the Listenbrainz plugin

### DIFF
--- a/beetsplug/lastimport.py
+++ b/beetsplug/lastimport.py
@@ -204,9 +204,13 @@ def process_tracks(lib, tracks, log):
 
     for num in range(0, total):
         song = None
-        trackid = tracks[num]["mbid"].strip() or None
-        artist = tracks[num]["artist"].get("name", "").strip() or None
-        title = tracks[num]["name"].strip() or None
+        trackid = tracks[num]["mbid"].strip() if tracks[num]["mbid"] else None
+        artist = (
+            tracks[num]["artist"].get("name", "").strip()
+            if tracks[num]["artist"].get("name", "")
+            else None
+        )
+        title = tracks[num]["name"].strip() if tracks[num]["name"] else None
         album = ""
         if "album" in tracks[num]:
             album = tracks[num]["album"].get("name", "").strip()

--- a/beetsplug/lastimport.py
+++ b/beetsplug/lastimport.py
@@ -204,9 +204,9 @@ def process_tracks(lib, tracks, log):
 
     for num in range(0, total):
         song = None
-        trackid = tracks[num]["mbid"].strip()
-        artist = tracks[num]["artist"].get("name", "").strip()
-        title = tracks[num]["name"].strip()
+        trackid = tracks[num]["mbid"].strip() or None
+        artist = tracks[num]["artist"].get("name", "").strip() or None
+        title = tracks[num]["name"].strip() or None
         album = ""
         if "album" in tracks[num]:
             album = tracks[num]["album"].get("name", "").strip()

--- a/beetsplug/lastimport.py
+++ b/beetsplug/lastimport.py
@@ -259,7 +259,7 @@ def process_tracks(lib, tracks, log):
 
         if song is not None:
             count = int(song.get("play_count", 0))
-            new_count = int(tracks[num]["playcount"]) if tracks[num]["playcount"] else 1
+            new_count = int(tracks[num].get("playcount", 1))
             log.debug(
                 "match: {0} - {1} ({2}) " "updating: play_count {3} => {4}",
                 song.artist,

--- a/beetsplug/lastimport.py
+++ b/beetsplug/lastimport.py
@@ -225,7 +225,9 @@ def process_tracks(lib, tracks, log):
 
         # If not, try just album/title
         if song is None:
-            log.debug("no album match, trying by album/title")
+            log.debug(
+                "no album match, trying by album/title: {0} - {1}", album, title
+            )
             query = dbcore.AndQuery(
                 [
                     dbcore.query.SubstringQuery("album", album),

--- a/beetsplug/lastimport.py
+++ b/beetsplug/lastimport.py
@@ -248,7 +248,7 @@ def process_tracks(lib, tracks, log):
 
         if song is not None:
             count = int(song.get("play_count", 0))
-            new_count = int(tracks[num]["playcount"])
+            new_count = int(tracks[num]["playcount"]) if tracks[num]["playcount"] else 1
             log.debug(
                 "match: {0} - {1} ({2}) " "updating: play_count {3} => {4}",
                 song.artist,

--- a/beetsplug/lastimport.py
+++ b/beetsplug/lastimport.py
@@ -223,6 +223,17 @@ def process_tracks(lib, tracks, log):
                 dbcore.query.MatchQuery("mb_trackid", trackid)
             ).get()
 
+        # If not, try just album/title
+        if song is None:
+            log.debug("no album match, trying by album/title")
+            query = dbcore.AndQuery(
+                [
+                    dbcore.query.SubstringQuery("album", album),
+                    dbcore.query.SubstringQuery("title", title),
+                ]
+            )
+            song = lib.items(query).get()
+
         # If not, try just artist/title
         if song is None:
             log.debug("no album match, trying by artist/title")

--- a/beetsplug/lastimport.py
+++ b/beetsplug/lastimport.py
@@ -213,7 +213,11 @@ def process_tracks(lib, tracks, log):
         title = tracks[num]["name"].strip() if tracks[num]["name"] else None
         album = ""
         if "album" in tracks[num]:
-            album = tracks[num]["album"].get("name", "").strip()
+            album = (
+                tracks[num]["album"].get("name", "").strip()
+                if tracks[num]["album"]
+                else None
+            )
 
         log.debug("query: {0} - {1} ({2})", artist, title, album)
 

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -126,7 +126,6 @@ class ListenBrainzPlugin(BeetsPlugin):
                     query=track["track_metadata"].get("track_name"),
                     release=track["track_metadata"].get("release_name"),
                     artist=track["track_metadata"].get("artist_name"),
-                    limit=5, strict=True,
                 )
                 print(json.dumps(resp, indent=4, sort_keys=True))
             tracks.append(

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -101,7 +101,6 @@ class ListenBrainzPlugin(BeetsPlugin):
         tracks = []
         for listen in listens:
             self._log.debug(f"listen: {listen.get('track_metadata')}")
-        return self.get_track_info(tracks)
 
     def get_playlists_createdfor(self, username):
         """Returns a list of playlists created by a user."""

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -119,15 +119,19 @@ class ListenBrainzPlugin(BeetsPlugin):
             if track["track_metadata"].get("release_name") is None:
                 continue
             mbid_mapping = track["track_metadata"].get("mbid_mapping", {})
-            #print(json.dumps(track, indent=4, sort_keys=True))
+            # print(json.dumps(track, indent=4, sort_keys=True))
             if mbid_mapping.get("recording_mbid") is None:
                 # search for the track using title and release
                 mbid = self.get_mb_recording_id(track)
             tracks.append(
                 {
-                    "album": {"name": track["track_metadata"].get("release_name")},
+                    "album": {
+                        "name": track["track_metadata"].get("release_name")
+                    },
                     "name": track["track_metadata"].get("track_name"),
-                    "artist": {"name": track["track_metadata"].get("artist_name")},
+                    "artist": {
+                        "name": track["track_metadata"].get("artist_name")
+                    },
                     "mbid": mbid,
                     "release_mbid": mbid_mapping.get("release_mbid"),
                     "listened_at": track.get("listened_at"),
@@ -138,10 +142,10 @@ class ListenBrainzPlugin(BeetsPlugin):
     def get_mb_recording_id(self, track):
         """Returns the MusicBrainz recording ID for a track."""
         resp = musicbrainzngs.search_recordings(
-                    query=track["track_metadata"].get("track_name"),
-                    release=track["track_metadata"].get("release_name"),
-                    strict=True
-                )
+            query=track["track_metadata"].get("track_name"),
+            release=track["track_metadata"].get("release_name"),
+            strict=True,
+        )
         if resp.get("recording-count") == "1":
             return resp.get("recording-list")[0].get("id")
         else:

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -100,14 +100,7 @@ class ListenBrainzPlugin(BeetsPlugin):
     def get_tracks_from_listens(self, listens):
         tracks = []
         for listen in listens:
-            tracks.append(
-                {
-                    "artist": listen.get("artist_name"),
-                    "identifier": listen.get("identifier"),
-                    "title": listen.get("track_name"),
-                }
-            )
-            self._log.debug(f"track: {tracks[-1]}")
+            self._log.debug(f"listen: {listen}")
         return self.get_track_info(tracks)
 
     def get_playlists_createdfor(self, username):

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -105,14 +105,24 @@ class ListenBrainzPlugin(BeetsPlugin):
     def get_tracks_from_listens(self, listens):
         tracks = []
         for track in listens:
-            self._log.debug(
-                "{0} - {1}, artist: {2}, listened at {3}".format(
-                    track["track_metadata"]["release_name"],
-                    track["track_metadata"]["track_name"],
-                    track["track_metadata"]["artist_name"],
-                    track["listened_at"],
-                )
+            tracks.append(
+                {
+                    "release_name": track["track_metadata"]["release_name"],
+                    "track_name": track["track_metadata"]["track_name"],
+                    "artist_name": track["track_metadata"]["artist_name"],
+                    "listened_at": track["listened_at"],
+                }
             )
+            self._log.debug(self.lookup_metadata(tracks[-1]))
+        return tracks
+
+    def lookup_metadata(self, track) -> dict:
+        """Looks up the metadata for a listen using track name and artist name."""
+
+        params = {"recording_name": track.track_name, "artist_name": track.artist_name}
+        url = f"{self.ROOT}/metadata/lookup/"
+        response = self._make_request(url, params)
+        return response.json()
 
     def get_playlists_createdfor(self, username):
         """Returns a list of playlists created by a user."""

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -126,6 +126,7 @@ class ListenBrainzPlugin(BeetsPlugin):
                     query=track["track_metadata"].get("track_name"),
                     release=track["track_metadata"].get("release_name"),
                     artist=track["track_metadata"].get("artist_name"),
+                    limit=5, strict=True,
                 )
                 self._log.debug(print(json.dumps(resp, indent=4, sort_keys=True)))
             tracks.append(
@@ -139,6 +140,7 @@ class ListenBrainzPlugin(BeetsPlugin):
                 }
             )
         return tracks
+
 
     def get_playlists_createdfor(self, username):
         """Returns a list of playlists created by a user."""

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -8,15 +8,8 @@ import datetime
 from beets import config, ui
 from beets.plugins import BeetsPlugin
 import musicbrainzngs
-
+from beetsplug import lastimport.process_tracks as process_tracks
 from beets.plugins import find_plugin
-
-lastimport_plugin = find_plugin("lastimport")
-
-if lastimport_plugin is not None:
-    process_tracks = lastimport_plugin.process_tracks
-else:
-    raise ImportError("lastimport plugin not found")
 
 
 class ListenBrainzPlugin(BeetsPlugin):

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -78,7 +78,7 @@ class ListenBrainzPlugin(BeetsPlugin):
             "min_ts": min_ts,
             "max_ts": max_ts,
             "count": count,
-        }.items() if v is not None},
+        }.items() if v is not None}
         response = self._make_request(url, params)
 
         if response is not None:

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -8,7 +8,7 @@ import datetime
 from beets import config, ui
 from beets.plugins import BeetsPlugin
 import musicbrainzngs
-from lastimport import process_tracks
+from beetsplug.lastimport import process_tracks
 
 
 class ListenBrainzPlugin(BeetsPlugin):

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -106,12 +106,14 @@ class ListenBrainzPlugin(BeetsPlugin):
     def get_tracks_from_listens(self, listens):
         tracks = []
         for track in listens:
-            print(json.dumps(track, indent=4))
+            #print(json.dumps(track, indent=4))
             tracks.append(
                 {
                     "release_name": track["track_metadata"]["release_name"],
                     "track_name": track["track_metadata"]["track_name"],
                     "artist_name": track["track_metadata"]["artist_name"],
+                    "recording_mbid": track["track_metadata"]["mbid_mapping"]["recording_mbid"],
+                    "release_mbid": track["track_metadata"]["mbid_mapping"]["release_mbid"],
                     "listened_at": track["listened_at"],
                 }
             )

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -120,6 +120,16 @@ class ListenBrainzPlugin(BeetsPlugin):
                 continue
             mbid_mapping = track["track_metadata"].get("mbid_mapping", {})
             print(json.dumps(track, indent=4, sort_keys=True))
+            if mbid_mapping.get("recording_mbid") is None:
+                # search for the track using title and release
+                resp = musicbrainzngs.search_recordings(
+                    query=track["track_metadata"].get("track_name"),
+                    release=track["track_metadata"].get("release_name"),
+                    artist=track["track_metadata"].get("artist_name"),
+                )
+                self._log.debug(
+                    f"Search response: {json.dumps(resp, indent=4, sort_keys=True)}"
+                )
             tracks.append(
                 {
                     "release_name": track["track_metadata"].get("release_name"),

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -2,6 +2,7 @@
 Adds Listenbrainz support to Beets.
 """
 
+import json
 import requests
 import datetime
 from beets import config, ui
@@ -105,6 +106,7 @@ class ListenBrainzPlugin(BeetsPlugin):
     def get_tracks_from_listens(self, listens):
         tracks = []
         for track in listens:
+            #print(json.dumps(track, indent=4))
             tracks.append(
                 {
                     "release_name": track["track_metadata"]["release_name"],
@@ -113,7 +115,6 @@ class ListenBrainzPlugin(BeetsPlugin):
                     "listened_at": track["listened_at"],
                 }
             )
-            self._log.debug(self.lookup_metadata(tracks[-1]))
         return tracks
 
     def lookup_metadata(self, track) -> dict:
@@ -125,6 +126,7 @@ class ListenBrainzPlugin(BeetsPlugin):
         }
         url = f"{self.ROOT}/metadata/lookup/"
         response = self._make_request(url, params)
+        print(json.dumps(response, indent=4))
         return response
 
     def get_playlists_createdfor(self, username):

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -125,7 +125,7 @@ class ListenBrainzPlugin(BeetsPlugin):
         }
         url = f"{self.ROOT}/metadata/lookup/"
         response = self._make_request(url, params)
-        return response.json()
+        return response
 
     def get_playlists_createdfor(self, username):
         """Returns a list of playlists created by a user."""

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -115,6 +115,7 @@ class ListenBrainzPlugin(BeetsPlugin):
                     "listened_at": track["listened_at"],
                 }
             )
+            self.lookup_metadata(tracks[-1])
         return tracks
 
     def lookup_metadata(self, track) -> dict:

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -109,7 +109,7 @@ class ListenBrainzPlugin(BeetsPlugin):
                 "{0} - {1}, Release MBID: {2}, listened at {3}".format(
                     track["track_metadata"]["release_name"],
                     track["track_metadata"]["track_name"],
-                    track["track_metadata"].get("additional_info"),
+                    track["track_metadata"].get("additional_info", "No additional info"),
                     track["listened_at"],
                 )
             )

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -71,11 +71,8 @@ class ListenBrainzPlugin(BeetsPlugin):
             A ValueError if the JSON in the response is invalid.
             An IndexError if the JSON is not structured as expected.
         """
-        response = self._make_request(
-            url="http://{0}/1/user/{1}/listens".format(
-                self.ROOT, self.username
-            ),
-        )
+        url = f"{self.ROOT}/user/{self.username}/listens"
+        response = self._make_request(url)
 
         if response is not None:
             return response["payload"]["listens"]

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -127,9 +127,7 @@ class ListenBrainzPlugin(BeetsPlugin):
                     release=track["track_metadata"].get("release_name"),
                     artist=track["track_metadata"].get("artist_name"),
                 )
-                self._log.debug(
-                    f"Search response: {json.dumps(resp, indent=4, sort_keys=True)}"
-                )
+                self._log.debug(print(json.dumps(resp, indent=4, sort_keys=True)))
             tracks.append(
                 {
                     "release_name": track["track_metadata"].get("release_name"),

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -102,7 +102,7 @@ class ListenBrainzPlugin(BeetsPlugin):
         for listen in listens:
             track_metadata = listen.get('track_metadata')
             if 'additional_info' in track_metadata:
-                self._log.debug(f"listen: {track_metadata}")
+                self._log.debug("listen: %s", track_metadata)
 
     def get_playlists_createdfor(self, username):
         """Returns a list of playlists created by a user."""

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -77,7 +77,7 @@ class ListenBrainzPlugin(BeetsPlugin):
             ),
         )
 
-        if response["status"] == "ok":
+        if response is not None:
             return response["payload"]["listens"]
         else:
             return None

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -74,11 +74,11 @@ class ListenBrainzPlugin(BeetsPlugin):
             An IndexError if the JSON is not structured as expected.
         """
         url = f"{self.ROOT}/user/{self.username}/listens"
-        params={
+        params = {k: v for k, v in {
             "min_ts": min_ts,
             "max_ts": max_ts,
             "count": count,
-        },
+        }.items() if v is not None},
         response = self._make_request(url, params)
 
         if response is not None:

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -8,8 +8,7 @@ import datetime
 from beets import config, ui
 from beets.plugins import BeetsPlugin
 import musicbrainzngs
-from beetsplug import lastimport.process_tracks as process_tracks
-from beets.plugins import find_plugin
+from lastimport import process_tracks
 
 
 class ListenBrainzPlugin(BeetsPlugin):

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -106,9 +106,12 @@ class ListenBrainzPlugin(BeetsPlugin):
         tracks = []
         for track in listens:
             self._log.debug(
-                f"{track['track_metadata']['release_name']} - {track['track_metadata']['track_name']}, "
-                f"Release MBID: {track['track_metadata'].get('additional_info', 'No additional info')}, "
-                f"listened at {track['listened_at']}"
+                "{0} - {1}, artist: {2}, listened at {3}".format(
+                    track["track_metadata"]["release_name"],
+                    track["track_metadata"]["track_name"],
+                    track["track_metadata"]["artist_name"],
+                    track["listened_at"],
+                )
             )
 
     def get_playlists_createdfor(self, username):

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -107,7 +107,7 @@ class ListenBrainzPlugin(BeetsPlugin):
         for track in listens:
             self._log.debug(
                 "Track: {0}, listened at {1}".format(
-                    track["track_metadata"]["track_name"], track["listened_at"]
+                    track["track_metadata"]["track_name"], track["track_metadata"]
                 )
             )
 

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -1,0 +1,182 @@
+"""
+Adds Listenbrainz support to Beets.
+"""
+
+import requests
+import datetime
+from beets import config, ui
+from beets.plugins import BeetsPlugin
+import musicbrainzngs
+
+
+class ListenBrainzPlugin(BeetsPlugin):
+    data_source = "ListenBrainz"
+    ROOT = "http://api.listenbrainz.org/1/"
+
+    def __init__(self):
+        super().__init__()
+        self.token = self.config["token"].get()
+        self.username = self.config["username"].get()
+        self.AUTH_HEADER = {"Authorization": f"Token {self.token}"}
+        config["listenbrainz"]["token"].redact = True
+
+    def commands(self):
+        """Add beet UI commands to interact with ListenBrainz."""
+        lbupdate_cmd = ui.Subcommand(
+            "lbimport", help=f"Import {self.data_source} history"
+        )
+
+        def func(lib, opts, args):
+            items = lib.items(ui.decargs(args))
+            self._lbupdate(items, ui.should_write())
+
+        lbupdate_cmd.func = func
+        return [lbupdate_cmd]
+
+    def _lbupdate(self, items, write):
+        """Obtain view count from Listenbrainz."""
+        ls = self.get_listens()
+        self._log.info(f"Found {len(ls)} listens")
+
+    def _make_request(self, url):
+        try:
+            response = requests.get(
+                url=url,
+                headers=self.AUTH_HEADER,
+                timeout=10,
+            )
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            self._log.debug(f"Invalid Search Error: {e}")
+            return None
+
+    def get_listens(self, min_ts=None, max_ts=None, count=None):
+        """Gets the listen history of a given user.
+
+        Args:
+            username: User to get listen history of.
+            min_ts: History before this timestamp will not be returned.
+                    DO NOT USE WITH max_ts.
+            max_ts: History after this timestamp will not be returned.
+                    DO NOT USE WITH min_ts.
+            count: How many listens to return. If not specified,
+                uses a default from the server.
+
+        Returns:
+            A list of listen info dictionaries if there's an OK status.
+
+        Raises:
+            An HTTPError if there's a failure.
+            A ValueError if the JSON in the response is invalid.
+            An IndexError if the JSON is not structured as expected.
+        """
+        response = self._make_request(
+            url="http://{0}/1/user/{1}/listens".format(
+                self.ROOT, self.username
+            ),
+        )
+
+        if response["status"] == "ok":
+            return response["payload"]["listens"]
+        else:
+            return None
+
+    def get_playlists_createdfor(self, username):
+        """Returns a list of playlists created by a user."""
+        url = f"{self.ROOT}/user/{username}/playlists/createdfor"
+        return self._make_request(url)
+
+    def get_listenbrainz_playlists(self):
+        resp = self.get_playlists_createdfor(self.username)
+        playlists = resp.get("playlists")
+        listenbrainz_playlists = []
+
+        for playlist in playlists:
+            playlist_info = playlist.get("playlist")
+            if playlist_info.get("creator") == "listenbrainz":
+                title = playlist_info.get("title")
+                playlist_type = (
+                    "Exploration" if "Exploration" in title else "Jams"
+                )
+                date_str = title.split("week of ")[1].split(" ")[0]
+                date = datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
+                identifier = playlist_info.get("identifier")
+                id = identifier.split("/")[-1]
+                listenbrainz_playlists.append(
+                    {"type": playlist_type, "date": date, "identifier": id}
+                )
+        return listenbrainz_playlists
+
+    def get_playlist(self, identifier):
+        """Returns a playlist."""
+        url = f"{self.ROOT}/playlist/{identifier}"
+        return self._make_request(url)
+
+    def get_tracks_from_playlist(self, playlist):
+        """This function returns a list of tracks in the playlist."""
+        tracks = []
+        for track in playlist.get("playlist").get("track"):
+            tracks.append(
+                {
+                    "artist": track.get("creator"),
+                    "identifier": track.get("identifier").split("/")[-1],
+                    "title": track.get("title"),
+                }
+            )
+        return self.get_track_info(tracks)
+
+    def get_track_info(self, tracks):
+        track_info = []
+        for track in tracks:
+            identifier = track.get("identifier")
+            resp = musicbrainzngs.get_recording_by_id(
+                identifier, includes=["releases", "artist-credits"]
+            )
+            recording = resp.get("recording")
+            title = recording.get("title")
+            artist_credit = recording.get("artist-credit", [])
+            if artist_credit:
+                artist = artist_credit[0].get("artist", {}).get("name")
+            else:
+                artist = None
+            releases = recording.get("release-list", [])
+            if releases:
+                album = releases[0].get("title")
+                date = releases[0].get("date")
+                year = date.split("-")[0] if date else None
+            else:
+                album = None
+                year = None
+            track_info.append(
+                {
+                    "identifier": identifier,
+                    "title": title,
+                    "artist": artist,
+                    "album": album,
+                    "year": year,
+                }
+            )
+        return track_info
+
+    def get_weekly_playlist(self, index):
+        """Returns a list of weekly playlists based on the index."""
+        playlists = self.get_listenbrainz_playlists()
+        playlist = self.get_playlist(playlists[index].get("identifier"))
+        return self.get_tracks_from_playlist(playlist)
+
+    def get_weekly_exploration(self):
+        """Returns a list of weekly exploration."""
+        return self.get_weekly_playlist(0)
+
+    def get_weekly_jams(self):
+        """Returns a list of weekly jams."""
+        return self.get_weekly_playlist(1)
+
+    def get_last_weekly_exploration(self):
+        """Returns a list of weekly exploration."""
+        return self.get_weekly_playlist(3)
+
+    def get_last_weekly_jams(self):
+        """Returns a list of weekly jams."""
+        return self.get_weekly_playlist(3)

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -109,7 +109,7 @@ class ListenBrainzPlugin(BeetsPlugin):
                 "{0} - {1}, Release MBID: {2}, listened at {3}".format(
                     track["track_metadata"]["release_name"],
                     track["track_metadata"]["track_name"],
-                    track["track_metadata"]["additional_info"],
+                    track["track_metadata"],
                     track["listened_at"],
                 )
             )

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -109,7 +109,7 @@ class ListenBrainzPlugin(BeetsPlugin):
                 "{0} - {1}, Release MBID: {2}, listened at {3}".format(
                     track["track_metadata"]["release_name"],
                     track["track_metadata"]["track_name"],
-                    track["track_metadata"]["release_mbid"],
+                    track["track_metadata"].get("additional_info", {}),
                     track["listened_at"],
                 )
             )

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -100,7 +100,7 @@ class ListenBrainzPlugin(BeetsPlugin):
     def get_tracks_from_listens(self, listens):
         tracks = []
         for listen in listens:
-            self._log.debug("listen: %s", listen)
+            self._log.debug(f"listen: {listen}")
 
     def get_playlists_createdfor(self, username):
         """Returns a list of playlists created by a user."""

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -106,12 +106,9 @@ class ListenBrainzPlugin(BeetsPlugin):
         tracks = []
         for track in listens:
             self._log.debug(
-                "{0} - {1}, Release MBID: {2}, listened at {3}".format(
-                    track["track_metadata"]["release_name"],
-                    track["track_metadata"]["track_name"],
-                    track["track_metadata"].get("additional_info", "No additional info"),
-                    track["listened_at"],
-                )
+                f"{track['track_metadata']['release_name']} - {track['track_metadata']['track_name']}, "
+                f"Release MBID: {track['track_metadata'].get('additional_info', 'No additional info')}, "
+                f"listened at {track['listened_at']}"
             )
 
     def get_playlists_createdfor(self, username):

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -128,7 +128,7 @@ class ListenBrainzPlugin(BeetsPlugin):
                     artist=track["track_metadata"].get("artist_name"),
                     limit=5, strict=True,
                 )
-                self._log.debug(print(json.dumps(resp, indent=4, sort_keys=True)))
+                print(json.dumps(resp, indent=4, sort_keys=True))
             tracks.append(
                 {
                     "release_name": track["track_metadata"].get("release_name"),

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -125,7 +125,7 @@ class ListenBrainzPlugin(BeetsPlugin):
                 mbid = self.get_mb_recording_id(track)
             tracks.append(
                 {
-                    "album": track["track_metadata"].get("release_name"),
+                    "album": {"name": track["track_metadata"].get("release_name")},
                     "name": track["track_metadata"].get("track_name"),
                     "artist": {"name": track["track_metadata"].get("artist_name")},
                     "mbid": mbid,

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -106,18 +106,17 @@ class ListenBrainzPlugin(BeetsPlugin):
     def get_tracks_from_listens(self, listens):
         tracks = []
         for track in listens:
-            #print(json.dumps(track, indent=4))
+            mbid_mapping = track["track_metadata"].get("mbid_mapping", {})
             tracks.append(
                 {
-                    "release_name": track["track_metadata"]["release_name"],
-                    "track_name": track["track_metadata"]["track_name"],
-                    "artist_name": track["track_metadata"]["artist_name"],
-                    "recording_mbid": track["track_metadata"]["mbid_mapping"]["recording_mbid"],
-                    "release_mbid": track["track_metadata"]["mbid_mapping"]["release_mbid"],
-                    "listened_at": track["listened_at"],
+                    "release_name": track["track_metadata"].get("release_name"),
+                    "track_name": track["track_metadata"].get("track_name"),
+                    "artist_name": track["track_metadata"].get("artist_name"),
+                    "recording_mbid": mbid_mapping.get("recording_mbid"),
+                    "release_mbid": mbid_mapping.get("release_mbid"),
+                    "listened_at": track.get("listened_at"),
                 }
             )
-            #self.lookup_metadata(tracks[-1])
         return tracks
 
     def lookup_metadata(self, track) -> dict:

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -36,7 +36,7 @@ class ListenBrainzPlugin(BeetsPlugin):
     def _lbupdate(self, items, write):
         """Obtain view count from Listenbrainz."""
         ls = self.get_listens()
-        tracks = self.get_tracks_from_listens(ls)
+        self.get_tracks_from_listens(ls)
         self._log.info(f"Found {len(ls)} listens")
 
     def _make_request(self, url, params=None):
@@ -100,9 +100,7 @@ class ListenBrainzPlugin(BeetsPlugin):
     def get_tracks_from_listens(self, listens):
         tracks = []
         for listen in listens:
-            track_metadata = listen.get('track_metadata')
-            if 'additional_info' in track_metadata:
-                self._log.debug("listen: {}".format(track_metadata))
+            self._log.debug("listen: %s", listen)
 
     def get_playlists_createdfor(self, username):
         """Returns a list of playlists created by a user."""

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -121,7 +121,7 @@ class ListenBrainzPlugin(BeetsPlugin):
                 {
                     "release_name": track["track_metadata"].get("release_name"),
                     "name": track["track_metadata"].get("track_name"),
-                    "artist": track["track_metadata"].get("artist_name"),
+                    "artist": {"name": track["track_metadata"].get("artist_name")},
                     "mbid": mbid_mapping.get("recording_mbid"),
                     "release_mbid": mbid_mapping.get("release_mbid"),
                     "listened_at": track.get("listened_at"),

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -119,7 +119,7 @@ class ListenBrainzPlugin(BeetsPlugin):
             if track["track_metadata"].get("release_name") is None:
                 continue
             mbid_mapping = track["track_metadata"].get("mbid_mapping", {})
-            print(json.dumps(track, indent=4, sort_keys=True))
+            #print(json.dumps(track, indent=4, sort_keys=True))
             if mbid_mapping.get("recording_mbid") is None:
                 # search for the track using title and release
                 mbid = self.get_mb_recording_id(track)

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -109,7 +109,7 @@ class ListenBrainzPlugin(BeetsPlugin):
                 "{0} - {1}, Release MBID: {2}, listened at {3}".format(
                     track["track_metadata"]["release_name"],
                     track["track_metadata"]["track_name"],
-                    track["track_metadata"].get("additional_info", {}),
+                    track["track_metadata"].get("additional_info"),
                     track["listened_at"],
                 )
             )

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -125,7 +125,7 @@ class ListenBrainzPlugin(BeetsPlugin):
                 mbid = self.get_mb_recording_id(track)
             tracks.append(
                 {
-                    "release_name": track["track_metadata"].get("release_name"),
+                    "album": track["track_metadata"].get("release_name"),
                     "name": track["track_metadata"].get("track_name"),
                     "artist": {"name": track["track_metadata"].get("artist_name")},
                     "mbid": mbid,

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -102,7 +102,7 @@ class ListenBrainzPlugin(BeetsPlugin):
         for listen in listens:
             track_metadata = listen.get('track_metadata')
             if 'additional_info' in track_metadata:
-                self._log.debug("listen: %s", track_metadata)
+                self._log.debug("listen: {}".format(track_metadata))
 
     def get_playlists_createdfor(self, username):
         """Returns a list of playlists created by a user."""

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -109,7 +109,7 @@ class ListenBrainzPlugin(BeetsPlugin):
                 "{0} - {1}, Release MBID: {2}, listened at {3}".format(
                     track["track_metadata"]["release_name"],
                     track["track_metadata"]["track_name"],
-                    track["track_metadata"]["additional_info"]["release_mbid"],
+                    track["track_metadata"]["additional_info"],
                     track["listened_at"],
                 )
             )

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -100,7 +100,7 @@ class ListenBrainzPlugin(BeetsPlugin):
     def get_tracks_from_listens(self, listens):
         tracks = []
         for listen in listens:
-            self._log.debug(f"listen: {listen}")
+            self._log.debug(f"listen: {listen.get('track_metadata')}")
         return self.get_track_info(tracks)
 
     def get_playlists_createdfor(self, username):

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -74,11 +74,15 @@ class ListenBrainzPlugin(BeetsPlugin):
             An IndexError if the JSON is not structured as expected.
         """
         url = f"{self.ROOT}/user/{self.username}/listens"
-        params = {k: v for k, v in {
-            "min_ts": min_ts,
-            "max_ts": max_ts,
-            "count": count,
-        }.items() if v is not None}
+        params = {
+            k: v
+            for k, v in {
+                "min_ts": min_ts,
+                "max_ts": max_ts,
+                "count": count,
+            }.items()
+            if v is not None
+        }
         response = self._make_request(url, params)
 
         if response is not None:
@@ -97,10 +101,15 @@ class ListenBrainzPlugin(BeetsPlugin):
         }
     ]
     """
+
     def get_tracks_from_listens(self, listens):
         tracks = []
-        for listen in listens:
-            self._log.debug(f"listen: {listen}")
+        for track in listens:
+            self._log.debug(
+                "Track: {0}, listened at {1}".format(
+                    track["track_metadata"]["track_name"], track["listened_at"]
+                )
+            )
 
     def get_playlists_createdfor(self, username):
         """Returns a list of playlists created by a user."""

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -109,7 +109,7 @@ class ListenBrainzPlugin(BeetsPlugin):
                 "{0} - {1}, Release MBID: {2}, listened at {3}".format(
                     track["track_metadata"]["release_name"],
                     track["track_metadata"]["track_name"],
-                    track["track_metadata"],
+                    track["track_metadata"]["release_mbid"],
                     track["listened_at"],
                 )
             )

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -116,6 +116,8 @@ class ListenBrainzPlugin(BeetsPlugin):
     def get_tracks_from_listens(self, listens):
         tracks = []
         for track in listens:
+            if track["track_metadata"].get("release_name") is None:
+                continue
             mbid_mapping = track["track_metadata"].get("mbid_mapping", {})
             tracks.append(
                 {

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -106,7 +106,7 @@ class ListenBrainzPlugin(BeetsPlugin):
     def get_tracks_from_listens(self, listens):
         tracks = []
         for track in listens:
-            #print(json.dumps(track, indent=4))
+            print(json.dumps(track, indent=4))
             tracks.append(
                 {
                     "release_name": track["track_metadata"]["release_name"],
@@ -115,7 +115,7 @@ class ListenBrainzPlugin(BeetsPlugin):
                     "listened_at": track["listened_at"],
                 }
             )
-            self.lookup_metadata(tracks[-1])
+            #self.lookup_metadata(tracks[-1])
         return tracks
 
     def lookup_metadata(self, track) -> dict:

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -106,8 +106,11 @@ class ListenBrainzPlugin(BeetsPlugin):
         tracks = []
         for track in listens:
             self._log.debug(
-                "Track: {0}; Release {1}, listened at {2}".format(
-                    track["track_metadata"]["track_name"], track["track_metadata"]["release_name"], track["listened_at"]
+                "{0} - {1}, Release MBID: {2}, listened at {3}".format(
+                    track["track_metadata"]["release_name"],
+                    track["track_metadata"]["track_name"],
+                    track["track_metadata"]["additional_info"]["release_mbid"],
+                    track["listened_at"],
                 )
             )
 

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -106,8 +106,8 @@ class ListenBrainzPlugin(BeetsPlugin):
         tracks = []
         for track in listens:
             self._log.debug(
-                "Track: {0}, listened at {1}".format(
-                    track["track_metadata"]["track_name"], track["track_metadata"]
+                "Track: {0}; Release {1}, listened at {2}".format(
+                    track["track_metadata"]["track_name"], track["track_metadata"]["release_name"], track["listened_at"]
                 )
             )
 

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -119,6 +119,7 @@ class ListenBrainzPlugin(BeetsPlugin):
             if track["track_metadata"].get("release_name") is None:
                 continue
             mbid_mapping = track["track_metadata"].get("mbid_mapping", {})
+            print(json.dumps(track, indent=4, sort_keys=True))
             tracks.append(
                 {
                     "release_name": track["track_metadata"].get("release_name"),

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -100,7 +100,9 @@ class ListenBrainzPlugin(BeetsPlugin):
     def get_tracks_from_listens(self, listens):
         tracks = []
         for listen in listens:
-            self._log.debug(f"listen: {listen.get('track_metadata')}")
+            track_metadata = listen.get('track_metadata')
+            if 'additional_info' in track_metadata:
+                self._log.debug(f"listen: {track_metadata}")
 
     def get_playlists_createdfor(self, username):
         """Returns a list of playlists created by a user."""

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -122,24 +122,31 @@ class ListenBrainzPlugin(BeetsPlugin):
             print(json.dumps(track, indent=4, sort_keys=True))
             if mbid_mapping.get("recording_mbid") is None:
                 # search for the track using title and release
-                resp = musicbrainzngs.search_recordings(
-                    query=track["track_metadata"].get("track_name"),
-                    release=track["track_metadata"].get("release_name"),
-                    artist=track["track_metadata"].get("artist_name"),
-                )
-                print(json.dumps(resp, indent=4, sort_keys=True))
+                mbid = self.get_mb_recording_id(track)
             tracks.append(
                 {
                     "release_name": track["track_metadata"].get("release_name"),
                     "name": track["track_metadata"].get("track_name"),
                     "artist": {"name": track["track_metadata"].get("artist_name")},
-                    "mbid": mbid_mapping.get("recording_mbid"),
+                    "mbid": mbid,
                     "release_mbid": mbid_mapping.get("release_mbid"),
                     "listened_at": track.get("listened_at"),
                 }
             )
         return tracks
 
+    def get_mb_recording_id(self, track):
+        """Returns the MusicBrainz recording ID for a track."""
+        resp = musicbrainzngs.search_recordings(
+                    query=track["track_metadata"].get("track_name"),
+                    release=track["track_metadata"].get("release_name"),
+                    strict=True
+                )
+        if resp.get("recording-count") == "1":
+            return resp.get("recording-list")[0].get("id")
+        else:
+            self._log.debug(f"Invalid Search Error: {resp}")
+            return None
 
     def get_playlists_createdfor(self, username):
         """Returns a list of playlists created by a user."""

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -145,7 +145,6 @@ class ListenBrainzPlugin(BeetsPlugin):
         if resp.get("recording-count") == "1":
             return resp.get("recording-list")[0].get("id")
         else:
-            self._log.debug(f"Invalid Search Error: {resp}")
             return None
 
     def get_playlists_createdfor(self, username):

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -119,7 +119,10 @@ class ListenBrainzPlugin(BeetsPlugin):
     def lookup_metadata(self, track) -> dict:
         """Looks up the metadata for a listen using track name and artist name."""
 
-        params = {"recording_name": track.track_name, "artist_name": track.artist_name}
+        params = {
+            "recording_name": track["track_name"],
+            "artist_name": track["artist_name"],
+        }
         url = f"{self.ROOT}/metadata/lookup/"
         response = self._make_request(url, params)
         return response.json()

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,8 @@ Major new features:
 
 New features:
 
+* :doc:`/plugins/listenbrainz`: Add initial support for importing history and playlists from `ListenBrainz`
+  :bug:`1719`
 * :doc:`plugins/mbsubmit`: add new prompt choices helping further to submit unmatched tracks to MusicBrainz faster.
 * :doc:`plugins/spotify`: We now fetch track's ISRC, EAN, and UPC identifiers from Spotify when using the ``spotifysync`` command.
   :bug:`4992`


### PR DESCRIPTION
## Description

Fixes #1719

I added a basic version of the LB plugin that imports the play history. It uses the same process used in the Lastimport plugin to update playcounts. 

There are few additional functions that I added here to import playlists created by Listenbrainz. These playlists can then be imported in other programs such as Plex. 

## To Do


- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
