### PR TITLE
Move queries and types to respective modules

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -49,3 +49,5 @@ f36bc497c8c8f89004f3f6879908d3f0b25123e1
 c490ac5810b70f3cf5fd8649669838e8fdb19f4d
 # Importer restructure
 9147577b2b19f43ca827e9650261a86fb0450cef
+# Copy paste query, types from library to dbcore
+1a045c91668c771686f4c871c84f1680af2e944b

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -40,6 +40,8 @@ else:
 # To use the SQLite "blob" type, it doesn't suffice to provide a byte
 # string; SQLite treats that as encoded text. Wrapping it in a
 # `memoryview` tells it that we actually mean non-text data.
+# needs to be defined in here due to circular import.
+# TODO: remove it from this module and define it in dbcore/types.py instead
 BLOB_TYPE = memoryview
 
 

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -283,26 +283,20 @@ class PathQuery(FieldQuery[bytes]):
     and case-sensitive otherwise.
     """
 
-    def __init__(self, field, pattern, fast=True, case_sensitive=None):
+    def __init__(self, field, pattern, fast=True):
         """Create a path query.
 
         `pattern` must be a path, either to a file or a directory.
-
-        `case_sensitive` can be a bool or `None`, indicating that the
-        behavior should depend on the filesystem.
         """
         super().__init__(field, pattern, fast)
 
         path = util.normpath(pattern)
 
-        # By default, the case sensitivity depends on the filesystem
-        # that the query path is located on.
-        if case_sensitive is None:
-            case_sensitive = util.case_sensitive(path)
-        self.case_sensitive = case_sensitive
+        # Case sensitivity depends on the filesystem that the query path is located on.
+        self.case_sensitive = util.case_sensitive(path)
 
         # Use a normalized-case pattern for case-insensitive matches.
-        if not case_sensitive:
+        if not self.case_sensitive:
             # We need to lowercase the entire path, not just the pattern.
             # In particular, on Windows, the drive letter is otherwise not
             # lowercased.

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -283,9 +283,6 @@ class PathQuery(FieldQuery[bytes]):
     and case-sensitive otherwise.
     """
 
