### PR TITLE
Spotify: Store track attributes even if audio features are missing [small PR]

### DIFF
--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -694,14 +694,13 @@ class SpotifyPlugin(
             audio_features = self.track_audio_features(spotify_track_id)
             if audio_features is None:
                 self._log.info("No audio features found for: {}", item)
-                continue
-            for feature in audio_features.keys():
-                if feature in self.spotify_audio_features.keys():
-                    item[self.spotify_audio_features[feature]] = audio_features[
-                        feature
-                    ]
+            else:
+                for feature, value in audio_features.items():
+                    if feature in self.spotify_audio_features:
+                        item[self.spotify_audio_features[feature]] = value
             item["spotify_updated"] = time.time()
             item.store()
+            self._log.debug("Stored spotify_track_popularity={} for {} (item id {})", item.get("spotify_track_popularity"), item.get("title"), item.id)
             if write:
                 item.try_write()
 

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -700,7 +700,6 @@ class SpotifyPlugin(
                         item[self.spotify_audio_features[feature]] = value
             item["spotify_updated"] = time.time()
             item.store()
-            self._log.debug("Stored spotify_track_popularity={} for {} (item id {})", item.get("spotify_track_popularity"), item.get("title"), item.id)
             if write:
                 item.try_write()
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,9 +19,8 @@ New features:
 
 Bug fixes:
 
-- :doc:`plugins/spotify` Ensure ``spotifysync`` keeps popularity, ISRC,
-  and related fields current even when audio features requests fail.
-  :bug:`6061`
+- :doc:`plugins/spotify` Ensure ``spotifysync`` keeps popularity, ISRC, and
+  related fields current even when audio features requests fail. :bug:`6061`
 - :doc:`plugins/spotify` Fixed an issue where track matching and lookups could
   return incorrect or misleading results when using the Spotify plugin. The
   problem occurred primarily when no album was provided or when the album field

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,9 @@ New features:
 
 Bug fixes:
 
+- :doc:`plugins/spotify` Ensure ``spotifysync`` keeps popularity, ISRC,
+  and related fields current even when audio features requests fail.
+  :bug:`6061`
 - :doc:`plugins/spotify` Fixed an issue where track matching and lookups could
   return incorrect or misleading results when using the Spotify plugin. The
   problem occurred primarily when no album was provided or when the album field


### PR DESCRIPTION
## Description

Fixes #6061

## To Do

- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
