### PR TITLE
Improve default pretty diff colors

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -127,19 +127,12 @@ ui:
         action_default: ['bold', 'cyan']
         action: ['bold', 'cyan']
         # New Colors
-        text: ['normal']
         text_faint: ['faint']
         import_path: ['bold', 'blue']
         import_path_items: ['bold', 'blue']
-        added:   ['green']
-        removed: ['red']
         changed: ['yellow']
-        added_highlight:   ['bold', 'green']
-        removed_highlight: ['bold', 'red']
-        changed_highlight: ['bold', 'yellow']
         text_diff_added:   ['bold', 'red']
         text_diff_removed: ['bold', 'red']
-        text_diff_changed: ['bold', 'red']
         action_description: ['white']
     import:
         indentation:

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -131,7 +131,7 @@ ui:
         import_path: ['bold', 'blue']
         import_path_items: ['bold', 'blue']
         changed: ['yellow']
-        text_diff_added:   ['bold', 'red']
+        text_diff_added: ['bold', 'green']
         text_diff_removed: ['bold', 'red']
         action_description: ['white']
     import:

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -620,7 +620,7 @@ def color_len(colored_text):
     return len(uncolorize(colored_text))
 
 
-def _colordiff(a, b):
+def _colordiff(a: Any, b: Any) -> tuple[str, str]:
     """Given two values, return the same pair of strings except with
     their differences highlighted in the specified color. Strings are
     highlighted intelligently to show differences; other values are
@@ -642,35 +642,21 @@ def _colordiff(a, b):
                 colorize("text_diff_added", str(b)),
             )
 
-    a_out = []
-    b_out = []
+    before = ""
+    after = ""
 
     matcher = SequenceMatcher(lambda x: False, a, b)
     for op, a_start, a_end, b_start, b_end in matcher.get_opcodes():
-        if op == "equal":
-            # In both strings.
-            a_out.append(a[a_start:a_end])
-            b_out.append(b[b_start:b_end])
-        elif op == "insert":
-            # Right only.
-            b_out.append(colorize("text_diff_added", b[b_start:b_end]))
-        elif op == "delete":
-            # Left only.
-            a_out.append(colorize("text_diff_removed", a[a_start:a_end]))
-        elif op == "replace":
-            # Right and left differ. Colorise with second highlight if
-            # it's just a case change.
-            if a[a_start:a_end].lower() != b[b_start:b_end].lower():
-                a_color = "text_diff_removed"
-                b_color = "text_diff_added"
-            else:
-                a_color = b_color = "text_highlight_minor"
-            a_out.append(colorize(a_color, a[a_start:a_end]))
-            b_out.append(colorize(b_color, b[b_start:b_end]))
-        else:
-            assert False
+        before_part, after_part = a[a_start:a_end], b[b_start:b_end]
+        if op in {"delete", "replace"}:
+            before_part = colorize("text_diff_removed", before_part)
+        if op in {"insert", "replace"}:
+            after_part = colorize("text_diff_added", after_part)
 
-    return "".join(a_out), "".join(b_out)
+        before += before_part
+        after += after_part
+
+    return before, after
 
 
 def colordiff(a, b):

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -1103,8 +1103,8 @@ def _field_diff(field, old, old_fmt, new, new_fmt):
     if isinstance(oldval, str):
         oldstr, newstr = colordiff(oldval, newstr)
     else:
-        oldstr = colorize("text_error", oldstr)
-        newstr = colorize("text_error", newstr)
+        oldstr = colorize("text_diff_removed", oldstr)
+        newstr = colorize("text_diff_added", newstr)
 
     return f"{oldstr} -> {newstr}"
 

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -507,20 +507,13 @@ COLOR_NAMES = [
     "action_default",
     "action",
     # New Colors
-    "text",
     "text_faint",
     "import_path",
     "import_path_items",
     "action_description",
-    "added",
-    "removed",
     "changed",
-    "added_highlight",
-    "removed_highlight",
-    "changed_highlight",
     "text_diff_added",
     "text_diff_removed",
-    "text_diff_changed",
 ]
 COLORS: dict[str, list[str]] | None = None
 

--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -21,6 +21,7 @@ import re
 import textwrap
 from collections import Counter
 from collections.abc import Sequence
+from functools import cached_property
 from itertools import chain
 from platform import python_version
 from typing import Any, NamedTuple
@@ -303,6 +304,10 @@ class ChangeRepresentation:
     TrackMatch object, accordingly.
     """
 
+    @cached_property
+    def changed_prefix(self) -> str:
+        return ui.colorize("changed", "\u2260")
+
     cur_artist = None
     # cur_album set if album, cur_title set if singleton
     cur_album = None
@@ -394,7 +399,6 @@ class ChangeRepresentation:
         """Print out the details of the match, including changes in album name
         and artist name.
         """
