### PR TITLE
Do not remove everything that follows a dot in item destination path

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -349,6 +349,7 @@ class LibModel(dbcore.Model["Library"]):
 
     # Config key that specifies how an instance should be formatted.
     _format_config_key: str
+    path: bytes
 
     @cached_classproperty
     def writable_media_fields(cls) -> set[str]:
@@ -644,7 +645,7 @@ class Item(LibModel):
     _format_config_key = "format_item"
 
     # Cached album object. Read-only.
-    __album = None
+    __album: Album | None = None
 
     @cached_classproperty
     def _relation(cls) -> type[Album]:
@@ -663,9 +664,9 @@ class Item(LibModel):
         )
 
     @property
-    def filepath(self) -> Path | None:
+    def filepath(self) -> Path:
         """The path to the item's file as pathlib.Path."""
-        return Path(os.fsdecode(self.path)) if self.path else self.path
+        return Path(os.fsdecode(self.path))
 
     @property
     def _cached_album(self):
@@ -1126,7 +1127,7 @@ class Item(LibModel):
             )
 
         lib_path_str, fallback = util.legalize_path(
-            subpath, db.replacements, os.path.splitext(self.path)[1]
+            subpath, db.replacements, self.filepath.suffix
         )
         if fallback:
             # Print an error message if legalization fell back to

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -715,7 +715,7 @@ def truncate_path(str_path: str) -> str:
     path = Path(str_path)
     parent_parts = [truncate_str(p, max_length) for p in path.parts[:-1]]
     stem = truncate_str(path.stem, max_length - len(path.suffix))
-    return str(Path(*parent_parts, stem).with_suffix(path.suffix))
+    return str(Path(*parent_parts, stem)) + path.suffix
 
 
 def _legalize_stage(

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,11 @@ New features:
 
 Bug fixes:
 
+* :doc:`/reference/pathformat`: Fixed a regression where path legalization
+  incorrectly removed parts of user-configured path formats that followed a dot
+  (**.**).
+  :bug:`5771`
+
 For packagers:
 
 Other changes:


### PR DESCRIPTION
## Description
This PR addresses an issue where path legalization, specifically the `truncate_path` function, incorrectly removed parts of filenames that followed a dot. This occurred because `pathlib.Path.with_suffix` was used, which replaces the existing suffix (or what it considers a suffix) rather than just appending.

The fix modifies `truncate_path` to manually append the original suffix after truncating the filename stem. This ensures that dots within the filename, not part of the actual extension, are preserved.

Fixes #5771.

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
