### PR TITLE
fish: complete files in more places

### DIFF
--- a/beetsplug/fish.py
+++ b/beetsplug/fish.py
@@ -183,16 +183,16 @@ def get_basic_beet_options():
         BL_NEED2.format("-l format-item", "-f -d 'print with custom format'")
         + BL_NEED2.format("-l format-album", "-f -d 'print with custom format'")
         + BL_NEED2.format(
-            "-s  l  -l library", "-f -r -d 'library database file to use'"
+            "-s  l  -l library", "-F -r -d 'library database file to use'"
         )
         + BL_NEED2.format(
-            "-s  d  -l directory", "-f -r -d 'destination music directory'"
+            "-s  d  -l directory", "-F -r -d 'destination music directory'"
         )
         + BL_NEED2.format(
             "-s  v  -l verbose", "-f -d 'print debugging information'"
         )
         + BL_NEED2.format(
-            "-s  c  -l config", "-f -r -d 'path to configuration file'"
+            "-s  c  -l config", "-F -r -d 'path to configuration file'"
         )
         + BL_NEED2.format(
             "-s  h  -l help", "-f -d 'print this help message and exit'"
@@ -216,7 +216,7 @@ def get_subcommands(cmd_name_and_help, nobasicfields, extravalues):
             word += BL_USE3.format(
                 cmdname,
                 f"-a {wrap('$FIELDS')}",
-                f"-f -d {wrap('fieldname')}",
+                f"-d {wrap('fieldname')}",
             )
 
         if extravalues:
@@ -270,7 +270,7 @@ def get_all_commands(beetcmds):
                 word += " ".join(
                     BL_USE3.format(
                         name,
-                        f"{cmd_need_arg}{cmd_s}{cmd_l} -f {cmd_arglist}",
+                        f"{cmd_need_arg}{cmd_s}{cmd_l} {cmd_arglist}",
                         cmd_helpstr,
                     ).split()
                 )
@@ -278,7 +278,7 @@ def get_all_commands(beetcmds):
 
             word = word + BL_USE3.format(
                 name,
-                "-s h -l help -f",
+                "-s h -l help",
                 f"-d {wrap('print help')}",
             )
     return word

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -50,6 +50,8 @@ New features:
   the ``clearart_on_import`` config option. Also, ``beet clearart`` is only
   going to update the files matching the query and with an embedded art, leaving
   untouched the files without.
+- :doc:`plugins/fish`: Filenames are now completed in more places, like after
+  ``beet import``.
 
 Bug fixes:
 


### PR DESCRIPTION
## Description

Normally, the Fish completion plugin won't complete filenames, which is useful for `beet import` and similar! This removes the `-f` (no filename completion) flag from various places in the output.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
