### PR TITLE
Fixes TypeError in the Discogs plugin

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -16,6 +16,8 @@
 python3-discogs-client library.
 """
 
+from __future__ import annotations
+
 import http.client
 import json
 import os
@@ -30,6 +32,7 @@ from discogs_client import Client, Master, Release
 from discogs_client import __version__ as dc_string
 from discogs_client.exceptions import DiscogsAPIError
 from requests.exceptions import ConnectionError
+from typing_extensions import TypedDict
 
 import beets
 import beets.ui
@@ -50,6 +53,12 @@ CONNECTION_ERRORS = (
     ValueError,  # JSON decoding raises a ValueError.
     DiscogsAPIError,
 )
+
+
+class ReleaseFormat(TypedDict):
+    name: str
+    qty: int
+    descriptions: list[str] | None
 
 
 class DiscogsPlugin(BeetsPlugin):
@@ -363,6 +372,18 @@ class DiscogsPlugin(BeetsPlugin):
             )
             return None
 
+    @staticmethod
+    def get_media_and_albumtype(
+        formats: list[ReleaseFormat] | None,
+    ) -> tuple[str | None, str | None]:
+        media = albumtype = None
+        if formats and (first_format := formats[0]):
+            if descriptions := first_format["descriptions"]:
+                albumtype = ", ".join(descriptions)
+            media = first_format["name"]
+
+        return media, albumtype
+
     def get_album_info(self, result):
         """Returns an AlbumInfo object for a discogs Release object."""
         # Explicitly reload the `Release` fields, as they might not be yet
@@ -413,11 +434,11 @@ class DiscogsPlugin(BeetsPlugin):
 
         # Extract information for the optional AlbumInfo fields that are
         # contained on nested discogs fields.
-        albumtype = media = label = catalogno = labelid = None
-        if (formats := result.data.get("formats")) and (fmt := formats[0]):
-            if descriptions := fmt["descriptions"]:
-                albumtype = ", ".join(descriptions)
-            media = fmt["name"]
+        media, albumtype = self.get_media_and_albumtype(
+            result.data.get("formats")
+        )
+
+        label = catalogno = labelid = None
         if result.data.get("labels"):
             label = result.data["labels"][0].get("name")
             catalogno = result.data["labels"][0].get("catno")

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -417,7 +417,7 @@ class DiscogsPlugin(BeetsPlugin):
         if result.data.get("formats"):
             albumtype = (
                 ", ".join(
-                    str(result.data["formats"][0].get("descriptions", []))
+                    list(result.data["formats"][0].get("descriptions", []))
                 )
                 or None
             )

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -414,14 +414,10 @@ class DiscogsPlugin(BeetsPlugin):
         # Extract information for the optional AlbumInfo fields that are
         # contained on nested discogs fields.
         albumtype = media = label = catalogno = labelid = None
-        if result.data.get("formats"):
-            albumtype = (
-                ", ".join(
-                    list(result.data["formats"][0].get("descriptions", []))
-                )
-                or None
-            )
-            media = result.data["formats"][0]["name"]
+        if (formats := result.data.get("formats")) and (fmt := formats[0]):
+            if descriptions := fmt["descriptions"]:
+                albumtype = ", ".join(descriptions)
+            media = fmt["name"]
         if result.data.get("labels"):
             label = result.data["labels"][0].get("name")
             catalogno = result.data["labels"][0].get("catno")

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -416,7 +416,9 @@ class DiscogsPlugin(BeetsPlugin):
         albumtype = media = label = catalogno = labelid = None
         if result.data.get("formats"):
             albumtype = (
-                ", ".join(str(result.data["formats"][0].get("descriptions", [])))
+                ", ".join(
+                    str(result.data["formats"][0].get("descriptions", []))
+                )
                 or None
             )
             media = result.data["formats"][0]["name"]

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -416,7 +416,7 @@ class DiscogsPlugin(BeetsPlugin):
         albumtype = media = label = catalogno = labelid = None
         if result.data.get("formats"):
             albumtype = (
-                ", ".join(result.data["formats"][0].get("descriptions", []))
+                ", ".join(str(result.data["formats"][0].get("descriptions", [])))
                 or None
             )
             media = result.data["formats"][0]["name"]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -241,6 +241,7 @@ New features:
 
 Bug fixes:
 
+* :doc:`/plugins/deezer`: Improve requests error handling.
 * :doc:`/plugins/lastimport`: Improve error handling in the `process_tracks` function and enable it to be used with other plugins.
 * :doc:`/plugins/spotify`: Improve handling of ConnectionError.
 * :doc:`/plugins/deezer`: Improve Deezer plugin error handling and set requests timeout to 10 seconds.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,7 @@ Bug fixes:
   as a numpy array. Update ``librosa`` dependency constraint to prevent similar
   issues in the future.
   :bug:`5289`
+* :doc:`plugins/discogs`: Fixed the ``TypeError`` when there is no description.
 
 For packagers:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,8 +30,8 @@ Bug fixes:
   such as `bandcamp_album_id` will be available on albums in addition to tracks.
   For albums already in your library, a re-import is required for the fields to be added.
   Such a re-import can be done with, in this case, `beet import -L data_source:=MusicBrainz`.
-* :doc:`plugins/autobpm`: Fix the ``TypeError`` where tempo was being returned
-  as a numpy array. Update ``librosa`` dependency constraint to prevent similar
+* :doc:`plugins/autobpm`: Fixed the ``TypeError`` where tempo was being returned
+  as a numpy array. Updated ``librosa`` dependency constraint to prevent similar
   issues in the future.
   :bug:`5289`
 * :doc:`plugins/discogs`: Fixed the ``TypeError`` when there is no description.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,18 +23,18 @@ New features:
 
 Bug fixes:
 
-* Improved naming of temporary files by separating the random part with the file extension.
-* Fixed the ``auto`` value for the :ref:`reflink` config option.
-* Fixed lyrics plugin only getting part of the lyrics from ``Genius.com`` :bug:`4815`
+* Improve naming of temporary files by separating the random part with the file extension.
+* Fix the ``auto`` value for the :ref:`reflink` config option.
+* Fix lyrics plugin only getting part of the lyrics from ``Genius.com`` :bug:`4815`
 * Album flexible fields are now correctly saved. For instance MusicBrainz external links
   such as `bandcamp_album_id` will be available on albums in addition to tracks.
   For albums already in your library, a re-import is required for the fields to be added.
   Such a re-import can be done with, in this case, `beet import -L data_source:=MusicBrainz`.
-* :doc:`plugins/autobpm`: Fixed the ``TypeError`` where tempo was being returned
-  as a numpy array. Updated ``librosa`` dependency constraint to prevent similar
+* :doc:`plugins/autobpm`: Fix the ``TypeError`` where tempo was being returned
+  as a numpy array. Update ``librosa`` dependency constraint to prevent similar
   issues in the future.
   :bug:`5289`
-* :doc:`plugins/discogs`: Fixed the ``TypeError`` when there is no description.
+* :doc:`plugins/discogs`: Fix the ``TypeError`` when there is no description.
 
 For packagers:
 
@@ -241,7 +241,6 @@ New features:
 
 Bug fixes:
 
-* :doc:`/plugins/deezer`: Improve requests error handling.
 * :doc:`/plugins/lastimport`: Improve error handling in the `process_tracks` function and enable it to be used with other plugins.
 * :doc:`/plugins/spotify`: Improve handling of ConnectionError.
 * :doc:`/plugins/deezer`: Improve Deezer plugin error handling and set requests timeout to 10 seconds.

--- a/test/plugins/test_discogs.py
+++ b/test/plugins/test_discogs.py
@@ -12,9 +12,9 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
-"""Tests for discogs plugin.
-"""
+"""Tests for discogs plugin."""
 
+import pytest
 
 from beets import config
 from beets.test._common import Bag
@@ -423,3 +423,26 @@ class DGAlbumInfoTest(BeetsTestCase):
         d = DiscogsPlugin().get_album_info(release)
         assert d.genre == "GENRE1, GENRE2"
         assert d.style is None
+
+
+@pytest.mark.parametrize(
+    "formats, expected_media, expected_albumtype",
+    [
+        (None, None, None),
+        (
+            [
+                {
+                    "descriptions": ['7"', "Single", "45 RPM"],
+                    "name": "Vinyl",
+                    "qty": 1,
+                }
+            ],
+            "Vinyl",
+            '7", Single, 45 RPM',
+        ),
+    ],
+)
+def test_get_media_and_albumtype(formats, expected_media, expected_albumtype):
+    result = DiscogsPlugin.get_media_and_albumtype(formats)
+
+    assert result == (expected_media, expected_albumtype)


### PR DESCRIPTION
## Description

Fixes the following error:

```
Traceback (most recent call last):
  File "/home/konstantink/.local/bin/beet", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beets/ui/__init__.py", line 1865, in main
    _raw_main(args)
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beets/ui/__init__.py", line 1852, in _raw_main
    subcommand.func(lib, suboptions, subargs)
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beets/ui/commands.py", line 1395, in import_func
    import_files(lib, paths, query)
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beets/ui/commands.py", line 1326, in import_files
    session.run()
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beets/importer.py", line 360, in run
    pl.run_parallel(QUEUE_SIZE)
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beets/util/pipeline.py", line 447, in run_parallel
    raise exc_info[1].with_traceback(exc_info[2])
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beets/util/pipeline.py", line 312, in run
    out = self.coro.send(msg)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beets/util/pipeline.py", line 195, in coro
    func(*(args + (task,)))
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beets/importer.py", line 1497, in lookup_candidates
    task.lookup_candidates()
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beets/importer.py", line 688, in lookup_candidates
    artist, album, prop = autotag.tag_album(
                          ^^^^^^^^^^^^^^^^^^
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beets/autotag/match.py", line 548, in tag_album
    for matched_candidate in hooks.album_candidates(
                             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beets/plugins.py", line 593, in decorated
    for v in generator(*args, **kwargs):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beets/autotag/hooks.py", line 759, in album_candidates
    yield from plugins.candidates(items, artist, album, va_likely, extra_tags)
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beets/plugins.py", line 390, in candidates
    yield from plugin.candidates(
               ^^^^^^^^^^^^^^^^^^
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beetsplug/discogs.py", line 188, in candidates
    return self.get_albums(query)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beetsplug/discogs.py", line 335, in get_albums
    return [
           ^
  File "/home/konstantink/.local/share/pipx/venvs/beets/lib64/python3.12/site-packages/beetsplug/discogs.py", line 419, in get_album_info
    ", ".join(result.data["formats"][0].get("descriptions", []))
TypeError: can only join an iterable
```
IDK what exactly caused it, but this seems to have fixed it without causing additional problems.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation.~
- [x] Changelog.
- [ ] Tests.
