### PR TITLE
Refactor `test_plugin.py`: Streamline plugin tests and migrate to pytest

### DIFF
--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -641,7 +641,7 @@ def get_available_plugins():
     ]
 
 
-class PluginTestCasePytest(PluginMixin, TestHelper):
+class PluginTest(PluginMixin, TestHelper):
     @pytest.fixture(autouse=True)
     def _setup_teardown(self):
         self.setup_beets()
@@ -650,7 +650,7 @@ class PluginTestCasePytest(PluginMixin, TestHelper):
 
 
 class PluginTestCase(PluginMixin, BeetsTestCase):
-    """DEPRECATED: Use PluginTestCasePytest instead for new code!"""
+    """DEPRECATED: Use PluginTestCase instead for new code using pytest!"""
 
     pass
 

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -507,7 +507,7 @@ class PluginMixin(TestHelper):
     def teardown_beets(self):
         super().teardown_beets()
         self.unload_plugins()
-        self.unregister_plugin(self.plugin)
+        self.unregister_plugin(name=self.plugin)
 
     @staticmethod
     def register_plugin(
@@ -555,12 +555,6 @@ class PluginMixin(TestHelper):
             if hasattr(parent_pkg, name):
                 delattr(parent_pkg, name)
 
-    def unregister_all_plugins(self) -> None:
-        # Remove plugin modules from sys.modules
-        for mod in list(sys.modules):
-            if mod.startswith("beetsplug."):
-                del sys.modules[mod]
-
     def load_plugins(self, *plugins: str) -> None:
         """Load and initialize plugins by names.
 
@@ -600,17 +594,26 @@ class PluginMixin(TestHelper):
         raise ValueError(f"No plugin found with name {name}")
 
     @contextmanager
-    def plugins(self, *plugins: tuple[str, type[beets.plugins.BeetsPlugin]]):
+    def plugins(
+        self, *plugins: tuple[str, type[beets.plugins.BeetsPlugin]] | str
+    ):
         """Context manager to register and load multiple plugins."""
         self.unload_plugins()
-        for name, plugin_type in plugins:
-            self.register_plugin(plugin_type, name)
-        self.load_plugins(*(name for name, _ in plugins))
+
+        names = []
+        for plug in plugins:
+            if isinstance(plug, str):
+                names.append(plug)
+            else:
+                names.append(plug[0])
+                self.register_plugin(plug[1], plug[0])
+        self.load_plugins(*names)
 
         yield
 
         self.unload_plugins()
-        self.unregister_all_plugins()
+        for name in names:
+            self.unregister_plugin(name)
 
     @contextmanager
     def configure_plugin(self, config: Any):

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -25,11 +25,14 @@ information or mock the environment.
 
 from __future__ import annotations
 
+import importlib
 import os
 import os.path
+import pkgutil
 import shutil
 import subprocess
 import sys
+import types
 import unittest
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -50,6 +53,7 @@ from beets import importer, logging, util
 from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.importer import ImportSession
 from beets.library import Item, Library
+from beets.plugins import PLUGIN_NAMESPACE
 from beets.test import _common
 from beets.ui.commands.import_.session import TerminalImportSession
 from beets.util import (
@@ -424,11 +428,78 @@ class ItemInDBTestCase(BeetsTestCase):
         self.i = _common.item(self.lib)
 
 
-class PluginMixin(ConfigMixin):
-    plugin: ClassVar[str]
+class PluginMixin(TestHelper):
+    """A mixin that handles plugin loading, unloading and registration.
+
+    Usage:
+    ------
+    Subclass this mixin and define a setup fixture
+    or call load/unload manually.
+
+    .. code-block:: python
+
+        class MyPluginTest(PluginMixin):
+            plugin = 'myplugin'
+
+            # Using fixtures:
+            @pytest.fixture(autouse=True)
+            def setup(self):
+                self.setup_beets()
+                yield
+                self.teardown_beets()
+
+            def test_something(self):
+                ...
+
+    This will load the plugin named `myplugin` before each test and unload it
+    afterwards. This requires a `myplugin.py` file in the `beetsplug` namespace.
+
+    If you need to register a plugin class directly, set the `plugin_type` class
+    variable to the plugin class type you want to register.
+
+    .. code-block:: python
+
+        class MyPluginTest(PluginMixin):
+            plugin = 'myplugin'
+            plugin_type = MyPluginClass
+
+            @pytest.fixture(autouse=True)
+            def setup(self):
+                self.setup_beets()
+                yield
+                self.teardown_beets()
+
+            def test_something(self):
+                ...
+
+    This will register `MyPluginClass` as `myplugin` in the `beetsplug`
+    namespace before loading it. This is useful if you want to test core plugin
+    functions.
+
+    You can also manually call `register_plugin()`, `load_plugins()` and
+    `unload_plugins()` in your test methods if you need more control.
+
+    .. code-block:: python
+
+        class MyPluginTest(PluginMixin):
+            plugin = 'myplugin'
+            plugin_type = MyPluginClass
+
+            def test_something(self):
+                self.register_plugin(self.plugin_type, self.plugin)
+                self.load_plugins(self.plugin)
+                ...
+                self.unload_plugins()
+    """
+
+    plugin: ClassVar[str | None] = None
+    plugin_type: ClassVar[type[beets.plugins.BeetsPlugin] | None] = None
     preload_plugin: ClassVar[bool] = True
 
     def setup_beets(self):
+        """Setup beets and register/load the plugin if specified."""
+        if self.plugin_type is not None:
+            self.register_plugin(self.plugin_type, self.plugin)
         super().setup_beets()
         if self.preload_plugin:
             self.load_plugins()
@@ -436,11 +507,59 @@ class PluginMixin(ConfigMixin):
     def teardown_beets(self):
         super().teardown_beets()
         self.unload_plugins()
+        self.unregister_plugin(self.plugin)
 
+    @staticmethod
     def register_plugin(
-        self, plugin_class: type[beets.plugins.BeetsPlugin]
+        plugin_class: type[beets.plugins.BeetsPlugin],
+        name: str | None = None,
     ) -> None:
-        beets.plugins._instances.append(plugin_class())
+        """Register a plugin class in the `beetsplug` namespace.
+
+        It does not have to exist as a file and is dynamically created.
+        """
+        name = name or plugin_class.__name__.lower().replace("plugin", "")
+        full_namespace = f"{PLUGIN_NAMESPACE}.{name}"
+
+        # Create the beetsplug (PLUGIN_NAMESPACE) module if it does not exist
+        if PLUGIN_NAMESPACE not in sys.modules:
+            beetsplug_pkg = types.ModuleType(PLUGIN_NAMESPACE)
+            beetsplug_pkg.__path__ = []
+            sys.modules[PLUGIN_NAMESPACE] = beetsplug_pkg
+
+        # Create the plugin module
+        if full_namespace in sys.modules:
+            raise ValueError(f"Plugin {name} already registered")
+        module = types.ModuleType(full_namespace)
+        module.__file__ = f"<{full_namespace}>"
+        module.__package__ = PLUGIN_NAMESPACE
+        setattr(module, plugin_class.__name__, plugin_class)
+
+        # Register in sys.modules and as attribute of parent package
+        # needed to allow finding the plugin through importlib
+        sys.modules[full_namespace] = module
+        setattr(sys.modules[PLUGIN_NAMESPACE], name, module)
+
+    @staticmethod
+    def unregister_plugin(name: str | None = None) -> None:
+        """Unregister a plugin class in the `beetsplug` namespace."""
+        if not name:
+            return
+
+        full_namespace = f"{PLUGIN_NAMESPACE}.{name}"
+        if full_namespace in sys.modules:
+            del sys.modules[full_namespace]
+
+        if PLUGIN_NAMESPACE in sys.modules:
+            parent_pkg = sys.modules[PLUGIN_NAMESPACE]
+            if hasattr(parent_pkg, name):
+                delattr(parent_pkg, name)
+
+    def unregister_all_plugins(self) -> None:
+        # Remove plugin modules from sys.modules
+        for mod in list(sys.modules):
+            if mod.startswith("beetsplug."):
+                del sys.modules[mod]
 
     def load_plugins(self, *plugins: str) -> None:
         """Load and initialize plugins by names.
@@ -449,8 +568,12 @@ class PluginMixin(ConfigMixin):
         sure you call ``unload_plugins()`` afterwards.
         """
         # FIXME this should eventually be handled by a plugin manager
-        plugins = (self.plugin,) if hasattr(self, "plugin") else plugins
-        self.config["plugins"] = plugins
+        if plugins:
+            self.config["plugins"] = plugins
+        elif self.plugin:
+            self.config["plugins"] = (self.plugin,)
+        else:
+            self.config["plugins"] = tuple()
         beets.plugins.load_plugins()
 
     def unload_plugins(self) -> None:
@@ -458,20 +581,77 @@ class PluginMixin(ConfigMixin):
         # FIXME this should eventually be handled by a plugin manager
         beets.plugins.BeetsPlugin.listeners.clear()
         beets.plugins.BeetsPlugin._raw_listeners.clear()
+        beets.plugins.BeetsPlugin.template_funcs.clear()
+        beets.plugins.BeetsPlugin.template_fields.clear()
+        beets.plugins.BeetsPlugin.album_template_fields.clear()
         self.config["plugins"] = []
         beets.plugins._instances.clear()
 
+    def get_plugin_instance(
+        self, name: str | None = None
+    ) -> beets.plugins.BeetsPlugin:
+        """Get the plugin instance for a registered and loaded plugin."""
+        name = name or self.plugin
+        for plugin in beets.plugins._instances:
+            if plugin.name == name or (
+                self.plugin_type and isinstance(plugin, self.plugin_type)
+            ):
+                return plugin
+        raise ValueError(f"No plugin found with name {name}")
+
     @contextmanager
-    def configure_plugin(self, config: Any):
-        self.config[self.plugin].set(config)
-        self.load_plugins(self.plugin)
+    def plugins(self, *plugins: tuple[str, type[beets.plugins.BeetsPlugin]]):
+        """Context manager to register and load multiple plugins."""
+        self.unload_plugins()
+        for name, plugin_type in plugins:
+            self.register_plugin(plugin_type, name)
+        self.load_plugins(*(name for name, _ in plugins))
 
         yield
 
         self.unload_plugins()
+        self.unregister_all_plugins()
+
+    @contextmanager
+    def configure_plugin(self, config: Any):
+        self.config[self.plugin].set(config)
+        if self.plugin_type is not None:
+            self.register_plugin(self.plugin_type, self.plugin)
+        if self.plugin:
+            self.load_plugins(self.plugin)
+
+        yield
+
+        self.unload_plugins()
+        if self.plugin_type is not None:
+            self.unregister_plugin(
+                self.plugin
+                or self.plugin_type.__name__.lower().replace("plugin", "")
+            )
+
+
+def get_available_plugins():
+    """Get all available plugins in the beetsplug namespace."""
+    namespace_pkg = importlib.import_module("beetsplug")
+
+    return [
+        m.name
+        for m in pkgutil.iter_modules(namespace_pkg.__path__)
+        if not m.name.startswith("_")
+    ]
+
+
+class PluginTestCasePytest(PluginMixin, TestHelper):
+    @pytest.fixture(autouse=True)
+    def _setup_teardown(self):
+        self.setup_beets()
+        yield
+        self.teardown_beets()
 
 
 class PluginTestCase(PluginMixin, BeetsTestCase):
+    """DEPRECATED: Use PluginTestCasePytest instead for new code!"""
+
     pass
 
 

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -527,12 +527,10 @@ class PluginMixin(TestHelper):
             beetsplug_pkg.__path__ = []
             sys.modules[PLUGIN_NAMESPACE] = beetsplug_pkg
 
-        # Create the plugin module
-        if full_namespace in sys.modules:
-            raise ValueError(f"Plugin {name} already registered")
         module = types.ModuleType(full_namespace)
         module.__file__ = f"<{full_namespace}>"
         module.__package__ = PLUGIN_NAMESPACE
+        plugin_class.__module__ = full_namespace
         setattr(module, plugin_class.__name__, plugin_class)
 
         # Register in sys.modules and as attribute of parent package

--- a/test/plugins/test_importfeeds.py
+++ b/test/plugins/test_importfeeds.py
@@ -2,11 +2,11 @@ import datetime
 import os
 
 from beets.library import Album, Item
-from beets.test.helper import PluginTestCase
+from beets.test.helper import PluginTest
 from beetsplug.importfeeds import ImportFeedsPlugin
 
 
-class ImportFeedsTest(PluginTestCase):
+class ImportFeedsTest(PluginTest):
     plugin = "importfeeds"
 
     def setUp(self):

--- a/test/plugins/test_inline.py
+++ b/test/plugins/test_inline.py
@@ -18,6 +18,8 @@ from beetsplug.inline import InlinePlugin
 
 
 class TestInlineRecursion(PluginTestCase):
+    plugin = "inline"
+
     def test_no_recursion_when_inline_shadows_fixed_field(self):
         config["plugins"] = ["inline"]
 

--- a/test/plugins/test_lastgenre.py
+++ b/test/plugins/test_lastgenre.py
@@ -23,12 +23,12 @@ import pytest
 
 from beets.library import Album
 from beets.test import _common
-from beets.test.helper import IOMixin, PluginTestCase
+from beets.test.helper import PluginTest
 from beetsplug import lastgenre
 from beetsplug.lastgenre.utils import is_ignored
 
 
-class LastGenrePluginTest(IOMixin, PluginTestCase):
+class LastGenrePluginTest(PluginTest):
     plugin = "lastgenre"
 
     def setUp(self):

--- a/test/plugins/test_mpdstats.py
+++ b/test/plugins/test_mpdstats.py
@@ -18,11 +18,11 @@ from unittest.mock import ANY, Mock, call
 
 from beets import util
 from beets.library import Item
-from beets.test.helper import PluginTestCase
+from beets.test.helper import PluginTest
 from beetsplug.mpdstats import MPDClientWrapper, MPDStats
 
 
-class TestMPDStats(PluginTestCase):
+class TestMPDStats(PluginTest):
     plugin = "mpdstats"
 
     def test_update_rating(self):

--- a/test/plugins/test_mpdstats.py
+++ b/test/plugins/test_mpdstats.py
@@ -13,6 +13,7 @@
 # included in all copies or substantial portions of the Software.
 
 
+from typing import Any, ClassVar
 from unittest.mock import ANY, Mock, call
 
 from beets import util

--- a/test/plugins/test_mpdstats.py
+++ b/test/plugins/test_mpdstats.py
@@ -13,16 +13,15 @@
 # included in all copies or substantial portions of the Software.
 
 
-from typing import Any, ClassVar
-from unittest.mock import ANY, Mock, call, patch
+from unittest.mock import ANY, Mock, call
 
 from beets import util
 from beets.library import Item
 from beets.test.helper import PluginTestCase
-from beetsplug.mpdstats import MPDStats
+from beetsplug.mpdstats import MPDClientWrapper, MPDStats
 
 
-class MPDStatsTest(PluginTestCase):
+class TestMPDStats(PluginTestCase):
     plugin = "mpdstats"
 
     def test_update_rating(self):
@@ -53,24 +52,34 @@ class MPDStatsTest(PluginTestCase):
         {"state": "play", "songid": 1, "time": "0:1"},
         {"state": "stop"},
     ]
+
     EVENTS = [["player"]] * (len(STATUSES) - 1) + [KeyboardInterrupt]
     item_path = util.normpath("/foo/bar.flac")
     songid = 1
 
-    @patch(
-        "beetsplug.mpdstats.MPDClientWrapper",
-        return_value=Mock(
-            **{
-                "events.side_effect": EVENTS,
-                "status.side_effect": STATUSES,
-                "currentsong.return_value": (item_path, songid),
-            }
-        ),
-    )
-    def test_run_mpdstats(self, mpd_mock):
+    def test_run_mpdstats(self, monkeypatch):
         item = Item(title="title", path=self.item_path, id=1)
         item.add(self.lib)
 
+        statuses = iter(self.STATUSES)
+        events = iter(self.EVENTS)
+
+        def iter_event_or_raise(*args):
+            i = next(events)
+            if i is KeyboardInterrupt:
+                raise i
+            return i
+
+        monkeypatch.setattr(
+            MPDClientWrapper, "status", lambda _: next(statuses)
+        )
+        monkeypatch.setattr(
+            MPDClientWrapper,
+            "currentsong",
+            lambda x: (self.item_path, self.songid),
+        )
+        monkeypatch.setattr(MPDClientWrapper, "events", iter_event_or_raise)
+        monkeypatch.setattr(MPDClientWrapper, "connect", lambda *_: None)
         log = Mock()
         try:
             MPDStats(self.lib, log).run()

--- a/test/plugins/test_titlecase.py
+++ b/test/plugins/test_titlecase.py
@@ -19,7 +19,7 @@ from unittest.mock import patch
 from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.importer import ImportSession, ImportTask
 from beets.library import Item
-from beets.test.helper import PluginTestCase
+from beets.test.helper import PluginTest
 from beetsplug.titlecase import TitlecasePlugin
 
 titlecase_fields_testcases = [
@@ -55,7 +55,7 @@ titlecase_fields_testcases = [
 ]
 
 
-class TestTitlecasePlugin(PluginTestCase):
+class TestTitlecasePlugin(PluginTest):
     plugin = "titlecase"
     preload_plugin = False
 

--- a/test/test_metadata_plugins.py
+++ b/test/test_metadata_plugins.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 import pytest
 
 from beets import metadata_plugins
-from beets.test.helper import PluginMixin
+from beets.test.helper import PluginMixin, PluginTest
 
 
 class ErrorMetadataMockPlugin(metadata_plugins.MetadataSourcePlugin):
@@ -24,21 +24,17 @@ class ErrorMetadataMockPlugin(metadata_plugins.MetadataSourcePlugin):
         raise ValueError("Mocked error")
 
 
-class TestMetadataPluginsException(PluginMixin):
+class TestMetadataPluginsException(PluginTest):
     """Check that errors during the metadata plugins do not crash beets.
     They should be logged as errors instead.
     """
 
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        metadata_plugins.find_metadata_source_plugins.cache_clear()
-        metadata_plugins.get_metadata_source.cache_clear()
-        self.register_plugin(ErrorMetadataMockPlugin)
-        yield
-        self.unload_plugins()
+    plugin = "ErrorMetadataMock"
+    plugin_type = ErrorMetadataMockPlugin
 
     @pytest.fixture
     def call_method(self, method_name, args):
+
         def _call():
             result = getattr(metadata_plugins, method_name)(*args)
             return list(result) if isinstance(result, Iterable) else result

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -33,7 +33,6 @@ from beets.test import helper
 from beets.test.helper import (
     AutotagStub,
     ImportHelper,
-    IOMixin,
     PluginMixin,
     PluginTest,
     TerminalImportMixin,

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -19,7 +19,7 @@ import logging
 import os
 import pkgutil
 import sys
-from typing import Any
+from typing import Any, ClassVar
 from unittest.mock import ANY, patch
 
 import pytest
@@ -52,11 +52,11 @@ class TestPluginRegistration(PluginTest):
     """
 
     class DummyPlugin(plugins.BeetsPlugin):
-        item_types = {
+        item_types: ClassVar[dict[str, types.Type]] = {
             "foo": types.Float(),
             "bar": types.MULTI_VALUE_DSV,
         }
-        album_types = {
+        album_types: ClassVar[dict[str, types.Type]] = {
             "baz": types.INTEGER,
         }
 
@@ -75,22 +75,15 @@ class TestPluginRegistration(PluginTest):
         assert Item._types.get("bar") is types.MULTI_VALUE_DSV
         assert Album._types.get("baz") is types.INTEGER
 
-    def test_multi_value_flex_field_type(self):
-        item = Item(path="apath", artist="aaa")
-        item.bar = ["one", "two", "three"]
-        item.add(self.lib)
-
-        out = self.run_with_output("ls", "-f", "$bar")
-        delimiter = types.MULTI_VALUE_DSV.delimiter
-        assert out == f"one{delimiter}two{delimiter}three\n"
-
     def test_duplicate_field_type(self):
         """A PluginConflictError should be raised if
         another plugin tries to register the same field_type str.
         """
 
         class DuplicateDummyPlugin(plugins.BeetsPlugin):
-            album_types = {"baz": types.Float()}
+            album_types: ClassVar[dict[str, types.Type]] = {
+                "baz": types.Float()
+            }
 
         with (
             self.plugins(
@@ -302,7 +295,9 @@ class PromptChoicesTest(TerminalImportMixin, ImportHelper, PluginMixin):
                 "Enter search",
                 "enter Id",
                 "aBort",
-            ) + ("Foo", "baR")
+                "Foo",
+                "baR",
+            )
 
             self.importer.add_choice(Action.SKIP)
             self.importer.run()
@@ -336,7 +331,9 @@ class PromptChoicesTest(TerminalImportMixin, ImportHelper, PluginMixin):
                 "Enter search",
                 "enter Id",
                 "aBort",
-            ) + ("Foo", "baR")
+                "Foo",
+                "baR",
+            )
 
             config["import"]["singletons"] = True
             self.importer.add_choice(Action.SKIP)
@@ -375,7 +372,8 @@ class PromptChoicesTest(TerminalImportMixin, ImportHelper, PluginMixin):
                 "Enter search",
                 "enter Id",
                 "aBort",
-            ) + ("baZ",)
+                "baZ",
+            )
             self.importer.add_choice(Action.SKIP)
             self.importer.run()
             self.mock_input_options.assert_called_once_with(
@@ -410,7 +408,8 @@ class PromptChoicesTest(TerminalImportMixin, ImportHelper, PluginMixin):
                 "Enter search",
                 "enter Id",
                 "aBort",
-            ) + ("Foo",)
+                "Foo",
+            )
 
             # DummyPlugin.foo() should be called once
             with patch.object(DummyPlugin, "foo", autospec=True) as mock_foo:
