### PR TITLE
Pin formatters version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,12 @@
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 24.2.0
     hooks:
       - id: black
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python)

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -122,8 +122,7 @@ class NamedQuery(Query):
     """
 
     @abstractmethod
-    def __init__(self, pattern):
-        ...
+    def __init__(self, pattern): ...
 
 
 P = TypeVar("P")

--- a/beets/dbcore/types.py
+++ b/beets/dbcore/types.py
@@ -35,8 +35,7 @@ if TYPE_CHECKING and sys.version_info >= (3, 8):
         given type.
         """
 
-        def __init__(self, value: Any = None):
-            ...
+        def __init__(self, value: Any = None): ...
 
 else:
     # No structural subtyping in Python < 3.8...

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -216,12 +216,14 @@ def get_singleton_disambig_fields(info: hooks.TrackInfo) -> Sequence[str]:
     calculated_values = {
         "index": "Index {}".format(str(info.index)),
         "track_alt": "Track {}".format(info.track_alt),
-        "album": "[{}]".format(info.album)
-        if (
-            config["import"]["singleton_album_disambig"].get()
-            and info.get("album")
-        )
-        else "",
+        "album": (
+            "[{}]".format(info.album)
+            if (
+                config["import"]["singleton_album_disambig"].get()
+                and info.get("album")
+            )
+            else ""
+        ),
     }
 
     for field in chosen_fields:
@@ -240,9 +242,11 @@ def get_album_disambig_fields(info: hooks.AlbumInfo) -> Sequence[str]:
     out = []
     chosen_fields = config["match"]["album_disambig_fields"].as_str_seq()
     calculated_values = {
-        "media": "{}x{}".format(info.mediums, info.media)
-        if (info.mediums and info.mediums > 1)
-        else info.media,
+        "media": (
+            "{}x{}".format(info.mediums, info.media)
+            if (info.mediums and info.mediums > 1)
+            else info.media
+        ),
     }
 
     for field in chosen_fields:
@@ -1160,9 +1164,11 @@ class TerminalImportSession(importer.ImportSession):
                 print_(
                     "Old: "
                     + summarize_items(
-                        list(duplicate.items())
-                        if task.is_album
-                        else [duplicate],
+                        (
+                            list(duplicate.items())
+                            if task.is_album
+                            else [duplicate]
+                        ),
                         not task.is_album,
                     )
                 )

--- a/beetsplug/export.py
+++ b/beetsplug/export.py
@@ -74,7 +74,7 @@ class ExportPlugin(BeetsPlugin):
                 "xml": {
                     # XML module formatting options.
                     "formatting": {}
-                }
+                },
                 # TODO: Use something like the edit plugin
                 # 'item_fields': []
             }

