### PR TITLE
Skip autobpm tests if librosa isn't available

### DIFF
--- a/test/plugins/test_autobpm.py
+++ b/test/plugins/test_autobpm.py
@@ -1,6 +1,13 @@
+import importlib.util
+import os
+
 import pytest
 
 from beets.test.helper import ImportHelper, PluginMixin
+
+github_ci = os.environ.get("GITHUB_ACTIONS") == "true"
+if not github_ci and not importlib.util.find_spec("librosa"):
+    pytest.skip("librosa isn't available", allow_module_level=True)
 
 
 class TestAutoBPMPlugin(PluginMixin, ImportHelper):


### PR DESCRIPTION
## Description

Debian doesn't have `librosa`. Allow the tests to continue.