### PR TITLE
db: disable DQS on Python >= 3.12

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -20,6 +20,7 @@ import contextlib
 import os
 import re
 import sqlite3
+import sys
 import threading
 import time
 from abc import ABC
@@ -1068,6 +1069,12 @@ class Database:
             # call conn.close() in _close()
             check_same_thread=False,
         )
+
+        if sys.version_info >= (3, 12) and sqlite3.sqlite_version_info >= (3, 29, 0):
+            # If possible, disable double-quoted strings
+            conn.setconfig(sqlite3.SQLITE_DBCONFIG_DQS_DDL, 0)
+            conn.setconfig(sqlite3.SQLITE_DBCONFIG_DQS_DML, 0)
+
         self.add_functions(conn)
 
         if self.supports_extensions:


### PR DESCRIPTION
cf. https://github.com/beetbox/beets/issues/4709, let's see how badly this breaks CI