### PR TITLE
lastgenre: Fix track-level handling and streamline logging

### DIFF
--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -451,15 +451,20 @@ class LastGenrePlugin(plugins.BeetsPlugin):
             self._log.debug(
                 "added last.fm album genre ({0}): {1}", src, album.genre
             )
-            album.store()
 
+            # If we're using track-level sources, store the album genre only,
+            # then also look up individual track genres.
             if "track" in self.sources:
+                album.store(inherit=False)
                 for item in album.items():
                     item.genre, src = self._get_genre(item)
                     self._log.debug(
                         "added last.fm item genre ({0}): {1}", src, item.genre
                     )
                     item.store()
+            # Store the album genre and inherit to tracks.
+            else:
+                album.store()
 
         else:
             item = task.item

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -409,7 +409,9 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 for album in lib.albums(ui.decargs(args)):
                     album.genre, src = self._get_genre(album)
                     self._log.info(
-                        "genre for album {0} ({1}): {0.genre}", album, src
+                        'genre for album "{0.album}" ({1}): {0.genre}',
+                        album,
+                        src,
                     )
                     if "track" in self.sources:
                         album.store(inherit=False)
@@ -423,7 +425,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                             item.genre, src = self._get_genre(item)
                             item.store()
                             self._log.info(
-                                "genre for track {0} ({1}): {0.genre}",
+                                'genre for track "{0.title}" ({1}): {0.genre}',
                                 item,
                                 src,
                             )
@@ -437,7 +439,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                     item.genre, src = self._get_genre(item)
                     item.store()
                     self._log.info(
-                        "genre for track {0} ({1}): {0.genre}", item, src
+                        "genre for track {0.title} ({1}): {0.genre}", item, src
                     )
 
         lastgenre_cmd.func = lastgenre_func
@@ -449,7 +451,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
             album = task.album
             album.genre, src = self._get_genre(album)
             self._log.debug(
-                "added last.fm album genre ({0}): {1}", src, album.genre
+                'genre for album "{0.album}" ({1}): {0.genre}', album, src
             )
 
             # If we're using track-level sources, store the album genre only,
@@ -459,7 +461,9 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 for item in album.items():
                     item.genre, src = self._get_genre(item)
                     self._log.debug(
-                        "added last.fm item genre ({0}): {1}", src, item.genre
+                        'genre for track "{0.title}" ({1}): {0.genre}',
+                        item,
+                        src,
                     )
                     item.store()
             # Store the album genre and inherit to tracks.
@@ -470,7 +474,9 @@ class LastGenrePlugin(plugins.BeetsPlugin):
             item = task.item
             item.genre, src = self._get_genre(item)
             self._log.debug(
-                "added last.fm item genre ({0}): {1}", src, item.genre
+                'genre for track "{0.title}" ({1}): {0.genre}',
+                item,
+                src,
             )
             item.store()
 

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -411,7 +411,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                     self._log.info(
                         "genre for album {0} ({1}): {0.genre}", album, src
                     )
-                    album.store()
+                    album.store(inherit=False)
 
                     for item in album.items():
                         # If we're using track-level sources, also look up each

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -411,7 +411,10 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                     self._log.info(
                         "genre for album {0} ({1}): {0.genre}", album, src
                     )
-                    album.store(inherit=False)
+                    if "track" in self.sources:
+                        album.store(inherit=False)
+                    else:
+                        album.store()
 
                     for item in album.items():
                         # If we're using track-level sources, also look up each

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -432,10 +432,10 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 # an album
                 for item in lib.items(ui.decargs(args)):
                     item.genre, src = self._get_genre(item)
-                    self._log.debug(
-                        "added last.fm item genre ({0}): {1}", src, item.genre
-                    )
                     item.store()
+                    self._log.info(
+                        "genre for track {0} ({1}): {0.genre}", item, src
+                    )
 
         lastgenre_cmd.func = lastgenre_func
         return [lastgenre_cmd]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,11 @@ Bug fixes:
 * :ref:`query-sort`: Fix a bug that would raise an exception when sorting on
   a non-string field that is not populated in all items.
   :bug:`5512`
+* :doc:`plugins/lastgenre`: Fix track-level genre handling. Now when an album-level
+  genre is set already, single tracks don't fall back to the album's genre and
+  request their own last.fm genre. Also log messages regarding what's been
+  tagged are now more polished.
+  :bug:`5582`
 
 For packagers:
 


### PR DESCRIPTION
## Description

- Fix `lastgenre -A` in combination with config option `source: track` (_Tracks inherited the album's genre even when this option was set_)
  - Now, When an album-level genre is set already, single tracks don't fall back to the album's genre and request their own last.fm genre.

- Fix log-level and message wording being slightly different for `source:` track, album, artist genre
  - Now log messages follow the same wording, level and structure throughout.

_Note: This was split out from PR #4982_

## To Do



- [x] Documentation. (The existing documentation describes the fixed behaviour already: https://beets.readthedocs.io/en/latest/plugins/lastgenre.html#genre-source)
- [x] Changelog.
- [x] Tests. (A simple test is in place already. Followup PR #4982 will include a better pytest-based test for the `_get_genre` function)