### PR TITLE
Change `zero` documentation mentions of genre to genres

### DIFF
--- a/docs/plugins/zero.rst
+++ b/docs/plugins/zero.rst
@@ -36,8 +36,9 @@ fields to nullify and the conditions for nullifying them:
 For example::
 
     zero:
-        fields: month day genres comments
+        fields: month day genre genres comments
         comments: [EAC, LAME, from.+collection, 'ripped by']
+        genre: [rnb, 'power metal']
         genres: [rnb, 'power metal']
         update_database: true
 
@@ -60,4 +61,4 @@ art from files' tags unless you tell it not to. To keep the album art, include
 the special field ``images`` in the list. For example::
 
     zero:
-        keep_fields: title artist album year track genres images
+        keep_fields: title artist album year track genre genres images

--- a/docs/plugins/zero.rst
+++ b/docs/plugins/zero.rst
@@ -36,9 +36,9 @@ fields to nullify and the conditions for nullifying them:
 For example::
 
     zero:
-        fields: month day genre comments
+        fields: month day genres comments
         comments: [EAC, LAME, from.+collection, 'ripped by']
-        genre: [rnb, 'power metal']
+        genres: [rnb, 'power metal']
         update_database: true
 
 If a custom pattern is not defined for a given field, the field will be nulled
@@ -60,4 +60,4 @@ art from files' tags unless you tell it not to. To keep the album art, include
 the special field ``images`` in the list. For example::
 
     zero:
-        keep_fields: title artist album year track genre images
+        keep_fields: title artist album year track genres images


### PR DESCRIPTION
## Description

I've spent 2 hours troubleshooting why none of my music had genre tag. It was because the single `genre`, without `s` doesn't seem to cover any good ganre tags... at least it didn't on my opus files

looking at the code: https://github.com/beetbox/mediafile/blob/7ecd86101ec3344e7fb25bbf781cd7f86646aa9d/mediafile.py#L1669-L2167 i don't honestly know why anyone created the single `ganre` field in the first place

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. // Kinda...
- [x] Changelog. /// yeah, not really
- [x] Tests.  // um....
