### PR TITLE
 Fix extension issue in convert plugin when exporting a playlist

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -48,6 +48,8 @@ def replace_ext(path, ext):
 
     The new extension must not contain a leading dot.
     """
+    assert isinstance(path, bytes)
+    assert isinstance(ext, bytes)
     ext_dot = b"." + ext
     return os.path.splitext(path)[0] + ext_dot
 

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -599,6 +599,8 @@ class ConvertPlugin(BeetsPlugin):
             items,
         )
 
+        # If the user supplied a playlist name, create a playlist containing
+        # all converted titles using this name.
         if playlist:
             # Playlist paths are understood as relative to the dest directory.
             pl_normpath = util.normpath(playlist)
@@ -610,10 +612,15 @@ class ConvertPlugin(BeetsPlugin):
             items_paths = [
                 os.path.relpath(
                     util.bytestring_path(
-                        item.destination(
-                            basedir=dest,
-                            path_formats=path_formats,
-                            fragment=False,
+                        # Substitute the before-conversion file extension by
+                        # the after-conversion extension.
+                        replace_ext(
+                            item.destination(
+                                basedir=dest,
+                                path_formats=path_formats,
+                                fragment=False,
+                            ),
+                            get_format()[1],
                         )
                     ),
                     pl_dir,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -303,6 +303,8 @@ Bug fixes:
 * Fix bug where unimported plugin would not ignore children directories of
   ignored directories.
   :bug:`5130` 
+* :doc:`/plugins/convert`: Fix extension substitution inside path of the
+  exported playlist.
 
 For plugin developers:
 


### PR DESCRIPTION
## Description

Fix extension substitution inside path of the exported playlist.

Before this, the exported playlist contained relative paths pointing to the
converted files BUT the extension were not substituted comparing to before and
the after the conversion. Therefore, running the playlist will fail for files
which have been converted and where extension have changed.

Example:
1. Convert `/path/to/library/artist.flac` to `/path/to/converted/artist.mp3` using the `-m playlist.m3u` command-line flag.
2. Open the generated playlist, and find the incorrect path `/path/to/converted/artist.flac` inside.

## To Do

- [X] Documentation
- [X] Changelog
- [X] Tests