@@ -452,7 +451,8 @@ class PromptChoicesTest(TerminalImportMixin, ImportHelper, PluginMixin):
                 "Enter search",
                 "enter Id",
                 "aBort",
-            ) + ("Foo",)
+                "Foo",
+            )
 
             # DummyPlugin.foo() should be called once
             with helper.control_stdin("f\n"):

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -12,28 +12,23 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
+from __future__ import annotations
 
 import importlib
-import itertools
 import logging
 import os
 import pkgutil
 import sys
-from typing import ClassVar
-from unittest.mock import ANY, Mock, patch
+from typing import Any
+from unittest.mock import ANY, patch
 
 import pytest
 from mediafile import MediaFile
 
 from beets import config, plugins, ui
 from beets.dbcore import types
-from beets.importer import (
-    Action,
-    ArchiveImportTask,
-    SentinelImportTask,
-    SingletonImportTask,
-)
-from beets.library import Item
+from beets.importer import Action
+from beets.library import Album, Item
 from beets.test import helper
 from beets.test.helper import (
     AutotagStub,
@@ -41,235 +36,232 @@ from beets.test.helper import (
     IOMixin,
     PluginMixin,
     PluginTestCase,
+    PluginTestCasePytest,
     TerminalImportMixin,
 )
-from beets.util import PromptChoice, displayable_path, syspath
+from beets.util import PromptChoice, syspath
 
 
-class TestPluginRegistration(IOMixin, PluginTestCase):
-    class RatingPlugin(plugins.BeetsPlugin):
-        item_types: ClassVar[dict[str, types.Type]] = {
-            "rating": types.Float(),
-            "multi_value": types.MULTI_VALUE_DSV,
+class TestPluginRegistration(PluginTestCasePytest):
+    """Ensure that we can dynamically add a plugin without creating
+    actual files on disk.
+
+    This is a meta test that ensures that our dynamic registration
+    mechanism works as intended.
+
+    TODO: Add a test for template functions, template fields and album template fields
+    """
+
+    class DummyPlugin(plugins.BeetsPlugin):
+        item_types = {
+            "foo": types.Float(),
+            "bar": types.MULTI_VALUE_DSV,
+        }
+        album_types = {
+            "baz": types.INTEGER,
         }
 
-        def __init__(self):
-            super().__init__()
-            self.register_listener("write", self.on_write)
+    plugin = "dummy"
+    plugin_type = DummyPlugin
 
-        @staticmethod
-        def on_write(item=None, path=None, tags=None):
-            if tags["artist"] == "XXX":
-                tags["artist"] = "YYY"
-
-    def setUp(self):
-        super().setUp()
-
-        self.register_plugin(self.RatingPlugin)
+    def test_get_plugin(self):
+        """Test that get_plugin returns the correct plugin class."""
+        plugin = plugins._get_plugin(self.plugin)
+        assert plugin is not None
+        assert isinstance(plugin, self.DummyPlugin)
 
     def test_field_type_registered(self):
-        assert isinstance(Item._types.get("rating"), types.Float)
-
-    def test_duplicate_type(self):
-        class DuplicateTypePlugin(plugins.BeetsPlugin):
-            item_types: ClassVar[dict[str, types.Type]] = {
-                "rating": types.INTEGER
-            }
-
-        self.register_plugin(DuplicateTypePlugin)
-        with pytest.raises(
-            plugins.PluginConflictError, match="already been defined"
-        ):
-            Item._types
-
-    def test_listener_registered(self):
-        self.RatingPlugin()
-        item = self.add_item_fixture(artist="XXX")
-
-        item.write()
-
-        assert MediaFile(syspath(item.path)).artist == "YYY"
+        """Test that the field types are registered on the Item class."""
+        assert isinstance(Item._types.get("foo"), types.Float)
+        assert Item._types.get("bar") is types.MULTI_VALUE_DSV
+        assert Album._types.get("baz") is types.INTEGER
 
     def test_multi_value_flex_field_type(self):
         item = Item(path="apath", artist="aaa")
-        item.multi_value = ["one", "two", "three"]
+        item.bar = ["one", "two", "three"]
         item.add(self.lib)
 
-        out = self.run_with_output("ls", "-f", "$multi_value")
-        assert out == "one; two; three\n"
+        out = self.run_with_output("ls", "-f", "$bar")
+        delimiter = types.MULTI_VALUE_DSV.delimiter
+        assert out == f"one{delimiter}two{delimiter}three\n"
+
+    def test_duplicate_field_typ(self):
+        """Test that if another plugin tries to register the same type,
+        a PluginConflictError is raised.
+        """
+
+        class DuplicateDummyPlugin(plugins.BeetsPlugin):
+            album_types = {"baz": types.Float()}
+
+        with (
+            self.plugins(
+                ("dummy", self.DummyPlugin), ("duplicate", DuplicateDummyPlugin)
+            ),
+            pytest.raises(
+                plugins.PluginConflictError, match="already been defined"
+            ),
+        ):
+            Album._types
 
 
-class PluginImportTestCase(ImportHelper, PluginTestCase):
+class TestPluginListeners(PluginTestCasePytest, ImportHelper):
+    """Test that plugin listeners are registered and called correctly."""
+
+    class DummyPlugin(plugins.BeetsPlugin):
+        records: list[Any]
+
+        def __init__(self):
+            super().__init__()
+            self.records = []
+            self.register_listener("cli_exit", self.on_cli_exit)
+            self.register_listener("write", self.on_write)
+            self.register_listener(
+                "import_task_created", self.on_import_task_created
+            )
+
+        def on_cli_exit(self, **kwargs):
+            self.records.append(("cli_exit", kwargs))
+
+        def on_write(
+            self, item=None, path=None, tags: dict[Any, Any] | None = None
+        ):
+            self.records.append(("write", item, path, tags))
+            if tags and tags["artist"] == "XXX":
+                tags["artist"] = "YYY"
+
+        def on_import_task_created(self, **kwargs):
+            self.records.append(("import_task_created", kwargs))
+
+    plugin_type = DummyPlugin
+    plugin = "dummy"
+
+    @pytest.fixture(autouse=True)
+    def clear_records(self):
+        plug = self.get_plugin_instance()
+        assert isinstance(plug, self.DummyPlugin)
+        plug.records.clear()
+
+    def get_records(self):
+        plug = self.get_plugin_instance()
+        assert isinstance(plug, self.DummyPlugin)
+        return plug.records
+
+    @pytest.mark.parametrize(
+        "event",
+        [
+            "cli_exit",
+            "write",
+            "import_task_created",
+        ],
+    )
+    def test_listener_events(self, event):
+        """Generic test for all events triggered via `plugins.send`."""
+        plugins.send(event)
+        records = self.get_records()
+        assert len(records) == 1
+        assert records[0][0] == event
+
+    def test_on_write(self):
+        # Additionally test that tags are modified correctly.
+        item = self.add_item_fixture(artist="XXX")
+        item.write()
+        assert MediaFile(syspath(item.path)).artist == "YYY"
+
+    def test_on_import_task_created(self, caplog):
+        """Test that the import_task_created event is triggered
+        when an import task is created."""
+
+        # Fixme: unittest ImportHelper in pytest setup
+        self.import_media = []
+        self.prepare_album_for_import(2)
+
+        self.importer = self.setup_importer(pretend=True)
+        self.importer.run()
+
+        assert self.get_records()[0][0] == "import_task_created"
+
+
+class TestPluginListenersParams(PluginMixin):
+    """Test that plugin listeners are called with correct parameters.
+
+    Also check that invalid parameters raise TypeErrors.
+    """
+
+    def dummy1(self, foo):
+        assert foo == 5
+
+    def dummy2(self, foo=None):
+        assert foo == 5
+
+    def dummy3(self):
+        # argument cut off
+        pass
+
+    def dummy4(self, bar=None):
+        # argument cut off
+        pass
+
+    def dummy5(self, bar):
+        assert not True
+
+    # more complex examples
+
+    def dummy6(self, foo, bar=None):
+        assert foo == 5
+        assert bar is None
+
+    def dummy7(self, foo, **kwargs):
+        assert foo == 5
+        assert kwargs == {}
+
+    def dummy8(self, foo, bar, **kwargs):
+        assert not True
+
+    def dummy9(self, **kwargs):
+        assert kwargs == {"foo": 5}
+
+    @pytest.mark.parametrize(
+        "func, raises",
+        [
+            ("dummy1", False),
+            ("dummy2", False),
+            ("dummy3", False),
+            ("dummy4", False),
+            ("dummy5", True),
+            ("dummy6", False),
+            ("dummy7", False),
+            ("dummy8", True),
+            ("dummy9", False),
+        ],
+    )
+    def test_listener_params(self, func, raises):
+        func_obj = getattr(self, func)
+
+        class DummyPlugin(plugins.BeetsPlugin):
+            def __init__(self):
+                super().__init__()
+                self.register_listener("exit_cli", func_obj)
+
+        with self.plugins(("dummy", DummyPlugin)):
+            if raises:
+                with pytest.raises(TypeError):
+                    plugins.send("exit_cli", foo=5)
+            else:
+                plugins.send("exit_cli", foo=5)
+
+
+class PromptChoicesTest(TerminalImportMixin, ImportHelper, PluginMixin):
+    @pytest.fixture(autouse=True)
+    def setup_teardown(self):
+        # FIXME: Run old unittest setup/teardown methods
+        self.setUp()
+        yield
+        self.tearDown()
+
     def setUp(self):
         super().setUp()
         self.prepare_album_for_import(2)
 
-
-class EventsTest(PluginImportTestCase):
-    def test_import_task_created(self):
-        self.importer = self.setup_importer(pretend=True)
-
-        with helper.capture_log() as logs:
-            self.importer.run()
-
-        # Exactly one event should have been imported (for the album).
-        # Sentinels do not get emitted.
-        assert logs.count("Sending event: import_task_created") == 1
-
-        logs = [line for line in logs if not line.startswith("Sending event:")]
-        assert logs == [
-            f"Album: {displayable_path(os.path.join(self.import_dir, b'album'))}",
-            f"  {displayable_path(self.import_media[0].path)}",
-            f"  {displayable_path(self.import_media[1].path)}",
-        ]
-
-    def test_import_task_created_with_plugin(self):
-        class ToSingletonPlugin(plugins.BeetsPlugin):
-            def __init__(self):
-                super().__init__()
-
-                self.register_listener(
-                    "import_task_created", self.import_task_created_event
-                )
-
-            def import_task_created_event(self, session, task):
-                if (
-                    isinstance(task, SingletonImportTask)
-                    or isinstance(task, SentinelImportTask)
-                    or isinstance(task, ArchiveImportTask)
-                ):
-                    return task
-
-                new_tasks = []
-                for item in task.items:
-                    new_tasks.append(SingletonImportTask(task.toppath, item))
-
-                return new_tasks
-
-        to_singleton_plugin = ToSingletonPlugin
-        self.register_plugin(to_singleton_plugin)
-
-        self.importer = self.setup_importer(pretend=True)
-
-        with helper.capture_log() as logs:
-            self.importer.run()
-
-        # Exactly one event should have been imported (for the album).
-        # Sentinels do not get emitted.
-        assert logs.count("Sending event: import_task_created") == 1
-
-        logs = [line for line in logs if not line.startswith("Sending event:")]
-        assert logs == [
-            f"Singleton: {displayable_path(self.import_media[0].path)}",
-            f"Singleton: {displayable_path(self.import_media[1].path)}",
-        ]
-
-
-class ListenersTest(PluginTestCase):
-    def test_register(self):
-        class DummyPlugin(plugins.BeetsPlugin):
-            def __init__(self):
-                super().__init__()
-                self.register_listener("cli_exit", self.dummy)
-                self.register_listener("cli_exit", self.dummy)
-
-            def dummy(self):
-                pass
-
-        d = DummyPlugin()
-        assert DummyPlugin._raw_listeners["cli_exit"] == [d.dummy]
-
-        d2 = DummyPlugin()
-        assert DummyPlugin._raw_listeners["cli_exit"] == [d.dummy, d2.dummy]
-
-        d.register_listener("cli_exit", d2.dummy)
-        assert DummyPlugin._raw_listeners["cli_exit"] == [d.dummy, d2.dummy]
-
-    def test_events_called(self):
-        class DummyPlugin(plugins.BeetsPlugin):
-            def __init__(self):
-                super().__init__()
-                self.foo = Mock(__name__="foo")
-                self.register_listener("event_foo", self.foo)
-                self.bar = Mock(__name__="bar")
-                self.register_listener("event_bar", self.bar)
-
-        d = DummyPlugin()
-
-        plugins.send("event")
-        d.foo.assert_has_calls([])
-        d.bar.assert_has_calls([])
-
-        plugins.send("event_foo", var="tagada")
-        d.foo.assert_called_once_with(var="tagada")
-        d.bar.assert_has_calls([])
-
-    def test_listener_params(self):
-        class DummyPlugin(plugins.BeetsPlugin):
-            def __init__(self):
-                super().__init__()
-                for i in itertools.count(1):
-                    try:
-                        meth = getattr(self, f"dummy{i}")
-                    except AttributeError:
-                        break
-                    self.register_listener(f"event{i}", meth)
-
-            def dummy1(self, foo):
-                assert foo == 5
-
-            def dummy2(self, foo=None):
-                assert foo == 5
-
-            def dummy3(self):
-                # argument cut off
-                pass
-
-            def dummy4(self, bar=None):
-                # argument cut off
-                pass
-
-            def dummy5(self, bar):
-                assert not True
-
-            # more complex examples
-
-            def dummy6(self, foo, bar=None):
-                assert foo == 5
-                assert bar is None
-
-            def dummy7(self, foo, **kwargs):
-                assert foo == 5
-                assert kwargs == {}
-
-            def dummy8(self, foo, bar, **kwargs):
-                assert not True
-
-            def dummy9(self, **kwargs):
-                assert kwargs == {"foo": 5}
-
-        DummyPlugin()
-
-        plugins.send("event1", foo=5)
-        plugins.send("event2", foo=5)
-        plugins.send("event3", foo=5)
-        plugins.send("event4", foo=5)
-
-        with pytest.raises(TypeError):
-            plugins.send("event5", foo=5)
-
-        plugins.send("event6", foo=5)
-        plugins.send("event7", foo=5)
-
-        with pytest.raises(TypeError):
-            plugins.send("event8", foo=5)
-
-        plugins.send("event9", foo=5)
-
-
-class PromptChoicesTest(TerminalImportMixin, PluginImportTestCase):
-    def setUp(self):
-        super().setUp()
         self.setup_importer()
         self.matcher = AutotagStub(AutotagStub.IDENT).install()
         self.addCleanup(self.matcher.restore)
@@ -299,27 +291,25 @@ class PromptChoicesTest(TerminalImportMixin, PluginImportTestCase):
                     PromptChoice("r", "baR", None),
                 ]
 
-        self.register_plugin(DummyPlugin)
-        # Default options + extra choices by the plugin ('Foo', 'Bar')
-        opts = (
-            "Apply",
-            "More candidates",
-            "Skip",
-            "Use as-is",
-            "as Tracks",
-            "Group albums",
-            "Enter search",
-            "enter Id",
-            "aBort",
-            "Foo",
-            "baR",
-        )
+        with self.plugins(("dummy", DummyPlugin)):
+            # Default options + extra choices by the plugin ('Foo', 'Bar')
+            opts = (
+                "Apply",
+                "More candidates",
+                "Skip",
+                "Use as-is",
+                "as Tracks",
+                "Group albums",
+                "Enter search",
+                "enter Id",
+                "aBort",
+            ) + ("Foo", "baR")
 
-        self.importer.add_choice(Action.SKIP)
-        self.importer.run()
-        self.mock_input_options.assert_called_once_with(
-            opts, default="a", require=ANY
-        )
+            self.importer.add_choice(Action.SKIP)
+            self.importer.run()
+            self.mock_input_options.assert_called_once_with(
+                opts, default="a", require=ANY
+            )
 
     def test_plugin_choices_in_ui_input_options_singleton(self):
         """Test the presence of plugin choices on the prompt (singleton)."""
@@ -337,26 +327,24 @@ class PromptChoicesTest(TerminalImportMixin, PluginImportTestCase):
                     PromptChoice("r", "baR", None),
                 ]
 
