### PR TITLE
Fixes to Replace Plugin

### DIFF
--- a/beetsplug/replace.py
+++ b/beetsplug/replace.py
@@ -23,7 +23,9 @@ class ReplacePlugin(BeetsPlugin):
         cmd.func = self.run
         return [cmd]
 
-    def run(self, lib: Library, opts: optparse.Values, args: list[str]) -> None:
+    def run(
+        self, lib: Library, _opts: optparse.Values, args: list[str]
+    ) -> None:
         if len(args) < 2:
             raise ui.UserError("Usage: beet replace <query> <new_file_path>")
 
@@ -61,7 +63,7 @@ class ReplacePlugin(BeetsPlugin):
         except mediafile.FileTypeError as fte:
             raise ui.UserError(fte)
 
-    def select_song(self, items: list[Item]):
+    def select_song(self, items: list[Item]) -> Item | None:
         """Present a menu of matching songs and get user selection."""
         ui.print_("Matching songs:")
         for i, item in enumerate(items, 1):
@@ -86,7 +88,7 @@ class ReplacePlugin(BeetsPlugin):
             except ValueError:
                 ui.print_("Invalid input. Please type in a number.")
 
-    def confirm_replacement(self, new_file_path: Path, song: Item):
+    def confirm_replacement(self, new_file_path: Path, song: Item) -> bool:
         """Get user confirmation for the replacement."""
         original_file_path: Path = Path(song.path.decode())
 

--- a/beetsplug/replace.py
+++ b/beetsplug/replace.py
@@ -101,12 +101,8 @@ class ReplacePlugin(BeetsPlugin):
             f"\nReplacing: {util.displayable_path(new_file_path)} "
             f"-> {util.displayable_path(original_file_path)}"
         )
-        decision: str = (
-            input("Are you sure you want to replace this track? (y/N): ")
-            .strip()
-            .casefold()
-        )
-        return decision in {"yes", "y"}
+
+        return ui.input_yn("Are you sure you want to replace this track (y/n)?")
 
     def replace_file(self, new_file_path: Path, song: Item) -> None:
         """Replace the existing file with the new one."""
@@ -128,7 +124,7 @@ class ReplacePlugin(BeetsPlugin):
                 raise ui.UserError(f"Could not delete original file: {e}")
 
         # Update the path to point to the new file.
-        song.path = str(dest).encode()
+        song.path = util.bytestring_path(dest)
         song.store()
 
         # Write the metadata in the database to the song file's tags.

--- a/beetsplug/replace.py
+++ b/beetsplug/replace.py
@@ -71,24 +71,19 @@ class ReplacePlugin(BeetsPlugin):
         for i, item in enumerate(items, 1):
             ui.print_(f"{i}. {util.displayable_path(item)}")
 
-        while True:
-            try:
-                index = int(
-                    input(
-                        f"Which song would you like to replace? "
-                        f"[1-{len(items)}] (0 to cancel): "
-                    )
-                )
-                if index == 0:
-                    return None
-                if 1 <= index <= len(items):
-                    return items[index - 1]
-                ui.print_(
-                    f"Invalid choice. Please enter a number "
-                    f"between 1 and {len(items)}."
-                )
-            except ValueError:
-                ui.print_("Invalid input. Please type in a number.")
+        index = ui.input_options(
+            [],
+            require=True,
+            prompt=(
+                f"Which song would you like to replace? "
+                f"[1-{len(items)}] (0 to cancel):"
+            ),
+            numrange=(0, len(items)),
+        )
+
+        if index == 0:
+            return None
+        return items[index - 1]
 
     def confirm_replacement(self, new_file_path: Path, song: Item) -> bool:
         """Get user confirmation for the replacement."""

--- a/beetsplug/replace.py
+++ b/beetsplug/replace.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 import mediafile
 
 from beets import ui, util
+from beets.library import Item, Library
+from beets.library.exceptions import FileOperationError
 from beets.plugins import BeetsPlugin
 
 if TYPE_CHECKING:
@@ -113,7 +115,7 @@ class ReplacePlugin(BeetsPlugin):
 
         try:
             shutil.move(util.syspath(new_file_path), util.syspath(dest))
-        except Exception as e:
+        except OSError as e:
             raise ui.UserError(f"Error replacing file: {e}")
 
         if (
@@ -122,7 +124,7 @@ class ReplacePlugin(BeetsPlugin):
         ):
             try:
                 original_file_path.unlink()
