### PR TITLE
Replace most `str.format()` uses with f-strings

### DIFF
--- a/beets/__init__.py
+++ b/beets/__init__.py
@@ -35,7 +35,7 @@ class IncludeLazyConfig(confuse.LazyConfig):
         except confuse.NotFoundError:
             pass
         except confuse.ConfigReadError as err:
-            stderr.write("configuration `import` failed: {}".format(err.reason))
+            stderr.write(f"configuration `import` failed: {err.reason}")
 
 
 config = IncludeLazyConfig("beets", __name__)

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -66,7 +66,9 @@ class MusicBrainzAPIError(util.HumanReadableError):
         super().__init__(reason, verb, tb)
 
     def get_message(self):
-        return f"{self._reasonstr()} in {self.verb} with query {self.query!r}"
+        return (
+            f"{self._reasonstr()} in {self.verb} with query {repr(self.query)}"
+        )
 
 
 log = logging.getLogger("beets")

--- a/beets/autotag/mb.py
+++ b/beets/autotag/mb.py
@@ -66,9 +66,7 @@ class MusicBrainzAPIError(util.HumanReadableError):
         super().__init__(reason, verb, tb)
 
     def get_message(self):
-        return "{} in {} with query {}".format(
-            self._reasonstr(), self.verb, repr(self.query)
-        )
+        return f"{self._reasonstr()} in {self.verb} with query {self.query!r}"
 
 
 log = logging.getLogger("beets")

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -397,7 +397,7 @@ class Model(ABC):
 
     def __repr__(self) -> str:
         name = type(self).__name__
-        fields = ", ".join(f"{k}={v!r}" for k, v in dict(self).items())
+        fields = ", ".join(f"{k}={repr(v)}" for k, v in dict(self).items())
         return f"{name}({fields})"
 
     def clear_dirty(self):
@@ -558,12 +558,12 @@ class Model(ABC):
 
     def __getattr__(self, key):
         if key.startswith("_"):
-            raise AttributeError(f"model has no attribute {key!r}")
+            raise AttributeError(f"model has no attribute {repr(key)}")
         else:
             try:
                 return self[key]
             except KeyError:
-                raise AttributeError(f"no such field {key!r}")
+                raise AttributeError(f"no such field {repr(key)}")
 
     def __setattr__(self, key, value):
         if key.startswith("_"):

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import contextlib
-import itertools
 import os
 import re
 import sqlite3

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -171,7 +171,7 @@ class FieldQuery(Query, Generic[P]):
 
     def __repr__(self) -> str:
         return (
-            f"{self.__class__.__name__}({self.field_name!r}, {self.pattern!r}, "
+            f"{self.__class__.__name__}({repr(self.field_name)}, {repr(self.pattern)}, "
             f"fast={self.fast})"
         )
 
@@ -210,7 +210,9 @@ class NoneQuery(FieldQuery[None]):
         return obj.get(self.field_name) is None
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.field_name!r}, {self.fast})"
+        return (
+            f"{self.__class__.__name__}({repr(self.field_name)}, {self.fast})"
+        )
 
 
 class StringFieldQuery(FieldQuery[P]):
@@ -503,7 +505,7 @@ class CollectionQuery(Query):
         return clause, subvals
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.subqueries!r})"
+        return f"{self.__class__.__name__}({repr(self.subqueries)})"
 
     def __eq__(self, other) -> bool:
         return super().__eq__(other) and self.subqueries == other.subqueries
@@ -548,7 +550,7 @@ class AnyFieldQuery(CollectionQuery):
 
     def __repr__(self) -> str:
         return (
-            f"{self.__class__.__name__}({self.pattern!r}, {self.fields!r}, "
+            f"{self.__class__.__name__}({repr(self.pattern)}, {repr(self.fields)}, "
             f"{self.query_class.__name__})"
         )
 
@@ -619,7 +621,7 @@ class NotQuery(Query):
         return not self.subquery.match(obj)
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self.subquery!r})"
+        return f"{self.__class__.__name__}({repr(self.subquery)})"
 
     def __eq__(self, other) -> bool:
         return super().__eq__(other) and self.subquery == other.subquery
@@ -975,7 +977,7 @@ class MultipleSort(Sort):
         return items
 
     def __repr__(self):
-        return f"{self.__class__.__name__}({self.sorts!r})"
+        return f"{self.__class__.__name__}({repr(self.sorts)})"
 
     def __hash__(self):
         return hash(tuple(self.sorts))
@@ -1015,7 +1017,7 @@ class FieldSort(Sort):
     def __repr__(self) -> str:
         return (
             f"{self.__class__.__name__}"
-            f"({self.field!r}, ascending={self.ascending!r})"
+            f"({repr(self.field)}, ascending={repr(self.ascending)})"
         )
 
     def __hash__(self) -> int:

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -1582,9 +1582,7 @@ def resolve_duplicates(session, task):
     if task.choice_flag in (action.ASIS, action.APPLY, action.RETAG):
         found_duplicates = task.find_duplicates(session.lib)
         if found_duplicates:
-            log.debug(
-                "found duplicates: {}".format([o.id for o in found_duplicates])
-            )
+            log.debug(f"found duplicates: {[o.id for o in found_duplicates]}")
 
             # Get the default action to follow from config.
             duplicate_action = config["import"]["duplicate_action"].as_choice(

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -1582,7 +1582,7 @@ def resolve_duplicates(session, task):
     if task.choice_flag in (action.ASIS, action.APPLY, action.RETAG):
         found_duplicates = task.find_duplicates(session.lib)
         if found_duplicates:
-            log.debug(f"found duplicates: {[o.id for o in found_duplicates]}")
+            log.debug("found duplicates: {0}", [o.id for o in found_duplicates])
 
             # Get the default action to follow from config.
             duplicate_action = config["import"]["duplicate_action"].as_choice(

--- a/beets/library.py
+++ b/beets/library.py
@@ -157,7 +157,7 @@ class PathQuery(dbcore.FieldQuery[bytes]):
 
     def __repr__(self) -> str:
         return (
-            f"{self.__class__.__name__}({self.field!r}, {self.pattern!r}, "
+            f"{self.__class__.__name__}({repr(self.field)}, {repr(self.pattern)}, "
             f"fast={self.fast}, case_sensitive={self.case_sensitive})"
         )
 
@@ -736,7 +736,7 @@ class Item(LibModel):
         # can even deadlock due to the database lock.
         name = type(self).__name__
         keys = self.keys(with_album=False)
-        fields = (f"{k}={self[k]!r}" for k in keys)
+        fields = (f"{k}={repr(self[k])}" for k in keys)
         return f"{name}({', '.join(fields)})"
 
     def keys(self, computed=False, with_album=True):
@@ -1579,7 +1579,7 @@ def parse_query_string(s, model_cls):
 
     The string is split into components using shell-like syntax.
     """
-    message = f"Query is not unicode: {s!r}"
+    message = f"Query is not unicode: {repr(s)}"
     assert isinstance(s, str), message
     try:
         parts = shlex.split(s)

--- a/beets/library.py
+++ b/beets/library.py
@@ -734,13 +734,10 @@ class Item(LibModel):
         # This must not use `with_album=True`, because that might access
         # the database. When debugging, that is not guaranteed to succeed, and
         # can even deadlock due to the database lock.
-        return "{}({})".format(
-            type(self).__name__,
-            ", ".join(
-                "{}={!r}".format(k, self[k])
-                for k in self.keys(with_album=False)
-            ),
-        )
+        name = type(self).__name__
+        keys = self.keys(with_album=False)
+        fields = (f"{k}={self[k]!r}" for k in keys)
+        return f"{name}({', '.join(fields)})"
 
     def keys(self, computed=False, with_album=True):
         """Get a list of available field names.

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -343,9 +343,9 @@ def types(model_cls):
         for field in plugin_types:
             if field in types and plugin_types[field] != types[field]:
                 raise PluginConflictError(
-                    "Plugin {} defines flexible field {} "
-                    "which has already been defined with "
-                    "another type.".format(plugin.name, field)
+                    f"Plugin {plugin.name} defines flexible field "
+                    f"{field} which has already been defined with "
+                    "another type."
                 )
         types.update(plugin_types)
     return types
@@ -518,9 +518,8 @@ def feat_tokens(for_artist=True):
     feat_words = ["ft", "featuring", "feat", "feat.", "ft."]
     if for_artist:
         feat_words += ["with", "vs", "and", "con", "&"]
-    return r"(?<=\s)(?:{})(?=\s)".format(
-        "|".join(re.escape(x) for x in feat_words)
-    )
+    matcher = "|".join(re.escape(x) for x in feat_words)
+    return rf"(?<=\s)(?:{matcher})(?=\s)"
 
 
 def sanitize_choices(choices, choices_all):

--- a/beets/test/_common.py
+++ b/beets/test/_common.py
@@ -178,7 +178,7 @@ class InputError(Exception):
     def __str__(self):
         msg = "Attempt to read with no input provided."
         if self.output is not None:
-            msg += f" Output: {self.output!r}"
+            msg += f" Output: {repr(self.output)}"
         return msg
 
 

--- a/beets/test/_common.py
+++ b/beets/test/_common.py
@@ -153,13 +153,13 @@ class Assertions:
         self.assertExists(path)
         assert os.path.isfile(
             syspath(path)
-        ), "path exists, but is not a regular file: {!r}".format(path)
+        ), f"path exists, but is not a regular file: {repr(path)}"
 
     def assertIsDir(self, path):
         self.assertExists(path)
         assert os.path.isdir(
             syspath(path)
-        ), "path exists, but is not a directory: {!r}".format(path)
+        ), f"path exists, but is not a directory: {repr(path)}"
 
     def assert_equal_path(self, a, b):
         """Check that two paths are equal."""

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -774,7 +774,7 @@ def get_replacements():
             replacements.append((re.compile(pattern), repl))
         except re.error:
             raise UserError(
-                "malformed regular expression in replace: {}".format(pattern)
+                f"malformed regular expression in replace: {pattern}"
             )
     return replacements
 
