### PR TITLE
Parallelize several built-in plugin operations

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -904,6 +904,8 @@ class Item(LibModel):
         `move` controls whether the path should be updated. In the
         latter case, files are *only* moved when they are inside their
         library's directory (if any).
+        `with_album` controls whether the album should also be updated when the
+        item is moved.
 
         Similar to calling :meth:`write`, :meth:`move`, and :meth:`store`
         (conditionally).
@@ -1713,7 +1715,7 @@ class Library(dbcore.Database):
 
     # Convenience accessors.
 
-    def get_item(self, id):
+    def get_item(self, id: int) -> Item | None:
         """Fetch a :class:`Item` by its ID.
 
         Return `None` if no match is found.

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -177,6 +177,10 @@ def should_move(move_opt=None):
     )
 
 
+def threaded():
+    """Decide whether to run commands in parallel."""
+    return config["threaded"].get(bool)
+
 # Input prompts.
 
 

--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -124,8 +124,9 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
                         return True
                     return False
 
+            ui.print_("Querying database for songs to process...")
             items = lib.items(ui.decargs(args))
-            with ThreadPool() as pool:
+            with ThreadPool(processes = None if ui.threaded() else 1) as pool:
                 self._log.debug("Processing {:d} items in a thread pool.", len(items))
                 updated = 0
                 for update in pool.imap_unordered(operation, items):

--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -15,8 +15,11 @@
 """Moves "featured" artists to the title from the artist field."""
 
 import re
+from multiprocessing.pool import ThreadPool
 
 from beets import plugins, ui
+from beets import library
+from beets.library import Library
 from beets.util import displayable_path
 
 
@@ -104,17 +107,30 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
             self.import_stages = [self.imported]
 
     def commands(self):
-        def func(lib, opts, args):
+        def func(lib: library.Library, opts, args):
             self.config.set_args(opts)
             drop_feat = self.config["drop"].get(bool)
             keep_in_artist_field = self.config["keep_in_artist"].get(bool)
             write = ui.should_write()
+            move = ui.should_move()
 
-            for item in lib.items(ui.decargs(args)):
-                self.ft_in_title(item, drop_feat, keep_in_artist_field)
-                item.store()
-                if write:
-                    item.try_write()
+            def operation(item: library.Item) -> bool:
+                with lib.transaction():
+                    item = lib.get_item(item.id)
+                    old = item.copy()
+                    if self.ft_in_title(item, drop_feat, keep_in_artist_field):
+                        ui.show_model_changes(item, old=old)
+                        item.try_sync(write, move, with_album=False)
+                        return True
+                    return False
+
+            items = lib.items(ui.decargs(args))
+            with ThreadPool() as pool:
+                self._log.debug("Processing {:d} items in a thread pool.", len(items))
+                updated = 0
+                for update in pool.imap_unordered(operation, items):
+                    updated += 1 if update else 0
+                self._log.debug("Updated {:d} items.", updated)
 
         self._command.func = func
         return [self._command]
@@ -136,11 +152,11 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
         """
         # In case the artist is kept, do not update the artist fields.
         if keep_in_artist_field:
-            self._log.info(
+            self._log.debug(
                 "artist: {0} (Not changing due to keep_in_artist)", item.artist
             )
         else:
-            self._log.info("artist: {0} -> {1}", item.artist, item.albumartist)
+            self._log.debug("artist: {0} -> {1}", item.artist, item.albumartist)
             item.artist = item.albumartist
 
         if item.artist_sort:
@@ -153,12 +169,15 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
             feat_format = self.config["format"].as_str()
             new_format = feat_format.format(feat_part)
             new_title = f"{item.title} {new_format}"
-            self._log.info("title: {0} -> {1}", item.title, new_title)
+            self._log.debug("title: {0} -> {1}", item.title, new_title)
             item.title = new_title
 
-    def ft_in_title(self, item, drop_feat, keep_in_artist_field):
+    def ft_in_title(self, item, drop_feat, keep_in_artist_field) -> bool:
         """Look for featured artists in the item's artist fields and move
         them to the title.
+
+        Returns:
+            True if the title was updated, False otherwise.
         """
         artist = item.artist.strip()
         albumartist = item.albumartist.strip()
@@ -168,8 +187,6 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
         # that case, we attempt to move the featured artist to the title.
         _, featured = split_on_feat(artist)
         if featured and albumartist != artist and albumartist:
-            self._log.info("{}", displayable_path(item.path))
-
             feat_part = None
 
             # Attempt to find the featured artist.
@@ -180,5 +197,6 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
                 self.update_metadata(
                     item, feat_part, drop_feat, keep_in_artist_field
                 )
-            else:
-                self._log.info("no featuring artists found")
+                return True
+
+        return False

--- a/beetsplug/mbsync.py
+++ b/beetsplug/mbsync.py
@@ -211,12 +211,12 @@ class MBSyncPlugin(BeetsPlugin):
                 return operation(a)
     
         # Process matching albums.
-        self._log.debug("Querying database for albums to process.")
+        ui.print_("Querying database for albums to process...")
         albums = lib.albums(query)
 
         self._log.debug("Processing {:d} albums.", len(albums))
         updated = 0
-        with ThreadPool() as pool:
+        with ThreadPool(processes = None if ui.threaded() else 1) as pool:
             for update in pool.imap_unordered(trans_operation, albums):
                 updated += 1 if update else 0
         self._log.debug("Updated {:d} albums.", updated)

--- a/beetsplug/mbsync.py
+++ b/beetsplug/mbsync.py
@@ -16,6 +16,7 @@
 
 import re
 from collections import defaultdict
+from multiprocessing.pool import ThreadPool
 
 from beets import autotag, library, ui, util
 from beets.autotag import hooks
@@ -107,18 +108,22 @@ class MBSyncPlugin(BeetsPlugin):
                 autotag.apply_item_metadata(item, track_info)
                 apply_item_changes(lib, item, move, pretend, write)
 
-    def albums(self, lib, query, move, pretend, write):
+    def albums(self, lib: library.Library, query, move, pretend, write):
         """Retrieve and apply info from the autotagger for albums matched by
         query and their items.
-        """
-        # Process matching albums.
-        for a in lib.albums(query):
+        """ 
+        def operation(a: library.Album) -> bool:
+            """Apply MusicBrainz metadata to an album and its items.
+            
+            Returns:
+                True if the album was updated, False otherwise.
+            """
             album_formatted = format(a)
             if not a.mb_albumid:
                 self._log.info(
                     "Skipping album with no mb_albumid: {0}", album_formatted
                 )
-                continue
+                return False
 
             items = list(a.items())
 
@@ -128,7 +133,7 @@ class MBSyncPlugin(BeetsPlugin):
                     "Skipping album with invalid mb_albumid: {0}",
                     album_formatted,
                 )
-                continue
+                return False
 
             # Get the MusicBrainz album information.
             album_info = hooks.album_for_mbid(a.mb_albumid)
@@ -138,7 +143,7 @@ class MBSyncPlugin(BeetsPlugin):
                     a.mb_albumid,
                     album_formatted,
                 )
-                continue
+                return False
 
             # Map release track and recording MBIDs to their information.
             # Recordings can appear multiple times on a release, so each MBID
@@ -176,29 +181,42 @@ class MBSyncPlugin(BeetsPlugin):
 
             # Apply.
             self._log.debug("applying changes to {}", album_formatted)
+            autotag.apply_metadata(album_info, mapping)
+            changed = False
+            any_changed_item = items[0]
+            for item in items:
+                item_changed = ui.show_model_changes(item)
+                changed |= item_changed
+                if item_changed:
+                    any_changed_item = item
+                    apply_item_changes(lib, item, move, pretend, write)
+
+            if changed and not pretend:
+                # Update album structure to reflect an item in it.
+                for key in library.Album.item_keys:
+                    a[key] = any_changed_item[key]
+                a.try_sync(write, move)
+                return True
+            
+            return False
+        
+        def trans_operation(a: library.Album) -> bool:
+            """Apply MusicBrainz metadata to an album and its items within a transaction.
+            
+            Returns:
+                True if the album was updated, False otherwise.
+            """
             with lib.transaction():
-                autotag.apply_metadata(album_info, mapping)
-                changed = False
-                # Find any changed item to apply MusicBrainz changes to album.
-                any_changed_item = items[0]
-                for item in items:
-                    item_changed = ui.show_model_changes(item)
-                    changed |= item_changed
-                    if item_changed:
-                        any_changed_item = item
-                        apply_item_changes(lib, item, move, pretend, write)
+                a = lib.get_album(a.id)
+                return operation(a)
+    
+        # Process matching albums.
+        self._log.debug("Querying database for albums to process.")
+        albums = lib.albums(query)
 
-                if not changed:
-                    # No change to any item.
-                    continue
-
-                if not pretend:
-                    # Update album structure to reflect an item in it.
-                    for key in library.Album.item_keys:
-                        a[key] = any_changed_item[key]
-                    a.store()
-
-                    # Move album art (and any inconsistent items).
-                    if move and lib.directory in util.ancestry(items[0].path):
-                        self._log.debug("moving album {0}", album_formatted)
-                        a.move()
+        self._log.debug("Processing {:d} albums.", len(albums))
+        updated = 0
+        with ThreadPool() as pool:
+            for update in pool.imap_unordered(trans_operation, albums):
+                updated += 1 if update else 0
+        self._log.debug("Updated {:d} albums.", updated)


### PR DESCRIPTION
## Description

Fixes #X.  <!-- Insert issue number here if applicable. -->

Several built-in plugins' operations can be parallelized, as they operate on albums or tracks individually, thus avoiding any race or synchronization issues. Thus, we can safely parallelize them with the Python multiprocessing libraries. This PR introduces parallelism to the ftintitle command.

On testing, the mbsync command does not gain any significant performance, as it is limited not by processing or database operations, but by the rate-limited requests made to the Musicbrainz backend.

FtInTitle, on the other hand, gains a substantial improvement, going from 2 titles / second to 200-2000 titles / second on a computer with 32 cores.

## To Do

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
