### PR TITLE
plugins: ensure to log the offending plugin on instantiation failure

### DIFF
--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -356,32 +356,30 @@ def load_plugins(names: Sequence[str] = ()) -> None:
     """
     for name in names:
         modname = f"{PLUGIN_NAMESPACE}.{name}"
-        try:
-            try:
-                namespace = __import__(modname, None, None)
-            except ImportError as exc:
-                # Again, this is hacky:
-                if exc.args[0].endswith(" " + name):
-                    log.warning("** plugin {0} not found", name)
-                else:
-                    raise
-            else:
-                for obj in getattr(namespace, name).__dict__.values():
-                    if (
-                        isinstance(obj, type)
-                        and issubclass(obj, BeetsPlugin)
-                        and obj != BeetsPlugin
-                        and obj != MetadataSourcePlugin
-                        and obj not in _classes
-                    ):
-                        _classes.add(obj)
 
-        except Exception:
-            log.warning(
-                "** error loading plugin {}:\n{}",
-                name,
-                traceback.format_exc(),
-            )
+        try:
+            namespace = __import__(modname, None, None)
+        except ImportError as exc:
+            # Again, this is hacky:
+            if exc.args[0].endswith(" " + name):
+                log.warning("** plugin {0} not found", name)
+            else:
+                log.warning(
+                    "** error loading plugin {}:\n{}",
+                    name,
+                    traceback.format_exc(),
+                )
+            continue
+
+        for obj in getattr(namespace, name).__dict__.values():
+            if (
+                isinstance(obj, type)
+                and issubclass(obj, BeetsPlugin)
+                and obj != BeetsPlugin
+                and obj != MetadataSourcePlugin
+                and obj not in _classes
+            ):
+                _classes.add(obj)
 
 
 _instances: dict[type[BeetsPlugin], BeetsPlugin] = {}

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -402,7 +402,15 @@ def find_plugins() -> list[BeetsPlugin]:
     for cls in _classes:
         # Only instantiate each plugin class once.
         if cls not in _instances:
-            _instances[cls] = cls()
+            try:
+                _instances[cls] = cls()
+            except Exception:
+                log.error(
+                    "failed to initialize plugin class {}.{}",
+                    cls.__module__,
+                    cls.__qualname__,
+                )
+                raise
         plugins.append(_instances[cls])
     return plugins
 

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -391,7 +391,6 @@ def find_plugins() -> list[BeetsPlugin]:
         # See https://github.com/beetbox/beets/pull/3810
         return list(_instances.values())
 
-    load_plugins()
     plugins = []
     for cls in _classes:
         # Only instantiate each plugin class once.

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -359,16 +359,15 @@ def load_plugins(names: Sequence[str] = ()) -> None:
 
         try:
             namespace = __import__(modname, None, None)
-        except ImportError as exc:
-            # Again, this is hacky:
-            if exc.args[0].endswith(" " + name):
-                log.warning("** plugin {0} not found", name)
-            else:
-                log.warning(
-                    "** error loading plugin {}:\n{}",
-                    name,
-                    traceback.format_exc(),
-                )
+        except ModuleNotFoundError:
+            log.warning("** plugin {} not found", name)
+            continue
+        except ImportError:
+            log.warning(
+                "** error loading plugin {}:\n{}",
+                name,
+                traceback.format_exc(),
+            )
             continue
 
         for obj in getattr(namespace, name).__dict__.values():

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -487,7 +487,6 @@ class PluginMixin(ConfigMixin):
         for plugin_class in beets.plugins._instances:
             plugin_class.listeners = None
         self.config["plugins"] = []
-        beets.plugins._classes = set()
         beets.plugins._instances = {}
         Item._types = self.original_item_types
         Album._types = self.original_album_types

--- a/test/rsrc/beetsplug/broken.py
+++ b/test/rsrc/beetsplug/broken.py
@@ -1,0 +1,8 @@
+from beets.plugins import BeetsPlugin
+
+# Raise an exception on plugin load
+assert False  # noqa
+
+
+class TestPlugin(BeetsPlugin):
+    pass

--- a/test/rsrc/beetsplug/broken_import.py
+++ b/test/rsrc/beetsplug/broken_import.py
@@ -1,0 +1,8 @@
+# Leads to a `ModuleNotFoundError` on plugin load, which must not be confused with
+# a plugin not found.
+import beets.foobarbaz  # # noqa
+from beets.plugins import BeetsPlugin
+
+
+class TestPlugin(BeetsPlugin):
+    pass

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -36,30 +36,22 @@ from beets.util import displayable_path, syspath
 
 
 class PluginLoaderTestCase(BasePluginTestCase):
-    def setup_plugin_loader(self):
-        # FIXME the mocking code is horrific, but this is the lowest and
-        # earliest level of the plugin mechanism we can hook into.
-        self._plugin_loader_patch = patch("beets.plugins.load_plugins")
-        self._plugin_classes = set()
-        load_plugins = self._plugin_loader_patch.start()
+    """A test case that adds an additional plugin to beets' plugin method
+    resolution mechanism.
 
-        def myload(names=()):
-            plugins._classes.update(self._plugin_classes)
-
-        load_plugins.side_effect = myload
-
-    def teardown_plugin_loader(self):
-        self._plugin_loader_patch.stop()
+    It does _not_ go through the full `plugins.load_plugins` code, which would
+    require that the plugin_class is part of an importable module.
+    """
 
     def register_plugin(self, plugin_class):
-        self._plugin_classes.add(plugin_class)
+        plugins._register_plugin(plugin_class)
 
     def setUp(self):
-        self.setup_plugin_loader()
         super().setUp()
+        self._prev_plugin_instances = plugins._instances.copy()
 
     def tearDown(self):
-        self.teardown_plugin_loader()
+        plugins._instances = self._prev_plugin_instances
         super().tearDown()
 
 

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -1059,7 +1059,7 @@ class ConfigTest(TestPluginTestCase):
             file.write("plugins: test")
 
         self.run_command("--config", self.cli_config_path, "plugin", lib=None)
-        assert plugins.find_plugins()[0].is_test_plugin
+        assert next(iter(plugins.find_plugins())).is_test_plugin
         self.unload_plugins()
 
     def test_beetsdir_config(self):


### PR DESCRIPTION
Came up in https://github.com/beetbox/beets/pull/5701#discussion_r2049220759 where an error can't easily be traced back to a plugin.

(Draft because I want to avoid creating merge conflicts for https://github.com/beetbox/beets/pull/5701 before that is merged<del>, and because I might a few additional improvements here</del>.)