### PR TITLE
importsource: fix potential prevent_suggest_removal crash

### DIFF
--- a/beetsplug/importsource.py
+++ b/beetsplug/importsource.py
@@ -39,6 +39,8 @@ class ImportSourcePlugin(BeetsPlugin):
         )
 
     def prevent_suggest_removal(self, session, task):
+        if task.skip:
+            return
         for item in task.imported_items():
             if "mb_albumid" in item:
                 self.stop_suggestions_for_albums.add(item.mb_albumid)


### PR DESCRIPTION
## Description

When skipping an import and `importsource` is enabled, the following (harmless so it seems) error is produced:

```
Traceback (most recent call last):
  File "/nix/store/ki157bjmj77w3837mvzrb68h4qidkmrz-python3.13-beets-2.5.1/bin/.beet-wrapped", line 9, in <module>
    sys.exit(main())
             ~~~~^^
  File "/nix/store/ki157bjmj77w3837mvzrb68h4qidkmrz-python3.13-beets-2.5.1/lib/python3.13/site-packages/beets/ui/__init__.py", line 1713, in main
    _raw_main(args)
    ~~~~~~~~~^^^^^^
  File "/nix/store/ki157bjmj77w3837mvzrb68h4qidkmrz-python3.13-beets-2.5.1/lib/python3.13/site-packages/beets/ui/__init__.py", line 1692, in _raw_main
    subcommand.func(lib, suboptions, subargs)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ki157bjmj77w3837mvzrb68h4qidkmrz-python3.13-beets-2.5.1/lib/python3.13/site-packages/beets/ui/commands.py", line 1378, in import_func
    import_files(lib, byte_paths, query)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ki157bjmj77w3837mvzrb68h4qidkmrz-python3.13-beets-2.5.1/lib/python3.13/site-packages/beets/ui/commands.py", line 1322, in import_files
    session.run()
    ~~~~~~~~~~~^^
  File "/nix/store/ki157bjmj77w3837mvzrb68h4qidkmrz-python3.13-beets-2.5.1/lib/python3.13/site-packages/beets/importer/session.py", line 234, in run
    pl.run_parallel(QUEUE_SIZE)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/nix/store/ki157bjmj77w3837mvzrb68h4qidkmrz-python3.13-beets-2.5.1/lib/python3.13/site-packages/beets/util/pipeline.py", line 468, in run_parallel
    raise exc_info[1].with_traceback(exc_info[2])
  File "/nix/store/ki157bjmj77w3837mvzrb68h4qidkmrz-python3.13-beets-2.5.1/lib/python3.13/site-packages/beets/util/pipeline.py", line 333, in run
    out = self.coro.send(msg)
  File "/nix/store/ki157bjmj77w3837mvzrb68h4qidkmrz-python3.13-beets-2.5.1/lib/python3.13/site-packages/beets/util/pipeline.py", line 192, in coro
    task = func(*(args + (task,)))
  File "/nix/store/ki157bjmj77w3837mvzrb68h4qidkmrz-python3.13-beets-2.5.1/lib/python3.13/site-packages/beets/importer/stages.py", line 169, in user_query
    plugins.send("import_task_choice", session=session, task=task)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/ki157bjmj77w3837mvzrb68h4qidkmrz-python3.13-beets-2.5.1/lib/python3.13/site-packages/beets/plugins.py", line 648, in send
    if (r := handler(**arguments)) is not None
             ~~~~~~~^^^^^^^^^^^^^
  File "/nix/store/ki157bjmj77w3837mvzrb68h4qidkmrz-python3.13-beets-2.5.1/lib/python3.13/site-packages/beets/plugins.py", line 329, in wrapper
    return func(*args, **kwargs)
  File "/nix/store/ki157bjmj77w3837mvzrb68h4qidkmrz-python3.13-beets-2.5.1/lib/python3.13/site-packages/beetsplug/importsource.py", line 42, in prevent_suggest_removal
    for item in task.imported_items():
                ~~~~~~~~~~~~~~~~~~~^^
  File "/nix/store/ki157bjmj77w3837mvzrb68h4qidkmrz-python3.13-beets-2.5.1/lib/python3.13/site-packages/beets/importer/tasks.py", line 253, in imported_items
    assert False
           ^^^^^
AssertionError
```

## To Do

Not sure if the following is critical:

- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
