### PR TITLE
lastgenre: Refactor genre applying and pretend mode

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -1078,7 +1078,9 @@ def _field_diff(field, old, old_fmt, new, new_fmt):
     return f"{oldstr} -> {newstr}"
 
 
-def show_model_changes(new, old=None, fields=None, always=False):
+def show_model_changes(
+    new, old=None, fields=None, always=False, print_obj: bool = True
+):
     """Given a Model object, print a list of changes from its pristine
     version stored in the database. Return a boolean indicating whether
     any changes were found.
@@ -1117,7 +1119,7 @@ def show_model_changes(new, old=None, fields=None, always=False):
         )
 
     # Print changes.
-    if changes or always:
+    if print_obj and (changes or always):
         print_(format(old))
     if changes:
         print_("\n".join(changes))

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -468,7 +468,9 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         """Fetch genre and log it."""
         self._log.info(str(obj))
         obj.genre, label = self._get_genre(obj)
-        self._log.info("Resolved ({}): {}", label, obj.genre)
+        self._log.debug("Resolved ({}): {}", label, obj.genre)
+
+        ui.show_model_changes(obj, fields=["genre"], print_obj=False)
 
     @singledispatchmethod
     def _process(self, obj: LibModel, write: bool) -> None:

--- a/test/plugins/test_lastgenre.py
+++ b/test/plugins/test_lastgenre.py
@@ -152,13 +152,10 @@ class LastGenrePluginTest(PluginTestCase):
             raise AssertionError("Unexpected store call")
 
         # Verify that try_write was never called (file operations skipped)
-        with (
-            patch("beetsplug.lastgenre.Item.store", unexpected_store),
-            self.assertLogs() as logs,
-        ):
-            self.run_command("lastgenre", "--pretend")
+        with patch("beetsplug.lastgenre.Item.store", unexpected_store):
+            output = self.run_with_output("lastgenre", "--pretend")
 
-        assert "Mock Genre" in str(logs.output)
+        assert "Mock Genre" in output
         album.load()
         assert album.genre == "Original Genre"
         assert album.items()[0].genre == "Original Genre"


### PR DESCRIPTION
## Description

Shorten final album/genre-apply code. This was longish code already and since the `--pretend` option is here it is even longer, thus I'd like to smarten/shorten that. Also behavior is changed so that `--pretend` is automatically enabling force mode (`-p` or `-f` is what the user usually expects to being the opposite of each other, but we can discuss that of course)

## To Do

- [x] ~Documentation.~ Not required. No behavioral changes
- [x] Changelog.
- [x] Test refactored to pytest