### PR TITLE
Fix docs build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: Test
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: Lint check
 run-name: Lint code
 on:
-  pull_request_target:
+  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -125,7 +125,7 @@ jobs:
           cache: poetry
 
       - name: Install dependencies
-        run: poetry install --only=docs
+        run: poetry install --extras=docs
 
       - name: Add Sphinx problem matcher
         run: echo "::add-matcher::.github/sphinx-problem-matcher.json"

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -84,6 +84,7 @@ def get_format(fmt=None):
 
     return (command.encode("utf-8"), extension.encode("utf-8"))
 
+
 def in_no_convert(item: Item) -> bool:
     no_convert_query = config["convert"]["no_convert"].as_str()
 
@@ -92,7 +93,8 @@ def in_no_convert(item: Item) -> bool:
         return query.match(item)
     else:
         return False
-    
+
+
 def should_transcode(item, fmt):
     """Determine whether the item should be transcoded as part of
     conversion (i.e., its bitrate is high or it has the wrong format).

--- a/poetry.lock
+++ b/poetry.lock
@@ -4,7 +4,7 @@
 name = "accessible-pygments"
 version = "0.0.4"
 description = "A collection of accessible pygments styles"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "accessible-pygments-0.0.4.tar.gz", hash = "sha256:e7b57a9b15958e9601c7e9eb07a440c813283545a20973f2574a5f453d0e953e"},
@@ -18,7 +18,7 @@ pygments = ">=1.5"
 name = "alabaster"
 version = "0.7.13"
 description = "A configurable sidebar-enabled Sphinx theme"
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "alabaster-0.7.13-py3-none-any.whl", hash = "sha256:1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3"},
@@ -76,7 +76,7 @@ test = ["tox"]
 name = "babel"
 version = "2.16.0"
 description = "Internationalization utilities"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "babel-2.16.0-py3-none-any.whl", hash = "sha256:368b5b98b37c06b7daf6696391c3240c938b37767d4584413e8438c5c435fa8b"},
@@ -611,7 +611,7 @@ files = [
 name = "docutils"
 version = "0.20.1"
 description = "Docutils -- Python Documentation Utilities"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "docutils-0.20.1-py3-none-any.whl", hash = "sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6"},
@@ -752,7 +752,7 @@ files = [
 name = "imagesize"
 version = "1.4.1"
 description = "Getting image size from png/jpeg/jpeg2000/gif file"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
     {file = "imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b"},
@@ -1980,7 +1980,7 @@ files = [
 name = "pydata-sphinx-theme"
 version = "0.14.4"
 description = "Bootstrap-based Sphinx theme from the PyData community"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "pydata_sphinx_theme-0.14.4-py3-none-any.whl", hash = "sha256:ac15201f4c2e2e7042b0cad8b30251433c1f92be762ddcefdb4ae68811d918d9"},
@@ -2007,7 +2007,7 @@ test = ["pytest", "pytest-cov", "pytest-regressions"]
 name = "pygments"
 version = "2.18.0"
 description = "Pygments is a syntax highlighting package written in Python."
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a"},
@@ -2244,7 +2244,7 @@ requests = "*"
 name = "pytz"
 version = "2024.1"
 description = "World timezone definitions, modern and historical"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "pytz-2024.1-py2.py3-none-any.whl", hash = "sha256:328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319"},
@@ -2665,7 +2665,7 @@ files = [
 name = "snowballstemmer"
 version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
@@ -2778,7 +2778,7 @@ test = ["pytest"]
 name = "sphinx"
 version = "7.1.2"
 description = "Python documentation generator"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "sphinx-7.1.2-py3-none-any.whl", hash = "sha256:d170a81825b2fcacb6dfd5a0d7f578a053e45d3f2b153fecc948c37344eb4cbe"},
@@ -2813,7 +2813,7 @@ test = ["cython", "filelock", "html5lib", "pytest (>=4.6)"]
 name = "sphinxcontrib-applehelp"
 version = "1.0.4"
 description = "sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "sphinxcontrib-applehelp-1.0.4.tar.gz", hash = "sha256:828f867945bbe39817c210a1abfd1bc4895c8b73fcaade56d45357a348a07d7e"},
@@ -2828,7 +2828,7 @@ test = ["pytest"]
 name = "sphinxcontrib-devhelp"
 version = "1.0.2"
 description = "sphinxcontrib-devhelp is a sphinx extension which outputs Devhelp document."
-optional = false
+optional = true
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-devhelp-1.0.2.tar.gz", hash = "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"},
@@ -2843,7 +2843,7 @@ test = ["pytest"]
 name = "sphinxcontrib-htmlhelp"
 version = "2.0.1"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "sphinxcontrib-htmlhelp-2.0.1.tar.gz", hash = "sha256:0cbdd302815330058422b98a113195c9249825d681e18f11e8b1f78a2f11efff"},
@@ -2858,7 +2858,7 @@ test = ["html5lib", "pytest"]
 name = "sphinxcontrib-jsmath"
 version = "1.0.1"
 description = "A sphinx extension which renders display math in HTML via JavaScript"
-optional = false
+optional = true
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"},
@@ -2872,7 +2872,7 @@ test = ["flake8", "mypy", "pytest"]
 name = "sphinxcontrib-qthelp"
 version = "1.0.3"
 description = "sphinxcontrib-qthelp is a sphinx extension which outputs QtHelp document."
-optional = false
+optional = true
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-qthelp-1.0.3.tar.gz", hash = "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72"},
@@ -2887,7 +2887,7 @@ test = ["pytest"]
 name = "sphinxcontrib-serializinghtml"
 version = "1.1.5"
 description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
-optional = false
+optional = true
 python-versions = ">=3.5"
 files = [
     {file = "sphinxcontrib-serializinghtml-1.1.5.tar.gz", hash = "sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952"},
@@ -3111,6 +3111,7 @@ beatport = ["requests-oauthlib"]
 bpd = ["PyGObject"]
 chroma = ["pyacoustid"]
 discogs = ["python3-discogs-client"]
+docs = ["pydata-sphinx-theme", "sphinx"]
 embedart = ["Pillow"]
 embyupdate = ["requests"]
 fetchart = ["Pillow", "beautifulsoup4", "langdetect", "requests"]
@@ -3132,4 +3133,4 @@ web = ["flask", "flask-cors"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4"
-content-hash = "b3eb66c6852cb14afcbe817619ea9ecea699e838885d8e9719f2809eb708bcc3"
+content-hash = "07f39a89dbb7ea5102327e5b2cccfde258ad190ba21b0793c044c2f45aa89f00"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,9 @@ resampy = { version = ">=0.4.3", optional = true }
 requests-oauthlib = { version = ">=0.6.1", optional = true }
 soco = { version = "*", optional = true }
 
+pydata-sphinx-theme = { version = "*", optional = true }
+sphinx = { version = "*", optional = true }
+
 [tool.poetry.group.test.dependencies]
 beautifulsoup4 = "*"
 codecov = ">=2.1.13"
@@ -96,10 +99,6 @@ types-PyYAML = "*"
 types-requests = "*"
 types-urllib3 = "*"
 
-[tool.poetry.group.docs.dependencies]
-pydata-sphinx-theme = "*"
-sphinx = "*"
-
 [tool.poetry.group.release.dependencies]
 click = ">=8.1.7"
 packaging = ">=24.0"
@@ -115,6 +114,7 @@ beatport = ["requests-oauthlib"]
 bpd = ["PyGObject"] # python-gi and GStreamer 1.0+
 chroma = ["pyacoustid"] # chromaprint or fpcalc
 # convert # ffmpeg
+docs = ["pydata-sphinx-theme", "sphinx"]
 discogs = ["python3-discogs-client"]
 embedart = ["Pillow"] # ImageMagick
 embyupdate = ["requests"]

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -18,12 +18,11 @@ import os.path
 import re
 import sys
 import unittest
-import pytest
 
+import pytest
 from mediafile import MediaFile
 
 from beets import util
-from beetsplug import convert
 from beets.library import Item
 from beets.test import _common
 from beets.test.helper import (
@@ -34,6 +33,7 @@ from beets.test.helper import (
     control_stdin,
 )
 from beets.util import bytestring_path, displayable_path
+from beetsplug import convert
 
 
 def shell_quote(text):
@@ -352,7 +352,6 @@ class TestNoConvert:
             ("bitrate:320 , format:ogg", True),
         ],
     )
-
     def test_no_convert_skip(self, config_value, should_skip):
         item = Item(format="ogg", bitrate=256)
         convert.config["convert"]["no_convert"] = config_value


### PR DESCRIPTION
## Description

Seems like readthedocs build expects docs dependencies to be available
as an extra, see one of the failing builds: https://app.readthedocs.org/projects/beets/builds/26079213/.

You can see this has been failing due to missing 'pydata_sphinx_theme' which is one of our dependencies:

```
    raise ThemeError(__('no theme named %r found (missing theme.toml?)') % name)
    sphinx.errors.ThemeError: no theme named 'pydata_sphinx_theme' found (missing theme.toml?)
    Theme error:
    no theme named 'pydata_sphinx_theme' found (missing theme.toml?)
```
