### PR TITLE
Add --remove option to duplicates plugin

### DIFF
--- a/beetsplug/duplicates.py
+++ b/beetsplug/duplicates.py
@@ -233,7 +233,7 @@ class DuplicatesPlugin(BeetsPlugin):
             item.store()
         if delete:
             item.remove(delete=True)
-        if remove:
+        elif remove:
             item.remove(delete=False)
         if tag:
             try:

--- a/beetsplug/duplicates.py
+++ b/beetsplug/duplicates.py
@@ -53,6 +53,7 @@ class DuplicatesPlugin(BeetsPlugin):
                 "tiebreak": {},
                 "strict": False,
                 "tag": "",
+                "remove": False,
             }
         )
 
@@ -131,6 +132,13 @@ class DuplicatesPlugin(BeetsPlugin):
             action="store",
             help="tag matched items with 'k=v' attribute",
         )
+        self._command.parser.add_option(
+            "-r",
+            "--remove",
+            dest="remove",
+            action="store_true",
+            help="remove items from library",
+        )
         self._command.parser.add_all_common_options()
 
     def commands(self):
@@ -141,6 +149,7 @@ class DuplicatesPlugin(BeetsPlugin):
             copy = bytestring_path(self.config["copy"].as_str())
             count = self.config["count"].get(bool)
             delete = self.config["delete"].get(bool)
+            remove = self.config["remove"].get(bool)
             fmt = self.config["format"].get(str)
             full = self.config["full"].get(bool)
             keys = self.config["keys"].as_str_seq()
@@ -196,6 +205,7 @@ class DuplicatesPlugin(BeetsPlugin):
                             copy=copy,
                             move=move,
                             delete=delete,
+                            remove=remove,
                             tag=tag,
                             fmt=fmt.format(obj_count),
                         )
@@ -204,7 +214,14 @@ class DuplicatesPlugin(BeetsPlugin):
         return [self._command]
 
     def _process_item(
-        self, item, copy=False, move=False, delete=False, tag=False, fmt=""
+        self,
+        item,
+        copy=False,
+        move=False,
+        delete=False,
+        tag=False,
+        fmt="",
+        remove=False,
     ):
         """Process Item `item`."""
         print_(format(item, fmt))
@@ -216,6 +233,8 @@ class DuplicatesPlugin(BeetsPlugin):
             item.store()
         if delete:
             item.remove(delete=True)
+        if remove:
+            item.remove(delete=False)
         if tag:
             try:
                 k, v = tag.split("=")

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,9 @@ New features:
   singletons by their Discogs ID.
   :bug:`4661`
 * :doc:`plugins/replace`: Add new plugin.
+* :doc:`plugins/duplicates`: Add ``--remove`` option, allowing to remove from
+  the library without deleting media files.
+  :bug:`5832`
 
 Bug fixes:
 

--- a/docs/plugins/duplicates.rst
+++ b/docs/plugins/duplicates.rst
@@ -34,6 +34,7 @@ duplicates themselves via command-line switches ::
   -o DEST, --copy=DEST  copy items to dest
   -p, --path            print paths for matched items or albums
   -t TAG, --tag=TAG     tag matched items with 'k=v' attribute
+  -r, --remove          remove items from library
 
 Configuration
 -------------
@@ -57,7 +58,7 @@ file. The available options mirror the command-line options:
   ``$albumartist - $album - $title: $count`` (for tracks) or ``$albumartist -
   $album: $count`` (for albums).
   Default: ``no``.
-- **delete**: Removes matched items from the library and from the disk.
+- **delete**: Remove matched items from the library and from the disk.
   Default: ``no``
 - **format**: A specific format with which to print every track
   or album. This uses the same template syntax as beets'
@@ -92,6 +93,8 @@ file. The available options mirror the command-line options:
   set. If you would like to consider the lower bitrates as duplicates,
   for example, set ``tiebreak: items: [bitrate]``.
   Default: ``{}``.
+- **remove**: Remove matched items from the library, but not from the disk.
+  Default: ``no``.
 
 Examples
 --------


### PR DESCRIPTION

## Description

The duplicates plugin currently only supports deleting files entirely, sometimes it's desired to only fix the library and keep files in place. This PR adds this possibility.



- [x] Documentation. 
- [x] Changelog. (will add after review)
- [x] ~Tests.~
