### PR TITLE
Lyrics: Resurrect translations and refactor ReST and command line handling

### DIFF
--- a/beetsplug/_typing.py
+++ b/beetsplug/_typing.py
@@ -113,3 +113,23 @@ class GoogleCustomSearchAPI:
         """Pagemap data with a single meta tags dict in a list."""
 
         metatags: list[JSONDict]
+
+
+class TranslatorAPI:
+    class Language(TypedDict):
+        """Language data returned by the translator API."""
+
+        language: str
+        score: float
+
+    class Translation(TypedDict):
+        """Translation data returned by the translator API."""
+
+        text: str
+        to: str
+
+    class Response(TypedDict):
+        """Response from the translator API."""
+
+        detectedLanguage: TranslatorAPI.Language
+        translations: list[TranslatorAPI.Translation]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,8 @@ New features:
   control the maximum allowed distance between the lyrics search result and the
   tagged item's artist and title. This is useful for preventing false positives
   when fetching lyrics.
+* :doc:`plugins/lyrics`: Rewrite lyrics translation functionality to use Azure
+  AI Translator API and add relevant instructions to the documentation.
 
 Bug fixes:
 

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -107,9 +107,8 @@ Rendering Lyrics into Other Formats
 -----------------------------------
 
 The ``-r directory, --write-rest directory`` option renders all lyrics as
-`reStructuredText`_ (ReST) documents in ``directory`` (by default, the current
-directory). That directory, in turn, can be parsed by tools like `Sphinx`_ to
-generate HTML, ePUB, or PDF documents.
+`reStructuredText`_ (ReST) documents in ``directory``. That directory, in turn,
+can be parsed by tools like `Sphinx`_ to generate HTML, ePUB, or PDF documents.
 
 Minimal ``conf.py`` and ``index.rst`` files are created the first time the
 command is run. They are not overwritten on subsequent runs, so you can safely
@@ -122,19 +121,19 @@ Sphinx supports various `builders`_, see a few suggestions:
 
   ::
 
-      sphinx-build -b html . _build/html
+      sphinx-build -b html <dir> <dir>/html
 
 .. admonition:: Build an ePUB3 formatted file, usable on ebook readers
 
   ::
 
-      sphinx-build -b epub3 . _build/epub
+      sphinx-build -b epub3 <dir> <dir>/epub
 
 .. admonition:: Build a PDF file, which incidentally also builds a LaTeX file
 
   ::
 
-      sphinx-build -b latex %s _build/latex && make -C _build/latex all-pdf
+      sphinx-build -b latex <dir> <dir>/latex && make -C <dir>/latex all-pdf
 
 
 .. _Sphinx: https://www.sphinx-doc.org/

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -47,6 +47,7 @@ Default configuration:
         force: no
         google_API_key: null
         google_engine_ID: 009217259823014548361:lndtuqkycfu
+        print: no
         sources: [lrclib, google, genius, tekstowo]
         synced: no
 
@@ -75,6 +76,7 @@ The available options are:
 - **google_engine_ID**: The custom search engine to use.
   Default: The `beets custom search engine`_, which gathers an updated list of
   sources known to be scrapeable.
+- **print**: Print lyrics to the console.
 - **sources**: List of sources to search for lyrics. An asterisk ``*`` expands
   to all available sources. The ``google`` source will be automatically
   deactivated if no ``google_API_key`` is setup.

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -38,9 +38,10 @@ Default configuration:
 
     lyrics:
         auto: yes
-        bing_client_secret: null
-        bing_lang_from: []
-        bing_lang_to: null
+        translate:
+            api_key:
+            from_languages: []
+            to_language:
         dist_thresh: 0.11
         fallback: null
         force: no
@@ -52,12 +53,14 @@ Default configuration:
 The available options are:
 
 - **auto**: Fetch lyrics automatically during import.
