### PR TITLE
lastgenre: Use albumartists field to improve last.fm results

### DIFF
--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -422,6 +422,19 @@ class LastGenrePlugin(plugins.BeetsPlugin):
             elif obj.albumartist != config["va_name"].as_str():
                 new_genres = self.fetch_artist_genre(obj.albumartist)
                 stage_label = "album artist"
+                if not new_genres:
+                    self._tunelog(
+                        'No album artist genre found for "{}", '
+                        "trying multi-valued field...",
+                        obj.albumartist,
+                    )
+                    for albumartist in obj.albumartists:
+                        self._tunelog(
+                            'Fetching artist genre for "{}"', albumartist
+                        )
+                        new_genres += self.fetch_artist_genre(albumartist)
+                    if new_genres:
+                        stage_label = "multi-valued album artist"
             else:
                 # For "Various Artists", pick the most popular track genre.
                 item_genres = []

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -438,6 +438,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
             else:
                 # For "Various Artists", pick the most popular track genre.
                 item_genres = []
+                assert isinstance(obj, Album)  # Type narrowing for mypy
                 for item in obj.items():
                     item_genre = None
                     if "track" in self.sources:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -73,6 +73,11 @@ Bug fixes:
   cancelling an edit session during import. :bug:`6104`
 - :ref:`update-cmd` :doc:`plugins/edit` fix display formatting of field changes
   to clearly show added and removed flexible fields.
+- :doc:`plugins/lastgenre`: Fix the issue where last.fm doesn't return any
+  result in the artist genre stage because "concatenation" words in the artist
+  name (like "feat.", "+", or "&") prevent it. Using the albumartists list field
+  and fetching a genre for each artist separately improves the chance of
+  receiving valid results in that stage.
 
 For plugin developers:
 

--- a/test/plugins/test_lastgenre.py
+++ b/test/plugins/test_lastgenre.py
@@ -546,13 +546,13 @@ class LastGenrePluginTest(PluginTestCase):
 def test_get_genre(config_values, item_genre, mock_genres, expected_result):
     """Test _get_genre with various configurations."""
 
-    def mock_fetch_track_genre(self, obj=None):
+    def mock_fetch_track_genre(self, trackartist, tracktitle):
         return mock_genres["track"]
 
-    def mock_fetch_album_genre(self, obj):
+    def mock_fetch_album_genre(self, albumartist, albumtitle):
         return mock_genres["album"]
 
-    def mock_fetch_artist_genre(self, obj):
+    def mock_fetch_artist_genre(self, artist):
         return mock_genres["artist"]
 
     # Mock the last.fm fetchers. When whitelist enabled, we can assume only


### PR DESCRIPTION
Often last.fm does not find artist genres for delimiter-separated artist names (eg. "Artist One, Artist Two") or where multiple artists are combined with "concatenation words" like "and" , "+", "featuring" and so on.

This fix gathers each artist's last.fm genre separately by using Beets' mutli-valued `albumartists` field to improve the likeliness of finding genres in the artist genre fetching stage.

Refactoring was done along the existing genre fetching helper functions (`fetch_album_genre`, `fetch_track_genre`, ...):

- last.fm can be asked for genre for these combinations of metadata:
   - albumartist/album
   - artist/track
   - artist
- Instead of passing `Album` or `Item` objects directly to these helpers., generalize them and pass the (string) metadata directly.
- Passing "what's to fetch" in the callers instead of hiding it in the methods also helps readability in `_get_genre()`
- And reduces the requirement at hand for another additional method (or adaptation) to support "multi-albumartist genre fetching" 

- [x] ~Documentation~ 
- [x] Changelog
- [x] Tests
