### PR TITLE
Enable skipped tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,12 @@ jobs:
         if: matrix.platform == 'ubuntu-latest'
         run: |
           sudo apt update
-          sudo apt install ffmpeg gobject-introspection libgirepository1.0-dev
+          sudo apt install \
+            ffmpeg \
+            gobject-introspection \
+            gstreamer1.0-plugins-good \
+            libgirepository1.0-dev \
+            mp3gain
           poetry install --extras replaygain
 
       - name: Install Python dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,10 @@ jobs:
             gstreamer1.0-plugins-good \
             libgirepository1.0-dev \
             mp3gain
-          poetry install --extras replaygain --extras embedart
+          poetry install \
+            --extras embedart \
+            --extras lyrics \
+            --extras replaygain
 
       - name: Install Python dependencies
         run: poetry install --only=main,test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install \
+            bash-completion \
             ffmpeg \
             gobject-introspection \
             gstreamer1.0-plugins-good \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
             gstreamer1.0-plugins-good \
             libgirepository1.0-dev \
             mp3gain
-          poetry install --extras replaygain
+          poetry install --extras replaygain --extras embedart
 
       - name: Install Python dependencies
         run: poetry install --only=main,test

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -18,8 +18,6 @@ information or mock the environment.
 - The `control_stdin` and `capture_stdout` context managers allow one to
   interact with the user interface.
 
-- `has_program` checks the presence of a command on the system.
-
 - The `generate_album_info` and `generate_track_info` functions return
   fixtures to be used when mocking the autotagger.
 
@@ -34,7 +32,6 @@ from __future__ import annotations
 import os
 import os.path
 import shutil
-import subprocess
 import sys
 from contextlib import contextmanager
 from enum import Enum
@@ -124,22 +121,6 @@ def _convert_args(args):
             args[i] = elem.decode(util.arg_encoding())
 
     return args
-
-
-def has_program(cmd, args=["--version"]):
-    """Returns `True` if `cmd` can be executed."""
-    full_cmd = _convert_args([cmd] + args)
-    try:
-        with open(os.devnull, "wb") as devnull:
-            subprocess.check_call(
-                full_cmd, stderr=devnull, stdout=devnull, stdin=devnull
-            )
-    except OSError:
-        return False
-    except subprocess.CalledProcessError:
-        return False
-    else:
-        return True
 
 
 class TestHelper:

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -884,21 +884,12 @@ class ArtForAlbumTest(UseThePlugin):
             self.plugin.art_for_album(self.album, [""], True)
             self.assertEqual(mock_operation.called, should_operate)
 
-    def _require_backend(self):
-        """Skip the test if the art resizer doesn't have ImageMagick or
-        PIL (so comparisons and measurements are unavailable).
-        """
-        if not ArtResizer.shared.local:
-            self.skipTest("ArtResizer has no local imaging backend available")
-
     def test_respect_minwidth(self):
-        self._require_backend()
         self.plugin.minwidth = 300
         self._assertImageIsValidArt(self.IMG_225x225, False)
         self._assertImageIsValidArt(self.IMG_348x348, True)
 
     def test_respect_enforce_ratio_yes(self):
-        self._require_backend()
         self.plugin.enforce_ratio = True
         self._assertImageIsValidArt(self.IMG_500x490, False)
         self._assertImageIsValidArt(self.IMG_225x225, True)
@@ -908,60 +899,50 @@ class ArtForAlbumTest(UseThePlugin):
         self._assertImageIsValidArt(self.IMG_500x490, True)
 
     def test_respect_enforce_ratio_px_above(self):
-        self._require_backend()
         self.plugin.enforce_ratio = True
         self.plugin.margin_px = 5
         self._assertImageIsValidArt(self.IMG_500x490, False)
 
     def test_respect_enforce_ratio_px_below(self):
-        self._require_backend()
         self.plugin.enforce_ratio = True
         self.plugin.margin_px = 15
         self._assertImageIsValidArt(self.IMG_500x490, True)
 
     def test_respect_enforce_ratio_percent_above(self):
-        self._require_backend()
         self.plugin.enforce_ratio = True
         self.plugin.margin_percent = (500 - 490) / 500 * 0.5
         self._assertImageIsValidArt(self.IMG_500x490, False)
 
     def test_respect_enforce_ratio_percent_below(self):
-        self._require_backend()
         self.plugin.enforce_ratio = True
         self.plugin.margin_percent = (500 - 490) / 500 * 1.5
         self._assertImageIsValidArt(self.IMG_500x490, True)
 
     def test_resize_if_necessary(self):
