### PR TITLE
Perform a regex substitution in the substitute plugin

### DIFF
--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -513,12 +513,8 @@ class PluginMixin:
         Album._queries = getattr(Album, "_original_queries", {})
 
     @contextmanager
-    def configure_plugin(self, config: list[Any] | dict[str, Any]):
-        if isinstance(config, list):
-            beets.config[self.plugin] = config
-        else:
-            for key, value in config.items():
-                beets.config[self.plugin][key] = value
+    def configure_plugin(self, config: Any):
+        beets.config[self.plugin].set(config)
         self.load_plugins(self.plugin)
 
         yield

--- a/beetsplug/substitute.py
+++ b/beetsplug/substitute.py
@@ -35,7 +35,7 @@ class Substitute(BeetsPlugin):
         """Do the actual replacing."""
         if text:
             for pattern, replacement in self.substitute_rules:
-                new_text, subs_made = re.subn(pattern, replacement, text)
+                new_text, subs_made = pattern.subn(replacement, text)
                 if subs_made > 0:
                     return new_text
             return text
@@ -48,7 +48,7 @@ class Substitute(BeetsPlugin):
         Get the configuration, register template function and create list of
         substitute rules.
         """
-        super(Substitute, self).__init__()
+        super().__init__()
         self.substitute_rules = []
         self.template_funcs["substitute"] = self.tmpl_substitute
 
@@ -70,7 +70,7 @@ class Substitute(BeetsPlugin):
                     """
                 )
             )
-            pairs = [(key, view.as_str()) for key, view in self.config.items()]
+            pairs = self.config.flatten().items()
         else:
             pairs = self.config.as_pairs()
 

--- a/beetsplug/substitute.py
+++ b/beetsplug/substitute.py
@@ -34,7 +34,7 @@ class Substitute(BeetsPlugin):
         """Do the actual replacing."""
         if text:
             for pattern, replacement in self.substitute_rules:
-                if pattern.match(text.lower()):
+                if pattern.match(text):
                     return replacement
             return text
         else:
@@ -52,5 +52,5 @@ class Substitute(BeetsPlugin):
 
         for key, view in self.config.items():
             value = view.as_str()
-            pattern = re.compile(key.lower())
+            pattern = re.compile(key, flags=re.IGNORECASE)
             self.substitute_rules.append((pattern, value))

--- a/beetsplug/substitute.py
+++ b/beetsplug/substitute.py
@@ -34,9 +34,9 @@ class Substitute(BeetsPlugin):
         """Do the actual replacing."""
         if text:
             for pattern, replacement in self.substitute_rules:
-                new_string, number_of_subs_made = re.subn(pattern, replacement, text)
-                if number_of_subs_made > 0:
-                    return new_string
+                new_text, subs_made = re.subn(pattern, replacement, text)
+                if subs_made > 0:
+                    return new_text
             return text
         else:
             return ""

--- a/beetsplug/substitute.py
+++ b/beetsplug/substitute.py
@@ -18,7 +18,6 @@ Uses user-specified substitution rules to canonicalize names for path formats.
 """
 
 import re
-import textwrap
 
 from beets.plugins import BeetsPlugin
 
@@ -49,31 +48,8 @@ class Substitute(BeetsPlugin):
         substitute rules.
         """
         super().__init__()
-        self.substitute_rules = []
         self.template_funcs["substitute"] = self.tmpl_substitute
-
-        if isinstance(self.config.get(), dict):
-            self._log.warning(
-                "Unordered configuration is deprecated, as it leads to"
-                + " unpredictable behaviour on overlapping rules.\n"
-                + textwrap.dedent(
-                    """
-                    Old syntax:
-                      substitute:
-                        a: b
-                        c: d
-
-                    New syntax:
-                      substitute:
-                      - a: b
-                      - c: d
-                    """
-                )
-            )
-            pairs = self.config.flatten().items()
-        else:
-            pairs = self.config.as_pairs()
-
-        for key, value in pairs:
-            pattern = re.compile(key, flags=re.IGNORECASE)
-            self.substitute_rules.append((pattern, value))
+        self.substitute_rules = [
+            (re.compile(key, flags=re.IGNORECASE), value)
+            for key, value in self.config.flatten().items()
+        ]