-    # For tests
-    force_implicit_query_detection = False
-
     def __init__(self, field, pattern, fast=True, case_sensitive=None):
         """Create a path query.
 
@@ -335,8 +332,6 @@ class PathQuery(FieldQuery[bytes]):
         ):
             return False
 
-        if cls.force_implicit_query_detection:
-            return True
         return os.path.exists(util.syspath(util.normpath(query_part)))
 
     def match(self, item):

--- a/beets/dbcore/types.py
+++ b/beets/dbcore/types.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
 import beets
 from beets import util
+from beets.util.units import human_seconds_short, raw_seconds_short
 
 from . import query
 
@@ -437,14 +438,14 @@ class DurationType(Float):
 
     def format(self, value):
         if not beets.config["format_raw_length"].get(bool):
-            return util.human_seconds_short(value or 0.0)
+            return human_seconds_short(value or 0.0)
         else:
             return value
 
     def parse(self, string):
         try:
             # Try to format back hh:ss to seconds.
-            return util.raw_seconds_short(string)
+            return raw_seconds_short(string)
         except ValueError:
             # Fall back to a plain float.
             try:

--- a/beets/library.py
+++ b/beets/library.py
@@ -910,7 +910,7 @@ class Album(LibModel):
     _always_dirty = True
     _fields = {
         "id": types.PRIMARY_ID,
-        "artpath": types.PathType(True),
+        "artpath": types.NullPathType(),
         "added": types.DATE,
         "albumartist": types.STRING,
         "albumartist_sort": types.STRING,

--- a/beets/library.py
+++ b/beets/library.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import os
-import re
 import shlex
 import string
 import sys
@@ -46,257 +45,7 @@ from beets.util.functemplate import Template, template
 if TYPE_CHECKING:
     from .dbcore.query import FieldQuery, FieldQueryType
 
-# To use the SQLite "blob" type, it doesn't suffice to provide a byte
-# string; SQLite treats that as encoded text. Wrapping it in a
-# `memoryview` tells it that we actually mean non-text data.
-BLOB_TYPE = memoryview
-
 log = logging.getLogger("beets")
-
-
-# Library-specific query types.
-
-
-class SingletonQuery(dbcore.FieldQuery[str]):
-    """This query is responsible for the 'singleton' lookup.
-
-    It is based on the FieldQuery and constructs a SQL clause
-    'album_id is NULL' which yields the same result as the previous filter
-    in Python but is more performant since it's done in SQL.
-
-    Using util.str2bool ensures that lookups like singleton:true, singleton:1
-    and singleton:false, singleton:0 are handled consistently.
-    """
-
-    def __new__(cls, field: str, value: str, *args, **kwargs):
-        query = dbcore.query.NoneQuery("album_id")
-        if util.str2bool(value):
-            return query
-        return dbcore.query.NotQuery(query)
-
-
-class PathQuery(dbcore.FieldQuery[bytes]):
-    """A query that matches all items under a given path.
-
-    Matching can either be case-insensitive or case-sensitive. By
-    default, the behavior depends on the OS: case-insensitive on Windows
-    and case-sensitive otherwise.
-    """
-
-    # For tests
-    force_implicit_query_detection = False
-
-    def __init__(self, field, pattern, fast=True, case_sensitive=None):
-        """Create a path query.
-
-        `pattern` must be a path, either to a file or a directory.
-
-        `case_sensitive` can be a bool or `None`, indicating that the
-        behavior should depend on the filesystem.
-        """
-        super().__init__(field, pattern, fast)
-
-        path = util.normpath(pattern)
-
-        # By default, the case sensitivity depends on the filesystem
-        # that the query path is located on.
-        if case_sensitive is None:
-            case_sensitive = util.case_sensitive(path)
-        self.case_sensitive = case_sensitive
-
-        # Use a normalized-case pattern for case-insensitive matches.
-        if not case_sensitive:
-            # We need to lowercase the entire path, not just the pattern.
-            # In particular, on Windows, the drive letter is otherwise not
-            # lowercased.
-            # This also ensures that the `match()` method below and the SQL
-            # from `col_clause()` do the same thing.
-            path = path.lower()
-
-        # Match the path as a single file.
-        self.file_path = path
-        # As a directory (prefix).
-        self.dir_path = os.path.join(path, b"")
-
-    @classmethod
-    def is_path_query(cls, query_part):
-        """Try to guess whether a unicode query part is a path query.
-
-        Condition: separator precedes colon and the file exists.
-        """
-        colon = query_part.find(":")
-        if colon != -1:
-            query_part = query_part[:colon]
-
-        # Test both `sep` and `altsep` (i.e., both slash and backslash on
-        # Windows).
-        if not (
-            os.sep in query_part or (os.altsep and os.altsep in query_part)
-        ):
-            return False
-
-        if cls.force_implicit_query_detection:
-            return True
-        return os.path.exists(syspath(normpath(query_part)))
-
-    def match(self, item):
-        path = item.path if self.case_sensitive else item.path.lower()
-        return (path == self.file_path) or path.startswith(self.dir_path)
-
-    def col_clause(self):
-        file_blob = BLOB_TYPE(self.file_path)
-        dir_blob = BLOB_TYPE(self.dir_path)
-
-        if self.case_sensitive:
-            query_part = "({0} = ?) || (substr({0}, 1, ?) = ?)"
-        else:
-            query_part = "(BYTELOWER({0}) = BYTELOWER(?)) || \
-                         (substr(BYTELOWER({0}), 1, ?) = BYTELOWER(?))"
-
-        return query_part.format(self.field), (
-            file_blob,
-            len(dir_blob),
-            dir_blob,
-        )
-
-    def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}({self.field!r}, {self.pattern!r}, "
-            f"fast={self.fast}, case_sensitive={self.case_sensitive})"
-        )
-
-
-# Library-specific field types.
-
-
-class DateType(types.Float):
-    # TODO representation should be `datetime` object
-    # TODO distinguish between date and time types
-    query = dbcore.query.DateQuery
-
-    def format(self, value):
-        return time.strftime(
-            beets.config["time_format"].as_str(), time.localtime(value or 0)
-        )
-
-    def parse(self, string):
-        try:
-            # Try a formatted date string.
-            return time.mktime(
-                time.strptime(string, beets.config["time_format"].as_str())
-            )
-        except ValueError:
-            # Fall back to a plain timestamp number.
-            try:
-                return float(string)
-            except ValueError:
-                return self.null
-
-
-class PathType(types.Type[bytes, bytes]):
-    """A dbcore type for filesystem paths.
-
-    These are represented as `bytes` objects, in keeping with
-    the Unix filesystem abstraction.
-    """
-
-    sql = "BLOB"
-    query = PathQuery
-    model_type = bytes
-
-    def __init__(self, nullable=False):
-        """Create a path type object.
-
-        `nullable` controls whether the type may be missing, i.e., None.
-        """
-        self.nullable = nullable
-
-    @property
-    def null(self):
-        if self.nullable:
-            return None
-        else:
-            return b""
-
-    def format(self, value):
-        return util.displayable_path(value)
-
-    def parse(self, string):
-        return normpath(bytestring_path(string))
-
-    def normalize(self, value):
-        if isinstance(value, str):
-            # Paths stored internally as encoded bytes.
-            return bytestring_path(value)
-
-        elif isinstance(value, BLOB_TYPE):
-            # We unwrap buffers to bytes.
-            return bytes(value)
-
-        else:
-            return value
-
-    def from_sql(self, sql_value):
-        return self.normalize(sql_value)
-
-    def to_sql(self, value):
-        if isinstance(value, bytes):
-            value = BLOB_TYPE(value)
-        return value
-
-
-class MusicalKey(types.String):
-    """String representing the musical key of a song.
-
-    The standard format is C, Cm, C#, C#m, etc.
-    """
-
-    ENHARMONIC = {
-        r"db": "c#",
-        r"eb": "d#",
-        r"gb": "f#",
-        r"ab": "g#",
-        r"bb": "a#",
-    }
-
-    null = None
-
-    def parse(self, key):
-        key = key.lower()
-        for flat, sharp in self.ENHARMONIC.items():
-            key = re.sub(flat, sharp, key)
-        key = re.sub(r"[\W\s]+minor", "m", key)
-        key = re.sub(r"[\W\s]+major", "", key)
-        return key.capitalize()
-
-    def normalize(self, key):
-        if key is None:
-            return None
-        else:
-            return self.parse(key)
-
-
-class DurationType(types.Float):
-    """Human-friendly (M:SS) representation of a time interval."""
-
-    query = dbcore.query.DurationQuery
-
-    def format(self, value):
-        if not beets.config["format_raw_length"].get(bool):
-            return beets.ui.human_seconds_short(value or 0.0)
-        else:
-            return value
-
-    def parse(self, string):
-        try:
-            # Try to format back hh:ss to seconds.
-            return util.raw_seconds_short(string)
-        except ValueError:
-            # Fall back to a plain float.
-            try:
-                return float(string)
-            except ValueError:
-                return self.null
 
 
 # Special path format key.
@@ -517,7 +266,7 @@ class Item(LibModel):
     _flex_table = "item_attributes"
     _fields = {
         "id": types.PRIMARY_ID,
-        "path": PathType(),
+        "path": types.PathType(),
         "album_id": types.FOREIGN_ID,
         "title": types.STRING,
         "artist": types.STRING,
@@ -596,8 +345,8 @@ class Item(LibModel):
         "original_year": types.PaddedInt(4),
         "original_month": types.PaddedInt(2),
         "original_day": types.PaddedInt(2),
-        "initial_key": MusicalKey(),
-        "length": DurationType(),
+        "initial_key": types.MusicalKey(),
+        "length": types.DurationType(),
         "bitrate": types.ScaledInt(1000, "kbps"),
         "bitrate_mode": types.STRING,
         "encoder_info": types.STRING,
@@ -606,8 +355,8 @@ class Item(LibModel):
         "samplerate": types.ScaledInt(1000, "kHz"),
         "bitdepth": types.INTEGER,
         "channels": types.INTEGER,
-        "mtime": DateType(),
-        "added": DateType(),
+        "mtime": types.DATE,
+        "added": types.DATE,
     }
 
     _search_fields = (
@@ -641,7 +390,7 @@ class Item(LibModel):
 
     _sorts = {"artist": dbcore.query.SmartArtistSort}
 
-    _queries = {"singleton": SingletonQuery}
+    _queries = {"singleton": dbcore.query.SingletonQuery}
 
     _format_config_key = "format_item"
 
@@ -717,7 +466,7 @@ class Item(LibModel):
         if key == "path":
             if isinstance(value, str):
                 value = bytestring_path(value)
-            elif isinstance(value, BLOB_TYPE):
+            elif isinstance(value, types.BLOB_TYPE):
                 value = bytes(value)
         elif key == "album_id":
             self._cached_album = None
@@ -1161,8 +910,8 @@ class Album(LibModel):
     _always_dirty = True
     _fields = {
         "id": types.PRIMARY_ID,
-        "artpath": PathType(True),
-        "added": DateType(),
+        "artpath": types.PathType(True),
+        "added": types.DATE,
         "albumartist": types.STRING,
         "albumartist_sort": types.STRING,
         "albumartist_credit": types.STRING,
@@ -1208,7 +957,7 @@ class Album(LibModel):
     _search_fields = ("album", "albumartist", "genre")
 
     _types = {
-        "path": PathType(),
+        "path": types.PathType(),
         "data_source": types.STRING,
     }
 
@@ -1563,7 +1312,10 @@ def parse_query_parts(parts, model_cls):
 
     # Special-case path-like queries, which are non-field queries
     # containing path separators (/).
-    parts = [f"path:{s}" if PathQuery.is_path_query(s) else s for s in parts]
+    parts = [
+        f"path:{s}" if dbcore.query.PathQuery.is_path_query(s) else s
+        for s in parts
+    ]
 
     case_insensitive = beets.config["sort_case_insensitive"].get(bool)
 

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -435,48 +435,6 @@ def input_select_objects(prompt, objs, rep, prompt_all=None):
         return []
 
 
-# Human output formatting.
-
-
-def human_bytes(size):
-    """Formats size, a number of bytes, in a human-readable way."""
-    powers = ["", "K", "M", "G", "T", "P", "E", "Z", "Y", "H"]
-    unit = "B"
-    for power in powers:
-        if size < 1024:
-            return f"{size:3.1f} {power}{unit}"
-        size /= 1024.0
-        unit = "iB"
-    return "big"
-
-
-def human_seconds(interval):
-    """Formats interval, a number of seconds, as a human-readable time
-    interval using English words.
-    """
-    units = [
-        (1, "second"),
-        (60, "minute"),
-        (60, "hour"),
-        (24, "day"),
-        (7, "week"),
-        (52, "year"),
-        (10, "decade"),
-    ]
-    for i in range(len(units) - 1):
-        increment, suffix = units[i]
-        next_increment, _ = units[i + 1]
-        interval /= float(increment)
-        if interval < next_increment:
-            break
-    else:
-        # Last unit.
-        increment, suffix = units[-1]
-        interval /= float(increment)
-
-    return f"{interval:3.1f} {suffix}s"
-
-
 # Colorization.
 
 # ANSI terminal colorization code heavily inspired by pygments:

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -477,14 +477,6 @@ def human_seconds(interval):
     return f"{interval:3.1f} {suffix}s"
 
 
-def human_seconds_short(interval):
-    """Formats a number of seconds as a short human-readable M:SS
-    string.
-    """
-    interval = int(interval)
-    return "%i:%02i" % (interval // 60, interval % 60)
-
-
 # Colorization.
 
 # ANSI terminal colorization code heavily inspired by pygments:

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -43,6 +43,7 @@ from beets.util import (
     normpath,
     syspath,
 )
+from beets.util.units import human_bytes, human_seconds, human_seconds_short
 
 from . import _store_dict
 
@@ -541,8 +542,8 @@ class ChangeRepresentation:
         cur_length0 = item.length if item.length else 0
         new_length0 = track_info.length if track_info.length else 0
         # format into string
-        cur_length = f"({util.human_seconds_short(cur_length0)})"
-        new_length = f"({util.human_seconds_short(new_length0)})"
+        cur_length = f"({human_seconds_short(cur_length0)})"
+        new_length = f"({human_seconds_short(new_length0)})"
         # colorize
         lhs_length = ui.colorize(highlight_color, cur_length)
         rhs_length = ui.colorize(highlight_color, new_length)
@@ -706,14 +707,14 @@ class AlbumChange(ChangeRepresentation):
         for track_info in self.match.extra_tracks:
             line = f" ! {track_info.title} (#{self.format_index(track_info)})"
             if track_info.length:
-                line += f" ({util.human_seconds_short(track_info.length)})"
+                line += f" ({human_seconds_short(track_info.length)})"
             print_(ui.colorize("text_warning", line))
         if self.match.extra_items:
             print_(f"Unmatched tracks ({len(self.match.extra_items)}):")
         for item in self.match.extra_items:
             line = " ! {} (#{})".format(item.title, self.format_index(item))
             if item.length:
-                line += " ({})".format(util.human_seconds_short(item.length))
+                line += " ({})".format(human_seconds_short(item.length))
             print_(ui.colorize("text_warning", line))
 
 
@@ -795,8 +796,8 @@ def summarize_items(items, singleton):
                 round(int(items[0].samplerate) / 1000, 1), items[0].bitdepth
             )
             summary_parts.append(sample_bits)
-        summary_parts.append(util.human_seconds_short(total_duration))
-        summary_parts.append(ui.human_bytes(total_filesize))
+        summary_parts.append(human_seconds_short(total_duration))
+        summary_parts.append(human_bytes(total_filesize))
 
     return ", ".join(summary_parts)
 
@@ -1906,7 +1907,7 @@ def show_stats(lib, query, exact):
         if item.album_id:
             albums.add(item.album_id)
 
-    size_str = "" + ui.human_bytes(total_size)
+    size_str = "" + human_bytes(total_size)
     if exact:
         size_str += f" ({total_size} bytes)"
 
@@ -1918,7 +1919,7 @@ Artists: {}
 Albums: {}
 Album artists: {}""".format(
             total_items,
-            ui.human_seconds(total_time),
+            human_seconds(total_time),
             f" ({total_time:.2f} seconds)" if exact else "",
             "Total size" if exact else "Approximate total size",
             size_str,

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -541,8 +541,8 @@ class ChangeRepresentation:
         cur_length0 = item.length if item.length else 0
         new_length0 = track_info.length if track_info.length else 0
         # format into string
-        cur_length = f"({ui.human_seconds_short(cur_length0)})"
-        new_length = f"({ui.human_seconds_short(new_length0)})"
+        cur_length = f"({util.human_seconds_short(cur_length0)})"
+        new_length = f"({util.human_seconds_short(new_length0)})"
         # colorize
         lhs_length = ui.colorize(highlight_color, cur_length)
         rhs_length = ui.colorize(highlight_color, new_length)
@@ -706,14 +706,14 @@ class AlbumChange(ChangeRepresentation):
         for track_info in self.match.extra_tracks:
             line = f" ! {track_info.title} (#{self.format_index(track_info)})"
             if track_info.length:
-                line += f" ({ui.human_seconds_short(track_info.length)})"
+                line += f" ({util.human_seconds_short(track_info.length)})"
             print_(ui.colorize("text_warning", line))
         if self.match.extra_items:
             print_(f"Unmatched tracks ({len(self.match.extra_items)}):")
         for item in self.match.extra_items:
             line = " ! {} (#{})".format(item.title, self.format_index(item))
             if item.length:
-                line += " ({})".format(ui.human_seconds_short(item.length))
+                line += " ({})".format(util.human_seconds_short(item.length))
             print_(ui.colorize("text_warning", line))
 
 
@@ -795,7 +795,7 @@ def summarize_items(items, singleton):
                 round(int(items[0].samplerate) / 1000, 1), items[0].bitdepth
             )
             summary_parts.append(sample_bits)
