### PR TITLE
Convert flexible field values to SQL before storing them

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -604,6 +604,7 @@ class Model(ABC, Generic[D]):
             for key, value in self._values_flex.items():
                 if key in self._dirty:
                     self._dirty.remove(key)
+                    value = self._type(key).to_sql(value)
                     tx.mutate(
                         "INSERT INTO {} "
                         "(entity_id, key, value) "


### PR DESCRIPTION
## Description

This is required to support multivalued fields as flexible fields.
See #5698 for more details.

## To Do

- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)

(will add those later)