### PR TITLE
typing_extensions requirement inconsistency

### DIFF
--- a/beets/util/pipeline.py
+++ b/beets/util/pipeline.py
@@ -41,8 +41,7 @@ from typing import Callable, Generator, TypeVar
 if sys.version_info >= (3, 11):
     from typing import TypeVarTuple, Unpack
 else:
-    from typing_extensions import TypeVar, TypeVarTuple, Unpack
-
+    from typing_extensions import TypeVarTuple, Unpack
 
 BUBBLE = "__PIPELINE_BUBBLE__"
 POISON = "__PIPELINE_POISON__"

--- a/beets/util/pipeline.py
+++ b/beets/util/pipeline.py
@@ -36,9 +36,13 @@ from __future__ import annotations
 import queue
 import sys
 from threading import Lock, Thread
-from typing import Callable, Generator
+from typing import Callable, Generator, TypeVar
 
-from typing_extensions import TypeVar, TypeVarTuple, Unpack
+if sys.version_info >= (3, 11):
+    from typing import TypeVarTuple, Unpack
+else:
+    from typing_extensions import TypeVar, TypeVarTuple, Unpack
+
 
 BUBBLE = "__PIPELINE_BUBBLE__"
 POISON = "__PIPELINE_POISON__"


### PR DESCRIPTION
Typing Extensions is an optional requirement for `python>3.10`, thus
TypeVarTuple and Unpack need another import in higher python versions as `typing_extensions` is not available

see https://docs.python.org/3.10/library/typing.html for supported types

close #5695