### PR TITLE
[Test] Fix path tests on windows

### DIFF
--- a/beets/library.py
+++ b/beets/library.py
@@ -1084,7 +1084,9 @@ class Item(LibModel):
         (i.e., where the file ought to be).
 
         The path is returned as a bytestring. ``basedir`` can override the
-        library's base directory for the destination.
+        library's base directory for the destination. If ``relative_to_libdir``
+        is true, returns just the fragment of the path underneath the library
+        base directory.
         """
         db = self._check_db()
         basedir = basedir or db.directory

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -553,6 +553,9 @@ class ItemFormattedMappingTest(ItemInDBTestCase):
 class PathFormattingMixin:
     """Utilities for testing path formatting."""
 
+    i: beets.library.Item
+    lib: beets.library.Library
+
     def _setf(self, fmt):
         self.lib.path_formats.insert(0, ("default", fmt))
 
@@ -560,9 +563,12 @@ class PathFormattingMixin:
         if i is None:
             i = self.i
 
+        # Handle paths on Windows.
         if os.path.sep != "/":
             dest = dest.replace(b"/", os.path.sep.encode())
-            dest = b"D:" + dest
+
+            systemDrive = os.environ.get("SystemDrive", "C:").encode("utf-8")
+            dest = systemDrive + dest
 
         actual = i.destination()
 


### PR DESCRIPTION
## Description

Fixes #5802.

Today, tests fail on most Windows machines because we hard-code `D:` as the root drive, but most machines use `C:`. This change fetches the `%SystemDrive%` environment variable instead, so tests work reliably across all Windows installs.

## To Do

- [ ] ~~Documentation.~~
- [ ] ~~Changelog.~~
- [x] Tests. (this is a tests change)

## How tested?

* [x] Tests pass locally.