### PR TITLE
Lastgenre fix early whitelist check breaking canonicalization

### DIFF
--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -380,12 +380,32 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         if isinstance(obj, library.Item) and "track" in self.sources:
             if new_genres := self.fetch_track_genre(obj):
                 label = "track"
+                resolved_genres = self._combine_resolve_and_log(
+                    keep_genres, new_genres
+                )
+                if resolved_genres:
+                    suffix = "whitelist" if self.whitelist else "any"
+                    label += f", {suffix}"
+                    if keep_genres:
+                        label = f"keep + {label}"
+                    return self._format_and_stringify(resolved_genres), label
+                new_genres = []
 
-        if not new_genres and "album" in self.sources:
+        if "album" in self.sources:
             if new_genres := self.fetch_album_genre(obj):
                 label = "album"
+                resolved_genres = self._combine_resolve_and_log(
+                    keep_genres, new_genres
+                )
+                if resolved_genres:
+                    suffix = "whitelist" if self.whitelist else "any"
+                    label += f", {suffix}"
+                    if keep_genres:
+                        label = f"keep + {label}"
+                    return self._format_and_stringify(resolved_genres), label
+                new_genres = []
 
-        if not new_genres and "artist" in self.sources:
+        if "artist" in self.sources:
             new_genres = []
             if isinstance(obj, library.Item):
                 new_genres = self.fetch_artist_genre(obj)
@@ -414,17 +434,17 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                         rank,
                     )
 
-        # Return with a combined or freshly fetched genre list.
-        if new_genres:
-            resolved_genres = self._combine_resolve_and_log(
-                keep_genres, new_genres
-            )
-            if resolved_genres:
-                suffix = "whitelist" if self.whitelist else "any"
-                label += f", {suffix}"
-                if keep_genres:
-                    label = f"keep + {label}"
-                return self._format_and_stringify(resolved_genres), label
+            if new_genres:
+                resolved_genres = self._combine_resolve_and_log(
+                    keep_genres, new_genres
+                )
+                if resolved_genres:
+                    suffix = "whitelist" if self.whitelist else "any"
+                    label += f", {suffix}"
+                    if keep_genres:
+                        label = f"keep + {label}"
+                    return self._format_and_stringify(resolved_genres), label
+                new_genres = []
 
         # Nothing found, leave original if configured and valid.
         if obj.genre and self.config["keep_existing"]:

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -42,10 +42,6 @@ PYLAST_EXCEPTIONS = (
     pylast.NetworkError,
 )
 
-REPLACE = {
-    "\u2010": "-",
-}
-
 
 # Canonicalization tree processing.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -52,6 +52,9 @@ Bug fixes:
   the config option ``spotify.search_query_ascii: yes``. :bug:`5699`
 - :doc:`plugins/discogs`: Beets will no longer crash if a release has been
   deleted, and returns a 404.
+- :doc:`plugins/lastgenre`: Fix the issue introduced in Beets 2.3.0 where
+  non-whitelisted last.fm genres were not canonicalized to parent genres.
+  :bug:`5930`
 
 For packagers:
 

--- a/docs/plugins/lastgenre.rst
+++ b/docs/plugins/lastgenre.rst
@@ -147,8 +147,9 @@ Add new last.fm genres when **empty**. Any present tags stay **untouched**.
 **Setup 3**
 
 **Combine** genres in present tags with new ones (be aware of that with an
-enabled ``whitelist`` setting, of course some genres might get cleaned up. To
-make sure any existing genres remain, set ``whitelist: no``).
+enabled ``whitelist`` setting, of course some genres might get cleaned up -
+existing genres take precedence over new ones though. To make sure any existing
+genres remain, set ``whitelist: no``).
 
 .. code-block:: yaml
 

--- a/test/plugins/test_lastgenre.py
+++ b/test/plugins/test_lastgenre.py
@@ -441,6 +441,77 @@ class LastGenrePluginTest(BeetsTestCase):
             },
             ("Jazz", "keep + artist, whitelist"),
         ),