-            except Exception as e:
+            except OSError as e:
                 raise ui.UserError(f"Could not delete original file: {e}")
 
         # Update the path to point to the new file.
@@ -131,7 +133,7 @@ class ReplacePlugin(BeetsPlugin):
         # Write the metadata in the database to the song file's tags.
         try:
             song.write()
-        except Exception as e:
+        except FileOperationError as e:
             raise ui.UserError(f"Error writing metadata to file: {e}")
 
         # Commit the new path to the database.

--- a/beetsplug/replace.py
+++ b/beetsplug/replace.py
@@ -123,7 +123,14 @@ class ReplacePlugin(BeetsPlugin):
             except Exception as e:
                 raise ui.UserError(f"Could not delete original file: {e}")
 
+        # Store the new path in the database.
         song.path = str(dest).encode()
         song.store()
+
+        # Write the metadata in the database to the song file's tags.
+        try:
+            song.write()
+        except Exception as e:
+            raise ui.UserError(f"Error writing metadata to file: {e}")
 
         ui.print_("Replacement successful.")

--- a/beetsplug/replace.py
+++ b/beetsplug/replace.py
@@ -10,6 +10,8 @@ from beets import ui, util
 from beets.plugins import BeetsPlugin
 
 if TYPE_CHECKING:
+    import optparse
+
     from beets.library import Item, Library
 
 
@@ -21,7 +23,7 @@ class ReplacePlugin(BeetsPlugin):
         cmd.func = self.run
         return [cmd]
 
-    def run(self, lib: Library, args: list[str]) -> None:
+    def run(self, lib: Library, opts: optparse.Values, args: list[str]) -> None:
         if len(args) < 2:
             raise ui.UserError("Usage: beet replace <query> <new_file_path>")
 
@@ -61,7 +63,7 @@ class ReplacePlugin(BeetsPlugin):
 
     def select_song(self, items: list[Item]):
         """Present a menu of matching songs and get user selection."""
-        ui.print_("\nMatching songs:")
+        ui.print_("Matching songs:")
         for i, item in enumerate(items, 1):
             ui.print_(f"{i}. {util.displayable_path(item)}")
 

--- a/beetsplug/replace.py
+++ b/beetsplug/replace.py
@@ -102,7 +102,9 @@ class ReplacePlugin(BeetsPlugin):
             f"-> {util.displayable_path(original_file_path)}"
         )
 
-        return ui.input_yn("Are you sure you want to replace this track (y/n)?")
+        return ui.input_yn(
+            "Are you sure you want to replace this track (y/n)?", require=True
+        )
 
     def replace_file(self, new_file_path: Path, song: Item) -> None:
         """Replace the existing file with the new one."""

--- a/beetsplug/replace.py
+++ b/beetsplug/replace.py
@@ -129,14 +129,12 @@ class ReplacePlugin(BeetsPlugin):
 
         # Update the path to point to the new file.
         song.path = str(dest).encode()
+        song.store()
 
         # Write the metadata in the database to the song file's tags.
         try:
             song.write()
         except FileOperationError as e:
             raise ui.UserError(f"Error writing metadata to file: {e}")
-
-        # Commit the new path to the database.
-        song.store()
 
         ui.print_("Replacement successful.")

--- a/beetsplug/replace.py
+++ b/beetsplug/replace.py
@@ -125,12 +125,8 @@ class ReplacePlugin(BeetsPlugin):
 
         # Update the path to point to the new file.
         song.path = util.bytestring_path(dest)
-        song.store()
 
-        # Write the metadata in the database to the song file's tags.
-        try:
-            song.write()
-        except FileOperationError as e:
-            raise ui.UserError(f"Error writing metadata to file: {e}")
-
-        ui.print_("Replacement successful.")
+        # Synchronise the new file with the database. This copies metadata from the
+        # Item to the new file (i.e. title, artist, album, etc.),
+        # and then from the Item to the database (i.e. path and mtime).
+        song.try_sync(write=True, move=False)

--- a/beetsplug/replace.py
+++ b/beetsplug/replace.py
@@ -8,7 +8,6 @@ import mediafile
 
 from beets import ui, util
 from beets.library import Item, Library
-from beets.library.exceptions import FileOperationError
 from beets.plugins import BeetsPlugin
 
 if TYPE_CHECKING:

--- a/beetsplug/replace.py
+++ b/beetsplug/replace.py
@@ -125,14 +125,16 @@ class ReplacePlugin(BeetsPlugin):
             except Exception as e:
                 raise ui.UserError(f"Could not delete original file: {e}")
 
-        # Store the new path in the database.
+        # Update the path to point to the new file.
         song.path = str(dest).encode()
-        song.store()
 
         # Write the metadata in the database to the song file's tags.
         try:
             song.write()
         except Exception as e:
             raise ui.UserError(f"Error writing metadata to file: {e}")
+
+        # Commit the new path to the database.
+        song.store()
 
         ui.print_("Replacement successful.")

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -284,10 +284,11 @@ Bug fixes
   won't crash beets anymore. If you want to raise exceptions instead, set the
   new configuration option ``raise_on_error`` to ``yes`` :bug:`5903`,
   :bug:`4789`.
+- :doc:`/plugins/replace`: Fixed the command failing to run, and now syncs
+  metadata in the database with the newly swapped-in file. :bug:`6260`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~
-
 - A new plugin event, ``album_matched``, is sent when an album that is being
   imported has been matched to its metadata and the corresponding distance has
   been calculated.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -289,6 +289,7 @@ Bug fixes
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~
+
 - A new plugin event, ``album_matched``, is sent when an album that is being
   imported has been matched to its metadata and the corresponding distance has
   been calculated.

--- a/docs/plugins/replace.rst
+++ b/docs/plugins/replace.rst
@@ -15,5 +15,8 @@ and then type:
 The plugin will show you a list of files for you to pick from, and then ask for
 confirmation.
 
+The file you pick will be replaced with the file at `path`, and the tags in the
+database will be written to that file's metadata.
+
 Consider using the ``replaygain`` command from the :doc:`/plugins/replaygain`
 plugin, if you usually use it during imports.

--- a/docs/plugins/replace.rst
+++ b/docs/plugins/replace.rst
@@ -15,8 +15,10 @@ and then type:
 The plugin will show you a list of files for you to pick from, and then ask for
 confirmation.
 
-The file you pick will be replaced with the file at `path`, and the tags in the
-database will be written to that file's metadata.
+The file you pick will be replaced with the file at `path`. Then, the new file's metadata
+will be synced with the database. This means that the tags in the database for that track
+(`title`, `artist`, etc.) will be written to the new file, and the `path` and `mtime` fields
+in the database will be updated to match the new file's path and the current modification time.
 
 Consider using the ``replaygain`` command from the :doc:`/plugins/replaygain`
 plugin, if you usually use it during imports.

--- a/docs/plugins/replace.rst
+++ b/docs/plugins/replace.rst
@@ -15,10 +15,11 @@ and then type:
 The plugin will show you a list of files for you to pick from, and then ask for
 confirmation.
 
-The file you pick will be replaced with the file at `path`. Then, the new file's metadata
-will be synced with the database. This means that the tags in the database for that track
-(`title`, `artist`, etc.) will be written to the new file, and the `path` and `mtime` fields
-in the database will be updated to match the new file's path and the current modification time.
+The file you pick will be replaced with the file at ``path``. Then, the new
+file's metadata will be synced with the database. This means that the tags in
+the database for that track (``title``, ``artist``, etc.) will be written to the
+new file, and the ``path`` and ``mtime`` fields in the database will be updated
+to match the new file's path and the current modification time.
 
 Consider using the ``replaygain`` command from the :doc:`/plugins/replaygain`
 plugin, if you usually use it during imports.

--- a/test/plugins/test_replace.py
+++ b/test/plugins/test_replace.py
@@ -1,18 +1,25 @@
+from __future__ import annotations
+
 import optparse
 import shutil
-from collections.abc import Generator
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
 from mediafile import MediaFile
 
 from beets import ui
-from beets.library import Item, Library
+from beets.library import Item
 from beets.library.exceptions import WriteError
 from beets.test import _common
 from beets.test.helper import TestHelper, capture_log
 from beetsplug.replace import ReplacePlugin
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from beets.library import Library
 
 replace = ReplacePlugin()
 

--- a/test/plugins/test_replace.py
+++ b/test/plugins/test_replace.py
@@ -175,7 +175,7 @@ class TestReplace:
 
     def test_confirm_replacement_yes(self, monkeypatch):
         src = Path(_common.RSRC.decode()) / "full.mp3"
-        monkeypatch.setattr("builtins.input", lambda _: "YES    ")
+        monkeypatch.setattr("builtins.input", always("yes"))
 
         class Song:
             path = str(src).encode()
