### PR TITLE
Fixup: use fast queries for fields shared between albums and items tables

### DIFF
--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -152,14 +152,15 @@ def construct_query_part(
     # Field queries get constructed according to the name of the field
     # they are querying.
     else:
-        key = key.lower()
-        if key in model_cls.shared_db_fields:
+        field = table = key.lower()
+        if field in model_cls.shared_db_fields:
             # This field exists in both tables, so SQLite will encounter
             # an OperationalError if we try to query it in a join.
             # Using an explicit table name resolves this.
-            key = f"{model_cls._table}.{key}"
+            table = f"{model_cls._table}.{field}"
 
-        out_query = query_class(key, pattern, key in model_cls.all_db_fields)
+        field_in_db = field in model_cls.all_db_fields
+        out_query = query_class(table, pattern, field_in_db)
 
     # Apply negation.
     if negate:


### PR DESCRIPTION
I surprisingly found that many queries for fields that exist in the database are 'slow'. Querying items with `month:0` used a slow query while `title:0` used a fast one.

I found the mistake in the logic: the field existence in the db check was done *after* prepending the table name to the field. This meant that the logic wrongly checked e.g. `items.field` instead of `field`.

This commit fixes the above and renames the variables for more clarity.
