### PR TITLE
badfiles: added config/cli options to automatically take action on error/warning

### DIFF
--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -220,6 +220,9 @@ class BadFiles(BeetsPlugin):
             found_error = False
             for error in task._badfiles_checks_failed:
                 for error_line in error:
+                    if 'checker found 0 errors or warnings' in error_line.lower():
+                        continue
+
                     if "warning" in error_line.lower():
                         found_warning = True
                     if "error" in error_line.lower():

--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -227,6 +227,8 @@ class BadFiles(BeetsPlugin):
 
                     ui.print_(error_line)
 
+            # Check for and handle automatic actions.
+            # Errors always take precedence over warnings.
             if found_error and error_action != "ask":
                 return self.handle_import_action(error_action, "error")
             elif found_warning and warning_action != "ask":

--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -168,17 +168,69 @@ class BadFiles(BeetsPlugin):
         if checks_failed:
             task._badfiles_checks_failed = checks_failed
 
+    def handle_import_action(self, action, failure_type):
+        if action == "abort":
+            ui.print_(
+                f"{ui.colorize('text_warning', 'Aborting')}"
+                f" due to import_action_on_{failure_type} configuration"
+            )
+            raise importer.ImportAbortError()
+        elif action == "skip":
+            ui.print_(
+                f"{ui.colorize('text_warning', 'Skipping')}"
+                f" due to import_action_on_{failure_type} configuration"
+            )
+            return importer.Action.SKIP
+        elif action == "continue":
+            ui.print_(
+                f"{ui.colorize('text_warning', 'Continuing')}"
+                f" due to import_action_on_{failure_type} configuration"
+            )
+            return None
+        else:
+            ui.print_(
+                ui.colorize(
+                    "text_warning",
+                    f"Got invalid import_action_on_{failure_type}"
+                    f" configuration: {action}",
+                )
+            )
+            ui.print_(
+                ui.colorize(
+                    "text_warning",
+                    f"import_action_on_{failure_type} should be one of:"
+                    f" ask abort skip continue",
+                )
+            )
+            raise importer.ImportAbortError()
+
     def on_import_task_before_choice(self, task, session):
         if config["import"]["quiet"]:
             return None
 
         if hasattr(task, "_badfiles_checks_failed"):
+            warning_action = self.config["import_action_on_warning"].get("ask")
+            error_action = self.config["import_action_on_error"].get("ask")
+
             ui.print_(
                 f"{colorize('text_warning', 'BAD')} one or more files failed checks:"
             )
+
+            found_warning = False
+            found_error = False
             for error in task._badfiles_checks_failed:
                 for error_line in error:
+                    if "warning" in error_line.lower():
+                        found_warning = True
+                    if "error" in error_line.lower():
+                        found_error = True
+
                     ui.print_(error_line)
+
+            if found_error and error_action != "ask":
+                return self.handle_import_action(error_action, "error")
+            elif found_warning and warning_action != "ask":
+                return self.handle_import_action(warning_action, "warning")
 
             ui.print_()
             ui.print_("What would you like to do?")

--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -19,6 +19,7 @@ import os
 import shlex
 import sys
 from subprocess import STDOUT, CalledProcessError, check_output, list2cmdline
+from typing import Literal
 
 import confuse
 
@@ -50,6 +51,10 @@ class BadFiles(BeetsPlugin):
     def __init__(self):
         super().__init__()
         self.verbose = False
