### PR TITLE
Support XDG user directories

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -36,8 +36,8 @@ from beets.util import (
     MoveOperation,
     bytestring_path,
     cached_classproperty,
+    get_user_dirs,
     normpath,
-    parse_user_dirs,
     samefile,
     syspath,
 )
@@ -1610,7 +1610,7 @@ class Library(dbcore.Database):
         else:
             # Check if the user specified something in the XDG user dirs.
             # Otherwise, fall back to '~/Music'.
-            user_dirs = parse_user_dirs()
+            user_dirs = get_user_dirs()
             music_dir = user_dirs.get("music", Path.home() / "Music")
             self.directory = bytes(music_dir)
 

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -54,7 +54,7 @@ from unidecode import unidecode
 
 from beets.util import hidden
 
-from .user_dirs import parse_user_dirs
+from .user_dirs import get_user_dirs
 
 MAX_FILENAME_LENGTH = 200
 WINDOWS_MAGIC_PREFIX = "\\\\?\\"

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -54,6 +54,8 @@ from unidecode import unidecode
 
 from beets.util import hidden
 
+from .user_dirs import parse_user_dirs
+
 MAX_FILENAME_LENGTH = 200
 WINDOWS_MAGIC_PREFIX = "\\\\?\\"
 T = TypeVar("T")

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -54,7 +54,7 @@ from unidecode import unidecode
 
 from beets.util import hidden
 
-from .user_dirs import get_user_dirs
+from .user_dirs import get_user_dirs  # noqa
 
 MAX_FILENAME_LENGTH = 200
 WINDOWS_MAGIC_PREFIX = "\\\\?\\"

--- a/beets/util/user_dirs.py
+++ b/beets/util/user_dirs.py
@@ -28,7 +28,7 @@ of any particular entry -- always provide a reasonable default.
 import os
 import re
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 
 from beets import logging
 
@@ -39,7 +39,7 @@ user_dir_regex = re.compile(b'XDG_(.*)_DIR=("[^"]*"|.*)')
 def get_user_dirs(
     home: Optional[Path] = None,
     xdg_config_home: Optional[Path] = None,
-) -> dict[str, Path]:
+) -> Dict[str, Path]:
     """
     Parse the 'user-dirs.dirs' file in the given configuration directory.
 
@@ -82,7 +82,7 @@ def parse_user_dirs(
     data: bytes,
     path: str,
     home: Path,
-) -> dict[str, Path]:
+) -> Dict[str, Path]:
     """
     Parse the given 'user-dirs.dirs' file.
 
@@ -98,7 +98,7 @@ def parse_user_dirs(
     """
 
     # Parse the loaded data line by line.
-    mapping: dict[str, Path] = {}
+    mapping: Dict[str, Path] = {}
     for line in map(bytes.strip, data.splitlines()):
 
         # Skip blank lines.

--- a/beets/util/user_dirs.py
+++ b/beets/util/user_dirs.py
@@ -1,0 +1,110 @@
+# This file is part of beets.
+# Copyright 2024, Arav K.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""
+Support for "well-known" user directories via XDG.
+
+This module implements a simple parser for 'user-dirs.dirs(5)', allowing users
+to instruct beets on where their music directory in an application-agnostic
+fashion.  This file is a mapping from directory names to paths, using a limited
+syntax that is compatible with 'sh'.
+
+XDG is a Unix-oriented mechanism; on other platforms, this module will simply
+return an empty mapping.  Users of this module should not rely on the existence
+of any particular entry -- always provide a reasonable default.
+"""
+
+import os
+import re
+from pathlib import Path
+from typing import Optional
+
+from beets import logging
+
+log = logging.getLogger("beets")
+user_dir_regex = re.compile(b'XDG_(.*)_DIR=("[^"]*"|.*)')
+
+
+def parse_user_dirs(
+    home: Optional[Path] = None,
+    xdg_config_home: Optional[Path] = None,
+) -> dict[str, Path]:
+    """
+    Parse the 'user-dirs.dirs' file in the given configuration directory.
+
+    If this is not a Unix-like platform, an empty mapping is returned.
+
+    :param home: the user's home directory.
+      If not provided, this defaults to `$HOME`.
+
+    :param xdg_config_home: the user's configuration directory.
+      If not provided, this defaults to `~/.config`.
+
+    :return: a mapping from (lower-cased) keys to paths.
+    """
+
+    # Ensure we're on an XDG-compatible system.
+    if os.name != "posix":
+        return {}
+
+    # Resolve the user's home directory.
+    home = home or Path.home()
+
+    # Resolve the user's configuration directory.
+    if xdg_config_home is None and "XDG_CONFIG_HOME" in os.environ:
+        xdg_config_home = Path(os.environ["XDG_CONFIG_HOME"])
+    xdg_config_home = xdg_config_home or (home / ".config")
+
+    # Find and read the 'user-dirs.dirs' file.
+    path = xdg_config_home / "user-dirs.dirs"
+    try:
+        with open(path, "rb") as file:
+            data = file.readlines()
+    except OSError:
+        return {}
+
+    # Parse the loaded data line by line.
+    mapping: dict[str, Path] = {}
+    for line in map(bytes.strip, data):
+
+        # Skip blank lines.
+        if len(line) == 0:
+            continue
+
+        # Skip comment lines.
+        if line.startswith(b"#"):
+            continue
+
+        # Check for the expected syntax.
+        m = user_dir_regex.fullmatch(line)
+        if m is None:
+            log.warning("malformed line in '{}': '{}'", path, line)
+            continue
+        key, val = m.groups()
+
+        # Parse the key.
+        key = key.decode().lower()
+
+        # Parse the path value.
+        if val.startswith(b"$HOME/"):
+            val = home / Path(os.fsdecode(val[6:]))
+        elif val.startswith(b"/"):
+            val = Path(os.fsdecode(val))
+        else:
+            log.warning("malformed line in '{}': '{}'", path, line)
+            continue
+
+        mapping[key] = val
+
+    return mapping

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,10 @@ New features:
   album queries involving `path` field have been sped up, like `beet list -a
   path:/path/`.
 
+* Beets now respects `XDG_MUSIC_DIR` if it is set in `user-dirs.dirs(5)` on
+  Unix-like systems.  It will continue to fall back to `~/Music`, but only if
+  `user-dirs.dirs` is not found (in `$XDG_CONFIG_HOME` or `$HOME/.config`).
+
 Bug fixes:
 
 * Improved naming of temporary files by separating the random part with the file extension.

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -237,6 +237,9 @@ class UserDirsTest(_common.TestCase):
 
         super().tearDown()
 
+    @unittest.skipIf(
+        os.name != "posix", "'user-dirs.dirs' is only used on Unix-like systems"
+    )
     def test_lookup(self):
         path1 = self.xdg_config_home / "user-dirs.dirs"
         path2 = self.def_config_home / "user-dirs.dirs"

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -17,7 +17,6 @@
 import os
 import platform
 import re
-import shutil
 import subprocess
 import sys
 import unittest


### PR DESCRIPTION
## Description

Fixes #5168.  A simple parser for `user-dirs.dirs` has been implemented, and it is used to change the default music directory path when `beets.Library` is initialized.

## To Do

- [x] ~Documentation~
- [x] Changelog
- [x] Tests
