### PR TITLE
advancedrewrite: Fix multi-valued fields specified as a single string

### DIFF
--- a/beetsplug/advancedrewrite.py
+++ b/beetsplug/advancedrewrite.py
@@ -161,7 +161,7 @@ class AdvancedRewritePlugin(BeetsPlugin):
                             )
                     elif isinstance(replacement, str):
                         if Item._fields[fieldname] is MULTI_VALUE_DSV:
-                            replacement = list(replacement)
+                            replacement = [replacement]
                     else:
                         raise UserError(
                             f"Invalid type of replacement {replacement} "


### PR DESCRIPTION
Unfortunately, I mistakenly assumed that `list()` was equivalent to `[]`. However, this transforms a rewrite `Value` into `['V', 'a', 'l', 'u', 'e']` instead of `['Value']` as it was intended.