### PR TITLE
fetchart: Add support for configurable fallback cover art

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -1101,6 +1101,16 @@ class FileSystem(LocalArtSource):
                 else:
                     remaining.append(fn)
 
+            # Fall back to a configured image.
+            if plugin.fallback:
+                self._log.debug(
+                    "using fallback art file {}",
+                    util.displayable_path(plugin.fallback),
+                )
+                yield self._candidate(
+                    path=plugin.fallback, match=MetadataMatch.FALLBACK
+                )
+
             # Fall back to any image in the folder.
             if remaining and not plugin.cautious:
                 self._log.debug(
@@ -1332,6 +1342,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                 "enforce_ratio": False,
                 "cautious": False,
                 "cover_names": ["cover", "front", "art", "album", "folder"],
+                "fallback": None,
                 "sources": [
                     "filesystem",
                     "coverart",
@@ -1380,6 +1391,9 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         cover_names = self.config["cover_names"].as_str_seq()
         self.cover_names = list(map(util.bytestring_path, cover_names))
         self.cautious = self.config["cautious"].get(bool)
+        self.fallback = self.config["fallback"].get(
+            confuse.Optional(confuse.Filename())
+        )
         self.store_source = self.config["store_source"].get(bool)
 
         self.cover_format = self.config["cover_format"].get(

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ been dropped.
 
 New features:
 
+- :doc:`plugins/fetchart`: Added config setting for a fallback cover art image.
 - :doc:`plugins/ftintitle`: Added argument for custom feat. words in ftintitle.
 - :doc:`plugins/ftintitle`: Added album template value ``album_artist_no_feat``.
 - :doc:`plugins/musicbrainz`: Allow selecting tags or genres to populate the

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -33,6 +33,8 @@ file. The available options are:
   contain one of the keywords in ``cover_names``. Default: ``no``.
 - **cover_names**: Prioritize images containing words in this list. Default:
   ``cover front art album folder``.
+- **fallback**: Path to a fallback album art file if no album art was found
+  otherwise. Default: ``None`` (disabled).
 - **minwidth**: Only images with a width bigger or equal to ``minwidth`` are
   considered as valid album art candidates. Default: 0.
 - **maxwidth**: A maximum image width to downscale fetched images if they are

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -261,7 +261,9 @@ class FSArtTest(UseThePlugin):
         os.mkdir(syspath(self.dpath))
 
         self.source = fetchart.FileSystem(logger, self.plugin.config)
-        self.settings = Settings(cautious=False, cover_names=("art",))
+        self.settings = Settings(
+            cautious=False, cover_names=("art",), fallback=None
+        )
 
     def test_finds_jpg_in_directory(self):
         _common.touch(os.path.join(self.dpath, b"a.jpg"))
@@ -284,6 +286,13 @@ class FSArtTest(UseThePlugin):
         self.settings.cautious = True
         with pytest.raises(StopIteration):
             next(self.source.get(None, self.settings, [self.dpath]))
+
+    def test_configured_fallback_is_used(self):
+        fallback = os.path.join(self.temp_dir, b"a.jpg")
+        _common.touch(fallback)
+        self.settings.fallback = fallback
+        candidate = next(self.source.get(None, self.settings, [self.dpath]))
+        assert candidate.path == fallback
 
     def test_empty_dir(self):
         with pytest.raises(StopIteration):


### PR DESCRIPTION
## Description

Fixes discussion #6252.  <!-- Insert issue number here if applicable. -->

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
