### PR TITLE
Configure mypy

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,5 +1,0 @@
-[mypy]
-allow_any_generics = false
-# FIXME: Would be better to actually type the libraries (if under our control),
-# or write our own stubs. For now, silence errors
-ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -181,6 +181,7 @@ per-file-ignores =
     ./beets/mediafile.py:D
 
 [mypy]
+files = beets,beetsplug,test
 allow_any_generics = false
 # FIXME: Would be better to actually type the libraries (if under our control),
 # or write our own stubs. For now, silence errors

--- a/setup.cfg
+++ b/setup.cfg
@@ -179,3 +179,9 @@ per-file-ignores =
     ./beets/dbcore/queryparse.py:D
     ./beets/dbcore/types.py:D
     ./beets/mediafile.py:D
+
+[mypy]
+allow_any_generics = false
+# FIXME: Would be better to actually type the libraries (if under our control),
+# or write our own stubs. For now, silence errors
+ignore_missing_imports = true

--- a/tox.ini
+++ b/tox.ini
@@ -27,8 +27,7 @@ passenv = INTEGRATION_TEST
 commands =
     test: python -m pytest {posargs}
     lint: python -m flake8 {posargs} {[_lint]files}
-    mypy: mypy -p beets -p beetsplug
-    mypy: mypy test
+    mypy: mypy
 
 [testenv:docs]
 basepython = python3.10


### PR DESCRIPTION
Move `mypy` configuration to `setup.cfg` and define the paths to lint in the
configuration, removing the need to explicitly specify them in `tox.ini`.
