### PR TITLE
Adjust temporary files

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -526,7 +526,7 @@ def move(path: bytes, dest: bytes, replace: bool = False):
         dirname = os.path.dirname(bytestring_path(dest))
         tmp = tempfile.NamedTemporaryFile(
             suffix=syspath(b".beets", prefix=False),
-            prefix=syspath(b"." + basename, prefix=False),
+            prefix=syspath(b"." + basename + b".", prefix=False),
             dir=syspath(dirname),
             delete=False,
         )

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,9 @@ Changelog
 
 Changelog goes here! Please add your entry to the bottom of one of the lists below!
 
+Bug fixes:
+
+* Improved naming of temporary files by separating the random part with the file extension.
 
 2.0.0 (May 30, 2024)
 --------------------


### PR DESCRIPTION
Rigth now it creates something like:
```
.../Perota Chingo/Un viajecito/.12 Rie Chinito.flac64u8gm5u.beets
```
where no separatio  between temp name and file extention, and it makes quite hard to read it.

So, this changes adjust name to
```
.../Perota Chingo/Un viajecito/.12 Rie Chinito.flac.64u8gm5u.beets
```

This was one of forgotten fixup from https://github.com/beetbox/beets/commit/8d50301be58463ac860cafaf898670fccb525bbe

## Description

Fixes #X.  <!-- Insert issue number here if applicable. -->

(...)

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
