### PR TITLE
[Inner loop] Require `langdetect` when running tests

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,8 @@ Bug fixes:
   event to be sent twice, not once.
   :bug:`5560`
 * Fix ``HiddenFileTest`` by using ``bytestring_path()``.
+* tests: Fix tests failing without ``langdetect`` (by making it required).
+  :bug:`5797`
 
 For packagers:
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1030,7 +1030,7 @@ files = [
 name = "langdetect"
 version = "1.0.9"
 description = "Language detection library ported from Google's language-detection."
-optional = true
+optional = false
 python-versions = "*"
 files = [
     {file = "langdetect-1.0.9-py2-none-any.whl", hash = "sha256:7cbc0746252f19e76f77c0b1690aadf01963be835ef0cd4b56dddf2a8f1dfc2a"},
@@ -1271,8 +1271,11 @@ files = [
     {file = "lxml-5.4.0-cp36-cp36m-win_amd64.whl", hash = "sha256:7ce1a171ec325192c6a636b64c94418e71a1964f56d002cc28122fceff0b6121"},
     {file = "lxml-5.4.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:795f61bcaf8770e1b37eec24edf9771b307df3af74d1d6f27d812e15a9ff3872"},
     {file = "lxml-5.4.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:29f451a4b614a7b5b6c2e043d7b64a15bd8304d7e767055e8ab68387a8cacf4e"},
+    {file = "lxml-5.4.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:891f7f991a68d20c75cb13c5c9142b2a3f9eb161f1f12a9489c82172d1f133c0"},
     {file = "lxml-5.4.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4aa412a82e460571fad592d0f93ce9935a20090029ba08eca05c614f99b0cc92"},
+    {file = "lxml-5.4.0-cp37-cp37m-manylinux_2_28_aarch64.whl", hash = "sha256:ac7ba71f9561cd7d7b55e1ea5511543c0282e2b6450f122672a2694621d63b7e"},
     {file = "lxml-5.4.0-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:c5d32f5284012deaccd37da1e2cd42f081feaa76981f0eaa474351b68df813c5"},
+    {file = "lxml-5.4.0-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:ce31158630a6ac85bddd6b830cffd46085ff90498b397bd0a259f59d27a12188"},
     {file = "lxml-5.4.0-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:31e63621e073e04697c1b2d23fcb89991790eef370ec37ce4d5d469f40924ed6"},
     {file = "lxml-5.4.0-cp37-cp37m-win32.whl", hash = "sha256:be2ba4c3c5b7900246a8f866580700ef0d538f2ca32535e991027bdaba944063"},
     {file = "lxml-5.4.0-cp37-cp37m-win_amd64.whl", hash = "sha256:09846782b1ef650b321484ad429217f5154da4d6e786636c38e434fa32e94e49"},
@@ -3276,4 +3279,4 @@ web = ["flask", "flask-cors"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4"
-content-hash = "d609e83f7ffeefc12e28d627e5646aa5c1a6f5a56d7013bb649a468069550dba"
+content-hash = "b3f2746a43227fe639d17eb22d7924e30c9d83eef53dce2c10388c602f0c6665"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ sphinx = { version = "*", optional = true }
 beautifulsoup4 = "*"
 codecov = ">=2.1.13"
 flask = "*"
+langdetect = "*"
 mock = "*"
 pylast = "*"
 pytest = "*"

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -14,8 +14,6 @@
 
 """Tests for the 'lyrics' plugin."""
 
-import importlib.util
-import os
 import re
 import textwrap
 from functools import partial
@@ -29,11 +27,6 @@ from beets.test.helper import PluginMixin, TestHelper
 from beetsplug import lyrics
 
 from .lyrics_pages import LyricsPage, lyrics_pages
-
-github_ci = os.environ.get("GITHUB_ACTIONS") == "true"
-if not github_ci and not importlib.util.find_spec("langdetect"):
-    pytest.skip("langdetect isn't available", allow_module_level=True)
-
 
 PHRASE_BY_TITLE = {
     "Lady Madonna": "friday night arrives without a suitcase",


### PR DESCRIPTION
## Description

Fixes #5797.

Today, local tests (`poe test`) will fail to run if `langdetect` is not installed. This change makes `langdetect` required for test runs.

Although this is easy to resolve with `poetry install --all-extras`, the code intends to work without that; it's a worthwhile fix.

## To Do

- [ ] ~~Documentation.~~
- [x] Changelog.
- [ ] ~~Tests.~~

## What changed?

* Added `langdetect` to the required test dependencies.
* Ran `poetry lock` to handle this new requirement.

## How tested?

Ran locally.

* [x] Tests now execute on my machine.