-        self.register_plugin(DummyPlugin)
-        # Default options + extra choices by the plugin ('Foo', 'Bar')
-        opts = (
-            "Apply",
-            "More candidates",
-            "Skip",
-            "Use as-is",
-            "Enter search",
-            "enter Id",
-            "aBort",
-            "Foo",
-            "baR",
-        )
+        with self.plugins(("dummy", DummyPlugin)):
+            # Default options + extra choices by the plugin ('Foo', 'Bar')
+            opts = (
+                "Apply",
+                "More candidates",
+                "Skip",
+                "Use as-is",
+                "Enter search",
+                "enter Id",
+                "aBort",
+            ) + ("Foo", "baR")
 
-        config["import"]["singletons"] = True
-        self.importer.add_choice(Action.SKIP)
-        self.importer.run()
-        self.mock_input_options.assert_called_with(
-            opts, default="a", require=ANY
-        )
+            config["import"]["singletons"] = True
+            self.importer.add_choice(Action.SKIP)
+            self.importer.run()
+            self.mock_input_options.assert_called_with(
+                opts, default="a", require=ANY
+            )
 
     def test_choices_conflicts(self):
         """Test the short letter conflict solving."""
@@ -376,25 +364,24 @@ class PromptChoicesTest(TerminalImportMixin, PluginImportTestCase):
                     PromptChoice("z", "Zoo", None),
                 ]  # dupe
 
