### PR TITLE
Fix pipx install action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Python tools
-        uses: BrandonLWhite/pipx-install-action@v1.0.3
+        # BrandonLWhite/pipx-install-action@v1.0.3 fails on Windows, thus we're using an alternative action here
+        uses: threeal/pipx-install-action@v1.0.0
+        with:
+          packages: poethepoet>=0.26 poetry<2
       - name: Setup Python with poetry caching
         # poetry cache requires poetry to already be installed, weirdly
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Python tools
-        uses: BrandonLWhite/pipx-install-action@v1.0.1
+        uses: BrandonLWhite/pipx-install-action@v1.0.3
       - name: Setup Python with poetry caching
         # poetry cache requires poetry to already be installed, weirdly
         uses: actions/setup-python@v5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,10 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Python tools
-        # BrandonLWhite/pipx-install-action@v1.0.3 fails on Windows, thus we're using an alternative action here
-        uses: threeal/pipx-install-action@v1.0.0
-        with:
-          packages: poethepoet>=0.26 poetry<2
+        uses: BrandonLWhite/pipx-install-action@v1.0.3
       - name: Setup Python with poetry caching
         # poetry cache requires poetry to already be installed, weirdly
         uses: actions/setup-python@v5

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Python tools
-        uses: BrandonLWhite/pipx-install-action@v1.0.1
+        uses: BrandonLWhite/pipx-install-action@v1.0.3
       - uses: actions/setup-python@v5
         with:
           python-version: 3.9

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Python tools
-        uses: BrandonLWhite/pipx-install-action@v1.0.1
+        uses: BrandonLWhite/pipx-install-action@v1.0.3
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Python tools
-        uses: BrandonLWhite/pipx-install-action@v1.0.1
+        uses: BrandonLWhite/pipx-install-action@v1.0.3
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -94,7 +94,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Python tools
-        uses: BrandonLWhite/pipx-install-action@v1.0.1
+        uses: BrandonLWhite/pipx-install-action@v1.0.3
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -118,7 +118,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Python tools
-        uses: BrandonLWhite/pipx-install-action@v1.0.1
+        uses: BrandonLWhite/pipx-install-action@v1.0.3
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/make_release.yaml
+++ b/.github/workflows/make_release.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Python tools
-        uses: BrandonLWhite/pipx-install-action@v1.0.1
+        uses: BrandonLWhite/pipx-install-action@v1.0.3
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -50,7 +50,7 @@ jobs:
           ref: ${{ env.NEW_TAG }}
 
       - name: Install Python tools
-        uses: BrandonLWhite/pipx-install-action@v1.0.1
+        uses: BrandonLWhite/pipx-install-action@v1.0.3
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}


### PR DESCRIPTION
## Fix pipx-install-action Windows compatibility issue

Replace `BrandonLWhite/pipx-install-action@v1.0.3` with `threeal/pipx-install-action@v1.0.0` in CI workflow due to Windows compatibility issues.

**Changes:**
- Switch to alternative pipx-install-action that works on Windows
- Add explicit package specification for poethepoet and poetry
- Resolves GitHub issue: https://github.com/BrandonLWhite/pipx-install-action/issues/62

**Edit**: received a reply from `pipx-install-action` maintainer with a fix: simply remove the breaking cache from GitHub Actions: this worked fine.

Thus I reverted the commit which introduced another action on Windows. The only change that this PR makes is `pipx-install-action` version upgrade.
