### PR TITLE
fetchart: defer file removal config option evaluation

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -1253,10 +1253,6 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         self.cautious = self.config["cautious"].get(bool)
         self.store_source = self.config["store_source"].get(bool)
 
-        self.src_removed = config["import"]["delete"].get(bool) or config[
-            "import"
-        ]["move"].get(bool)
-
         self.cover_format = self.config["cover_format"].get(
             confuse.Optional(str)
         )
@@ -1340,10 +1336,11 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         """Place the discovered art in the filesystem."""
         if task in self.art_candidates:
             candidate = self.art_candidates.pop(task)
+            removal_enabled = _is_source_file_removal_enabled()
 
-            self._set_art(task.album, candidate, not self.src_removed)
+            self._set_art(task.album, candidate, not removal_enabled)
 
-            if self.src_removed:
+            if removal_enabled:
                 task.prune(candidate.path)
 
     # Manual album art fetching.
@@ -1443,3 +1440,9 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                 else:
                     message = ui.colorize("text_error", "no art found")
                 self._log.info("{0}: {1}", album, message)
+
+
+def _is_source_file_removal_enabled():
+    delete_enabled = config["import"]["delete"].get(bool)
+    move_enabled = config["import"]["move"].get(bool)
+    return delete_enabled or move_enabled

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -1294,6 +1294,10 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             for s, c in sources
         ]
 
+    @staticmethod
+    def _is_source_file_removal_enabled():
+        return config["import"]["delete"] or config["import"]["move"]
+
     # Asynchronous; after music is added to the library.
     def fetch_art(self, session, task):
         """Find art for the album being imported."""
@@ -1336,7 +1340,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         """Place the discovered art in the filesystem."""
         if task in self.art_candidates:
             candidate = self.art_candidates.pop(task)
-            removal_enabled = _is_source_file_removal_enabled()
+            removal_enabled = FetchArtPlugin._is_source_file_removal_enabled()
 
             self._set_art(task.album, candidate, not removal_enabled)
 
@@ -1440,9 +1444,3 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                 else:
                     message = ui.colorize("text_error", "no art found")
                 self._log.info("{0}: {1}", album, message)
-
-
-def _is_source_file_removal_enabled():
-    delete_enabled = config["import"]["delete"].get(bool)
-    move_enabled = config["import"]["move"].get(bool)
-    return delete_enabled or move_enabled

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -208,6 +208,8 @@ New features:
 * Add support for `barcode` field.
   :bug:`3172`
 * :doc:`/plugins/smartplaylist`: Add new config option `smartplaylist.fields`.
+* :doc:`/plugins/fetchart`: Defer source removal config option evaluation to
+  the point where they are used really, supporting temporary config changes.
 
 Bug fixes:
 

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -825,9 +825,13 @@ class ArtImporterTest(UseThePlugin):
         self.assertExists(self.art_file)
 
     def test_delete_original_file(self):
-        self.plugin.src_removed = True
-        self._fetch_art(True)
-        self.assertNotExists(self.art_file)
+        prev_move = config["import"]["move"].get()
+        try:
+            config["import"]["move"] = True
+            self._fetch_art(True)
+            self.assertNotExists(self.art_file)
+        finally:
+            config["import"]["move"] = prev_move
 
     def test_do_not_delete_original_if_already_in_place(self):
         artdest = os.path.join(os.path.dirname(self.i.path), b"cover.jpg")


### PR DESCRIPTION
## Description

Defer the evaluation of the source file removal options (`import.delete` and `import.move`) to the point where the fetchart plugin is actually called instead of only evaluating those configuration options on plugin initialization.
This is to allow other plugins (such as the [ytimport](https://github.com/mgoltzsche/beets-ytimport/blob/v1.8.1/beetsplug/ytimport/__init__.py#L194) plugin) to invoke the import directly (within the same python process; implicitly invoking the fetchart plugin) with temporarily overwritten configuration options.

Addresses https://github.com/beetbox/beets/issues/5167#issuecomment-2106465172

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)~
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] ~Tests. (Very much encouraged but not strictly required.)~
