### PR TITLE
Sanitize log messages by removing control characters

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -54,6 +54,8 @@ Bug fixes:
   endpoints. Previously, due to single-quotes (ie. string literal) in the SQL
   query, the query eg. `GET /item/values/albumartist` would return the literal
   "albumartist" instead of a list of unique album artists.
+- Sanitize log messages by removing control characters preventing terminal
+  rendering issues.
 
 For plugin developers:
 


### PR DESCRIPTION
## Description

This pull request addresses an issue where control characters in log messages could halt beets execution entirely. The fix implements sanitization of log messages by removing C0 and C1 control characters before they reach the terminal, ensuring stable application behavior regardless of input data.

### Issue Discovery

The issue was identified when the `lastimport` plugin consistently failed on a specific track titled ["Djevojčice Koje Miše Koža" by Zabranjeno Pušenje](https://www.last.fm/music/Zabranjeno+Pu%C5%A1enje/_/Djevoj%C3%A8ice+Kojima+Miri%C2%9Ae+Ko%C2%9Ea). The track name contained the character `\x9e` (a C1 control code), which caused the program to terminate unexpectedly when logged to the terminal. Testing revealed that while some terminal environments handle this gracefully, others would completely stop execution. 

Command to test, it should output `hello` string:

```sh
$ python3 -c 'print("\x9e", "hello")'
```

Terminals tested (command fails in):

* Gnome Terminal 3.56.2 (gnome 48)
* Konsole 25.04.2
* LXTerminal 0.4.1
* MATE Terminal 1.26.1
* xfce4-terminal 1.1.4

Note: tmux sessions were NOT affected by this issue.

## To Do

- [X] ~~Documentation.~~
- [x] Changelog.
- [X] Tests.
