### PR TITLE
Bring back source files to codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,8 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - uses: actions/checkout@v4
+
       - name: Get the coverage report
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
While the commit merged yesterday fixed the coverage upload to coveralls, it broke the source files preview on the platform.

This was due to the missing actions/checkout step in the coverage upload job.
