### PR TITLE
Added duduping on mb_trackid to the duplicates plugin

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -52,6 +52,7 @@ import:
         item: artist title
     duplicate_action: ask
     duplicate_verbose_prompt: no
+    duplicate_track_resolution: no
     bell: no
     set_fields: {}
     ignored_alias_types: []

--- a/beets/importer/session.py
+++ b/beets/importer/session.py
@@ -185,6 +185,13 @@ class ImportSession:
     def resolve_duplicate(self, task: ImportTask, found_duplicates):
         raise NotImplementedError
 
+    def resolve_track_duplicates(self, task: ImportTask, duplicates) -> str:
+        """Decide what to do with album tracks that already exist in the
+        library. Return ``"s"`` (skip the duplicate tracks), ``"k"`` (keep
+        all) or ``"r"`` (remove the old items).
+        """
+        raise NotImplementedError
+
     def choose_item(self, task: ImportTask):
         raise NotImplementedError
 
@@ -206,6 +213,10 @@ class ImportSession:
             if self.config["group_albums"] and not self.config["singletons"]:
                 # Split directory tasks into one task for each album.
                 stages += [stagefuncs.group_albums(self)]
+
+            # Optionally drop or replace album tracks that already exist in
+            # the library before the autotag lookup runs.
+            stages += [stagefuncs.resolve_track_duplicates(self)]
 
             # These stages either talk to the user to get a decision or,
             # in the case of a non-autotagged import, just choose to

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -19,7 +19,7 @@ import itertools
 import logging
 from typing import TYPE_CHECKING
 
