### PR TITLE
missingfiles: init

### DIFF
--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -225,7 +225,7 @@ class Album(LibModel):
     Reflects the library's "albums" table, including album art.
     """
 
-    artpath: bytes
+    artpath: bytes | None
 
     _table = "albums"
     _flex_table = "album_attributes"

--- a/beetsplug/missingfiles.py
+++ b/beetsplug/missingfiles.py
@@ -1,0 +1,75 @@
+# This file is part of beets.
+# Copyright 2025, Rebecca Turner.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+"""Detect missing files and album art."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from beets import plugins, ui, util
+
+if TYPE_CHECKING:
+    import optparse
+
+    from beets.library import Library
+
+
+class MissingFilesPlugin(plugins.BeetsPlugin):
+    def __init__(self) -> None:
+        super().__init__()
+
+    def commands(self) -> list[ui.Subcommand]:
+        cmd = ui.Subcommand(
+            "missingfiles", help="Detect missing files and album art"
+        )
+
+        cmd.parser.add_option(
+            "--delete",
+            help="Also delete missing items from the library",
+            action="store_true",
+        )
+
+        cmd.func = self.detect_missing
+
+        return [cmd]
+
+    def detect_missing(
+        self, lib: Library, opts: optparse.Values, _args: list[str]
+    ) -> None:
+        should_delete: bool = opts.delete or False
+
+        for album in lib.albums():
+            art_filepath = album.art_filepath
+            if art_filepath is not None and not art_filepath.exists():
+                print(f"{art_filepath}")
+
+                if should_delete:
+                    with lib.transaction():
+                        album.artpath = None
+                        album.store(fields=["artpath"])
+
+        for item in lib.items():
+            if item.path is not None:
+                path = Path(os.fsdecode(item.path))
+                if not path.exists():
+                    print(f"{path}")
+
+                    if should_delete:
+                        with lib.transaction():
+                            item.remove(delete=False, with_album=True)
+                        util.prune_dirs(
+                            os.path.dirname(item.path), lib.directory
+                        )

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,9 +9,11 @@ below!
 Unreleased
 ----------
 
-..
-    New features
-    ~~~~~~~~~~~~
+New features
+~~~~~~~~~~~~
+
+- :doc:`plugins/missingfiles`: Added new ``missingfiles`` plugin to scan your
+  library for missing files and album art.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -71,6 +71,7 @@ databases. They share the following configuration options:
     chroma
     convert
     deezer
+    missingfiles
     discogs
     duplicates
     edit
@@ -345,6 +346,10 @@ Miscellaneous
 :doc:`convert <convert>`
     Transcode music and embed album art while exporting to a different
     directory.
+
+:doc:`missingfiles <missingfiles>`
+    Detect library entries with missing files, folders, or album art, and
+    optionally delete them.
 
 :doc:`duplicates <duplicates>`
     List duplicate tracks or albums.

--- a/docs/plugins/missingfiles.rst
+++ b/docs/plugins/missingfiles.rst
@@ -1,0 +1,38 @@
+missingfiles plugin
+===================
+
+The ``missingfiles`` plugin lets you scan your library for missing files and
+album art, and optionally delete them from your library database.
+
+Installation
+------------
+
+To use ``missingfiles``, enable the plugin in your configuration (see
+:ref:`using-plugins`); no additional configuration is necessary.
+
+Usage
+-----
+
+Use ``beet missingfiles`` to scan your library for missing files and album art.
+This does not modify your library.
+
+::
+
+    $ beet missingfiles
+    /Users/example/Music/Music/Susumu Hirasawa/AURORA/cover.jpg
+    /Users/example/Music/Music/Compilations/Enforcers_ The Beginning of the End/09 Distorted Tax.mp3
+    /Users/example/Music/Music/Compilations/Distorted Reality (Future Drum & Bass)/03 The Killer.mp3
+    /Users/example/Music/Music/Compilations/Distorted Reality (Future Drum & Bass)/07 The Killer (Radio Edit).mp3
+    /Users/example/Music/Music/Compilations/Distorted Reality (Future Drum & Bass)/04 Toxic.mp3
+
+``beet missingfiles --delete`` works the same way, but additionally deletes the
+database entries from your library. Note that the files on disk are already
+deleted, but if the files were contained in directories that are now empty,
+those will be removed as well. The output format is the same as ``beet
+missingfiles``:
+
+::
+
+    $ beet missingfiles --delete
+    /Users/example/Music/Music/Susumu Hirasawa/AURORA/cover.jpg
+    /Users/example/Music/Music/Compilations/Enforcers_ The Beginning of the End/09 Distorted Tax.mp3

