### PR TITLE
fix spacing for "finding tags for" prompt

### DIFF
--- a/beets/ui/commands.py
+++ b/beets/ui/commands.py
@@ -904,7 +904,7 @@ def choose_candidate(
             # Display list of candidates.
             print_("")
             print_(
-                f"Finding tags for {'track' if singleton else 'album'}"
+                f"Finding tags for {'track' if singleton else 'album'} "
                 f'"{item.artist if singleton else cur_artist} -'
                 f' {item.title if singleton else cur_album}".'
             )


### PR DESCRIPTION
Add missing space to "Finding tags for album" prompt

<img width="602" height="89" alt="image" src="https://github.com/user-attachments/assets/db538a86-d803-4ff5-8859-adcf8a75b538" />

(It was annoying me, and it's a simple enough fix!)

