### PR TITLE
Fix the MusicBrainz search not taking into account the album/recordin…

### DIFF
--- a/beetsplug/musicbrainz.py
+++ b/beetsplug/musicbrainz.py
@@ -771,6 +771,7 @@ class MusicBrainzPlugin(BeetsPlugin):
     ) -> dict[str, str]:
         criteria = {
             "release": album,
+            "alias": album,
             "tracks": str(len(items)),
         } | ({"arid": VARIOUS_ARTISTS_ID} if va_likely else {"artist": artist})
 
@@ -826,7 +827,7 @@ class MusicBrainzPlugin(BeetsPlugin):
     def item_candidates(
         self, item: Item, artist: str, title: str
     ) -> Iterator[beets.autotag.hooks.TrackInfo]:
-        criteria = {"artist": artist, "recording": title}
+        criteria = {"artist": artist, "recording": title, "alias": title}
 
         yield from filter(
             None, map(self.track_info, self._search_api("recording", criteria))

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -37,6 +37,8 @@ Bug fixes:
 * Fix ``HiddenFileTest`` by using ``bytestring_path()``.
 * tests: Fix tests failing without ``langdetect`` (by making it required).
   :bug:`5797`
+* :doc:`plugins/musicbrainz`: Fix the MusicBrainz search not taking into
+  account the album/recording aliases
 
 For packagers:
 

--- a/test/plugins/test_musicbrainz.py
+++ b/test/plugins/test_musicbrainz.py
@@ -1025,6 +1025,7 @@ class TestMusicBrainzPlugin(PluginMixin):
 
         assert mb.get_album_criteria(items, "Artist ", " Album", va_likely) == {
             "release": " Album",
+            "alias": " Album",
             "tracks": str(len(items)),
             **expected_additional_criteria,
         }


### PR DESCRIPTION
…g aliases

## Description

When searching on MusicBrainz, beets does not add the `alias` field that allows for searching on the entity aliases.

As per [the MusicBrainz Indexed Search Syntax](https://musicbrainz.org/doc/Indexed_Search_Syntax#Search_Fields_9):
> alias	| (part of) any alias attached to the release group (diacritics are ignored)
> [...]
> release | (part of) the title of any of the releases in the release group

By adding the `alias` field assigned with the entity title, the search returns better results for titles that can be aliased.

The problem can be reproduced with the following album: https://musicbrainz.org/release-group/b5b4eed2-e871-4268-80bb-7625ee0c6cd0:
- Currently, beets searches using the following query: [`release:(rude lose dance \- single) tracks:(1) artist:(minami)`](https://musicbrainz.org/search?query=release%3A%28rude+lose+dance+%5C-+single%29+tracks%3A%281%29+artist%3A%28minami%29&type=release_group&limit=25&method=advanced)
  - We can see that the correct album cannot be found (even after 5 pages!)
- With this PR, beets now searches using the following query: [`release:(rude lose dance \- single) alias:(rude lose dance \- single) tracks:(1) artist:(minami)`](https://musicbrainz.org/search?query=release%3A%28rude+lose+dance+%5C-+single%29+alias%3A%28rude+lose+dance+%5C-+single%29+tracks%3A%281%29+artist%3A%28minami%29&type=release_group&limit=25&method=advanced)
  - We can see that the correct album is now found in 1st position!

Tests had to be updated due to the addition of the `alias` criteria.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation.~
- [x] Changelog.
- [x] ~Tests.~