-        summary_parts.append(ui.human_seconds_short(total_duration))
+        summary_parts.append(util.human_seconds_short(total_duration))
         summary_parts.append(ui.human_bytes(total_filesize))
 
     return ", ".join(summary_parts)

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -1032,6 +1032,14 @@ def raw_seconds_short(string: str) -> float:
     return float(minutes * 60 + seconds)
 
 
+def human_seconds_short(interval):
+    """Formats a number of seconds as a short human-readable M:SS
+    string.
+    """
+    interval = int(interval)
+    return "%i:%02i" % (interval // 60, interval % 60)
+
+
 def asciify_path(path: str, sep_replace: str) -> str:
     """Decodes all unicode characters in a path into ASCII equivalents.
 

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -1019,27 +1019,6 @@ def case_sensitive(path: bytes) -> bool:
         return not os.path.samefile(lower_sys, upper_sys)
 
 
-def raw_seconds_short(string: str) -> float:
-    """Formats a human-readable M:SS string as a float (number of seconds).
-
-    Raises ValueError if the conversion cannot take place due to `string` not
-    being in the right format.
-    """
-    match = re.match(r"^(\d+):([0-5]\d)$", string)
-    if not match:
-        raise ValueError("String not in M:SS format")
-    minutes, seconds = map(int, match.groups())
-    return float(minutes * 60 + seconds)
-
-
-def human_seconds_short(interval):
-    """Formats a number of seconds as a short human-readable M:SS
-    string.
-    """
-    interval = int(interval)
-    return "%i:%02i" % (interval // 60, interval % 60)
-
-
 def asciify_path(path: str, sep_replace: str) -> str:
     """Decodes all unicode characters in a path into ASCII equivalents.
 

--- a/beets/util/units.py
+++ b/beets/util/units.py
@@ -1,0 +1,61 @@
+import re
+
+
+def raw_seconds_short(string: str) -> float:
+    """Formats a human-readable M:SS string as a float (number of seconds).
+
+    Raises ValueError if the conversion cannot take place due to `string` not
+    being in the right format.
+    """
+    match = re.match(r"^(\d+):([0-5]\d)$", string)
+    if not match:
+        raise ValueError("String not in M:SS format")
+    minutes, seconds = map(int, match.groups())
+    return float(minutes * 60 + seconds)
+
+
+def human_seconds_short(interval):
+    """Formats a number of seconds as a short human-readable M:SS
+    string.
+    """
+    interval = int(interval)
+    return "%i:%02i" % (interval // 60, interval % 60)
+
+
+def human_bytes(size):
+    """Formats size, a number of bytes, in a human-readable way."""
+    powers = ["", "K", "M", "G", "T", "P", "E", "Z", "Y", "H"]
+    unit = "B"
+    for power in powers:
+        if size < 1024:
+            return f"{size:3.1f} {power}{unit}"
+        size /= 1024.0
+        unit = "iB"
+    return "big"
+
+
+def human_seconds(interval):
+    """Formats interval, a number of seconds, as a human-readable time
+    interval using English words.
+    """
+    units = [
+        (1, "second"),
+        (60, "minute"),
+        (60, "hour"),
+        (24, "day"),
+        (7, "week"),
+        (52, "year"),
+        (10, "decade"),
+    ]
+    for i in range(len(units) - 1):
+        increment, suffix = units[i]
+        next_increment, _ = units[i + 1]
+        interval /= float(increment)
+        if interval < next_increment:
+            break
+    else:
+        # Last unit.
+        increment, suffix = units[-1]
+        interval /= float(increment)
+
+    return f"{interval:3.1f} {suffix}s"

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -25,7 +25,6 @@ import unidecode
 from beets import ui
 from beets.autotag import AlbumInfo, TrackInfo
 from beets.dbcore import types
-from beets.library import DateType
 from beets.plugins import BeetsPlugin, MetadataSourcePlugin
 
 
@@ -35,7 +34,7 @@ class DeezerPlugin(MetadataSourcePlugin, BeetsPlugin):
     item_types = {
         "deezer_track_rank": types.INTEGER,
         "deezer_track_id": types.INTEGER,
-        "deezer_updated": DateType(),
+        "deezer_updated": types.DATE,
     }
 
     # Base URLs for the Deezer API

--- a/beetsplug/metasync/amarok.py
+++ b/beetsplug/metasync/amarok.py
@@ -20,7 +20,6 @@ from time import mktime
 from xml.sax.saxutils import quoteattr
 
 from beets.dbcore import types
-from beets.library import DateType
 from beets.util import displayable_path
 from beetsplug.metasync import MetaSource
 
@@ -41,8 +40,8 @@ class Amarok(MetaSource):
         "amarok_score": types.FLOAT,
         "amarok_uid": types.STRING,
         "amarok_playcount": types.INTEGER,
-        "amarok_firstplayed": DateType(),
-        "amarok_lastplayed": DateType(),
+        "amarok_firstplayed": types.DATE,
+        "amarok_lastplayed": types.DATE,
     }
 
     query_xml = '<query version="1.0"> \

--- a/beetsplug/metasync/itunes.py
+++ b/beetsplug/metasync/itunes.py
@@ -26,7 +26,6 @@ from confuse import ConfigValueError
 
 from beets import util
 from beets.dbcore import types
-from beets.library import DateType
 from beets.util import bytestring_path, syspath
 from beetsplug.metasync import MetaSource
 
@@ -63,9 +62,9 @@ class Itunes(MetaSource):
         "itunes_rating": types.INTEGER,  # 0..100 scale
         "itunes_playcount": types.INTEGER,
         "itunes_skipcount": types.INTEGER,
-        "itunes_lastplayed": DateType(),
-        "itunes_lastskipped": DateType(),
-        "itunes_dateadded": DateType(),
+        "itunes_lastplayed": types.DATE,
+        "itunes_lastskipped": types.DATE,
+        "itunes_dateadded": types.DATE,
     }
 
     def __init__(self, config, log):

