### PR TITLE
Add aliases support

### DIFF
--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -563,7 +563,17 @@ def album_info(release: Dict) -> beets.autotag.hooks.AlbumInfo:
     info.albumstatus = release.get("status")
 
     if release["release-group"].get("title"):
-        info.release_group_title = release["release-group"].get("title")
+        if "alias-list" in release["release-group"]:
+            alias = _preferred_alias(release["release-group"]["alias-list"])
+        else:
+            alias = None
+
+        if alias:
+            title = alias["alias"]
+        else:
+            title = release["release-group"].get("title")
+
+        info.release_group_title = title
 
     # Get the disambiguation strings at the release and release group level.
     if release["release-group"].get("disambiguation"):

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -527,8 +527,19 @@ def album_info(release: Dict) -> beets.autotag.hooks.AlbumInfo:
             track_infos.append(ti)
 
     album_artist_ids = _artist_ids(release["artist-credit"])
+
+    if "alias-list" in release:
+        alias = _preferred_alias(release["alias-list"])
+    else:
+        alias = None
+
+    if alias:
+        title = alias["alias"]
+    else:
+        title = release["title"]
+
     info = beets.autotag.hooks.AlbumInfo(
-        album=release["title"],
+        album=title,
         album_id=release["id"],
         artist=artist_name,
         artist_id=album_artist_ids[0],

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -288,8 +288,18 @@ def track_info(
     ``medium_index``, the track's index on its medium; ``medium_total``,
     the number of tracks on the medium. Each number is a 1-based index.
     """
+    if "alias-list" in recording:
+        alias = _preferred_alias(recording["alias-list"])
+    else:
+        alias = None
+
+    if alias:
+        title = alias["alias"]
+    else:
+        title = recording["title"]
+
     info = beets.autotag.hooks.TrackInfo(
-        title=recording["title"],
+        title=title,
         track_id=recording["id"],
         index=index,
         medium=medium,


### PR DESCRIPTION
## Description

This PR add support for aliases to releases, release-groups and recordings.

This PR is a must have (IMO at least) for people that listen to Japanese, Chinese and other songs that has other symbols for letters. With this, not only the artist name will use the alias if available, but now the album and track name will also use aliases.

NOTE: This PR requires a fork of the `python-musicbrainzngs` package. That package seems to be dead (more than 2 years without any commit) and is lacking in a lot of updates to Musicbrainz API.

Here is my PR adding support for the new fields https://github.com/alastair/python-musicbrainzngs/pull/289 but I have no hope that will be merged since the package seems to be dead.

Personally I think beets can create a fork of that package and just add the bare minimum to it to make new features work (for example this one).

I didn't add any tests and changelog changes yet since this PR requires forking `python-musicbrainzngs`, so first I want to discuss if this can be merged and then after getting the confirmation I will add the missing parts.