@@ -186,7 +186,7 @@ class TestReplace:
 
     def test_confirm_replacement_no(self, monkeypatch):
         src = Path(_common.RSRC.decode()) / "full.mp3"
-        monkeypatch.setattr("builtins.input", lambda _: "test123")
+        monkeypatch.setattr("builtins.input", always("no"))
 
         class Song:
             path = str(src).encode()

--- a/test/plugins/test_replace.py
+++ b/test/plugins/test_replace.py
@@ -1,4 +1,5 @@
 import shutil
+from collections.abc import Generator
 from pathlib import Path
 
 import pytest
@@ -31,7 +32,7 @@ class TestReplace:
         return dest
 
     @pytest.fixture
-    def library(self) -> Library:
+    def library(self) -> Generator[Library]:
         helper = TestHelper()
         helper.setup_beets()
 

--- a/test/plugins/test_replace.py
+++ b/test/plugins/test_replace.py
@@ -5,46 +5,54 @@ import pytest
 from mediafile import MediaFile
 
 from beets import ui
+from beets.library import Item, Library
 from beets.test import _common
+from beets.test.helper import TestHelper
 from beetsplug.replace import ReplacePlugin
 
 replace = ReplacePlugin()
 
 
 class TestReplace:
-    @pytest.fixture(autouse=True)
-    def _fake_dir(self, tmp_path):
-        self.fake_dir = tmp_path
+    @pytest.fixture
+    def mp3_file(self, tmp_path) -> Path:
+        dest = tmp_path / "full.mp3"
+        src = Path(_common.RSRC.decode()) / "full.mp3"
+        shutil.copyfile(src, dest)
 
-    @pytest.fixture(autouse=True)
-    def _fake_file(self, tmp_path):
-        self.fake_file = tmp_path
+        return dest
 
-    def test_path_is_dir(self):
-        fake_directory = self.fake_dir / "fakeDir"
+    @pytest.fixture
+    def opus_file(self, tmp_path) -> Path:
+        dest = tmp_path / "full.opus"
+        src = Path(_common.RSRC.decode()) / "full.opus"
+        shutil.copyfile(src, dest)
+
+        return dest
+
+    @pytest.fixture
+    def library(self) -> Library:
+        helper = TestHelper()
+        helper.setup_beets()
+
+        yield helper.lib
+
+        helper.teardown_beets()
+
+    def test_path_is_dir(self, tmp_path):
+        fake_directory = tmp_path / "fakeDir"
         fake_directory.mkdir()
         with pytest.raises(ui.UserError):
             replace.file_check(fake_directory)
 
-    def test_path_is_unsupported_file(self):
-        fake_file = self.fake_file / "fakefile.txt"
+    def test_path_is_unsupported_file(self, tmp_path):
+        fake_file = tmp_path / "fakefile.txt"
         fake_file.write_text("test", encoding="utf-8")
         with pytest.raises(ui.UserError):
             replace.file_check(fake_file)
 
-    def test_path_is_supported_file(self):
-        dest = self.fake_file / "full.mp3"
-        src = Path(_common.RSRC.decode()) / "full.mp3"
-        shutil.copyfile(src, dest)
-
-        mediafile = MediaFile(dest)
-        mediafile.albumartist = "AAA"
-        mediafile.disctitle = "DDD"
-        mediafile.genres = ["a", "b", "c"]
-        mediafile.composer = None
-        mediafile.save()
-
-        replace.file_check(Path(str(dest)))
+    def test_path_is_supported_file(self, mp3_file):
+        replace.file_check(mp3_file)
 
     def test_select_song_valid_choice(self, monkeypatch, capfd):
         songs = ["Song A", "Song B", "Song C"]
@@ -113,3 +121,30 @@ class TestReplace:
         song = Song()
 
         assert replace.confirm_replacement("test", song) is False
+
+    def test_replace_file(
+        self, mp3_file: Path, opus_file: Path, library: Library
+    ):
+        old_mediafile = MediaFile(mp3_file)
+        old_mediafile.albumartist = "ABC"
+        old_mediafile.disctitle = "DEF"
+        old_mediafile.genre = "GHI"
+        old_mediafile.save()
+
+        item = Item.from_path(mp3_file)
+        library.add(item)
+
+        replace.replace_file(opus_file, item)
+
+        # Check that the file has been replaced.
+        assert opus_file.exists()
+        assert not mp3_file.exists()
+
+        # Check that the database path has been updated.
+        assert item.path == bytes(opus_file)
+
+        # Check that the new file has the old file's metadata.
+        new_mediafile = MediaFile(opus_file)
+        assert new_mediafile.albumartist == old_mediafile.albumartist
+        assert new_mediafile.disctitle == old_mediafile.disctitle
+        assert new_mediafile.genre == old_mediafile.genre

