### PR TITLE
Feat: Smartplaylist: Add dest_regen option for regenerating destination path 

### DIFF
--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -105,7 +105,8 @@ class SmartPlaylistPlugin(BeetsPlugin):
             "--dest-regen",
             action="store_true",
             dest="dest_regen",
-            help="regenerate the destination path as 'move' or 'convert' commands would do.",
+            help="regenerate the destination path as 'move' or 'convert' "
+            "commands would do.",
         )
         spl_update.parser.add_option(
             "--relative-to",

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -53,6 +53,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
         super().__init__()
         self.config.add(
             {
+                "dest_regen": False,
                 "relative_to": None,
                 "playlist_dir": ".",
                 "auto": True,
@@ -99,6 +100,12 @@ class SmartPlaylistPlugin(BeetsPlugin):
             metavar="PATH",
             type="string",
             help="directory to write the generated playlist files to.",
+        )
+        spl_update.parser.add_option(
+            "--dest-regen",
+            action="store_true",
+            dest="dest_regen",
+            help="regenerate the destination path as 'move' or 'convert' commands would do.",
         )
         spl_update.parser.add_option(
             "--relative-to",
@@ -267,6 +274,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
         )
         tpl = self.config["uri_format"].get()
         prefix = bytestring_path(self.config["prefix"].as_str())
+        dest_regen = self.config["dest_regen"].get()
         relative_to = self.config["relative_to"].get()
         if relative_to:
             relative_to = normpath(relative_to)
@@ -318,6 +326,8 @@ class SmartPlaylistPlugin(BeetsPlugin):
                 if tpl:
                     item_uri = tpl.replace("$id", str(item.id)).encode("utf-8")
                 else:
+                    if dest_regen is True:
+                        item_uri = item.destination()
                     if relative_to:
                         item_uri = os.path.relpath(item_uri, relative_to)
                     if self.config["forward_slash"].get():

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -97,12 +97,12 @@ New features
   2. Semicolon followed by a space
   3. Comma followed by a space
   4. Slash wrapped by spaces
+
 - :doc:`plugins/smartplaylist`: Add new configuration option ``dest_regen`` to
   regenerate items' path in the generated playlist instead of using the ones of
   the library. This is useful when items have been imported in don't copy-move
   (`-C -M`) mode in the library but are later passed through the `convert`
   plugin which will regenerate new paths according to the Beets path format.
-
 - :doc:`plugins/lyrics`: With ``synced`` enabled, existing synced lyrics are no
   longer replaced by newly fetched plain lyrics, even when ``force`` is enabled.
 - :doc:`plugins/lyrics`: Remove ``Source: <lyrics-url>`` suffix from lyrics.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -99,9 +99,9 @@ New features
   4. Slash wrapped by spaces
 
 - :doc:`plugins/smartplaylist`: Add new configuration option ``dest_regen`` to
-  regenerate items' path in the generated playlist instead of using the ones of
+  regenerate items' path in the generated playlist instead of using those in
   the library. This is useful when items have been imported in don't copy-move
-  (`-C -M`) mode in the library but are later passed through the `convert`
+  (``-C -M``) mode in the library but are later passed through the ``convert``
   plugin which will regenerate new paths according to the Beets path format.
 - :doc:`plugins/lyrics`: With ``synced`` enabled, existing synced lyrics are no
   longer replaced by newly fetched plain lyrics, even when ``force`` is enabled.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -97,6 +97,11 @@ New features
   2. Semicolon followed by a space
   3. Comma followed by a space
   4. Slash wrapped by spaces
+- :doc:`plugins/smartplaylist`: Add new configuration option ``dest_regen`` to
+  regenerate items' path in the generated playlist instead of using the ones of
+  the library. This is useful when items have been imported in don't copy-move
+  (`-C -M`) mode in the library but are later passed through the `convert`
+  plugin which will regenerate new paths according to the Beets path format.
 
 - :doc:`plugins/lyrics`: With ``synced`` enabled, existing synced lyrics are no
   longer replaced by newly fetched plain lyrics, even when ``force`` is enabled.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,11 @@ New features
 - :doc:`plugins/discogs`: Add :conf:`plugins.discogs:extra_tags` option to use
   additional tags (such as ``barcode``, ``catalognum``, ``country``, ``label``,
   ``media``, and ``year``) in Discogs search queries.
+- :doc:`plugins/smartplaylist`: Add new configuration option ``dest_regen`` to
+  regenerate items' path in the generated playlist instead of using those in the
+  library. This is useful when items have been imported in don't copy-move (``-C
+  -M``) mode in the library but are later passed through the ``convert`` plugin
+  which will regenerate new paths according to the Beets path format.
 
 Bug fixes
 ~~~~~~~~~
@@ -98,11 +103,6 @@ New features
   3. Comma followed by a space
   4. Slash wrapped by spaces
 
-- :doc:`plugins/smartplaylist`: Add new configuration option ``dest_regen`` to
-  regenerate items' path in the generated playlist instead of using those in the
-  library. This is useful when items have been imported in don't copy-move (``-C
-  -M``) mode in the library but are later passed through the ``convert`` plugin
-  which will regenerate new paths according to the Beets path format.
 - :doc:`plugins/lyrics`: With ``synced`` enabled, existing synced lyrics are no
   longer replaced by newly fetched plain lyrics, even when ``force`` is enabled.
 - :doc:`plugins/lyrics`: Remove ``Source: <lyrics-url>`` suffix from lyrics.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -99,10 +99,10 @@ New features
   4. Slash wrapped by spaces
 
 - :doc:`plugins/smartplaylist`: Add new configuration option ``dest_regen`` to
