### PR TITLE
Use python3 print in plugins.rst

### DIFF
--- a/docs/dev/plugins.rst
+++ b/docs/dev/plugins.rst
@@ -78,7 +78,7 @@ Here's an example plugin that adds a simple command::
 
     my_super_command = Subcommand('super', help='do something super')
     def say_hi(lib, opts, args):
-        print "Hello everybody! I'm a plugin!"
+        print("Hello everybody! I'm a plugin!")
     my_super_command.func = say_hi
 
     class SuperPlug(BeetsPlugin):


### PR DESCRIPTION
## Description

Use python3 print in plugins.rst docs

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)~
- [x] ~Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)~
- [x] ~Tests. (Very much encouraged but not strictly required.)~