-        self._require_backend()
         self.plugin.maxwidth = 300
         self._assert_image_operated(self.IMG_225x225, self.RESIZE_OP, False)
         self._assert_image_operated(self.IMG_348x348, self.RESIZE_OP, True)
 
     def test_fileresize(self):
-        self._require_backend()
         self.plugin.max_filesize = self.IMG_225x225_SIZE // 2
         self._assert_image_operated(self.IMG_225x225, self.RESIZE_OP, True)
 
     def test_fileresize_if_necessary(self):
-        self._require_backend()
         self.plugin.max_filesize = self.IMG_225x225_SIZE
         self._assert_image_operated(self.IMG_225x225, self.RESIZE_OP, False)
         self._assertImageIsValidArt(self.IMG_225x225, True)
 
     def test_fileresize_no_scale(self):
-        self._require_backend()
         self.plugin.maxwidth = 300
         self.plugin.max_filesize = self.IMG_225x225_SIZE // 2
         self._assert_image_operated(self.IMG_225x225, self.RESIZE_OP, True)
 
     def test_fileresize_and_scale(self):
-        self._require_backend()
         self.plugin.maxwidth = 200
         self.plugin.max_filesize = self.IMG_225x225_SIZE // 2
         self._assert_image_operated(self.IMG_225x225, self.RESIZE_OP, True)
 
     def test_deinterlace(self):
-        self._require_backend()
         self.plugin.deinterlace = True
         self._assert_image_operated(self.IMG_225x225, self.DEINTERLACE_OP, True)
         self.plugin.deinterlace = False
@@ -970,7 +951,6 @@ class ArtForAlbumTest(UseThePlugin):
         )
 
     def test_deinterlace_and_resize(self):
-        self._require_backend()
         self.plugin.maxwidth = 300
         self.plugin.deinterlace = True
         self._assert_image_operated(self.IMG_348x348, self.DEINTERLACE_OP, True)

--- a/test/plugins/test_embedart.py
+++ b/test/plugins/test_embedart.py
@@ -40,7 +40,7 @@ def require_artresizer_compare(test):
     return wrapper
 
 
-class EmbedartCliTest(TestHelper, FetchImageHelper):
+class EmbedartCliTest(TestHelper, FetchImageHelper, unittest.TestCase):
     small_artpath = os.path.join(_common.RSRC, b"image-2x3.jpg")
     abbey_artpath = os.path.join(_common.RSRC, b"abbey.jpg")
     abbey_similarpath = os.path.join(_common.RSRC, b"abbey-similar.jpg")

--- a/test/plugins/test_fetchart.py
+++ b/test/plugins/test_fetchart.py
@@ -42,11 +42,12 @@ class FetchartCliTest(unittest.TestCase, TestHelper):
 
     def hide_file_windows(self):
         hidden_mask = 2
-        success = ctypes.windll.kernel32.SetFileAttributesW(
-            self.cover_path, hidden_mask
+        self.assertTrue(
+            ctypes.windll.kernel32.SetFileAttributesW(
+                self.cover_path, hidden_mask
+            ),
+            "Could not set file attributes",
         )
-        if not success:
-            self.skipTest("unable to set file attributes")
 
     def test_set_art_from_folder(self):
         self.touch(b"c\xc3\xb6ver.jpg", dir=self.album.path, content="IMAGE")

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -750,7 +750,7 @@ class LRCLibLyricsTest(unittest.TestCase):
         self.assertIsNone(lyrics)
 
 
-class LRCLibIntegrationTest(LyricsAssertions):
+class LRCLibIntegrationTest(LyricsAssertions, unittest.TestCase):
     def setUp(self):
         self.plugin = lyrics.LyricsPlugin()
         lrclib.config = self.plugin.config

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -249,16 +249,12 @@ yaml_path = os.path.join(_common.RSRC, b"lyricstext.yaml")
 LYRICS_TEXTS = confuse.load_yaml(yaml_path)
 
 
-class LyricsGoogleBaseTest(unittest.TestCase):
+class LyricsTestCase(unittest.TestCase):
     def setUp(self):
-        """Set up configuration."""
-        try:
-            __import__("bs4")
-        except ImportError:
-            self.skipTest("Beautiful Soup 4 not available")
+        self.plugin = lyrics.LyricsPlugin()
 
 
-class LyricsPluginSourcesTest(LyricsGoogleBaseTest, LyricsAssertions):
+class LyricsPluginSourcesTest(LyricsTestCase, LyricsAssertions):
     """Check that beets google custom search engine sources are correctly
     scraped.
     """
@@ -346,10 +342,6 @@ class LyricsPluginSourcesTest(LyricsGoogleBaseTest, LyricsAssertions):
         ),
     ]
 
