### PR TITLE
Lastgenre: Cleanup existing genres

### DIFF
--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -107,6 +107,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 "count": 1,
                 "fallback": None,
                 "canonical": False,
+                "cleanup_existing": False,
                 "source": "album",
                 "force": False,
                 "keep_existing": False,
@@ -395,7 +396,19 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         genres = self._get_existing_genres(obj)
 
         if genres and not self.config["force"]:
-            # Without force pre-populated tags are returned as-is.
+            # Without force, but cleanup_existing enabled, we attempt
+            # to canonicalize pre-populated tags before returning them.
+            # If none are found, we use the fallback (if set).
+            if self.config["cleanup_existing"]:
+                keep_genres = [g.lower() for g in genres]
+                if result := _try_resolve_stage("cleanup", keep_genres, []):
+                    return result
+
+                # Return fallback string (None if not set).
+                return self.config["fallback"].get(), "fallback"
+
+            # If cleanup_existing is not set, the pre-populated tags are
+            # returned as-is.
             return genres, "keep any, no-force"
 
         if self.config["force"]:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,8 @@ Unreleased
 New features
 ~~~~~~~~~~~~
 
+- :doc:`plugins/lastgenre`: Added ``cleanup_existing`` configuration flag to
+  allow whitelist canonicalization of existing genres.
 - Add native support for multiple genres per album/track. The ``genres`` field
   now stores genres as a list and is written to files as multiple individual
   genre tags (e.g., separate GENRE tags for FLAC/MP3). The

--- a/docs/plugins/lastgenre.rst
+++ b/docs/plugins/lastgenre.rst
@@ -170,6 +170,11 @@ file. The available options are:
 - **canonical**: Use a canonicalization tree. Setting this to ``yes`` will use a
   built-in tree. You can also set it to a path, like the ``whitelist`` config
   value, to use your own tree. Default: ``no`` (disabled).
+- **cleanup_existing**: This option only takes effect with ``force: no``,
+  Setting this to ``yes`` will result in cleanup of existing genres. That
+  includes canonicalization and whitelisting, if enabled. If no matching genre
+  can be determined, the ``fallback`` is used instead. Default: ``no``
+  (disabled).
 - **count**: Number of genres to fetch. Default: 1
 - **fallback**: A string to use as a fallback genre when no genre is found
   ``or`` the original genre is not desired to be kept (``keep_existing: no``).

--- a/test/plugins/test_lastgenre.py
+++ b/test/plugins/test_lastgenre.py
@@ -316,6 +316,30 @@ def config(config):
             },
             (["Jazzin"], "album, any"),
         ),
+        # Canonicalize original genre when force is **off** and
+        # whitelist, canonical and cleanup_existing are on.
+        # "Cosmic Disco" is not in the default whitelist, thus gets resolved "up" in the
+        # tree to "Disco" and "Electronic".
+        (
+            {
+                "force": False,
+                "keep_existing": False,
+                "source": "artist",
+                "whitelist": True,
+                "canonical": True,
+                "cleanup_existing": True,
+                "prefer_specific": False,
+                "count": 10,
+            },
+            ["Cosmic Disco"],
+            {
+                "artist": [],
+            },
+            (
+                ["Disco", "Electronic"],
+                "keep + cleanup, whitelist",
+            ),
+        ),
         # fallback to next stages until found
         (
             {


### PR DESCRIPTION
## Description

Fixes #6305 

Implements a new `cleanup_existing` config flag. The added documentation should explain its behavior. If there're any unclarities, we need to adjust the docs :)

## To Do

- [x] Documentation.
- [x] Changelog.
- [x] Tests.