-        self.register_plugin(DummyPlugin)
-        # Default options + not dupe extra choices by the plugin ('baZ')
-        opts = (
-            "Apply",
-            "More candidates",
-            "Skip",
-            "Use as-is",
-            "as Tracks",
-            "Group albums",
-            "Enter search",
-            "enter Id",
-            "aBort",
-            "baZ",
-        )
-        self.importer.add_choice(Action.SKIP)
-        self.importer.run()
-        self.mock_input_options.assert_called_once_with(
-            opts, default="a", require=ANY
-        )
+        with self.plugins(("dummy", DummyPlugin)):
+            # Default options + not dupe extra choices by the plugin ('baZ')
+            opts = (
+                "Apply",
+                "More candidates",
+                "Skip",
+                "Use as-is",
+                "as Tracks",
+                "Group albums",
+                "Enter search",
+                "enter Id",
+                "aBort",
+            ) + ("baZ",)
+            self.importer.add_choice(Action.SKIP)
+            self.importer.run()
+            self.mock_input_options.assert_called_once_with(
+                opts, default="a", require=ANY
+            )
 
     def test_plugin_callback(self):
         """Test that plugin callbacks are being called upon user choice."""
@@ -412,33 +399,31 @@ class PromptChoicesTest(TerminalImportMixin, PluginImportTestCase):
             def foo(self, session, task):
                 pass
 
