### PR TITLE
lastgenre: Move file loading to helpers

### DIFF
--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -120,7 +120,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         if wl_filename in (True, ""):  # Indicates the default whitelist.
             wl_filename = WHITELIST
         if wl_filename:
-            text = Path(wl_filename).read_text(encoding="utf-8")
+            text = Path(wl_filename).expanduser().read_text(encoding="utf-8")
             for line in text.splitlines():
                 if (line := line.strip().lower()) and not line.startswith("#"):
                     whitelist.add(line)
@@ -140,7 +140,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         # Read the tree
         if c14n_filename:
             self._log.debug("Loading canonicalization tree {}", c14n_filename)
-            with Path(c14n_filename).open(encoding="utf-8") as f:
+            with Path(c14n_filename).expanduser().open(encoding="utf-8") as f:
                 genres_tree = yaml.safe_load(f)
             flatten_tree(genres_tree, [], c14n_branches)
         return c14n_branches, canonicalize

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -24,6 +24,7 @@ https://gist.github.com/1241307
 
 import os
 import traceback
+from pathlib import Path
 from typing import Union
 
 import pylast
@@ -140,9 +141,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         # Read the tree
         if c14n_filename:
             self._log.debug("Loading canonicalization tree {}", c14n_filename)
-            with open(
-                syspath(normpath(c14n_filename)), "r", encoding="utf-8"
-            ) as f:
+            with Path(c14n_filename).open(encoding="utf-8") as f:
                 genres_tree = yaml.safe_load(f)
             flatten_tree(genres_tree, [], c14n_branches)
         return c14n_branches, canonicalize

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -117,7 +117,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
     def _load_whitelist(self) -> set[str]:
         """Load the whitelist from a text file.
 
-        Default whitelist is used if config is True or empty string.
+        Default whitelist is used if config is True, empty string or set to "nothing".
         """
         whitelist = set()
         wl_filename = self.config["whitelist"].get()
