### PR TITLE
Fix/sqlite func exceptions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,7 @@ name: Test
 on:
   pull_request:
   push:
-    branches:
-      - master
+
 env:
   PY_COLORS: 1
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,6 @@ run-name: Lint code
 on:
   pull_request:
   push:
-    branches:
-      - master
 
 env:
   PYTHON_VERSION: 3.8

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -73,6 +73,16 @@ class DBAccessError(Exception):
     """
 
 
+class DBCustomFunctionError(Exception):
+    """A sqlite function registered by beets failed."""
+
+    def __init__(self):
+        super().__init__(
+            "beets defined SQLite function failed; "
+            "see the other errors above for details"
+        )
+
+
 class FormattedMapping(Mapping[str, str]):
     """A `dict`-like formatted view of a model.
 
@@ -970,6 +980,12 @@ class Transaction:
             self._mutated = False
             self.db._db_lock.release()
 
+        if (
+            isinstance(exc_value, sqlite3.OperationalError)
+            and exc_value.args[0] == "user-defined function raised exception"
+        ):
+            raise DBCustomFunctionError()
+
     def query(self, statement: str, subvals: Sequence = ()) -> List:
         """Execute an SQL statement with substitution values and return
         a list of rows from the database.
@@ -1027,6 +1043,10 @@ class Database:
             raise RuntimeError(
                 "sqlite3 must be compiled with multi-threading support"
             )
+
+        # Print tracebacks for exceptions in user defined functions
+        # See also `self.add_functions` and `DBCustomFunctionError`.
+        sqlite3.enable_callback_tracebacks(True)
 
         self.path = path
         self.timeout = timeout


### PR DESCRIPTION
## Description

A bit niche but I tried setting my bareasc prefix to an empty string,
and was getting an obtuse error. This should help make clearer what is
happening when queries fail.

The exception is not properly raised up the stack in the first place
because it happens across 2 FFI boundaries: the DB query
(Python -> SQLite), and the custom DB function (SQLite -> Python).
Thus Python cannot forwarded it back to itself through SQLite, and it's
treated as an "unraisable" exception.

We could override `sys.unraisablehook` to not print anything for the
original exception, and store it in a global for the outer Python
interpreter to fetch and raise properly, but that's pretty hacky,
limited to a single DB instance and query at once, and risks swallowing
other "unraisable" exceptions.
Instead we just tell the user to look above for what Python prints.

Sample output:
```
Exception ignored in: <function unidecode_expect_ascii at 0x7f7fa20bb060>
Traceback (most recent call last):
  File "site-packages/unidecode/__init__.py", line 60, in unidecode_expect_ascii
    bytestring = string.encode('ASCII')
                 ^^^^^^^^^^^^^
AttributeError: 'bytes' object has no attribute 'encode'
Traceback (most recent call last):
  File "site-packages/beets/dbcore/db.py", line 988, in query
    cursor = self.db._connection().execute(statement, subvals)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
sqlite3.OperationalError: user-defined function raised exception

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "site-packages/beets/__main__.py", line 9, in <module>
    sys.exit(main())
             ^^^^^^
  File "site-packages/beets/ui/__init__.py", line 1865, in main
    _raw_main(args)
  File "site-packages/beets/ui/__init__.py", line 1852, in _raw_main
    subcommand.func(lib, suboptions, subargs)
  File "site-packages/beets/ui/commands.py", line 1599, in list_func
    list_items(lib, decargs(args), opts.album)
  File "site-packages/beets/ui/commands.py", line 1594, in list_items
    for item in lib.items(query):
                ^^^^^^^^^^^^^^^^
  File "site-packages/beets/library.py", line 1695, in items
    return self._fetch(Item, query, sort or self.get_default_item_sort())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "site-packages/beets/library.py", line 1673, in _fetch
    return super()._fetch(model_cls, query, sort)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "site-packages/beets/dbcore/db.py", line 1301, in _fetch
    rows = tx.query(sql, subvals)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "site-packages/beets/dbcore/db.py", line 991, in query
    raise DBCustomFunctionError()
beets.dbcore.db.DBCustomFunctionError: beets defined custom SQLite function failed; see the other errors above for details
```

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)~
- [x] ~Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)~
- [ ] Tests. (Very much encouraged but not strictly required.)
