### PR TITLE
Update the bash completion script

### DIFF
--- a/beets/ui/completion_base.sh
+++ b/beets/ui/completion_base.sh
@@ -31,7 +31,7 @@
 # plugins dynamically
 #
 # Currently, only Bash 3.2 and newer is supported and the
-# `bash-completion` package (v2.10 or newer) is required.
+# `bash-completion` package (v2.8 or newer) is required.
 #
 # TODO
 # ----
@@ -46,17 +46,20 @@
 # * Support long options with `=`, e.g. `--config=file`. Debian's bash
 #   completion package can handle this.
 #
+# Note that 'bash-completion' v2.8 is a part of Debian 10, which is part of
+# LTS until 2024-06-30.  After this date, the minimum version requirement can
+# be changed, and newer features can be used unconditionally.  See PR#5301.
+#
 
 if [[ ${BASH_COMPLETION_VERSINFO[0]} -ne 2 \
-   || ${BASH_COMPLETION_VERSINFO[1]} -lt 10 ]]; then
+   || ${BASH_COMPLETION_VERSINFO[1]} -lt 8 ]]; then
   echo "Incompatible version of 'bash-completion'!"
   return 1
 fi
 
-# The following functions are introduced by bash-completion v2.12, and
-# at the same time the functions they replace are deprecated.  In order
-# to avoid using deprecated functions, here are some forward-compatible
-# aliases which use the deprecated functions when necessary.
+# The later code relies on 'bash-completion' version 2.12, but older versions
+# are still supported.  Here, we provide implementations of the newer functions
+# in terms of older ones, if 'bash-completion' is too old to have them.
 
 if [[ ${BASH_COMPLETION_VERSINFO[1]} -lt 12 ]]; then
   _comp_get_words() {

--- a/beets/ui/completion_base.sh
+++ b/beets/ui/completion_base.sh
@@ -31,7 +31,7 @@
 # plugins dynamically
 #
 # Currently, only Bash 3.2 and newer is supported and the
-# `bash-completion` package is required.
+# `bash-completion` package (v2.10 or newer) is required.
 #
 # TODO
 # ----
@@ -47,6 +47,26 @@
 #   completion package can handle this.
 #
 
+if [[ ${BASH_COMPLETION_VERSINFO[0]} -ne 2 \
+   || ${BASH_COMPLETION_VERSINFO[1]} -lt 10 ]]; then
+  echo "Incompatible version of 'bash-completion'!"
+  return 1
+fi
+
+# The following functions are introduced by bash-completion v2.12, and
+# at the same time the functions they replace are deprecated.  In order
+# to avoid using deprecated functions, here are some forward-compatible
+# aliases which use the deprecated functions when necessary.
+
+if [[ ${BASH_COMPLETION_VERSINFO[1]} -lt 12 ]]; then
+  _comp_get_words() {
+    _get_comp_words_by_ref "$@"
+  }
+
+  _comp_compgen_filedir() {
+    _filedir "$@"
+  }
+fi
 
 # Determines the beets subcommand and dispatches the completion
 # accordingly.
@@ -54,7 +74,7 @@ _beet_dispatch() {
   local cur prev cmd=
 
   COMPREPLY=()
-  _get_comp_words_by_ref -n : cur prev
+  _comp_get_words -n : cur prev
 
   # Look for the beets subcommand
   local arg
@@ -99,7 +119,7 @@ _beet_complete() {
     completions="${flags___common} ${opts} ${flags}"
     COMPREPLY+=( $(compgen -W "$completions"  -- $cur) )
   else
-    _filedir
+    _comp_compgen_filedir
   fi
 }
 
@@ -114,12 +134,12 @@ _beet_complete_global() {
       ;;
     -l|--library|-c|--config)
       # Filename completion
-      _filedir
+      _comp_compgen_filedir
       return
       ;;
     -d|--directory)
       # Directory completion
-      _filedir -d
+      _comp_compgen_filedir -d
       return
       ;;
   esac


### PR DESCRIPTION
Some functions used by the bash completion script have become deprecated.  This was causing the test suite to break on faster-moving distributions (e.g. Arch Linux and Gentoo).  The issue is only noticeable because the tests for the completion function explicitly disallow compatibility implementations from being loaded.  Rather than allowing compatibility implementations, I've added some basic logic to the completion script so that older and newer versions of `bash-completion` can be supported simultaneously.

For some reason, this issue wasn't caught on CI - I think the newer `bash-completion` hasn't reached the distribution used there.  Still, this code is now forward-compatible.

## Description

Fixes #5243 ([see here](https://github.com/beetbox/beets/issues/5243#issuecomment-2164074169)).

## To Do

- [x] ~Documentation.~
- [x] ~Changelog.~
- [x] ~Tests.~

I suppose it may be possible to set up tests for this, but that doesn't sound fun or particularly necessary.  Still, I'll leave that decision up to the reviewer.
