### PR TITLE
Clean up skipped tests and document those still needed for win32

### DIFF
--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -951,7 +951,6 @@ def is_path_on_ntfs(path):
     Determine if the given path is on an NTFS filesystem in WSL.
     """
     path = os.path.abspath(path)
-    mount_point = None
     fs_type = None
     max_len = 0
 
@@ -963,7 +962,6 @@ def is_path_on_ntfs(path):
                     mount = parts[1]
                     fstype = parts[2]
                     if path.startswith(mount) and len(mount) > max_len:
-                        mount_point = mount
                         fs_type = fstype
                         max_len = len(mount)
     except Exception as e:

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -934,3 +934,44 @@ class CleanupModulesMixin:
         """Remove files created by the plugin."""
         for module in cls.modules:
             clean_module_tempdir(module)
+
+
+# Added to try and support testing in WSL on NTFS filesystems
+def is_wsl():
+    try:
+        with open("/proc/version", "r") as f:
+            version_info = f.read()
+        return "Microsoft" in version_info or "WSL" in version_info
+    except FileNotFoundError:
+        return False
+
+
+def is_path_on_ntfs(path):
+    """
+    Determine if the given path is on an NTFS filesystem in WSL.
+    """
+    path = os.path.abspath(path)
+    mount_point = None
+    fs_type = None
+    max_len = 0
+
+    try:
+        with open("/proc/mounts", "r") as mounts:
+            for line in mounts:
+                parts = line.split()
+                if len(parts) >= 3:
+                    mount = parts[1]
+                    fstype = parts[2]
+                    if path.startswith(mount) and len(mount) > max_len:
+                        mount_point = mount
+                        fs_type = fstype
+                        max_len = len(mount)
+    except Exception as e:
+        print(f"Error reading /proc/mounts: {e}")
+        return False
+
+    return fs_type.lower() == "9p"
+
+
+def is_wsl_and_ntfs(path):
+    return is_wsl() and is_path_on_ntfs(path)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,8 @@ New features:
   singletons by their Discogs ID.
   :bug:`4661`
 * :doc:`plugins/replace`: Add new plugin.
+* :doc: Tests that fail on windows now are skipped instead of failing.
+  Tests under WSL on NTFS are now skipped as well.
 
 Bug fixes:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,7 +23,7 @@ New features:
   singletons by their Discogs ID.
   :bug:`4661`
 * :doc:`plugins/replace`: Add new plugin.
-* :doc: Tests that fail on windows now are skipped instead of failing.
+* tests: Tests that fail on windows now are skipped instead of failing.
   Permissions tests under WSL on NTFS are now skipped as well.
 
 Bug fixes:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,7 +24,7 @@ New features:
   :bug:`4661`
 * :doc:`plugins/replace`: Add new plugin.
 * :doc: Tests that fail on windows now are skipped instead of failing.
-  Tests under WSL on NTFS are now skipped as well.
+  Permissions tests under WSL on NTFS are now skipped as well.
 
 Bug fixes:
 

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -109,6 +109,7 @@ class ImportConvertTest(AsIsImporterMixin, ImportHelper, ConvertTestCase):
         self.assertFileTag(item.path, "convert")
 
     # FIXME: fails on windows
+    # This fails as pytest does not seem to copy the input file track_1.mp3?
     @unittest.skipIf(sys.platform == "win32", "win32")
     def test_import_original_on_convert_error(self):
         # `false` exits with non-zero code

--- a/test/plugins/test_permissions.py
+++ b/test/plugins/test_permissions.py
@@ -5,7 +5,14 @@ import platform
 from unittest.mock import Mock, patch
 
 from beets.test._common import touch
-from beets.test.helper import AsIsImporterMixin, ImportTestCase, PluginMixin
+from beets.test.helper import (
+    AsIsImporterMixin,
+    ImportTestCase,
+    is_path_on_ntfs,
+    is_wsl,
+    is_wsl_and_ntfs,
+    PluginMixin,
+)
 from beets.util import displayable_path
 from beetsplug.permissions import (
     check_permissions,
@@ -36,6 +43,8 @@ class PermissionsPluginTest(AsIsImporterMixin, PluginMixin, ImportTestCase):
     def do_thing(self, expect_success):
         if platform.system() == "Windows":
             self.skipTest("permissions not available on Windows")
+        if is_wsl_and_ntfs(os.getcwd()):  # WSL on NTFS does not support chmod
+            self.skipTest("WSL on NTFS does not support chmod")
 
         def get_stat(v):
             return (

--- a/test/plugins/test_permissions.py
+++ b/test/plugins/test_permissions.py
@@ -8,10 +8,8 @@ from beets.test._common import touch
 from beets.test.helper import (
     AsIsImporterMixin,
     ImportTestCase,
-    is_path_on_ntfs,
-    is_wsl,
-    is_wsl_and_ntfs,
     PluginMixin,
+    is_wsl_and_ntfs,
 )
 from beets.util import displayable_path
 from beetsplug.permissions import (

--- a/test/plugins/test_play.py
+++ b/test/plugins/test_play.py
@@ -77,6 +77,7 @@ class PlayPluginTest(CleanupModulesMixin, PluginTestCase):
         self.run_and_assert(open_mock, ["title:aNiceTitle"], "echo other")
 
     # FIXME: fails on windows
+    # more joys of Windows not having a root start unless you only have 1 drive
     @unittest.skipIf(sys.platform == "win32", "win32")
     def test_relative_to(self, open_mock):
         self.config["play"]["command"] = "echo"

--- a/test/plugins/test_player.py
+++ b/test/plugins/test_player.py
@@ -36,6 +36,11 @@ from beets.test.helper import PluginTestCase
 from beets.util import bluelet
 from beetsplug import bpd
 
+# Skip the tests on Windows as they require a socket server.
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="Skip on Windows"
+)
+
 gstplayer = importlib.util.module_from_spec(
     importlib.util.find_spec("beetsplug.bpd.gstplayer")
 )

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -624,7 +624,8 @@ class PathQueryTest(ItemInDBTestCase, AssertsMixin):
             assert not is_path_query("foo:/bar")
 
     # FIXME: shouldn't this also work on windows?
-    # this fails as Path: b'C:\\Users\\user\\AppData\\Local\\Temp\\tmpz9ju2h0t\\foo\\bar'
+    # this fails as
+    # Path: b'C:\\Users\\user\\AppData\\Local\\Temp\\tmpz9ju2h0t\\foo\\bar'
     # Syspath: \\?\C:\Users\user\AppData\Local\Temp\tmpz9ju2h0t\foo\bar
     @unittest.skipIf(sys.platform == "win32", WIN32_NO_IMPLICIT_PATHS)
     def test_detect_absolute_path(self):

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -478,8 +478,6 @@ class PathQueryTest(ItemInDBTestCase, AssertsMixin):
         results = self.lib.albums(q)
         self.assert_albums_matched(results, ["path album"])
 
-    # FIXME: fails on windows
-    @unittest.skipIf(sys.platform == "win32", "win32")
     def test_parent_directory_no_slash(self):
         q = "path:/a"
         results = self.lib.items(q)
@@ -488,8 +486,6 @@ class PathQueryTest(ItemInDBTestCase, AssertsMixin):
         results = self.lib.albums(q)
         self.assert_albums_matched(results, ["path album"])
 
-    # FIXME: fails on windows
-    @unittest.skipIf(sys.platform == "win32", "win32")
     def test_parent_directory_with_slash(self):
         q = "path:/a/"
         results = self.lib.items(q)
@@ -522,7 +518,6 @@ class PathQueryTest(ItemInDBTestCase, AssertsMixin):
         results = self.lib.albums(q)
         self.assert_albums_matched(results, ["path album"])
 
-    @unittest.skipIf(sys.platform == "win32", WIN32_NO_IMPLICIT_PATHS)
     def test_slashed_query_matches_path(self):
         with self.force_implicit_query_detection():
             q = "/a/b"
@@ -532,7 +527,6 @@ class PathQueryTest(ItemInDBTestCase, AssertsMixin):
             results = self.lib.albums(q)
             self.assert_albums_matched(results, ["path album"])
 
-    @unittest.skipIf(sys.platform == "win32", WIN32_NO_IMPLICIT_PATHS)
     def test_path_query_in_or_query(self):
         with self.force_implicit_query_detection():
             q = "/a/b , /a/b"
@@ -617,9 +611,6 @@ class PathQueryTest(ItemInDBTestCase, AssertsMixin):
         results = self.lib.items(makeq(case_sensitive=False))
         self.assert_items_matched(results, ["path item", "caps path"])
 
-    # FIXME: Also create a variant of this test for windows, which tests
-    # both os.sep and os.altsep
-    @unittest.skipIf(sys.platform == "win32", "win32")
     def test_path_sep_detection(self):
         is_path_query = beets.library.PathQuery.is_path_query
 
@@ -633,6 +624,8 @@ class PathQueryTest(ItemInDBTestCase, AssertsMixin):
             assert not is_path_query("foo:/bar")
 
     # FIXME: shouldn't this also work on windows?
+    # this fails as Path: b'C:\\Users\\user\\AppData\\Local\\Temp\\tmpz9ju2h0t\\foo\\bar'
+    # Syspath: \\?\C:\Users\user\AppData\Local\Temp\tmpz9ju2h0t\foo\bar
     @unittest.skipIf(sys.platform == "win32", WIN32_NO_IMPLICIT_PATHS)
     def test_detect_absolute_path(self):
         """Test detection of implicit path queries based on whether or

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 
 import pytest
