### PR TITLE
Fix symlink tests for macOS

### DIFF
--- a/test/test_files.py
+++ b/test/test_files.py
@@ -165,7 +165,7 @@ class MoveTest(BeetsTestCase):
         self.i.move(operation=MoveOperation.LINK)
         assert self.dest.exists()
         assert os.path.islink(syspath(self.dest))
-        assert self.dest.resolve() == self.path
+        assert self.dest.resolve() == self.path.resolve()
 
     @unittest.skipUnless(_common.HAVE_SYMLINK, "need symlinks")
     def test_link_does_not_depart(self):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -131,7 +131,7 @@ class NonAutotaggedImportTest(PathsMixin, AsIsImporterMixin, ImportTestCase):
 
         assert self.track_lib_path.exists()
         assert self.track_lib_path.is_symlink()
-        assert self.track_lib_path.resolve() == self.track_import_path
+        assert self.track_lib_path.resolve() == self.track_import_path.resolve()
 
     @unittest.skipUnless(_common.HAVE_HARDLINK, "need hardlinks")
     def test_import_hardlink_arrives(self):


### PR DESCRIPTION
## Description

👋🏻 I was trying to set up a local dev environment and noticed a couple of tests were failing. On macOS, temporary files are created under `/var`, which is itself a symlink to `/private/var`. This PR resolves the `assert`s against temp file paths in tests.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation~
- [x] ~Changelog~ (seems unnecessary for a tests-only fix, but I can add if you'd like)
- [x] Tests
