### PR TITLE
Ftintitle typing

### DIFF
--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -188,21 +188,22 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
         # Check whether there is a featured artist on this track and the
         # artist field does not exactly match the album artist field. In
         # that case, we attempt to move the featured artist to the title.
+        if not albumartist or albumartist == artist:
+            return False
+
         _, featured = split_on_feat(artist)
-        if featured and albumartist != artist and albumartist:
-            self._log.info("{}", displayable_path(item.path))
+        if not featured:
+            return False
 
-            feat_part = None
+        self._log.info("{}", displayable_path(item.path))
 
-            # Attempt to find the featured artist.
-            feat_part = find_feat_part(artist, albumartist)
+        # Attempt to find the featured artist.
+        feat_part = find_feat_part(artist, albumartist)
 
-            # If we have a featuring artist, move it to the title.
-            if feat_part:
-                self.update_metadata(
-                    item, feat_part, drop_feat, keep_in_artist_field
-                )
-                return True
-            else:
-                self._log.info("no featuring artists found")
-        return False
+        if not feat_part:
+            self._log.info("no featuring artists found")
+            return False
+
+        # If we have a featuring artist, move it to the title.
+        self.update_metadata(item, feat_part, drop_feat, keep_in_artist_field)
+        return True

--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -14,13 +14,20 @@
 
 """Moves "featured" artists to the title from the artist field."""
 
+from __future__ import annotations
+
 import re
+from typing import TYPE_CHECKING
 
 from beets import plugins, ui
 from beets.util import displayable_path
 
+if TYPE_CHECKING:
+    from beets.importer import ImportSession, ImportTask
+    from beets.library import Item
 
-def split_on_feat(artist):
+
+def split_on_feat(artist: str) -> tuple[str, str | None]:
     """Given an artist string, split the "main" artist from any artist
     on the right-hand side of a string like "feat". Return the main
     artist, which is always a string, and the featuring artist, which
@@ -28,14 +35,15 @@ def split_on_feat(artist):
     """
     # split on the first "feat".
     regex = re.compile(plugins.feat_tokens(), re.IGNORECASE)
-    parts = [s.strip() for s in regex.split(artist, 1)]
+    parts = tuple(s.strip() for s in regex.split(artist, 1))
     if len(parts) == 1:
         return parts[0], None
     else:
-        return tuple(parts)
+        assert len(parts) == 2  # help mypy out
+        return parts
 
 
-def contains_feat(title):
+def contains_feat(title: str) -> bool:
     """Determine whether the title contains a "featured" marker."""
     return bool(
         re.search(
@@ -46,7 +54,7 @@ def contains_feat(title):
     )
 
 
-def find_feat_part(artist, albumartist):
+def find_feat_part(artist: str, albumartist: str) -> str | None:
     """Attempt to find featured artists in the item's artist fields and
     return the results. Returns None if no featured artist found.
     """
@@ -75,7 +83,7 @@ def find_feat_part(artist, albumartist):
 
 
 class FtInTitlePlugin(plugins.BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
         self.config.add(
@@ -103,7 +111,7 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
         if self.config["auto"]:
             self.import_stages = [self.imported]
 
-    def commands(self):
+    def commands(self) -> list[ui.Subcommand]:
         def func(lib, opts, args):
             self.config.set_args(opts)
             drop_feat = self.config["drop"].get(bool)
@@ -119,7 +127,7 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
         self._command.func = func
         return [self._command]
 
-    def imported(self, session, task):
+    def imported(self, session: ImportSession, task: ImportTask) -> None:
         """Import hook for moving featuring artist automatically."""
         drop_feat = self.config["drop"].get(bool)
         keep_in_artist_field = self.config["keep_in_artist"].get(bool)
@@ -128,7 +136,13 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
             if self.ft_in_title(item, drop_feat, keep_in_artist_field):
                 item.store()
 
-    def update_metadata(self, item, feat_part, drop_feat, keep_in_artist_field):
+    def update_metadata(
+        self,
+        item: Item,
+        feat_part: str,
+        drop_feat: bool,
+        keep_in_artist_field: bool,
+    ) -> None:
         """Choose how to add new artists to the title and set the new
         metadata. Also, print out messages about any changes that are made.
         If `drop_feat` is set, then do not add the artist to the title; just
@@ -156,7 +170,12 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
             self._log.info("title: {0} -> {1}", item.title, new_title)
             item.title = new_title
 
-    def ft_in_title(self, item, drop_feat, keep_in_artist_field) -> bool:
+    def ft_in_title(
+        self,
+        item: Item,
+        drop_feat: bool,
+        keep_in_artist_field: bool,
+    ) -> bool:
         """Look for featured artists in the item's artist fields and move
         them to the title.
 


### PR DESCRIPTION
Due to reviewing #5718, I was looking at the `ftintitle` plugin (which I'm otherwise not familiar with). Given that it is simple enough, I quickly added typings. The second commit adds a refactoring that flattens the logic in the core `ft_in_title` function, motivated by the fact that I found this more difficult to read than necessary during the review.