### PR TITLE
fetchart: gracefully handle permissions errors when setting album art

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -547,7 +547,10 @@ def move(path: bytes, dest: bytes, replace: bool = False):
             )
         finally:
             if tmp_filename:
-                os.remove(tmp_filename)
+                try:
+                    os.remove(tmp_filename)
+                except OSError:
+                    pass
 
 
 def link(path: bytes, dest: bytes, replace: bool = False):

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -1492,7 +1492,11 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             candidate = self.art_candidates.pop(task)
             removal_enabled = self._is_source_file_removal_enabled()
 
-            self._set_art(task.album, candidate, not removal_enabled)
+            try:
+                self._set_art(task.album, candidate, not removal_enabled)
+            except util.FilesystemError as exc:
+                self._log.warning("failed to set album art: {}", exc)
+                return
 
             if removal_enabled:
                 task.prune(candidate.path)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,8 @@ Bug fixes
 - :doc:`plugins/musicbrainz`: Fix fetching very large releases that have more
   than 500 tracks. :bug:`6355`
 - :doc:`plugins/badfiles`: Fix number of found errors in log message
+- :doc:`plugins/fetchart`: Gracefully handle permissions errors when setting
+  album art instead of crashing the import. :bug:`6193`
 
 ..
     For plugin developers


### PR DESCRIPTION
## Summary

Fixes #6193. When another process (e.g., foobar2000) holds a lock on the
destination file, `util.move()` raises a `PermissionError` during
`os.replace()`. The `finally` cleanup block then also fails on `os.remove()`,
masking the original error and crashing the entire import pipeline.

### Changes

**`beets/util/__init__.py`** — The `finally` block in `move()` now wraps
`os.remove(tmp_filename)` in a `try/except OSError` so it never masks the
original error when the temp file is also locked.

**`beetsplug/fetchart.py`** — `assign_art()` now catches `FilesystemError`
from `_set_art()` and logs a warning instead of letting it propagate up the
call stack and crash the import. This matches the graceful error handling
pattern already used elsewhere in fetchart (e.g., `cleanup()` at line 514).

**`docs/changelog.rst`** — Added changelog entry.

## Test plan

- Verified the fix handles the exact traceback from the issue (Windows
  `PermissionError` [WinError 32] during cross-drive art move)
- The `finally` cleanup no longer raises when the temp file is locked
- Art fetch failures now log a warning and continue the import gracefully

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments!*