### PR TITLE
Rewrite and speed up query tests

### DIFF
--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -85,6 +85,7 @@ class Query(ABC):
         """Return a set with field names that this query operates on."""
         return set()
 
+    @abstractmethod
     def clause(self) -> tuple[str | None, Sequence[Any]]:
         """Generate an SQLite expression implementing the query.
 
@@ -95,14 +96,12 @@ class Query(ABC):
         The default implementation returns None, falling back to a slow query
         using `match()`.
         """
-        return None, ()
 
     @abstractmethod
     def match(self, obj: Model):
         """Check whether this query matches a given Model. Can be used to
         perform queries on arbitrary sets of Model.
         """
-        ...
 
     def __and__(self, other: Query) -> AndQuery:
         return AndQuery([self, other])
@@ -152,7 +151,7 @@ class FieldQuery(Query, Generic[P]):
         self.fast = fast
 
     def col_clause(self) -> tuple[str, Sequence[SQLiteType]]:
-        return self.field, ()
+        raise NotImplementedError
 
     def clause(self) -> tuple[str | None, Sequence[SQLiteType]]:
         if self.fast:
@@ -164,7 +163,7 @@ class FieldQuery(Query, Generic[P]):
     @classmethod
     def value_match(cls, pattern: P, value: Any):
         """Determine whether the value matches the pattern."""
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def match(self, obj: Model) -> bool:
         return self.value_match(self.pattern, obj.get(self.field_name))
