### PR TITLE
Add feature of refreshing converted files if original files are modified

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -428,9 +428,10 @@ class ConvertPlugin(BeetsPlugin):
         # Delete existing destination files when original files have been
         # modified since the last conversion. NOTE: Only when not using the
         # --keep-new option because I'm not sure what to do in this case.
-        if ((refresh and not keep_new) and
-            (os.path.exists(util.syspath(dest))) and
-            (os.path.getmtime(util.syspath(item.path)) > os.path.getmtime(util.syspath(dest)))):
+        if ((refresh and not keep_new)
+            and (os.path.exists(util.syspath(dest)))
+            and (os.path.getmtime(util.syspath(item.path)) 
+                 > os.path.getmtime(util.syspath(dest)))):
             if pretend:
                 self._log.info(
                     "rm {0} (original file modified)",
@@ -438,7 +439,8 @@ class ConvertPlugin(BeetsPlugin):
                 )
             else:
                 self._log.info(
-                    "Removing {0} (original file modified)", util.displayable_path(dest)
+                    "Removing {0} (original file modified)",
+                    util.displayable_path(dest)
                 )
                 util.remove(util.syspath(dest))
 

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -428,10 +428,14 @@ class ConvertPlugin(BeetsPlugin):
         # Delete existing destination files when original files have been
         # modified since the last conversion. NOTE: Only when not using the
         # --keep-new option because I'm not sure what to do in this case.