-        self.register_plugin(DummyPlugin)
-        # Default options + extra choices by the plugin ('Foo', 'Bar')
-        opts = (
-            "Apply",
-            "More candidates",
-            "Skip",
-            "Use as-is",
-            "as Tracks",
-            "Group albums",
-            "Enter search",
-            "enter Id",
-            "aBort",
-            "Foo",
-        )
+        with self.plugins(("dummy", DummyPlugin)):
+            # Default options + extra choices by the plugin ('Foo', 'Bar')
+            opts = (
+                "Apply",
+                "More candidates",
+                "Skip",
+                "Use as-is",
+                "as Tracks",
+                "Group albums",
+                "Enter search",
+                "enter Id",
+                "aBort",
+            ) + ("Foo",)
 
-        # DummyPlugin.foo() should be called once
-        with patch.object(DummyPlugin, "foo", autospec=True) as mock_foo:
-            self.io.addinput("f")
-            self.io.addinput("n")
-            self.importer.run()
-            assert mock_foo.call_count == 1
+            # DummyPlugin.foo() should be called once
+            with patch.object(DummyPlugin, "foo", autospec=True) as mock_foo:
+                with helper.control_stdin("\n".join(["f", "s"])):
+                    self.importer.run()
+                assert mock_foo.call_count == 1
 
