### PR TITLE
lastgenre: Some whitelist and genres-tree updates

### DIFF
--- a/beetsplug/lastgenre/genres-tree.yaml
+++ b/beetsplug/lastgenre/genres-tree.yaml
@@ -9,6 +9,7 @@
     - cape jazz
     - chimurenga
     - coupé-décalé
+    - egyptian
     - fuji music
     - genge
     - highlife
@@ -35,6 +36,7 @@
     - sega
     - seggae
     - semba
+    - shangaan electro
     - soukous
     - taarab
     - zouglou
@@ -133,6 +135,7 @@
     - chutney
     - chutney soca
     - compas
+    - folklore argentino
     - mambo
     - merengue
     - méringue
@@ -185,6 +188,7 @@
     - humor
     - parody music
     - stand-up
+    - kabarett
 - country:
     - alternative country:
         - cowpunk
@@ -287,12 +291,16 @@
         - jump-up
         - liquid funk
         - neurofunk
-        - oldschool jungle:
+        - jungle:
             - darkside jungle
             - ragga jungle
+            - oldschool jungle
+            - uk hardcore
         - raggacore
         - sambass
         - techstep
+        - leftfield
+        - halftime
     - electro:
         - crunk
         - electro backbeat
@@ -336,6 +344,7 @@
         - skweee
         - sound art
         - synthcore
+        - experimental
     - eurodance:
         - bubblegum dance
         - italo dance
@@ -354,7 +363,6 @@
         - makina
         - speedcore
         - terrorcore
-        - uk hardcore
     - hi-nrg:
         - eurobeat
         - hard nrg
@@ -400,6 +408,8 @@
             - power electronics
             - power noise
         - witch house
+    - juke:
+        - footwork
     - post-disco:
         - boogie
         - dance-pop
@@ -414,6 +424,7 @@
     - techno:
         - acid techno
         - detroit techno
+        - dub techno
         - free tekno
         - ghettotech
         - minimal
@@ -481,6 +492,7 @@
     - freestyle rap
     - g-funk
     - gangsta rap
+    - glitch hop
     - golden age hip hop
     - hip hop soul
     - hip pop
@@ -521,11 +533,14 @@
     - west coast hip hop:
         - chicano rap
         - jerkin'
+    - austrian hip hop
+    - german hip hop
 - jazz:
     - asian american jazz
     - avant-garde jazz
     - bebop
     - boogie-woogie
+    - brass band
     - british dance band
     - chamber jazz
     - continental jazz
@@ -568,14 +583,13 @@
     - vocal jazz
     - west coast gypsy jazz
     - west coast jazz
-- other:
-    - worldbeat
+- kids music:
+    - kinderlieder
 - pop:
     - adult contemporary
     - arab pop
     - baroque pop
     - bubblegum pop
-    - chanson
     - christian pop
     - classical crossover
     - europop:
@@ -640,6 +654,7 @@
     - beat music
     - chinese rock
     - christian rock
+    - classic rock
     - dark cabaret
     - desert rock
     - experimental rock
@@ -720,6 +735,7 @@
         - art punk
         - christian punk
         - deathrock
+        - deutschpunk
         - folk punk:
             - celtic punk
             - gypsy punk
@@ -762,5 +778,18 @@
     - dancehall
     - ska:
         - 2 tone
-        - dub
         - rocksteady
+    - dub
+- soundtrack:
+- singer-songwriter:
+    - cantautorato
+    - cantautor
+    - cantautora
+    - chanson
+    - canción de autor
+    - nueva canción
+- world:
+    - world dub
+    - world fusion
+    - worldbeat
+

--- a/beetsplug/lastgenre/genres-tree.yaml
+++ b/beetsplug/lastgenre/genres-tree.yaml
@@ -342,7 +342,6 @@
         - skweee
         - sound art
         - synthcore
-        - experimental
     - eurodance:
         - bubblegum dance
         - italo dance

--- a/beetsplug/lastgenre/genres-tree.yaml
+++ b/beetsplug/lastgenre/genres-tree.yaml
@@ -480,7 +480,6 @@
     - chap hop
     - christian hip hop
     - conscious hip hop
-    - country-rap
     - crunkcore
     - cumbia rap
     - east coast hip hop:

--- a/beetsplug/lastgenre/genres-tree.yaml
+++ b/beetsplug/lastgenre/genres-tree.yaml
@@ -254,7 +254,6 @@
         - acid breaks
         - baltimore club
         - big beat
-        - breakbeat hardcore
         - broken beat
         - florida breaks
         - nu skool breaks
@@ -295,7 +294,6 @@
             - darkside jungle
             - ragga jungle
             - oldschool jungle
-            - uk hardcore
         - raggacore
         - sambass
         - techstep
@@ -352,6 +350,7 @@
     - hardcore:
         - bouncy house
         - bouncy techno
+        - breakbeat hardcore
         - breakcore
         - digital hardcore
         - doomcore
@@ -363,6 +362,7 @@
         - makina
         - speedcore
         - terrorcore
+        - uk hardcore
     - hi-nrg:
         - eurobeat
         - hard nrg

--- a/beetsplug/lastgenre/genres.txt
+++ b/beetsplug/lastgenre/genres.txt
@@ -160,10 +160,14 @@ calypso jazz
 calypso-style baila
 campursari
 canatronic
+canción de autor
 candombe
 canon
 canrock
 cantata
+cantautorato
+cantautor
+cantautora
 cante chico
 cante jondo
 canterbury scene
@@ -371,6 +375,7 @@ desert rock
 desi
 detroit blues
 detroit techno
+dub techno
 dhamar
 dhimotiká
 dhrupad
@@ -1069,10 +1074,10 @@ nortec
 norteño
 northern soul
 nota
-nu breaks
 nu jazz
 nu metal
 nu soul
+nu skool breaks
 nueva canción
 nyatiti
 néo kýma

--- a/beetsplug/lastgenre/genres.txt
+++ b/beetsplug/lastgenre/genres.txt
@@ -689,7 +689,7 @@ indo rock
 indonesian pop
 indoyíftika
 industrial death metal
-industrial hip-hop
+industrial hip hop
 industrial metal
 industrial music
 industrial musical

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -133,6 +133,8 @@ Other changes:
 - :doc:`/guides/main`: Add instructions to install beets on Void Linux.
 - :doc:`plugins/lastgenre`: Refactor loading whitelist and canonicalization
   file. :bug:`5979`
+- :doc:`plugins/lastgenre`: Updated and streamlined the genre whitelist and
+  canonicalization tree :bug:`5977`
 
 2.3.1 (May 14, 2025)
 --------------------


### PR DESCRIPTION
## Description

Addresses some fixes and additions mentioned here #5915 and some I collected myself over the years.

Of course genres and sub-genres classifications always are rather opinionated, but I consider them useful for others too. Critical feedback is welcome. 


## To Do

- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)

## Summary by Sourcery

Enhance the lastgenre plugin’s genre whitelist by adding new genres and refining the hierarchy.

Enhancements:
- Add multiple new genres across world, electronic, hip hop, jazz, rock, punk, and other categories
- Reorganize subgenre tree: nest oldschool jungle under jungle, add leftfield and halftime, relocate uk hardcore and dub
- Remove obsolete genre country-rap
- Update genres.txt to sync with the revised genres-tree.yaml