### PR TITLE
Enhancement: Refactor Test Code for Efficiency and Quality

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -334,6 +334,7 @@ Other changes:
   :bug:`4585`
 * :doc:`/faq`: :ref:`multidisc`: Elaborated the multi-disc FAQ :bug:`4806`
 * :doc:`/faq`: :ref:`src`: Removed some long lines.
+* Refactor the test cases to avoid test smells.
 
 1.6.0 (November 27, 2021)
 -------------------------

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -225,12 +225,12 @@ class FetchImageTest(FetchImageHelper, UseThePlugin):
     def test_invalid_type_returns_none(self):
         self.mock_response(self.URL, "image/watercolour")
         self.source.fetch_image(self.candidate, self.settings)
-        self.assertEqual(self.candidate.path, None)
+        self.assertIsNone(self.candidate.path)
 
     def test_jpeg_type_returns_path(self):
         self.mock_response(self.URL, "image/jpeg")
         self.source.fetch_image(self.candidate, self.settings)
-        self.assertNotEqual(self.candidate.path, None)
+        self.assertIsNotNone(self.candidate.path)
 
     def test_extension_set_by_content_type(self):
         self.mock_response(self.URL, "image/png")
@@ -600,7 +600,7 @@ class CoverArtArchiveTest(UseThePlugin, CAAHelper):
         candidates = list(self.source.get(album, self.settings, []))
         self.assertEqual(len(candidates), 3)
         for candidate in candidates:
-            self.assertTrue(f"-{maxwidth}.jpg" in candidate.url)
+            self.assertIn(f"-{maxwidth}.jpg", candidate.url)
 
     def test_caa_finds_image_if_maxwidth_is_set_and_thumbnails_is_empty(self):
         # CAA provides pre-sized thumbnails of width 250px, 500px, and 1200px
@@ -621,7 +621,7 @@ class CoverArtArchiveTest(UseThePlugin, CAAHelper):
         candidates = list(self.source.get(album, self.settings, []))
         self.assertEqual(len(candidates), 3)
         for candidate in candidates:
-            self.assertFalse(f"-{maxwidth}.jpg" in candidate.url)
+            self.assertNotIn(f"-{maxwidth}.jpg", candidate.url)
 
 
 class FanartTVTest(UseThePlugin):

--- a/test/plugins/test_bareasc.py
+++ b/test/plugins/test_bareasc.py
@@ -3,7 +3,6 @@
 
 """Tests for the 'bareasc' plugin."""
 
-
 import unittest
 
 from beets import logging
@@ -28,96 +27,23 @@ class BareascPluginTest(unittest.TestCase, TestHelper):
         self.add_item(title="without umlaut or e", artist="Bruggen")
         self.add_item(title="without umlaut with e", artist="Brueggen")
 
-    def test_search_normal_noaccent(self):
-        """Normal search, no accents, not using bare-ASCII match.
+    def test_bareasc_search(self):
+        test_cases = [
+            ("dvorak", ["without accents"]),  # Normal search, no accents, not using bare-ASCII match.
+            ("dvořák", ["with accents"]), # Normal search, with accents, not using bare-ASCII match.
+            ("#dvorak", ["without accents", "with accents"]), # Bare-ASCII search, no accents.
+            ("#dvořák", ["without accents", "with accents"]), # Bare-ASCII search, with accents.
+            ("#dvořäk", ["without accents", "with accents"]), # Bare-ASCII search, with incorrect accent.
+            ("#Bruggen", ["without umlaut or e", "with umlaut"]), # Bare-ASCII search, with no umlaut.
+            ("#Brüggen", ["without umlaut or e", "with umlaut"]), # Bare-ASCII search, with umlaut.
+        ]
 
-        Finds just the unaccented entry.
-        """
-        items = self.lib.items("dvorak")
-
-        self.assertEqual(len(items), 1)
-        self.assertEqual([items[0].title], ["without accents"])
-
-    def test_search_normal_accent(self):
-        """Normal search, with accents, not using bare-ASCII match.
-
-        Finds just the accented entry.
-        """
-        items = self.lib.items("dvořák")
-
-        self.assertEqual(len(items), 1)
-        self.assertEqual([items[0].title], ["with accents"])
-
-    def test_search_bareasc_noaccent(self):
-        """Bare-ASCII search, no accents.
-
-        Finds both entries.
-        """
-        items = self.lib.items("#dvorak")
-
-        self.assertEqual(len(items), 2)
-        self.assertEqual(
-            {items[0].title, items[1].title},
-            {"without accents", "with accents"},
-        )
-
-    def test_search_bareasc_accent(self):
-        """Bare-ASCII search, with accents.
-
-        Finds both entries.
-        """
-        items = self.lib.items("#dvořák")
-
-        self.assertEqual(len(items), 2)
-        self.assertEqual(
-            {items[0].title, items[1].title},
-            {"without accents", "with accents"},
-        )
-
-    def test_search_bareasc_wrong_accent(self):
-        """Bare-ASCII search, with incorrect accent.
-
-        Finds both entries.
-        """
-        items = self.lib.items("#dvořäk")
-
-        self.assertEqual(len(items), 2)
-        self.assertEqual(
-            {items[0].title, items[1].title},
-            {"without accents", "with accents"},
-        )
-
-    def test_search_bareasc_noumlaut(self):
-        """Bare-ASCII search, with no umlaut.
-
-        Finds entry with 'u' not 'ue', although German speaker would
-        normally replace ü with ue.
-
-        This is expected behaviour for this simple plugin.
-        """
-        items = self.lib.items("#Bruggen")
-
-        self.assertEqual(len(items), 2)
-        self.assertEqual(
-            {items[0].title, items[1].title},
-            {"without umlaut or e", "with umlaut"},
-        )
-
-    def test_search_bareasc_umlaut(self):
-        """Bare-ASCII search, with umlaut.
-
-        Finds entry with 'u' not 'ue', although German speaker would
-        normally replace ü with ue.
-
-        This is expected behaviour for this simple plugin.
-        """
-        items = self.lib.items("#Brüggen")
-
-        self.assertEqual(len(items), 2)
-        self.assertEqual(
-            {items[0].title, items[1].title},
-            {"without umlaut or e", "with umlaut"},
-        )
+        for query, expected_titles in test_cases:
+            with self.subTest(query=query, expected_titles=expected_titles):
+                items = self.lib.items(query)
+                titles = [item.title for item in items]
+                self.assertEqual(len(items), len(expected_titles))
+                self.assertEqual(titles, expected_titles)
 
     def test_bareasc_list_output(self):
         """Bare-ASCII version of list command - check output."""

