### PR TITLE
Fix IMBackend#compare on ImageMagick 7.1.1-44

### DIFF
--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -314,6 +314,11 @@ class IMBackend(LocalBackend):
         else:
             out_str = stdout
 
+        # ImageMagick 7.1.1-44 outputs in a different format.
+        if b"(" in out_str and out_str.endswith(b")"):
+            # Extract diff from "... (diff)".
+            out_str = out_str[out_str.index(b"(") + 1 : -1]
+
         try:
             phash_diff = float(out_str)
         except ValueError:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -75,6 +75,7 @@ Bug fixes:
 * :doc:`plugins/lyrics`: Fix plugin crash when ``genius`` backend returns empty
   lyrics.
   :bug:`5583`
+* ImageMagick 7.1.1-44 is now supported.
 
 For packagers:
 

--- a/test/plugins/test_embedart.py
+++ b/test/plugins/test_embedart.py
@@ -285,8 +285,8 @@ class ArtSimilarityTest(unittest.TestCase):
         mock_extract,
         mock_subprocess,
         compare_status=0,
-        compare_stdout="",
-        compare_stderr="",
+        compare_stdout=b"",
+        compare_stderr=b"",
         convert_status=0,
     ):
         mock_extract.return_value = b"extracted_path"
@@ -298,33 +298,33 @@ class ArtSimilarityTest(unittest.TestCase):
         ]
 
     def test_compare_success_similar(self, mock_extract, mock_subprocess):
-        self._mock_popens(mock_extract, mock_subprocess, 0, "10", "err")
+        self._mock_popens(mock_extract, mock_subprocess, 0, b"10", b"err")
         assert self._similarity(20)
 
     def test_compare_success_different(self, mock_extract, mock_subprocess):
-        self._mock_popens(mock_extract, mock_subprocess, 0, "10", "err")
+        self._mock_popens(mock_extract, mock_subprocess, 0, b"10", b"err")
         assert not self._similarity(5)
 
     def test_compare_status1_similar(self, mock_extract, mock_subprocess):
-        self._mock_popens(mock_extract, mock_subprocess, 1, "out", "10")
+        self._mock_popens(mock_extract, mock_subprocess, 1, b"out", b"10")
         assert self._similarity(20)
 
     def test_compare_status1_different(self, mock_extract, mock_subprocess):
-        self._mock_popens(mock_extract, mock_subprocess, 1, "out", "10")
+        self._mock_popens(mock_extract, mock_subprocess, 1, b"out", b"10")
         assert not self._similarity(5)
 
     def test_compare_failed(self, mock_extract, mock_subprocess):
-        self._mock_popens(mock_extract, mock_subprocess, 2, "out", "10")
+        self._mock_popens(mock_extract, mock_subprocess, 2, b"out", b"10")
         assert self._similarity(20) is None
 
     def test_compare_parsing_error(self, mock_extract, mock_subprocess):
-        self._mock_popens(mock_extract, mock_subprocess, 0, "foo", "bar")
+        self._mock_popens(mock_extract, mock_subprocess, 0, b"foo", b"bar")
         assert self._similarity(20) is None
 
     def test_compare_parsing_error_and_failure(
         self, mock_extract, mock_subprocess
     ):
-        self._mock_popens(mock_extract, mock_subprocess, 1, "foo", "bar")
+        self._mock_popens(mock_extract, mock_subprocess, 1, b"foo", b"bar")
         assert self._similarity(20) is None
 
     def test_convert_failure(self, mock_extract, mock_subprocess):


### PR DESCRIPTION
## Description

ImageMagick 7.1.1-44 now outputs phash result in a different format (as of https://github.com/ImageMagick/ImageMagick/commit/d85a7583f9a96bf031941c24d774b71529de3ce0):

```shell
$ magick --version | head -n1
Version: ImageMagick 7.1.1-43 Q16-HDRI x86_64 afd817ca6:20241222 https://imagemagick.org
$ compare -metric PHASH a.jpg b.jpg NULL:
649.922
```

```shell
$ magick --version | head -n1
Version: ImageMagick 7.1.1-44 Q16-HDRI x86_64 f1c26bed0:20250222 https://imagemagick.org
$ compare -metric PHASH a.jpg b.jpg NULL:
4.25933e+07 (649.931)
```

Fixes #5527.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
