### PR TITLE
fixup #5701

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -281,12 +281,3 @@ ignore-variadic-names = true
 [tool.ruff.lint.pep8-naming]
 classmethod-decorators = ["cached_classproperty"]
 extend-ignore-names = ["assert*", "cached_classproperty"]
-
-# Temporary, until we decide on a mypy
-# config for all files.
-[[tool.mypy.overrides]]
-module = "beets.plugins"
-disallow_untyped_decorators = true
-disallow_any_generics = true
-check_untyped_defs = true
-allow_redefinition = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,3 +41,11 @@ allow_any_generics = false
 ignore_missing_imports = true
 namespace_packages = true
 explicit_package_bases = true
+
+# Temporary, until we decide on a mypy
+# config for all files.
+[[mypy-beets.plugins]]
+disallow_untyped_decorators = true
+disallow_any_generics = true
+check_untyped_defs = true
+allow_redefinition = true


### PR DESCRIPTION
which added some mypy config to pyproject.toml, leading to mypy ignoring setup.cfg (this shows up in CI output for #5701, but is not very visible since we currently ignore mypy errors)

Related: https://github.com/beetbox/beets/pull/5728