--- a/test/plugins/test_replace.py
+++ b/test/plugins/test_replace.py
@@ -24,17 +24,6 @@ if TYPE_CHECKING:
 replace = ReplacePlugin()
 
 
-def always(x):
-    return lambda *args, **kwargs: x
-
-
-def always_raise(x):
-    def err(*args, **kwargs):
-        raise x
-
-    return err
-
-
 class TestReplace:
     @pytest.fixture
     def mp3_file(self, tmp_path) -> Path:
@@ -76,8 +65,8 @@ class TestReplace:
     def test_run_replace_no_song_selected(
         self, library, mp3_file, opus_file, monkeypatch
     ):
-        monkeypatch.setattr(replace, "file_check", always(None))
-        monkeypatch.setattr(replace, "select_song", always(None))
+        monkeypatch.setattr(replace, "file_check", Mock(return_value=None))
+        monkeypatch.setattr(replace, "select_song", Mock(return_value=None))
 
         item = Item.from_path(mp3_file)
         library.add(item)
@@ -90,13 +79,15 @@ class TestReplace:
     def test_run_replace_not_confirmed(
         self, library, mp3_file, opus_file, monkeypatch
     ):
-        monkeypatch.setattr(replace, "file_check", always(None))
-        monkeypatch.setattr(replace, "confirm_replacement", always(False))
+        monkeypatch.setattr(replace, "file_check", Mock(return_value=None))
+        monkeypatch.setattr(
+            replace, "confirm_replacement", Mock(return_value=False)
+        )
 
         item = Item.from_path(mp3_file)
         library.add(item)
 
-        monkeypatch.setattr(replace, "select_song", always(item))
+        monkeypatch.setattr(replace, "select_song", Mock(return_value=item))
 
         replace.run(library, optparse.Values(), ["AAA", str(opus_file)])
 
@@ -107,13 +98,15 @@ class TestReplace:
         replace_file = Mock(replace.replace_file, return_value=None)
         monkeypatch.setattr(replace, "replace_file", replace_file)
 
-        monkeypatch.setattr(replace, "file_check", always(None))
-        monkeypatch.setattr(replace, "confirm_replacement", always(True))
+        monkeypatch.setattr(replace, "file_check", Mock(return_value=None))
+        monkeypatch.setattr(
+            replace, "confirm_replacement", Mock(return_value=True)
+        )
 
         item = Item.from_path(mp3_file)
         library.add(item)
 
-        monkeypatch.setattr(replace, "select_song", always(item))
+        monkeypatch.setattr(replace, "select_song", Mock(return_value=item))
 
         replace.run(library, optparse.Values(), ["AAA", str(opus_file)])
 
@@ -136,7 +129,7 @@ class TestReplace:
 
     def test_select_song_valid_choice(self, monkeypatch, capfd):
         songs = ["Song A", "Song B", "Song C"]
-        monkeypatch.setattr("builtins.input", lambda _: "2")
+        monkeypatch.setattr("builtins.input", Mock(return_value="2"))
 
         selected_song = replace.select_song(songs)
 
@@ -149,26 +142,23 @@ class TestReplace:
 
     def test_select_song_cancel(self, monkeypatch):
         songs = ["Song A", "Song B", "Song C"]
-        monkeypatch.setattr("builtins.input", lambda _: "0")
+        monkeypatch.setattr("builtins.input", Mock(return_value="0"))
 
         selected_song = replace.select_song(songs)
 
         assert selected_song is None
 
-    def test_select_song_invalid_then_valid(self, monkeypatch, capfd):
+    def test_select_song_invalid_then_valid(self, monkeypatch):
         songs = ["Song A", "Song B", "Song C"]
-        inputs = iter(["invalid", "4", "3"])
-        monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+        inputs = ["invalid", "4", "3"]
+        mock_input = Mock(side_effect=iter(inputs))
+        monkeypatch.setattr("builtins.input", mock_input)
 
         selected_song = replace.select_song(songs)
 
