### PR TITLE
Fix extension issue in convert plugin when exporting a playlist

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -48,6 +48,8 @@ def replace_ext(path, ext):
 
     The new extension must not contain a leading dot.
     """
+    assert isinstance(path, bytes)
+    assert isinstance(ext, bytes)
     ext_dot = b"." + ext
     return os.path.splitext(path)[0] + ext_dot
 

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -146,6 +146,7 @@ class ConvertPlugin(BeetsPlugin):
                 "album_art_maxwidth": 0,
                 "delete_originals": False,
                 "playlist": None,
+                "refresh": False,
             }
         )
         self.early_import_stages = [self.auto_convert, self.auto_convert_keep]
@@ -253,12 +254,13 @@ class ConvertPlugin(BeetsPlugin):
                 hardlink,
                 link,
                 playlist,
+                refresh,
             ) = self._get_opts_and_config(empty_opts)
 
             items = task.imported_items()
             self._parallel_convert(
                 dest,
-                False,
+                refresh,
                 False,
                 path_formats,
                 fmt,
@@ -588,6 +590,7 @@ class ConvertPlugin(BeetsPlugin):
             hardlink,
             link,
             playlist,
+            refresh,
         ) = self._get_opts_and_config(opts)
 
         if opts.album:
@@ -616,7 +619,7 @@ class ConvertPlugin(BeetsPlugin):
 
         self._parallel_convert(
             dest,
-            opts.refresh,
+            refresh,
             opts.keep_new,
             path_formats,
             fmt,
@@ -754,6 +757,11 @@ class ConvertPlugin(BeetsPlugin):
             hardlink = self.config["hardlink"].get(bool)
             link = self.config["link"].get(bool)
 
+        if opts.refresh is not None:
+            refresh = opts.refresh
+        else:
+            refresh = self.config["refresh"].get(bool)
+
         return (
             dest,
             threads,
@@ -763,6 +771,7 @@ class ConvertPlugin(BeetsPlugin):
             hardlink,
             link,
             playlist,
+            refresh,
         )
 
     def _parallel_convert(

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -630,6 +630,8 @@ class ConvertPlugin(BeetsPlugin):
             items,
         )
 
+        # If the user supplied a playlist name, create a playlist containing
+        # all converted titles using this name.
         if playlist:
             # Playlist paths are understood as relative to the dest directory.
             pl_normpath = util.normpath(playlist)
@@ -641,10 +643,15 @@ class ConvertPlugin(BeetsPlugin):
             items_paths = [
                 os.path.relpath(
                     util.bytestring_path(
-                        item.destination(
-                            basedir=dest,
-                            path_formats=path_formats,
-                            fragment=False,
+                        # Substitute the before-conversion file extension by
+                        # the after-conversion extension.
+                        replace_ext(
+                            item.destination(
+                                basedir=dest,
+                                path_formats=path_formats,
+                                fragment=False,
+                            ),
+                            get_format()[1],
                         )
                     ),
                     pl_dir,

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -169,6 +169,14 @@ class ConvertPlugin(BeetsPlugin):
                               defaults to maximum available processors",
         )
         cmd.parser.add_option(
+            "-r",
+            "--refresh",
+            action="store_true",
+            dest="refresh",
+            help="reconvert if original file is \
+                            newer than converted file",
+        )
+        cmd.parser.add_option(
             "-k",
             "--keep-new",
             action="store_true",
@@ -251,6 +259,7 @@ class ConvertPlugin(BeetsPlugin):
             self._parallel_convert(
                 dest,
                 False,
+                False,
                 path_formats,
                 fmt,
                 pretend,
@@ -330,6 +339,7 @@ class ConvertPlugin(BeetsPlugin):
     def convert_item(
         self,
         dest_dir,
+        refresh,
         keep_new,
         path_formats,
         fmt,
@@ -367,12 +377,9 @@ class ConvertPlugin(BeetsPlugin):
                 with _fs_lock:
                     util.mkdirall(dest)
 
-            # TODO: Implement the option as --refresh.
-            refresh = True
-
             # Delete existing destination files when original files have been
-            # modified since the last conversion [only when not using the
-            # --keep-new option].
+            # modified since the last conversion. NOTE: Only when not using the
+            # --keep-new option because I'm not sure what to do in this case.
             if ((refresh and not keep_new) and
                 (os.path.exists(util.syspath(dest))) and
                 (os.path.getmtime(util.syspath(item.path)) > os.path.getmtime(util.syspath(dest)))):
@@ -609,6 +616,7 @@ class ConvertPlugin(BeetsPlugin):
 
         self._parallel_convert(
             dest,
+            opts.refresh,
             opts.keep_new,
             path_formats,
             fmt,
@@ -760,6 +768,7 @@ class ConvertPlugin(BeetsPlugin):
     def _parallel_convert(
         self,
         dest,
+        refresh,
         keep_new,
         path_formats,
         fmt,
@@ -774,7 +783,7 @@ class ConvertPlugin(BeetsPlugin):
         """
         convert = [
             self.convert_item(
-                dest, keep_new, path_formats, fmt, pretend, link, hardlink
+                dest, refresh, keep_new, path_formats, fmt, pretend, link, hardlink
             )
             for _ in range(threads)
         ]

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -367,6 +367,26 @@ class ConvertPlugin(BeetsPlugin):
                 with _fs_lock:
                     util.mkdirall(dest)
 
