### PR TITLE
Fix plugin loading

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,6 +32,8 @@ Bug fixes:
   extraartists field.
 - :doc:`plugins/spotify` Fixed an issue where candidate lookup would not find
   matches due to query escaping (single vs double quotes).
+- :doc:`plugins/chroma` :doc:`plugins/bpsync` Fix plugin loading issue caused by
+  an import of another :class:`beets.plugins.BeetsPlugin` class. :bug:`6033`
 
 For packagers:
 


### PR DESCRIPTION
Fixes #6033

This PR addresses a bug where plugin loading failed when plugins imported other `BeetsPlugin` classes, namely `chroma` and `bpsync`.

- Add module path filtering to ensure only classes from the target plugin module are considered, preventing conflicts when plugins import other `BeetsPlugin` classes
