### PR TITLE
Add a wavpack default configuration to the badfiles plugin

### DIFF
--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -84,6 +84,9 @@ class BadFiles(BeetsPlugin):
     def check_flac(self, path):
         return self.run_command(["flac", "-wst", path])
 
+    def check_wv(self, path):
+        return self.run_command(["wvunpack", "-vq", path])
+
     def check_custom(self, command):
         def checker(path):
             cmd = shlex.split(command)
@@ -104,6 +107,8 @@ class BadFiles(BeetsPlugin):
             return self.check_mp3val
         if ext == "flac":
             return self.check_flac
+        if ext == "wv":
+            return self.check_wv
 
     def check_item(self, item):
         # First, check whether the path exists. If not, the user

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -158,6 +158,7 @@ New features:
 * :doc:`/plugins/convert`: Don't treat WAVE (`.wav`) files as lossy anymore
   when using the `never_convert_lossy_files` option. They will get transcoded
   like the other lossless formats.
+* :doc:`/plugins/badfiles`: Add default configuration for wavpack files.
 
 Bug fixes:
 

--- a/docs/plugins/badfiles.rst
+++ b/docs/plugins/badfiles.rst
@@ -13,6 +13,7 @@ install yourself:
 
 * `mp3val`_ for MP3 files
 * `FLAC`_ command-line tools for FLAC files
+* `wvunpack`_ for wavpack files
 
 You can also add custom commands for a specific extension, like this::
 
@@ -32,6 +33,7 @@ and errors will be presented when selecting a tagging option.
 
 .. _mp3val: http://mp3val.sourceforge.net/
 .. _flac: https://xiph.org/flac/
+.. _wvunpack: https://www.wavpack.com/index.html
 
 Using
 -----


### PR DESCRIPTION
## Description

Wavpack files can now be verified by the `badfiles` plugin without addition configuration by the user.

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
