### PR TITLE
Support non-POSIX text editor file paths for Windows.

### DIFF
--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -17,6 +17,7 @@
 
 import codecs
 import os
+import platform
 import shlex
 import subprocess
 from tempfile import NamedTemporaryFile
@@ -41,7 +42,8 @@ class ParseError(Exception):
 
 def edit(filename, log):
     """Open `filename` in a text editor."""
-    cmd = shlex.split(util.editor_command())
+    is_windows = platform.system() == "Windows"
+    cmd = shlex.split(util.editor_command(), posix=not is_windows)
     cmd.append(filename)
     log.debug("invoking editor command: {!r}", cmd)
     try:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -163,6 +163,7 @@ Bug fixes:
 
 * :doc:`/plugins/lastimport`: Improve error handling in the `process_tracks` function and enable it to be used with other plugins.
 * :doc:`/plugins/spotify`: Improve handling of ConnectionError.
+* :doc:`/plugins/edit`: Support non-POSIX text editor file paths for Windows.
 * :doc:`/plugins/deezer`: Improve Deezer plugin error handling and set requests timeout to 10 seconds.
   :bug:`4983`
 * :doc:`/plugins/spotify`: Add bad gateway (502) error handling.


### PR DESCRIPTION
## Description

Fixes issue with `shlex.split` parsing Windows editor program file paths as POSIX.

This resulted in the following error for a program located in `C:\Program Files` when running `beet edit`

```
error: could not run editor command 'C:Program': [WinError 2] The system cannot find the file specified
```

Setting `posix = not is_windows` changes the parsing mode for Windows platform and allows Windows file paths to be used to specify the text editor.


## To Do

- [x] ~Documentation~
- [x] Changelog
- [ ] Tests
