### PR TITLE
Fix crash in task.imported_items

### DIFF
--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -253,7 +253,7 @@ class ImportTask(BaseImportTask):
         ):
             return self.match.items
         else:
-            assert False
+            return []
 
     def apply_metadata(self):
         """Copy metadata from match info to the items."""


### PR DESCRIPTION
## Description

Fixes #6291

I think it does not hurt if the imported_items() method returned an empty list instead of an throwing an exception if there is nothing in it!

## To Do


- [x] ~Documentation.~ 
- [ ] Changelog.
- [ ] Tests.
