### PR TITLE
feat: plugins/web: use media session api for notifications.

### DIFF
--- a/beetsplug/web/static/beets.js
+++ b/beetsplug/web/static/beets.js
@@ -266,13 +266,35 @@ var AppView = Backbone.View.extend({
     playItem: function(item) {
         var url = 'item/' + item.get('id') + '/file';
         $('#player audio').attr('src', url);
-        $('#player audio').get(0).play();
+        $('#player audio').get(0).play().then(() => {
+            this.updateMediaSession(item);
+        });
 
         if (this.playingItem != null) {
             this.playingItem.entryView.setPlaying(false);
         }
         item.entryView.setPlaying(true);
         this.playingItem = item;
+    },
+
+    updateMediaSession: function (item) {
+      if ("mediaSession" in navigator) {
+        album_id = item.get("album_id");
+        album_art_url = "album/" + album_id + "/art";
+        navigator.mediaSession.metadata = new MediaMetadata({
+          title: item.get("title"),
+          artist: item.get("artist"),
+          album: item.get("album"),
+          artwork: [
+            { src: album_art_url, sizes: "96x96" },
+            { src: album_art_url, sizes: "128x128" },
+            { src: album_art_url, sizes: "192x192" },
+            { src: album_art_url, sizes: "256x256" },
+            { src: album_art_url, sizes: "384x384" },
+            { src: album_art_url, sizes: "512x512" },
+          ],
+        });
+      }
     },
 
     audioPause: function() {

--- a/beetsplug/web/static/beets.js
+++ b/beetsplug/web/static/beets.js
@@ -280,7 +280,7 @@ var AppView = Backbone.View.extend({
     updateMediaSession: function (item) {
       if ("mediaSession" in navigator) {
         const album_id = item.get("album_id");
-        album_art_url = "album/" + album_id + "/art";
+        const album_art_url = "album/" + album_id + "/art";
         navigator.mediaSession.metadata = new MediaMetadata({
           title: item.get("title"),
           artist: item.get("artist"),

--- a/beetsplug/web/static/beets.js
+++ b/beetsplug/web/static/beets.js
@@ -279,7 +279,7 @@ var AppView = Backbone.View.extend({
 
     updateMediaSession: function (item) {
       if ("mediaSession" in navigator) {
-        album_id = item.get("album_id");
+        const album_id = item.get("album_id");
         album_art_url = "album/" + album_id + "/art";
         navigator.mediaSession.metadata = new MediaMetadata({
           title: item.get("title"),

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,9 @@ Unreleased
 
 New features:
 
+* :doc:`plugins/web`: Show notifications when a track plays. This uses the
+  Media Session API to customize media notifications.
+
 Bug fixes:
 
 For packagers:


### PR DESCRIPTION
## Description

The Media Session API provides a way to customize media notifications. This PR has commits that, in summary, updates the metadata for the media session whenever a new track (item) starts playing.

https://developer.mozilla.org/en-US/docs/Web/API/Media_Session_API

- [x] ~Documentation.~ (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog.
- [x] ~Tests.~
