### PR TITLE
Add timeout argument to all `requests` calls

### DIFF
--- a/beetsplug/absubmit.py
+++ b/beetsplug/absubmit.py
@@ -203,7 +203,10 @@ only files which would be processed",
         mbid = item["mb_trackid"]
         headers = {"Content-Type": "application/json"}
         response = requests.post(
-            self.url.format(mbid=mbid), json=data, headers=headers
+            self.url.format(mbid=mbid),
+            json=data,
+            headers=headers,
+            timeout=10,
         )
         # Test that request was successful and raise an error on failure.
         if response.status_code != 200:

--- a/beetsplug/acousticbrainz.py
+++ b/beetsplug/acousticbrainz.py
@@ -142,10 +142,7 @@ class AcousticPlugin(plugins.BeetsPlugin):
             self._log.debug("fetching URL: {}", url)
 
             try:
-                res = requests.get(
-                    url,
-                    timeout=10,
-                )
+                res = requests.get(url, timeout=10)
             except requests.RequestException as exc:
                 self._log.info("request error: {}", exc)
                 return {}

--- a/beetsplug/acousticbrainz.py
+++ b/beetsplug/acousticbrainz.py
@@ -142,7 +142,10 @@ class AcousticPlugin(plugins.BeetsPlugin):
             self._log.debug("fetching URL: {}", url)
 
             try:
-                res = requests.get(url)
+                res = requests.get(
+                    url,
+                    timeout=10,
+                )
             except requests.RequestException as exc:
                 self._log.info("request error: {}", exc)
                 return {}

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -126,7 +126,10 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
         if not tracks_data:
             return None
         while "next" in tracks_obj:
-            tracks_obj = requests.get(tracks_obj["next"]).json()
+            tracks_obj = requests.get(
+                tracks_obj["next"],
+                timeout=10,
+            ).json()
             tracks_data.extend(tracks_obj["data"])
 
         tracks = []
@@ -277,7 +280,9 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
             return None
         self._log.debug(f"Searching {self.data_source} for '{query}'")
         response = requests.get(
-            self.search_url + query_type, params={"q": query}
+            self.search_url + query_type,
+            params={"q": query},
+            timeout=10,
         )
         response.raise_for_status()
         response_data = response.json().get("data", [])

--- a/beetsplug/embyupdate.py
+++ b/beetsplug/embyupdate.py
@@ -112,7 +112,12 @@ def get_token(host, port, headers, auth_data):
     :rtype: str
     """
     url = api_url(host, port, "/Users/AuthenticateByName")
-    r = requests.post(url, headers=headers, data=auth_data)
+    r = requests.post(
+        url,
+        headers=headers,
+        data=auth_data,
+        timeout=10,
+    )
 
     return r.json().get("AccessToken")
 
@@ -130,7 +135,10 @@ def get_user(host, port, username):
     :rtype: list
     """
     url = api_url(host, port, "/Users/Public")
-    r = requests.get(url)
+    r = requests.get(
+        url,
+        timeout=10,
+    )
     user = [i for i in r.json() if i["Name"] == username]
 
     return user
@@ -196,7 +204,11 @@ class EmbyUpdate(BeetsPlugin):
 
         # Trigger the Update.
         url = api_url(host, port, "/Library/Refresh")
-        r = requests.post(url, headers=headers)
+        r = requests.post(
+            url,
+            headers=headers,
+            timeout=10,
+        )
         if r.status_code != 204:
             self._log.warning("Update could not be triggered")
         else:

--- a/beetsplug/embyupdate.py
+++ b/beetsplug/embyupdate.py
@@ -135,10 +135,7 @@ def get_user(host, port, username):
     :rtype: list
     """
     url = api_url(host, port, "/Users/Public")
-    r = requests.get(
-        url,
-        timeout=10,
-    )
+    r = requests.get(url, timeout=10)
     user = [i for i in r.json() if i["Name"] == username]
 
     return user

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -239,6 +239,8 @@ def _logged_get(log, *args, **kwargs):
     for arg in ("stream", "verify", "proxies", "cert", "timeout"):
         if arg in kwargs:
             send_kwargs[arg] = req_kwargs.pop(arg)
+    if "timeout" not in send_kwargs:
+        send_kwargs["timeout"] = 10
 
     # Our special logging message parameter.
     if "message" in kwargs:
@@ -1067,7 +1069,10 @@ class Spotify(RemoteArtSource):
             self._log.debug("Fetchart: no Spotify album ID found")
             return
         try:
-            response = requests.get(url)
+            response = requests.get(
+                url,
+                timeout=10,
+            )
             response.raise_for_status()
         except requests.RequestException as e:
             self._log.debug("Error: " + str(e))

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -1069,10 +1069,7 @@ class Spotify(RemoteArtSource):
             self._log.debug("Fetchart: no Spotify album ID found")
             return
         try:
-            response = requests.get(
-                url,
-                timeout=10,
-            )
+            response = requests.get(url, timeout=10)
             response.raise_for_status()
         except requests.RequestException as e:
             self._log.debug("Error: " + str(e))

--- a/beetsplug/kodiupdate.py
+++ b/beetsplug/kodiupdate.py
@@ -40,7 +40,13 @@ def update_kodi(host, port, user, password):
 
     # Create the payload. Id seems to be mandatory.
     payload = {"jsonrpc": "2.0", "method": "AudioLibrary.Scan", "id": 1}
-    r = requests.post(url, auth=(user, password), json=payload, headers=headers)
+    r = requests.post(
+        url,
+        auth=(user, password),
+        json=payload,
+        headers=headers,
+        timeout=10,
+    )
 
     return r
 

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -267,6 +267,7 @@ class Backend:
                     headers={
                         "User-Agent": USER_AGENT,
                     },
+                    timeout=10,
                 )
         except requests.RequestException as exc:
             self._log.debug("lyrics request failed: {0}", exc)
@@ -293,7 +294,11 @@ class LRCLib(Backend):
         }
 
         try:
-            response = requests.get(self.base_url, params=params)
+            response = requests.get(
+                self.base_url,
+                params=params,
+                timeout=10,
+            )
             data = response.json()
         except (requests.RequestException, json.decoder.JSONDecodeError) as exc:
             self._log.debug("LRCLib API request failed: {0}", exc)
@@ -410,7 +415,10 @@ class Genius(Backend):
         data = {"q": title + " " + artist.lower()}
         try:
             response = requests.get(
-                search_url, params=data, headers=self.headers
+                search_url,
+                params=data,
+                headers=self.headers,
+                timeout=10,
             )
         except requests.RequestException as exc:
             self._log.debug("Genius API request failed: {0}", exc)
@@ -868,7 +876,9 @@ class LyricsPlugin(plugins.BeetsPlugin):
         oauth_url = "https://datamarket.accesscontrol.windows.net/v2/OAuth2-13"
         oauth_token = json.loads(
             requests.post(
-                oauth_url, data=urllib.parse.urlencode(params)
+                oauth_url,
+                data=urllib.parse.urlencode(params),
+                timeout=10,
             ).content
         )
         if "access_token" in oauth_token:
@@ -1092,7 +1102,9 @@ class LyricsPlugin(plugins.BeetsPlugin):
                 "Translate?text=%s&to=%s" % ("|".join(text_lines), to_lang)
             )
             r = requests.get(
-                url, headers={"Authorization ": self.bing_auth_token}
+                url,
+                headers={"Authorization ": self.bing_auth_token},
+                timeout=10,
             )
             if r.status_code != 200:
                 self._log.debug(

--- a/beetsplug/plexupdate.py
+++ b/beetsplug/plexupdate.py
@@ -27,7 +27,11 @@ def get_music_section(
     )
 
     # Sends request.
-    r = requests.get(url, verify=not ignore_cert_errors)
+    r = requests.get(
+        url,
+        verify=not ignore_cert_errors,
+        timeout=10,
+    )
 
     # Parse xml tree and extract music section key.
     tree = ElementTree.fromstring(r.content)
@@ -55,7 +59,11 @@ def update_plex(host, port, token, library_name, secure, ignore_cert_errors):
     )
 
     # Sends request and returns requests object.
-    r = requests.get(url, verify=not ignore_cert_errors)
+    r = requests.get(
+        url,
+        verify=not ignore_cert_errors,
+        timeout=10,
+    )
     return r
 
 

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -140,6 +140,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
             self.oauth_token_url,
             data={"grant_type": "client_credentials"},
             headers=headers,
+            timeout=10,
         )
         try:
             response.raise_for_status()

--- a/beetsplug/subsonicplaylist.py
+++ b/beetsplug/subsonicplaylist.py
@@ -170,7 +170,8 @@ class SubsonicPlaylistPlugin(BeetsPlugin):
         resp = requests.get(
             "{}/rest/{}?{}".format(
                 self.config["base_url"].get(), endpoint, urlencode(params)
-            )
+            ),
+            timeout=10,
         )
         return resp
 

--- a/beetsplug/subsonicupdate.py
+++ b/beetsplug/subsonicupdate.py
@@ -135,7 +135,11 @@ class SubsonicUpdate(BeetsPlugin):
         else:
             return
         try:
-            response = requests.get(url, params=payload)
+            response = requests.get(
+                url,
+                params=payload,
+                timeout=10,
+            )
             json = response.json()
 
             if (

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -303,6 +303,8 @@ Bug fixes:
 * Fix bug where unimported plugin would not ignore children directories of
   ignored directories.
   :bug:`5130` 
+* Fix bug where some plugin commands hang indefinitely due to a missing
+  `requests` timeout.
 
 For plugin developers:
 

--- a/test/plugins/lyrics_download_samples.py
+++ b/test/plugins/lyrics_download_samples.py
@@ -46,7 +46,11 @@ def main(argv=None):
         url = s["url"] + s["path"]
         fn = test_lyrics.url_to_filename(url)
         if not os.path.isfile(fn):
-            html = requests.get(url, verify=False).text
+            html = requests.get(
+                url,
+                verify=False,
+                timeout=10,
+            ).text
             with safe_open_w(fn) as f:
                 f.write(html.encode("utf-8"))
 


### PR DESCRIPTION
## Description

Fixes bug where some plugin commands hang indefinitely. 8 years have passed since opening https://github.com/psf/requests/issues/3070, and we still have to deal with this stuff 😔 10 seconds value have been chosen as it's used multiple times in the codebase.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)~
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] ~Tests. (Very much encouraged but not strictly required.)~
