### PR TITLE
Replace outdated bitesized label link

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -154,7 +154,7 @@ Code Contribution Ideas
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 -  We maintain a set of `issues marked as
-   “bite-sized” <https://github.com/beetbox/beets/labels/bitesize>`__.
+   “good first issue” <https://github.com/beetbox/beets/labels/good%20first%20issue>`__.
    These are issues that would serve as a good introduction to the
    codebase. Claim one and start exploring!
 -  Like testing? Our `test


### PR DESCRIPTION
## Description

Meta: I was looking for possible contribution opportunities, so I noticed this in the docs. I assume that the `bite-size` label is outdated, as there aren't actually any issues with that label. Looks like https://github.com/beetbox/beets/labels/good%20first%20issue is currently used.

Note: Further below there's also mention of a `first timers only` label – that link also yields no results and even gives a message about the label being invalid. I wasn't sure if/how that should be replaced, so I didn't touch it. Maybe the sentence I am changing should actually be moved down and replace the one mentioning `first timers only`?

## To Do

- [x] ~Documentation~
- [x] ~Changelog~
- [X] ~Tests~