--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -18,8 +18,9 @@ import time
 
 import mpd
 
-from beets import config, library, plugins, ui
+from beets import config, plugins, ui
 from beets.dbcore import types
+from beets.dbcore.query import PathQuery
 from beets.util import displayable_path
 
 # If we lose the connection, how many times do we want to retry and how
@@ -160,7 +161,7 @@ class MPDStats:
 
     def get_item(self, path):
         """Return the beets item related to path."""
-        query = library.PathQuery("path", path)
+        query = PathQuery("path", path)
         item = self.lib.items(query).get()
         if item:
             return item
@@ -321,7 +322,7 @@ class MPDStatsPlugin(plugins.BeetsPlugin):
     item_types = {
         "play_count": types.INTEGER,
         "skip_count": types.INTEGER,
-        "last_played": library.DateType(),
+        "last_played": types.DATE,
         "rating": types.FLOAT,
     }
 

--- a/beetsplug/playlist.py
+++ b/beetsplug/playlist.py
@@ -18,8 +18,7 @@ import tempfile
 from collections.abc import Sequence
 
 import beets
-from beets.dbcore.query import InQuery
-from beets.library import BLOB_TYPE
+from beets.dbcore.query import BLOB_TYPE, InQuery
 from beets.util import path_as_posix
 
 

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -34,10 +34,10 @@ import unidecode
 from beets import ui
 from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.dbcore import types
-from beets.library import DateType, Library
 from beets.plugins import BeetsPlugin, MetadataSourcePlugin, Response
 
 if TYPE_CHECKING:
+    from beets.library import Library
     from beetsplug._typing import JSONDict
 
 DEFAULT_WAITING_TIME = 5
@@ -64,7 +64,7 @@ class SpotifyPlugin(MetadataSourcePlugin, BeetsPlugin):
         "spotify_tempo": types.FLOAT,
         "spotify_time_signature": types.INTEGER,
         "spotify_valence": types.FLOAT,
-        "spotify_updated": DateType(),
+        "spotify_updated": types.DATE,
     }
 
     # Base URLs for the Spotify API

--- a/beetsplug/types.py
+++ b/beetsplug/types.py
@@ -15,7 +15,6 @@
 
 from confuse import ConfigValueError
 
-from beets import library
 from beets.dbcore import types
 from beets.plugins import BeetsPlugin
 
@@ -42,7 +41,7 @@ class TypesPlugin(BeetsPlugin):
             elif value.get() == "bool":
                 mytypes[key] = types.BOOLEAN
             elif value.get() == "date":
-                mytypes[key] = library.DateType()
+                mytypes[key] = types.DATE
             else:
                 raise ConfigValueError(
                     "unknown type '{}' for the '{}' field".format(value, key)

--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -25,6 +25,7 @@ from werkzeug.routing import BaseConverter, PathConverter
 
 import beets.library
 from beets import ui, util
+from beets.dbcore.query import PathQuery
 from beets.plugins import BeetsPlugin
 
 # Utilities.
@@ -342,7 +343,7 @@ def item_query(queries):
 
 @app.route("/item/path/<everything:path>")
 def item_at_path(path):
-    query = beets.library.PathQuery("path", path.encode("utf-8"))
+    query = PathQuery("path", path.encode("utf-8"))
     item = g.lib.items(query).get()
     if item:
         return flask.jsonify(_rep(item))

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -19,7 +19,6 @@ import os.path
 import re
 import shutil
 import stat
-import time
 import unicodedata
 import unittest
 from unittest.mock import patch
@@ -1320,56 +1319,3 @@ class ParseQueryTest(unittest.TestCase):
     def test_parse_bytes(self):
         with pytest.raises(AssertionError):
             beets.library.parse_query_string(b"query", None)
-
-
-class LibraryFieldTypesTest(unittest.TestCase):
-    """Test format() and parse() for library-specific field types"""
-
-    def test_datetype(self):
-        t = beets.library.DateType()
-
-        # format
-        time_format = beets.config["time_format"].as_str()
-        time_local = time.strftime(time_format, time.localtime(123456789))
-        assert time_local == t.format(123456789)
-        # parse
-        assert 123456789.0 == t.parse(time_local)
-        assert 123456789.0 == t.parse("123456789.0")
-        assert t.null == t.parse("not123456789.0")
-        assert t.null == t.parse("1973-11-29")
-
-    def test_pathtype(self):
-        t = beets.library.PathType()
-
-        # format
-        assert "/tmp" == t.format("/tmp")
-        assert "/tmp/\xe4lbum" == t.format("/tmp/\u00e4lbum")
-        # parse
-        assert np(b"/tmp") == t.parse("/tmp")
-        assert np(b"/tmp/\xc3\xa4lbum") == t.parse("/tmp/\u00e4lbum/")
-
-    def test_musicalkey(self):
-        t = beets.library.MusicalKey()
-
-        # parse
-        assert "C#m" == t.parse("c#m")
-        assert "Gm" == t.parse("g   minor")
-        assert "Not c#m" == t.parse("not C#m")
-
-    def test_durationtype(self):
-        t = beets.library.DurationType()
-
-        # format
-        assert "1:01" == t.format(61.23)
-        assert "60:01" == t.format(3601.23)
-        assert "0:00" == t.format(None)
-        # parse
-        assert 61.0 == t.parse("1:01")
-        assert 61.23 == t.parse("61.23")
-        assert 3601.0 == t.parse("60:01")
-        assert t.null == t.parse("1:00:01")
-        assert t.null == t.parse("not61.23")
-        # config format_raw_length
-        beets.config["format_raw_length"] = True
-        assert 61.23 == t.format(61.23)
-        assert 3601.23 == t.format(3601.23)

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -904,7 +904,9 @@ class TestPathQuery:
             _p("path:/c/\\\\x", ["with backslash"], id="backslash-escaped"),
         ],
     )
