### PR TITLE
Fix the ``TypeError`` when ``import.set_fields`` is provided non-string values

### DIFF
--- a/beets/importer.py
+++ b/beets/importer.py
@@ -605,7 +605,8 @@ class ImportTask(BaseImportTask):
         """
         items = self.imported_items()
         for field, view in config["import"]["set_fields"].items():
-            value = view.get()
+            value = str(view.get())
+            print("EEE ", value)
             log.debug(
                 "Set field {1}={2} for {0}",
                 displayable_path(self.paths),
@@ -1062,7 +1063,7 @@ class SingletonImportTask(ImportTask):
         values, for the singleton item.
         """
         for field, view in config["import"]["set_fields"].items():
-            value = view.get()
+            value = str(view.get())
             log.debug(
                 "Set field {1}={2} for {0}",
                 displayable_path(self.paths),

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -606,7 +606,6 @@ class ImportTask(BaseImportTask):
         items = self.imported_items()
         for field, view in config["import"]["set_fields"].items():
             value = str(view.get())
-            print("EEE ", value)
             log.debug(
                 "Set field {1}={2} for {0}",
                 displayable_path(self.paths),

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -51,7 +51,7 @@ Bug fixes:
   that it no longer treats "and" and "or" queries the same. To maintain
   previous behaviour add commas between your query keywords. For help see
   :ref:`combiningqueries`.
-* Fix the ``TypeError`` when ``import.set_fields`` is provided non-string values. :bug:`4840`
+* Fix the ``TypeError`` when :ref:`set_fields` is provided non-string values. :bug:`4840`
 
 For packagers:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -51,6 +51,7 @@ Bug fixes:
   that it no longer treats "and" and "or" queries the same. To maintain
   previous behaviour add commas between your query keywords. For help see
   :ref:`combiningqueries`.
+* Fix the ``TypeError`` when ``import.set_fields`` is provided non-string values. :bug:`4840`
 
 For packagers:
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -395,11 +395,13 @@ class ImportSingletonTest(ImportTestCase):
     def test_set_fields(self):
         genre = "\U0001f3b7 Jazz"
         collection = "To Listen"
+        disc = 0
 
         config["import"]["set_fields"] = {
             "collection": collection,
             "genre": genre,
             "title": "$title - formatted",
+            "disc": disc,
         }
 
         # As-is item import.
@@ -412,6 +414,7 @@ class ImportSingletonTest(ImportTestCase):
             assert item.genre == genre
             assert item.collection == collection
             assert item.title == "Tag Track 1 - formatted"
+            assert item.disc == disc
             # Remove item from library to test again with APPLY choice.
             item.remove()
 
@@ -426,6 +429,7 @@ class ImportSingletonTest(ImportTestCase):
             assert item.genre == genre
             assert item.collection == collection
             assert item.title == "Applied Track 1 - formatted"
+            assert item.disc == disc
 
 
 class ImportTest(ImportTestCase):
@@ -583,12 +587,14 @@ class ImportTest(ImportTestCase):
         genre = "\U0001f3b7 Jazz"
         collection = "To Listen"
         comments = "managed by beets"
+        disc = 0
 
         config["import"]["set_fields"] = {
             "genre": genre,
             "collection": collection,
             "comments": comments,
             "album": "$album - formatted",
+            "disc": disc,
         }
 
         # As-is album import.
@@ -608,6 +614,7 @@ class ImportTest(ImportTestCase):
                     item.get("album", with_album=False)
                     == "Tag Album - formatted"
                 )
+                assert item.disc == disc
             # Remove album from library to test again with APPLY choice.
             album.remove()
 
@@ -629,6 +636,7 @@ class ImportTest(ImportTestCase):
                     item.get("album", with_album=False)
                     == "Applied Album - formatted"
                 )
+                assert item.disc == disc
 
 
 class ImportTracksTest(ImportTestCase):


### PR DESCRIPTION
## Description

Fixes #4840 by converting input values to strings before they are used. Modifies the test cases for ``set_fields`` to appropriately test this behavior.



## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~~Documentation~~
- [x] Changelog.
- [x] Tests.
