### PR TITLE
Improves SubsonicUpdate error messages when server is unavailable #5635

### DIFF
--- a/beetsplug/subsonicupdate.py
+++ b/beetsplug/subsonicupdate.py
@@ -138,6 +138,7 @@ class SubsonicUpdate(BeetsPlugin):
                 params=payload,
                 timeout=10,
             )
+            response.raise_for_status()
             try:
                 json = response.json()
             except ValueError:
@@ -145,15 +146,14 @@ class SubsonicUpdate(BeetsPlugin):
                     "Invalid JSON from Subsonic: {}", response.text[:200]
                 )
                 return
-            resp = json.get("subsonic-response")
-            if not resp:
+            if not (resp := json.get("subsonic-response")):
                 self._log.error("Missing 'subsonic-response' field: {}", json)
                 return
             status = resp.get("status")
-            if response.status_code == 200 and status == "ok":
+            if status == "ok":
                 count = resp.get("scanStatus", {}).get("count", 0)
                 self._log.info("Updating Subsonic; scanning {} tracks", count)
-            elif response.status_code == 200 and status == "failed":
+            elif status == "failed":
                 msg = resp.get("error", {}).get("message", "Unknown error")
                 self._log.error("Error: {}", msg)
             else:

--- a/beetsplug/subsonicupdate.py
+++ b/beetsplug/subsonicupdate.py
@@ -141,27 +141,21 @@ class SubsonicUpdate(BeetsPlugin):
             try:
                 json = response.json()
             except ValueError:
-                self._log.error("Invalid JSON from Subsonic: {}", response.text[:200])
+                self._log.error(
+                    "Invalid JSON from Subsonic: {}", response.text[:200]
+                )
                 return
             resp = json.get("subsonic-response")
             if not resp:
                 self._log.error("Missing 'subsonic-response' field: {}", json)
                 return
             status = resp.get("status")
-            if (
-                response.status_code == 200
-                and status == "ok"
-            ):
+            if response.status_code == 200 and status == "ok":
                 count = resp.get("scanStatus", {}).get("count", 0)
                 self._log.info("Updating Subsonic; scanning {} tracks", count)
-            elif (
-                response.status_code == 200
-                and status == "failed"
-            ):
+            elif response.status_code == 200 and status == "failed":
                 msg = resp.get("error", {}).get("message", "Unknown error")
-                self._log.error(
-                    "Error: {}", msg
-                )
+                self._log.error("Error: {}", msg)
             else:
                 self._log.error("Error: {}", json)
         except Exception as error:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,7 +33,9 @@ New features:
       resolve differences in metadata source styles.
 
 Bug fixes:
-
+- :doc:`plugins/subsonicupdate`: Improve error messages when the Subsonic server 
+  is unavailable or returns invalid/missing JSON. Previously, failures were 
+  cryptic (e.g., "Expecting value: line 1 column 1 (char 0)"). :bug:`5635`
 - :doc:`plugins/inline`: Fix recursion error when an inline field definition
   shadows a built-in item field (e.g., redefining ``track_no``). Inline
   expressions now skip self-references during evaluation to avoid infinite

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,8 +33,8 @@ New features:
       resolve differences in metadata source styles.
 
 Bug fixes:
-- :doc:`plugins/subsonicupdate`: Improve error messages when the Subsonic server 
-  is unavailable or returns invalid/missing JSON. Previously, failures were 
+- :doc:`plugins/subsonicupdate`: Improve error messages when the Subsonic server
+  is unavailable or returns invalid or missing JSON. Previously, failures were
   cryptic (e.g., "Expecting value: line 1 column 1 (char 0)"). :bug:`5635`
 - :doc:`plugins/inline`: Fix recursion error when an inline field definition
   shadows a built-in item field (e.g., redefining ``track_no``). Inline

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,8 +35,8 @@ New features:
 Bug fixes:
 
 - :doc:`plugins/subsonicupdate`: Improve error messages when the Subsonic server
-    is unavailable or returns invalid or missing JSON. Previously, failures were
-    cryptic (for instance, "Expecting value: line 1 column 1 (char 0)"). :bug:`5635`
+      is unavailable or returns invalid JSON. Previously, failures were cryptic
+      (for instance, "Expecting value: line 1 column 1 (char 0)"). :bug:`5635`
 - :doc:`plugins/inline`: Fix recursion error when an inline field definition
   shadows a built-in item field (e.g., redefining ``track_no``). Inline
   expressions now skip self-references during evaluation to avoid infinite

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,9 +33,10 @@ New features:
       resolve differences in metadata source styles.
 
 Bug fixes:
+
 - :doc:`plugins/subsonicupdate`: Improve error messages when the Subsonic server
-  is unavailable or returns invalid or missing JSON. Previously, failures were
-  cryptic (e.g., "Expecting value: line 1 column 1 (char 0)"). :bug:`5635`
+    is unavailable or returns invalid or missing JSON. Previously, failures were
+    cryptic (for instance, "Expecting value: line 1 column 1 (char 0)"). :bug:`5635`
 - :doc:`plugins/inline`: Fix recursion error when an inline field definition
   shadows a built-in item field (e.g., redefining ``track_no``). Inline
   expressions now skip self-references during evaluation to avoid infinite


### PR DESCRIPTION
## Description

Fixes #5635: subsonicupdate fails cryptically when server is not available

The plugin previously produced unhelpful JSON-parsing errors when the server was down or returned unexpected data. This PR improves the error handling so that these situations now produce clear, user-friendly messages instead of cryptic failures such as: 

> Error: Expecting value: line 1 column 1 (char 0)

This update adds explicit handling for:
- HTTP connection errors and timeouts 
- Invalid or non-JSON responses 
- Missing subsonic-response fields in returned data 

Mocked Subsonic responses confirm the improved behavior: 

- Normal response --> unchanged 
- Timeout/connection error --> now produce a clear and readable error 
- Invalid JSON --> now reported as “Invalid JSON from Subsonic” and shows the server’s returned text for context
- Missing subsonic-response --> now produces a clear message identifying that the required field is missing 

These changes ensure that subsonicupdate failures are now clearly reported and no longer cryptic. 
- [X] Documentation. (Only changelog was updated. No additional docs required.)
- [X] Changelog. (Added an entry to `docs/changelog.rst`.)
- [X] Tests. While no formal unit tests were added, the fix was verified using local mock servers simulating various Subsonic server conditions: 
- Normal response: Verified scanning proceeds normally with a valid server response (test_subsonic.py). 
- Timeout: Verified that server timeout produces a clear, user-friendly error message (test_subsonic_timeout.py). 
- Invalid JSON: Verified that invalid JSON produces a clear error (test_subsonic_invalid_json.py). 
- Missing subsonic-response field: Verified that a clear error message is shown when the expected field is missing (test_subsonic_missing_response.py).