@@ -1252,22 +1252,15 @@ def show_path_changes(path_changes):
         # Print every change over two lines
         for source, dest in zip(sources, destinations):
             color_source, color_dest = colordiff(source, dest)
-            print_("{0} \n  -> {1}".format(color_source, color_dest))
+            print_(f"{color_source} \n  -> {color_dest}")
     else:
         # Print every change on a single line, and add a header
-        title_pad = max_width - len("Source ") + len(" -> ")
-
-        print_("Source {0} Destination".format(" " * title_pad))
+        source = "Source "
+        print_(f"{source:<{max_width}}     Destination")
         for source, dest in zip(sources, destinations):
-            pad = max_width - len(source)
             color_source, color_dest = colordiff(source, dest)
-            print_(
-                "{0} {1} -> {2}".format(
-                    color_source,
-                    " " * pad,
-                    color_dest,
-                )
-            )
+            width = max_width - len(source) + len(color_source)
+            print_(f"{color_source:<{width}}  -> {color_dest}")
 
 
 # Helper functions for option parsing.
@@ -1293,9 +1286,7 @@ def _store_dict(option, opt_str, value, parser):
             raise ValueError
     except ValueError:
         raise UserError(
-            "supplied argument `{}' is not of the form `key=value'".format(
-                value
-            )
+            f"supplied argument `{value}' is not of the form `key=value'"
         )
 
     option_values[key] = value

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -18,7 +18,6 @@ CLI commands are implemented in the ui.commands module.
 """
 
 import errno
-import itertools
 import optparse
 import os.path
 import re

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -212,7 +212,7 @@ def get_singleton_disambig_fields(info: hooks.TrackInfo) -> Sequence[str]:
     out = []
     chosen_fields = config["match"]["singleton_disambig_fields"].as_str_seq()
     calculated_values = {
-        "index": f"Index {info.index!s}",
+        "index": f"Index {str(info.index)}",
         "track_alt": f"Track {info.track_alt}",
         "album": (
             f"[{info.album}]"

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -212,10 +212,10 @@ def get_singleton_disambig_fields(info: hooks.TrackInfo) -> Sequence[str]:
     out = []
     chosen_fields = config["match"]["singleton_disambig_fields"].as_str_seq()
     calculated_values = {
-        "index": "Index {}".format(str(info.index)),
-        "track_alt": "Track {}".format(info.track_alt),
+        "index": f"Index {info.index!s}",
+        "track_alt": f"Track {info.track_alt}",
         "album": (
-            "[{}]".format(info.album)
+            f"[{info.album}]"
             if (
                 config["import"]["singleton_album_disambig"].get()
                 and info.get("album")
@@ -241,7 +241,7 @@ def get_album_disambig_fields(info: hooks.AlbumInfo) -> Sequence[str]:
     chosen_fields = config["match"]["album_disambig_fields"].as_str_seq()
     calculated_values = {
         "media": (
-            "{}x{}".format(info.mediums, info.media)
+            f"{info.mediums}x{info.media}"
             if (info.mediums and info.mediums > 1)
             else info.media
         ),
@@ -489,7 +489,6 @@ class ChangeRepresentation:
         """Format colored track indices."""
         cur_track = self.format_index(item)
         new_track = self.format_index(track_info)
-        templ = "(#{})"
         changed = False
         # Choose color based on change.
         if cur_track != new_track:
@@ -501,8 +500,8 @@ class ChangeRepresentation:
         else:
             highlight_color = "text_faint"
 
-        cur_track = templ.format(cur_track)
-        new_track = templ.format(new_track)
+        cur_track = f"(#{cur_track})"
+        new_track = f"(#{new_track})"
         lhs_track = ui.colorize(highlight_color, cur_track)
         rhs_track = ui.colorize(highlight_color, new_track)
         return lhs_track, rhs_track, changed
@@ -710,9 +709,9 @@ class AlbumChange(ChangeRepresentation):
         if self.match.extra_items:
             print_(f"Unmatched tracks ({len(self.match.extra_items)}):")
         for item in self.match.extra_items:
-            line = " ! {} (#{})".format(item.title, self.format_index(item))
+            line = f" ! {item.title} (#{self.format_index(item)})"
             if item.length:
-                line += " ({})".format(ui.human_seconds_short(item.length))
+                line += f" ({ui.human_seconds_short(item.length)})"
             print_(ui.colorize("text_warning", line))
 
 
@@ -768,7 +767,7 @@ def summarize_items(items, singleton):
     """
     summary_parts = []
     if not singleton:
-        summary_parts.append("{} items".format(len(items)))
+        summary_parts.append(f"{len(items)} items")
 
     format_counts = {}
     for item in items:
