### PR TITLE
New Plugin: Save skipped imports

### DIFF
--- a/beetsplug/saveskippedsongs.py
+++ b/beetsplug/saveskippedsongs.py
@@ -1,0 +1,157 @@
+# This file is part of beets.
+# Copyright 2025, Jacob Danell.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""
+Save all skipped songs to a text file for later review.
+This plugin uses the Spotify plugin (if available) to try to find
+the Spotify links for the skipped songs.
+"""
+
+import os
+from typing import TYPE_CHECKING, Optional
+
+from beets import plugins
+from beets.importer import Action
+from beets.plugins import BeetsPlugin
+
+if TYPE_CHECKING:
+    from beets.metadata_plugins import SearchFilter
+    from beets.plugins import ImportSession, ImportTask
+
+__author__ = "jacob@emberlight.se"
+__version__ = "1.0"
+
+
+def summary(task: "ImportTask"):
+    """Given an ImportTask, produce a short string identifying the
+    object.
+    """
+    if task.is_album:
+        return f"{task.cur_artist} - {task.cur_album}"
+    else:
+        item = task.item  # type: ignore[attr-defined]
+        return f"{item.artist} - {item.title}"
+
+
+class SaveSkippedSongsPlugin(BeetsPlugin):
+    def __init__(self):
+        """Initialize the plugin and read configuration."""
+        super().__init__()
+        self.config.add(
+            {
+                "spotify": True,
+                "path": "skipped_songs.txt",
+            }
+        )
+        self.register_listener("import_task_choice", self.log_skipped_song)
+
+    def log_skipped_song(self, task: "ImportTask", session: "ImportSession"):
+        if task.choice_flag == Action.SKIP:
+            # If spotify integration is enabled, try to match with Spotify
+            link = None
+            if self.config["spotify"].get(bool):
+                link = self._match_with_spotify(task, session)
+
+            result = f"{summary(task)}{' (' + link + ')' if link else ''}"
+            self._log.info(f"Skipped: {result}")
+            path = self.config["path"].get(str)
+            if path:
+                path = os.path.abspath(path)
+                try:
+                    # Read existing lines (if file exists) and avoid duplicates.
+                    try:
+                        with open(path, "r", encoding="utf-8") as f:
+                            existing = {line.rstrip("\n") for line in f}
+                    except FileNotFoundError:
+                        existing = set()
+
+                    if result not in existing:
+                        with open(path, "a", encoding="utf-8") as f:
+                            f.write(f"{result}\n")
+                    else:
+                        self._log.debug(f"Song already recorded in {path}")
+                except OSError as exc:
+                    # Don't crash import; just log the I/O problem.
+                    self._log.debug(
+                        f"Could not write skipped song to {path}: {exc}"
+                    )
+
+    def _match_with_spotify(
+        self, task: "ImportTask", session: "ImportSession"
+    ) -> Optional[str]:
+        """Try to match the skipped track/album with Spotify by directly
+        calling the Spotify API search.
+        """
+        try:
+            # Try to get the spotify plugin if it's already loaded
+            spotify_plugin = None
+            for plugin in plugins.find_plugins():
+                if plugin.name == "spotify":
+                    spotify_plugin = plugin
+                    break
+
+            # If not loaded, try to load it dynamically
+            if not spotify_plugin:
+                try:
+                    from beetsplug.spotify import SpotifyPlugin
+
+                    spotify_plugin = SpotifyPlugin()
+                    self._log.debug("Loaded Spotify plugin dynamically")
+                except ImportError as e:
+                    self._log.debug(f"Could not import Spotify plugin: {e}")
+                    return
+                except Exception as e:
+                    self._log.debug(f"Could not initialize Spotify plugin: {e}")
+                    return
+
+            # Build search parameters based on the task
+            query_filters: SearchFilter = {}
+            if task.is_album:
+                query_string = task.cur_album or ""
+                if task.cur_artist:
+                    query_filters["artist"] = task.cur_artist
+                search_type = "album"
+            else:
+                # For singleton imports
+                item = task.item  # type: ignore[attr-defined]
+                query_string = item.title or ""
+                if item.artist:
+                    query_filters["artist"] = item.artist
+                if item.album:
+                    query_filters["album"] = item.album
+                search_type = "track"
+
+            self._log.info(
+                f"Searching Spotify for: {query_string} ({query_filters})"
+            )
+
+            # Call the Spotify API directly via the plugin's search method
+            results = spotify_plugin._search_api(  # type: ignore[attr-defined]
+                query_type=search_type,  # type: ignore[arg-type]
+                query_string=query_string,
+                filters=query_filters,
+            )
+
+            if results:
+                self._log.info(f"Found {len(results)} Spotify match(es)!")
+                self._log.info("Returning first Spotify match link")
+                return results[0].get("external_urls", {}).get("spotify", "")
+            else:
+                self._log.info("No Spotify matches found")
+
+        except AttributeError as e:
+            self._log.debug(f"Spotify plugin method not available: {e}")
+        except Exception as e:
+            self._log.debug(f"Error searching Spotify: {e}")
+        return

--- a/beetsplug/saveskippedsongs.py
+++ b/beetsplug/saveskippedsongs.py
@@ -72,11 +72,15 @@ class SaveSkippedSongsPlugin(BeetsPlugin):
                     # Read existing lines (if file exists) and avoid duplicates.
                     try:
                         with open(path, "r", encoding="utf-8") as f:
-                            existing = {line.rstrip("\n") for line in f}
+                            existing = {
+                                line.rstrip("\n").strip().lower()
+                                for line in f
+                            }
                     except FileNotFoundError:
                         existing = set()
 
-                    if result not in existing:
+                    normalized_result = result.strip().lower()
+                    if normalized_result not in existing:
                         with open(path, "a", encoding="utf-8") as f:
                             f.write(f"{result}\n")
                     else:

--- a/beetsplug/saveskippedsongs.py
+++ b/beetsplug/saveskippedsongs.py
@@ -39,8 +39,7 @@ def summary(task: "SingletonImportTask"):
     """
     if task.is_album:
         return f"{task.cur_artist} - {task.cur_album}"
