### PR TITLE
Fix matcher typo

### DIFF
--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -675,7 +675,7 @@ class ImportSessionFixture(ImportSession):
     >>> importer.run()
 
     This imports ``/path/to/import`` into `lib`. It skips the first
-    album and imports thesecond one with metadata from the tags. For the
+    album and imports the second one with metadata from the tags. For the
     remaining albums, the metadata from the autotagger will be applied.
     """
 

--- a/test/plugins/test_importadded.py
+++ b/test/plugins/test_importadded.py
@@ -57,7 +57,7 @@ class ImportAddedTest(PluginMixin, ImportTestCase):
             os.path.getmtime(mfile.path) for mfile in self.import_media
         )
         self.matcher = AutotagStub().install()
-        self.matcher.matching = AutotagStub.GOOD
+        self.matcher.matching = AutotagStub.IDENT
         self.importer = self.setup_importer()
         self.importer.add_choice(importer.action.APPLY)
 

--- a/test/plugins/test_importadded.py
+++ b/test/plugins/test_importadded.py
@@ -57,7 +57,7 @@ class ImportAddedTest(PluginMixin, ImportTestCase):
             os.path.getmtime(mfile.path) for mfile in self.import_media
         )
         self.matcher = AutotagStub().install()
-        self.matcher.macthin = AutotagStub.GOOD
+        self.matcher.matching = AutotagStub.GOOD
         self.importer = self.setup_importer()
         self.importer.add_choice(importer.action.APPLY)
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -440,7 +440,7 @@ class ImportTest(ImportTestCase):
         self.prepare_album_for_import(1)
         self.setup_importer()
         self.matcher = AutotagStub().install()
-        self.matcher.matching = AutotagStub.GOOD
+        self.matcher.matching = AutotagStub.IDENT
 
     def tearDown(self):
         super().tearDown()

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -440,7 +440,7 @@ class ImportTest(ImportTestCase):
         self.prepare_album_for_import(1)
         self.setup_importer()
         self.matcher = AutotagStub().install()
-        self.matcher.macthin = AutotagStub.GOOD
+        self.matcher.matching = AutotagStub.GOOD
 
     def tearDown(self):
         super().tearDown()


### PR DESCRIPTION
## Description

Fixes a confusing typo when setting the MusicBrainz matcher in a few tests. It looks like the matcher defaults to `IDENT` so change it to that, since that would have been the value used in the tests with the typo.

- [x] Documentation: N/A
- [x] Changelog. N/A, I think
- [x] Tests. N/A, I think