-        if ((refresh and not keep_new)
+        if (
+            (refresh and not keep_new)
             and (os.path.exists(util.syspath(dest)))
-            and (os.path.getmtime(util.syspath(item.path))
-                 > os.path.getmtime(util.syspath(dest)))):
+            and (
+                os.path.getmtime(util.syspath(item.path))
+                > os.path.getmtime(util.syspath(dest))
+            )
+        ):
             if pretend:
                 self._log.info(
                     "rm {0} (original file modified)",
@@ -440,7 +444,7 @@ class ConvertPlugin(BeetsPlugin):
             else:
                 self._log.info(
                     "Removing {0} (original file modified)",
-                    util.displayable_path(dest)
+                    util.displayable_path(dest),
                 )
                 util.remove(util.syspath(dest))
 

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -440,14 +440,16 @@ class ConvertPlugin(BeetsPlugin):
 
         if os.path.exists(dest):
             # Delete existing destination files when original files have been modified since the last convert run.
-            if refresh and os.path.getmtime(original) > os.path.getmtime(dest):
+            if refresh and os.path.getmtime(original) > os.path.getmtime(
+                dest
+            ):
                 self._log.info(
                     "Removing {0} (original file modified)",
                     util.displayable_path(dest),
                 )
                 if not pretend:
                     util.remove(dest)
-            else
+            else:
                 self._log.info(
                     "Skipping {0} (target file exists)",
                     util.displayable_path(item.path),

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -439,7 +439,8 @@ class ConvertPlugin(BeetsPlugin):
             converted = dest
 
         if os.path.exists(dest):
-            # Delete existing destination files when original files have been modified since the last convert run.
+            # Delete existing destination files when original files have
+            # been modified since the last convert run.
             if refresh and os.path.getmtime(original) > os.path.getmtime(
                 dest
             ):

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -153,6 +153,7 @@ class ConvertPlugin(BeetsPlugin):
             "--refresh",
             action="store_true",
             dest="refresh",
+            default=self.config["refresh"].get(),
             help="reconvert if original file is newer than converted file",
         )
         cmd.parser.add_option(

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -263,6 +263,10 @@ class ConvertPlugin(BeetsPlugin):
         return self.config["force"].get(bool)
 
     @cached_property
+    def refresh(self) -> bool:
+        return self.config["refresh"].get(bool)
+
+    @cached_property
     def hardlink(self) -> bool:
         return self.config["hardlink"].get(bool)
 
@@ -315,7 +319,7 @@ class ConvertPlugin(BeetsPlugin):
             # Filter items based on should_transcode function
             items = [item for item in items if self.should_transcode(item)]
 
-            self._parallel_convert(items, refresh=False, keep_new=False)
+            self._parallel_convert(items, keep_new=False)
 
     # Utilities converted from functions to methods on logging overhaul
 
@@ -409,9 +413,14 @@ class ConvertPlugin(BeetsPlugin):
         )
 
     @pipeline.mutator_stage
-    def convert_item(self, refresh: bool, keep_new: bool, item: Item) -> None:
+    def convert_item(self, keep_new: bool, item: Item) -> None:
         """Convert an Item from the library."""
-        pretend, link, hardlink = self.pretend, self.link, self.hardlink
+        pretend, link, hardlink, refresh = (
+            self.pretend,
+            self.link,
+            self.hardlink,
+            self.refresh,
+        )
         command, ext = self.command
 
         dest = self.get_item_destination(item)
@@ -701,9 +710,7 @@ class ConvertPlugin(BeetsPlugin):
                 items_paths.append(os.path.relpath(item_path, pl_dir))
 
         self._parallel_convert(
-            items,
-            refresh=self.config["refresh"].get(bool),
-            keep_new=self.config["keep_new"].get(bool),
+            items, keep_new=self.config["keep_new"].get(bool)
         )
 
         if playlist:
@@ -778,14 +785,10 @@ class ConvertPlugin(BeetsPlugin):
                     util.remove(path)
                 _temp_files.remove(path)
 
-    def _parallel_convert(
-        self, items: list[Item], refresh: bool, keep_new: bool
-    ):
+    def _parallel_convert(self, items: list[Item], keep_new: bool):
         """Run the convert_item function for every items on as many thread as
         defined in threads
         """
-        convert = [
-            self.convert_item(refresh, keep_new) for _ in range(self.threads)
-        ]
+        convert = [self.convert_item(keep_new) for _ in range(self.threads)]
         pipe = pipeline.Pipeline([iter(items), convert])
         pipe.run_parallel()

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -430,7 +430,7 @@ class ConvertPlugin(BeetsPlugin):
         # --keep-new option because I'm not sure what to do in this case.
         if ((refresh and not keep_new)
             and (os.path.exists(util.syspath(dest)))
-            and (os.path.getmtime(util.syspath(item.path)) 
+            and (os.path.getmtime(util.syspath(item.path))
                  > os.path.getmtime(util.syspath(dest)))):
             if pretend:
                 self._log.info(

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -459,7 +459,7 @@ class ConvertPlugin(BeetsPlugin):
                     self._log.debug(
                         "Skipping refresh: not supported with keep_new"
                     )
-                continue
+                return
             # If reached, `refresh` is true, `keep_new` is false, and original file
             # is newer than the destination file -> consider deleting the existing
             # destination files

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -435,17 +435,12 @@ class ConvertPlugin(BeetsPlugin):
                 > os.path.getmtime(util.syspath(dest))
             )
         ):
-            if pretend:
-                self._log.info(
-                    "rm {0} (original file modified)",
-                    util.displayable_path(dest),
-                )
-            else:
-                self._log.info(
-                    "Removing {0} (original file modified)",
-                    util.displayable_path(dest),
-                )
-                util.remove(util.syspath(dest))
+            self._log.info(
+                "Removing {0} (original file modified)",
+                util.displayable_path(dest),
+            )
+            if not pretend:
+                util.remove(dest)
 
         # When keeping the new file in the library, we first move the
         # current (pristine) file to the destination. We'll then copy it

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -439,17 +439,24 @@ class ConvertPlugin(BeetsPlugin):
             converted = dest
 
         if os.path.exists(dest):
-            # Delete existing destination files when original files have
-            # been modified since the last convert run.
+            # If `refresh` option is enabled, delete existing destination files
+            # when original files have been modified since the last convert run.
             if refresh and os.path.getmtime(original) > os.path.getmtime(
                 dest
             ):
-                self._log.info(
-                    "Removing {0} (original file modified)",
-                    util.displayable_path(dest),
-                )
                 if not pretend:
+                    self._log.info(
+                        "Removing {0} (original file modified)",
+                        util.displayable_path(dest),
+                    )
                     util.remove(dest)
+                # If we pretend to convert files, only inform user about what
+                # would be removed without removing anything.
+                else:
+                    self._log.info(
+                        "Pretend to remove {0} (original file modified)",
+                        util.displayable_path(dest),
+                    )
             else:
                 self._log.info(
                     "Skipping {0} (target file exists)",
@@ -471,7 +478,7 @@ class ConvertPlugin(BeetsPlugin):
         if keep_new:
             if pretend:
                 self._log.info(
-                    "mv {.filepath} {}", item, util.displayable_path(original)
+                    "Pretend to move {.filepath} to {}", item, util.displayable_path(original)
                 )
             else:
                 self._log.info("Moving to {}", util.displayable_path(original))

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -438,31 +438,40 @@ class ConvertPlugin(BeetsPlugin):
                 dest = replace_ext(dest, ext)
             converted = dest
 
+        # When the target file exists, we choose between:
+        # 1) Skipping current conversion
+        # 2) Removing the target file to start a fresh conversion
         if os.path.exists(dest):
-            # If `refresh` option is enabled, delete existing destination files
-            # when original files have been modified since the last convert run.
-            if refresh and os.path.getmtime(original) > os.path.getmtime(
-                dest
-            ):
-                if not pretend:
+            # Test to skip the conversion, whether because:
+            # 1) `refresh` is false (default)
+            # 2) `keep_new` is true (incompatible with `refresh`)
+            # 3) The original file is older than the destination file
+            if not refresh or keep_new or os.path.getmtime(original) <= os.path.getmtime(dest):
+                self._log.info(
+                    "Skipping {0} (destination file exists)",
+                    util.displayable_path(item.path),
+                )
+                if keep_new and refresh:
+                    self._log.debug("Skipping refresh: not supported with keep_new")
+                continue
+            # If reached, `refresh` is true, `keep_new` is false, and original file
+            # is newer than the destination file -> consider deleting the existing
+            # destination files
+            else:
+                # If we pretend to convert files, only inform user about what
+                # would be removed without removing anything
+                if pretend:
+                    self._log.info(
+                        "Pretend to remove {0} (original file modified)",
+                        util.displayable_path(dest),
+                    )
+                # Otherwise, actually remove the destination file
+                else:
                     self._log.info(
                         "Removing {0} (original file modified)",
                         util.displayable_path(dest),
                     )
                     util.remove(dest)
-                # If we pretend to convert files, only inform user about what
-                # would be removed without removing anything.
-                else:
-                    self._log.info(
-                        "Pretend to remove {0} (original file modified)",
-                        util.displayable_path(dest),
-                    )
-            else:
-                self._log.info(
-                    "Skipping {0} (target file exists)",
-                    util.displayable_path(item.path),
-                )
-                continue
 
         # Ensure that only one thread tries to create directories at a
         # time. (The existence check is not atomic with the directory
@@ -595,7 +604,7 @@ class ConvertPlugin(BeetsPlugin):
 
         if os.path.exists(util.syspath(dest)):
             self._log.info(
-                "Skipping {.art_filepath} (target file exists)", album
+                "Skipping {.art_filepath} (destination file exists)", album
             )
             return
 

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -416,6 +416,26 @@ class ConvertPlugin(BeetsPlugin):
             self._log.error("Could not open file to convert: {}", exc)
             return
 
+        # TODO: Implement the option as --refresh.
+        refresh = True
+
+        # Delete existing destination files when original files have been
+        # modified since the last conversion [only when not using the
+        # --keep-new option].
+        if ((refresh and not keep_new) and
+            (os.path.exists(util.syspath(dest))) and
+            (os.path.getmtime(util.syspath(item.path)) > os.path.getmtime(util.syspath(dest)))):
+            if pretend:
+                self._log.info(
+                    "rm {0} (original file modified)",
+                    util.displayable_path(dest),
+                )
+            else:
+                self._log.info(
+                    "Removing {0} (original file modified)", util.displayable_path(dest)
+                )
+                util.remove(util.syspath(dest))
+
         # When keeping the new file in the library, we first move the
         # current (pristine) file to the destination. We'll then copy it
         # back to its old path or transcode it to a new path.

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -442,7 +442,7 @@ class ConvertPlugin(BeetsPlugin):
         # If the destination file exists, we have to choose between:
         # 1) Skipping current conversion
         # 2) Removing the target file to start a fresh conversion
-        if os.path.exists(dest):
+        if os.path.exists(util.syspath(dest)):
             # Test to skip the conversion, whether because:
             # 1) `refresh` is false (default)
             # 2) `keep_new` is true (incompatible with `refresh`)
@@ -453,8 +453,7 @@ class ConvertPlugin(BeetsPlugin):
                 or os.path.getmtime(item.path) <= os.path.getmtime(dest)
             ):
                 self._log.info(
-                    "Skipping {0} (destination file exists)",
-                    util.displayable_path(item.path),
+                    "Skipping {.filepath} (destination file exists)", item
                 )
                 if keep_new and refresh:
                     self._log.debug(
@@ -484,10 +483,6 @@ class ConvertPlugin(BeetsPlugin):
         if not pretend:
             with _fs_lock:
                 util.mkdirall(dest)
-
-        if os.path.exists(util.syspath(dest)):
-            self._log.info("Skipping {.filepath} (target file exists)", item)
-            return
 
         if keep_new:
             if pretend:

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -456,6 +456,24 @@ class ConvertPlugin(BeetsPlugin):
                 dest = replace_ext(dest, ext)
             converted = dest
 
+        # Delete existing destination files when original files have been
+        # modified since the last conversion. NOTE: Only when not using the
+        # --keep-new option because I'm not sure what to do in this case.
+        if (
+            (refresh and not keep_new)
+            and (os.path.exists(dest))
+            and (
+                os.path.getmtime(item.path)
+                > os.path.getmtime(dest)
+            )
+        ):
+            self._log.info(
+                "Removing {0} (original file modified)",
+                util.displayable_path(dest),
+            )
+            if not pretend:
+                util.remove(dest)
+
         # Ensure that only one thread tries to create directories at a
         # time. (The existence check is not atomic with the directory
         # creation inside this function.)

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -446,7 +446,7 @@ class ConvertPlugin(BeetsPlugin):
             # 1) `refresh` is false (default)
             # 2) `keep_new` is true (incompatible with `refresh`)
             # 3) The original file is older than the destination file
-            if not refresh or keep_new or os.path.getmtime(original) <= os.path.getmtime(dest):
+            if not refresh or keep_new or os.path.getmtime(item.path) <= os.path.getmtime(dest):
                 self._log.info(
                     "Skipping {0} (destination file exists)",
                     util.displayable_path(item.path),

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -424,24 +424,6 @@ class ConvertPlugin(BeetsPlugin):
             self._log.error("Could not open file to convert: {}", exc)
             return
 
-        # Delete existing destination files when original files have been
-        # modified since the last conversion. NOTE: Only when not using the
-        # --keep-new option because I'm not sure what to do in this case.
-        if (
-            (refresh and not keep_new)
-            and (os.path.exists(util.syspath(dest)))
-            and (
-                os.path.getmtime(util.syspath(item.path))
-                > os.path.getmtime(util.syspath(dest))
-            )
-        ):
-            self._log.info(
-                "Removing {0} (original file modified)",
-                util.displayable_path(dest),
-            )
-            if not pretend:
-                util.remove(dest)
-
         # When keeping the new file in the library, we first move the
         # current (pristine) file to the destination. We'll then copy it
         # back to its old path or transcode it to a new path.
@@ -456,23 +438,21 @@ class ConvertPlugin(BeetsPlugin):
                 dest = replace_ext(dest, ext)
             converted = dest
 
-        # Delete existing destination files when original files have been
-        # modified since the last conversion. NOTE: Only when not using the
-        # --keep-new option because I'm not sure what to do in this case.
-        if (
-            (refresh and not keep_new)
-            and (os.path.exists(dest))
-            and (
-                os.path.getmtime(item.path)
-                > os.path.getmtime(dest)
-            )
-        ):
-            self._log.info(
-                "Removing {0} (original file modified)",
-                util.displayable_path(dest),
-            )
-            if not pretend:
-                util.remove(dest)
+        if os.path.exists(dest):
+            # Delete existing destination files when original files have been modified since the last convert run.
+            if refresh and os.path.getmtime(original) > os.path.getmtime(dest):
+                self._log.info(
+                    "Removing {0} (original file modified)",
+                    util.displayable_path(dest),
+                )
+                if not pretend:
+                    util.remove(dest)
+            else
+                self._log.info(
+                    "Skipping {0} (target file exists)",
+                    util.displayable_path(item.path),
+                )
+                continue
 
         # Ensure that only one thread tries to create directories at a
         # time. (The existence check is not atomic with the directory

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -148,6 +148,14 @@ class ConvertPlugin(BeetsPlugin):
             ),
         )
         cmd.parser.add_option(
+            "-r",
+            "--refresh",
+            action="store_true",
+            dest="refresh",
+            help="reconvert if original file is \
+                            newer than converted file",
+        )
+        cmd.parser.add_option(
             "-k",
             "--keep-new",
             action="store_true",
@@ -306,7 +314,7 @@ class ConvertPlugin(BeetsPlugin):
             # Filter items based on should_transcode function
             items = [item for item in items if self.should_transcode(item)]
 
-            self._parallel_convert(items, keep_new=False)
+            self._parallel_convert(items, refresh=False, keep_new=False)
 
     # Utilities converted from functions to methods on logging overhaul
 
@@ -400,7 +408,7 @@ class ConvertPlugin(BeetsPlugin):
         )
 
     @pipeline.mutator_stage
-    def convert_item(self, keep_new: bool, item: Item) -> None:
+    def convert_item(self, refresh: bool, keep_new: bool, item: Item) -> None:
         """Convert an Item from the library."""
         pretend, link, hardlink = self.pretend, self.link, self.hardlink
         command, ext = self.command
@@ -416,12 +424,9 @@ class ConvertPlugin(BeetsPlugin):
             self._log.error("Could not open file to convert: {}", exc)
             return
 
-        # TODO: Implement the option as --refresh.
-        refresh = True
-
         # Delete existing destination files when original files have been
-        # modified since the last conversion [only when not using the
-        # --keep-new option].
+        # modified since the last conversion. NOTE: Only when not using the
+        # --keep-new option because I'm not sure what to do in this case.
         if ((refresh and not keep_new) and
             (os.path.exists(util.syspath(dest))) and
             (os.path.getmtime(util.syspath(item.path)) > os.path.getmtime(util.syspath(dest)))):
@@ -676,7 +681,7 @@ class ConvertPlugin(BeetsPlugin):
                 items_paths.append(os.path.relpath(item_path, pl_dir))
 
         self._parallel_convert(
-            items, keep_new=self.config["keep_new"].get(bool)
+            items, refresh=self.config["refresh"].get(bool), keep_new=self.config["keep_new"].get(bool)
         )
 
         if playlist:
@@ -751,10 +756,10 @@ class ConvertPlugin(BeetsPlugin):
                     util.remove(path)
                 _temp_files.remove(path)
 
-    def _parallel_convert(self, items: list[Item], keep_new: bool):
+    def _parallel_convert(self, items: list[Item], refresh: bool, keep_new: bool):
         """Run the convert_item function for every items on as many thread as
         defined in threads
         """
-        convert = [self.convert_item(keep_new) for _ in range(self.threads)]
+        convert = [self.convert_item(refresh, keep_new) for _ in range(self.threads)]
         pipe = pipeline.Pipeline([iter(items), convert])
         pipe.run_parallel()

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -120,6 +120,7 @@ class ConvertPlugin(BeetsPlugin):
                 "delete_originals": False,
                 "playlist": None,
                 "force": False,
+                "refresh": False,
                 "keep_new": False,
             }
         )

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -446,13 +446,19 @@ class ConvertPlugin(BeetsPlugin):
             # 1) `refresh` is false (default)
             # 2) `keep_new` is true (incompatible with `refresh`)
             # 3) The original file is older than the destination file
