### PR TITLE
Only consider release collections in mbcollection plugin

### DIFF
--- a/beetsplug/mbcollection.py
+++ b/beetsplug/mbcollection.py
@@ -70,10 +70,14 @@ class MusicBrainzCollectionPlugin(BeetsPlugin):
         if not collections["collection-list"]:
             raise ui.UserError("no collections exist for user")
 
-        # Get all collection IDs, avoiding event collections
-        collection_ids = [x["id"] for x in collections["collection-list"]]
+        # Get all release collection IDs, avoiding event collections
+        collection_ids = [
+            x["id"]
+            for x in collections["collection-list"]
+            if x["entity-type"] == "release"
+        ]
         if not collection_ids:
-            raise ui.UserError("No collection found.")
+            raise ui.UserError("No release collection found.")
 
         # Check that the collection exists so we can present a nice error
         collection = self.config["collection"].as_str()

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,8 @@ New features:
   singletons by their Discogs ID.
   :bug:`4661`
 * :doc:`plugins/replace`: Add new plugin.
+* :doc:`plugins/mbcollection`: When getting the user collections, only consider
+  collections of releases, and ignore collections of other entity types.
 
 Bug fixes:
 


### PR DESCRIPTION
## Description

Currently, `mbcollection` takes the first collection it finds (if the user does not explicitely indicates one in the configuration).

The problem is that the user may have collections of types that we are not interested in (e.g. recording collections, artist collections, etc.).

Since the `get_collections` response returns the collections types, we can only keep the `release` collections.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation.~ (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