-from beets import config, plugins
+from beets import config, dbcore, plugins
 from beets.util import MoveOperation, displayable_path, pipeline
 
 from .tasks import (
@@ -125,6 +125,70 @@ def group_albums(session: ImportSession):
         tasks.append(SentinelImportTask(task.toppath, task.paths))
 
         task = pipeline.multiple(tasks)
+
+
+@pipeline.mutator_stage
+def resolve_track_duplicates(session: ImportSession, task: ImportTask):
+    """Resolve tracks of an album that already exist in the library.
+
+    When ``import.duplicate_track_resolution`` is enabled, each item of an
+    album import is checked against the library using
+    ``import.duplicate_keys.item``. Matched tracks are resolved according to
+    ``import.duplicate_action``:
+
+    * ``skip`` drops the duplicate tracks and imports the rest of the album
+      (if every track is a duplicate, the whole album is skipped);
+    * ``remove`` removes the matching old library items;
+    * ``keep`` (and ``merge``) import everything as-is;
+    * ``ask`` prompts the session for one of the above.
+
+    This runs before :func:`lookup_candidates` so that dropped tracks are
+    excluded from the autotag match. Singleton imports are handled by the
+    regular duplicate resolution and are ignored here.
+    """
+    if (
+        task.skip
+        or not getattr(task, "is_album", False)
+        or not task.items
+        or not config["import"]["duplicate_track_resolution"].get(bool)
+    ):
+        return
+
+    keys = config["import"]["duplicate_keys"]["item"].as_str_seq()
+    if not keys:
+        return
+
+    # Map each incoming item to the existing library items it duplicates.
+    duplicates: dict[library.Item, list[library.Item]] = {}
+    for item in task.items:
+        if not any(item.get(k) for k in keys):
+            continue
+        matches = _find_track_duplicates(session.lib, item, keys)
+        if matches:
+            duplicates[item] = matches
+
+    if not duplicates:
+        return
+
+    action = config["import"]["duplicate_action"].as_choice(
+        {"skip": "s", "keep": "k", "remove": "r", "merge": "m", "ask": "a"}
+    )
+    if action == "a":
+        action = session.resolve_track_duplicates(task, duplicates)
+
+    if action == "s":
+        for item in duplicates:
+            log.info(
+                "skipping duplicate track: {}", displayable_path(item.path)
+            )
+            task.items.remove(item)
+        if not task.items:
+            task.set_choice(Action.SKIP)
+    elif action == "r":
+        for matches in duplicates.values():
+            task.duplicate_track_items_to_remove.extend(matches)
+    # "k" (keep) and "m" (merge) leave the incoming tracks untouched; whole
+    # album duplicates are still handled by the regular resolution stage.
 
 
 @pipeline.mutator_stage
@@ -283,6 +347,9 @@ def manipulate_files(session: ImportSession, task: ImportTask):
         if task.should_remove_duplicates:
             task.remove_duplicates(session.lib)
 
+        if task.duplicate_track_items_to_remove:
+            task.remove_duplicate_track_items(session.lib)
+
         if session.config["move"]:
             operation = MoveOperation.MOVE
         elif session.config["copy"]:
@@ -331,6 +398,18 @@ def _apply_choice(session: ImportSession, task: ImportTask):
     # it can set the fields.
     if config["import"]["set_fields"]:
         task.set_fields(session.lib)
+
+
+def _find_track_duplicates(
+    lib: library.Library, item: library.Item, keys: list[str]
+) -> list[library.Item]:
+    """Return library items matching `item` on all `keys`, excluding the
+    item itself (so re-imports do not match their own files).
+    """
+    query = dbcore.AndQuery(
+        [item.field_query(k, item.get(k), dbcore.MatchQuery) for k in keys]
+    )
+    return [other for other in lib.items(query) if other.path != item.path]
 
 
 def _resolve_duplicates(session: ImportSession, task: ImportTask):

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -179,6 +179,9 @@ class ImportTask(BaseImportTask):
         super().__init__(toppath, paths, items)
         self.should_remove_duplicates = False
         self.should_merge_duplicates = False
+        # Existing library items to remove because individual tracks of this
+        # album duplicate them (see ``duplicate_track_resolution``).
+        self.duplicate_track_items_to_remove: list[library.Item] = []
         self.is_album = True
 
     def set_choice(self, choice: Action | AlbumMatch | TrackMatch):
@@ -292,6 +295,25 @@ class ImportTask(BaseImportTask):
                 util.remove(artpath)
                 util.prune_dirs(
                     os.path.dirname(artpath),
+                    lib.directory,
+                    clutter=config["clutter"].as_str_seq(),
+                )
+
+    def remove_duplicate_track_items(self, lib: library.Library):
+        """Remove the old library items that individual tracks of this album
+        duplicate, as recorded in ``duplicate_track_items_to_remove``.
+        """
+        seen: set[int] = set()
+        for item in self.duplicate_track_items_to_remove:
+            if item.id in seen:
+                continue
+            seen.add(item.id)
+            log.debug("removing duplicate track {.filepath}", item)
+            item.remove()
+            if lib.directory in util.ancestry(item.path):
+                util.remove(item.path)
+                util.prune_dirs(
+                    os.path.dirname(item.path),
                     lib.directory,
                     clutter=config["clutter"].as_str_seq(),
                 )

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -681,6 +681,18 @@ class ImportSessionFixture(ImportSession):
         elif res == self.Resolution.MERGE:
             task.should_merge_duplicates = True
 
+    def resolve_track_duplicates(self, task, duplicates):
+        try:
+            res = self._resolutions.pop(0)
+        except IndexError:
+            res = self.default_resolution
+
+        return {
+            self.Resolution.SKIP: "s",
+            self.Resolution.KEEPBOTH: "k",
+            self.Resolution.REMOVE: "r",
+        }.get(res, "k")
+
 
 class TerminalImportSessionFixture(TerminalImportSession):
     def __init__(self, *args, **kwargs):

--- a/beets/ui/commands/import_/session.py
+++ b/beets/ui/commands/import_/session.py
@@ -204,6 +204,28 @@ class TerminalImportSession(importer.ImportSession):
         else:
             assert False
 
+    def resolve_track_duplicates(self, task, duplicates) -> str:
+        """Decide what to do with album tracks already in the library."""
+        log.warning("Some tracks are already in the library!")
+
+        if config["import"]["quiet"]:
+            # In quiet mode, don't prompt -- just skip the duplicate tracks.
+            log.info("Skipping duplicate tracks.")
+            return "s"
+
+        existing = [item for matches in duplicates.values() for item in matches]
+        ui.print_("Old: " + summarize_items(existing, True))
+        if config["import"]["duplicate_verbose_prompt"]:
+            for item in existing:
+                print(f"  {item}")
+
+        ui.print_("New: " + summarize_items(list(duplicates), True))
+        if config["import"]["duplicate_verbose_prompt"]:
+            for item in duplicates:
+                print(f"  {item}")
+
+        return ui.input_options(("Skip dupes", "Keep all", "Remove old"))
+
     def should_resume(self, path):
         return ui.input_yn(
             f"Import of the directory:\n{displayable_path(path)}\n"

--- a/beetsplug/duplicates.py
+++ b/beetsplug/duplicates.py
@@ -17,9 +17,10 @@
 import os
 import shlex
 
+from beets.dbcore.query import MatchQuery
 from beets.library import Album, Item
 from beets.plugins import BeetsPlugin
-from beets.ui import Subcommand, UserError, print_
+from beets.ui import Subcommand, UserError, colorize, print_
 from beets.util import (
     MoveOperation,
     bytestring_path,
@@ -140,6 +141,49 @@ class DuplicatesPlugin(BeetsPlugin):
             help="remove items from library",
         )
         self._command.parser.add_all_common_options()
+
+        self.register_listener("import_task_created", self.import_task_created)
+
+    def import_task_created(self, task, session):
+        if "dedupe_mb_trackid_on_import" in self.config and self.config[
+            "dedupe_mb_trackid_on_import"
+        ].get(bool):
+            return self._dedupe_task_on_mb_trackid(task, session)
+
+    def _dedupe_task_on_mb_trackid(self, task, session):
+        # Find all items that already have the same track imported
+        dupes = []
+        for item in task.items:
+            if not item.mb_trackid:
+                continue
+
+            # Query the library for any matching tracks
+            resp = session.lib.items(
+                query=MatchQuery("mb_trackid", item.mb_trackid)
+            )
+            if len(resp.rows) > 0:
+                log_prefix = f"{item.artist} - {item.album} - {item.title}"
+                print_(
+                    f"{colorize('text_warning', log_prefix)}:"
+                    "Item already imported, skipping..."
+                )
+                dupes.append(item)
+
+        # Remove the dupes
+        album = ""
+        for dup in dupes:
+            album = f"{dup.artist} - {dup.album}"
+            task.items.remove(dup)
+
+        # Get rid of the task if all items were removed
+        if len(task.items) == 0:
+            print_(
+                f"{colorize('text_warning', album)}:" if album != "" else "",
+                "All items removed due to duplicates, removing task",
+            )
+            return []
+
+        return [task]
 
     def commands(self):
         def _dup(lib, opts, args):

--- a/beetsplug/duplicates.py
+++ b/beetsplug/duplicates.py
@@ -17,10 +17,9 @@
 import os
 import shlex
 
-from beets.dbcore.query import MatchQuery
 from beets.library import Album, Item
 from beets.plugins import BeetsPlugin
-from beets.ui import Subcommand, UserError, colorize, print_
+from beets.ui import Subcommand, UserError, print_
 from beets.util import (
     MoveOperation,
     bytestring_path,
@@ -142,49 +141,6 @@ class DuplicatesPlugin(BeetsPlugin):
         )
         self._command.parser.add_all_common_options()
 
-        self.register_listener("import_task_created", self.import_task_created)
-
-    def import_task_created(self, task, session):
-        if "dedupe_mb_trackid_on_import" in self.config and self.config[
-            "dedupe_mb_trackid_on_import"
-        ].get(bool):
-            return self._dedupe_task_on_mb_trackid(task, session)
-
-    def _dedupe_task_on_mb_trackid(self, task, session):
-        # Find all items that already have the same track imported
-        dupes = []
-        for item in task.items:
-            if not item.mb_trackid:
-                continue
-
-            # Query the library for any matching tracks
-            resp = session.lib.items(
-                query=MatchQuery("mb_trackid", item.mb_trackid)
-            )
-            if len(resp.rows) > 0:
-                log_prefix = f"{item.artist} - {item.album} - {item.title}"
-                print_(
-                    f"{colorize('text_warning', log_prefix)}:"
-                    "Item already imported, skipping..."
-                )
-                dupes.append(item)
-
-        # Remove the dupes
-        album = ""
-        for dup in dupes:
-            album = f"{dup.artist} - {dup.album}"
-            task.items.remove(dup)
-
-        # Get rid of the task if all items were removed
-        if len(task.items) == 0:
-            print_(
-                f"{colorize('text_warning', album)}:" if album != "" else "",
-                "All items removed due to duplicates, removing task",
-            )
-            return []
-
-        return [task]
-
     def commands(self):
         def _dup(lib, opts, args):
             self.config.set_args(opts)
@@ -220,7 +176,9 @@ class DuplicatesPlugin(BeetsPlugin):
 
             if path:
                 fmt_tmpl = "$path"
-            elif not fmt_tmpl:
+
+            # Default format string for count mode.
+            if count and not fmt_tmpl:
                 if album:
                     fmt_tmpl = "$albumartist - $album"
                 else:
@@ -248,11 +206,7 @@ class DuplicatesPlugin(BeetsPlugin):
                             delete=delete,
                             remove=remove,
                             tag=tag,
-                            fmt=(
-                                fmt_tmpl
-                                if not count
-                                else f"{fmt_tmpl}: {obj_count}"
-                            ),
+                            fmt=f"{fmt_tmpl}: {obj_count}",
                         )
 
         self._command.func = _dup

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -345,7 +345,6 @@ class TidalPlugin(MetadataSourcePlugin):
         track_by_id: dict[str, TidalTrack],
         artist_by_id: dict[str, TidalArtist],
     ) -> AlbumInfo:
-
         track_infos: list[TrackInfo] = []
         for i, track_rel in enumerate(
             album["relationships"]["items"]["data"], start=1

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,8 +26,11 @@ New features
 - :doc:`plugins/musicbrainz`: Introduce
   :conf:`plugins.musicbrainz:aliases_as_credits` to make
   aliases-as-artist-credit optional.
-- :doc:`plugins/duplicates`: ``dedupe_mb_trackid_on_import`` option added
-  to deduplicate during imports based on already-imported ``mb_trackid``.
+- Add the :ref:`duplicate_track_resolution` import option, which checks each
+  track of an album import against the library (using the
+  :ref:`duplicate_keys` ``item`` fields) and resolves matches via
+  :ref:`duplicate_action`. With ``skip`` this drops already-imported tracks and
+  imports the rest of the album. Disabled by default.
 
 Bug fixes
 ~~~~~~~~~
@@ -125,8 +128,6 @@ New features
   See :doc:`plugins/tidal` for more information.
 
 - Add support for adding or modifying a subtitle (ID3 tag ``TIT3``) field
-- :doc:`plugins/duplicates`: ``dedupe_mb_trackid_on_import`` option added to
-  deduplicate during imports based on already-imported ``mb_trackid``.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,8 @@ New features
 - :doc:`plugins/musicbrainz`: Introduce
   :conf:`plugins.musicbrainz:aliases_as_credits` to make
   aliases-as-artist-credit optional.
+- :doc:`plugins/duplicates`: ``dedupe_mb_trackid_on_import`` option added
+  to deduplicate during imports based on already-imported ``mb_trackid``.
 
 Bug fixes
 ~~~~~~~~~
@@ -123,6 +125,8 @@ New features
   See :doc:`plugins/tidal` for more information.
 
 - Add support for adding or modifying a subtitle (ID3 tag ``TIT3``) field
+- :doc:`plugins/duplicates`: ``dedupe_mb_trackid_on_import`` option added to
+  deduplicate during imports based on already-imported ``mb_trackid``.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/plugins/duplicates.rst
+++ b/docs/plugins/duplicates.rst
@@ -36,6 +36,11 @@ duplicates or just the duplicates themselves via command-line switches
     -t TAG, --tag=TAG     tag matched items with 'k=v' attribute
     -r, --remove          remove items from library
 
+Generally, beets operates on Albums or Track singletons. As a way to bridge the
+gap, the ``duplicates`` plugin can be configured to duduplicate tracks on import
+by checking for already-imported items with the same ``mb_trackid``. See the
+``dedupe_mb_trackid_on_import`` option for details.
+
 Configuration
 -------------
 
@@ -54,6 +59,8 @@ file. The available options mirror the command-line options:
 - **count**: Print a count of duplicate tracks or albums in the format
   ``$albumartist - $album - $title: $count`` (for tracks) or ``$albumartist -
   $album: $count`` (for albums). Default: ``no``.
+- **dedupe_mb_trackid_on_import**: Deduplicate album tracks when an
+  already-imported track has the same mb_trackid.
 - **delete**: Remove matched items from the library and from the disk. Default:
   ``no``
 - **format**: A specific format with which to print every track or album. This

--- a/docs/plugins/duplicates.rst
+++ b/docs/plugins/duplicates.rst
@@ -36,11 +36,6 @@ duplicates or just the duplicates themselves via command-line switches
     -t TAG, --tag=TAG     tag matched items with 'k=v' attribute
     -r, --remove          remove items from library
 
-Generally, beets operates on Albums or Track singletons. As a way to bridge the
-gap, the ``duplicates`` plugin can be configured to duduplicate tracks on import
-by checking for already-imported items with the same ``mb_trackid``. See the
-``dedupe_mb_trackid_on_import`` option for details.
-
 Configuration
 -------------
 
@@ -59,14 +54,12 @@ file. The available options mirror the command-line options:
 - **count**: Print a count of duplicate tracks or albums in the format
   ``$albumartist - $album - $title: $count`` (for tracks) or ``$albumartist -
   $album: $count`` (for albums). Default: ``no``.
-- **dedupe_mb_trackid_on_import**: Deduplicate album tracks when an
-  already-imported track has the same mb_trackid.
 - **delete**: Remove matched items from the library and from the disk. Default:
   ``no``
 - **format**: A specific format with which to print every track or album. This
-  uses the same template syntax as beets' :doc:`path formats
-  </reference/pathformat>`. The usage is inspired by, and therefore similar to,
-  the :ref:`list <list-cmd>` command. Default: :ref:`format_item`
+  uses the same template syntax as beets' :doc:`path
+  formats</reference/pathformat>`. The usage is inspired by, and therefore
+  similar to, the :ref:`list <list-cmd>` command. Default: :ref:`format_item`
 - **full**: List every track or album that has duplicates, not just the
   duplicates themselves. Default: ``no``
 - **keys**: Define in which track or album fields duplicates are to be searched.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -842,6 +842,29 @@ is applied, which would, considering the default, look like this:
 
 Default: ``no``.
 
+.. _duplicate_track_resolution:
+
+duplicate_track_resolution
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When enabled, album imports also check each *individual track* against the
+library, using the same fields as :ref:`duplicate_keys` ``item`` (by default
+``artist`` and ``title``; set it to e.g. ``mb_trackid`` to match on the
+MusicBrainz track ID). Tracks already in the library are resolved according to
+:ref:`duplicate_action`:
+
+- ``skip`` drops the duplicate tracks and imports the rest of the album. If
+  every track is already present, the whole album is skipped.
+- ``remove`` removes the matching old items from the library before importing.
+- ``keep`` (and ``merge``) import the album unchanged.
+- ``ask`` prompts you to choose one of the above.
+
+This complements the album-level duplicate check (which matches whole albums on
+:ref:`duplicate_keys` ``album``): it catches the case where some tracks of an
+album are already in your library even though the album itself is not.
+
+Default: ``no``.
+
 .. _bell:
 
 bell

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1299,6 +1299,87 @@ class ImportDuplicateSingletonTest(ImportTestCase):
         return item
 
 
+class ImportTrackDuplicateResolutionTest(ImportTestCase):
+    """``import.duplicate_track_resolution``: per-track dedup on album import.
+
+    The imported album has two tracks (``Tag Track 1`` and ``Tag Track 2``);
+    tests seed the library with singletons matching one or both of them.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.prepare_album_for_import(2)
+
+    def add_item_fixture(self, **kwargs):
+        item = self.add_item_fixtures()[0]
+        item.update(kwargs)
+        item.store()
+        return item
+
+    def _import(self, action="skip", enabled=True):
+        self.setup_importer(
+            autotag=False,
+            duplicate_track_resolution=enabled,
+            duplicate_action=action,
+        )
+        self.importer.run()
+
+    def test_skip_drops_duplicate_track(self):
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        self._import(action="skip")
+
+        # The duplicate "Tag Track 1" is dropped; "Tag Track 2" is imported.
+        assert len(self.lib.albums()) == 1
+        assert {i.title for i in self.lib.items()} == {
+            "Tag Track 1",
+            "Tag Track 2",
+        }
+        assert len(self.lib.items()) == 2
+
+    def test_skip_all_duplicates_skips_album(self):
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 2")
+
+        self._import(action="skip")
+
+        # Every track is a duplicate, so the whole album is skipped.
+        assert len(self.lib.albums()) == 0
+        assert len(self.lib.items()) == 2
+
+    def test_remove_replaces_old_item(self):
+        old = self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+        assert old.filepath.exists()
+
+        self._import(action="remove")
+
+        # The old matching item (and its file) is removed; both album tracks
+        # are imported.
+        assert not old.filepath.exists()
+        assert sorted(i.title for i in self.lib.items()) == [
+            "Tag Track 1",
+            "Tag Track 2",
+        ]
+        assert len(self.lib.albums()) == 1
+
+    def test_keep_imports_all(self):
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        self._import(action="keep")
+
+        # Nothing is dropped or removed.
+        assert len(self.lib.items()) == 3
+        assert len(self.lib.albums()) == 1
+
+    def test_disabled_by_default(self):
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        self._import(action="skip", enabled=False)
+
+        # With the option off, no track-level resolution happens.
+        assert len(self.lib.items()) == 3
+
+
 class TagLogTest(unittest.TestCase):
     def test_tag_log_line(self):
         sio = StringIO()


### PR DESCRIPTION
## Description
`plugins/duplicates`: ``dedupe_mb_trackid_on_import`` option added to deduplicate during imports based on already-imported ``mb_trackid``.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] ~Tests. (Very much encouraged but not strictly required.)~
