### PR TITLE
Adds a zero_disc_if_single_disc to the zero plugin

### DIFF
--- a/beetsplug/zero.py
+++ b/beetsplug/zero.py
@@ -41,6 +41,7 @@ class ZeroPlugin(BeetsPlugin):
                 "fields": [],
                 "keep_fields": [],
                 "update_database": False,
+                "zero_disc_if_single_disc": False,
             }
         )
 
@@ -123,8 +124,13 @@ class ZeroPlugin(BeetsPlugin):
         """
         fields_set = False
 
+        if "disc" in tags and self.config["zero_disc_if_single_disc"].get(bool):
+            if item.disctotal == 1:
+                self._log.debug("disc: {.disc} -> None", item)
+                tags["disc"] = None
+
         if not self.fields_to_progs:
-            self._log.warning("no fields, nothing to do")
+            self._log.warning("no fields list to remove")
             return False
 
         for field, progs in self.fields_to_progs.items():

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,9 @@ Unreleased
 ----------
 
 New features:
+* :doc:`plugins/zero`: Add new configuration option,
+  ``zero_disc_number_if_single_disc``, to allow zeroing the disc number on
+  write for single-disc albums. Defaults to False.
 
 Bug fixes:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,7 +9,7 @@ Unreleased
 
 New features:
 * :doc:`plugins/zero`: Add new configuration option,
-  ``zero_disc_number_if_single_disc``, to allow zeroing the disc number on
+  ``zero_disc_if_single_disc``, to allow zeroing the disc number on
   write for single-disc albums. Defaults to False.
 
 Bug fixes:

--- a/docs/plugins/zero.rst
+++ b/docs/plugins/zero.rst
@@ -31,6 +31,8 @@ to nullify and the conditions for nullifying them:
   ``keep_fields``---not both!
 - To conditionally filter a field, use ``field: [regexp, regexp]`` to specify
   regular expressions.
+- Set ``zero_disc_if_single_disc`` to ``True`` to zero the disc number field
+  only if the album contains a disctotal count and is a single disc.
 - By default this plugin only affects files' tags; the beets database is left
   unchanged. To update the tags in the database, set the ``update_database``
   option to true.


### PR DESCRIPTION
Adds a `zero_disc_if_single_disc` boolean to the zero plugin for writing to files.  Adds the logic that, if disctotal is set and there is only one disc in disctotal, that the disc is not set.

This keeps tags cleaner, only using disc on multi-disc albums. The disctotal is not touched, particularly as this is not usually displayed in most clients.

The field is removed only for writing the tags, but the disc number is maintained in the database to avoid breaking anything that may depend on a disc number or avoid possible loops or failed logic.

A column of disc 1 makes me feel there should be a disc 2, when most albums are a single disc only.

NOTE: This was originally at https://github.com/beetbox/beets/pull/5909 but I managed to screw up the source/patch repo while trying to bring things up to date with master, so I just recreated the final version of it.  I've also changed the parameter to remove the 'number' which I'm told won't always translate well (and technically the disc could be a letter such as 'A').

## Description

This addresses concerns such as https://beets-users.narkive.com/fxh0cgmC/beets-remove-disc-field-for-single-disc-albums and accomplishes things like https://github.com/beetbox/beets/discussions/5670 but in tags instead of just in the path.

## To Do
- [ ] Tests. (Very much encouraged but not strictly required.)

## Summary by Sourcery

Introduce a zero_disc_if_single_disc configuration to the zero plugin, skipping the disc tag on single-disc albums when writing tags.

New Features:
- Add zero_disc_if_single_disc boolean option to the zero plugin to omit the disc tag when only one disc is present.

Documentation:
- Update plugin documentation and changelog to describe the zero_disc_if_single_disc option.