### PR TITLE
Add two new plugin events for recommendation and assign_items

### DIFF
--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -390,6 +390,11 @@ def _recommendation(
         rec = Recommendation.low
     else:
         # No conclusion. Return immediately. Can't be downgraded any further.
+        # but allow plugins to modify the recommendation
+        new_rec_list = plugins.send("recommendation", results=results, org_rec=Recommendation.none)
+        # take the first recommendation from a plugin
+        if len(new_rec_list) > 0 and isinstance(new_rec_list[0], Recommendation):
+            return new_rec_list[0]
         return Recommendation.none
 
     # Downgrade to the max rec if it is lower than the current rec for an
@@ -411,6 +416,11 @@ def _recommendation(
             )
             rec = min(rec, max_rec)
 
+    # allow plugins to modify the recommendation
+    new_rec_list = plugins.send("recommendation", results=results, org_rec=rec)
+    # take the first recommendation from a plugin
+    if len(new_rec_list) > 0 and isinstance(new_rec_list[0], Recommendation):
+        rec = new_rec_list[0]
     return rec
 
 

--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -142,6 +142,16 @@ def assign_items(
         for iidx, t in zip(assigned_item_idxs, tracks)
         if iidx != -1
     }
+
+    # allow plugins to modify the mapping
+    new_assign_list = plugins.send("assign_items", mapping=mapping, org_items=items, org_tracks=tracks)
+    
+    # get the first plugin provided mapping that is a dict and not empty
+    new_mapping = next((item for item in new_assign_list if isinstance(item, dict) and item), None)
+    if new_mapping:
+        # if a plugin provided a mapping, use that instead of the default one
+        mapping = new_mapping
+    
     extra_items = list(set(items) - mapping.keys())
     extra_items.sort(key=lambda i: (i.disc, i.track, i.title))
     extra_tracks = list(set(tracks) - set(mapping.values()))

--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -144,14 +144,19 @@ def assign_items(
     }
 
     # allow plugins to modify the mapping
-    new_assign_list = plugins.send("assign_items", mapping=mapping, org_items=items, org_tracks=tracks)
-    
+    new_assign_list = plugins.send(
+        "assign_items", mapping=mapping, org_items=items, org_tracks=tracks
+    )
+
     # get the first plugin provided mapping that is a dict and not empty
-    new_mapping = next((item for item in new_assign_list if isinstance(item, dict) and item), None)
+    new_mapping = next(
+        (item for item in new_assign_list if isinstance(item, dict) and item),
+        None,
+    )
     if new_mapping:
         # if a plugin provided a mapping, use that instead of the default one
         mapping = new_mapping
-    
+
     extra_items = list(set(items) - mapping.keys())
     extra_items.sort(key=lambda i: (i.disc, i.track, i.title))
     extra_tracks = list(set(tracks) - set(mapping.values()))
@@ -401,9 +406,13 @@ def _recommendation(
     else:
         # No conclusion. Return immediately. Can't be downgraded any further.
         # but allow plugins to modify the recommendation
-        new_rec_list = plugins.send("recommendation", results=results, org_rec=Recommendation.none)
+        new_rec_list = plugins.send(
+            "recommendation", results=results, org_rec=Recommendation.none
+        )
         # take the first recommendation from a plugin
-        if len(new_rec_list) > 0 and isinstance(new_rec_list[0], Recommendation):
+        if len(new_rec_list) > 0 and isinstance(
+            new_rec_list[0], Recommendation
+        ):
             return new_rec_list[0]
         return Recommendation.none
 


### PR DESCRIPTION
## Description

I wanted to be able to influence

1. recommendation behavior
2. Item to TrackInfo matching

from a plugin.
So I added those to events to the beets code.

Please let me know if you are generally interested in merging this to beets.
Then I will update the docs and changelog...

More background:
I'm using beets for sorting audiobooks using audible data. But if there is no clean match beets mixes the order of my tracks.
With that plugin event I'm able to control the matching and make sure that the order is keeps the same.

I plan to use the recommendation event to downgrade a strong recommendation if the next candidate is closer than a threshold.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