-        changed_prefix = ui.colorize("changed", "\u2260")
         # Artist.
         artist_l, artist_r = self.cur_artist or "", self.match.info.artist
         if artist_r == VARIOUS_ARTISTS:
@@ -402,9 +406,8 @@ class ChangeRepresentation:
             artist_l, artist_r = "", ""
         if artist_l != artist_r:
             artist_l, artist_r = ui.colordiff(artist_l, artist_r)
-            # Prefix with U+2260: Not Equal To
             left = {
-                "prefix": f"{changed_prefix} Artist: ",
+                "prefix": f"{self.changed_prefix} Artist: ",
                 "contents": artist_l,
                 "suffix": "",
             }
@@ -422,9 +425,8 @@ class ChangeRepresentation:
                 and self.match.info.album != VARIOUS_ARTISTS
             ):
                 album_l, album_r = ui.colordiff(album_l, album_r)
-                # Prefix with U+2260: Not Equal To
                 left = {
-                    "prefix": f"{changed_prefix} Album: ",
+                    "prefix": f"{self.changed_prefix} Album: ",
                     "contents": album_l,
                     "suffix": "",
                 }
@@ -437,9 +439,8 @@ class ChangeRepresentation:
             title_l, title_r = self.cur_title or "", self.match.info.title
             if self.cur_title != self.match.info.title:
                 title_l, title_r = ui.colordiff(title_l, title_r)
-                # Prefix with U+2260: Not Equal To
                 left = {
-                    "prefix": f"{changed_prefix} Title: ",
+                    "prefix": f"{self.changed_prefix} Title: ",
                     "contents": title_l,
                     "suffix": "",
                 }
@@ -568,9 +569,8 @@ class ChangeRepresentation:
         # the case, thus the 'info' dictionary is unneeded.
         # penalties = penalty_string(self.match.distance.tracks[track_info])
 
-        prefix = ui.colorize("changed", "\u2260 ") if changed else "* "
         lhs = {
-            "prefix": f"{prefix}{lhs_track} ",
+            "prefix": f"{self.changed_prefix if changed else '*'} {lhs_track} ",
             "contents": lhs_title,
             "suffix": f" {lhs_length}",
         }

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -138,7 +138,7 @@ Other changes:
 - UI: Update default ``text_diff_added`` color from **bold red** to **bold
   green.**
 - UI: Use ``text_diff_added`` and ``text_diff_removed`` colors in **all** diff
-  comparisons.
+  comparisons, including case differences.
 
 2.3.1 (May 14, 2025)
 --------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -135,6 +135,10 @@ Other changes:
   file. :bug:`5979`
 - :doc:`plugins/lastgenre`: Updated and streamlined the genre whitelist and
   canonicalization tree :bug:`5977`
+- UI: Update default ``text_diff_added`` color from **bold red** to **bold
+  green.**
+- UI: Use ``text_diff_added`` and ``text_diff_removed`` colors in **all** diff
+  comparisons.
 
 2.3.1 (May 14, 2025)
 --------------------

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -465,19 +465,12 @@ your configuration file that looks like this:
             action_default: ['bold', 'cyan']
             action: ['bold', 'cyan']
             # New colors after UI overhaul
-            text: ['normal']
             text_faint: ['faint']
             import_path: ['bold', 'blue']
             import_path_items: ['bold', 'blue']
-            added:   ['green']
-            removed: ['red']
             changed: ['yellow']
-            added_highlight:   ['bold', 'green']
-            removed_highlight: ['bold', 'red']
-            changed_highlight: ['bold', 'yellow']
             text_diff_added:   ['bold', 'red']
             text_diff_removed: ['bold', 'red']
-            text_diff_changed: ['bold', 'red']
             action_description: ['white']
 
 Available colors: black, darkred, darkgreen, brown (darkyellow), darkblue,

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -469,7 +469,7 @@ your configuration file that looks like this:
             import_path: ['bold', 'blue']
             import_path_items: ['bold', 'blue']
             changed: ['yellow']
-            text_diff_added:   ['bold', 'red']
+            text_diff_added: ['bold', 'green']
             text_diff_removed: ['bold', 'red']
             action_description: ['white']
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -429,20 +429,11 @@ UI Options
 The options that allow for customization of the visual appearance of the console
 interface.
 
-These options are available in this section:
-
 color
 ~~~~~
 
-Either ``yes`` or ``no``; whether to use color in console output (currently only
-in the ``import`` command). Turn this off if your terminal doesn't support ANSI
-colors.
-
-.. note::
-
-    The ``color`` option was previously a top-level configuration. This is still
-    respected, but a deprecation message will be shown until your top-level
-    ``color`` configuration has been nested under ``ui``.
+Either ``yes`` or ``no``; whether to use color in console output. Turn this off
+if your terminal doesn't support ANSI colors.
 
 .. _colors:
 