-  regenerate items' path in the generated playlist instead of using those in
-  the library. This is useful when items have been imported in don't copy-move
-  (``-C -M``) mode in the library but are later passed through the ``convert``
-  plugin which will regenerate new paths according to the Beets path format.
+  regenerate items' path in the generated playlist instead of using those in the
+  library. This is useful when items have been imported in don't copy-move (``-C
+  -M``) mode in the library but are later passed through the ``convert`` plugin
+  which will regenerate new paths according to the Beets path format.
 - :doc:`plugins/lyrics`: With ``synced`` enabled, existing synced lyrics are no
   longer replaced by newly fetched plain lyrics, even when ``force`` is enabled.
 - :doc:`plugins/lyrics`: Remove ``Source: <lyrics-url>`` suffix from lyrics.

--- a/docs/plugins/smartplaylist.rst
+++ b/docs/plugins/smartplaylist.rst
@@ -153,6 +153,11 @@ options are:
   ``yes``.
 - **playlist_dir**: Where to put the generated playlist files. Default: The
   current working directory (i.e., ``'.'``).
+- **dest_regen**: Regenerate the destination path as 'move' or 'convert'
+  commands would do. This operation will happen before ``relative_to`` and
+  ``prefix``. Helpful to generate playlists compatible with the ``convert``
+  plugin when items have been imported with the `-C -M` options.
+  Default: ``false``
 - **relative_to**: Generate paths in the playlist files relative to a base
   directory. If you intend to use this plugin to generate playlists for MPD,
   point this to your MPD music directory. Default: Use absolute paths.
@@ -167,7 +172,7 @@ options are:
   that will be written to the m3u file. Default: ``false``.
 - **uri_format**: Template with an ``$id`` placeholder used generate a playlist
   item URI, e.g. ``http://beets:8337/item/$id/file``. When this option is
-  specified, the local path-related options ``prefix``, ``relative_to``,
+  specified, the local path-related options ``dest_regen``, ``prefix``, ``relative_to``,
   ``forward_slash`` and ``urlencode`` are ignored.
 - **output**: Specify the playlist format: m3u|extm3u. Default ``m3u``.
 - **fields**: Specify the names of the additional item fields to export into the
@@ -176,6 +181,6 @@ options are:
   ``output`` option to ``extm3u``.
 
 For many configuration options, there is a corresponding CLI option, e.g.