-    item = task.item  # type: ignore[attr-defined]
-    return f"{item.artist} - {item.title}"
+    return f"{task.item.artist} - {task.item.title}"
 
 
 class SaveSkippedSongsPlugin(BeetsPlugin):
@@ -76,8 +75,7 @@ class SaveSkippedSongsPlugin(BeetsPlugin):
                     try:
                         with open(path, "r", encoding="utf-8") as f:
                             existing = {
-                                line.rstrip("\n").strip().lower()
-                                for line in f
+                                line.rstrip("\n").strip().lower() for line in f
                             }
                     except FileNotFoundError:
                         existing = set()
@@ -146,8 +144,8 @@ class SaveSkippedSongsPlugin(BeetsPlugin):
             # Call the Spotify API directly via the plugin's search method
             results = spotify_plugin._search_api(  # type: ignore[attr-defined]
                 query_type=search_type,  # type: ignore[arg-type]
-                query_string=query_string,
                 filters=query_filters,
+                query_string=query_string,
             )
 
             if results:

--- a/beetsplug/saveskippedsongs.py
+++ b/beetsplug/saveskippedsongs.py
@@ -115,10 +115,10 @@ class SaveSkippedSongsPlugin(BeetsPlugin):
                     self._log.debug("Loaded Spotify plugin dynamically")
                 except ImportError as e:
                     self._log.debug(f"Could not import Spotify plugin: {e}")
-                    return
+                    return None
                 except Exception as e:
                     self._log.debug(f"Could not initialize Spotify plugin: {e}")
-                    return
+                    return None
 
             # Build search parameters based on the task
             query_filters: SearchFilter = {}
@@ -151,7 +151,7 @@ class SaveSkippedSongsPlugin(BeetsPlugin):
             if results:
                 self._log.info(f"Found {len(results)} Spotify match(es)!")
                 self._log.info("Returning first Spotify match link")
-                return results[0].get("external_urls", {}).get("spotify", "")
+                return results[0].get("external_urls", {}).get("spotify", None)
             else:
                 self._log.info("No Spotify matches found")
 
@@ -159,4 +159,4 @@ class SaveSkippedSongsPlugin(BeetsPlugin):
             self._log.debug(f"Spotify plugin method not available: {e}")
         except Exception as e:
             self._log.debug(f"Error searching Spotify: {e}")
-        return
+        return None

--- a/beetsplug/saveskippedsongs.py
+++ b/beetsplug/saveskippedsongs.py
@@ -39,9 +39,8 @@ def summary(task: "ImportTask"):
     """
     if task.is_album:
         return f"{task.cur_artist} - {task.cur_album}"
-    else:
-        item = task.item  # type: ignore[attr-defined]
-        return f"{item.artist} - {item.title}"
+    item = task.item  # type: ignore[attr-defined]
+    return f"{item.artist} - {item.title}"
 
 
 class SaveSkippedSongsPlugin(BeetsPlugin):

--- a/beetsplug/saveskippedsongs.py
+++ b/beetsplug/saveskippedsongs.py
@@ -26,14 +26,14 @@ from beets.importer import Action
 from beets.plugins import BeetsPlugin
 
 if TYPE_CHECKING:
+    from beets.importer import ImportSession, SingletonImportTask
     from beets.metadata_plugins import SearchFilter
-    from beets.plugins import ImportSession, ImportTask
 
 __author__ = "jacob@emberlight.se"
 __version__ = "1.0"
 
 
-def summary(task: "ImportTask"):
+def summary(task: "SingletonImportTask"):
     """Given an ImportTask, produce a short string identifying the
     object.
     """
@@ -55,7 +55,9 @@ class SaveSkippedSongsPlugin(BeetsPlugin):
         )
         self.register_listener("import_task_choice", self.log_skipped_song)
 
-    def log_skipped_song(self, task: "ImportTask", session: "ImportSession"):
+    def log_skipped_song(
+        self, task: "SingletonImportTask", session: "ImportSession"
+    ):
         if task.choice_flag == Action.SKIP:
             # If spotify integration is enabled, try to match with Spotify
             link = None
@@ -93,7 +95,7 @@ class SaveSkippedSongsPlugin(BeetsPlugin):
                     )
 
     def _match_with_spotify(
-        self, task: "ImportTask", session: "ImportSession"
+        self, task: "SingletonImportTask", session: "ImportSession"
     ) -> Optional[str]:
         """Try to match the skipped track/album with Spotify by directly
         calling the Spotify API search.
