### PR TITLE
FIX: Dereference symlinks before hardlinking

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -605,7 +605,9 @@ def hardlink(path: bytes, dest: bytes, replace: bool = False):
     if os.path.exists(syspath(dest)) and not replace:
         raise FilesystemError("file exists", "rename", (path, dest))
     try:
-        os.link(syspath(path), syspath(dest))
+        # This step dereferences any symlinks and converts to an absolute path
+        resolved_origin = Path(syspath(path)).resolve()
+        os.link(resolved_origin, syspath(dest))
     except NotImplementedError:
         raise FilesystemError(
             "OS does not support hard links." "link",

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,10 @@ Bug fixes:
 * :doc:`plugins/fetchart`: Fix fetchart bug where a tempfile could not be deleted due to never being
   properly closed.
   :bug:`5521`
+* When hardlinking from a symlink (e.g. importing a symlink with hardlinking
+  enabled), dereference the symlink then hardlink, rather than creating a new
+  (potentially broken) symlink
+  :bug:`5676`
 * :doc:`plugins/lyrics`: LRCLib will fallback to plain lyrics if synced lyrics
   are not found and `synced` flag is set to `yes`.
 * Synchronise files included in the source distribution with what we used to

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -35,7 +35,8 @@ class MoveTest(BeetsTestCase):
         super().setUp()
 
         # make a temporary file
-        self.path = join(self.temp_dir, b"temp.mp3")
+        self.temp_music_file_name = b"temp.mp3"
+        self.path = join(self.temp_dir, self.temp_music_file_name)
         shutil.copy(
             syspath(join(_common.RSRC, b"full.mp3")),
             syspath(self.path),
@@ -198,6 +199,21 @@ class MoveTest(BeetsTestCase):
     def test_hardlink_changes_path(self):
         self.i.move(operation=MoveOperation.HARDLINK)
         assert self.i.path == util.normpath(self.dest)
+
+    @unittest.skipUnless(_common.HAVE_HARDLINK, "need hardlinks")
+    def test_hardlink_from_symlink(self):
+        link_path = join(self.temp_dir, b"temp_link.mp3")
+        link_source = join(b"./", self.temp_music_file_name)
+        os.symlink(syspath(link_source), syspath(link_path))
+        self.i.path = link_path
+        self.i.move(operation=MoveOperation.HARDLINK)
+
+        s1 = os.stat(syspath(self.path))
+        s2 = os.stat(syspath(self.dest))
+        assert (s1[stat.ST_INO], s1[stat.ST_DEV]) == (
+            s2[stat.ST_INO],
+            s2[stat.ST_DEV],
+        )
 
 
 class HelperTest(BeetsTestCase):


### PR DESCRIPTION
When creating a hardlink, either during import or `beet convert`, if the origin of the hardlink was a symlink, that symlink used to be directly copied.  This could create broken symlinks if the origin symlink was relative, and in either case, probably wasn't the user's desired behavior.

This change de-references all symlinks before creating a hardlink, such that the end result is a normal file with the same inode as the original file.  See #5676 for more discussion about the original issue.

Fixes #5676

- [X] ~~Documentation~~ (N/A)
- [X] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [X] Tests. (Very much encouraged but not strictly required.)
