### PR TITLE
Add art:true/false album query to detect embedded cover art

### DIFF
--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -1052,3 +1052,13 @@ class SmartArtistSort(FieldSort):
             return val.lower() if self.case_insensitive else val
 
         return sorted(objs, key=key, reverse=not self.ascending)
+
+
+from beets.dbcore.query import FieldQuery, BooleanQuery
+from beets import util
+
+class ArtQuery(FieldQuery):
+    """Query that matches albums with or without embedded art."""
+    def __new__(cls, field, pattern, *args, **kwargs):
+        val = util.str2bool(pattern)
+        return BooleanQuery(field, val, *args, **kwargs)

--- a/beets/importer.py
+++ b/beets/importer.py
@@ -30,6 +30,8 @@ from dataclasses import dataclass
 from enum import Enum
 from tempfile import mkdtemp
 from typing import Callable, Iterable, Sequence
+from mediafile import MediaFile
+from beets.util import syspath
 
 import mediafile
 
@@ -875,7 +877,15 @@ class ImportTask(BaseImportTask):
             self.record_replaced(lib)
             self.remove_replaced(lib)
 
-            self.album = lib.add_album(self.imported_items())
+	    # Detect embedded album art across imported items
+            has_art = False
+            for item in self.imported_items():
+                mf = MediaFile(syspath(item.path))
+                if mf.art:
+                    has_art = True
+                    break
+
+            self.album = lib.add_album(self.imported_items(), art=has_art)
             if self.choice_flag == action.APPLY and isinstance(
                 self.match, autotag.AlbumMatch
             ):


### PR DESCRIPTION
Adds support for a new `art:true` / `art:false` album-level query that allows users to filter albums based on whether they contain embedded cover art in their audio files.

- Adds a new `art` boolean field to the Album model
- Detects embedded art using `MediaFile.art` during import
- Persists the field in the library database
- Registers a custom `ArtQuery` so users can run CLI queries
- Example usage: `beet ls -a art:true`

This feature improves the usability of beets for users who embed artwork directly into music files and want to better manage or detect it.