--- a/test/plugins/test_bareasc.py
+++ b/test/plugins/test_bareasc.py
@@ -29,13 +29,34 @@ class BareascPluginTest(unittest.TestCase, TestHelper):
 
     def test_bareasc_search(self):
         test_cases = [
-            ("dvorak", ["without accents"]),  # Normal search, no accents, not using bare-ASCII match.
-            ("dvořák", ["with accents"]), # Normal search, with accents, not using bare-ASCII match.
-            ("#dvorak", ["without accents", "with accents"]), # Bare-ASCII search, no accents.
-            ("#dvořák", ["without accents", "with accents"]), # Bare-ASCII search, with accents.
-            ("#dvořäk", ["without accents", "with accents"]), # Bare-ASCII search, with incorrect accent.
-            ("#Bruggen", ["without umlaut or e", "with umlaut"]), # Bare-ASCII search, with no umlaut.
-            ("#Brüggen", ["without umlaut or e", "with umlaut"]), # Bare-ASCII search, with umlaut.
+            (
+                "dvorak",
+                ["without accents"],
+            ),  # Normal search, no accents, not using bare-ASCII match.
+            (
+                "dvořák",
+                ["with accents"],
+            ),  # Normal search, with accents, not using bare-ASCII match.
+            (
+                "#dvorak",
+                ["without accents", "with accents"],
+            ),  # Bare-ASCII search, no accents.
+            (
+                "#dvořák",
+                ["without accents", "with accents"],
+            ),  # Bare-ASCII search, with accents.
+            (
+                "#dvořäk",
+                ["without accents", "with accents"],
+            ),  # Bare-ASCII search, with incorrect accent.
+            (
+                "#Bruggen",
+                ["without umlaut or e", "with umlaut"],
+            ),  # Bare-ASCII search, with no umlaut.
+            (
+                "#Brüggen",
+                ["without umlaut or e", "with umlaut"],
+            ),  # Bare-ASCII search, with umlaut.
         ]
 
         for query, expected_titles in test_cases:

--- a/test/plugins/test_bareasc.py
+++ b/test/plugins/test_bareasc.py
@@ -62,10 +62,9 @@ class BareascPluginTest(unittest.TestCase, TestHelper):
         for query, expected_titles in test_cases:
             with self.subTest(query=query, expected_titles=expected_titles):
                 items = self.lib.items(query)
-                titles = [item.title for item in items]
-                self.assertEqual(len(items), len(expected_titles))
-                self.assertEqual(titles, expected_titles)
-
+                self.assertListEqual(
+                    [item.title for item in items], expected_titles
+                )
     def test_bareasc_list_output(self):
         """Bare-ASCII version of list command - check output."""
         with capture_stdout() as output:

--- a/test/plugins/test_bareasc.py
+++ b/test/plugins/test_bareasc.py
@@ -65,6 +65,7 @@ class BareascPluginTest(unittest.TestCase, TestHelper):
                 self.assertListEqual(
                     [item.title for item in items], expected_titles
                 )
+
     def test_bareasc_list_output(self):
         """Bare-ASCII version of list command - check output."""
         with capture_stdout() as output:

--- a/test/plugins/test_export.py
+++ b/test/plugins/test_export.py
@@ -56,7 +56,7 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
         out = self.execute_command(format_type="json", artist=item1.artist)
         json_data = json.loads(out)[0]
         for key, val in self.test_values.items():
-            self.assertTrue(key in json_data)
+            self.assertIn(key, json_data)
             self.assertEqual(val, json_data[key])
 
     def test_jsonlines_output(self):
@@ -64,7 +64,7 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
         out = self.execute_command(format_type="jsonlines", artist=item1.artist)
         json_data = json.loads(out)
         for key, val in self.test_values.items():
-            self.assertTrue(key in json_data)
+            self.assertIn(key, json_data)
             self.assertEqual(val, json_data[key])
 
     def test_csv_output(self):
@@ -74,7 +74,7 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
         head = re.split(",", csv_list[0])
         vals = re.split(",|\r", csv_list[1])
         for index, column in enumerate(head):
-            self.assertTrue(self.test_values.get(column, None) is not None)
+            self.assertIsNotNone(self.test_values.get(column, None))
             self.assertEqual(vals[index], self.test_values[column])
 
     def test_xml_output(self):
@@ -86,7 +86,7 @@ class ExportPluginTest(unittest.TestCase, TestHelper):
             for details in track:
                 tag = details.tag
                 txt = details.text
-                self.assertTrue(tag in self.test_values, msg=tag)
+                self.assertIn(tag, self.test_values, msg=tag)
                 self.assertEqual(self.test_values[tag], txt, msg=txt)
 
 

--- a/test/plugins/test_fetchart.py
+++ b/test/plugins/test_fetchart.py
@@ -60,14 +60,14 @@ class FetchartCliTest(unittest.TestCase, TestHelper):
         os.makedirs(os.path.join(self.album.path, b"mycover.jpg"))
         self.run_command("fetchart")
         self.album.load()
-        self.assertEqual(self.album["artpath"], None)
+        self.assertIsNone(self.album["artpath"])
 
     def test_filesystem_does_not_pick_up_ignored_file(self):
         self.touch(b"co_ver.jpg", dir=self.album.path, content="IMAGE")
         self.config["ignore"] = ["*_*"]
         self.run_command("fetchart")
         self.album.load()
-        self.assertEqual(self.album["artpath"], None)
+        self.assertIsNone(self.album["artpath"])
 
     def test_filesystem_picks_up_non_ignored_file(self):
         self.touch(b"cover.jpg", dir=self.album.path, content="IMAGE")
@@ -84,7 +84,7 @@ class FetchartCliTest(unittest.TestCase, TestHelper):
         self.config["ignore_hidden"] = True
         self.run_command("fetchart")
         self.album.load()
-        self.assertEqual(self.album["artpath"], None)
+        self.assertIsNone(self.album["artpath"])
 
     def test_filesystem_picks_up_non_hidden_file(self):
         self.touch(b"cover.jpg", dir=self.album.path, content="IMAGE")

--- a/test/plugins/test_keyfinder.py
+++ b/test/plugins/test_keyfinder.py
@@ -82,7 +82,7 @@ class KeyFinderTest(unittest.TestCase, TestHelper):
         self.run_command("keyfinder")
 
         item.load()
-        self.assertEqual(item["initial_key"], None)
+        self.assertIsNone(item["initial_key"])
 
 
 def suite():

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -419,11 +419,10 @@ class LyricsGooglePluginMachineryTest(LyricsGoogleBaseTest, LyricsAssertions):
         soup = BeautifulSoup(
             html, "html.parser", parse_only=SoupStrainer("title")
         )