@@ -450,10 +441,9 @@ colors
 ~~~~~~
 
 The colors that are used throughout the user interface. These are only used if
-the ``color`` option is set to ``yes``. For example, you might have a section in
-your configuration file that looks like this:
+the ``color`` option is set to ``yes``. See the default configuration:
 
-::
+.. code-block:: yaml
 
     ui:
         colors:
@@ -473,13 +463,18 @@ your configuration file that looks like this:
             text_diff_removed: ['bold', 'red']
             action_description: ['white']
 
-Available colors: black, darkred, darkgreen, brown (darkyellow), darkblue,
-purple (darkmagenta), teal (darkcyan), lightgray, darkgray, red, green, yellow,
-blue, fuchsia (magenta), turquoise (cyan), white
+Available attributes:
 
-Legacy UI colors config directive used strings. If any colors value is still a
-string instead of a list, it will be translated to list automatically. For
-example ``blue`` will become ``['blue']``.
+Foreground colors
+    ``black``, ``red``, ``green``, ``yellow``, ``blue``, ``magenta``, ``cyan``,
+    ``white``
+
+Background colors
+    ``bg_black``, ``bg_red``, ``bg_green``, ``bg_yellow``, ``bg_blue``,
+    ``bg_magenta``, ``bg_cyan``, ``bg_white``
+
+Text styles
+    ``normal``, ``bold``, ``faint``, ``underline``, ``reverse``
 
 terminal_width
 ~~~~~~~~~~~~~~
@@ -488,7 +483,7 @@ Controls line wrapping on non-Unix systems. On Unix systems, the width of the
 terminal is detected automatically. If this fails, or on non-Unix systems, the
 specified value is used as a fallback. Defaults to ``80`` characters:
 
-::
+.. code-block:: yaml
 
     ui:
         terminal_width: 80
@@ -504,7 +499,7 @@ different track lengths are colored with ``text_highlight_minor``.
 matching or distance score calculation (see :ref:`match-config`,
 ``distance_weights`` and :ref:`colors`):
 
-::
+.. code-block:: yaml
 
     ui:
         length_diff_thresh: 10.0
@@ -516,18 +511,18 @@ When importing, beets will read several options to configure the visuals of the
 import dialogue. There are two layouts controlling how horizontal space and line
 wrapping is dealt with: ``column`` and ``newline``. The indentation of the
 respective elements of the import UI can also be configured. For example setting
-``4`` for ``match_header`` will indent the very first block of a proposed match
-by five characters in the terminal:
+``2`` for ``match_header`` will indent the very first block of a proposed match
+by two characters in the terminal:
 
-::
+.. code-block:: yaml
 
     ui:
         import:
             indentation:
-                match_header: 4
-                match_details: 4
-                match_tracklist: 7
-            layout: newline
+                match_header: 2
+                match_details: 2
+                match_tracklist: 5
+            layout: column
 
 Importer Options
 ----------------


### PR DESCRIPTION
- Switch default `text_diff_added` color from bold **red** to bold **green**; unify all diff/case comparisons to use `text_diff_added` and `text_diff_removed` colors consistently.
- Simplify color handling and setup: introduce cached color config (validation + legacy normalization), consolidate regexes
- Remove unused colors names
- Update `ui` configuration docs.

### `beet write -p year:2000..2005`

#### Before
<img width="1261" height="460" alt="image" src="https://github.com/user-attachments/assets/70207350-6d9a-48d8-a314-457ac07c5ad1" />

#### After
<img width="1257" height="536" alt="image" src="https://github.com/user-attachments/assets/efcf3453-016a-490f-84ab-dedfb2aca97b" />

### `beet move -p albumtype:broadcast`

#### Before
<img width="1103" height="505" alt="image" src="https://github.com/user-attachments/assets/9e76c5d6-d878-4535-9da3-a949e6c0830c" />

#### After
<img width="1134" height="508" alt="image" src="https://github.com/user-attachments/assets/3dc03988-8011-4072-8840-6f0a0d12350f" />

## Summary by Sourcery

Improve default diff colors from red to green and streamline color handling by refactoring ANSI code management, removing legacy logic, and unifying diff highlighting. Also extract a cached changed_prefix property and update UI config documentation.

Enhancements:
- Introduce cached get_color_config and consolidate ANSI escape regex patterns to simplify color configuration parsing
- Refactor diff highlighting to consistently use text_diff_added and text_diff_removed and simplify _colordiff implementation
- Add ChangeRepresentation.changed_prefix cached property for consistent ‘not equal’ prefix formatting

Documentation:
- Update UI configuration documentation to reflect new default colors and removed settings

Chores:
- Remove unused color names and legacy normalization code