### PR TITLE
Add beets-fillmissing to the list of plugins

### DIFF
--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -481,6 +481,10 @@ beets-filetote_
     Helps bring non-music extra files, attachments, and artifacts during imports
     and CLI file manipulation actions (``beet move``, etc.).
 
+beets-fillmissing_
+    Interactively prompts you to fill in missing or incomplete metadata fields
+    for music tracks.
+
 beets-follow_
     Lets you check for new albums from artists you like.
 
@@ -595,6 +599,8 @@ beets-youtube_
 .. _beets-describe: https://github.com/adamjakab/BeetsPluginDescribe
 
 .. _beets-filetote: https://github.com/gtronset/beets-filetote
+
+.. _beets-fillmissing: https://github.com/amiv1/beets-fillmissing
 
 .. _beets-follow: https://github.com/nolsto/beets-follow
 


### PR DESCRIPTION
## Description

Purpose of the plugin is to make manual metadata editing faster.

I wanted to add custom metadata like "language", "mood", and "context" but existing methods felt too slow, especially when I needed to find and open the music file to playback separately. So I created this plugin and I'd like to share it with the community. It helped me to update metadata for 500 tracks in about 1.5 hours.

See plugin's [README](https://github.com/amiv1/beets-fillmissing/blob/main/README.md) file for more details.

## To Do

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] ~Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)~
- [x] ~Tests. (Very much encouraged but not strictly required.)~
