### PR TITLE
Only output verbose details for parentwork plugin when running explicitly

### DIFF
--- a/beetsplug/parentwork.py
+++ b/beetsplug/parentwork.py
@@ -89,7 +89,7 @@ class ParentWorkPlugin(BeetsPlugin):
             write = ui.should_write()
 
             for item in lib.items(ui.decargs(args)):
-                changed = self.find_work(item, force_parent)
+                changed = self.find_work(item, force_parent, verbose=True)
                 if changed:
                     item.store()
                     if write:
@@ -116,7 +116,7 @@ class ParentWorkPlugin(BeetsPlugin):
         force_parent = self.config["force"].get(bool)
 
         for item in task.imported_items():
-            self.find_work(item, force_parent)
+            self.find_work(item, force_parent, verbose=False)
             item.store()
 
     def get_info(self, item, work_info):
@@ -165,7 +165,7 @@ class ParentWorkPlugin(BeetsPlugin):
 
         return parentwork_info
 
-    def find_work(self, item, force):
+    def find_work(self, item, force, verbose):
         """Finds the parent work of a recording and populates the tags
         accordingly.
 
@@ -221,16 +221,17 @@ add one at https://musicbrainz.org/recording/{}",
 
         if work_date:
             item["work_date"] = work_date
-        return ui.show_model_changes(
-            item,
-            fields=[
-                "parentwork",
-                "parentwork_disambig",
-                "mb_parentworkid",
-                "parent_composer",
-                "parent_composer_sort",
-                "work_date",
-                "parentwork_workid_current",
-                "parentwork_date",
-            ],
-        )
+        if verbose:
+            return ui.show_model_changes(
+                item,
+                fields=[
+                    "parentwork",
+                    "parentwork_disambig",
+                    "mb_parentworkid",
+                    "parent_composer",
+                    "parent_composer_sort",
+                    "work_date",
+                    "parentwork_workid_current",
+                    "parentwork_date",
+                ],
+            )

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -83,6 +83,7 @@ Bug fixes:
   lyrics.
   :bug:`5583`
 * ImageMagick 7.1.1-44 is now supported.
+* :doc:`plugins/parentwork`: Only output parentwork changes when running in verbose mode.
 
 For packagers:
 


### PR DESCRIPTION


## Description

Fixes #4120.

This may not be the fully desired behavior, let me know if there's anything I should tweak.,

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
