### PR TITLE
`mbsync` / `missing` plugins: consider all metadata backends

### DIFF
--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -602,8 +602,7 @@ def album_for_mbid(release_id: str) -> AlbumInfo | None:
     if the ID is not found.
     """
     try:
-        album = mb.album_for_id(release_id)
-        if album:
+        if album := mb.album_for_id(release_id):
             plugins.send("albuminfo_received", info=album)
         return album
     except mb.MusicBrainzAPIError as exc:
@@ -616,8 +615,7 @@ def track_for_mbid(recording_id: str) -> TrackInfo | None:
     if the ID is not found.
     """
     try:
-        track = mb.track_for_id(recording_id)
-        if track:
+        if track := mb.track_for_id(recording_id):
             plugins.send("trackinfo_received", info=track)
         return track
     except mb.MusicBrainzAPIError as exc:
@@ -625,26 +623,14 @@ def track_for_mbid(recording_id: str) -> TrackInfo | None:
         return None
 
 
-def albums_for_id(album_id: str) -> Iterable[AlbumInfo]:
-    """Get a list of albums for an ID."""
-    a = album_for_mbid(album_id)
-    if a:
-        yield a
-    for a in plugins.album_for_id(album_id):
-        if a:
-            plugins.send("albuminfo_received", info=a)
-            yield a
+def album_for_id(_id: str) -> AlbumInfo | None:
+    """Get AlbumInfo object for the given ID string."""
+    return album_for_mbid(_id) or plugins.album_for_id(_id)
 
 
-def tracks_for_id(track_id: str) -> Iterable[TrackInfo]:
-    """Get a list of tracks for an ID."""
-    t = track_for_mbid(track_id)
-    if t:
-        yield t
-    for t in plugins.track_for_id(track_id):
-        if t:
-            plugins.send("trackinfo_received", info=t)
-            yield t
+def track_for_id(_id: str) -> TrackInfo | None:
+    """Get TrackInfo object for the given ID string."""
+    return track_for_mbid(_id) or plugins.track_for_id(_id)
 
 
 def invoke_mb(call_func: Callable, *args):

