### PR TITLE
Fix Media Headers on Import

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -596,7 +596,7 @@ def album_info(release: Dict) -> beets.autotag.hooks.AlbumInfo:
     # Media (format).
     if release["medium-list"]:
         # If all media are the same, use that medium name
-        if len(set([x.get("format") for x in release["medium-list"]])) == 1:
+        if len(set([m.get("format") for m in release["medium-list"]])) == 1:
             info.media = release["medium-list"][0].get("format")
         # Otherwise, let's just call it "Media"
         else:

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -595,8 +595,12 @@ def album_info(release: Dict) -> beets.autotag.hooks.AlbumInfo:
 
     # Media (format).
     if release["medium-list"]:
-        first_medium = release["medium-list"][0]
-        info.media = first_medium.get("format")
+        # If all media are the same, use that medium name
+        if len(set([x.get("format") for x in release["medium-list"]])) == 1:
+            info.media = release["medium-list"][0].get("format")
+        # Otherwise, let's just call it "Media"
+        else:
+            info.media = "Media"
 
     if config["musicbrainz"]["genres"]:
         sources = [

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -453,14 +453,14 @@ class ChangeRepresentation(object):
 
     def make_medium_info_line(self, track_info):
         """Construct a line with the current medium's info."""
-        media = self.match.info.media or "Media"
+        track_media = track_info.get("media", "Media")
         # Build output string.
         if self.match.info.mediums > 1 and track_info.disctitle:
-            return f"* {media} {track_info.medium}: {track_info.disctitle}"
+            return f"* {track_media} {track_info.medium}: {track_info.disctitle}"
         elif self.match.info.mediums > 1:
-            return f"* {media} {track_info.medium}"
+            return f"* {track_media} {track_info.medium}"
         elif track_info.disctitle:
-            return f"* {media}: {track_info.disctitle}"
+            return f"* {track_media}: {track_info.disctitle}"
         else:
             return ""
 

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -456,7 +456,9 @@ class ChangeRepresentation(object):
         track_media = track_info.get("media", "Media")
         # Build output string.
         if self.match.info.mediums > 1 and track_info.disctitle:
-            return f"* {track_media} {track_info.medium}: {track_info.disctitle}"
+            return (
+                f"* {track_media} {track_info.medium}: {track_info.disctitle}"
+            )
         elif self.match.info.mediums > 1:
             return f"* {track_media} {track_info.medium}"
         elif track_info.disctitle:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -292,6 +292,8 @@ Bug fixes:
   and caching in `zsh`.
   :bug:`3546`
 * Remove unused functions :bug:`5103`
+* Fix bug where all media types are reported as the first media type
+  :bug:`5134`
 
 For plugin developers:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -292,8 +292,9 @@ Bug fixes:
   and caching in `zsh`.
   :bug:`3546`
 * Remove unused functions :bug:`5103`
-* Fix bug where all media types are reported as the first media type
-  :bug:`5134`
+* Fix bug where all media types are reported as the first media type when
+  importing with MusicBrainz as the data source
+  :bug:`4947`
 
 For plugin developers:
 


### PR DESCRIPTION
## Description

Fixes when you import a release with mixed media, the importer just shows the first medium for every medium.
https://github.com/beetbox/beets/issues/4947

Is this the best fix? Any ideas for improving the format?

## Behavior
### Before 

```
$ beet imp .

/Volumes/Music/ti/hh/Four (14 items)

  Match (97.7%):
  Hampton Hawes with Barney Kessel, Shelly Manne & Red Mitchell - Four!
  ≠ media, year
  MusicBrainz, 2xHybrid SACD (CD layer), 2023, US, Contemporary Records, CR00501, Contemporary Records Acoustic Sounds Series
  https://musicbrainz.org/release/03f118d7-99bb-4daa-ad58-ab86d5325398
  * Artist: Hampton Hawes with Barney Kessel, Shelly Manne & Red Mitchell
  * Album: Four!
  * Hybrid SACD (CD layer) 1
     ≠ (#2-1) Yardbird Suite (6:43) -> (#1-1) Yardbird Suite (6:40)
     ≠ (#2-2) There Will Never Be Another You (7:02) -> (#1-2) There Will Never Be Another You (6:59)
     ≠ (#2-3) Bow Jest (6:33) -> (#1-3) Bow Jest (6:30)
     ≠ (#2-4) Sweet Sue (5:37) -> (#1-4) Sweet Sue (5:36)
     ≠ (#2-5) Up Blues (5:11) -> (#1-5) Up Blues (5:10)
     ≠ (#2-6) Like Someone in Love (3:23) -> (#1-6) Like Someone in Love (3:21)
     ≠ (#2-7) Love Is Just Around the Corner (5:45) -> (#1-7) Love Is Just Around the Corner (5:43)
  * Hybrid SACD (CD layer) 2
     ≠ (#1-1) Yardbird Suite (6:43) -> (#2-1) Yardbird Suite (6:40)
     ≠ (#1-2) There Will Never Be Another You (7:02) -> (#2-2) There Will Never Be Another You (6:59)
     ≠ (#1-3) Bow Jest (6:33) -> (#2-3) Bow Jest (6:30)
     ≠ (#1-4) Sweet Sue (5:37) -> (#2-4) Sweet Sue (5:36)
     ≠ (#1-5) Up Blues (5:11) -> (#2-5) Up Blues (5:10)
     ≠ (#1-6) Like Someone in Love (3:23) -> (#2-6) Like Someone in Love (3:21)
     ≠ (#1-7) Love Is Just Around the Corner (5:45) -> (#2-7) Love Is Just Around the Corner (5:43)
➜ [A]pply, More candidates, Skip, Use as-is, as Tracks, Group albums,
Enter search, enter Id, aBort, eDit, edit Candidates?
```

### After

```
$ beet imp .

/Volumes/Music/ti/hh/Four (14 items)

  Match (97.7%):
  Hampton Hawes with Barney Kessel, Shelly Manne & Red Mitchell - Four!
  ≠ media, year
  MusicBrainz, 2xMedia, 2023, US, Contemporary Records, CR00501, Contemporary Records Acoustic Sounds Series
  https://musicbrainz.org/release/03f118d7-99bb-4daa-ad58-ab86d5325398
  * Artist: Hampton Hawes with Barney Kessel, Shelly Manne & Red Mitchell
  * Album: Four!
  * Hybrid SACD (CD layer) 1
     ≠ (#2-1) Yardbird Suite (6:43) -> (#1-1) Yardbird Suite (6:40)
     ≠ (#2-2) There Will Never Be Another You (7:02) -> (#1-2) There Will Never Be Another You (6:59)
     ≠ (#2-3) Bow Jest (6:33) -> (#1-3) Bow Jest (6:30)
     ≠ (#2-4) Sweet Sue (5:37) -> (#1-4) Sweet Sue (5:36)
     ≠ (#2-5) Up Blues (5:11) -> (#1-5) Up Blues (5:10)
     ≠ (#2-6) Like Someone in Love (3:23) -> (#1-6) Like Someone in Love (3:21)
     ≠ (#2-7) Love Is Just Around the Corner (5:45) -> (#1-7) Love Is Just Around the Corner (5:43)
  * Hybrid SACD (SACD layer, 2 channels) 2
     ≠ (#1-1) Yardbird Suite (6:43) -> (#2-1) Yardbird Suite (6:40)
     ≠ (#1-2) There Will Never Be Another You (7:02) -> (#2-2) There Will Never Be Another You (6:59)
     ≠ (#1-3) Bow Jest (6:33) -> (#2-3) Bow Jest (6:30)
     ≠ (#1-4) Sweet Sue (5:37) -> (#2-4) Sweet Sue (5:36)
     ≠ (#1-5) Up Blues (5:11) -> (#2-5) Up Blues (5:10)
     ≠ (#1-6) Like Someone in Love (3:23) -> (#2-6) Like Someone in Love (3:21)
     ≠ (#1-7) Love Is Just Around the Corner (5:45) -> (#2-7) Love Is Just Around the Corner (5:43)
➜ [A]pply, More candidates, Skip, Use as-is, as Tracks, Group albums,
Enter search, enter Id, aBort, eDit, edit Candidates?
```

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)~
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.) (Would love to do this if someone could give me pointers.)
