### PR TITLE
Fix ftintitle plugin to prioritize explicit featuring tokens

### DIFF
--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -36,11 +36,23 @@ def split_on_feat(
     artist, which is always a string, and the featuring artist, which
     may be a string or None if none is present.
     """
-    # split on the first "feat".
-    regex = re.compile(
-        plugins.feat_tokens(for_artist, custom_words), re.IGNORECASE
+    # Try explicit featuring tokens first (ft, feat, featuring, etc.)
+    # to avoid splitting on generic separators like "&" when both are present
+    regex_explicit = re.compile(
+        plugins.feat_tokens(for_artist=False, custom_words=custom_words),
+        re.IGNORECASE,
     )
-    parts = tuple(s.strip() for s in regex.split(artist, 1))
+    parts = tuple(s.strip() for s in regex_explicit.split(artist, 1))
+    if len(parts) == 2:
+        return parts
+
+    # Fall back to all tokens including generic separators if no explicit match
+    if for_artist:
+        regex = re.compile(
+            plugins.feat_tokens(for_artist, custom_words), re.IGNORECASE
+        )
+        parts = tuple(s.strip() for s in regex.split(artist, 1))
+
     if len(parts) == 1:
         return parts[0], None
     else:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -62,6 +62,9 @@ Bug fixes:
   "albumartist" instead of a list of unique album artists.
 - Sanitize log messages by removing control characters preventing terminal
   rendering issues.
+- :doc:`/plugins/ftintitle`: Fixed artist name splitting to prioritize explicit
+  featuring tokens (feat, ft, featuring) over generic separators (&, and),
+  preventing incorrect splits when both are present.
 
 For plugin developers:
 

--- a/test/plugins/test_ftintitle.py
+++ b/test/plugins/test_ftintitle.py
@@ -303,6 +303,10 @@ def test_find_feat_part(
         ("Alice and Bob", ("Alice", "Bob")),
         ("Alice With Bob", ("Alice", "Bob")),
         ("Alice defeat Bob", ("Alice defeat Bob", None)),
+        ("Alice & Bob feat Charlie", ("Alice & Bob", "Charlie")),
+        ("Alice & Bob ft. Charlie", ("Alice & Bob", "Charlie")),
+        ("Alice & Bob featuring Charlie", ("Alice & Bob", "Charlie")),
+        ("Alice and Bob feat Charlie", ("Alice and Bob", "Charlie")),
     ],
 )
 def test_split_on_feat(


### PR DESCRIPTION
## Description

Fixes an issue where the ftintitle plugin would incorrectly split artist names on generic separators (&, and) when explicit featuring tokens (feat, ft, featuring) were also present.

### Example
- Before: `Alice & Bob feat Charlie` could split on `&` → `("Alice", "Bob feat Charlie")`
- After: `Alice & Bob feat Charlie` splits on `feat` → `("Alice & Bob", "Charlie")` ✓

## Changes
- Modified `split_on_feat()` to try explicit featuring tokens first
- Falls back to generic separators only if no explicit tokens are found
- Added test cases to verify correct behavior

## To Do

- [x] Documentation. (Not applicable - internal behavior fix)
- [x] Changelog. (Added entry to docs/changelog.rst)
- [x] Tests. (Added 4 new test cases, all 76 tests passing)