### PR TITLE
Fix `reflink: "auto"` option

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -1684,6 +1684,8 @@ def manipulate_files(session, task):
             operation = MoveOperation.LINK
         elif session.config["hardlink"]:
             operation = MoveOperation.HARDLINK
+        elif session.config["reflink"] == "auto":
+            operation = MoveOperation.REFLINK_AUTO
         elif session.config["reflink"]:
             operation = MoveOperation.REFLINK
         else:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changelog goes here! Please add your entry to the bottom of one of the lists bel
 Bug fixes:
 
 * Improved naming of temporary files by separating the random part with the file extension.
+* Fixed the ``auto`` value for the :ref:`reflink` config option.
 
 For packagers:
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -235,6 +235,30 @@ class NonAutotaggedImportTest(_common.TestCase, ImportHelper):
                 == (s2[stat.ST_INO], s2[stat.ST_DEV])
             )
 
+    @unittest.skipUnless(_common.HAVE_REFLINK, "need reflinks")
+    def test_import_reflink_arrives(self):
+        # Detecting reflinks is currently tricky due to various fs
+        # implementations, we'll just check the file exists.
+        config["import"]["reflink"] = True
+        self.importer.run()
+        for mediafile in self.import_media:
+            self.assert_file_in_lib(
+                b"Tag Artist",
+                b"Tag Album",
+                util.bytestring_path(f"{mediafile.title}.mp3"),
+            )
+
+    def test_import_reflink_auto_arrives(self):
+        # Should pass regardless of reflink support due to fallback.
+        config["import"]["reflink"] = "auto"
+        self.importer.run()
+        for mediafile in self.import_media:
+            self.assert_file_in_lib(
+                b"Tag Artist",
+                b"Tag Album",
+                util.bytestring_path(f"{mediafile.title}.mp3"),
+            )
+
 
 def create_archive(session):
     (handle, path) = mkstemp(dir=py3_path(session.temp_dir))


### PR DESCRIPTION
## Description

The docs say:

> The `auto` option uses reflinks when possible and falls back to plain
> copying when necessary.

I've been using this option for a while, and recently discovered that despite the option, copying fails between two BTRFS filesystems with:

    Error: OS/filesystem does not support reflinks. during link of paths /mnt/fs1/file, /mnt/fs2/file

I tracked this down to how the configuration is handled in the importer.

I love beets dearly, thanks for your great work :)

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