-        # input_options should be called twice, as foo() returns None
-        assert self.mock_input_options.call_count == 2
-        self.mock_input_options.assert_called_with(
-            opts, default="a", require=ANY
-        )
+            # input_options should be called twice, as foo() returns None
+            assert self.mock_input_options.call_count == 2
+            self.mock_input_options.assert_called_with(
+                opts, default="a", require=ANY
+            )
 
     def test_plugin_callback_return(self):
         """Test that plugin callbacks that return a value exit the loop."""
@@ -456,29 +441,28 @@ class PromptChoicesTest(TerminalImportMixin, PluginImportTestCase):
             def foo(self, session, task):
                 return Action.SKIP
 
-        self.register_plugin(DummyPlugin)
-        # Default options + extra choices by the plugin ('Foo', 'Bar')
-        opts = (
-            "Apply",
-            "More candidates",
-            "Skip",
-            "Use as-is",
-            "as Tracks",
-            "Group albums",
-            "Enter search",
-            "enter Id",
-            "aBort",
-            "Foo",
-        )
+        with self.plugins(("dummy", DummyPlugin)):
+            # Default options + extra choices by the plugin ('Foo', 'Bar')
+            opts = (
+                "Apply",
+                "More candidates",
+                "Skip",
+                "Use as-is",
+                "as Tracks",
+                "Group albums",
+                "Enter search",
+                "enter Id",
+                "aBort",
+            ) + ("Foo",)
 
