### PR TITLE
Fix to properly redact Acoustid API key when dumping configuration file

### DIFF
--- a/beetsplug/chroma.py
+++ b/beetsplug/chroma.py
@@ -169,7 +169,6 @@ def _all_releases(items):
     for item in items:
         if item.path not in _matches:
             continue
-        
         _, release_ids = _matches[item.path]
         for release_id in release_ids:
             relcounts[release_id] += 1


### PR DESCRIPTION
## Description

Fixes #6276 

Fix to properly redact Acoustid API key when dumping configuration file

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation. 
- [ ] Changelog. 
- [X ] Tests. 

As simple as it gets.  This is my first open source PR btw which is cool (though I wish it were something more interesting