-            if not refresh or keep_new or os.path.getmtime(item.path) <= os.path.getmtime(dest):
+            if (
+                not refresh
+                or keep_new
+                or os.path.getmtime(item.path) <= os.path.getmtime(dest)
+            ):
                 self._log.info(
                     "Skipping {0} (destination file exists)",
                     util.displayable_path(item.path),
                 )
                 if keep_new and refresh:
-                    self._log.debug("Skipping refresh: not supported with keep_new")
+                    self._log.debug(
+                        "Skipping refresh: not supported with keep_new"
+                    )
                 continue
             # If reached, `refresh` is true, `keep_new` is false, and original file
             # is newer than the destination file -> consider deleting the existing

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -439,7 +439,7 @@ class ConvertPlugin(BeetsPlugin):
                 dest = replace_ext(dest, ext)
             converted = dest
 
-        # When the target file exists, we choose between:
+        # If the destination file exists, we have to choose between:
         # 1) Skipping current conversion
         # 2) Removing the target file to start a fresh conversion
         if os.path.exists(dest):
@@ -462,23 +462,21 @@ class ConvertPlugin(BeetsPlugin):
                     )
                 return
             # If reached, `refresh` is true, `keep_new` is false, and original file
-            # is newer than the destination file -> consider deleting the existing
-            # destination files
+            # is newer than the destination file: we should consider deleting the
+            # existing destination files. If we pretend to convert files, only inform
+            # user about what would be removed without removing anything.
+            if pretend:
+                self._log.info(
+                    "Pretend to remove {0} (original file modified)",
+                    util.displayable_path(dest),
+                )
+            # Otherwise, actually remove the destination file
             else:
-                # If we pretend to convert files, only inform user about what
-                # would be removed without removing anything
-                if pretend:
-                    self._log.info(
-                        "Pretend to remove {0} (original file modified)",
-                        util.displayable_path(dest),
-                    )
-                # Otherwise, actually remove the destination file
-                else:
-                    self._log.info(
-                        "Removing {0} (original file modified)",
-                        util.displayable_path(dest),
-                    )
-                    util.remove(dest)
+                self._log.info(
+                    "Removing {0} (original file modified)",
+                    util.displayable_path(dest),
+                )
+                util.remove(dest)
 
         # Ensure that only one thread tries to create directories at a
         # time. (The existence check is not atomic with the directory

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -494,7 +494,9 @@ class ConvertPlugin(BeetsPlugin):
         if keep_new:
             if pretend:
                 self._log.info(
-                    "Pretend to move {.filepath} to {}", item, util.displayable_path(original)
+                    "Pretend to move {.filepath} to {}",
+                    item,
+                    util.displayable_path(original),
                 )
             else:
                 self._log.info("Moving to {}", util.displayable_path(original))
@@ -706,7 +708,9 @@ class ConvertPlugin(BeetsPlugin):
                 items_paths.append(os.path.relpath(item_path, pl_dir))
 
         self._parallel_convert(
-            items, refresh=self.config["refresh"].get(bool), keep_new=self.config["keep_new"].get(bool)
+            items,
+            refresh=self.config["refresh"].get(bool),
+            keep_new=self.config["keep_new"].get(bool),
         )
 
         if playlist:
@@ -781,10 +785,14 @@ class ConvertPlugin(BeetsPlugin):
                     util.remove(path)
                 _temp_files.remove(path)
 
-    def _parallel_convert(self, items: list[Item], refresh: bool, keep_new: bool):
+    def _parallel_convert(
+        self, items: list[Item], refresh: bool, keep_new: bool
+    ):
         """Run the convert_item function for every items on as many thread as
         defined in threads
         """
-        convert = [self.convert_item(refresh, keep_new) for _ in range(self.threads)]
+        convert = [
+            self.convert_item(refresh, keep_new) for _ in range(self.threads)
+        ]
         pipe = pipeline.Pipeline([iter(items), convert])
         pipe.run_parallel()

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -153,8 +153,7 @@ class ConvertPlugin(BeetsPlugin):
             "--refresh",
             action="store_true",
             dest="refresh",
-            help="reconvert if original file is \
-                            newer than converted file",
+            help="reconvert if original file is newer than converted file",
         )
         cmd.parser.add_option(
             "-k",

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,8 +12,9 @@ Unreleased
 New features
 ~~~~~~~~~~~~
 
-- :doc:`plugins/convert`: Add new configuration option `convert.refresh` and
-  command-line option ``--refresh``.
+- :doc:`/plugins/convert`: Add new configuration option `convert.refresh` and
+  command-line option ``--refresh``, allowing to force `convert` operation when
+  original file is newer than existing converted file.
 - :doc:`plugins/lyrics`: Added a ``rest_directory`` configuration option for
   specifying a reStructuredText output directory, semantically equivalent to
   ``-r, --write-rest``. :bug:`2806`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,9 +12,9 @@ Unreleased
 New features
 ~~~~~~~~~~~~
 
-- :doc:`/plugins/convert`: Add new configuration option `convert.refresh` and
-  command-line option ``--refresh``, allowing to force `convert` operation when
-  original file is newer than existing converted file.
+- :doc:`/plugins/convert`: Add new configuration option ``convert.refresh`` and
+  command-line option ``--refresh``, allowing to force ``convert`` operation
+  when original file is newer than existing converted file.
 - :doc:`plugins/lyrics`: Added a ``rest_directory`` configuration option for
   specifying a reStructuredText output directory, semantically equivalent to
   ``-r, --write-rest``. :bug:`2806`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,8 @@ Unreleased
 New features
 ~~~~~~~~~~~~
 
+- :doc:`plugins/convert`: Add new configuration option `convert.refresh` and
+  command-line option ``--refresh``.
 - :doc:`plugins/lyrics`: Added a ``rest_directory`` configuration option for
   specifying a reStructuredText output directory, semantically equivalent to
   ``-r, --write-rest``. :bug:`2806`

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -64,7 +64,9 @@ absolute or relative to the ``dest`` directory. The contents will always be
 relative paths to media files, which tries to ensure compatibility when read
 from external drives or on computers other than the one used for the conversion.
 There is one caveat though: A list generated on Unix/macOS can't be read on
-Windows and vice versa.
+Windows and vice versa. Depending on the beets user's settings a generated
+playlist potentially could contain unicode characters. This is supported,
+playlists are written in `M3U8 format`_.
 
 The ``-r`` (or ``--refresh``) option allows to refresh the converted files if
 the originals ones are modified. It instructs the plugin to compare the
@@ -72,10 +74,6 @@ timestamps of the latest modification for both the originals and the converted
 files. If an original file is newer than a converted file, the converted file
 will be removed from the filesystem, and the original file will be converted
 once again.
-
-Depending on the beets user's settings a generated playlist potentially could
-contain unicode characters. This is supported, playlists are written in `M3U8
-format`_.
 
 Configuration
 -------------

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -66,6 +66,13 @@ from external drives or on computers other than the one used for the conversion.
 There is one caveat though: A list generated on Unix/macOS can't be read on
 Windows and vice versa.
 
+The ``-r`` (or ``--refresh``) option allows to refresh the converted files if
+the originals ones are modified. It instructs the plugin to compare the
+timestamps of the latest modification for both the originals and the converted
+files. If an original file is newer than a converted file, the converted file
+will be removed from the filesystem, and the original file will be converted
+once again.
+
 Depending on the beets user's settings a generated playlist potentially could
 contain unicode characters. This is supported, playlists are written in `M3U8
 format`_.
@@ -162,6 +169,10 @@ The available options are:
   as well. The final destination of the playlist file will always be relative to
   the destination path (``dest``, ``--dest``, ``-d``). This configuration is
   overridden by the ``-m`` (``--playlist``) command line option. Default: none.
+- **refresh**: Refresh the converted files if needed by re-converting modified
+  original files. This configuration is overridden by the ``-r``
+  (``--refresh``) command line option.
+  Default: ``false``.
 
 You can also configure the format to use for transcoding (see the next section):
 

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -168,9 +168,8 @@ The available options are:
   the destination path (``dest``, ``--dest``, ``-d``). This configuration is
   overridden by the ``-m`` (``--playlist``) command line option. Default: none.
 - **refresh**: Refresh the converted files if needed by re-converting modified
-  original files. This configuration is overridden by the ``-r``
-  (``--refresh``) command line option.
-  Default: ``false``.
+  original files. This configuration is overridden by the ``-r`` (``--refresh``)
+  command line option. Default: ``false``.
 
 You can also configure the format to use for transcoding (see the next section):
 


### PR DESCRIPTION
## Description

By default, the `convert` plugin will skip every pending conversion if the converted file is already existing on the filesystem. However, when making changes (_e.g._, tags) in the original files, the changes are not reflected to the converted library. Adding the `--refresh` command-line option and the `refresh` option to the `convert` plugin allows to re-convert the original files if they are modified more recently than the time when converted files were converted.

## To Do

- [X] Documentation.
- [X] Changelog.
- [X] Tests.
