### PR TITLE
Missing enhancements

### DIFF
--- a/beetsplug/missing.py
+++ b/beetsplug/missing.py
@@ -248,13 +248,13 @@ class MissingPlugin(BeetsPlugin):
                     continue
 
                 missing_release = (missing_release_group["id"],
-                                   release_year , missing_release_group["title"])
+                                   release_year , missing_release_group["title"], missing_release_group["type"])
 
                 missing_releases.append(missing_release)
 
             # print out missing albums for artist sorted by release year
             for entry in list(sorted(missing_releases, key=lambda item: item[1])):
-                print_("{} - [{}] {}".format(artist[0], entry[1], entry[2]))
+                print_("{} - [{}] {} ({})".format(artist[0], entry[1], entry[2], entry[3]))
 
         if total:
             print(total_missing)

--- a/beetsplug/missing.py
+++ b/beetsplug/missing.py
@@ -229,8 +229,17 @@ class MissingPlugin(BeetsPlugin):
 
             for missing_release_group in missing:
                 # Get releases (e.g. album editions) for release-group
-                resp = musicbrainzngs.browse_releases(release_group=missing_release_group["id"])
-                releases = resp["release-list"]
+                try:
+                    resp = musicbrainzngs.browse_releases(release_group=missing_release_group["id"])
+                    releases = resp["release-list"]
+                except MusicBrainzError as err:
+                    self._log.info(
+                        "Couldn't fetch info for release-group '{}' ({}) - '{}'",
+                        missing_release_group["title"],
+                        missing_release_group["id"],
+                        err,
+                        )
+                    continue
 
                 release_year = self._year_of_oldest_release(releases)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,10 @@ Changelog
 
 Changelog goes here! Please add your entry to the bottom of one of the lists below!
 
+New features:
+
+* :doc:`/plugins/missing`: Add config options to show release years for missing albums and to show only releases not older than the latest in the library.
+
 
 2.0.0 (May 30, 2024)
 --------------------

--- a/docs/plugins/missing.rst
+++ b/docs/plugins/missing.rst
@@ -43,6 +43,12 @@ configuration file. The available options are:
   Default: :ref:`format_item`.
 - **total**: Print a single count of missing tracks in all albums.
   Default: ``no``.
+- albums: Configuration options for displaying missing albums.
+    - **years**: Show release years of missing albums (see note below).
+    - **recent**: Show only releases of an artist not older than those already in the library.
+
+**Note:** Fetching the release year of missing releases results in additional data fetched from MusicBrainz, which
+makes this process rather slow. So make sure to grab a coffee while waiting for the results ;-).
 
 Here's an example ::
 
@@ -50,6 +56,9 @@ Here's an example ::
         format: $albumartist - $album - $title
         count: no
         total: no
+        albums:
+            years: no
+            recent: no
 
 Template Fields
 ---------------


### PR DESCRIPTION
## Description

Enhances the missing plugin in its search for missing releases. One can now configure the plugin to also show the year of missing releases and only search for releases that are not older than the ones already in the library. 

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] ~Tests.~ (Very much encouraged but not strictly required.)