-    def test_explicit(self, lib, q, expected_titles):
+    def test_explicit(self, monkeypatch, lib, q, expected_titles):
+        monkeypatch.setattr("beets.util.case_sensitive", lambda *_: True)
+
         assert {i.title for i in lib.items(q)} == set(expected_titles)
 
     @pytest.mark.skipif(sys.platform == "win32", reason=WIN32_NO_IMPLICIT_PATHS)

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -466,9 +466,9 @@ class PathQueryTest(ItemInDBTestCase, AssertsMixin):
         # Unadorned path queries with path separators in them are considered
         # path queries only when the path in question actually exists. So we
         # mock the existence check to return true.
-        beets.library.PathQuery.force_implicit_query_detection = True
+        beets.dbcore.query.PathQuery.force_implicit_query_detection = True
         yield
-        beets.library.PathQuery.force_implicit_query_detection = False
+        beets.dbcore.query.PathQuery.force_implicit_query_detection = False
 
     def test_path_exact_match(self):
         q = "path:/a/b/c.mp3"
@@ -609,7 +609,7 @@ class PathQueryTest(ItemInDBTestCase, AssertsMixin):
     def test_case_sensitivity(self):
         self.add_album(path=b"/A/B/C2.mp3", title="caps path")
 
-        makeq = partial(beets.library.PathQuery, "path", "/A/B")
+        makeq = partial(beets.dbcore.query.PathQuery, "path", "/A/B")
 
         results = self.lib.items(makeq(case_sensitive=True))
         self.assert_items_matched(results, ["caps path"])
@@ -621,7 +621,7 @@ class PathQueryTest(ItemInDBTestCase, AssertsMixin):
     # both os.sep and os.altsep
     @unittest.skipIf(sys.platform == "win32", "win32")
     def test_path_sep_detection(self):
-        is_path_query = beets.library.PathQuery.is_path_query
+        is_path_query = beets.dbcore.query.PathQuery.is_path_query
 
         with self.force_implicit_query_detection():
             assert is_path_query("/foo/bar")
@@ -641,7 +641,7 @@ class PathQueryTest(ItemInDBTestCase, AssertsMixin):
         Thus, don't use the `force_implicit_query_detection()`
         contextmanager which would disable the existence check.
         """
-        is_path_query = beets.library.PathQuery.is_path_query
+        is_path_query = beets.dbcore.query.PathQuery.is_path_query
 
         path = self.touch(os.path.join(b"foo", b"bar"))
         assert os.path.isabs(util.syspath(path))
@@ -664,7 +664,7 @@ class PathQueryTest(ItemInDBTestCase, AssertsMixin):
         Thus, don't use the `force_implicit_query_detection()`
         contextmanager which would disable the existence check.
         """
-        is_path_query = beets.library.PathQuery.is_path_query
+        is_path_query = beets.dbcore.query.PathQuery.is_path_query
 
         self.touch(os.path.join(b"foo", b"bar"))
 

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -880,7 +880,7 @@ class TestPathQuery:
 
     @pytest.fixture(scope="class")
     def lib(self, helper):
-        helper.add_item(path=b"/a/b/c.mp3", title="path item")
+        helper.add_item(path=b"/aaa/bb/c.mp3", title="path item")
         helper.add_item(path=b"/x/y/z.mp3", title="another item")
         helper.add_item(path=b"/c/_/title.mp3", title="with underscore")
         helper.add_item(path=b"/c/%/title.mp3", title="with percent")
