### PR TITLE
Incorrect assumption that all media_fields are fixed fields

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1631,8 +1631,8 @@ def update_items(lib, query, album, move, pretend, fields, exclude_fields=None):
             # database.
             fields.append("path")
         if fields is None:
-            # no fields were provided, update all media fields
-            item_fields = fields or library.Item._media_fields
+            # no fields were provided, update all fields
+            item_fields = fields or library.Item._fields.keys()
             if move and "path" not in item_fields:
                 # move is enabled, add 'path' to the list of fields to update
                 item_fields.add("path")


### PR DESCRIPTION
## Description

Fixes #5580

(...)

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)~
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