--- a/beetsplug/permissions.py
+++ b/beetsplug/permissions.py
@@ -5,6 +5,7 @@ like the following in your config.yaml to configure:
             file: 644
             dir: 755
 """
+
 import os
 import stat
 

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -819,9 +819,9 @@ class GStreamerBackend(Backend):
         self._files = [i.path for i in items]
 
         # FIXME: Turn this into DefaultDict[bytes, Gain]
-        self._file_tags: DefaultDict[
-            bytes, Dict[str, float]
-        ] = collections.defaultdict(dict)
+        self._file_tags: DefaultDict[bytes, Dict[str, float]] = (
+            collections.defaultdict(dict)
+        )
 
         self._rg.set_property("reference-level", target_level)
 
@@ -930,9 +930,9 @@ class GStreamerBackend(Backend):
                     tag
                 )[1]
             elif tag == self.Gst.TAG_REFERENCE_LEVEL:
-                self._file_tags[self._file][
-                    "REFERENCE_LEVEL"
-                ] = taglist.get_double(tag)[1]
+                self._file_tags[self._file]["REFERENCE_LEVEL"] = (
+                    taglist.get_double(tag)[1]
+                )
 
         tags.foreach(handle_tag, None)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,8 +27,9 @@ ignore =
     C901,
     # Exception subclasses should be named with an Error suffix
     N818,
-    # Exclude rule for black compatibility
+    # Exclude rules for black compatibility
     E203,
+    E704,
 per-file-ignores =
     ./beet:D
     ./docs/conf.py:D

--- a/test/plugins/test_ihate.py
+++ b/test/plugins/test_ihate.py
@@ -1,6 +1,5 @@
 """Tests for the 'ihate' plugin"""
 
-
 import unittest
 
 from beets import importer

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -89,12 +89,16 @@ class LyricsPluginTest(unittest.TestCase):
             ("CHVRCHΞS", ["song"]), list(lyrics.search_pairs(item))[0]
         )
 
-        item = Item(artist="横山克", title="song", artist_sort="Masaru Yokoyama")
+        item = Item(
+            artist="横山克", title="song", artist_sort="Masaru Yokoyama"
+        )
         self.assertIn(("横山克", ["song"]), lyrics.search_pairs(item))
         self.assertIn(("Masaru Yokoyama", ["song"]), lyrics.search_pairs(item))
 
         # Make sure that the original artist name is still the first entry
-        self.assertEqual(("横山克", ["song"]), list(lyrics.search_pairs(item))[0])
+        self.assertEqual(
+            ("横山克", ["song"]), list(lyrics.search_pairs(item))[0]
+        )
 
     def test_search_pairs_multi_titles(self):
         item = Item(title="1 / 2", artist="A")

--- a/test/plugins/test_spotify.py
+++ b/test/plugins/test_spotify.py
@@ -1,6 +1,5 @@
 """Tests for the 'spotify' plugin"""
 
-
 import os
 import unittest
 from urllib.parse import parse_qs, urlparse

--- a/test/plugins/test_subsonicupdate.py
+++ b/test/plugins/test_subsonicupdate.py
@@ -1,6 +1,5 @@
 """Tests for the 'subsonic' plugin."""
 
-
 import unittest
 from urllib.parse import parse_qs, urlparse
 

--- a/test/plugins/test_the.py
+++ b/test/plugins/test_the.py
@@ -1,6 +1,5 @@
 """Tests for the 'the' plugin"""
 
-
 import unittest
 
 from beets import config

--- a/test/plugins/test_web.py
+++ b/test/plugins/test_web.py
@@ -1,6 +1,5 @@
 """Tests for the 'web' plugin"""
 
-
 import json
 import os.path
 import platform

--- a/test/plugins/test_zero.py
+++ b/test/plugins/test_zero.py
@@ -1,6 +1,5 @@
 """Tests for the 'zero' plugin"""
 
-
 import unittest
 
 from mediafile import MediaFile

--- a/test/test_metasync.py
+++ b/test/test_metasync.py
@@ -71,12 +71,12 @@ class MetaSyncTest(_common.TestCase, TestHelper):
         items[1].album = "An Awesome Wave"
 
         if _is_windows():
-            items[
-                0
-            ].path = "G:\\Music\\Alt-J\\An Awesome Wave\\03 Tessellate.mp3"
-            items[
-                1
-            ].path = "G:\\Music\\Alt-J\\An Awesome Wave\\04 Breezeblocks.mp3"
+            items[0].path = (
+                "G:\\Music\\Alt-J\\An Awesome Wave\\03 Tessellate.mp3"
+            )
+            items[1].path = (
+                "G:\\Music\\Alt-J\\An Awesome Wave\\04 Breezeblocks.mp3"
+            )
         else:
             items[0].path = "/Music/Alt-J/An Awesome Wave/03 Tessellate.mp3"
             items[1].path = "/Music/Alt-J/An Awesome Wave/04 Breezeblocks.mp3"

--- a/tox.ini
+++ b/tox.ini
@@ -52,8 +52,8 @@ commands = python -bb -m pytest {posargs}
 
 [testenv:format]
 deps =
-    isort
-    black
+    isort==5.13.2
+    black==24.2.0
 skip_install = True
 commands =
     isort beets beetsplug test
@@ -61,8 +61,8 @@ commands =
 
 [testenv:format_check]
 deps =
-    isort
-    black
+    isort==5.13.2
+    black==24.2.0
 skip_install = True
 commands =
     isort beets beetsplug test --check


### PR DESCRIPTION
Recent commits have been showing the formatting action failing due to black and isort not being pinned to a specific version in the tox. Changes to the tool were causing additional formatting to be applied to a small subset of files that the PRs hadn't actually touched. This PR pins the versions in the tox files to the current versions while also applying the few changes that have occurred.

In the future, upgrading the formatters will be done in a PR process, explicitly, to catch this kind of change.