-        # DummyPlugin.foo() should be called once
-        self.io.addinput("f")
-        self.importer.run()
+            # DummyPlugin.foo() should be called once
+            with helper.control_stdin("f\n"):
+                self.importer.run()
 
-        # input_options should be called once, as foo() returns SKIP
-        self.mock_input_options.assert_called_once_with(
-            opts, default="a", require=ANY
-        )
+            # input_options should be called once, as foo() returns SKIP
+            self.mock_input_options.assert_called_once_with(
+                opts, default="a", require=ANY
+            )
 
 
 def get_available_plugins():
@@ -493,6 +477,8 @@ def get_available_plugins():
 
 
 class TestImportPlugin(PluginMixin):
+    """Test that all available plugins can be imported without error."""
+
     @pytest.fixture(params=get_available_plugins())
     def plugin_name(self, request):
         """Fixture to provide the name of each available plugin."""
@@ -504,13 +490,6 @@ class TestImportPlugin(PluginMixin):
             pytest.skip(f"GStreamer is not available on Windows: {name}")
 
         return name
-
-    def unload_plugins(self):
-        """Unimport plugins before each test to avoid conflicts."""
-        super().unload_plugins()
-        for mod in list(sys.modules):
-            if mod.startswith("beetsplug."):
-                del sys.modules[mod]
 
     @pytest.fixture(autouse=True)
     def cleanup(self):
