### PR TITLE
Prefer VISUAL environment variable over EDITOR (for e.g. `beet config -e`)

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -2371,7 +2371,9 @@ def config_edit():
     except OSError as exc:
         message = f"Could not edit configuration: {exc}"
         if not editor:
-            message += ". Please set the EDITOR environment variable"
+            message += (
+                ". Please set the VISUAL (or EDITOR) environment variable"
+            )
         raise ui.UserError(message)
 
 
@@ -2386,7 +2388,7 @@ config_cmd.parser.add_option(
     "-e",
     "--edit",
     action="store_true",
-    help="edit user configuration with $EDITOR",
+    help="edit user configuration with $VISUAL (or $EDITOR)",
 )
 config_cmd.parser.add_option(
     "-d",

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -978,14 +978,14 @@ def open_anything() -> str:
 def editor_command() -> str:
     """Get a command for opening a text file.
 
-    Use the `EDITOR` environment variable by default. If it is not
-    present, fall back to `open_anything()`, the platform-specific tool
-    for opening files in general.
+    First try environment variable `VISUAL` followed by `EDITOR`. As last resort
+    fall back to `open_anything()`, the platform-specific tool for opening files
+    in general.
+
     """
-    editor = os.environ.get("EDITOR")
-    if editor:
-        return editor
-    return open_anything()
+    return (
+        os.environ.get("VISUAL") or os.environ.get("EDITOR") or open_anything()
+    )
 
 
 def interactive_open(targets: Sequence[str], command: str):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,8 @@ Major new features:
 
 New features:
 
+* :doc:`/plugins/edit`: Prefer editor from ``VISUAL`` environment variable over ``EDITOR``.
+* :ref:`config-cmd`: Prefer editor from ``VISUAL`` environment variable over ``EDITOR``.
 * :doc:`/plugins/listenbrainz`: Add initial support for importing history and playlists from `ListenBrainz`
   :bug:`1719`
 * :doc:`plugins/mbsubmit`: add new prompt choices helping further to submit unmatched tracks to MusicBrainz faster.

--- a/docs/plugins/edit.rst
+++ b/docs/plugins/edit.rst
@@ -9,9 +9,9 @@ then type::
 
      beet edit QUERY
 
-Your text editor (i.e., the command in your ``$EDITOR`` environment variable)
-will open with a list of tracks to edit. Make your changes and exit your text
-editor to apply them to your music.
+Your text editor (i.e., the command in your ``$VISUAL`` or ``$EDITOR``
+environment variable) will open with a list of tracks to edit. Make your changes
+and exit your text editor to apply them to your music.
 
 Command-Line Options
 --------------------

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -444,9 +444,9 @@ Show or edit the user configuration. This command does one of three things:
 * By default, sensitive information like passwords is removed when dumping the
   configuration. The ``--clear`` option includes this sensitive data.
 * With the ``--edit`` option, beets attempts to open your config file for
-  editing. It first tries the ``$EDITOR`` environment variable and then a
-  fallback option depending on your platform: ``open`` on OS X, ``xdg-open``
-  on Unix, and direct invocation on Windows.
+  editing. It first tries the ``$EDITOR`` environment variable, followed by
+  ``$EDITOR`` and then a fallback option depending on your platform: ``open`` on
+  OS X, ``xdg-open`` on Unix, and direct invocation on Windows.
 
 
 .. _global-flags:

--- a/test/test_config_command.py
+++ b/test/test_config_command.py
@@ -15,8 +15,9 @@ class ConfigCommandTest(unittest.TestCase, TestHelper):
     def setUp(self):
         self.lib = Library(":memory:")
         self.temp_dir = mkdtemp()
-        if "EDITOR" in os.environ:
-            del os.environ["EDITOR"]
+        for k in ("VISUAL", "EDITOR"):
+            if k in os.environ:
+                del os.environ[k]
 
         os.environ["BEETSDIR"] = self.temp_dir
         self.config_path = os.path.join(self.temp_dir, "config.yaml")
@@ -90,11 +91,21 @@ class ConfigCommandTest(unittest.TestCase, TestHelper):
         self.assertEqual(len(paths), 3)
         self.assertEqual(paths[0], self.cli_config_path)
 
-    def test_edit_config_with_editor_env(self):
+    def test_edit_config_with_visual_or_editor_env(self):
         os.environ["EDITOR"] = "myeditor"
         with patch("os.execlp") as execlp:
             self.run_command("config", "-e")
         execlp.assert_called_once_with("myeditor", "myeditor", self.config_path)
+
+        os.environ["VISUAL"] = ""  # empty environment variables gets ignored
+        with patch("os.execlp") as execlp:
+            self.run_command("config", "-e")
+        execlp.assert_called_once_with("myeditor", "myeditor", self.config_path)
+
+        os.environ["VISUAL"] = "myvisual"
+        with patch("os.execlp") as execlp:
+            self.run_command("config", "-e")
+        execlp.assert_called_once_with("myvisual", "myvisual", self.config_path)
 
     def test_edit_config_with_automatic_open(self):
         with patch("beets.util.open_anything") as open:


### PR DESCRIPTION
## Description

When unix tools make use of an external editor, they typically check the environment variable VISUAL and fall back to EDITOR. This commit adds the additional check for VISUAL to the existing EDITOR check (where VISUAL is preferred over EDITOR).

## To Do

- [x] Documentation
- [x] Changelog
- [x] Tests