+
+        self.config.add(
+            {"import_action_on_warning": "ask", "import_action_on_error": "ask"}
+        )
 
         self.register_listener("import_task_start", self.on_import_task_start)
         self.register_listener(
@@ -168,49 +173,33 @@ class BadFiles(BeetsPlugin):
         if checks_failed:
             task._badfiles_checks_failed = checks_failed
 
-    def handle_import_action(self, action, failure_type):
+    def handle_import_action(
+        self,
+        action: Literal["abort", "skip", "continue"],
+        failure_type: Literal["error", "warning"],
+    ) -> importer.Action | None:
+        action_name_by_action = {
+            "abort": "Aborting",
+            "skip": "Skipping",
+            "continue": "Continuing",
+        }
+        ui.print_(
+            f"{ui.colorize('text_warning', action_name_by_action[action])}"
+            f" due to import_action_on_{failure_type} configuration"
+        )
         if action == "abort":
-            ui.print_(
-                f"{ui.colorize('text_warning', 'Aborting')}"
-                f" due to import_action_on_{failure_type} configuration"
-            )
             raise importer.ImportAbortError()
-        elif action == "skip":
-            ui.print_(
-                f"{ui.colorize('text_warning', 'Skipping')}"
-                f" due to import_action_on_{failure_type} configuration"
-            )
+        if action == "skip":
             return importer.Action.SKIP
-        elif action == "continue":
-            ui.print_(
-                f"{ui.colorize('text_warning', 'Continuing')}"
-                f" due to import_action_on_{failure_type} configuration"
-            )
-            return None
-        else:
-            ui.print_(
-                ui.colorize(
-                    "text_warning",
-                    f"Got invalid import_action_on_{failure_type}"
-                    f" configuration: {action}",
-                )
-            )
-            ui.print_(
-                ui.colorize(
-                    "text_warning",
-                    f"import_action_on_{failure_type} should be one of:"
-                    f" ask abort skip continue",
-                )
-            )
-            raise importer.ImportAbortError()
+        return None
 
     def on_import_task_before_choice(self, task, session):
-        if config["import"]["quiet"]:
-            return None
-
         if hasattr(task, "_badfiles_checks_failed"):
-            warning_action = self.config["import_action_on_warning"].get("ask")
-            error_action = self.config["import_action_on_error"].get("ask")
+            actions = confuse.Choice(["ask", "abort", "skip", "continue"])
+            warning_action = self.config["import_action_on_warning"].get(
+                actions
+            )
+            error_action = self.config["import_action_on_error"].get(actions)
 
             ui.print_(
                 f"{colorize('text_warning', 'BAD')} one or more files failed checks:"
@@ -239,6 +228,10 @@ class BadFiles(BeetsPlugin):
                 return self.handle_import_action(error_action, "error")
             elif found_warning and warning_action != "ask":
                 return self.handle_import_action(warning_action, "warning")
+
+            # Defer the quiet check to after automatic import action options are handled
+            if config["import"]["quiet"]:
+                return None
 
             ui.print_()
             ui.print_("What would you like to do?")

--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -220,7 +220,10 @@ class BadFiles(BeetsPlugin):
             found_error = False
             for error in task._badfiles_checks_failed:
                 for error_line in error:
-                    if 'checker found 0 errors or warnings' in error_line.lower():
+                    if (
+                        "checker found 0 errors or warnings"
+                        in error_line.lower()
+                    ):
                         continue
 
                     if "warning" in error_line.lower():

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -345,6 +345,7 @@ class TidalPlugin(MetadataSourcePlugin):
         track_by_id: dict[str, TidalTrack],
         artist_by_id: dict[str, TidalArtist],
     ) -> AlbumInfo:
+
         track_infos: list[TrackInfo] = []
         for i, track_rel in enumerate(
             album["relationships"]["items"]["data"], start=1

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -345,7 +345,6 @@ class TidalPlugin(MetadataSourcePlugin):
         track_by_id: dict[str, TidalTrack],
         artist_by_id: dict[str, TidalArtist],
     ) -> AlbumInfo:
-
         track_infos: list[TrackInfo] = []
         for i, track_rel in enumerate(
             album["relationships"]["items"]["data"], start=1

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,7 @@ New features
 - :doc:`plugins/musicbrainz`: Introduce
   :conf:`plugins.musicbrainz:aliases_as_credits` to make
   aliases-as-artist-credit optional.
+- :doc:`plugins/badfiles`: Added settings for auto error and warning actions.
 
 Bug fixes
 ~~~~~~~~~
@@ -123,7 +124,6 @@ New features
   See :doc:`plugins/tidal` for more information.
 
 - Add support for adding or modifying a subtitle (ID3 tag ``TIT3``) field
-- :doc:`plugins/badfiles`: Added settings for auto error and warning actions.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -123,6 +123,7 @@ New features
   See :doc:`plugins/tidal` for more information.
 
 - Add support for adding or modifying a subtitle (ID3 tag ``TIT3``) field
+- :doc:`plugins/badfiles`: Added settings for auto error and warning actions.
 
 Bug fixes
 ~~~~~~~~~
@@ -564,7 +565,6 @@ been dropped.
 New features
 ~~~~~~~~~~~~
 
-- :doc:`plugins/badfiles`: Added settings for auto error and warning actions.
 - :doc:`plugins/fetchart`: Added config setting for a fallback cover art image.
 - :doc:`plugins/ftintitle`: Added argument for custom feat. words in ftintitle.
 - :doc:`plugins/ftintitle`: Added album template value ``album_artist_no_feat``.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -564,6 +564,7 @@ been dropped.
 New features
 ~~~~~~~~~~~~
 
+- :doc:`plugins/badfiles`: Added settings for auto error and warning actions.
 - :doc:`plugins/fetchart`: Added config setting for a fallback cover art image.
 - :doc:`plugins/ftintitle`: Added argument for custom feat. words in ftintitle.
 - :doc:`plugins/ftintitle`: Added album template value ``album_artist_no_feat``.

--- a/docs/plugins/badfiles.rst
+++ b/docs/plugins/badfiles.rst
@@ -35,7 +35,7 @@ option. When on, checkers will be run against every imported file and warnings
 and errors will be presented when selecting a tagging option.
 
 `import_action_on_error` and `import_action_on_warning` can be used to take
-automatic action on warning and errors. Both options default to `ask`.
+automatic action on warnings and errors. Both options default to `ask`.
 Valid options for both `import_action_on_(warning|error)` are
 `ask skip abort continue`.
 

--- a/docs/plugins/badfiles.rst
+++ b/docs/plugins/badfiles.rst
@@ -20,6 +20,8 @@ You can also add custom commands for a specific extension, like this:
 
     badfiles:
         check_on_import: yes
+        import_action_on_error: skip
+        import_action_on_warning: continue
         commands:
             ogg: myoggchecker --opt1 --opt2
             flac: flac --test --warnings-as-errors --silent
@@ -31,6 +33,11 @@ greater than zero for a file to be considered corrupt.
 You can run the checkers when importing files by using the ``check_on_import``
 option. When on, checkers will be run against every imported file and warnings
 and errors will be presented when selecting a tagging option.
+
+`import_action_on_error` and `import_action_on_warning` can be used to take
+automatic action on warning and errors. Both options default to `ask`.
+Valid options for both `import_action_on_(warning|error)` are
+`ask skip abort continue`.
 
 .. _flac: https://xiph.org/flac/
 

--- a/docs/plugins/badfiles.rst
+++ b/docs/plugins/badfiles.rst
@@ -35,9 +35,9 @@ option. When on, checkers will be run against every imported file and warnings
 and errors will be presented when selecting a tagging option.
 
 `import_action_on_error` and `import_action_on_warning` can be used to take
-automatic action on warnings and errors. Both options default to `ask`.
-Valid options for both `import_action_on_(warning|error)` are
-`ask skip abort continue`.
+automatic action on warnings and errors. Both options default to `ask`. Valid
+options for both `import_action_on_(warning|error)` are `ask skip abort
+continue`.
 
 .. _flac: https://xiph.org/flac/
 

--- a/docs/plugins/badfiles.rst
+++ b/docs/plugins/badfiles.rst
@@ -34,10 +34,10 @@ You can run the checkers when importing files by using the ``check_on_import``
 option. When on, checkers will be run against every imported file and warnings
 and errors will be presented when selecting a tagging option.
 
-`import_action_on_error` and `import_action_on_warning` can be used to take
-automatic action on warnings and errors. Both options default to `ask`. Valid
-options for both `import_action_on_(warning|error)` are `ask skip abort
-continue`.
+``import_action_on_error`` and ``import_action_on_warning`` can be used to take
+automatic action on warnings and errors. Both options default to ``ask``. Valid
+options for both ``import_action_on_(warning|error)`` are ``ask skip abort
+continue``.
 
 .. _flac: https://xiph.org/flac/
 


### PR DESCRIPTION
## Description
Updated the `badfiles` plugin to support automatic actions taken on warning or error imports, to be used with `check_on_import: yes`.

Example usage:
```yaml
badfiles:
    check_on_import: yes
    import_action_on_warning: continue
    import_action_on_error: skip
```
The above configuration will skip badfiles that error out, but ignore any warnings found.
The default for both options is `ask`, preserving current behavior.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] ~Tests. (Very much encouraged but not strictly required.)~