### PR TITLE
Suggested improvements to discogs fixes

### DIFF
--- a/beetsplug/discogs.py
+++ b/beetsplug/discogs.py
@@ -127,7 +127,23 @@ class TracklistInfo(TypedDict):
 
 @dataclass
 class ArtistState:
+    """Represent Discogs artist credits.
+
+    This object centralizes the plugin's policy for which Discogs artist fields
+    to prefer (name vs. ANV), how to treat 'Various', how to format join
+    phrases, and how to separate featured artists. It exposes both per-artist
+    components and fully joined strings for common tag targets like 'artist' and
+    'artist_credit'.
+    """
+
     class ValidArtist(NamedTuple):
+        """A normalized, render-ready artist entry extracted from Discogs data.
+
+        Instances represent the subset of Discogs artist information needed for
+        tagging, including the join token following the artist and whether the
+        entry is considered a featured appearance.
+        """
+
         id: str
         name: str
         credit: str
@@ -135,9 +151,14 @@ class ArtistState:
         is_feat: bool
 
         def get_artist(self, property_name: str) -> str:
-            return getattr(self, property_name) + (
-                {",": ", ", "": ""}.get(self.join, f" {self.join} ")
-            )
+            """Return the requested display field with its trailing join token.
+
+            The join token is normalized so commas become ', ' and other join
+            phrases are surrounded with spaces, producing a single fragment that
+            can be concatenated to form a full artist string.
+            """
+            join = {",": ", ", "": ""}.get(self.join, f" {self.join} ")
+            return f"{getattr(self, property_name)}{join}"
 
     raw_artists: list[Artist]
     use_anv: bool
@@ -147,25 +168,38 @@ class ArtistState:
 
     @property
     def info(self) -> ArtistInfo:
+        """Expose the state in the shape expected by downstream tag mapping."""
         return {k: getattr(self, k) for k in ArtistInfo.__annotations__}  # type: ignore[return-value]
 
     def strip_disambiguation(self, text: str) -> str:
-        """Removes discogs specific disambiguations from a string.
-        Turns 'Label Name (5)' to 'Label Name' or 'Artist (1) & Another Artist (2)'
-        to 'Artist & Another Artist'. Does nothing if strip_disambiguation is False."""
+        """Strip Discogs disambiguation suffixes from an artist or label string.
+
+        This removes Discogs-specific numeric suffixes like 'Name (5)' and can
+        be applied to multi-artist strings as well (e.g., 'A (1) & B (2)'). When
+        the feature is disabled, the input is returned unchanged.
+        """
         if self.should_strip_disambiguation:
             return DISAMBIGUATION_RE.sub("", text)
         return text
 
     @cached_property
     def valid_artists(self) -> list[ValidArtist]:
