### PR TITLE
Fix edit plugin cancel flow restoring in-memory tags (#6104)

### DIFF
--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -275,24 +275,17 @@ class EditPlugin(plugins.BeetsPlugin):
                     ui.print_("No changes to apply.")
                     return False
 
-                # Confirm the changes.
+                # For cancel/keep-editing, restore objects to their original
+                # in-memory state so temp edits don't leak into the session
                 choice = ui.input_options(
                     ("continue Editing", "apply", "cancel")
                 )
                 if choice == "a":  # Apply.
                     return True
                 elif choice == "c":  # Cancel.
-                    # Revert all temporary changes made in this edit session
-                    # so that objects return to their original in-memory
-                    # state (including tags provided by other plugins such as
-                    # `fromfilename`).
                     self.apply_data(objs, new_data, old_data)
                     return False
                 elif choice == "e":  # Keep editing.
-                    # Revert changes on the objects, but keep the edited YAML
-                    # file so the user can continue editing from their last
-                    # version. On the next iteration, differences will again
-                    # be computed against the original state (`old_data`).
                     self.apply_data(objs, new_data, old_data)
                     continue
 
@@ -382,10 +375,6 @@ class EditPlugin(plugins.BeetsPlugin):
             # to the files if needed without re-applying metadata.
             return Action.RETAG
         else:
-            # Edit cancelled / no edits made. `edit_objects` has already
-            # restored each object to its original in-memory state, so there
-            # is nothing more to do here. Returning None lets the importer
-            # resume the candidate prompt.
             return None
 
     def importer_edit_candidate(self, session, task):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,9 +34,9 @@ New features:
 
 Bug fixes:
 
-- When using :doc:`plugins/fromfilename` together with
-  :doc:`plugins/edit`, temporary tags extracted from filenames are no longer
-  lost when discarding or cancelling an edit session during import. :bug:`6104`
+- When using :doc:`plugins/fromfilename` together with :doc:`plugins/edit`,
+  temporary tags extracted from filenames are no longer lost when discarding or
+  cancelling an edit session during import. :bug:`6104`
 - :doc:`plugins/inline`: Fix recursion error when an inline field definition
   shadows a built-in item field (e.g., redefining ``track_no``). Inline
   expressions now skip self-references during evaluation to avoid infinite

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,9 @@ New features:
 
 Bug fixes:
 
+- When using :doc:`plugins/fromfilename` together with
+  :doc:`plugins/edit`, temporary tags extracted from filenames are no longer
+  lost when discarding or cancelling an edit session during import. :bug:`6104`
 - :doc:`plugins/inline`: Fix recursion error when an inline field definition
   shadows a built-in item field (e.g., redefining ``track_no``). Inline
   expressions now skip self-references during evaluation to avoid infinite

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -176,6 +176,25 @@ class EditCommandTest(EditMixin, BeetsTestCase):
         )
         assert list(self.album.items())[-1].title == "modified t\u00eftle 9"
 
+    def test_title_edit_keep_editing_then_apply(self, mock_write):
+        """Edit titles, keep editing once, then apply changes."""
+        # First, choose "keep editing" so changes are reverted in memory but
+        # kept in the YAML file; then choose "apply" to commit them.
+        self.run_mocked_command(
+            {"replacements": {"t\u00eftle": "modified t\u00eftle"}},
+            # keep Editing, then Apply
+            ["e", "a"],
+        )
+
+        # Writes should only happen once per track, when we finally apply.
+        assert mock_write.call_count == self.TRACK_COUNT
+        # All item titles (and mtimes) should now reflect the modified values.
+        self.assertItemFieldsModified(
+            self.album.items(),
+            self.items_orig,
+            ["title", "mtime"],
+        )
+
     def test_noedit(self, mock_write):
         """Do not edit anything."""
         # Do not edit anything.

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -178,21 +178,32 @@ class EditCommandTest(EditMixin, BeetsTestCase):
 
     def test_title_edit_keep_editing_then_apply(self, mock_write):
         """Edit titles, keep editing once, then apply changes."""
-        # First, choose "keep editing" so changes are reverted in memory but
-        # kept in the YAML file; then choose "apply" to commit them.
         self.run_mocked_command(
             {"replacements": {"t\u00eftle": "modified t\u00eftle"}},
             # keep Editing, then Apply
             ["e", "a"],
         )
 
-        # Writes should only happen once per track, when we finally apply.
         assert mock_write.call_count == self.TRACK_COUNT
-        # All item titles (and mtimes) should now reflect the modified values.
         self.assertItemFieldsModified(
             self.album.items(),
             self.items_orig,
             ["title", "mtime"],
+        )
+
+    def test_title_edit_keep_editing_then_cancel(self, mock_write):
+        """Edit titles, keep editing once, then cancel."""
+        self.run_mocked_command(
+            {"replacements": {"t\u00eftle": "modified t\u00eftle"}},
+            # keep Editing, then Cancel
+            ["e", "c"],
+        )
+
+        assert mock_write.call_count == 0
+        self.assertItemFieldsModified(
+            self.album.items(),
+            self.items_orig,
+            [],
         )
 
     def test_noedit(self, mock_write):


### PR DESCRIPTION
## Description

Fixes [#6104](https://github.com/beetbox/beets/issues/6104).

When using the `fromfilename` and `edit` plugins together during import, aborted edit sessions could silently discard the temporary tags injected by `fromfilename` (e.g., track number and title derived from the filename). This happened when using `eDit` or `edit Candidates` and then cancelling: the edit plugin reverted objects by re-reading from disk, which does not contain the `fromfilename`-generated metadata.

This PR changes the `edit` plugin so that cancel and “continue Editing” both roll back objects to the original in-memory snapshot captured before opening the editor, instead of reloading from the files. This preserves temporary tags provided by other plugins (like `fromfilename`) across aborted edit sessions, while still only writing to disk when the user chooses Apply.

`importer_edit` is also updated to rely on this rollback behavior when edits are cancelled, rather than re-reading from disk, so interactive imports resume with the same in-memory metadata they started with.

## To Do

- [x] Documentation
- [x] Changelog (Entry added under the Unreleased “Bug fixes” section.)
- [x] Tests (Existing `edit` plugin tests exercised and extended to cover the updated cancel/rollback behavior.)