### PR TITLE
Update index.rst to link to Libera.Chat

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ Then you can get a more detailed look at beets' features in the
 be interested in exploring the :doc:`plugins </plugins/index>`.
 
 If you still need help, your can drop by the ``#beets`` IRC channel on
-Libera.Chat, drop by `the discussion board`_, send email to
+`Libera.Chat <https://libera.chat/>`_, drop by `the discussion board`_, send email to
 `the mailing list`_, or `file a bug`_ in the issue tracker. Please let us know
 where you think this documentation can be improved.
 


### PR DESCRIPTION
Update documentation to link to Libera.Chat for IRC support

Changed the reference to Libera.Chat in the documentation to a hyperlink pointing to https://libera.chat/ for better accessibility

## Description

Fixes #X.  <!-- Insert issue number here if applicable. -->

(...)

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
