### PR TITLE
docs: add 'pretend' flag to update command example

### DIFF
--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -323,7 +323,7 @@ update
 
 ::
 
-    beet update [-F] FIELD [-e] EXCLUDE_FIELD [-aM] QUERY
+    beet update [-F] FIELD [-e] EXCLUDE_FIELD [-aMp] QUERY
 
 Update the library (and, by default, move files) to reflect out-of-band metadata
 changes and file deletions.


### PR DESCRIPTION

## Description

Add `p` as an acceptable flag for the `update` command to match the long form section of the command's docs


## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] ~Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)~
- [x] ~Tests. (Very much encouraged but not strictly required.)~
