### PR TITLE
fix(metadata_plugins): add distance penalty when sources do not match

### DIFF
--- a/beets/metadata_plugins.py
+++ b/beets/metadata_plugins.py
@@ -132,7 +132,7 @@ def _get_distance(
     from beets.autotag.distance import Distance
 
     dist = Distance()
-    if info.data_source == data_source:
+    if info.data_source != data_source:
         dist.add("source", config["source_weight"].as_number())
     return dist
 


### PR DESCRIPTION
## Description

Fixes #6066.  <!-- Insert issue number here if applicable. -->

Allows for tracks to be properly penalized when sources do not match.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
