### PR TITLE
Fix bug in fetching preferred release event.

### DIFF
--- a/beetsplug/musicbrainz.py
+++ b/beetsplug/musicbrainz.py
@@ -247,8 +247,9 @@ def _preferred_release_event(
     for country in preferred_countries:
         for event in release.get("release-events", {}):
             try:
-                if country in event["area"]["iso-3166-1-codes"]:
-                    return country, event["date"]
+                if area := event.get("area"):
+                    if country in area["iso-3166-1-codes"]:
+                        return country, event["date"]
             except KeyError:
                 pass
 

--- a/test/plugins/test_musicbrainz.py
+++ b/test/plugins/test_musicbrainz.py
@@ -29,6 +29,7 @@ class MusicBrainzTestCase(BeetsTestCase):
     def setUp(self):
         super().setUp()
         self.mb = musicbrainz.MusicBrainzPlugin()
+        self.config["match"]["preferred"]["countries"] = ["US"]
 
 
 class MBAlbumInfoTest(MusicBrainzTestCase):
@@ -80,6 +81,7 @@ class MBAlbumInfoTest(MusicBrainzTestCase):
             "country": "COUNTRY",
             "status": "STATUS",
             "barcode": "BARCODE",
+            "release-events": [{"area": None, "date": "2021-03-26"}],
         }
 
         if multi_artist_credit:


### PR DESCRIPTION
With the changes to how data is fetched from MusicBrainz, empty releases are now `None` instead of an empty dict.