### PR TITLE
Convert plugin: Update auto_keep to respect no_convert/never_convert_lossy_files in configuration

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -256,7 +256,7 @@ class ConvertPlugin(BeetsPlugin):
 
             # Filter items based on should_transcode function
             items = [item for item in items if should_transcode(item, fmt)]
-            
+
             self._parallel_convert(
                 dest,
                 False,


### PR DESCRIPTION
## Description

According to the docs, the auto_keep function will "Convert your files automatically on import to dest but import the non transcoded version." This is true but not 100% accurate. In cases where no conversion is required (say, importing lossy files where there's no need to convert), auto_keep will copy the files to dest. 

This behavior results in duplicate files being created on import when the auto_keep function is set to yes - a lossy file will be imported into the default directory (say /music) and then copied to the dest location (say /transcodes).

This is ideal if you wish to have all music formats in your default directory (lossy and lossless) and all lossy files (original imports and transcodes) in a secondary directory (say /lossy). 

But what if you want a separate directory of all music you've transcoded? auto_keep won't provide that, as it copies lossy files to the dest location. In addition, if the dest is set to the same location as default directory, auto_keep will copy lossy files into the same directory that beets previously imported files into, resulting in the directory having two files for each file in an album. If you use paths (say to have singletons imported into /music/singles), auto_keep will import the file into the path location, then copy the file to the dest, creating directories to match the path.

Unlike with the auto option or using "beet convert", auto_keep does not follow the never_convert_lossy_files or no_convert options and will not validate whether files need to be converted or copied on import to dest - it transcodes or it copies, no questions asked.

This change updates the auto_convert_keep function to filter items using should_transcode. This way, if the user sets never_convert_lossy_files to no or no_convert: 'format:mp3', lossy files will **not** be copied to the dest, while lossless files will be converted to the dest (perfect for a seperate /transcodes directory). If the user sets never_convert_lossy_files to yes, lossy files will to be copied to the dest and lossless files will be converted to the dest (perfect for a /lossy directory). In turn, this change makes behavior consistent with "beet convert" and the auto option.

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
