### PR TITLE
Allow to pickle db models by removing the current connection.

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -716,6 +716,15 @@ class Model(ABC, Generic[D]):
         """Set the object's key to a value represented by a string."""
         self[key] = self._parse(key, string)
 
+    def __getstate__(self):
+        """Return the state of the object for pickling.
+        Remove the database connection as sqlite connections are not
+        picklable.
+        """
+        state = self.__dict__.copy()
+        state["_db"] = None
+        return state
+
 
 # Database controller and supporting interfaces.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -84,7 +84,7 @@ For packagers:
   from your plugin as beets now uses native/implicit namespace package setup.
 
 Other changes:
-
+* Database models are now serializable with pickle.
 * Release workflow: fix the issue where the new release tag is created for the
   wrong (outdated) commit. Now the tag is created in the same workflow step
   right after committing the version update.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -84,7 +84,7 @@ For packagers:
   from your plugin as beets now uses native/implicit namespace package setup.
 
 Other changes:
-* Database models are now serializable with pickle.
+
 * Release workflow: fix the issue where the new release tag is created for the
   wrong (outdated) commit. Now the tag is created in the same workflow step
   right after committing the version update.
@@ -93,6 +93,7 @@ Other changes:
   improve useability for new developers.
 * :doc:`/plugins/smartplaylist`: URL-encode additional item `fields` within generated
   EXTM3U playlists instead of JSON-encoding them.
+* Database models are now serializable with pickle.
 
 2.2.0 (December 02, 2024)
 -------------------------

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -421,6 +421,20 @@ class ModelTest(unittest.TestCase):
         with pytest.raises(TypeError, match="must be a string"):
             dbcore.Model._parse(None, 42)
 
+    def test_pickle_dump(self):
+        """Tries to pickle an item. This tests the __getstate__ method
+        of the Model ABC"""
+        import pickle
+
+        model = ModelFixture1(self.db)
+        model.add(self.db)
+        model.field_one = 123
+
+        model.store()
+        assert model._db is not None
+
+        pickle.dumps(model)
+
 
 class FormatTest(unittest.TestCase):
     def test_format_fixed_field_integer(self):

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1394,16 +1394,3 @@ class LibraryFieldTypesTest(unittest.TestCase):
         beets.config["format_raw_length"] = True
         assert 61.23 == t.format(61.23)
         assert 3601.23 == t.format(3601.23)
-
-
-class PickleTest(ItemInDBTestCase):
-    def test_pickle_dump(self):
-        """Tries to pickle an item. This tests the __getstate__ method
-        of the Model ABC"""
-        import pickle
-
-        item = self.i
-        # Fetch album
-        item._cached_album
-
-        pickle.dumps(item)

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1394,3 +1394,16 @@ class LibraryFieldTypesTest(unittest.TestCase):
         beets.config["format_raw_length"] = True
         assert 61.23 == t.format(61.23)
         assert 3601.23 == t.format(3601.23)
+
+
+class PickleTest(ItemInDBTestCase):
+    def test_pickle_dump(self):
+        """Tries to pickle an item. This tests the __getstate__ method
+        of the Model ABC"""
+        import pickle
+
+        item = self.i
+        # Fetch album
+        item._cached_album
+
+        pickle.dumps(item)


### PR DESCRIPTION
## Description

This might be a quick one, depending on how you feel about it... It allows you to pickle DB model objects. I don't think this is used directly in Beets, but it might be useful in general. For instance, we encountered an issue where we wanted to quickly pickle an Item or Album. This sometimes worked and other times failed, which seemed quite inconsistent.

Some DB model methods and properties have the side effect of attaching an SQLite connection to self (._db), which prevents serialization. The fix is quite straightforward, so I thought we might want to integrate this into beets directly.

## To Do

- [x] Changelog
- [x] Tests
