### PR TITLE
Close file descriptor generated from tempfile.mkstemp()

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -1130,7 +1130,10 @@ def get_temp_filename(
     tempdir = get_module_tempdir(module)
     tempdir.mkdir(parents=True, exist_ok=True)
 
-    _, filename = tempfile.mkstemp(dir=tempdir, prefix=prefix, suffix=suffix)
+    descriptor, filename = tempfile.mkstemp(
+        dir=tempdir, prefix=prefix, suffix=suffix
+    )
+    os.close(descriptor)
     return bytestring_path(filename)
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,7 +22,7 @@ New features:
 
 Bug fixes:
 
-* Fix fetchart bug where a tempfile could not be deleted due to never being
+* :doc:`plugins/fetchart`: Fix fetchart bug where a tempfile could not be deleted due to never being
   properly closed.
   :bug:`5521`
 * :doc:`plugins/lyrics`: LRCLib will fallback to plain lyrics if synced lyrics

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,9 @@ New features:
 
 Bug fixes:
 
+* Fix fetchart bug where a tempfile could not be deleted due to never being
+  properly closed.
+  :bug:`5521`
 * :doc:`plugins/lyrics`: LRCLib will fallback to plain lyrics if synced lyrics
   are not found and `synced` flag is set to `yes`.
 * Synchronise files included in the source distribution with what we used to


### PR DESCRIPTION
## Description

Without explicitly closing this file descriptor, the temp file would be kept open until the program exited and could not be deleted by the fetchart plugin.

Fixes #5521

## To Do

- [x] Documentation.
- [x] Changelog.
- [x] Tests.
