### PR TITLE
Allow user to use m3u in relative_to to create playlists relative to m3u_path

### DIFF
--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -328,12 +328,16 @@ class SmartPlaylistPlugin(BeetsPlugin):
                     for entry in m3us[m3u]:
                         item = entry.item
                         if entry.uri == "m3u":
-                            entry.uri = os.path.relpath(item.path, os.path.dirname(m3u_path))
+                            entry.uri = os.path.relpath(
+                                item.path, os.path.dirname(m3u_path)
+                            )
                             if self.config["forward_slash"].get():
                                 item_uri = path_as_posix(item_uri)
                             if self.config["urlencode"]:
-                                 item_uri = bytestring_path(pathname2url(item_uri))
-                                 item_uri = prefix + item_uri
+                                item_uri = bytestring_path(
+                                    pathname2url(item_uri)
+                                )
+                                item_uri = prefix + item_uri
                         comment = ""
                         if extm3u:
                             attr = [(k, entry.item[k]) for k in keys]

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -259,7 +259,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
         tpl = self.config["uri_format"].get()
         prefix = bytestring_path(self.config["prefix"].as_str())
         relative_to = self.config["relative_to"].get()
-        if relative_to:
+        if relative_to != "m3u":
             relative_to = normpath(relative_to)
 
         # Maps playlist filenames to lists of track filenames.
@@ -289,6 +289,8 @@ class SmartPlaylistPlugin(BeetsPlugin):
                 item_uri = item.path
                 if tpl:
                     item_uri = tpl.replace("$id", str(item.id)).encode("utf-8")
+                if relative_to == "m3u":
+                    item_uri = "m3u"
                 else:
                     if relative_to:
                         item_uri = os.path.relpath(item_uri, relative_to)
@@ -325,6 +327,13 @@ class SmartPlaylistPlugin(BeetsPlugin):
                         f.write(b"#EXTM3U\n")
                     for entry in m3us[m3u]:
                         item = entry.item
+                        if entry.uri == "m3u":
+                            entry.uri = os.path.relpath(item.path, os.path.dirname(m3u_path))
+                            if self.config["forward_slash"].get():
+                                item_uri = path_as_posix(item_uri)
+                            if self.config["urlencode"]:
+                                 item_uri = bytestring_path(pathname2url(item_uri))
+                                 item_uri = prefix + item_uri
                         comment = ""
                         if extm3u:
                             attr = [(k, entry.item[k]) for k in keys]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ New features:
   album queries involving `path` field have been sped up, like `beet list -a
   path:/path/`.
 
+* Ability to use relative_to as "m3u" to set playlist files as relative to where each playlist is at, including subdirectories.
 Bug fixes:
 
 * Improved naming of temporary files by separating the random part with the file extension.


### PR DESCRIPTION
Allow user to use m3u in relative_to to create playlists relative to

## Description
Allows the user to use "m3u" in relative_to to create playlists which use paths relative to where the playlists are located, even if they are in subdirectories, for example, this allows users  to have a working playlist config like
```
smartplaylist:
    target_dir: ~/Music
    relative_to: m3u
    #relative_to: ~/Music/Playlists
    playlist_dir: ~/Music/Playlists
    forward_slash: no
    playlists:
        - name: 'Genres/$genre/$genre.m3u'
          query: ''
```
And have it actually work

This is something that Still needs some work, and I haven't tested *everything*, but it works for my purposes, but I haven't tested everything. This is my first attempt at this, so it's rough, and needs alot of work... I want to see if anyone else is interested in this, so I can work on it more, or not

I haven't contributed to a python project before, so sorry if im a little disorganized...  this is my first time doing _stuff_ in python, so hope it's fine :)
## To Do

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
