### PR TITLE
Use typing_extensions only when needed

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -45,7 +45,11 @@ from typing import (
     Union,
 )
 
-from typing_extensions import TypeAlias
+try:
+    # Python 3.10+
+    from typing import TypeAlias
+except ImportError:
+    from typing_extensions import TypeAlias
 from unidecode import unidecode
 
 from beets.util import hidden

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -45,11 +45,11 @@ from typing import (
     Union,
 )
 
-try:
-    # Python 3.10+
+if sys.version_info >= (3, 10):
     from typing import TypeAlias
-except ImportError:
+else:
     from typing_extensions import TypeAlias
+
 from unidecode import unidecode
 
 from beets.util import hidden

--- a/beetsplug/aura.py
+++ b/beetsplug/aura.py
@@ -17,6 +17,7 @@
 
 import os
 import re
+import sys
 from dataclasses import dataclass
 from mimetypes import guess_type
 from typing import ClassVar, Mapping, Type
@@ -30,10 +31,9 @@ from flask import (
     send_file,
 )
 
-try:
-    # Python 3.11+
+if sys.version_info >= (3, 11):
     from typing import Self
-except ImportError:
+else:
     from typing_extensions import Self
 
 from beets import config

--- a/beetsplug/aura.py
+++ b/beetsplug/aura.py
@@ -29,7 +29,12 @@ from flask import (
     request,
     send_file,
 )
-from typing_extensions import Self
+
+try:
+    # Python 3.11+
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 from beets import config
 from beets.dbcore.query import (

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ For packagers:
 
 * The minimum supported Python version is now 3.8.
 * The `beet` script has been removed from the repository.
+* The `typing_extensions` is required for Python 3.10 and below.
 
 Other changes:
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2720,4 +2720,4 @@ web = ["flask", "flask-cors"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "740281ee3ddba4c6015eab9cfc24bb947e8816e3b7f5a6bebeb39ff2413d7ac3"
+content-hash = "48fba7c7149c8cb7824f96329bd469a9e9c84b13d233f957889b8b1d7076392f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ mediafile = ">=0.12.0"
 munkres = ">=1.0.0"
 musicbrainzngs = ">=0.4"
 pyyaml = "*"
-typing_extensions = "*"
+typing_extensions = { version = "*", python = "<=3.10" }
 unidecode = ">=1.3.6"
 beautifulsoup4 = { version = "*", optional = true }
 dbus-python = { version = "*", optional = true }


### PR DESCRIPTION
## Description

Use `typing_extensions` only for Python <= 3.10.

`Self` was added in Python 3.11.
`TypeAlias` was added in Python 3.10.


## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation.
- [x] Changelog.
- [x] Tests.
