### PR TITLE
plugins/thumbnails: fix FFI with GIO on s390x

### DIFF
--- a/beetsplug/thumbnails.py
+++ b/beetsplug/thumbnails.py
@@ -246,7 +246,7 @@ class GioURI(URIGetter):
         if self.available:
             self.libgio.g_type_init()  # for glib < 2.36
 
-            self.libgio.g_file_get_uri.argtypes = [ctypes.c_char_p]
+            self.libgio.g_file_new_for_path.argtypes = [ctypes.c_char_p]
             self.libgio.g_file_new_for_path.restype = ctypes.c_void_p
 
             self.libgio.g_file_get_uri.argtypes = [ctypes.c_void_p]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,8 @@ New features:
 
 Bug fixes:
 
+* Fix API call to GIO on big endian architectures (like s390x) in thumbnails plugin.
+  :bug:`5708`
 * :doc:`plugins/listenbrainz`: Fix rST formatting for URLs of Listenbrainz API Key documentation and config.yaml.
 * :doc:`plugins/listenbrainz`: Fix ``UnboundLocalError`` in cases where 'mbid' is not defined.
 * :doc:`plugins/fetchart`: Fix fetchart bug where a tempfile could not be deleted due to never being

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,7 +24,8 @@ New features:
 
 Bug fixes:
 
-* Fix API call to GIO on big endian architectures (like s390x) in thumbnails plugin.
+* :doc:`plugins/thumbnails`: Fix API call to GIO on big endian architectures
+  (like s390x) in thumbnails plugin.
   :bug:`5708`
 * :doc:`plugins/listenbrainz`: Fix rST formatting for URLs of Listenbrainz API Key documentation and config.yaml.
 * :doc:`plugins/listenbrainz`: Fix ``UnboundLocalError`` in cases where 'mbid' is not defined.

--- a/test/plugins/test_thumbnails.py
+++ b/test/plugins/test_thumbnails.py
@@ -265,7 +265,10 @@ class ThumbnailsTest(BeetsTestCase):
         if not gio.available:
             self.skipTest("GIO library not found")
 
-        assert gio.uri("/foo") == "file:///"  # silent fail
+        import ctypes
+
+        with pytest.raises(ctypes.ArgumentError):
+            gio.uri("/foo")
         assert gio.uri(b"/foo") == "file:///foo"
         assert gio.uri(b"/foo!") == "file:///foo!"
         assert (


### PR DESCRIPTION
## Description

Using the correct function signature for g_file_new_for_path fixes the tests on s390x.
I do not have the full story on why this failed consistently only on s390x, but I guess the big endian might have something to play with this.

Here is how the tests were failing:
```
169s ___________________________ ThumbnailsTest.test_uri ____________________________
169s
169s self = <test.plugins.test_thumbnails.ThumbnailsTest testMethod=test_uri>
169s
169s     def test_uri(self):
169s         gio = GioURI()
169s         if not gio.available:
169s             self.skipTest("GIO library not found")
169s
169s >       assert gio.uri("/foo") == "file:///"  # silent fail
169s E       AssertionError: assert '' == 'file:///'
169s E
169s E         - file:///
169s
169s test/plugins/test_thumbnails.py:268: AssertionError
```
You can see a full log here [1] and a history of consistent failure here [2]. Both links are bound to expire at some point, sorry future archeologist 🤷.

[1]: https://autopkgtest.ubuntu.com/results/autopkgtest-plucky/plucky/s390x/b/beets/20250403_162414_5d1da@/log.gz#S5
[2]: https://autopkgtest.ubuntu.com/packages/beets/plucky/s390x


## To Do

- Discuss the behavior in case a string is passed. I've currently updated the test to reflect the exception being raised, but I did not do a thorough check of the code to know if that exception would need to be caught elsewhere in the code, or if that API might be used externally.