@@ -234,7 +233,7 @@ class StringFieldQuery(FieldQuery[P]):
         """Determine whether the value matches the pattern. Both
         arguments are strings. Subclasses implement this method.
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
 
 class StringQuery(StringFieldQuery[str]):

--- a/beets/test/_common.py
+++ b/beets/test/_common.py
@@ -63,8 +63,8 @@ HAVE_SYMLINK = sys.platform != "win32"
 HAVE_HARDLINK = sys.platform != "win32"
 
 
-def item(lib=None):
-    i = beets.library.Item(
+def item(lib=None, **kwargs):
+    defaults = dict(
         title="the title",
         artist="the artist",
         albumartist="the album artist",
@@ -99,6 +99,7 @@ def item(lib=None):
         album_id=None,
         mtime=12345,
     )
+    i = beets.library.Item(**{**defaults, **kwargs})
     if lib:
         lib.add(i)
     return i

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,9 @@
+import inspect
 import os
 
 import pytest
+
+from beets.dbcore.query import Query
 
 
 def skip_marked_items(items: list[pytest.Item], marker_name: str, reason: str):
@@ -21,3 +24,20 @@ def pytest_collection_modifyitems(
         skip_marked_items(
             items, "on_lyrics_update", "No change in lyrics source code"
         )
+
+
+def pytest_make_parametrize_id(config, val, argname):
+    """Generate readable test identifiers for pytest parametrized tests.
+
+    Provides custom string representations for:
+    - Query classes/instances: use class name
+    - Lambda functions: show abbreviated source
+    - Other values: use standard repr()
+    """
+    if inspect.isclass(val) and issubclass(val, Query):
+        return val.__name__
+
+    if inspect.isfunction(val) and val.__name__ == "<lambda>":
+        return inspect.getsource(val).split("lambda")[-1][:30]
+
+    return repr(val)

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -44,14 +44,6 @@ class AssertsMixin:
     def assert_albums_matched(self, results, albums):
         assert {a.album for a in results} == set(albums)
 
-    def assertInResult(self, item, results):
-        result_ids = [i.id for i in results]
-        assert item.id in result_ids
-
-    def assertNotInResult(self, item, results):
-        result_ids = [i.id for i in results]
-        assert item.id not in result_ids
-
 
 # A test case class providing a library with some dummy data and some
 # assertions involving that data.
@@ -477,44 +469,44 @@ class BoolQueryTest(BeetsTestCase, AssertsMixin):
         item_true = self.add_item(comp=True)
         item_false = self.add_item(comp=False)
         matched = self.lib.items("comp:true")
-        self.assertInResult(item_true, matched)
-        self.assertNotInResult(item_false, matched)
+        assert item_true.id in {i.id for i in matched}
+        assert item_false.id not in {i.id for i in matched}
 
     def test_flex_parse_true(self):
         item_true = self.add_item(flexbool=True)
         item_false = self.add_item(flexbool=False)
         matched = self.lib.items("flexbool:true")
-        self.assertInResult(item_true, matched)
-        self.assertNotInResult(item_false, matched)
+        assert item_true.id in {i.id for i in matched}
+        assert item_false.id not in {i.id for i in matched}
 
     def test_flex_parse_false(self):
         item_true = self.add_item(flexbool=True)
         item_false = self.add_item(flexbool=False)
         matched = self.lib.items("flexbool:false")
-        self.assertInResult(item_false, matched)
-        self.assertNotInResult(item_true, matched)
+        assert item_false.id in {i.id for i in matched}
+        assert item_true.id not in {i.id for i in matched}
 
     def test_flex_parse_1(self):
         item_true = self.add_item(flexbool=True)
         item_false = self.add_item(flexbool=False)
         matched = self.lib.items("flexbool:1")
-        self.assertInResult(item_true, matched)
-        self.assertNotInResult(item_false, matched)
+        assert item_true.id in {i.id for i in matched}
+        assert item_false.id not in {i.id for i in matched}
 
     def test_flex_parse_0(self):
         item_true = self.add_item(flexbool=True)
         item_false = self.add_item(flexbool=False)
         matched = self.lib.items("flexbool:0")
-        self.assertInResult(item_false, matched)
-        self.assertNotInResult(item_true, matched)
+        assert item_false.id in {i.id for i in matched}
+        assert item_true.id not in {i.id for i in matched}
 
     def test_flex_parse_any_string(self):
         # TODO this should be the other way around
         item_true = self.add_item(flexbool=True)
         item_false = self.add_item(flexbool=False)
         matched = self.lib.items("flexbool:something")
-        self.assertInResult(item_false, matched)
-        self.assertNotInResult(item_true, matched)
+        assert item_false.id in {i.id for i in matched}
+        assert item_true.id not in {i.id for i in matched}
 
 
 class DefaultSearchFieldsTest(DummyDataTestCase):
@@ -541,33 +533,33 @@ class NoneQueryTest(BeetsTestCase, AssertsMixin):
         album_item = self.add_album().items().get()
 
         matched = self.lib.items(NoneQuery("album_id"))
-        self.assertInResult(singleton, matched)
-        self.assertNotInResult(album_item, matched)
+        assert singleton.id in {i.id for i in matched}
+        assert album_item.id not in {i.id for i in matched}
 
     def test_match_after_set_none(self):
         item = self.add_item(rg_track_gain=0)
         matched = self.lib.items(NoneQuery("rg_track_gain"))
-        self.assertNotInResult(item, matched)
+        assert item.id not in {i.id for i in matched}
 
         item["rg_track_gain"] = None
         item.store()
         matched = self.lib.items(NoneQuery("rg_track_gain"))
-        self.assertInResult(item, matched)
+        assert item.id in {i.id for i in matched}
 
     def test_match_slow(self):
         item = self.add_item()
         matched = self.lib.items(NoneQuery("rg_track_peak", fast=False))
-        self.assertInResult(item, matched)
+        assert item.id in {i.id for i in matched}
 
     def test_match_slow_after_set_none(self):
         item = self.add_item(rg_track_gain=0)
         matched = self.lib.items(NoneQuery("rg_track_gain", fast=False))
-        self.assertNotInResult(item, matched)
+        assert item.id not in {i.id for i in matched}
 
         item["rg_track_gain"] = None
         item.store()
         matched = self.lib.items(NoneQuery("rg_track_gain", fast=False))
-        self.assertInResult(item, matched)
+        assert item.id in {i.id for i in matched}
 
 
 class NotQueryMatchTest(unittest.TestCase):


### PR DESCRIPTION
Previously:

```sh
Poe => pytest -p no:cov test/test_query.py --durations=10
=============================================================================== test session starts ===============================================================================
platform linux -- Python 3.9.20, pytest-8.3.5, pluggy-1.5.0
cachedir: /tmp/pytest_cache
rootdir: /home/sarunas/repo/beets
configfile: setup.cfg
plugins: anyio-4.9.0, xdist-3.6.1, requests-mock-1.12.1, flask-1.3.0
collected 133 items                                                                                                                                                               

test/test_query.py .....................................................................................................................................                 [133/133]

============================================================================== slowest 10 durations ===============================================================================
0.13s call     test/test_query.py::NotQueryTest::test_type_none
0.12s call     test/test_query.py::NotQueryTest::test_fast_vs_slow
0.11s call     test/test_query.py::GetTest::test_singleton_0
0.11s call     test/test_query.py::NotQueryTest::test_type_substring
0.11s call     test/test_query.py::RelatedQueriesTest::test_filter_items_by_common_field
0.11s call     test/test_query.py::RelatedQueriesTest::test_get_items_filter_by_album_field
0.11s call     test/test_query.py::NotQueryTest::test_type_boolean
0.11s call     test/test_query.py::NotQueryTest::test_type_or
0.11s call     test/test_query.py::NotQueryTest::test_type_numeric
0.11s call     test/test_query.py::NotQueryTest::test_type_true
=============================================================================== 133 passed in 9.94s ===============================================================================
```

Now:
```sh
Poe => pytest -p no:cov test/test_query.py --durations=10
=============================================================================== test session starts ================================================================================
platform linux -- Python 3.9.20, pytest-8.3.5, pluggy-1.5.0
cachedir: /tmp/pytest_cache
rootdir: /home/sarunas/repo/beets
configfile: setup.cfg
plugins: anyio-4.9.0, xdist-3.6.1, requests-mock-1.12.1, flask-1.3.0
collected 129 items                                                                                                                                                                

test/test_query.py .................................................................................................................................                      [129/129]

=============================================================================== slowest 10 durations ===============================================================================
0.10s setup    test/test_query.py::TestRelatedQueries::test_related_query[match-album-with-item-field-query]
0.09s setup    test/test_query.py::TestGet::test_get_query[''-['first', 'second', 'third']]
0.09s setup    test/test_query.py::TestPathQuery::test_explicit[exact-match]
0.09s setup    test/test_query.py::TestQuery::test_value_type[parse-true]
0.08s setup    test/test_query.py::TestDefaultSearchFields::test_search[album-match-album]
0.02s call     test/test_query.py::TestGet::test_query_logic[SubstringQuery('album', 'ba', fast=True)-{'third'}]
0.02s call     test/test_query.py::TestGet::test_query_logic[NoneQuery('rg_track_gain', True)-set()]
0.02s call     test/test_query.py::TestGet::test_query_logic[NumericQuery('year', '2001..2002', fast=True)-{'third'}]
0.02s call     test/test_query.py::TestGet::test_query_logic[RegexpQuery('artist', re.compile('^t'), fast=True)-{'first'}]
0.02s call     test/test_query.py::TestGet::test_query_logic[OrQuery([BooleanQuery('comp', 1, fast=True), NumericQuery('year', '2002', fast=True)])-{'third'}]
=============================================================================== 129 passed in 2.53s ================================================================================
```