@@ -892,12 +892,13 @@ class TestPathQuery:
     @pytest.mark.parametrize(
         "q, expected_titles",
         [
-            _p("path:/a/b/c.mp3", ["path item"], id="exact-match"),
-            _p("path:/a", ["path item"], id="parent-dir-no-slash"),
-            _p("path:/a/", ["path item"], id="parent-dir-with-slash"),
+            _p("path:/aaa/bb/c.mp3", ["path item"], id="exact-match"),
+            _p("path:/aaa", ["path item"], id="parent-dir-no-slash"),
+            _p("path:/aaa/", ["path item"], id="parent-dir-with-slash"),
+            _p("path:/aa", [], id="no-match-does-not-match-parent-dir"),
             _p("path:/xyzzy/", [], id="no-match"),
             _p("path:/b/", [], id="fragment-no-match"),
-            _p("path:/x/../a/b", ["path item"], id="non-normalized"),
+            _p("path:/x/../aaa/bb", ["path item"], id="non-normalized"),
             _p("path::c\\.mp3$", ["path item"], id="regex"),
             _p("path:/c/_", ["with underscore"], id="underscore-escaped"),
             _p("path:/c/%", ["with percent"], id="percent-escaped"),
@@ -913,8 +914,8 @@ class TestPathQuery:
     @pytest.mark.parametrize(
         "q, expected_titles",
         [
-            _p("/a/b", ["path item"], id="slashed-query"),
-            _p("/a/b , /a/b", ["path item"], id="path-in-or-query"),
+            _p("/aaa/bb", ["path item"], id="slashed-query"),
+            _p("/aaa/bb , /aaa", ["path item"], id="path-in-or-query"),
             _p("c.mp3", [], id="no-slash-no-match"),
             _p("title:/a/b", [], id="slash-with-explicit-field-no-match"),
         ],

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -14,26 +14,23 @@
 
 """Various tests for querying the library database."""
 
-import os
 import sys
 import unittest
-from contextlib import contextmanager
-from functools import partial
+from pathlib import Path
 
 import pytest
 from mock import patch
 
-import beets.library
-from beets import dbcore, util
+from beets import dbcore
 from beets.dbcore import types
 from beets.dbcore.query import (
     InvalidQueryArgumentValueError,
     NoneQuery,
     ParsingError,
+    PathQuery,
 )
 from beets.test import _common
-from beets.test.helper import BeetsTestCase, ItemInDBTestCase
-from beets.util import syspath
+from beets.test.helper import BeetsTestCase, TestHelper
 
 # Because the absolute path begins with something like C:, we
 # can't disambiguate it from an ordinary query.
@@ -440,244 +437,6 @@ class MatchTest(unittest.TestCase):
         assert q1 != q3
         assert q1 != q4
         assert q3 != q4
-
-
-class PathQueryTest(ItemInDBTestCase, AssertsMixin):
-    def setUp(self):
-        super().setUp()
-
-        # This is the item we'll try to match.
-        self.i.path = util.normpath("/a/b/c.mp3")
-        self.i.title = "path item"
-        self.i.album = "path album"
-        self.i.store()
-        self.lib.add_album([self.i])
-
-        # A second item for testing exclusion.
-        i2 = _common.item()
-        i2.path = util.normpath("/x/y/z.mp3")
-        i2.title = "another item"
-        i2.album = "another album"
-        self.lib.add(i2)
-        self.lib.add_album([i2])
-
-    @contextmanager
-    def force_implicit_query_detection(self):
-        # Unadorned path queries with path separators in them are considered
-        # path queries only when the path in question actually exists. So we
-        # mock the existence check to return true.
-        beets.dbcore.query.PathQuery.force_implicit_query_detection = True
-        yield
-        beets.dbcore.query.PathQuery.force_implicit_query_detection = False
-
-    def test_path_exact_match(self):
-        q = "path:/a/b/c.mp3"
-        results = self.lib.items(q)
-        self.assert_items_matched(results, ["path item"])
-
-        results = self.lib.albums(q)
-        self.assert_albums_matched(results, ["path album"])
-
-    # FIXME: fails on windows
-    @unittest.skipIf(sys.platform == "win32", "win32")
-    def test_parent_directory_no_slash(self):
-        q = "path:/a"
-        results = self.lib.items(q)
-        self.assert_items_matched(results, ["path item"])
-
-        results = self.lib.albums(q)
-        self.assert_albums_matched(results, ["path album"])
-
-    # FIXME: fails on windows
-    @unittest.skipIf(sys.platform == "win32", "win32")
-    def test_parent_directory_with_slash(self):
-        q = "path:/a/"
-        results = self.lib.items(q)
-        self.assert_items_matched(results, ["path item"])
-
-        results = self.lib.albums(q)
-        self.assert_albums_matched(results, ["path album"])
-
-    def test_no_match(self):
-        q = "path:/xyzzy/"
-        results = self.lib.items(q)
-        self.assert_items_matched(results, [])
-
-        results = self.lib.albums(q)
-        self.assert_albums_matched(results, [])
-
-    def test_fragment_no_match(self):
-        q = "path:/b/"
-        results = self.lib.items(q)
-        self.assert_items_matched(results, [])
-
-        results = self.lib.albums(q)
-        self.assert_albums_matched(results, [])
-
-    def test_nonnorm_path(self):
-        q = "path:/x/../a/b"
-        results = self.lib.items(q)
-        self.assert_items_matched(results, ["path item"])
-
-        results = self.lib.albums(q)
-        self.assert_albums_matched(results, ["path album"])
-
-    @unittest.skipIf(sys.platform == "win32", WIN32_NO_IMPLICIT_PATHS)
-    def test_slashed_query_matches_path(self):
-        with self.force_implicit_query_detection():
-            q = "/a/b"
-            results = self.lib.items(q)
-            self.assert_items_matched(results, ["path item"])
-
-            results = self.lib.albums(q)
-            self.assert_albums_matched(results, ["path album"])
-
-    @unittest.skipIf(sys.platform == "win32", WIN32_NO_IMPLICIT_PATHS)
-    def test_path_query_in_or_query(self):
-        with self.force_implicit_query_detection():
-            q = "/a/b , /a/b"
-            results = self.lib.items(q)
-            self.assert_items_matched(results, ["path item"])
-
-    def test_non_slashed_does_not_match_path(self):
-        with self.force_implicit_query_detection():
-            q = "c.mp3"
-            results = self.lib.items(q)
-            self.assert_items_matched(results, [])
-
-            results = self.lib.albums(q)
-            self.assert_albums_matched(results, [])
-
-    def test_slashes_in_explicit_field_does_not_match_path(self):
-        with self.force_implicit_query_detection():
-            q = "title:/a/b"
-            results = self.lib.items(q)
-            self.assert_items_matched(results, [])
-
-    def test_path_item_regex(self):
-        q = "path::c\\.mp3$"
-        results = self.lib.items(q)
-        self.assert_items_matched(results, ["path item"])
-
-        results = self.lib.albums(q)
-        self.assert_albums_matched(results, ["path album"])
-
-    def test_path_album_regex(self):
-        q = "path::b"
-        results = self.lib.albums(q)
-        self.assert_albums_matched(results, ["path album"])
-
-    def test_escape_underscore(self):
-        self.add_album(
-            path=b"/a/_/title.mp3",
-            title="with underscore",
-            album="album with underscore",
-        )
-        q = "path:/a/_"
-        results = self.lib.items(q)
-        self.assert_items_matched(results, ["with underscore"])
-
-        results = self.lib.albums(q)
-        self.assert_albums_matched(results, ["album with underscore"])
-
-    def test_escape_percent(self):
-        self.add_album(
-            path=b"/a/%/title.mp3",
-            title="with percent",
-            album="album with percent",
-        )
-        q = "path:/a/%"
-        results = self.lib.items(q)
-        self.assert_items_matched(results, ["with percent"])
-
-        results = self.lib.albums(q)
-        self.assert_albums_matched(results, ["album with percent"])
-
-    def test_escape_backslash(self):
-        self.add_album(
-            path=rb"/a/\x/title.mp3",
-            title="with backslash",
-            album="album with backslash",
-        )
-        q = "path:/a/\\\\x"
-        results = self.lib.items(q)
-        self.assert_items_matched(results, ["with backslash"])
-
-        results = self.lib.albums(q)
-        self.assert_albums_matched(results, ["album with backslash"])
-
-    def test_case_sensitivity(self):
-        self.add_album(path=b"/A/B/C2.mp3", title="caps path")
-
-        makeq = partial(beets.dbcore.query.PathQuery, "path", "/A/B")
-
-        results = self.lib.items(makeq(case_sensitive=True))
-        self.assert_items_matched(results, ["caps path"])
-
-        results = self.lib.items(makeq(case_sensitive=False))
-        self.assert_items_matched(results, ["path item", "caps path"])
-
-    # FIXME: Also create a variant of this test for windows, which tests
-    # both os.sep and os.altsep
-    @unittest.skipIf(sys.platform == "win32", "win32")
-    def test_path_sep_detection(self):
-        is_path_query = beets.dbcore.query.PathQuery.is_path_query
-
-        with self.force_implicit_query_detection():
-            assert is_path_query("/foo/bar")
-            assert is_path_query("foo/bar")
-            assert is_path_query("foo/")
-            assert not is_path_query("foo")
-            assert is_path_query("foo/:bar")
-            assert not is_path_query("foo:bar/")
-            assert not is_path_query("foo:/bar")
-
-    # FIXME: shouldn't this also work on windows?
-    @unittest.skipIf(sys.platform == "win32", WIN32_NO_IMPLICIT_PATHS)
-    def test_detect_absolute_path(self):
-        """Test detection of implicit path queries based on whether or
-        not the path actually exists, when using an absolute path query.
-
-        Thus, don't use the `force_implicit_query_detection()`
-        contextmanager which would disable the existence check.
-        """
-        is_path_query = beets.dbcore.query.PathQuery.is_path_query
-
-        path = self.touch(os.path.join(b"foo", b"bar"))
-        assert os.path.isabs(util.syspath(path))
-        path_str = path.decode("utf-8")
-
-        # The file itself.
-        assert is_path_query(path_str)
-
-        # The parent directory.
-        parent = os.path.dirname(path_str)
-        assert is_path_query(parent)
-
-        # Some non-existent path.
-        assert not is_path_query(f"{path_str}baz")
-
-    def test_detect_relative_path(self):
-        """Test detection of implicit path queries based on whether or
-        not the path actually exists, when using a relative path query.
-
-        Thus, don't use the `force_implicit_query_detection()`
-        contextmanager which would disable the existence check.
-        """
-        is_path_query = beets.dbcore.query.PathQuery.is_path_query
-
-        self.touch(os.path.join(b"foo", b"bar"))
-
-        # Temporarily change directory so relative paths work.
-        cur_dir = os.getcwd()
-        try:
-            os.chdir(syspath(self.temp_dir))
-            assert is_path_query("foo/")
-            assert is_path_query("foo/bar")
-            assert is_path_query("foo/bar:tagada")
-            assert not is_path_query("bar")
-        finally:
-            os.chdir(cur_dir)
 
 
 class IntQueryTest(BeetsTestCase):
@@ -1104,3 +863,104 @@ class RelatedQueriesTest(BeetsTestCase, AssertsMixin):
         q = "artpath::A Album1"
         results = self.lib.items(q)
         self.assert_items_matched(results, ["Album1 Item1", "Album1 Item2"])
+
+
+@pytest.fixture(scope="class")
+def helper():
+    helper = TestHelper()
+    helper.setup_beets()
+
+    yield helper
+
+    helper.teardown_beets()
+
+
+class TestPathQuery:
+    _p = pytest.param
+
+    @pytest.fixture(scope="class")
+    def lib(self, helper):
+        helper.add_item(path=b"/a/b/c.mp3", title="path item")
+        helper.add_item(path=b"/x/y/z.mp3", title="another item")
+        helper.add_item(path=b"/c/_/title.mp3", title="with underscore")
+        helper.add_item(path=b"/c/%/title.mp3", title="with percent")
+        helper.add_item(path=rb"/c/\x/title.mp3", title="with backslash")
+        helper.add_item(path=b"/A/B/C2.mp3", title="caps path")
+
+        return helper.lib
+
+    @pytest.mark.parametrize(
+        "q, expected_titles",
+        [
+            _p("path:/a/b/c.mp3", ["path item"], id="exact-match"),
+            _p("path:/a", ["path item"], id="parent-dir-no-slash"),
+            _p("path:/a/", ["path item"], id="parent-dir-with-slash"),
+            _p("path:/xyzzy/", [], id="no-match"),
+            _p("path:/b/", [], id="fragment-no-match"),
+            _p("path:/x/../a/b", ["path item"], id="non-normalized"),
+            _p("path::c\\.mp3$", ["path item"], id="regex"),
+            _p("path:/c/_", ["with underscore"], id="underscore-escaped"),
+            _p("path:/c/%", ["with percent"], id="percent-escaped"),
+            _p("path:/c/\\\\x", ["with backslash"], id="backslash-escaped"),
+        ],
+    )
+    def test_explicit(self, lib, q, expected_titles):
+        assert {i.title for i in lib.items(q)} == set(expected_titles)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason=WIN32_NO_IMPLICIT_PATHS)
+    @pytest.mark.parametrize(
+        "q, expected_titles",
+        [
+            _p("/a/b", ["path item"], id="slashed-query"),
+            _p("/a/b , /a/b", ["path item"], id="path-in-or-query"),
+            _p("c.mp3", [], id="no-slash-no-match"),
+            _p("title:/a/b", [], id="slash-with-explicit-field-no-match"),
+        ],
+    )
+    def test_implicit(self, monkeypatch, lib, q, expected_titles):
+        monkeypatch.setattr(
+            "beets.dbcore.query.PathQuery.is_path_query", lambda path: True
+        )
+
+        assert {i.title for i in lib.items(q)} == set(expected_titles)
+
+    @pytest.mark.parametrize(
+        "case_sensitive, expected_titles",
+        [
+            _p(True, [], id="non-caps-dont-match-caps"),
+            _p(False, ["caps path"], id="non-caps-match-caps"),
+        ],
+    )
+    def test_case_sensitivity(
+        self, lib, monkeypatch, case_sensitive, expected_titles
+    ):
+        q = "path:/a/b/c2.mp3"
+        monkeypatch.setattr(
+            "beets.util.case_sensitive", lambda *_: case_sensitive
+        )
+
+        assert {i.title for i in lib.items(q)} == set(expected_titles)
+
+    # FIXME: Also create a variant of this test for windows, which tests
+    # both os.sep and os.altsep
+    @pytest.mark.skipif(sys.platform == "win32", reason=WIN32_NO_IMPLICIT_PATHS)
+    @pytest.mark.parametrize(
+        "q, is_path_query",
+        [
+            ("/foo/bar", True),
+            ("foo/bar", True),
+            ("foo/", True),
+            ("foo", False),
+            ("foo/:bar", True),
+            ("foo:bar/", False),
+            ("foo:/bar", False),
+        ],
+    )
+    def test_path_sep_detection(self, monkeypatch, tmp_path, q, is_path_query):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "foo").mkdir()
+        (tmp_path / "foo" / "bar").touch()
+        if Path(q).is_absolute():
+            q = str(tmp_path / q[1:])
+
+        assert PathQuery.is_path_query(q) == is_path_query

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1,59 +1,58 @@
 import time
-import unittest
 
 import beets
 from beets.dbcore import types
 from beets.util import normpath
 
 
-class LibraryFieldTypesTest(unittest.TestCase):
-    """Test format() and parse() for library-specific field types"""
+def test_datetype():
+    t = types.DATE
 
-    def test_datetype(self):
-        t = types.DATE
+    # format
+    time_format = beets.config["time_format"].as_str()
+    time_local = time.strftime(time_format, time.localtime(123456789))
+    assert time_local == t.format(123456789)
+    # parse
+    assert 123456789.0 == t.parse(time_local)
+    assert 123456789.0 == t.parse("123456789.0")
+    assert t.null == t.parse("not123456789.0")
+    assert t.null == t.parse("1973-11-29")
 
-        # format
-        time_format = beets.config["time_format"].as_str()
-        time_local = time.strftime(time_format, time.localtime(123456789))
-        assert time_local == t.format(123456789)
-        # parse
-        assert 123456789.0 == t.parse(time_local)
-        assert 123456789.0 == t.parse("123456789.0")
-        assert t.null == t.parse("not123456789.0")
-        assert t.null == t.parse("1973-11-29")
 
-    def test_pathtype(self):
-        t = types.PathType()
+def test_pathtype():
+    t = types.PathType()
 
-        # format
-        assert "/tmp" == t.format("/tmp")
-        assert "/tmp/\xe4lbum" == t.format("/tmp/\u00e4lbum")
-        # parse
-        assert normpath(b"/tmp") == t.parse("/tmp")
-        assert normpath(b"/tmp/\xc3\xa4lbum") == t.parse("/tmp/\u00e4lbum/")
+    # format
+    assert "/tmp" == t.format("/tmp")
+    assert "/tmp/\xe4lbum" == t.format("/tmp/\u00e4lbum")
+    # parse
+    assert normpath(b"/tmp") == t.parse("/tmp")
+    assert normpath(b"/tmp/\xc3\xa4lbum") == t.parse("/tmp/\u00e4lbum/")
 
-    def test_musicalkey(self):
-        t = types.MusicalKey()
 
-        # parse
-        assert "C#m" == t.parse("c#m")
-        assert "Gm" == t.parse("g   minor")
-        assert "Not c#m" == t.parse("not C#m")
+def test_musicalkey():
+    t = types.MusicalKey()
 
-    def test_durationtype(self):
-        t = types.DurationType()
+    # parse
+    assert "C#m" == t.parse("c#m")
+    assert "Gm" == t.parse("g   minor")
+    assert "Not c#m" == t.parse("not C#m")
 
-        # format
-        assert "1:01" == t.format(61.23)
-        assert "60:01" == t.format(3601.23)
-        assert "0:00" == t.format(None)
-        # parse
-        assert 61.0 == t.parse("1:01")
-        assert 61.23 == t.parse("61.23")
-        assert 3601.0 == t.parse("60:01")
-        assert t.null == t.parse("1:00:01")
-        assert t.null == t.parse("not61.23")
-        # config format_raw_length
-        beets.config["format_raw_length"] = True
-        assert 61.23 == t.format(61.23)
-        assert 3601.23 == t.format(3601.23)
+
+def test_durationtype():
+    t = types.DurationType()
+
+    # format
+    assert "1:01" == t.format(61.23)
+    assert "60:01" == t.format(3601.23)
+    assert "0:00" == t.format(None)
+    # parse
+    assert 61.0 == t.parse("1:01")
+    assert 61.23 == t.parse("61.23")
+    assert 3601.0 == t.parse("60:01")
+    assert t.null == t.parse("1:00:01")
+    assert t.null == t.parse("not61.23")
+    # config format_raw_length
+    beets.config["format_raw_length"] = True
+    assert 61.23 == t.format(61.23)
+    assert 3601.23 == t.format(3601.23)

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -1,0 +1,59 @@
+import time
+import unittest
+
+import beets
+from beets.dbcore import types
+from beets.util import normpath
+
+
+class LibraryFieldTypesTest(unittest.TestCase):
+    """Test format() and parse() for library-specific field types"""
+
+    def test_datetype(self):
+        t = types.DATE
+
+        # format
+        time_format = beets.config["time_format"].as_str()
+        time_local = time.strftime(time_format, time.localtime(123456789))
+        assert time_local == t.format(123456789)
+        # parse
+        assert 123456789.0 == t.parse(time_local)
+        assert 123456789.0 == t.parse("123456789.0")
+        assert t.null == t.parse("not123456789.0")
+        assert t.null == t.parse("1973-11-29")
+
+    def test_pathtype(self):
+        t = types.PathType()
+
+        # format
+        assert "/tmp" == t.format("/tmp")
+        assert "/tmp/\xe4lbum" == t.format("/tmp/\u00e4lbum")
+        # parse
+        assert normpath(b"/tmp") == t.parse("/tmp")
+        assert normpath(b"/tmp/\xc3\xa4lbum") == t.parse("/tmp/\u00e4lbum/")
+
+    def test_musicalkey(self):
+        t = types.MusicalKey()
+
+        # parse
+        assert "C#m" == t.parse("c#m")
+        assert "Gm" == t.parse("g   minor")
+        assert "Not c#m" == t.parse("not C#m")
+
+    def test_durationtype(self):
+        t = types.DurationType()
+
+        # format
+        assert "1:01" == t.format(61.23)
+        assert "60:01" == t.format(3601.23)
+        assert "0:00" == t.format(None)
+        # parse
+        assert 61.0 == t.parse("1:01")
+        assert 61.23 == t.parse("61.23")
+        assert 3601.0 == t.parse("60:01")
+        assert t.null == t.parse("1:00:01")
+        assert t.null == t.parse("not61.23")
+        # config format_raw_length
+        beets.config["format_raw_length"] = True
+        assert 61.23 == t.format(61.23)
+        assert 3601.23 == t.format(3601.23)

--- a/test/test_ui_init.py
+++ b/test/test_ui_init.py
@@ -21,7 +21,7 @@ from random import random
 
 from beets import config, ui
 from beets.test import _common
-from beets.test.helper import BeetsTestCase, ItemInDBTestCase, control_stdin
+from beets.test.helper import BeetsTestCase, control_stdin
 
 
 class InputMethodsTest(BeetsTestCase):
@@ -86,42 +86,6 @@ class InputMethodsTest(BeetsTestCase):
             "Prompt", full_items, self._print_helper
         )
         assert items == ["1", "3"]