-        captured = capfd.readouterr()
-
-        assert "Invalid input. Please type in a number." in captured.out
-        assert (
-            "Invalid choice. Please enter a number between 1 and 3."
-            in captured.out
-        )
+        # The first two inputs should be considered invalid, so the third
+        # input of 3 should be used, resulting in Song C being selected.
+        assert mock_input.call_count == 3
         assert selected_song == "Song C"
 
     def test_confirm_replacement_file_not_exist(self):
@@ -182,7 +172,7 @@ class TestReplace:
 
     def test_confirm_replacement_yes(self, monkeypatch):
         src = Path(_common.RSRC.decode()) / "full.mp3"
-        monkeypatch.setattr("builtins.input", always("yes"))
+        monkeypatch.setattr("builtins.input", Mock(return_value="yes"))
 
         class Song:
             path = str(src).encode()
@@ -193,7 +183,7 @@ class TestReplace:
 
     def test_confirm_replacement_no(self, monkeypatch):
         src = Path(_common.RSRC.decode()) / "full.mp3"
-        monkeypatch.setattr("builtins.input", always("no"))
+        monkeypatch.setattr("builtins.input", Mock(return_value="no"))
 
         class Song:
             path = str(src).encode()
@@ -212,7 +202,8 @@ class TestReplace:
     def test_replace_file_delete_fails(
         self, library, mp3_file, opus_file, monkeypatch
     ):
-        monkeypatch.setattr(Path, "unlink", always_raise(OSError))
+        fail_unlink = Mock(side_effect=OSError("cannot delete"))
+        monkeypatch.setattr(Path, "unlink", fail_unlink)
 
         item = Item.from_path(mp3_file)
         library.add(item)
@@ -223,9 +214,8 @@ class TestReplace:
     def test_replace_file_write_fails(
         self, library, mp3_file, opus_file, monkeypatch
     ):
-        monkeypatch.setattr(
-            Item, "write", always_raise(WriteError("path", "reason"))
-        )
+        fail_write = Mock(side_effect=WriteError("path", "reason"))
+        monkeypatch.setattr(Item, "write", fail_write)
 
         item = Item.from_path(mp3_file)
         library.add(item)


### PR DESCRIPTION
## Description

This is my first contribution here, hope it makes sense!

When running the [Replace Plugin](https://beets.readthedocs.io/en/v2.5.1/plugins/replace.html) it fails due to the plugin's callback method having the wrong signature.

```
➜ ~ beet replace bowie changes ~/Downloads/changes.flac
Traceback (most recent call last):
  File "/home/will/.local/bin/beet", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/will/.local/share/pipx/venvs/beets/lib64/python3.13/site-packages/beets/ui/__init__.py", line 1713, in main
    _raw_main(args)
    ~~~~~~~~~^^^^^^
  File "/home/will/.local/share/pipx/venvs/beets/lib64/python3.13/site-packages/beets/ui/__init__.py", line 1692, in _raw_main
    subcommand.func(lib, suboptions, subargs)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: ReplacePlugin.run() takes 3 positional arguments but 4 were given
```

On fixing this, I noticed that when replacing a file, the tags in the database are kept intact but are not written to the newly swapped-in file's metadata.

```
$ beet ls hunky dory changes
David Bowie - Hunky Dory - Changes

$ beet replace hunky dory changes ~/Downloads/changes_no_metadata.mp3 
Matching songs:
1. David Bowie - Hunky Dory - Changes
Which song would you like to replace? [1-1] (0 to cancel): 1

Replacing: /home/will/Downloads/changes_no_metadata.mp3 -> /home/will/Music/library/shared/David Bowie/Hunky Dory/01 Changes.mp3
Are you sure you want to replace this track? (y/N): y
Replacement successful.

$ beet ls hunky dory changes
David Bowie - Hunky Dory - Changes   (the database still has the tags)

$ beet write -p hunky dory changes   (but the file doesn't, so the user needs to run beet write)
 -  - 
  title:  -> Changes
  artist:  -> David Bowie
  artists:  -> David Bowie
  artist_sort:  -> David Bowie
  [...]
```

So I've updated it to call `Item.write()` immediately after replacing. To me this is a more intuitive behaviour but if it's preferred that the user should have to manually run `beet write`, I'm happy to undo this second change and just update the docs to reflect that.

I've written a test for the replacement behaviour.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Decide if automatically writing the metadata to the new file is okay.
- [x] Documentation.
- [X] Tests.
- [x] Changelog.
