### PR TITLE
spotify, deezer: Store IDs in dedicated fields instead of MusicBrainz fields

### DIFF
--- a/docs/plugins/deezer.rst
+++ b/docs/plugins/deezer.rst
@@ -57,3 +57,13 @@ The ``deezer`` plugin provides an additional command ``deezerupdate`` to update
 the ``rank`` information from Deezer. The ``rank`` (ranges from 0 to 1M) is a
 global indicator of a song's popularity on Deezer that is updated daily based on
 streams. The higher the ``rank``, the more popular the track is.
+
+Stored Fields
+-------------
+
+When Deezer is used as a metadata source during import, the plugin stores these
+identifiers:
+
+- ``deezer_track_id``
+- ``deezer_album_id``
+- ``deezer_artist_id``

--- a/docs/plugins/spotify.rst
+++ b/docs/plugins/spotify.rst
@@ -181,3 +181,13 @@ these track attributes from Spotify:
   - ``tempo``
   - ``time_signature``
   - ``valence``
+
+Stored Fields
+-------------
+
+When Spotify is used as a metadata source during import, the plugin stores these
+identifiers:
+
+- ``spotify_track_id``
+- ``spotify_album_id``
+- ``spotify_artist_id``

--- a/test/plugins/test_deezer.py
+++ b/test/plugins/test_deezer.py
@@ -1,0 +1,97 @@
+"""Tests for the 'deezer' plugin"""
+
+from mediafile import MediaFile
+
+from beets.library import Item
+from beets.test.helper import PluginTestCase
+from beets.util import syspath
+
+
+class DeezerMediaFieldTest(PluginTestCase):
+    """Test that Deezer IDs are written to and read from media files."""
+
+    plugin = "deezer"
+
+    def test_deezer_track_id_written_to_file(self):
+        """Verify deezer_track_id is written to media files."""
+        item = self.add_item_fixture()
+        item.deezer_track_id = 123456789
+        item.write()
+
+        # Read back from file (media files store as strings)
+        mf = MediaFile(syspath(item.path))
+        assert mf.deezer_track_id == "123456789"
+
+    def test_deezer_album_id_written_to_file(self):
+        """Verify deezer_album_id is written to media files."""
+        item = self.add_item_fixture()
+        item.deezer_album_id = 987654321
+        item.write()
+
+        # Read back from file (media files store as strings)
+        mf = MediaFile(syspath(item.path))
+        assert mf.deezer_album_id == "987654321"
+
+    def test_deezer_artist_id_written_to_file(self):
+        """Verify deezer_artist_id is written to media files."""
+        item = self.add_item_fixture()
+        item.deezer_artist_id = 111222333
+        item.write()
+
+        # Read back from file (media files store as strings)
+        mf = MediaFile(syspath(item.path))
+        assert mf.deezer_artist_id == "111222333"
+
+    def test_deezer_ids_read_from_file(self):
+        """Verify Deezer IDs can be read from file into Item."""
+        item = self.add_item_fixture()
+        mf = MediaFile(syspath(item.path))
+        mf.deezer_track_id = "123456"
+        mf.deezer_album_id = "654321"
+        mf.deezer_artist_id = "999888"
+        mf.save()
+
+        # Read back into Item (beets converts to int from item_types)
+        item_reloaded = Item.from_path(item.path)
+        assert item_reloaded.deezer_track_id == 123456
+        assert item_reloaded.deezer_album_id == 654321
+        assert item_reloaded.deezer_artist_id == 999888
+
+    def test_deezer_ids_persist_across_writes(self):
+        """Verify IDs are not lost when updating other fields."""
+        item = self.add_item_fixture()
+        item.deezer_track_id = 123456
+        item.deezer_album_id = 654321
+        item.write()
+
+        # Update different field
+        item.title = "New Title"
+        item.write()
+
+        # Verify IDs still in file (media files store as strings)
+        mf = MediaFile(syspath(item.path))
+        assert mf.deezer_track_id == "123456"
+        assert mf.deezer_album_id == "654321"
+
+    def test_deezer_ids_not_in_musicbrainz_fields(self):
+        """Verify Deezer IDs don't pollute MusicBrainz fields."""
+        item = self.add_item_fixture()
+        # Set Deezer IDs
+        item.deezer_track_id = 123456789
+        item.deezer_album_id = 987654321
+        item.deezer_artist_id = 111222333
+        item.write()
+
+        # Read back and verify MusicBrainz fields are NOT set to Deezer IDs
+        mf = MediaFile(syspath(item.path))
+
+        # MusicBrainz fields should be None or empty, not Deezer IDs
+        assert mf.mb_trackid != "123456789"
+        assert mf.mb_albumid != "987654321"
+        assert mf.mb_artistid != "111222333"
+        assert mf.mb_albumartistid != "111222333"
+
+        # Deezer IDs should be in their own fields
+        assert mf.deezer_track_id == "123456789"
+        assert mf.deezer_album_id == "987654321"
+        assert mf.deezer_artist_id == "111222333"


### PR DESCRIPTION
## Description

Previously the Spotify and Deezer plugins wrote their IDs into the MusicBrainz fields. This prevents those files from being imported into Music Assistant, which checks for valid MusicBrainz IDs during import and refuses to import those files (error: “Invalid MusicBrainz identifier”).

I considered fixing this in Music Assistant, but it seemed cleaner to store Spotify and Deezer IDs in separate fields from the start.

This change adds dedicated fields when tagging and leaves the MusicBrainz ID fields untouched:

* **Spotify:** `spotify_track_id`, `spotify_album_id`, `spotify_artist_id`
* **Deezer:** `deezer_track_id`, `deezer_album_id`, `deezer_artist_id`

I’m curious whether the current behavior is considered a feature or a bug. That is, if there are any cases where populating MusicBrainz ID fields with non-MusicBrainz values is actually useful.

If this turns out to be controversial, making it configurable could be a solution, allowing users to preserve the old behavior.

Looking forward to your thoughts!

## To Do

- [x] Documentation. *Could potentially be extended, e.g., with commands to update existing files tagged before this change.*
- [ ] Changelog.
- [x] Tests.
