### PR TITLE
lastgenre: Apply canonicalization to genres of items with no Last.fm results

### DIFF
--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -480,15 +480,11 @@ class LastGenrePlugin(plugins.BeetsPlugin):
 
         # Nothing found, leave original if configured and valid.
         if obj.genre and self.config["keep_existing"]:
-            if not self.whitelist or self._is_valid(obj.genre.lower()):
-                return obj.genre, "original fallback"
-            else:
-                # If the original genre doesn't match a whitelisted genre, check
-                # if we can canonicalize it to find a matching, whitelisted genre!
-                if result := _try_resolve_stage(
-                    "original fallback", keep_genres, []
-                ):
-                    return result
+            # Process existing genres to apply whitelist and canonicalization
+            if result := _try_resolve_stage(
+                "original fallback", keep_genres, []
+            ):
+                return result
 
         # Return fallback string.
         if fallback := self.config["fallback"].get():

--- a/beetsplug/lastgenre/genres-tree.yaml
+++ b/beetsplug/lastgenre/genres-tree.yaml
@@ -791,3 +791,5 @@
     - world fusion
     - worldbeat
 
+- '':
+  - blacklisted genre

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,8 @@ Bug fixes
 - :doc:`plugins/musicbrainz`: Fix fetching very large releases that have more
   than 500 tracks. :bug:`6355`
 - :doc:`plugins/badfiles`: Fix number of found errors in log message
+- :doc:`plugins/lastgenre`: Apply canonicalization to genres of items with no
+  Last.fm results
 
 ..
     For plugin developers

--- a/test/plugins/test_lastgenre.py
+++ b/test/plugins/test_lastgenre.py
@@ -338,7 +338,7 @@ class LastGenrePluginTest(IOMixin, PluginTestCase):
                 "album": None,
                 "artist": None,
             },
-            ("any existing", "original fallback"),
+            ("Any Existing", "keep + original fallback, any"),
         ),
         # 7.1 - Keep the original genre when force and keep_existing are on, and
         # whitelist is enabled, and genre is valid.
@@ -358,7 +358,7 @@ class LastGenrePluginTest(IOMixin, PluginTestCase):
                 "album": None,
                 "artist": None,
             },
-            ("Jazz", "original fallback"),
+            ("Jazz", "keep + original fallback, whitelist"),
         ),
         # 7.2 - Return the configured fallback when force is on but
         # keep_existing is not.
@@ -373,6 +373,26 @@ class LastGenrePluginTest(IOMixin, PluginTestCase):
                 "prefer_specific": False,
             },
             "Jazz",
+            {
+                "track": None,
+                "album": None,
+                "artist": None,
+            },
+            ("fallback genre", "fallback"),
+        ),
+        # 7.3 - Filter out genres that map to an empty string in tree when
+        # keep_existing is enabled and no Last.fm results are found
+        (
+            {
+                "force": True,
+                "keep_existing": True,
+                "source": "track",
+                "whitelist": False,
+                "fallback": "fallback genre",
+                "canonical": True,
+                "prefer_specific": False,
+            },
+            "blacklisted genre",
             {
                 "track": None,
                 "album": None,


### PR DESCRIPTION
I've been configuring my canonicalization tree to remove tags I don't like, essentially using it like a blacklist, and noticed some tags not being removed after re-running the lastgenre command.

The reason for this is that when `keep_existing` is enabled and no Last.fm results are found, the existing genres are returned as-is without being processed through `_resolve_genres()`. This means existing genres that should be filtered by the canonicalization tree are kept unchanged.

As an example, if I had this in my canonicalization tree:

```yaml
- '':
  - 'some tag'
```

and then ran lastgenre on a track with 'some tag', but which had no data on Last.fm, it wouldn't get removed from the track. This PR fixes that.