-
-
-class InitTest(ItemInDBTestCase):
-    def test_human_bytes(self):
-        tests = [
-            (0, "0.0 B"),
-            (30, "30.0 B"),
-            (pow(2, 10), "1.0 KiB"),
-            (pow(2, 20), "1.0 MiB"),
-            (pow(2, 30), "1.0 GiB"),
-            (pow(2, 40), "1.0 TiB"),
-            (pow(2, 50), "1.0 PiB"),
-            (pow(2, 60), "1.0 EiB"),
-            (pow(2, 70), "1.0 ZiB"),
-            (pow(2, 80), "1.0 YiB"),
-            (pow(2, 90), "1.0 HiB"),
-            (pow(2, 100), "big"),
-        ]
-        for i, h in tests:
-            assert h == ui.human_bytes(i)
-
-    def test_human_seconds(self):
-        tests = [
-            (0, "0.0 seconds"),
-            (30, "30.0 seconds"),
-            (60, "1.0 minutes"),
-            (90, "1.5 minutes"),
-            (125, "2.1 minutes"),
-            (3600, "1.0 hours"),
-            (86400, "1.0 days"),
-            (604800, "1.0 weeks"),
-            (31449600, "1.0 years"),
-            (314496000, "1.0 decades"),
-        ]
-        for i, h in tests:
-            assert h == ui.human_seconds(i)
 
 
 class ParentalDirCreation(BeetsTestCase):

