### PR TITLE
autotagger: match file name if the file has no title metadata

### DIFF
--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -19,6 +19,7 @@ releases and tracks.
 from __future__ import annotations
 
 import datetime
+import os
 import re
 from enum import IntEnum
 from typing import (
@@ -190,7 +191,8 @@ def track_distance(
         dist.add_ratio("track_length", diff, track_length_max)
 
     # Title.
-    dist.add_string("track_title", item.title, track_info.title)
+    cur_title = item.title or os.fsdecode(os.path.basename(item.path))
+    dist.add_string("track_title", cur_title, track_info.title)
 
     # Artist. Only check if there is actually an artist in the track data.
     if (

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,7 @@ New features:
 * Beets now uses ``platformdirs`` to determine the default music directory.
   This location varies between systems -- for example, users can configure it
   on Unix systems via ``user-dirs.dirs(5)``.
+* The autotagger matches the file name if the track has no ``title`` metadata.
 
 Bug fixes:
 

--- a/test/test_autotag.py
+++ b/test/test_autotag.py
@@ -354,6 +354,14 @@ class TrackDistanceTest(BeetsTestCase):
         dist = match.track_distance(item, info, incl_artist=True)
         assert dist == 0.0
 
+    def test_missing_metadata(self):
+        item = _make_item("", 0)
+        info = _make_trackinfo()[0]
+        dist1 = match.track_distance(item, info)
+        item.path = b"/tmp/01 One.mp3"
+        dist2 = match.track_distance(item, info)
+        assert dist2 < dist1
+
 
 class AlbumDistanceTest(BeetsTestCase):
     def _mapping(self, items, info):


### PR DESCRIPTION
This improves autotagging of items without metadata

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)~
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
