### PR TITLE
Remove unused functions

### DIFF
--- a/beets/util/functemplate.py
+++ b/beets/util/functemplate.py
@@ -58,11 +58,6 @@ class Environment:
 # Code generation helpers.
 
 
-def ex_lvalue(name):
-    """A variable load expression."""
-    return ast.Name(name, ast.Store())
-
-
 def ex_rvalue(name):
     """A variable store expression."""
     return ast.Name(name, ast.Load())
@@ -73,15 +68,6 @@ def ex_literal(val):
     value.
     """
     return ast.Constant(val)
-
-
-def ex_varassign(name, expr):
-    """Assign an expression into a single variable. The expression may
-    either be an `ast.expr` object or a value to be used as a literal.
-    """
-    if not isinstance(expr, ast.expr):
-        expr = ex_literal(expr)
-    return ast.Assign([ex_lvalue(name)], expr)
 
 
 def ex_call(func, args):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -285,6 +285,7 @@ Bug fixes:
   variant of `awk` installed and required specific settings for `sqlite3`
   and caching in `zsh`.
   :bug:`3546`
+* Remove unused functions :bug:`5103`
 
 For plugin developers:
 


### PR DESCRIPTION
## Description

Remove unused functions. Fixes #5103.

The function `ex_varassign` is never called. The function `ex_lvalue` is only called by `ex_varassign`.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
