### PR TITLE
Add py.typed marker file to support PEP 561 typing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -107,7 +107,7 @@ jobs:
         uses: liskin/gh-problem-matcher-wrap@v3
         with:
           linters: mypy
-          run: poe check-types --show-column-numbers --no-error-summary ${{ needs.changed-files.outputs.changed_python_files }}
+          run: poe check-types --show-column-numbers --no-error-summary .
 
   docs:
     if: needs.changed-files.outputs.any_docs_changed == 'true'

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -92,6 +92,10 @@ For plugin developers:
 
   Old imports are now deprecated and will be removed in version ``3.0.0``.
 * ``beets.ui.decargs`` is deprecated and will be removed in version ``3.0.0``.
+* Beets is now pep 561 compliant, which means that it provides type hints
+  for all public APIs. This allows IDEs to provide better autocompletion and
+  type checking for downstream users of the beets API.
+
 
 Other changes:
 

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -25,6 +25,7 @@ import pytest
 from beets import dbcore
 from beets.library import LibModel
 from beets.test import _common
+from beets.util import cached_classproperty
 
 # Fixture: concrete database and model classes. For migration tests, we
 # have multiple models with different numbers of fields.
@@ -53,15 +54,22 @@ class ModelFixture1(LibModel):
         "field_one": dbcore.types.INTEGER,
         "field_two": dbcore.types.STRING,
     }
-    _types = {
-        "some_float_field": dbcore.types.FLOAT,
-    }
+
     _sorts = {
         "some_sort": SortFixture,
     }
-    _queries = {
-        "some_query": QueryFixture,
-    }
+
+    @cached_classproperty
+    def _types(cls):
+        return {
+            "some_float_field": dbcore.types.FLOAT,
+        }
+
+    @cached_classproperty
+    def _queries(cls):
+        return {
+            "some_query": QueryFixture,
+        }
 
     @classmethod
     def _getters(cls):


### PR DESCRIPTION
 Add `py.typed` marker file to support PEP 561 typing

This PR adds a `py.typed` marker file to the package directory to indicate that the package includes inline type hints and is PEP 561 compliant.

### Why this is needed

* The `py.typed` file signals to type checkers (e.g. `mypy`, `pyright`) that type information is available within the package.
* Without this file, external projects using this package will not be able to consume its type hints.
* This improves developer experience and enables better static analysis for downstream users.
