### PR TITLE
ftintitle: Fix false positives in "feat. X" detection in title

### DIFF
--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -35,11 +35,11 @@ def split_on_feat(artist):
         return tuple(parts)
 
 
-def contains_feat(title, for_artist=True):
+def contains_feat(title):
     """Determine whether the title contains a "featured" marker."""
     return bool(
         re.search(
-            plugins.feat_tokens(for_artist=for_artist),
+            plugins.feat_tokens(for_artist=False),
             title,
             flags=re.IGNORECASE,
         )
@@ -149,7 +149,7 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
 
         # Only update the title if it does not already contain a featured
         # artist and if we do not drop featuring information.
-        if not drop_feat and not contains_feat(item.title, for_artist=False):
+        if not drop_feat and not contains_feat(item.title):
             feat_format = self.config["format"].as_str()
             new_format = feat_format.format(feat_part)
             new_title = f"{item.title} {new_format}"

--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -35,9 +35,15 @@ def split_on_feat(artist):
         return tuple(parts)
 
 
-def contains_feat(title):
+def contains_feat(title, for_artist=True):
     """Determine whether the title contains a "featured" marker."""
-    return bool(re.search(plugins.feat_tokens(), title, flags=re.IGNORECASE))
+    return bool(
+        re.search(
+            plugins.feat_tokens(for_artist=for_artist),
+            title,
+            flags=re.IGNORECASE,
+        )
+    )
 
 
 def find_feat_part(artist, albumartist):
@@ -143,7 +149,7 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
 
         # Only update the title if it does not already contain a featured
         # artist and if we do not drop featuring information.
-        if not drop_feat and not contains_feat(item.title):
+        if not drop_feat and not contains_feat(item.title, for_artist=False):
             feat_format = self.config["format"].as_str()
             new_format = feat_format.format(feat_part)
             new_title = f"{item.title} {new_format}"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,8 @@ New features:
 
 Bug fixes:
 
+* The detection of a "feat. X" part in a song title does not produce any false
+  positives caused by words like "and" or "with" anymore. :bug:`5441`
 * The detection of a "feat. X" part now also matches such parts if they are in
   parentheses or brackets. :bug:`5436`
 * Improve naming of temporary files by separating the random part with the file extension.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,9 +26,9 @@ New features:
 
 Bug fixes:
 
-* The detection of a "feat. X" part in a song title does not produce any false
+* :doc:`plugins/ftintitle`: The detection of a "feat. X" part in a song title does not produce any false
   positives caused by words like "and" or "with" anymore. :bug:`5441`
-* The detection of a "feat. X" part now also matches such parts if they are in
+* :doc:`plugins/ftintitle`: The detection of a "feat. X" part now also matches such parts if they are in
   parentheses or brackets. :bug:`5436`
 * Improve naming of temporary files by separating the random part with the file extension.
 * Fix the ``auto`` value for the :ref:`reflink` config option.

--- a/test/plugins/test_ftintitle.py
+++ b/test/plugins/test_ftintitle.py
@@ -175,14 +175,11 @@ class FtInTitlePluginTest(unittest.TestCase):
         parts = ftintitle.split_on_feat("Alice defeat Bob")
         assert parts == ("Alice defeat Bob", None)
 
-    def test_contains_feat_artist(self):
+    def test_contains_feat(self):
         assert ftintitle.contains_feat("Alice ft. Bob")
         assert ftintitle.contains_feat("Alice feat. Bob")
         assert ftintitle.contains_feat("Alice feat Bob")
         assert ftintitle.contains_feat("Alice featuring Bob")
-        assert ftintitle.contains_feat("Alice & Bob")
-        assert ftintitle.contains_feat("Alice and Bob")
-        assert ftintitle.contains_feat("Alice With Bob")
         assert ftintitle.contains_feat("Alice (ft. Bob)")
         assert ftintitle.contains_feat("Alice (feat. Bob)")
         assert ftintitle.contains_feat("Alice [ft. Bob]")
@@ -190,16 +187,8 @@ class FtInTitlePluginTest(unittest.TestCase):
         assert not ftintitle.contains_feat("Alice defeat Bob")
         assert not ftintitle.contains_feat("Aliceft.Bob")
         assert not ftintitle.contains_feat("Alice (defeat Bob)")
-
-    def test_contains_feat_title(self):
-        assert ftintitle.contains_feat(
-            "Live and Let Go (feat. Alice)", for_artist=False
-        )
-        assert ftintitle.contains_feat(
-            "Live and Let Go [feat. Alice]", for_artist=False
-        )
-        assert ftintitle.contains_feat(
-            "Live and Let Go feat. Alice", for_artist=False
-        )
-        assert not ftintitle.contains_feat("Live and Let Go", for_artist=False)
-        assert not ftintitle.contains_feat("Come With Me", for_artist=False)
+        assert ftintitle.contains_feat("Live and Let Go (feat. Alice)")
+        assert ftintitle.contains_feat("Live and Let Go [feat. Alice]")
+        assert ftintitle.contains_feat("Live and Let Go feat. Alice")
+        assert not ftintitle.contains_feat("Live and Let Go")
+        assert not ftintitle.contains_feat("Come With Me")

--- a/test/plugins/test_ftintitle.py
+++ b/test/plugins/test_ftintitle.py
@@ -175,7 +175,7 @@ class FtInTitlePluginTest(unittest.TestCase):
         parts = ftintitle.split_on_feat("Alice defeat Bob")
         assert parts == ("Alice defeat Bob", None)
 
-    def test_contains_feat(self):
+    def test_contains_feat_artist(self):
         assert ftintitle.contains_feat("Alice ft. Bob")
         assert ftintitle.contains_feat("Alice feat. Bob")
         assert ftintitle.contains_feat("Alice feat Bob")
@@ -190,3 +190,16 @@ class FtInTitlePluginTest(unittest.TestCase):
         assert not ftintitle.contains_feat("Alice defeat Bob")
         assert not ftintitle.contains_feat("Aliceft.Bob")
         assert not ftintitle.contains_feat("Alice (defeat Bob)")
+
+    def test_contains_feat_title(self):
+        assert ftintitle.contains_feat(
+            "Live and Let Go (feat. Alice)", for_artist=False
+        )
+        assert ftintitle.contains_feat(
+            "Live and Let Go [feat. Alice]", for_artist=False
+        )
+        assert ftintitle.contains_feat(
+            "Live and Let Go feat. Alice", for_artist=False
+        )
+        assert not ftintitle.contains_feat("Live and Let Go", for_artist=False)
+        assert not ftintitle.contains_feat("Come With Me", for_artist=False)

--- a/test/plugins/test_ftintitle.py
+++ b/test/plugins/test_ftintitle.py
@@ -187,8 +187,5 @@ class FtInTitlePluginTest(unittest.TestCase):
         assert not ftintitle.contains_feat("Alice defeat Bob")
         assert not ftintitle.contains_feat("Aliceft.Bob")
         assert not ftintitle.contains_feat("Alice (defeat Bob)")
-        assert ftintitle.contains_feat("Live and Let Go (feat. Alice)")
-        assert ftintitle.contains_feat("Live and Let Go [feat. Alice]")
-        assert ftintitle.contains_feat("Live and Let Go feat. Alice")
         assert not ftintitle.contains_feat("Live and Let Go")
         assert not ftintitle.contains_feat("Come With Me")


### PR DESCRIPTION
## Description

Fixes #5441 

This small change explicitly passes the `for_artist` keyword to the `plugins.feat_tokens` function that constructs the regex for matching existing "feat. X" parts in song titles.
Previously, it was not passed and set to the default (`True`), which caused using the pattern intended for the artist field to also be used for the title field.
This caused some false positives as shown in #5441 


## To Do

- [ ] Documentation.
- [X] Changelog.
- [X] Tests.
