### PR TITLE
Fix import_task_before_choice event for singleton imports

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -1117,6 +1117,22 @@ class TerminalImportSession(importer.ImportSession):
         """
         print_()
         print_(displayable_path(task.item.path))
+
+        # Let plugins display info or prompt the user before we go through the
+        # process of selecting candidate.
+        results = plugins.send(
+            "import_task_before_choice", session=self, task=task
+        )
+        actions = [action for action in results if action]
+
+        if len(actions) == 1:
+            return actions[0]
+        elif len(actions) > 1:
+            raise plugins.PluginConflictError(
+                "Only one handler for `import_task_before_choice` may return "
+                "an action."
+            )
+
         candidates, rec = task.candidates, task.rec
 
         # Take immediate action if appropriate.


### PR DESCRIPTION
## Description

This PR fixes a bug which caused the `import_task_before_choice` event not to be sent for singleton imports.

I suppose this was just an oversight, as this behavior is not mentioned in the [documentation](https://beets.readthedocs.io/en/stable/dev/plugins.html#listen-for-events).

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
