### PR TITLE
Clarify TODOs in is_hidden docstring

### DIFF
--- a/beets/util/hidden.py
+++ b/beets/util/hidden.py
@@ -25,6 +25,9 @@ from pathlib import Path
 def is_hidden(path: bytes | Path) -> bool:
     """
     Determine whether the given path is treated as a 'hidden file' by the OS.
+
+    Note: A platform-specific check is performed on each invocation. Bytes
+    inputs are supported for backward compatibility.
     """
 
     if isinstance(path, bytes):


### PR DESCRIPTION
This PR clarifies existing TODOs by documenting known limitations in the
is_hidden() docstring. No behavior is changed.