-- **bing_client_secret**: Your Bing Translation application password
-  (see :ref:`lyrics-translation`)
-- **bing_lang_from**: By default all lyrics with a language other than
-  ``bing_lang_to`` are translated. Use a list of lang codes to restrict the set
-  of source languages to translate.
-- **bing_lang_to**: Language to translate lyrics into.
+- **translate**:
+
+  - **api_key**: Api key to access your Azure Translator resource. (see
+    :ref:`lyrics-translation`)
+  - **from_languages**: By default all lyrics with a language other than
+    ``translate_to`` are translated. Use a list of language codes to restrict
+    them.
+  - **to_language**: Language code to translate lyrics to.
 - **dist_thresh**: The maximum distance between the artist and title
   combination of the music file and lyrics candidate to consider them a match.
   Lower values will make the plugin more strict, higher values will make it
@@ -165,10 +168,28 @@ After that, the lyrics plugin will fall back on other declared data sources.
 Activate On-the-Fly Translation
 -------------------------------
 
-You need to register for a Microsoft Azure Marketplace free account and
-to the `Microsoft Translator API`_. Follow the four steps process, specifically
-at step 3 enter ``beets`` as *Client ID* and copy/paste the generated
-*Client secret* into your ``bing_client_secret`` configuration, alongside
-``bing_lang_to`` target ``language code``.
+We use Azure to optionally translate your lyrics. To set up the integration,
+follow these steps:
 
-.. _Microsoft Translator API: https://docs.microsoft.com/en-us/azure/cognitive-services/translator/translator-how-to-signup
+1. `Create a Translator resource`_ on Azure.
+2. `Obtain its API key`_.
+3. Add the API key to your configuration as ``translate.api_key``.
+4. Configure your target language using the ``translate.to_language`` option.
+
+
+For example, with the following configuration
+
+.. code-block:: yaml
+
+  lyrics:
+    translate:
+      api_key: YOUR_TRANSLATOR_API_KEY
+      to_language: de
+
+You should expect lyrics like this::
+
+  Original verse / Ursprünglicher Vers
+  Some other verse / Ein anderer Vers
+
+.. _create a Translator resource: https://learn.microsoft.com/en-us/azure/ai-services/translator/create-translator-resource
+.. _obtain its API key: https://learn.microsoft.com/en-us/python/api/overview/azure/ai-translation-text-readme?view=azure-python&preserve-view=true#get-an-api-key

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,9 @@ markers =
 data_file = .reports/coverage/data
 branch = true
 relative_files = true