@@ -129,7 +131,7 @@ class SaveSkippedSongsPlugin(BeetsPlugin):
                 search_type = "album"
             else:
                 # For singleton imports
-                item = task.item  # type: ignore[attr-defined]
+                item = task.item
                 query_string = item.title or ""
                 if item.artist:
                     query_filters["artist"] = item.artist

--- a/beetsplug/saveskippedsongs.py
+++ b/beetsplug/saveskippedsongs.py
@@ -67,6 +67,8 @@ class SaveSkippedSongsPlugin(BeetsPlugin):
             self._log.info(f"Skipped: {result}")
             path = self.config["path"].get(str)
             if path:
+                # Expand user home (~) and environment variables in the path
+                path = os.path.expanduser(os.path.expandvars(path))
                 path = os.path.abspath(path)
                 try:
                     # Read existing lines (if file exists) and avoid duplicates.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,8 @@ New features:
       resolved. The ``extended_debug`` config setting and ``--debug`` option
       have been removed.
 - Added support for Python 3.13.
+- :doc:`plugins/saveskippedsongs`: Added new plugin that saves skipped songs
+      to a text file during import for later review.
 
 Bug fixes:
 

--- a/docs/plugins/saveskippedsongs.rst
+++ b/docs/plugins/saveskippedsongs.rst
@@ -1,0 +1,23 @@
+Save Skipped Songs Plugin
+================
+
+The ``saveskippedsongs`` plugin will save the name of the skipped song/album 
+to a text file during import for later review.
+
+It will also allow you to try to find the Spotify link for the skipped songs if
+the Spotify plugin is installed and configured.
+This information can later be used together with other MB importers like Harmony.
+
+If any song has already been written to the file, it will not be written again.
+
+To use the ``saveskippedsongs`` plugin, enable it in your configuration (see
+:ref:`using-plugins`).
+
+Configuration
+-------------
+
+To configure the plugin, make a ``saveskippedsongs:`` section in your configuration
+file. The available options are:
+
+- **spotify**: Search Spotify for the song/album and return the link. Default: ``yes``.
+- **path**: Path to the file to write the skipped songs to. Default: ``skipped_songs.txt``.

--- a/docs/plugins/saveskippedsongs.rst
+++ b/docs/plugins/saveskippedsongs.rst
@@ -1,12 +1,12 @@
 Save Skipped Songs Plugin
-================
+=========================
 
-The ``saveskippedsongs`` plugin will save the name of the skipped song/album 
-to a text file during import for later review.
+The ``saveskippedsongs`` plugin will save the name of the skipped song/album to
+a text file during import for later review.
 
 It will also allow you to try to find the Spotify link for the skipped songs if
-the Spotify plugin is installed and configured.
-This information can later be used together with other MB importers like Harmony.
+the Spotify plugin is installed and configured. This information can later be
+used together with other MB importers like Harmony.
 
 If any song has already been written to the file, it will not be written again.
 
@@ -16,8 +16,10 @@ To use the ``saveskippedsongs`` plugin, enable it in your configuration (see
 Configuration
 -------------
 
-To configure the plugin, make a ``saveskippedsongs:`` section in your configuration
-file. The available options are:
+To configure the plugin, make a ``saveskippedsongs:`` section in your
+configuration file. The available options are:
 
-- **spotify**: Search Spotify for the song/album and return the link. Default: ``yes``.
-- **path**: Path to the file to write the skipped songs to. Default: ``skipped_songs.txt``.
+- **spotify**: Search Spotify for the song/album and return the link. Default:
+  ``yes``.
+- **path**: Path to the file to write the skipped songs to. Default:
+  ``skipped_songs.txt``.


### PR DESCRIPTION
## Description

This plugin will save the name of the skipped song/album to a text file during import for later review.

It will also allow you to try to find the Spotify link for the skipped songs if the Spotify plugin is installed and configured.
This information can later be used together with other MB importers like Harmony.

If any song has already been written to the file, it will not be written again.

## To Do

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)

## Extra Info

I haven't written any tests for this plugin as I'm not sure how to write tests for this kind of thing. If anyone knows how to write some good tests for this plugin I'm more than happy to add them to this PR!

I personally wrote this plugin to later use with Harmony as I currently manually save the skipped song-info from my library of not found songs, search spotify for them and add them through Harmony. Currently I have over 100 skipped songs and I'm only on the letter D in my library so this plugin will save me A LOT of time getting the information to later add.