### PR TITLE
Fix: Spotify plugin unable to find Chinese/Japanese albums

### DIFF
--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -26,7 +26,6 @@ import webbrowser
 
 import confuse
 import requests
-import unidecode
 
 from beets import ui
 from beets.autotag.hooks import AlbumInfo, TrackInfo

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -403,7 +403,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
         query = " ".join([q for q in query_components if q])
         if not isinstance(query, str):
             query = query.decode("utf8")
-        return unidecode.unidecode(query)
+        return query
 
     def _search_api(self, query_type, filters=None, keywords=""):
         """Query the Spotify Search API for the specified ``keywords``,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -78,6 +78,7 @@ Bug fixes:
   lyrics.
   :bug:`5583`
 * ImageMagick 7.1.1-44 is now supported.
+* :bug:`5699`: Spotify plugin now properly handles utf-8 characters in searches
 
 For packagers:
 


### PR DESCRIPTION
## Description

Removing the unicode.unidecode as it is not required for url param encoding. Maybe the spotify api changed throughout the years :shrug: 

close #5699

Tested the fix locally and the matches seem better:
```bash
(venv) (base) sebastian:/mnt/Repositories/beets$ beet import ./裘盛戎\ -\ 盗御马/ -t 
  Match (89.7%):
  裘盛戎 - 盗御马
  ≠ source, tracks
  Spotify, None, 2023, None, China Recording Group Co., Ltd, None, None
  https://open.spotify.com/album/6OoLtNfZXRCYJT0LKnG94P
  * Artist: 裘盛戎
  * Album: 盗御马
     * (#1) 盗御马（一） (3:02)
     * (#2) 盗御马（二） (3:21)
➜ [A]pply, More candidates, Skip, Use as-is, as Tracks, Group albums,
Enter search, enter Id, aBort, eDit, edit Candidates? B

```
vs old
```bash
(venv) (base) sebastian:/mnt/Repositories/beets$ beet import ./裘盛戎\ -\ 盗御马/ -t 
Finding tags for album "裘盛戎 - 盗御马".
  Candidates:
  1. (37.9%) 小倉唯 with ぷるぷるいゃ〜ん - 盗んだハートはココですよ?
             ≠ artist, album, tracks, ...
             MusicBrainz, Digital Media, 2010, JP, UP‐FRONT WORKS, None, None
  2. (33.2%) 裘德 - 荔枝
             ≠ album, tracks, artist, ...
             MusicBrainz, Digital Media, 2022, XW, 杭州网易云音乐科技有限公司, None, None
  3. (28.2%) 戎きあら - 君がいない世界に
             ≠ album, artist, tracks, ...
             MusicBrainz, CD, 2024, JP, BAKKY RECORDS, BAKKY-204, None
  4. (18.6%) 裘盛戎, 高盛麟 & 萧长华 - Zhōng guó xì qǔ míng jiā míng xì jīng jù: Luò mǎ hú (xuǎn chǎng) Lián huán tào (xuǎn chǎng)
             ≠ album, missing tracks, tracks, ...
             MusicBrainz, 2xCD, 2005, CN, 北京中唱时代音像出版有限公司, ACD-097, None
  5. (18.2%) 裘盛戎, 高盛麟 & 萧长华 - 中国戏曲名家名戏 京剧：落马湖（选场） 连环套（选场）
             ≠ album, missing tracks, tracks, ...
             MusicBrainz, 2xCD, 2005, CN, 北京中唱时代音像出版有限公司, ACD-097, None
➜ # selection (default 1), Skip, Use as-is, as Tracks, Group albums,
Enter search, enter Id, aBort, eDit, edit Candidates? B
```

- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
