### PR TITLE
fix: plugins/listenbrainz: Fix UnboundLocalError in cases where 'mbid' is not defined

### DIFF
--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -110,7 +110,7 @@ class ListenBrainzPlugin(BeetsPlugin):
             if track["track_metadata"].get("release_name") is None:
                 continue
             mbid_mapping = track["track_metadata"].get("mbid_mapping", {})
-            # print(json.dumps(track, indent=4, sort_keys=True))
+            mbid = None
             if mbid_mapping.get("recording_mbid") is None:
                 # search for the track using title and release
                 mbid = self.get_mb_recording_id(track)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,8 @@ New features:
 
 Bug fixes:
 
+* :doc:`plugins/listenbrainz`: Fix rST formatting for URLs of Listenbrainz API Key documentation and config.yaml.
+* :doc:`plugins/listenbrainz`: Fix ``UnboundLocalError`` in cases where 'mbid' is not defined.
 * :doc:`plugins/fetchart`: Fix fetchart bug where a tempfile could not be deleted due to never being
   properly closed.
   :bug:`5521`

--- a/docs/plugins/listenbrainz.rst
+++ b/docs/plugins/listenbrainz.rst
@@ -8,14 +8,14 @@ The ListenBrainz plugin for beets allows you to interact with the ListenBrainz s
 Installation
 ------------
 
-To enable the ListenBrainz plugin, add the following to your beets configuration file (`config.yaml`):
+To enable the ListenBrainz plugin, add the following to your beets configuration file (`config.yaml`_):
 
 .. code-block:: yaml
 
    plugins:
        - listenbrainz
 
-You can then configure the plugin by providing your Listenbrainz token (see intructions `here`_`)and username::
+You can then configure the plugin by providing your Listenbrainz token (see intructions `here`_) and username::
 
     listenbrainz:
         token: TOKEN
@@ -29,3 +29,4 @@ Once the plugin is enabled, you can import the listening history using the `lbim
 
 
 .. _here: https://listenbrainz.readthedocs.io/en/latest/users/api/index.html#get-the-user-token
+.. _config.yaml: ../reference/config.rst


### PR DESCRIPTION
## Description

Fix ocurrence of `UnboundLocalError` in plugins/listenbrainz > `get_tracks_from_listens()` when `mbid` is not available.
Removed a print statment.
Fix link to config.yaml.
Fix link to Listenbrainz "get the token" documentation.


## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
