### PR TITLE
lastgenre: Add --pretend option for previewing genre changes

### DIFF
--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -578,6 +578,8 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                     if not pretend:
                         item.genre = item_genre
                         item.store()
+                    if write and not pretend:
+                        item.try_write()
 
         lastgenre_cmd.func = lastgenre_func
         return [lastgenre_cmd]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,9 @@ Unreleased
 
 New features:
 
+- :doc:`plugins/lastgenre`: Add a ``--pretend`` option to preview genre changes
+  without storing or writing them.
+
 Bug fixes:
 
 For packagers:

--- a/docs/plugins/lastgenre.rst
+++ b/docs/plugins/lastgenre.rst
@@ -213,9 +213,9 @@ fetch genres for albums or items matching a certain query.
 By default, ``beet lastgenre`` matches albums. To match individual tracks or
 singletons, use the ``-A`` switch: ``beet lastgenre -A [QUERY]``.
 
-To preview the changes that would be made without applying them, use the
-``-p`` or ``--pretend`` flag. This shows which genres would be set but does
-not write or store any changes.
+To preview the changes that would be made without applying them, use the ``-p``
+or ``--pretend`` flag. This shows which genres would be set but does not write
+or store any changes.
 
 To disable automatic genre fetching on import, set the ``auto`` config option to
 false.

--- a/docs/plugins/lastgenre.rst
+++ b/docs/plugins/lastgenre.rst
@@ -213,9 +213,9 @@ fetch genres for albums or items matching a certain query.
 By default, ``beet lastgenre`` matches albums. To match individual tracks or
 singletons, use the ``-A`` switch: ``beet lastgenre -A [QUERY]``.
 
-- To preview the changes that would be made without applying them, use the
-  ``-p`` (``--pretend``) flag. This shows which genres would be set but does
-  not write or store any changes.
+To preview the changes that would be made without applying them, use the
+``-p`` or ``--pretend`` flag. This shows which genres would be set but does
+not write or store any changes.
 
 To disable automatic genre fetching on import, set the ``auto`` config option to
 false.

--- a/docs/plugins/lastgenre.rst
+++ b/docs/plugins/lastgenre.rst
@@ -124,7 +124,7 @@ tags** and will only **fetch new genres for empty tags**. When ``force`` is
 ``yes`` the setting of the ``whitelist`` option (as documented in Usage_)
 applies to any existing or newly fetched genres.
 
-The follwing configurations are possible:
+The following configurations are possible:
 
 **Setup 1** (default)
 
@@ -213,9 +213,9 @@ fetch genres for albums or items matching a certain query.
 By default, ``beet lastgenre`` matches albums. To match individual tracks or
 singletons, use the ``-A`` switch: ``beet lastgenre -A [QUERY]``.
 
-To preview changes without modifying your library, use the ``-p``
-(``--pretend``) flag. This shows which genres would be set but does not write
-or store any changes.
+- To preview the changes that would be made without applying them, use the
+  ``-p`` (``--pretend``) flag. This shows which genres would be set but does
+  not write or store any changes.
 
 To disable automatic genre fetching on import, set the ``auto`` config option to
 false.

--- a/docs/plugins/lastgenre.rst
+++ b/docs/plugins/lastgenre.rst
@@ -213,5 +213,9 @@ fetch genres for albums or items matching a certain query.
 By default, ``beet lastgenre`` matches albums. To match individual tracks or
 singletons, use the ``-A`` switch: ``beet lastgenre -A [QUERY]``.
 
+To preview changes without modifying your library, use the ``-p``
+(``--pretend``) flag. This shows which genres would be set but does not write
+or store any changes.
+
 To disable automatic genre fetching on import, set the ``auto`` config option to
 false.


### PR DESCRIPTION
## Description

Introduce a `--pretend` option to the lastgenre plugin, allowing users to preview genre changes without making any modifications to their library. This feature enhances user control by showing potential changes before they are applied.

## To Do

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [X] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [X] Tests. (Very much encouraged but not strictly required.)

cc: @JOJ0

## Summary by Sourcery

Introduce a --pretend option to the lastgenre plugin to allow users to preview genre assignments without altering their library files.

New Features:
- Add --pretend flag to preview genre changes without modifying files

Enhancements:
- Conditionally skip updating item and album genres and file writes when --pretend is enabled

Documentation:
- Document the --pretend option in the plugin documentation and update the changelog