### PR TITLE
Change missing plugin to allow for filtering albums by release type

### DIFF
--- a/beetsplug/missing.py
+++ b/beetsplug/missing.py
@@ -124,7 +124,10 @@ class MissingPlugin(BeetsPlugin):
             "--album",
             dest="album",
             action="store_true",
-            help="show missing albums for artist instead of tracks",
+            help=(
+                "show missing release for artist instead of tracks. Defaults "
+                "to only releases of type 'album'"
+            )
         )
         self._command.parser.add_option(
             "--release-type",

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -49,6 +49,11 @@ Other changes:
   wrong (outdated) commit. Now the tag is created in the same workflow step
   right after committing the version update.
   :bug:`5539`
+* :doc:`plugins/missing`: When running in missing album mode, allows users to specify
+  MusicBrainz release types that they want to show using the ``--release-type``
+  flag. The default behavior is also changed to just show releases of type
+  ``album``. 
+  :bug:`2661`
 
 2.2.0 (December 02, 2024)
 -------------------------

--- a/docs/plugins/missing.rst
+++ b/docs/plugins/missing.rst
@@ -22,10 +22,16 @@ tracks over your whole library, using command-line switches::
       -c, --count           count missing tracks per album
       -t, --total           count total of missing tracks or albums
       -a, --album           show missing albums for artist instead of tracks
+      --release-type        show only missing albums of specified release type.
+                            You can provide this argument multiple times to
+                            specify multiple release types to filter to. If not
+                            provided, defaults to just the "album" release type.
 
 …or by editing corresponding options.
 
-Note that ``-c`` is ignored when used with ``-a``.
+Note that ``-c`` is ignored when used with ``-a``, and ``--release-type`` is
+ignored when not used with ``-a``. Valid release types can be shown by running
+``beet missing -h``.
 
 Configuration
 -------------
@@ -64,9 +70,17 @@ List all missing tracks in your collection::
 
   beet missing
 
-List all missing albums in your collection::
+List all missing albums of release type "album" in your collection::
 
   beet missing -a
+
+List all missing albums of release type "compilation" in your collection::
+
+  beet missing -a --release-type compilation
+
+List all missing albums of release type "compilation" and album in your collection::
+
+  beet missing -a --release-type compilation --release-type album
 
 List all missing tracks from 2008::
 

--- a/test/plugins/test_missing.py
+++ b/test/plugins/test_missing.py
@@ -1,0 +1,201 @@
+# This file is part of beets.
+# Copyright 2016, Stig Inge Lea Bjornsen.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+
+"""Tests for the `missing` plugin."""
+
+import itertools
+from unittest.mock import patch
+
+import pytest
+
+from beets.autotag.hooks import AlbumInfo, TrackInfo
+from beets.library import Item
+from beets.test.helper import PluginMixin, TestHelper, capture_log
+
+
+def mock_browse_release_groups(
+    artist: str,
+    release_type: list[str],
+):
+    """Helper to mock getting an artist's release groups of multiple release types."""
+    release_groups = [
+        {"id": "album_id", "title": "title", "release_type": "album"},
+        {"id": "album2_id", "title": "title 2", "release_type": "album"},
+        {
+            "id": "compilation_id",
+            "title": "compilation",
+            "release_type": "compilation",
+        },
+    ]
+
+    return {
+        "release-group-list": [
+            x for x in release_groups if x["release_type"] in release_type
+        ]
+    }
+
+
+class TestMissingPlugin(PluginMixin, TestHelper):
+    # The minimum mtime of the files to be imported
+    plugin = "missing"
+
+    def setup_method(self, method):
+        """Setup pristine beets config and items for testing."""
+        self.setup_beets()
+        self.album_items = [
+            Item(
+                album="album",
+                mb_albumid="81ae60d4-5b75-38df-903a-db2cfa51c2c6",
+                mb_releasegroupid="album_id",
+                mb_trackid="track_1",
+                mb_albumartistid="artist_id",
+                albumartist="artist",
+                tracktotal=3,
+            ),
+            Item(
+                album="album",
+                mb_albumid="81ae60d4-5b75-38df-903a-db2cfa51c2c6",
+                mb_releasegroupid="album_id",
+                mb_albumartistid="artist_id",
+                albumartist="artist",
+                tracktotal=3,
+            ),
+            Item(
+                album="album",
+                mb_albumid="81ae60d4-5b75-38df-903a-db2cfa51c2c6",
+                mb_releasegroupid="album_id",
+                mb_trackid="track_3",
+                mb_albumartistid="artist_id",
+                albumartist="artist",
+                tracktotal=3,
+            ),
+        ]
+
+    def teardown_method(self, method):
+        """Clean all beets data."""
+        self.teardown_beets()
+
+    @pytest.mark.parametrize(
+        "total,count",
+        list(itertools.product((True, False), repeat=2)),
+    )
+    @patch("beets.autotag.hooks.album_for_mbid")
+    def test_missing_tracks(self, album_for_mbid, total, count):
+        """Test getting missing tracks works with expected logs."""
+        self.lib.add_album(self.album_items[:2])
+
+        album_for_mbid.return_value = AlbumInfo(
+            album_id="album_id",
+            album="album",
+            tracks=[
+                TrackInfo(track_id=album_item.mb_trackid)
+                for album_item in self.album_items
+            ],
+        )
+
+        with capture_log() as logs:
+            command = ["missing"]
+            if total:
+                command.append("-t")
+            if count:
+                command.append("-c")
+            self.run_command(*command)
+
+        if not total and not count:
+            assert (
+                f"missing: track {self.album_items[-1].mb_trackid} in album album_id"
+            ) in logs
+
+        if not total and count:
+            assert "missing: artist - album: 1" in logs
+
+        assert ("missing: 1" in logs) == total
+
+    def test_missing_albums(self):
+        """Test getting missing albums works with expected logs."""
+        with patch(
+            "musicbrainzngs.browse_release_groups",
+            wraps=mock_browse_release_groups,
+        ):
+            self.lib.add_album(self.album_items)
+
+            with capture_log() as logs:
+                command = ["missing", "-a"]
+                self.run_command(*command)
+
+            assert "missing: artist - compilation" not in logs
+            assert "missing: artist - title" not in logs
+            assert "missing: artist - title 2" in logs
+
+    def test_missing_albums_compilation(self):
+        """Test getting missing albums works for a specific release type."""
+        with patch(
+            "musicbrainzngs.browse_release_groups",
+            wraps=mock_browse_release_groups,
+        ):
+            self.lib.add_album(self.album_items)
+
+            with capture_log() as logs:
+                command = ["missing", "-a", "--release-type", "compilation"]
+                self.run_command(*command)
+
+            assert "missing: artist - compilation" in logs
+            assert "missing: artist - title" not in logs
+            assert "missing: artist - title 2" not in logs
+
+    def test_missing_albums_all(self):
+        """Test getting missing albums works for all release types."""
+        with patch(
+            "musicbrainzngs.browse_release_groups",
+            wraps=mock_browse_release_groups,
+        ):
+            self.lib.add_album(self.album_items)
+
+            with capture_log() as logs:
+                command = [
+                    "missing",
+                    "-a",
+                    "--release-type",
+                    "compilation",
+                    "--release-type",
+                    "album",
+                ]
+                self.run_command(*command)
+
+            assert "missing: artist - compilation" in logs
+            assert "missing: artist - title" not in logs
+            assert "missing: artist - title 2" in logs
+
+    def test_missing_albums_total(self):
+        """Test getting missing albums works with the total flag."""
+        with patch(
+            "musicbrainzngs.browse_release_groups",
+            wraps=mock_browse_release_groups,
+        ):
+            self.lib.add_album(self.album_items)
+
+            with capture_log() as logs:
+                command = [
+                    "missing",
+                    "-a",
+                    "-t",
+                ]
+                self.run_command(*command)
+
+            assert "missing: 1" in logs
+            # Specific missing logs omitted if total provided
+            assert "missing: artist - compilation" not in logs
+            assert "missing: artist - title" not in logs
+            assert "missing: artist - title 2" not in logs


### PR DESCRIPTION
## Description

Addresses #2661.  

Currently, the missing plugin when ran in album mode only allows for getting all release groups attached to a single artist. Users may want to restrict this search to only show releases of a specific type (such as albums or compilations). This CR adds a new `--release-type` flag to the missing plugin. If users want to filter to a specific type (or set of types), they simply need to provide this flag for every release type that they want included. 

As part of this change, the default behavior has been shifted to only select `album` type releases as is suggested in the issue- to avoid breaking default behavior I could easily switch this back. I am also wondering if it might make sense to address the following idea (https://github.com/beetbox/beets/discussions/5101) in a follow-up.

The tests I wrote are written using `pytest`, as it is suggested in the documentation to stay away from `unittest`. As a result, I required a slightly different mixin inheritance schema than is usually seen. If there are any other recommended ways to accomplish this I'd be happy to switch!

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
