### PR TITLE
Fix the no_convert option of the convert plugin stopping conversion when there is only a partial match.

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -84,17 +84,20 @@ def get_format(fmt=None):
 
     return (command.encode("utf-8"), extension.encode("utf-8"))
 
+def in_no_convert(item: Item) -> bool:
+    no_convert_query = config["convert"]["no_convert"].as_str()
 
+    if no_convert_query:
+        query, _ = parse_query_string(no_convert_query, Item)
+        return query.match(item)
+    else:
+        return False
+    
 def should_transcode(item, fmt):
     """Determine whether the item should be transcoded as part of
     conversion (i.e., its bitrate is high or it has the wrong format).
     """
-    no_convert_query = config["convert"]["no_convert"].as_str()
-    if no_convert_query:
-        query, _ = parse_query_string(no_convert_query, Item)
-        if query.match(item):
-            return False
-    if (
+    if in_no_convert(item) or (
         config["convert"]["never_convert_lossy_files"]
         and item.format.lower() not in LOSSLESS_FORMATS
     ):

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -89,12 +89,11 @@ def should_transcode(item, fmt):
     """Determine whether the item should be transcoded as part of
     conversion (i.e., its bitrate is high or it has the wrong format).
     """
-    no_convert_queries = config["convert"]["no_convert"].as_str_seq()
-    if no_convert_queries:
-        for query_string in no_convert_queries:
-            query, _ = parse_query_string(query_string, Item)
-            if query.match(item):
-                return False
+    no_convert_query = config["convert"]["no_convert"].as_str()
+    if no_convert_query:
+        query, _ = parse_query_string(no_convert_query, Item)
+        if query.match(item):
+            return False
     if (
         config["convert"]["never_convert_lossy_files"]
         and item.format.lower() not in LOSSLESS_FORMATS

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -47,6 +47,10 @@ Bug fixes:
 * :doc:`plugins/lyrics`: Update ``tekstowo`` backend to fetch lyrics directly
   since recent updates to their website made it unsearchable.
   :bug:`5456`
+* :doc:`plugins/convert`: Fixed the convert plugin ``no_convert`` option so
+  that it no longer treats "and" and "or" queries the same. To maintain
+  previous behaviour add commas between your query keywords. For help see
+  :ref:`combiningqueries`.
 
 For packagers:
 

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -360,7 +360,7 @@ class NoConvertTest(ConvertTestCase, ConvertCommand):
         with control_stdin("y"):
             self.run_convert_path(item.path)
         converted = os.path.join(self.convert_dest, b"converted.mp3")
-        self.assertFalse(os.path.exists(converted))
+        self.assertNotExists(converted)
 
     def test_no_transcode_when_and_query_no_convert_set(self):
         self.config["convert"]["no_convert"] = "format:OGG bitrate:..256"
@@ -370,7 +370,7 @@ class NoConvertTest(ConvertTestCase, ConvertCommand):
         with control_stdin("y"):
             self.run_convert_path(item.path)
         converted = os.path.join(self.convert_dest, b"converted.mp3")
-        self.assertFalse(os.path.exists(converted))
+        self.assertNotExists(converted)
 
     def test_transcode_when_and_query_no_convert_set_partial_match(self):
         self.config["convert"]["no_convert"] = "format:OGG bitrate:..256"
@@ -380,7 +380,7 @@ class NoConvertTest(ConvertTestCase, ConvertCommand):
         with control_stdin("y"):
             self.run_convert_path(item.path)
         converted = os.path.join(self.convert_dest, b"converted.mp3")
-        self.assertTrue(os.path.exists(converted))
+        self.assertExists(converted)
 
     def test_no_transcode_when_or_query_no_convert_set_partial_match(self):
         self.config["convert"]["no_convert"] = "format:OGG , bitrate:..256"
@@ -390,4 +390,4 @@ class NoConvertTest(ConvertTestCase, ConvertCommand):
         with control_stdin("y"):
             self.run_convert_path(item.path)
         converted = os.path.join(self.convert_dest, b"converted.mp3")
-        self.assertFalse(os.path.exists(converted))
+        self.assertNotExists(converted)

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -362,7 +362,7 @@ class NoConvertTest(ConvertTestCase, ConvertCommand):
         converted = os.path.join(self.convert_dest, b"converted.mp3")
         self.assertFalse(os.path.exists(converted))
 
-    def test_no_transcode_when_multi_no_convert_set(self):
+    def test_no_transcode_when_and_query_no_convert_set(self):
         self.config["convert"]["no_convert"] = "format:OGG bitrate:..256"
         [item] = self.add_item_fixtures(ext="ogg")
         item.bitrate = 128
@@ -372,7 +372,7 @@ class NoConvertTest(ConvertTestCase, ConvertCommand):
         converted = os.path.join(self.convert_dest, b"converted.mp3")
         self.assertFalse(os.path.exists(converted))
 
-    def test_transcode_when_multi_no_convert_set_partial_match(self):
+    def test_transcode_when_and_query_no_convert_set_partial_match(self):
         self.config["convert"]["no_convert"] = "format:OGG bitrate:..256"
         [item] = self.add_item_fixtures(ext="ogg")
         item.bitrate = 320
@@ -381,3 +381,13 @@ class NoConvertTest(ConvertTestCase, ConvertCommand):
             self.run_convert_path(item.path)
         converted = os.path.join(self.convert_dest, b"converted.mp3")
         self.assertTrue(os.path.exists(converted))
+
+    def test_no_transcode_when_or_query_no_convert_set_partial_match(self):
+        self.config["convert"]["no_convert"] = "format:OGG , bitrate:..256"
+        [item] = self.add_item_fixtures(ext="ogg")
+        item.bitrate = 320
+        item.store()
+        with control_stdin("y"):
+            self.run_convert_path(item.path)
+        converted = os.path.join(self.convert_dest, b"converted.mp3")
+        self.assertFalse(os.path.exists(converted))


### PR DESCRIPTION
## Description

I was running the `convert` plugin with the following config:

```
no_convert: samplerate:..48000 bitdepth:..16
```

but anything that was 24/48 was also not being converted, this was due to the code returning `False` for `should_transcode` if any part of the query matches, rather than considering the whole query. This meant that `bitdepth:...16` was being ignored.

I have changed this so the `no_convert` value is considered as one query.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [X] ~Documentation.~
- [X] Changelog.
- [X] Tests.
