### PR TITLE
Fix for Spotify Candidate Lookup. Changed query from double to single quotes.

### DIFF
--- a/beets/metadata_plugins.py
+++ b/beets/metadata_plugins.py
@@ -412,7 +412,7 @@ class SearchApiMetadataSourcePlugin(
         :return: Query string to be provided to the search API.
         """
 
-        components = [query_string, *(f'{k}:"{v}"' for k, v in filters.items())]
+        components = [query_string, *(f"{k}:'{v}'" for k, v in filters.items())]
         query = " ".join(filter(None, components))
 
         if self.config["search_query_ascii"].get():

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,8 @@ Bug fixes:
   matching. :bug:`5189`
 - :doc:`plugins/discogs` Fixed inconsistency in stripping disambiguation from
   artists but not labels. :bug:`5366`
+- :doc:`plugins/spotify` Fixed an issue where candidate lookup would not find
+  matches due to query escaping (single vs double quotes).
 
 For packagers:
 


### PR DESCRIPTION
## Description

I noticed that spotify did not return any candidates for some of my examples, but adding the search id manually would give a very good match. I debugged it a bit and it seems like spotify does not like double quotes we used for the search query.

Using single quotes fixed it for me.

Note that this does not seem to be documented in the [spotify api documentation](https://developer.spotify.com/documentation/web-api/reference/search)

The example I used:

```


# Query with double quotes, which does not return any candidates
# Searching Spotify for 'album:"Flamethrower" artist:"Circadian, Cody Frost"'
https://api.spotify.com/v1/search?offset=0&limit=50&query=album%3A%22Flamethrower%22%20artist%3A%22Circadian%2C%20Cody%20Frost%22&type=album


# New Query
# Searching Spotify for 'album:'Flamethrower' artist:'Circadian, Cody Frost''
https://api.spotify.com/v1/search?offset=0&limit=5&query=album%3A%27Flamethrower%27%20artist%3A%27Circadian%2C%20Cody%20Frost%27&type=album
```



## To Do

- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