--- a/test/util/test_units.py
+++ b/test/util/test_units.py
@@ -1,0 +1,43 @@
+import pytest
+
+from beets.util.units import human_bytes, human_seconds
+
+
+@pytest.mark.parametrize(
+    "input_bytes,expected",
+    [
+        (0, "0.0 B"),
+        (30, "30.0 B"),
+        (pow(2, 10), "1.0 KiB"),
+        (pow(2, 20), "1.0 MiB"),
+        (pow(2, 30), "1.0 GiB"),
+        (pow(2, 40), "1.0 TiB"),
+        (pow(2, 50), "1.0 PiB"),
+        (pow(2, 60), "1.0 EiB"),
+        (pow(2, 70), "1.0 ZiB"),
+        (pow(2, 80), "1.0 YiB"),
+        (pow(2, 90), "1.0 HiB"),
+        (pow(2, 100), "big"),
+    ],
+)
+def test_human_bytes(input_bytes, expected):
+    assert human_bytes(input_bytes) == expected
+
+
+@pytest.mark.parametrize(
+    "input_seconds,expected",
+    [
+        (0, "0.0 seconds"),
+        (30, "30.0 seconds"),
+        (60, "1.0 minutes"),
+        (90, "1.5 minutes"),
+        (125, "2.1 minutes"),
+        (3600, "1.0 hours"),
+        (86400, "1.0 days"),
+        (604800, "1.0 weeks"),
+        (31449600, "1.0 years"),
+        (314496000, "1.0 decades"),
+    ],
+)
+def test_human_seconds(input_seconds, expected):
+    assert human_seconds(input_seconds) == expected


### PR DESCRIPTION
This PR moves query and type definitions away from `library.py` to `dbcore` to improve modularity and organization.

**Key Changes:**

*   **Query and Type Relocation:**
    *   `PathQuery` and `SingletonQuery` moved from `beets.library` to `beets.dbcore.query`.
    *   `DateType`, `PathType` (and its variants `NullPathType`), `MusicalKey`, and `DurationType` moved from `beets.library` to `beets.dbcore.types`.
    *   The `BLOB_TYPE` definition was moved from `beets.library` to `beets.dbcore.query` and then referenced in `beets.dbcore.types`.
    *   The `human_seconds_short` utility function was moved from `beets.ui` to `beets.util` due to circular dependency.
*   **Test Modernization:**
    *   The `PathQueryTest` class in `test/test_query.py` has been rewritten to use `pytest.mark.parametrize` for more concise and readable test cases.
*   **Import Updates:** All internal references to these moved classes and functions have been updated across the codebase.
