### PR TITLE
lyrics: Fallback to plain lyrics if synced lyrics not available

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -277,7 +277,7 @@ class LRCLib(Backend):
             return None
 
         if self.config["synced"]:
-            return data.get("syncedLyrics")
+            return data.get("syncedLyrics") or data.get("plainLyrics")
 
         return data.get("plainLyrics")
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,10 @@ Unreleased
 
 New features:
 Bug fixes:
+
+* :doc:`plugins/lyrics`: LRCLib will fallback to plain lyrics if synced lyrics
+  are not found and `synced` flag is set to `yes`.
+
 For packagers:
 Other changes:
 

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -620,12 +620,26 @@ class LRCLibLyricsTest(unittest.TestCase):
         mock_get.return_value.json.return_value = mock_response
         mock_get.return_value.status_code = 200
 
+        self.plugin.config["synced"] = False
         lyrics = lrclib.fetch("la", "la", "la", 999)
         assert lyrics == mock_response["plainLyrics"]
 
         self.plugin.config["synced"] = True
         lyrics = lrclib.fetch("la", "la", "la", 999)
         assert lyrics == mock_response["syncedLyrics"]
+
+    @patch("beetsplug.lyrics.requests.get")
+    def test_fetch_synced_lyrics_fallback(self, mock_get):
+        mock_response = {
+            "syncedLyrics": "",
+            "plainLyrics": "la la la",
+        }
+        mock_get.return_value.json.return_value = mock_response
+        mock_get.return_value.status_code = 200
+
+        self.plugin.config["synced"] = True
+        lyrics = lrclib.fetch("la", "la", "la", 999)
+        assert lyrics == mock_response["plainLyrics"]
 
     @patch("beetsplug.lyrics.requests.get")
     def test_fetch_plain_lyrics(self, mock_get):
@@ -636,6 +650,7 @@ class LRCLibLyricsTest(unittest.TestCase):
         mock_get.return_value.json.return_value = mock_response
         mock_get.return_value.status_code = 200
 
+        self.plugin.config["synced"] = False
         lyrics = lrclib.fetch("la", "la", "la", 999)
 
         assert lyrics == mock_response["plainLyrics"]


### PR DESCRIPTION
## Description

The `synced` config flag was not working the way the docs described it for the LRCLIB source. With `synced: yes`, if a track does not have synced lyrics, but does have plain lyrics, the plugin would return no lyrics. The docs imply that, with the flag enabled, it would still use plain lyrics if there are no synced lyrics.

LRCLIB API call that returns plain lyrics can be found [here](https://lrclib.net/api/get?artist_name=Hania%20Rani&track_name=Moans&album_name=Ghosts&duration=274).

## To Do

- [x] ~Documentation~
- [x] Changelog
- [x] Tests