-    def setUp(self):
-        LyricsGoogleBaseTest.setUp(self)
-        self.plugin = lyrics.LyricsPlugin()
-
     @unittest.skipUnless(
         os.environ.get("INTEGRATION_TEST", "0") == "1",
         "integration testing not enabled",
@@ -383,7 +375,7 @@ class LyricsPluginSourcesTest(LyricsGoogleBaseTest, LyricsAssertions):
             self.assertLyricsContentOk(s["title"], res, url)
 
 
-class LyricsGooglePluginMachineryTest(LyricsGoogleBaseTest, LyricsAssertions):
+class LyricsGooglePluginMachineryTest(LyricsTestCase, LyricsAssertions):
     """Test scraping heuristics on a fake html page."""
 
     source = dict(
@@ -392,11 +384,6 @@ class LyricsGooglePluginMachineryTest(LyricsGoogleBaseTest, LyricsAssertions):
         title="Beets song",
         path="/lyrics/beetssong",
     )
-
-    def setUp(self):
-        """Set up configuration"""
-        LyricsGoogleBaseTest.setUp(self)
-        self.plugin = lyrics.LyricsPlugin()
 
     @patch.object(lyrics.Backend, "fetch_url", MockFetchUrl())
     def test_mocked_source_ok(self):
@@ -461,22 +448,8 @@ class LyricsGooglePluginMachineryTest(LyricsGoogleBaseTest, LyricsAssertions):
 # test Genius backend
 
 
-class GeniusBaseTest(unittest.TestCase):
-    def setUp(self):
-        """Set up configuration."""
-        try:
-            __import__("bs4")
-        except ImportError:
-            self.skipTest("Beautiful Soup 4 not available")
-
-
-class GeniusScrapeLyricsFromHtmlTest(GeniusBaseTest):
+class GeniusScrapeLyricsFromHtmlTest(LyricsTestCase):
     """tests Genius._scrape_lyrics_from_html()"""
-
-    def setUp(self):
-        """Set up configuration"""
-        GeniusBaseTest.setUp(self)
-        self.plugin = lyrics.LyricsPlugin()
 
     def test_no_lyrics_div(self):
         """Ensure we don't crash when the scraping the html for a genius page
@@ -507,13 +480,8 @@ class GeniusScrapeLyricsFromHtmlTest(GeniusBaseTest):
     # TODO: find an example of a lyrics page with multiple divs and test it
 
 
-class GeniusFetchTest(GeniusBaseTest):
+class GeniusFetchTest(LyricsTestCase):
     """tests Genius.fetch()"""
-
-    def setUp(self):
-        """Set up configuration"""
-        GeniusBaseTest.setUp(self)
-        self.plugin = lyrics.LyricsPlugin()
 
     @patch.object(lyrics.Genius, "_scrape_lyrics_from_html")
     @patch.object(lyrics.Backend, "fetch_url", return_value=True)
@@ -567,22 +535,12 @@ class GeniusFetchTest(GeniusBaseTest):
 # test Tekstowo
 
 
-class TekstowoBaseTest(unittest.TestCase):
-    def setUp(self):
-        """Set up configuration."""
-        try:
-            __import__("bs4")
-        except ImportError:
-            self.skipTest("Beautiful Soup 4 not available")
-
-
-class TekstowoExtractLyricsTest(TekstowoBaseTest):
+class TekstowoExtractLyricsTest(LyricsTestCase):
     """tests Tekstowo.extract_lyrics()"""
 
     def setUp(self):
         """Set up configuration"""
-        TekstowoBaseTest.setUp(self)
-        self.plugin = lyrics.LyricsPlugin()
+        super().setUp()
         tekstowo.config = self.plugin.config
 
     def test_good_lyrics(self):
@@ -628,13 +586,8 @@ class TekstowoExtractLyricsTest(TekstowoBaseTest):
         )
 
 
-class TekstowoParseSearchResultsTest(TekstowoBaseTest):
+class TekstowoParseSearchResultsTest(LyricsTestCase):
     """tests Tekstowo.parse_search_results()"""
-
-    def setUp(self):
-        """Set up configuration"""
-        TekstowoBaseTest.setUp(self)
-        self.plugin = lyrics.LyricsPlugin()
 
     def test_multiple_results(self):
         """Ensure we are able to scrape a page with multiple search results"""
@@ -659,13 +612,12 @@ class TekstowoParseSearchResultsTest(TekstowoBaseTest):
         self.assertEqual(tekstowo.parse_search_results(mock(url)), None)
 
 
-class TekstowoIntegrationTest(TekstowoBaseTest, LyricsAssertions):
+class TekstowoIntegrationTest(LyricsTestCase, LyricsAssertions):
     """Tests Tekstowo lyric source with real requests"""
 
     def setUp(self):
         """Set up configuration"""
-        TekstowoBaseTest.setUp(self)
-        self.plugin = lyrics.LyricsPlugin()
+        super().setUp()
         tekstowo.config = self.plugin.config
 
     @unittest.skipUnless(
@@ -693,9 +645,9 @@ class TekstowoIntegrationTest(TekstowoBaseTest, LyricsAssertions):
 # test LRCLib backend
 
 
-class LRCLibLyricsTest(unittest.TestCase):
+class LRCLibLyricsTest(LyricsTestCase):
     def setUp(self):
-        self.plugin = lyrics.LyricsPlugin()
+        super().setUp()
         lrclib.config = self.plugin.config
 
     @patch("beetsplug.lyrics.requests.get")
@@ -750,9 +702,9 @@ class LRCLibLyricsTest(unittest.TestCase):
         self.assertIsNone(lyrics)
 
 
-class LRCLibIntegrationTest(LyricsAssertions, unittest.TestCase):
+class LRCLibIntegrationTest(LyricsTestCase, LyricsAssertions):
     def setUp(self):
-        self.plugin = lyrics.LyricsPlugin()
+        super().setUp()
         lrclib.config = self.plugin.config
 
     @unittest.skipUnless(

--- a/test/plugins/test_replaygain.py
+++ b/test/plugins/test_replaygain.py
@@ -13,12 +13,13 @@
 # included in all copies or substantial portions of the Software.
 
 
+import shutil
 import unittest
 
 from mediafile import MediaFile
 
 from beets import config
-from beets.test.helper import TestHelper, has_program
+from beets.test.helper import TestHelper
 from beetsplug.replaygain import (
     FatalGstreamerPluginReplayGainError,
     GStreamerBackend,
@@ -32,12 +33,12 @@ try:
 except (ImportError, ValueError):
     GST_AVAILABLE = False
 
-if any(has_program(cmd, ["-v"]) for cmd in ["mp3gain", "aacgain"]):
+if shutil.which("mp3gain") or shutil.which("aacgain"):
     GAIN_PROG_AVAILABLE = True
 else:
     GAIN_PROG_AVAILABLE = False
 
-FFMPEG_AVAILABLE = has_program("ffmpeg", ["-version"])
+FFMPEG_AVAILABLE = shutil.which("ffmpeg")
 
 
 def reset_replaygain(item):

--- a/test/test_art_resize.py
+++ b/test/test_art_resize.py
@@ -110,7 +110,6 @@ class ArtResizerFileSizeTest(CleanupModulesMixin, _common.TestCase, TestHelper):
             os.stat(syspath(im_b)).st_size, os.stat(syspath(im_75_qual)).st_size
         )
 
-    @unittest.skipUnless(PILBackend.available(), "PIL not available")
     def test_pil_file_resize(self):
         """Test PIL resize function is lowering file size."""
         self._test_img_resize(PILBackend())
@@ -120,7 +119,6 @@ class ArtResizerFileSizeTest(CleanupModulesMixin, _common.TestCase, TestHelper):
         """Test IM resize function is lowering file size."""
         self._test_img_resize(IMBackend())
 
-    @unittest.skipUnless(PILBackend.available(), "PIL not available")
     def test_pil_file_deinterlace(self):
         """Test PIL deinterlace function.
 

--- a/test/test_art_resize.py
+++ b/test/test_art_resize.py
@@ -114,7 +114,6 @@ class ArtResizerFileSizeTest(CleanupModulesMixin, _common.TestCase, TestHelper):
         """Test PIL resize function is lowering file size."""
         self._test_img_resize(PILBackend())
 
-    @unittest.skipUnless(IMBackend.available(), "ImageMagick not available")
     def test_im_file_resize(self):
         """Test IM resize function is lowering file size."""
         self._test_img_resize(IMBackend())
@@ -131,7 +130,6 @@ class ArtResizerFileSizeTest(CleanupModulesMixin, _common.TestCase, TestHelper):
         with Image.open(path) as img:
             self.assertNotIn("progression", img.info)
 
-    @unittest.skipUnless(IMBackend.available(), "ImageMagick not available")
     def test_im_file_deinterlace(self):
         """Test ImageMagick deinterlace function.
 

--- a/test/test_hidden.py
+++ b/test/test_hidden.py
@@ -57,13 +57,10 @@ class HiddenFileTest(unittest.TestCase):
 
         with tempfile.NamedTemporaryFile() as f:
             # Hide the file using
-            success = ctypes.windll.kernel32.SetFileAttributesW(
-                f.name, hidden_mask
+            self.assertTrue(
+                ctypes.windll.kernel32.SetFileAttributesW(f.name, hidden_mask),
+                "Could not set file attributes",
             )
-
-            if not success:
-                self.skipTest("unable to set file attributes")
-
             self.assertTrue(hidden.is_hidden(f.name))
 
     def test_other_hidden(self):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -34,13 +34,7 @@ from beets import config, importer, logging, util
 from beets.autotag import AlbumInfo, AlbumMatch, TrackInfo
 from beets.importer import albums_in_dir
 from beets.test import _common
-from beets.test.helper import (
-    AutotagStub,
-    ImportHelper,
-    TestHelper,
-    capture_log,
-    has_program,
-)
+from beets.test.helper import AutotagStub, ImportHelper, TestHelper, capture_log
 from beets.util import bytestring_path, displayable_path, syspath
 
 
@@ -327,7 +321,7 @@ class ImportTarTest(ImportZipTest):
         return path
 
 
-@unittest.skipIf(not has_program("unrar"), "unrar program not found")
+@unittest.skipIf(not shutil.which("unrar"), "unrar program not found")
 class ImportRarTest(ImportZipTest):
     def create_archive(self):
         return os.path.join(_common.RSRC, b"archive.rar")

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -321,7 +321,6 @@ class ImportTarTest(ImportZipTest):
         return path
 
 
-@unittest.skipIf(not shutil.which("unrar"), "unrar program not found")
 class ImportRarTest(ImportZipTest):
     def create_archive(self):
         return os.path.join(_common.RSRC, b"archive.rar")

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -1411,7 +1411,6 @@ class PluginTest(_common.TestCase, TestHelper):
 
 
 @_common.slow_test()
-@unittest.skipIf(not shutil.which("bash"), "bash not available")
 class CompletionTest(_common.TestCase, TestHelper):
     def test_completion(self):
         # Load plugin commands
@@ -1436,12 +1435,12 @@ class CompletionTest(_common.TestCase, TestHelper):
                 bash_completion = path
                 break
         else:
-            self.skipTest("bash-completion script not found")
+            self.fail("bash-completion script not found")
         try:
             with open(util.syspath(bash_completion), "rb") as f:
                 tester.stdin.writelines(f)
         except OSError:
-            self.skipTest("could not read bash-completion script")
+            self.fail("could not read bash-completion script")
 
         # Load completion script.
         self.io.install()

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -30,12 +30,7 @@ from mediafile import MediaFile
 from beets import autotag, config, library, plugins, ui, util
 from beets.autotag.match import distance
 from beets.test import _common
-from beets.test.helper import (
-    TestHelper,
-    capture_stdout,
-    control_stdin,
-    has_program,
-)
+from beets.test.helper import TestHelper, capture_stdout, control_stdin
 from beets.ui import commands
 from beets.util import MoveOperation, syspath
 
@@ -1416,6 +1411,7 @@ class PluginTest(_common.TestCase, TestHelper):
 
 
 @_common.slow_test()
+@unittest.skipIf(not shutil.which("bash"), "bash not available")
 class CompletionTest(_common.TestCase, TestHelper):
     def test_completion(self):
         # Load plugin commands
@@ -1430,8 +1426,6 @@ class CompletionTest(_common.TestCase, TestHelper):
         # Open a `bash` process to run the tests in. We'll pipe in bash
         # commands via stdin.
         cmd = os.environ.get("BEETS_TEST_SHELL", "/bin/bash --norc").split()
-        if not has_program(cmd[0]):
-            self.skipTest("bash not available")
         tester = subprocess.Popen(
             cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, env=env
         )


### PR DESCRIPTION
Under #5362 me and @bal-e found out that `EmbedartCliTest` does not run since it does not
inherit from `unittest.TestCase`.

This PR fixes the above and another test that also had the same issue:
`LRCLibIntegrationTest`.

Additionally, I went ahead and removed `unittest.skip` from tests that are skipped because
of missing dependencies, and added installation instructions for those dependencies in the
build.
