### PR TITLE
build: remove version pin for Sphinx

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
 [testenv:docs]
 basepython = python3.10
 deps =
-    sphinx<4.4.0
+    sphinx>=5
     pydata_sphinx_theme
 commands = sphinx-build -W -q -b html docs {envtmpdir}/html {posargs}
 


### PR DESCRIPTION
In cf69cad56f6 the Sphinx version was pinned to "<4.4.0".

The issue at that time (a spurious warning) is described in:
  https://github.com/sphinx-doc/sphinx/issues/10112

The problematic check was removed in Sphinx v4.5:
  https://www.sphinx-doc.org/en/master/changes.html#id334

The issue of spurious warnings was fixed in v5.x:
  https://github.com/sphinx-doc/sphinx/pull/10137

Technically it would be suitable to add negative version pin of Sphinx for "4.4".
But that version is quite outdated and at least Debian never shipped Sphinx v4.4 in a stable release.

This change fixes the current CI build failure, which is caused by an incompatibility of `sphinxcontrib-applehelp` with the older version of Sphinx.