--- a/test/plugins/test_missingfiles.py
+++ b/test/plugins/test_missingfiles.py
@@ -1,0 +1,157 @@
+# This file is part of beets.
+# Copyright 2025, Rebecca Turner.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+"""Tests for the missingfiles plugin."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+from beets.test.helper import PluginTestCase
+from beets.util import bytestring_path, syspath
+
+
+class MissingFilesPluginTest(PluginTestCase):
+    plugin = "missingfiles"
+
+    def test_detect_missing_track_file(self):
+        """Test that missingfiles detects a missing track file."""
+        # Add an item with a real file
+        item = self.add_item_fixture()
+        item_path = item.path
+
+        # Verify the file exists
+        assert os.path.exists(syspath(item_path))
+
+        # Delete the backing file
+        os.remove(syspath(item_path))
+
+        # Run missingfiles command
+        output = self.run_with_output("missingfiles")
+
+        # Verify the missing file path is printed
+        assert str(item.filepath) in output
+
+        # Verify the item still exists in the library (no deletion without
+        # --delete flag)
+        items = list(self.lib.items())
+        assert len(items) == 1
+        assert items[0].path == item_path
+
+    def test_detect_missing_album_art(self):
+        """Test that missingfiles detects missing album art."""
+        # Add an album with items
+        album = self.add_album_fixture()
+
+        # Create a temporary art file and set it as album.artpath
+        handle, tmp_path = tempfile.mkstemp(suffix=".jpg")
+        os.close(handle)
+        album.artpath = bytestring_path(tmp_path)
+        album.store()
+
+        # Verify the art file exists
+        assert os.path.exists(tmp_path)
+
+        # Delete the art file
+        os.remove(tmp_path)
+
+        # Run missingfiles command
+        output = self.run_with_output("missingfiles")
+
+        # Verify the missing art path is printed
+        assert tmp_path in output
+
+        # Verify the album still has the artpath reference (no deletion without
+        # --delete flag)
+        albums = list(self.lib.albums())
+        assert len(albums) == 1
+        assert albums[0].artpath == bytestring_path(tmp_path)
+
+    def test_delete_missing_track_file(self):
+        """Test that missingfiles --delete removes items with missing files."""
+        # Add an item with a real file
+        item = self.add_item_fixture()
+        item_path = item.path
+        item_dir = os.path.dirname(syspath(item_path))
+
+        # Verify the file exists
+        assert os.path.exists(syspath(item_path))
+
+        # Delete the backing file
+        os.remove(syspath(item_path))
+
+        # Run missingfiles --delete
+        output = self.run_with_output("missingfiles", "--delete")
+
+        # Verify the missing file path is printed
+        assert str(item.filepath) in output
+
+        # Verify the item is removed from the library
+        items = list(self.lib.items())
+        assert len(items) == 0
+
+        # Verify empty parent directories are pruned
+        # The directory should be removed if it's now empty
+        assert not os.path.exists(item_dir)
+
+    def test_delete_missing_album_art(self):
+        """Test that missingfiles --delete clears artpath for missing album art."""
+        # Add an album with items
+        album = self.add_album_fixture()
+
+        # Create a temporary art file and assign it
+        handle, tmp_path = tempfile.mkstemp(suffix=".jpg")
+        os.close(handle)
+        album.artpath = bytestring_path(tmp_path)
+        album.store()
+
+        # Verify the art file exists
+        assert os.path.exists(tmp_path)
+
+        # Delete the art file
+        os.remove(tmp_path)
+
+        # Run missingfiles --delete
+        output = self.run_with_output("missingfiles", "--delete")
+
+        # Verify the missing art path is printed
+        assert tmp_path in output
+
+        # Verify the album's artpath is set to None
+        albums = list(self.lib.albums())
+        assert len(albums) == 1
+        assert albums[0].artpath is None
+
+        # Verify the album still exists in library (only art reference removed)
+        assert len(list(self.lib.albums())) == 1
+
+    def test_no_missing_files(self):
+        """Test that missingfiles produces no output when all files are present."""
+        # Add items and albums with all files present
+        item = self.add_item_fixture()
+        album = self.add_album_fixture()
+
+        # Verify files exist
+        assert os.path.exists(syspath(item.path))
+        for album_item in album.items():
+            assert os.path.exists(syspath(album_item.path))
+
+        # Run missingfiles
+        output = self.run_with_output("missingfiles")
+
+        # Verify no output is produced
+        assert output.strip() == ""
+
+        # Verify all items remain in library
+        assert len(list(self.lib.items())) == 2  # 1 from item, 1 from album


### PR DESCRIPTION
## Description

This lets users detect missing files and albums, in case they've deleted files outside of `beet remove -d`.

The UI could use a bit more polish, but how's the concept look? Happy to clean this up if you're interested in it.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