@@ -135,8 +135,8 @@ class LastGenrePlugin(plugins.BeetsPlugin):
     def _load_c14n_tree(self) -> tuple[list[list[str]], bool]:
         """Load the canonicalization tree from a YAML file.
 
-        Default tree is used if config is True or empty string, or if
-        prefer_specific is enabled.
+        Default tree is used if config is True, empty string, set to "nothing"
+        or if prefer_specific is enabled.
         """
         c14n_branches: list[list[str]] = []
         c14n_filename = self.config["canonical"].get()

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -22,7 +22,6 @@ The scraper script used is available here:
 https://gist.github.com/1241307
 """
 
-import codecs
 import os
 import traceback
 from typing import Union
@@ -141,7 +140,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         # Read the tree
         if c14n_filename:
             self._log.debug("Loading canonicalization tree {0}", c14n_filename)
-            with codecs.open(
+            with open(
                 syspath(normpath(c14n_filename)), "r", encoding="utf-8"
             ) as f:
                 genres_tree = yaml.safe_load(f)

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -140,9 +140,10 @@ class LastGenrePlugin(plugins.BeetsPlugin):
             c14n_filename = C14N_TREE
         # Read the tree
         if c14n_filename:
-            self._log.debug("Loading canonicalization tree {}", c14n_filename)
-            c14n_filename = normpath(c14n_filename)
-            with codecs.open(c14n_filename, "r", encoding="utf-8") as f:
+            self._log.debug("Loading canonicalization tree {0}", c14n_filename)
+            with codecs.open(
+                str(normpath(c14n_filename)), "r", encoding="utf-8"
+            ) as f:
                 genres_tree = yaml.safe_load(f)
             flatten_tree(genres_tree, [], c14n_branches)
         return c14n_branches, canonicalize

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -32,7 +32,7 @@ import yaml
 
 from beets import config, library, plugins, ui
 from beets.library import Album, Item
-from beets.util import normpath, plurality, syspath, unique_list
+from beets.util import plurality, unique_list
 
 LASTFM = pylast.LastFMNetwork(api_key=plugins.LASTFM_KEY)
 
@@ -120,12 +120,11 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         if wl_filename in (True, ""):  # Indicates the default whitelist.
             wl_filename = WHITELIST
         if wl_filename:
-            wl_filename = normpath(wl_filename)
-            with open(wl_filename, "rb") as f:
-                for raw_line in f:
-                    line = raw_line.decode("utf-8").strip().lower()
-                    if line and not line.startswith("#"):
-                        whitelist.add(line)
+            text = Path(wl_filename).read_text(encoding="utf-8")
+            for line in text.splitlines():
+                if (line := line.strip().lower()) and not line.startswith("#"):
+                    whitelist.add(line)
+
         return whitelist
 
     def _load_c14n_tree(self) -> tuple[list[list[str]], bool]:

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -132,10 +132,10 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         c14n_filename = self.config["canonical"].get()
         canonicalize = c14n_filename is not False
         # Default tree
-        if c14n_filename in (True, ""):
-            c14n_filename = C14N_TREE
-        elif not canonicalize and self.config["prefer_specific"].get():
+        if c14n_filename in (True, "") or (
             # prefer_specific requires a tree, load default tree
+            not canonicalize and self.config["prefer_specific"].get()
+        ):
             c14n_filename = C14N_TREE
         # Read the tree
         if c14n_filename:

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -139,7 +139,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
             c14n_filename = C14N_TREE
         # Read the tree
         if c14n_filename:
-            self._log.debug("Loading canonicalization tree {0}", c14n_filename)
+            self._log.debug("Loading canonicalization tree {}", c14n_filename)
             with open(
                 syspath(normpath(c14n_filename)), "r", encoding="utf-8"
             ) as f:

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -124,6 +124,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         if wl_filename in (True, "", None):  # Indicates the default whitelist.
             wl_filename = WHITELIST
         if wl_filename:
+            self._log.debug("Loading whitelist {}", wl_filename)
             text = Path(wl_filename).expanduser().read_text(encoding="utf-8")
             for line in text.splitlines():
                 if (line := line.strip().lower()) and not line.startswith("#"):

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -114,7 +114,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         self.whitelist = self._load_whitelist()
         self.c14n_branches, self.canonicalize = self._load_c14n_tree()
 
-    def _load_whitelist(self) -> set[bytes]:
+    def _load_whitelist(self) -> set[str]:
         whitelist = set()
         wl_filename = self.config["whitelist"].get()
         if wl_filename in (True, ""):  # Indicates the default whitelist.
@@ -122,14 +122,14 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         if wl_filename:
             wl_filename = normpath(wl_filename)
             with open(wl_filename, "rb") as f:
-                for line in f:
-                    line = line.decode("utf-8").strip().lower()
+                for raw_line in f:
+                    line = raw_line.decode("utf-8").strip().lower()
                     if line and not line.startswith("#"):
                         whitelist.add(line)
         return whitelist
 
     def _load_c14n_tree(self) -> tuple[list[list[str]], bool]:
-        c14n_branches = []
+        c14n_branches: list[list[str]] = []
         c14n_filename = self.config["canonical"].get()
         canonicalize = c14n_filename is not False
         # Default tree

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -115,6 +115,10 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         self.c14n_branches, self.canonicalize = self._load_c14n_tree()
 
     def _load_whitelist(self) -> set[str]:
+        """Load the whitelist from a text file.
+
+        Default whitelist is used if config is True or empty string.
+        """
         whitelist = set()
         wl_filename = self.config["whitelist"].get()
         if wl_filename in (True, ""):  # Indicates the default whitelist.
@@ -128,6 +132,11 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         return whitelist
 
     def _load_c14n_tree(self) -> tuple[list[list[str]], bool]:
+        """Load the canonicalization tree from a YAML file.
+
+        Default tree is used if config is True or empty string, or if
+        prefer_specific is enabled.
+        """
         c14n_branches: list[list[str]] = []
         c14n_filename = self.config["canonical"].get()
         canonicalize = c14n_filename is not False

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -114,7 +114,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         self.whitelist = self._load_whitelist()
         self.c14n_branches, self.canonicalize = self._load_c14n_tree()
 
-    def _load_whitelist(self) -> set[str]:
+    def _load_whitelist(self) -> set[bytes]:
         whitelist = set()
         wl_filename = self.config["whitelist"].get()
         if wl_filename in (True, ""):  # Indicates the default whitelist.

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -121,7 +121,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         """
         whitelist = set()
         wl_filename = self.config["whitelist"].get()
