### PR TITLE
Add remove_missing option to convert plugin

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -796,11 +796,11 @@ class ConvertPlugin(BeetsPlugin):
         convert = [self.convert_item(keep_new) for _ in range(self.threads)]
         pipeline.Pipeline([iter(items), convert]).run_parallel()
 
-    def remove_non_item_files(self, items: list[Item], yes: bool):
+    def remove_non_item_files(self, items: list[Item], yes: bool) -> None:
         """
         Remove all files in the destination directory ``dest`` that do not
         correspond to an item to be converted.
-        
+
         If ``pretend`` is set, keep files and report what would be removed.
         If ``yes`` is set, do not ask for confirmation.
         """

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -271,6 +271,10 @@ class ConvertPlugin(BeetsPlugin):
         return not self.hardlink and self.config["link"].get(bool)
 
     @cached_property
+    def remove_missing(self) -> bool:
+        return self.config["remove_missing"].get(bool)
+
+    @cached_property
     def command(self) -> FormatCommand:
         """Return the command template and the extension from the config."""
         fmt = ALIASES.get(self.fmt, self.fmt)
@@ -686,8 +690,10 @@ class ConvertPlugin(BeetsPlugin):
             for album in albums:
                 self.copy_album_art(album)
 
-        if remove_missing:
-            self.remove_non_item_files(items, dest, fmt, pretend, opts.yes)
+        if self.remove_missing:
+            self.remove_non_item_files(
+                items, self.dest, self.fmt, pretend, opts.yes
+            )
 
         # If the user supplied a playlist name, create a playlist for files
         # copied to the destination.
@@ -798,7 +804,7 @@ class ConvertPlugin(BeetsPlugin):
         not actually remove any files and only print a list of files to be
         deleted. If ``yes=True`` it will not ask for confirmation.
         """
-        _, ext = get_format(fmt)
+        _, ext = self.command
         item_destinations = {
             replace_ext(item.destination(basedir=dest), ext) for item in items
         }

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -108,6 +108,7 @@ class ConvertPlugin(BeetsPlugin):
                 "force": False,
                 "refresh": False,
                 "keep_new": False,
+                "remove_missing": False,
             }
         )
         self.early_import_stages = [self.auto_convert, self.auto_convert_keep]
@@ -199,6 +200,13 @@ class ConvertPlugin(BeetsPlugin):
                 " different computer, or opened from an external drive,"
                 " relative paths pointing to media files will be used."
             ),
+        )
+        cmd.parser.add_option(
+            "-r",
+            "--remove-missing",
+            action="store_true",
+            help="""remove all files in the destination directory that are not
+                    present in the library.""",
         )
         cmd.parser.add_option(
             "-F",
@@ -675,6 +683,9 @@ class ConvertPlugin(BeetsPlugin):
         if opts.album and self.config["copy_album_art"]:
             for album in albums:
                 self.copy_album_art(album)
+        
+        if remove_missing:
+            self.remove_non_item_files(items, dest, fmt, pretend, opts.yes)
 
         # If the user supplied a playlist name, create a playlist for files
         # copied to the destination.
@@ -777,3 +788,35 @@ class ConvertPlugin(BeetsPlugin):
         """
         convert = [self.convert_item(keep_new) for _ in range(self.threads)]
         pipeline.Pipeline([iter(items), convert]).run_parallel()
+
+    def remove_non_item_files(self, items, dest, fmt, pretend, yes):
+        """
+        Remove all files in the destination directory ``dest`` that do not
+        correspond to an item to be converted. If ``pretend=True`` it will
+        not actually remove any files and only print a list of files to be
+        deleted. If ``yes=True`` it will not ask for confirmation.
+        """
+        _, ext = get_format(fmt)
+        item_destinations = {
+            replace_ext(item.destination(basedir=dest), ext) for item in items
+        }
+        files_to_remove = list()
+
+        for dirpath, _, filenames in os.walk(dest):
+            for filename in filenames:
+                filepath = util.bytestring_path(os.path.join(dirpath, filename))
+                if filepath not in item_destinations:
+                    files_to_remove.append(filepath)
+
+        if not files_to_remove:
+            ui.print_("No files to be removed")
+            return
+
+        ui.print_("Files to be deleted in the destination folder:")
+        for f in files_to_remove:
+            ui.print_(util.displayable_path(f))
+
+        if (not pretend) and (yes or ui.input_yn("Delete files? (Y/n)")):
+            for file in files_to_remove:
+                util.remove(file)
+                self._log.info(f'Removed file "{util.displayable_path(file)}"')

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -692,9 +692,7 @@ class ConvertPlugin(BeetsPlugin):
                 self.copy_album_art(album)
 
         if self.remove_missing:
-            self.remove_non_item_files(
-                items, self.dest, self.fmt, pretend, opts.yes
-            )
+            self.remove_non_item_files(items, opts.yes)
 
         # If the user supplied a playlist name, create a playlist for files
         # copied to the destination.
@@ -798,7 +796,7 @@ class ConvertPlugin(BeetsPlugin):
         convert = [self.convert_item(keep_new) for _ in range(self.threads)]
         pipeline.Pipeline([iter(items), convert]).run_parallel()
 
-    def remove_non_item_files(self, items, dest, fmt, pretend, yes):
+    def remove_non_item_files(self, items: list[Item], yes: bool):
         """
         Remove all files in the destination directory ``dest`` that do not
         correspond to an item to be converted. If ``pretend=True`` it will
@@ -807,11 +805,12 @@ class ConvertPlugin(BeetsPlugin):
         """
         _, ext = self.command
         item_destinations = {
-            replace_ext(item.destination(basedir=dest), ext) for item in items
+            replace_ext(item.destination(basedir=self.dest), ext)
+            for item in items
         }
         files_to_remove = list()
 
-        for dirpath, _, filenames in os.walk(dest):
+        for dirpath, _, filenames in os.walk(self.dest):
             for filename in filenames:
                 filepath = util.bytestring_path(os.path.join(dirpath, filename))
                 if filepath not in item_destinations:
@@ -825,7 +824,7 @@ class ConvertPlugin(BeetsPlugin):
         for f in files_to_remove:
             ui.print_(util.displayable_path(f))
 
-        if (not pretend) and (yes or ui.input_yn("Delete files? (Y/n)")):
+        if (not self.pretend) and (yes or ui.input_yn("Delete files? (Y/n)")):
             for file in files_to_remove:
                 util.remove(file)
                 self._log.info(f'Removed file "{util.displayable_path(file)}"')

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -205,8 +205,10 @@ class ConvertPlugin(BeetsPlugin):
             "-r",
             "--remove-missing",
             action="store_true",
-            help="""remove all files in the destination directory that are not
-                    present in the library.""",
+            help=(
+                "remove all files in the destination directory that are not"
+                " present in the library."
+            ),
         )
         cmd.parser.add_option(
             "-F",
@@ -683,7 +685,7 @@ class ConvertPlugin(BeetsPlugin):
         if opts.album and self.config["copy_album_art"]:
             for album in albums:
                 self.copy_album_art(album)
-        
+
         if remove_missing:
             self.remove_non_item_files(items, dest, fmt, pretend, opts.yes)
 

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -202,7 +202,7 @@ class ConvertPlugin(BeetsPlugin):
             ),
         )
         cmd.parser.add_option(
-            "-r",
+            "-s",
             "--remove-missing",
             default=self.config["remove_missing"].get(),
             action="store_true",

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -204,6 +204,7 @@ class ConvertPlugin(BeetsPlugin):
         cmd.parser.add_option(
             "-r",
             "--remove-missing",
+            default=self.config["remove_missing"].get(),
             action="store_true",
             help=(
                 "remove all files in the destination directory that are not"

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -799,9 +799,10 @@ class ConvertPlugin(BeetsPlugin):
     def remove_non_item_files(self, items: list[Item], yes: bool):
         """
         Remove all files in the destination directory ``dest`` that do not
-        correspond to an item to be converted. If ``pretend=True`` it will
-        not actually remove any files and only print a list of files to be
-        deleted. If ``yes=True`` it will not ask for confirmation.
+        correspond to an item to be converted.
+        
+        If ``pretend`` is set, keep files and report what would be removed.
+        If ``yes`` is set, do not ask for confirmation.
         """
         _, ext = self.command
         item_destinations = {

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -211,6 +211,7 @@ class ConvertPlugin(BeetsPlugin):
         cmd.parser.add_option(
             "-r",
             "--remove-missing",
+            default=self.config["remove_missing"].get(),
             action="store_true",
             help=(
                 "remove all files in the destination directory that are not"

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -115,6 +115,7 @@ class ConvertPlugin(BeetsPlugin):
                 "force": False,
                 "refresh": False,
                 "keep_new": False,
+                "remove_missing": False,
             }
         )
         self.early_import_stages = [self.auto_convert, self.auto_convert_keep]
@@ -206,6 +207,13 @@ class ConvertPlugin(BeetsPlugin):
                 " different computer, or opened from an external drive,"
                 " relative paths pointing to media files will be used."
             ),
+        )
+        cmd.parser.add_option(
+            "-r",
+            "--remove-missing",
+            action="store_true",
+            help="""remove all files in the destination directory that are not
+                    present in the library.""",
         )
         cmd.parser.add_option(
             "-F",
@@ -694,6 +702,9 @@ class ConvertPlugin(BeetsPlugin):
         if opts.album and self.config["copy_album_art"]:
             for album in albums:
                 self.copy_album_art(album)
+        
+        if remove_missing:
+            self.remove_non_item_files(items, dest, fmt, pretend, opts.yes)
 
         # If the user supplied a playlist name, create a playlist for files
         # copied to the destination.
@@ -796,3 +807,35 @@ class ConvertPlugin(BeetsPlugin):
         """
         convert = [self.convert_item(keep_new) for _ in range(self.threads)]
         pipeline.Pipeline([iter(items), convert]).run_parallel()
+
+    def remove_non_item_files(self, items, dest, fmt, pretend, yes):
+        """
+        Remove all files in the destination directory ``dest`` that do not
+        correspond to an item to be converted. If ``pretend=True`` it will
+        not actually remove any files and only print a list of files to be
+        deleted. If ``yes=True`` it will not ask for confirmation.
+        """
+        _, ext = get_format(fmt)
+        item_destinations = {
+            replace_ext(item.destination(basedir=dest), ext) for item in items
+        }
+        files_to_remove = list()
+
+        for dirpath, _, filenames in os.walk(dest):
+            for filename in filenames:
+                filepath = util.bytestring_path(os.path.join(dirpath, filename))
+                if filepath not in item_destinations:
+                    files_to_remove.append(filepath)
+
+        if not files_to_remove:
+            ui.print_("No files to be removed")
+            return
+
+        ui.print_("Files to be deleted in the destination folder:")
+        for f in files_to_remove:
+            ui.print_(util.displayable_path(f))
+
+        if (not pretend) and (yes or ui.input_yn("Delete files? (Y/n)")):
+            for file in files_to_remove:
+                util.remove(file)
+                self._log.info(f'Removed file "{util.displayable_path(file)}"')

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -209,7 +209,7 @@ class ConvertPlugin(BeetsPlugin):
             ),
         )
         cmd.parser.add_option(
-            "-r",
+            "-s",
             "--remove-missing",
             default=self.config["remove_missing"].get(),
             action="store_true",

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -212,8 +212,10 @@ class ConvertPlugin(BeetsPlugin):
             "-r",
             "--remove-missing",
             action="store_true",
-            help="""remove all files in the destination directory that are not
-                    present in the library.""",
+            help=(
+                "remove all files in the destination directory that are not"
+                " present in the library."
+            ),
         )
         cmd.parser.add_option(
             "-F",
@@ -702,7 +704,7 @@ class ConvertPlugin(BeetsPlugin):
         if opts.album and self.config["copy_album_art"]:
             for album in albums:
                 self.copy_album_art(album)
-        
+
         if remove_missing:
             self.remove_non_item_files(items, dest, fmt, pretend, opts.yes)
 

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -818,9 +818,10 @@ class ConvertPlugin(BeetsPlugin):
     def remove_non_item_files(self, items: list[Item], yes: bool):
         """
         Remove all files in the destination directory ``dest`` that do not
-        correspond to an item to be converted. If ``pretend=True`` it will
-        not actually remove any files and only print a list of files to be
-        deleted. If ``yes=True`` it will not ask for confirmation.
+        correspond to an item to be converted.
+        
+        If ``pretend`` is set, keep files and report what would be removed.
+        If ``yes`` is set, do not ask for confirmation.
         """
         _, ext = self.command
         item_destinations = {

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -815,11 +815,11 @@ class ConvertPlugin(BeetsPlugin):
         convert = [self.convert_item(keep_new) for _ in range(self.threads)]
         pipeline.Pipeline([iter(items), convert]).run_parallel()
 
-    def remove_non_item_files(self, items: list[Item], yes: bool):
+    def remove_non_item_files(self, items: list[Item], yes: bool) -> None:
         """
         Remove all files in the destination directory ``dest`` that do not
         correspond to an item to be converted.
-        
+
         If ``pretend`` is set, keep files and report what would be removed.
         If ``yes`` is set, do not ask for confirmation.
         """

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -711,9 +711,7 @@ class ConvertPlugin(BeetsPlugin):
                 self.copy_album_art(album)
 
         if self.remove_missing:
-            self.remove_non_item_files(
-                items, self.dest, self.fmt, pretend, opts.yes
-            )
+            self.remove_non_item_files(items, opts.yes)
 
         # If the user supplied a playlist name, create a playlist for files
         # copied to the destination.
@@ -817,7 +815,7 @@ class ConvertPlugin(BeetsPlugin):
         convert = [self.convert_item(keep_new) for _ in range(self.threads)]
         pipeline.Pipeline([iter(items), convert]).run_parallel()
 
-    def remove_non_item_files(self, items, dest, fmt, pretend, yes):
+    def remove_non_item_files(self, items: list[Item], yes: bool):
         """
         Remove all files in the destination directory ``dest`` that do not
         correspond to an item to be converted. If ``pretend=True`` it will
@@ -826,11 +824,12 @@ class ConvertPlugin(BeetsPlugin):
         """
         _, ext = self.command
         item_destinations = {
-            replace_ext(item.destination(basedir=dest), ext) for item in items
+            replace_ext(item.destination(basedir=self.dest), ext)
+            for item in items
         }
         files_to_remove = list()
 
-        for dirpath, _, filenames in os.walk(dest):
+        for dirpath, _, filenames in os.walk(self.dest):
             for filename in filenames:
                 filepath = util.bytestring_path(os.path.join(dirpath, filename))
                 if filepath not in item_destinations:
@@ -844,7 +843,7 @@ class ConvertPlugin(BeetsPlugin):
         for f in files_to_remove:
             ui.print_(util.displayable_path(f))
 
-        if (not pretend) and (yes or ui.input_yn("Delete files? (Y/n)")):
+        if (not self.pretend) and (yes or ui.input_yn("Delete files? (Y/n)")):
             for file in files_to_remove:
                 util.remove(file)
                 self._log.info(f'Removed file "{util.displayable_path(file)}"')

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -278,6 +278,10 @@ class ConvertPlugin(BeetsPlugin):
         return not self.hardlink and self.config["link"].get(bool)
 
     @cached_property
+    def remove_missing(self) -> bool:
+        return self.config["remove_missing"].get(bool)
+
+    @cached_property
     def command(self) -> FormatCommand:
         """Return the command template and the extension from the config."""
         fmt = ALIASES.get(self.fmt, self.fmt)
@@ -705,8 +709,10 @@ class ConvertPlugin(BeetsPlugin):
             for album in albums:
                 self.copy_album_art(album)
 
-        if remove_missing:
-            self.remove_non_item_files(items, dest, fmt, pretend, opts.yes)
+        if self.remove_missing:
+            self.remove_non_item_files(
+                items, self.dest, self.fmt, pretend, opts.yes
+            )
 
         # If the user supplied a playlist name, create a playlist for files
         # copied to the destination.
@@ -817,7 +823,7 @@ class ConvertPlugin(BeetsPlugin):
         not actually remove any files and only print a list of files to be
         deleted. If ``yes=True`` it will not ask for confirmation.
         """
-        _, ext = get_format(fmt)
+        _, ext = self.command
         item_destinations = {
             replace_ext(item.destination(basedir=dest), ext) for item in items
         }

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -711,7 +711,9 @@ class ConvertPlugin(BeetsPlugin):
                 self.copy_album_art(album)
 
         if self.remove_missing:
-            self.remove_non_item_files(items, opts.yes)
+            self.remove_non_item_files(
+                items, opts.yes if opts.yes is not None else False
+            )
 
         # If the user supplied a playlist name, create a playlist for files
         # copied to the destination.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -49,6 +49,9 @@ New features
   :bug:`6466`
 - :doc:`plugins/lyrics`: Add ``lrcmux`` backend, which aggregates lyrics from
   various other sources.
+- :doc:`plugins/convert`: Added the new ``remove_missing`` configuration and
+  corresponding ``--remove-missing`` option to enable removing files in the
+  destination directory that were removed from the library.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -49,9 +49,9 @@ New features
   :bug:`6466`
 - :doc:`plugins/lyrics`: Add ``lrcmux`` backend, which aggregates lyrics from
   various other sources.
-- :doc:`plugins/convert`: Added the new ``remove_missing`` configuration and
-  corresponding ``--remove-missing`` option to enable removing files in the
-  destination directory that were removed from the library.
+- :doc:`plugins/convert`: Added a new ``remove_missing`` configuration option
+  and corresponding ``-s``/``--remove-missing`` flags to remove files from the
+  destination directory when they have been removed from the library.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,7 +12,7 @@ Unreleased
 ..
     New features
     ~~~~~~~~~~~~
-  
+
 - :doc:`plugins/convert`: Added a new ``remove_missing`` configuration option
   and corresponding ``-s``/``--remove-missing`` flags to remove files from the
   destination directory when they have been removed from the library.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,9 +13,9 @@ Unreleased
     New features
     ~~~~~~~~~~~~
   
-- :doc:`plugins/convert`: Added the new ``remove_missing`` configuration and
-  corresponding ``--remove-missing`` option to enable removing files in the
-  destination directory that were removed from the library.
+- :doc:`plugins/convert`: Added a new ``remove_missing`` configuration option
+  and corresponding ``-s``/``--remove-missing`` flags to remove files from the
+  destination directory when they have been removed from the library.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,10 @@ Unreleased
 ..
     New features
     ~~~~~~~~~~~~
+  
+- :doc:`plugins/convert`: Added the new ``remove_missing`` configuration and
+  corresponding ``--remove-missing`` option to enable removing files in the
+  destination directory that were removed from the library.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -75,6 +75,9 @@ files. If an original file is newer than a converted file, the converted file
 will be removed from the filesystem, and the original file will be converted
 once again.
 
+The ``-r`` (or ``--remove-missing``) option will remove files in the destination
+folder that are not present in the library.
+
 Configuration
 -------------
 
@@ -170,6 +173,12 @@ The available options are:
 - **refresh**: Refresh the converted files if needed by re-converting modified
   original files. This configuration is overridden by the ``-r`` (``--refresh``)
   command line option. Default: ``false``.
+- **remove_missing**: Whether or not to remove files in the destination folder
+  that are no longer present in the library. This means that if you removed an
+  item from the database that was previously converted, it will be removed in
+  the next run of the ``convert`` command (it will ask for confirmation unless
+  the ``--yes`` option is enabled). This is useful if you want to keep a
+  converted version of your library synced. Default: ``false``.
 
 You can also configure the format to use for transcoding (see the next section):
 

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -173,12 +173,12 @@ The available options are:
 - **refresh**: Refresh the converted files if needed by re-converting modified
   original files. This configuration is overridden by the ``-r`` (``--refresh``)
   command line option. Default: ``false``.
-- **remove_missing**: Whether or not to remove files in the destination folder
-  that are no longer present in the library. This means that if you removed an
-  item from the database that was previously converted, it will be removed in
-  the next run of the ``convert`` command (it will ask for confirmation unless
-  the ``--yes`` option is enabled). This is useful if you want to keep a
-  converted version of your library synced. Default: ``false``.
+- **remove_missing**: Whether to remove files in the destination folder that are
+  no longer present in the library. This means that if you remove an item from
+  the database that was previously converted, it will be removed on the next run
+  of the ``convert`` command (you will be asked for confirmation unless the
+  ``--yes`` option is enabled). This is useful if you want to keep a converted
+  version of your library in sync. Default: ``false``.
 
 You can also configure the format to use for transcoding (see the next section):
 

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -179,12 +179,12 @@ The available options are:
 - **refresh**: Refresh the converted files if needed by re-converting modified
   original files. This configuration is overridden by the ``-r`` (``--refresh``)
   command line option. Default: ``false``.
-- **remove_missing**: Whether or not to remove files in the destination folder
-  that are no longer present in the library. This means that if you removed an
-  item from the database that was previously converted, it will be removed in
-  the next run of the ``convert`` command (it will ask for confirmation unless
-  the ``--yes`` option is enabled). This is useful if you want to keep a
-  converted version of your library synced. Default: ``false``.
+- **remove_missing**: Whether to remove files in the destination folder that are
+  no longer present in the library. This means that if you remove an item from
+  the database that was previously converted, it will be removed on the next run
+  of the ``convert`` command (you will be asked for confirmation unless the
+  ``--yes`` option is enabled). This is useful if you want to keep a converted
+  version of your library in sync. Default: ``false``.
 
 You can also configure the format to use for transcoding (see the next section):
 

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -75,6 +75,9 @@ files. If an original file is newer than a converted file, the converted file
 will be removed from the filesystem, and the original file will be converted
 once again.
 
+The ``-r`` (or ``--remove-missing``) option will remove files in the destination
+folder that are not present in the library.
+
 Plugin Event
 ------------
 
@@ -176,6 +179,12 @@ The available options are:
 - **refresh**: Refresh the converted files if needed by re-converting modified
   original files. This configuration is overridden by the ``-r`` (``--refresh``)
   command line option. Default: ``false``.
+- **remove_missing**: Whether or not to remove files in the destination folder
+  that are no longer present in the library. This means that if you removed an
+  item from the database that was previously converted, it will be removed in
+  the next run of the ``convert`` command (it will ask for confirmation unless
+  the ``--yes`` option is enabled). This is useful if you want to keep a
+  converted version of your library synced. Default: ``false``.
 
 You can also configure the format to use for transcoding (see the next section):
 

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -348,7 +348,7 @@ class TestConvertRemoveMissing(ConvertPluginHelper, ConvertCommand):
             f.write("test")
         return p
 
-    def test_convert_not_removemissing(self):
+    def test_default_convert(self):
         "Test that files are not removed when the remove_missing option is not enabled"
         file_to_remove = self.create_dummy_file("to_remove.mp3")
 

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -323,7 +323,7 @@ class TestNoConvert(PluginTestHelper):
         assert convert.ConvertPlugin().in_no_convert(item) == should_skip
 
 
-class ConvertRemoveMissingTest(ConvertPluginHelper, ConvertCommand):
+class TestConvertRemoveMissing(ConvertPluginHelper, ConvertCommand):
     "Tests the effect of the `remove_missing option`"
 
     @pytest.fixture(autouse=True)

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -321,3 +321,34 @@ class TestNoConvert(PluginTestHelper):
         item = Item(format="ogg", bitrate=256)
         config["convert"]["no_convert"] = config_value
         assert convert.ConvertPlugin().in_no_convert(item) == should_skip
+
+
+class ConvertRemoveMissingTest(ConvertPluginHelper, ConvertCommand):
+    "Tests the effect of the `remove_missing option`"
+
+    @pytest.fixture(autouse=True)
+    def setup_removemissing(self, setup):
+        self.album = self.add_album_fixture(ext="ogg")
+        self.item = self.album.items()[0]
+
+        self.convert_dest = self.temp_dir_path / "convert_dest"
+        self.file_to_remove = self.convert_dest / "to_remove.mp3"
+        self.convert_dest.mkdir(parents=True)
+
+        self.config["convert"] = {
+            "dest": str(self.convert_dest),
+            "format": "mp3",
+        }
+
+        with self.file_to_remove.open("w") as f:
+            f.write("test")
+
+    def test_convert_not_removemissing(self):
+        self.run_convert("--yes")
+
+        assert self.file_to_remove.exists()
+
+    def test_convert_removemissing(self):
+        self.run_convert("--remove-missing", "--yes")
+
+        assert not self.file_to_remove.exists()

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -389,7 +389,9 @@ class TestConvertRemoveMissing(ConvertPluginHelper, ConvertCommand):
         remove_missing option is enabled"""
         # This file mocks an already existing converted file that should not be
         # removed or modified.
-        file_not_to_remove = self.create_dummy_file("artist/album/01 title.mp3")
+        file_not_to_remove = self.create_dummy_file(
+            util.syspath(self.item.path)
+        )
         original_mtime = os.path.getmtime(file_not_to_remove)
 
         self.run_convert("--yes", "--remove-missing")

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -328,10 +328,11 @@ class ConvertRemoveMissingTest(ConvertPluginHelper, ConvertCommand):
 
     @pytest.fixture(autouse=True)
     def setup_removemissing(self, setup):
-        self.item = self.add_item(title="title", album="album", format="ogg")
+        self.item = self.add_item_fixture(
+            title="title", artist="artist", album="album", format="flac"
+        )
 
         self.convert_dest = self.temp_dir_path / "convert_dest"
-        self.file_to_remove = self.convert_dest / "to_remove.mp3"
         self.convert_dest.mkdir(parents=True)
 
         self.config["convert"] = {
@@ -339,23 +340,59 @@ class ConvertRemoveMissingTest(ConvertPluginHelper, ConvertCommand):
             "format": "mp3",
         }
 
-        with self.file_to_remove.open("w") as f:
+    def create_dummy_file(self, path):
+        "Creates a dummy file in the conversion directory"
+        p = self.convert_dest / path
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with p.open("w") as f:
             f.write("test")
+        return p
 
     def test_convert_not_removemissing(self):
+        "Test that files are not removed when the remove_missing option is not enabled"
+        file_to_remove = self.create_dummy_file("to_remove.mp3")
+
         self.run_convert("--yes")
 
-        assert self.file_to_remove.exists()
+        assert file_to_remove.exists()
 
     def test_convert_pretend_removemissing(self):
+        "Test that files are not removed when the pretend flag is enabled"
+        file_to_remove = self.create_dummy_file("to_remove.mp3")
+
         self.run_convert("--yes", "--remove-missing", "--pretend")
 
-        assert self.file_to_remove.exists()
+        assert file_to_remove.exists()
 
-    def test_convert_removemissing(self):
+    def test_convert_removemissing_option(self):
+        "Test that files are removed when the remove_missing option is enabled"
+        file_to_remove = self.create_dummy_file("to_remove.mp3")
+
         self.run_convert("--yes", "--remove-missing")
 
-        assert not self.file_to_remove.exists()
+        assert not file_to_remove.exists()
 
         # This should hit the case where no files to remove are present
-        self.run_convert("--remove-missing", "--yes")
+        self.run_convert("--yes", "--remove-missing")
+
+    def test_convert_removemissing_config(self):
+        "Test that files are removed when the remove_missing config is set to True"
+        file_to_remove = self.create_dummy_file("to_remove.mp3")
+
+        self.config["convert"]["remove_missing"] = True
+        self.run_convert("--yes")
+
+        assert not file_to_remove.exists()
+
+    def test_convert_dont_remove_present(self):
+        """Test that already converted files are not removed when the
+        remove_missing option is enabled"""
+        # This file mocks an already existing converted file that should not be
+        # removed or modified.
+        file_not_to_remove = self.create_dummy_file("artist/album/01 title.mp3")
+        original_mtime = os.path.getmtime(file_not_to_remove)
+
+        self.run_convert("--yes", "--remove-missing")
+
+        assert file_not_to_remove.exists()
+        assert os.path.getmtime(file_not_to_remove) == original_mtime

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -347,7 +347,15 @@ class ConvertRemoveMissingTest(ConvertPluginHelper, ConvertCommand):
 
         assert self.file_to_remove.exists()
 
+    def test_convert_pretend_removemissing(self):
+        self.run_convert("--yes", "--remove-missing", "--pretend")
+
+        assert self.file_to_remove.exists()
+
     def test_convert_removemissing(self):
-        self.run_convert("--remove-missing", "--yes")
+        self.run_convert("--yes", "--remove-missing")
 
         assert not self.file_to_remove.exists()
+
+        # This should hit the case where no files to remove are present
+        self.run_convert("--remove-missing", "--yes")

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -4,7 +4,7 @@ import fnmatch
 import os.path
 import shlex
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from mediafile import MediaFile
@@ -359,7 +359,7 @@ class TestConvertRemoveMissing(ConvertPluginHelper, ConvertCommand):
     )
     def test_convert_remove_missing(
         self,
-        plugin_config: dict,
+        plugin_config: dict[str, Any],
         cli_options: list[str],
         files_to_mark_for_removal: list[str],
         expect_removal: bool,

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -340,7 +340,7 @@ class TestConvertRemoveMissing(ConvertPluginHelper, ConvertCommand):
             "format": "mp3",
         }
 
-    def create_dummy_file(self, path):
+    def create_dummy_file(self, path: str) -> Path:
         "Creates a dummy file in the conversion directory"
         p = self.convert_dest / path
         p.parent.mkdir(parents=True, exist_ok=True)

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -348,45 +348,22 @@ class TestConvertRemoveMissing(ConvertPluginHelper, ConvertCommand):
             f.write("test")
         return p
 
-    def test_default_convert(self):
-        "Test that files are not removed when the remove_missing option is not enabled"
-        file_to_remove = self.create_dummy_file("to_remove.mp3")
-
-        self.run_convert("--yes")
-
-        assert file_to_remove.exists()
-
-    def test_convert_pretend_removemissing(self):
-        "Test that files are not removed when the pretend flag is enabled"
-        file_to_remove = self.create_dummy_file("to_remove.mp3")
-
-        self.run_convert("--yes", "--remove-missing", "--pretend")
-
-        assert file_to_remove.exists()
-
-    def test_convert_removemissing_option(self):
-        "Test that files are removed when the remove_missing option is enabled"
-        file_to_remove = self.create_dummy_file("to_remove.mp3")
-
-        self.run_convert("--yes", "--remove-missing")
-
-        assert not file_to_remove.exists()
-
-        # This should hit the case where no files to remove are present
-        self.run_convert("--yes", "--remove-missing")
-
-    def test_convert_removemissing_config(self):
-        "Test that files are removed when the remove_missing config is set to True"
-        file_to_remove = self.create_dummy_file("to_remove.mp3")
-
-        self.config["convert"]["remove_missing"] = True
-        self.run_convert("--yes")
-
-        assert not file_to_remove.exists()
-
-    def test_convert_dont_remove_present(self):
-        """Test that already converted files are not removed when the
-        remove_missing option is enabled"""
+    @pytest.mark.parametrize(
+        "plugin_config,cli_options,files_to_mark_for_removal,expect_removal",
+        [
+            ({}, [], ["to_remove.mp3"], False),
+            ({}, ["--remove-missing", "--pretend"], ["to_remove.mp3"], False),
+            ({}, ["--remove-missing"], ["to_remove.mp3"], True),
+            ({"remove_missing": True}, [], ["to_remove.mp3"], True),
+        ],
+    )
+    def test_convert_remove_missing(
+        self,
+        plugin_config: dict,
+        cli_options: list[str],
+        files_to_mark_for_removal: list[str],
+        expect_removal: bool,
+    ):
         # This file mocks an already existing converted file that should not be
         # removed or modified.
         file_not_to_remove = self.create_dummy_file(
@@ -394,7 +371,21 @@ class TestConvertRemoveMissing(ConvertPluginHelper, ConvertCommand):
         )
         original_mtime = os.path.getmtime(file_not_to_remove)
 
-        self.run_convert("--yes", "--remove-missing")
+        # Create files to be marked for removal
+        paths_to_mark_for_removal = [
+            self.create_dummy_file(f) for f in files_to_mark_for_removal
+        ]
 
+        # Set configurations
+        for key, val in plugin_config.items():
+            self.config["convert"][key] = val
+
+        self.run_convert("--yes", *cli_options)
+
+        # Check if files were expectedly removed or not
+        for p in paths_to_mark_for_removal:
+            assert (not p.exists()) == expect_removal
+
+        # Check that files not to be removed are still there unmodified
         assert file_not_to_remove.exists()
         assert os.path.getmtime(file_not_to_remove) == original_mtime

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -328,8 +328,7 @@ class ConvertRemoveMissingTest(ConvertPluginHelper, ConvertCommand):
 
     @pytest.fixture(autouse=True)
     def setup_removemissing(self, setup):
-        self.album = self.add_album_fixture(ext="ogg")
-        self.item = self.album.items()[0]
+        self.item = self.add_item(title="title", album="album", format="ogg")
 
         self.convert_dest = self.temp_dir_path / "convert_dest"
         self.file_to_remove = self.convert_dest / "to_remove.mp3"

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -322,7 +322,7 @@ class TestNoConvert(PluginTestHelper):
         assert convert.ConvertPlugin().in_no_convert(item) == should_skip
 
 
-class ConvertRemoveMissingTest(ConvertPluginHelper, ConvertCommand):
+class TestConvertRemoveMissing(ConvertPluginHelper, ConvertCommand):
     "Tests the effect of the `remove_missing option`"
 
     @pytest.fixture(autouse=True)

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -371,9 +371,7 @@ class TestConvertRemoveMissing(ConvertPluginHelper, ConvertCommand):
         original_mtime = os.path.getmtime(file_not_to_remove)
 
         # Create files to be marked for removal
-        paths_to_mark_for_removal = [
-            self.create_dummy_file(f) for f in files_to_mark_for_removal
-        ]
+        path_to_mark_for_removal = self.create_dummy_file("to_remove.mp3")
 
         # Set configurations
         for key, val in plugin_config.items():

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -347,45 +347,22 @@ class TestConvertRemoveMissing(ConvertPluginHelper, ConvertCommand):
             f.write("test")
         return p
 
-    def test_default_convert(self):
-        "Test that files are not removed when the remove_missing option is not enabled"
-        file_to_remove = self.create_dummy_file("to_remove.mp3")
-
-        self.run_convert("--yes")
-
-        assert file_to_remove.exists()
-
-    def test_convert_pretend_removemissing(self):
-        "Test that files are not removed when the pretend flag is enabled"
-        file_to_remove = self.create_dummy_file("to_remove.mp3")
-
-        self.run_convert("--yes", "--remove-missing", "--pretend")
-
-        assert file_to_remove.exists()
-
-    def test_convert_removemissing_option(self):
-        "Test that files are removed when the remove_missing option is enabled"
-        file_to_remove = self.create_dummy_file("to_remove.mp3")
-
-        self.run_convert("--yes", "--remove-missing")
-
-        assert not file_to_remove.exists()
-
-        # This should hit the case where no files to remove are present
-        self.run_convert("--yes", "--remove-missing")
-
-    def test_convert_removemissing_config(self):
-        "Test that files are removed when the remove_missing config is set to True"
-        file_to_remove = self.create_dummy_file("to_remove.mp3")
-
-        self.config["convert"]["remove_missing"] = True
-        self.run_convert("--yes")
-
-        assert not file_to_remove.exists()
-
-    def test_convert_dont_remove_present(self):
-        """Test that already converted files are not removed when the
-        remove_missing option is enabled"""
+    @pytest.mark.parametrize(
+        "plugin_config,cli_options,files_to_mark_for_removal,expect_removal",
+        [
+            ({}, [], ["to_remove.mp3"], False),
+            ({}, ["--remove-missing", "--pretend"], ["to_remove.mp3"], False),
+            ({}, ["--remove-missing"], ["to_remove.mp3"], True),
+            ({"remove_missing": True}, [], ["to_remove.mp3"], True),
+        ],
+    )
+    def test_convert_remove_missing(
+        self,
+        plugin_config: dict,
+        cli_options: list[str],
+        files_to_mark_for_removal: list[str],
+        expect_removal: bool,
+    ):
         # This file mocks an already existing converted file that should not be
         # removed or modified.
         file_not_to_remove = self.create_dummy_file(
@@ -393,7 +370,21 @@ class TestConvertRemoveMissing(ConvertPluginHelper, ConvertCommand):
         )
         original_mtime = os.path.getmtime(file_not_to_remove)
 
-        self.run_convert("--yes", "--remove-missing")
+        # Create files to be marked for removal
+        paths_to_mark_for_removal = [
+            self.create_dummy_file(f) for f in files_to_mark_for_removal
+        ]
 
+        # Set configurations
+        for key, val in plugin_config.items():
+            self.config["convert"][key] = val
+
+        self.run_convert("--yes", *cli_options)
+
+        # Check if files were expectedly removed or not
+        for p in paths_to_mark_for_removal:
+            assert (not p.exists()) == expect_removal
+
+        # Check that files not to be removed are still there unmodified
         assert file_not_to_remove.exists()
         assert os.path.getmtime(file_not_to_remove) == original_mtime

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -323,7 +323,7 @@ class TestNoConvert(PluginTestHelper):
 
 
 class TestConvertRemoveMissing(ConvertPluginHelper, ConvertCommand):
-    "Tests the effect of the `remove_missing option`"
+    """Tests the effect of the `remove_missing option`"""
 
     @pytest.fixture(autouse=True)
     def setup_removemissing(self, setup):

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -347,7 +347,7 @@ class TestConvertRemoveMissing(ConvertPluginHelper, ConvertCommand):
             f.write("test")
         return p
 
-    def test_convert_not_removemissing(self):
+    def test_default_convert(self):
         "Test that files are not removed when the remove_missing option is not enabled"
         file_to_remove = self.create_dummy_file("to_remove.mp3")
 

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -4,7 +4,7 @@ import fnmatch
 import os
 import shlex
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from mediafile import MediaFile
@@ -358,7 +358,7 @@ class TestConvertRemoveMissing(ConvertPluginHelper, ConvertCommand):
     )
     def test_convert_remove_missing(
         self,
-        plugin_config: dict,
+        plugin_config: dict[str, Any],
         cli_options: list[str],
         files_to_mark_for_removal: list[str],
         expect_removal: bool,

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -388,7 +388,9 @@ class TestConvertRemoveMissing(ConvertPluginHelper, ConvertCommand):
         remove_missing option is enabled"""
         # This file mocks an already existing converted file that should not be
         # removed or modified.
-        file_not_to_remove = self.create_dummy_file("artist/album/01 title.mp3")
+        file_not_to_remove = self.create_dummy_file(
+            util.syspath(self.item.path)
+        )
         original_mtime = os.path.getmtime(file_not_to_remove)
 
         self.run_convert("--yes", "--remove-missing")

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -327,10 +327,11 @@ class ConvertRemoveMissingTest(ConvertPluginHelper, ConvertCommand):
 
     @pytest.fixture(autouse=True)
     def setup_removemissing(self, setup):
-        self.item = self.add_item(title="title", album="album", format="ogg")
+        self.item = self.add_item_fixture(
+            title="title", artist="artist", album="album", format="flac"
+        )
 
         self.convert_dest = self.temp_dir_path / "convert_dest"
-        self.file_to_remove = self.convert_dest / "to_remove.mp3"
         self.convert_dest.mkdir(parents=True)
 
         self.config["convert"] = {
@@ -338,23 +339,59 @@ class ConvertRemoveMissingTest(ConvertPluginHelper, ConvertCommand):
             "format": "mp3",
         }
 
-        with self.file_to_remove.open("w") as f:
+    def create_dummy_file(self, path):
+        "Creates a dummy file in the conversion directory"
+        p = self.convert_dest / path
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with p.open("w") as f:
             f.write("test")
+        return p
 
     def test_convert_not_removemissing(self):
+        "Test that files are not removed when the remove_missing option is not enabled"
+        file_to_remove = self.create_dummy_file("to_remove.mp3")
+
         self.run_convert("--yes")
 
-        assert self.file_to_remove.exists()
+        assert file_to_remove.exists()
 
     def test_convert_pretend_removemissing(self):
+        "Test that files are not removed when the pretend flag is enabled"
+        file_to_remove = self.create_dummy_file("to_remove.mp3")
+
         self.run_convert("--yes", "--remove-missing", "--pretend")
 
-        assert self.file_to_remove.exists()
+        assert file_to_remove.exists()
 
-    def test_convert_removemissing(self):
+    def test_convert_removemissing_option(self):
+        "Test that files are removed when the remove_missing option is enabled"
+        file_to_remove = self.create_dummy_file("to_remove.mp3")
+
         self.run_convert("--yes", "--remove-missing")
 
-        assert not self.file_to_remove.exists()
+        assert not file_to_remove.exists()
 
         # This should hit the case where no files to remove are present
-        self.run_convert("--remove-missing", "--yes")
+        self.run_convert("--yes", "--remove-missing")
+
+    def test_convert_removemissing_config(self):
+        "Test that files are removed when the remove_missing config is set to True"
+        file_to_remove = self.create_dummy_file("to_remove.mp3")
+
+        self.config["convert"]["remove_missing"] = True
+        self.run_convert("--yes")
+
+        assert not file_to_remove.exists()
+
+    def test_convert_dont_remove_present(self):
+        """Test that already converted files are not removed when the
+        remove_missing option is enabled"""
+        # This file mocks an already existing converted file that should not be
+        # removed or modified.
+        file_not_to_remove = self.create_dummy_file("artist/album/01 title.mp3")
+        original_mtime = os.path.getmtime(file_not_to_remove)
+
+        self.run_convert("--yes", "--remove-missing")
+
+        assert file_not_to_remove.exists()
+        assert os.path.getmtime(file_not_to_remove) == original_mtime

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -339,35 +339,33 @@ class TestConvertRemoveMissing(ConvertPluginHelper, ConvertCommand):
             "format": "mp3",
         }
 
-    def create_dummy_file(self, path: str) -> Path:
+    def create_dummy_file(self, filename: str) -> Path:
         "Creates a dummy file in the conversion directory"
-        p = self.convert_dest / path
+        p = self.convert_dest / filename
         p.parent.mkdir(parents=True, exist_ok=True)
         with p.open("w") as f:
             f.write("test")
         return p
 
     @pytest.mark.parametrize(
-        "plugin_config,cli_options,files_to_mark_for_removal,expect_removal",
+        "plugin_config,cli_options,expect_removal",
         [
-            ({}, [], ["to_remove.mp3"], False),
-            ({}, ["--remove-missing", "--pretend"], ["to_remove.mp3"], False),
-            ({}, ["--remove-missing"], ["to_remove.mp3"], True),
-            ({"remove_missing": True}, [], ["to_remove.mp3"], True),
+            ({}, [], False),
+            ({}, ["--remove-missing", "--pretend"], False),
+            ({}, ["--remove-missing"], True),
+            ({"remove_missing": True}, [], True),
         ],
     )
     def test_convert_remove_missing(
         self,
         plugin_config: dict[str, Any],
         cli_options: list[str],
-        files_to_mark_for_removal: list[str],
         expect_removal: bool,
     ):
         # This file mocks an already existing converted file that should not be
         # removed or modified.
-        file_not_to_remove = self.create_dummy_file(
-            util.syspath(self.item.path)
-        )
+        file_not_to_remove = self.item.filepath
+
         original_mtime = os.path.getmtime(file_not_to_remove)
 
         # Create files to be marked for removal
@@ -379,9 +377,8 @@ class TestConvertRemoveMissing(ConvertPluginHelper, ConvertCommand):
 
         self.run_convert("--yes", *cli_options)
 
-        # Check if files were expectedly removed or not
-        for p in paths_to_mark_for_removal:
-            assert (not p.exists()) == expect_removal
+        # Check if file was expectedly removed or not
+        assert (not path_to_mark_for_removal.exists()) == expect_removal
 
         # Check that files not to be removed are still there unmodified
         assert file_not_to_remove.exists()

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -331,7 +331,7 @@ class TestConvertRemoveMissing(ConvertPluginHelper, ConvertCommand):
             title="title", artist="artist", album="album", format="flac"
         )
 
-        self.convert_dest = self.temp_dir_path / "convert_dest"
+        self.convert_dest = self.temp_path / "convert_dest"
         self.convert_dest.mkdir(parents=True)
 
         self.config["convert"] = {

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -346,7 +346,15 @@ class ConvertRemoveMissingTest(ConvertPluginHelper, ConvertCommand):
 
         assert self.file_to_remove.exists()
 
+    def test_convert_pretend_removemissing(self):
+        self.run_convert("--yes", "--remove-missing", "--pretend")
+
+        assert self.file_to_remove.exists()
+
     def test_convert_removemissing(self):
-        self.run_convert("--remove-missing", "--yes")
+        self.run_convert("--yes", "--remove-missing")
 
         assert not self.file_to_remove.exists()
+
+        # This should hit the case where no files to remove are present
+        self.run_convert("--remove-missing", "--yes")

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -320,3 +320,34 @@ class TestNoConvert(PluginTestHelper):
         item = Item(format="ogg", bitrate=256)
         config["convert"]["no_convert"] = config_value
         assert convert.ConvertPlugin().in_no_convert(item) == should_skip
+
+
+class ConvertRemoveMissingTest(ConvertPluginHelper, ConvertCommand):
+    "Tests the effect of the `remove_missing option`"
+
+    @pytest.fixture(autouse=True)
+    def setup_removemissing(self, setup):
+        self.album = self.add_album_fixture(ext="ogg")
+        self.item = self.album.items()[0]
+
+        self.convert_dest = self.temp_dir_path / "convert_dest"
+        self.file_to_remove = self.convert_dest / "to_remove.mp3"
+        self.convert_dest.mkdir(parents=True)
+
+        self.config["convert"] = {
+            "dest": str(self.convert_dest),
+            "format": "mp3",
+        }
+
+        with self.file_to_remove.open("w") as f:
+            f.write("test")
+
+    def test_convert_not_removemissing(self):
+        self.run_convert("--yes")
+
+        assert self.file_to_remove.exists()
+
+    def test_convert_removemissing(self):
+        self.run_convert("--remove-missing", "--yes")
+
+        assert not self.file_to_remove.exists()

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -339,7 +339,7 @@ class TestConvertRemoveMissing(ConvertPluginHelper, ConvertCommand):
             "format": "mp3",
         }
 
-    def create_dummy_file(self, path):
+    def create_dummy_file(self, path: str) -> Path:
         "Creates a dummy file in the conversion directory"
         p = self.convert_dest / path
         p.parent.mkdir(parents=True, exist_ok=True)

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -327,8 +327,7 @@ class ConvertRemoveMissingTest(ConvertPluginHelper, ConvertCommand):
 
     @pytest.fixture(autouse=True)
     def setup_removemissing(self, setup):
-        self.album = self.add_album_fixture(ext="ogg")
-        self.item = self.album.items()[0]
+        self.item = self.add_item(title="title", album="album", format="ogg")
 
         self.convert_dest = self.temp_dir_path / "convert_dest"
         self.file_to_remove = self.convert_dest / "to_remove.mp3"


### PR DESCRIPTION
## Description

This PR adds a new configuration/option to the convert plugin.

The "remove_missing" option indicates that files in the convert destination directory not present in the library should be removed (asking for confirmation).

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation
- [x] Changelog
- [x] Tests

Beware that this is my first PR here, so I'm still unaware of common practices. I tried to follow the same principles that I saw in the `convert.py` file, but I'm sure a lot of them will be outdated, feel free to suggest any changes.

Also, I'm still not 100% sold on the config/option name. Let me know if you have a suggestion.