### PR TITLE
docs: update discogs.rst - add default of index_tracks configuration option

### DIFF
--- a/docs/plugins/discogs.rst
+++ b/docs/plugins/discogs.rst
@@ -76,7 +76,7 @@ between distinct works on the same release or within works. When
         index_tracks: yes
 
 beets will incorporate the names of the divisions containing each track into the
-imported track's title.
+imported track's title. Default: ``no``.
 
 For example, importing `divisions album`_ would result in track names like:
 


### PR DESCRIPTION
## Description

In the documentation of the Discogs plugin the ``index_tracks`` configuration option does not include the detail about the default configuration that is applied when the option is not explicitly managed in the configuration file.

If this PR is approved, the documentation will include that default ;)

## To Do

- [x] Documentation.
- [x] Changelog.
- [x] Tests.