-omit = beets/test/*
+omit = 
+    beets/test/*
+    beetsplug/_typing.py
 
 [coverage:report]
 precision = 2

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -583,7 +583,7 @@ class TestTranslation:
         requests_mock.post(lyrics.Translator.TRANSLATE_URL, json=callback)
 
     @pytest.mark.parametrize(
-        "initial_lyrics, expected",
+        "new_lyrics, old_lyrics, expected",
         [
             pytest.param(
                 """
@@ -592,6 +592,7 @@ class TestTranslation:
                 My body wouldn't let me hide it (Hide it)
                 No matter what, I wouldn't fold (Wouldn't fold, wouldn't fold)
                 Ridin' through the thunder, lightnin'""",
+                "",
                 """
                 [Refrain: Doja Cat] / [Refrain : Doja Cat]
                 Hard for me to let you go (Let you go, let you go) / Difficile pour moi de te laisser partir (Te laisser partir, te laisser partir)
@@ -607,6 +608,7 @@ class TestTranslation:
                 [00:01.00] Some more synced lyrics
 
                 Source: https://lrclib.net/api/123""",
+                "",
                 """
                 [00:00.00] Some synced lyrics / Quelques paroles synchronisées
                 [00:00:50]
@@ -617,17 +619,24 @@ class TestTranslation:
             ),
             pytest.param(
                 "Quelques paroles",
+                "",
                 "Quelques paroles",
                 id="already in the target language",
             ),
+            pytest.param(
+                "Some lyrics",
+                "Some lyrics / Some translation",
+                "Some lyrics / Some translation",
+                id="already translated",
+            ),
         ],
     )
-    def test_translate(self, initial_lyrics, expected):
+    def test_translate(self, new_lyrics, old_lyrics, expected):
         plugin = lyrics.LyricsPlugin()
         bing = lyrics.Translator(plugin._log, "123", "FR", ["EN"])
 
         assert bing.translate(
-            textwrap.dedent(initial_lyrics)
+            textwrap.dedent(new_lyrics), old_lyrics
         ) == textwrap.dedent(expected)
 
 

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -554,23 +554,23 @@ class TestTranslation:
             if b"Refrain" in request.body:
                 translations = (
                     ""
-                    "|[Refrain : Doja Cat]"
-                    "|Difficile pour moi de te laisser partir (Te laisser partir, te laisser partir)"  # noqa: E501
-                    "|Mon corps ne me laissait pas le cacher (Cachez-le)"
-                    "|Quoi qu’il arrive, je ne plierais pas (Ne plierait pas, ne plierais pas)"  # noqa: E501
-                    "|Chevauchant à travers le tonnerre, la foudre"
+                    " | [Refrain : Doja Cat]"
+                    " | Difficile pour moi de te laisser partir (Te laisser partir, te laisser partir)"  # noqa: E501
+                    " | Mon corps ne me laissait pas le cacher (Cachez-le)"
+                    " | Quoi qu’il arrive, je ne plierais pas (Ne plierait pas, ne plierais pas)"  # noqa: E501
+                    " | Chevauchant à travers le tonnerre, la foudre"
                 )
             elif b"00:00.00" in request.body:
                 translations = (
                     ""
-                    "|[00:00.00] Quelques paroles synchronisées"
-                    "|[00:01.00] Quelques paroles plus synchronisées"
+                    " | [00:00.00] Quelques paroles synchronisées"
+                    " | [00:01.00] Quelques paroles plus synchronisées"
                 )
             else:
                 translations = (
                     ""
-                    "|Quelques paroles synchronisées"
-                    "|Quelques paroles plus synchronisées"
+                    " | Quelques paroles synchronisées"
+                    " | Quelques paroles plus synchronisées"
                 )
 
             return [


### PR DESCRIPTION
🎵 The Refactoring Blues 🎵 by [Claude](https://claude.ai)

Verse 1:
Got those lyrics plugin blues
Cleaning up some messy code
Moving classes, fixing views
Making changes down the road

Chorus:
We're refactoring tonight
Making the codebase clean and bright
Translation's got a brand new home
And ReST files found their own

Verse 2:
Added Microsoft Translate
Keeping tokens safe and sound
Config options up-to-date
Better structure all around

Bridge:
Path operations simplified
Groups of artists, neat and tied
Error handling's looking fine
Comments clear along each line

Verse 3:
RestFiles in their own class now
Cleaning imports, showing how
Better typing makes it clear
What should go and what stays here

Final Chorus:
We're refactoring tonight
Making the codebase clean and bright
Translation's got a brand new home
And our code can stand alone!

—  inspired by _the diff_

---

### Technical Changes

- Replaced deprecated and broken Bing translations by Microsoft Translator API
  - Isolated all functionality in the `Translator` class.
  - Updated translation settings configuration.
  - Added support for synced lyrics from LRCLib.
  - Added support for preserving existing translations to help users to manage their characters quota.
  - Added error handling and logging
  - Added tests

- Created RestFiles class for ReST document handling
  - Simplified path operations using pathlib
  - Added tests

- Improved command line options handling

#### Caching of translations
The plugin will not re-translate lyrics if translations already exist, see

```fish
$ beet -v lyrics albumartist::Sel karta -f
...
lyrics: LyricsPlugin: Fetching lyrics for Sel - Saulės Miestas
lyrics: LRCLib: Fetching JSON from https://lrclib.net/api/get
lyrics: LyricsPlugin: 🟢 Found lyrics: 32275 | 1996 / Neįvertinta Karta: Sel - Saulės Miestas
lyrics: Translator: Posting data to https://api.cognitive.microsofttranslator.com/translate
lyrics: Translator: 🟢 Translated lyrics to EN

$ beet -v lyrics albumartist::Sel karta -f
...
lyrics: LyricsPlugin: Fetching lyrics for Sel - Saulės Miestas
lyrics: LRCLib: Fetching JSON from https://lrclib.net/api/get
lyrics: LyricsPlugin: 🟢 Found lyrics: 32275 | 1996 / Neįvertinta Karta: Sel - Saulės Miestas
lyrics: Translator: 🔵 Translations already exist
```
