### PR TITLE
pyproject.toml: don't install docs et al into the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,11 @@ packages = [
     { include = "beetsplug" },
 ]
 include = [ # extra files to include in the sdist
-    "docs",
-    "extra",
-    "man/**/*",
-    "test/*.py",
-    "test/rsrc/**/*",
+    { path = "docs", format = "sdist" },
+    { path = "extra", format = "sdist" },
+    { path = "man/**/*", format = "sdist" },
+    { path = "test/*.py", format = "sdist" },
+    { path = "test/rsrc/**/*", format = "sdist" },
 ]
 exclude = ["docs/_build", "docs/modd.conf", "docs/**/*.css"]
 


### PR DESCRIPTION
## Description

wheels are directly unpacked into site-packages, so this means likely conflict with other packages

## To Do

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)

if a changelog entry is needed, I am happy to add one.  tests/docs seem not applicable (as this is purely a packaging issue)