### PR TITLE
musicbrainz: fix release type

### DIFF
--- a/beetsplug/musicbrainz.py
+++ b/beetsplug/musicbrainz.py
@@ -607,12 +607,8 @@ class MusicBrainzPlugin(MusicBrainzAPIMixin, MetadataSourcePlugin):
         if release.get("disambiguation"):
             info.albumdisambig = release.get("disambiguation")
 
-        # Get the "classic" Release type. This data comes from a legacy API
-        # feature before MusicBrainz supported multiple release types.
-        if "type" in release["release-group"]:
-            reltype = release["release-group"]["type"]
-            if reltype:
-                info.albumtype = reltype.lower()
+        if reltype := release["release-group"].get("primary-type"):
+            info.albumtype = reltype.lower()
 
         # Set the new-style "primary" and "secondary" release types.
         albumtypes = []

--- a/test/plugins/test_musicbrainz.py
+++ b/test/plugins/test_musicbrainz.py
@@ -52,7 +52,7 @@ class MBAlbumInfoTest(MusicBrainzTestCase):
             "asin": "ALBUM ASIN",
             "disambiguation": "R_DISAMBIGUATION",
             "release-group": {
-                "type": "Album",
+                "primary-type": "Album",
                 "first-release-date": date_str,
                 "id": "RELEASE GROUP ID",
                 "disambiguation": "RG_DISAMBIGUATION",


### PR DESCRIPTION
- Update the MusicBrainz integration to read the release group's canonical `'primary-type'` field instead of the legacy `'type'` field when deriving `info.albumtype`.

Noticed that `albumtype` was missing from the metadata when I did some imports in my library.
