### PR TITLE
Add support for `platformdirs`

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -1609,12 +1609,7 @@ class Library(dbcore.Database):
         timeout = beets.config["timeout"].as_number()
         super().__init__(path, timeout=timeout)
 
-        if directory is not None:
-            self.directory = normpath(directory)
-        else:
-            # Use the appropriate platform-specific fallback directory.
-            music_dir = platformdirs.user_music_path()
-            self.directory = bytestring_path(music_dir)
+        self.directory = normpath(directory or platformdirs.user_music_path())
 
         self.path_formats = path_formats
         self.replacements = replacements

--- a/beets/library.py
+++ b/beets/library.py
@@ -26,6 +26,7 @@ import unicodedata
 from functools import cached_property
 from pathlib import Path
 
+import platformdirs
 from mediafile import MediaFile, UnreadableFileError
 
 import beets
@@ -1601,14 +1602,20 @@ class Library(dbcore.Database):
     def __init__(
         self,
         path="library.blb",
-        directory="~/Music",
+        directory: str | None = None,
         path_formats=((PF_KEY_DEFAULT, "$artist/$album/$track $title"),),
         replacements=None,
     ):
         timeout = beets.config["timeout"].as_number()
         super().__init__(path, timeout=timeout)
 
-        self.directory = bytestring_path(normpath(directory))
+        if directory is not None:
+            self.directory = normpath(directory)
+        else:
+            # Use the appropriate platform-specific fallback directory.
+            music_dir = platformdirs.user_music_path()
+            self.directory = bytestring_path(music_dir)
+
         self.path_formats = path_formats
         self.replacements = replacements
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,9 @@ New features:
 * :doc:`plugins/autobpm`: Add new configuration option ``beat_track_kwargs``
   which enables adjusting keyword arguments supplied to librosa's
   ``beat_track`` function call.
+* Beets now uses ``platformdirs`` to determine the default music directory.
+  This location varies between systems -- for example, users can configure it
+  on Unix systems via ``user-dirs.dirs(5)``.
 
 Bug fixes:
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3242,4 +3242,4 @@ web = ["flask", "flask-cors"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "b24bff904f040cb57c9496a2d1ce129459123372a739b58baf6de973a6a41571"
+content-hash = "09b64b25f3ff363a3c31d44fd99e4c07309b27dda65523f9ec3d1279ca3a3143"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ jellyfish = "*"
 mediafile = ">=0.12.0"
 munkres = ">=1.0.0"
 musicbrainzngs = ">=0.4"
+platformdirs = ">=3.5.0"
 pyyaml = "*"
 typing_extensions = { version = "*", python = "<=3.10" }
 unidecode = ">=1.3.6"


### PR DESCRIPTION
## Description

Fixes #5168 and follows on #5333.

Thanks to @snejus for suggesting `platformdirs` instead of trying to roll my own XDG `user-dirs.dirs` parser.  It's well-tested, supports more platforms, and may come in handy for other features in the future.

## To Do

- [ ] ~Documentation~
- [x] Changelog
- [ ] ~Tests~