+        # 13 - canonicalization transforms non-whitelisted genres to canonical forms
+        #
+        # "Acid Techno" is not in the default whitelist, thus gets resolved "up" in the
+        # tree to "Techno" and "Electronic".
+        (
+            {
+                "force": True,
+                "keep_existing": False,
+                "source": "album",
+                "whitelist": True,
+                "canonical": True,
+                "prefer_specific": False,
+                "count": 10,
+            },
+            "",
+            {
+                "album": ["acid techno"],
+            },
+            ("Techno, Electronic", "album, whitelist"),
+        ),
+        # 14 - canonicalization transforms whitelisted genres to canonical forms and
+        # includes originals
+        #
+        # "Detroit Techno" is in the default whitelist, thus it stays and and also gets
+        # resolved "up" in the tree to "Techno" and "Electronic". The same happens for
+        # newly fetched genre "Acid House".
+        (
+            {
+                "force": True,
+                "keep_existing": True,
+                "source": "album",
+                "whitelist": True,
+                "canonical": True,
+                "prefer_specific": False,
+                "count": 10,
+                "extended_debug": True,
+            },
+            "detroit techno",
+            {
+                "album": ["acid house"],
+            },
+            (
+                "Detroit Techno, Techno, Electronic, Acid House, House",
+                "keep + album, whitelist",
+            ),
+        ),
+        # 15 - canonicalization transforms non-whitelisted original genres to canonical
+        # forms and deduplication works.
+        #
+        # "Cosmic Disco" is not in the default whitelist, thus gets resolved "up" in the
+        # tree to "Disco" and "Electronic". New genre "Detroit Techno" resolves to
+        # "Techno". Both resolve to "Electronic" which gets deduplicated.
+        (
+            {
+                "force": True,
+                "keep_existing": True,
+                "source": "album",
+                "whitelist": True,
+                "canonical": True,
+                "prefer_specific": False,
+                "count": 10,
+            },
+            "Cosmic Disco",
+            {
+                "album": ["Detroit Techno"],
+            },
+            (
+                "Disco, Electronic, Detroit Techno, Techno",
+                "keep + album, whitelist",
+            ),
+        ),
     ],
 )
 def test_get_genre(config_values, item_genre, mock_genres, expected_result):

--- a/test/plugins/test_lastgenre.py
+++ b/test/plugins/test_lastgenre.py
@@ -537,6 +537,7 @@ def test_get_genre(config_values, item_genre, mock_genres, expected_result):
     plugin = lastgenre.LastGenrePlugin()
     # Configure
     plugin.config.set(config_values)
+    plugin.setup()  # Loads default whitelist and canonicalization tree
     item = _common.item()
     item.genre = item_genre
 


### PR DESCRIPTION
## Description

Fixes #5930.  

- Removed whitelist check immediately after last.fm fetch, which fixes canonicalization - also unwanted genres need to remain at this point to get successfully resolved "up" to parent genres
- Removed the `_filter_valid_genres()` helper method and went back to _inline_ list comprehensions (readability)
- Ensured bug #5649 does not regress (the part were a resolve would kick out everything and no fallback happens) by running a full `_resolve_genre()` in each stage - if no genres remain in a stage the next one is hit.
- Refactored `_get_genre` using a local helper method and returning immediately on a satisfying outcome (Commits https://github.com/beetbox/beets/pull/5946/commits/d28738d92fc966fae198f5655a06d76b08332dc3 and https://github.com/beetbox/beets/pull/5946/commits/bb516a3a9c1f9c2a9619bf956fb9860a8ccb4f64)
- Three new `test_get_genre` cases proof canonicalization works properly 


Unrelated tiny fixes along the way:
- Clarified `--keep-existing` option docs
- Ensured list return type in `_last_lookup()`


## To Do


- [x] Documentation.
- [x] Changelog.
- [x] Tests. 