### PR TITLE
convert: Correctly identify WAVE format as lossless

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -40,7 +40,7 @@ ALIASES = {
     "vorbis": "ogg",
 }
 
-LOSSLESS_FORMATS = ["ape", "flac", "alac", "wav", "aiff"]
+LOSSLESS_FORMATS = ["ape", "flac", "alac", "wave", "aiff"]
 
 
 def replace_ext(path, ext):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -153,6 +153,9 @@ New features:
 * :doc:`/plugins/smartplaylist`: Add new option `smartplaylist.uri_format`.
 * Sorted the default configuration file into categories.
   :bug:`4987`
+* :doc:`/plugins/convert`: Don't treat WAVE (`.wav`) files as lossy anymore
+  when using the `never_convert_lossy_files` option. They will get transcoded
+  like the other lossless formats.
 
 Bug fixes:
 


### PR DESCRIPTION
## Description

I've noticed that `beet convert` with the `never_convert_lossy_files: yes` just copies `.wav` files instead of converting them. This fixes that. (see commit message for details)