-``--playlist-dir``, ``--relative-to``, ``--prefix``, ``--forward-slash``,
+``--playlist-dir``, ``--dest-regen``, ``--relative-to``, ``--prefix``, ``--forward-slash``,
 ``--urlencode``, ``--uri-format``, ``--output``, ``--pretend-paths``. CLI
 options take precedence over those specified within the configuration file.

--- a/docs/plugins/smartplaylist.rst
+++ b/docs/plugins/smartplaylist.rst
@@ -156,7 +156,7 @@ options are:
 - **dest_regen**: Regenerate the destination path as 'move' or 'convert'
   commands would do. This operation will happen before ``relative_to`` and
   ``prefix``. Helpful to generate playlists compatible with the ``convert``
-  plugin when items have been imported with the `-C -M` options. Default:
+  plugin when items have been imported with the ``-C -M`` options. Default:
   ``false``
 - **relative_to**: Generate paths in the playlist files relative to a base
   directory. If you intend to use this plugin to generate playlists for MPD,

--- a/docs/plugins/smartplaylist.rst
+++ b/docs/plugins/smartplaylist.rst
@@ -156,8 +156,8 @@ options are:
 - **dest_regen**: Regenerate the destination path as 'move' or 'convert'
   commands would do. This operation will happen before ``relative_to`` and
   ``prefix``. Helpful to generate playlists compatible with the ``convert``
-  plugin when items have been imported with the `-C -M` options.
-  Default: ``false``
+  plugin when items have been imported with the `-C -M` options. Default:
+  ``false``
 - **relative_to**: Generate paths in the playlist files relative to a base
   directory. If you intend to use this plugin to generate playlists for MPD,
   point this to your MPD music directory. Default: Use absolute paths.
@@ -172,8 +172,8 @@ options are:
   that will be written to the m3u file. Default: ``false``.
 - **uri_format**: Template with an ``$id`` placeholder used generate a playlist
   item URI, e.g. ``http://beets:8337/item/$id/file``. When this option is
-  specified, the local path-related options ``dest_regen``, ``prefix``, ``relative_to``,
-  ``forward_slash`` and ``urlencode`` are ignored.
+  specified, the local path-related options ``dest_regen``, ``prefix``,
+  ``relative_to``, ``forward_slash`` and ``urlencode`` are ignored.
 - **output**: Specify the playlist format: m3u|extm3u. Default ``m3u``.
 - **fields**: Specify the names of the additional item fields to export into the
   playlist. This allows using e.g. the ``id`` field within other tools such as
@@ -181,6 +181,7 @@ options are:
   ``output`` option to ``extm3u``.
 
 For many configuration options, there is a corresponding CLI option, e.g.
-``--playlist-dir``, ``--dest-regen``, ``--relative-to``, ``--prefix``, ``--forward-slash``,
-``--urlencode``, ``--uri-format``, ``--output``, ``--pretend-paths``. CLI
-options take precedence over those specified within the configuration file.
+``--playlist-dir``, ``--dest-regen``, ``--relative-to``, ``--prefix``,
+``--forward-slash``, ``--urlencode``, ``--uri-format``, ``--output``,
+``--pretend-paths``. CLI options take precedence over those specified within the
+configuration file.

--- a/docs/plugins/smartplaylist.rst
+++ b/docs/plugins/smartplaylist.rst
@@ -153,11 +153,11 @@ options are:
   ``yes``.
 - **playlist_dir**: Where to put the generated playlist files. Default: The
   current working directory (i.e., ``'.'``).
-- **dest_regen**: Regenerate the destination path as 'move' or 'convert'
+- **dest_regen**: Regenerate the destination path as ``move`` or ``convert``
   commands would do. This operation will happen before ``relative_to`` and
   ``prefix``. Helpful to generate playlists compatible with the ``convert``
   plugin when items have been imported with the ``-C -M`` options. Default:
-  ``false``
+  ``false``.
 - **relative_to**: Generate paths in the playlist files relative to a base
   directory. If you intend to use this plugin to generate playlists for MPD,
   point this to your MPD music directory. Default: Use absolute paths.

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -457,6 +457,88 @@ class SmartPlaylistTest(BeetsTestCase):
         # Verify i2 is not duplicated
         assert content.count(b"/item2.mp3") == 1
 
