### PR TITLE
Add stripfeat plugin

### DIFF
--- a/beetsplug/stripfeat.py
+++ b/beetsplug/stripfeat.py
@@ -1,0 +1,110 @@
+# This file is part of beets.
+# Copyright 2025, Austin Tinkel, <github.com/ARTINKEL/beets-plugin-stripfeat>
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""Splits featured artist by delimiter."""
+
+import re
+
+from beets import plugins, ui
+from beets.importer import ImportSession, ImportTask
+from beets.library import Item
+
+
+def artist_contains_feat_token(artist) -> bool:
+    return (
+        re.search(plugins.feat_tokens(), artist, flags=re.IGNORECASE)
+        is not None
+    )
+
+
+def convert_feat_to_delimiter(artist: str, delimiter: str) -> str:
+    # split on the first "feat"
+    regex_result = re.compile(plugins.feat_tokens(), re.IGNORECASE)
+    regex_groups = regex_result.split(artist)
+    split_artist = regex_groups[0].strip() + delimiter + regex_groups[1].strip()
+
+    return split_artist
+
+
+class StripFeatPlugin(plugins.BeetsPlugin):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self.config.add(
+            {"auto": True, "delimiter": ";", "strip_from_album_artist": False}
+        )
+
+        self._command = ui.Subcommand(
+            "stripfeat", help="convert feat. in artist name to delimiter"
+        )
+
+        self._command.parser.add_option(
+            "-a",
+            "--albumartist",
+            dest="strip_from_album_artist",
+            action="store_true",
+            default=None,
+            help="convert feat. in albumartist name to delimiter as well",
+        )
+
+        if self.config["auto"]:
+            self.import_stages = [self.imported]
+
+    def commands(self) -> list[ui.Subcommand]:
+        def func(lib, opts, args):
+            self.config.set_args(opts)
+            delimiter = self.config["delimiter"].as_str()
+            strip_from_album_artist = self.config[
+                "strip_from_album_artist"
+            ].get(bool)
+            write = ui.should_write()
+
+            for item in lib.items(args):
+                if self.strip_feat(item, delimiter, strip_from_album_artist):
+                    item.store()
+                    if write:
+                        item.try_write()
+
+        self._command.func = func
+        return [self._command]
+
+    def imported(self, session: ImportSession, task: ImportTask) -> None:
+        strip_from_album_artist = self.config["strip_from_album_artist"].get(
+            bool
+        )
+        delimiter = self.config["delimiter"].as_str()
+
+        for item in task.imported_items():
+            if self.strip_feat(item, delimiter, strip_from_album_artist):
+                item.store()
+
+    def strip_feat(
+        self, item: Item, delimiter: str, strip_from_album_artist: bool
+    ) -> None:
+        artist = item.artist.strip()
+
+        if not artist_contains_feat_token(artist):
+            self._log.info("no featuring artist in artist")
+            return False
+
+        if strip_from_album_artist:
+            albumartist = item.albumartist.strip()
+            if not artist_contains_feat_token(albumartist):
+                self._log.info("no featuring artist in albumartist")
+            item.albumartist = convert_feat_to_delimiter(albumartist, delimiter)
+            self._log.info("Changed " + albumartist + " to " + item.albumartist)
+
+        item.artist = convert_feat_to_delimiter(artist, delimiter)
+        self._log.info("Changed " + artist + " to " + item.artist)
+        return True

--- a/beetsplug/stripfeat.py
+++ b/beetsplug/stripfeat.py
@@ -91,7 +91,7 @@ class StripFeatPlugin(plugins.BeetsPlugin):
 
     def strip_feat(
         self, item: Item, delimiter: str, strip_from_album_artist: bool
-    ) -> None:
+    ) -> bool:
         artist = item.artist.strip()
 
         if not artist_contains_feat_token(artist):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,6 +32,7 @@ New features:
   ``played_ratio_threshold``, to allow configuring the percentage the song must
   be played for it to be counted as played instead of skipped.
 - :doc:`plugins/web`: Display artist and album as part of the search results.
+- :doc:`plugins/stripfeat`: Add new plugin.
 
 Bug fixes:
 

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -132,6 +132,7 @@ following to your configuration:
     smartplaylist
     sonosupdate
     spotify
+    stripfeat
     subsonicplaylist
     subsonicupdate
     substitute
@@ -239,6 +240,9 @@ Metadata
 
 :doc:`scrub <scrub>`
     Clean extraneous metadata from music files.
+
+:doc:`stripfeat`
+    Replace featured artists token with delimiter.
 
 :doc:`zero <zero>`
     Nullify fields by pattern or unconditionally.

--- a/docs/plugins/stripfeat.rst
+++ b/docs/plugins/stripfeat.rst
@@ -1,9 +1,9 @@
 StripFeat Plugin
 ================
 
-The ``stripfeat`` plugin automatically removes the "featured artist" token
-from the ``artist`` or ``albumartist`` field and replaces it with a delimiter 
-of your choice.
+The ``stripfeat`` plugin automatically removes the "featured artist" token from
+the ``artist`` or ``albumartist`` field and replaces it with a delimiter of your
+choice.
 
 To use the ``stripfeat`` plugin, enable it in your configuration (see
 :ref:`using-plugins`).
@@ -16,9 +16,9 @@ file. The available options are:
 
 - **auto**: Enable metadata rewriting during import. Default: ``yes``.
 - **delimiter**: Defines the delimiter you want to replace the "featured artist"
-    token with. Default: ``;``.
+      token with. Default: ``;``.
 - **strip_from_album_artist**: Also replace "featured artist" token in the ``albumartist``
-    field. Default: ``no``.
+      field. Default: ``no``.
 
 Running Manually
 ----------------
@@ -32,5 +32,5 @@ From the command line, type:
 The query is optional; if it's left off, the transformation will be applied to
 your entire collection.
 
-Use the ``-a`` flag to also apply to the ``albumartist`` field (equivalent of the 
-``strip_from_album_artist`` config option).
+Use the ``-a`` flag to also apply to the ``albumartist`` field (equivalent of
+the ``strip_from_album_artist`` config option).

--- a/docs/plugins/stripfeat.rst
+++ b/docs/plugins/stripfeat.rst
@@ -1,0 +1,36 @@
+StripFeat Plugin
+================
+
+The ``stripfeat`` plugin automatically removes the "featured artist" token
+from the ``artist`` or ``albumartist`` field and replaces it with a delimiter 
+of your choice.
+
+To use the ``stripfeat`` plugin, enable it in your configuration (see
+:ref:`using-plugins`).
+
+Configuration
+-------------
+
+To configure the plugin, make a ``stripfeat:`` section in your configuration
+file. The available options are:
+
+- **auto**: Enable metadata rewriting during import. Default: ``yes``.
+- **delimiter**: Defines the delimiter you want to replace the "featured artist"
+    token with. Default: ``;``.
+- **strip_from_album_artist**: Also replace "featured artist" token in the ``albumartist``
+    field. Default: ``no``.
+
+Running Manually
+----------------
+
+From the command line, type:
+
+::
+
+    $ beet stripfeat [QUERY]
+
+The query is optional; if it's left off, the transformation will be applied to
+your entire collection.
+
+Use the ``-a`` flag to also apply to the ``albumartist`` field (equivalent of the 
+``strip_from_album_artist`` config option).

--- a/docs/plugins/stripfeat.rst
+++ b/docs/plugins/stripfeat.rst
@@ -17,8 +17,8 @@ file. The available options are:
 - **auto**: Enable metadata rewriting during import. Default: ``yes``.
 - **delimiter**: Defines the delimiter you want to replace the "featured artist"
       token with. Default: ``;``.
-- **strip_from_album_artist**: Also replace "featured artist" token in the ``albumartist``
-      field. Default: ``no``.
+- **strip_from_album_artist**: Also replace "featured artist" token in the
+      ``albumartist`` field. Default: ``no``.
 
 Running Manually
 ----------------

--- a/test/plugins/test_stripfeat.py
+++ b/test/plugins/test_stripfeat.py
@@ -1,0 +1,94 @@
+# This file is part of beets.
+# Copyright 2025, Austin Tinkel.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""Tests for the 'stripfeat' plugin."""
+
+from beets.test.helper import PluginTestCase
+
+
+class TestStripFeatPlugin(PluginTestCase):
+    plugin = "stripfeat"
+
+    def _add_item(self, path, artist, title, album_artist):
+        return self.add_item(
+            path=path,
+            artist=artist,
+            artist_sort=artist,
+            title=title,
+            albumartist=album_artist,
+        )
+
+    def _set_config(
+        self,
+        delimiter=";",
+        strip_from_album_artist=False,
+        auto=True,
+    ):
+        self.config["stripfeat"]["delimiter"] = delimiter
+        self.config["stripfeat"]["strip_from_album_artist"] = (
+            strip_from_album_artist
+        )
+        self.config["stripfeat"]["auto"] = auto
+
+    def test_strip_feature(self):
+        item = self._add_item(
+            "/", "Bob Ross feat. Steve Ross", "Happy Little Trees", "Bob Ross"
+        )
+        self.run_command("stripfeat")
+        item.load()
+        assert item["artist"] == "Bob Ross;Steve Ross"
+        assert item["albumartist"] == "Bob Ross"
+        assert item["title"] == "Happy Little Trees"
+
+    def test_strip_from_album_artist(self):
+        item = self._add_item(
+            "/",
+            "Bob Ross feat. Steve Ross",
+            "Happy Little Trees",
+            "Bob Ross feat. Steve Ross",
+        )
+        self.run_command("stripfeat", "-a")
+        item.load()
+        assert item["artist"] == "Bob Ross;Steve Ross"
+        assert item["albumartist"] == "Bob Ross;Steve Ross"
+        assert item["title"] == "Happy Little Trees"
+
+    def test_no_feature(self):
+        item = self._add_item("/", "Bob Ross", "Happy Little Trees", "Bob Ross")
+        self.run_command("stripfeat")
+        item.load()
+        assert item["artist"] == "Bob Ross"
+        assert item["albumartist"] == "Bob Ross"
+        assert item["title"] == "Happy Little Trees"
+
+    def test_custom_delimiter(self):
+        self._set_config(delimiter=" and ")
+        item = self._add_item(
+            "/", "Bob Ross feat. Steve Ross", "Happy Little Trees", "Bob Ross"
+        )
+        self.run_command("stripfeat")
+        item.load()
+        assert item["artist"] == "Bob Ross and Steve Ross"
+        assert item["albumartist"] == "Bob Ross"
+        assert item["title"] == "Happy Little Trees"
+
+        self._set_config(delimiter=",")
+        item = self._add_item(
+            "/", "Bob Ross feat. Steve Ross", "Happy Little Trees", "Bob Ross"
+        )
+        self.run_command("stripfeat")
+        item.load()
+        assert item["artist"] == "Bob Ross,Steve Ross"
+        assert item["albumartist"] == "Bob Ross"
+        assert item["title"] == "Happy Little Trees"


### PR DESCRIPTION
## Description

Adds new plugin ``stripfeat``, which allows the user to automatically replace the featuring artist token in the artist metadata tag with a delimiter of their choice.

This is particularly useful when using beets in conjunction with something like Jellyfin, which expects multiple artists to be formatted in a certain way, and will create separate artists for every feature combination otherwise.

**Example**

A song with artist metadata ``underscores feat. Jane Remover`` would become ``underscores;Jane Remover``.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
