### PR TITLE
Fix missing keep_in_artist option in ftintitle plugin (introduced in #5356)

### DIFF
--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -117,9 +117,10 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
     def imported(self, session, task):
         """Import hook for moving featuring artist automatically."""
         drop_feat = self.config["drop"].get(bool)
+        keep_in_artist_field = self.config["keep_in_artist"].get(bool)
 
         for item in task.imported_items():
-            self.ft_in_title(item, drop_feat)
+            self.ft_in_title(item, drop_feat, keep_in_artist_field)
             item.store()
 
     def update_metadata(self, item, feat_part, drop_feat, keep_in_artist_field):


### PR DESCRIPTION
## Description

Fixes bug introduced in #5356.

The new `keep_in_artist` option for the ftintitle plugin was introduced in #5356.
However, it was not passed to the `imported` function. (See @chrishoage's comment in #5356).

This is fixed with this PR.

## To Do

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
