### PR TITLE
Create a new template function: capitalize

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -1784,6 +1784,11 @@ class DefaultTemplateFunctions:
         return s.upper()
 
     @staticmethod
+    def tmpl_capitalize(s):
+        """Converts to a capitalized string."""
+        return s.capitalize()
+
+    @staticmethod
     def tmpl_title(s):
         """Convert a string to title case."""
         return string.capwords(s)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,8 @@ Changelog goes here! Please add your entry to the bottom of one of the lists bel
 
 New features:
 
+* New template function added: ``%capitalize``. Converts the first letter of
+  the text to uppercase and the rest to lowercase.
 * Ability to query albums with track db fields and vice-versa, for example
   `beet list -a title:something` or `beet list artpath:cover`. Consequently
   album queries involving `path` field have been sped up, like `beet list -a

--- a/docs/reference/pathformat.rst
+++ b/docs/reference/pathformat.rst
@@ -60,6 +60,7 @@ These functions are built in to beets:
 
 * ``%lower{text}``: Convert ``text`` to lowercase.
 * ``%upper{text}``: Convert ``text`` to UPPERCASE.
+* ``%capitalize{text}``: Make the first letter of ``text`` UPPERCASE and the rest lowercase.
 * ``%title{text}``: Convert ``text`` to Title Case.
 * ``%left{text,n}``: Return the first ``n`` characters of ``text``.
 * ``%right{text,n}``: Return the last ``n`` characters of  ``text``.

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -629,6 +629,10 @@ class DestinationFunctionTest(BeetsTestCase, PathFormattingMixin):
         self._setf("%upper{$title}")
         self._assert_dest(b"/base/THE TITLE")
 
+    def test_capitalize_variable(self):
+        self._setf("%capitalize{$title}")
+        self._assert_dest(b"/base/The title")
+
     def test_title_case_variable(self):
         self._setf("%title{$title}")
         self._assert_dest(b"/base/The Title")


### PR DESCRIPTION
## Description

This creates a new template function that capitalizes the text (make the first character have upper case and the rest lower case). Example:
```console
beet list -f '%capitalize{$title}'
```

This does not do the same as the *%title* function.

(...)

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation.
- [x] Changelog.
- [x] Tests.
