### PR TITLE
smartplaylist: allow exporting item fields, rename m3u8 output to extm3u

### DIFF
--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -121,7 +121,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
         spl_update.parser.add_option(
             "--output",
             type="string",
-            help="specify the playlist format: m3u|m3u8.",
+            help="specify the playlist format: m3u|extm3u.",
         )
         spl_update.func = self.update_cmd
         return [spl_update]
@@ -313,20 +313,20 @@ class SmartPlaylistPlugin(BeetsPlugin):
                 )
                 mkdirall(m3u_path)
                 pl_format = self.config["output"].get()
-                if pl_format != "m3u" and pl_format != "m3u8":
+                if pl_format != "m3u" and pl_format != "extm3u":
                     msg = "Unsupported output format '{}' provided! "
-                    msg += "Supported: m3u, m3u8"
+                    msg += "Supported: m3u, extm3u"
                     raise Exception(msg.format(pl_format))
-                m3u8 = pl_format == "m3u8"
+                extm3u = pl_format == "extm3u"
                 with open(syspath(m3u_path), "wb") as f:
                     keys = []
-                    if m3u8:
+                    if extm3u:
                         keys = self.config["fields"].get(list)
                         f.write(b"#EXTM3U\n")
                     for entry in m3us[m3u]:
                         item = entry.item
                         comment = ""