-        if wl_filename in (True, ""):  # Indicates the default whitelist.
+        if wl_filename in (True, "", None):  # Indicates the default whitelist.
             wl_filename = WHITELIST
         if wl_filename:
             text = Path(wl_filename).expanduser().read_text(encoding="utf-8")
@@ -141,7 +141,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         c14n_filename = self.config["canonical"].get()
         canonicalize = c14n_filename is not False
         # Default tree
-        if c14n_filename in (True, "") or (
+        if c14n_filename in (True, "", None) or (
             # prefer_specific requires a tree, load default tree
             not canonicalize and self.config["prefer_specific"].get()
         ):

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -32,7 +32,7 @@ import yaml
 
 from beets import config, library, plugins, ui
 from beets.library import Album, Item
-from beets.util import normpath, plurality, unique_list
+from beets.util import normpath, plurality, syspath, unique_list
 
 LASTFM = pylast.LastFMNetwork(api_key=plugins.LASTFM_KEY)
 
@@ -142,7 +142,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         if c14n_filename:
             self._log.debug("Loading canonicalization tree {0}", c14n_filename)
             with codecs.open(
-                str(normpath(c14n_filename)), "r", encoding="utf-8"
+                syspath(normpath(c14n_filename)), "r", encoding="utf-8"
             ) as f:
                 genres_tree = yaml.safe_load(f)
             flatten_tree(genres_tree, [], c14n_branches)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -131,6 +131,8 @@ Other changes:
   beets/library directory.
 - Added a test to check that all plugins can be imported without errors.
 - :doc:`/guides/main`: Add instructions to install beets on Void Linux.
+- :doc:`plugins/lastgenre`: Refactor loading whitelist and canonicalization
+  file. :bug:`5979`
 
 2.3.1 (May 14, 2025)
 --------------------


### PR DESCRIPTION
## Description

I split out this refactor from #5744 to make the blacklist PR just a little bit easier to read. ~No code changes in here just moving to helpers!~

- Separate _load methods for whitelist and canonicalization tree file loading.
- Add return type hints for those methods.
- Use `pathlib.Path()` instead of `normpath()`
- Additionally respect None value to fall back to built-in settings for `canonical` and `whitelist` files (was only `""` before) - this code exists for backwards compatibility (see https://github.com/beetbox/beets/commit/233f71a4574b5a10d1182a3a63ce5cd23c4268f4), and might be better sanity checked and vanish in the future... (a None value is set eg. `canoncial:`) -> #5994 



## To Do

- [x] Documentation. (not required)
- [x] Changelog.
- [x] Tests. (already available, nothing changes)

## Summary by Sourcery

Extract file loading logic for the whitelist and canonicalization tree into dedicated helper methods and add return type annotations

Enhancements:
- Move whitelist file parsing into a new _load_whitelist helper and return the set of genres
- Move canonicalization tree loading into a new _load_c14n_tree helper and return branches and canonicalize flag
- Import and use syspath with normpath for consistent file path handling
- Add return type hints for the new helper methods
- Simplify setup by delegating to the new helper methods and adjusting debug formatting