### PR TITLE
Fix fetchart colors broken by 67e668d81ff03d7ce14671e68676a7ad9d0ed94a

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -1588,7 +1588,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                     message = ui.colorize(
                         "text_highlight_minor", "has album art"
                     )
-                    self._log.info("{}: {}", album, message)
+                    ui.print_(f"{album}: {message}")
             else:
                 # In ordinary invocations, look for images on the
                 # filesystem. When forcing, however, always go to the Web
@@ -1601,4 +1601,4 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                     message = ui.colorize("text_success", "found album art")
                 else:
                     message = ui.colorize("text_error", "no art found")
-                self._log.info("{}: {}", album, message)
+                ui.print_(f"{album}: {message}")

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -37,6 +37,7 @@ New features:
   differences in metadata source styles.
 - :doc:`plugins/spotify`: Added support for multi-artist albums and tracks,
   saving all contributing artists to the respective fields.
+- :doc:`plugins/fetchart`: Fix colorized output text.
 - :doc:`plugins/ftintitle`: Featured artists are now inserted before brackets
   containing remix/edit-related keywords (e.g., "Remix", "Live", "Edit") instead
   of being appended at the end. This improves formatting for titles like "Song 1

--- a/test/plugins/test_fetchart.py
+++ b/test/plugins/test_fetchart.py
@@ -98,3 +98,8 @@ class FetchartCliTest(PluginTestCase):
         self.run_command("fetchart")
         self.album.load()
         self.check_cover_is_stored()
+
+    def test_colorization(self):
+        self.config["ui"]["color"] = True
+        out = self.run_with_output("fetchart")
+        assert " - the älbum: \x1b[1;31mno art found\x1b[39;49;00m\n" == out


### PR DESCRIPTION
## Description

Fetchart colors were broken by 67e668d81ff03d7ce14671e68676a7ad9d0ed94a.  Since that commit fetchart displays this, with escape codes instead of colorized output:
```
fetchart: Alasdair Fraser & Natalie Haas - Meridians: �[37mhas album art�[39;49;00m
```

This fixes it by using `ui.print_` instead of `Logger`.  This seems to be in line with other plugins such as play:
https://github.com/beetbox/beets/blob/1a899cc92af57b72a76570fb37d1c4eda0f5e842/beetsplug/play.py#L135

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
