### PR TITLE
WIP: Consider disambiguation in an album name when calculation distance

### DIFF
--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -239,7 +239,17 @@ def distance(
         dist.add_string("artist", likelies["artist"], album_info.artist)
 
     # Album.
-    dist.add_string("album", likelies["album"], album_info.album)
+    compare_album = album_info.album
+    if album_info.albumdisambig:
+        # See if "$album ($albumdisambig)" is a closer match, and use that if so.
+        album_with_disambig = f"{compare_album} ({album_info.albumdisambig})"
+        album_dist = hooks.string_dist(likelies["album"], compare_album)
+        album_disambig_dist = hooks.string_dist(
+            likelies["album"], album_with_disambig
+        )
+        if album_disambig_dist < album_dist:
+            compare_album = album_with_disambig
+    dist.add_string("album", likelies["album"], compare_album)
 
     # Current or preferred media.
     if album_info.media:

--- a/test/test_autotag.py
+++ b/test/test_autotag.py
@@ -106,12 +106,12 @@ class PluralityTest(BeetsTestCase):
                 assert likelies[f] == f"{f}_1"
 
 
-def _make_item(title, track, artist="some artist"):
+def _make_item(title, track, artist="some artist", album="some_album"):
     return Item(
         title=title,
         track=track,
         artist=artist,
-        album="some album",
+        album=album,
         length=1,
         mb_trackid="",
         mb_albumid="",
@@ -496,6 +496,24 @@ class AlbumDistanceTest(BeetsTestCase):
         info.tracks[2].medium_index = 1
         dist = self._dist(items, info)
         assert dist == 0
+
+    def test_album_disambiguation(self):
+        album = "some album"
+        disambig = "disambig"
+        album_disambig = f"{album} ({disambig})"
+        items = []
+        items.append(_make_item("one", 1, album=album_disambig))
+        items.append(_make_item("two", 2, album=album_disambig))
+        items.append(_make_item("three", 3, album=album_disambig))
+        info = AlbumInfo(
+            artist="some artist",
+            album=album,
+            albumdisambig=disambig,
+            tracks=_make_trackinfo(),
+            va=False,
+        )
+
+        assert self._dist(items, info) == 0
 
 
 class TestAssignment(ConfigMixin):


### PR DESCRIPTION
## Description

When calculating distance between the local album name and one from a database consider the option that the disambiguation text has been included in the local album's name.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
