### PR TITLE
Deezer: Improve requests error handling

### DIFF
--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -293,13 +293,6 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
                 e,
             )
             return None
-        except requests.exceptions.HTTPError as e:
-            self._log.error(
-                "HTTP error fetching data from {} API\n Error: {}",
-                self.data_source,
-                e,
-            )
-            return None
         response_data = response.json().get("data", [])
         self._log.debug(
             "Found {} result(s) from {} for '{}'",

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -279,12 +279,23 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
         if not query:
             return None
         self._log.debug(f"Searching {self.data_source} for '{query}'")
-        response = requests.get(
-            self.search_url + query_type,
-            params={"q": query},
-            timeout=10,
-        )
-        response.raise_for_status()
+        try:
+            response = requests.get(
+                self.search_url + query_type,
+                params={"q": query},
+                timeout=10,
+            )
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            self._log.error(
+                "Error fetching data from {} API\n Error: {}", self.data_source, e
+            )
+            return None
+        except requests.exceptions.HTTPError as e:
+            self._log.error(
+                "HTTP error fetching data from {} API\n Error: {}", self.data_source, e
+            )
+            return None
         response_data = response.json().get("data", [])
         self._log.debug(
             "Found {} result(s) from {} for '{}'",

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -288,12 +288,16 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             self._log.error(
-                "Error fetching data from {} API\n Error: {}", self.data_source, e
+                "Error fetching data from {} API\n Error: {}",
+                self.data_source,
+                e,
             )
             return None
         except requests.exceptions.HTTPError as e:
             self._log.error(
-                "HTTP error fetching data from {} API\n Error: {}", self.data_source, e
+                "HTTP error fetching data from {} API\n Error: {}",
+                self.data_source,
+                e,
             )
             return None
         response_data = response.json().get("data", [])

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -238,6 +238,7 @@ New features:
 
 Bug fixes:
 
+* :doc:`/plugins/deezer`: Improve requests error handling.
 * :doc:`/plugins/lastimport`: Improve error handling in the `process_tracks` function and enable it to be used with other plugins.
 * :doc:`/plugins/spotify`: Improve handling of ConnectionError.
 * :doc:`/plugins/deezer`: Improve Deezer plugin error handling and set requests timeout to 10 seconds.


### PR DESCRIPTION
## Description

This PR adds gracefully handling requests error in teh Deezer plugin. Right now, it errors out when it receives error:

```bash
Traceback (most recent call last):
  File "/home/arsaboo/.local/bin/beet", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/arsaboo/.local/lib/python3.12/site-packages/beets/ui/__init__.py", line 1865, in main
    _raw_main(args)
  File "/home/arsaboo/.local/lib/python3.12/site-packages/beets/ui/__init__.py", line 1852, in _raw_main
    subcommand.func(lib, suboptions, subargs)
  File "/home/arsaboo/.local/lib/python3.12/site-packages/beets/ui/commands.py", line 1395, in import_func
    import_files(lib, paths, query)
  File "/home/arsaboo/.local/lib/python3.12/site-packages/beets/ui/commands.py", line 1326, in import_files
    session.run()
  File "/home/arsaboo/.local/lib/python3.12/site-packages/beets/importer.py", line 360, in run
    pl.run_parallel(QUEUE_SIZE)
  File "/home/arsaboo/.local/lib/python3.12/site-packages/beets/util/pipeline.py", line 447, in run_parallel
    raise exc_info[1].with_traceback(exc_info[2])
  File "/home/arsaboo/.local/lib/python3.12/site-packages/beets/util/pipeline.py", line 312, in run
    out = self.coro.send(msg)
          ^^^^^^^^^^^^^^^^^^^
  File "/home/arsaboo/.local/lib/python3.12/site-packages/beets/util/pipeline.py", line 195, in coro
    func(*(args + (task,)))
  File "/home/arsaboo/.local/lib/python3.12/site-packages/beets/importer.py", line 1497, in lookup_candidates
    task.lookup_candidates()
  File "/home/arsaboo/.local/lib/python3.12/site-packages/beets/importer.py", line 688, in lookup_candidates
    artist, album, prop = autotag.tag_album(
                          ^^^^^^^^^^^^^^^^^^
  File "/home/arsaboo/.local/lib/python3.12/site-packages/beets/autotag/match.py", line 548, in tag_album
    for matched_candidate in hooks.album_candidates(
  File "/home/arsaboo/.local/lib/python3.12/site-packages/beets/plugins.py", line 593, in decorated
    for v in generator(*args, **kwargs):
  File "/home/arsaboo/.local/lib/python3.12/site-packages/beets/autotag/hooks.py", line 759, in album_candidates
    yield from plugins.candidates(items, artist, album, va_likely, extra_tags)
  File "/home/arsaboo/.local/lib/python3.12/site-packages/beets/plugins.py", line 390, in candidates
    yield from plugin.candidates(
               ^^^^^^^^^^^^^^^^^^
  File "/home/arsaboo/.local/lib/python3.12/site-packages/beets/plugins.py", line 772, in candidates
    results = self._search_api(query_type="album", filters=query_filters)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/arsaboo/.local/lib/python3.12/site-packages/beetsplug/deezer.py", line 282, in _search_api
    response.raise_for_status()
  File "/home/arsaboo/.local/lib/python3.12/site-packages/requests/models.py", line 1024, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://api.deezer.com/search/album?q=album%3A%22Y+Hate+%3F%22+artist%3A%22Parmish+Verma%22
```

## To Do

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
