### PR TITLE
Fix musicbrainz plugin documentation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,7 @@ Bug fixes:
 For packagers:
 
 Other changes:
+
 - :doc:`plugins/index`: Clarify that musicbrainz must be mentioned if plugin list modified :bug:`6020`
 - :doc:`plugins/faq`: Add check for musicbrainz plugin if auto-tagger can't find a match :bug:`6020`
 - :doc:`guides/tagger`: Section on no matching release found, related to possibly disabled musicbrainz plugin :bug:`6020`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,10 @@ Bug fixes:
 For packagers:
 
 Other changes:
+- :doc:`plugins/index`: Clarify that musicbrainz must be mentioned if plugin list modified :bug:`6020`
+- :doc:`plugins/faq`: Add check for musicbrainz plugin if auto-tagger can't find a match :bug:`6020`
+- :doc:`guides/tagger`: Section on no matching release found, related to possibly disabled musicbrainz plugin :bug:`6020`
+
 
 2.4.0 (September 13, 2025)
 --------------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -240,6 +240,7 @@ There are a number of possibilities:
   <https://musicbrainz.org/>`__. You can search on their site to make sure it's
   cataloged there. (If not, anyone can edit MusicBrainz---so consider adding the
   data yourself.)
+- If you are using plugins, make sure that musicbrainz is in the plugin list.
 - If the album in question is a multi-disc release, see the relevant FAQ answer
   above.
 - The music files' metadata might be insufficient. Try using the "enter search"

--- a/docs/guides/tagger.rst
+++ b/docs/guides/tagger.rst
@@ -289,10 +289,14 @@ MusicBrainz---so consider adding the data yourself.
 
 .. _the musicbrainz database: https://musicbrainz.org/
 
+If you recieve a "No matching release found" message from the Auto-Tagger for an album you know is present in MusicBrainz, check that musicbrainz is in the plugin list. Until version `v2.4.0`_ the default metadate source for the Auto-Tagger, the :doc:`musicbrainz plugin </plugins/musicbrainz>`, had to be manually disabled. At present, if the plugin list is changed, musicbrainz needs to be added to the plugin list in order to continue contributing results to Auto-Tagger. 
+
 If you think beets is ignoring an album that's listed in MusicBrainz, please
 `file a bug report`_.
 
 .. _file a bug report: https://github.com/beetbox/beets/issues
+
+.. _v2.4.0: https://github.com/beetbox/beets/releases/tag/v2.4.0
 
 I Hope That Makes Sense
 -----------------------

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -18,7 +18,7 @@ list), just use the ``plugins`` option in your :doc:`config.yaml
 
 .. code-block:: sh
 
-    plugins: inline convert web
+    plugins: musicbrainz inline convert web
 
 The value for ``plugins`` can be a space-separated list of plugin names or a
 YAML list like ``[foo, bar]``. You can see which plugins are currently enabled
@@ -29,7 +29,7 @@ its name:
 
 .. code-block:: yaml
 
-    plugins: inline convert web
+    plugins: musicbrainz inline convert web
 
     convert:
         auto: true

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -58,7 +58,7 @@ following to your configuration:
 
 .. code-block:: yaml
 
-    plugins: discogs
+    plugins: musicbrainz discogs
 
     discogs:
        source_weight: 0.0


### PR DESCRIPTION
## Description

Fixes #6020

Add several lines to documentation to clear up possible confusion on musicbrainz plugin being disabled when plugin list is modified.

## To Do

I'm not too familiar with the general roadmap or ideology behind beets yet, but there might be a later benefit to later looking into making the config.yaml generate with the musicbrainz plugin filled out by default, instead of it silently being enabled or disabled. 

Another option could be to throw a warning if the Auto-Tagger doesn't detect a valid database source to query from.

Thanks for making getting my toes into contributing to open source feel easy - and let me know if there are any further changes or fixes I can apply.

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] ~Tests. (Very much encouraged but not strictly required.)~
