### PR TITLE
Handle potential OSError when unlinking temporary files in ArtResizer

### DIFF
--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -655,7 +655,10 @@ class ArtResizer(metaclass=Shareable):
             )
         finally:
             if result_path != path_in:
-                os.unlink(path_in)
+                try:
+                    os.unlink(path_in)
+                except OSError:
+                    pass
         return result_path
 
     @property


### PR DESCRIPTION
## Description

was getting permission error because after png is converted to jpg beets want to delete the png but somehow it is still being used causing the import to fail. this temporarily fixes the import but still needs a proper way to know what is using the file and how to delete it.

```
  File "C:\Users\DELL\projects\_myForks\beets\beetsplug\fetchart.py", line 1321, in fetch_art
    candidate = self.art_for_album(task.album, task.paths, local)
  File "C:\Users\DELL\projects\_myForks\beets\beetsplug\fetchart.py", line 1413, in art_for_album
    out.resize(self)
    ~~~~~~~~~~^^^^^^
  File "C:\Users\DELL\projects\_myForks\beets\beetsplug\fetchart.py", line 218, in resize
    self._resize(plugin, current_check)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\DELL\projects\_myForks\beets\beetsplug\fetchart.py", line 246, in _resize
    self.path = ArtResizer.shared.reformat(
                ~~~~~~~~~~~~~~~~~~~~~~~~~~^
        self.path,
        ^^^^^^^^^^
        plugin.cover_format,
        ^^^^^^^^^^^^^^^^^^^^
        deinterlaced=plugin.deinterlace,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "C:\Users\DELL\projects\_myForks\beets\beets\util\artresizer.py", line 658, in reformat
    os.unlink(path_in)
    ~~~~~~~~~^^^^^^^^^
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: b'C:\\Users\\DELL\\AppData\\Local\\Temp\\beets\\beetsplug_fetchart\\4kqx2um2.png'
```
when importing https://musicbrainz.org/release/5744ddb7-e9b6-4b46-a55c-38e75aa95460

beet config

```yaml
fetchart:
    minwidth: 500
    maxwidth: 3000
    max_filesize: 3500000
    sources:
    -   coverart: release
    -   coverart: releasegroup
    - itunes
    - amazon
    - filesystem
    - albumart
    - '*'
    cautious: yes
    cover_names: cover front art artwork folder album
    store_source: yes
    cover_format: JPEG
    auto: yes
    quality: 0
    enforce_ratio: no
    high_resolution: no
    deinterlace: no
```

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
