### PR TITLE
Removed data source from listenbrainz as it is not an metadata source plugin.

### DIFF
--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -13,7 +13,6 @@ from beetsplug.lastimport import process_tracks
 class ListenBrainzPlugin(BeetsPlugin):
     """A Beets plugin for interacting with ListenBrainz."""
 
-    data_source = "ListenBrainz"
     ROOT = "http://api.listenbrainz.org/1/"
 
     def __init__(self):
@@ -27,7 +26,7 @@ class ListenBrainzPlugin(BeetsPlugin):
     def commands(self):
         """Add beet UI commands to interact with ListenBrainz."""
         lbupdate_cmd = ui.Subcommand(
-            "lbimport", help=f"Import {self.data_source} history"
+            "lbimport", help="Import ListenBrainz history"
         )
 
         def func(lib, opts, args):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -63,6 +63,8 @@ Bug fixes:
   ascii encoded. This resulted in bad matches for queries that contained special
   e.g. non latin characters as 盗作. If you want to keep the legacy behavior set
   the config option ``deezer.search_query_ascii: yes``. :bug:`5860`
+- Fixed regression with :doc:`/plugins/listenbrainz` where the plugin could not
+  be loaded :bug:`5975`
 
 For packagers:
 


### PR DESCRIPTION
closes #5975

## Summary by Sourcery

Remove the unused data_source property from the ListenBrainz plugin and update the lbimport command help message to reference ListenBrainz explicitly.

Enhancements:
- Remove data_source attribute from ListenBrainz plugin
- Simplify lbimport command help text to reference ListenBrainz directly

Documentation:
- Update changelog entry for ListenBrainz plugin change