@@ -534,6 +513,11 @@ class TestImportPlugin(PluginMixin):
         assert "PluginImportError" not in caplog.text, (
             f"Plugin '{plugin_name}' has issues during import."
         )
+
+    def test_import_error(self, caplog):
+        """Test that an invalid plugin raises PluginImportError."""
+        self.load_plugins("this_does_not_exist")
+        assert "PluginImportError" in caplog.text
 
 
 class TestDeprecationCopy:

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -35,14 +35,13 @@ from beets.test.helper import (
     ImportHelper,
     IOMixin,
     PluginMixin,
-    PluginTestCase,
-    PluginTestCasePytest,
+    PluginTest,
     TerminalImportMixin,
 )
 from beets.util import PromptChoice, syspath
 
 
-class TestPluginRegistration(PluginTestCasePytest):
+class TestPluginRegistration(PluginTest):
     """Ensure that we can dynamically add a plugin without creating
     actual files on disk.
 
@@ -104,7 +103,7 @@ class TestPluginRegistration(PluginTestCasePytest):
             Album._types
 
 
-class TestPluginListeners(PluginTestCasePytest, ImportHelper):
+class TestPluginListeners(PluginTest, ImportHelper):
     """Test that plugin listeners are registered and called correctly."""
 
     class DummyPlugin(plugins.BeetsPlugin):

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -84,9 +84,9 @@ class TestPluginRegistration(PluginTest):
         delimiter = types.MULTI_VALUE_DSV.delimiter
         assert out == f"one{delimiter}two{delimiter}three\n"
 
-    def test_duplicate_field_typ(self):
-        """Test that if another plugin tries to register the same type,
-        a PluginConflictError is raised.
+    def test_duplicate_field_type(self):
+        """A PluginConflictError should be raised if
+        another plugin tries to register the same field_type str.
         """
 
         class DuplicateDummyPlugin(plugins.BeetsPlugin):

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -507,11 +507,10 @@ class TestImportPlugin(PluginMixin):
     def test_import_plugin(self, caplog, plugin_name):
         """Test that a plugin is importable without an error."""
         caplog.set_level(logging.WARNING)
-        self.load_plugins(plugin_name)
-
-        assert "PluginImportError" not in caplog.text, (
-            f"Plugin '{plugin_name}' has issues during import."
-        )
+        with self.plugins(plugin_name):
+            assert "PluginImportError" not in caplog.text, (
+                f"Plugin '{plugin_name}' has issues during import."
+            )
 
     def test_import_error(self, caplog):
         """Test that an invalid plugin raises PluginImportError."""


### PR DESCRIPTION
## Overview

This PR addresses historical testing debt in `test_plugins.py` by standardizing plugin test infrastructure.
- `PluginTestCase` is now using pytest, old test mixing is still available via `PluginUnitTestCase` (unittest-based)
- Enhances `PluginMixin` with programmatic plugin registration/unregistration while still working through standard `load_plugins`, improving test isolation and avoiding fragile disk/module hacks.
- Simplifies and modernizes individual tests in `test_plugins.py` where possible, reducing boilerplate and making future plugin tests easier to extend.

There is still the `PromptChoicesTest` left which I have not touched, tbh I have no idea why this test is located in `test_plugins.py` at all...

## Coverage
```
# before
Name               Stmts   Miss Branch BrPart   Cover   Missing
---------------------------------------------------------------
beets/plugins.py     228     57     70      6  70.13%   119, 131-136, 184->186, 186->188, 188->191, 279-282, 299-305, 315-321, 352, 366-387, 473-475, 489, 523-529, 544-547, 575-578, 595-607
---------------------------------------------------------------
TOTAL                228     57     70      6  70.13%

# after
Name               Stmts   Miss Branch BrPart   Cover   Missing
---------------------------------------------------------------
beets/plugins.py     228     45     70      8  74.83%   131-136, 184->186, 186->188, 188->191, 279-282, 286->exit, 299-305, 315-321, 352, 372->387, 473-475, 489, 523-529, 544-547, 575-578, 595-607
---------------------------------------------------------------
TOTAL                228     45     70      8  74.83%
```

## Open questions / decisions

Since test_plugins.py has effectively been rewritten, should the legacy
Copyright 2016, Thomas Scholtes notice be removed?

Current authorship distribution per git blame:
```
git blame --line-porcelain ./test/test_plugins.py | grep '^author ' | sort | uniq -c | sort -nr
    341 author Sebastian Mohr
     76 author Šarūnas Nejus
     51 author Diego Moreda
     31 author Serene-Arc
     22 author Thomas Scholtes
     17 author Bruno Cauet
     15 author Malte Ried
      7 author Maxr1998
      6 author Andrew Rogl
      2 author pscn
      1 author Lars Kruse
      1 author Johnny Robeson
      1 author Jack Wilsdon
      1 author Carl Suster
```

Currently the `PluginTestCase` loads the plugin before each function and unloads it after each function, this is most likely not what we want as this comes with quite a bit of overhead. We might need some adjustments to run as class level fixture instead.

## Long term direction

This PR is an early step toward modernizing the plugin test suite and reducing reliance on legacy unittest-style patterns, with the goal of making pytest the primary testing model going forward.