+    def test_playlist_update_dest_regen(self):
+        spl = SmartPlaylistPlugin()
+
+        i = MagicMock()
+        type(i).artist = PropertyMock(return_value="fake artist")
+        type(i).title = PropertyMock(return_value="fake title")
+        type(i).length = PropertyMock(return_value=300.123)
+        # Set a path which is not equal to the one returned by `item.destination`.
+        type(i).path = PropertyMock(return_value=b"/imported/path/with/dont/move/tagada.mp3")
+        # Set a path which would be equal to the one returned by `item.destination`.
+        type(i).destination = PropertyMock(return_value=lambda: b"/tagada.mp3")
+        i.evaluate_template.side_effect = lambda pl, _: pl.replace(
+            b"$title",
+            b"ta:ga:da",
+        ).decode()
+
+        lib = Mock()
+        lib.replacements = CHAR_REPLACE
+        lib.items.return_value = [i]
+        lib.albums.return_value = []
+
+        q = Mock()
+        a_q = Mock()
+        pl = b"$title-my<playlist>.m3u", (q, None), (a_q, None)
+        spl._matched_playlists = [pl]
+
+        dir = bytestring_path(mkdtemp())
+        config["smartplaylist"]["output"] = "extm3u"
+        config["smartplaylist"]["prefix"] = "http://beets:8337/files"
+        config["smartplaylist"]["relative_to"] = False
+        config["smartplaylist"]["playlist_dir"] = fsdecode(dir)
+
+        # Test when `dest_regen` is set to True:
+        # Intended behavior is to use the path of `i.destination`.
+
+        config["smartplaylist"]["dest_regen"] = True
+        try:
+            spl.update_playlists(lib)
+        except Exception:
+            rmtree(syspath(dir))
+            raise
+
+        lib.items.assert_called_once_with(q, None)
+        lib.albums.assert_called_once_with(a_q, None)
+
+        m3u_filepath = path.join(dir, b"ta_ga_da-my_playlist_.m3u")
+        self.assertExists(m3u_filepath)
+        with open(syspath(m3u_filepath), "rb") as f:
+            content = f.read()
+        rmtree(syspath(dir))
+
+        assert (
+            content
+            == b"#EXTM3U\n"
+            + b"#EXTINF:300,fake artist - fake title\n"
+            + b"http://beets:8337/files/tagada.mp3\n"
+        )
+
+        # Test when `dest_regen` is set to False:
+        # Intended behavior is to use the path of `i.path`.
+
+        config["smartplaylist"]["dest_regen"] = False
+
+        try:
+            spl.update_playlists(lib)
+        except Exception:
+            rmtree(syspath(dir))
+            raise
+
+        m3u_filepath = path.join(dir, b"ta_ga_da-my_playlist_.m3u")
+        self.assertExists(m3u_filepath)
+        with open(syspath(m3u_filepath), "rb") as f:
+            content = f.read()
+        rmtree(syspath(dir))
+
+        assert (
+            content
+            == b"#EXTM3U\n"
+            + b"#EXTINF:300,fake artist - fake title\n"
+            + b"http://beets:8337/files/imported/path/with/dont/move/tagada.mp3\n"
+        )
+
 
 class SmartPlaylistCLITest(IOMixin, PluginTestCase):
     plugin = "smartplaylist"

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -465,7 +465,9 @@ class SmartPlaylistTest(BeetsTestCase):
         type(i).title = PropertyMock(return_value="fake title")
         type(i).length = PropertyMock(return_value=300.123)
         # Set a path which is not equal to the one returned by `item.destination`.