+            # TODO: Implement the option as --refresh.
+            refresh = True
+
+            # Delete existing destination files when original files have been
+            # modified since the last conversion [only when not using the
+            # --keep-new option].
+            if ((refresh and not keep_new) and
+                (os.path.exists(util.syspath(dest))) and
+                (os.path.getmtime(util.syspath(item.path)) > os.path.getmtime(util.syspath(dest)))):
+                if pretend:
+                    self._log.info(
+                        "rm {0} (original file modified)",
+                        util.displayable_path(dest),
+                    )
+                else:
+                    self._log.info(
+                        "Removing {0} (original file modified)", util.displayable_path(dest)
+                    )
+                    util.remove(util.syspath(dest))
+
             if os.path.exists(util.syspath(dest)):
                 self._log.info(
                     "Skipping {0} (target file exists)",

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -163,6 +163,8 @@ New features:
 * Add support for `barcode` field.
   :bug:`3172`
 * :doc:`/plugins/smartplaylist`: Add new config option `smartplaylist.fields`.
+* :doc:`/plugins/convert`: Add new configuration option `convert.refresh` and
+  command-line option ``--refresh``.
 
 Bug fixes:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -305,6 +305,8 @@ Bug fixes:
 * Fix bug where unimported plugin would not ignore children directories of
   ignored directories.
   :bug:`5130` 
+* :doc:`/plugins/convert`: Fix extension substitution inside path of the
+  exported playlist.
 
 For plugin developers:
 

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -62,7 +62,9 @@ absolute or relative to the ``dest`` directory. The contents will always be
 relative paths to media files, which tries to ensure compatibility when read
 from external drives or on computers other than the one used for the
 conversion. There is one caveat though: A list generated on Unix/macOS can't be
-read on Windows and vice versa.
+read on Windows and vice versa. Depending on the beets user's settings a
+generated playlist potentially could contain unicode characters. This is
+supported, playlists are written in `M3U8 format`_.
 
 The ``-r`` (or ``--refresh``) option allows to refresh the converted files if
 the originals ones are modified. It instructs the plugin to compare the
@@ -70,10 +72,6 @@ timestamps of the latest modification for both the originals and the converted
 files. If an original file is newer than a converted file, the converted file
 will be removed from the filesystem, and the original file will be converted
 once again.
-
-Depending on the beets user's settings a generated playlist potentially could
-contain unicode characters. This is supported, playlists are written in `M3U8
-format`_.
 
 Configuration
 -------------

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -64,6 +64,13 @@ from external drives or on computers other than the one used for the
 conversion. There is one caveat though: A list generated on Unix/macOS can't be
 read on Windows and vice versa.
 
+The ``-r`` (or ``--refresh``) option allows to refresh the converted files if
+the originals ones are modified. It instructs the plugin to compare the
+timestamps of the latest modification for both the originals and the converted
+files. If an original file is newer than a converted file, the converted file
+will be removed from the filesystem, and the original file will be converted
+once again.
+
 Depending on the beets user's settings a generated playlist potentially could
 contain unicode characters. This is supported, playlists are written in `M3U8
 format`_.
@@ -143,6 +150,10 @@ file. The available options are:
   to the destination path (``dest``, ``--dest``, ``-d``). This configuration is
   overridden by the ``-m`` (``--playlist``) command line option.
   Default: none.
+- **refresh**: Refresh the converted files if needed by re-converting modified
+  original files. This configuration is overridden by the ``-r``
+  (``--refresh``) command line option.
+  Default: ``false``.
 
 You can also configure the format to use for transcoding (see the next
 section):


### PR DESCRIPTION
## Description

Fix extension substitution inside path of the exported playlist.

Before this, the exported playlist contained relative paths pointing to the
converted files BUT the extension were not substituted comparing to before and
the after the conversion. Therefore, running the playlist will fail for files
which have been converted and where extension have changed.

Example:
1. Convert `/path/to/library/artist.flac` to `/path/to/converted/artist.mp3` using the `-m playlist.m3u` command-line flag.
2. Open the generated playlist, and find the incorrect path `/path/to/converted/artist.flac` inside.

## To Do

- [X] Documentation
- [X] Changelog
- [X] Tests
