### PR TITLE
Safely handle metadata plugin exceptions.

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -10,6 +10,8 @@ plugins: [musicbrainz]
 
 pluginpath: []
 
+raise_on_error: no
+
 # --------------- Import ---------------
 
 clutter: ["Thumbs.DB", ".DS_Store"]

--- a/beets/metadata_plugins.py
+++ b/beets/metadata_plugins.py
@@ -392,15 +392,15 @@ class SafeProxy(base):
     without crashing beets. E.g. on long running autotag operations.
     """
 
-    _plugin: MetadataSourcePlugin
+    __plugin: MetadataSourcePlugin
 
     def __init__(self, plugin: MetadataSourcePlugin):
-        self._plugin = plugin
+        self.__plugin = plugin
 
     def __getattribute__(self, name):
         if name in {
-            "_plugin",
-            "_handle_exception",
+            "_SafeProxy__plugin",
+            "_SafeProxy__handle_exception",
             "candidates",
             "item_candidates",
             "album_for_id",
@@ -408,21 +408,21 @@ class SafeProxy(base):
         }:
             return super().__getattribute__(name)
         else:
-            return getattr(self._plugin, name)
+            return getattr(self.__plugin, name)
 
     def __setattr__(self, name, value):
-        if name == "_plugin":
+        if name == "_SafeProxy__plugin":
             super().__setattr__(name, value)
         else:
-            self._plugin.__setattr__(name, value)
+            self.__plugin.__setattr__(name, value)
 
-    def _handle_exception(self, func: Callable[P, R], e: Exception) -> None:
+    def __handle_exception(self, func: Callable[P, R], e: Exception) -> None:
         """Helper function to log exceptions from metadata source plugins."""
         if config["raise_on_error"].get(bool):
             raise e
         log.error(
             "Error in '{}.{}': {}",
-            self._plugin.data_source,
+            self.__plugin.data_source,
             func.__name__,
             e,
         )
@@ -430,24 +430,24 @@ class SafeProxy(base):
 
     def album_for_id(self, *args, **kwargs):
         try:
-            return self._plugin.album_for_id(*args, **kwargs)
+            return self.__plugin.album_for_id(*args, **kwargs)
         except Exception as e:
-            return self._handle_exception(self._plugin.album_for_id, e)
+            return self.__handle_exception(self.__plugin.album_for_id, e)
 
     def track_for_id(self, track_id: str):
         try:
-            return self._plugin.track_for_id(track_id)
+            return self.__plugin.track_for_id(track_id)
         except Exception as e:
-            return self._handle_exception(self._plugin.track_for_id, e)
+            return self.__handle_exception(self.__plugin.track_for_id, e)
 
     def candidates(self, *args, **kwargs):
         try:
-            yield from self._plugin.candidates(*args, **kwargs)
+            yield from self.__plugin.candidates(*args, **kwargs)
         except Exception as e:
-            return self._handle_exception(self._plugin.candidates, e)
+            return self.__handle_exception(self.__plugin.candidates, e)
 
     def item_candidates(self, *args, **kwargs):
         try:
-            yield from self._plugin.item_candidates(*args, **kwargs)
+            yield from self.__plugin.item_candidates(*args, **kwargs)
         except Exception as e:
-            return self._handle_exception(self._plugin.item_candidates, e)
+            return self.__handle_exception(self.__plugin.item_candidates, e)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -111,6 +111,10 @@ Bug fixes:
   avoiding extra lossy duplicates.
 - :doc:`plugins/discogs`: Fixed unexpected flex attr from the Discogs plugin.
   :bug:`6177`
+- Errors in metadata plugins during autotage process will now be logged but
+  won't crash beets anymore. If you want to raise exceptions instead, set the
+  new configuration option ``raise_on_error`` to ``yes`` :bug:`5903`,
+  :bug:`4789`.
 
 For plugin developers:
 

--- a/test/test_metadata_plugins.py
+++ b/test/test_metadata_plugins.py
@@ -45,18 +45,23 @@ class TestMetadataPluginsException(PluginMixin):
         self.unload_plugins()
 
     @pytest.mark.parametrize(
-        "method_name,args",
+        "method_name,error_method_name,args",
         [
-            ("candidates", ()),
-            ("item_candidates", ()),
-            ("album_for_id", ("some_id",)),
-            ("track_for_id", ("some_id",)),
+            ("candidates", "candidates", ()),
+            ("item_candidates", "item_candidates", ()),
+            ("albums_for_ids", "albums_for_ids", (["some_id"],)),
+            ("tracks_for_ids", "tracks_for_ids", (["some_id"],)),
+            # Currently, singular methods call plural ones internally and log
+            # errors from there
+            ("album_for_id", "albums_for_ids", ("some_id",)),
+            ("track_for_id", "tracks_for_ids", ("some_id",)),
         ],
     )
     def test_logging(
         self,
         caplog,
         method_name,
+        error_method_name,
         args,
     ):
         self.config["raise_on_error"] = False
@@ -72,7 +77,7 @@ class TestMetadataPluginsException(PluginMixin):
             for msg in logs:
                 assert (
                     msg
-                    == f"Error in 'ErrorMetadataMockPlugin.{method_name}': Mocked error"
+                    == f"Error in 'ErrorMetadataMockPlugin.{error_method_name}': Mocked error"  # noqa: E501
                 )
 
             caplog.clear()

--- a/test/test_metadata_plugins.py
+++ b/test/test_metadata_plugins.py
@@ -1,0 +1,97 @@
+from typing import Iterable
+
+import pytest
+
+from beets import metadata_plugins
+from beets.test.helper import PluginMixin
+
+
+class ErrorMetadataMockPlugin(metadata_plugins.MetadataSourcePlugin):
+    """A metadata source plugin that raises errors in all its methods."""
+
+    data_source = "ErrorMetadataMockPlugin"
+
+    def candidates(self, *args, **kwargs):
+        raise ValueError("Mocked error")
+
+    def item_candidates(self, *args, **kwargs):
+        for i in range(3):
+            raise ValueError("Mocked error")
+            yield  # This is just to make this a generator
+
+    def album_for_id(self, *args, **kwargs):
+        raise ValueError("Mocked error")
+
+    def track_for_id(self, *args, **kwargs):
+        raise ValueError("Mocked error")
+
+    def track_distance(self, *args, **kwargs):
+        raise ValueError("Mocked error")
+
+    def album_distance(self, *args, **kwargs):
+        raise ValueError("Mocked error")
+
+
+class TestMetadataPluginsException(PluginMixin):
+    """Check that errors during the metadata plugins do not crash beets.
+    They should be logged as errors instead.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.register_plugin(ErrorMetadataMockPlugin)
+        yield
+        self.unload_plugins()
+
+    @pytest.mark.parametrize(
+        "method_name,args",
+        [
+            ("candidates", ()),
+            ("item_candidates", ()),
+            ("album_for_id", ("some_id",)),
+            ("track_for_id", ("some_id",)),
+        ],
+    )
+    def test_logging(
+        self,
+        caplog,
+        method_name,
+        args,
+    ):
+        self.config["raise_on_error"] = False
+        with caplog.at_level("ERROR"):
+            # Call the method to trigger the error
+            ret = getattr(metadata_plugins, method_name)(*args)
+            if isinstance(ret, Iterable):
+                list(ret)
+
+            # Check that an error was logged
+            assert len(caplog.records) >= 1
+            logs = [record.getMessage() for record in caplog.records]
+            for msg in logs:
+                assert (
+                    msg
+                    == f"Error in 'ErrorMetadataMockPlugin.{method_name}': Mocked error"
+                )
+
+            caplog.clear()
+
+    @pytest.mark.parametrize(
+        "method_name,args",
+        [
+            ("candidates", ()),
+            ("item_candidates", ()),
+            ("album_for_id", ("some_id",)),
+            ("track_for_id", ("some_id",)),
+        ],
+    )
+    def test_raising(
+        self,
+        method_name,
+        args,
+    ):
+        self.config["raise_on_error"] = True
+        with pytest.raises(ValueError, match="Mocked error"):
+            getattr(metadata_plugins, method_name)(*args) if not isinstance(
+                args, Iterable
+            ) else list(getattr(metadata_plugins, method_name)(*args))

--- a/test/test_metadata_plugins.py
+++ b/test/test_metadata_plugins.py
@@ -39,6 +39,7 @@ class TestMetadataPluginsException(PluginMixin):
 
     @pytest.fixture(autouse=True)
     def setup(self):
+        metadata_plugins.find_metadata_source_plugins.cache_clear()
         self.register_plugin(ErrorMetadataMockPlugin)
         yield
         self.unload_plugins()


### PR DESCRIPTION
## Description

When a metadata plugin raises an exception during the auto-tagger process, the entire operation crashes. This behavior is not desirable, since metadata lookups can legitimately fail for various reasons (e.g., temporary API downtime, network issues, or offline usage).

This PR introduces a safeguard by adding general exception handling around metadata plugin calls. Instead of causing the whole process to fail, exceptions from individual plugins are now caught and logged. This ensures that the auto-tagger continues to function with the remaining available metadata sources. I used a proxy pattern here as this
seems like an elegant solution to me.

This replaces the efforts from #5910

## Decisions needed

How do we want to name the configuration option which controls if an error should be propagated and also where/how do we want this to be documented?

## Todos:
- [x] Changelog.
- [ ] Documetnation.
