### PR TITLE
Change double blank line following class to single blank line: The Black Code Style - Extra empty lines (beets/ui/__init__.py) file 

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -66,9 +66,7 @@ class UserError(Exception):
     nonrecoverable errors to the user.
     """
 
-
 # Encoding utilities.
-
 
 def _in_encoding():
     """Get the encoding to use for *inputting* strings from the console."""


### PR DESCRIPTION
I reviewed the "black formatting" documentation in beets' style guide section in the Contributing file which states, "Black will enforce single empty lines between a class-level docstring and the first following field or method." What I found on line 68 in the (beets/ui/init.py) file however, was two empty lines between a class-level ("UserError" - class, line 64) docstring and the following field. This seems to violate the style convention.

I believe the comment on line 69 should begin on line 68.

Problem
I believe that this is a minor stylistic issue in the (beets/ui/init.py) file. This minor issue does not effect functionality but might be important for consistency in the code.

Setup
OS: N/A
Python version: N/A
beets version: N/A
Turning off plugins made problem go away (yes/no): N/A
My configuration (output of beet config) is:

N/A