-                        if m3u8:
+                        if extm3u:
                             attr = [(k, entry.item[k]) for k in keys]
                             al = [
                                 f" {a[0]}={json.dumps(str(a[1]))}" for a in attr

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -160,6 +160,7 @@ New features:
   like the other lossless formats.
 * Add support for `barcode` field.
   :bug:`3172`
+* :doc:`/plugins/smartplaylist`: Add new config option `smartplaylist.fields`.
 
 Bug fixes:
 

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -313,6 +313,9 @@ Interoperability
    Automatically notifies `Subsonic`_ whenever the beets
    library changes.
 
+`webm3u`_
+   Serves the (:doc:`smartplaylist <smartplaylist>` plugin generated) M3U
+   playlists via HTTP.
 
 .. _AURA: https://auraspec.readthedocs.io
 .. _Emby: https://emby.media
@@ -321,6 +324,7 @@ Interoperability
 .. _Kodi: https://kodi.tv
 .. _Sonos: https://sonos.com
 .. _Subsonic: http://www.subsonic.org/
+.. _webm3u: https://github.com/mgoltzsche/beets-webm3u
 
 Miscellaneous
 -------------

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -313,9 +313,6 @@ Interoperability
    Automatically notifies `Subsonic`_ whenever the beets
    library changes.
 
-`webm3u`_
-   Serves the (:doc:`smartplaylist <smartplaylist>` plugin generated) M3U
-   playlists via HTTP.
 
 .. _AURA: https://auraspec.readthedocs.io
 .. _Emby: https://emby.media
@@ -324,7 +321,6 @@ Interoperability
 .. _Kodi: https://kodi.tv
 .. _Sonos: https://sonos.com
 .. _Subsonic: http://www.subsonic.org/
-.. _webm3u: https://github.com/mgoltzsche/beets-webm3u
 
 Miscellaneous
 -------------
@@ -438,7 +434,9 @@ Here are a few of the plugins written by the beets community:
    Enables **bandcamp.com** autotagger with a fairly extensive amount of metadata.
 
 `beetstream`_
-   Is server implementation of the `SubSonic API`_ specification, allowing you to stream your music on a multitude of clients.
+   Server implementation of the `Subsonic API`_ specification, serving the
+   beets library and (:doc:`smartplaylist <smartplaylist>` plugin generated)
+   M3U playlists, allowing you to stream your music on a multitude of clients.
 
 `beets-bpmanalyser`_
    Analyses songs and calculates their tempo (BPM).
@@ -512,6 +510,15 @@ Here are a few of the plugins written by the beets community:
 `beets-usertag`_
    Lets you use keywords to tag and organize your music.
 
+`beets-webm3u`_
+   Serves the (:doc:`smartplaylist <smartplaylist>` plugin generated) M3U
+   playlists via HTTP.
+
+`beets-webrouter`_
+   Serves multiple beets webapps (e.g. :doc:`web <web>`, `beets-webm3u`_,
+   `beetstream`_, :doc:`aura <aura>`) using a single command/process/host/port,
+   each under a different path.
+
 `whatlastgenre`_
    Fetches genres from various music sites.
 
@@ -533,7 +540,7 @@ Here are a few of the plugins written by the beets community:
 .. _beets-barcode: https://github.com/8h2a/beets-barcode
 .. _beetcamp: https://github.com/snejus/beetcamp
 .. _beetstream: https://github.com/BinaryBrain/Beetstream
-.. _SubSonic API: http://www.subsonic.org/pages/api.jsp
+.. _Subsonic API: http://www.subsonic.org/pages/api.jsp
 .. _beets-check: https://github.com/geigerzaehler/beets-check
 .. _beets-copyartifacts: https://github.com/adammillerio/beets-copyartifacts
 .. _dsedivec: https://github.com/dsedivec/beets-plugins
@@ -572,3 +579,5 @@ Here are a few of the plugins written by the beets community:
 .. _beets-audible: https://github.com/Neurrone/beets-audible
 .. _beets-more: https://forgejo.sny.sh/sun/beetsplug/src/branch/main/more
 .. _beets-mpd-utils: https://github.com/thekakkun/beets-mpd-utils
+.. _beets-webm3u: https://github.com/mgoltzsche/beets-webm3u
+.. _beets-webrouter: https://github.com/mgoltzsche/beets-webrouter

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -422,6 +422,10 @@ Here are a few of the plugins written by the beets community:
 `beets-autofix`_
    Automates repetitive tasks to keep your library in order.
 
+`beets-autogenre`_
+   Assigns genres to your library items using the :doc:`lastgenre <lastgenre>`
+   and `beets-xtractor`_ plugins as well as additional rules.
+
 `beets-audible`_
    Adds Audible as a tagger data source and provides
    other features for managing audiobook collections.
@@ -581,3 +585,4 @@ Here are a few of the plugins written by the beets community:
 .. _beets-mpd-utils: https://github.com/thekakkun/beets-mpd-utils
 .. _beets-webm3u: https://github.com/mgoltzsche/beets-webm3u
 .. _beets-webrouter: https://github.com/mgoltzsche/beets-webrouter
+.. _beets-autogenre: https://github.com/mgoltzsche/beets-autogenre

--- a/docs/plugins/smartplaylist.rst
+++ b/docs/plugins/smartplaylist.rst
@@ -122,11 +122,11 @@ other configuration options are:
   playlist item URI, e.g. ``http://beets:8337/item/$id/file``.
   When this option is specified, the local path-related options ``prefix``,
   ``relative_to``, ``forward_slash`` and ``urlencode`` are ignored.
-- **output**: Specify the playlist format: m3u|m3u8. Default ``m3u``.
+- **output**: Specify the playlist format: m3u|extm3u. Default ``m3u``.
 - **fields**: Specify the names of the additional item fields to export into
   the playlist. This allows using e.g. the ``id`` field within other tools such
   as the `webm3u`_ plugin.
-  To use this option, you must set the ``output`` option to ``m3u8``.
+  To use this option, you must set the ``output`` option to ``extm3u``.
 
 .. _webm3u: https://github.com/mgoltzsche/beets-webm3u
 

--- a/docs/plugins/smartplaylist.rst
+++ b/docs/plugins/smartplaylist.rst
@@ -93,6 +93,38 @@ The ``pretend_paths`` configuration option sets whether the items should be
 displayed as per the user's ``format_item`` setting or what the file
 paths as they would be written to the m3u file look like.
 
+In case you want to export additional fields from the beets database into the
+generated playlists, you can do so by specifying them within the ``fields``
+configuration option and setting the ``output`` option to ``extm3u``.
+For instance the following configuration exports the ``id`` and ``genre``
+fields:
+
+    smartplaylist:
+        playlist_dir: /data/playlists
+        relative_to: /data/playlists
+        output: extm3u
+        fields:
+
+            - id
+            - genre
+
+        playlists:
+
+            - name: all.m3u
+              query: ''
+
+A resulting ``all.m3u`` file could look as follows:
+
+    #EXTM3U
+    #EXTINF:805 id="1931" genre="Jazz",Miles Davis - Autumn Leaves
+    ../music/Albums/Miles Davis/Autumn Leaves/02 Autumn Leaves.mp3
+
+To give a usage example, the `webm3u`_ and `Beetstream`_ plugins read the
+exported ``id`` field, allowing you to serve your local m3u playlists via HTTP.
+
+.. _Beetstream: https://github.com/BinaryBrain/Beetstream
+.. _webm3u: https://github.com/mgoltzsche/beets-webm3u
+
 Configuration
 -------------
 

--- a/docs/plugins/smartplaylist.rst
+++ b/docs/plugins/smartplaylist.rst
@@ -125,9 +125,10 @@ other configuration options are:
 - **output**: Specify the playlist format: m3u|extm3u. Default ``m3u``.
 - **fields**: Specify the names of the additional item fields to export into
   the playlist. This allows using e.g. the ``id`` field within other tools such
-  as the `webm3u`_ plugin.
+  as the `webm3u`_ and `Beetstream`_ plugins.
   To use this option, you must set the ``output`` option to ``extm3u``.
 
+.. _Beetstream: https://github.com/BinaryBrain/Beetstream
 .. _webm3u: https://github.com/mgoltzsche/beets-webm3u
 
 For many configuration options, there is a corresponding CLI option, e.g.

--- a/docs/plugins/smartplaylist.rst
+++ b/docs/plugins/smartplaylist.rst
@@ -123,6 +123,12 @@ other configuration options are:
   When this option is specified, the local path-related options ``prefix``,
   ``relative_to``, ``forward_slash`` and ``urlencode`` are ignored.
 - **output**: Specify the playlist format: m3u|m3u8. Default ``m3u``.
+- **fields**: Specify the names of the additional item fields to export into
+  the playlist. This allows using e.g. the ``id`` field within other tools such
+  as the `webm3u`_ plugin.
+  To use this option, you must set the ``output`` option to ``m3u8``.
+
+.. _webm3u: https://github.com/mgoltzsche/beets-webm3u
 
 For many configuration options, there is a corresponding CLI option, e.g.
 ``--playlist-dir``, ``--relative-to``, ``--prefix``, ``--forward-slash``,

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -191,7 +191,7 @@ class SmartPlaylistTest(_common.TestCase):
 
         self.assertEqual(content, b"/tagada.mp3\n")
 
-    def test_playlist_update_output_m3u8(self):
+    def test_playlist_update_output_extm3u(self):
         spl = SmartPlaylistPlugin()
 
         i = MagicMock()
@@ -215,7 +215,7 @@ class SmartPlaylistTest(_common.TestCase):
         spl._matched_playlists = [pl]
 
         dir = bytestring_path(mkdtemp())
-        config["smartplaylist"]["output"] = "m3u8"
+        config["smartplaylist"]["output"] = "extm3u"
         config["smartplaylist"]["prefix"] = "http://beets:8337/files"
         config["smartplaylist"]["relative_to"] = False
         config["smartplaylist"]["playlist_dir"] = py3_path(dir)
@@ -241,7 +241,7 @@ class SmartPlaylistTest(_common.TestCase):
             + b"http://beets:8337/files/tagada.mp3\n",
         )
 
-    def test_playlist_update_output_m3u8_fields(self):
+    def test_playlist_update_output_extm3u_fields(self):
         spl = SmartPlaylistPlugin()
 
         i = MagicMock()
@@ -267,7 +267,7 @@ class SmartPlaylistTest(_common.TestCase):
         spl._matched_playlists = [pl]
 
         dir = bytestring_path(mkdtemp())
-        config["smartplaylist"]["output"] = "m3u8"
+        config["smartplaylist"]["output"] = "extm3u"
         config["smartplaylist"]["relative_to"] = False
         config["smartplaylist"]["playlist_dir"] = py3_path(dir)
         config["smartplaylist"]["fields"] = ["id", "genre"]


### PR DESCRIPTION
## Description

Allow generating extm3u playlists so that they contain additional item fields such as the `id`.
    
The feature is required by the [webm3u plugin](https://github.com/mgoltzsche/beets-webm3u) (M3U server) to transform playlists using a request based item URI template which may require additional fields such as the `id`, e.g. `beets:library:track;$id`.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