--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -510,8 +510,8 @@ def tag_album(
     if search_ids:
         for search_id in search_ids:
             log.debug("Searching for album ID: {0}", search_id)
-            for album_info_for_id in hooks.albums_for_id(search_id):
-                _add_candidate(items, candidates, album_info_for_id)
+            if info := hooks.album_for_id(search_id):
+                _add_candidate(items, candidates, info)
 
     # Use existing metadata or text search.
     else:
@@ -590,11 +590,9 @@ def tag_item(
     if trackids:
         for trackid in trackids:
             log.debug("Searching for track ID: {0}", trackid)
-            for track_info in hooks.tracks_for_id(trackid):
-                dist = track_distance(item, track_info, incl_artist=True)
-                candidates[track_info.track_id] = hooks.TrackMatch(
-                    dist, track_info
-                )
+            if info := hooks.track_for_id(trackid):
+                dist = track_distance(item, info, incl_artist=True)
+                candidates[info.track_id] = hooks.TrackMatch(dist, info)
                 # If this is a good match, then don't keep searching.
                 rec = _recommendation(_sort_candidates(candidates.values()))
                 if (

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -71,7 +71,7 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
             self._log.error("Error fetching data from {}\n Error: {}", url, e)
             return None
         if "error" in data:
-            self._log.error("Deezer API error: {}", data["error"]["message"])
+            self._log.debug("Deezer API error: {}", data["error"]["message"])
             return None
         return data
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,7 @@ New features:
   when fetching lyrics.
 * :doc:`plugins/lyrics`: Rewrite lyrics translation functionality to use Azure
   AI Translator API and add relevant instructions to the documentation.
+* :doc:`plugins/missing`: Add support for all metadata sources.
 
 Bug fixes:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,7 @@ New features:
 * :doc:`plugins/lyrics`: Rewrite lyrics translation functionality to use Azure
   AI Translator API and add relevant instructions to the documentation.
 * :doc:`plugins/missing`: Add support for all metadata sources.
+* :doc:`plugins/mbsync`: Add support for all metadata sorces.
 
 Bug fixes:
 

--- a/docs/plugins/mbsync.rst
+++ b/docs/plugins/mbsync.rst
@@ -1,14 +1,13 @@
 MBSync Plugin
 =============
 
-This plugin provides the ``mbsync`` command, which lets you fetch metadata
-from MusicBrainz for albums and tracks that already have MusicBrainz IDs. This
-is useful for updating tags as they are fixed in the MusicBrainz database, or
-when you change your mind about some config options that change how tags are
-written to files. If you have a music library that is already nicely tagged by
-a program that also uses MusicBrainz like Picard, this can speed up the
-initial import if you just import "as-is" and then use ``mbsync`` to get
-up-to-date tags that are written to the files according to your beets
+This plugin provides the ``mbsync`` command, which lets you synchronize
+metadata for albums and tracks that have external data source IDs.
+
+This is useful for syncing your library with online data or when changing
+configuration options that affect tag writing. If your music library already
+contains correct tags, you can speed up the initial import by importing files
+"as-is" and then using ``mbsync`` to write tags according to your beets
 configuration.
 
 

--- a/docs/plugins/missing.rst
+++ b/docs/plugins/missing.rst
@@ -8,24 +8,28 @@ call to album data source.
 Usage
 -----
 
-Add the ``missing`` plugin to your configuration (see :ref:`using-plugins`). By
-default, the ``beet missing`` command fetches album information from the origin
-data source and lists names of the **tracks** that are missing from your
-library. It can also list the names of albums that
-your library is missing from each artist.
-You can customize the output format, count
-the number of missing tracks per album, or total up the number of missing
-tracks over your whole library, using command-line switches::
+Add the ``missing`` plugin to your configuration (see :ref:`using-plugins`).
+The ``beet missing`` command fetches album information from the origin data
+source and lists names of the **tracks** that are missing from your library.
+
+It can also list the names of missing **albums** for each artist, although this
+is limited to albums from the MusicBrainz data source only.
+
+You can customize the output format, show missing counts instead of track
+titles, or display the total number of missing entities across your entire
+library::
 
       -f FORMAT, --format=FORMAT
                             print with custom FORMAT
       -c, --count           count missing tracks per album
-      -t, --total           count total of missing tracks or albums
-      -a, --album           show missing albums for artist instead of tracks
+      -t, --total           count totals across the entire library
+      -a, --album           show missing albums for artist instead of tracks for album
 
-…or by editing corresponding options.
+…or by editing the corresponding configuration options.
 
-Note that ``-c`` is ignored when used with ``-a``.
+.. warning::
+
+    Option ``-c`` is ignored when used with ``-a``.
 
 Configuration
 -------------

--- a/docs/plugins/missing.rst
+++ b/docs/plugins/missing.rst
@@ -1,17 +1,17 @@
 Missing Plugin
 ==============
 
-This plugin adds a new command, ``missing`` or ``miss``, which finds
-and lists, for every album in your collection, which or how many
-tracks are missing. Listing missing files requires one network call to
-MusicBrainz. Merely counting missing files avoids any network calls.
+This plugin adds a new command, ``missing`` or ``miss``, which finds and lists
+missing tracks for albums in your collection. Each album requires one network
+call to album data source.
 
 Usage
 -----
 
-Add the ``missing`` plugin to your configuration (see :ref:`using-plugins`).
-By default, the ``beet missing`` command lists the names of tracks that your
-library is missing from each album. It can also list the names of albums that
+Add the ``missing`` plugin to your configuration (see :ref:`using-plugins`). By
+default, the ``beet missing`` command fetches album information from the origin
+data source and lists names of the **tracks** that are missing from your
+library. It can also list the names of albums that
 your library is missing from each artist.
 You can customize the output format, count
 the number of missing tracks per album, or total up the number of missing

--- a/test/plugins/test_discogs.py
+++ b/test/plugins/test_discogs.py
@@ -14,6 +14,8 @@
 
 """Tests for discogs plugin."""
 
+from unittest.mock import Mock, patch
+
 import pytest
 
 from beets import config
@@ -23,6 +25,7 @@ from beets.util.id_extractors import extract_discogs_id_regex
 from beetsplug.discogs import DiscogsPlugin
 
 
+@patch("beetsplug.discogs.DiscogsPlugin.setup", Mock())
 class DGAlbumInfoTest(BeetsTestCase):
     def _make_release(self, tracks=None):
         """Returns a Bag that mimics a discogs_client.Release. The list

--- a/test/plugins/test_mbsync.py
+++ b/test/plugins/test_mbsync.py
@@ -12,7 +12,7 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.library import Item
@@ -22,37 +22,36 @@ from beets.test.helper import PluginTestCase, capture_log
 class MbsyncCliTest(PluginTestCase):
     plugin = "mbsync"
 
-    @patch("beets.autotag.mb.album_for_id")
-    @patch("beets.autotag.mb.track_for_id")
-    def test_update_library(self, track_for_id, album_for_id):
+    @patch(
+        "beets.plugins.album_for_id",
+        Mock(
+            side_effect=lambda *_: AlbumInfo(
+                album_id="album id",
+                album="new album",
+                tracks=[TrackInfo(track_id="track id", title="new title")],
+            )
+        ),
+    )
+    @patch(
+        "beets.plugins.track_for_id",
+        Mock(
+            side_effect=lambda *_: TrackInfo(
+                track_id="singleton id", title="new title"
+            )
+        ),
+    )
+    def test_update_library(self):
         album_item = Item(
             album="old album",
-            mb_albumid="81ae60d4-5b75-38df-903a-db2cfa51c2c6",
+            mb_albumid="album id",
             mb_trackid="track id",
         )
         self.lib.add_album([album_item])
 
-        singleton = Item(
-            title="old title", mb_trackid="b8c2cf90-83f9-3b5f-8ccd-31fb866fcf37"
-        )
+        singleton = Item(title="old title", mb_trackid="singleton id")
         self.lib.add(singleton)
 
-        album_for_id.return_value = AlbumInfo(
-            album_id="album id",
-            album="new album",
-            tracks=[
-                TrackInfo(track_id=album_item.mb_trackid, title="new title")
-            ],
-        )
-        track_for_id.return_value = TrackInfo(
-            track_id=singleton.mb_trackid, title="new title"
-        )
-
-        with capture_log() as logs:
-            self.run_command("mbsync")
-
-        assert "Sending event: albuminfo_received" in logs
-        assert "Sending event: trackinfo_received" in logs
+        self.run_command("mbsync")
 
         singleton.load()
         assert singleton.title == "new title"
@@ -81,9 +80,6 @@ class MbsyncCliTest(PluginTestCase):
 
         with capture_log("beets.mbsync") as logs:
             self.run_command("mbsync", "-f", "'%if{$album,$album,$title}'")
-        assert set(logs) == {
-            "mbsync: Skipping album with no mb_albumid: 'no id'",
-            "mbsync: Skipping album with invalid mb_albumid: 'invalid id'",
-            "mbsync: Skipping singleton with no mb_trackid: 'no id'",
-            "mbsync: Skipping singleton with invalid mb_trackid: 'invalid id'",
-        }
+
+        assert "mbsync: Skipping album with no mb_albumid: 'no id'" in logs
+        assert "mbsync: Skipping singleton with no mb_trackid: 'no id'" in logs


### PR DESCRIPTION
This PR adds support for alternate metadata backends in the `mbsync` and `missing` plugins, allowing them to work with any metadata backend the items are tagged with instead of being limited to just MusicBrainz.

Key changes:
- Removed redundant `albums_for_id` and `items_for_id` methods.
- Updated `album_for_id` and `track_for_id` implementations to return a single album/track as their names suggest.
- Updated both plugins to use the above functions instead of MusicBrainz-specific ones.
- Updated `missing` plugin docs to make it clear that missing albums for artists can only be obtained for the `musicbrainz` metadata backend
  - This is possible with other backends but implementation was outside of this PR's scope.
  - Slightly simplified the existing implementation

The changes maintain backwards compatibility while enabling users to leverage metadata from sources like Deezer, Discogs or Bandcamp when syncing their libraries.

**Note**: this change came about because I'm working on making `musicbrainz` a separate plugin: this will be submitted in the next PR.
