### PR TITLE
Fixes zsh completion dependency on specific awk/sed/sqlite3 versions and settings

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -281,6 +281,10 @@ Bug fixes:
   displayed unless the detail configuration is enabled.
 * :doc:`/plugins/web`: Fix range request support, allowing to play large audio/
   opus files using e.g. a browser/firefox or gstreamer/mopidy directly.
+* Fix bug where `zsh` completion script made assumptions about the specific
+  variant of `awk` installed and required specific settings for `sqlite3`
+  and caching in `zsh`.
+  :bug:`3546`
 
 For plugin developers:
 

--- a/extra/_beet
+++ b/extra/_beet
@@ -8,7 +8,8 @@ local BEETS_LIBRARY=~/.config/beets/library.db
 local BEETS_CONFIG=~/.config/beets/config.yaml
 # Use separate caches for file locations, command completions, and query completions.
 # This allows the use of different rules for when to update each one.
-zstyle ":completion:${curcontext}:" cache-policy _beet_check_cache
+zstyle ":completion:${curcontext%:*}:*" cache-policy _beet_check_cache
+zstyle ":completion:${curcontext%:*}:*" use-cache true
 _beet_check_cache () {
     local cachefile="$(basename ${1})"
     if [[ ! -a "${1}" ]] || [[ "${1}" -ot =beet ]]; then
@@ -51,7 +52,7 @@ if ! _retrieve_cache beetscmds || _cache_invalid beetscmds; then
     # Useful function for joining grouped lines of output into single lines (taken from _completion_helpers)
     _join_lines() {
 	awk -v SEP="$1" -v ARG2="$2" -v START="$3" -v END2="$4" 'BEGIN {if(START==""){f=1}{f=0};
-         if(ARG2 ~ "^[0-9]+"){LINE1 = "^[[:space:]]{,"ARG2"}[^[:space:]]"}else{LINE1 = ARG2}}
+         if(ARG2 ~ "^[0-9]+"){LINE1 = "^[[:space:]]{0,"ARG2"}[^[:space:]]"}else{LINE1 = ARG2}}
          ($0 ~ END2 && f>0 && END2!="") {exit}
          ($0 ~ START && f<1) {f=1; if(length(START)!=0){next}}
          ($0 ~ LINE1 && f>0) {if(f<2){f=2; printf("%s",$0)}else{printf("\n%s",$0)}; next}
@@ -109,7 +110,7 @@ _beet_field_values() {
 	    if [[ "$(sqlite3 ${~BEETS_LIBRARY} ${sqlcmd} 2>&1)" =~ "no such column" ]]; then
 		sqlcmd="select distinct value from item_attributes where key=='$1' and value!='';"
 	    fi
-	    output="$(sqlite3 ${~BEETS_LIBRARY} ${sqlcmd} 2>/dev/null | sed -rn '/^-+$/,${{/^[- ]+$/n};p}')"
+	    output="$(sqlite3 -list -noheader ${~BEETS_LIBRARY} ${sqlcmd} 2>/dev/null)"
             fieldvals=("${(f)output[@]}")
             ;;
     esac


### PR DESCRIPTION
## Description

The `zsh` completion script for the `beet` command is more portable now:

- avoids the `mawk`-specific `{,n}` regex operator
- a directly usable `sqlite3` output format is selected explicitly, when retrieving suggestions for field values; this avoids the previously used GNU-`sed`-specific post-processing of the `sqlite3` output
- `zsh` completion caching is enabled for the `beet` command and its parameter contexts, even if not enabled globally by the user; caching is required for field value suggestions

Fixes #3546.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation~. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] ~Tests~. (Very much encouraged but not strictly required.)