-        type(i).path = PropertyMock(return_value=b"/imported/path/with/dont/move/tagada.mp3")
+        type(i).path = PropertyMock(
+            return_value=b"/imported/path/with/dont/move/tagada.mp3"
+        )
         # Set a path which would be equal to the one returned by `item.destination`.
         type(i).destination = PropertyMock(return_value=lambda: b"/tagada.mp3")
         i.evaluate_template.side_effect = lambda pl, _: pl.replace(

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -13,7 +13,7 @@
 # included in all copies or substantial portions of the Software.
 
 
-from os import path, remove
+from os import path, remove, fsdecode
 from pathlib import Path
 from shutil import rmtree
 from tempfile import mkdtemp
@@ -26,7 +26,7 @@ from beets.dbcore.query import FixedFieldSort, MultipleSort, NullSort
 from beets.library import Album, Item, parse_query_string
 from beets.test.helper import BeetsTestCase, IOMixin, PluginTestCase
 from beets.ui import UserError
-from beets.util import CHAR_REPLACE, syspath
+from beets.util import CHAR_REPLACE, syspath, bytestring_path
 from beetsplug.smartplaylist import SmartPlaylistPlugin
 
 
@@ -512,9 +512,9 @@ class SmartPlaylistTest(BeetsTestCase):
 
         assert (
             content
-            == b"#EXTM3U\n"
-            + b"#EXTINF:300,fake artist - fake title\n"
-            + b"http://beets:8337/files/tagada.mp3\n"
+            == (b"#EXTM3U\n"
+                b"#EXTINF:300,fake artist - fake title\n"
+                b"http://beets:8337/files/tagada.mp3\n")
         )
 
         # Test when `dest_regen` is set to False:
@@ -536,9 +536,9 @@ class SmartPlaylistTest(BeetsTestCase):
 
         assert (
             content
-            == b"#EXTM3U\n"
-            + b"#EXTINF:300,fake artist - fake title\n"
-            + b"http://beets:8337/files/imported/path/with/dont/move/tagada.mp3\n"
+            == (b"#EXTM3U\n"
+                b"#EXTINF:300,fake artist - fake title\n"
+                b"http://beets:8337/files/imported/path/with/dont/move/tagada.mp3\n")
         )
 
 

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -510,11 +510,10 @@ class SmartPlaylistTest(BeetsTestCase):
             content = f.read()
         rmtree(syspath(dir))
 
-        assert (
-            content
-            == (b"#EXTM3U\n"
-                b"#EXTINF:300,fake artist - fake title\n"
-                b"http://beets:8337/files/tagada.mp3\n")
+        assert content == (
+            b"#EXTM3U\n"
+            b"#EXTINF:300,fake artist - fake title\n"
+            b"http://beets:8337/files/tagada.mp3\n"
         )
 
         # Test when `dest_regen` is set to False:
@@ -534,11 +533,10 @@ class SmartPlaylistTest(BeetsTestCase):
             content = f.read()
         rmtree(syspath(dir))
 
-        assert (
-            content
-            == (b"#EXTM3U\n"
-                b"#EXTINF:300,fake artist - fake title\n"
-                b"http://beets:8337/files/imported/path/with/dont/move/tagada.mp3\n")
+        assert content == (
+            b"#EXTM3U\n"
+            b"#EXTINF:300,fake artist - fake title\n"
+            b"http://beets:8337/files/imported/path/with/dont/move/tagada.mp3\n"
         )
 
 

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -483,7 +483,7 @@ class SmartPlaylistTest(BeetsTestCase):
         q = Mock()
         a_q = Mock()
         pl = b"$title-my<playlist>.m3u", (q, None), (a_q, None)
-        spl._matched_playlists = [pl]
+        spl._matched_playlists = {pl}
 
         dir = mkdtemp()
         config["smartplaylist"]["output"] = "extm3u"

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -12,6 +12,7 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
+# TODO: Tests in this fire are very bad. Stop using Mocks in this module.
 
 from os import path, remove
 from pathlib import Path

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -13,7 +13,7 @@
 # included in all copies or substantial portions of the Software.
 
 
-from os import fsdecode, path, remove
+from os import path, remove
 from pathlib import Path
 from shutil import rmtree
 from tempfile import mkdtemp
@@ -26,7 +26,7 @@ from beets.dbcore.query import FixedFieldSort, MultipleSort, NullSort
 from beets.library import Album, Item, parse_query_string
 from beets.test.helper import BeetsTestCase, IOMixin, PluginTestCase
 from beets.ui import UserError
-from beets.util import CHAR_REPLACE, bytestring_path, syspath
+from beets.util import CHAR_REPLACE, syspath
 from beetsplug.smartplaylist import SmartPlaylistPlugin
 
 
@@ -485,11 +485,11 @@ class SmartPlaylistTest(BeetsTestCase):
         pl = b"$title-my<playlist>.m3u", (q, None), (a_q, None)
         spl._matched_playlists = [pl]
 
-        dir = bytestring_path(mkdtemp())
+        dir = mkdtemp()
         config["smartplaylist"]["output"] = "extm3u"
         config["smartplaylist"]["prefix"] = "http://beets:8337/files"
         config["smartplaylist"]["relative_to"] = False
-        config["smartplaylist"]["playlist_dir"] = fsdecode(dir)
+        config["smartplaylist"]["playlist_dir"] = str(dir)
 
         # Test when `dest_regen` is set to True:
         # Intended behavior is to use the path of `i.destination`.
@@ -504,8 +504,8 @@ class SmartPlaylistTest(BeetsTestCase):
         lib.items.assert_called_once_with(q, None)
         lib.albums.assert_called_once_with(a_q, None)
 
-        m3u_filepath = path.join(dir, b"ta_ga_da-my_playlist_.m3u")
-        self.assertExists(m3u_filepath)
+        m3u_filepath = Path(dir, "ta_ga_da-my_playlist_.m3u")
+        assert m3u_filepath.exists()
         with open(syspath(m3u_filepath), "rb") as f:
             content = f.read()
         rmtree(syspath(dir))
@@ -527,8 +527,8 @@ class SmartPlaylistTest(BeetsTestCase):
             rmtree(syspath(dir))
             raise
 
-        m3u_filepath = path.join(dir, b"ta_ga_da-my_playlist_.m3u")
-        self.assertExists(m3u_filepath)
+        m3u_filepath = Path(dir, "ta_ga_da-my_playlist_.m3u")
+        assert m3u_filepath.exists()
         with open(syspath(m3u_filepath), "rb") as f:
             content = f.read()
         rmtree(syspath(dir))

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -13,7 +13,7 @@
 # included in all copies or substantial portions of the Software.
 
 
-from os import path, remove, fsdecode
+from os import fsdecode, path, remove
 from pathlib import Path
 from shutil import rmtree
 from tempfile import mkdtemp
@@ -26,7 +26,7 @@ from beets.dbcore.query import FixedFieldSort, MultipleSort, NullSort
 from beets.library import Album, Item, parse_query_string
 from beets.test.helper import BeetsTestCase, IOMixin, PluginTestCase
 from beets.ui import UserError
-from beets.util import CHAR_REPLACE, syspath, bytestring_path
+from beets.util import CHAR_REPLACE, bytestring_path, syspath
 from beetsplug.smartplaylist import SmartPlaylistPlugin
 
 


### PR DESCRIPTION
## Problem

1. When items are imported into the library in a don't copy-move mode (`-C -M` options), they will be registered inside the Beets database using their **original paths**. However, during subsequent processing (*e.g.*, a `convert` operation), a path following the Beets path format can be generated.
2. When generating playlists using `smartplaylist` plugin, only the path registered inside the Beets database (the **original path**) can be use inside the output playlist. This block the compatibility with other plugins.

## Solution

I added a a new optional configuration option known as ``dest_regen`` (as well as its equivalent ``dest-regen`` on the CLI) to regenerate items' path in the generated playlist instead of using the ones of  the library, just like a `convert` or a `move` operation would have done. This operation will happen before the ``relative_to`` and ``prefix`` options, which makes sense to do so and not in another order, otherwise this new option (``dest_regen``)) would overwrite the desired behavior of the other mentioned options (``relative_to`` and ``prefix``). It is then helpful to generate playlists compatible with the ``convert`` plugin.

## To Do

- [x] Documentation
- [x] Changelog
- [ ] Tests. (I may write one in the future if this PR is considered)