### PR TITLE
Fix Hybrid SACD importing

### DIFF
--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -208,6 +208,10 @@ def track_distance(
     if item.mb_trackid:
         dist.add_expr("track_id", item.mb_trackid != track_info.track_id)
 
+    # Penalize mismatching disc numbers.
+    if track_info.medium and item.disc:
+        dist.add_expr("medium", item.disc != track_info.medium)
+
     # Plugins.
     dist.update(plugins.track_distance(item, track_info))
 

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -207,6 +207,7 @@ match:
         track_index: 1.0
         track_length: 2.0
         track_id: 5.0
+        medium: 1.0
     preferred:
         countries: []
         media: []

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,9 @@ Bug fixes:
 * Check if running python from the Microsoft Store and provide feedback to install
   from python.org.
   :bug:`5467`
+* Fix bug where matcher doesn't consider medium number when importing. This makes
+  it difficult to import hybrid SACDs and other releases with duplicate tracks.
+  :bug:`5148`
 
 For packagers:
 


### PR DESCRIPTION
## Description

Fixes #5148.  <!-- Insert issue number here if applicable. -->

When importing, the code that matches tracks does not consider the medium number. This causes problems on Hybrid SACDs (and other releases) where the artists, track numbers, titles, and lengths are the same on both layers.

I added a distance penalty for mismatching medium numbers.

Before:

```
$ beet imp .

/Volumes/Music/ti/Red Garland/1958 - All Mornin' Long - 1 (6 items)

  Match (95.4%):
  The Red Garland Quintet - All Mornin' Long
  ≠ media, year
  MusicBrainz, 2xHybrid SACD (CD layer), 2013, US, Analogue Productions, CPRJ 7130 SA, mono
  https://musicbrainz.org/release/6a584522-58ea-470b-81fb-e60e5cd7b21e
  * Artist: The Red Garland Quintet
  * Album: All Mornin' Long
  * Hybrid SACD (CD layer) 1
     ≠ (#2-1) All Mornin' Long (20:21) -> (#1-1) All Mornin' Long (20:21)
     ≠ (#2-2) They Can't Take That Away From Me (10:24) -> (#1-2) They Can't Take That Away From Me (10:27)
     ≠ (#2-3) Our Delight (6:23) -> (#1-3) Our Delight (6:23)
  * Hybrid SACD (CD layer) 2
     ≠ (#1-1) All mornin' long (20:21) -> (#2-1) All Mornin' Long (20:21)
     ≠ (#1-2) They can't take that away from me (10:27) -> (#2-2) They Can't Take That Away From Me (10:25)
     ≠ (#1-3) Our delight (6:23) -> (#2-3) Our Delight (6:23)
➜ [A]pply, More candidates, Skip, Use as-is, as Tracks, Group albums,
Enter search, enter Id, aBort, eDit, edit Candidates?
```

Note that all tracks tagged with disc 1 get moved to disc 2 and vice versa.

After:

```
$ beet-test imp .

/Volumes/Music/ti/Red Garland/1958 - All Mornin' Long - 1 (6 items)

  Match (95.4%):
  The Red Garland Quintet - All Mornin' Long
  ≠ media, year
  MusicBrainz, 2xMedia, 2013, US, Analogue Productions, CPRJ 7130 SA, mono
  https://musicbrainz.org/release/6a584522-58ea-470b-81fb-e60e5cd7b21e
  * Artist: The Red Garland Quintet
  * Album: All Mornin' Long
  * Hybrid SACD (CD layer) 1
     ≠ (#1-1) All mornin' long (20:21) -> (#1-1) All Mornin' Long (20:21)
     ≠ (#1-2) They can't take that away from me (10:27) -> (#1-2) They Can't Take That Away From Me (10:27)
     ≠ (#1-3) Our delight (6:23) -> (#1-3) Our Delight (6:23)
  * Hybrid SACD (SACD layer) 2
     * (#2-1) All Mornin' Long (20:21)
     * (#2-2) They Can't Take That Away From Me (10:24)
     * (#2-3) Our Delight (6:23)
➜ [A]pply, More candidates, Skip, Use as-is, as Tracks, Group albums,
Enter search, enter Id, aBort, eDit, edit Candidates?
```

Yay!


## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [] ~Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)~
- [X] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.) (I don't really know how to do this effectively and would appreciate pointers.)
