### PR TITLE
feat: mpdstats: adds config option for remaining time threshold to determine if track was played.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,6 +30,9 @@ New features:
   :bug:`5829`
 * :doc:`plugins/mbcollection`: When getting the user collections, only consider
   collections of releases, and ignore collections of other entity types.
+* :doc:`plugins/mpdstats`: Add new configuration option,
+  ``played_ratio_threshold``, to allow configuring the percentage the song must
+  be played for it to be counted as played instead of skipped.
 
 Bug fixes:
 

--- a/docs/plugins/mpdstats.rst
+++ b/docs/plugins/mpdstats.rst
@@ -58,6 +58,9 @@ configuration file. The available options are:
   Default: ``yes``.
 - **rating_mix**: Tune the way rating is calculated (see below).
   Default: 0.75.
+- **played_ratio_threshold**: If a song was played for less than this percentage
+  of its duration it will be considered a skip.
+  Default: 0.85
 
 A Word on Ratings
 -----------------


### PR DESCRIPTION
## Description
Add new configuration option for mpdstats plugin, `played_ratio_threshold`, to allow configuring the percentage the song must be played for it to be counted as played instead of skipped.


## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation.
- [x] Changelog. 
- [x] Tests.