-        self.assertEqual(
+        self.assertTrue(
             google.is_page_candidate(
                 url, soup.title.string, s["title"], s["artist"]
             ),
-            True,
             url,
         )
 
@@ -436,16 +435,14 @@ class LyricsGooglePluginMachineryTest(LyricsGoogleBaseTest, LyricsAssertions):
         url_title = "example.com | Beats song by John doe"
 
         # very small diffs (typo) are ok eg 'beats' vs 'beets' with same artist
-        self.assertEqual(
+        self.assertTrue(
             google.is_page_candidate(url, url_title, s["title"], s["artist"]),
-            True,
             url,
         )
         # reject different title
         url_title = "example.com | seets bong lyrics by John doe"
-        self.assertEqual(
+        self.assertTrue(
             google.is_page_candidate(url, url_title, s["title"], s["artist"]),
-            False,
             url,
         )
 
@@ -489,7 +486,7 @@ class GeniusScrapeLyricsFromHtmlTest(GeniusBaseTest):
         # expected return value None
         url = "https://genius.com/sample"
         mock = MockFetchUrl()
-        self.assertEqual(genius._scrape_lyrics_from_html(mock(url)), None)
+        self.assertIsNone(genius._scrape_lyrics_from_html(mock(url)))
 
     def test_good_lyrics(self):
         """Ensure we are able to scrape a page with lyrics"""

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -441,7 +441,7 @@ class LyricsGooglePluginMachineryTest(LyricsGoogleBaseTest, LyricsAssertions):
         )
         # reject different title
         url_title = "example.com | seets bong lyrics by John doe"
-        self.assertTrue(
+        self.assertFalse(
             google.is_page_candidate(url, url_title, s["title"], s["artist"]),
             url,
         )

--- a/test/plugins/test_player.py
+++ b/test/plugins/test_player.py
@@ -15,7 +15,6 @@
 """Tests for BPD's implementation of the MPD protocol.
 """
 
-import asyncio
 import importlib.util
 import multiprocessing as mp
 import os
@@ -23,6 +22,7 @@ import socket
 import sys
 import tempfile
 import threading
+import time
 import unittest
 from contextlib import contextmanager
 
@@ -549,7 +549,7 @@ class BPDQueryTest(BPDTestHelper):
             # Manually send a command without reading a response.
             request = client.serialise_command("idle")
             client.sock.sendall(request)
-            asyncio.sleep(0.01)
+            time.sleep(0.01)
             response = client.send_command("noidle")
         self._assert_ok(response)
 

--- a/test/plugins/test_player.py
+++ b/test/plugins/test_player.py
@@ -15,6 +15,7 @@
 """Tests for BPD's implementation of the MPD protocol.
 """
 
+import asyncio
 import importlib.util
 import multiprocessing as mp
 import os
@@ -23,7 +24,6 @@ import sys
 import tempfile
 import threading
 import unittest
-import asyncio
 from contextlib import contextmanager
 
 # Mock GstPlayer so that the forked process doesn't attempt to import gi:

--- a/test/plugins/test_player.py
+++ b/test/plugins/test_player.py
@@ -22,7 +22,6 @@ import socket
 import sys
 import tempfile
 import threading
-import time
 import unittest
 import asyncio
 from contextlib import contextmanager

--- a/test/plugins/test_player.py
+++ b/test/plugins/test_player.py
@@ -24,6 +24,7 @@ import tempfile
 import threading
 import time
 import unittest
+import asyncio
 from contextlib import contextmanager
 
 # Mock GstPlayer so that the forked process doesn't attempt to import gi:
@@ -549,7 +550,7 @@ class BPDQueryTest(BPDTestHelper):
             # Manually send a command without reading a response.
             request = client.serialise_command("idle")
             client.sock.sendall(request)
-            time.sleep(0.01)
+            asyncio.sleep(0.01)
             response = client.send_command("noidle")
         self._assert_ok(response)
 

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -33,8 +33,8 @@ from beetsplug.smartplaylist import SmartPlaylistPlugin
 class SmartPlaylistTest(_common.TestCase):
     def test_build_queries(self):
         spl = SmartPlaylistPlugin()
-        self.assertEqual(spl._matched_playlists, None)
-        self.assertEqual(spl._unmatched_playlists, None)
+        self.assertIsNone(spl._matched_playlists)
+        self.assertIsNone(spl._unmatched_playlists)
 
         config["smartplaylist"]["playlists"].set([])
         spl.build_queries()

--- a/test/plugins/test_spotify.py
+++ b/test/plugins/test_spotify.py
@@ -56,9 +56,7 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
         self.assertTrue(self.spotify._parse_opts(opts))
 
     def test_empty_query(self):
-        self.assertIsNone(
-            self.spotify._match_library_tracks(self.lib, "1=2")
-        )
+        self.assertIsNone(self.spotify._match_library_tracks(self.lib, "1=2"))
 
     @responses.activate
     def test_missing_request(self):

--- a/test/plugins/test_spotify.py
+++ b/test/plugins/test_spotify.py
@@ -51,13 +51,13 @@ class SpotifyPluginTest(_common.TestCase, TestHelper):
 
     def test_args(self):
         opts = ArgumentsMock("fail", True)
-        self.assertEqual(False, self.spotify._parse_opts(opts))
+        self.assertFalse(self.spotify._parse_opts(opts))
         opts = ArgumentsMock("list", False)
-        self.assertEqual(True, self.spotify._parse_opts(opts))
+        self.assertTrue(self.spotify._parse_opts(opts))
 
     def test_empty_query(self):
-        self.assertEqual(
-            None, self.spotify._match_library_tracks(self.lib, "1=2")
+        self.assertIsNone(
+            self.spotify._match_library_tracks(self.lib, "1=2")
         )
 
     @responses.activate

--- a/test/plugins/test_types_plugin.py
+++ b/test/plugins/test_types_plugin.py
@@ -92,12 +92,12 @@ class TypesPluginTest(unittest.TestCase, TestHelper):
         # Set true
         self.modify("mybool=1", "artist:true")
         true.load()
-        self.assertEqual(true["mybool"], True)
+        self.assertTrue(true["mybool"])
 
         # Set false
         self.modify("mybool=false", "artist:false")
         false.load()
-        self.assertEqual(false["mybool"], False)
+        self.assertFalse(false["mybool"])
 
         # Query bools
         out = self.list("mybool:true", "$artist $mybool")

--- a/test/plugins/test_zero.py
+++ b/test/plugins/test_zero.py
@@ -137,7 +137,7 @@ class ZeroPluginTest(unittest.TestCase, TestHelper):
 
         self.assertEqual(item["year"], 2016)
         self.assertEqual(mf.year, 2016)
-        self.assertEqual(mf.comments, None)
+        self.assertIsNone(mf.comments)
         self.assertEqual(item["comments"], "")
 
     def test_subcommand_update_database_false(self):
@@ -161,7 +161,7 @@ class ZeroPluginTest(unittest.TestCase, TestHelper):
         self.assertEqual(item["year"], 2016)
         self.assertEqual(mf.year, 2016)
         self.assertEqual(item["comments"], "test comment")
-        self.assertEqual(mf.comments, None)
+        self.assertIsNone(mf.comments)
 
     def test_subcommand_query_include(self):
         item = self.add_item_fixture(
@@ -180,7 +180,7 @@ class ZeroPluginTest(unittest.TestCase, TestHelper):
         mf = MediaFile(syspath(item.path))
 
         self.assertEqual(mf.year, 2016)
-        self.assertEqual(mf.comments, None)
+        self.assertIsNone(mf.comments)
 
     def test_subcommand_query_exclude(self):
         item = self.add_item_fixture(
@@ -251,7 +251,7 @@ class ZeroPluginTest(unittest.TestCase, TestHelper):
 
         z = ZeroPlugin()
         z.write_event(item, item.path, tags)
-        self.assertEqual(tags["comments"], None)
+        self.assertIsNone(tags["comments"])
         self.assertEqual(tags["year"], 2016)
 
     def test_keep_fields_removes_preserved_tags(self):

--- a/test/test_art_resize.py
+++ b/test/test_art_resize.py
@@ -129,7 +129,7 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
         from PIL import Image
 
         with Image.open(path) as img:
-            self.assertFalse("progression" in img.info)
+            self.assertNotIn("progression", img.info)
 
     @unittest.skipUnless(IMBackend.available(), "ImageMagick not available")
     def test_im_file_deinterlace(self):
@@ -146,7 +146,7 @@ class ArtResizerFileSizeTest(_common.TestCase, TestHelper):
             syspath(path, prefix=False),
         ]
         out = command_output(cmd).stdout
-        self.assertTrue(out == b"None")
+        self.assertEqual(out, b"None")
 
     @patch("beets.util.artresizer.util")
     def test_write_metadata_im(self, mock_util):

--- a/test/test_autotag.py
+++ b/test/test_autotag.py
@@ -42,7 +42,7 @@ class PluralityTest(_common.TestCase):
     def test_plurality_conflict(self):
         objs = [1, 1, 2, 2, 3]
         obj, freq = plurality(objs)
-        self.assertTrue(obj in (1, 2))
+        self.assertIn(obj, (1, 2))
         self.assertEqual(freq, 2)
 
     def test_plurality_empty_sequence_raises_error(self):
@@ -279,9 +279,9 @@ class DistanceTest(_common.TestCase):
         dist.add("medium", 0.75)
         self.assertEqual(len(dist), 2)
         self.assertEqual(list(dist), [("album", 0.2), ("medium", 0.2)])
-        self.assertTrue(dist == 0.4)
-        self.assertTrue(dist < 1.0)
-        self.assertTrue(dist > 0.0)
+        self.assertEqual(dist, 0.4)
+        self.assertLess(dist, 1.0)
+        self.assertGreater(dist, 0.0)
         self.assertEqual(dist - 0.4, 0.0)
         self.assertEqual(0.4 - dist, 0.0)
         self.assertEqual(float(dist), 0.4)
@@ -394,7 +394,7 @@ class AlbumDistanceTest(_common.TestCase):
         dist = self._dist(items, info)
         self.assertNotEqual(dist, 0)
         # Make sure the distance is not too great
-        self.assertTrue(dist < 0.2)
+        self.assertLess(dist, 0.2)
 
     def test_global_artists_differ(self):
         items = []
@@ -1017,17 +1017,17 @@ class StringDistanceTest(unittest.TestCase):
     def test_leading_the_has_lower_weight(self):
         dist1 = string_dist("XXX Band Name", "Band Name")
         dist2 = string_dist("The Band Name", "Band Name")
-        self.assertTrue(dist2 < dist1)
+        self.assertLess(dist2, dist1)
 
     def test_parens_have_lower_weight(self):
         dist1 = string_dist("One .Two.", "One")
         dist2 = string_dist("One (Two)", "One")
-        self.assertTrue(dist2 < dist1)
+        self.assertLess(dist2, dist1)
 
     def test_brackets_have_lower_weight(self):
         dist1 = string_dist("One .Two.", "One")
         dist2 = string_dist("One [Two]", "One")
-        self.assertTrue(dist2 < dist1)
+        self.assertLess(dist2, dist1)
 
     def test_ep_label_has_zero_weight(self):
         dist = string_dist("My Song (EP)", "My Song")
@@ -1036,7 +1036,7 @@ class StringDistanceTest(unittest.TestCase):
     def test_featured_has_lower_weight(self):
         dist1 = string_dist("My Song blah Someone", "My Song")
         dist2 = string_dist("My Song feat Someone", "My Song")
-        self.assertTrue(dist2 < dist1)
+        self.assertLess(dist2, dist1)
 
     def test_postfix_the(self):
         dist = string_dist("The Song Title", "Song Title, The")

--- a/test/test_config_command.py
+++ b/test/test_config_command.py
@@ -52,7 +52,7 @@ class ConfigCommandTest(unittest.TestCase, TestHelper):
         self.assertEqual(output["option"], "value")
         self.assertEqual(output["password"], "password_value")
         self.assertEqual(output["library"], "lib")
-        self.assertEqual(output["import"]["timid"], False)
+        self.assertFalse(output["import"]["timid"])
 
     def test_show_user_config_with_cli(self):
         output = self._run_with_yaml_output(
@@ -73,7 +73,7 @@ class ConfigCommandTest(unittest.TestCase, TestHelper):
 
         self.assertEqual(output["option"], "value")
         self.assertEqual(output["password"], "REDACTED")
-        self.assertEqual(output["import"]["timid"], False)
+        self.assertFalse(output["import"]["timid"])
 
     def test_config_paths(self):
         output = self.run_with_output("config", "-p")

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -315,16 +315,16 @@ class ModelTest(unittest.TestCase):
     def test_delete_flexattr(self):
         model = ModelFixture1()
         model["foo"] = "bar"
-        self.assertTrue("foo" in model)
+        self.assertIn("foo", model)
         del model["foo"]
-        self.assertFalse("foo" in model)
+        self.assertNotIn("foo", model)
 
     def test_delete_flexattr_via_dot(self):
         model = ModelFixture1()
         model["foo"] = "bar"
-        self.assertTrue("foo" in model)
+        self.assertIn("foo", model)
         del model.foo
-        self.assertFalse("foo" in model)
+        self.assertNotIn("foo", model)
 
     def test_delete_flexattr_persists(self):
         model = ModelFixture1()
@@ -337,7 +337,7 @@ class ModelTest(unittest.TestCase):
         model.store()
 
         model = self.db._get(ModelFixture1, model.id)
-        self.assertFalse("foo" in model)
+        self.assertNotIn("foo", model)
 
     def test_delete_non_existent_attribute(self):
         model = ModelFixture1()
@@ -365,7 +365,7 @@ class ModelTest(unittest.TestCase):
     def test_null_value_stays_none_for_untyped_field(self):
         model = ModelFixture1()
         model.foo = None
-        self.assertEqual(model.foo, None)
+        self.assertIsNone(model.foo)
 
     def test_normalization_for_typed_flex_fields(self):
         model = ModelFixture1()

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -128,7 +128,7 @@ class MoveTest(_common.TestCase):
         self.assertIn("C_DOS", self.i.path.decode())
 
     def test_move_file_with_multiple_colons(self):
-        print(beets.config["replace"])
+        # print(beets.config["replace"])
         self.i.artist = "COM:DOS"
         self.i.move()
         self.assertIn("COM_DOS", self.i.path.decode())

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -306,7 +306,7 @@ class AlbumFileTest(_common.TestCase):
         self.ai.move(basedir=self.otherdir)
         self.i.load()
         self.ai.store()
-        self.assertTrue(b"testotherdir" in self.i.path)
+        self.assertIn(b"testotherdir", self.i.path)
 
 
 class ArtFileTest(_common.TestCase):
@@ -359,7 +359,7 @@ class ArtFileTest(_common.TestCase):
         self.assertNotExists(self.art)
         newart = self.lib.get_album(self.i).artpath
         self.assertExists(newart)
-        self.assertTrue(b"testotherdir" in newart)
+        self.assertIn(b"testotherdir", newart)
 
     def test_setart_copies_image(self):
         util.remove(self.art)
@@ -372,7 +372,7 @@ class ArtFileTest(_common.TestCase):
         ai = self.lib.add_album((i2,))
         i2.move(operation=MoveOperation.COPY)
 
-        self.assertEqual(ai.artpath, None)
+        self.assertIsNone(ai.artpath)
         ai.set_art(newart)
         self.assertExists(ai.artpath)
 
@@ -478,7 +478,7 @@ class ArtFileTest(_common.TestCase):
         self.i.move()
 
         artpath = self.lib.albums()[0].artpath
-        self.assertFalse(b"different_album" in artpath)
+        self.assertNotIn(b"different_album", artpath)
         self.assertEqual(artpath, oldartpath)
         self.assertExists(oldartpath)
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -94,8 +94,8 @@ class ScrubbedImportTest(_common.TestCase, ImportHelper):
         for item in self.lib.items():
             imported_file = os.path.join(item.path)
             imported_file = MediaFile(imported_file)
-            self.assertEqual(imported_file.artist, None)
-            self.assertEqual(imported_file.album, None)
+            self.assertIsNone(imported_file.artist)
+            self.assertIsNone(imported_file.album)
 
 
 @_common.slow_test()
@@ -337,18 +337,18 @@ class ImportSingletonTest(_common.TestCase, ImportHelper):
         self.matcher.restore()
 
     def test_apply_asis_adds_track(self):
-        self.assertEqual(self.lib.items().get(), None)
+        self.assertIsNone(self.lib.items().get())
 
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
         self.assertEqual(self.lib.items().get().title, "Tag Title 1")
 
     def test_apply_asis_does_not_add_album(self):
-        self.assertEqual(self.lib.albums().get(), None)
+        self.assertIsNone(self.lib.albums().get())
 
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
-        self.assertEqual(self.lib.albums().get(), None)
+        self.assertIsNone(self.lib.albums().get())
 
     def test_apply_asis_adds_singleton_path(self):
         self.assert_lib_dir_empty()
@@ -358,7 +358,7 @@ class ImportSingletonTest(_common.TestCase, ImportHelper):
         self.assert_file_in_lib(b"singletons", b"Tag Title 1.mp3")
 
     def test_apply_candidate_adds_track(self):
-        self.assertEqual(self.lib.items().get(), None)
+        self.assertIsNone(self.lib.items().get())
 
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
@@ -367,7 +367,7 @@ class ImportSingletonTest(_common.TestCase, ImportHelper):
     def test_apply_candidate_does_not_add_album(self):
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
-        self.assertEqual(self.lib.albums().get(), None)
+        self.assertIsNone(self.lib.albums().get())
 
     def test_apply_candidate_adds_singleton_path(self):
         self.assert_lib_dir_empty()
@@ -379,7 +379,7 @@ class ImportSingletonTest(_common.TestCase, ImportHelper):
     def test_skip_does_not_add_first_track(self):
         self.importer.add_choice(importer.action.SKIP)
         self.importer.run()
-        self.assertEqual(self.lib.items().get(), None)
+        self.assertIsNone(self.lib.items().get())
 
     def test_skip_adds_other_tracks(self):
         self._create_import_dir(2)
@@ -418,7 +418,7 @@ class ImportSingletonTest(_common.TestCase, ImportHelper):
         }
 
         # As-is item import.
-        self.assertEqual(self.lib.albums().get(), None)
+        self.assertIsNone(self.lib.albums().get())
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
 
@@ -431,7 +431,7 @@ class ImportSingletonTest(_common.TestCase, ImportHelper):
             item.remove()
 
         # Autotagged.
-        self.assertEqual(self.lib.albums().get(), None)
+        self.assertIsNone(self.lib.albums().get())
         self.importer.clear_choices()
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
@@ -458,14 +458,14 @@ class ImportTest(_common.TestCase, ImportHelper):
         self.matcher.restore()
 
     def test_apply_asis_adds_album(self):
-        self.assertEqual(self.lib.albums().get(), None)
+        self.assertIsNone(self.lib.albums().get())
 
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
         self.assertEqual(self.lib.albums().get().album, "Tag Album")
 
     def test_apply_asis_adds_tracks(self):
-        self.assertEqual(self.lib.items().get(), None)
+        self.assertIsNone(self.lib.items().get())
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
         self.assertEqual(self.lib.items().get().title, "Tag Title 1")
@@ -478,14 +478,14 @@ class ImportTest(_common.TestCase, ImportHelper):
         self.assert_file_in_lib(b"Tag Artist", b"Tag Album", b"Tag Title 1.mp3")
 
     def test_apply_candidate_adds_album(self):
-        self.assertEqual(self.lib.albums().get(), None)
+        self.assertIsNone(self.lib.albums().get())
 
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
         self.assertEqual(self.lib.albums().get().album, "Applied Album")
 
     def test_apply_candidate_adds_tracks(self):
-        self.assertEqual(self.lib.items().get(), None)
+        self.assertIsNone(self.lib.items().get())
 
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
@@ -553,7 +553,7 @@ class ImportTest(_common.TestCase, ImportHelper):
     def test_skip_does_not_add_track(self):
         self.importer.add_choice(importer.action.SKIP)
         self.importer.run()
-        self.assertEqual(self.lib.items().get(), None)
+        self.assertIsNone(self.lib.items().get())
 
     def test_skip_non_album_dirs(self):
         self.assertIsDir(os.path.join(self.import_dir, b"the_album"))
@@ -590,7 +590,7 @@ class ImportTest(_common.TestCase, ImportHelper):
         self.assertIn(f"No files imported from {import_dir}", logs)
 
     def test_asis_no_data_source(self):
-        self.assertEqual(self.lib.items().get(), None)
+        self.assertIsNone(self.lib.items().get())
 
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
@@ -611,7 +611,7 @@ class ImportTest(_common.TestCase, ImportHelper):
         }
 
         # As-is album import.
-        self.assertEqual(self.lib.albums().get(), None)
+        self.assertIsNone(self.lib.albums().get())
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
 
@@ -634,7 +634,7 @@ class ImportTest(_common.TestCase, ImportHelper):
             album.remove()
 
         # Autotagged.
-        self.assertEqual(self.lib.albums().get(), None)
+        self.assertIsNone(self.lib.albums().get())
         self.importer.clear_choices()
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
@@ -671,15 +671,15 @@ class ImportTracksTest(_common.TestCase, ImportHelper):
         self.matcher.restore()
 
     def test_apply_tracks_adds_singleton_track(self):
-        self.assertEqual(self.lib.items().get(), None)
-        self.assertEqual(self.lib.albums().get(), None)
+        self.assertIsNone(self.lib.items().get())
+        self.assertIsNone(self.lib.albums().get())
 
         self.importer.add_choice(importer.action.TRACKS)
         self.importer.add_choice(importer.action.APPLY)
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
         self.assertEqual(self.lib.items().get().title, "Applied Title 1")
-        self.assertEqual(self.lib.albums().get(), None)
+        self.assertIsNone(self.lib.albums().get())
 
     def test_apply_tracks_adds_singleton_path(self):
         self.assert_lib_dir_empty()
@@ -1492,10 +1492,10 @@ class AlbumsInDirTest(_common.TestCase):
         found = []
         for _, album in albums_in_dir(self.base):
             found.append(re.search(rb"album(.)song", album[0]).group(1))
-        self.assertTrue(b"1" in found)
-        self.assertTrue(b"2" in found)
-        self.assertTrue(b"3" in found)
-        self.assertTrue(b"4" in found)
+        self.assertIn(b"1", found)
+        self.assertIn(b"2", found)
+        self.assertIn(b"3", found)
+        self.assertIn(b"4", found)
 
     def test_finds_multiple_songs(self):
         for _, album in albums_in_dir(self.base):

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -318,7 +318,7 @@ class MBAlbumInfoTest(_common.TestCase):
         tracks = [self._make_track("TITLE", "ID", None)]
         release = self._make_release(tracks=tracks)
         d = mb.album_info(release)
-        self.assertEqual(d.tracks[0].length, None)
+        self.assertIsNone(d.tracks[0].length)
 
     def test_track_length_overrides_recording_length(self):
         tracks = [self._make_track("TITLE", "ID", 1.0 * 1000.0)]
@@ -415,7 +415,7 @@ class MBAlbumInfoTest(_common.TestCase):
         release = self._make_release(None)
         del release["text-representation"]["language"]
         d = mb.album_info(release)
-        self.assertEqual(d.language, None)
+        self.assertIsNone(d.language)
 
     def test_parse_recording_artist(self):
         tracks = [self._make_track("a", "b", 1, True)]
@@ -658,7 +658,7 @@ class MBAlbumInfoTest(_common.TestCase):
         d = mb.album_info(release)
         t = d.tracks
         self.assertEqual(len(t), 2)
-        self.assertEqual(t[0].trackdisambig, None)
+        self.assertIsNone(t[0].trackdisambig)
         self.assertEqual(t[1].trackdisambig, "SECOND TRACK")
 
 
@@ -671,7 +671,7 @@ class ParseIDTest(_common.TestCase):
     def test_parse_id_non_id_returns_none(self):
         id_string = "blah blah"
         out = mb._parse_id(id_string)
-        self.assertEqual(out, None)
+        self.assertIsNone(out)
 
     def test_parse_id_url_finds_id(self):
         id_string = "28e32c71-1450-463e-92bf-e0a46446fc11"
@@ -981,7 +981,7 @@ class MBLibraryTest(unittest.TestCase):
         with mock.patch("musicbrainzngs.get_release_by_id") as gp:
             gp.side_effect = side_effect
             album = mb.album_for_id("d2a6f856-b553-40a0-ac54-a321e8e2da02")
-            self.assertEqual(album.country, None)
+            self.assertIsNone(album.country)
 
     def test_pseudo_releases_without_links(self):
         side_effect = [
@@ -1025,7 +1025,7 @@ class MBLibraryTest(unittest.TestCase):
         with mock.patch("musicbrainzngs.get_release_by_id") as gp:
             gp.side_effect = side_effect
             album = mb.album_for_id("d2a6f856-b553-40a0-ac54-a321e8e2da02")
-            self.assertEqual(album.country, None)
+            self.assertIsNone(album.country)
 
     def test_pseudo_releases_with_unsupported_links(self):
         side_effect = [
@@ -1076,7 +1076,7 @@ class MBLibraryTest(unittest.TestCase):
         with mock.patch("musicbrainzngs.get_release_by_id") as gp:
             gp.side_effect = side_effect
             album = mb.album_for_id("d2a6f856-b553-40a0-ac54-a321e8e2da02")
-            self.assertEqual(album.country, None)
+            self.assertIsNone(album.country)
 
 
 def suite():

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -167,7 +167,7 @@ class ItemTypeConflictTest(unittest.TestCase, TestHelper):
         self.advent_listener_plugin = AdventListenerPlugin
         self.register_plugin(EventListenerPlugin)
         self.register_plugin(AdventListenerPlugin)
-        self.assertNotEqual(None, plugins.types(Item))
+        self.assertIsNotNone(plugins.types(Item))
 
 
 class EventsTest(unittest.TestCase, ImportHelper, TestHelper):
@@ -647,7 +647,7 @@ class ParseSpotifyIDTest(unittest.TestCase):
     def test_parse_id_non_id_returns_none(self):
         id_string = "blah blah"
         out = MetadataSourcePlugin._get_id("album", id_string, spotify_id_regex)
-        self.assertEqual(out, None)
+        self.assertIsNone(out)
 
     def test_parse_id_url_finds_id(self):
         id_string = "39WqpoPgZxygo6YQjehLJJ"
@@ -665,7 +665,7 @@ class ParseDeezerIDTest(unittest.TestCase):
     def test_parse_id_non_id_returns_none(self):
         id_string = "blah blah"
         out = MetadataSourcePlugin._get_id("album", id_string, deezer_id_regex)
-        self.assertEqual(out, None)
+        self.assertIsNone(out)
 
     def test_parse_id_url_finds_id(self):
         id_string = "176356382"
@@ -687,7 +687,7 @@ class ParseBeatportIDTest(unittest.TestCase):
         out = MetadataSourcePlugin._get_id(
             "album", id_string, beatport_id_regex
         )
-        self.assertEqual(out, None)
+        self.assertIsNone(out)
 
     def test_parse_id_url_finds_id(self):
         id_string = "3089651"

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -67,7 +67,7 @@ class AnyFieldQueryTest(_common.LibTestCase):
         q = dbcore.query.AnyFieldQuery(
             "title", ["artist"], dbcore.query.SubstringQuery
         )
-        self.assertEqual(self.lib.items(q).get(), None)
+        self.assertIsNone(self.lib.items(q).get())
 
     def test_eq(self):
         q1 = dbcore.query.AnyFieldQuery(

--- a/test/test_sort.py
+++ b/test/test_sort.py
@@ -460,7 +460,7 @@ class CaseSensitivityTest(DummyDataTestCase, _common.TestCase):
         results = list(self.lib.items(q))
         # If the numerical values were sorted as strings,
         # then ['1', '10', '2'] would be valid.
-        print([r.track for r in results])
+        # print([r.track for r in results])
         self.assertEqual(results[0].track, 1)
         self.assertEqual(results[1].track, 2)
         self.assertEqual(results[-1].track, 10)

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -1344,9 +1344,7 @@ class ShowChangeTest(_common.TestCase):
             long_title = "a track with a" + (" very" * 10) + " long name"
             self.items[0].title = long_title
             msg = self._show_change()
-            self.assertIn(
-                "(#1) a track (1:00) -> (#1) the title (0:00)", msg
-            )
+            self.assertIn("(#1) a track (1:00) -> (#1) the title (0:00)", msg)
 
     def test_item_data_change_wrap_newline(self):
         # Patch ui.term_width to force wrapping
@@ -1463,8 +1461,11 @@ class CompletionTest(_common.TestCase, TestHelper):
         with open(test_script_name, "rb") as test_script_file:
             tester.stdin.writelines(test_script_file)
         out, err = tester.communicate()
-        self.assertTrue(tester.returncode != 0 or out != b"completion tests passed\n", f'test/test_completion.sh did not execute properly. Output:{out.decode("utf-8")}')
-
+        self.assertTrue(
+            tester.returncode != 0 or out != b"completion tests passed\n",
+            f'test/test_completion.sh did not execute properly. '
+            f'Output:{out.decode("utf-8")}',
+        )
 
 
 class CommonOptionsParserCliTest(unittest.TestCase, TestHelper):

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -1461,7 +1461,7 @@ class CompletionTest(_common.TestCase, TestHelper):
         with open(test_script_name, "rb") as test_script_file:
             tester.stdin.writelines(test_script_file)
         out, err = tester.communicate()
-        self.assertTrue(
+        self.assertFalse(
             tester.returncode != 0 or out != b"completion tests passed\n",
             f"test/test_completion.sh did not execute properly. "
             f'Output:{out.decode("utf-8")}',

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -1463,7 +1463,7 @@ class CompletionTest(_common.TestCase, TestHelper):
         out, err = tester.communicate()
         self.assertTrue(
             tester.returncode != 0 or out != b"completion tests passed\n",
-            f'test/test_completion.sh did not execute properly. '
+            f"test/test_completion.sh did not execute properly. "
             f'Output:{out.decode("utf-8")}',
         )
 

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -64,7 +64,7 @@ class ListTest(unittest.TestCase):
 
         stdout = self._run_list(["na\xefve"])
         out = stdout.getvalue()
-        self.assertTrue("na\xefve" in out)
+        self.assertIn("na\xefve", out)
 
     def test_list_item_path(self):
         stdout = self._run_list(fmt="$path")
@@ -451,7 +451,7 @@ class WriteTest(unittest.TestCase, TestHelper):
 
         output = self.write_cmd()
 
-        self.assertTrue(f"{old_title} -> new title" in output)
+        self.assertIn(f"{old_title} -> new title", output)
 
 
 class MoveTest(_common.TestCase):
@@ -494,42 +494,42 @@ class MoveTest(_common.TestCase):
     def test_move_item(self):
         self._move()
         self.i.load()
-        self.assertTrue(b"testlibdir" in self.i.path)
+        self.assertIn(b"testlibdir", self.i.path)
         self.assertExists(self.i.path)
         self.assertNotExists(self.itempath)
 
     def test_copy_item(self):
         self._move(copy=True)
         self.i.load()
-        self.assertTrue(b"testlibdir" in self.i.path)
+        self.assertIn(b"testlibdir", self.i.path)
         self.assertExists(self.i.path)
         self.assertExists(self.itempath)
 
     def test_move_album(self):
         self._move(album=True)
         self.i.load()
-        self.assertTrue(b"testlibdir" in self.i.path)
+        self.assertIn(b"testlibdir", self.i.path)
         self.assertExists(self.i.path)
         self.assertNotExists(self.itempath)
 
     def test_copy_album(self):
         self._move(copy=True, album=True)
         self.i.load()
-        self.assertTrue(b"testlibdir" in self.i.path)
+        self.assertIn(b"testlibdir", self.i.path)
         self.assertExists(self.i.path)
         self.assertExists(self.itempath)
 
     def test_move_item_custom_dir(self):
         self._move(dest=self.otherdir)
         self.i.load()
-        self.assertTrue(b"testotherdir" in self.i.path)
+        self.assertIn(b"testotherdir", self.i.path)
         self.assertExists(self.i.path)
         self.assertNotExists(self.itempath)
 
     def test_move_album_custom_dir(self):
         self._move(dest=self.otherdir, album=True)
         self.i.load()
-        self.assertTrue(b"testotherdir" in self.i.path)
+        self.assertIn(b"testotherdir", self.i.path)
         self.assertExists(self.i.path)
         self.assertNotExists(self.itempath)
 
@@ -648,7 +648,7 @@ class UpdateTest(_common.TestCase):
         mf.save()
         self._update(move=True)
         item = self.lib.items().get()
-        self.assertTrue(b"differentTitle" in item.path)
+        self.assertIn(b"differentTitle", item.path)
 
     def test_modified_metadata_not_moved(self):
         mf = MediaFile(syspath(self.i.path))
@@ -656,7 +656,7 @@ class UpdateTest(_common.TestCase):
         mf.save()
         self._update(move=False)
         item = self.lib.items().get()
-        self.assertTrue(b"differentTitle" not in item.path)
+        self.assertNotIn(b"differentTitle", item.path)
 
     def test_selective_modified_metadata_moved(self):
         mf = MediaFile(syspath(self.i.path))
@@ -665,7 +665,7 @@ class UpdateTest(_common.TestCase):
         mf.save()
         self._update(move=True, fields=["title"])
         item = self.lib.items().get()
-        self.assertTrue(b"differentTitle" in item.path)
+        self.assertIn(b"differentTitle", item.path)
         self.assertNotEqual(item.genre, "differentGenre")
 
     def test_selective_modified_metadata_not_moved(self):
@@ -675,7 +675,7 @@ class UpdateTest(_common.TestCase):
         mf.save()
         self._update(move=False, fields=["title"])
         item = self.lib.items().get()
-        self.assertTrue(b"differentTitle" not in item.path)
+        self.assertNotIn(b"differentTitle", item.path)
         self.assertNotEqual(item.genre, "differentGenre")
 
     def test_modified_album_metadata_moved(self):
@@ -684,7 +684,7 @@ class UpdateTest(_common.TestCase):
         mf.save()
         self._update(move=True)
         item = self.lib.items().get()
-        self.assertTrue(b"differentAlbum" in item.path)
+        self.assertIn(b"differentAlbum", item.path)
 
     def test_modified_album_metadata_art_moved(self):
         artpath = self.album.artpath
@@ -703,7 +703,7 @@ class UpdateTest(_common.TestCase):
         mf.save()
         self._update(move=True, fields=["album"])
         item = self.lib.items().get()
-        self.assertTrue(b"differentAlbum" in item.path)
+        self.assertIn(b"differentAlbum", item.path)
         self.assertNotEqual(item.genre, "differentGenre")
 
     def test_selective_modified_album_metadata_not_moved(self):
@@ -713,7 +713,7 @@ class UpdateTest(_common.TestCase):
         mf.save()
         self._update(move=True, fields=["genre"])
         item = self.lib.items().get()
-        self.assertTrue(b"differentAlbum" not in item.path)
+        self.assertNotIn(b"differentAlbum", item.path)
         self.assertEqual(item.genre, "differentGenre")
 
     def test_mtime_match_skips_update(self):
@@ -1167,13 +1167,13 @@ class ShowModelChangeTest(_common.TestCase):
         self.b.title = "x"
         change, out = self._show()
         self.assertTrue(change)
-        self.assertTrue("title" in out)
+        self.assertIn("title", out)
 
     def test_int_fixed_field_change(self):
         self.b.track = 9
         change, out = self._show()
         self.assertTrue(change)
-        self.assertTrue("track" in out)
+        self.assertIn("track", out)
 
     def test_floats_close_to_identical(self):
         self.a.length = 1.00001
@@ -1187,14 +1187,14 @@ class ShowModelChangeTest(_common.TestCase):
         self.b.length = 2.00001
         change, out = self._show()
         self.assertTrue(change)
-        self.assertTrue("length" in out)
+        self.assertIn("length", out)
 
     def test_both_values_shown(self):
         self.a.title = "foo"
         self.b.title = "bar"
         change, out = self._show()
-        self.assertTrue("foo" in out)
-        self.assertTrue("bar" in out)
+        self.assertIn("foo", out)
+        self.assertIn("bar", out)
 
 
 class ShowChangeTest(_common.TestCase):
@@ -1243,15 +1243,15 @@ class ShowChangeTest(_common.TestCase):
 
     def test_null_change(self):
         msg = self._show_change()
-        self.assertTrue("match (90.0%)" in msg)
-        self.assertTrue("album, artist" in msg)
+        self.assertIn("match (90.0%)", msg)
+        self.assertIn("album, artist", msg)
 
     def test_album_data_change(self):
         msg = self._show_change(
             cur_artist="another artist", cur_album="another album"
         )
-        self.assertTrue("another artist -> the artist" in msg)
-        self.assertTrue("another album -> the album" in msg)
+        self.assertIn("another artist -> the artist", msg)
+        self.assertIn("another album -> the album", msg)
 
     def test_item_data_change(self):
         self.items[0].title = "different"
@@ -1332,9 +1332,9 @@ class ShowChangeTest(_common.TestCase):
                 cur_artist=long_name, cur_album="another album"
             )
             # _common.log.info("Message:{}".format(msg))
-            self.assertTrue("artist: another artist" in msg)
-            self.assertTrue("  -> the artist" in msg)
-            self.assertFalse("another album -> the album" in msg)
+            self.assertIn("artist: another artist", msg)
+            self.assertIn("  -> the artist", msg)
+            self.assertNotIn("another album -> the album", msg)
 
     def test_item_data_change_wrap_column(self):
         # Patch ui.term_width to force wrapping
@@ -1344,8 +1344,8 @@ class ShowChangeTest(_common.TestCase):
             long_title = "a track with a" + (" very" * 10) + " long name"
             self.items[0].title = long_title
             msg = self._show_change()
-            self.assertTrue(
-                "(#1) a track (1:00) -> (#1) the title (0:00)" in msg
+            self.assertIn(
+                "(#1) a track (1:00) -> (#1) the title (0:00)", msg
             )
 
     def test_item_data_change_wrap_newline(self):
@@ -1355,8 +1355,8 @@ class ShowChangeTest(_common.TestCase):
             long_title = "a track with a" + (" very" * 10) + " long name"
             self.items[0].title = long_title
             msg = self._show_change()
-            self.assertTrue("(#1) a track with" in msg)
-            self.assertTrue("     -> (#1) the title (0:00)" in msg)
+            self.assertIn("(#1) a track with", msg)
+            self.assertIn("     -> (#1) the title (0:00)", msg)
 
 
 @patch("beets.library.Item.try_filesize", Mock(return_value=987))

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -1463,9 +1463,8 @@ class CompletionTest(_common.TestCase, TestHelper):
         with open(test_script_name, "rb") as test_script_file:
             tester.stdin.writelines(test_script_file)
         out, err = tester.communicate()
-        if tester.returncode != 0 or out != b"completion tests passed\n":
-            print(out.decode("utf-8"))
-            self.fail("test/test_completion.sh did not execute properly")
+        self.assertTrue(tester.returncode != 0 or out != b"completion tests passed\n", f'test/test_completion.sh did not execute properly. Output:{out.decode("utf-8")}')
+
 
 
 class CommonOptionsParserCliTest(unittest.TestCase, TestHelper):

--- a/test/test_ui_commands.py
+++ b/test/test_ui_commands.py
@@ -37,7 +37,7 @@ class QueryTest(_common.TestCase):
         self.lib = library.Library(":memory:", self.libdir)
 
         # Alternate destination directory.
-        self.otherdir = os.path.join(self.temp_dir, b"testotherdir")
+        # self.otherdir = os.path.join(self.temp_dir, b"testotherdir")
 
     def add_item(self, filename=b"srcfile", templatefile=b"full.mp3"):
         itempath = os.path.join(self.libdir, filename)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -51,28 +51,28 @@ class UtilTest(unittest.TestCase):
     def test_sanitize_unix_replaces_leading_dot(self):
         with _common.platform_posix():
             p = util.sanitize_path("one/.two/three")
-        self.assertFalse("." in p)
+        self.assertNotIn(".", p)
 
     def test_sanitize_windows_replaces_trailing_dot(self):
         with _common.platform_windows():
             p = util.sanitize_path("one/two./three")
-        self.assertFalse("." in p)
+        self.assertNotIn(".", p)
 
     def test_sanitize_windows_replaces_illegal_chars(self):
         with _common.platform_windows():
             p = util.sanitize_path(':*?"<>|')
-        self.assertFalse(":" in p)
-        self.assertFalse("*" in p)
-        self.assertFalse("?" in p)
-        self.assertFalse('"' in p)
-        self.assertFalse("<" in p)
-        self.assertFalse(">" in p)
-        self.assertFalse("|" in p)
+        self.assertNotIn(":", p)
+        self.assertNotIn("*", p)
+        self.assertNotIn("?", p)
+        self.assertNotIn('"', p)
+        self.assertNotIn("<", p)
+        self.assertNotIn(">", p)
+        self.assertNotIn("|", p)
 
     def test_sanitize_windows_replaces_trailing_space(self):
         with _common.platform_windows():
             p = util.sanitize_path("one/two /three")
-        self.assertFalse(" " in p)
+        self.assertNotIn(" ", p)
 
     def test_sanitize_path_works_on_empty_string(self):
         with _common.platform_posix():


### PR DESCRIPTION
## Description
As a first-time contributor with a background in researching Python unit tests, I conducted a thorough static analysis of the project's test code. This examination revealed various "test smells" that could potentially degrade both the efficiency and quality of our tests. To address these issues, I've refactored the relevant code segments. The modifications I propose not only aim to eliminate these inefficiencies but are also expected to reduce execution time within GitHub Actions. This reduction could contribute to lower operational costs for the project.

Test smells refactored:

- Suboptimal Assert: Instead of using statements such as assertIsNone, assertIsInstance, always simply use assertTrue or assertFalse. This will decrease the code overall readability and increase the execution time as extra logic needed.
- Similar Test Methods: Test methods within the same test class that have similar code. Refactor such cases with unittest.Subtest can not only reduce code redundancy, but also saves execution time by caching similar code base.
- General Fixture: Not all parameters in the setup function were used. Given that Setup function will be triggered everytime when the test method under the same class is executed, we should comment out the unused fixtures for the efficiency concern. For some the test class, we should also consider to break them into small classes.
- Redundant Print: Having print called within the test method. This was considered not a good practice as printing costs extra time and will normally hidden in the long output from the CICD. Instead, put them into the assert messages for debug purposes.
- Sleepy Test: occurs when developers need to pause the execution of statements in a test case for a certain duration. Sometimes the sleep command can be inevitable, but instead of time.sleep, consider to use asyncio.sleep. Also, consider to comment out the sleep is that is not inevitable.

I didn't change any of the testing logic or testing values. The refactoring only focuses on reducing the test smells.

Please feel free to let me know if you are interested in more refactoring like this or if there're any changes that you don't wish.

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~~Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)~~
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