@@ -884,7 +883,7 @@ def choose_candidate(
         if singleton:
             print_("No matching recordings found.")
         else:
-            print_("No matching release found for {} tracks.".format(itemcount))
+            print_(f"No matching release found for {itemcount} tracks.")
             print_(
                 "For help, see: "
                 "https://beets.readthedocs.org/en/latest/faq.html#nomatch"
@@ -919,7 +918,7 @@ def choose_candidate(
             print_(ui.indent(2) + "Candidates:")
             for i, match in enumerate(candidates):
                 # Index, metadata, and distance.
-                index0 = "{0}.".format(i + 1)
+                index0 = f"{i + 1}."
                 index = dist_colorize(index0, match.distance)
                 dist = "({:.1f}%)".format((1 - match.distance) * 100)
                 distance = dist_colorize(dist, match.distance)
@@ -1042,9 +1041,9 @@ class TerminalImportSession(importer.ImportSession):
 
         path_str0 = displayable_path(task.paths, "\n")
         path_str = ui.colorize("import_path", path_str0)
-        items_str0 = "({} items)".format(len(task.items))
+        items_str0 = f"({len(task.items)} items)"
         items_str = ui.colorize("import_path_items", items_str0)
-        print_(" ".join([path_str, items_str]))
+        print_(f"{path_str} {items_str}")
 
         # Let plugins display info or prompt the user before we go through the
         # process of selecting candidate.

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -106,7 +106,7 @@ class HumanReadableError(Exception):
         elif hasattr(self.reason, "strerror"):  # i.e., EnvironmentError
             return self.reason.strerror
         else:
-            return f'"{self.reason!s}"'
+            return f'"{str(self.reason)}"'
 
     def get_message(self):
         """Create the human-readable description of the error, sans

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -106,7 +106,7 @@ class HumanReadableError(Exception):
         elif hasattr(self.reason, "strerror"):  # i.e., EnvironmentError
             return self.reason.strerror
         else:
-            return '"{}"'.format(str(self.reason))
+            return f'"{self.reason!s}"'
 
     def get_message(self):
         """Create the human-readable description of the error, sans

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -44,7 +44,7 @@ def resize_url(url, maxwidth, quality=0):
     if quality > 0:
         params["q"] = quality
 
-    return "{}?{}".format(PROXY_URL, urlencode(params))
+    return f"{PROXY_URL}?{urlencode(params)}"
 
 
 class LocalBackendNotAvailableError(Exception):

--- a/beets/util/functemplate.py
+++ b/beets/util/functemplate.py
@@ -165,9 +165,7 @@ class Call:
         self.original = original
 
     def __repr__(self):
-        return "Call({}, {}, {})".format(
-            repr(self.ident), repr(self.args), repr(self.original)
-        )
+        return f"Call({self.ident!r}, {self.args!r}, {self.original!r})"
 
     def evaluate(self, env):
         """Evaluate the function call in the environment, returning a

--- a/beets/util/functemplate.py
+++ b/beets/util/functemplate.py
@@ -165,7 +165,7 @@ class Call:
         self.original = original
 
     def __repr__(self):
-        return f"Call({self.ident!r}, {self.args!r}, {self.original!r})"
+        return f"Call({repr(self.ident)}, {repr(self.args)}, {repr(self.original)})"
 
     def evaluate(self, env):
         """Evaluate the function call in the environment, returning a

--- a/beetsplug/absubmit.py
+++ b/beetsplug/absubmit.py
@@ -42,9 +42,7 @@ def call(args):
     try:
         return util.command_output(args).stdout
     except subprocess.CalledProcessError as e:
-        raise ABSubmitError(
-            "{} exited with status {}".format(args[0], e.returncode)
-        )
+        raise ABSubmitError(f"{args[0]} exited with status {e.returncode}")
 
 
 class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
@@ -63,9 +61,7 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
             # Explicit path to extractor
             if not os.path.isfile(self.extractor):
                 raise ui.UserError(
-                    "Extractor command does not exist: {0}.".format(
-                        self.extractor
-                    )
+                    f"Extractor command does not exist: {self.extractor}."
                 )
         else:
             # Implicit path to extractor, search for it in path

--- a/beetsplug/aura.py
+++ b/beetsplug/aura.py
@@ -245,7 +245,7 @@ class AURADocument:
             else:
                 # Increment page token by 1
                 next_url = request.url.replace(
-                    f"page={page}", "page={}".format(page + 1)
+                    f"page={page}", f"page={page + 1}"
                 )
         # Get only the items in the page range
         data = [
@@ -430,9 +430,7 @@ class TrackDocument(AURADocument):
             return self.error(
                 "404 Not Found",
                 "No track with the requested id.",
-                "There is no track with an id of {} in the library.".format(
-                    track_id
-                ),
+                f"There is no track with an id of {track_id} in the library.",
             )
         return self.single_resource_document(
             self.get_resource_object(self.lib, track)
@@ -516,9 +514,7 @@ class AlbumDocument(AURADocument):
             return self.error(
                 "404 Not Found",
                 "No album with the requested id.",
-                "There is no album with an id of {} in the library.".format(
-                    album_id
-                ),
+                f"There is no album with an id of {album_id} in the library.",
             )
         return self.single_resource_document(
             self.get_resource_object(self.lib, album)
@@ -603,9 +599,7 @@ class ArtistDocument(AURADocument):
             return self.error(
                 "404 Not Found",
                 "No artist with the requested id.",
-                "There is no artist with an id of {} in the library.".format(
-                    artist_id
-                ),
+                f"There is no artist with an id of {artist_id} in the library.",
             )
         return self.single_resource_document(artist_resource)
 
@@ -730,9 +724,7 @@ class ImageDocument(AURADocument):
             return self.error(
                 "404 Not Found",
                 "No image with the requested id.",
-                "There is no image with an id of {} in the library.".format(
-                    image_id
-                ),
+                f"There is no image with an id of {image_id} in the library.",
             )
         return self.single_resource_document(image_resource)
 
@@ -778,9 +770,7 @@ def audio_file(track_id):
         return AURADocument.error(
             "404 Not Found",
             "No track with the requested id.",
-            "There is no track with an id of {} in the library.".format(
-                track_id
-            ),
+            f"There is no track with an id of {track_id} in the library.",
         )
 
     path = os.fsdecode(track.path)
@@ -788,9 +778,7 @@ def audio_file(track_id):
         return AURADocument.error(
             "404 Not Found",
             "No audio file for the requested track.",
-            (
-                "There is no audio file for track {} at the expected location"
-            ).format(track_id),
+            f"There is no audio file for track {track_id} at the expected location",
         )
 
     file_mimetype = guess_type(path)[0]
@@ -798,10 +786,8 @@ def audio_file(track_id):
         return AURADocument.error(
             "500 Internal Server Error",
             "Requested audio file has an unknown mimetype.",
-            (
-                "The audio file for track {} has an unknown mimetype. "
-                "Its file extension is {}."
-            ).format(track_id, path.split(".")[-1]),
+            f"The audio file for track {track_id} has an unknown mimetype. "
+            f"Its file extension is {path.split('.')[-1]}.",
         )
 
     # Check that the Accept header contains the file's mimetype
@@ -813,10 +799,8 @@ def audio_file(track_id):
         return AURADocument.error(
             "406 Not Acceptable",
             "Unsupported MIME type or bitrate parameter in Accept header.",
-            (
-                "The audio file for track {} is only available as {} and "
-                "bitrate parameters are not supported."
-            ).format(track_id, file_mimetype),
+            f"The audio file for track {track_id} is only available as "
+            f"{file_mimetype} and bitrate parameters are not supported.",
         )
 
     return send_file(
@@ -899,9 +883,7 @@ def image_file(image_id):
         return AURADocument.error(
             "404 Not Found",
             "No image with the requested id.",
-            "There is no image with an id of {} in the library".format(
-                image_id
-            ),
+            f"There is no image with an id of {image_id} in the library",
         )
     return send_file(img_path)
 

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -200,14 +200,10 @@ class BeatportClient:
         try:
             response = self.api.get(self._make_url(endpoint), params=kwargs)
         except Exception as e:
-            raise BeatportAPIError(
-                "Error connecting to Beatport API: {}".format(e)
-            )
+            raise BeatportAPIError(f"Error connecting to Beatport API: {e}")
         if not response:
             raise BeatportAPIError(
-                "Error {0.status_code} for '{0.request.path_url}".format(
-                    response
-                )
+                f"Error {response.status_code} for '{response.request.path_url}"
             )
         return response.json()["results"]
 
@@ -218,11 +214,7 @@ class BeatportRelease(BeatportObject):
             artist_str = ", ".join(x[1] for x in self.artists)
         else:
             artist_str = "Various Artists"
-        return "<BeatportRelease: {} - {} ({})>".format(
-            artist_str,
-            self.name,
-            self.catalog_number,
-        )
+        return f"<BeatportRelease: {artist_str} - {self.name} ({self.catalog_number})>"
 
     def __repr__(self):
         return str(self).encode("utf-8")
@@ -236,8 +228,8 @@ class BeatportRelease(BeatportObject):
         if "category" in data:
             self.category = data["category"]
         if "slug" in data:
-            self.url = "https://beatport.com/release/{}/{}".format(
-                data["slug"], data["id"]
+            self.url = (
+                f"https://beatport.com/release/{data['slug']}/{data['id']}"
             )
         self.genre = data.get("genre")
 
@@ -245,9 +237,7 @@ class BeatportRelease(BeatportObject):
 class BeatportTrack(BeatportObject):
     def __str__(self):
         artist_str = ", ".join(x[1] for x in self.artists)
-        return "<BeatportTrack: {} - {} ({})>".format(
-            artist_str, self.name, self.mix_name
-        )
+        return f"<BeatportTrack: {artist_str} - {self.name} ({self.mix_name})>"
 
     def __repr__(self):
         return str(self).encode("utf-8")
@@ -266,9 +256,7 @@ class BeatportTrack(BeatportObject):
             except ValueError:
                 pass
         if "slug" in data:
-            self.url = "https://beatport.com/track/{}/{}".format(
-                data["slug"], data["id"]
-            )
+            self.url = f"https://beatport.com/track/{data['slug']}/{data['id']}"
         self.track_number = data.get("trackNumber")
         self.bpm = data.get("bpm")
         self.initial_key = str((data.get("key") or {}).get("shortName"))

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -228,8 +228,8 @@ class BeatportRelease(BeatportObject):
         if "category" in data:
             self.category = data["category"]
         if "slug" in data:
-            self.url = (
-                f"https://beatport.com/release/{data['slug']}/{data['id']}"
+            self.url = "https://beatport.com/release/{}/{}".format(
+                data["slug"], data["id"]
             )
         self.genre = data.get("genre")
 
@@ -256,7 +256,9 @@ class BeatportTrack(BeatportObject):
             except ValueError:
                 pass
         if "slug" in data:
-            self.url = f"https://beatport.com/track/{data['slug']}/{data['id']}"
+            self.url = "https://beatport.com/track/{}/{}".format(
+                data["slug"], data["id"]
+            )
         self.track_number = data.get("trackNumber")
         self.bpm = data.get("bpm")
         self.initial_key = str((data.get("key") or {}).get("shortName"))

--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -894,9 +894,7 @@ class MPDConnection(Connection):
                     return
                 except BPDIdleError as e:
                     self.idle_subscriptions = e.subsystems
-                    self.debug(
-                        "awaiting: {}".format(" ".join(e.subsystems)), kind="z"
-                    )
+                    self.debug(f"awaiting: {' '.join(e.subsystems)}", kind="z")
                 yield bluelet.call(self.server.dispatch_events())
 
 
@@ -928,7 +926,7 @@ class ControlConnection(Connection):
                 func = command.delegate("ctrl_", self)
                 yield bluelet.call(func(*command.args))
             except (AttributeError, TypeError) as e:
-                yield self.send("ERROR: {}".format(e.args[0]))
+                yield self.send(f"ERROR: {e.args[0]}")
             except Exception:
                 yield self.send(
                     ["ERROR: server error", traceback.format_exc().rstrip()]
@@ -1006,7 +1004,7 @@ class Command:
         # If the command accepts a variable number of arguments skip the check.
         if wrong_num and not argspec.varargs:
             raise TypeError(
-                'wrong number of arguments for "{}"'.format(self.name),
+                f'wrong number of arguments for "{self.name}"',
                 self.name,
             )
 
@@ -1113,10 +1111,8 @@ class Server(BaseServer):
         self.lib = library
         self.player = gstplayer.GstPlayer(self.play_finished)
         self.cmd_update(None)
-        log.info("Server ready and listening on {}:{}".format(host, port))
-        log.debug(
-            "Listening for control signals on {}:{}".format(host, ctrl_port)
-        )
+        log.info(f"Server ready and listening on {host}:{port}")
+        log.debug(f"Listening for control signals on {host}:{ctrl_port}")
 
     def run(self):
         self.player.run()
@@ -1145,9 +1141,7 @@ class Server(BaseServer):
             pass
 
         for tagtype, field in self.tagtype_map.items():
-            info_lines.append(
-                "{}: {}".format(tagtype, str(getattr(item, field)))
-            )
+            info_lines.append(f"{tagtype}: {getattr(item, field)!s}")
 
         return info_lines
 
@@ -1305,22 +1299,15 @@ class Server(BaseServer):
             item = self.playlist[self.current_index]
 
             yield (
-                "bitrate: " + str(item.bitrate / 1000),
-                "audio: {}:{}:{}".format(
-                    str(item.samplerate),
-                    str(item.bitdepth),
-                    str(item.channels),
-                ),
+                f"bitrate: {item.bitrate / 1000}",
+                f"audio: {item.samplerate!s}:{item.bitdepth!s}:{item.channels!s}",
             )
 
             (pos, total) = self.player.time()
             yield (
-                "time: {}:{}".format(
-                    str(int(pos)),
-                    str(int(total)),
-                ),
-                "elapsed: " + f"{pos:.3f}",
-                "duration: " + f"{total:.3f}",
+                f"time: {int(pos)}:{int(total)}",
+                f"elapsed: {pos:.3f}",
+                f"duration: {total:.3f}",
             )
 
         # Also missing 'updating_db'.

--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -1300,7 +1300,7 @@ class Server(BaseServer):
 
             yield (
                 f"bitrate: {item.bitrate / 1000}",
-                f"audio: {str(item.samplerate)}:{str(item.bitdepth)}:{str(item.channels)}",
+                f"audio: {item.samplerate}:{item.bitdepth}:{item.channels}",
             )
 
             (pos, total) = self.player.time()

--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -1141,7 +1141,7 @@ class Server(BaseServer):
             pass
 
         for tagtype, field in self.tagtype_map.items():
-            info_lines.append(f"{tagtype}: {getattr(item, field)!s}")
+            info_lines.append(f"{tagtype}: {str(getattr(item, field))}")
 
         return info_lines
 
@@ -1300,7 +1300,7 @@ class Server(BaseServer):
 
             yield (
                 f"bitrate: {item.bitrate / 1000}",
-                f"audio: {item.samplerate!s}:{item.bitdepth!s}:{item.channels!s}",
+                f"audio: {str(item.samplerate)}:{str(item.bitdepth)}:{str(item.channels)}",
             )
 
             (pos, total) = self.player.time()

--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -1111,8 +1111,8 @@ class Server(BaseServer):
         self.lib = library
         self.player = gstplayer.GstPlayer(self.play_finished)
         self.cmd_update(None)
-        log.info(f"Server ready and listening on {host}:{port}")
-        log.debug(f"Listening for control signals on {host}:{ctrl_port}")
+        log.info("Server ready and listening on {}:{}", host, port)
+        log.debug("Listening for control signals on {}:{}", host, ctrl_port)
 
     def run(self):
         self.player.run()

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -63,9 +63,7 @@ def get_format(fmt=None):
         command = format_info["command"]
         extension = format_info.get("extension", fmt)
     except KeyError:
-        raise ui.UserError(
-            'convert: format {} needs the "command" field'.format(fmt)
-        )
+        raise ui.UserError(f'convert: format {fmt} needs the "command" field')
     except ConfigTypeError:
         command = config["convert"]["formats"][fmt].get(str)
         extension = fmt

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -629,7 +629,7 @@ class DiscogsPlugin(BeetsPlugin):
             idx, medium_idx, sub_idx = self.get_track_index(
                 subtracks[0]["position"]
             )
-            position = "{}{}".format(idx or "", medium_idx or "")
+            position = f"{idx or ''}{medium_idx or ''}"
 
             if tracklist and not tracklist[-1]["position"]:
                 # Assume the previous index track contains the track title.
@@ -651,8 +651,8 @@ class DiscogsPlugin(BeetsPlugin):
                     # option is set
                     if self.config["index_tracks"]:
                         for subtrack in subtracks:
-                            subtrack["title"] = "{}: {}".format(
-                                index_track["title"], subtrack["title"]
+                            subtrack["title"] = (
+                                f"{index_track['title']}: {subtrack['title']}"
                             )
                     tracklist.extend(subtracks)
             else:

--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -46,7 +46,9 @@ def edit(filename, log):
     try:
         subprocess.call(cmd)
     except OSError as exc:
-        raise ui.UserError(f"could not run editor command {cmd[0]!r}: {exc}")
+        raise ui.UserError(
+            f"could not run editor command {repr(cmd[0])}: {exc}"
+        )
 
 
 def dump(arg):

--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -46,9 +46,7 @@ def edit(filename, log):
     try:
         subprocess.call(cmd)
     except OSError as exc:
-        raise ui.UserError(
-            "could not run editor command {!r}: {}".format(cmd[0], exc)
-        )
+        raise ui.UserError(f"could not run editor command {cmd[0]!r}: {exc}")
 
 
 def dump(arg):
@@ -71,9 +69,7 @@ def load(s):
         for d in yaml.safe_load_all(s):
             if not isinstance(d, dict):
                 raise ParseError(
-                    "each entry must be a dictionary; found {}".format(
-                        type(d).__name__
-                    )
+                    f"each entry must be a dictionary; found {type(d).__name__}"
                 )
 
             # Convert all keys to strings. They started out as strings,

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -137,7 +137,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                     response = requests.get(opts.url, timeout=5)
                     response.raise_for_status()
                 except requests.exceptions.RequestException as e:
-                    self._log.error("{}".format(e))
+                    self._log.error(str(e))
                     return
                 extension = guess_extension(response.headers["Content-Type"])
                 if extension is None:
@@ -149,7 +149,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                     with open(tempimg, "wb") as f:
                         f.write(response.content)
                 except Exception as e:
-                    self._log.error("Unable to save image: {}".format(e))
+                    self._log.error(f"Unable to save image: {e}")
                     return
                 items = lib.items(decargs(args))
                 # Confirm with user.

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -149,7 +149,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                     with open(tempimg, "wb") as f:
                         f.write(response.content)
                 except Exception as e:
-                    self._log.error(f"Unable to save image: {e}")
+                    self._log.error("Unable to save image: {}", e)
                     return
                 items = lib.items(decargs(args))
                 # Confirm with user.

--- a/beetsplug/embyupdate.py
+++ b/beetsplug/embyupdate.py
@@ -39,9 +39,7 @@ def api_url(host, port, endpoint):
         hostname_list.insert(0, "http://")
         hostname = "".join(hostname_list)
 
-    joined = urljoin(
-        "{hostname}:{port}".format(hostname=hostname, port=port), endpoint
-    )
+    joined = urljoin(f"{hostname}:{port}", endpoint)
 
     scheme, netloc, path, query_string, fragment = urlsplit(joined)
     query_params = parse_qs(query_string)
@@ -82,12 +80,12 @@ def create_headers(user_id, token=None):
     headers = {}
 
     authorization = (
-        'MediaBrowser UserId="{user_id}", '
+        f'MediaBrowser UserId="{user_id}", '
         'Client="other", '
         'Device="beets", '
         'DeviceId="beets", '
         'Version="0.0.0"'
-    ).format(user_id=user_id)
+    )
 
     headers["x-emby-authorization"] = authorization
 

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -455,18 +455,14 @@ class CoverArtArchive(RemoteArtSource):
             try:
                 response = self.request(url)
             except requests.RequestException:
-                self._log.debug(
-                    "{}: error receiving response".format(self.NAME)
-                )
+                self._log.debug(f"{self.NAME}: error receiving response")
                 return
 
             try:
                 data = response.json()
             except ValueError:
                 self._log.debug(
-                    "{}: error loading response: {}".format(
-                        self.NAME, response.text
-                    )
+                    f"{self.NAME}: error loading response: {response.text}"
                 )
                 return
 
@@ -600,9 +596,7 @@ class GoogleImages(RemoteArtSource):
         try:
             data = response.json()
         except ValueError:
-            self._log.debug(
-                "google: error loading response: {}".format(response.text)
-            )
+            self._log.debug(f"google: error loading response: {response.text}")
             return
 
         if "error" in data:
@@ -1070,9 +1064,7 @@ class LastFM(RemoteArtSource):
                             url=images[size], size=self.SIZES[size]
                         )
         except ValueError:
-            self._log.debug(
-                "lastfm: error loading response: {}".format(response.text)
-            )
+            self._log.debug(f"lastfm: error loading response: {response.text}")
             return
 
 
@@ -1111,9 +1103,7 @@ class Spotify(RemoteArtSource):
             ]
             yield self._candidate(url=image_url, match=Candidate.MATCH_EXACT)
         except ValueError:
-            self._log.debug(
-                "Spotify: error loading response: {}".format(response.text)
-            )
+            self._log.debug(f"Spotify: error loading response: {response.text}")
             return
 
 

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -455,14 +455,14 @@ class CoverArtArchive(RemoteArtSource):
             try:
                 response = self.request(url)
             except requests.RequestException:
-                self._log.debug(f"{self.NAME}: error receiving response")
+                self._log.debug("{}: error receiving response", self.NAME)
                 return
 
             try:
                 data = response.json()
             except ValueError:
                 self._log.debug(
-                    f"{self.NAME}: error loading response: {response.text}"
+                    "{}: error loading response: {}", self.NAME, response.text
                 )
                 return
 
@@ -596,7 +596,7 @@ class GoogleImages(RemoteArtSource):
         try:
             data = response.json()
         except ValueError:
-            self._log.debug(f"google: error loading response: {response.text}")
+            self._log.debug("google: error loading response: {}", response.text)
             return
 
         if "error" in data:
@@ -1064,7 +1064,7 @@ class LastFM(RemoteArtSource):
                             url=images[size], size=self.SIZES[size]
                         )
         except ValueError:
-            self._log.debug(f"lastfm: error loading response: {response.text}")
+            self._log.debug("lastfm: error loading response: {}", response.text)
             return
 
 
@@ -1123,14 +1123,14 @@ class CoverArtUrl(RemoteArtSource):
                 image_url = album.cover_art_url
             else:
                 image_url = album.items().get().cover_art_url
-            self._log.debug(f"Cover art URL {image_url} found for {album}")
+            self._log.debug("Cover art URL {} found for {}", image_url, album)
         except (AttributeError, TypeError):
-            self._log.debug(f"Cover art URL not found for {album}")
+            self._log.debug("Cover art URL not found for {}", album)
             return
         if image_url:
             yield self._candidate(url=image_url, match=Candidate.MATCH_EXACT)
         else:
-            self._log.debug(f"Cover art URL not found for {album}")
+            self._log.debug("Cover art URL not found for {}", album)
             return
 
 

--- a/beetsplug/fish.py
+++ b/beetsplug/fish.py
@@ -126,18 +126,10 @@ class FishPlugin(BeetsPlugin):
         totstring += get_cmds_list([name[0] for name in cmd_names_help])
         totstring += "" if nobasicfields else get_standard_fields(fields)
         totstring += get_extravalues(lib, extravalues) if extravalues else ""
-        totstring += (
-            "\n"
-            + "# ====== {} =====".format("setup basic beet completion")
-            + "\n" * 2
-        )
+        totstring += "\n" "# ====== setup basic beet completion =====" "\n\n"
         totstring += get_basic_beet_options()
         totstring += (
-            "\n"
-            + "# ====== {} =====".format(
-                "setup field completion for subcommands"
-            )
-            + "\n"
+            "\n" "# ====== setup field completion for subcommands =====" "\n"
         )
         totstring += get_subcommands(cmd_names_help, nobasicfields, extravalues)
         # Set up completion for all the command options
@@ -226,11 +218,7 @@ def get_subcommands(cmd_name_and_help, nobasicfields, extravalues):
     for cmdname, cmdhelp in cmd_name_and_help:
         cmdname = _escape(cmdname)
 
-        word += (
-            "\n"
-            + "# ------ {} -------".format("fieldsetups for  " + cmdname)
-            + "\n"
-        )
+        word += "\n" f"# ------ fieldsetups for {cmdname} -------" "\n"
         word += BL_NEED2.format(
             ("-a " + cmdname), ("-f " + "-d " + wrap(clean_whitespace(cmdhelp)))
         )
@@ -268,11 +256,7 @@ def get_all_commands(beetcmds):
             name = _escape(name)
 
             word += "\n"
-            word += (
-                ("\n" * 2)
-                + "# ====== {} =====".format("completions for  " + name)
-                + "\n"
-            )
+            word += "\n\n" f"# ====== completions for {name} =====" "\n"
 
             for option in cmd.parser._get_all_options()[1:]:
                 cmd_l = (

--- a/beetsplug/fish.py
+++ b/beetsplug/fish.py
@@ -122,15 +122,13 @@ class FishPlugin(BeetsPlugin):
             for name in names:
                 cmd_names_help.append((name, cmd.help))
         # Concatenate the string
-        totstring = HEAD + "\n"
+        totstring = f"{HEAD}\n"
         totstring += get_cmds_list([name[0] for name in cmd_names_help])
         totstring += "" if nobasicfields else get_standard_fields(fields)
         totstring += get_extravalues(lib, extravalues) if extravalues else ""
-        totstring += "\n" "# ====== setup basic beet completion =====" "\n\n"
+        totstring += "\n# ====== setup basic beet completion =====\n\n"
         totstring += get_basic_beet_options()
-        totstring += (
-            "\n" "# ====== setup field completion for subcommands =====" "\n"
-        )
+        totstring += "\n# ====== setup field completion for subcommands =====\n"
         totstring += get_subcommands(cmd_names_help, nobasicfields, extravalues)
         # Set up completion for all the command options
         totstring += get_all_commands(beetcmds)
@@ -148,17 +146,13 @@ def _escape(name):
 
 def get_cmds_list(cmds_names):
     # Make a list of all Beets core & plugin commands
-    substr = ""
-    substr += "set CMDS " + " ".join(cmds_names) + ("\n" * 2)
-    return substr
+    return f"set CMDS {' '.join(cmds_names)}\n\n"
 
 
 def get_standard_fields(fields):
     # Make a list of album/track fields and append with ':'
-    fields = (field + ":" for field in fields)
-    substr = ""
-    substr += "set FIELDS " + " ".join(fields) + ("\n" * 2)
-    return substr
+    fields = (f"{field}:" for field in fields)
+    return f"set FIELDS {' '.join(fields)}\n\n"
 
 
 def get_extravalues(lib, extravalues):
@@ -167,14 +161,7 @@ def get_extravalues(lib, extravalues):
     word = ""
     values_set = get_set_of_values_for_field(lib, extravalues)
     for fld in extravalues:
-        extraname = fld.upper() + "S"
-        word += (
-            "set  "
-            + extraname
-            + " "
-            + " ".join(sorted(values_set[fld]))
-            + ("\n" * 2)
-        )
+        word += f"set {fld.upper()}S {' '.join(sorted(values_set[fld]))}\n\n"
     return word
 
 
@@ -218,7 +205,7 @@ def get_subcommands(cmd_name_and_help, nobasicfields, extravalues):
     for cmdname, cmdhelp in cmd_name_and_help:
         cmdname = _escape(cmdname)
 
-        word += "\n" f"# ------ fieldsetups for {cmdname} -------" "\n"
+        word += f"\n# ------ fieldsetups for {cmdname} -------\n"
         word += BL_NEED2.format(
             ("-a " + cmdname), ("-f " + "-d " + wrap(clean_whitespace(cmdhelp)))
         )
@@ -255,8 +242,7 @@ def get_all_commands(beetcmds):
         for name in names:
             name = _escape(name)
 
-            word += "\n"
-            word += "\n\n" f"# ====== completions for {name} =====" "\n"
+            word += "\n\n\n# ====== completions for {name} =====\n"
 
             for option in cmd.parser._get_all_options()[1:]:
                 cmd_l = (

--- a/beetsplug/fromfilename.py
+++ b/beetsplug/fromfilename.py
@@ -112,7 +112,7 @@ def apply_matches(d, log):
         for item in d:
             if not item.artist:
                 item.artist = artist
-                log.info("Artist replaced with: {}".format(item.artist))
+                log.info(f"Artist replaced with: {item.artist}")
 
     # No artist field: remaining field is the title.
     else:
@@ -122,11 +122,11 @@ def apply_matches(d, log):
     for item in d:
         if bad_title(item.title):
             item.title = str(d[item][title_field])
-            log.info("Title replaced with: {}".format(item.title))
+            log.info(f"Title replaced with: {item.title}")
 
         if "track" in d[item] and item.track == 0:
             item.track = int(d[item]["track"])
-            log.info("Track replaced with: {}".format(item.track))
+            log.info(f"Track replaced with: {item.track}")
 
 
 # Plugin structure and hook into import process.

--- a/beetsplug/fromfilename.py
+++ b/beetsplug/fromfilename.py
@@ -112,7 +112,7 @@ def apply_matches(d, log):
         for item in d:
             if not item.artist:
                 item.artist = artist
-                log.info(f"Artist replaced with: {item.artist}")
+                log.info("Artist replaced with: {}", item.artist)
 
     # No artist field: remaining field is the title.
     else:
@@ -122,11 +122,11 @@ def apply_matches(d, log):
     for item in d:
         if bad_title(item.title):
             item.title = str(d[item][title_field])
-            log.info(f"Title replaced with: {item.title}")
+            log.info("Title replaced with: {}", item.title)
 
         if "track" in d[item] and item.track == 0:
             item.track = int(d[item]["track"])
-            log.info(f"Track replaced with: {item.track}")
+            log.info("Track replaced with: {}", item.track)
 
 
 # Plugin structure and hook into import process.

--- a/beetsplug/info.py
+++ b/beetsplug/info.py
@@ -117,7 +117,6 @@ def print_data(data, item=None, fmt=None):
         return
 
     maxwidth = max(len(key) for key in formatted)
-    lineformat = f"{{0:>{maxwidth}}}: {{1}}"
 
     if path:
         ui.print_(displayable_path(path))
@@ -126,7 +125,7 @@ def print_data(data, item=None, fmt=None):
         value = formatted[field]
         if isinstance(value, list):
             value = "; ".join(value)
-        ui.print_(lineformat.format(field, value))
+        ui.print_(f"{field:>{maxwidth}}: {value}")
 
 
 def print_data_keys(data, item=None):
@@ -139,12 +138,11 @@ def print_data_keys(data, item=None):
     if len(formatted) == 0:
         return
 
-    line_format = "{0}{{0}}".format(" " * 4)
     if path:
         ui.print_(displayable_path(path))
 
     for field in sorted(formatted):
-        ui.print_(line_format.format(field))
+        ui.print_(f"    {field}")
 
 
 class InfoPlugin(BeetsPlugin):

--- a/beetsplug/inline.py
+++ b/beetsplug/inline.py
@@ -37,7 +37,8 @@ def _compile_func(body):
     """Given Python code for a function body, return a compiled
     callable that invokes that code.
     """
-    body = "def {}():\n    {}".format(FUNC_NAME, body.replace("\n", "\n    "))
+    body = body.replace("\n", "\n    ")
+    body = f"def {FUNC_NAME}():\n    {body}"
     code = compile(body, "inline", "exec")
     env = {}
     eval(code, env)

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -180,7 +180,7 @@ def search_pairs(item):
         # examples include (live), (remix), and (acoustic).
         r"(.+?)\s+[(].*[)]$",
         # Remove any featuring artists from the title
-        r"(.*?) {}".format(plugins.feat_tokens(for_artist=False)),
+        rf"(.*?) {plugins.feat_tokens(for_artist=False)}",
         # Remove part of title after colon ':' for songs with subtitles
         r"(.+?)\s*:.*",
     ]
@@ -995,12 +995,10 @@ class LyricsPlugin(plugins.BeetsPlugin):
             tmpalbum = self.album = item.album.strip()
             if self.album == "":
                 tmpalbum = "Unknown album"
-            self.rest += "{}\n{}\n\n".format(tmpalbum, "-" * len(tmpalbum))
+            self.rest += f"{tmpalbum}\n{'-'*len(tmpalbum)}\n\n"
         title_str = ":index:`%s`" % item.title.strip()
         block = "| " + item.lyrics.replace("\n", "\n| ")
-        self.rest += "{}\n{}\n\n{}\n\n".format(
-            title_str, "~" * len(title_str), block
-        )
+        self.rest += f"{title_str}\n{'~'*len(title_str)}\n\n{block}\n\n"
 
     def writerest(self, directory):
         """Write self.rest to a ReST file"""
@@ -1130,5 +1128,5 @@ class LyricsPlugin(plugins.BeetsPlugin):
             translations = dict(zip(text_lines, lines_translated.split("|")))
             result = ""
             for line in text.split("\n"):
-                result += "{} / {}\n".format(line, translations[line])
+                result += f"{line} / {translations[line]}\n"
             return result

--- a/beetsplug/mbcollection.py
+++ b/beetsplug/mbcollection.py
@@ -79,9 +79,7 @@ class MusicBrainzCollectionPlugin(BeetsPlugin):
         collection = self.config["collection"].as_str()
         if collection:
             if collection not in collection_ids:
-                raise ui.UserError(
-                    "invalid collection ID: {}".format(collection)
-                )
+                raise ui.UserError(f"invalid collection ID: {collection}")
             return collection
 
         # No specified collection. Just return the first collection ID

--- a/beetsplug/metasync/__init__.py
+++ b/beetsplug/metasync/__init__.py
@@ -118,13 +118,13 @@ class MetaSyncPlugin(BeetsPlugin):
             try:
                 cls = META_SOURCES[player]
             except KeyError:
-                self._log.error(f"Unknown metadata source '{player}'")
+                self._log.error("Unknown metadata source '{}'", player)
 
             try:
                 meta_source_instances[player] = cls(self.config, self._log)
             except (ImportError, ConfigValueError) as e:
                 self._log.error(
-                    f"Failed to instantiate metadata source {player!r}: {e}"
+                    "Failed to instantiate metadata source {!r}: {}", player, e
                 )
 
         # Avoid needlessly iterating over items

--- a/beetsplug/metasync/__init__.py
+++ b/beetsplug/metasync/__init__.py
@@ -118,7 +118,7 @@ class MetaSyncPlugin(BeetsPlugin):
             try:
                 cls = META_SOURCES[player]
             except KeyError:
-                self._log.error("Unknown metadata source '{}'".format(player))
+                self._log.error(f"Unknown metadata source '{player}'")
 
             try:
                 meta_source_instances[player] = cls(self.config, self._log)

--- a/beetsplug/missing.py
+++ b/beetsplug/missing.py
@@ -221,7 +221,7 @@ class MissingPlugin(BeetsPlugin):
             missing_titles = {rg["title"] for rg in missing}
 
             for release_title in missing_titles:
-                print_("{} - {}".format(artist[0], release_title))
+                print_(f"{artist[0]} - {release_title}")
 
         if total:
             print(total_missing)

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -43,7 +43,7 @@ def play(
     """
     # Print number of tracks or albums to be played, log command to be run.
     item_type += "s" if len(selection) > 1 else ""
-    ui.print_("Playing {} {}.".format(len(selection), item_type))
+    ui.print_(f"Playing {len(selection)} {item_type}.")
     log.debug("executing command: {} {!r}", command_str, open_args)
 
     try:
@@ -179,9 +179,7 @@ class PlayPlugin(BeetsPlugin):
             ui.print_(
                 ui.colorize(
                     "text_warning",
-                    "You are about to queue {} {}.".format(
-                        len(selection), item_type
-                    ),
+                    f"You are about to queue {len(selection)} {item_type}.",
                 )
             )
 

--- a/beetsplug/playlist.py
+++ b/beetsplug/playlist.py
@@ -192,8 +192,10 @@ class PlaylistPlugin(beets.plugins.BeetsPlugin):
 
         if changes or deletions:
             self._log.info(
-                f"Updated playlist {filename} "
-                f"({changes} changes, {deletions} deletions)"
+                "Updated playlist {} ({} changes, {} deletions)",
+                filename,
+                changes,
+                deletions,
             )
             beets.util.copy(new_playlist, filename, replace=True)
         beets.util.remove(new_playlist)

--- a/beetsplug/playlist.py
+++ b/beetsplug/playlist.py
@@ -192,7 +192,8 @@ class PlaylistPlugin(beets.plugins.BeetsPlugin):
 
         if changes or deletions:
             self._log.info(
-                f"Updated playlist {filename} ({changes} changes, {deletions} deletions)"
+                f"Updated playlist {filename} "
+                f"({changes} changes, {deletions} deletions)"
             )
             beets.util.copy(new_playlist, filename, replace=True)
         beets.util.remove(new_playlist)

--- a/beetsplug/playlist.py
+++ b/beetsplug/playlist.py
@@ -192,9 +192,7 @@ class PlaylistPlugin(beets.plugins.BeetsPlugin):
 
         if changes or deletions:
             self._log.info(
-                "Updated playlist {} ({} changes, {} deletions)".format(
-                    filename, changes, deletions
-                )
+                f"Updated playlist {filename} ({changes} changes, {deletions} deletions)"
             )
             beets.util.copy(new_playlist, filename, replace=True)
         beets.util.remove(new_playlist)

--- a/beetsplug/plexupdate.py
+++ b/beetsplug/plexupdate.py
@@ -22,7 +22,9 @@ def get_music_section(
 ):
     """Getting the section key for the music library in Plex."""
     api_endpoint = append_token("library/sections", token)
-    url = urljoin(f"{get_protocol(secure)}://{host}:{port}", api_endpoint)
+    url = urljoin(
+        "{}://{}:{}".format(get_protocol(secure), host, port), api_endpoint
+    )
 
     # Sends request.
     r = requests.get(
@@ -52,7 +54,9 @@ def update_plex(host, port, token, library_name, secure, ignore_cert_errors):
     )
     api_endpoint = f"library/sections/{section_key}/refresh"
     api_endpoint = append_token(api_endpoint, token)
-    url = urljoin(f"{get_protocol(secure)}://{host}:{port}", api_endpoint)
+    url = urljoin(
+        "{}://{}:{}".format(get_protocol(secure), host, port), api_endpoint
+    )
 
     # Sends request and returns requests object.
     r = requests.get(

--- a/beetsplug/plexupdate.py
+++ b/beetsplug/plexupdate.py
@@ -22,9 +22,7 @@ def get_music_section(
 ):
     """Getting the section key for the music library in Plex."""
     api_endpoint = append_token("library/sections", token)
-    url = urljoin(
-        "{}://{}:{}".format(get_protocol(secure), host, port), api_endpoint
-    )
+    url = urljoin(f"{get_protocol(secure)}://{host}:{port}", api_endpoint)
 
     # Sends request.
     r = requests.get(
@@ -54,9 +52,7 @@ def update_plex(host, port, token, library_name, secure, ignore_cert_errors):
     )
     api_endpoint = f"library/sections/{section_key}/refresh"
     api_endpoint = append_token(api_endpoint, token)
-    url = urljoin(
-        "{}://{}:{}".format(get_protocol(secure), host, port), api_endpoint
-    )
+    url = urljoin(f"{get_protocol(secure)}://{host}:{port}", api_endpoint)
 
     # Sends request and returns requests object.
     r = requests.get(

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -532,7 +532,7 @@ class FfmpegBackend(Backend):
             if output[i].startswith(search):
                 return i
         raise ReplayGainError(
-            f"ffmpeg output: missing {search!r} after line {start_line}"
+            f"ffmpeg output: missing {repr(search)} after line {start_line}"
         )
 
     def _parse_float(self, line: bytes) -> float:
@@ -545,7 +545,7 @@ class FfmpegBackend(Backend):
         parts = line.split(b":", 1)
         if len(parts) < 2:
             raise ReplayGainError(
-                f"ffmpeg output: expected key value pair, found {line!r}"
+                f"ffmpeg output: expected key value pair, found {repr(line)}"
             )
         value = parts[1].lstrip()
         # strip unit
@@ -555,7 +555,7 @@ class FfmpegBackend(Backend):
             return float(value)
         except ValueError:
             raise ReplayGainError(
-                f"ffmpeg output: expected float value, found {value!r}"
+                f"ffmpeg output: expected float value, found {repr(value)}"
             )
 
 
@@ -884,7 +884,7 @@ class GStreamerBackend(Backend):
         f = self._src.get_property("location")
         # A GStreamer error, either an unsupported format or a bug.
         self._error = ReplayGainError(
-            f"Error {err!r} - {debug!r} on file {f!r}"
+            f"Error {repr(err)} - {repr(debug)} on file {repr(f)}"
         )
 
     def _on_tag(self, bus, message):

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -509,10 +509,10 @@ class FfmpegBackend(Backend):
                 if self._parse_float(b"M: " + line[1]) >= gating_threshold:
                     n_blocks += 1
             self._log.debug(
-                f"{item}: {n_blocks} blocks over {gating_threshold} LUFS"
+                "{}: {} blocks over {} LUFS", item, n_blocks, gating_threshold
             )
 
-        self._log.debug(f"{item}: gain {gain} LU, peak {peak}")
+        self._log.debug("{}: gain {} LU, peak {}", item, gain, peak)
 
         return Gain(gain, peak), n_blocks
 
@@ -1527,14 +1527,18 @@ class ReplayGainPlugin(BeetsPlugin):
             if opts.album:
                 albums = lib.albums(ui.decargs(args))
                 self._log.info(
-                    f"Analyzing {len(albums)} albums ~ {self.backend_name} backend..."
+                    "Analyzing {} albums ~ {} backend...",
+                    len(albums),
+                    self.backend_name,
                 )
                 for album in albums:
                     self.handle_album(album, write, force)
             else:
                 items = lib.items(ui.decargs(args))
                 self._log.info(
-                    f"Analyzing {len(items)} tracks ~ {self.backend_name} backend..."
+                    "Analyzing {} tracks ~ {} backend...",
+                    len(items),
+                    self.backend_name,
                 )
                 for item in items:
                     self.handle_track(item, write, force)

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -311,10 +311,11 @@ class SmartPlaylistPlugin(BeetsPlugin):
                 )
                 mkdirall(m3u_path)
                 pl_format = self.config["output"].get()
-                if pl_format != "m3u" and pl_format != "extm3u":
-                    msg = "Unsupported output format '{}' provided! "
-                    msg += "Supported: m3u, extm3u"
-                    raise Exception(msg.format(pl_format))
+                if pl_format not in ["m3u", "extm3u"]:
+                    raise Exception(
+                        f"Unsupported output format '{pl_format}' provided! "
+                        "Supported: m3u, extm3u"
+                    )
                 extm3u = pl_format == "extm3u"
                 with open(syspath(m3u_path), "wb") as f:
                     keys = []
@@ -330,9 +331,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
                                 f" {a[0]}={json.dumps(str(a[1]))}" for a in attr
                             ]
                             attrs = "".join(al)
-                            comment = "#EXTINF:{}{},{} - {}\n".format(
-                                int(item.length), attrs, item.artist, item.title
-                            )
+                            comment = f"#EXTINF:{int(item.length)}{attrs},{item.artist} - {item.title}\n"
                         f.write(comment.encode("utf-8") + entry.uri + b"\n")
             # Send an event when playlists were updated.
             send_event("smartplaylist_update")

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -331,7 +331,10 @@ class SmartPlaylistPlugin(BeetsPlugin):
                                 f" {a[0]}={json.dumps(str(a[1]))}" for a in attr
                             ]
                             attrs = "".join(al)
-                            comment = f"#EXTINF:{int(item.length)}{attrs},{item.artist} - {item.title}\n"
+                            comment = (
+                                f"#EXTINF:{int(item.length)}{attrs},"
+                                f"{item.artist} - {item.title}\n"
+                            )
                         f.write(comment.encode("utf-8") + entry.uri + b"\n")
             # Send an event when playlists were updated.
             send_event("smartplaylist_update")

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -146,7 +146,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
             raise ui.UserError(
-                "Spotify authorization failed: {}\n{}".format(e, response.text)
+                f"Spotify authorization failed: {e}\n{response.text}"
             )
         self.access_token = response.json()["access_token"]
 
@@ -271,9 +271,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
         else:
             raise ui.UserError(
                 "Invalid `release_date_precision` returned "
-                "by {} API: '{}'".format(
-                    self.data_source, release_date_precision
-                )
+                f"by {self.data_source} API: '{release_date_precision}'"
             )
 
         tracks_data = album_data["tracks"]
@@ -457,17 +455,15 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
             "-m",
             "--mode",
             action="store",
-            help='"open" to open {} with playlist, '
-            '"list" to print (default)'.format(self.data_source),
+            help=f'"open" to open {self.data_source} with '
+            'playlist, "list" to print (default)',
         )
         spotify_cmd.parser.add_option(
             "-f",
             "--show-failures",
             action="store_true",
             dest="show_failures",
-            help="list tracks that did not match a {} ID".format(
-                self.data_source
-            ),
+            help=f"list tracks that did not match a {self.data_source} ID",
         )
         spotify_cmd.func = queries
 
@@ -628,9 +624,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
             spotify_ids = [track_data["id"] for track_data in results]
             if self.config["mode"].get() == "open":
                 self._log.info(
-                    "Attempting to open {} with playlist".format(
-                        self.data_source
-                    )
+                    f"Attempting to open {self.data_source} with playlist"
                 )
                 spotify_url = "spotify:trackset:Playlist:" + ",".join(
                     spotify_ids

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -624,7 +624,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
             spotify_ids = [track_data["id"] for track_data in results]
             if self.config["mode"].get() == "open":
                 self._log.info(
-                    f"Attempting to open {self.data_source} with playlist"
+                    "Attempting to open {} with playlist", self.data_source
                 )
                 spotify_url = "spotify:trackset:Playlist:" + ",".join(
                     spotify_ids

--- a/beetsplug/thumbnails.py
+++ b/beetsplug/thumbnails.py
@@ -203,7 +203,7 @@ class ThumbnailsPlugin(BeetsPlugin):
         artfile = os.path.split(album.artpath)[1]
         with open(syspath(outfilename), "w") as f:
             f.write("[Desktop Entry]\n")
-            f.write("Icon=./{}".format(artfile.decode("utf-8")))
+            f.write(f"Icon=./{artfile.decode('utf-8')}")
             f.close()
         self._log.debug("Wrote file {0}", displayable_path(outfilename))
 

--- a/beetsplug/thumbnails.py
+++ b/beetsplug/thumbnails.py
@@ -290,4 +290,6 @@ class GioURI(URIGetter):
         try:
             return uri.decode(util._fsencoding())
         except UnicodeDecodeError:
-            raise RuntimeError(f"Could not decode filename from GIO: {uri!r}")
+            raise RuntimeError(
+                f"Could not decode filename from GIO: {repr(uri)}"
+            )

--- a/beetsplug/types.py
+++ b/beetsplug/types.py
@@ -45,6 +45,6 @@ class TypesPlugin(BeetsPlugin):
                 mytypes[key] = library.DateType()
             else:
                 raise ConfigValueError(
-                    "unknown type '{}' for the '{}' field".format(value, key)
+                    f"unknown type '{value}' for the '{key}' field"
                 )
         return mytypes

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -66,11 +66,8 @@ class CAAHelper:
     MBID_RELEASE = "rid"
     MBID_GROUP = "rgid"
 
-    RELEASE_URL = f"coverartarchive.org/release/{MBID_RELEASE}"
-    GROUP_URL = f"coverartarchive.org/release-group/{MBID_GROUP}"
-
-    RELEASE_URL = "https://" + RELEASE_URL
-    GROUP_URL = "https://" + GROUP_URL
+    RELEASE_URL = f"https://coverartarchive.org/release/{MBID_RELEASE}"
+    GROUP_URL = f"https://coverartarchive.org/release-group/{MBID_GROUP}"
 
     RESPONSE_RELEASE = """{
     "images": [

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -63,11 +63,11 @@ class FetchImageTestCase(FetchImageHelper, UseThePlugin):
 class CAAHelper:
     """Helper mixin for mocking requests to the Cover Art Archive."""
 
-    MBID_RELASE = "rid"
+    MBID_RELEASE = "rid"
     MBID_GROUP = "rgid"
 
-    RELEASE_URL = "coverartarchive.org/release/{}".format(MBID_RELASE)
-    GROUP_URL = "coverartarchive.org/release-group/{}".format(MBID_GROUP)
+    RELEASE_URL = f"coverartarchive.org/release/{MBID_RELEASE}"
+    GROUP_URL = f"coverartarchive.org/release-group/{MBID_GROUP}"
 
     RELEASE_URL = "https://" + RELEASE_URL
     GROUP_URL = "https://" + GROUP_URL
@@ -280,10 +280,8 @@ class FSArtTest(UseThePlugin):
 class CombinedTest(FetchImageTestCase, CAAHelper):
     ASIN = "xxxx"
     MBID = "releaseid"
-    AMAZON_URL = "https://images.amazon.com/images/P/{}.01.LZZZZZZZ.jpg".format(
-        ASIN
-    )
-    AAO_URL = "https://www.albumart.org/index_detail.php?asin={}".format(ASIN)
+    AMAZON_URL = f"https://images.amazon.com/images/P/{ASIN}.01.LZZZZZZZ.jpg"
+    AAO_URL = f"https://www.albumart.org/index_detail.php?asin={ASIN}"
 
     def setUp(self):
         super().setUp()
@@ -341,7 +339,7 @@ class CombinedTest(FetchImageTestCase, CAAHelper):
             content_type="image/jpeg",
         )
         album = _common.Bag(
-            mb_albumid=self.MBID_RELASE,
+            mb_albumid=self.MBID_RELEASE,
             mb_releasegroupid=self.MBID_GROUP,
             asin=self.ASIN,
         )
@@ -561,7 +559,7 @@ class CoverArtArchiveTest(UseThePlugin, CAAHelper):
 
     def test_caa_finds_image(self):
         album = _common.Bag(
-            mb_albumid=self.MBID_RELASE, mb_releasegroupid=self.MBID_GROUP
+            mb_albumid=self.MBID_RELEASE, mb_releasegroupid=self.MBID_GROUP
         )
         self.mock_caa_response(self.RELEASE_URL, self.RESPONSE_RELEASE)
         self.mock_caa_response(self.GROUP_URL, self.RESPONSE_GROUP)
@@ -577,7 +575,7 @@ class CoverArtArchiveTest(UseThePlugin, CAAHelper):
         self.settings = Settings(maxwidth=maxwidth)
 
         album = _common.Bag(
-            mb_albumid=self.MBID_RELASE, mb_releasegroupid=self.MBID_GROUP
+            mb_albumid=self.MBID_RELEASE, mb_releasegroupid=self.MBID_GROUP
         )
         self.mock_caa_response(self.RELEASE_URL, self.RESPONSE_RELEASE)
         self.mock_caa_response(self.GROUP_URL, self.RESPONSE_GROUP)
@@ -593,7 +591,7 @@ class CoverArtArchiveTest(UseThePlugin, CAAHelper):
         self.settings = Settings(maxwidth=maxwidth)
 
         album = _common.Bag(
-            mb_albumid=self.MBID_RELASE, mb_releasegroupid=self.MBID_GROUP
+            mb_albumid=self.MBID_RELEASE, mb_releasegroupid=self.MBID_GROUP
         )
         self.mock_caa_response(
             self.RELEASE_URL, self.RESPONSE_RELEASE_WITHOUT_THUMBNAILS

--- a/test/plugins/test_ipfs.py
+++ b/test/plugins/test_ipfs.py
@@ -39,7 +39,7 @@ class IPFSPluginTest(PluginTestCase):
                     ipfs_item = os.path.basename(want_item.path).decode(
                         _fsencoding(),
                     )
-                    want_path = "/ipfs/{}/{}".format(test_album.ipfs, ipfs_item)
+                    want_path = f"/ipfs/{test_album.ipfs}/{ipfs_item}"
                     want_path = bytestring_path(want_path)
                     assert check_item.path == want_path
                     assert (

--- a/test/plugins/test_ipfs.py
+++ b/test/plugins/test_ipfs.py
@@ -39,7 +39,7 @@ class IPFSPluginTest(PluginTestCase):
                     ipfs_item = os.path.basename(want_item.path).decode(
                         _fsencoding(),
                     )
-                    want_path = f"/ipfs/{test_album.ipfs}/{ipfs_item}"
+                    want_path = "/ipfs/{}/{}".format(test_album.ipfs, ipfs_item)
                     want_path = bytestring_path(want_path)
                     assert check_item.path == want_path
                     assert (

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -223,9 +223,9 @@ class LyricsAssertions:
 
         if not keywords <= words:
             details = (
-                f"{keywords!r} is not a subset of {words!r}."
-                f" Words only in expected set {keywords - words!r},"
-                f" Words only in result set {words - keywords!r}."
+                f"{repr(keywords)} is not a subset of {repr(words)}."
+                f" Words only in expected set {repr(keywords - words)},"
+                f" Words only in result set {repr(words - keywords)}."
             )
             self.fail(f"{details} : {msg}")
 

--- a/test/plugins/test_player.py
+++ b/test/plugins/test_player.py
@@ -132,7 +132,7 @@ class MPCResponse:
             cmd, rest = rest[2:].split("}")
             return False, (int(code), int(pos), cmd, rest[1:])
         else:
-            raise RuntimeError(f"Unexpected status: {status!r}")
+            raise RuntimeError(f"Unexpected status: {repr(status)}")
 
     def _parse_body(self, body):
         """Messages are generally in the format "header: content".
@@ -145,7 +145,7 @@ class MPCResponse:
             if not line:
                 continue
             if ":" not in line:
-                raise RuntimeError(f"Unexpected line: {line!r}")
+                raise RuntimeError(f"Unexpected line: {repr(line)}")
             header, content = line.split(":", 1)
             content = content.lstrip()
             if header in repeated_headers:
@@ -191,7 +191,7 @@ class MPCClient:
                 responses.append(MPCResponse(response))
                 response = b""
             elif not line:
-                raise RuntimeError(f"Unexpected response: {line!r}")
+                raise RuntimeError(f"Unexpected response: {repr(line)}")
 
     def serialise_command(self, command, *args):
         cmd = [command.encode("utf-8")]

--- a/test/plugins/test_random.py
+++ b/test/plugins/test_random.py
@@ -69,7 +69,7 @@ class RandomTest(TestHelper, unittest.TestCase):
             # Print a histogram (useful for debugging).
             if histogram:
                 for i in range(len(self.items)):
-                    print("{:2d} {}".format(i, "*" * positions.count(i)))
+                    print(f"{i:2d} {'*'*positions.count(i)}")
             return self._stats(positions)
 
         mean1, stdev1, median1 = experiment("artist")

--- a/test/plugins/test_replaygain.py
+++ b/test/plugins/test_replaygain.py
@@ -204,9 +204,7 @@ class ReplayGainCliTest:
             # This test is a lot less interesting if the backend cannot write
             # both tag types.
             self.skipTest(
-                "r128 tags for opus not supported on backend {}".format(
-                    self.backend
-                )
+                f"r128 tags for opus not supported on backend {self.backend}"
             )
 
         album_rg = self._add_album(1)
@@ -263,9 +261,7 @@ class ReplayGainCliTest:
     def test_cli_writes_only_r128_tags(self):
         if not self.has_r128_support:
             self.skipTest(
-                "r128 tags for opus not supported on backend {}".format(
-                    self.backend
-                )
+                f"r128 tags for opus not supported on backend {self.backend}"
             )
 
         album = self._add_album(2, ext="opus")
@@ -299,9 +295,7 @@ class ReplayGainCliTest:
     def test_r128_targetlevel_has_effect(self):
         if not self.has_r128_support:
             self.skipTest(
-                "r128 tags for opus not supported on backend {}".format(
-                    self.backend
-                )
+                f"r128 tags for opus not supported on backend {self.backend}"
             )
 
         album = self._add_album(1, ext="opus")

--- a/test/plugins/test_thumbnails.py
+++ b/test/plugins/test_thumbnails.py
@@ -71,7 +71,7 @@ class ThumbnailsTest(BeetsTestCase):
                 return False
             if path == syspath(LARGE_DIR):
                 return True
-            raise ValueError(f"unexpected path {path!r}")
+            raise ValueError(f"unexpected path {repr(path)}")
 
         mock_os.path.exists = exists
         plugin = ThumbnailsPlugin()


### PR DESCRIPTION
Fixes #5293.

Along the way, I've made some small code improvements beyond just the use of f-strings; I don't think these will conflict with others' work. In particular, I've avoided modifying the formatting of paths; there is work to greatly simplify that using 'pathlib', at which point a second commit can clean them up.