+import unittest
 
 release = pytest.importorskip("extra.release")
 
@@ -102,6 +103,8 @@ You can do something with this command:
 - Fixed something."""  # noqa: E501
 
 
+# Fixme windows
+@unittest.skipIf(sys.platform == "win32", "win32")
 def test_convert_rst_to_md(rst_changelog, md_changelog):
     actual = release.changelog_as_markdown(rst_changelog)
 

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -3,9 +3,9 @@
 import os
 import shutil
 import sys
+import unittest
 
 import pytest
-import unittest
 
 release = pytest.importorskip("extra.release")
 

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -911,6 +911,9 @@ class ConfigTest(TestPluginTestCase):
         assert key == "x"
         assert template.original == "y"
 
+    # FIXME: fails on windows as folder is created in current folder rather than
+    # the tmp dir for testing.
+    @unittest.skipIf(sys.platform == "win32", "win32")
     def test_default_paths_preserved(self):
         default_formats = ui.get_path_formats()
 
@@ -956,6 +959,9 @@ class ConfigTest(TestPluginTestCase):
         repls = [(p.pattern, s) for p, s in replacements]
         assert repls == [("[xy]", "z"), ("foo", "bar")]
 
+    # FIXME: fails on windows as folder is created in current folder rather than
+    # the tmp dir for testing.
+    @unittest.skipIf(sys.platform == "win32", "win32")
     def test_cli_config_option(self):
         with open(self.cli_config_path, "w") as file:
             file.write("anoption: value")
@@ -1050,6 +1056,9 @@ class ConfigTest(TestPluginTestCase):
             os.path.join(self.beetsdir, b"state"),
         )
 
+    # FIXME: fails on windows as folder is created in current folder rather than
+    # the tmp dir for testing.
+    @unittest.skipIf(sys.platform == "win32", "win32")
     def test_command_line_option_relative_to_working_dir(self):
         config.read()
         os.chdir(syspath(self.temp_dir))
@@ -1058,6 +1067,9 @@ class ConfigTest(TestPluginTestCase):
             config["library"].as_filename(), os.path.join(os.getcwd(), "foo.db")
         )
 
+    # FIXME: fails on windows as folder is created in current folder rather than
+    # the tmp dir for testing.
+    @unittest.skipIf(sys.platform == "win32", "win32")
     def test_cli_config_file_loads_plugin_commands(self):
         with open(self.cli_config_path, "w") as file:
             file.write("pluginpath: %s\n" % _common.PLUGINPATH)

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -923,9 +923,10 @@ class ConfigTest(TestPluginTestCase):
         assert template.original == "y"
         assert self.test_cmd.lib.path_formats[1:] == default_formats
 
+    @unittest.skipIf(sys.platform == "win32", "win32")  # Fails on Windows
     def test_nonexistant_db(self):
         with self.write_config_file() as config:
-            config.write("library: /xxx/yyy/not/a/real/path")
+            config.write("library: xxx/yyy/not/a/real/path")
 
         with pytest.raises(ui.UserError):
             self.run_command("test", lib=None)

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -923,10 +923,11 @@ class ConfigTest(TestPluginTestCase):
         assert template.original == "y"
         assert self.test_cmd.lib.path_formats[1:] == default_formats
 
-    @unittest.skipIf(sys.platform == "win32", "win32")  # Fails on Windows
+    # FIXME: workaround on windows, asks to create the file
+    @unittest.skipIf(sys.platform == "win32", "win32")
     def test_nonexistant_db(self):
         with self.write_config_file() as config:
-            config.write("library: xxx/yyy/not/a/real/path")
+            config.write("library: /xxx/yyy/not/a/real/path")
 
         with pytest.raises(ui.UserError):
             self.run_command("test", lib=None)
@@ -1012,7 +1013,10 @@ class ConfigTest(TestPluginTestCase):
     #                      '--config', cli_overwrite_config_path, 'test')
     #        assert config['anoption'].get() == 'cli overwrite'
 
-    # FIXME: fails on windows
+    # FIXME: fails on windows as folder is created in current folder rather than
+    # the tmp dir for testing.
+    # AssertionError: a_bytes=b'E:\\Git\\my-beets\\~\\AppData\\Roaming\\beets\\beets.db'
+    # != b_bytes=b'C:\\Users\\username\\AppData\\Local\\Temp\\tmpfnjucufd\\AppData\\Roaming\\beets\\beets.db'
     @unittest.skipIf(sys.platform == "win32", "win32")
     def test_cli_config_paths_resolve_relative_to_user_dir(self):
         with open(self.cli_config_path, "w") as file:

--- a/test/test_ui.py
+++ b/test/test_ui.py
@@ -1016,7 +1016,7 @@ class ConfigTest(TestPluginTestCase):
     # FIXME: fails on windows as folder is created in current folder rather than
     # the tmp dir for testing.
     # AssertionError: a_bytes=b'E:\\Git\\my-beets\\~\\AppData\\Roaming\\beets\\beets.db'
-    # != b_bytes=b'C:\\Users\\username\\AppData\\Local\\Temp\\tmpfnjucufd\\AppData\\Roaming\\beets\\beets.db'
+    # != b_bytes=b'C:\\Users\\username\\AppData\\Local\\Temp\\tmpfnjucufd\\AppData\\Roaming\\beets\\beets.db'  # noqa: E501
     @unittest.skipIf(sys.platform == "win32", "win32")
     def test_cli_config_paths_resolve_relative_to_user_dir(self):
         with open(self.cli_config_path, "w") as file:


### PR DESCRIPTION
## Description

Marked tests needing not to be tested on windows.

Documented why tests need to be skipped IF the code is not logical.

Most tests are more to how windows manages the filesystem compared to *nix & MacOS

The [test_player](https://github.com/beetbox/beets/blob/master/test/plugins/test_player.py) tests, I have completely skipped as I think the failures are lack of sockets being easily used for the tests. 

## To Do

A few tests still create files in the local folder rather than in TEMP. I'll add those as updates, but looking for feedback on changes?

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [X] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [X] Tests. (Very much encouraged but not strictly required.)
