### PR TITLE
Improved `beets/logging.py` typing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 # assign the entire repo to the maintainers team
 * @beetbox/maintainers
+
+# Specific ownerships:
+/beets/metadata_plugins.py @semohr

--- a/beets/logging.py
+++ b/beets/logging.py
@@ -37,9 +37,7 @@ from logging import (
     RootLogger,
     StreamHandler,
 )
-from typing import TYPE_CHECKING, Any, Mapping, TypeVar, overload
-
-from typing_extensions import TypeAlias
+from typing import TYPE_CHECKING, Any, Mapping, TypeVar, Union, overload
 
 __all__ = [
     "DEBUG",
@@ -60,12 +58,12 @@ if TYPE_CHECKING:
     from types import TracebackType
 
     # see https://github.com/python/typeshed/blob/main/stdlib/logging/__init__.pyi
-    _SysExcInfoType: TypeAlias = (
-        tuple[type[BaseException], BaseException, TracebackType | None]
-        | tuple[None, None, None]
-    )
-    _ExcInfoType: TypeAlias = None | bool | _SysExcInfoType | BaseException
-    _ArgsType: TypeAlias = tuple[object, ...] | Mapping[str, object]
+    _SysExcInfoType = Union[
+        tuple[type[BaseException], BaseException, Union[TracebackType, None]],
+        tuple[None, None, None],
+    ]
+    _ExcInfoType = Union[None, bool, _SysExcInfoType, BaseException]
+    _ArgsType = Union[tuple[object, ...], Mapping[str, object]]
 
 
 def _logsafe(val: T) -> str | T:

--- a/beets/logging.py
+++ b/beets/logging.py
@@ -35,9 +35,10 @@ from logging import (
     Handler,
     Logger,
     NullHandler,
+    RootLogger,
     StreamHandler,
 )
-from typing import TYPE_CHECKING, Any, Mapping, TypeVar
+from typing import TYPE_CHECKING, Any, Mapping, TypeVar, overload
 
 from typing_extensions import ParamSpec
 
@@ -173,9 +174,12 @@ my_manager = copy(Logger.manager)
 my_manager.loggerClass = BeetsLogger
 
 
-# Override the `getLogger` to use our machinery.
-def getLogger(name=None):  # noqa
+@overload
+def getLogger(name: str) -> BeetsLogger: ...
+@overload
+def getLogger(name: None = ...) -> RootLogger: ...
+def getLogger(name=None) -> BeetsLogger | RootLogger:  # noqa: N802
     if name:
-        return my_manager.getLogger(name)
+        return my_manager.getLogger(name)  # type: ignore[return-value]
     else:
         return Logger.root

--- a/beets/logging.py
+++ b/beets/logging.py
@@ -40,8 +40,6 @@ from logging import (
 )
 from typing import TYPE_CHECKING, Any, Mapping, TypeVar, overload
 
-from typing_extensions import ParamSpec
-
 __all__ = [
     "DEBUG",
     "INFO",
@@ -58,9 +56,6 @@ __all__ = [
 
 if TYPE_CHECKING:
     T = TypeVar("T")
-
-
-P = ParamSpec("P")
 
 
 def _logsafe(val: T) -> str | T:

--- a/beets/logging.py
+++ b/beets/logging.py
@@ -22,7 +22,6 @@ calls (`debug`, `info`, etc).
 
 from __future__ import annotations
 
-import logging
 import threading
 from copy import copy
 from logging import (
@@ -40,6 +39,8 @@ from logging import (
 )
 from typing import TYPE_CHECKING, Any, Mapping, TypeVar, overload
 
+from typing_extensions import TypeAlias
+
 __all__ = [
     "DEBUG",
     "INFO",
@@ -56,6 +57,15 @@ __all__ = [
 
 if TYPE_CHECKING:
     T = TypeVar("T")
+    from types import TracebackType
+
+    # see https://github.com/python/typeshed/blob/main/stdlib/logging/__init__.pyi
+    _SysExcInfoType: TypeAlias = (
+        tuple[type[BaseException], BaseException, TracebackType | None]
+        | tuple[None, None, None]
+    )
+    _ExcInfoType: TypeAlias = None | bool | _SysExcInfoType | BaseException
+    _ArgsType: TypeAlias = tuple[object, ...] | Mapping[str, object]
 
 
 def _logsafe(val: T) -> str | T:
@@ -94,7 +104,7 @@ class StrFormatLogger(Logger):
         def __init__(
             self,
             msg: str,
-            args: logging._ArgsType,
+            args: _ArgsType,
             kwargs: dict[str, Any],
         ):
             self.msg = msg
@@ -110,8 +120,8 @@ class StrFormatLogger(Logger):
         self,
         level: int,
         msg: object,
-        args: logging._ArgsType = (),
-        exc_info: logging._ExcInfoType = None,
+        args: _ArgsType,
+        exc_info: _ExcInfoType = None,
         extra: Mapping[str, Any] | None = None,
         stack_info: bool = False,
         stacklevel: int = 1,

--- a/beets/logging.py
+++ b/beets/logging.py
@@ -20,6 +20,9 @@ use {}-style formatting and can interpolate keywords arguments to the logging
 calls (`debug`, `info`, etc).
 """
 
+from __future__ import annotations
+
+import logging
 import threading
 from copy import copy
 from logging import (
@@ -34,6 +37,9 @@ from logging import (
     NullHandler,
     StreamHandler,
 )
+from typing import TYPE_CHECKING, Any, Mapping, TypeVar
+
+from typing_extensions import ParamSpec
 
 __all__ = [
     "DEBUG",
@@ -49,8 +55,14 @@ __all__ = [
     "getLogger",
 ]
 
+if TYPE_CHECKING:
+    T = TypeVar("T")
 
-def logsafe(val):
+
+P = ParamSpec("P")
+
+
+def _logsafe(val: T) -> str | T:
     """Coerce `bytes` to `str` to avoid crashes solely due to logging.
 
     This is particularly relevant for bytestring paths. Much of our code
@@ -83,40 +95,45 @@ class StrFormatLogger(Logger):
     """
 
     class _LogMessage:
-        def __init__(self, msg, args, kwargs):
+        def __init__(
+            self,
+            msg: str,
+            args: logging._ArgsType,
+            kwargs: dict[str, Any],
+        ):
             self.msg = msg
             self.args = args
             self.kwargs = kwargs
 
         def __str__(self):
-            args = [logsafe(a) for a in self.args]
-            kwargs = {k: logsafe(v) for (k, v) in self.kwargs.items()}
+            args = [_logsafe(a) for a in self.args]
+            kwargs = {k: _logsafe(v) for (k, v) in self.kwargs.items()}
             return self.msg.format(*args, **kwargs)
 
     def _log(
         self,
-        level,
-        msg,
-        args,
-        exc_info=None,
-        extra=None,
-        stack_info=False,
+        level: int,
+        msg: object,
+        args: logging._ArgsType = (),
+        exc_info: logging._ExcInfoType = None,
+        extra: Mapping[str, Any] | None = None,
+        stack_info: bool = False,
+        stacklevel: int = 1,
         **kwargs,
     ):
         """Log msg.format(*args, **kwargs)"""
-        m = self._LogMessage(msg, args, kwargs)
 
-        stacklevel = kwargs.pop("stacklevel", 1)
-        stacklevel = {"stacklevel": stacklevel}
+        if isinstance(msg, str):
+            msg = self._LogMessage(msg, args, kwargs)
 
         return super()._log(
             level,
-            m,
+            msg,
             (),
             exc_info=exc_info,
             extra=extra,
             stack_info=stack_info,
-            **stacklevel,
+            stacklevel=stacklevel,
         )
 
 

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -36,10 +36,10 @@ from beets.util.config import sanitize_pairs
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Sequence
-    from logging import Logger
 
     from beets.importer import ImportSession, ImportTask
     from beets.library import Album, Library
+    from beets.logging import BeetsLogger as Logger
 
 try:
     from bs4 import BeautifulSoup, Tag

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -42,10 +42,9 @@ from beets.autotag.distance import string_dist
 from beets.util.config import sanitize_choices
 
 if TYPE_CHECKING:
-    from logging import Logger
-
     from beets.importer import ImportTask
     from beets.library import Item, Library
+    from beets.logging import BeetsLogger as Logger
 
     from ._typing import (
         GeniusAPI,
@@ -186,7 +185,7 @@ def slug(text: str) -> str:
 
 
 class RequestHandler:
-    _log: beets.logging.Logger
+    _log: Logger
 
     def debug(self, message: str, *args) -> None:
         """Log a debug message with the class name."""

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -51,6 +51,12 @@ Other changes:
 - :class:`beets.metadata_plugin.MetadataSourcePlugin`: Remove discogs specific
   disambiguation stripping.
 
+For developers and plugin authors:
+
+- Typing improvements in ``beets/logging.py``: ``getLogger`` now returns
+  ``BeetsLogger`` when called with a name, or ``RootLogger`` when called without
+  a name.
+
 2.4.0 (September 13, 2025)
 --------------------------
 

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -4,6 +4,7 @@ import logging as log
 import sys
 import threading
 from types import ModuleType
+from unittest.mock import patch
 
 import pytest
 

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -62,6 +62,7 @@ class TestStrFormatLogger:
         with caplog.at_level(level, logger="test_logger"):
             logger.log(level, msg, *args, **kwargs)
 
+        assert caplog.records, "No log records were captured"
         assert str(caplog.records[0].msg) == expected
 
 


### PR DESCRIPTION
This PR enhances `beets/logging.py` with improved typing and tests:

* `getLogger` now returns the precise logger type (`BeetsLogger` or `RootLogger`).
* Tests use `pytest` and `parametrize` for more concise and readable coverage.
