### PR TITLE
Stop perpetually writing `mb_artistid`, `mb_albumartistid` and `albumtypes` fields

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -39,6 +39,7 @@ from typing import (
     Any,
     AnyStr,
     Callable,
+    Iterable,
     NamedTuple,
     TypeVar,
     Union,
@@ -1126,3 +1127,8 @@ def get_temp_filename(
 
     _, filename = tempfile.mkstemp(dir=tempdir, prefix=prefix, suffix=suffix)
     return bytestring_path(filename)
+
+
+def unique_list(elements: Iterable[T]) -> list[T]:
+    """Return a list with unique elements in the original order."""
+    return list(dict.fromkeys(elements))

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,14 @@ Bug fixes:
   have before the introduction of Poetry.
   :bug:`5531`
   :bug:`5526`
+* :ref:`write-cmd`: Fix the issue where for certain files differences in
+  ``mb_artistid``, ``mb_albumartistid`` and ``albumtype`` fields are shown on
+  every attempt to write tags. Note: your music needs to be reimported with
+  ``beet import -LI`` or synchronised with ``beet mbsync`` in order to fix
+  this!
+  :bug:`5265`
+  :bug:`5371`
+  :bug:`4715`
 
 For packagers:
 

--- a/test/test_autotag.py
+++ b/test/test_autotag.py
@@ -20,12 +20,7 @@ import unittest
 import pytest
 
 from beets import autotag, config
-from beets.autotag import (
-    AlbumInfo,
-    TrackInfo,
-    ensure_consistent_list_fields,
-    match,
-)
+from beets.autotag import AlbumInfo, TrackInfo, correct_list_fields, match
 from beets.autotag.hooks import Distance, string_dist
 from beets.library import Item
 from beets.test.helper import BeetsTestCase
@@ -1067,13 +1062,14 @@ class StringDistanceTest(unittest.TestCase):
         ("1", ["2", "1"]),
     ],
 )
-def test_ensure_consistent_list_fields(
+def test_correct_list_fields(
     single_field, list_field, single_value, list_value
 ):
+    """Ensure that the first value in a list field matches the single field."""
     data = {single_field: single_value, list_field: list_value}
     item = Item(**data)
 
-    ensure_consistent_list_fields(item)
+    correct_list_fields(item)
 
     single_val, list_val = item[single_field], item[list_field]
     assert (not single_val and not list_val) or single_val == list_val[0]


### PR DESCRIPTION
This PR fixes an issue where the `beet write` command repeatedly shows differences for certain fields (`mb_artistid`, `mb_albumartistid`, `albumtype`) even after writing the tags. 
This happens because these fields are actually stored as lists in the media files (`mb_artistids`, `mb_albumartistids`, `albumtypes`), but beets maintains both single and list versions in its database.

This PR addresses this issue in a non-invasive way: the fix ensures consistency between single fields and their list counterparts by:
1. When setting a single field value, making it the first element of the corresponding list
2. When setting a list, using its first element as the single field value

This resolves long-standing issues #5265, #5371, and #4715 where users experienced persistent "differences" in these fields despite writing tags multiple times.

Changes:
- Added `ensure_consistent_list_fields()` function to synchronize field pairs
- Applied this function during metadata application
- Added tests for all field combinations

Fixes #5265, #5371, #4715

**Note**: your music needs to be reimported with `beet import -LI` or synchronised with `beet mbsync` in order to fix these fields!
