### PR TITLE
Do not run coverage by default

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,14 +41,14 @@ jobs:
 
       - if: ${{ env.IS_MAIN_PYTHON != 'true' }}
         name: Test without coverage
-        run: poe test --no-cov
+        run: poe test
 
       - if: ${{ env.IS_MAIN_PYTHON == 'true' }}
         name: Test with coverage
         uses: liskin/gh-problem-matcher-wrap@v3
         with:
           linters: pytest
-          run: poe test
+          run: poe test-with-coverage
 
       - if: ${{ env.IS_MAIN_PYTHON == 'true' }}
         name: Store the coverage report

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ htmlcov/
 coverage.xml
 *,cover
 .hypothesis/
+.reports
 
 # Flask stuff:
 instance/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,7 +211,25 @@ cmd = "poetry update -vv"
 
 [tool.poe.tasks.test]
 help = "Run tests with pytest"
-cmd = "pytest"
+cmd = "pytest $OPTS"
+env.OPTS.default = "-p no:cov"
+
+[tool.poe.tasks.test-with-coverage]
+help = "Run tests and record coverage"
+ref = "test"
+# record coverage in beets and beetsplug packages
+# save xml for coverage upload to coveralls
+# save html report for local dev use
+# measure coverage across logical branches
+# show which tests cover specific lines in the code (see the HTML report)
+env.OPTS = """
+--cov=beets
+--cov=beetsplug
+--cov-report=xml:.reports/coverage.xml
+--cov-report=html:.reports/html
+--cov-branch
+--cov-context=test
+"""
 
 [tool.black]
 line-length = 80

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,17 +7,6 @@ addopts =
     # show all skipped/failed/xfailed tests in the summary except passed
     -ra
     --strict-config
-    # record coverage in these two packages
-    --cov=beets
-    --cov=beetsplug
-    # save xml for coverage upload
-    --cov-report=xml:.reports/coverage.xml
-    # save html files for local dev use
-    --cov-report=html:.reports/html
-    # record coverage across logical branches
-    --cov-branch
-    # show which tests cover specific lines in the code (available in HTML)
-    --cov-context=test
 
 [coverage:run]
 data_file = .reports/coverage/data


### PR DESCRIPTION
Fixes #5242.

This PR moves coverage measurement from the default `pytest` invocation to a separate action `test-with-coverage`.
