### PR TITLE
library: add subtitle (id3 TIT3) field

### DIFF
--- a/beets/library/fields.py
+++ b/beets/library/fields.py
@@ -54,6 +54,7 @@ TYPE_BY_FIELD: dict[str, types.Type] = {
     "format": types.STRING,
     "genres": types.MULTI_VALUE_DSV,
     "grouping": types.STRING,
+    "subtitle": types.STRING,
     "id": types.PRIMARY_ID,
     "initial_key": types.MusicalKey(),
     "isrc": types.STRING,

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -642,6 +642,7 @@ class Item(LibModel):
         "encoder_settings",
         "format",
         "grouping",
+        "subtitle",
         "initial_key",
         "isrc",
         "length",

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,7 @@ New features
   ``albums_for_ids`` and ``tracks_for_ids``. It also enables search by query as
   well as identifier-based retrieval, with support for ISRC codes (tracks) and
   barcode/EANs (albums).
+- Add support for adding or modifying a subtitle (ID3 tag ``TIT3``) field
 
   This is an initial, relatively minimal implementation, but already fully
   usable for common metadata workflows. We welcome feedback, improvement ideas,

--- a/docs/reference/pathformat.rst
+++ b/docs/reference/pathformat.rst
@@ -241,6 +241,7 @@ Ordinary metadata:
 - lyricists: The track lyricists as a multi-valued field.
 - remixers: The track remixers as a multi-valued field.
 - grouping
+- subtitle
 - year, month, day: The release date of the specific release.
 - original_year, original_month, original_day: The release date of the original
   version of the album.


### PR DESCRIPTION
## Description

Adds support for a subtitle field, corresponding to the `TIT3` id3 tag. Requires beetbox/mediafile#82

I don't think tests are required for this - I can't really see a comprehensive test suite for all available fields - but I might be wrong.

I'll add the changelog entry after your review.

## To Do

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
