### PR TITLE
Update poetry command

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -124,7 +124,7 @@ command. Instead, you can activate the virtual environment in your shell with:
 
     $ poetry env activate
 
-You should see ``(beets-py3.10)`` prefix in your shell prompt. Now you can run
+Now you can run
 commands directly, for example:
 
 ::


### PR DESCRIPTION
I was getting my development environment set up so I could start contributing code again (yay!) when I noticed that the docs are out of date. `poetry shell` is no longer part of the core poetry tool, but a plugin. Using `poetry env activate` is given as a replacement. This just updates the docs to reflect that. I also added a shortcut so people could understand how to install all the extras, since that's pretty necessary for developers.

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
