### PR TITLE
Catch ValueError when beetsplug.bpd cannot be imported

### DIFF
--- a/beetsplug/bpd/gstplayer.py
+++ b/beetsplug/bpd/gstplayer.py
@@ -27,7 +27,16 @@ import gi
 
 from beets import ui
 
-gi.require_version("Gst", "1.0")
+try:
+    gi.require_version("Gst", "1.0")
+except ValueError as e:
+    # on some scenarios, gi may be importable, but we get a ValueError when
+    # trying to specify the required version. This is problematic in the test
+    # suite where test_bpd.py has a call to
+    # pytest.importorskip("beetsplug.bpd"). Re-raising as an ImportError
+    # makes it so the test collector functions as inteded.
+    raise ImportError from e
+
 from gi.repository import GLib, Gst  # noqa: E402
 
 Gst.init(None)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -66,6 +66,8 @@ Other changes:
 - Refactored the ``beets/ui/commands.py`` monolithic file (2000+ lines) into
   multiple modules within the ``beets/ui/commands`` directory for better
   maintainability.
+- :doc:`plugins/bpd`: Raise ImportError instead of ValueError when GStreamer is
+  unavailable, enabling ``importorskip`` usage in pytest setup.
 
 2.5.1 (October 14, 2025)
 ------------------------


### PR DESCRIPTION
## Description

Catch ValueError when setting gst required version

`pytest.importskip` is used to catch the case when beetsplug.bpd cannot be imported. On macOS, the `gi` module was able to be imported, but when trying to specify `gi.require_version`, a `ValueError` is raised about Gst being unavailable. pytest does not catch this `ValueError` during `importskip` as it is not an `ImportError`, and thus the test suite errors during the test collection phase.

With this change, we catch the ValueError, and re-raise it as an `ImportError` and pytest gracefully skips those tests.

Fixes #3324

## To Do

I do not have a linux system to check to see if this change catches the appropriate failure mode there.  This failure occurs strictly on macOS

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