+        """Build the ordered, filtered list of artists used for rendering.
+
+        The resulting list normalizes Discogs entries by:
+        - substituting the configured 'Various Artists' name when Discogs uses
+          'Various'
+        - choosing between name and ANV according to plugin settings
+        - excluding non-empty roles unless they indicate a featured appearance
+        - capturing join tokens so the original credit formatting is preserved
+        """
         va_name = config["va_name"].as_str()
         return [
             self.ValidArtist(
                 str(a["id"]),
                 self.strip_disambiguation(anv if self.use_anv else name),
                 self.strip_disambiguation(anv if self.use_credit_anv else name),
-                a["join"],
+                a["join"].strip(),
                 is_feat,
             )
             for a in self.raw_artists
@@ -181,29 +215,42 @@ class ArtistState:
 
     @property
     def artists_ids(self) -> list[str]:
+        """Return Discogs artist IDs for all valid artists, preserving order."""
         return [a.id for a in self.valid_artists]
 
     @property
     def artist_id(self) -> str:
+        """Return the primary Discogs artist ID."""
         return self.artists_ids[0]
 
     @property
     def artists(self) -> list[str]:
+        """Return the per-artist display names used for the 'artist' field."""
         return [a.name for a in self.valid_artists]
 
     @property
     def artists_credit(self) -> list[str]:
+        """Return the per-artist display names used for the credit field."""
         return [a.credit for a in self.valid_artists]
 
     @property
     def artist(self) -> str:
+        """Return the fully rendered artist string using display names."""
         return self.join_artists("name")
 
     @property
     def artist_credit(self) -> str:
+        """Return the fully rendered artist credit string."""
         return self.join_artists("credit")
 
     def join_artists(self, property_name: str) -> str:
+        """Render a single artist string with join phrases and featured artists.
+
+        Non-featured artists are concatenated using their join tokens. Featured
+        artists are appended after the configured 'featured' marker, preserving
+        Discogs order while keeping featured credits separate from the main
+        artist string.
+        """
         non_featured = [a for a in self.valid_artists if not a.is_feat]
         featured = [a for a in self.valid_artists if a.is_feat]
 

--- a/test/plugins/test_discogs.py
+++ b/test/plugins/test_discogs.py
@@ -24,6 +24,18 @@ from beets.test.helper import BeetsTestCase, capture_log
 from beetsplug.discogs import ArtistState, DiscogsPlugin
 
 
+def _artist(name: str, **kwargs):
+    return {
+        "id": 1,
+        "name": name,
+        "join": "",
+        "role": "",
+        "anv": "",
+        "tracks": "",
+        "resource_url": "",
+    } | kwargs
+
+
 @patch("beetsplug.discogs.DiscogsPlugin.setup", Mock())
 class DGAlbumInfoTest(BeetsTestCase):
     def _make_release(self, tracks=None):
@@ -35,9 +47,7 @@ class DGAlbumInfoTest(BeetsTestCase):
             "uri": "https://www.discogs.com/release/release/13633721",
             "title": "ALBUM TITLE",
             "year": "3001",
-            "artists": [
-                {"name": "ARTIST NAME", "id": "ARTIST ID", "join": ","}
-            ],
+            "artists": [_artist("ARTIST NAME", id="ARTIST ID", join=",")],
             "formats": [
                 {
                     "descriptions": ["FORMAT DESC 1", "FORMAT DESC 2"],
@@ -325,7 +335,7 @@ class DGAlbumInfoTest(BeetsTestCase):
             "id": 123,
             "uri": "https://www.discogs.com/release/123456-something",
             "tracklist": [self._make_track("A", "1", "01:01")],
-            "artists": [{"name": "ARTIST NAME", "id": 321, "join": ""}],
+            "artists": [_artist("ARTIST NAME", id=321)],
             "title": "TITLE",
         }
         release = Bag(
@@ -385,14 +395,12 @@ class DGAlbumInfoTest(BeetsTestCase):
                     "position": "A",
                     "type_": "track",
                     "duration": "5:44",
-                    "artists": [
-                        {"name": "TEST ARTIST (5)", "tracks": "", "id": 11146}
-                    ],
+                    "artists": [_artist("TEST ARTIST (5)", id=11146)],
                 }
             ],
             "artists": [
-                {"name": "ARTIST NAME (2)", "id": 321, "join": "&"},
-                {"name": "OTHER ARTIST (5)", "id": 321, "join": ""},
+                _artist("ARTIST NAME (2)", id=321, join="&"),
+                _artist("OTHER ARTIST (5)", id=321),
             ],
             "title": "title",
             "labels": [
@@ -429,14 +437,12 @@ class DGAlbumInfoTest(BeetsTestCase):
                     "position": "A",
                     "type_": "track",
                     "duration": "5:44",
-                    "artists": [
-                        {"name": "TEST ARTIST (5)", "tracks": "", "id": 11146}
-                    ],
+                    "artists": [_artist("TEST ARTIST (5)", id=11146)],
                 }
             ],
             "artists": [
-                {"name": "ARTIST NAME (2)", "id": 321, "join": "&"},
-                {"name": "OTHER ARTIST (5)", "id": 321, "join": ""},
+                _artist("ARTIST NAME (2)", id=321, join="&"),
+                _artist("OTHER ARTIST (5)", id=321),
             ],
             "title": "title",
             "labels": [
@@ -520,28 +526,21 @@ def test_anv(
                 "position": "A",
                 "type_": "track",
                 "duration": "5:44",
-                "artists": [
-                    {
-                        "name": "ARTIST",
-                        "tracks": "",
-                        "anv": "ART",
-                        "id": 11146,
-                    }
-                ],
+                "artists": [_artist("ARTIST", id=11146, anv="ART")],
                 "extraartists": [
-                    {
-                        "name": "PERFORMER",
-                        "role": "Featuring",
-                        "anv": "PERF",
-                        "id": 787,
-                    }
+                    _artist(
+                        "PERFORMER",
+                        id=787,
+                        role="Featuring",
+                        anv="PERF",
+                    )
                 ],
             }
         ],
         "artists": [
-            {"name": "DRUMMER", "anv": "DRUM", "id": 445, "join": ", "},
-            {"name": "ARTIST (4)", "anv": "ARTY", "id": 321, "join": "&"},
-            {"name": "SOLOIST", "anv": "SOLO", "id": 445, "join": ""},
+            _artist("DRUMMER", id=445, anv="DRUM", join=", "),
+            _artist("ARTIST (4)", id=321, anv="ARTY", join="&"),
+            _artist("SOLOIST", id=445, anv="SOLO"),
         ],
         "title": "title",
     }
@@ -579,19 +578,10 @@ def test_anv_no_variation(artist_anv, albumartist_anv, artistcredit_anv):
                 "position": "A",
                 "type_": "track",
                 "duration": "5:44",
-                "artists": [
-                    {
-                        "name": "PERFORMER",
-                        "tracks": "",
-                        "anv": "",
-                        "id": 1,
-                    }
-                ],
+                "artists": [_artist("PERFORMER", id=1)],
             }
         ],
-        "artists": [
-            {"name": "ARTIST", "anv": "", "id": 2},
-        ],
+        "artists": [_artist("ARTIST", id=2)],
         "title": "title",
     }
     release = Bag(
@@ -629,9 +619,7 @@ def test_anv_album_artist():
                 "duration": "5:44",
             }
         ],
