### PR TITLE
bugfix: ignore subdirectories of ignored directories in unimported plugin

### DIFF
--- a/beetsplug/unimported.py
+++ b/beetsplug/unimported.py
@@ -41,15 +41,17 @@ class Unimported(BeetsPlugin):
                 os.path.join(lib.directory, x.encode())
                 for x in self.config["ignore_subdirectories"].as_str_seq()
             ]
-            in_folder = {
-                os.path.join(r, file)
-                for r, d, f in os.walk(lib.directory)
-                for file in f
-                if not any(
-                    [file.endswith(ext) for ext in ignore_exts]
-                    + [r in ignore_dirs]
-                )
-            }
+            in_folder = set()
+            for root, _, files in os.walk(lib.directory):
+                # do not traverse if root is a child of an ignored directory
+                if any(root.startswith(ignored) for ignored in ignore_dirs):
+                    continue
+                for file in files:
+                    # ignore files with ignored extensions
+                    if any(file.endswith(ext) for ext in ignore_exts):
+                        continue
+                    in_folder.add(os.path.join(root, file))
+
             in_library = {x.path for x in lib.items()}
             art_files = {x.artpath for x in lib.albums()}
             for f in in_folder - in_library - art_files:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -295,6 +295,9 @@ Bug fixes:
 * Fix bug where all media types are reported as the first media type when
   importing with MusicBrainz as the data source
   :bug:`4947`
+* Fix bug where unimported plugin would not ignore children directories of
+  ignored directories.
+  :bug:`5130` 
 
 For plugin developers:
 


### PR DESCRIPTION
## Description

Fixes #5130 

only immediate children of ignored directories were discounted.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
