### PR TITLE
logging: make levels/formats configurable

### DIFF
--- a/beets/autotag/__init__.py
+++ b/beets/autotag/__init__.py
@@ -67,7 +67,7 @@ __all__ = [
 ]
 
 # Global logger.
-log = logging.getLogger("beets")
+log = logging.getLogger(__name__)
 
 # Metadata fields that are already hardcoded, or where the tag name changes.
 SPECIAL_FIELDS = {

--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import logging
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
@@ -25,6 +26,8 @@ if TYPE_CHECKING:
     from beets.library import Item
 
     from .distance import Distance
+
+log = logging.getLogger(__name__)
 
 V = TypeVar("V")
 

--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from beets.library import Item
 
 # Global logger.
-log = logging.getLogger("beets")
+log = logging.getLogger(__name__)
 
 
 # Recommendation enumeration.

--- a/beets/importer/session.py
+++ b/beets/importer/session.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 QUEUE_SIZE = 128
 
 # Global logger.
-log = logging.getLogger("beets")
+log = logging.getLogger(__name__)
 
 
 class ImportAbortError(Exception):

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -15,10 +15,9 @@
 from __future__ import annotations
 
 import itertools
-import logging
 from typing import TYPE_CHECKING, Callable
 
-from beets import config, plugins
+from beets import config, logging, plugins
 from beets.util import MoveOperation, displayable_path, pipeline
 
 from .tasks import (

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from .session import ImportSession
 
 # Global logger.
-log = logging.getLogger("beets")
+log = logging.getLogger(__name__)
 
 # ---------------------------- Producer functions ---------------------------- #
 # Functions that are called first i.e. they generate import tasks

--- a/beets/importer/state.py
+++ b/beets/importer/state.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 
 # Global logger.
-log = logging.getLogger("beets")
+log = logging.getLogger(__name__)
 
 
 @dataclass

--- a/beets/importer/state.py
+++ b/beets/importer/state.py
@@ -14,14 +14,13 @@
 
 from __future__ import annotations
 
-import logging
 import os
 import pickle
 from bisect import bisect_left, insort
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from beets import config
+from beets import config, logging
 
 if TYPE_CHECKING:
     from beets.util import PathBytes

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import logging
 import os
 import re
 import shutil
@@ -26,7 +25,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence
 
 import mediafile
 
-from beets import autotag, config, library, plugins, util
+from beets import autotag, config, library, logging, plugins, util
 from beets.dbcore.query import PathQuery
 
 from .state import ImportState
@@ -35,9 +34,6 @@ if TYPE_CHECKING:
     from beets.autotag.match import Recommendation
 
     from .session import ImportSession
-
-# Global logger.
-log = logging.getLogger(__name__)
 
 
 SINGLE_ARTIST_THRESH = 0.25

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from .session import ImportSession
 
 # Global logger.
-log = logging.getLogger("beets")
+log = logging.getLogger(__name__)
 
 
 SINGLE_ARTIST_THRESH = 0.25
@@ -63,7 +63,7 @@ REIMPORT_FRESH_FIELDS_ITEM = [
 REIMPORT_FRESH_FIELDS_ALBUM = [*REIMPORT_FRESH_FIELDS_ITEM, "media"]
 
 # Global logger.
-log = logging.getLogger("beets")
+log = logging.getLogger(__name__)
 
 
 class ImportAbortError(Exception):

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from ..dbcore.query import FieldQuery, FieldQueryType
     from .library import Library  # noqa: F401
 
-log = logging.getLogger("beets")
+log = logging.getLogger(__name__)
 
 
 class LibModel(dbcore.Model["Library"]):

--- a/beets/library/queries.py
+++ b/beets/library/queries.py
@@ -5,7 +5,7 @@ import shlex
 import beets
 from beets import dbcore, logging, plugins
 
-log = logging.getLogger("beets")
+log = logging.getLogger(__name__)
 
 
 # Special path format key.

--- a/beets/logging.py
+++ b/beets/logging.py
@@ -22,7 +22,6 @@ calls (`debug`, `info`, etc).
 
 from __future__ import annotations
 
-import threading
 from copy import copy
 from logging import (
     DEBUG,
@@ -141,35 +140,7 @@ class StrFormatLogger(Logger):
         )
 
 
-class ThreadLocalLevelLogger(Logger):
-    """A version of `Logger` whose level is thread-local instead of shared."""
-
-    def __init__(self, name, level=NOTSET):
-        self._thread_level = threading.local()
-        self.default_level = NOTSET
-        super().__init__(name, level)
-
-    @property
-    def level(self):
-        try:
-            return self._thread_level.level
-        except AttributeError:
-            self._thread_level.level = self.default_level
-            return self.level
-
-    @level.setter
-    def level(self, value):
-        self._thread_level.level = value
-
-    def set_global_level(self, level):
-        """Set the level on the current thread + the default value for all
-        threads.
-        """
-        self.default_level = level
-        self.setLevel(level)
-
-
-class BeetsLogger(ThreadLocalLevelLogger, StrFormatLogger):
+class BeetsLogger(StrFormatLogger):
     pass
 
 

--- a/beets/logging.py
+++ b/beets/logging.py
@@ -30,11 +30,13 @@ from logging import (
     WARNING,
     FileHandler,
     Filter,
+    Formatter,
     Handler,
     Logger,
     NullHandler,
     RootLogger,
     StreamHandler,
+    _levelToName,
 )
 from typing import TYPE_CHECKING, Any, Mapping, TypeVar, Union, overload
 
@@ -45,11 +47,13 @@ __all__ = [
     "WARNING",
     "FileHandler",
     "Filter",
+    "Formatter",
     "Handler",
     "Logger",
     "NullHandler",
     "StreamHandler",
     "getLogger",
+    "getLevelNamesMapping",
 ]
 
 if TYPE_CHECKING:
@@ -63,6 +67,18 @@ if TYPE_CHECKING:
     ]
     _ExcInfoType = Union[None, bool, _SysExcInfoType, BaseException]
     _ArgsType = Union[tuple[object, ...], Mapping[str, object]]
+
+
+def getLevelNamesMapping() -> dict[str, int]:  # noqa: N802  # Hey, I didn't name it!
+    """Returns a mapping from level names to their corresponding logging
+    levels. For example, the string “CRITICAL” maps to CRITICAL. The returned
+    mapping is copied from an internal mapping on each call to this function.
+
+    Polyfill for `logging.getLevelNamesMapping`, which was only added in Python
+    3.11.
+    """
+
+    return {name: level for (level, name) in _levelToName.items()}
 
 
 def _logsafe(val: T) -> str | T:

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -99,7 +99,7 @@ EventType = Literal[
     "write",
 ]
 # Global logger.
-log = logging.getLogger("beets")
+log = logging.getLogger(__name__)
 
 
 class PluginConflictError(Exception):

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -1543,6 +1543,8 @@ def _configure(options):
         overlay_path = None
     config.set_args(options)
 
+    beet_logger = logging.getLogger("beets")
+
     # Configure the logger.
     if config["verbose"].get(int):
         log.setLevel(logging.DEBUG)

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -1545,9 +1545,9 @@ def _configure(options):
 
     # Configure the logger.
     if config["verbose"].get(int):
-        log.set_global_level(logging.DEBUG)
+        log.setLevel(logging.DEBUG)
     else:
-        log.set_global_level(logging.INFO)
+        log.setLevel(logging.INFO)
 
     if overlay_path:
         log.debug(

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -51,7 +51,7 @@ from . import _store_dict
 VARIOUS_ARTISTS = "Various Artists"
 
 # Global logger.
-log = logging.getLogger("beets")
+log = logging.getLogger(__name__)
 
 # The list of default subcommands. This is populated with Subcommand
 # objects that can be fed to a SubcommandsOptionParser.

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -39,7 +39,7 @@ from beets.util import (
 
 PROXY_URL = "https://images.weserv.nl/"
 
-log = logging.getLogger("beets")
+log = logging.getLogger(__name__)
 
 
 def resize_url(url: str, maxwidth: int, quality: int = 0) -> str:

--- a/beets/util/id_extractors.py
+++ b/beets/util/id_extractors.py
@@ -20,7 +20,7 @@ import re
 
 from beets import logging
 
-log = logging.getLogger("beets")
+log = logging.getLogger(__name__)
 
 
 PATTERN_BY_SOURCE = {

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -14,7 +14,6 @@
 
 """Converts tracks or albums to external directory"""
 
-import logging
 import os
 import shlex
 import subprocess
@@ -25,7 +24,7 @@ from string import Template
 import mediafile
 from confuse import ConfigTypeError, Optional
 
-from beets import config, plugins, ui, util
+from beets import config, logging, plugins, ui, util
 from beets.library import Item, parse_query_string
 from beets.plugins import BeetsPlugin
 from beets.util import par_map

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -47,6 +47,9 @@ if TYPE_CHECKING:
 
     from beets.library import Item
 
+# Global logger.
+log = logging.getLogger(__name__)
+
 USER_AGENT = f"beets/{beets.__version__} +https://beets.io/"
 API_KEY = "rAzVUQYRaoFjeBjyWuWZ"
 API_SECRET = "plxtUTqoCzwxZpqdPysCwGuBSmZNdZVy"

--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -37,7 +37,7 @@ from typing_extensions import NotRequired, TypedDict
 
 import beets
 import beets.ui
-from beets import config
+from beets import config, logging
 from beets.autotag.distance import string_dist
 from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.metadata_plugins import MetadataSourcePlugin

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -206,7 +206,7 @@ class ConvertCliTest(ConvertTestCase, ConvertCommand):
         assert not self.converted_mp3.exists()
 
     def test_empty_query(self):
-        with capture_log("beets.convert") as logs:
+        with capture_log("beets.plugins.convert") as logs:
             self.run_convert("An impossible query")
         assert logs[0] == "convert: Empty query result."
 

--- a/test/plugins/test_hook.py
+++ b/test/plugins/test_hook.py
@@ -43,7 +43,10 @@ class HookLogsTest(HookTestCase):
     def _configure_logs(self, command: str) -> Iterator[list[str]]:
         config = {"hooks": [self._get_hook(self.HOOK, command)]}
 
-        with self.configure_plugin(config), capture_log("beets.hook") as logs:
+        with (
+            self.configure_plugin(config),
+            capture_log("beets.plugins.hook") as logs,
+        ):
             plugins.send(self.HOOK)
             yield logs
 

--- a/test/plugins/test_mbsync.py
+++ b/test/plugins/test_mbsync.py
@@ -78,7 +78,7 @@ class MbsyncCliTest(PluginTestCase):
         ]:
             self.lib.add(item)
 
-        with capture_log("beets.mbsync") as logs:
+        with capture_log("beets.plugins.mbsync") as logs:
             self.run_command("mbsync", "-f", "'%if{$album,$album,$title}'")
 
         assert "mbsync: Skipping album with no mb_albumid: 'no id'" in logs

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -139,7 +139,7 @@ class AddTest(BeetsTestCase):
         self.item.album = "a"
         self.item.title = "b"
 
-        blog.getLogger("beets").set_global_level(blog.DEBUG)
+        blog.getLogger("beets").setLevel(blog.DEBUG)
         with capture_log() as logs:
             self.lib.add(self.item)
 

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -27,9 +27,6 @@ class TestStrFormatLogger:
         l4 = log.getLogger("bar123")
         assert l3 == l4
         assert l3.__class__ == blog.BeetsLogger
-        assert isinstance(
-            l3, (blog.StrFormatLogger, blog.ThreadLocalLevelLogger)
-        )
 
         l5 = l3.getChild("shalala")
         assert l5.__class__ == blog.BeetsLogger
@@ -278,24 +275,3 @@ class ConcurrentEventsTest(AsIsImporterMixin, ImportTestCase):
                 dp.lock2.release()
             print("Alive threads:", threading.enumerate())
             raise
-
-    def test_root_logger_levels(self):
-        """Root logger level should be shared between threads."""
-        self.config["threaded"] = True
-
-        blog.getLogger("beets").set_global_level(blog.WARNING)
-        with helper.capture_log() as logs:
-            self.run_asis_importer()
-        assert logs == []
-
-        blog.getLogger("beets").set_global_level(blog.INFO)
-        with helper.capture_log() as logs:
-            self.run_asis_importer()
-        for line in logs:
-            assert "import" in line
-            assert "album" in line
-
-        blog.getLogger("beets").set_global_level(blog.DEBUG)
-        with helper.capture_log() as logs:
-            self.run_asis_importer()
-        assert "Sending event: database_change" in logs


### PR DESCRIPTION


## Description

This keeps the root logger from swallowing logs, for example logs emitted by plugins and dependencies (such as the MusicBrainz API client).

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
