### PR TITLE
Update release workflow with poetry

### DIFF
--- a/.github/workflows/make_release.yaml
+++ b/.github/workflows/make_release.yaml
@@ -49,7 +49,7 @@ jobs:
         run: poetry build
 
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
@@ -78,7 +78,7 @@ jobs:
 
       - name: Tag the commit
         id: tag_version
-        uses: mathieudutour/github-tag-action@v6.1
+        uses: mathieudutour/github-tag-action@v6
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ env.NEW_VERSION }}
@@ -117,7 +117,7 @@ jobs:
       id-token: write
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/make_release.yaml
+++ b/.github/workflows/make_release.yaml
@@ -67,10 +67,28 @@ jobs:
           name: python-package-distributions
           path: dist/
 
+  publish-to-pypi:
+    name: Publish distribution 📦 to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: pypi
+      url: https://pypi.org/p/beets
+    permissions:
+      id-token: write
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
   make-github-release:
     name: Create GitHub release
     runs-on: ubuntu-latest
-    needs: build
+    needs: publish-to-pypi
     env:
       CHANGELOG: ${{ needs.build.outputs.changelog }}
     steps:
@@ -103,21 +121,3 @@ jobs:
           access-token: ${{ secrets.MASTODON_ACCESS_TOKEN }}
           url: ${{ secrets.MASTODON_URL }}
           message: "Version ${{ steps.tag_version.outputs.new_tag }} of beets has been released! Check out all of the new changes at ${{ steps.create_release.outputs.html_url }}"
-
-  publish-to-pypi:
-    name: Publish distribution 📦 to PyPI
-    runs-on: ubuntu-latest
-    needs: build
-    environment:
-      name: pypi
-      url: https://pypi.org/p/beets
-    permissions:
-      id-token: write
-    steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/
-      - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/make_release.yaml
+++ b/.github/workflows/make_release.yaml
@@ -54,36 +54,49 @@ jobs:
           name: python-package-distributions
           path: dist/
 
-  make_github_release:
+  make-github-release:
+    name: Create GitHub release
     runs-on: ubuntu-latest
     needs: build
     steps:
       - uses: actions/checkout@v4
+      - name: Install Python tools
+        uses: BrandonLWhite/pipx-install-action@v0.1.1
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: poetry
+
+      - name: Install dependencies
+        run: poetry install --only=release
+
       - name: Install pandoc
         run: sudo apt update && sudo apt install pandoc -y
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
+
       - name: Obtain the changelog
-        run: echo CHANGELOG="$(python ./extra/release.py changelog)" >> $GITHUB_ENV
-      - name: Bump version and push tag
+        run: echo CHANGELOG="$(poe changelog)" >> $GITHUB_ENV
+
+      - name: Tag the commit
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ env.NEW_VERSION }}
+
       - name: Download all the dists
         uses: actions/download-artifact@v3
         with:
           name: python-package-distributions
           path: dist/
+
       - name: Create a GitHub release
         id: make_release
         uses: ncipollo/release-action@v1
+        env:
+          NEW_TAG: ${{ steps.tag_version.outputs.new_tag }}
         with:
-          tag: ${{ steps.tag_version.outputs.new_tag }}
-          name: Release ${{ steps.tag_version.outputs.new_tag }}
+          tag: ${{ env.NEW_TAG }}
+          name: Release ${{ env.NEW_TAG }}
           body: ${{ env.CHANGELOG }}
           artifacts: dist/*
       - name: Send release toot to Fosstodon
@@ -93,7 +106,8 @@ jobs:
           url: ${{ secrets.MASTODON_URL }}
           message: "Version ${{ steps.tag_version.outputs.new_tag }} of beets has been released! Check out all of the new changes at ${{ steps.create_release.outputs.html_url }}"
 
-  publish_to_pypi:
+  publish-to-pypi:
+    name: Publish distribution 📦 to PyPI
     runs-on: ubuntu-latest
     needs: build
     environment:

--- a/.github/workflows/make_release.yaml
+++ b/.github/workflows/make_release.yaml
@@ -37,27 +37,9 @@ jobs:
           message: "Increment version to ${{ env.NEW_VERSION }}"
 
   build:
-    name: Build the distribution packages
+    name: Get changelog and build the distribution package
     runs-on: ubuntu-latest
     needs: increment-version
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Python tools
-        uses: BrandonLWhite/pipx-install-action@v0.1.1
-
-      - name: Build a binary wheel and a source tarball
-        run: poetry build
-
-      - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/
-
-  make-github-release:
-    name: Create GitHub release
-    runs-on: ubuntu-latest
-    needs: build
     steps:
       - uses: actions/checkout@v4
       - name: Install Python tools
@@ -74,8 +56,24 @@ jobs:
         run: sudo apt update && sudo apt install pandoc -y
 
       - name: Obtain the changelog
-        run: echo CHANGELOG="$(poe changelog)" >> $GITHUB_ENV
+        run: echo "changelog=$(poe changelog)" >> $GITHUB_OUTPUT
 
+      - name: Build a binary wheel and a source tarball
+        run: poetry build
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  make-github-release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      CHANGELOG: ${{ needs.build.outputs.changelog }}
+    steps:
       - name: Tag the commit
         id: tag_version
         uses: mathieudutour/github-tag-action@v6

--- a/.github/workflows/make_release.yaml
+++ b/.github/workflows/make_release.yaml
@@ -7,27 +7,38 @@ on:
         description: 'Version of the new release, just as a number with no prepended "v"'
         required: true
 
+env:
+  PYTHON_VERSION: 3.8
+  NEW_VERSION: ${{ inputs.version }}
+
 jobs:
-  increment_version:
+  increment-version:
+    name: Bump project version and commit it
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Install Python tools
+        uses: BrandonLWhite/pipx-install-action@v0.1.1
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
-      - name: Run version script
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: poetry
+
+      - name: Install dependencies
+        run: poetry install --only=release
+
+      - name: Bump project version
         id: script
-        run: |
-          python extra/release.py bump "${{ inputs.version }}"
+        run: poe bump "${{ env.NEW_VERSION }}"
+
       - uses: EndBug/add-and-commit@v9
         name: Commit the changes
         with:
-          message: "Increment version numbers to ${{ inputs.version }}"
+          message: "Increment version to ${{ env.NEW_VERSION }}"
 
   build:
     runs-on: ubuntu-latest
-    needs: increment_version
+    needs: increment-version
     steps:
       - uses: actions/checkout@v4
         with:
@@ -66,7 +77,7 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: ${{ inputs.version }}
+          custom_tag: ${{ env.NEW_VERSION }}
       - name: Download all the dists
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/make_release.yaml
+++ b/.github/workflows/make_release.yaml
@@ -37,22 +37,17 @@ jobs:
           message: "Increment version to ${{ env.NEW_VERSION }}"
 
   build:
+    name: Build the distribution packages
     runs-on: ubuntu-latest
     needs: increment-version
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: master
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
-      - run: pip install build wheel sphinx
+      - name: Install Python tools
+        uses: BrandonLWhite/pipx-install-action@v0.1.1
+
       - name: Build a binary wheel and a source tarball
-        env:
-          TZ: UTC
-        run: python3 -m build
+        run: poetry build
+
       - name: Store the distribution packages
         uses: actions/upload-artifact@v3
         with:

--- a/poetry.lock
+++ b/poetry.lock
@@ -2752,4 +2752,4 @@ web = ["flask", "flask-cors"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "2ff0a67fbc8099eed500963f3338cf00d687abee9af56aac744a169f8f22d50d"
+content-hash = "4ae4e4157dd4a0c7951ba1f642c8dc36ae8ca264789b2a224ecaaf5e3a2f289a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,16 +34,13 @@ Changelog = "https://github.com/beetbox/beets/blob/master/docs/changelog.rst"
 [tool.poetry.dependencies]
 python = ">=3.8,<4"
 
-click = ">=8.1.7"
 colorama = { version = "*", markers = "sys_platform == 'win32'" }
 confuse = ">=1.5.0"
 jellyfish = "*"
 mediafile = ">=0.12.0"
 munkres = ">=1.0.0"
 musicbrainzngs = ">=0.4"
-packaging = ">=24.0"
 pyyaml = "*"
-tomli = ">=2.0.1"
 typing_extensions = "*"
 unidecode = ">=1.3.6"
 beautifulsoup4 = { version = "*", optional = true }
@@ -105,6 +102,11 @@ types-urllib3 = "*"
 [tool.poetry.group.docs.dependencies]
 pydata-sphinx-theme = "*"
 sphinx = "*"
+
+[tool.poetry.group.release.dependencies]
+click = ">=8.1.7"
+packaging = ">=24.0"
+tomli = ">=2.0.1"
 
 [tool.poetry.extras]
 # inline comments note required external / non-python dependencies


### PR DESCRIPTION
This was missed out in #5266: build the Python package distribution using Poetry in the release workflow.

In addition to the above, I slightly simplified the release pipeline which should hopefully make it easier to debug if things go wrong in the future.
