### PR TITLE
Stricter mypy config

### DIFF
--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -35,12 +35,11 @@ import mediafile
 
 import beets
 from beets import logging
-from beets.autotag import Distance
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from beets.autotag import AlbumInfo, TrackInfo
+    from beets.autotag import AlbumInfo, Distance, TrackInfo
     from beets.dbcore import Query
     from beets.library import Item
     from beets.ui import Subcommand
@@ -177,6 +176,8 @@ class BeetsPlugin:
         """Should return a Distance object to be added to the
         distance for every track comparison.
         """
+        from beets.autotag.hooks import Distance
+
         return Distance()
 
     def album_distance(
@@ -188,6 +189,8 @@ class BeetsPlugin:
         """Should return a Distance object to be added to the
         distance for every album-level comparison.
         """
+        from beets.autotag.hooks import Distance
+
         return Distance()
 
     def candidates(
@@ -651,6 +654,8 @@ def get_distance(config, data_source, info) -> Distance:
     """Returns the ``data_source`` weight and the maximum source weight
     for albums or individual tracks.
     """
+    from beets.autotag.hooks import Distance
+
     dist = Distance()
     if info.data_source == data_source:
         dist.add("source", config["source_weight"].as_number())

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -28,7 +28,6 @@ from typing import (
     Callable,
     Generic,
     Sequence,
-    Type,
     TypedDict,
     TypeVar,
 )
@@ -37,6 +36,7 @@ import mediafile
 
 import beets
 from beets import logging
+from beets.library import Album, Item, Library
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -45,7 +45,6 @@ if TYPE_CHECKING:
 
     from beets.autotag import AlbumInfo, Distance, TrackInfo
     from beets.dbcore import Query
-    from beets.library import Album, Item, Library
     from beets.ui import Subcommand
 
 
@@ -350,7 +349,6 @@ def load_plugins(names: Sequence[str] = ()):
             )
 
 
-
 _instances: dict[type[BeetsPlugin], BeetsPlugin] = {}
 
 
@@ -466,7 +464,6 @@ def item_candidates(item: Item, artist: str, title: str) -> Iterable[TrackInfo]:
     """Gets MusicBrainz candidates for an item from the plugins."""
     for plugin in find_plugins():
         yield from plugin.item_candidates(item, artist, title)
-
 
 
 def album_for_id(_id: str) -> AlbumInfo | None:

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -36,7 +36,6 @@ import mediafile
 
 import beets
 from beets import logging
-from beets.library import Album, Item, Library
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -45,6 +44,7 @@ if TYPE_CHECKING:
 
     from beets.autotag import AlbumInfo, Distance, TrackInfo
     from beets.dbcore import Query
+    from beets.library import Album, Item, Library
     from beets.ui import Subcommand
 
 
@@ -520,7 +520,11 @@ def import_stages():
 
 
 # New-style (lazy) plugin-provided fields.
-F = TypeVar("F", Callable[[Item], str], Callable[[Album], str])
+
+if (
+    TYPE_CHECKING
+):  # Needed because Item, Album circular introduce circular import
+    F = TypeVar("F", Callable[[Item], str], Callable[[Album], str])
 
 
 def _check_conflicts_and_merge(

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
 
     from beets.autotag import AlbumInfo, Distance, TrackInfo
     from beets.dbcore import Query
+    from beets.importer import ImportSession, ImportTask
     from beets.library import Album, Item, Library
     from beets.ui import Subcommand
 
@@ -96,6 +97,8 @@ class BeetsPlugin:
 
     name: str
     config: ConfigView
+    early_import_stages: list[Callable[[ImportSession, ImportTask], None]]
+    import_stages: list[Callable[[ImportSession, ImportTask], None]]
 
     def __init__(self, name: str | None = None):
         """Perform one-time plugin setup."""
@@ -584,7 +587,7 @@ def send(event: str, **arguments: Any) -> list[Any]:
     Return a list of non-None values returned from the handlers.
     """
     log.debug("Sending event: {0}", event)
-    results = []
+    results: list[Any] = []
     for handler in event_handlers()[event]:
         result = handler(**arguments)
         if result is not None:

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -82,8 +82,6 @@ class PluginLogFilter(logging.Filter):
         return True
 
 
-# Typing for listeners, we are not too sure about the
-# kwargs and args here, depends on the plugin
 Listener = Callable[..., None]
 
 
@@ -521,9 +519,8 @@ def import_stages():
 
 # New-style (lazy) plugin-provided fields.
 
-if (
-    TYPE_CHECKING
-):  # Needed because Item, Album circular introduce circular import
+if TYPE_CHECKING:
+    # Needed because Item, Album circular introduce circular import
     F = TypeVar("F", Callable[[Item], str], Callable[[Album], str])
 
 
@@ -578,7 +575,7 @@ def event_handlers() -> dict[str, list[Listener]]:
     return all_handlers
 
 
-def send(event: str, **arguments: Any):
+def send(event: str, **arguments: Any) -> list[Any]:
     """Send an event to all assigned event listeners.
 
     `event` is the name of  the event to send, all other named arguments

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -91,10 +91,10 @@ Other changes:
   wrong (outdated) commit. Now the tag is created in the same workflow step
   right after committing the version update.
   :bug:`5539`
-* Added some typehints: ImportSession and Pipeline have typehints now. Should
-  improve useability for new developers.
 * :doc:`/plugins/smartplaylist`: URL-encode additional item `fields` within generated
   EXTM3U playlists instead of JSON-encoding them.
+* typehints: `./beets/importer.py` file now has improved typehints. 
+* typehints: `./beets/plugins.py` file now includes typehints. 
 
 2.2.0 (December 02, 2024)
 -------------------------

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -367,7 +367,7 @@ Here's an example::
             super().__init__()
             self.template_funcs['initial'] = _tmpl_initial
 
-    def _tmpl_initial(text:str) -> str:
+    def _tmpl_initial(text: str) -> str:
         if text:
             return text[0].upper()
         else:

--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -367,7 +367,7 @@ Here's an example::
             super().__init__()
             self.template_funcs['initial'] = _tmpl_initial
 
-    def _tmpl_initial(text):
+    def _tmpl_initial(text:str) -> str:
         if text:
             return text[0].upper()
         else:
@@ -387,7 +387,7 @@ Here's an example that adds a ``$disc_and_track`` field::
             super().__init__()
             self.template_fields['disc_and_track'] = _tmpl_disc_and_track
 
-    def _tmpl_disc_and_track(item):
+    def _tmpl_disc_and_track(item: Item) -> str:
         """Expand to the disc number and track number if this is a
         multi-disc release. Otherwise, just expands to the track
         number.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -281,3 +281,13 @@ ignore-variadic-names = true
 [tool.ruff.lint.pep8-naming]
 classmethod-decorators = ["cached_classproperty"]
 extend-ignore-names = ["assert*", "cached_classproperty"]
+
+[tool.mypy]
+disallow_untyped_decorators = true
+check_untyped_defs = true
+disallow_any_generics = true
+strict_optional = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+warn_return_any = true
+allow_redefinition = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -283,11 +283,8 @@ classmethod-decorators = ["cached_classproperty"]
 extend-ignore-names = ["assert*", "cached_classproperty"]
 
 [tool.mypy]
-disallow_untyped_decorators = true
-check_untyped_defs = true
-disallow_any_generics = true
-strict_optional = true
-disallow_incomplete_defs = true
-disallow_untyped_defs = true
-warn_return_any = true
 allow_redefinition = true
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_any_generics = true
+disallow_untyped_decorators = true


### PR DESCRIPTION
## Description

Since we are working a lot on type hints at the moment, how about we review the available [mypy configuration options](https://mypy.readthedocs.io/en/stable/config_file.html) and decide on a standard setup going forward?

This is meant as a discussion to align on which settings we want to adopt to improve our code quality, type safety, and overall developer experience.

---

## Proposal

I propose enabling the following options:

### [`allow_redefinition = true`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-allow_redefinition)
- **Why**: This allows reassigning or shadowing a name with a different type within a function or scope. It’s helpful for code clarity, especially in cases like variable narrowing or reusing loop variables.
- **Example**:
  ```python
  x: int = 1
  x: str = "foo"  # Without this flag, mypy would complain
  ```

### [`check_untyped_defs = true`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-check_untyped_defs)
- **Why**: This tells mypy to check the bodies of functions even if they don’t have type annotations. It helps catch errors early, even in partially typed code.
- **Impact**: Encourages typing functions over time while still providing coverage for legacy code.

### [`disallow_incomplete_defs = true`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-disallow_incomplete_defs)
- **Why**: Disallows defining functions with partial type annotations (including arguments). This enforces consistency and helps ensure that function if they are typed, are typed fully.
- **Example**:
  ```python
  def f(x : int, y):  # This would error without a type for y and return type
      ...
  ```

### [`disallow_any_generics = true`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-disallow_any_generics)
- **Why**: Requires specifying type parameters for generic types like `List`, `Dict`, etc. Avoids untyped containers which can mask bugs or make type inference harder.
- **Example**:
  ```python
  x: list = []  # Error
  x: list[int] = []  # OK
  ```

### [`disallow_untyped_decorators = true`](https://mypy.readthedocs.io/en/stable/config_file.html#confval-disallow_untyped_decorators)
- **Why**: Ensures that decorators are properly typed. Untyped decorators can cause the function they decorate to become untyped too, making it harder for mypy to validate code.
- **Impact**: Should help with typing pipelines where we heavily use decorators.

---

Me can even go stricter (e.g. `disallow_untyped_calls`, `warn_unused_ignores`) or more lenient (e.g. leave `check_untyped_defs` off). I think the proposed setup strikes a good balance between safety and practicality.

Would love to hear thoughts or additions!
