### PR TITLE
fix(fetchart): prevent deletion of configured fallback cover art

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -1446,6 +1446,16 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             "move"
         ].get(bool)
 
+    def _is_candidate_fallback(self, candidate: Candidate) -> bool:
+        try:
+            return (
+                candidate.path is not None
+                and self.fallback is not None
+                and os.path.samefile(candidate.path, self.fallback)
+            )
+        except OSError:
+            return False
+
     # Asynchronous; after music is added to the library.
     def fetch_art(self, session: ImportSession, task: ImportTask) -> None:
         """Find art for the album being imported."""
@@ -1494,7 +1504,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
 
             self._set_art(task.album, candidate, not removal_enabled)
 
-            if removal_enabled:
+            if removal_enabled and not self._is_candidate_fallback(candidate):
                 task.prune(candidate.path)
 
     # Manual album art fetching.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -43,6 +43,7 @@ Bug fixes
   ampersand.
 - :doc:`plugins/zero`: When the ``omit_single_disc`` option is set,
   ``disctotal`` is zeroed alongside ``disc``.
+- :doc:`plugins/fetchart`: Prevent deletion of configured fallback cover art
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -310,6 +310,16 @@ class FSArtTest(UseThePlugin):
         ]
         assert candidates == paths
 
+    @patch("os.path.samefile")
+    def test_is_candidate_fallback_os_error(self, mock_samefile):
+        mock_samefile.side_effect = OSError("os error")
+        fallback = os.path.join(self.temp_dir, b"a.jpg")
+        self.plugin.fallback = fallback
+        candidate = fetchart.Candidate(logger, self.source.ID, fallback)
+        result = self.plugin._is_candidate_fallback(candidate)
+        mock_samefile.assert_called_once()
+        assert not result
+
 
 class CombinedTest(FetchImageTestCase, CAAHelper):
     ASIN = "xxxx"


### PR DESCRIPTION
## Description

When `import.delete` or `import.move` is enabled, the `assign_art` method calls `task.prune(candidate.path)` unconditionally. This incorrectly deletes the configured `fetchart.fallback` file. Add explicit check to skip pruning when the candidate path matches the configured fallback.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.) - not required because it's a fixup for 9ddddf4c3948d8405b7a9e4da761005d456e3aa9
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
