### PR TITLE
fix incorrect matches when album is missing or empty in spotify plugin search filter

### DIFF
--- a/beets/metadata_plugins.py
+++ b/beets/metadata_plugins.py
@@ -371,7 +371,9 @@ class SearchApiMetadataSourcePlugin(
         album: str,
         va_likely: bool,
     ) -> Iterable[AlbumInfo]:
-        query_filters: SearchFilter = {"album": album}
+        query_filters: SearchFilter = {}
+        if album:
+            query_filters["album"] = album
         if not va_likely:
             query_filters["artist"] = artist
 

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -130,9 +130,6 @@ class SpotifyPlugin(
                 "mode": "list",
                 "tiebreak": "popularity",
                 "show_failures": False,
-                "artist_field": "albumartist",
-                "album_field": "album",
-                "track_field": "title",
                 "region_filter": None,
                 "regex": [],
                 "client_id": "4e414367a1d14c75a5c5129a627fcab8",
@@ -563,13 +560,11 @@ class SpotifyPlugin(
                     regex["search"], regex["replace"], value
                 )
 
-            # Custom values can be passed in the config (just in case)
-            artist = item[self.config["artist_field"].get()]
-            album = item[self.config["album_field"].get()]
-            query_string = item[self.config["track_field"].get()]
+            artist = item["artist"] or item["albumartist"]
+            album = item["album"]
+            query_string = item["title"]
 
             # Query the Web API for each track, look for the items' JSON data
-
             query_filters: SearchFilter = {}
             if artist:
                 query_filters["artist"] = artist

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -569,7 +569,13 @@ class SpotifyPlugin(
             query_string = item[self.config["track_field"].get()]
 
             # Query the Web API for each track, look for the items' JSON data
-            query_filters: SearchFilter = {"artist": artist, "album": album}
+
+            query_filters: SearchFilter = {}
+            if artist:
+                query_filters["artist"] = artist
+            if album:
+                query_filters["album"] = album
+
             response_data_tracks = self._search_api(
                 query_type="track",
                 query_string=query_string,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,9 @@ Bug fixes:
   return incorrect or misleading results when using the Spotify plugin. The
   problem occurred primarily when no album was provided or when the album field
   was an empty string. :bug:`5189`
+- :doc:`plugins/spotify` Removed old and undocumented config options
+  `artist_field`, `album_field` and `track` that were causing issues with track
+  matching. :bug:`5189`
 
 For packagers:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,11 @@ New features:
 
 Bug fixes:
 
+- :doc:`plugins/spotify` Fixed an issue where track matching and lookups could
+  return incorrect or misleading results when using the Spotify plugin. The
+  problem occurred primarily when no album was provided or when the album field
+  was an empty string. :bug:`5189`
+
 For packagers:
 
 Other changes:


### PR DESCRIPTION
closes #5189

## Summary by Sourcery

Bug Fixes:
- Only include non-empty artist and album filters in Spotify track search and metadata candidate queries to prevent incorrect matches when the album field is missing or empty.