### PR TITLE
Centralize test setup

### DIFF
--- a/beets/test/_common.py
+++ b/beets/test/_common.py
@@ -18,19 +18,17 @@ import os
 import shutil
 import sys
 import tempfile
-import time
 import unittest
 from contextlib import contextmanager
 
-import beets  # noqa: E402
-import beets.library  # noqa: E402
+import beets
+import beets.library
 
 # Make sure the development versions of the plugins are used
-import beetsplug  # noqa: E402
-from beets import util  # noqa: E402
-from beets import importer, logging  # noqa: E402
-from beets.ui import commands  # noqa: E402
-from beets.util import bytestring_path, syspath  # noqa: E402
+import beetsplug
+from beets import importer, logging, util
+from beets.ui import commands
+from beets.util import syspath
 
 beetsplug.__path__ = [
     os.path.abspath(
@@ -119,9 +117,6 @@ def item(lib=None):
     if lib:
         lib.add(i)
     return i
-
-
-_album_ident = 0
 
 
 def album(lib=None):
@@ -254,36 +249,6 @@ class LibTestCase(TestCase):
         super().tearDown()
 
 
-# Mock timing.
-
-
-class Timecop:
-    """Mocks the timing system (namely time() and sleep()) for testing.
-    Inspired by the Ruby timecop library.
-    """
-
-    def __init__(self):
-        self.now = time.time()
-
-    def time(self):
-        return self.now
-
-    def sleep(self, amount):
-        self.now += amount
-
-    def install(self):
-        self.orig = {
-            "time": time.time,
-            "sleep": time.sleep,
-        }
-        time.time = self.time
-        time.sleep = self.sleep
-
-    def restore(self):
-        time.time = self.orig["time"]
-        time.sleep = self.orig["sleep"]
-
-
 # Mock I/O.
 
 
@@ -386,25 +351,6 @@ class Bag:
 
     def __getattr__(self, key):
         return self.fields.get(key)
-
-
-# Convenience methods for setting up a temporary sandbox directory for tests
-# that need to interact with the filesystem.
-
-
-class TempDirMixin:
-    """Text mixin for creating and deleting a temporary directory."""
-
-    def create_temp_dir(self):
-        """Create a temporary directory and assign it into `self.temp_dir`.
-        Call `remove_temp_dir` later to delete it.
-        """
-        self.temp_dir = bytestring_path(tempfile.mkdtemp())
-
-    def remove_temp_dir(self):
-        """Delete the temporary directory created by `create_temp_dir`."""
-        if os.path.isdir(syspath(self.temp_dir)):
-            shutil.rmtree(syspath(self.temp_dir))
 
 
 # Platform mocking.

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -151,9 +151,11 @@ class TestHelper(_common.Assertions):
     fixtures.
     """
 
+    db_on_disk: ClassVar[bool] = False
+
     # TODO automate teardown through hook registration
 
-    def setup_beets(self, disk=False):
+    def setup_beets(self):
         """Setup pristine global configuration and library for testing.
 
         Sets ``beets.config`` so we can safely use any functionality
@@ -199,7 +201,7 @@ class TestHelper(_common.Assertions):
         os.mkdir(syspath(self.libdir))
         self.config["directory"] = os.fsdecode(self.libdir)
 
-        if disk:
+        if self.db_on_disk:
             dbpath = util.bytestring_path(self.config["library"].as_filename())
         else:
             dbpath = ":memory:"
@@ -538,8 +540,8 @@ class ImportHelper:
 
     importer: importer.ImportSession
 
-    def setup_beets(self, disk=False):
-        super().setup_beets(disk)
+    def setup_beets(self):
+        super().setup_beets()
         self.lib.path_formats = [
             ("default", os.path.join("$artist", "$album", "$title")),
             ("singleton:true", os.path.join("singletons", "$title")),

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -520,19 +520,14 @@ class BeetsTestCase(unittest.TestCase, TestHelper):
         self.teardown_beets()
 
 
-class LibTestCase(BeetsTestCase):
+class ItemInDBTestCase(BeetsTestCase):
     """A test case that includes an in-memory library object (`lib`) and
     an item added to the library (`i`).
     """
 
     def setUp(self):
         super().setUp()
-        self.lib = beets.library.Library(":memory:")
         self.i = _common.item(self.lib)
-
-    def tearDown(self):
-        self.lib._connection().close()
-        super().tearDown()
 
 
 class ImportHelper:
@@ -985,3 +980,4 @@ class CleanupModulesMixin:
         """Remove files created by the plugin."""
         for module in cls.modules:
             clean_module_tempdir(module)
+        self.lib = beets.library.Library(":memory:")

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -43,7 +43,7 @@ from functools import cached_property
 from io import StringIO
 from pathlib import Path
 from tempfile import mkdtemp, mkstemp
-from typing import ClassVar
+from typing import Any, ClassVar
 from unittest.mock import patch
 
 import responses
@@ -497,6 +497,19 @@ class PluginMixin:
         Album._types = getattr(Album, "_original_types", {})
         Item._queries = getattr(Item, "_original_queries", {})
         Album._queries = getattr(Album, "_original_queries", {})
+
+    @contextmanager
+    def configure_plugin(self, config: list[Any] | dict[str, Any]):
+        if isinstance(config, list):
+            beets.config[self.plugin] = config
+        else:
+            for key, value in config.items():
+                beets.config[self.plugin][key] = value
+        self.load_plugins(self.plugin)
+
+        yield
+
+        self.unload_plugins()
 
 
 class PluginTestCase(PluginMixin, BeetsTestCase):

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -624,6 +624,17 @@ class ImportHelper(TestHelper):
         self.assertEqual(len(os.listdir(syspath(self.libdir))), 0)
 
 
+class AsIsImporterMixin:
+    def setUp(self):
+        super().setUp()
+        self.prepare_album_for_import(1)
+
+    def run_asis_importer(self, **kwargs):
+        importer = self.setup_importer(autotag=False, **kwargs)
+        importer.run()
+        return importer
+
+
 class ImportTestCase(ImportHelper, BeetsTestCase):
     pass
 

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -565,7 +565,10 @@ class ImportHelper(TestHelper):
         return track_path
 
     def prepare_album_for_import(
-        self, item_count: int, album_id: int | None = None
+        self,
+        item_count: int,
+        album_id: int | None = None,
+        album_path: Path | None = None,
     ) -> list[Path]:
         """Create an album directory with media files to import.
 
@@ -575,8 +578,10 @@ class ImportHelper(TestHelper):
             track_2.mp3
             track_3.mp3
         """
-        album_dir = f"album_{album_id}" if album_id else "album"
-        album_path = self.import_path / album_dir
+        if not album_path:
+            album_dir = f"album_{album_id}" if album_id else "album"
+            album_path = self.import_path / album_dir
+
         album_path.mkdir(exist_ok=True)
 
         return [

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -251,10 +251,10 @@ class TestHelper(_common.Assertions):
         beets.config["plugins"] = []
         beets.plugins._classes = set()
         beets.plugins._instances = {}
-        Item._types = Item._original_types
-        Album._types = Album._original_types
-        Item._queries = Item._original_queries
-        Album._queries = Album._original_queries
+        Item._types = getattr(Item, "_original_types", {})
+        Album._types = getattr(Album, "_original_types", {})
+        Item._queries = getattr(Item, "_original_queries", {})
+        Album._queries = getattr(Album, "_original_queries", {})
 
     # Library fixtures methods
 

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -253,59 +253,6 @@ class TestHelper(_common.Assertions):
         Item._queries = Item._original_queries
         Album._queries = Album._original_queries
 
-    def create_importer(self, item_count=1, album_count=1):
-        """Create files to import and return corresponding session.
-
-        Copies the specified number of files to a subdirectory of
-        `self.temp_dir` and creates a `ImportSessionFixture` for this path.
-        """
-        import_dir = os.path.join(self.temp_dir, b"import")
-        if not os.path.isdir(syspath(import_dir)):
-            os.mkdir(syspath(import_dir))
-
-        album_no = 0
-        while album_count:
-            album = util.bytestring_path(f"album {album_no}")
-            album_dir = os.path.join(import_dir, album)
-            if os.path.exists(syspath(album_dir)):
-                album_no += 1
-                continue
-            os.mkdir(syspath(album_dir))
-            album_count -= 1
-
-            track_no = 0
-            album_item_count = item_count
-            while album_item_count:
-                title = f"track {track_no}"
-                src = os.path.join(_common.RSRC, b"full.mp3")
-                title_file = util.bytestring_path(f"{title}.mp3")
-                dest = os.path.join(album_dir, title_file)
-                if os.path.exists(syspath(dest)):
-                    track_no += 1
-                    continue
-                album_item_count -= 1
-                shutil.copy(syspath(src), syspath(dest))
-                mediafile = MediaFile(dest)
-                mediafile.update(
-                    {
-                        "artist": "artist",
-                        "albumartist": "album artist",
-                        "title": title,
-                        "album": album,
-                        "mb_albumid": None,
-                        "mb_trackid": None,
-                    }
-                )
-                mediafile.save()
-
-        config["import"]["quiet"] = True
-        config["import"]["autotag"] = False
-        config["import"]["resume"] = False
-
-        return ImportSessionFixture(
-            self.lib, loghandler=None, query=None, paths=[import_dir]
-        )
-
     # Library fixtures methods
 
     def create_item(self, **values):
@@ -641,6 +588,59 @@ class ImportHelper:
         config["import"]["hardlink"] = False
 
         self._get_import_session(import_dir or self.import_dir)
+
+    def create_importer(self, item_count=1, album_count=1):
+        """Create files to import and return corresponding session.
+
+        Copies the specified number of files to a subdirectory of
+        `self.temp_dir` and creates a `ImportSessionFixture` for this path.
+        """
+        import_dir = os.path.join(self.temp_dir, b"import")
+        if not os.path.isdir(syspath(import_dir)):
+            os.mkdir(syspath(import_dir))
+
+        album_no = 0
+        while album_count:
+            album = util.bytestring_path(f"album {album_no}")
+            album_dir = os.path.join(import_dir, album)
+            if os.path.exists(syspath(album_dir)):
+                album_no += 1
+                continue
+            os.mkdir(syspath(album_dir))
+            album_count -= 1
+
+            track_no = 0
+            album_item_count = item_count
+            while album_item_count:
+                title = f"track {track_no}"
+                src = os.path.join(_common.RSRC, b"full.mp3")
+                title_file = util.bytestring_path(f"{title}.mp3")
+                dest = os.path.join(album_dir, title_file)
+                if os.path.exists(syspath(dest)):
+                    track_no += 1
+                    continue
+                album_item_count -= 1
+                shutil.copy(syspath(src), syspath(dest))
+                mediafile = MediaFile(dest)
+                mediafile.update(
+                    {
+                        "artist": "artist",
+                        "albumartist": "album artist",
+                        "title": title,
+                        "album": album,
+                        "mb_albumid": None,
+                        "mb_trackid": None,
+                    }
+                )
+                mediafile.save()
+
+        config["import"]["quiet"] = True
+        config["import"]["autotag"] = False
+        config["import"]["resume"] = False
+
+        return ImportSessionFixture(
+            self.lib, loghandler=None, query=None, paths=[import_dir]
+        )
 
     def assert_file_in_lib(self, *segments):
         """Join the ``segments`` and assert that this path exists in the

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -535,7 +535,7 @@ class LibTestCase(BeetsTestCase):
         super().tearDown()
 
 
-class ImportHelper(TestHelper):
+class ImportHelper:
     """Provides tools to setup a library, a directory containing files that are
     to be imported and an import session. The class also provides stubs for the
     autotagging library and several assertions for the library.
@@ -642,6 +642,10 @@ class ImportHelper(TestHelper):
 
     def assert_lib_dir_empty(self):
         self.assertEqual(len(os.listdir(syspath(self.libdir))), 0)
+
+
+class ImportTestCase(ImportHelper, BeetsTestCase):
+    pass
 
 
 class ImportSessionFixture(importer.ImportSession):

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -142,7 +142,7 @@ def has_program(cmd, args=["--version"]):
         return True
 
 
-class TestHelper:
+class TestHelper(_common.Assertions):
     """Helper mixin for high-level cli and plugin tests.
 
     This mixin provides methods to isolate beets' global state provide

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -520,7 +520,7 @@ class ImportHelper:
             ("comp:true", os.path.join("compilations", "$album", "$title")),
         ]
 
-    def _create_import_dir(self, count=3):
+    def prepare_album_for_import(self, count=3):
         """Creates a directory with media files to import.
         Sets ``self.import_dir`` to the path of the directory. Also sets
         ``self.import_media`` to a list :class:`MediaFile` for all the files in

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -470,11 +470,11 @@ class TestHelper(_common.Assertions):
 
     # Safe file operations
 
-    def create_temp_dir(self):
+    def create_temp_dir(self, **kwargs):
         """Create a temporary directory and assign it into
         `self.temp_dir`. Call `remove_temp_dir` later to delete it.
         """
-        temp_dir = mkdtemp()
+        temp_dir = mkdtemp(**kwargs)
         self.temp_dir = util.bytestring_path(temp_dir)
 
     def remove_temp_dir(self):
@@ -980,4 +980,3 @@ class CleanupModulesMixin:
         """Remove files created by the plugin."""
         for module in cls.modules:
             clean_module_tempdir(module)
-        self.lib = beets.library.Library(":memory:")

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -225,6 +225,7 @@ class TestHelper(_common.Assertions):
         sure you call ``unload_plugins()`` afterwards.
         """
         # FIXME this should eventually be handled by a plugin manager
+        plugins = (self.plugin,) if hasattr(self, "plugin") else plugins
         beets.config["plugins"] = plugins
         beets.plugins.load_plugins(plugins)
         beets.plugins.find_plugins()
@@ -242,7 +243,7 @@ class TestHelper(_common.Assertions):
         Album._queries.update(beets.plugins.named_queries(Album))
 
     def unload_plugins(self):
-        """Unload all plugins and remove the from the configuration."""
+        """Unload all plugins and remove them from the configuration."""
         # FIXME this should eventually be handled by a plugin manager
         beets.config["plugins"] = []
         beets.plugins._classes = set()
@@ -530,6 +531,22 @@ class ItemInDBTestCase(BeetsTestCase):
     def setUp(self):
         super().setUp()
         self.i = _common.item(self.lib)
+
+
+class PluginMixin:
+    plugin: ClassVar[str]
+
+    def setUp(self):
+        super().setUp()
+        self.load_plugins()
+
+    def tearDown(self):
+        super().tearDown()
+        self.unload_plugins()
+
+
+class PluginTestCase(PluginMixin, BeetsTestCase):
+    pass
 
 
 class ImportHelper:

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -387,7 +387,7 @@ def _fsencoding() -> str:
     return encoding
 
 
-def bytestring_path(path: Bytes_or_String) -> bytes:
+def bytestring_path(path: PathLike) -> bytes:
     """Given a path, which is either a bytes or a unicode, returns a str
     path (ensuring that we never deal with Unicode pathnames). Path should be
     bytes but has safeguards for strings to be converted.
@@ -396,17 +396,21 @@ def bytestring_path(path: Bytes_or_String) -> bytes:
     if isinstance(path, bytes):
         return path
 
+    str_path = str(path)
+
     # On Windows, remove the magic prefix added by `syspath`. This makes
     # ``bytestring_path(syspath(X)) == X``, i.e., we can safely
     # round-trip through `syspath`.
-    if os.path.__name__ == "ntpath" and path.startswith(WINDOWS_MAGIC_PREFIX):
-        path = path[len(WINDOWS_MAGIC_PREFIX) :]
+    if os.path.__name__ == "ntpath" and str_path.startswith(
+        WINDOWS_MAGIC_PREFIX
+    ):
+        str_path = str_path[len(WINDOWS_MAGIC_PREFIX) :]
 
     # Try to encode with default encodings, but fall back to utf-8.
     try:
-        return path.encode(_fsencoding())
+        return str_path.encode(_fsencoding())
     except (UnicodeError, LookupError):
-        return path.encode("utf-8")
+        return str_path.encode("utf-8")
 
 
 PATH_SEP: bytes = bytestring_path(os.sep)
@@ -434,39 +438,27 @@ def displayable_path(
         return path.decode("utf-8", "ignore")
 
 
-def syspath(path: Bytes_or_String, prefix: bool = True) -> str:
+def syspath(path: PathLike, prefix: bool = True) -> str:
     """Convert a path for use by the operating system. In particular,
     paths on Windows must receive a magic prefix and must be converted
     to Unicode before they are sent to the OS. To disable the magic
     prefix on Windows, set `prefix` to False---but only do this if you
     *really* know what you're doing.
     """
+    str_path = os.fsdecode(path)
     # Don't do anything if we're not on windows
     if os.path.__name__ != "ntpath":
-        return path
-
-    if not isinstance(path, str):
-        # Beets currently represents Windows paths internally with UTF-8
-        # arbitrarily. But earlier versions used MBCS because it is
-        # reported as the FS encoding by Windows. Try both.
-        try:
-            path = path.decode("utf-8")
-        except UnicodeError:
-            # The encoding should always be MBCS, Windows' broken
-            # Unicode representation.
-            assert isinstance(path, bytes)
-            encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
-            path = path.decode(encoding, "replace")
+        return str_path
 
     # Add the magic prefix if it isn't already there.
     # https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247.aspx
-    if prefix and not path.startswith(WINDOWS_MAGIC_PREFIX):
-        if path.startswith("\\\\"):
+    if prefix and not str_path.startswith(WINDOWS_MAGIC_PREFIX):
+        if str_path.startswith("\\\\"):
             # UNC path. Final path should look like \\?\UNC\...
-            path = "UNC" + path[1:]
-        path = WINDOWS_MAGIC_PREFIX + path
+            str_path = "UNC" + str_path[1:]
+        str_path = WINDOWS_MAGIC_PREFIX + str_path
 
-    return path
+    return str_path
 
 
 def samefile(p1: bytes, p2: bytes) -> bool:

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -434,7 +434,7 @@ def displayable_path(
         return path.decode("utf-8", "ignore")
 
 
-def syspath(path: Bytes_or_String, prefix: bool = True) -> Bytes_or_String:
+def syspath(path: Bytes_or_String, prefix: bool = True) -> str:
     """Convert a path for use by the operating system. In particular,
     paths on Windows must receive a magic prefix and must be converted
     to Unicode before they are sent to the OS. To disable the magic

--- a/test/plugins/test_acousticbrainz.py
+++ b/test/plugins/test_acousticbrainz.py
@@ -99,11 +99,3 @@ class MapDataToSchemeTest(unittest.TestCase):
             ("timbre", "bright"),
         }
         self.assertEqual(mapping, expected)
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_advancedrewrite.py
+++ b/test/plugins/test_advancedrewrite.py
@@ -16,16 +16,15 @@
 """
 
 
-from beets.test.helper import BeetsTestCase
+from beets.test.helper import BeetsTestCase, PluginMixin
 from beets.ui import UserError
 
 PLUGIN_NAME = "advancedrewrite"
 
 
-class AdvancedRewritePluginTest(BeetsTestCase):
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
+class AdvancedRewritePluginTest(PluginMixin, BeetsTestCase):
+    plugin = "advancedrewrite"
+    preload_plugin = False
 
     def test_simple_rewrite_example(self):
         self.config[PLUGIN_NAME] = [

--- a/test/plugins/test_advancedrewrite.py
+++ b/test/plugins/test_advancedrewrite.py
@@ -17,13 +17,13 @@
 
 import unittest
 
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 from beets.ui import UserError
 
 PLUGIN_NAME = "advancedrewrite"
 
 
-class AdvancedRewritePluginTest(unittest.TestCase, TestHelper):
+class AdvancedRewritePluginTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
 

--- a/test/plugins/test_advancedrewrite.py
+++ b/test/plugins/test_advancedrewrite.py
@@ -15,7 +15,6 @@
 """Test the advancedrewrite plugin for various configurations.
 """
 
-import unittest
 
 from beets.test.helper import BeetsTestCase
 from beets.ui import UserError
@@ -154,11 +153,3 @@ class AdvancedRewritePluginTest(BeetsTestCase):
             album="C",
         )
         self.assertEqual(item.artist, "D")
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_advancedrewrite.py
+++ b/test/plugins/test_advancedrewrite.py
@@ -16,139 +16,106 @@
 """
 
 
-from beets.test.helper import BeetsTestCase, PluginMixin
+from beets.test.helper import PluginTestCase
 from beets.ui import UserError
 
 PLUGIN_NAME = "advancedrewrite"
 
 
-class AdvancedRewritePluginTest(PluginMixin, BeetsTestCase):
+class AdvancedRewritePluginTest(PluginTestCase):
     plugin = "advancedrewrite"
     preload_plugin = False
 
     def test_simple_rewrite_example(self):
-        self.config[PLUGIN_NAME] = [
-            {"artist ODD EYE CIRCLE": "이달의 소녀 오드아이써클"},
-        ]
-        self.load_plugins(PLUGIN_NAME)
+        with self.configure_plugin(
+            [{"artist ODD EYE CIRCLE": "이달의 소녀 오드아이써클"}]
+        ):
+            item = self.add_item(
+                artist="ODD EYE CIRCLE",
+                albumartist="ODD EYE CIRCLE",
+            )
 
-        item = self.add_item(
-            title="Uncover",
-            artist="ODD EYE CIRCLE",
-            albumartist="ODD EYE CIRCLE",
-            album="Mix & Match",
-        )
-
-        self.assertEqual(item.artist, "이달의 소녀 오드아이써클")
+            self.assertEqual(item.artist, "이달의 소녀 오드아이써클")
 
     def test_advanced_rewrite_example(self):
-        self.config[PLUGIN_NAME] = [
-            {
-                "match": "mb_artistid:dec0f331-cb08-4c8e-9c9f-aeb1f0f6d88c year:..2022",
-                "replacements": {
-                    "artist": "이달의 소녀 오드아이써클",
-                    "artist_sort": "LOONA / ODD EYE CIRCLE",
+        with self.configure_plugin(
+            [
+                {
+                    "match": "mb_artistid:dec0f331-cb08-4c8e-9c9f-aeb1f0f6d88c year:..2022",  # noqa: E501
+                    "replacements": {
+                        "artist": "이달의 소녀 오드아이써클",
+                        "artist_sort": "LOONA / ODD EYE CIRCLE",
+                    },
                 },
-            },
-        ]
-        self.load_plugins(PLUGIN_NAME)
+            ]
+        ):
+            item_a = self.add_item(
+                artist="ODD EYE CIRCLE",
+                artist_sort="ODD EYE CIRCLE",
+                mb_artistid="dec0f331-cb08-4c8e-9c9f-aeb1f0f6d88c",
+                year=2017,
+            )
+            item_b = self.add_item(
+                artist="ODD EYE CIRCLE",
+                artist_sort="ODD EYE CIRCLE",
+                mb_artistid="dec0f331-cb08-4c8e-9c9f-aeb1f0f6d88c",
+                year=2023,
+            )
 
-        item_a = self.add_item(
-            title="Uncover",
-            artist="ODD EYE CIRCLE",
-            albumartist="ODD EYE CIRCLE",
-            artist_sort="ODD EYE CIRCLE",
-            albumartist_sort="ODD EYE CIRCLE",
-            album="Mix & Match",
-            mb_artistid="dec0f331-cb08-4c8e-9c9f-aeb1f0f6d88c",
-            year=2017,
-        )
-        item_b = self.add_item(
-            title="Air Force One",
-            artist="ODD EYE CIRCLE",
-            albumartist="ODD EYE CIRCLE",
-            artist_sort="ODD EYE CIRCLE",
-            albumartist_sort="ODD EYE CIRCLE",
-            album="ODD EYE CIRCLE <Version Up>",
-            mb_artistid="dec0f331-cb08-4c8e-9c9f-aeb1f0f6d88c",
-            year=2023,
-        )
+            # Assert that all replacements were applied to item_a
+            self.assertEqual("이달의 소녀 오드아이써클", item_a.artist)
+            self.assertEqual("LOONA / ODD EYE CIRCLE", item_a.artist_sort)
+            self.assertEqual("LOONA / ODD EYE CIRCLE", item_a.albumartist_sort)
 
-        # Assert that all replacements were applied to item_a
-        self.assertEqual("이달의 소녀 오드아이써클", item_a.artist)
-        self.assertEqual("LOONA / ODD EYE CIRCLE", item_a.artist_sort)
-        self.assertEqual("LOONA / ODD EYE CIRCLE", item_a.albumartist_sort)
-
-        # Assert that no replacements were applied to item_b
-        self.assertEqual("ODD EYE CIRCLE", item_b.artist)
+            # Assert that no replacements were applied to item_b
+            self.assertEqual("ODD EYE CIRCLE", item_b.artist)
 
     def test_advanced_rewrite_example_with_multi_valued_field(self):
-        self.config[PLUGIN_NAME] = [
-            {
-                "match": "artist:배유빈 feat. 김미현",
-                "replacements": {
-                    "artists": ["유빈", "미미"],
+        with self.configure_plugin(
+            [
+                {
+                    "match": "artist:배유빈 feat. 김미현",
+                    "replacements": {"artists": ["유빈", "미미"]},
                 },
-            },
-        ]
-        self.load_plugins(PLUGIN_NAME)
+            ]
+        ):
+            item = self.add_item(
+                artist="배유빈 feat. 김미현",
+                artists=["배유빈", "김미현"],
+            )
 
-        item = self.add_item(
-            artist="배유빈 feat. 김미현",
-            artists=["배유빈", "김미현"],
-        )
-
-        self.assertEqual(item.artists, ["유빈", "미미"])
+            self.assertEqual(item.artists, ["유빈", "미미"])
 
     def test_fail_when_replacements_empty(self):
-        self.config[PLUGIN_NAME] = [
-            {
-                "match": "artist:A",
-                "replacements": {},
-            },
-        ]
         with self.assertRaises(
             UserError,
             msg="Advanced rewrites must have at least one replacement",
-        ):
-            self.load_plugins(PLUGIN_NAME)
+        ), self.configure_plugin([{"match": "artist:A", "replacements": {}}]):
+            pass
 
     def test_fail_when_rewriting_single_valued_field_with_list(self):
-        self.config[PLUGIN_NAME] = [
-            {
-                "match": "artist:'A & B'",
-                "replacements": {
-                    "artist": ["C", "D"],
-                },
-            },
-        ]
         with self.assertRaises(
             UserError,
             msg="Field artist is not a multi-valued field but a list was given: C, D",
+        ), self.configure_plugin(
+            [
+                {
+                    "match": "artist:'A & B'",
+                    "replacements": {"artist": ["C", "D"]},
+                },
+            ]
         ):
-            self.load_plugins(PLUGIN_NAME)
+            pass
 
     def test_combined_rewrite_example(self):
-        self.config[PLUGIN_NAME] = [
-            {"artist A": "B"},
-            {
-                "match": "album:'C'",
-                "replacements": {
-                    "artist": "D",
-                },
-            },
-        ]
-        self.load_plugins(PLUGIN_NAME)
+        with self.configure_plugin(
+            [
+                {"artist A": "B"},
+                {"match": "album:'C'", "replacements": {"artist": "D"}},
+            ]
+        ):
+            item = self.add_item(artist="A", albumartist="A")
+            self.assertEqual(item.artist, "B")
 
-        item = self.add_item(
-            artist="A",
-            albumartist="A",
-        )
-        self.assertEqual(item.artist, "B")
-
-        item = self.add_item(
-            artist="C",
-            albumartist="C",
-            album="C",
-        )
-        self.assertEqual(item.artist, "D")
+            item = self.add_item(artist="C", albumartist="C", album="C")
+            self.assertEqual(item.artist, "D")

--- a/test/plugins/test_advancedrewrite.py
+++ b/test/plugins/test_advancedrewrite.py
@@ -24,12 +24,9 @@ PLUGIN_NAME = "advancedrewrite"
 
 
 class AdvancedRewritePluginTest(BeetsTestCase):
-    def setUp(self):
-        self.setup_beets()
-
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def test_simple_rewrite_example(self):
         self.config[PLUGIN_NAME] = [

--- a/test/plugins/test_albumtypes.py
+++ b/test/plugins/test_albumtypes.py
@@ -24,6 +24,7 @@ from beetsplug.albumtypes import AlbumTypesPlugin
 
 class AlbumTypesPluginTest(PluginTestCase):
     """Tests for albumtypes plugin."""
+
     plugin = "albumtypes"
 
     def test_renames_types(self):

--- a/test/plugins/test_albumtypes.py
+++ b/test/plugins/test_albumtypes.py
@@ -18,22 +18,13 @@
 from typing import Sequence, Tuple
 
 from beets.autotag.mb import VARIOUS_ARTISTS_ID
-from beets.test.helper import BeetsTestCase
+from beets.test.helper import PluginTestCase
 from beetsplug.albumtypes import AlbumTypesPlugin
 
 
-class AlbumTypesPluginTest(BeetsTestCase):
+class AlbumTypesPluginTest(PluginTestCase):
     """Tests for albumtypes plugin."""
-
-    def setUp(self):
-        """Set up tests."""
-        super().setUp()
-        self.load_plugins("albumtypes")
-
-    def tearDown(self):
-        """Tear down tests."""
-        self.unload_plugins()
-        super().tearDown()
+    plugin = "albumtypes"
 
     def test_renames_types(self):
         """Tests if the plugin correctly renames the specified types."""

--- a/test/plugins/test_albumtypes.py
+++ b/test/plugins/test_albumtypes.py
@@ -15,15 +15,14 @@
 """Tests for the 'albumtypes' plugin."""
 
 
-import unittest
 from typing import Sequence, Tuple
 
 from beets.autotag.mb import VARIOUS_ARTISTS_ID
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 from beetsplug.albumtypes import AlbumTypesPlugin
 
 
-class AlbumTypesPluginTest(unittest.TestCase, TestHelper):
+class AlbumTypesPluginTest(BeetsTestCase):
     """Tests for albumtypes plugin."""
 
     def setUp(self):

--- a/test/plugins/test_albumtypes.py
+++ b/test/plugins/test_albumtypes.py
@@ -27,13 +27,13 @@ class AlbumTypesPluginTest(BeetsTestCase):
 
     def setUp(self):
         """Set up tests."""
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("albumtypes")
 
     def tearDown(self):
         """Tear down tests."""
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def test_renames_types(self):
         """Tests if the plugin correctly renames the specified types."""

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -17,7 +17,6 @@
 
 import os
 import shutil
-import unittest
 from unittest.mock import patch
 
 import confuse
@@ -1016,11 +1015,3 @@ class EnforceRatioConfigTest(BeetsTestCase):
     def test_percent(self):
         self._load_with_config("0% 0.00% 5.1% 5% 100%".split(), False)
         self._load_with_config("00% 1.234% foo5% 100.1%".split(), True)
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -23,7 +23,7 @@ from unittest.mock import patch
 import confuse
 import responses
 
-from beets import config, importer, library, logging, util
+from beets import config, importer, logging, util
 from beets.autotag import AlbumInfo, AlbumMatch
 from beets.test import _common
 from beets.test.helper import (
@@ -736,16 +736,12 @@ class ArtImporterTest(UseThePlugin):
         self.plugin.art_for_album = art_for_album
 
         # Test library.
-        self.libpath = os.path.join(self.temp_dir, b"tmplib.blb")
-        self.libdir = os.path.join(self.temp_dir, b"tmplib")
-        os.mkdir(syspath(self.libdir))
         os.mkdir(syspath(os.path.join(self.libdir, b"album")))
         itempath = os.path.join(self.libdir, b"album", b"test.mp3")
         shutil.copyfile(
             syspath(os.path.join(_common.RSRC, b"full.mp3")),
             syspath(itempath),
         )
-        self.lib = library.Library(self.libpath)
         self.i = _common.item()
         self.i.path = itempath
         self.album = self.lib.add_album([self.i])
@@ -768,7 +764,6 @@ class ArtImporterTest(UseThePlugin):
         self.task.set_choice(AlbumMatch(0, info, {}, set(), set()))
 
     def tearDown(self):
-        self.lib._connection().close()
         super().tearDown()
         self.plugin.art_for_album = self.old_afa
 

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -26,7 +26,12 @@ import responses
 from beets import config, importer, library, logging, util
 from beets.autotag import AlbumInfo, AlbumMatch
 from beets.test import _common
-from beets.test.helper import CleanupModulesMixin, FetchImageHelper, capture_log
+from beets.test.helper import (
+    BeetsTestCase,
+    CleanupModulesMixin,
+    FetchImageHelper,
+    capture_log,
+)
 from beets.util import syspath
 from beets.util.artresizer import ArtResizer
 from beetsplug import fetchart
@@ -44,7 +49,7 @@ class Settings:
             setattr(self, k, v)
 
 
-class UseThePlugin(CleanupModulesMixin, _common.TestCase):
+class UseThePlugin(CleanupModulesMixin, BeetsTestCase):
     modules = (fetchart.__name__, ArtResizer.__module__)
 
     def setUp(self):
@@ -977,14 +982,14 @@ class ArtForAlbumTest(UseThePlugin):
         self._assert_image_operated(self.IMG_348x348, self.RESIZE_OP, True)
 
 
-class DeprecatedConfigTest(_common.TestCase):
+class DeprecatedConfigTest(BeetsTestCase):
     """While refactoring the plugin, the remote_priority option was deprecated,
     and a new codepath should translate its effect. Check that it actually does
     so.
     """
 
     # If we subclassed UseThePlugin, the configuration change would either be
-    # overwritten by _common.TestCase or be set after constructing the
+    # overwritten by BeetsTestCase or be set after constructing the
     # plugin object
     def setUp(self):
         super().setUp()
@@ -995,7 +1000,7 @@ class DeprecatedConfigTest(_common.TestCase):
         self.assertEqual(type(self.plugin.sources[-1]), fetchart.FileSystem)
 
 
-class EnforceRatioConfigTest(_common.TestCase):
+class EnforceRatioConfigTest(BeetsTestCase):
     """Throw some data at the regexes."""
 
     def _load_with_config(self, values, should_raise):

--- a/test/plugins/test_bareasc.py
+++ b/test/plugins/test_bareasc.py
@@ -6,18 +6,18 @@
 import unittest
 
 from beets import logging
-from beets.test.helper import BeetsTestCase, capture_stdout
+from beets.test.helper import PluginTestCase, capture_stdout
 
 
-class BareascPluginTest(BeetsTestCase):
+class BareascPluginTest(PluginTestCase):
     """Test bare ASCII query matching."""
+    plugin = "bareasc"
 
     def setUp(self):
         """Set up test environment for bare ASCII query matching."""
         super().setUp()
         self.log = logging.getLogger("beets.web")
         self.config["bareasc"]["prefix"] = "#"
-        self.load_plugins("bareasc")
 
         # Add library elements. Note that self.lib.add overrides any "id=<n>"
         # and assigns the next free id number.

--- a/test/plugins/test_bareasc.py
+++ b/test/plugins/test_bareasc.py
@@ -6,10 +6,10 @@
 import unittest
 
 from beets import logging
-from beets.test.helper import TestHelper, capture_stdout
+from beets.test.helper import BeetsTestCase, capture_stdout
 
 
-class BareascPluginTest(unittest.TestCase, TestHelper):
+class BareascPluginTest(BeetsTestCase):
     """Test bare ASCII query matching."""
 
     def setUp(self):

--- a/test/plugins/test_bareasc.py
+++ b/test/plugins/test_bareasc.py
@@ -14,7 +14,7 @@ class BareascPluginTest(BeetsTestCase):
 
     def setUp(self):
         """Set up test environment for bare ASCII query matching."""
-        self.setup_beets()
+        super().setUp()
         self.log = logging.getLogger("beets.web")
         self.config["bareasc"]["prefix"] = "#"
         self.load_plugins("bareasc")
@@ -26,9 +26,6 @@ class BareascPluginTest(BeetsTestCase):
         self.add_item(title="with umlaut", album_id=2, artist="Brüggen")
         self.add_item(title="without umlaut or e", artist="Bruggen")
         self.add_item(title="without umlaut with e", artist="Brueggen")
-
-    def tearDown(self):
-        self.teardown_beets()
 
     def test_bareasc_search(self):
         test_cases = [

--- a/test/plugins/test_bareasc.py
+++ b/test/plugins/test_bareasc.py
@@ -3,7 +3,6 @@
 
 """Tests for the 'bareasc' plugin."""
 
-import unittest
 
 from beets import logging
 from beets.test.helper import PluginTestCase, capture_stdout
@@ -11,6 +10,7 @@ from beets.test.helper import PluginTestCase, capture_stdout
 
 class BareascPluginTest(PluginTestCase):
     """Test bare ASCII query matching."""
+
     plugin = "bareasc"
 
     def setUp(self):
@@ -81,12 +81,3 @@ class BareascPluginTest(PluginTestCase):
             )
 
         self.assertEqual("Antonin Dvorak:: with accents\n", output.getvalue())
-
-
-def suite():
-    """loader."""
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_beatport.py
+++ b/test/plugins/test_beatport.py
@@ -18,7 +18,6 @@
 import unittest
 from datetime import timedelta
 
-from beets import library
 from beets.test import _common
 from beets.test.helper import BeetsTestCase
 from beetsplug import beatport
@@ -452,7 +451,6 @@ class BeatportTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
         self.load_plugins("beatport")
-        self.lib = library.Library(":memory:")
 
         # Set up 'album'.
         response_release = self._make_release_response()
@@ -630,7 +628,6 @@ class BeatportResponseEmptyTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
         self.load_plugins("beatport")
-        self.lib = library.Library(":memory:")
 
         # Set up 'tracks'.
         self.response_tracks = self._make_tracks_response()

--- a/test/plugins/test_beatport.py
+++ b/test/plugins/test_beatport.py
@@ -20,11 +20,11 @@ from datetime import timedelta
 
 from beets import library
 from beets.test import _common
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 from beetsplug import beatport
 
 
-class BeatportTest(_common.TestCase, TestHelper):
+class BeatportTest(BeetsTestCase):
     def _make_release_response(self):
         """Returns a dict that mimics a response from the beatport API.
 
@@ -601,7 +601,7 @@ class BeatportTest(_common.TestCase, TestHelper):
             self.assertEqual(track.genre, test_track.genre)
 
 
-class BeatportResponseEmptyTest(_common.TestCase, TestHelper):
+class BeatportResponseEmptyTest(BeetsTestCase):
     def _make_tracks_response(self):
         results = [
             {

--- a/test/plugins/test_beatport.py
+++ b/test/plugins/test_beatport.py
@@ -15,7 +15,6 @@
 """Tests for the 'beatport' plugin.
 """
 
-import unittest
 from datetime import timedelta
 
 from beets.test import _common
@@ -656,11 +655,3 @@ class BeatportResponseEmptyTest(BeetsTestCase):
         self.assertEqual(
             tracks[0].genre, self.test_tracks[0]["subGenres"][0]["name"]
         )
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_beatport.py
+++ b/test/plugins/test_beatport.py
@@ -450,7 +450,7 @@ class BeatportTest(BeetsTestCase):
         return results
 
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("beatport")
         self.lib = library.Library(":memory:")
 
@@ -470,7 +470,7 @@ class BeatportTest(BeetsTestCase):
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def mk_test_album(self):
         items = [_common.item() for _ in range(6)]
@@ -628,7 +628,7 @@ class BeatportResponseEmptyTest(BeetsTestCase):
         return results
 
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("beatport")
         self.lib = library.Library(":memory:")
 
@@ -641,7 +641,7 @@ class BeatportResponseEmptyTest(BeetsTestCase):
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def test_response_tracks_empty(self):
         response_tracks = []

--- a/test/plugins/test_beatport.py
+++ b/test/plugins/test_beatport.py
@@ -450,7 +450,6 @@ class BeatportTest(BeetsTestCase):
 
     def setUp(self):
         super().setUp()
-        self.load_plugins("beatport")
 
         # Set up 'album'.
         response_release = self._make_release_response()
@@ -465,10 +464,6 @@ class BeatportTest(BeetsTestCase):
 
         # Set up 'test_tracks'
         self.test_tracks = self.test_album.items()
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
 
     def mk_test_album(self):
         items = [_common.item() for _ in range(6)]
@@ -627,7 +622,6 @@ class BeatportResponseEmptyTest(BeetsTestCase):
 
     def setUp(self):
         super().setUp()
-        self.load_plugins("beatport")
 
         # Set up 'tracks'.
         self.response_tracks = self._make_tracks_response()
@@ -635,10 +629,6 @@ class BeatportResponseEmptyTest(BeetsTestCase):
 
         # Make alias to be congruent with class `BeatportTest`.
         self.test_tracks = self.response_tracks
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
 
     def test_response_tracks_empty(self):
         response_tracks = []

--- a/test/plugins/test_bucket.py
+++ b/test/plugins/test_bucket.py
@@ -15,8 +15,6 @@
 """Tests for the 'bucket' plugin."""
 
 
-import unittest
-
 from beets import config, ui
 from beets.test.helper import BeetsTestCase
 from beetsplug import bucket
@@ -165,11 +163,3 @@ class BucketPluginTest(BeetsTestCase):
         self.check_span_from_str("1980 00", 1980, 2000)
         self.check_span_from_str("1930 00", 1930, 2000)
         self.check_span_from_str("1930 50", 1930, 1950)
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_bucket.py
+++ b/test/plugins/test_bucket.py
@@ -18,11 +18,11 @@
 import unittest
 
 from beets import config, ui
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 from beetsplug import bucket
 
 
-class BucketPluginTest(unittest.TestCase, TestHelper):
+class BucketPluginTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
         self.plugin = bucket.BucketPlugin()

--- a/test/plugins/test_bucket.py
+++ b/test/plugins/test_bucket.py
@@ -24,11 +24,8 @@ from beetsplug import bucket
 
 class BucketPluginTest(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.plugin = bucket.BucketPlugin()
-
-    def tearDown(self):
-        self.teardown_beets()
 
     def _setup_config(
         self,

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -85,13 +85,13 @@ class ConvertMixin:
 
 
 class ConvertTestCase(BeetsTestCase, ConvertMixin):
-    pass
+    db_on_disk = True
 
 
 @_common.slow_test()
 class ImportConvertTest(ConvertTestCase):
     def setUp(self):
-        self.setup_beets(disk=True)  # Converter is threaded
+        super().setUp()
         self.importer = self.create_importer()
         self.load_plugins("convert")
 
@@ -169,7 +169,7 @@ class ConvertCommand:
 @_common.slow_test()
 class ConvertCliTest(ConvertTestCase, ConvertCommand):
     def setUp(self):
-        self.setup_beets(disk=True)  # Converter is threaded
+        super().setUp()
         self.album = self.add_album_fixture(ext="ogg")
         self.item = self.album.items()[0]
         self.load_plugins("convert")
@@ -318,7 +318,7 @@ class NeverConvertLossyFilesTest(ConvertTestCase, ConvertCommand):
     """Test the effect of the `never_convert_lossy_files` option."""
 
     def setUp(self):
-        self.setup_beets(disk=True)  # Converter is threaded
+        super().setUp()
         self.load_plugins("convert")
 
         self.convert_dest = os.path.join(self.temp_dir, b"convert_dest")

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -24,6 +24,7 @@ from mediafile import MediaFile
 from beets import util
 from beets.test import _common
 from beets.test.helper import (
+    AsIsImporterMixin,
     ImportHelper,
     PluginTestCase,
     capture_log,
@@ -95,12 +96,9 @@ class ConvertTestCase(ConvertMixin, PluginTestCase):
 
 
 @_common.slow_test()
-class ImportConvertTest(ImportHelper, ConvertTestCase):
+class ImportConvertTest(AsIsImporterMixin, ImportHelper, ConvertTestCase):
     def setUp(self):
         super().setUp()
-        self.prepare_album_for_import(1)
-        self.importer = self.setup_importer(autotag=False)
-
         self.config["convert"] = {
             "dest": os.path.join(self.temp_dir, b"convert"),
             "command": self.tagged_copy_cmd("convert"),
@@ -111,7 +109,7 @@ class ImportConvertTest(ImportHelper, ConvertTestCase):
         }
 
     def test_import_converted(self):
-        self.importer.run()
+        self.run_asis_importer()
         item = self.lib.items().get()
         self.assertFileTag(item.path, "convert")
 
@@ -120,7 +118,7 @@ class ImportConvertTest(ImportHelper, ConvertTestCase):
     def test_import_original_on_convert_error(self):
         # `false` exits with non-zero code
         self.config["convert"]["command"] = "false"
-        self.importer.run()
+        self.run_asis_importer()
 
         item = self.lib.items().get()
         self.assertIsNotNone(item)
@@ -128,7 +126,7 @@ class ImportConvertTest(ImportHelper, ConvertTestCase):
 
     def test_delete_originals(self):
         self.config["convert"]["delete_originals"] = True
-        self.importer.run()
+        self.run_asis_importer()
         for path in self.importer.paths:
             for root, dirnames, filenames in os.walk(path):
                 self.assertEqual(

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -23,7 +23,12 @@ from mediafile import MediaFile
 
 from beets import util
 from beets.test import _common
-from beets.test.helper import PluginTestCase, capture_log, control_stdin
+from beets.test.helper import (
+    ImportHelper,
+    PluginTestCase,
+    capture_log,
+    control_stdin,
+)
 from beets.util import bytestring_path, displayable_path
 
 
@@ -90,7 +95,7 @@ class ConvertTestCase(ConvertMixin, PluginTestCase):
 
 
 @_common.slow_test()
-class ImportConvertTest(ConvertTestCase):
+class ImportConvertTest(ImportHelper, ConvertTestCase):
     def setUp(self):
         super().setUp()
         self.importer = self.create_importer()

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -22,8 +22,8 @@ import unittest
 from mediafile import MediaFile
 
 from beets import util
-from beets.test import _common, helper
-from beets.test.helper import capture_log, control_stdin
+from beets.test import _common
+from beets.test.helper import BeetsTestCase, capture_log, control_stdin
 from beets.util import bytestring_path, displayable_path
 
 
@@ -33,7 +33,7 @@ def shell_quote(text):
     return shlex.quote(text)
 
 
-class TestHelper(helper.TestHelper):
+class ConvertMixin:
     def tagged_copy_cmd(self, tag):
         """Return a conversion command that copies files and appends
         `tag` to the copy.
@@ -84,8 +84,12 @@ class TestHelper(helper.TestHelper):
             )
 
 
+class ConvertTestCase(BeetsTestCase, ConvertMixin):
+    pass
+
+
 @_common.slow_test()
-class ImportConvertTest(_common.TestCase, TestHelper):
+class ImportConvertTest(ConvertTestCase):
     def setUp(self):
         self.setup_beets(disk=True)  # Converter is threaded
         self.importer = self.create_importer()
@@ -163,7 +167,7 @@ class ConvertCommand:
 
 
 @_common.slow_test()
-class ConvertCliTest(_common.TestCase, TestHelper, ConvertCommand):
+class ConvertCliTest(ConvertTestCase, ConvertCommand):
     def setUp(self):
         self.setup_beets(disk=True)  # Converter is threaded
         self.album = self.add_album_fixture(ext="ogg")
@@ -310,7 +314,7 @@ class ConvertCliTest(_common.TestCase, TestHelper, ConvertCommand):
 
 
 @_common.slow_test()
-class NeverConvertLossyFilesTest(_common.TestCase, TestHelper, ConvertCommand):
+class NeverConvertLossyFilesTest(ConvertTestCase, ConvertCommand):
     """Test the effect of the `never_convert_lossy_files` option."""
 
     def setUp(self):

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -106,7 +106,7 @@ class ImportConvertTest(ConvertTestCase):
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def test_import_converted(self):
         self.importer.run()
@@ -193,7 +193,7 @@ class ConvertCliTest(ConvertTestCase, ConvertCommand):
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def test_convert(self):
         with control_stdin("y"):
@@ -334,7 +334,7 @@ class NeverConvertLossyFilesTest(ConvertTestCase, ConvertCommand):
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def test_transcode_from_lossless(self):
         [item] = self.add_item_fixtures(ext="flac")

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -98,7 +98,8 @@ class ConvertTestCase(ConvertMixin, PluginTestCase):
 class ImportConvertTest(ImportHelper, ConvertTestCase):
     def setUp(self):
         super().setUp()
-        self.importer = self.create_importer()
+        self.prepare_album_for_import(1)
+        self.importer = self.setup_importer(autotag=False)
 
         self.config["convert"] = {
             "dest": os.path.join(self.temp_dir, b"convert"),

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -23,7 +23,7 @@ from mediafile import MediaFile
 
 from beets import util
 from beets.test import _common
-from beets.test.helper import BeetsTestCase, capture_log, control_stdin
+from beets.test.helper import PluginTestCase, capture_log, control_stdin
 from beets.util import bytestring_path, displayable_path
 
 
@@ -84,8 +84,9 @@ class ConvertMixin:
             )
 
 
-class ConvertTestCase(BeetsTestCase, ConvertMixin):
+class ConvertTestCase(ConvertMixin, PluginTestCase):
     db_on_disk = True
+    plugin = "convert"
 
 
 @_common.slow_test()
@@ -93,7 +94,6 @@ class ImportConvertTest(ConvertTestCase):
     def setUp(self):
         super().setUp()
         self.importer = self.create_importer()
-        self.load_plugins("convert")
 
         self.config["convert"] = {
             "dest": os.path.join(self.temp_dir, b"convert"),
@@ -103,10 +103,6 @@ class ImportConvertTest(ConvertTestCase):
             "auto": True,
             "quiet": False,
         }
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
 
     def test_import_converted(self):
         self.importer.run()
@@ -172,7 +168,6 @@ class ConvertCliTest(ConvertTestCase, ConvertCommand):
         super().setUp()
         self.album = self.add_album_fixture(ext="ogg")
         self.item = self.album.items()[0]
-        self.load_plugins("convert")
 
         self.convert_dest = bytestring_path(
             os.path.join(self.temp_dir, b"convert_dest")
@@ -190,10 +185,6 @@ class ConvertCliTest(ConvertTestCase, ConvertCommand):
                 },
             },
         }
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
 
     def test_convert(self):
         with control_stdin("y"):
@@ -319,7 +310,6 @@ class NeverConvertLossyFilesTest(ConvertTestCase, ConvertCommand):
 
     def setUp(self):
         super().setUp()
-        self.load_plugins("convert")
 
         self.convert_dest = os.path.join(self.temp_dir, b"convert_dest")
         self.config["convert"] = {
@@ -331,10 +321,6 @@ class NeverConvertLossyFilesTest(ConvertTestCase, ConvertCommand):
                 "mp3": self.tagged_copy_cmd("mp3"),
             },
         }
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
 
     def test_transcode_from_lossless(self):
         [item] = self.add_item_fixtures(ext="flac")

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -343,11 +343,3 @@ class NeverConvertLossyFilesTest(ConvertTestCase, ConvertCommand):
             self.run_convert_path(item.path)
         converted = os.path.join(self.convert_dest, b"converted.ogg")
         self.assertNoFileTag(converted, "mp3")
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_discogs.py
+++ b/test/plugins/test_discogs.py
@@ -15,7 +15,6 @@
 """Tests for discogs plugin.
 """
 
-import unittest
 
 from beets import config
 from beets.test._common import Bag
@@ -424,11 +423,3 @@ class DGAlbumInfoTest(BeetsTestCase):
         d = DiscogsPlugin().get_album_info(release)
         self.assertEqual(d.genre, "GENRE1, GENRE2")
         self.assertEqual(d.style, None)
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_discogs.py
+++ b/test/plugins/test_discogs.py
@@ -18,14 +18,13 @@
 import unittest
 
 from beets import config
-from beets.test import _common
 from beets.test._common import Bag
-from beets.test.helper import capture_log
+from beets.test.helper import BeetsTestCase, capture_log
 from beets.util.id_extractors import extract_discogs_id_regex
 from beetsplug.discogs import DiscogsPlugin
 
 
-class DGAlbumInfoTest(_common.TestCase):
+class DGAlbumInfoTest(BeetsTestCase):
     def _make_release(self, tracks=None):
         """Returns a Bag that mimics a discogs_client.Release. The list
         of elements on the returned Bag is incomplete, including just

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -21,9 +21,9 @@ from beets.library import Item
 from beets.test import _common
 from beets.test.helper import (
     AutotagStub,
+    BeetsTestCase,
     ImportHelper,
     TerminalImportSessionSetup,
-    TestHelper,
     control_stdin,
 )
 from beetsplug.edit import EditPlugin
@@ -115,7 +115,7 @@ class EditMixin:
 
 @_common.slow_test()
 @patch("beets.library.Item.write")
-class EditCommandTest(unittest.TestCase, TestHelper, EditMixin):
+class EditCommandTest(BeetsTestCase, EditMixin):
     """Black box tests for `beetsplug.edit`. Command line interaction is
     simulated using `test.helper.control_stdin()`, and yaml editing via an
     external editor is simulated using `ModifyFileMocker`.
@@ -323,11 +323,7 @@ class EditCommandTest(unittest.TestCase, TestHelper, EditMixin):
 
 @_common.slow_test()
 class EditDuringImporterTest(
-    TerminalImportSessionSetup,
-    unittest.TestCase,
-    ImportHelper,
-    TestHelper,
-    EditMixin,
+    TerminalImportSessionSetup, BeetsTestCase, ImportHelper, EditMixin
 ):
     """TODO"""
 

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -22,7 +22,7 @@ from beets.test import _common
 from beets.test.helper import (
     AutotagStub,
     BeetsTestCase,
-    ImportHelper,
+    ImportTestCase,
     TerminalImportSessionSetup,
     control_stdin,
 )
@@ -323,7 +323,7 @@ class EditCommandTest(BeetsTestCase, EditMixin):
 
 @_common.slow_test()
 class EditDuringImporterTest(
-    TerminalImportSessionSetup, BeetsTestCase, ImportHelper, EditMixin
+    TerminalImportSessionSetup, ImportTestCase, EditMixin
 ):
     """TODO"""
 

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -21,8 +21,8 @@ from beets.library import Item
 from beets.test import _common
 from beets.test.helper import (
     AutotagStub,
-    BeetsTestCase,
     ImportTestCase,
+    PluginTestCase,
     TerminalImportMixin,
     control_stdin,
 )
@@ -73,8 +73,10 @@ class ModifyFileMocker:
             f.write(contents)
 
 
-class EditMixin:
+class EditMixin(PluginTestCase):
     """Helper containing some common functionality used for the Edit tests."""
+
+    plugin = "edit"
 
     def assertItemFieldsModified(  # noqa
         self, library_items, items, fields=[], allowed=["path"]
@@ -115,7 +117,7 @@ class EditMixin:
 
 @_common.slow_test()
 @patch("beets.library.Item.write")
-class EditCommandTest(BeetsTestCase, EditMixin):
+class EditCommandTest(EditMixin):
     """Black box tests for `beetsplug.edit`. Command line interaction is
     simulated using `test.helper.control_stdin()`, and yaml editing via an
     external editor is simulated using `ModifyFileMocker`.
@@ -126,7 +128,6 @@ class EditCommandTest(BeetsTestCase, EditMixin):
 
     def setUp(self):
         super().setUp()
-        self.load_plugins("edit")
         # Add an album, storing the original fields for comparison.
         self.album = self.add_album_fixture(track_count=self.TRACK_COUNT)
         self.album_orig = {f: self.album[f] for f in self.album._fields}
@@ -137,7 +138,6 @@ class EditCommandTest(BeetsTestCase, EditMixin):
     def tearDown(self):
         EditPlugin.listeners = None
         super().tearDown()
-        self.unload_plugins()
 
     def assertCounts(  # noqa
         self,
@@ -331,7 +331,6 @@ class EditDuringImporterTestCase(
 
     def setUp(self):
         super().setUp()
-        self.load_plugins("edit")
         # Create some mediafiles, and store them for comparison.
         self._create_import_dir(3)
         self.items_orig = [Item.from_path(f.path) for f in self.media_files]
@@ -341,7 +340,6 @@ class EditDuringImporterTestCase(
 
     def tearDown(self):
         EditPlugin.listeners = None
-        self.unload_plugins()
         super().tearDown()
         self.matcher.restore()
 

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -125,7 +125,7 @@ class EditCommandTest(BeetsTestCase, EditMixin):
     TRACK_COUNT = 10
 
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("edit")
         # Add an album, storing the original fields for comparison.
         self.album = self.add_album_fixture(track_count=self.TRACK_COUNT)
@@ -136,7 +136,7 @@ class EditCommandTest(BeetsTestCase, EditMixin):
 
     def tearDown(self):
         EditPlugin.listeners = None
-        self.teardown_beets()
+        super().tearDown()
         self.unload_plugins()
 
     def assertCounts(  # noqa
@@ -330,7 +330,7 @@ class EditDuringImporterTestCase(
     IGNORED = ["added", "album_id", "id", "mtime", "path"]
 
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("edit")
         # Create some mediafiles, and store them for comparison.
         self._create_import_dir(3)
@@ -342,7 +342,7 @@ class EditDuringImporterTestCase(
     def tearDown(self):
         EditPlugin.listeners = None
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
         self.matcher.restore()
 
     def test_edit_apply_asis(self):

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -26,7 +26,6 @@ from beets.test.helper import (
     TerminalImportMixin,
     control_stdin,
 )
-from beetsplug.edit import EditPlugin
 
 
 class ModifyFileMocker:
@@ -134,10 +133,6 @@ class EditCommandTest(EditMixin, BeetsTestCase):
         self.items_orig = [
             {f: item[f] for f in item._fields} for item in self.album.items()
         ]
-
-    def tearDown(self):
-        EditPlugin.listeners = None
-        super().tearDown()
 
     def assertCounts(  # noqa
         self,
@@ -338,7 +333,6 @@ class EditDuringImporterTestCase(
         self.matcher.matching = AutotagStub.GOOD
 
     def tearDown(self):
-        EditPlugin.listeners = None
         super().tearDown()
         self.matcher.restore()
 

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -23,7 +23,7 @@ from beets.test.helper import (
     AutotagStub,
     BeetsTestCase,
     ImportTestCase,
-    TerminalImportSessionSetup,
+    TerminalImportMixin,
     control_stdin,
 )
 from beetsplug.edit import EditPlugin
@@ -322,8 +322,8 @@ class EditCommandTest(BeetsTestCase, EditMixin):
 
 
 @_common.slow_test()
-class EditDuringImporterTest(
-    TerminalImportSessionSetup, ImportTestCase, EditMixin
+class EditDuringImporterTestCase(
+    EditMixin, TerminalImportMixin, ImportTestCase
 ):
     """TODO"""
 

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -332,7 +332,7 @@ class EditDuringImporterTestCase(
         super().setUp()
         # Create some mediafiles, and store them for comparison.
         self._create_import_dir(3)
-        self.items_orig = [Item.from_path(f.path) for f in self.media_files]
+        self.items_orig = [Item.from_path(f.path) for f in self.import_media]
         self.matcher = AutotagStub().install()
         self.matcher.matching = AutotagStub.GOOD
         self.config["import"]["timid"] = True
@@ -349,7 +349,7 @@ class EditDuringImporterTestCase(
         self._setup_import_session()
         # Edit track titles.
         self.run_mocked_interpreter(
-            {"replacements": {"Tag Title": "Edited Title"}},
+            {"replacements": {"Tag Track": "Edited Track"}},
             # eDit, Apply changes.
             ["d", "a"],
         )
@@ -367,7 +367,7 @@ class EditDuringImporterTestCase(
             ],
         )
         self.assertTrue(
-            all("Edited Title" in i.title for i in self.lib.items())
+            all("Edited Track" in i.title for i in self.lib.items())
         )
 
         # Ensure album is *not* fetched from a candidate.
@@ -380,7 +380,7 @@ class EditDuringImporterTestCase(
         self._setup_import_session()
         # Edit track titles.
         self.run_mocked_interpreter(
-            {"replacements": {"Tag Title": "Edited Title"}},
+            {"replacements": {"Tag Track": "Edited Track"}},
             # eDit, Cancel, Use as-is.
             ["d", "c", "u"],
         )
@@ -392,7 +392,7 @@ class EditDuringImporterTestCase(
             [],
             self.IGNORED + ["albumartist", "mb_albumartistid"],
         )
-        self.assertTrue(all("Tag Title" in i.title for i in self.lib.items()))
+        self.assertTrue(all("Tag Track" in i.title for i in self.lib.items()))
 
         # Ensure album is *not* fetched from a candidate.
         self.assertEqual(self.lib.albums()[0].mb_albumid, "")
@@ -404,7 +404,7 @@ class EditDuringImporterTestCase(
         self._setup_import_session()
         # Edit track titles.
         self.run_mocked_interpreter(
-            {"replacements": {"Applied Title": "Edited Title"}},
+            {"replacements": {"Applied Track": "Edited Track"}},
             # edit Candidates, 1, Apply changes.
             ["c", "1", "a"],
         )
@@ -412,7 +412,7 @@ class EditDuringImporterTestCase(
         # Check that 'title' field is modified, and other fields come from
         # the candidate.
         self.assertTrue(
-            all("Edited Title " in i.title for i in self.lib.items())
+            all("Edited Track " in i.title for i in self.lib.items())
         )
         self.assertTrue(all("match " in i.mb_trackid for i in self.lib.items()))
 
@@ -435,7 +435,7 @@ class EditDuringImporterTestCase(
         self.importer.paths = []
         self.importer.query = TrueQuery()
         self.run_mocked_interpreter(
-            {"replacements": {"Applied Title": "Edited Title"}},
+            {"replacements": {"Applied Track": "Edited Track"}},
             # eDit, Apply changes.
             ["d", "a"],
         )
@@ -443,7 +443,7 @@ class EditDuringImporterTestCase(
         # Check that 'title' field is modified, and other fields come from
         # the candidate.
         self.assertTrue(
-            all("Edited Title " in i.title for i in self.lib.items())
+            all("Edited Track " in i.title for i in self.lib.items())
         )
         self.assertTrue(all("match " in i.mb_trackid for i in self.lib.items()))
 
@@ -457,7 +457,7 @@ class EditDuringImporterTestCase(
         self._setup_import_session()
         # Edit track titles.
         self.run_mocked_interpreter(
-            {"replacements": {"Applied Title": "Edited Title"}},
+            {"replacements": {"Applied Track": "Edited Track"}},
             # edit Candidates, 1, Apply changes.
             ["c", "1", "a"],
         )
@@ -465,7 +465,7 @@ class EditDuringImporterTestCase(
         # Check that 'title' field is modified, and other fields come from
         # the candidate.
         self.assertTrue(
-            all("Edited Title " in i.title for i in self.lib.items())
+            all("Edited Track " in i.title for i in self.lib.items())
         )
         self.assertTrue(all("match " in i.mb_trackid for i in self.lib.items()))
 
@@ -479,7 +479,7 @@ class EditDuringImporterTestCase(
         self._setup_import_session(singletons=True)
         # Edit track titles.
         self.run_mocked_interpreter(
-            {"replacements": {"Tag Title": "Edited Title"}},
+            {"replacements": {"Tag Track": "Edited Track"}},
             # eDit, Apply changes, aBort.
             ["d", "a", "b"],
         )
@@ -492,7 +492,7 @@ class EditDuringImporterTestCase(
             self.IGNORED + ["albumartist", "mb_albumartistid"],
         )
         self.assertTrue(
-            all("Edited Title" in i.title for i in self.lib.items())
+            all("Edited Track" in i.title for i in self.lib.items())
         )
 
     def test_edit_apply_candidate_singleton(self):
@@ -502,7 +502,7 @@ class EditDuringImporterTestCase(
         self._setup_import_session()
         # Edit track titles.
         self.run_mocked_interpreter(
-            {"replacements": {"Applied Title": "Edited Title"}},
+            {"replacements": {"Applied Track": "Edited Track"}},
             # edit Candidates, 1, Apply changes, aBort.
             ["c", "1", "a", "b"],
         )
@@ -510,6 +510,6 @@ class EditDuringImporterTestCase(
         # Check that 'title' field is modified, and other fields come from
         # the candidate.
         self.assertTrue(
-            all("Edited Title " in i.title for i in self.lib.items())
+            all("Edited Track " in i.title for i in self.lib.items())
         )
         self.assertTrue(all("match " in i.mb_trackid for i in self.lib.items()))

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -331,7 +331,7 @@ class EditDuringImporterTestCase(
     def setUp(self):
         super().setUp()
         # Create some mediafiles, and store them for comparison.
-        self._create_import_dir(3)
+        self.prepare_album_for_import()
         self.items_orig = [Item.from_path(f.path) for f in self.import_media]
         self.matcher = AutotagStub().install()
         self.matcher.matching = AutotagStub.GOOD

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -13,7 +13,6 @@
 # included in all copies or substantial portions of the Software.
 
 import codecs
-import unittest
 from unittest.mock import patch
 
 from beets.dbcore.query import TrueQuery
@@ -514,11 +513,3 @@ class EditDuringImporterTestCase(
             all("Edited Title " in i.title for i in self.lib.items())
         )
         self.assertTrue(all("match " in i.mb_trackid for i in self.lib.items()))
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -13,7 +13,6 @@
 # included in all copies or substantial portions of the Software.
 
 import codecs
-from typing import ClassVar
 from unittest.mock import patch
 
 from beets.dbcore.query import TrueQuery
@@ -329,17 +328,14 @@ class EditDuringImporterTestCase(
     """TODO"""
 
     IGNORED = ["added", "album_id", "id", "mtime", "path"]
-    singletons: ClassVar[bool]
 
     def setUp(self):
         super().setUp()
         # Create some mediafiles, and store them for comparison.
-        self.prepare_album_for_import()
-        self._setup_import_session(singletons=self.singletons)
+        self.prepare_album_for_import(1)
         self.items_orig = [Item.from_path(f.path) for f in self.import_media]
         self.matcher = AutotagStub().install()
         self.matcher.matching = AutotagStub.GOOD
-        self.config["import"]["timid"] = True
 
     def tearDown(self):
         EditPlugin.listeners = None
@@ -349,7 +345,9 @@ class EditDuringImporterTestCase(
 
 @_common.slow_test()
 class EditDuringImporterNonSingletonTest(EditDuringImporterTestCase):
-    singletons = False
+    def setUp(self):
+        super().setUp()
+        self.importer = self.setup_importer()
 
     def test_edit_apply_asis(self):
         """Edit the album field for all items in the library, apply changes,
@@ -497,7 +495,9 @@ class EditDuringImporterNonSingletonTest(EditDuringImporterTestCase):
 
 @_common.slow_test()
 class EditDuringImporterSingletonTest(EditDuringImporterTestCase):
-    singletons = True
+    def setUp(self):
+        super().setUp()
+        self.importer = self.setup_singleton_importer()
 
     def test_edit_apply_asis_singleton(self):
         """Edit the album field for all items in the library, apply changes,

--- a/test/plugins/test_embedart.py
+++ b/test/plugins/test_embedart.py
@@ -339,11 +339,3 @@ class ArtSimilarityTest(unittest.TestCase):
     def test_convert_failure(self, mock_extract, mock_subprocess):
         self._mock_popens(mock_extract, mock_subprocess, convert_status=1)
         self.assertIsNone(self._similarity(20))
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_embedart.py
+++ b/test/plugins/test_embedart.py
@@ -47,8 +47,8 @@ class EmbedartCliTest(FetchImageHelper, BeetsTestCase):
     abbey_differentpath = os.path.join(_common.RSRC, b"abbey-different.jpg")
 
     def setUp(self):
+        super().setUp()  # Converter is threaded
         self.io.install()
-        self.setup_beets()  # Converter is threaded
         self.load_plugins("embedart")
 
     def _setup_data(self, artpath=None):
@@ -59,7 +59,7 @@ class EmbedartCliTest(FetchImageHelper, BeetsTestCase):
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def test_embed_art_from_file_with_yes_input(self):
         self._setup_data()

--- a/test/plugins/test_embedart.py
+++ b/test/plugins/test_embedart.py
@@ -47,7 +47,6 @@ class EmbedartCliTest(TestHelper, FetchImageHelper):
     abbey_differentpath = os.path.join(_common.RSRC, b"abbey-different.jpg")
 
     def setUp(self):
-        self.io = _common.DummyIO()
         self.io.install()
         self.setup_beets()  # Converter is threaded
         self.load_plugins("embedart")

--- a/test/plugins/test_embedart.py
+++ b/test/plugins/test_embedart.py
@@ -24,7 +24,7 @@ from mediafile import MediaFile
 
 from beets import art, config, logging, ui
 from beets.test import _common
-from beets.test.helper import FetchImageHelper, TestHelper
+from beets.test.helper import BeetsTestCase, FetchImageHelper
 from beets.util import bytestring_path, displayable_path, syspath
 from beets.util.artresizer import ArtResizer
 
@@ -40,7 +40,7 @@ def require_artresizer_compare(test):
     return wrapper
 
 
-class EmbedartCliTest(TestHelper, FetchImageHelper):
+class EmbedartCliTest(FetchImageHelper, BeetsTestCase):
     small_artpath = os.path.join(_common.RSRC, b"image-2x3.jpg")
     abbey_artpath = os.path.join(_common.RSRC, b"abbey.jpg")
     abbey_similarpath = os.path.join(_common.RSRC, b"abbey-similar.jpg")

--- a/test/plugins/test_embedart.py
+++ b/test/plugins/test_embedart.py
@@ -24,7 +24,7 @@ from mediafile import MediaFile
 
 from beets import art, config, logging, ui
 from beets.test import _common
-from beets.test.helper import BeetsTestCase, FetchImageHelper
+from beets.test.helper import BeetsTestCase, FetchImageHelper, PluginMixin
 from beets.util import bytestring_path, displayable_path, syspath
 from beets.util.artresizer import ArtResizer
 
@@ -40,7 +40,8 @@ def require_artresizer_compare(test):
     return wrapper
 
 
-class EmbedartCliTest(FetchImageHelper, BeetsTestCase):
+class EmbedartCliTest(PluginMixin, FetchImageHelper, BeetsTestCase):
+    plugin = "embedart"
     small_artpath = os.path.join(_common.RSRC, b"image-2x3.jpg")
     abbey_artpath = os.path.join(_common.RSRC, b"abbey.jpg")
     abbey_similarpath = os.path.join(_common.RSRC, b"abbey-similar.jpg")
@@ -49,17 +50,12 @@ class EmbedartCliTest(FetchImageHelper, BeetsTestCase):
     def setUp(self):
         super().setUp()  # Converter is threaded
         self.io.install()
-        self.load_plugins("embedart")
 
     def _setup_data(self, artpath=None):
         if not artpath:
             artpath = self.small_artpath
         with open(syspath(artpath), "rb") as f:
             self.image_data = f.read()
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
 
     def test_embed_art_from_file_with_yes_input(self):
         self._setup_data()

--- a/test/plugins/test_embyupdate.py
+++ b/test/plugins/test_embyupdate.py
@@ -1,5 +1,3 @@
-import unittest
-
 import responses
 
 from beets.test.helper import PluginTestCase
@@ -235,11 +233,3 @@ class EmbyUpdateTest(PluginTestCase):
         self.assertEqual(response[0]["Id"], "2ec276a2642e54a19b612b9418a8bd3b")
 
         self.assertEqual(response[0]["Name"], "username")
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_embyupdate.py
+++ b/test/plugins/test_embyupdate.py
@@ -8,7 +8,7 @@ from beetsplug import embyupdate
 
 class EmbyUpdateTest(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("embyupdate")
 
         self.config["emby"] = {
@@ -19,7 +19,7 @@ class EmbyUpdateTest(BeetsTestCase):
         }
 
     def tearDown(self):
-        self.teardown_beets()
+        super().tearDown()
         self.unload_plugins()
 
     def test_api_url_only_name(self):

--- a/test/plugins/test_embyupdate.py
+++ b/test/plugins/test_embyupdate.py
@@ -2,14 +2,15 @@ import unittest
 
 import responses
 
-from beets.test.helper import BeetsTestCase
+from beets.test.helper import PluginTestCase
 from beetsplug import embyupdate
 
 
-class EmbyUpdateTest(BeetsTestCase):
+class EmbyUpdateTest(PluginTestCase):
+    plugin = "embyupdate"
+
     def setUp(self):
         super().setUp()
-        self.load_plugins("embyupdate")
 
         self.config["emby"] = {
             "host": "localhost",
@@ -17,10 +18,6 @@ class EmbyUpdateTest(BeetsTestCase):
             "username": "username",
             "password": "password",
         }
-
-    def tearDown(self):
-        super().tearDown()
-        self.unload_plugins()
 
     def test_api_url_only_name(self):
         self.assertEqual(

--- a/test/plugins/test_embyupdate.py
+++ b/test/plugins/test_embyupdate.py
@@ -2,11 +2,11 @@ import unittest
 
 import responses
 
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 from beetsplug import embyupdate
 
 
-class EmbyUpdateTest(unittest.TestCase, TestHelper):
+class EmbyUpdateTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
         self.load_plugins("embyupdate")

--- a/test/plugins/test_export.py
+++ b/test/plugins/test_export.py
@@ -27,13 +27,13 @@ from beets.test.helper import BeetsTestCase
 
 class ExportPluginTest(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("export")
         self.test_values = {"title": "xtitle", "album": "xalbum"}
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def execute_command(self, format_type, artist):
         query = ",".join(self.test_values.keys())

--- a/test/plugins/test_export.py
+++ b/test/plugins/test_export.py
@@ -22,18 +22,15 @@ import unittest
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
 
-from beets.test.helper import BeetsTestCase
+from beets.test.helper import PluginTestCase
 
 
-class ExportPluginTest(BeetsTestCase):
+class ExportPluginTest(PluginTestCase):
+    plugin = "export"
+
     def setUp(self):
         super().setUp()
-        self.load_plugins("export")
         self.test_values = {"title": "xtitle", "album": "xalbum"}
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
 
     def execute_command(self, format_type, artist):
         query = ",".join(self.test_values.keys())

--- a/test/plugins/test_export.py
+++ b/test/plugins/test_export.py
@@ -18,7 +18,6 @@
 
 import json
 import re  # used to test csv format
-import unittest
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
 
@@ -85,11 +84,3 @@ class ExportPluginTest(PluginTestCase):
                 txt = details.text
                 self.assertIn(tag, self.test_values, msg=tag)
                 self.assertEqual(self.test_values[tag], txt, msg=txt)
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_export.py
+++ b/test/plugins/test_export.py
@@ -22,10 +22,10 @@ import unittest
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
 
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 
 
-class ExportPluginTest(unittest.TestCase, TestHelper):
+class ExportPluginTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
         self.load_plugins("export")

--- a/test/plugins/test_fetchart.py
+++ b/test/plugins/test_fetchart.py
@@ -16,7 +16,6 @@
 import ctypes
 import os
 import sys
-import unittest
 
 from beets import util
 from beets.test.helper import PluginTestCase
@@ -99,11 +98,3 @@ class FetchartCliTest(PluginTestCase):
         self.run_command("fetchart")
         self.album.load()
         self.check_cover_is_stored()
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_fetchart.py
+++ b/test/plugins/test_fetchart.py
@@ -19,21 +19,18 @@ import sys
 import unittest
 
 from beets import util
-from beets.test.helper import BeetsTestCase
+from beets.test.helper import PluginTestCase
 
 
-class FetchartCliTest(BeetsTestCase):
+class FetchartCliTest(PluginTestCase):
+    plugin = "fetchart"
+
     def setUp(self):
         super().setUp()
-        self.load_plugins("fetchart")
         self.config["fetchart"]["cover_names"] = "c\xc3\xb6ver.jpg"
         self.config["art_filename"] = "mycover"
         self.album = self.add_album()
         self.cover_path = os.path.join(self.album.path, b"mycover.jpg")
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
 
     def check_cover_is_stored(self):
         self.assertEqual(self.album["artpath"], self.cover_path)

--- a/test/plugins/test_fetchart.py
+++ b/test/plugins/test_fetchart.py
@@ -24,7 +24,7 @@ from beets.test.helper import BeetsTestCase
 
 class FetchartCliTest(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("fetchart")
         self.config["fetchart"]["cover_names"] = "c\xc3\xb6ver.jpg"
         self.config["art_filename"] = "mycover"
@@ -33,7 +33,7 @@ class FetchartCliTest(BeetsTestCase):
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def check_cover_is_stored(self):
         self.assertEqual(self.album["artpath"], self.cover_path)

--- a/test/plugins/test_fetchart.py
+++ b/test/plugins/test_fetchart.py
@@ -19,10 +19,10 @@ import sys
 import unittest
 
 from beets import util
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 
 
-class FetchartCliTest(unittest.TestCase, TestHelper):
+class FetchartCliTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
         self.load_plugins("fetchart")

--- a/test/plugins/test_filefilter.py
+++ b/test/plugins/test_filefilter.py
@@ -31,13 +31,10 @@ from beetsplug.filefilter import FileFilterPlugin
 
 class FileFilterPluginTest(ImportTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.__create_import_dir(2)
         self._setup_import_session()
         config["import"]["pretend"] = True
-
-    def tearDown(self):
-        self.teardown_beets()
 
     def __copy_file(self, dest_path, metadata):
         # Copy files

--- a/test/plugins/test_filefilter.py
+++ b/test/plugins/test_filefilter.py
@@ -24,12 +24,12 @@ from mediafile import MediaFile
 
 from beets import config
 from beets.test import _common
-from beets.test.helper import ImportHelper, capture_log
+from beets.test.helper import ImportTestCase, capture_log
 from beets.util import bytestring_path, displayable_path, syspath
 from beetsplug.filefilter import FileFilterPlugin
 
 
-class FileFilterPluginTest(unittest.TestCase, ImportHelper):
+class FileFilterPluginTest(ImportTestCase):
     def setUp(self):
         self.setup_beets()
         self.__create_import_dir(2)

--- a/test/plugins/test_filefilter.py
+++ b/test/plugins/test_filefilter.py
@@ -18,7 +18,6 @@
 
 import os
 import shutil
-from typing import ClassVar
 
 from mediafile import MediaFile
 
@@ -30,17 +29,9 @@ from beetsplug.filefilter import FileFilterPlugin
 
 
 class FileFilterPluginMixin(ImportTestCase):
-    singletons: ClassVar[bool]
-
     def setUp(self):
         super().setUp()
         self.__create_import_dir(2)
-        self._setup_import_session()
-        config["import"]["pretend"] = True
-
-        import_files = [self.import_dir]
-        self._setup_import_session(singletons=self.singletons)
-        self.importer.paths = import_files
 
     def tearDown(self):
         self.unload_plugins()
@@ -112,7 +103,9 @@ class FileFilterPluginMixin(ImportTestCase):
 
 
 class FileFilterPluginNonSingletonTest(FileFilterPluginMixin):
-    singletons = False
+    def setUp(self):
+        super().setUp()
+        self.importer = self.setup_importer(pretend=True)
 
     def test_import_default(self):
         """The default configuration should import everything."""
@@ -189,7 +182,9 @@ class FileFilterPluginNonSingletonTest(FileFilterPluginMixin):
 
 
 class FileFilterPluginSingletonTest(FileFilterPluginMixin):
-    singletons = True
+    def setUp(self):
+        super().setUp()
+        self.importer = self.setup_singleton_importer(pretend=True)
 
     def test_import_global(self):
         config["filefilter"]["path"] = ".*track_1.*\\.mp3"

--- a/test/plugins/test_filefilter.py
+++ b/test/plugins/test_filefilter.py
@@ -18,7 +18,6 @@
 
 import os
 import shutil
-import unittest
 
 from mediafile import MediaFile
 
@@ -217,11 +216,3 @@ class FileFilterPluginTest(ImportTestCase):
             ],
             singletons=True,
         )
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_filefilter.py
+++ b/test/plugins/test_filefilter.py
@@ -46,10 +46,6 @@ class FileFilterPluginTest(ImportTestCase):
         medium.save()
 
     def __create_import_dir(self, count):
-        self.import_dir = os.path.join(self.temp_dir, b"testsrcdir")
-        if os.path.isdir(syspath(self.import_dir)):
-            shutil.rmtree(syspath(self.import_dir))
-
         self.artist_path = os.path.join(self.import_dir, b"artist")
         self.album_path = os.path.join(self.artist_path, b"album")
         self.misc_path = os.path.join(self.import_dir, b"misc")

--- a/test/plugins/test_filefilter.py
+++ b/test/plugins/test_filefilter.py
@@ -15,20 +15,17 @@
 """Tests for the `filefilter` plugin.
 """
 from beets import config
-from beets.test.helper import ImportTestCase
+from beets.test.helper import ImportTestCase, PluginMixin
 from beets.util import bytestring_path
-from beetsplug.filefilter import FileFilterPlugin
 
 
-class FileFilterPluginMixin(ImportTestCase):
+class FileFilterPluginMixin(PluginMixin, ImportTestCase):
+    plugin = "filefilter"
+    preload_plugin = False
+
     def setUp(self):
         super().setUp()
         self.prepare_tracks_for_import()
-
-    def tearDown(self):
-        self.unload_plugins()
-        FileFilterPlugin.listeners = None
-        super().tearDown()
 
     def prepare_tracks_for_import(self):
         self.album_track, self.other_album_track, self.single_track = (

--- a/test/plugins/test_filefilter.py
+++ b/test/plugins/test_filefilter.py
@@ -63,7 +63,7 @@ class FileFilterPluginTest(ImportTestCase):
         self.album_paths = []
         for i in range(count):
             metadata["track"] = i + 1
-            metadata["title"] = "Tag Title Album %d" % (i + 1)
+            metadata["title"] = "Tag Track Album %d" % (i + 1)
             track_file = bytestring_path("%02d - track.mp3" % (i + 1))
             dest_path = os.path.join(self.album_path, track_file)
             self.__copy_file(dest_path, metadata)
@@ -73,7 +73,7 @@ class FileFilterPluginTest(ImportTestCase):
         metadata["album"] = None
         for i in range(count):
             metadata["track"] = i + 10
-            metadata["title"] = "Tag Title Artist %d" % (i + 1)
+            metadata["title"] = "Tag Track Artist %d" % (i + 1)
             track_file = bytestring_path("track_%d.mp3" % (i + 1))
             dest_path = os.path.join(self.artist_path, track_file)
             self.__copy_file(dest_path, metadata)
@@ -83,7 +83,7 @@ class FileFilterPluginTest(ImportTestCase):
         for i in range(count):
             metadata["artist"] = "Artist %d" % (i + 42)
             metadata["track"] = i + 5
-            metadata["title"] = "Tag Title Misc %d" % (i + 1)
+            metadata["title"] = "Tag Track Misc %d" % (i + 1)
             track_file = bytestring_path("track_%d.mp3" % (i + 1))
             dest_path = os.path.join(self.misc_path, track_file)
             self.__copy_file(dest_path, metadata)

--- a/test/plugins/test_ftintitle.py
+++ b/test/plugins/test_ftintitle.py
@@ -169,11 +169,3 @@ class FtInTitlePluginTest(unittest.TestCase):
         self.assertTrue(ftintitle.contains_feat("Alice With Bob"))
         self.assertFalse(ftintitle.contains_feat("Alice defeat Bob"))
         self.assertFalse(ftintitle.contains_feat("Aliceft.Bob"))
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_ftintitle.py
+++ b/test/plugins/test_ftintitle.py
@@ -17,19 +17,12 @@
 
 import unittest
 
-from beets.test.helper import BeetsTestCase
+from beets.test.helper import PluginTestCase
 from beetsplug import ftintitle
 
 
-class FtInTitlePluginFunctional(BeetsTestCase):
-    def setUp(self):
-        """Set up configuration"""
-        super().setUp()
-        self.load_plugins("ftintitle")
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
+class FtInTitlePluginFunctional(PluginTestCase):
+    plugin = "ftintitle"
 
     def _ft_add_item(self, path, artist, title, aartist):
         return self.add_item(

--- a/test/plugins/test_ftintitle.py
+++ b/test/plugins/test_ftintitle.py
@@ -17,11 +17,11 @@
 
 import unittest
 
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 from beetsplug import ftintitle
 
 
-class FtInTitlePluginFunctional(unittest.TestCase, TestHelper):
+class FtInTitlePluginFunctional(BeetsTestCase):
     def setUp(self):
         """Set up configuration"""
         self.setup_beets()

--- a/test/plugins/test_ftintitle.py
+++ b/test/plugins/test_ftintitle.py
@@ -24,12 +24,12 @@ from beetsplug import ftintitle
 class FtInTitlePluginFunctional(BeetsTestCase):
     def setUp(self):
         """Set up configuration"""
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("ftintitle")
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def _ft_add_item(self, path, artist, title, aartist):
         return self.add_item(

--- a/test/plugins/test_hook.py
+++ b/test/plugins/test_hook.py
@@ -13,148 +13,112 @@
 # included in all copies or substantial portions of the Software.
 
 
+from __future__ import annotations
+
 import os.path
 import sys
-import tempfile
 import unittest
+from contextlib import contextmanager
+from typing import Callable, Iterator
 
-from beets import config, plugins
-from beets.test.helper import BeetsTestCase, PluginMixin, capture_log
-
-
-def get_temporary_path():
-    temporary_directory = tempfile._get_default_tempdir()
-    temporary_name = next(tempfile._get_candidate_names())
-
-    return os.path.join(temporary_directory, temporary_name)
+from beets import plugins
+from beets.test.helper import PluginTestCase, capture_log
 
 
-class HookTest(PluginMixin, BeetsTestCase):
+class HookTestCase(PluginTestCase):
     plugin = "hook"
     preload_plugin = False
-    TEST_HOOK_COUNT = 5
 
-    def _add_hook(self, event, command):
-        hook = {"event": event, "command": command}
+    def _get_hook(self, event: str, command: str) -> dict[str, str]:
+        return {"event": event, "command": command}
 
-        hooks = config["hook"]["hooks"].get(list) if "hook" in config else []
-        hooks.append(hook)
 
-        config["hook"]["hooks"] = hooks
+class HookLogsTest(HookTestCase):
+    @contextmanager
+    def _configure_logs(self, command: str) -> Iterator[list[str]]:
+        config = {"hooks": [self._get_hook("test_event", command)]}
+
+        with self.configure_plugin(config), capture_log("beets.hook") as logs:
+            plugins.send("test_event")
+            yield logs
 
     def test_hook_empty_command(self):
-        self._add_hook("test_event", "")
-
-        self.load_plugins("hook")
-
-        with capture_log("beets.hook") as logs:
-            plugins.send("test_event")
-
-        self.assertIn('hook: invalid command ""', logs)
+        with self._configure_logs("") as logs:
+            self.assertIn('hook: invalid command ""', logs)
 
     # FIXME: fails on windows
     @unittest.skipIf(sys.platform == "win32", "win32")
     def test_hook_non_zero_exit(self):
-        self._add_hook("test_event", 'sh -c "exit 1"')
-
-        self.load_plugins("hook")
-
-        with capture_log("beets.hook") as logs:
-            plugins.send("test_event")
-
-        self.assertIn("hook: hook for test_event exited with status 1", logs)
+        with self._configure_logs('sh -c "exit 1"') as logs:
+            self.assertIn(
+                "hook: hook for test_event exited with status 1", logs
+            )
 
     def test_hook_non_existent_command(self):
-        self._add_hook("test_event", "non-existent-command")
+        with self._configure_logs("non-existent-command") as logs:
+            logs = "\n".join(logs)
 
-        self.load_plugins("hook")
+        self.assertIn("hook: hook for test_event failed: ", logs)
+        # The error message is different for each OS. Unfortunately the text is
+        # different in each case, where the only shared text is the string
+        # 'file' and substring 'Err'
+        self.assertIn("Err", logs)
+        self.assertIn("file", logs)
 
-        with capture_log("beets.hook") as logs:
-            plugins.send("test_event")
 
-        self.assertTrue(
-            any(
-                message.startswith("hook: hook for test_event failed: ")
-                for message in logs
-            )
-        )
+class HookCommandTest(HookTestCase):
+    TEST_HOOK_COUNT = 2
 
-    # FIXME: fails on windows
+    events = [f"test_event_{i}" for i in range(TEST_HOOK_COUNT)]
+
+    def setUp(self):
+        super().setUp()
+        temp_dir = os.fsdecode(self.temp_dir)
+        self.paths = [os.path.join(temp_dir, e) for e in self.events]
+
+    def _test_command(
+        self,
+        make_test_path: Callable[[str, str], str],
+        send_path_kwarg: bool = False,
+    ) -> None:
+        """Check that each of the configured hooks is executed.
+
+        Configure hooks for each event:
+        1. Use the given 'make_test_path' callable to create a test path from the event
+           and the original path.
+        2. Configure a hook with a command to touch this path.
+
+        For each of the original paths:
+        1. Send a test event
+        2. Assert that a file has been created under the original path, which proves
+           that the configured hook command has been executed.
+        """
+        hooks = [
+            self._get_hook(e, f"touch {make_test_path(e, p)}")
+            for e, p in zip(self.events, self.paths)
+        ]
+
+        with self.configure_plugin({"hooks": hooks}):
+            for event, path in zip(self.events, self.paths):
+                if send_path_kwarg:
+                    plugins.send(event, path=path)
+                else:
+                    plugins.send(event)
+                self.assertTrue(os.path.isfile(path))
+
     @unittest.skipIf(sys.platform == "win32", "win32")
     def test_hook_no_arguments(self):
-        temporary_paths = [
-            get_temporary_path() for i in range(self.TEST_HOOK_COUNT)
-        ]
+        self._test_command(lambda _, p: p)
 
-        for index, path in enumerate(temporary_paths):
-            self._add_hook(f"test_no_argument_event_{index}", f'touch "{path}"')
-
-        self.load_plugins("hook")
-
-        for index in range(len(temporary_paths)):
-            plugins.send(f"test_no_argument_event_{index}")
-
-        for path in temporary_paths:
-            self.assertTrue(os.path.isfile(path))
-            os.remove(path)
-
-    # FIXME: fails on windows
     @unittest.skipIf(sys.platform == "win32", "win32")
     def test_hook_event_substitution(self):
-        temporary_directory = tempfile._get_default_tempdir()
-        event_names = [
-            f"test_event_event_{i}" for i in range(self.TEST_HOOK_COUNT)
-        ]
+        self._test_command(lambda e, p: p.replace(e, "{event}"))
 
-        for event in event_names:
-            self._add_hook(event, f'touch "{temporary_directory}/{{event}}"')
-
-        self.load_plugins("hook")
-
-        for event in event_names:
-            plugins.send(event)
-
-        for event in event_names:
-            path = os.path.join(temporary_directory, event)
-
-            self.assertTrue(os.path.isfile(path))
-            os.remove(path)
-
-    # FIXME: fails on windows
     @unittest.skipIf(sys.platform == "win32", "win32")
     def test_hook_argument_substitution(self):
-        temporary_paths = [
-            get_temporary_path() for i in range(self.TEST_HOOK_COUNT)
-        ]
+        self._test_command(lambda *_: "{path}", send_path_kwarg=True)
 
-        for index, path in enumerate(temporary_paths):
-            self._add_hook(f"test_argument_event_{index}", 'touch "{path}"')
-
-        self.load_plugins("hook")
-
-        for index, path in enumerate(temporary_paths):
-            plugins.send(f"test_argument_event_{index}", path=path)
-
-        for path in temporary_paths:
-            self.assertTrue(os.path.isfile(path))
-            os.remove(path)
-
-    # FIXME: fails on windows
     @unittest.skipIf(sys.platform == "win32", "win32")
     def test_hook_bytes_interpolation(self):
-        temporary_paths = [
-            get_temporary_path().encode("utf-8")
-            for i in range(self.TEST_HOOK_COUNT)
-        ]
-
-        for index, path in enumerate(temporary_paths):
-            self._add_hook(f"test_bytes_event_{index}", 'touch "{path}"')
-
-        self.load_plugins("hook")
-
-        for index, path in enumerate(temporary_paths):
-            plugins.send(f"test_bytes_event_{index}", path=path)
-
-        for path in temporary_paths:
-            self.assertTrue(os.path.isfile(path))
-            os.remove(path)
+        self.paths = [p.encode() for p in self.paths]
+        self._test_command(lambda *_: "{path}", send_path_kwarg=True)

--- a/test/plugins/test_hook.py
+++ b/test/plugins/test_hook.py
@@ -32,12 +32,9 @@ def get_temporary_path():
 class HookTest(BeetsTestCase):
     TEST_HOOK_COUNT = 5
 
-    def setUp(self):
-        self.setup_beets()
-
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def _add_hook(self, event, command):
         hook = {"event": event, "command": command}

--- a/test/plugins/test_hook.py
+++ b/test/plugins/test_hook.py
@@ -19,8 +19,7 @@ import tempfile
 import unittest
 
 from beets import config, plugins
-from beets.test import _common
-from beets.test.helper import TestHelper, capture_log
+from beets.test.helper import BeetsTestCase, capture_log
 
 
 def get_temporary_path():
@@ -30,7 +29,7 @@ def get_temporary_path():
     return os.path.join(temporary_directory, temporary_name)
 
 
-class HookTest(_common.TestCase, TestHelper):
+class HookTest(BeetsTestCase):
     TEST_HOOK_COUNT = 5
 
     def setUp(self):

--- a/test/plugins/test_hook.py
+++ b/test/plugins/test_hook.py
@@ -19,7 +19,7 @@ import tempfile
 import unittest
 
 from beets import config, plugins
-from beets.test.helper import BeetsTestCase, capture_log
+from beets.test.helper import BeetsTestCase, PluginMixin, capture_log
 
 
 def get_temporary_path():
@@ -29,12 +29,10 @@ def get_temporary_path():
     return os.path.join(temporary_directory, temporary_name)
 
 
-class HookTest(BeetsTestCase):
+class HookTest(PluginMixin, BeetsTestCase):
+    plugin = "hook"
+    preload_plugin = False
     TEST_HOOK_COUNT = 5
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
 
     def _add_hook(self, event, command):
         hook = {"event": event, "command": command}

--- a/test/plugins/test_hook.py
+++ b/test/plugins/test_hook.py
@@ -160,11 +160,3 @@ class HookTest(BeetsTestCase):
         for path in temporary_paths:
             self.assertTrue(os.path.isfile(path))
             os.remove(path)
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_ihate.py
+++ b/test/plugins/test_ihate.py
@@ -43,11 +43,3 @@ class IHatePluginTest(unittest.TestCase):
             "artist:testartist album:notthis",
         ]
         self.assertTrue(IHatePlugin.do_i_hate_this(task, match_pattern))
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_importadded.py
+++ b/test/plugins/test_importadded.py
@@ -47,7 +47,7 @@ class ImportAddedTest(PluginMixin, ImportTestCase):
     def setUp(self):
         preserve_plugin_listeners()
         super().setUp()
-        self._create_import_dir(2)
+        self.prepare_album_for_import(2)
         # Different mtimes on the files to be imported in order to test the
         # plugin
         modify_mtimes(mfile.path for mfile in self.import_media)

--- a/test/plugins/test_importadded.py
+++ b/test/plugins/test_importadded.py
@@ -50,9 +50,9 @@ class ImportAddedTest(PluginMixin, ImportTestCase):
         self._create_import_dir(2)
         # Different mtimes on the files to be imported in order to test the
         # plugin
-        modify_mtimes(mfile.path for mfile in self.media_files)
+        modify_mtimes(mfile.path for mfile in self.import_media)
         self.min_mtime = min(
-            os.path.getmtime(mfile.path) for mfile in self.media_files
+            os.path.getmtime(mfile.path) for mfile in self.import_media
         )
         self.matcher = AutotagStub().install()
         self.matcher.macthin = AutotagStub.GOOD
@@ -65,7 +65,7 @@ class ImportAddedTest(PluginMixin, ImportTestCase):
 
     def find_media_file(self, item):
         """Find the pre-import MediaFile for an Item"""
-        for m in self.media_files:
+        for m in self.import_media:
             if m.title.replace("Tag", "Applied") == item.title:
                 return m
         raise AssertionError(

--- a/test/plugins/test_importadded.py
+++ b/test/plugins/test_importadded.py
@@ -46,7 +46,7 @@ class ImportAddedTest(ImportTestCase):
 
     def setUp(self):
         preserve_plugin_listeners()
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("importadded")
         self._create_import_dir(2)
         # Different mtimes on the files to be imported in order to test the
@@ -62,7 +62,7 @@ class ImportAddedTest(ImportTestCase):
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
         self.matcher.restore()
 
     def find_media_file(self, item):

--- a/test/plugins/test_importadded.py
+++ b/test/plugins/test_importadded.py
@@ -16,7 +16,6 @@
 """Tests for the `importadded` plugin."""
 
 import os
-import unittest
 
 from beets import importer
 from beets.test.helper import AutotagStub, ImportTestCase, PluginMixin
@@ -167,11 +166,3 @@ class ImportAddedTest(PluginMixin, ImportTestCase):
                 "reimport modified Item.added for "
                 + displayable_path(item_path),
             )
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_importadded.py
+++ b/test/plugins/test_importadded.py
@@ -19,7 +19,7 @@ import os
 import unittest
 
 from beets import importer
-from beets.test.helper import AutotagStub, ImportTestCase
+from beets.test.helper import AutotagStub, ImportTestCase, PluginMixin
 from beets.util import displayable_path, syspath
 from beetsplug.importadded import ImportAddedPlugin
 
@@ -40,14 +40,14 @@ def modify_mtimes(paths, offset=-60000):
         os.utime(syspath(path), (mstat.st_atime, mstat.st_mtime + offset * i))
 
 
-class ImportAddedTest(ImportTestCase):
+class ImportAddedTest(PluginMixin, ImportTestCase):
     # The minimum mtime of the files to be imported
+    plugin = "importadded"
     min_mtime = None
 
     def setUp(self):
         preserve_plugin_listeners()
         super().setUp()
-        self.load_plugins("importadded")
         self._create_import_dir(2)
         # Different mtimes on the files to be imported in order to test the
         # plugin
@@ -61,7 +61,6 @@ class ImportAddedTest(ImportTestCase):
         self.importer.add_choice(importer.action.APPLY)
 
     def tearDown(self):
-        self.unload_plugins()
         super().tearDown()
         self.matcher.restore()
 

--- a/test/plugins/test_importadded.py
+++ b/test/plugins/test_importadded.py
@@ -56,7 +56,7 @@ class ImportAddedTest(PluginMixin, ImportTestCase):
         )
         self.matcher = AutotagStub().install()
         self.matcher.macthin = AutotagStub.GOOD
-        self._setup_import_session()
+        self.importer = self.setup_importer()
         self.importer.add_choice(importer.action.APPLY)
 
     def tearDown(self):
@@ -113,7 +113,7 @@ class ImportAddedTest(PluginMixin, ImportTestCase):
         # Newer Item path mtimes as if Beets had modified them
         modify_mtimes(items_added_before.keys(), offset=10000)
         # Reimport
-        self._setup_import_session(import_dir=album.path)
+        self.setup_importer(import_dir=self.libdir)
         self.importer.run()
         # Verify the reimported items
         album = self.lib.albums().get()
@@ -154,8 +154,7 @@ class ImportAddedTest(PluginMixin, ImportTestCase):
         # Newer Item path mtimes as if Beets had modified them
         modify_mtimes(items_added_before.keys(), offset=10000)
         # Reimport
-        import_dir = os.path.dirname(list(items_added_before.keys())[0])
-        self._setup_import_session(import_dir=import_dir, singletons=True)
+        self.setup_importer(import_dir=self.libdir, singletons=True)
         self.importer.run()
         # Verify the reimported items
         items_added_after = {item.path: item.added for item in self.lib.items()}

--- a/test/plugins/test_importadded.py
+++ b/test/plugins/test_importadded.py
@@ -19,7 +19,7 @@ import os
 import unittest
 
 from beets import importer
-from beets.test.helper import AutotagStub, ImportHelper
+from beets.test.helper import AutotagStub, ImportTestCase
 from beets.util import displayable_path, syspath
 from beetsplug.importadded import ImportAddedPlugin
 
@@ -40,7 +40,7 @@ def modify_mtimes(paths, offset=-60000):
         os.utime(syspath(path), (mstat.st_atime, mstat.st_mtime + offset * i))
 
 
-class ImportAddedTest(unittest.TestCase, ImportHelper):
+class ImportAddedTest(ImportTestCase):
     # The minimum mtime of the files to be imported
     min_mtime = None
 

--- a/test/plugins/test_importfeeds.py
+++ b/test/plugins/test_importfeeds.py
@@ -1,26 +1,20 @@
 import datetime
 import os
 import os.path
-import shutil
-import tempfile
 import unittest
 
 from beets import config
-from beets.library import Album, Item, Library
+from beets.library import Album, Item
+from beets.test.helper import BeetsTestCase
 from beetsplug.importfeeds import ImportFeedsPlugin
 
 
-class ImportfeedsTestTest(unittest.TestCase):
+class ImportfeedsTestTest(BeetsTestCase):
     def setUp(self):
-        config.clear()
-        config.read(user=False)
+        super().setUp()
         self.importfeeds = ImportFeedsPlugin()
-        self.lib = Library(":memory:")
-        self.feeds_dir = tempfile.mkdtemp()
+        self.feeds_dir = os.path.join(os.fsdecode(self.temp_dir), "importfeeds")
         config["importfeeds"]["dir"] = self.feeds_dir
-
-    def tearDown(self):
-        shutil.rmtree(self.feeds_dir)
 
     def test_multi_format_album_playlist(self):
         config["importfeeds"]["formats"] = "m3u_multi"

--- a/test/plugins/test_importfeeds.py
+++ b/test/plugins/test_importfeeds.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 import os.path
-import unittest
 
 from beets import config
 from beets.library import Album, Item
@@ -67,11 +66,3 @@ class ImportfeedsTestTest(BeetsTestCase):
         self.assertTrue(os.path.isfile(playlist))
         with open(playlist) as playlist_contents:
             self.assertIn(item_path, playlist_contents.read())
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_info.py
+++ b/test/plugins/test_info.py
@@ -13,8 +13,6 @@
 # included in all copies or substantial portions of the Software.
 
 
-import unittest
-
 from mediafile import MediaFile
 
 from beets.test.helper import PluginTestCase
@@ -118,11 +116,3 @@ class InfoTest(PluginTestCase):
             "$track. $title - $artist ($length)",
         )
         self.assertEqual("02. tïtle 0 - the artist (0:01)\n", out)
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_info.py
+++ b/test/plugins/test_info.py
@@ -17,18 +17,12 @@ import unittest
 
 from mediafile import MediaFile
 
-from beets.test.helper import BeetsTestCase
+from beets.test.helper import PluginTestCase
 from beets.util import displayable_path
 
 
-class InfoTest(BeetsTestCase):
-    def setUp(self):
-        super().setUp()
-        self.load_plugins("info")
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
+class InfoTest(PluginTestCase):
+    plugin = "info"
 
     def test_path(self):
         path = self.create_mediafile_fixture()

--- a/test/plugins/test_info.py
+++ b/test/plugins/test_info.py
@@ -23,12 +23,12 @@ from beets.util import displayable_path
 
 class InfoTest(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("info")
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def test_path(self):
         path = self.create_mediafile_fixture()

--- a/test/plugins/test_info.py
+++ b/test/plugins/test_info.py
@@ -17,11 +17,11 @@ import unittest
 
 from mediafile import MediaFile
 
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 from beets.util import displayable_path
 
 
-class InfoTest(unittest.TestCase, TestHelper):
+class InfoTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
         self.load_plugins("info")

--- a/test/plugins/test_ipfs.py
+++ b/test/plugins/test_ipfs.py
@@ -18,13 +18,13 @@ from unittest.mock import Mock, patch
 
 from beets import library
 from beets.test import _common
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 from beets.util import _fsencoding, bytestring_path
 from beetsplug.ipfs import IPFSPlugin
 
 
 @patch("beets.util.command_output", Mock())
-class IPFSPluginTest(unittest.TestCase, TestHelper):
+class IPFSPluginTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
         self.load_plugins("ipfs")

--- a/test/plugins/test_ipfs.py
+++ b/test/plugins/test_ipfs.py
@@ -17,20 +17,14 @@ import unittest
 from unittest.mock import Mock, patch
 
 from beets.test import _common
-from beets.test.helper import BeetsTestCase
+from beets.test.helper import PluginTestCase
 from beets.util import _fsencoding, bytestring_path
 from beetsplug.ipfs import IPFSPlugin
 
 
 @patch("beets.util.command_output", Mock())
-class IPFSPluginTest(BeetsTestCase):
-    def setUp(self):
-        super().setUp()
-        self.load_plugins("ipfs")
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
+class IPFSPluginTest(PluginTestCase):
+    plugin = "ipfs"
 
     def test_stored_hashes(self):
         test_album = self.mk_test_album()

--- a/test/plugins/test_ipfs.py
+++ b/test/plugins/test_ipfs.py
@@ -16,7 +16,6 @@ import os
 import unittest
 from unittest.mock import Mock, patch
 
-from beets import library
 from beets.test import _common
 from beets.test.helper import BeetsTestCase
 from beets.util import _fsencoding, bytestring_path
@@ -28,7 +27,6 @@ class IPFSPluginTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
         self.load_plugins("ipfs")
-        self.lib = library.Library(":memory:")
 
     def tearDown(self):
         self.unload_plugins()

--- a/test/plugins/test_ipfs.py
+++ b/test/plugins/test_ipfs.py
@@ -26,13 +26,13 @@ from beetsplug.ipfs import IPFSPlugin
 @patch("beets.util.command_output", Mock())
 class IPFSPluginTest(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("ipfs")
         self.lib = library.Library(":memory:")
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def test_stored_hashes(self):
         test_album = self.mk_test_album()

--- a/test/plugins/test_ipfs.py
+++ b/test/plugins/test_ipfs.py
@@ -13,7 +13,6 @@
 
 
 import os
-import unittest
 from unittest.mock import Mock, patch
 
 from beets.test import _common
@@ -79,11 +78,3 @@ class IPFSPluginTest(PluginTestCase):
         album.store(inherit=False)
 
         return album
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_keyfinder.py
+++ b/test/plugins/test_keyfinder.py
@@ -17,11 +17,11 @@ from unittest.mock import patch
 
 from beets import util
 from beets.library import Item
-from beets.test.helper import ImportTestCase, PluginMixin
+from beets.test.helper import AsIsImporterMixin, ImportTestCase, PluginMixin
 
 
 @patch("beets.util.command_output")
-class KeyFinderTest(PluginMixin, ImportTestCase):
+class KeyFinderTest(AsIsImporterMixin, PluginMixin, ImportTestCase):
     plugin = "keyfinder"
 
     def test_add_key(self, command_output):
@@ -39,8 +39,7 @@ class KeyFinderTest(PluginMixin, ImportTestCase):
 
     def test_add_key_on_import(self, command_output):
         command_output.return_value = util.CommandOutput(b"dbm", b"")
-        self.prepare_album_for_import(1)
-        self.setup_importer(autotag=False).run()
+        self.run_asis_importer()
 
         item = self.lib.items().get()
         self.assertEqual(item["initial_key"], "C#m")

--- a/test/plugins/test_keyfinder.py
+++ b/test/plugins/test_keyfinder.py
@@ -39,8 +39,8 @@ class KeyFinderTest(PluginMixin, ImportTestCase):
 
     def test_add_key_on_import(self, command_output):
         command_output.return_value = util.CommandOutput(b"dbm", b"")
-        importer = self.create_importer()
-        importer.run()
+        self.prepare_album_for_import(1)
+        self.setup_importer(autotag=False).run()
 
         item = self.lib.items().get()
         self.assertEqual(item["initial_key"], "C#m")

--- a/test/plugins/test_keyfinder.py
+++ b/test/plugins/test_keyfinder.py
@@ -18,11 +18,11 @@ from unittest.mock import patch
 
 from beets import util
 from beets.library import Item
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 
 
 @patch("beets.util.command_output")
-class KeyFinderTest(unittest.TestCase, TestHelper):
+class KeyFinderTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
         self.load_plugins("keyfinder")

--- a/test/plugins/test_keyfinder.py
+++ b/test/plugins/test_keyfinder.py
@@ -18,18 +18,12 @@ from unittest.mock import patch
 
 from beets import util
 from beets.library import Item
-from beets.test.helper import BeetsTestCase
+from beets.test.helper import PluginTestCase
 
 
 @patch("beets.util.command_output")
-class KeyFinderTest(BeetsTestCase):
-    def setUp(self):
-        super().setUp()
-        self.load_plugins("keyfinder")
-
-    def tearDown(self):
-        super().tearDown()
-        self.unload_plugins()
+class KeyFinderTest(PluginTestCase):
+    plugin = "keyfinder"
 
     def test_add_key(self, command_output):
         item = Item(path="/file")

--- a/test/plugins/test_keyfinder.py
+++ b/test/plugins/test_keyfinder.py
@@ -17,11 +17,11 @@ from unittest.mock import patch
 
 from beets import util
 from beets.library import Item
-from beets.test.helper import PluginTestCase
+from beets.test.helper import ImportTestCase, PluginMixin
 
 
 @patch("beets.util.command_output")
-class KeyFinderTest(PluginTestCase):
+class KeyFinderTest(PluginMixin, ImportTestCase):
     plugin = "keyfinder"
 
     def test_add_key(self, command_output):

--- a/test/plugins/test_keyfinder.py
+++ b/test/plugins/test_keyfinder.py
@@ -13,7 +13,6 @@
 # included in all copies or substantial portions of the Software.
 
 
-import unittest
 from unittest.mock import patch
 
 from beets import util
@@ -77,11 +76,3 @@ class KeyFinderTest(PluginTestCase):
 
         item.load()
         self.assertIsNone(item["initial_key"])
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_keyfinder.py
+++ b/test/plugins/test_keyfinder.py
@@ -24,11 +24,11 @@ from beets.test.helper import BeetsTestCase
 @patch("beets.util.command_output")
 class KeyFinderTest(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("keyfinder")
 
     def tearDown(self):
-        self.teardown_beets()
+        super().tearDown()
         self.unload_plugins()
 
     def test_add_key(self, command_output):

--- a/test/plugins/test_lastgenre.py
+++ b/test/plugins/test_lastgenre.py
@@ -20,11 +20,11 @@ from unittest.mock import Mock
 
 from beets import config
 from beets.test import _common
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 from beetsplug import lastgenre
 
 
-class LastGenrePluginTest(unittest.TestCase, TestHelper):
+class LastGenrePluginTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
         self.plugin = lastgenre.LastGenrePlugin()

--- a/test/plugins/test_lastgenre.py
+++ b/test/plugins/test_lastgenre.py
@@ -26,11 +26,8 @@ from beetsplug import lastgenre
 
 class LastGenrePluginTest(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.plugin = lastgenre.LastGenrePlugin()
-
-    def tearDown(self):
-        self.teardown_beets()
 
     def _setup_config(
         self, whitelist=False, canonical=False, count=1, prefer_specific=False

--- a/test/plugins/test_lastgenre.py
+++ b/test/plugins/test_lastgenre.py
@@ -15,7 +15,6 @@
 """Tests for the 'lastgenre' plugin."""
 
 
-import unittest
 from unittest.mock import Mock
 
 from beets import config
@@ -230,11 +229,3 @@ class LastGenrePluginTest(BeetsTestCase):
         tags = ("electronic", "ambient", "chillout")
         res = self.plugin._sort_by_depth(tags)
         self.assertEqual(res, ["ambient", "electronic"])
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_limit.py
+++ b/test/plugins/test_limit.py
@@ -15,10 +15,10 @@
 
 import unittest
 
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 
 
-class LimitPluginTest(unittest.TestCase, TestHelper):
+class LimitPluginTest(BeetsTestCase):
     """Unit tests for LimitPlugin
 
     Note: query prefix tests do not work correctly with `run_with_output`.

--- a/test/plugins/test_limit.py
+++ b/test/plugins/test_limit.py
@@ -13,7 +13,6 @@
 
 """Tests for the 'limit' plugin."""
 
-import unittest
 
 from beets.test.helper import PluginTestCase
 
@@ -94,11 +93,3 @@ class LimitPluginTest(PluginTestCase):
         incorrect_order = self.num_limit_prefix + " " + self.track_tail_range
         result = self.lib.items(incorrect_order)
         self.assertEqual(len(result), 0)
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_limit.py
+++ b/test/plugins/test_limit.py
@@ -15,18 +15,19 @@
 
 import unittest
 
-from beets.test.helper import BeetsTestCase
+from beets.test.helper import PluginTestCase
 
 
-class LimitPluginTest(BeetsTestCase):
+class LimitPluginTest(PluginTestCase):
     """Unit tests for LimitPlugin
 
     Note: query prefix tests do not work correctly with `run_with_output`.
     """
 
+    plugin = "limit"
+
     def setUp(self):
         super().setUp()
-        self.load_plugins("limit")
 
         # we'll create an even number of tracks in the library
         self.num_test_items = 10
@@ -45,10 +46,6 @@ class LimitPluginTest(BeetsTestCase):
         # range filter on the track number
         self.track_head_range = "track:.." + str(self.num_limit)
         self.track_tail_range = "track:" + str(self.num_limit + 1) + ".."
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
 
     def test_no_limit(self):
         """Returns all when there is no limit or filter."""

--- a/test/plugins/test_limit.py
+++ b/test/plugins/test_limit.py
@@ -25,7 +25,7 @@ class LimitPluginTest(BeetsTestCase):
     """
 
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("limit")
 
         # we'll create an even number of tracks in the library
@@ -48,7 +48,7 @@ class LimitPluginTest(BeetsTestCase):
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def test_no_limit(self):
         """Returns all when there is no limit or filter."""

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -816,11 +816,3 @@ class SlugTests(unittest.TestCase):
         dashes = ["\u200D", "\u2010"]
         for dash1, dash2 in itertools.combinations(dashes, 2):
             self.assertEqual(lyrics.slug(dash1), lyrics.slug(dash2))
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_mbsubmit.py
+++ b/test/plugins/test_mbsubmit.py
@@ -18,13 +18,13 @@ import unittest
 from beets.test.helper import (
     AutotagStub,
     ImportTestCase,
-    TerminalImportSessionSetup,
+    TerminalImportMixin,
     capture_stdout,
     control_stdin,
 )
 
 
-class MBSubmitPluginTest(TerminalImportSessionSetup, ImportTestCase):
+class MBSubmitPluginTest(TerminalImportMixin, ImportTestCase):
     def setUp(self):
         self.setup_beets()
         self.load_plugins("mbsubmit")

--- a/test/plugins/test_mbsubmit.py
+++ b/test/plugins/test_mbsubmit.py
@@ -29,7 +29,7 @@ class MBSubmitPluginTest(PluginMixin, TerminalImportMixin, ImportTestCase):
     def setUp(self):
         super().setUp()
         self.prepare_album_for_import(2)
-        self._setup_import_session()
+        self.setup_importer()
         self.matcher = AutotagStub().install()
 
     def tearDown(self):

--- a/test/plugins/test_mbsubmit.py
+++ b/test/plugins/test_mbsubmit.py
@@ -13,8 +13,6 @@
 # included in all copies or substantial portions of the Software.
 
 
-import unittest
-
 from beets.test.helper import (
     AutotagStub,
     ImportTestCase,
@@ -69,11 +67,3 @@ class MBSubmitPluginTest(PluginMixin, TerminalImportMixin, ImportTestCase):
             "Open files with Picard? " "02. Tag Title 2 - Tag Artist (0:01)"
         )
         self.assertIn(tracklist, output.getvalue())
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_mbsubmit.py
+++ b/test/plugins/test_mbsubmit.py
@@ -17,17 +17,14 @@ import unittest
 
 from beets.test.helper import (
     AutotagStub,
-    BeetsTestCase,
-    ImportHelper,
+    ImportTestCase,
     TerminalImportSessionSetup,
     capture_stdout,
     control_stdin,
 )
 
 
-class MBSubmitPluginTest(
-    TerminalImportSessionSetup, BeetsTestCase, ImportHelper
-):
+class MBSubmitPluginTest(TerminalImportSessionSetup, ImportTestCase):
     def setUp(self):
         self.setup_beets()
         self.load_plugins("mbsubmit")

--- a/test/plugins/test_mbsubmit.py
+++ b/test/plugins/test_mbsubmit.py
@@ -26,7 +26,7 @@ from beets.test.helper import (
 
 class MBSubmitPluginTest(TerminalImportMixin, ImportTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("mbsubmit")
         self._create_import_dir(2)
         self._setup_import_session()
@@ -34,7 +34,7 @@ class MBSubmitPluginTest(TerminalImportMixin, ImportTestCase):
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
         self.matcher.restore()
 
     def test_print_tracks_output(self):

--- a/test/plugins/test_mbsubmit.py
+++ b/test/plugins/test_mbsubmit.py
@@ -28,7 +28,7 @@ class MBSubmitPluginTest(PluginMixin, TerminalImportMixin, ImportTestCase):
 
     def setUp(self):
         super().setUp()
-        self._create_import_dir(2)
+        self.prepare_album_for_import(2)
         self._setup_import_session()
         self.matcher = AutotagStub().install()
 

--- a/test/plugins/test_mbsubmit.py
+++ b/test/plugins/test_mbsubmit.py
@@ -18,22 +18,23 @@ import unittest
 from beets.test.helper import (
     AutotagStub,
     ImportTestCase,
+    PluginMixin,
     TerminalImportMixin,
     capture_stdout,
     control_stdin,
 )
 
 
-class MBSubmitPluginTest(TerminalImportMixin, ImportTestCase):
+class MBSubmitPluginTest(PluginMixin, TerminalImportMixin, ImportTestCase):
+    plugin = "mbsubmit"
+
     def setUp(self):
         super().setUp()
-        self.load_plugins("mbsubmit")
         self._create_import_dir(2)
         self._setup_import_session()
         self.matcher = AutotagStub().install()
 
     def tearDown(self):
-        self.unload_plugins()
         super().tearDown()
         self.matcher.restore()
 

--- a/test/plugins/test_mbsubmit.py
+++ b/test/plugins/test_mbsubmit.py
@@ -17,16 +17,16 @@ import unittest
 
 from beets.test.helper import (
     AutotagStub,
+    BeetsTestCase,
     ImportHelper,
     TerminalImportSessionSetup,
-    TestHelper,
     capture_stdout,
     control_stdin,
 )
 
 
 class MBSubmitPluginTest(
-    TerminalImportSessionSetup, unittest.TestCase, ImportHelper, TestHelper
+    TerminalImportSessionSetup, BeetsTestCase, ImportHelper
 ):
     def setUp(self):
         self.setup_beets()

--- a/test/plugins/test_mbsubmit.py
+++ b/test/plugins/test_mbsubmit.py
@@ -48,8 +48,8 @@ class MBSubmitPluginTest(PluginMixin, TerminalImportMixin, ImportTestCase):
         # Manually build the string for comparing the output.
         tracklist = (
             "Open files with Picard? "
-            "01. Tag Title 1 - Tag Artist (0:01)\n"
-            "02. Tag Title 2 - Tag Artist (0:01)"
+            "01. Tag Track 1 - Tag Artist (0:01)\n"
+            "02. Tag Track 2 - Tag Artist (0:01)"
         )
         self.assertIn(tracklist, output.getvalue())
 
@@ -64,6 +64,6 @@ class MBSubmitPluginTest(PluginMixin, TerminalImportMixin, ImportTestCase):
 
         # Manually build the string for comparing the output.
         tracklist = (
-            "Open files with Picard? " "02. Tag Title 2 - Tag Artist (0:01)"
+            "Open files with Picard? " "02. Tag Track 2 - Tag Artist (0:01)"
         )
         self.assertIn(tracklist, output.getvalue())

--- a/test/plugins/test_mbsync.py
+++ b/test/plugins/test_mbsync.py
@@ -19,21 +19,15 @@ from unittest.mock import patch
 from beets import config
 from beets.library import Item
 from beets.test.helper import (
-    BeetsTestCase,
+    PluginTestCase,
     capture_log,
     generate_album_info,
     generate_track_info,
 )
 
 
-class MbsyncCliTest(BeetsTestCase):
-    def setUp(self):
-        super().setUp()
-        self.load_plugins("mbsync")
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
+class MbsyncCliTest(PluginTestCase):
+    plugin = "mbsync"
 
     @patch("beets.autotag.mb.album_for_id")
     @patch("beets.autotag.mb.track_for_id")

--- a/test/plugins/test_mbsync.py
+++ b/test/plugins/test_mbsync.py
@@ -13,7 +13,6 @@
 # included in all copies or substantial portions of the Software.
 
 
-import unittest
 from unittest.mock import patch
 
 from beets import config
@@ -188,11 +187,3 @@ class MbsyncCliTest(PluginTestCase):
             self.run_command("mbsync", "-f", "'$title'")
         e = "mbsync: Skipping singleton with invalid mb_trackid: 'old title'"
         self.assertEqual(e, logs[0])
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_mbsync.py
+++ b/test/plugins/test_mbsync.py
@@ -28,12 +28,12 @@ from beets.test.helper import (
 
 class MbsyncCliTest(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("mbsync")
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     @patch("beets.autotag.mb.album_for_id")
     @patch("beets.autotag.mb.track_for_id")

--- a/test/plugins/test_mbsync.py
+++ b/test/plugins/test_mbsync.py
@@ -19,14 +19,14 @@ from unittest.mock import patch
 from beets import config
 from beets.library import Item
 from beets.test.helper import (
-    TestHelper,
+    BeetsTestCase,
     capture_log,
     generate_album_info,
     generate_track_info,
 )
 
 
-class MbsyncCliTest(unittest.TestCase, TestHelper):
+class MbsyncCliTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
         self.load_plugins("mbsync")

--- a/test/plugins/test_mpdstats.py
+++ b/test/plugins/test_mpdstats.py
@@ -18,18 +18,12 @@ from unittest.mock import ANY, Mock, call, patch
 
 from beets import util
 from beets.library import Item
-from beets.test.helper import BeetsTestCase
+from beets.test.helper import PluginTestCase
 from beetsplug.mpdstats import MPDStats
 
 
-class MPDStatsTest(BeetsTestCase):
-    def setUp(self):
-        super().setUp()
-        self.load_plugins("mpdstats")
-
-    def tearDown(self):
-        super().tearDown()
-        self.unload_plugins()
+class MPDStatsTest(PluginTestCase):
+    plugin = "mpdstats"
 
     def test_update_rating(self):
         item = Item(title="title", path="", id=1)

--- a/test/plugins/test_mpdstats.py
+++ b/test/plugins/test_mpdstats.py
@@ -13,7 +13,6 @@
 # included in all copies or substantial portions of the Software.
 
 
-import unittest
 from unittest.mock import ANY, Mock, call, patch
 
 from beets import util
@@ -82,11 +81,3 @@ class MPDStatsTest(PluginTestCase):
         log.info.assert_has_calls(
             [call("pause"), call("playing {0}", ANY), call("stop")]
         )
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_mpdstats.py
+++ b/test/plugins/test_mpdstats.py
@@ -24,11 +24,11 @@ from beetsplug.mpdstats import MPDStats
 
 class MPDStatsTest(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("mpdstats")
 
     def tearDown(self):
-        self.teardown_beets()
+        super().tearDown()
         self.unload_plugins()
 
     def test_update_rating(self):

--- a/test/plugins/test_mpdstats.py
+++ b/test/plugins/test_mpdstats.py
@@ -18,11 +18,11 @@ from unittest.mock import ANY, Mock, call, patch
 
 from beets import util
 from beets.library import Item
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 from beetsplug.mpdstats import MPDStats
 
 
-class MPDStatsTest(unittest.TestCase, TestHelper):
+class MPDStatsTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
         self.load_plugins("mpdstats")

--- a/test/plugins/test_parentwork.py
+++ b/test/plugins/test_parentwork.py
@@ -88,12 +88,12 @@ def mock_workid_response(mbid, includes):
 class ParentWorkIntegrationTest(BeetsTestCase):
     def setUp(self):
         """Set up configuration"""
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("parentwork")
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     # test how it works with real musicbrainz data
     @unittest.skipUnless(
@@ -183,7 +183,7 @@ class ParentWorkIntegrationTest(BeetsTestCase):
 class ParentWorkTest(BeetsTestCase):
     def setUp(self):
         """Set up configuration"""
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("parentwork")
         self.patcher = patch(
             "musicbrainzngs.get_work_by_id", side_effect=mock_workid_response
@@ -192,7 +192,7 @@ class ParentWorkTest(BeetsTestCase):
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
         self.patcher.stop()
 
     def test_normal_case(self):

--- a/test/plugins/test_parentwork.py
+++ b/test/plugins/test_parentwork.py
@@ -20,7 +20,7 @@ import unittest
 from unittest.mock import patch
 
 from beets.library import Item
-from beets.test.helper import BeetsTestCase
+from beets.test.helper import PluginTestCase
 from beetsplug import parentwork
 
 work = {
@@ -85,15 +85,8 @@ def mock_workid_response(mbid, includes):
         return p_work
 
 
-class ParentWorkIntegrationTest(BeetsTestCase):
-    def setUp(self):
-        """Set up configuration"""
-        super().setUp()
-        self.load_plugins("parentwork")
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
+class ParentWorkIntegrationTest(PluginTestCase):
+    plugin = "parentwork"
 
     # test how it works with real musicbrainz data
     @unittest.skipUnless(
@@ -180,18 +173,18 @@ class ParentWorkIntegrationTest(BeetsTestCase):
         )
 
 
-class ParentWorkTest(BeetsTestCase):
+class ParentWorkTest(PluginTestCase):
+    plugin = "parentwork"
+
     def setUp(self):
         """Set up configuration"""
         super().setUp()
-        self.load_plugins("parentwork")
         self.patcher = patch(
             "musicbrainzngs.get_work_by_id", side_effect=mock_workid_response
         )
         self.patcher.start()
 
     def tearDown(self):
-        self.unload_plugins()
         super().tearDown()
         self.patcher.stop()
 

--- a/test/plugins/test_parentwork.py
+++ b/test/plugins/test_parentwork.py
@@ -20,7 +20,7 @@ import unittest
 from unittest.mock import patch
 
 from beets.library import Item
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 from beetsplug import parentwork
 
 work = {
@@ -85,7 +85,7 @@ def mock_workid_response(mbid, includes):
         return p_work
 
 
-class ParentWorkIntegrationTest(unittest.TestCase, TestHelper):
+class ParentWorkIntegrationTest(BeetsTestCase):
     def setUp(self):
         """Set up configuration"""
         self.setup_beets()
@@ -180,7 +180,7 @@ class ParentWorkIntegrationTest(unittest.TestCase, TestHelper):
         )
 
 
-class ParentWorkTest(unittest.TestCase, TestHelper):
+class ParentWorkTest(BeetsTestCase):
     def setUp(self):
         """Set up configuration"""
         self.setup_beets()

--- a/test/plugins/test_parentwork.py
+++ b/test/plugins/test_parentwork.py
@@ -232,11 +232,3 @@ class ParentWorkTest(PluginTestCase):
     def test_direct_parent_work(self):
         self.assertEqual("2", parentwork.direct_parent_id("1")[0])
         self.assertEqual("3", parentwork.work_parent_id("1")[0])
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_permissions.py
+++ b/test/plugins/test_permissions.py
@@ -6,7 +6,7 @@ import platform
 from unittest.mock import Mock, patch
 
 from beets.test._common import touch
-from beets.test.helper import ImportTestCase, PluginMixin
+from beets.test.helper import AsIsImporterMixin, ImportTestCase, PluginMixin
 from beets.util import displayable_path
 from beetsplug.permissions import (
     check_permissions,
@@ -15,14 +15,13 @@ from beetsplug.permissions import (
 )
 
 
-class PermissionsPluginTest(PluginMixin, ImportTestCase):
+class PermissionsPluginTest(AsIsImporterMixin, PluginMixin, ImportTestCase):
     plugin = "permissions"
 
     def setUp(self):
         super().setUp()
 
         self.config["permissions"] = {"file": "777", "dir": "777"}
-        self.prepare_album_for_import(1)
 
     def test_permissions_on_album_imported(self):
         self.do_thing(True)
@@ -45,7 +44,6 @@ class PermissionsPluginTest(PluginMixin, ImportTestCase):
                 & 0o777
             )
 
-        self.importer = self.setup_importer(autotag=False)
         typs = ["file", "dir"]
 
         track_file = (b"album", b"track_1.mp3")
@@ -57,7 +55,7 @@ class PermissionsPluginTest(PluginMixin, ImportTestCase):
             False: {k: get_stat(v) for (k, v) in zip(typs, (track_file, ()))},
         }
 
-        self.importer.run()
+        self.run_asis_importer()
         item = self.lib.items().get()
 
         self.assertPerms(item.path, "file", expect_success)
@@ -94,7 +92,7 @@ class PermissionsPluginTest(PluginMixin, ImportTestCase):
     def do_set_art(self, expect_success):
         if platform.system() == "Windows":
             self.skipTest("permissions not available on Windows")
-        self.setup_importer(autotag=False).run()
+        self.run_asis_importer()
         album = self.lib.albums().get()
         artpath = os.path.join(self.temp_dir, b"cover.jpg")
         touch(artpath)

--- a/test/plugins/test_permissions.py
+++ b/test/plugins/test_permissions.py
@@ -22,6 +22,7 @@ class PermissionsPluginTest(PluginMixin, ImportTestCase):
         super().setUp()
 
         self.config["permissions"] = {"file": "777", "dir": "777"}
+        self.prepare_album_for_import(1)
 
     def test_permissions_on_album_imported(self):
         self.do_thing(True)
@@ -44,10 +45,10 @@ class PermissionsPluginTest(PluginMixin, ImportTestCase):
                 & 0o777
             )
 
-        self.importer = self.create_importer()
+        self.importer = self.setup_importer(autotag=False)
         typs = ["file", "dir"]
 
-        track_file = (b"album_1", b"track_1.mp3")
+        track_file = (b"album", b"track_1.mp3")
         self.exp_perms = {
             True: {
                 k: convert_perm(self.config["permissions"][k].get())
@@ -93,8 +94,7 @@ class PermissionsPluginTest(PluginMixin, ImportTestCase):
     def do_set_art(self, expect_success):
         if platform.system() == "Windows":
             self.skipTest("permissions not available on Windows")
-        self.importer = self.create_importer()
-        self.importer.run()
+        self.setup_importer(autotag=False).run()
         album = self.lib.albums().get()
         artpath = os.path.join(self.temp_dir, b"cover.jpg")
         touch(artpath)

--- a/test/plugins/test_permissions.py
+++ b/test/plugins/test_permissions.py
@@ -18,13 +18,13 @@ from beetsplug.permissions import (
 
 class PermissionsPluginTest(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("permissions")
 
         self.config["permissions"] = {"file": "777", "dir": "777"}
 
     def tearDown(self):
-        self.teardown_beets()
+        super().tearDown()
         self.unload_plugins()
 
     def test_permissions_on_album_imported(self):

--- a/test/plugins/test_permissions.py
+++ b/test/plugins/test_permissions.py
@@ -6,7 +6,7 @@ import platform
 from unittest.mock import Mock, patch
 
 from beets.test._common import touch
-from beets.test.helper import PluginTestCase
+from beets.test.helper import ImportTestCase, PluginMixin
 from beets.util import displayable_path
 from beetsplug.permissions import (
     check_permissions,
@@ -15,7 +15,7 @@ from beetsplug.permissions import (
 )
 
 
-class PermissionsPluginTest(PluginTestCase):
+class PermissionsPluginTest(PluginMixin, ImportTestCase):
     plugin = "permissions"
 
     def setUp(self):

--- a/test/plugins/test_permissions.py
+++ b/test/plugins/test_permissions.py
@@ -47,7 +47,7 @@ class PermissionsPluginTest(PluginMixin, ImportTestCase):
         self.importer = self.create_importer()
         typs = ["file", "dir"]
 
-        track_file = (b"album 0", b"track 0.mp3")
+        track_file = (b"album_1", b"track_1.mp3")
         self.exp_perms = {
             True: {
                 k: convert_perm(self.config["permissions"][k].get())

--- a/test/plugins/test_permissions.py
+++ b/test/plugins/test_permissions.py
@@ -3,7 +3,6 @@
 
 import os
 import platform
-import unittest
 from unittest.mock import Mock, patch
 
 from beets.test._common import touch
@@ -103,11 +102,3 @@ class PermissionsPluginTest(PluginTestCase):
         self.assertEqual(
             expect_success, check_permissions(album.artpath, 0o777)
         )
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_permissions.py
+++ b/test/plugins/test_permissions.py
@@ -7,7 +7,7 @@ import unittest
 from unittest.mock import Mock, patch
 
 from beets.test._common import touch
-from beets.test.helper import BeetsTestCase
+from beets.test.helper import PluginTestCase
 from beets.util import displayable_path
 from beetsplug.permissions import (
     check_permissions,
@@ -16,16 +16,13 @@ from beetsplug.permissions import (
 )
 
 
-class PermissionsPluginTest(BeetsTestCase):
+class PermissionsPluginTest(PluginTestCase):
+    plugin = "permissions"
+
     def setUp(self):
         super().setUp()
-        self.load_plugins("permissions")
 
         self.config["permissions"] = {"file": "777", "dir": "777"}
-
-    def tearDown(self):
-        super().tearDown()
-        self.unload_plugins()
 
     def test_permissions_on_album_imported(self):
         self.do_thing(True)

--- a/test/plugins/test_permissions.py
+++ b/test/plugins/test_permissions.py
@@ -7,7 +7,7 @@ import unittest
 from unittest.mock import Mock, patch
 
 from beets.test._common import touch
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 from beets.util import displayable_path
 from beetsplug.permissions import (
     check_permissions,
@@ -16,7 +16,7 @@ from beetsplug.permissions import (
 )
 
 
-class PermissionsPluginTest(unittest.TestCase, TestHelper):
+class PermissionsPluginTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
         self.load_plugins("permissions")

--- a/test/plugins/test_play.py
+++ b/test/plugins/test_play.py
@@ -20,26 +20,22 @@ import sys
 import unittest
 from unittest.mock import ANY, patch
 
-from beets.test.helper import BeetsTestCase, CleanupModulesMixin, control_stdin
+from beets.test.helper import CleanupModulesMixin, PluginTestCase, control_stdin
 from beets.ui import UserError
 from beets.util import open_anything
 from beetsplug.play import PlayPlugin
 
 
 @patch("beetsplug.play.util.interactive_open")
-class PlayPluginTest(CleanupModulesMixin, BeetsTestCase):
+class PlayPluginTest(CleanupModulesMixin, PluginTestCase):
     modules = (PlayPlugin.__module__,)
+    plugin = "play"
 
     def setUp(self):
         super().setUp()
-        self.load_plugins("play")
         self.item = self.add_item(album="a nice älbum", title="aNiceTitle")
         self.lib.add_album([self.item])
         self.config["play"]["command"] = "echo"
-
-    def tearDown(self):
-        super().tearDown()
-        self.unload_plugins()
 
     def run_and_assert(
         self,

--- a/test/plugins/test_play.py
+++ b/test/plugins/test_play.py
@@ -20,14 +20,14 @@ import sys
 import unittest
 from unittest.mock import ANY, patch
 
-from beets.test.helper import CleanupModulesMixin, TestHelper, control_stdin
+from beets.test.helper import BeetsTestCase, CleanupModulesMixin, control_stdin
 from beets.ui import UserError
 from beets.util import open_anything
 from beetsplug.play import PlayPlugin
 
 
 @patch("beetsplug.play.util.interactive_open")
-class PlayPluginTest(CleanupModulesMixin, unittest.TestCase, TestHelper):
+class PlayPluginTest(CleanupModulesMixin, BeetsTestCase):
     modules = (PlayPlugin.__module__,)
 
     def setUp(self):

--- a/test/plugins/test_play.py
+++ b/test/plugins/test_play.py
@@ -141,11 +141,3 @@ class PlayPluginTest(CleanupModulesMixin, PluginTestCase):
 
         with self.assertRaises(UserError):
             self.run_command("play", "title:aNiceTitle")
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_play.py
+++ b/test/plugins/test_play.py
@@ -31,14 +31,14 @@ class PlayPluginTest(CleanupModulesMixin, BeetsTestCase):
     modules = (PlayPlugin.__module__,)
 
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("play")
         self.item = self.add_item(album="a nice älbum", title="aNiceTitle")
         self.lib.add_album([self.item])
         self.config["play"]["command"] = "echo"
 
     def tearDown(self):
-        self.teardown_beets()
+        super().tearDown()
         self.unload_plugins()
 
     def run_and_assert(

--- a/test/plugins/test_player.py
+++ b/test/plugins/test_player.py
@@ -32,7 +32,7 @@ from unittest import mock
 import confuse
 import yaml
 
-from beets.test.helper import BeetsTestCase
+from beets.test.helper import PluginTestCase
 from beets.util import bluelet
 from beetsplug import bpd
 
@@ -277,12 +277,12 @@ def start_server(args, assigned_port, listener_patch):
     beets.ui.main(args)
 
 
-class BPDTestHelper(BeetsTestCase):
+class BPDTestHelper(PluginTestCase):
     db_on_disk = True
+    plugin = "bpd"
 
     def setUp(self):
         super().setUp()
-        self.load_plugins("bpd")
         self.item1 = self.add_item(
             title="Track One Title",
             track=1,
@@ -296,10 +296,6 @@ class BPDTestHelper(BeetsTestCase):
             artist="Artist Name",
         )
         self.lib.add_album([self.item1, self.item2])
-
-    def tearDown(self):
-        super().tearDown()
-        self.unload_plugins()
 
     @contextmanager
     def run_bpd(

--- a/test/plugins/test_player.py
+++ b/test/plugins/test_player.py
@@ -296,7 +296,7 @@ class BPDTestHelper(BeetsTestCase):
         self.lib.add_album([self.item1, self.item2])
 
     def tearDown(self):
-        self.teardown_beets()
+        super().tearDown()
         self.unload_plugins()
 
     @contextmanager

--- a/test/plugins/test_player.py
+++ b/test/plugins/test_player.py
@@ -278,8 +278,10 @@ def start_server(args, assigned_port, listener_patch):
 
 
 class BPDTestHelper(BeetsTestCase):
+    db_on_disk = True
+
     def setUp(self):
-        self.setup_beets(disk=True)
+        super().setUp()
         self.load_plugins("bpd")
         self.item1 = self.add_item(
             title="Track One Title",

--- a/test/plugins/test_player.py
+++ b/test/plugins/test_player.py
@@ -32,7 +32,7 @@ from unittest import mock
 import confuse
 import yaml
 
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 from beets.util import bluelet
 from beetsplug import bpd
 
@@ -277,7 +277,7 @@ def start_server(args, assigned_port, listener_patch):
     beets.ui.main(args)
 
 
-class BPDTestHelper(unittest.TestCase, TestHelper):
+class BPDTestHelper(BeetsTestCase):
     def setUp(self):
         self.setup_beets(disk=True)
         self.load_plugins("bpd")

--- a/test/plugins/test_player.py
+++ b/test/plugins/test_player.py
@@ -1193,11 +1193,3 @@ class BPDPeersTest(BPDTestHelper):
         },
         expectedFailure=True,
     )
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_playlist.py
+++ b/test/plugins/test_playlist.py
@@ -25,7 +25,6 @@ from beets.test.helper import BeetsTestCase
 class PlaylistTestCase(BeetsTestCase):
     def setUp(self):
         super().setUp()
-        self.lib = beets.library.Library(":memory:")
 
         self.music_dir = os.path.expanduser(os.path.join("~", "Music"))
 

--- a/test/plugins/test_playlist.py
+++ b/test/plugins/test_playlist.py
@@ -18,10 +18,11 @@ import unittest
 from shlex import quote
 
 import beets
-from beets.test import _common, helper
+from beets.test import _common
+from beets.test.helper import BeetsTestCase
 
 
-class PlaylistTestHelper(helper.TestHelper):
+class PlaylistTestCase(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
         self.lib = beets.library.Library(":memory:")
@@ -88,7 +89,7 @@ class PlaylistTestHelper(helper.TestHelper):
         self.teardown_beets()
 
 
-class PlaylistQueryTestHelper(PlaylistTestHelper):
+class PlaylistQueryTest:
     def test_name_query_with_absolute_paths_in_playlist(self):
         q = "playlist:absolute"
         results = self.lib.items(q)
@@ -166,7 +167,7 @@ class PlaylistQueryTestHelper(PlaylistTestHelper):
         self.assertEqual(set(results), set())
 
 
-class PlaylistTestRelativeToLib(PlaylistQueryTestHelper, unittest.TestCase):
+class PlaylistTestRelativeToLib(PlaylistQueryTest, PlaylistTestCase):
     def setup_test(self):
         with open(os.path.join(self.playlist_dir, "absolute.m3u"), "w") as f:
             f.write(
@@ -187,7 +188,7 @@ class PlaylistTestRelativeToLib(PlaylistQueryTestHelper, unittest.TestCase):
         self.config["playlist"]["relative_to"] = "library"
 
 
-class PlaylistTestRelativeToDir(PlaylistQueryTestHelper, unittest.TestCase):
+class PlaylistTestRelativeToDir(PlaylistQueryTest, PlaylistTestCase):
     def setup_test(self):
         with open(os.path.join(self.playlist_dir, "absolute.m3u"), "w") as f:
             f.write(
@@ -208,7 +209,7 @@ class PlaylistTestRelativeToDir(PlaylistQueryTestHelper, unittest.TestCase):
         self.config["playlist"]["relative_to"] = self.music_dir
 
 
-class PlaylistTestRelativeToPls(PlaylistQueryTestHelper, unittest.TestCase):
+class PlaylistTestRelativeToPls(PlaylistQueryTest, PlaylistTestCase):
     def setup_test(self):
         with open(os.path.join(self.playlist_dir, "absolute.m3u"), "w") as f:
             f.write(
@@ -251,7 +252,7 @@ class PlaylistTestRelativeToPls(PlaylistQueryTestHelper, unittest.TestCase):
         self.config["playlist"]["playlist_dir"] = self.playlist_dir
 
 
-class PlaylistUpdateTestHelper(PlaylistTestHelper):
+class PlaylistUpdateTest:
     def setup_test(self):
         with open(os.path.join(self.playlist_dir, "absolute.m3u"), "w") as f:
             f.write(
@@ -273,7 +274,7 @@ class PlaylistUpdateTestHelper(PlaylistTestHelper):
         self.config["playlist"]["relative_to"] = "library"
 
 
-class PlaylistTestItemMoved(PlaylistUpdateTestHelper, unittest.TestCase):
+class PlaylistTestItemMoved(PlaylistUpdateTest, PlaylistTestCase):
     def test_item_moved(self):
         # Emit item_moved event for an item that is in a playlist
         results = self.lib.items(
@@ -339,7 +340,7 @@ class PlaylistTestItemMoved(PlaylistUpdateTestHelper, unittest.TestCase):
         )
 
 
-class PlaylistTestItemRemoved(PlaylistUpdateTestHelper, unittest.TestCase):
+class PlaylistTestItemRemoved(PlaylistUpdateTest, PlaylistTestCase):
     def test_item_removed(self):
         # Emit item_removed event for an item that is in a playlist
         results = self.lib.items(

--- a/test/plugins/test_playlist.py
+++ b/test/plugins/test_playlist.py
@@ -14,7 +14,6 @@
 
 
 import os
-import unittest
 from shlex import quote
 
 import beets
@@ -387,11 +386,3 @@ class PlaylistTestItemRemoved(PlaylistUpdateTest, PlaylistTestCase):
                 "nonexisting.mp3",
             ],
         )
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_playlist.py
+++ b/test/plugins/test_playlist.py
@@ -24,7 +24,7 @@ from beets.test.helper import BeetsTestCase
 
 class PlaylistTestCase(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.lib = beets.library.Library(":memory:")
 
         self.music_dir = os.path.expanduser(os.path.join("~", "Music"))
@@ -86,7 +86,7 @@ class PlaylistTestCase(BeetsTestCase):
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
 
 class PlaylistQueryTest:

--- a/test/plugins/test_playlist.py
+++ b/test/plugins/test_playlist.py
@@ -18,10 +18,13 @@ from shlex import quote
 
 import beets
 from beets.test import _common
-from beets.test.helper import BeetsTestCase
+from beets.test.helper import PluginTestCase
 
 
-class PlaylistTestCase(BeetsTestCase):
+class PlaylistTestCase(PluginTestCase):
+    plugin = "playlist"
+    preload_plugin = False
+
     def setUp(self):
         super().setUp()
 
@@ -77,14 +80,10 @@ class PlaylistTestCase(BeetsTestCase):
         self.config["playlist"]["playlist_dir"] = self.playlist_dir
 
         self.setup_test()
-        self.load_plugins("playlist")
+        self.load_plugins()
 
     def setup_test(self):
         raise NotImplementedError
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
 
 
 class PlaylistQueryTest:

--- a/test/plugins/test_plexupdate.py
+++ b/test/plugins/test_plexupdate.py
@@ -2,11 +2,13 @@ import unittest
 
 import responses
 
-from beets.test.helper import BeetsTestCase
+from beets.test.helper import PluginTestCase
 from beetsplug.plexupdate import get_music_section, update_plex
 
 
-class PlexUpdateTest(BeetsTestCase):
+class PlexUpdateTest(PluginTestCase):
+    plugin = "plexupdate"
+
     def add_response_get_music_section(self, section_name="Music"):
         """Create response for mocking the get_music_section function."""
 
@@ -74,13 +76,8 @@ class PlexUpdateTest(BeetsTestCase):
 
     def setUp(self):
         super().setUp()
-        self.load_plugins("plexupdate")
 
         self.config["plex"] = {"host": "localhost", "port": 32400}
-
-    def tearDown(self):
-        super().tearDown()
-        self.unload_plugins()
 
     @responses.activate
     def test_get_music_section(self):

--- a/test/plugins/test_plexupdate.py
+++ b/test/plugins/test_plexupdate.py
@@ -2,11 +2,11 @@ import unittest
 
 import responses
 
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 from beetsplug.plexupdate import get_music_section, update_plex
 
 
-class PlexUpdateTest(unittest.TestCase, TestHelper):
+class PlexUpdateTest(BeetsTestCase):
     def add_response_get_music_section(self, section_name="Music"):
         """Create response for mocking the get_music_section function."""
 

--- a/test/plugins/test_plexupdate.py
+++ b/test/plugins/test_plexupdate.py
@@ -1,5 +1,3 @@
-import unittest
-
 import responses
 
 from beets.test.helper import PluginTestCase
@@ -132,11 +130,3 @@ class PlexUpdateTest(PluginTestCase):
             ).status_code,
             200,
         )
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_plexupdate.py
+++ b/test/plugins/test_plexupdate.py
@@ -73,13 +73,13 @@ class PlexUpdateTest(BeetsTestCase):
         )
 
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("plexupdate")
 
         self.config["plex"] = {"host": "localhost", "port": 32400}
 
     def tearDown(self):
-        self.teardown_beets()
+        super().tearDown()
         self.unload_plugins()
 
     @responses.activate

--- a/test/plugins/test_plugin_mediafield.py
+++ b/test/plugins/test_plugin_mediafield.py
@@ -17,7 +17,6 @@
 
 import os
 import shutil
-import unittest
 
 import mediafile
 
@@ -124,11 +123,3 @@ class ExtendedFieldTestMixin(BeetsTestCase):
         with self.assertRaises(ValueError) as cm:
             mediafile.MediaFile.add_field("artist", mediafile.MediaField())
         self.assertIn('property "artist" already exists', str(cm.exception))
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_plugin_mediafield.py
+++ b/test/plugins/test_plugin_mediafield.py
@@ -24,6 +24,7 @@ import mediafile
 from beets.library import Item
 from beets.plugins import BeetsPlugin
 from beets.test import _common
+from beets.test.helper import BeetsTestCase
 from beets.util import bytestring_path, syspath
 
 field_extension = mediafile.MediaField(
@@ -41,7 +42,7 @@ list_field_extension = mediafile.ListMediaField(
 )
 
 
-class ExtendedFieldTestMixin(_common.TestCase):
+class ExtendedFieldTestMixin(BeetsTestCase):
     def _mediafile_fixture(self, name, extension="mp3"):
         name = bytestring_path(name + "." + extension)
         src = os.path.join(_common.RSRC, name)

--- a/test/plugins/test_random.py
+++ b/test/plugins/test_random.py
@@ -24,7 +24,7 @@ from beets import random
 from beets.test.helper import TestHelper
 
 
-class RandomTest(unittest.TestCase, TestHelper):
+class RandomTest(TestHelper, unittest.TestCase):
     def setUp(self):
         self.lib = None
         self.artist1 = "Artist 1"
@@ -36,9 +36,6 @@ class RandomTest(unittest.TestCase, TestHelper):
             self.items.append(self.create_item(artist=self.artist2))
         self.random_gen = Random()
         self.random_gen.seed(12345)
-
-    def tearDown(self):
-        pass
 
     def _stats(self, data):
         mean = sum(data) / len(data)

--- a/test/plugins/test_random.py
+++ b/test/plugins/test_random.py
@@ -77,11 +77,3 @@ class RandomTest(TestHelper, unittest.TestCase):
         self.assertAlmostEqual(0, median1, delta=1)
         self.assertAlmostEqual(len(self.items) // 2, median2, delta=1)
         self.assertGreater(stdev2, stdev1)
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_replaygain.py
+++ b/test/plugins/test_replaygain.py
@@ -392,12 +392,3 @@ class ReplayGainFfmpegThreadedImportTest(
     ThreadedImportMixin, ImportTest, ReplayGainTestCase, FfmpegBackendMixin
 ):
     pass
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_replaygain.py
+++ b/test/plugins/test_replaygain.py
@@ -68,7 +68,8 @@ class ReplayGainTestCase(ImportTestCase):
         except Exception:
             self.tearDown()
 
-        self.importer = self.create_importer()
+        self.prepare_album_for_import(1)
+        self.importer = self.setup_importer(autotag=False)
 
     def tearDown(self):
         self.unload_plugins()

--- a/test/plugins/test_replaygain.py
+++ b/test/plugins/test_replaygain.py
@@ -19,7 +19,7 @@ from typing import ClassVar
 from mediafile import MediaFile
 
 from beets import config
-from beets.test.helper import ImportTestCase, has_program
+from beets.test.helper import AsIsImporterMixin, ImportTestCase, has_program
 from beetsplug.replaygain import (
     FatalGstreamerPluginReplayGainError,
     GStreamerBackend,
@@ -67,9 +67,6 @@ class ReplayGainTestCase(ImportTestCase):
             self.load_plugins("replaygain")
         except Exception:
             self.tearDown()
-
-        self.prepare_album_for_import(1)
-        self.importer = self.setup_importer(autotag=False)
 
     def tearDown(self):
         self.unload_plugins()
@@ -360,9 +357,9 @@ class ReplayGainFfmpegNoiseCliTest(
     FNAME = "whitenoise"
 
 
-class ImportTest:
+class ImportTest(AsIsImporterMixin):
     def test_import_converted(self):
-        self.importer.run()
+        self.run_asis_importer()
         for item in self.lib.items():
             # FIXME: Add fixtures with known track/album gain (within a
             # suitable tolerance) so that we can actually check correct

--- a/test/plugins/test_replaygain.py
+++ b/test/plugins/test_replaygain.py
@@ -19,7 +19,7 @@ from typing import ClassVar
 from mediafile import MediaFile
 
 from beets import config
-from beets.test.helper import BeetsTestCase, has_program
+from beets.test.helper import ImportTestCase, has_program
 from beetsplug.replaygain import (
     FatalGstreamerPluginReplayGainError,
     GStreamerBackend,
@@ -52,7 +52,7 @@ def reset_replaygain(item):
     item.store()
 
 
-class ReplayGainTestCase(BeetsTestCase):
+class ReplayGainTestCase(ImportTestCase):
     db_on_disk = True
     backend: ClassVar[str]
 

--- a/test/plugins/test_replaygain.py
+++ b/test/plugins/test_replaygain.py
@@ -19,7 +19,12 @@ from typing import ClassVar
 from mediafile import MediaFile
 
 from beets import config
-from beets.test.helper import AsIsImporterMixin, ImportTestCase, has_program
+from beets.test.helper import (
+    AsIsImporterMixin,
+    ImportTestCase,
+    PluginMixin,
+    has_program,
+)
 from beetsplug.replaygain import (
     FatalGstreamerPluginReplayGainError,
     GStreamerBackend,
@@ -52,8 +57,11 @@ def reset_replaygain(item):
     item.store()
 
 
-class ReplayGainTestCase(ImportTestCase):
+class ReplayGainTestCase(PluginMixin, ImportTestCase):
     db_on_disk = True
+    plugin = "replaygain"
+    preload_plugin = False
+
     backend: ClassVar[str]
 
     def setUp(self):
@@ -63,14 +71,7 @@ class ReplayGainTestCase(ImportTestCase):
         super().setUp()
         self.config["replaygain"]["backend"] = self.backend
 
-        try:
-            self.load_plugins("replaygain")
-        except Exception:
-            self.tearDown()
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
+        self.load_plugins()
 
 
 class ThreadedImportMixin:

--- a/test/plugins/test_replaygain.py
+++ b/test/plugins/test_replaygain.py
@@ -53,13 +53,14 @@ def reset_replaygain(item):
 
 
 class ReplayGainTestCase(BeetsTestCase):
+    db_on_disk = True
     backend: ClassVar[str]
 
     def setUp(self):
         # Implemented by Mixins, see above. This may decide to skip the test.
         self.test_backend()
 
-        self.setup_beets(disk=True)
+        super().setUp()
         self.config["replaygain"]["backend"] = self.backend
 
         try:

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -13,7 +13,6 @@
 # included in all copies or substantial portions of the Software.
 
 
-import unittest
 from os import fsdecode, path, remove
 from shutil import rmtree
 from tempfile import mkdtemp
@@ -373,11 +372,3 @@ class SmartPlaylistCLITest(PluginTestCase):
         for name in (b"my_playlist.m3u", b"all.m3u"):
             with open(path.join(self.temp_dir, name), "rb") as f:
                 self.assertEqual(f.read(), self.item.path + b"\n")
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -23,7 +23,7 @@ from beets import config
 from beets.dbcore import OrQuery
 from beets.dbcore.query import FixedFieldSort, MultipleSort, NullSort
 from beets.library import Album, Item, parse_query_string
-from beets.test.helper import BeetsTestCase
+from beets.test.helper import BeetsTestCase, PluginTestCase
 from beets.ui import UserError
 from beets.util import CHAR_REPLACE, bytestring_path, syspath
 from beetsplug.smartplaylist import SmartPlaylistPlugin
@@ -338,7 +338,9 @@ class SmartPlaylistTest(BeetsTestCase):
         self.assertEqual(content, b"http://beets:8337/item/3/file\n")
 
 
-class SmartPlaylistCLITest(BeetsTestCase):
+class SmartPlaylistCLITest(PluginTestCase):
+    plugin = "smartplaylist"
+
     def setUp(self):
         super().setUp()
 
@@ -350,11 +352,6 @@ class SmartPlaylistCLITest(BeetsTestCase):
             ]
         )
         config["smartplaylist"]["playlist_dir"].set(fsdecode(self.temp_dir))
-        self.load_plugins("smartplaylist")
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
 
     def test_splupdate(self):
         with self.assertRaises(UserError):

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -340,7 +340,7 @@ class SmartPlaylistTest(BeetsTestCase):
 
 class SmartPlaylistCLITest(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
 
         self.item = self.add_item()
         config["smartplaylist"]["playlists"].set(
@@ -354,7 +354,7 @@ class SmartPlaylistCLITest(BeetsTestCase):
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def test_splupdate(self):
         with self.assertRaises(UserError):

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -23,14 +23,13 @@ from beets import config
 from beets.dbcore import OrQuery
 from beets.dbcore.query import FixedFieldSort, MultipleSort, NullSort
 from beets.library import Album, Item, parse_query_string
-from beets.test import _common
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 from beets.ui import UserError
 from beets.util import CHAR_REPLACE, bytestring_path, syspath
 from beetsplug.smartplaylist import SmartPlaylistPlugin
 
 
-class SmartPlaylistTest(_common.TestCase):
+class SmartPlaylistTest(BeetsTestCase):
     def test_build_queries(self):
         spl = SmartPlaylistPlugin()
         self.assertIsNone(spl._matched_playlists)
@@ -339,7 +338,7 @@ class SmartPlaylistTest(_common.TestCase):
         self.assertEqual(content, b"http://beets:8337/item/3/file\n")
 
 
-class SmartPlaylistCLITest(_common.TestCase, TestHelper):
+class SmartPlaylistCLITest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
 

--- a/test/plugins/test_spotify.py
+++ b/test/plugins/test_spotify.py
@@ -9,7 +9,7 @@ import responses
 from beets import config
 from beets.library import Item
 from beets.test import _common
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 from beetsplug import spotify
 
 
@@ -25,7 +25,7 @@ def _params(url):
     return parse_qs(urlparse(url).query)
 
 
-class SpotifyPluginTest(_common.TestCase, TestHelper):
+class SpotifyPluginTest(BeetsTestCase):
     @responses.activate
     def setUp(self):
         config.clear()

--- a/test/plugins/test_spotify.py
+++ b/test/plugins/test_spotify.py
@@ -1,7 +1,6 @@
 """Tests for the 'spotify' plugin"""
 
 import os
-import unittest
 from urllib.parse import parse_qs, urlparse
 
 import responses
@@ -177,11 +176,3 @@ class SpotifyPluginTest(BeetsTestCase):
         results = self.spotify._match_library_tracks(self.lib, "Happy")
         self.assertEqual(1, len(results))
         self.assertEqual("6NPVjNh8Jhru9xOmyQigds", results[0]["id"])
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_spotify.py
+++ b/test/plugins/test_spotify.py
@@ -6,7 +6,6 @@ from urllib.parse import parse_qs, urlparse
 
 import responses
 
-from beets import config
 from beets.library import Item
 from beets.test import _common
 from beets.test.helper import BeetsTestCase
@@ -28,8 +27,7 @@ def _params(url):
 class SpotifyPluginTest(BeetsTestCase):
     @responses.activate
     def setUp(self):
-        config.clear()
-        self.setup_beets()
+        super().setUp()
         responses.add(
             responses.POST,
             spotify.SpotifyPlugin.oauth_token_url,
@@ -45,9 +43,6 @@ class SpotifyPluginTest(BeetsTestCase):
         self.spotify = spotify.SpotifyPlugin()
         opts = ArgumentsMock("list", False)
         self.spotify._parse_opts(opts)
-
-    def tearDown(self):
-        self.teardown_beets()
 
     def test_args(self):
         opts = ArgumentsMock("fail", True)

--- a/test/plugins/test_subsonicupdate.py
+++ b/test/plugins/test_subsonicupdate.py
@@ -6,8 +6,7 @@ from urllib.parse import parse_qs, urlparse
 import responses
 
 from beets import config
-from beets.test import _common
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 from beetsplug import subsonicupdate
 
 
@@ -26,7 +25,7 @@ def _params(url):
     return parse_qs(urlparse(url).query)
 
 
-class SubsonicPluginTest(_common.TestCase, TestHelper):
+class SubsonicPluginTest(BeetsTestCase):
     """Test class for subsonicupdate."""
 
     @responses.activate

--- a/test/plugins/test_subsonicupdate.py
+++ b/test/plugins/test_subsonicupdate.py
@@ -31,8 +31,7 @@ class SubsonicPluginTest(BeetsTestCase):
     @responses.activate
     def setUp(self):
         """Sets up config and plugin for test."""
-        config.clear()
-        self.setup_beets()
+        super().setUp()
 
         config["subsonic"]["user"] = "admin"
         config["subsonic"]["pass"] = "admin"
@@ -88,10 +87,6 @@ class SubsonicPluginTest(BeetsTestCase):
     "path": "/rest/startScn"
 }
 """
-
-    def tearDown(self):
-        """Tears down tests."""
-        self.teardown_beets()
 
     @responses.activate
     def test_start_scan(self):

--- a/test/plugins/test_subsonicupdate.py
+++ b/test/plugins/test_subsonicupdate.py
@@ -1,6 +1,5 @@
 """Tests for the 'subsonic' plugin."""
 
-import unittest
 from urllib.parse import parse_qs, urlparse
 
 import responses
@@ -183,12 +182,3 @@ class SubsonicPluginTest(BeetsTestCase):
         )
 
         self.subsonicupdate.start_scan()
-
-
-def suite():
-    """Default test suite."""
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_the.py
+++ b/test/plugins/test_the.py
@@ -3,11 +3,11 @@
 import unittest
 
 from beets import config
-from beets.test import _common
+from beets.test.helper import BeetsTestCase
 from beetsplug.the import FORMAT, PATTERN_A, PATTERN_THE, ThePlugin
 
 
-class ThePluginTest(_common.TestCase):
+class ThePluginTest(BeetsTestCase):
     def test_unthe_with_default_patterns(self):
         self.assertEqual(ThePlugin().unthe("", PATTERN_THE), "")
         self.assertEqual(

--- a/test/plugins/test_the.py
+++ b/test/plugins/test_the.py
@@ -1,7 +1,5 @@
 """Tests for the 'the' plugin"""
 
-import unittest
-
 from beets import config
 from beets.test.helper import BeetsTestCase
 from beetsplug.the import FORMAT, PATTERN_A, PATTERN_THE, ThePlugin
@@ -61,11 +59,3 @@ class ThePluginTest(BeetsTestCase):
         config["the"]["patterns"] = [PATTERN_THE, PATTERN_A]
         config["the"]["format"] = "{1} ({0})"
         self.assertEqual(ThePlugin().the_template_func("The A"), "The (A)")
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_thumbnails.py
+++ b/test/plugins/test_thumbnails.py
@@ -19,7 +19,7 @@ from shutil import rmtree
 from tempfile import mkdtemp
 from unittest.mock import Mock, call, patch
 
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 from beets.util import bytestring_path, syspath
 from beetsplug.thumbnails import (
     LARGE_DIR,
@@ -30,7 +30,7 @@ from beetsplug.thumbnails import (
 )
 
 
-class ThumbnailsTest(unittest.TestCase, TestHelper):
+class ThumbnailsTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
 

--- a/test/plugins/test_thumbnails.py
+++ b/test/plugins/test_thumbnails.py
@@ -31,12 +31,6 @@ from beetsplug.thumbnails import (
 
 
 class ThumbnailsTest(BeetsTestCase):
-    def setUp(self):
-        self.setup_beets()
-
-    def tearDown(self):
-        self.teardown_beets()
-
     @patch("beetsplug.thumbnails.ArtResizer")
     @patch("beetsplug.thumbnails.ThumbnailsPlugin._check_local_ok")
     @patch("beetsplug.thumbnails.os.stat")

--- a/test/plugins/test_thumbnails.py
+++ b/test/plugins/test_thumbnails.py
@@ -14,7 +14,6 @@
 
 
 import os.path
-import unittest
 from shutil import rmtree
 from tempfile import mkdtemp
 from unittest.mock import Mock, call, patch
@@ -281,11 +280,3 @@ class TestPathlibURI:
 
         # test it won't break if we pass it bytes for a path
         test_uri.uri(b"/")
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_types_plugin.py
+++ b/test/plugins/test_types_plugin.py
@@ -14,7 +14,6 @@
 
 
 import time
-import unittest
 from datetime import datetime
 
 from confuse import ConfigValueError
@@ -193,11 +192,3 @@ class TypesPluginTest(PluginTestCase):
 
 def mktime(*args):
     return time.mktime(datetime(*args).timetuple())
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_types_plugin.py
+++ b/test/plugins/test_types_plugin.py
@@ -19,10 +19,10 @@ from datetime import datetime
 
 from confuse import ConfigValueError
 
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 
 
-class TypesPluginTest(unittest.TestCase, TestHelper):
+class TypesPluginTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
         self.load_plugins("types")

--- a/test/plugins/test_types_plugin.py
+++ b/test/plugins/test_types_plugin.py
@@ -19,17 +19,11 @@ from datetime import datetime
 
 from confuse import ConfigValueError
 
-from beets.test.helper import BeetsTestCase
+from beets.test.helper import PluginTestCase
 
 
-class TypesPluginTest(BeetsTestCase):
-    def setUp(self):
-        super().setUp()
-        self.load_plugins("types")
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
+class TypesPluginTest(PluginTestCase):
+    plugin = "types"
 
     def test_integer_modify_and_query(self):
         self.config["types"] = {"myint": "int"}

--- a/test/plugins/test_types_plugin.py
+++ b/test/plugins/test_types_plugin.py
@@ -24,12 +24,12 @@ from beets.test.helper import BeetsTestCase
 
 class TypesPluginTest(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("types")
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def test_integer_modify_and_query(self):
         self.config["types"] = {"myint": "int"}

--- a/test/plugins/test_web.py
+++ b/test/plugins/test_web.py
@@ -9,11 +9,11 @@ import unittest
 from beets import logging
 from beets.library import Album, Item
 from beets.test import _common
-from beets.test.helper import LibTestCase
+from beets.test.helper import ItemInDBTestCase
 from beetsplug import web
 
 
-class WebPluginTest(LibTestCase):
+class WebPluginTest(ItemInDBTestCase):
     def setUp(self):
         super().setUp()
         self.log = logging.getLogger("beets.web")

--- a/test/plugins/test_web.py
+++ b/test/plugins/test_web.py
@@ -9,10 +9,11 @@ import unittest
 from beets import logging
 from beets.library import Album, Item
 from beets.test import _common
+from beets.test.helper import LibTestCase
 from beetsplug import web
 
 
-class WebPluginTest(_common.LibTestCase):
+class WebPluginTest(LibTestCase):
     def setUp(self):
         super().setUp()
         self.log = logging.getLogger("beets.web")

--- a/test/plugins/test_web.py
+++ b/test/plugins/test_web.py
@@ -4,7 +4,6 @@ import json
 import os.path
 import platform
 import shutil
-import unittest
 
 from beets import logging
 from beets.library import Album, Item
@@ -677,11 +676,3 @@ class WebPluginTest(ItemInDBTestCase):
         response = self.client.get("/item/" + str(item_id) + "/file")
 
         self.assertEqual(response.status_code, 200)
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_zero.py
+++ b/test/plugins/test_zero.py
@@ -12,7 +12,7 @@ from beetsplug.zero import ZeroPlugin
 
 class ZeroPluginTest(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.config["zero"] = {
             "fields": [],
             "keep_fields": [],
@@ -21,7 +21,7 @@ class ZeroPluginTest(BeetsTestCase):
 
     def tearDown(self):
         ZeroPlugin.listeners = None
-        self.teardown_beets()
+        super().tearDown()
         self.unload_plugins()
 
     def test_no_patterns(self):

--- a/test/plugins/test_zero.py
+++ b/test/plugins/test_zero.py
@@ -1,7 +1,5 @@
 """Tests for the 'zero' plugin"""
 
-import unittest
-
 from mediafile import MediaFile
 
 from beets.library import Item
@@ -292,11 +290,3 @@ class ZeroPluginTest(BeetsTestCase):
         self.assertEqual(mf.year, 2016)
         self.assertEqual(mf.comments, "test comment")
         self.assertEqual(item["comments"], "test comment")
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/plugins/test_zero.py
+++ b/test/plugins/test_zero.py
@@ -3,12 +3,15 @@
 from mediafile import MediaFile
 
 from beets.library import Item
-from beets.test.helper import BeetsTestCase, control_stdin
+from beets.test.helper import BeetsTestCase, PluginMixin, control_stdin
 from beets.util import syspath
 from beetsplug.zero import ZeroPlugin
 
 
-class ZeroPluginTest(BeetsTestCase):
+class ZeroPluginTest(PluginMixin, BeetsTestCase):
+    plugin = "zero"
+    preload_plugin = False
+
     def setUp(self):
         super().setUp()
         self.config["zero"] = {
@@ -16,11 +19,6 @@ class ZeroPluginTest(BeetsTestCase):
             "keep_fields": [],
             "update_database": False,
         }
-
-    def tearDown(self):
-        ZeroPlugin.listeners = None
-        super().tearDown()
-        self.unload_plugins()
 
     def test_no_patterns(self):
         self.config["zero"]["fields"] = ["comments", "month"]

--- a/test/plugins/test_zero.py
+++ b/test/plugins/test_zero.py
@@ -3,26 +3,16 @@
 from mediafile import MediaFile
 
 from beets.library import Item
-from beets.test.helper import BeetsTestCase, PluginMixin, control_stdin
+from beets.test.helper import PluginTestCase, control_stdin
 from beets.util import syspath
 from beetsplug.zero import ZeroPlugin
 
 
-class ZeroPluginTest(PluginMixin, BeetsTestCase):
+class ZeroPluginTest(PluginTestCase):
     plugin = "zero"
     preload_plugin = False
 
-    def setUp(self):
-        super().setUp()
-        self.config["zero"] = {
-            "fields": [],
-            "keep_fields": [],
-            "update_database": False,
-        }
-
     def test_no_patterns(self):
-        self.config["zero"]["fields"] = ["comments", "month"]
-
         item = self.add_item_fixture(
             comments="test comment",
             title="Title",
@@ -31,8 +21,8 @@ class ZeroPluginTest(PluginMixin, BeetsTestCase):
         )
         item.write()
 
-        self.load_plugins("zero")
-        item.write()
+        with self.configure_plugin({"fields": ["comments", "month"]}):
+            item.write()
 
         mf = MediaFile(syspath(item.path))
         self.assertIsNone(mf.comments)
@@ -41,76 +31,67 @@ class ZeroPluginTest(PluginMixin, BeetsTestCase):
         self.assertEqual(mf.year, 2000)
 
     def test_pattern_match(self):
-        self.config["zero"]["fields"] = ["comments"]
-        self.config["zero"]["comments"] = ["encoded by"]
-
         item = self.add_item_fixture(comments="encoded by encoder")
         item.write()
 
-        self.load_plugins("zero")
-        item.write()
+        with self.configure_plugin(
+            {"fields": ["comments"], "comments": ["encoded by"]}
+        ):
+            item.write()
 
         mf = MediaFile(syspath(item.path))
         self.assertIsNone(mf.comments)
 
     def test_pattern_nomatch(self):
-        self.config["zero"]["fields"] = ["comments"]
-        self.config["zero"]["comments"] = ["encoded by"]
-
         item = self.add_item_fixture(comments="recorded at place")
         item.write()
 
-        self.load_plugins("zero")
-        item.write()
+        with self.configure_plugin(
+            {"fields": ["comments"], "comments": ["encoded_by"]}
+        ):
+            item.write()
 
         mf = MediaFile(syspath(item.path))
         self.assertEqual(mf.comments, "recorded at place")
 
     def test_do_not_change_database(self):
-        self.config["zero"]["fields"] = ["year"]
-
         item = self.add_item_fixture(year=2000)
         item.write()
 
-        self.load_plugins("zero")
-        item.write()
+        with self.configure_plugin({"fields": ["year"]}):
+            item.write()
 
         self.assertEqual(item["year"], 2000)
 
     def test_change_database(self):
-        self.config["zero"]["fields"] = ["year"]
-        self.config["zero"]["update_database"] = True
-
         item = self.add_item_fixture(year=2000)
         item.write()
 
-        self.load_plugins("zero")
-        item.write()
+        with self.configure_plugin(
+            {"fields": ["year"], "update_database": True}
+        ):
+            item.write()
 
         self.assertEqual(item["year"], 0)
 
     def test_album_art(self):
-        self.config["zero"]["fields"] = ["images"]
-
         path = self.create_mediafile_fixture(images=["jpg"])
         item = Item.from_path(path)
 
-        self.load_plugins("zero")
-        item.write()
+        with self.configure_plugin({"fields": ["images"]}):
+            item.write()
 
         mf = MediaFile(syspath(path))
         self.assertFalse(mf.images)
 
     def test_auto_false(self):
-        self.config["zero"]["fields"] = ["year"]
-        self.config["zero"]["update_database"] = True
-        self.config["zero"]["auto"] = False
-
         item = self.add_item_fixture(year=2000)
         item.write()
 
-        self.load_plugins("zero")
-        item.write()
+        with self.configure_plugin(
+            {"fields": ["year"], "update_database": True, "auto": False}
+        ):
+            item.write()
 
         self.assertEqual(item["year"], 2000)
 
@@ -120,12 +101,10 @@ class ZeroPluginTest(PluginMixin, BeetsTestCase):
         )
         item.write()
         item_id = item.id
-        self.config["zero"]["fields"] = ["comments"]
-        self.config["zero"]["update_database"] = True
-        self.config["zero"]["auto"] = False
 
-        self.load_plugins("zero")
-        with control_stdin("y"):
+        with self.configure_plugin(
+            {"fields": ["comments"], "update_database": True, "auto": False}
+        ), control_stdin("y"):
             self.run_command("zero")
 
         mf = MediaFile(syspath(item.path))
@@ -143,12 +122,9 @@ class ZeroPluginTest(PluginMixin, BeetsTestCase):
         item.write()
         item_id = item.id
 
-        self.config["zero"]["fields"] = ["comments"]
-        self.config["zero"]["update_database"] = False
-        self.config["zero"]["auto"] = False
-
-        self.load_plugins("zero")
-        with control_stdin("y"):
+        with self.configure_plugin(
+            {"fields": ["comments"], "update_database": False, "auto": False}
+        ), control_stdin("y"):
             self.run_command("zero")
 
         mf = MediaFile(syspath(item.path))
@@ -166,12 +142,10 @@ class ZeroPluginTest(PluginMixin, BeetsTestCase):
 
         item.write()
 
-        self.config["zero"]["fields"] = ["comments"]
-        self.config["zero"]["update_database"] = False
-        self.config["zero"]["auto"] = False
-
-        self.load_plugins("zero")
-        self.run_command("zero", "year: 2016")
+        with self.configure_plugin(
+            {"fields": ["comments"], "update_database": False, "auto": False}
+        ):
+            self.run_command("zero", "year: 2016")
 
         mf = MediaFile(syspath(item.path))
 
@@ -185,12 +159,10 @@ class ZeroPluginTest(PluginMixin, BeetsTestCase):
 
         item.write()
 
-        self.config["zero"]["fields"] = ["comments"]
-        self.config["zero"]["update_database"] = False
-        self.config["zero"]["auto"] = False
-
-        self.load_plugins("zero")
-        self.run_command("zero", "year: 0000")
+        with self.configure_plugin(
+            {"fields": ["comments"], "update_database": False, "auto": False}
+        ):
+            self.run_command("zero", "year: 0000")
 
         mf = MediaFile(syspath(item.path))
 
@@ -205,8 +177,7 @@ class ZeroPluginTest(PluginMixin, BeetsTestCase):
 
         item_id = item.id
 
-        self.load_plugins("zero")
-        with control_stdin("y"):
+        with self.configure_plugin({"fields": []}), control_stdin("y"):
             self.run_command("zero")
 
         item = self.lib.get_item(item_id)
@@ -221,11 +192,10 @@ class ZeroPluginTest(PluginMixin, BeetsTestCase):
         self.assertEqual(mf.year, 2016)
 
         item_id = item.id
-        self.config["zero"]["fields"] = ["year"]
-        self.config["zero"]["keep_fields"] = ["comments"]
 
-        self.load_plugins("zero")
-        with control_stdin("y"):
+        with self.configure_plugin(
+            {"fields": ["year"], "keep_fields": ["comments"]}
+        ), control_stdin("y"):
             self.run_command("zero")
 
         item = self.lib.get_item(item_id)
@@ -235,18 +205,17 @@ class ZeroPluginTest(PluginMixin, BeetsTestCase):
 
     def test_keep_fields(self):
         item = self.add_item_fixture(year=2016, comments="test comment")
-        self.config["zero"]["keep_fields"] = ["year"]
-        self.config["zero"]["fields"] = None
-        self.config["zero"]["update_database"] = True
-
         tags = {
             "comments": "test comment",
             "year": 2016,
         }
-        self.load_plugins("zero")
 
-        z = ZeroPlugin()
-        z.write_event(item, item.path, tags)
+        with self.configure_plugin(
+            {"fields": None, "keep_fields": ["year"], "update_database": True}
+        ):
+            z = ZeroPlugin()
+            z.write_event(item, item.path, tags)
+
         self.assertIsNone(tags["comments"])
         self.assertEqual(tags["year"], 2016)
 
@@ -273,12 +242,9 @@ class ZeroPluginTest(PluginMixin, BeetsTestCase):
         )
         item.write()
         item_id = item.id
-        self.config["zero"]["fields"] = ["comments"]
-        self.config["zero"]["update_database"] = True
-        self.config["zero"]["auto"] = False
-
-        self.load_plugins("zero")
-        with control_stdin("n"):
+        with self.configure_plugin(
+            {"fields": ["comments"], "update_database": True, "auto": False}
+        ), control_stdin("n"):
             self.run_command("zero")
 
         mf = MediaFile(syspath(item.path))

--- a/test/plugins/test_zero.py
+++ b/test/plugins/test_zero.py
@@ -5,12 +5,12 @@ import unittest
 from mediafile import MediaFile
 
 from beets.library import Item
-from beets.test.helper import TestHelper, control_stdin
+from beets.test.helper import BeetsTestCase, control_stdin
 from beets.util import syspath
 from beetsplug.zero import ZeroPlugin
 
 
-class ZeroPluginTest(unittest.TestCase, TestHelper):
+class ZeroPluginTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
         self.config["zero"] = {

--- a/test/test_art_resize.py
+++ b/test/test_art_resize.py
@@ -56,14 +56,6 @@ class ArtResizerFileSizeTest(CleanupModulesMixin, BeetsTestCase):
     IMG_225x225 = os.path.join(_common.RSRC, b"abbey.jpg")
     IMG_225x225_SIZE = os.stat(syspath(IMG_225x225)).st_size
 
-    def setUp(self):
-        """Called before each test, setting up beets."""
-        self.setup_beets()
-
-    def tearDown(self):
-        """Called after each test, unloading all plugins."""
-        self.teardown_beets()
-
     def _test_img_resize(self, backend):
         """Test resizing based on file size, given a resize_func."""
         # Check quality setting unaffected by new parameter

--- a/test/test_art_resize.py
+++ b/test/test_art_resize.py
@@ -20,7 +20,7 @@ import unittest
 from unittest.mock import patch
 
 from beets.test import _common
-from beets.test.helper import CleanupModulesMixin, TestHelper
+from beets.test.helper import BeetsTestCase, CleanupModulesMixin
 from beets.util import command_output, syspath
 from beets.util.artresizer import IMBackend, PILBackend
 
@@ -48,7 +48,7 @@ class DummyPILBackend(PILBackend):
         pass
 
 
-class ArtResizerFileSizeTest(CleanupModulesMixin, _common.TestCase, TestHelper):
+class ArtResizerFileSizeTest(CleanupModulesMixin, BeetsTestCase):
     """Unittest test case for Art Resizer to a specific filesize."""
 
     modules = (IMBackend.__module__,)

--- a/test/test_art_resize.py
+++ b/test/test_art_resize.py
@@ -154,12 +154,3 @@ class ArtResizerFileSizeTest(CleanupModulesMixin, BeetsTestCase):
         except AssertionError:
             command = im.convert_cmd + "foo -set b B -set a A foo".split()
             mock_util.command_output.assert_called_once_with(command)
-
-
-def suite():
-    """Run this suite of tests."""
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_autotag.py
+++ b/test/test_autotag.py
@@ -22,11 +22,11 @@ from beets import autotag, config
 from beets.autotag import AlbumInfo, TrackInfo, match
 from beets.autotag.hooks import Distance, string_dist
 from beets.library import Item
-from beets.test import _common
+from beets.test.helper import BeetsTestCase
 from beets.util import plurality
 
 
-class PluralityTest(_common.TestCase):
+class PluralityTest(BeetsTestCase):
     def test_plurality_consensus(self):
         objs = [1, 1, 1, 1]
         obj, freq = plurality(objs)
@@ -146,7 +146,7 @@ def _clear_weights():
     Distance.__dict__["_weights"].cache = {}
 
 
-class DistanceTest(_common.TestCase):
+class DistanceTest(BeetsTestCase):
     def tearDown(self):
         super().tearDown()
         _clear_weights()
@@ -330,7 +330,7 @@ class DistanceTest(_common.TestCase):
         )
 
 
-class TrackDistanceTest(_common.TestCase):
+class TrackDistanceTest(BeetsTestCase):
     def test_identical_tracks(self):
         item = _make_item("one", 1)
         info = _make_trackinfo()[0]
@@ -358,7 +358,7 @@ class TrackDistanceTest(_common.TestCase):
         self.assertEqual(dist, 0.0)
 
 
-class AlbumDistanceTest(_common.TestCase):
+class AlbumDistanceTest(BeetsTestCase):
     def _mapping(self, items, info):
         out = {}
         for i, t in zip(items, info.tracks):
@@ -664,7 +664,7 @@ class ApplyTestUtil:
         autotag.apply_metadata(info, mapping)
 
 
-class ApplyTest(_common.TestCase, ApplyTestUtil):
+class ApplyTest(BeetsTestCase, ApplyTestUtil):
     def setUp(self):
         super().setUp()
 
@@ -925,7 +925,7 @@ class ApplyTest(_common.TestCase, ApplyTestUtil):
         self.assertEqual(self.items[0].data_source, "MusicBrainz")
 
 
-class ApplyCompilationTest(_common.TestCase, ApplyTestUtil):
+class ApplyCompilationTest(BeetsTestCase, ApplyTestUtil):
     def setUp(self):
         super().setUp()
 
@@ -1073,7 +1073,7 @@ class StringDistanceTest(unittest.TestCase):
         self.assertEqual(dist, 0.0)
 
 
-class EnumTest(_common.TestCase):
+class EnumTest(BeetsTestCase):
     """
     Test Enum Subclasses defined in beets.util.enumeration
     """

--- a/test/test_autotag.py
+++ b/test/test_autotag.py
@@ -1088,11 +1088,3 @@ class EnumTest(BeetsTestCase):
         self.assertGreater(OrderedEnumClass.b, OrderedEnumClass.a)
         self.assertGreater(OrderedEnumClass.c, OrderedEnumClass.a)
         self.assertGreater(OrderedEnumClass.c, OrderedEnumClass.b)
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_config_command.py
+++ b/test/test_config_command.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 from unittest.mock import patch
 
 import yaml
@@ -128,11 +127,3 @@ class ConfigCommandTest(BeetsTestCase):
         with patch("os.execlp") as execlp:
             self.run_command("config", "-e")
         execlp.assert_called_once_with("myeditor", "myeditor", self.config_path)
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_config_command.py
+++ b/test/test_config_command.py
@@ -10,7 +10,7 @@ from beets.test.helper import BeetsTestCase
 
 class ConfigCommandTest(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         for k in ("VISUAL", "EDITOR"):
             if k in os.environ:
                 del os.environ[k]
@@ -30,9 +30,6 @@ class ConfigCommandTest(BeetsTestCase):
         config.clear()
         config["password"].redact = True
         config._materialized = False
-
-    def tearDown(self):
-        self.teardown_beets()
 
     def _run_with_yaml_output(self, *args):
         output = self.run_with_output(*args)

--- a/test/test_config_command.py
+++ b/test/test_config_command.py
@@ -5,10 +5,10 @@ from unittest.mock import patch
 import yaml
 
 from beets import config, ui
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 
 
-class ConfigCommandTest(unittest.TestCase, TestHelper):
+class ConfigCommandTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
         for k in ("VISUAL", "EDITOR"):

--- a/test/test_datequery.py
+++ b/test/test_datequery.py
@@ -318,11 +318,3 @@ class DateQueryConstructTest(unittest.TestCase):
     def test_datetime_invalid_separator(self):
         with self.assertRaises(InvalidQueryArgumentValueError):
             DateQuery("added", "2000-01-01x12")
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_datequery.py
+++ b/test/test_datequery.py
@@ -25,7 +25,7 @@ from beets.dbcore.query import (
     InvalidQueryArgumentValueError,
     _parse_periods,
 )
-from beets.test.helper import LibTestCase
+from beets.test.helper import ItemInDBTestCase
 
 
 def _date(string):
@@ -152,7 +152,7 @@ def _parsetime(s):
     return time.mktime(datetime.strptime(s, "%Y-%m-%d %H:%M").timetuple())
 
 
-class DateQueryTest(LibTestCase):
+class DateQueryTest(ItemInDBTestCase):
     def setUp(self):
         super().setUp()
         self.i.added = _parsetime("2013-03-30 22:21")
@@ -187,7 +187,7 @@ class DateQueryTest(LibTestCase):
         self.assertEqual(len(matched), 0)
 
 
-class DateQueryTestRelative(LibTestCase):
+class DateQueryTestRelative(ItemInDBTestCase):
     def setUp(self):
         super().setUp()
 
@@ -233,7 +233,7 @@ class DateQueryTestRelative(LibTestCase):
         self.assertEqual(len(matched), 0)
 
 
-class DateQueryTestRelativeMore(LibTestCase):
+class DateQueryTestRelativeMore(ItemInDBTestCase):
     def setUp(self):
         super().setUp()
         self.i.added = _parsetime(datetime.now().strftime("%Y-%m-%d %H:%M"))

--- a/test/test_datequery.py
+++ b/test/test_datequery.py
@@ -25,7 +25,7 @@ from beets.dbcore.query import (
     InvalidQueryArgumentValueError,
     _parse_periods,
 )
-from beets.test import _common
+from beets.test.helper import LibTestCase
 
 
 def _date(string):
@@ -152,7 +152,7 @@ def _parsetime(s):
     return time.mktime(datetime.strptime(s, "%Y-%m-%d %H:%M").timetuple())
 
 
-class DateQueryTest(_common.LibTestCase):
+class DateQueryTest(LibTestCase):
     def setUp(self):
         super().setUp()
         self.i.added = _parsetime("2013-03-30 22:21")
@@ -187,7 +187,7 @@ class DateQueryTest(_common.LibTestCase):
         self.assertEqual(len(matched), 0)
 
 
-class DateQueryTestRelative(_common.LibTestCase):
+class DateQueryTestRelative(LibTestCase):
     def setUp(self):
         super().setUp()
 
@@ -233,7 +233,7 @@ class DateQueryTestRelative(_common.LibTestCase):
         self.assertEqual(len(matched), 0)
 
 
-class DateQueryTestRelativeMore(_common.LibTestCase):
+class DateQueryTestRelativeMore(LibTestCase):
     def setUp(self):
         super().setUp()
         self.i.added = _parsetime(datetime.now().strftime("%Y-%m-%d %H:%M"))

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -762,11 +762,3 @@ class ResultsIteratorTest(unittest.TestCase):
         self.assertIsNone(
             self.db._fetch(ModelFixture1, dbcore.query.FalseQuery()).get()
         )
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -41,14 +41,10 @@ class MoveTest(BeetsTestCase):
         )
 
         # add it to a temporary library
-        self.lib = beets.library.Library(":memory:")
         self.i = beets.library.Item.from_path(self.path)
         self.lib.add(self.i)
 
         # set up the destination
-        self.libdir = join(self.temp_dir, b"testlibdir")
-        os.mkdir(syspath(self.libdir))
-        self.lib.directory = self.libdir
         self.lib.path_formats = [
             ("default", join("$artist", "$album", "$title"))
         ]
@@ -250,12 +246,9 @@ class AlbumFileTest(BeetsTestCase):
         super().setUp()
 
         # Make library and item.
-        self.lib = beets.library.Library(":memory:")
         self.lib.path_formats = [
             ("default", join("$albumartist", "$album", "$title"))
         ]
-        self.libdir = os.path.join(self.temp_dir, b"testlibdir")
-        self.lib.directory = self.libdir
         self.i = item(self.lib)
         # Make a file for the item.
         self.i.path = self.i.destination()
@@ -317,9 +310,6 @@ class ArtFileTest(BeetsTestCase):
         super().setUp()
 
         # Make library and item.
-        self.lib = beets.library.Library(":memory:")
-        self.libdir = os.path.join(self.temp_dir, b"testlibdir")
-        self.lib.directory = self.libdir
         self.i = item(self.lib)
         self.i.path = self.i.destination()
         # Make a music file.
@@ -491,9 +481,6 @@ class RemoveTest(BeetsTestCase):
         super().setUp()
 
         # Make library and item.
-        self.lib = beets.library.Library(":memory:")
-        self.libdir = os.path.join(self.temp_dir, b"testlibdir")
-        self.lib.directory = self.libdir
         self.i = item(self.lib)
         self.i.path = self.i.destination()
         # Make a music file.

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -692,11 +692,3 @@ class MkDirAllTest(BeetsTestCase):
         path = os.path.join(self.temp_dir, b"foo", b"bar", b"baz", b"qux.mp3")
         util.mkdirall(path)
         self.assertNotExists(path)
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -25,10 +25,11 @@ import beets.library
 from beets import util
 from beets.test import _common
 from beets.test._common import item, touch
+from beets.test.helper import BeetsTestCase
 from beets.util import MoveOperation, bytestring_path, syspath
 
 
-class MoveTest(_common.TestCase):
+class MoveTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
@@ -207,7 +208,7 @@ class MoveTest(_common.TestCase):
         self.assertEqual(self.i.path, util.normpath(self.dest))
 
 
-class HelperTest(_common.TestCase):
+class HelperTest(BeetsTestCase):
     def test_ancestry_works_on_file(self):
         p = "/a/b/c"
         a = ["/", "/a", "/a/b"]
@@ -244,7 +245,7 @@ class HelperTest(_common.TestCase):
         self.assertEqual(util.path_as_posix(p), a)
 
 
-class AlbumFileTest(_common.TestCase):
+class AlbumFileTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
@@ -311,7 +312,7 @@ class AlbumFileTest(_common.TestCase):
         self.assertIn(b"testotherdir", self.i.path)
 
 
-class ArtFileTest(_common.TestCase):
+class ArtFileTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
@@ -485,7 +486,7 @@ class ArtFileTest(_common.TestCase):
         self.assertExists(oldartpath)
 
 
-class RemoveTest(_common.TestCase):
+class RemoveTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
@@ -546,7 +547,7 @@ class RemoveTest(_common.TestCase):
 
 
 # Tests that we can "delete" nonexistent files.
-class SoftRemoveTest(_common.TestCase):
+class SoftRemoveTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
@@ -564,7 +565,7 @@ class SoftRemoveTest(_common.TestCase):
             self.fail("OSError when removing path")
 
 
-class SafeMoveCopyTest(_common.TestCase):
+class SafeMoveCopyTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
@@ -612,7 +613,7 @@ class SafeMoveCopyTest(_common.TestCase):
         self.assertExists(self.path)
 
 
-class PruneTest(_common.TestCase):
+class PruneTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
@@ -632,7 +633,7 @@ class PruneTest(_common.TestCase):
         self.assertNotExists(self.sub)
 
 
-class WalkTest(_common.TestCase):
+class WalkTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
@@ -666,7 +667,7 @@ class WalkTest(_common.TestCase):
         self.assertEqual(res[0], (self.base, [], []))
 
 
-class UniquePathTest(_common.TestCase):
+class UniquePathTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
@@ -694,7 +695,7 @@ class UniquePathTest(_common.TestCase):
         self.assertEqual(path, os.path.join(self.base, b"x.3.mp3"))
 
 
-class MkDirAllTest(_common.TestCase):
+class MkDirAllTest(BeetsTestCase):
     def test_parent_exists(self):
         path = os.path.join(self.temp_dir, b"foo", b"bar", b"baz", b"qux.mp3")
         util.mkdirall(path)

--- a/test/test_hidden.py
+++ b/test/test_hidden.py
@@ -74,11 +74,3 @@ class HiddenFileTest(unittest.TestCase):
         with tempfile.NamedTemporaryFile(prefix=".tmp") as f:
             fn = util.bytestring_path(f.name)
             self.assertTrue(hidden.is_hidden(fn))
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -45,8 +45,10 @@ from beets.util import bytestring_path, displayable_path, syspath
 
 
 class ScrubbedImportTest(ImportTestCase):
+    db_on_disk = True
+
     def setUp(self):
-        self.setup_beets(disk=True)
+        super().setUp()
         self.load_plugins("scrub")
         self._create_import_dir(2)
         self._setup_import_session(autotag=False)
@@ -100,8 +102,10 @@ class ScrubbedImportTest(ImportTestCase):
 
 @_common.slow_test()
 class NonAutotaggedImportTest(ImportTestCase):
+    db_on_disk = True
+
     def setUp(self):
-        self.setup_beets(disk=True)
+        super().setUp()
         self._create_import_dir(2)
         self._setup_import_session(autotag=False)
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -53,7 +53,7 @@ class ScrubbedImportTest(ImportTestCase):
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def test_tags_not_scrubbed(self):
         config["plugins"] = ["scrub"]
@@ -104,9 +104,6 @@ class NonAutotaggedImportTest(ImportTestCase):
         self.setup_beets(disk=True)
         self._create_import_dir(2)
         self._setup_import_session(autotag=False)
-
-    def tearDown(self):
-        self.teardown_beets()
 
     def test_album_created_with_track_artist(self):
         self.importer.run()
@@ -277,13 +274,10 @@ class RmTempTest(ImportTestCase):
     """
 
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.want_resume = False
         self.config["incremental"] = False
         self._old_home = None
-
-    def tearDown(self):
-        self.teardown_beets()
 
     def test_rm(self):
         zip_path = create_archive(self)
@@ -297,12 +291,6 @@ class RmTempTest(ImportTestCase):
 
 
 class ImportZipTest(ImportTestCase):
-    def setUp(self):
-        self.setup_beets()
-
-    def tearDown(self):
-        self.teardown_beets()
-
     def test_import_zip(self):
         zip_path = create_archive(self)
         self.assertEqual(len(self.lib.items()), 0)
@@ -350,14 +338,14 @@ class ImportSingletonTest(ImportTestCase):
     """
 
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self._create_import_dir(1)
         self._setup_import_session()
         config["import"]["singletons"] = True
         self.matcher = AutotagStub().install()
 
     def tearDown(self):
-        self.teardown_beets()
+        super().tearDown()
         self.matcher.restore()
 
     def test_apply_asis_adds_track(self):
@@ -471,14 +459,14 @@ class ImportTest(ImportTestCase):
     """Test APPLY, ASIS and SKIP choices."""
 
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self._create_import_dir(1)
         self._setup_import_session()
         self.matcher = AutotagStub().install()
         self.matcher.macthin = AutotagStub.GOOD
 
     def tearDown(self):
-        self.teardown_beets()
+        super().tearDown()
         self.matcher.restore()
 
     def test_apply_asis_adds_album(self):
@@ -685,13 +673,13 @@ class ImportTracksTest(ImportTestCase):
     """Test TRACKS and APPLY choice."""
 
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self._create_import_dir(1)
         self._setup_import_session()
         self.matcher = AutotagStub().install()
 
     def tearDown(self):
-        self.teardown_beets()
+        super().tearDown()
         self.matcher.restore()
 
     def test_apply_tracks_adds_singleton_track(self):
@@ -719,13 +707,13 @@ class ImportCompilationTest(ImportTestCase):
     """Test ASIS import of a folder containing tracks with different artists."""
 
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self._create_import_dir(3)
         self._setup_import_session()
         self.matcher = AutotagStub().install()
 
     def tearDown(self):
-        self.teardown_beets()
+        super().tearDown()
         self.matcher.restore()
 
     def test_asis_homogenous_sets_albumartist(self):
@@ -838,7 +826,7 @@ class ImportExistingTest(ImportTestCase):
     """Test importing files that are already in the library directory."""
 
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self._create_import_dir(1)
         self.matcher = AutotagStub().install()
 
@@ -849,7 +837,7 @@ class ImportExistingTest(ImportTestCase):
         self._setup_import_session(import_dir=self.libdir)
 
     def tearDown(self):
-        self.teardown_beets()
+        super().tearDown()
         self.matcher.restore()
 
     def test_does_not_duplicate_item(self):
@@ -961,7 +949,7 @@ class ImportExistingTest(ImportTestCase):
 
 class GroupAlbumsImportTest(ImportTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self._create_import_dir(3)
         self.matcher = AutotagStub().install()
         self.matcher.matching = AutotagStub.NONE
@@ -973,7 +961,7 @@ class GroupAlbumsImportTest(ImportTestCase):
         self.importer.add_choice(importer.action.ASIS)
 
     def tearDown(self):
-        self.teardown_beets()
+        super().tearDown()
         self.matcher.restore()
 
     def test_add_album_for_different_artist_and_different_album(self):
@@ -1033,14 +1021,14 @@ class GlobalGroupAlbumsImportTest(GroupAlbumsImportTest):
 
 class ChooseCandidateTest(ImportTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self._create_import_dir(1)
         self._setup_import_session()
         self.matcher = AutotagStub().install()
         self.matcher.matching = AutotagStub.BAD
 
     def tearDown(self):
-        self.teardown_beets()
+        super().tearDown()
         self.matcher.restore()
 
     def test_choose_first_candidate(self):
@@ -1172,7 +1160,7 @@ def match_album_mock(*args, **kwargs):
 @patch("beets.autotag.mb.match_album", Mock(side_effect=match_album_mock))
 class ImportDuplicateAlbumTest(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
 
         # Original album
         self.add_album_fixture(albumartist="artist", album="album")
@@ -1181,9 +1169,6 @@ class ImportDuplicateAlbumTest(BeetsTestCase):
         self.importer = self.create_importer()
         config["import"]["autotag"] = True
         config["import"]["duplicate_keys"]["album"] = "albumartist album"
-
-    def tearDown(self):
-        self.teardown_beets()
 
     def test_remove_duplicate_album(self):
         item = self.lib.items().get()
@@ -1294,7 +1279,7 @@ def match_track_mock(*args, **kwargs):
 @patch("beets.autotag.mb.match_track", Mock(side_effect=match_track_mock))
 class ImportDuplicateSingletonTest(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
 
         # Original file in library
         self.add_item_fixture(
@@ -1306,9 +1291,6 @@ class ImportDuplicateSingletonTest(BeetsTestCase):
         config["import"]["autotag"] = True
         config["import"]["singletons"] = True
         config["import"]["duplicate_keys"]["item"] = "artist title"
-
-    def tearDown(self):
-        self.teardown_beets()
 
     def test_remove_duplicate(self):
         item = self.lib.items().get()
@@ -1382,12 +1364,6 @@ class TagLogTest(BeetsTestCase):
 
 
 class ResumeImportTest(BeetsTestCase):
-    def setUp(self):
-        self.setup_beets()
-
-    def tearDown(self):
-        self.teardown_beets()
-
     @patch("beets.plugins.send")
     def test_resume_album(self, plugins_send):
         self.importer = self.create_importer(album_count=2)
@@ -1434,11 +1410,8 @@ class ResumeImportTest(BeetsTestCase):
 
 class IncrementalImportTest(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.config["import"]["incremental"] = True
-
-    def tearDown(self):
-        self.teardown_beets()
 
     def test_incremental_album(self):
         importer = self.create_importer(album_count=1)
@@ -1656,7 +1629,7 @@ class ReimportTest(ImportTestCase):
     """
 
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
 
         # The existing album.
         album = self.add_album_fixture()
@@ -1674,7 +1647,7 @@ class ReimportTest(ImportTestCase):
         self.matcher.matching = AutotagStub.GOOD
 
     def tearDown(self):
-        self.teardown_beets()
+        super().tearDown()
         self.matcher.restore()
 
     def _setup_session(self, singletons=False):
@@ -1759,8 +1732,7 @@ class ImportPretendTest(ImportTestCase):
         self.matcher = None
 
     def setUp(self):
-        self.io = _common.DummyIO()
-        self.setup_beets()
+        super().setUp()
         self.__create_import_dir()
         self.__create_empty_import_dir()
         self._setup_import_session()
@@ -1769,7 +1741,7 @@ class ImportPretendTest(ImportTestCase):
         self.io.install()
 
     def tearDown(self):
-        self.teardown_beets()
+        super().tearDown()
         self.matcher.restore()
 
     def __create_import_dir(self):
@@ -1955,11 +1927,8 @@ class ImportMusicBrainzIdTest(ImportTestCase):
     ID_RECORDING_1 = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self._create_import_dir(1)
-
-    def tearDown(self):
-        self.teardown_beets()
 
     def test_one_mbid_one_album(self):
         self.config["import"]["search_ids"] = [

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -144,18 +144,18 @@ class NonAutotaggedImportTest(ImportTestCase):
     def test_import_with_move_prunes_directory_empty(self):
         config["import"]["move"] = True
 
-        self.assertExists(os.path.join(self.import_dir, b"the_album"))
+        self.assertExists(os.path.join(self.import_dir, b"album"))
         self.importer.run()
-        self.assertNotExists(os.path.join(self.import_dir, b"the_album"))
+        self.assertNotExists(os.path.join(self.import_dir, b"album"))
 
     def test_import_with_move_prunes_with_extra_clutter(self):
-        self.touch(os.path.join(self.import_dir, b"the_album", b"alog.log"))
+        self.touch(os.path.join(self.import_dir, b"album", b"alog.log"))
         config["clutter"] = ["*.log"]
         config["import"]["move"] = True
 
-        self.assertExists(os.path.join(self.import_dir, b"the_album"))
+        self.assertExists(os.path.join(self.import_dir, b"album"))
         self.importer.run()
-        self.assertNotExists(os.path.join(self.import_dir, b"the_album"))
+        self.assertNotExists(os.path.join(self.import_dir, b"album"))
 
     def test_threaded_import_move_arrives(self):
         config["import"]["move"] = True
@@ -192,9 +192,9 @@ class NonAutotaggedImportTest(ImportTestCase):
 
     def test_import_with_delete_prunes_directory_empty(self):
         config["import"]["delete"] = True
-        self.assertExists(os.path.join(self.import_dir, b"the_album"))
+        self.assertExists(os.path.join(self.import_dir, b"album"))
         self.importer.run()
-        self.assertNotExists(os.path.join(self.import_dir, b"the_album"))
+        self.assertNotExists(os.path.join(self.import_dir, b"album"))
 
     @unittest.skipUnless(_common.HAVE_SYMLINK, "need symlinks")
     def test_import_link_arrives(self):
@@ -354,7 +354,7 @@ class ImportSingletonTest(ImportTestCase):
 
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
-        self.assertEqual(self.lib.items().get().title, "Tag Title 1")
+        self.assertEqual(self.lib.items().get().title, "Tag Track 1")
 
     def test_apply_asis_does_not_add_album(self):
         self.assertIsNone(self.lib.albums().get())
@@ -368,14 +368,14 @@ class ImportSingletonTest(ImportTestCase):
 
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
-        self.assert_file_in_lib(b"singletons", b"Tag Title 1.mp3")
+        self.assert_file_in_lib(b"singletons", b"Tag Track 1.mp3")
 
     def test_apply_candidate_adds_track(self):
         self.assertIsNone(self.lib.items().get())
 
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
-        self.assertEqual(self.lib.items().get().title, "Applied Title 1")
+        self.assertEqual(self.lib.items().get().title, "Applied Track 1")
 
     def test_apply_candidate_does_not_add_album(self):
         self.importer.add_choice(importer.action.APPLY)
@@ -387,7 +387,7 @@ class ImportSingletonTest(ImportTestCase):
 
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
-        self.assert_file_in_lib(b"singletons", b"Applied Title 1.mp3")
+        self.assert_file_in_lib(b"singletons", b"Applied Track 1.mp3")
 
     def test_skip_does_not_add_first_track(self):
         self.importer.add_choice(importer.action.SKIP)
@@ -407,7 +407,7 @@ class ImportSingletonTest(ImportTestCase):
 
         util.copy(resource_path, single_path)
         import_files = [
-            os.path.join(self.import_dir, b"the_album"),
+            os.path.join(self.import_dir, b"album"),
             single_path,
         ]
         self._setup_import_session(singletons=False)
@@ -439,7 +439,7 @@ class ImportSingletonTest(ImportTestCase):
             item.load()  # TODO: Not sure this is necessary.
             self.assertEqual(item.genre, genre)
             self.assertEqual(item.collection, collection)
-            self.assertEqual(item.title, "Tag Title 1 - formatted")
+            self.assertEqual(item.title, "Tag Track 1 - formatted")
             # Remove item from library to test again with APPLY choice.
             item.remove()
 
@@ -453,7 +453,7 @@ class ImportSingletonTest(ImportTestCase):
             item.load()
             self.assertEqual(item.genre, genre)
             self.assertEqual(item.collection, collection)
-            self.assertEqual(item.title, "Applied Title 1 - formatted")
+            self.assertEqual(item.title, "Applied Track 1 - formatted")
 
 
 class ImportTest(ImportTestCase):
@@ -481,14 +481,14 @@ class ImportTest(ImportTestCase):
         self.assertIsNone(self.lib.items().get())
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
-        self.assertEqual(self.lib.items().get().title, "Tag Title 1")
+        self.assertEqual(self.lib.items().get().title, "Tag Track 1")
 
     def test_apply_asis_adds_album_path(self):
         self.assert_lib_dir_empty()
 
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
-        self.assert_file_in_lib(b"Tag Artist", b"Tag Album", b"Tag Title 1.mp3")
+        self.assert_file_in_lib(b"Tag Artist", b"Tag Album", b"Tag Track 1.mp3")
 
     def test_apply_candidate_adds_album(self):
         self.assertIsNone(self.lib.albums().get())
@@ -502,7 +502,7 @@ class ImportTest(ImportTestCase):
 
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
-        self.assertEqual(self.lib.items().get().title, "Applied Title 1")
+        self.assertEqual(self.lib.items().get().title, "Applied Track 1")
 
     def test_apply_candidate_adds_album_path(self):
         self.assert_lib_dir_empty()
@@ -510,7 +510,7 @@ class ImportTest(ImportTestCase):
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
         self.assert_file_in_lib(
-            b"Applied Artist", b"Applied Album", b"Applied Title 1.mp3"
+            b"Applied Artist", b"Applied Album", b"Applied Track 1.mp3"
         )
 
     def test_apply_from_scratch_removes_other_metadata(self):
@@ -542,9 +542,7 @@ class ImportTest(ImportTestCase):
     def test_apply_with_move_deletes_import(self):
         config["import"]["move"] = True
 
-        import_file = os.path.join(
-            self.import_dir, b"the_album", b"track_1.mp3"
-        )
+        import_file = os.path.join(self.import_dir, b"album", b"track_1.mp3")
         self.assertExists(import_file)
 
         self.importer.add_choice(importer.action.APPLY)
@@ -554,9 +552,7 @@ class ImportTest(ImportTestCase):
     def test_apply_with_delete_deletes_import(self):
         config["import"]["delete"] = True
 
-        import_file = os.path.join(
-            self.import_dir, b"the_album", b"track_1.mp3"
-        )
+        import_file = os.path.join(self.import_dir, b"album", b"track_1.mp3")
         self.assertExists(import_file)
 
         self.importer.add_choice(importer.action.APPLY)
@@ -569,7 +565,7 @@ class ImportTest(ImportTestCase):
         self.assertIsNone(self.lib.items().get())
 
     def test_skip_non_album_dirs(self):
-        self.assertIsDir(os.path.join(self.import_dir, b"the_album"))
+        self.assertIsDir(os.path.join(self.import_dir, b"album"))
         self.touch(b"cruft", dir=self.import_dir)
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
@@ -691,7 +687,7 @@ class ImportTracksTest(ImportTestCase):
         self.importer.add_choice(importer.action.APPLY)
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
-        self.assertEqual(self.lib.items().get().title, "Applied Title 1")
+        self.assertEqual(self.lib.items().get().title, "Applied Track 1")
         self.assertIsNone(self.lib.albums().get())
 
     def test_apply_tracks_adds_singleton_path(self):
@@ -701,7 +697,7 @@ class ImportTracksTest(ImportTestCase):
         self.importer.add_choice(importer.action.APPLY)
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
-        self.assert_file_in_lib(b"singletons", b"Applied Title 1.mp3")
+        self.assert_file_in_lib(b"singletons", b"Applied Track 1.mp3")
 
 
 class ImportCompilationTest(ImportTestCase):
@@ -885,7 +881,7 @@ class ImportExistingTest(ImportTestCase):
         medium.save()
 
         old_path = os.path.join(
-            b"Applied Artist", b"Applied Album", b"Applied Title 1.mp3"
+            b"Applied Artist", b"Applied Album", b"Applied Track 1.mp3"
         )
         self.assert_file_in_lib(old_path)
 
@@ -903,7 +899,7 @@ class ImportExistingTest(ImportTestCase):
         medium.save()
 
         old_path = os.path.join(
-            b"Applied Artist", b"Applied Album", b"Applied Title 1.mp3"
+            b"Applied Artist", b"Applied Album", b"Applied Track 1.mp3"
         )
         self.assert_file_in_lib(old_path)
 
@@ -927,7 +923,7 @@ class ImportExistingTest(ImportTestCase):
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
         new_path = os.path.join(
-            b"Applied Artist", b"Applied Album", b"Applied Title 1.mp3"
+            b"Applied Artist", b"Applied Album", b"Applied Track 1.mp3"
         )
 
         self.assert_file_in_lib(new_path)
@@ -1194,7 +1190,7 @@ class ImportDuplicateAlbumTest(ImportTestCase):
         # Imported item has the same artist and album as the one in the
         # library.
         import_file = os.path.join(
-            self.importer.paths[0], b"album 0", b"track 0.mp3"
+            self.importer.paths[0], b"album_1", b"track_1.mp3"
         )
         import_file = MediaFile(import_file)
         import_file.artist = item["artist"]
@@ -1242,7 +1238,7 @@ class ImportDuplicateAlbumTest(ImportTestCase):
 
         item = self.lib.items().get()
         import_file = MediaFile(
-            os.path.join(self.importer.paths[0], b"album 0", b"track 0.mp3")
+            os.path.join(self.importer.paths[0], b"album_1", b"track_1.mp3")
         )
         import_file.artist = item["artist"]
         import_file.albumartist = item["artist"]
@@ -1380,11 +1376,11 @@ class ResumeImportTest(ImportTestCase):
 
         self.importer.run()
         self.assertEqual(len(self.lib.albums()), 1)
-        self.assertIsNotNone(self.lib.albums("album:album 0").get())
+        self.assertIsNotNone(self.lib.albums("album:'Album 1'").get())
 
         self.importer.run()
         self.assertEqual(len(self.lib.albums()), 2)
-        self.assertIsNotNone(self.lib.albums("album:album 1").get())
+        self.assertIsNotNone(self.lib.albums("album:'Album 2'").get())
 
     @patch("beets.plugins.send")
     def test_resume_singleton(self, plugins_send):
@@ -1402,11 +1398,11 @@ class ResumeImportTest(ImportTestCase):
 
         self.importer.run()
         self.assertEqual(len(self.lib.items()), 1)
-        self.assertIsNotNone(self.lib.items("title:track 0").get())
+        self.assertIsNotNone(self.lib.items("title:'Track 1'").get())
 
         self.importer.run()
         self.assertEqual(len(self.lib.items()), 2)
-        self.assertIsNotNone(self.lib.items("title:track 1").get())
+        self.assertIsNotNone(self.lib.items("title:'Track 1'").get())
 
 
 class IncrementalImportTest(ImportTestCase):
@@ -1751,7 +1747,7 @@ class ImportPretendTest(ImportTestCase):
         single_path = os.path.join(self.import_dir, b"track_2.mp3")
         shutil.copy(syspath(resource_path), syspath(single_path))
         self.import_paths = [
-            os.path.join(self.import_dir, b"the_album"),
+            os.path.join(self.import_dir, b"album"),
             single_path,
         ]
         self.import_files = [

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -38,24 +38,21 @@ from beets.test.helper import (
     AutotagStub,
     BeetsTestCase,
     ImportTestCase,
+    PluginMixin,
     capture_log,
     has_program,
 )
 from beets.util import bytestring_path, displayable_path, syspath
 
 
-class ScrubbedImportTest(ImportTestCase):
+class ScrubbedImportTest(PluginMixin, ImportTestCase):
     db_on_disk = True
+    plugin = "scrub"
 
     def setUp(self):
         super().setUp()
-        self.load_plugins("scrub")
         self._create_import_dir(2)
         self._setup_import_session(autotag=False)
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
 
     def test_tags_not_scrubbed(self):
         config["plugins"] = ["scrub"]

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1159,7 +1159,7 @@ def match_album_mock(*args, **kwargs):
 
 
 @patch("beets.autotag.mb.match_album", Mock(side_effect=match_album_mock))
-class ImportDuplicateAlbumTest(BeetsTestCase):
+class ImportDuplicateAlbumTest(ImportTestCase):
     def setUp(self):
         super().setUp()
 
@@ -1278,7 +1278,7 @@ def match_track_mock(*args, **kwargs):
 
 
 @patch("beets.autotag.mb.match_track", Mock(side_effect=match_track_mock))
-class ImportDuplicateSingletonTest(BeetsTestCase):
+class ImportDuplicateSingletonTest(ImportTestCase):
     def setUp(self):
         super().setUp()
 
@@ -1364,7 +1364,7 @@ class TagLogTest(BeetsTestCase):
         self.assertIn("status caf\xe9", sio.getvalue())
 
 
-class ResumeImportTest(BeetsTestCase):
+class ResumeImportTest(ImportTestCase):
     @patch("beets.plugins.send")
     def test_resume_album(self, plugins_send):
         self.importer = self.create_importer(album_count=2)
@@ -1409,7 +1409,7 @@ class ResumeImportTest(BeetsTestCase):
         self.assertIsNotNone(self.lib.items("title:track 1").get())
 
 
-class IncrementalImportTest(BeetsTestCase):
+class IncrementalImportTest(ImportTestCase):
     def setUp(self):
         super().setUp()
         self.config["import"]["incremental"] = True

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1687,7 +1687,7 @@ class ImportPretendTest(ImportTestCase):
         self.matcher = AutotagStub().install()
         self.io.install()
 
-        self.album_track_path, *_ = self.prepare_album_for_import(1)
+        self.album_track_path = self.prepare_album_for_import(1)[0]
         self.single_path = self.prepare_track_for_import(2, self.import_path)
         self.album_path = self.album_track_path.parent
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -271,7 +271,7 @@ def create_archive(session):
     return path
 
 
-class RmTempTest(unittest.TestCase, ImportHelper, _common.Assertions):
+class RmTempTest(unittest.TestCase, ImportHelper):
     """Tests that temporarily extracted archives are properly removed
     after usage.
     """
@@ -1170,9 +1170,7 @@ def match_album_mock(*args, **kwargs):
 
 
 @patch("beets.autotag.mb.match_album", Mock(side_effect=match_album_mock))
-class ImportDuplicateAlbumTest(
-    unittest.TestCase, TestHelper, _common.Assertions
-):
+class ImportDuplicateAlbumTest(unittest.TestCase, TestHelper):
     def setUp(self):
         self.setup_beets()
 
@@ -1294,9 +1292,7 @@ def match_track_mock(*args, **kwargs):
 
 
 @patch("beets.autotag.mb.match_track", Mock(side_effect=match_track_mock))
-class ImportDuplicateSingletonTest(
-    unittest.TestCase, TestHelper, _common.Assertions
-):
+class ImportDuplicateSingletonTest(unittest.TestCase, TestHelper):
     def setUp(self):
         self.setup_beets()
 
@@ -1650,7 +1646,7 @@ class MultiDiscAlbumsInDirTest(_common.TestCase):
         self.assertEqual(len(items), 3)
 
 
-class ReimportTest(unittest.TestCase, ImportHelper, _common.Assertions):
+class ReimportTest(unittest.TestCase, ImportHelper):
     """Test "re-imports", in which the autotagging machinery is used for
     music that's already in the library.
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -38,7 +38,6 @@ from beets.test.helper import (
     AutotagStub,
     BeetsTestCase,
     ImportHelper,
-    TestHelper,
     capture_log,
     has_program,
 )
@@ -1171,7 +1170,7 @@ def match_album_mock(*args, **kwargs):
 
 
 @patch("beets.autotag.mb.match_album", Mock(side_effect=match_album_mock))
-class ImportDuplicateAlbumTest(unittest.TestCase, TestHelper):
+class ImportDuplicateAlbumTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
 
@@ -1293,7 +1292,7 @@ def match_track_mock(*args, **kwargs):
 
 
 @patch("beets.autotag.mb.match_track", Mock(side_effect=match_track_mock))
-class ImportDuplicateSingletonTest(unittest.TestCase, TestHelper):
+class ImportDuplicateSingletonTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
 
@@ -1382,7 +1381,7 @@ class TagLogTest(BeetsTestCase):
         self.assertIn("status caf\xe9", sio.getvalue())
 
 
-class ResumeImportTest(unittest.TestCase, TestHelper):
+class ResumeImportTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
 
@@ -1433,7 +1432,7 @@ class ResumeImportTest(unittest.TestCase, TestHelper):
         self.assertIsNotNone(self.lib.items("title:track 1").get())
 
 
-class IncrementalImportTest(unittest.TestCase, TestHelper):
+class IncrementalImportTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
         self.config["import"]["incremental"] = True

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -2008,11 +2008,3 @@ class ImportMusicBrainzIdTest(ImportTestCase):
             {"VALID_RECORDING_0", "VALID_RECORDING_1"},
             {c.info.title for c in task.candidates},
         )
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -51,7 +51,7 @@ class ScrubbedImportTest(PluginMixin, ImportTestCase):
 
     def setUp(self):
         super().setUp()
-        self._create_import_dir(2)
+        self.prepare_album_for_import(2)
         self._setup_import_session(autotag=False)
 
     def test_tags_not_scrubbed(self):
@@ -103,7 +103,7 @@ class NonAutotaggedImportTest(ImportTestCase):
 
     def setUp(self):
         super().setUp()
-        self._create_import_dir(2)
+        self.prepare_album_for_import(2)
         self._setup_import_session(autotag=False)
 
     def test_album_created_with_track_artist(self):
@@ -340,7 +340,7 @@ class ImportSingletonTest(ImportTestCase):
 
     def setUp(self):
         super().setUp()
-        self._create_import_dir(1)
+        self.prepare_album_for_import(1)
         self._setup_import_session()
         config["import"]["singletons"] = True
         self.matcher = AutotagStub().install()
@@ -395,7 +395,7 @@ class ImportSingletonTest(ImportTestCase):
         self.assertIsNone(self.lib.items().get())
 
     def test_skip_adds_other_tracks(self):
-        self._create_import_dir(2)
+        self.prepare_album_for_import(2)
         self.importer.add_choice(importer.action.SKIP)
         self.importer.add_choice(importer.action.ASIS)
         self.importer.run()
@@ -461,7 +461,7 @@ class ImportTest(ImportTestCase):
 
     def setUp(self):
         super().setUp()
-        self._create_import_dir(1)
+        self.prepare_album_for_import(1)
         self._setup_import_session()
         self.matcher = AutotagStub().install()
         self.matcher.macthin = AutotagStub.GOOD
@@ -572,7 +572,7 @@ class ImportTest(ImportTestCase):
         self.assertEqual(len(self.lib.albums()), 1)
 
     def test_unmatched_tracks_not_added(self):
-        self._create_import_dir(2)
+        self.prepare_album_for_import(2)
         self.matcher.matching = self.matcher.MISSING
         self.importer.add_choice(importer.action.APPLY)
         self.importer.run()
@@ -671,7 +671,7 @@ class ImportTracksTest(ImportTestCase):
 
     def setUp(self):
         super().setUp()
-        self._create_import_dir(1)
+        self.prepare_album_for_import(1)
         self._setup_import_session()
         self.matcher = AutotagStub().install()
 
@@ -705,7 +705,7 @@ class ImportCompilationTest(ImportTestCase):
 
     def setUp(self):
         super().setUp()
-        self._create_import_dir(3)
+        self.prepare_album_for_import(3)
         self._setup_import_session()
         self.matcher = AutotagStub().install()
 
@@ -824,7 +824,7 @@ class ImportExistingTest(ImportTestCase):
 
     def setUp(self):
         super().setUp()
-        self._create_import_dir(1)
+        self.prepare_album_for_import(1)
         self.matcher = AutotagStub().install()
 
         self._setup_import_session()
@@ -947,7 +947,7 @@ class ImportExistingTest(ImportTestCase):
 class GroupAlbumsImportTest(ImportTestCase):
     def setUp(self):
         super().setUp()
-        self._create_import_dir(3)
+        self.prepare_album_for_import(3)
         self.matcher = AutotagStub().install()
         self.matcher.matching = AutotagStub.NONE
         self._setup_import_session()
@@ -1019,7 +1019,7 @@ class GlobalGroupAlbumsImportTest(GroupAlbumsImportTest):
 class ChooseCandidateTest(ImportTestCase):
     def setUp(self):
         super().setUp()
-        self._create_import_dir(1)
+        self.prepare_album_for_import(1)
         self._setup_import_session()
         self.matcher = AutotagStub().install()
         self.matcher.matching = AutotagStub.BAD
@@ -1742,7 +1742,7 @@ class ImportPretendTest(ImportTestCase):
         self.matcher.restore()
 
     def __create_import_dir(self):
-        self._create_import_dir(1)
+        self.prepare_album_for_import(1)
         resource_path = os.path.join(_common.RSRC, b"empty.mp3")
         single_path = os.path.join(self.import_dir, b"track_2.mp3")
         shutil.copy(syspath(resource_path), syspath(single_path))
@@ -1822,7 +1822,7 @@ def mocked_get_release_by_id(
     """Mimic musicbrainzngs.get_release_by_id, accepting only a restricted list
     of MB ids (ID_RELEASE_0, ID_RELEASE_1). The returned dict differs only in
     the release title and artist name, so that ID_RELEASE_0 is a closer match
-    to the items created by ImportHelper._create_import_dir()."""
+    to the items created by ImportHelper.prepare_album_for_import()."""
     # Map IDs to (release title, artist), so the distances are different.
     releases = {
         ImportMusicBrainzIdTest.ID_RELEASE_0: ("VALID_RELEASE_0", "TAG ARTIST"),
@@ -1875,7 +1875,8 @@ def mocked_get_recording_by_id(
     """Mimic musicbrainzngs.get_recording_by_id, accepting only a restricted
     list of MB ids (ID_RECORDING_0, ID_RECORDING_1). The returned dict differs
     only in the recording title and artist name, so that ID_RECORDING_0 is a
-    closer match to the items created by ImportHelper._create_import_dir()."""
+    closer match to the items created by ImportHelper.prepare_album_for_import().
+    """
     # Map IDs to (recording title, artist), so the distances are different.
     releases = {
         ImportMusicBrainzIdTest.ID_RECORDING_0: (
@@ -1925,7 +1926,7 @@ class ImportMusicBrainzIdTest(ImportTestCase):
 
     def setUp(self):
         super().setUp()
-        self._create_import_dir(1)
+        self.prepare_album_for_import(1)
 
     def test_one_mbid_one_album(self):
         self.config["import"]["search_ids"] = [

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -37,14 +37,14 @@ from beets.test import _common
 from beets.test.helper import (
     AutotagStub,
     BeetsTestCase,
-    ImportHelper,
+    ImportTestCase,
     capture_log,
     has_program,
 )
 from beets.util import bytestring_path, displayable_path, syspath
 
 
-class ScrubbedImportTest(BeetsTestCase, ImportHelper):
+class ScrubbedImportTest(ImportTestCase):
     def setUp(self):
         self.setup_beets(disk=True)
         self.load_plugins("scrub")
@@ -99,7 +99,7 @@ class ScrubbedImportTest(BeetsTestCase, ImportHelper):
 
 
 @_common.slow_test()
-class NonAutotaggedImportTest(BeetsTestCase, ImportHelper):
+class NonAutotaggedImportTest(ImportTestCase):
     def setUp(self):
         self.setup_beets(disk=True)
         self._create_import_dir(2)
@@ -271,7 +271,7 @@ def create_archive(session):
     return path
 
 
-class RmTempTest(unittest.TestCase, ImportHelper):
+class RmTempTest(ImportTestCase):
     """Tests that temporarily extracted archives are properly removed
     after usage.
     """
@@ -296,7 +296,7 @@ class RmTempTest(unittest.TestCase, ImportHelper):
         self.assertNotExists(tmp_path)
 
 
-class ImportZipTest(unittest.TestCase, ImportHelper):
+class ImportZipTest(ImportTestCase):
     def setUp(self):
         self.setup_beets()
 
@@ -344,7 +344,7 @@ class ImportPasswordRarTest(ImportZipTest):
         return os.path.join(_common.RSRC, b"password.rar")
 
 
-class ImportSingletonTest(BeetsTestCase, ImportHelper):
+class ImportSingletonTest(ImportTestCase):
     """Test ``APPLY`` and ``ASIS`` choices for an import session with
     singletons config set to True.
     """
@@ -467,7 +467,7 @@ class ImportSingletonTest(BeetsTestCase, ImportHelper):
             self.assertEqual(item.title, "Applied Title 1 - formatted")
 
 
-class ImportTest(BeetsTestCase, ImportHelper):
+class ImportTest(ImportTestCase):
     """Test APPLY, ASIS and SKIP choices."""
 
     def setUp(self):
@@ -681,7 +681,7 @@ class ImportTest(BeetsTestCase, ImportHelper):
                 )
 
 
-class ImportTracksTest(BeetsTestCase, ImportHelper):
+class ImportTracksTest(ImportTestCase):
     """Test TRACKS and APPLY choice."""
 
     def setUp(self):
@@ -715,7 +715,7 @@ class ImportTracksTest(BeetsTestCase, ImportHelper):
         self.assert_file_in_lib(b"singletons", b"Applied Title 1.mp3")
 
 
-class ImportCompilationTest(BeetsTestCase, ImportHelper):
+class ImportCompilationTest(ImportTestCase):
     """Test ASIS import of a folder containing tracks with different artists."""
 
     def setUp(self):
@@ -834,7 +834,7 @@ class ImportCompilationTest(BeetsTestCase, ImportHelper):
         self.assertTrue(asserted_multi_artists_0 and asserted_multi_artists_1)
 
 
-class ImportExistingTest(BeetsTestCase, ImportHelper):
+class ImportExistingTest(ImportTestCase):
     """Test importing files that are already in the library directory."""
 
     def setUp(self):
@@ -959,7 +959,7 @@ class ImportExistingTest(BeetsTestCase, ImportHelper):
         self.assertNotExists(self.import_media[0].path)
 
 
-class GroupAlbumsImportTest(BeetsTestCase, ImportHelper):
+class GroupAlbumsImportTest(ImportTestCase):
     def setUp(self):
         self.setup_beets()
         self._create_import_dir(3)
@@ -1031,7 +1031,7 @@ class GlobalGroupAlbumsImportTest(GroupAlbumsImportTest):
         config["import"]["group_albums"] = True
 
 
-class ChooseCandidateTest(BeetsTestCase, ImportHelper):
+class ChooseCandidateTest(ImportTestCase):
     def setUp(self):
         self.setup_beets()
         self._create_import_dir(1)
@@ -1646,7 +1646,7 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
         self.assertEqual(len(items), 3)
 
 
-class ReimportTest(unittest.TestCase, ImportHelper):
+class ReimportTest(ImportTestCase):
     """Test "re-imports", in which the autotagging machinery is used for
     music that's already in the library.
 
@@ -1751,7 +1751,7 @@ class ReimportTest(unittest.TestCase, ImportHelper):
         self.assertEqual(self._album().data_source, "match_source")
 
 
-class ImportPretendTest(BeetsTestCase, ImportHelper):
+class ImportPretendTest(ImportTestCase):
     """Test the pretend commandline option"""
 
     def __init__(self, method_name="runTest"):
@@ -1944,7 +1944,7 @@ def mocked_get_recording_by_id(
     "musicbrainzngs.get_release_by_id",
     Mock(side_effect=mocked_get_release_by_id),
 )
-class ImportMusicBrainzIdTest(BeetsTestCase, ImportHelper):
+class ImportMusicBrainzIdTest(ImportTestCase):
     """Test the --musicbrainzid argument."""
 
     MB_RELEASE_PREFIX = "https://musicbrainz.org/release/"

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -36,6 +36,7 @@ from beets.importer import albums_in_dir
 from beets.test import _common
 from beets.test.helper import (
     AutotagStub,
+    BeetsTestCase,
     ImportHelper,
     TestHelper,
     capture_log,
@@ -44,7 +45,7 @@ from beets.test.helper import (
 from beets.util import bytestring_path, displayable_path, syspath
 
 
-class ScrubbedImportTest(_common.TestCase, ImportHelper):
+class ScrubbedImportTest(BeetsTestCase, ImportHelper):
     def setUp(self):
         self.setup_beets(disk=True)
         self.load_plugins("scrub")
@@ -99,7 +100,7 @@ class ScrubbedImportTest(_common.TestCase, ImportHelper):
 
 
 @_common.slow_test()
-class NonAutotaggedImportTest(_common.TestCase, ImportHelper):
+class NonAutotaggedImportTest(BeetsTestCase, ImportHelper):
     def setUp(self):
         self.setup_beets(disk=True)
         self._create_import_dir(2)
@@ -344,7 +345,7 @@ class ImportPasswordRarTest(ImportZipTest):
         return os.path.join(_common.RSRC, b"password.rar")
 
 
-class ImportSingletonTest(_common.TestCase, ImportHelper):
+class ImportSingletonTest(BeetsTestCase, ImportHelper):
     """Test ``APPLY`` and ``ASIS`` choices for an import session with
     singletons config set to True.
     """
@@ -467,7 +468,7 @@ class ImportSingletonTest(_common.TestCase, ImportHelper):
             self.assertEqual(item.title, "Applied Title 1 - formatted")
 
 
-class ImportTest(_common.TestCase, ImportHelper):
+class ImportTest(BeetsTestCase, ImportHelper):
     """Test APPLY, ASIS and SKIP choices."""
 
     def setUp(self):
@@ -681,7 +682,7 @@ class ImportTest(_common.TestCase, ImportHelper):
                 )
 
 
-class ImportTracksTest(_common.TestCase, ImportHelper):
+class ImportTracksTest(BeetsTestCase, ImportHelper):
     """Test TRACKS and APPLY choice."""
 
     def setUp(self):
@@ -715,7 +716,7 @@ class ImportTracksTest(_common.TestCase, ImportHelper):
         self.assert_file_in_lib(b"singletons", b"Applied Title 1.mp3")
 
 
-class ImportCompilationTest(_common.TestCase, ImportHelper):
+class ImportCompilationTest(BeetsTestCase, ImportHelper):
     """Test ASIS import of a folder containing tracks with different artists."""
 
     def setUp(self):
@@ -834,7 +835,7 @@ class ImportCompilationTest(_common.TestCase, ImportHelper):
         self.assertTrue(asserted_multi_artists_0 and asserted_multi_artists_1)
 
 
-class ImportExistingTest(_common.TestCase, ImportHelper):
+class ImportExistingTest(BeetsTestCase, ImportHelper):
     """Test importing files that are already in the library directory."""
 
     def setUp(self):
@@ -959,7 +960,7 @@ class ImportExistingTest(_common.TestCase, ImportHelper):
         self.assertNotExists(self.import_media[0].path)
 
 
-class GroupAlbumsImportTest(_common.TestCase, ImportHelper):
+class GroupAlbumsImportTest(BeetsTestCase, ImportHelper):
     def setUp(self):
         self.setup_beets()
         self._create_import_dir(3)
@@ -1031,7 +1032,7 @@ class GlobalGroupAlbumsImportTest(GroupAlbumsImportTest):
         config["import"]["group_albums"] = True
 
 
-class ChooseCandidateTest(_common.TestCase, ImportHelper):
+class ChooseCandidateTest(BeetsTestCase, ImportHelper):
     def setUp(self):
         self.setup_beets()
         self._create_import_dir(1)
@@ -1054,7 +1055,7 @@ class ChooseCandidateTest(_common.TestCase, ImportHelper):
         self.assertEqual(self.lib.albums().get().album, "Applied Album MM")
 
 
-class InferAlbumDataTest(_common.TestCase):
+class InferAlbumDataTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
@@ -1365,7 +1366,7 @@ class ImportDuplicateSingletonTest(unittest.TestCase, TestHelper):
         return item
 
 
-class TagLogTest(_common.TestCase):
+class TagLogTest(BeetsTestCase):
     def test_tag_log_line(self):
         sio = StringIO()
         handler = logging.StreamHandler(sio)
@@ -1484,7 +1485,7 @@ def _mkmp3(path):
     )
 
 
-class AlbumsInDirTest(_common.TestCase):
+class AlbumsInDirTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
@@ -1526,7 +1527,7 @@ class AlbumsInDirTest(_common.TestCase):
                 self.assertEqual(len(album), 1)
 
 
-class MultiDiscAlbumsInDirTest(_common.TestCase):
+class MultiDiscAlbumsInDirTest(BeetsTestCase):
     def create_music(self, files=True, ascii=True):
         """Create some music in multiple album directories.
 
@@ -1751,7 +1752,7 @@ class ReimportTest(unittest.TestCase, ImportHelper):
         self.assertEqual(self._album().data_source, "match_source")
 
 
-class ImportPretendTest(_common.TestCase, ImportHelper):
+class ImportPretendTest(BeetsTestCase, ImportHelper):
     """Test the pretend commandline option"""
 
     def __init__(self, method_name="runTest"):
@@ -1944,7 +1945,7 @@ def mocked_get_recording_by_id(
     "musicbrainzngs.get_release_by_id",
     Mock(side_effect=mocked_get_release_by_id),
 )
-class ImportMusicBrainzIdTest(_common.TestCase, ImportHelper):
+class ImportMusicBrainzIdTest(BeetsTestCase, ImportHelper):
     """Test the --musicbrainzid argument."""
 
     MB_RELEASE_PREFIX = "https://musicbrainz.org/release/"

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1268,12 +1268,6 @@ class UnicodePathTest(ItemInDBTestCase):
 
 
 class WriteTest(BeetsTestCase):
-    def setUp(self):
-        self.setup_beets()
-
-    def tearDown(self):
-        self.teardown_beets()
-
     def test_write_nonexistant(self):
         item = self.create_item()
         item.path = b"/path/does/not/exist"
@@ -1356,12 +1350,6 @@ class ItemReadTest(unittest.TestCase):
 
 
 class FilesizeTest(BeetsTestCase):
-    def setUp(self):
-        self.setup_beets()
-
-    def tearDown(self):
-        self.teardown_beets()
-
     def test_filesize(self):
         item = self.add_item_fixture()
         self.assertNotEqual(item.filesize, 0)

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1392,11 +1392,3 @@ class LibraryFieldTypesTest(unittest.TestCase):
         beets.config["format_raw_length"] = True
         self.assertEqual(61.23, t.format(61.23))
         self.assertEqual(3601.23, t.format(3601.23))
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -32,14 +32,14 @@ import beets.library
 from beets import config, plugins, util
 from beets.test import _common
 from beets.test._common import item
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase, LibTestCase, TestHelper
 from beets.util import bytestring_path, syspath
 
 # Shortcut to path normalization.
 np = util.normpath
 
 
-class LoadTest(_common.LibTestCase):
+class LoadTest(LibTestCase):
     def test_load_restores_data_from_db(self):
         original_title = self.i.title
         self.i.title = "something"
@@ -53,7 +53,7 @@ class LoadTest(_common.LibTestCase):
         self.assertNotIn("artist", self.i._dirty)
 
 
-class StoreTest(_common.LibTestCase):
+class StoreTest(LibTestCase):
     def test_store_changes_database_value(self):
         self.i.year = 1987
         self.i.store()
@@ -94,7 +94,7 @@ class StoreTest(_common.LibTestCase):
         self.assertNotIn("flex1", album.items()[0])
 
 
-class AddTest(_common.TestCase):
+class AddTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
         self.lib = beets.library.Library(":memory:")
@@ -126,14 +126,14 @@ class AddTest(_common.TestCase):
         self.assertEqual(new_grouping, self.i.grouping)
 
 
-class RemoveTest(_common.LibTestCase):
+class RemoveTest(LibTestCase):
     def test_remove_deletes_from_db(self):
         self.i.remove()
         c = self.lib._connection().execute("select * from items")
         self.assertIsNone(c.fetchone())
 
 
-class GetSetTest(_common.TestCase):
+class GetSetTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
         self.i = item()
@@ -169,7 +169,7 @@ class GetSetTest(_common.TestCase):
         self.assertIsNone(i.get("flexx"))
 
 
-class DestinationTest(_common.TestCase):
+class DestinationTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
         # default directory is ~/Music and the only reason why it was switched
@@ -181,10 +181,6 @@ class DestinationTest(_common.TestCase):
     def tearDown(self):
         super().tearDown()
         self.lib._connection().close()
-
-        # Reset config if it was changed in test cases
-        config.clear()
-        config.read(user=False, defaults=True)
 
     def test_directory_works_with_trailing_slash(self):
         self.lib.directory = b"one/"
@@ -551,7 +547,7 @@ class DestinationTest(_common.TestCase):
         self.assertEqual(self.i.destination(), np("one/foo/two"))
 
 
-class ItemFormattedMappingTest(_common.LibTestCase):
+class ItemFormattedMappingTest(LibTestCase):
     def test_formatted_item_value(self):
         formatted = self.i.formatted()
         self.assertEqual(formatted["artist"], "the artist")
@@ -624,7 +620,7 @@ class PathFormattingMixin:
         self.assertEqual(actual, dest)
 
 
-class DestinationFunctionTest(_common.TestCase, PathFormattingMixin):
+class DestinationFunctionTest(BeetsTestCase, PathFormattingMixin):
     def setUp(self):
         super().setUp()
         self.lib = beets.library.Library(":memory:")
@@ -733,7 +729,7 @@ class DestinationFunctionTest(_common.TestCase, PathFormattingMixin):
         self._assert_dest(b"/base/Alice & Bob")
 
 
-class DisambiguationTest(_common.TestCase, PathFormattingMixin):
+class DisambiguationTest(BeetsTestCase, PathFormattingMixin):
     def setUp(self):
         super().setUp()
         self.lib = beets.library.Library(":memory:")
@@ -822,7 +818,7 @@ class DisambiguationTest(_common.TestCase, PathFormattingMixin):
         self._assert_dest(b"/base/foo/the title", self.i1)
 
 
-class SingletonDisambiguationTest(_common.TestCase, PathFormattingMixin):
+class SingletonDisambiguationTest(BeetsTestCase, PathFormattingMixin):
     def setUp(self):
         super().setUp()
         self.lib = beets.library.Library(":memory:")
@@ -907,7 +903,7 @@ class SingletonDisambiguationTest(_common.TestCase, PathFormattingMixin):
         self._assert_dest(b"/base/foo/the title", self.i1)
 
 
-class PluginDestinationTest(_common.TestCase):
+class PluginDestinationTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
@@ -959,7 +955,7 @@ class PluginDestinationTest(_common.TestCase):
         self._assert_dest(b"the artist bar_baz")
 
 
-class AlbumInfoTest(_common.TestCase):
+class AlbumInfoTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
         self.lib = beets.library.Library(":memory:")
@@ -1064,7 +1060,7 @@ class AlbumInfoTest(_common.TestCase):
         self.assertEqual(i.album, ai.album)
 
 
-class ArtDestinationTest(_common.TestCase):
+class ArtDestinationTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
         config["art_filename"] = "artimage"
@@ -1092,7 +1088,7 @@ class ArtDestinationTest(_common.TestCase):
         self.assertIn(b"artYimage", art)
 
 
-class PathStringTest(_common.TestCase):
+class PathStringTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
         self.lib = beets.library.Library(":memory:")
@@ -1178,7 +1174,7 @@ class PathStringTest(_common.TestCase):
         self.assertTrue(isinstance(alb.artpath, bytes))
 
 
-class MtimeTest(_common.TestCase):
+class MtimeTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
         self.ipath = os.path.join(self.temp_dir, b"testfile.mp3")
@@ -1216,7 +1212,7 @@ class MtimeTest(_common.TestCase):
         self.assertGreaterEqual(self.i.mtime, self._mtime())
 
 
-class ImportTimeTest(_common.TestCase):
+class ImportTimeTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
         self.lib = beets.library.Library(":memory:")
@@ -1232,7 +1228,7 @@ class ImportTimeTest(_common.TestCase):
         self.assertGreater(self.singleton.added, 0)
 
 
-class TemplateTest(_common.LibTestCase):
+class TemplateTest(LibTestCase):
     def test_year_formatted_in_template(self):
         self.i.year = 123
         self.i.store()
@@ -1262,7 +1258,7 @@ class TemplateTest(_common.LibTestCase):
         self.assertEqual(f"{item:$tagada}", "togodo")
 
 
-class UnicodePathTest(_common.LibTestCase):
+class UnicodePathTest(LibTestCase):
     def test_unicode_path(self):
         self.i.path = os.path.join(_common.RSRC, "unicode\u2019d.mp3".encode())
         # If there are any problems with unicode paths, we will raise

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -32,14 +32,14 @@ import beets.library
 from beets import config, plugins, util
 from beets.test import _common
 from beets.test._common import item
-from beets.test.helper import BeetsTestCase, LibTestCase
+from beets.test.helper import BeetsTestCase, ItemInDBTestCase
 from beets.util import bytestring_path, syspath
 
 # Shortcut to path normalization.
 np = util.normpath
 
 
-class LoadTest(LibTestCase):
+class LoadTest(ItemInDBTestCase):
     def test_load_restores_data_from_db(self):
         original_title = self.i.title
         self.i.title = "something"
@@ -53,7 +53,7 @@ class LoadTest(LibTestCase):
         self.assertNotIn("artist", self.i._dirty)
 
 
-class StoreTest(LibTestCase):
+class StoreTest(ItemInDBTestCase):
     def test_store_changes_database_value(self):
         self.i.year = 1987
         self.i.store()
@@ -126,7 +126,7 @@ class AddTest(BeetsTestCase):
         self.assertEqual(new_grouping, self.i.grouping)
 
 
-class RemoveTest(LibTestCase):
+class RemoveTest(ItemInDBTestCase):
     def test_remove_deletes_from_db(self):
         self.i.remove()
         c = self.lib._connection().execute("select * from items")
@@ -547,7 +547,7 @@ class DestinationTest(BeetsTestCase):
         self.assertEqual(self.i.destination(), np("one/foo/two"))
 
 
-class ItemFormattedMappingTest(LibTestCase):
+class ItemFormattedMappingTest(ItemInDBTestCase):
     def test_formatted_item_value(self):
         formatted = self.i.formatted()
         self.assertEqual(formatted["artist"], "the artist")
@@ -1228,7 +1228,7 @@ class ImportTimeTest(BeetsTestCase):
         self.assertGreater(self.singleton.added, 0)
 
 
-class TemplateTest(LibTestCase):
+class TemplateTest(ItemInDBTestCase):
     def test_year_formatted_in_template(self):
         self.i.year = 123
         self.i.store()
@@ -1258,7 +1258,7 @@ class TemplateTest(LibTestCase):
         self.assertEqual(f"{item:$tagada}", "togodo")
 
 
-class UnicodePathTest(LibTestCase):
+class UnicodePathTest(ItemInDBTestCase):
     def test_unicode_path(self):
         self.i.path = os.path.join(_common.RSRC, "unicode\u2019d.mp3".encode())
         # If there are any problems with unicode paths, we will raise

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -32,7 +32,7 @@ import beets.library
 from beets import config, plugins, util
 from beets.test import _common
 from beets.test._common import item
-from beets.test.helper import BeetsTestCase, LibTestCase, TestHelper
+from beets.test.helper import BeetsTestCase, LibTestCase
 from beets.util import bytestring_path, syspath
 
 # Shortcut to path normalization.
@@ -1267,7 +1267,7 @@ class UnicodePathTest(LibTestCase):
         self.i.write()
 
 
-class WriteTest(unittest.TestCase, TestHelper):
+class WriteTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
 
@@ -1355,7 +1355,7 @@ class ItemReadTest(unittest.TestCase):
             item.read("/thisfiledoesnotexist")
 
 
-class FilesizeTest(unittest.TestCase, TestHelper):
+class FilesizeTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
 

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -9,7 +9,7 @@ import beets.logging as blog
 import beetsplug
 from beets import plugins, ui
 from beets.test import _common, helper
-from beets.test.helper import BeetsTestCase, PluginTestCase
+from beets.test.helper import BeetsTestCase, ImportTestCase, PluginMixin
 
 
 class LoggingTest(BeetsTestCase):
@@ -46,7 +46,7 @@ class LoggingTest(BeetsTestCase):
         self.assertTrue(stream.getvalue(), "foo oof baz")
 
 
-class LoggingLevelTest(PluginTestCase):
+class LoggingLevelTest(PluginMixin, ImportTestCase):
     plugin = "dummy"
 
     class DummyModule:
@@ -161,7 +161,7 @@ class LoggingLevelTest(PluginTestCase):
 
 
 @_common.slow_test()
-class ConcurrentEventsTest(BeetsTestCase):
+class ConcurrentEventsTest(ImportTestCase):
     """Similar to LoggingLevelTest but lower-level and focused on multiple
     events interaction. Since this is a bit heavy we don't do it in
     LoggingLevelTest.

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -135,8 +135,8 @@ class LoggingLevelTest(PluginMixin, ImportTestCase):
     def test_import_stage_level0(self):
         self.config["verbose"] = 0
         with helper.capture_log() as logs:
-            importer = self.create_importer()
-            importer.run()
+            self.prepare_album_for_import(1)
+            self.setup_importer(autotag=False).run()
         self.assertIn("dummy: warning import_stage", logs)
         self.assertNotIn("dummy: info import_stage", logs)
         self.assertNotIn("dummy: debug import_stage", logs)
@@ -144,8 +144,8 @@ class LoggingLevelTest(PluginMixin, ImportTestCase):
     def test_import_stage_level1(self):
         self.config["verbose"] = 1
         with helper.capture_log() as logs:
-            importer = self.create_importer()
-            importer.run()
+            self.prepare_album_for_import(1)
+            self.setup_importer(autotag=False).run()
         self.assertIn("dummy: warning import_stage", logs)
         self.assertIn("dummy: info import_stage", logs)
         self.assertNotIn("dummy: debug import_stage", logs)
@@ -153,8 +153,8 @@ class LoggingLevelTest(PluginMixin, ImportTestCase):
     def test_import_stage_level2(self):
         self.config["verbose"] = 2
         with helper.capture_log() as logs:
-            importer = self.create_importer()
-            importer.run()
+            self.prepare_album_for_import(1)
+            self.setup_importer(autotag=False).run()
         self.assertIn("dummy: warning import_stage", logs)
         self.assertIn("dummy: info import_stage", logs)
         self.assertIn("dummy: debug import_stage", logs)
@@ -264,20 +264,20 @@ class ConcurrentEventsTest(ImportTestCase):
 
         blog.getLogger("beets").set_global_level(blog.WARNING)
         with helper.capture_log() as logs:
-            importer = self.create_importer()
-            importer.run()
+            self.prepare_album_for_import(1)
+            self.setup_importer(autotag=False).run()
         self.assertEqual(logs, [])
 
         blog.getLogger("beets").set_global_level(blog.INFO)
         with helper.capture_log() as logs:
-            importer = self.create_importer()
-            importer.run()
+            self.prepare_album_for_import(1)
+            self.setup_importer(autotag=False).run()
         for l in logs:
             self.assertIn("import", l)
             self.assertIn("album", l)
 
         blog.getLogger("beets").set_global_level(blog.DEBUG)
         with helper.capture_log() as logs:
-            importer = self.create_importer()
-            importer.run()
+            self.prepare_album_for_import(1)
+            self.setup_importer(autotag=False).run()
         self.assertIn("Sending event: database_change", logs)

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -10,7 +10,7 @@ import beets.logging as blog
 import beetsplug
 from beets import plugins, ui
 from beets.test import _common, helper
-from beets.test.helper import BeetsTestCase
+from beets.test.helper import BeetsTestCase, PluginTestCase
 
 
 class LoggingTest(BeetsTestCase):
@@ -47,7 +47,8 @@ class LoggingTest(BeetsTestCase):
         self.assertTrue(stream.getvalue(), "foo oof baz")
 
 
-class LoggingLevelTest(BeetsTestCase):
+class LoggingLevelTest(PluginTestCase):
+    plugin = "dummy"
     class DummyModule:
         class DummyPlugin(plugins.BeetsPlugin):
             def __init__(self):
@@ -75,10 +76,8 @@ class LoggingLevelTest(BeetsTestCase):
         sys.modules["beetsplug.dummy"] = self.DummyModule
         beetsplug.dummy = self.DummyModule
         super().setUp()
-        self.load_plugins("dummy")
 
     def tearDown(self):
-        self.unload_plugins()
         super().tearDown()
         del beetsplug.dummy
         sys.modules.pop("beetsplug.dummy")

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -74,12 +74,12 @@ class LoggingLevelTest(BeetsTestCase):
     def setUp(self):
         sys.modules["beetsplug.dummy"] = self.DummyModule
         beetsplug.dummy = self.DummyModule
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("dummy")
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
         del beetsplug.dummy
         sys.modules.pop("beetsplug.dummy")
         self.DummyModule.DummyPlugin.listeners = None
@@ -206,9 +206,6 @@ class ConcurrentEventsTest(BeetsTestCase):
 
     def setUp(self):
         self.setup_beets(disk=True)
-
-    def tearDown(self):
-        self.teardown_beets()
 
     def test_concurrent_events(self):
         dp = self.DummyPlugin(self)

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -82,13 +82,6 @@ class LoggingLevelTest(AsIsImporterMixin, PluginMixin, ImportTestCase):
         beetsplug.dummy = self.DummyModule
         super().setUp()
 
-    def tearDown(self):
-        super().tearDown()
-        del beetsplug.dummy
-        sys.modules.pop("beetsplug.dummy")
-        self.DummyModule.DummyPlugin.listeners = None
-        self.DummyModule.DummyPlugin._raw_listeners = None
-
     def test_command_level0(self):
         self.config["verbose"] = 0
         with helper.capture_log() as logs:

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -168,6 +168,8 @@ class ConcurrentEventsTest(BeetsTestCase):
     LoggingLevelTest.
     """
 
+    db_on_disk = True
+
     class DummyPlugin(plugins.BeetsPlugin):
         def __init__(self, test_case):
             plugins.BeetsPlugin.__init__(self, "dummy")
@@ -203,9 +205,6 @@ class ConcurrentEventsTest(BeetsTestCase):
                 self.t2_step = 2
             except Exception as e:
                 self.exc = e
-
-    def setUp(self):
-        self.setup_beets(disk=True)
 
     def test_concurrent_events(self):
         dp = self.DummyPlugin(self)

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -3,7 +3,6 @@
 import logging as log
 import sys
 import threading
-import unittest
 from io import StringIO
 
 import beets.logging as blog
@@ -49,6 +48,7 @@ class LoggingTest(BeetsTestCase):
 
 class LoggingLevelTest(PluginTestCase):
     plugin = "dummy"
+
     class DummyModule:
         class DummyPlugin(plugins.BeetsPlugin):
             def __init__(self):
@@ -281,11 +281,3 @@ class ConcurrentEventsTest(BeetsTestCase):
             importer = self.create_importer()
             importer.run()
         self.assertIn("Sending event: database_change", logs)
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -10,10 +10,10 @@ import beets.logging as blog
 import beetsplug
 from beets import plugins, ui
 from beets.test import _common, helper
-from beets.test._common import TestCase
+from beets.test.helper import BeetsTestCase
 
 
-class LoggingTest(TestCase):
+class LoggingTest(BeetsTestCase):
     def test_logging_management(self):
         l1 = log.getLogger("foo123")
         l2 = blog.getLogger("foo123")
@@ -162,7 +162,7 @@ class LoggingLevelTest(unittest.TestCase, helper.TestHelper):
 
 
 @_common.slow_test()
-class ConcurrentEventsTest(TestCase, helper.TestHelper):
+class ConcurrentEventsTest(BeetsTestCase):
     """Similar to LoggingLevelTest but lower-level and focused on multiple
     events interaction. Since this is a bit heavy we don't do it in
     LoggingLevelTest.

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -47,7 +47,7 @@ class LoggingTest(BeetsTestCase):
         self.assertTrue(stream.getvalue(), "foo oof baz")
 
 
-class LoggingLevelTest(unittest.TestCase, helper.TestHelper):
+class LoggingLevelTest(BeetsTestCase):
     class DummyModule:
         class DummyPlugin(plugins.BeetsPlugin):
             def __init__(self):

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -9,7 +9,12 @@ import beets.logging as blog
 import beetsplug
 from beets import plugins, ui
 from beets.test import _common, helper
-from beets.test.helper import BeetsTestCase, ImportTestCase, PluginMixin
+from beets.test.helper import (
+    AsIsImporterMixin,
+    BeetsTestCase,
+    ImportTestCase,
+    PluginMixin,
+)
 
 
 class LoggingTest(BeetsTestCase):
@@ -46,7 +51,7 @@ class LoggingTest(BeetsTestCase):
         self.assertTrue(stream.getvalue(), "foo oof baz")
 
 
-class LoggingLevelTest(PluginMixin, ImportTestCase):
+class LoggingLevelTest(AsIsImporterMixin, PluginMixin, ImportTestCase):
     plugin = "dummy"
 
     class DummyModule:
@@ -135,8 +140,7 @@ class LoggingLevelTest(PluginMixin, ImportTestCase):
     def test_import_stage_level0(self):
         self.config["verbose"] = 0
         with helper.capture_log() as logs:
-            self.prepare_album_for_import(1)
-            self.setup_importer(autotag=False).run()
+            self.run_asis_importer()
         self.assertIn("dummy: warning import_stage", logs)
         self.assertNotIn("dummy: info import_stage", logs)
         self.assertNotIn("dummy: debug import_stage", logs)
@@ -144,8 +148,7 @@ class LoggingLevelTest(PluginMixin, ImportTestCase):
     def test_import_stage_level1(self):
         self.config["verbose"] = 1
         with helper.capture_log() as logs:
-            self.prepare_album_for_import(1)
-            self.setup_importer(autotag=False).run()
+            self.run_asis_importer()
         self.assertIn("dummy: warning import_stage", logs)
         self.assertIn("dummy: info import_stage", logs)
         self.assertNotIn("dummy: debug import_stage", logs)
@@ -153,15 +156,14 @@ class LoggingLevelTest(PluginMixin, ImportTestCase):
     def test_import_stage_level2(self):
         self.config["verbose"] = 2
         with helper.capture_log() as logs:
-            self.prepare_album_for_import(1)
-            self.setup_importer(autotag=False).run()
+            self.run_asis_importer()
         self.assertIn("dummy: warning import_stage", logs)
         self.assertIn("dummy: info import_stage", logs)
         self.assertIn("dummy: debug import_stage", logs)
 
 
 @_common.slow_test()
-class ConcurrentEventsTest(ImportTestCase):
+class ConcurrentEventsTest(AsIsImporterMixin, ImportTestCase):
     """Similar to LoggingLevelTest but lower-level and focused on multiple
     events interaction. Since this is a bit heavy we don't do it in
     LoggingLevelTest.
@@ -264,20 +266,17 @@ class ConcurrentEventsTest(ImportTestCase):
 
         blog.getLogger("beets").set_global_level(blog.WARNING)
         with helper.capture_log() as logs:
-            self.prepare_album_for_import(1)
-            self.setup_importer(autotag=False).run()
+            self.run_asis_importer()
         self.assertEqual(logs, [])
 
         blog.getLogger("beets").set_global_level(blog.INFO)
         with helper.capture_log() as logs:
-            self.prepare_album_for_import(1)
-            self.setup_importer(autotag=False).run()
+            self.run_asis_importer()
         for l in logs:
             self.assertIn("import", l)
             self.assertIn("album", l)
 
         blog.getLogger("beets").set_global_level(blog.DEBUG)
         with helper.capture_log() as logs:
-            self.prepare_album_for_import(1)
-            self.setup_importer(autotag=False).run()
+            self.run_asis_importer()
         self.assertIn("Sending event: database_change", logs)

--- a/test/test_m3ufile.py
+++ b/test/test_m3ufile.py
@@ -148,12 +148,3 @@ class M3UFileTest(unittest.TestCase):
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.load()
         self.assertFalse(m3ufile.extm3u)
-
-
-def suite():
-    """This testsuite's main function."""
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -20,10 +20,10 @@ from unittest import mock
 
 from beets import config
 from beets.autotag import mb
-from beets.test import _common
+from beets.test.helper import BeetsTestCase
 
 
-class MBAlbumInfoTest(_common.TestCase):
+class MBAlbumInfoTest(BeetsTestCase):
     def _make_release(
         self,
         date_str="2009",
@@ -662,7 +662,7 @@ class MBAlbumInfoTest(_common.TestCase):
         self.assertEqual(t[1].trackdisambig, "SECOND TRACK")
 
 
-class ParseIDTest(_common.TestCase):
+class ParseIDTest(BeetsTestCase):
     def test_parse_id_correct(self):
         id_string = "28e32c71-1450-463e-92bf-e0a46446fc11"
         out = mb._parse_id(id_string)
@@ -680,7 +680,7 @@ class ParseIDTest(_common.TestCase):
         self.assertEqual(out, id_string)
 
 
-class ArtistFlatteningTest(_common.TestCase):
+class ArtistFlatteningTest(BeetsTestCase):
     def _credit_dict(self, suffix=""):
         return {
             "artist": {

--- a/test/test_mb.py
+++ b/test/test_mb.py
@@ -1077,11 +1077,3 @@ class MBLibraryTest(unittest.TestCase):
             gp.side_effect = side_effect
             album = mb.album_for_id("d2a6f856-b553-40a0-ac54-a321e8e2da02")
             self.assertIsNone(album.country)
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_metasync.py
+++ b/test/test_metasync.py
@@ -16,7 +16,6 @@
 import os
 import platform
 import time
-import unittest
 from datetime import datetime
 
 from beets.library import Item
@@ -128,11 +127,3 @@ class MetaSyncTest(PluginTestCase):
             _parsetime("2014-04-24 09:28:38"),
         )
         self.assertFalse(hasattr(self.lib.items()[1], "itunes_lastskipped"))
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_metasync.py
+++ b/test/test_metasync.py
@@ -21,7 +21,7 @@ from datetime import datetime
 
 from beets.library import Item
 from beets.test import _common
-from beets.test.helper import TestHelper
+from beets.test.helper import BeetsTestCase
 
 
 def _parsetime(s):
@@ -32,7 +32,7 @@ def _is_windows():
     return platform.system() == "Windows"
 
 
-class MetaSyncTest(_common.TestCase, TestHelper):
+class MetaSyncTest(BeetsTestCase):
     itunes_library_unix = os.path.join(_common.RSRC, b"itunes_library_unix.xml")
     itunes_library_windows = os.path.join(
         _common.RSRC, b"itunes_library_windows.xml"

--- a/test/test_metasync.py
+++ b/test/test_metasync.py
@@ -39,7 +39,7 @@ class MetaSyncTest(BeetsTestCase):
     )
 
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.load_plugins("metasync")
 
         self.config["metasync"]["source"] = "itunes"
@@ -85,7 +85,7 @@ class MetaSyncTest(BeetsTestCase):
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def test_load_item_types(self):
         # This test also verifies that the MetaSources have loaded correctly

--- a/test/test_metasync.py
+++ b/test/test_metasync.py
@@ -21,7 +21,7 @@ from datetime import datetime
 
 from beets.library import Item
 from beets.test import _common
-from beets.test.helper import BeetsTestCase
+from beets.test.helper import PluginTestCase
 
 
 def _parsetime(s):
@@ -32,7 +32,8 @@ def _is_windows():
     return platform.system() == "Windows"
 
 
-class MetaSyncTest(BeetsTestCase):
+class MetaSyncTest(PluginTestCase):
+    plugin = "metasync"
     itunes_library_unix = os.path.join(_common.RSRC, b"itunes_library_unix.xml")
     itunes_library_windows = os.path.join(
         _common.RSRC, b"itunes_library_windows.xml"
@@ -40,7 +41,6 @@ class MetaSyncTest(BeetsTestCase):
 
     def setUp(self):
         super().setUp()
-        self.load_plugins("metasync")
 
         self.config["metasync"]["source"] = "itunes"
 
@@ -82,10 +82,6 @@ class MetaSyncTest(BeetsTestCase):
 
         for item in items:
             self.lib.add(item)
-
-    def tearDown(self):
-        self.unload_plugins()
-        super().tearDown()
 
     def test_load_item_types(self):
         # This test also verifies that the MetaSources have loaded correctly

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -230,11 +230,3 @@ class StageDecoratorTest(unittest.TestCase):
         self.assertEqual(
             list(pl.pull()), [{"x": True}, {"a": False, "x": True}]
         )
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -632,11 +632,3 @@ class ParseBeatportIDTest(unittest.TestCase):
         id_url = "https://www.beatport.com/release/album-name/%s" % id_string
         out = MetadataSourcePlugin._get_id("album", id_url, beatport_id_regex)
         self.assertEqual(out, id_string)
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -35,7 +35,7 @@ from beets.test.helper import (
     AutotagStub,
     BeetsTestCase,
     ImportHelper,
-    TerminalImportSessionSetup,
+    TerminalImportMixin,
 )
 from beets.util import displayable_path, syspath
 from beets.util.id_extractors import (
@@ -377,7 +377,7 @@ class ListenersTest(PluginLoaderTestCase):
         plugins.send("event9", foo=5)
 
 
-class PromptChoicesTest(TerminalImportSessionSetup, PluginImportTestCase):
+class PromptChoicesTest(TerminalImportMixin, PluginImportTestCase):
     def setUp(self):
         super().setUp()
         self._setup_import_session()

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -179,12 +179,10 @@ class EventsTest(PluginImportTestCase):
             logs,
             [
                 "Album: {}".format(
-                    displayable_path(
-                        os.path.join(self.import_dir, b"the_album")
-                    )
+                    displayable_path(os.path.join(self.import_dir, b"album"))
                 ),
-                "  {}".format(displayable_path(self.media_files[0].path)),
-                "  {}".format(displayable_path(self.media_files[1].path)),
+                "  {}".format(displayable_path(self.import_media[0].path)),
+                "  {}".format(displayable_path(self.import_media[1].path)),
             ],
         )
 
@@ -230,10 +228,10 @@ class EventsTest(PluginImportTestCase):
             logs,
             [
                 "Singleton: {}".format(
-                    displayable_path(self.media_files[0].path)
+                    displayable_path(self.import_media[0].path)
                 ),
                 "Singleton: {}".format(
-                    displayable_path(self.media_files[1].path)
+                    displayable_path(self.import_media[1].path)
                 ),
             ],
         )

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -58,7 +58,7 @@ class PluginLoaderTestCase(BeetsTestCase):
             plugins._classes.update(self._plugin_classes)
 
         load_plugins.side_effect = myload
-        self.setup_beets()
+        super().setUp()
 
     def teardown_plugin_loader(self):
         self._plugin_loader_patch.stop()
@@ -72,7 +72,7 @@ class PluginLoaderTestCase(BeetsTestCase):
 
     def tearDown(self):
         self.teardown_plugin_loader()
-        self.teardown_beets()
+        super().tearDown()
 
 
 class PluginImportTestCase(ImportHelper, PluginLoaderTestCase):

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -160,12 +160,9 @@ class ItemTypeConflictTest(PluginLoaderTestCase):
 class EventsTest(PluginImportTestCase):
     def setUp(self):
         super().setUp()
-        config["import"]["pretend"] = True
 
     def test_import_task_created(self):
-        import_files = [self.import_dir]
-        self._setup_import_session(singletons=False)
-        self.importer.paths = import_files
+        self.importer = self.setup_importer(pretend=True)
 
         with helper.capture_log() as logs:
             self.importer.run()
@@ -212,9 +209,7 @@ class EventsTest(PluginImportTestCase):
         to_singleton_plugin = ToSingletonPlugin
         self.register_plugin(to_singleton_plugin)
 
-        import_files = [self.import_dir]
-        self._setup_import_session(singletons=False)
-        self.importer.paths = import_files
+        self.importer = self.setup_importer(pretend=True)
 
         with helper.capture_log() as logs:
             self.importer.run()
@@ -371,7 +366,7 @@ class ListenersTest(PluginLoaderTestCase):
 class PromptChoicesTest(TerminalImportMixin, PluginImportTestCase):
     def setUp(self):
         super().setUp()
-        self._setup_import_session()
+        self.setup_importer()
         self.matcher = AutotagStub().install()
         # keep track of ui.input_option() calls
         self.input_options_patcher = patch(

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -31,12 +31,9 @@ from beets.importer import (
 from beets.library import Item
 from beets.plugins import MetadataSourcePlugin
 from beets.test import helper
-from beets.test.helper import (
-    AutotagStub,
-    BeetsTestCase,
-    ImportHelper,
-    TerminalImportMixin,
-)
+from beets.test.helper import AutotagStub, ImportHelper
+from beets.test.helper import PluginTestCase as BasePluginTestCase
+from beets.test.helper import TerminalImportMixin
 from beets.util import displayable_path, syspath
 from beets.util.id_extractors import (
     beatport_id_regex,
@@ -45,11 +42,10 @@ from beets.util.id_extractors import (
 )
 
 
-class PluginLoaderTestCase(BeetsTestCase):
+class PluginLoaderTestCase(BasePluginTestCase):
     def setup_plugin_loader(self):
         # FIXME the mocking code is horrific, but this is the lowest and
         # earliest level of the plugin mechanism we can hook into.
-        self.load_plugins()
         self._plugin_loader_patch = patch("beets.plugins.load_plugins")
         self._plugin_classes = set()
         load_plugins = self._plugin_loader_patch.start()
@@ -58,17 +54,16 @@ class PluginLoaderTestCase(BeetsTestCase):
             plugins._classes.update(self._plugin_classes)
 
         load_plugins.side_effect = myload
-        super().setUp()
 
     def teardown_plugin_loader(self):
         self._plugin_loader_patch.stop()
-        self.unload_plugins()
 
     def register_plugin(self, plugin_class):
         self._plugin_classes.add(plugin_class)
 
     def setUp(self):
         self.setup_plugin_loader()
+        super().setUp()
 
     def tearDown(self):
         self.teardown_plugin_loader()
@@ -174,7 +169,6 @@ class EventsTest(PluginImportTestCase):
 
         with helper.capture_log() as logs:
             self.importer.run()
-        self.unload_plugins()
 
         # Exactly one event should have been imported (for the album).
         # Sentinels do not get emitted.
@@ -226,7 +220,6 @@ class EventsTest(PluginImportTestCase):
 
         with helper.capture_log() as logs:
             self.importer.run()
-        self.unload_plugins()
 
         # Exactly one event should have been imported (for the album).
         # Sentinels do not get emitted.

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -35,9 +35,9 @@ from beets.test import helper
 from beets.test._common import RSRC
 from beets.test.helper import (
     AutotagStub,
+    BeetsTestCase,
     ImportHelper,
     TerminalImportSessionSetup,
-    TestHelper,
 )
 from beets.util import bytestring_path, displayable_path, syspath
 from beets.util.id_extractors import (
@@ -47,7 +47,7 @@ from beets.util.id_extractors import (
 )
 
 
-class PluginLoaderTestCase(unittest.TestCase, TestHelper):
+class PluginLoaderTestCase(BeetsTestCase):
     def setup_plugin_loader(self):
         # FIXME the mocking code is horrific, but this is the lowest and
         # earliest level of the plugin mechanism we can hook into.

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -73,7 +73,7 @@ class PluginLoaderTestCase(BasePluginTestCase):
 class PluginImportTestCase(ImportHelper, PluginLoaderTestCase):
     def setUp(self):
         super().setUp()
-        self._create_import_dir(2)
+        self.prepare_album_for_import(2)
 
 
 class ItemTypesTest(PluginLoaderTestCase):

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -31,7 +31,7 @@ from beets.dbcore.query import (
 )
 from beets.library import Item, Library
 from beets.test import _common
-from beets.test.helper import BeetsTestCase, LibTestCase
+from beets.test.helper import BeetsTestCase, ItemInDBTestCase
 from beets.util import syspath
 
 # Because the absolute path begins with something like C:, we
@@ -55,7 +55,7 @@ class AssertsMixin:
         self.assertNotIn(item.id, result_ids)
 
 
-class AnyFieldQueryTest(LibTestCase):
+class AnyFieldQueryTest(ItemInDBTestCase):
     def test_no_restriction(self):
         q = dbcore.query.AnyFieldQuery(
             "title",
@@ -486,7 +486,7 @@ class MatchTest(BeetsTestCase):
         self.assertNotEqual(q3, q4)
 
 
-class PathQueryTest(LibTestCase, AssertsMixin):
+class PathQueryTest(ItemInDBTestCase, AssertsMixin):
     def setUp(self):
         super().setUp()
 

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -30,7 +30,7 @@ from beets.dbcore.query import (
     ParsingError,
 )
 from beets.library import Item, Library
-from beets.test import _common, helper
+from beets.test import _common
 from beets.test.helper import BeetsTestCase, LibTestCase
 from beets.util import syspath
 
@@ -39,7 +39,13 @@ from beets.util import syspath
 WIN32_NO_IMPLICIT_PATHS = "Implicit paths are not supported on Windows"
 
 
-class TestHelper(helper.TestHelper):
+class AssertsMixin:
+    def assert_items_matched(self, results, titles):
+        self.assertEqual({i.title for i in results}, set(titles))
+
+    def assert_albums_matched(self, results, albums):
+        self.assertEqual({a.album for a in results}, set(albums))
+
     def assertInResult(self, item, results):  # noqa
         result_ids = [i.id for i in results]
         self.assertIn(item.id, result_ids)
@@ -81,14 +87,6 @@ class AnyFieldQueryTest(LibTestCase):
 
         q2.query_class = None
         self.assertNotEqual(q1, q2)
-
-
-class AssertsMixin:
-    def assert_items_matched(self, results, titles):
-        self.assertEqual({i.title for i in results}, set(titles))
-
-    def assert_albums_matched(self, results, albums):
-        self.assertEqual({a.album for a in results}, set(albums))
 
 
 # A test case class providing a library with some dummy data and some
@@ -488,7 +486,7 @@ class MatchTest(BeetsTestCase):
         self.assertNotEqual(q3, q4)
 
 
-class PathQueryTest(LibTestCase, TestHelper, AssertsMixin):
+class PathQueryTest(LibTestCase, AssertsMixin):
     def setUp(self):
         super().setUp()
 
@@ -726,11 +724,12 @@ class PathQueryTest(LibTestCase, TestHelper, AssertsMixin):
             os.chdir(cur_dir)
 
 
-class IntQueryTest(unittest.TestCase, TestHelper):
+class IntQueryTest(BeetsTestCase):
     def setUp(self):
         self.lib = Library(":memory:")
 
     def tearDown(self):
+        super().tearDown()
         Item._types = {}
 
     def test_exact_value_match(self):
@@ -764,12 +763,14 @@ class IntQueryTest(unittest.TestCase, TestHelper):
         self.assertIsNone(matched)
 
 
-class BoolQueryTest(unittest.TestCase, TestHelper):
+class BoolQueryTest(BeetsTestCase, AssertsMixin):
     def setUp(self):
+        super().setUp()
         self.lib = Library(":memory:")
         Item._types = {"flexbool": types.Boolean()}
 
     def tearDown(self):
+        super().tearDown()
         Item._types = {}
 
     def test_parse_true(self):
@@ -834,8 +835,9 @@ class DefaultSearchFieldsTest(DummyDataTestCase):
         self.assert_items_matched(items, [])
 
 
-class NoneQueryTest(unittest.TestCase, TestHelper):
+class NoneQueryTest(BeetsTestCase, AssertsMixin):
     def setUp(self):
+        super().setUp()
         self.lib = Library(":memory:")
 
     def test_match_singletons(self):

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -29,7 +29,7 @@ from beets.dbcore.query import (
     NoneQuery,
     ParsingError,
 )
-from beets.library import Item, Library
+from beets.library import Item
 from beets.test import _common
 from beets.test.helper import BeetsTestCase, ItemInDBTestCase
 from beets.util import syspath
@@ -94,7 +94,6 @@ class AnyFieldQueryTest(ItemInDBTestCase):
 class DummyDataTestCase(BeetsTestCase, AssertsMixin):
     def setUp(self):
         super().setUp()
-        self.lib = beets.library.Library(":memory:")
         items = [_common.item() for _ in range(3)]
         items[0].title = "foo bar"
         items[0].artist = "one"
@@ -725,9 +724,6 @@ class PathQueryTest(ItemInDBTestCase, AssertsMixin):
 
 
 class IntQueryTest(BeetsTestCase):
-    def setUp(self):
-        self.lib = Library(":memory:")
-
     def tearDown(self):
         super().tearDown()
         Item._types = {}
@@ -766,7 +762,6 @@ class IntQueryTest(BeetsTestCase):
 class BoolQueryTest(BeetsTestCase, AssertsMixin):
     def setUp(self):
         super().setUp()
-        self.lib = Library(":memory:")
         Item._types = {"flexbool": types.Boolean()}
 
     def tearDown(self):
@@ -836,10 +831,6 @@ class DefaultSearchFieldsTest(DummyDataTestCase):
 
 
 class NoneQueryTest(BeetsTestCase, AssertsMixin):
-    def setUp(self):
-        super().setUp()
-        self.lib = Library(":memory:")
-
     def test_match_singletons(self):
         singleton = self.add_item()
         album_item = self.add_album().items().get()
@@ -1137,7 +1128,6 @@ class RelatedQueriesTest(BeetsTestCase, AssertsMixin):
 
     def setUp(self):
         super().setUp()
-        self.lib = beets.library.Library(":memory:")
 
         albums = []
         for album_idx in range(1, 3):

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -31,6 +31,7 @@ from beets.dbcore.query import (
 )
 from beets.library import Item, Library
 from beets.test import _common, helper
+from beets.test.helper import BeetsTestCase, LibTestCase
 from beets.util import syspath
 
 # Because the absolute path begins with something like C:, we
@@ -48,7 +49,7 @@ class TestHelper(helper.TestHelper):
         self.assertNotIn(item.id, result_ids)
 
 
-class AnyFieldQueryTest(_common.LibTestCase):
+class AnyFieldQueryTest(LibTestCase):
     def test_no_restriction(self):
         q = dbcore.query.AnyFieldQuery(
             "title",
@@ -92,7 +93,7 @@ class AssertsMixin:
 
 # A test case class providing a library with some dummy data and some
 # assertions involving that data.
-class DummyDataTestCase(_common.TestCase, AssertsMixin):
+class DummyDataTestCase(BeetsTestCase, AssertsMixin):
     def setUp(self):
         super().setUp()
         self.lib = beets.library.Library(":memory:")
@@ -418,7 +419,7 @@ class GetTest(DummyDataTestCase):
         self.assertIsInstance(raised.exception, ParsingError)
 
 
-class MatchTest(_common.TestCase):
+class MatchTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
         self.item = _common.item()
@@ -487,7 +488,7 @@ class MatchTest(_common.TestCase):
         self.assertNotEqual(q3, q4)
 
 
-class PathQueryTest(_common.LibTestCase, TestHelper, AssertsMixin):
+class PathQueryTest(LibTestCase, TestHelper, AssertsMixin):
     def setUp(self):
         super().setUp()
 
@@ -871,7 +872,7 @@ class NoneQueryTest(unittest.TestCase, TestHelper):
         self.assertInResult(item, matched)
 
 
-class NotQueryMatchTest(_common.TestCase):
+class NotQueryMatchTest(BeetsTestCase):
     """Test `query.NotQuery` matching against a single item, using the same
     cases and assertions as on `MatchTest`, plus assertion on the negated
     queries (ie. assertTrue(q) -> assertFalse(NotQuery(q))).
@@ -1129,7 +1130,7 @@ class NotQueryTest(DummyDataTestCase):
                 pass
 
 
-class RelatedQueriesTest(_common.TestCase, AssertsMixin):
+class RelatedQueriesTest(BeetsTestCase, AssertsMixin):
     """Test album-level queries with track-level filters and vice-versa."""
 
     def setUp(self):

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -1161,11 +1161,3 @@ class RelatedQueriesTest(BeetsTestCase, AssertsMixin):
         q = "catalognum:ABC Album1"
         results = self.lib.albums(q)
         self.assert_albums_matched(results, ["Album1"])
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_sort.py
+++ b/test/test_sort.py
@@ -28,7 +28,6 @@ from beets.test.helper import BeetsTestCase
 class DummyDataTestCase(BeetsTestCase):
     def setUp(self):
         super().setUp()
-        self.lib = beets.library.Library(":memory:")
 
         albums = [_common.album() for _ in range(3)]
         albums[0].album = "Album A"

--- a/test/test_sort.py
+++ b/test/test_sort.py
@@ -20,11 +20,12 @@ import unittest
 import beets.library
 from beets import config, dbcore
 from beets.test import _common
+from beets.test.helper import BeetsTestCase
 
 
 # A test case class providing a library with some dummy data and some
 # assertions involving that data.
-class DummyDataTestCase(_common.TestCase):
+class DummyDataTestCase(BeetsTestCase):
     def setUp(self):
         super().setUp()
         self.lib = beets.library.Library(":memory:")
@@ -373,7 +374,7 @@ class ConfigSortTest(DummyDataTestCase):
         self.assertGreater(results[0].albumartist, results[1].albumartist)
 
 
-class CaseSensitivityTest(DummyDataTestCase, _common.TestCase):
+class CaseSensitivityTest(DummyDataTestCase, BeetsTestCase):
     """If case_insensitive is false, lower-case values should be placed
     after all upper-case values. E.g., `Foo Qux bar`
     """

--- a/test/test_sort.py
+++ b/test/test_sort.py
@@ -15,7 +15,6 @@
 """Various tests for querying the library database.
 """
 
-import unittest
 
 import beets.library
 from beets import config, dbcore
@@ -531,11 +530,3 @@ class NonExistingFieldTest(DummyDataTestCase):
         self.assertTrue(isinstance(query.subqueries[0], dbcore.query.TrueQuery))
         self.assertTrue(isinstance(sort, dbcore.query.SlowFieldSort))
         self.assertEqual(sort.field, "-bar")
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -290,11 +290,3 @@ class EvalTest(unittest.TestCase):
 
     def test_function_call_with_empty_arg(self):
         self.assertEqual(self._eval("%len{}"), "0")
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -191,12 +191,9 @@ class RemoveTest(BeetsTestCase):
 
 class ModifyTest(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.album = self.add_album_fixture()
         [self.item] = self.album.items()
-
-    def tearDown(self):
-        self.teardown_beets()
 
     def modify_inp(self, inp, *args):
         with control_stdin(inp):
@@ -404,12 +401,6 @@ class ModifyTest(BeetsTestCase):
 
 
 class WriteTest(BeetsTestCase):
-    def setUp(self):
-        self.setup_beets()
-
-    def tearDown(self):
-        self.teardown_beets()
-
     def write_cmd(self, *args):
         return self.run_with_output("write", *args)
 
@@ -846,7 +837,7 @@ class ImportTest(BeetsTestCase):
 @_common.slow_test()
 class ConfigTest(BeetsTestCase):
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
 
         # Don't use the BEETSDIR from `helper`. Instead, we point the home
         # directory there. Some tests will set `BEETSDIR` themselves.
@@ -895,7 +886,7 @@ class ConfigTest(BeetsTestCase):
         else:
             os.environ["APPDATA"] = self._old_appdata
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def _make_test_cmd(self):
         test_cmd = ui.Subcommand("test", help="test")
@@ -1474,7 +1465,7 @@ class CommonOptionsParserCliTest(BeetsTestCase):
     """
 
     def setUp(self):
-        self.setup_beets()
+        super().setUp()
         self.item = _common.item()
         self.item.path = b"xxx/yyy"
         self.lib.add(self.item)
@@ -1483,7 +1474,7 @@ class CommonOptionsParserCliTest(BeetsTestCase):
 
     def tearDown(self):
         self.unload_plugins()
-        self.teardown_beets()
+        super().tearDown()
 
     def test_base(self):
         l = self.run_with_output("ls")
@@ -1552,12 +1543,6 @@ class CommonOptionsParserCliTest(BeetsTestCase):
 
 
 class CommonOptionsParserTest(BeetsTestCase):
-    def setUp(self):
-        self.setup_beets()
-
-    def tearDown(self):
-        self.teardown_beets()
-
     def test_album_option(self):
         parser = ui.CommonOptionsParser()
         self.assertFalse(parser._album_flags)

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -844,7 +844,7 @@ class ImportTest(_common.TestCase):
 
 
 @_common.slow_test()
-class ConfigTest(unittest.TestCase, TestHelper, _common.Assertions):
+class ConfigTest(unittest.TestCase, TestHelper):
     def setUp(self):
         self.setup_beets()
 

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -32,7 +32,6 @@ from beets.autotag.match import distance
 from beets.test import _common
 from beets.test.helper import (
     BeetsTestCase,
-    TestHelper,
     capture_stdout,
     control_stdin,
     has_program,
@@ -190,7 +189,7 @@ class RemoveTest(BeetsTestCase):
         self.assertEqual(num_existing, 1)
 
 
-class ModifyTest(unittest.TestCase, TestHelper):
+class ModifyTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
         self.album = self.add_album_fixture()
@@ -404,7 +403,7 @@ class ModifyTest(unittest.TestCase, TestHelper):
         self.assertEqual(mods, {"title": "newTitle"})
 
 
-class WriteTest(unittest.TestCase, TestHelper):
+class WriteTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
 
@@ -845,7 +844,7 @@ class ImportTest(BeetsTestCase):
 
 
 @_common.slow_test()
-class ConfigTest(unittest.TestCase, TestHelper):
+class ConfigTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
 
@@ -1469,7 +1468,7 @@ class CompletionTest(BeetsTestCase):
         )
 
 
-class CommonOptionsParserCliTest(unittest.TestCase, TestHelper):
+class CommonOptionsParserCliTest(BeetsTestCase):
     """Test CommonOptionsParser and formatting LibModel formatting on 'list'
     command.
     """
@@ -1552,7 +1551,7 @@ class CommonOptionsParserCliTest(unittest.TestCase, TestHelper):
         # self.assertIn('plugins: ', l)
 
 
-class CommonOptionsParserTest(unittest.TestCase, TestHelper):
+class CommonOptionsParserTest(BeetsTestCase):
     def setUp(self):
         self.setup_beets()
 

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -40,9 +40,9 @@ from beets.ui import commands
 from beets.util import MoveOperation, syspath
 
 
-class ListTest(unittest.TestCase):
+class ListTest(BeetsTestCase):
     def setUp(self):
-        self.lib = library.Library(":memory:")
+        super().setUp()
         self.item = _common.item()
         self.item.path = "xxx/yyy"
         self.lib.add(self.item)
@@ -114,11 +114,7 @@ class RemoveTest(BeetsTestCase):
 
         self.io.install()
 
-        self.libdir = os.path.join(self.temp_dir, b"testlibdir")
-        os.mkdir(syspath(self.libdir))
-
         # Copy a file into the library.
-        self.lib = library.Library(":memory:", self.libdir)
         self.item_path = os.path.join(_common.RSRC, b"full.mp3")
         self.i = library.Item.from_path(self.item_path)
         self.lib.add(self.i)
@@ -451,9 +447,6 @@ class MoveTest(BeetsTestCase):
 
         self.io.install()
 
-        self.libdir = os.path.join(self.temp_dir, b"testlibdir")
-        os.mkdir(syspath(self.libdir))
-
         self.itempath = os.path.join(self.libdir, b"srcfile")
         shutil.copy(
             syspath(os.path.join(_common.RSRC, b"full.mp3")),
@@ -461,7 +454,6 @@ class MoveTest(BeetsTestCase):
         )
 
         # Add a file to the library but don't copy it in yet.
-        self.lib = library.Library(":memory:", self.libdir)
         self.i = library.Item.from_path(self.itempath)
         self.lib.add(self.i)
         self.album = self.lib.add_album([self.i])
@@ -485,28 +477,28 @@ class MoveTest(BeetsTestCase):
     def test_move_item(self):
         self._move()
         self.i.load()
-        self.assertIn(b"testlibdir", self.i.path)
+        self.assertIn(b"libdir", self.i.path)
         self.assertExists(self.i.path)
         self.assertNotExists(self.itempath)
 
     def test_copy_item(self):
         self._move(copy=True)
         self.i.load()
-        self.assertIn(b"testlibdir", self.i.path)
+        self.assertIn(b"libdir", self.i.path)
         self.assertExists(self.i.path)
         self.assertExists(self.itempath)
 
     def test_move_album(self):
         self._move(album=True)
         self.i.load()
-        self.assertIn(b"testlibdir", self.i.path)
+        self.assertIn(b"libdir", self.i.path)
         self.assertExists(self.i.path)
         self.assertNotExists(self.itempath)
 
     def test_copy_album(self):
         self._move(copy=True, album=True)
         self.i.load()
-        self.assertIn(b"testlibdir", self.i.path)
+        self.assertIn(b"libdir", self.i.path)
         self.assertExists(self.i.path)
         self.assertExists(self.itempath)
 
@@ -559,10 +551,7 @@ class UpdateTest(BeetsTestCase):
 
         self.io.install()
 
-        self.libdir = os.path.join(self.temp_dir, b"testlibdir")
-
         # Copy a file into the library.
-        self.lib = library.Library(":memory:", self.libdir)
         item_path = os.path.join(_common.RSRC, b"full.mp3")
         item_path_two = os.path.join(_common.RSRC, b"full.flac")
         self.i = library.Item.from_path(item_path)

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -31,6 +31,7 @@ from beets import autotag, config, library, plugins, ui, util
 from beets.autotag.match import distance
 from beets.test import _common
 from beets.test.helper import (
+    BeetsTestCase,
     TestHelper,
     capture_stdout,
     control_stdin,
@@ -108,7 +109,7 @@ class ListTest(unittest.TestCase):
         self.assertNotIn("the album", stdout.getvalue())
 
 
-class RemoveTest(_common.TestCase, TestHelper):
+class RemoveTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
@@ -454,7 +455,7 @@ class WriteTest(unittest.TestCase, TestHelper):
         self.assertIn(f"{old_title} -> new title", output)
 
 
-class MoveTest(_common.TestCase):
+class MoveTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
@@ -562,7 +563,7 @@ class MoveTest(_common.TestCase):
         self.assertNotExists(self.otherdir)
 
 
-class UpdateTest(_common.TestCase):
+class UpdateTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
@@ -763,7 +764,7 @@ class UpdateTest(_common.TestCase):
         self.assertNotEqual(item.lyrics, "new lyrics")
 
 
-class PrintTest(_common.TestCase):
+class PrintTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
         self.io.install()
@@ -802,7 +803,7 @@ class PrintTest(_common.TestCase):
                 del os.environ["LC_CTYPE"]
 
 
-class ImportTest(_common.TestCase):
+class ImportTest(BeetsTestCase):
     def test_quiet_timid_disallowed(self):
         config["import"]["quiet"] = True
         config["import"]["timid"] = True
@@ -1145,7 +1146,7 @@ class ConfigTest(unittest.TestCase, TestHelper):
         )
 
 
-class ShowModelChangeTest(_common.TestCase):
+class ShowModelChangeTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
         self.io.install()
@@ -1197,7 +1198,7 @@ class ShowModelChangeTest(_common.TestCase):
         self.assertIn("bar", out)
 
 
-class ShowChangeTest(_common.TestCase):
+class ShowChangeTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
         self.io.install()
@@ -1358,7 +1359,7 @@ class ShowChangeTest(_common.TestCase):
 
 
 @patch("beets.library.Item.try_filesize", Mock(return_value=987))
-class SummarizeItemsTest(_common.TestCase):
+class SummarizeItemsTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
         item = library.Item()
@@ -1395,7 +1396,7 @@ class SummarizeItemsTest(_common.TestCase):
         self.assertEqual(summary, "3 items, G 2, F 1, 4kbps, 32:42, 2.9 KiB")
 
 
-class PathFormatTest(_common.TestCase):
+class PathFormatTest(BeetsTestCase):
     def test_custom_paths_prepend(self):
         default_formats = ui.get_path_formats()
 
@@ -1408,7 +1409,7 @@ class PathFormatTest(_common.TestCase):
 
 
 @_common.slow_test()
-class PluginTest(_common.TestCase, TestHelper):
+class PluginTest(BeetsTestCase):
     def test_plugin_command_from_pluginpath(self):
         config["pluginpath"] = [_common.PLUGINPATH]
         config["plugins"] = ["test"]
@@ -1416,7 +1417,7 @@ class PluginTest(_common.TestCase, TestHelper):
 
 
 @_common.slow_test()
-class CompletionTest(_common.TestCase, TestHelper):
+class CompletionTest(BeetsTestCase):
     def test_completion(self):
         # Load plugin commands
         config["pluginpath"] = [_common.PLUGINPATH]
@@ -1652,7 +1653,7 @@ class CommonOptionsParserTest(unittest.TestCase, TestHelper):
         )
 
 
-class EncodingTest(_common.TestCase):
+class EncodingTest(BeetsTestCase):
     """Tests for the `terminal_encoding` config option and our
     `_in_encoding` and `_out_encoding` utility functions.
     """

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -1648,11 +1648,3 @@ class EncodingTest(BeetsTestCase):
         with patch("sys.stdin") as stdin:
             stdin.encoding = None
             self.assertEqual(ui._in_encoding(), "utf-8")
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_ui_commands.py
+++ b/test/test_ui_commands.py
@@ -22,7 +22,7 @@ import unittest
 
 from beets import library, ui
 from beets.test import _common
-from beets.test.helper import BeetsTestCase, LibTestCase
+from beets.test.helper import BeetsTestCase, ItemInDBTestCase
 from beets.ui import commands
 from beets.util import syspath
 
@@ -88,7 +88,7 @@ class QueryTest(BeetsTestCase):
         self.check_do_query(0, 2, album=True, also_items=False)
 
 
-class FieldsTest(LibTestCase):
+class FieldsTest(ItemInDBTestCase):
     def setUp(self):
         super().setUp()
 

--- a/test/test_ui_commands.py
+++ b/test/test_ui_commands.py
@@ -28,18 +28,6 @@ from beets.util import syspath
 
 
 class QueryTest(BeetsTestCase):
-    def setUp(self):
-        super().setUp()
-
-        self.libdir = os.path.join(self.temp_dir, b"testlibdir")
-        os.mkdir(syspath(self.libdir))
-
-        # Add a file to the library but don't copy it in yet.
-        self.lib = library.Library(":memory:", self.libdir)
-
-        # Alternate destination directory.
-        # self.otherdir = os.path.join(self.temp_dir, b"testotherdir")
-
     def add_item(self, filename=b"srcfile", templatefile=b"full.mp3"):
         itempath = os.path.join(self.libdir, filename)
         shutil.copy(

--- a/test/test_ui_commands.py
+++ b/test/test_ui_commands.py
@@ -18,7 +18,6 @@
 
 import os
 import shutil
-import unittest
 
 from beets import library, ui
 from beets.test import _common
@@ -104,11 +103,3 @@ class FieldsTest(ItemInDBTestCase):
 
         self.assertEqual(len(items), 0)
         self.assertEqual(len(albums), 0)
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_ui_commands.py
+++ b/test/test_ui_commands.py
@@ -22,11 +22,12 @@ import unittest
 
 from beets import library, ui
 from beets.test import _common
+from beets.test.helper import BeetsTestCase, LibTestCase
 from beets.ui import commands
 from beets.util import syspath
 
 
-class QueryTest(_common.TestCase):
+class QueryTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
@@ -87,7 +88,7 @@ class QueryTest(_common.TestCase):
         self.check_do_query(0, 2, album=True, also_items=False)
 
 
-class FieldsTest(_common.LibTestCase):
+class FieldsTest(LibTestCase):
     def setUp(self):
         super().setUp()
 

--- a/test/test_ui_importer.py
+++ b/test/test_ui_importer.py
@@ -21,57 +21,53 @@ test_importer module. But here the test importer inherits from
 import unittest
 from test import test_importer
 
-from beets.test.helper import TerminalImportSessionSetup
+from beets.test.helper import TerminalImportMixin
 
 
 class NonAutotaggedImportTest(
-    TerminalImportSessionSetup, test_importer.NonAutotaggedImportTest
+    TerminalImportMixin, test_importer.NonAutotaggedImportTest
 ):
     pass
 
 
-class ImportTest(TerminalImportSessionSetup, test_importer.ImportTest):
+class ImportTest(TerminalImportMixin, test_importer.ImportTest):
     pass
 
 
 class ImportSingletonTest(
-    TerminalImportSessionSetup, test_importer.ImportSingletonTest
+    TerminalImportMixin, test_importer.ImportSingletonTest
 ):
     pass
 
 
-class ImportTracksTest(
-    TerminalImportSessionSetup, test_importer.ImportTracksTest
-):
+class ImportTracksTest(TerminalImportMixin, test_importer.ImportTracksTest):
     pass
 
 
 class ImportCompilationTest(
-    TerminalImportSessionSetup, test_importer.ImportCompilationTest
+    TerminalImportMixin, test_importer.ImportCompilationTest
 ):
     pass
 
 
-class ImportExistingTest(
-    TerminalImportSessionSetup, test_importer.ImportExistingTest
-):
+class ImportExistingTest(TerminalImportMixin, test_importer.ImportExistingTest):
     pass
 
 
 class ChooseCandidateTest(
-    TerminalImportSessionSetup, test_importer.ChooseCandidateTest
+    TerminalImportMixin, test_importer.ChooseCandidateTest
 ):
     pass
 
 
 class GroupAlbumsImportTest(
-    TerminalImportSessionSetup, test_importer.GroupAlbumsImportTest
+    TerminalImportMixin, test_importer.GroupAlbumsImportTest
 ):
     pass
 
 
 class GlobalGroupAlbumsImportTest(
-    TerminalImportSessionSetup, test_importer.GlobalGroupAlbumsImportTest
+    TerminalImportMixin, test_importer.GlobalGroupAlbumsImportTest
 ):
     pass
 

--- a/test/test_ui_importer.py
+++ b/test/test_ui_importer.py
@@ -18,7 +18,6 @@ test_importer module. But here the test importer inherits from
 ``TerminalImportSession``. So we test this class, too.
 """
 
-import unittest
 from test import test_importer
 
 from beets.test.helper import TerminalImportMixin
@@ -70,11 +69,3 @@ class GlobalGroupAlbumsImportTest(
     TerminalImportMixin, test_importer.GlobalGroupAlbumsImportTest
 ):
     pass
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_ui_init.py
+++ b/test/test_ui_init.py
@@ -91,9 +91,6 @@ class InputMethodsTest(BeetsTestCase):
 
 
 class InitTest(ItemInDBTestCase):
-    def setUp(self):
-        super().setUp()
-
     def test_human_bytes(self):
         tests = [
             (0, "0.0 B"),

--- a/test/test_ui_init.py
+++ b/test/test_ui_init.py
@@ -23,7 +23,7 @@ from random import random
 
 from beets import config, ui
 from beets.test import _common
-from beets.test.helper import BeetsTestCase, LibTestCase, control_stdin
+from beets.test.helper import BeetsTestCase, ItemInDBTestCase, control_stdin
 
 
 class InputMethodsTest(BeetsTestCase):
@@ -90,7 +90,7 @@ class InputMethodsTest(BeetsTestCase):
         self.assertEqual(items, ["1", "3"])
 
 
-class InitTest(LibTestCase):
+class InitTest(ItemInDBTestCase):
     def setUp(self):
         super().setUp()
 

--- a/test/test_ui_init.py
+++ b/test/test_ui_init.py
@@ -23,10 +23,10 @@ from random import random
 
 from beets import config, ui
 from beets.test import _common
-from beets.test.helper import control_stdin
+from beets.test.helper import BeetsTestCase, LibTestCase, control_stdin
 
 
-class InputMethodsTest(_common.TestCase):
+class InputMethodsTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
         self.io.install()
@@ -90,7 +90,7 @@ class InputMethodsTest(_common.TestCase):
         self.assertEqual(items, ["1", "3"])
 
 
-class InitTest(_common.LibTestCase):
+class InitTest(LibTestCase):
     def setUp(self):
         super().setUp()
 
@@ -129,7 +129,7 @@ class InitTest(_common.LibTestCase):
             self.assertEqual(h, ui.human_seconds(i))
 
 
-class ParentalDirCreation(_common.TestCase):
+class ParentalDirCreation(BeetsTestCase):
     def test_create_yes(self):
         non_exist_path = _common.os.fsdecode(
             os.path.join(self.temp_dir, b"nonexist", str(random()).encode())

--- a/test/test_ui_init.py
+++ b/test/test_ui_init.py
@@ -17,7 +17,6 @@
 
 import os
 import shutil
-import unittest
 from copy import deepcopy
 from random import random
 
@@ -160,11 +159,3 @@ class ParentalDirCreation(BeetsTestCase):
                 if lib:
                     lib._close()
                 raise OSError("Parent directories should not be created.")
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -24,6 +24,7 @@ from unittest.mock import Mock, patch
 
 from beets import util
 from beets.test import _common
+from beets.test.helper import BeetsTestCase
 
 
 class UtilTest(unittest.TestCase):
@@ -157,7 +158,7 @@ class UtilTest(unittest.TestCase):
         pass
 
 
-class PathConversionTest(_common.TestCase):
+class PathConversionTest(BeetsTestCase):
     def test_syspath_windows_format(self):
         with _common.platform_windows():
             path = os.path.join("a", "b", "c")
@@ -200,7 +201,7 @@ class PathConversionTest(_common.TestCase):
         self.assertEqual(outpath, "C:\\caf\xe9".encode())
 
 
-class PathTruncationTest(_common.TestCase):
+class PathTruncationTest(BeetsTestCase):
     def test_truncate_bytestring(self):
         with _common.platform_posix():
             p = util.truncate_path(b"abcde/fgh", 4)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -216,11 +216,3 @@ class PathTruncationTest(BeetsTestCase):
         with _common.platform_posix():
             p = util.truncate_path("abcde/fgh.ext", 5)
         self.assertEqual(p, "abcde/f.ext")
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_vfs.py
+++ b/test/test_vfs.py
@@ -14,7 +14,6 @@
 
 """Tests for the virtual filesystem builder.."""
 
-import unittest
 
 from beets import vfs
 from beets.test import _common
@@ -41,11 +40,3 @@ class VFSTest(BeetsTestCase):
         self.assertEqual(
             self.tree.dirs["albums"].dirs["the album"].files["the title"], 2
         )
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromName(__name__)
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")

--- a/test/test_vfs.py
+++ b/test/test_vfs.py
@@ -16,7 +16,7 @@
 
 import unittest
 
-from beets import library, vfs
+from beets import vfs
 from beets.test import _common
 from beets.test.helper import BeetsTestCase
 
@@ -24,13 +24,10 @@ from beets.test.helper import BeetsTestCase
 class VFSTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
-        self.lib = library.Library(
-            ":memory:",
-            path_formats=[
-                ("default", "albums/$album/$title"),
-                ("singleton:true", "tracks/$artist/$title"),
-            ],
-        )
+        self.lib.path_formats = [
+            ("default", "albums/$album/$title"),
+            ("singleton:true", "tracks/$artist/$title"),
+        ]
         self.lib.add(_common.item())
         self.lib.add_album([_common.item()])
         self.tree = vfs.libtree(self.lib)

--- a/test/test_vfs.py
+++ b/test/test_vfs.py
@@ -18,9 +18,10 @@ import unittest
 
 from beets import library, vfs
 from beets.test import _common
+from beets.test.helper import BeetsTestCase
 
 
-class VFSTest(_common.TestCase):
+class VFSTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
         self.lib = library.Library(

--- a/test/testall.py
+++ b/test/testall.py
@@ -16,25 +16,7 @@
 
 
 import os
-import re
 import sys
-import unittest
 
 pkgpath = os.path.dirname(os.path.dirname(os.path.realpath(__file__))) or ".."
 sys.path.insert(0, pkgpath)
-
-
-def suite():
-    s = unittest.TestSuite()
-    # Get the suite() of every module in this directory beginning with
-    # "test_".
-    for fname in os.listdir(os.path.join(pkgpath, "test")):
-        match = re.match(r"(test_\S+)\.py$", fname)
-        if match:
-            modname = match.group(1)
-            s.addTest(__import__(modname).suite())
-    return s
-
-
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")


### PR DESCRIPTION
This PR deduplicates shared tests setup that was used across test files. It attempts to centralise the setup into a single source of truth implementation in `beets.test.helper`.

This works towards the eventual migration to `pytest` (#5361) making it easier to replace the tests setup with `pytest` fixtures.

It builds upon the temporary files cleanup in #5345.

## Details

### Test setup

* Mostly duplicate test setup implementations in `beets.test._common.TestCase` and `beets.test.helper.TestHelper` were merged into a single implementation as `beets.test.helper.BeetsTestCase`.
* Replaced `unittest.TestCase` and `beets.test.helper.TestHelper` combination with `beets.test.helper.ImportTestCase`
* Refactored `test/test_plugins.py` removing duplicate import files setup.
* Centralised setting up the database on disk.
* Centralised plugin test setup into `beets.test.helpers.PluginMixin`.

### Removals

* Around 1/3 of the removed lines correspond to the removal of `def suite()` functions that were previously used for tests collection.
* Removed redundant `setUp` and `tearDown` methods from many test files given that the functions that they performed had been centralised in `beets.test.helper`.
* Removed redundant library initialisations


### Importing

* Centralised import directory creation (only gets created on the first access).
* Deduplicated `_setup_import_session` implementations in `TerminalImportSessionSetup` and `ImportHelper`.
* Merged `ImportHelper._create_import_dir` and `TestHelper.create_importer` implementations into `ImportHelper.setup_importer`.
* Merged various takes on import files prep into `ImportHelper.prepare_albums_for_import` and `ImportHelper.prepare_album_for_import`.
* Seeing that many tests used it, defined `AsIsImporterMixin` which provides a method `run_asis_importer` to setup _asis_ (non-autotag) importer and run it
