### PR TITLE
Fix convert plugin attempting to process a non-media file

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -20,9 +20,9 @@ import shlex
 import subprocess
 import tempfile
 import threading
-import mediafile
 from string import Template
 
+import mediafile
 from confuse import ConfigTypeError, Optional
 
 from beets import art, config, plugins, ui, util

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -356,7 +356,7 @@ class ConvertPlugin(BeetsPlugin):
             # to avoid any side-effect of the conversion (linking, keep_new,
             # refresh) if we already know that it will fail.
             try:
-                mf = mediafile.MediaFile(util.syspath(item.path))
+                mediafile.MediaFile(util.syspath(item.path))
             except mediafile.UnreadableFileError as exc:
                 self._log.error("Could not open file to convert: {0}", exc)
                 continue

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -20,6 +20,7 @@ import shlex
 import subprocess
 import tempfile
 import threading
+import mediafile
 from string import Template
 
 from confuse import ConfigTypeError, Optional
@@ -350,6 +351,15 @@ class ConvertPlugin(BeetsPlugin):
         while True:
             item = yield (item, original, converted)
             dest = item.destination(basedir=dest_dir, path_formats=path_formats)
+
+            # Ensure that desired item is readable before processing it. Needed
+            # to avoid any side-effect of the conversion (linking, keep_new,
+            # refresh) if we already know that it will fail.
+            try:
+                mf = mediafile.MediaFile(util.syspath(item.path))
+            except mediafile.UnreadableFileError as exc:
+                self._log.error("Could not open file to convert: {0}", exc)
+                continue
 
             # When keeping the new file in the library, we first move the
             # current (pristine) file to the destination. We'll then copy it

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -519,6 +519,8 @@ Bug fixes:
   `requests` timeout.
 * Fix cover art resizing logic to support multiple steps of resizing
   :bug:`5151`
+* :doc:`/plugins/convert`: Fix attempt to convert and perform side-effects if
+  library file is not readable.
 
 For plugin developers:
 


### PR DESCRIPTION
## Description

My library is managed using Beets for organization and [git-annex](https://git-annex.branchable.com/) as storage backend. Therefore when using this system, while my library files always exists on my filesystem, some files may be empty (without content). In this case, when I'm running the `convert` plugin,  I don't wants it to process files which are empty (same apply for any Beets plugin). Hence, I added a check that the file is readable as a `MediaFile` before doing any process. 

Before this fix, trying to encode an empty file would have lead to an error  while leaving `convert` doing its side-effects **and** `convert` would also copy empty files to destination for files that doesn't need to be re-encoded.

In my case, this is empty files, but the problem can be anything else (depending on the storage backend) and/or corrupted files. Conclusion, I think **checking that the file is readable is always recommended before proceeding to heavy operation** like this.

## To Do

- [X] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [X] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [X] Tests. (Very much encouraged but not strictly required.)