--- a/beetsplug/substitute.py
+++ b/beetsplug/substitute.py
@@ -48,34 +48,32 @@ class Substitute(BeetsPlugin):
         Get the configuration, register template function and create list of
         substitute rules.
         """
-        super().__init__()
+        super(Substitute, self).__init__()
         self.substitute_rules = []
         self.template_funcs["substitute"] = self.tmpl_substitute
 
-        match self.config.get():
-            case list():
-                pairs = self.config.as_pairs()
-            case dict():
-                pairs = [
-                    (key, view.as_str()) for key, view in self.config.items()
-                ]
-                self._log.warning(
-                    "Unordered configuration is deprecated, as it leads to"
-                    + " unpredictable behaviour on overlapping rules.\n"
-                    + textwrap.dedent(
-                        """
-                        Old syntax:
-                          substitute:
-                            a: b
-                            c: d
+        if isinstance(self.config.get(), dict):
+            self._log.warning(
+                "Unordered configuration is deprecated, as it leads to"
+                + " unpredictable behaviour on overlapping rules.\n"
+                + textwrap.dedent(
+                    """
+                    Old syntax:
+                      substitute:
+                        a: b
+                        c: d
 
-                        New syntax:
-                          substitute:
-                          - a: b
-                          - c: d
-                        """
-                    )
+                    New syntax:
+                      substitute:
+                      - a: b
+                      - c: d
+                    """
                 )
+            )
+            pairs = [(key, view.as_str()) for key, view in self.config.items()]
+        else:
+            pairs = self.config.as_pairs()
+
         for key, value in pairs:
             pattern = re.compile(key, flags=re.IGNORECASE)
             self.substitute_rules.append((pattern, value))

--- a/beetsplug/substitute.py
+++ b/beetsplug/substitute.py
@@ -34,8 +34,9 @@ class Substitute(BeetsPlugin):
         """Do the actual replacing."""
         if text:
             for pattern, replacement in self.substitute_rules:
-                if pattern.match(text):
-                    return replacement
+                new_string, number_of_subs_made = re.subn(pattern, replacement, text)
+                if number_of_subs_made > 0:
+                    return new_string
             return text
         else:
             return ""

--- a/beetsplug/substitute.py
+++ b/beetsplug/substitute.py
@@ -34,9 +34,7 @@ class Substitute(BeetsPlugin):
         """Do the actual replacing."""
         if text:
             for pattern, replacement in self.substitute_rules:
-                new_text, subs_made = pattern.subn(replacement, text)
-                if subs_made > 0:
-                    return new_text
+                text = pattern.sub(replacement, text)
             return text
         else:
             return ""

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,9 @@ New features:
 * Beets now uses ``platformdirs`` to determine the default music directory.
   This location varies between systems -- for example, users can configure it
   on Unix systems via ``user-dirs.dirs(5)``.
+* :doc:`/plugins/substitute`: Allow the replacement string to use capture groups
+  from the match. It is thus possible to create more general rules, applying to
+  many different artists at once.
 
 Bug fixes:
 

--- a/docs/plugins/substitute.rst
+++ b/docs/plugins/substitute.rst
@@ -13,6 +13,7 @@ Enable the ``substitute`` plugin (see :ref:`using-plugins`), then make a ``subst
 Each rule consists of a case-insensitive regular expression pattern, and a
 replacement string. For example, you might use:
 
+.. code-block:: yaml
     substitute:
       - .*jimi hendrix.*: Jimi Hendrix
 
@@ -22,6 +23,7 @@ multiple artists into the directory of the first artist. We can thus capture
 everything before the first ``,``, `` &`` or `` and``, and use this capture
 group in the output, discarding the rest of the string.
 
+.. code-block:: yaml
     substitute:
       - ^(.*?)(,| &| and).*: \1
 
@@ -34,5 +36,6 @@ This would handle all the below cases in a single rule:
 
 To apply the substitution, you have to call the function ``%substitute{}`` in the paths section. For example:
 
+.. code-block:: yaml
     paths:
         default: %substitute{$albumartist}/$year - $album%aunique{}/$track - $title

--- a/docs/plugins/substitute.rst
+++ b/docs/plugins/substitute.rst
@@ -14,6 +14,7 @@ Each rule consists of a case-insensitive regular expression pattern, and a
 replacement string. For example, you might use:
 
 .. code-block:: yaml
+
     substitute:
       - .*jimi hendrix.*: Jimi Hendrix
 
@@ -24,6 +25,7 @@ everything before the first ``,``, `` &`` or `` and``, and use this capture
 group in the output, discarding the rest of the string.
 
 .. code-block:: yaml
+
     substitute:
       - ^(.*?)(,| &| and).*: \1
 
@@ -37,5 +39,6 @@ This would handle all the below cases in a single rule:
 To apply the substitution, you have to call the function ``%substitute{}`` in the paths section. For example:
 
 .. code-block:: yaml
+
     paths:
-        default: %substitute{$albumartist}/$year - $album%aunique{}/$track - $title
+        default: \%substitute{$albumartist}/$year - $album\%aunique{}/$track - $title

--- a/docs/plugins/substitute.rst
+++ b/docs/plugins/substitute.rst
@@ -9,14 +9,14 @@ Experience to be sorted into the same folder as solo Hendrix albums.
 This plugin is intended as a replacement for the ``rewrite`` plugin. While
 the ``rewrite`` plugin modifies the metadata, this plugin does not.
 
-Enable the ``substitute`` plugin (see :ref:`using-plugins`), then make a ``substitute:`` section in your config file to contain a list of your rules.
+Enable the ``substitute`` plugin (see :ref:`using-plugins`), then make a ``substitute:`` section in your config file to contain your rules.
 Each rule consists of a case-insensitive regular expression pattern, and a
 replacement string. For example, you might use:
 
 .. code-block:: yaml
 
     substitute:
-      - .*jimi hendrix.*: Jimi Hendrix
+      .*jimi hendrix.*: Jimi Hendrix
 
 The replacement can be an expression utilising the matched regex, allowing us
 to create more general rules. Say for example, we want to sort all albums by
@@ -27,7 +27,7 @@ group in the output, discarding the rest of the string.
 .. code-block:: yaml
 
     substitute:
-      - ^(.*?)(,| &| and).*: \1
+      ^(.*?)(,| &| and).*: \1
 
 This would handle all the below cases in a single rule:
 

--- a/docs/plugins/substitute.rst
+++ b/docs/plugins/substitute.rst
@@ -9,12 +9,12 @@ Experience to be sorted into the same folder as solo Hendrix albums.
 This plugin is intended as a replacement for the ``rewrite`` plugin. While
 the ``rewrite`` plugin modifies the metadata, this plugin does not.
 
-Enable the ``substitute`` plugin (see :ref:`using-plugins`), then make a ``substitute:`` section in your config file to contain your rules.
+Enable the ``substitute`` plugin (see :ref:`using-plugins`), then make a ``substitute:`` section in your config file to contain a list of your rules.
 Each rule consists of a case-insensitive regular expression pattern, and a
 replacement string. For example, you might use:
 
     substitute:
-        .*jimi hendrix.*: Jimi Hendrix
+      - .*jimi hendrix.*: Jimi Hendrix
 
 The replacement can be an expression utilising the matched regex, allowing us
 to create more general rules. Say for example, we want to sort all albums by
@@ -23,7 +23,7 @@ everything before the first ``,``, `` &`` or `` and``, and use this capture
 group in the output, discarding the rest of the string.
 
     substitute:
-        ^(.*?)(,| &| and).*: \1
+      - ^(.*?)(,| &| and).*: \1
 
 This would handle all the below cases in a single rule:
 

--- a/docs/plugins/substitute.rst
+++ b/docs/plugins/substitute.rst
@@ -11,13 +11,28 @@ the ``rewrite`` plugin modifies the metadata, this plugin does not.
 
 Enable the ``substitute`` plugin (see :ref:`using-plugins`), then make a ``substitute:`` section in your config file to contain your rules.
 Each rule consists of a case-insensitive regular expression pattern, and a
-replacement value. For example, you might use:
+replacement string. For example, you might use:
 
     substitute:
         .*jimi hendrix.*: Jimi Hendrix
 
+The replacement can be an expression utilising the matched regex, allowing us
+to create more general rules. Say for example, we want to sort all albums by
+multiple artists into the directory of the first artist. We can thus capture
+everything before the first ``,``, `` &`` or `` and``, and use this capture
+group in the output, discarding the rest of the string.
+
+    substitute:
+        ^(.*?)(,| &| and).*: \1
+
+This would handle all the below cases in a single rule:
+
+    Bob Dylan and The Band -> Bob Dylan
+    Neil Young & Crazy Horse -> Neil Young
+    James Yorkston, Nina Persson & The Second Hand Orchestra -> James Yorkston
+
 
 To apply the substitution, you have to call the function ``%substitute{}`` in the paths section. For example:
-    
+
     paths:
         default: %substitute{$albumartist}/$year - $album%aunique{}/$track - $title

--- a/test/plugins/test_substitute.py
+++ b/test/plugins/test_substitute.py
@@ -30,18 +30,18 @@ class SubstitutePluginTest(PluginTestCase):
     def test_simple_substitute(self):
         self.run_substitute(
             {
-                "a": "b",
-                "b": "c",
-                "c": "d",
+                "a": "x",
+                "b": "y",
+                "c": "z",
             },
-            [("a", "b"), ("b", "c"), ("c", "d")],
+            [("a", "x"), ("b", "y"), ("c", "z")],
         )
 
     def test_case_insensitivity(self):
-        self.run_substitute({"a": "b"}, [("A", "b")])
+        self.run_substitute({"a": "x"}, [("A", "x")])
 
     def test_unmatched_input_preserved(self):
-        self.run_substitute({"a": "b"}, [("c", "c")])
+        self.run_substitute({"a": "x"}, [("c", "c")])
 
     def test_regex_to_static(self):
         self.run_substitute(
@@ -66,11 +66,12 @@ class SubstitutePluginTest(PluginTestCase):
     def test_partial_substitution(self):
         self.run_substitute({r"\.": ""}, [("U.N.P.O.C.", "UNPOC")])
 
-    def test_break_on_first_match(self):
+    def test_rules_applied_in_definition_order(self):
         self.run_substitute(
             {
                 "a": "x",
                 "[ab]": "y",
+                "b": "z",
             },
             [
                 ("a", "x"),

--- a/test/plugins/test_substitute.py
+++ b/test/plugins/test_substitute.py
@@ -78,3 +78,13 @@ class SubstitutePluginTest(PluginTestCase):
                 ("b", "y"),
             ],
         )
+
+    def test_rules_applied_in_sequence(self):
+        self.run_substitute(
+            {"a": "b", "b": "c", "d": "a"},
+            [
+                ("a", "c"),
+                ("b", "c"),
+                ("d", "a"),
+            ],
+        )

--- a/test/plugins/test_substitute.py
+++ b/test/plugins/test_substitute.py
@@ -14,11 +14,11 @@
 
 """Test the substitute plugin regex functionality."""
 
-
 from beets.test.helper import PluginTestCase
 from beetsplug.substitute import Substitute
 
 PLUGIN_NAME = "substitute"
+
 
 class SubstitutePluginTest(PluginTestCase):
     plugin = "substitute"
@@ -32,42 +32,33 @@ class SubstitutePluginTest(PluginTestCase):
                 "c": "d",
             }
         ):
-            cases = [
-                ("a", "b"),
-                ("b", "c"),
-                ("c", "d")
-            ]
+            cases = [("a", "b"), ("b", "c"), ("c", "d")]
             for input, expected in cases:
                 assert Substitute().tmpl_substitute(input) == expected
 
     def test_case_insensitivity(self):
-        with self.configure_plugin(
-            { "a": "b" }
-        ):
+        with self.configure_plugin({"a": "b"}):
             assert Substitute().tmpl_substitute("A") == "b"
 
     def test_unmatched_input_preserved(self):
-        with self.configure_plugin(
-            { "a": "b" }
-        ):
+        with self.configure_plugin({"a": "b"}):
             assert Substitute().tmpl_substitute("c") == "c"
 
     def test_regex_to_static(self):
-        with self.configure_plugin(
-            { ".*jimi hendrix.*": "Jimi Hendrix" }
-        ):
+        with self.configure_plugin({".*jimi hendrix.*": "Jimi Hendrix"}):
             result = Substitute().tmpl_substitute("The Jimi Hendrix Experience")
             assert result == "Jimi Hendrix"
 
     def test_regex_capture_group(self):
-        with self.configure_plugin(
-            { "^(.*?)(,| &| and).*": r"\1" }
-        ):
+        with self.configure_plugin({"^(.*?)(,| &| and).*": r"\1"}):
             cases = [
                 ("King Creosote & Jon Hopkins", "King Creosote"),
-                ("Michael Hurley, The Holy Modal Rounders,"
-                  + "Jeffrey Frederick & The Clamtones", "Michael Hurley"),
-                ("James Yorkston and the Athletes", "James Yorkston")
+                (
+                    "Michael Hurley, The Holy Modal Rounders, Jeffrey Frederick & "
+                    + "The Clamtones",
+                    "Michael Hurley",
+                ),
+                ("James Yorkston and the Athletes", "James Yorkston"),
             ]
             for input, expected in cases:
                 assert Substitute().tmpl_substitute(input) == expected
@@ -83,7 +74,6 @@ class SubstitutePluginTest(PluginTestCase):
             ]
             for input, expected in cases:
                 assert Substitute().tmpl_substitute(input) == expected
-
 
     def test_break_on_first_match(self):
         with self.configure_plugin(

--- a/test/plugins/test_substitute.py
+++ b/test/plugins/test_substitute.py
@@ -1,0 +1,99 @@
+# This file is part of beets.
+# Copyright 2024, Nicholas Boyd Isacsson.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""Test the substitute plugin regex functionality."""
+
+import pytest
+
+from beets.test.helper import PluginTestCase
+from beetsplug.substitute import Substitute
+
+PLUGIN_NAME = "substitute"
+
+class SubstitutePluginTest(PluginTestCase):
+    plugin = "substitute"
+    preload_plugin = False
+
+    def test_simple_substitute(self):
+        with self.configure_plugin(
+            {
+                "a": "b",
+                "b": "c",
+                "c": "d",
+            }
+        ):
+            cases = [
+                ("a", "b"),
+                ("b", "c"),
+                ("c", "d")
+            ]
+            for input, expected in cases:
+                assert Substitute().tmpl_substitute(input) == expected
+
+    def test_case_insensitivity(self):
+        with self.configure_plugin(
+            { "a": "b" }
+        ):
+            assert Substitute().tmpl_substitute("A") == "b"
+
+    def test_unmatched_input_preserved(self):
+        with self.configure_plugin(
+            { "a": "b" }
+        ):
+            assert Substitute().tmpl_substitute("c") == "c"
+
+    def test_regex_to_static(self):
+        with self.configure_plugin(
+            { ".*jimi hendrix.*": "Jimi Hendrix" }
+        ):
+            assert Substitute().tmpl_substitute("The Jimi Hendrix Experience") == "Jimi Hendrix"
+
+    def test_regex_capture_group(self):
+        with self.configure_plugin(
+            { "^(.*?)(,| &| and).*": r"\1" }
+        ):
+            cases = [
+                ("King Creosote & Jon Hopkins", "King Creosote"),
+                ("Michael Hurley, The Holy Modal Rounders, Jeffrey Frederick & The Clamtones", "Michael Hurley"),
+                ("James Yorkston and the Athletes", "James Yorkston")
+            ]
+            for case in cases:
+                assert Substitute().tmpl_substitute(case[0]) == case[1]
+
+    def test_partial_substitution(self):
+        with self.configure_plugin(
+            {
+                r"\.": "",
+            }
+        ):
+            cases = [
+                ("U.N.P.O.C.", "UNPOC"),
+            ]
+            for input, expected in cases:
+                assert Substitute().tmpl_substitute(input) == expected
+
+
+    def test_break_on_first_match(self):
+        with self.configure_plugin(
+            {
+                "a": "b",
+                "[ab]": "c",
+            }
+        ):
+            cases = [
+                ("a", "b"),
+                ("b", "c"),
+            ]
+            for case in cases:
+                assert Substitute().tmpl_substitute(case[0]) == case[1]

--- a/test/plugins/test_substitute.py
+++ b/test/plugins/test_substitute.py
@@ -14,7 +14,6 @@
 
 """Test the substitute plugin regex functionality."""
 
-import pytest
 
 from beets.test.helper import PluginTestCase
 from beetsplug.substitute import Substitute
@@ -57,7 +56,8 @@ class SubstitutePluginTest(PluginTestCase):
         with self.configure_plugin(
             { ".*jimi hendrix.*": "Jimi Hendrix" }
         ):
-            assert Substitute().tmpl_substitute("The Jimi Hendrix Experience") == "Jimi Hendrix"
+            result = Substitute().tmpl_substitute("The Jimi Hendrix Experience")
+            assert result == "Jimi Hendrix"
 
     def test_regex_capture_group(self):
         with self.configure_plugin(
@@ -65,11 +65,12 @@ class SubstitutePluginTest(PluginTestCase):
         ):
             cases = [
                 ("King Creosote & Jon Hopkins", "King Creosote"),
-                ("Michael Hurley, The Holy Modal Rounders, Jeffrey Frederick & The Clamtones", "Michael Hurley"),
+                ("Michael Hurley, The Holy Modal Rounders,"
+                  + "Jeffrey Frederick & The Clamtones", "Michael Hurley"),
                 ("James Yorkston and the Athletes", "James Yorkston")
             ]
-            for case in cases:
-                assert Substitute().tmpl_substitute(case[0]) == case[1]
+            for input, expected in cases:
+                assert Substitute().tmpl_substitute(input) == expected
 
     def test_partial_substitution(self):
         with self.configure_plugin(
@@ -95,5 +96,5 @@ class SubstitutePluginTest(PluginTestCase):
                 ("a", "b"),
                 ("b", "c"),
             ]
-            for case in cases:
-                assert Substitute().tmpl_substitute(case[0]) == case[1]
+            for input, expected in cases:
+                assert Substitute().tmpl_substitute(input) == expected

--- a/test/plugins/test_substitute.py
+++ b/test/plugins/test_substitute.py
@@ -14,7 +14,7 @@
 
 """Test the substitute plugin regex functionality."""
 
-from beets.test.helper import PluginTestCase, capture_log
+from beets.test.helper import PluginTestCase
 from beetsplug.substitute import Substitute
 
 
@@ -29,29 +29,29 @@ class SubstitutePluginTest(PluginTestCase):
 
     def test_simple_substitute(self):
         self.run_substitute(
-            [
-                {"a": "b"},
-                {"b": "c"},
-                {"c": "d"},
-            ],
+            {
+                "a": "b",
+                "b": "c",
+                "c": "d",
+            },
             [("a", "b"), ("b", "c"), ("c", "d")],
         )
 
     def test_case_insensitivity(self):
-        self.run_substitute([{"a": "b"}], [("A", "b")])
+        self.run_substitute({"a": "b"}, [("A", "b")])
 
     def test_unmatched_input_preserved(self):
-        self.run_substitute([{"a": "b"}], [("c", "c")])
+        self.run_substitute({"a": "b"}, [("c", "c")])
 
     def test_regex_to_static(self):
         self.run_substitute(
-            [{".*jimi hendrix.*": "Jimi Hendrix"}],
+            {".*jimi hendrix.*": "Jimi Hendrix"},
             [("The Jimi Hendrix Experience", "Jimi Hendrix")],
         )
 
     def test_regex_capture_group(self):
         self.run_substitute(
-            [{"^(.*?)(,| &| and).*": r"\1"}],
+            {"^(.*?)(,| &| and).*": r"\1"},
             [
                 ("King Creosote & Jon Hopkins", "King Creosote"),
                 (
@@ -64,44 +64,16 @@ class SubstitutePluginTest(PluginTestCase):
         )
 
     def test_partial_substitution(self):
-        self.run_substitute([{r"\.": ""}], [("U.N.P.O.C.", "UNPOC")])
+        self.run_substitute({r"\.": ""}, [("U.N.P.O.C.", "UNPOC")])
 
     def test_break_on_first_match(self):
         self.run_substitute(
-            [
-                {"a": "b"},
-                {"[ab]": "c"},
-            ],
-            [
-                ("a", "b"),
-                ("b", "c"),
-            ],
-        )
-
-    def test_deprecated_config(self):
-        self.run_substitute(
             {
-                "a": "b",
-                "b": "c",
-                "c": "d",
+                "a": "x",
+                "[ab]": "y",
             },
-            [("a", "b"), ("b", "c"), ("c", "d")],
+            [
+                ("a", "x"),
+                ("b", "y"),
+            ],
         )
-
-    def test_deprecated_config_warning(self):
-        with capture_log() as logs:
-            with self.configure_plugin(
-                {
-                    "a": "b",
-                    "b": "c",
-                    "c": "d",
-                }
-            ):
-                assert any(
-                    [
-                        "Unordered configuration is deprecated, as it leads to"
-                        + " unpredictable behaviour on overlapping rules"
-                        in log
-                        for log in logs
-                    ]
-                )


### PR DESCRIPTION
## Description

This utilises regex substitution in the substitute plugin. The previous approach only used regex to match the pattern, then replaced it with a static string. This change allows more complex substitutions, where the output depends on the input.

### Example use case
Say we want to keep only the first artist of a multi-artist credit, as in the following list:
```
Neil Young & Crazy Horse -> Neil Young
Michael Hurley, The Holy Modal Rounders, Jeffrey Frederick & The Clamtones -> Michael Hurley
James Yorkston and the Athletes -> James Yorkston
````
This would previously have required three separate rules, one for each resulting artist. By using a regex substitution, we can get the desired behaviour in a single rule: 
```yaml
substitute:
  ^(.*?)(,| &| and).*: \1
```
(Capture the text until the first `,` ` &` or ` and`, then use that capture group as the output)

### Notes
I've kept the previous behaviour of only applying the first matching rule, but I'm not 100% sure it's the ideal approach.
I can imagine both cases where you want to apply several rules in sequence and cases where you want to stop after the first match.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
