### PR TITLE
Fix lrclib lyrics

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -783,7 +783,7 @@ class Google(Backend):
 
 
 class LyricsPlugin(plugins.BeetsPlugin):
-    SOURCES = ["google", "musixmatch", "genius", "tekstowo", "lrclib"]
+    SOURCES = ["lrclib", "google", "musixmatch", "genius", "tekstowo"]
     SOURCE_BACKENDS = {
         "google": Google,
         "musixmatch": MusiXmatch,

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -60,6 +60,7 @@ COMMENT_RE = re.compile(r"<!--.*-->", re.S)
 TAG_RE = re.compile(r"<[^>]*>")
 BREAK_RE = re.compile(r"\n?\s*<br([\s|/][^>]*)*>\s*\n?", re.I)
 USER_AGENT = f"beets/{beets.__version__}"
+INSTRUMENTAL_LYRICS = "[Instrumental]"
 
 # The content for the base index.rst generated in ReST mode.
 REST_INDEX_TEMPLATE = """Lyrics
@@ -349,6 +350,9 @@ class LRCLib(Backend):
             if data:
                 item = self.pick_lyrics(length, data)
 
+                if item["instrumental"]:
+                    return INSTRUMENTAL_LYRICS
+
                 if self.config["synced"] and (synced := item["syncedLyrics"]):
                     return synced
 
@@ -536,7 +540,7 @@ class Genius(Backend):
                 string="This song is an instrumental",
             ):
                 self._log.debug("Detected instrumental")
-                return "[Instrumental]"
+                return INSTRUMENTAL_LYRICS
             else:
                 self._log.debug("Couldn't scrape page using known layouts")
                 return None

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -348,7 +348,10 @@ class LRCLyrics:
         if self.instrumental:
             return INSTRUMENTAL_LYRICS
 
-        return self.synced if want_synced and self.synced else self.plain
+        if want_synced and self.synced:
+            return "\n".join(map(str.strip, self.synced.splitlines()))
+
+        return self.plain
 
 
 class LRCLib(Backend):

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, ClassVar
 from urllib.parse import quote, urlencode
 
 import requests
+from typing_extensions import TypedDict
 from unidecode import unidecode
 
 import beets
@@ -266,12 +267,55 @@ class Backend:
         raise NotImplementedError
 
 
+class LRCLibItem(TypedDict):
+    """Lyrics data item returned by the LRCLib API."""
+
+    id: int
+    name: str
+    trackName: str
+    artistName: str
+    albumName: str
+    duration: float
+    instrumental: bool
+    plainLyrics: str
+    syncedLyrics: str | None
+
+
 class LRCLib(Backend):
-    base_url = "https://lrclib.net/api/get"
+    base_url = "https://lrclib.net/api/search"
+
+    @staticmethod
+    def get_rank(
+        target_duration: float, item: LRCLibItem
+    ) -> tuple[float, bool]:
+        """Rank the given lyrics item.
+
+        Return a tuple with the following values:
+        1. Absolute difference between lyrics and target duration
+        2. Boolean telling whether synced lyrics are available.
+        """
+        return (
+            abs(item["duration"] - target_duration),
+            not item["syncedLyrics"],
+        )
+
+    @classmethod
+    def pick_lyrics(
+        cls, target_duration: float, data: list[LRCLibItem]
+    ) -> LRCLibItem:
+        """Return best matching lyrics item from the given list.
+
+        Best lyrics match is the one that has the closest duration to
+        ``target_duration`` and has synced lyrics available.
+
+        Note that the incoming list is guaranteed to be non-empty.
+        """
+        return min(data, key=lambda item: cls.get_rank(target_duration, item))
 
     def fetch(
         self, artist: str, title: str, album: str, length: int
     ) -> str | None:
+        """Fetch lyrics for the given artist, title, and album."""
         params: dict[str, str | int] = {
             "artist_name": artist,
             "track_name": title,
@@ -288,15 +332,20 @@ class LRCLib(Backend):
                 params=params,
                 timeout=10,
             )
-            data = response.json()
+            data: list[LRCLibItem] = response.json()
         except (requests.RequestException, json.decoder.JSONDecodeError) as exc:
             self._log.debug("LRCLib API request failed: {0}", exc)
             return None
 
-        if self.config["synced"]:
-            return data.get("syncedLyrics") or data.get("plainLyrics")
+        if not data:
+            return None
 
-        return data.get("plainLyrics")
+        item = self.pick_lyrics(length, data)
+
+        if self.config["synced"] and (synced_lyrics := item["syncedLyrics"]):
+            return synced_lyrics
+
+        return item["plainLyrics"]
 
 
 class DirectBackend(Backend):

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -25,8 +25,11 @@ import re
 import struct
 import unicodedata
 import warnings
-from functools import partial
-from typing import TYPE_CHECKING, ClassVar
+from contextlib import suppress
+from dataclasses import dataclass
+from functools import cached_property, partial, total_ordering
+from http import HTTPStatus
+from typing import TYPE_CHECKING, ClassVar, Iterable, Iterator
 from urllib.parse import quote, urlencode
 
 import requests
@@ -96,6 +99,10 @@ epub_exclude_files = ['search.html']
 epub_tocdepth = 1
 epub_tocdup = False
 """
+
+
+class NotFoundError(requests.exceptions.HTTPError):
+    pass
 
 
 # Utilities.
@@ -276,14 +283,80 @@ class LRCLibItem(TypedDict):
     trackName: str
     artistName: str
     albumName: str
-    duration: float
+    duration: float | None
     instrumental: bool
     plainLyrics: str
     syncedLyrics: str | None
 
 
+@dataclass
+@total_ordering
+class LRCLyrics:
+    #: Percentage tolerance for max duration difference between lyrics and item.
+    DURATION_DIFF_TOLERANCE = 0.05
+
+    target_duration: float
+    duration: float
+    instrumental: bool
+    plain: str
+    synced: str | None
+
+    def __le__(self, other: LRCLyrics) -> bool:
+        """Compare two lyrics items by their score."""
+        return self.dist < other.dist
+
+    @classmethod
+    def make(cls, candidate: LRCLibItem, target_duration: float) -> LRCLyrics:
+        return cls(
+            target_duration,
+            candidate["duration"] or 0.0,
+            candidate["instrumental"],
+            candidate["plainLyrics"],
+            candidate["syncedLyrics"],
+        )
+
+    @cached_property
+    def duration_dist(self) -> float:
+        """Return the absolute difference between lyrics and target duration."""
+        return abs(self.duration - self.target_duration)
+
+    @cached_property
+    def is_valid(self) -> bool:
+        """Return whether the lyrics item is valid.
+        Lyrics duration must be within the tolerance defined by
+        :attr:`DURATION_DIFF_TOLERANCE`.
+        """
+        return (
+            self.duration_dist
+            <= self.target_duration * self.DURATION_DIFF_TOLERANCE
+        )
+
+    @cached_property
+    def dist(self) -> tuple[float, bool]:
+        """Distance/score of the given lyrics item.
+
+        Return a tuple with the following values:
+        1. Absolute difference between lyrics and target duration
+        2. Boolean telling whether synced lyrics are available.
+
+        Best lyrics match is the one that has the closest duration to
+        ``target_duration`` and has synced lyrics available.
+        """
+        return self.duration_dist, not self.synced
+
+    def get_text(self, want_synced: bool) -> str:
+        if self.instrumental:
+            return INSTRUMENTAL_LYRICS
+
+        return self.synced if want_synced and self.synced else self.plain
+
+
 class LRCLib(Backend):
-    base_url = "https://lrclib.net/api/search"
+    """Fetch lyrics from the LRCLib API."""
+
+    BASE_URL = "https://lrclib.net/api"
+    GET_URL = f"{BASE_URL}/get"
+    SEARCH_URL = f"{BASE_URL}/search"
 
     def warn(self, message: str, *args) -> None:
         """Log a warning message with the class name."""
@@ -294,69 +367,54 @@ class LRCLib(Backend):
         kwargs.setdefault("timeout", 10)
         kwargs.setdefault("headers", {"User-Agent": USER_AGENT})
         r = requests.get(*args, **kwargs)
+        if r.status_code == HTTPStatus.NOT_FOUND:
+            raise NotFoundError("HTTP Error: Not Found", response=r)
         r.raise_for_status()
 
         return r.json()
 
-    @staticmethod
-    def get_rank(
-        target_duration: float, item: LRCLibItem
-    ) -> tuple[float, bool]:
-        """Rank the given lyrics item.
+    def fetch_candidates(
+        self, artist: str, title: str, album: str, length: int
+    ) -> Iterator[list[LRCLibItem]]:
+        """Yield lyrics candidates for the given song data.
 
-        Return a tuple with the following values:
-        1. Absolute difference between lyrics and target duration
-        2. Boolean telling whether synced lyrics are available.
+        Firstly, attempt to GET lyrics directly, and then search the API if
+        lyrics are not found or the duration does not match.
+
+        Return an iterator over lists of candidates.
         """
-        return (
-            abs(item["duration"] - target_duration),
-            not item["syncedLyrics"],
-        )
+        base_params = {"artist_name": artist, "track_name": title}
+        get_params = {**base_params, "duration": length}
+        if album:
+            get_params["album_name"] = album
+
+        with suppress(NotFoundError):
+            yield [self.fetch_json(self.GET_URL, params=get_params)]
+
+        yield self.fetch_json(self.SEARCH_URL, params=base_params)
 
     @classmethod
-    def pick_lyrics(
-        cls, target_duration: float, data: list[LRCLibItem]
-    ) -> LRCLibItem:
-        """Return best matching lyrics item from the given list.
-
-        Best lyrics match is the one that has the closest duration to
-        ``target_duration`` and has synced lyrics available.
-
-        Note that the incoming list is guaranteed to be non-empty.
-        """
-        return min(data, key=lambda item: cls.get_rank(target_duration, item))
+    def pick_best_match(cls, lyrics: Iterable[LRCLyrics]) -> LRCLyrics | None:
+        """Return best matching lyrics item from the given list."""
+        return min((li for li in lyrics if li.is_valid), default=None)
 
     def fetch(
         self, artist: str, title: str, album: str, length: int
     ) -> str | None:
-        """Fetch lyrics for the given artist, title, and album."""
-        params: dict[str, str | int] = {
-            "artist_name": artist,
-            "track_name": title,
-        }
-        if album:
-            params["album_name"] = album
-
-        if length:
-            params["duration"] = length
+        """Fetch lyrics text for the given song data."""
+        evaluate_item = partial(LRCLyrics.make, target_duration=length)
 
         try:
-            data = self.fetch_json(self.base_url, params=params)
+            for group in self.fetch_candidates(artist, title, album, length):
+                candidates = [evaluate_item(item) for item in group]
+                if item := self.pick_best_match(candidates):
+                    return item.get_text(self.config["synced"])
+        except StopIteration:
+            pass
         except requests.JSONDecodeError:
             self.warn("Could not decode response JSON data")
         except requests.RequestException as exc:
             self.warn("Request error: {}", exc)
-        else:
-            if data:
-                item = self.pick_lyrics(length, data)
-
-                if item["instrumental"]:
-                    return INSTRUMENTAL_LYRICS
-
-                if self.config["synced"] and (synced := item["syncedLyrics"]):
-                    return synced
-
-                return item["plainLyrics"]
 
         return None
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -48,6 +48,10 @@ Bug fixes:
 * :doc:`plugins/lyrics`: Do not attempt to search for lyrics if either the
   artist or title is missing and ignore ``artist_sort`` value if it is empty.
   :bug:`2635`
+* :doc:`plugins/lyrics`: Fix fetching lyrics from ``lrclib`` source. Instead of
+  attempting to fetch lyrics for a specific album, artist, title and duration
+  combination, the plugin now performs a search which yields many results.
+  :bug:`5102`
 
 For packagers:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -48,11 +48,12 @@ Bug fixes:
 * :doc:`plugins/lyrics`: Do not attempt to search for lyrics if either the
   artist or title is missing and ignore ``artist_sort`` value if it is empty.
   :bug:`2635`
-* :doc:`plugins/lyrics`: Fix fetching lyrics from ``lrclib`` source. Instead of
-  attempting to fetch lyrics for a specific album, artist, title and duration
-  combination, the plugin now performs a search which yields many results.
-  Update the default ``sources`` configuration to prioritize ``lrclib`` over
-  other sources since it returns reliable results quicker than others.
+* :doc:`plugins/lyrics`: Fix fetching lyrics from ``lrclib`` source. If we
+  cannot find lyrics for a specific album, artist, title combination, the
+  plugin now tries to search for the artist and title and picks the most
+  relevant result. Update the default ``sources`` configuration to prioritize
+  ``lrclib`` over other sources since it returns reliable results quicker than
+  others.
   :bug:`5102`
 
 For packagers:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -51,6 +51,8 @@ Bug fixes:
 * :doc:`plugins/lyrics`: Fix fetching lyrics from ``lrclib`` source. Instead of
   attempting to fetch lyrics for a specific album, artist, title and duration
   combination, the plugin now performs a search which yields many results.
+  Update the default ``sources`` configuration to prioritize ``lrclib`` over
+  other sources since it returns reliable results quicker than others.
   :bug:`5102`
 
 For packagers:

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -56,7 +56,7 @@ configuration file. The available options are:
   sources known to be scrapeable.
 - **sources**: List of sources to search for lyrics. An asterisk ``*`` expands
   to all available sources.
-  Default: ``google genius tekstowo lrclib``, i.e., all the available sources. The
+  Default: ``lrclib google genius tekstowo``, i.e., all the available sources. The
   ``google`` source will be automatically deactivated if no ``google_API_key``
   is setup.
   The ``google``, ``genius``, and ``tekstowo`` sources will only be enabled if

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -347,6 +347,7 @@ LYRICS_DURATION = 950
 
 def lyrics_match(**overrides):
     return {
+        "instrumental": False,
         "duration": LYRICS_DURATION,
         "syncedLyrics": "synced",
         "plainLyrics": "plain",
@@ -385,6 +386,11 @@ class TestLRCLibLyrics(LyricsBackendTest):
             pytest.param([], None, id="handle non-matching lyrics"),
             pytest.param(
                 [lyrics_match()], "synced", id="synced when available"
+            ),
+            pytest.param(
+                [lyrics_match(instrumental=True)],
+                "[Instrumental]",
+                id="instrumental track",
             ),
             pytest.param(
                 [lyrics_match(syncedLyrics=None)],

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -368,7 +368,8 @@ class TestLRCLibLyrics(LyricsBackendTest):
 
     @pytest.fixture
     def fetch_lyrics(self, backend, requests_mock, request_kwargs):
-        requests_mock.get(backend.base_url, **request_kwargs)
+        requests_mock.get(backend.GET_URL, status_code=HTTPStatus.NOT_FOUND)
+        requests_mock.get(backend.SEARCH_URL, **request_kwargs)
 
         return partial(backend.fetch, "la", "la", "la", self.ITEM_DURATION)
 
@@ -385,7 +386,14 @@ class TestLRCLibLyrics(LyricsBackendTest):
         [
             pytest.param([], None, id="handle non-matching lyrics"),
             pytest.param(
-                [lyrics_match()], "synced", id="synced when available"
+                [lyrics_match()],
+                "synced",
+                id="synced when available",
+            ),
+            pytest.param(
+                [lyrics_match(duration=1)],
+                None,
+                id="none: duration too short",
             ),
             pytest.param(
                 [lyrics_match(instrumental=True)],

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -414,8 +414,23 @@ class TestLRCLibLyrics(LyricsBackendTest):
                     ),
                     lyrics_match(syncedLyrics="synced", plainLyrics="plain 2"),
                 ],
-                "plain with closer duration",
-                id="prefer closer duration",
+                "synced",
+                id="prefer synced lyrics even if plain duration is closer",
+            ),
+            pytest.param(
+                [
+                    lyrics_match(
+                        duration=ITEM_DURATION,
+                        syncedLyrics=None,
+                        plainLyrics="valid plain",
+                    ),
+                    lyrics_match(
+                        duration=1,
+                        syncedLyrics="synced with invalid duration",
+                    ),
+                ],
+                "valid plain",
+                id="ignore synced with invalid duration",
             ),
             pytest.param(
                 [lyrics_match(syncedLyrics=None), lyrics_match()],


### PR DESCRIPTION
Fixes #5102

### LRCLib lyrics backend fixes

#### Bug Fixes
- Fixed fetching lyrics from `lrclib` source. If lyrics for a specific album, artist, and title combination are not found, the plugin now searches for the artist and title and picks the most relevant result, scoring them by
  1. Duration similarity to the target item 
  1. Availability of synced lyrics
- Updated the default `sources` configuration to prioritize `lrclib` over other sources for faster and more reliable results.

#### Code Improvements
  - Added type annotations to `fetch` method in all backends.
  - Introduced `LRCLyrics` and `LRCLibItem` classes to encapsulate lyrics data and improve code structure.
  - Enhanced error handling and logging enchancements to the `LRCLib` backend. These will be added to the rest of the backends in a separate PR.

#### Tests
  - Added new tests to cover the updated functionality and error handling scenarios.

## To Do

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