-        "artists": [
-            {"name": "ARTIST (4)", "anv": "VARIATION", "id": 321},
-        ],
+        "artists": [_artist("ARTIST (4)", id=321, anv="VARIATION")],
         "title": "title",
     }
     release = Bag(
@@ -664,33 +652,19 @@ def test_anv_album_artist():
                 "position": "1",
                 "duration": "5:00",
                 "artists": [
-                    {"name": "NEW ARTIST", "tracks": "", "id": 11146},
-                    {"name": "VOCALIST", "tracks": "", "id": 344, "join": "&"},
+                    _artist("NEW ARTIST", id=11146, join="&"),
+                    _artist("VOCALIST", id=344, join="feat."),
                 ],
                 "extraartists": [
-                    {
-                        "name": "SOLOIST",
-                        "id": 3,
-                        "role": "Featuring",
-                    },
-                    {
-                        "name": "PERFORMER (1)",
-                        "id": 5,
-                        "role": "Other Role, Featuring",
-                    },
-                    {
-                        "name": "RANDOM",
-                        "id": 8,
-                        "role": "Written-By",
-                    },
-                    {
-                        "name": "MUSICIAN",
-                        "id": 10,
-                        "role": "Featuring [Uncredited]",
-                    },
+                    _artist("SOLOIST", id=3, role="Featuring"),
+                    _artist(
+                        "PERFORMER (1)", id=5, role="Other Role, Featuring"
+                    ),
+                    _artist("RANDOM", id=8, role="Written-By"),
+                    _artist("MUSICIAN", id=10, role="Featuring [Uncredited]"),
                 ],
             },
-            "NEW ARTIST, VOCALIST Feat. SOLOIST, PERFORMER, MUSICIAN",
+            "NEW ARTIST & VOCALIST feat. SOLOIST, PERFORMER, MUSICIAN",
             ["NEW ARTIST", "VOCALIST", "SOLOIST", "PERFORMER", "MUSICIAN"],
         ),
     ],
@@ -733,7 +707,7 @@ def test_get_media_and_albumtype(formats, expected_media, expected_albumtype):
     "given_artists,expected_info,config_va_name",
     [
         (
-            [{"name": "Various", "id": "1"}],
+            [_artist("Various")],
             {
                 "artist": "VARIOUS ARTISTS",
                 "artist_id": "1",

--- a/test/plugins/test_discogs.py
+++ b/test/plugins/test_discogs.py
@@ -699,15 +699,9 @@ def test_anv_album_artist():
 def test_parse_featured_artists(track, expected_artist, expected_artists):
     """Tests the plugins ability to parse a featured artist.
     Ignores artists that are not listed as featured."""
-    artistinfo = ArtistState(
-        artist="ARTIST",
-        artist_id="1",
-        artists=["ARTIST"],
-        artists_ids=["1"],
-        artist_credit="ARTIST",
-        artists_credit=["ARTIST"],
-    )
-    t, _, _ = DiscogsPlugin().get_track_info(track, 1, 1, artistinfo)
+    plugin = DiscogsPlugin()
+    artistinfo = ArtistState.from_plugin(plugin, [_artist("ARTIST")])
+    t, _, _ = plugin.get_track_info(track, 1, 1, artistinfo)
     assert t.artist == expected_artist
     assert t.artists == expected_artists
 
@@ -756,7 +750,8 @@ def test_get_media_and_albumtype(formats, expected_media, expected_albumtype):
 def test_va_buildartistinfo(given_artists, expected_info, config_va_name):
     config["va_name"] = config_va_name
     assert (
-        ArtistState.build(DiscogsPlugin(), given_artists).info == expected_info
+        ArtistState.from_plugin(DiscogsPlugin(), given_artists).info
+        == expected_info
     )
 
 


### PR DESCRIPTION
Summary
- Refactors artist/tracklist construction into dataclasses to isolate parsing logic:
  - Introduces `ArtistState` (with `ValidArtist`, `from_plugin`, properties like `artists`, `artist_id`, and `info`) and `TracklistState` to encapsulate artist- and tracklist-building behavior in `beetsplug/discogs.py`.
  - Moves logic previously spread across `_build_artistinfo`/`_assign_anv`/`_process_clean_tracklist` into those dataclasses, and removes duplicated imperative code in the plugin class.

- Simplifies plugin flow and responsibilities:
  - `DiscogsPlugin` now delegates artist/tracklist assembly to `ArtistState.from_plugin` and `TracklistState.build`, reducing the plugin surface and concentrating transformation rules in typed data objects.
  - Combines track `artists` and `extraartists` handling into a single `ArtistState` construction so featured/credit/anv logic is applied consistently.

- Tests updated for correctness and clarity:
  - `test/plugins/test_discogs.py` adds an `_artist` factory to ensure artist dicts in tests always include required fields, and updates `test_parse_featured_artists` to include a certain edge case.
  - Tests implementation to use `ArtistState.from_plugin` where appropriate.
