### PR TITLE
Use shutil.move() to move files.

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -533,8 +533,13 @@ def move(path: bytes, dest: bytes, replace: bool = False):
         finally:
             tmp.close()
 
-        # Copy file metadata
-        shutil.copystat(syspath(path), tmp.name)
+        try:
+            # Copy file metadata
+            shutil.copystat(syspath(path), tmp.name)
+        except OSError:
+            # Ignore errors because it doesn't matter too much.  We may be on a
+            # filesystem that doesn't support this.
+            pass
 
         # Move the copied file into place.
         try:

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -503,10 +503,7 @@ def copy(path: bytes, dest: bytes, replace: bool = False):
 def move(path: bytes, dest: bytes, replace: bool = False):
     """Rename a file. `dest` may not be a directory. If `dest` already
     exists, raises an OSError unless `replace` is True. Has no effect if
-    `path` is the same as `dest`. If the paths are on different
-    filesystems (or the rename otherwise fails), a copy is attempted
-    instead, in which case metadata will *not* be preserved. Paths are
-    translated to system paths.
+    `path` is the same as `dest`. Paths are translated to system paths.
     """
     if os.path.isdir(syspath(path)):
         raise FilesystemError("source is directory", "move", (path, dest))
@@ -535,6 +532,9 @@ def move(path: bytes, dest: bytes, replace: bool = False):
                 shutil.copyfileobj(f, tmp)
         finally:
             tmp.close()
+
+        # Copy file metadata
+        shutil.copystat(syspath(path), tmp.name)
 
         # Move the copied file into place.
         try:


### PR DESCRIPTION
## Description

Fixes #4622.

I don't think this changes other behavior of the function, but it fixes the problem with the moved files being created with the wrong permissions for me.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (Changed the docstring)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
