### PR TITLE
Properly type db on the model, sort out generic types issues

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -38,6 +38,7 @@ from .query import (
     AndQuery,
     FieldQuery,
     FieldQueryType,
+    FieldSort,
     MatchQuery,
     NullSort,
     Query,
@@ -294,7 +295,7 @@ class Model(ABC, Generic[D]):
     """Optional Types for non-fixed (i.e., flexible and computed) fields.
     """
 
-    _sorts: dict[str, type[Sort]] = {}
+    _sorts: dict[str, type[FieldSort]] = {}
     """Optional named sort criteria. The keys are strings and the values
     are subclasses of `Sort`.
     """

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -48,6 +48,8 @@ from .query import (
 if TYPE_CHECKING:
     from types import TracebackType
 
+    from .query import SQLiteType
+
     D = TypeVar("D", bound="Database", default=Any)
 else:
     D = TypeVar("D", bound="Database")
@@ -579,7 +581,7 @@ class Model(ABC, Generic[D]):
 
         # Build assignments for query.
         assignments = []
-        subvars = []
+        subvars: list[SQLiteType] = []
         for key in fields:
             if key != "id" and key in self._dirty:
                 self._dirty.remove(key)
@@ -959,14 +961,14 @@ class Transaction:
             self._mutated = False
             self.db._db_lock.release()
 
-    def query(self, statement: str, subvals: Sequence = ()) -> list:
+    def query(self, statement: str, subvals: Sequence[SQLiteType] = ()) -> list:
         """Execute an SQL statement with substitution values and return
         a list of rows from the database.
         """
         cursor = self.db._connection().execute(statement, subvals)
         return cursor.fetchall()
 
-    def mutate(self, statement: str, subvals: Sequence = ()) -> Any:
+    def mutate(self, statement: str, subvals: Sequence[SQLiteType] = ()) -> Any:
         """Execute an SQL statement with substitution values and return
         the row ID of the last affected row.
         """

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -37,6 +37,7 @@ from . import types
 from .query import (
     AndQuery,
     FieldQuery,
+    FieldQueryType,
     MatchQuery,
     NullSort,
     Query,
@@ -293,7 +294,7 @@ class Model(ABC, Generic[D]):
     are subclasses of `Sort`.
     """
 
-    _queries: dict[str, type[FieldQuery]] = {}
+    _queries: dict[str, FieldQueryType] = {}
     """Named queries that use a field-like `name:value` syntax but which
     do not relate to any specific field.
     """
@@ -718,7 +719,7 @@ class Model(ABC, Generic[D]):
         cls,
         field,
         pattern,
-        query_cls: type[FieldQuery] = MatchQuery,
+        query_cls: FieldQueryType = MatchQuery,
     ) -> FieldQuery:
         """Get a `FieldQuery` for this model."""
         return query_cls(field, pattern, field in cls._fields)
@@ -727,7 +728,7 @@ class Model(ABC, Generic[D]):
     def all_fields_query(
         cls: type[Model],
         pats: Mapping,
-        query_cls: type[FieldQuery] = MatchQuery,
+        query_cls: FieldQueryType = MatchQuery,
     ):
         """Get a query that matches many fields with different patterns.
 

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import re
 import unicodedata
 from abc import ABC, abstractmethod
-from collections.abc import Collection, Iterator, MutableSequence, Sequence
+from collections.abc import Iterator, MutableSequence, Sequence
 from datetime import datetime, timedelta
 from functools import reduce
 from operator import mul, or_
@@ -294,7 +294,7 @@ class RegexpQuery(StringFieldQuery[Pattern[str]]):
         return unicodedata.normalize("NFC", s)
 
     @classmethod
-    def string_match(cls, pattern: Pattern, value: str) -> bool:
+    def string_match(cls, pattern: Pattern[str], value: str) -> bool:
         return pattern.search(cls._normalize(value)) is not None
 
 
@@ -456,7 +456,7 @@ class CollectionQuery(Query):
         """Return a set with field names that this query operates on."""
         return reduce(or_, (sq.field_names for sq in self.subqueries))
 
-    def __init__(self, subqueries: Sequence = ()):
+    def __init__(self, subqueries: Sequence[Query] = ()):
         self.subqueries = subqueries
 
     # Act like a sequence.
@@ -467,7 +467,7 @@ class CollectionQuery(Query):
     def __getitem__(self, key):
         return self.subqueries[key]
 
-    def __iter__(self) -> Iterator:
+    def __iter__(self) -> Iterator[Query]:
         return iter(self.subqueries)
 
     def __contains__(self, subq) -> bool:
@@ -554,7 +554,7 @@ class MutableCollectionQuery(CollectionQuery):
     query is initialized.
     """
 
-    subqueries: MutableSequence
+    subqueries: MutableSequence[Query]
 
     def __setitem__(self, key, value):
         self.subqueries[key] = value
@@ -899,7 +899,7 @@ class Sort:
         """
         return None
 
-    def sort(self, items: list) -> list:
+    def sort(self, items: list[AnyModel]) -> list[AnyModel]:
         """Sort the list of objects and return a list."""
         return sorted(items)
 
@@ -993,7 +993,7 @@ class FieldSort(Sort):
         self.ascending = ascending
         self.case_insensitive = case_insensitive
 
-    def sort(self, objs: Collection):
+    def sort(self, objs: list[AnyModel]) -> list[AnyModel]:
         # TODO: Conversion and null-detection here. In Python 3,
         # comparisons with None fail. We should also support flexible
         # attributes with different types without falling over.
@@ -1052,7 +1052,7 @@ class SlowFieldSort(FieldSort):
 class NullSort(Sort):
     """No sorting. Leave results unsorted."""
 
-    def sort(self, items: list) -> list:
+    def sort(self, items: list[AnyModel]) -> list[AnyModel]:
         return items
 
     def __nonzero__(self) -> bool:

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -30,6 +30,11 @@ from beets import util
 
 if TYPE_CHECKING:
     from beets.dbcore import Model
+    from beets.dbcore.db import AnyModel
+
+    P = TypeVar("P", default=Any)
+else:
+    P = TypeVar("P")
 
 
 class ParsingError(ValueError):
@@ -107,9 +112,9 @@ class Query(ABC):
         return hash(type(self))
 
 
-P = TypeVar("P")
 SQLiteType = Union[str, bytes, float, int, memoryview]
 AnySQLiteType = TypeVar("AnySQLiteType", bound=SQLiteType)
+FieldQueryType = type["FieldQuery"]
 
 
 class FieldQuery(Query, Generic[P]):
@@ -511,7 +516,7 @@ class AnyFieldQuery(CollectionQuery):
         """Return a set with field names that this query operates on."""
         return set(self.fields)
 
-    def __init__(self, pattern, fields, cls: type[FieldQuery]):
+    def __init__(self, pattern, fields, cls: FieldQueryType):
         self.pattern = pattern
         self.fields = fields
         self.query_class = cls

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -112,7 +112,7 @@ class Query(ABC):
         return hash(type(self))
 
 
-SQLiteType = Union[str, bytes, float, int, memoryview]
+SQLiteType = Union[str, bytes, float, int, memoryview, None]
 AnySQLiteType = TypeVar("AnySQLiteType", bound=SQLiteType)
 FieldQueryType = type["FieldQuery"]
 
@@ -481,7 +481,7 @@ class CollectionQuery(Query):
         all subqueries with the string joiner (padded by spaces).
         """
         clause_parts = []
-        subvals = []
+        subvals: list[SQLiteType] = []
         for subq in self.subqueries:
             subq_clause, subq_subvals = subq.clause()
             if not subq_clause:

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
 
     from .query import FieldQueryType, Sort
 
+    Prefixes = dict[str, FieldQueryType]
+
 PARSE_QUERY_PART_REGEX = re.compile(
     # Non-capturing optional segment for the keyword.
     r"(-|\^)?"  # Negation prefixes.
@@ -42,7 +44,7 @@ PARSE_QUERY_PART_REGEX = re.compile(
 def parse_query_part(
     part: str,
     query_classes: dict[str, FieldQueryType] = {},
-    prefixes: dict = {},
+    prefixes: Prefixes = {},
     default_class: type[query.SubstringQuery] = query.SubstringQuery,
 ) -> tuple[str | None, str, FieldQueryType, bool]:
     """Parse a single *query part*, which is a chunk of a complete query
@@ -111,7 +113,7 @@ def parse_query_part(
 
 def construct_query_part(
     model_cls: type[Model],
-    prefixes: dict,
+    prefixes: Prefixes,
     query_part: str,
 ) -> query.Query:
     """Parse a *query part* string and return a :class:`Query` object.
@@ -179,7 +181,7 @@ def construct_query_part(
 def query_from_strings(
     query_cls: type[query.CollectionQuery],
     model_cls: type[Model],
-    prefixes: dict,
+    prefixes: Prefixes,
     query_parts: Collection[str],
 ) -> query.Query:
     """Creates a collection query of type `query_cls` from a list of
@@ -247,7 +249,7 @@ def sort_from_strings(
 def parse_sorted_query(
     model_cls: type[Model],
     parts: list[str],
-    prefixes: dict = {},
+    prefixes: Prefixes = {},
     case_insensitive: bool = True,
 ) -> tuple[query.Query, Sort]:
     """Given a list of strings, create the `Query` and `Sort` that they

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -213,16 +213,16 @@ def construct_sort_part(
     assert direction in ("+", "-"), "part must end with + or -"
     is_ascending = direction == "+"
 
-    if field in model_cls._sorts:
-        sort = model_cls._sorts[field](
-            model_cls, is_ascending, case_insensitive
-        )
+    if sort_cls := model_cls._sorts.get(field):
+        if isinstance(sort_cls, query.SmartArtistSort):
+            field = "albumartist" if model_cls.__name__ == "Album" else "artist"
     elif field in model_cls._fields:
-        sort = query.FixedFieldSort(field, is_ascending, case_insensitive)
+        sort_cls = query.FixedFieldSort
     else:
         # Flexible or computed.
-        sort = query.SlowFieldSort(field, is_ascending, case_insensitive)
-    return sort
+        sort_cls = query.SlowFieldSort
+
+    return sort_cls(field, is_ascending, case_insensitive)
 
 
 def sort_from_strings(

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -25,7 +25,7 @@ from . import Model, query
 if TYPE_CHECKING:
     from collections.abc import Collection, Sequence
 
-    from .query import Sort
+    from .query import FieldQueryType, Sort
 
 PARSE_QUERY_PART_REGEX = re.compile(
     # Non-capturing optional segment for the keyword.
@@ -41,10 +41,10 @@ PARSE_QUERY_PART_REGEX = re.compile(
 
 def parse_query_part(
     part: str,
-    query_classes: dict[str, type[query.FieldQuery]] = {},
+    query_classes: dict[str, FieldQueryType] = {},
     prefixes: dict = {},
     default_class: type[query.SubstringQuery] = query.SubstringQuery,
-) -> tuple[str | None, str, type[query.FieldQuery], bool]:
+) -> tuple[str | None, str, FieldQueryType, bool]:
     """Parse a single *query part*, which is a chunk of a complete query
     string representing a single criterion.
 
@@ -133,7 +133,7 @@ def construct_query_part(
 
     # Use `model_cls` to build up a map from field (or query) names to
     # `Query` classes.
-    query_classes: dict[str, type[query.FieldQuery]] = {}
+    query_classes: dict[str, FieldQueryType] = {}
     for k, t in itertools.chain(
         model_cls._fields.items(), model_cls._types.items()
     ):

--- a/beets/dbcore/types.py
+++ b/beets/dbcore/types.py
@@ -22,7 +22,7 @@ from typing import Any, Generic, TypeVar, cast
 
 from beets.util import str2bool
 
-from .query import BooleanQuery, FieldQuery, NumericQuery, SubstringQuery
+from .query import BooleanQuery, FieldQueryType, NumericQuery, SubstringQuery
 
 
 class ModelType(typing.Protocol):
@@ -51,7 +51,7 @@ class Type(ABC, Generic[T, N]):
     """The SQLite column type for the value.
     """
 
-    query: type[FieldQuery] = SubstringQuery
+    query: FieldQueryType = SubstringQuery
     """The `Query` subclass to be used when querying the field.
     """
 
@@ -234,7 +234,7 @@ class BaseFloat(Type[float, N]):
     """
 
     sql = "REAL"
-    query: type[FieldQuery[Any]] = NumericQuery
+    query: FieldQueryType = NumericQuery
     model_type = float
 
     def __init__(self, digits: int = 1):

--- a/beets/dbcore/types.py
+++ b/beets/dbcore/types.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import typing
 from abc import ABC
-from typing import Any, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
 from beets.util import str2bool
 
@@ -43,8 +43,12 @@ class ModelType(typing.Protocol):
 # Generic type variables, used for the value type T and null type N (if
 # nullable, else T and N are set to the same type for the concrete subclasses
 # of Type).
-N = TypeVar("N")
-T = TypeVar("T", bound=ModelType)
+if TYPE_CHECKING:
+    N = TypeVar("N", default=Any)
+    T = TypeVar("T", bound=ModelType, default=Any)
+else:
+    N = TypeVar("N")
+    T = TypeVar("T", bound=ModelType)
 
 
 class Type(ABC, Generic[T, N]):

--- a/beets/dbcore/types.py
+++ b/beets/dbcore/types.py
@@ -22,7 +22,13 @@ from typing import Any, Generic, TypeVar, cast
 
 from beets.util import str2bool
 
-from .query import BooleanQuery, FieldQueryType, NumericQuery, SubstringQuery
+from .query import (
+    BooleanQuery,
+    FieldQueryType,
+    NumericQuery,
+    SQLiteType,
+    SubstringQuery,
+)
 
 
 class ModelType(typing.Protocol):
@@ -107,10 +113,7 @@ class Type(ABC, Generic[T, N]):
             # `self.model_type(value)`
             return cast(T, value)
 
-    def from_sql(
-        self,
-        sql_value: None | int | float | str | bytes,
-    ) -> T | N:
+    def from_sql(self, sql_value: SQLiteType) -> T | N:
         """Receives the value stored in the SQL backend and return the
         value to be stored in the model.
 
@@ -131,7 +134,7 @@ class Type(ABC, Generic[T, N]):
         else:
             return self.normalize(sql_value)
 
-    def to_sql(self, model_value: Any) -> None | int | float | str | bytes:
+    def to_sql(self, model_value: Any) -> SQLiteType:
         """Convert a value as stored in the model object to a value used
         by the database adapter.
         """

--- a/beets/library.py
+++ b/beets/library.py
@@ -381,7 +381,7 @@ class WriteError(FileOperationError):
 # Item and Album model classes.
 
 
-class LibModel(dbcore.Model):
+class LibModel(dbcore.Model["Library"]):
     """Shared concrete functionality for Items and Albums."""
 
     # Config key that specifies how an instance should be formatted.
@@ -1074,9 +1074,9 @@ class Item(LibModel):
         The path is returned as a bytestring. ``basedir`` can override the
         library's base directory for the destination.
         """
-        self._check_db()
-        basedir = basedir or self._db.directory
-        path_formats = path_formats or self._db.path_formats
+        db = self._check_db()
+        basedir = basedir or db.directory
+        path_formats = path_formats or db.path_formats
 
         # Use a path format based on a query, falling back on the
         # default.
@@ -1117,11 +1117,11 @@ class Item(LibModel):
         maxlen = beets.config["max_filename_length"].get(int)
         if not maxlen:
             # When zero, try to determine from filesystem.
-            maxlen = util.max_filename_length(self._db.directory)
+            maxlen = util.max_filename_length(db.directory)
 
         lib_path_str, fallback = util.legalize_path(
             subpath,
-            self._db.replacements,
+            db.replacements,
             maxlen,
             os.path.splitext(self.path)[1],
         )
@@ -1604,7 +1604,8 @@ class Library(dbcore.Database):
         self.path_formats = path_formats
         self.replacements = replacements
 
-        self._memotable = {}  # Used for template substitution performance.
+        # Used for template substitution performance.
+        self._memotable: dict[tuple[str, ...], str] = {}
 
     # Adding objects to the database.
 

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -163,7 +163,7 @@ class MoveOperation(Enum):
     REFLINK_AUTO = 5
 
 
-def normpath(path: bytes) -> bytes:
+def normpath(path: PathLike) -> bytes:
     """Provide the canonical form of the path suitable for storing in
     the database.
     """


### PR DESCRIPTION
Thanks to @wisp3rwind's suggestion this PR adds types to the relationship between `Model`, `Database` and `Library`.

Then I worked through the rest of the issues found in the edited files. Most of this involved providing type parameters for generic types (or defining defaults, rather 😉).

There `queryparse` module had a somewhat significant issue where the sorting construction logic only expected to receive `FieldSort` subclasses, while `SmartArtistSort` was not one. Thus `SmartArtistSort` has now been forced to behave and is a `FieldSort` subclass. It's also been moved to `query.py` module which is where the rest of sorts are defined.

