### PR TITLE
Make coverage token available in forks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: Test
 on:
-  pull_request:
+  pull_request_target:
   push:
     branches:
       - master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: Lint check
 run-name: Lint code
 on:
-  pull_request:
+  pull_request_target:
   push:
     branches:
       - master


### PR DESCRIPTION
This fixes coverage submission in CI, which has been failing for PRs submitted from forks.
