### PR TITLE
Fix for #5289

### DIFF
--- a/beetsplug/autobpm.py
+++ b/beetsplug/autobpm.py
@@ -14,7 +14,7 @@
 """Uses Librosa to calculate the `bpm` field.
 """
 
-
+import numpy
 from librosa import beat, load
 from soundfile import LibsndfileError
 
@@ -79,7 +79,7 @@ class AutoBPMPlugin(BeetsPlugin):
                 continue
 
             tempo, _ = beat.beat_track(y=y, sr=sr)
-            bpm = round(tempo)
+            bpm = numpy.round(tempo)
             item["bpm"] = bpm
             self._log.info(
                 "added computed bpm {0} for {1}",

--- a/beetsplug/autobpm.py
+++ b/beetsplug/autobpm.py
@@ -14,7 +14,7 @@
 """Uses Librosa to calculate the `bpm` field.
 """
 
-import numpy
+from numpy import round
 from librosa import beat, load
 from soundfile import LibsndfileError
 
@@ -79,7 +79,7 @@ class AutoBPMPlugin(BeetsPlugin):
                 continue
 
             tempo, _ = beat.beat_track(y=y, sr=sr)
-            bpm = numpy.round(tempo)
+            bpm = round(tempo)
             item["bpm"] = bpm
             self._log.info(
                 "added computed bpm {0} for {1}",


### PR DESCRIPTION
## Description

Fixes #5289   <!-- Insert issue number here if applicable. -->

As stated in issue 5289, `tempo, _ = beat.beat_track(y=y, sr=sr)` was assigning a numpy.ndarray to `tempo`. Trying to use Pythons built-in `round()` method doesn't work, so as suggested in the issue, this PR changes the line to use `numpy.round()` instead to get the BPM from the returning value. 

We could make the fix more elaborate, as `beat.beat_track()` returns either a float or numpy.ndarray.
[Librosa docs: beat.beat_track()](https://librosa.org/doc/main/generated/librosa.beat.beat_track.html)

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation.
- [x] Changelog.
- [x] Tests.
