### PR TITLE
Fix missing artist-credit field in mbpseudo

### DIFF
--- a/beetsplug/_utils/musicbrainz.py
+++ b/beetsplug/_utils/musicbrainz.py
@@ -36,6 +36,33 @@ log = logging.getLogger("beets")
 
 LUCENE_SPECIAL_CHAR_PAT = re.compile(r'([-+&|!(){}[\]^"~*?:\\/])')
 
+RELEASE_INCLUDES = [
+    "artists",
+    "media",
+    "recordings",
+    "release-groups",
+    "labels",
+    "artist-credits",
+    "aliases",
+    "recording-level-rels",
+    "work-rels",
+    "work-level-rels",
+    "artist-rels",
+    "isrcs",
+    "url-rels",
+    "release-rels",
+    "genres",
+    "tags",
+]
+
+RECORDING_INCLUDES = [
+    "artists",
+    "aliases",
+    "isrcs",
+    "work-level-rels",
+    "artist-rels",
+]
+
 
 class LimiterTimeoutSession(LimiterMixin, TimeoutAndRetrySession):
     """HTTP session that enforces rate limits."""
@@ -223,12 +250,14 @@ class MusicBrainzAPI(RequestHandler):
 
     def get_release(self, id_: str, **kwargs: Unpack[LookupKwargs]) -> JSONDict:
         """Retrieve a release by its MusicBrainz ID."""
+        kwargs.setdefault("includes", RELEASE_INCLUDES)
         return self._lookup("release", id_, **kwargs)
 
     def get_recording(
         self, id_: str, **kwargs: Unpack[LookupKwargs]
     ) -> JSONDict:
         """Retrieve a recording by its MusicBrainz ID."""
+        kwargs.setdefault("includes", RECORDING_INCLUDES)
         return self._lookup("recording", id_, **kwargs)
 
     def get_work(self, id_: str, **kwargs: Unpack[LookupKwargs]) -> JSONDict:

--- a/beetsplug/musicbrainz.py
+++ b/beetsplug/musicbrainz.py
@@ -60,34 +60,6 @@ FIELDS_TO_MB_KEYS = {
     "alias": "alias",
 }
 
-
-RELEASE_INCLUDES = [
-    "artists",
-    "media",
-    "recordings",
-    "release-groups",
-    "labels",
-    "artist-credits",
-    "aliases",
-    "recording-level-rels",
-    "work-rels",
-    "work-level-rels",
-    "artist-rels",
-    "isrcs",
-    "url-rels",
-    "release-rels",
-    "genres",
-    "tags",
-]
-
-TRACK_INCLUDES = [
-    "artists",
-    "aliases",
-    "isrcs",
-    "work-level-rels",
-    "artist-rels",
-]
-
 BROWSE_INCLUDES = [
     "artist-credits",
     "work-rels",
@@ -797,7 +769,7 @@ class MusicBrainzPlugin(MusicBrainzAPIMixin, MetadataSourcePlugin):
         # A 404 error here is fine. e.g. re-importing a release that has
         # been deleted on MusicBrainz.
         try:
-            res = self.mb_api.get_release(albumid, includes=RELEASE_INCLUDES)
+            res = self.mb_api.get_release(albumid)
         except HTTPNotFoundError:
             self._log.debug("Release {} not found on MusicBrainz.", albumid)
             return None
@@ -813,9 +785,7 @@ class MusicBrainzPlugin(MusicBrainzAPIMixin, MetadataSourcePlugin):
                     rel["type"] == "transl-tracklisting"
                     and rel["direction"] == "backward"
                 ):
-                    actual_res = self.mb_api.get_release(
-                        rel["release"]["id"], includes=RELEASE_INCLUDES
-                    )
+                    actual_res = self.mb_api.get_release(rel["release"]["id"])
 
         # release is potentially a pseudo release
         release = self.album_info(res)
@@ -838,8 +808,6 @@ class MusicBrainzPlugin(MusicBrainzAPIMixin, MetadataSourcePlugin):
             return None
 
         with suppress(HTTPNotFoundError):
-            return self.track_info(
-                self.mb_api.get_recording(trackid, includes=TRACK_INCLUDES)
-            )
+            return self.track_info(self.mb_api.get_recording(trackid))
 
         return None

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,8 @@ Bug fixes
 - :doc:`plugins/badfiles`: Fix number of found errors in log message
 - :doc:`plugins/replaygain`: Avoid magic Windows prefix in calls to command
   backends, such as ``mp3gain``. :bug:`2946`
+- :doc:`plugins/mbpseudo`: Fix crash due to missing ``artist_credit`` field in
+  the MusicBrainz API response. :bug:`6339`
 
 ..
     For plugin developers


### PR DESCRIPTION
Fixes #6339

This change moves MusicBrainz lookup defaults into `beetsplug/_utils/musicbrainz.py` so `MusicBrainzAPI` now owns the default `includes` for both `get_release` and `get_recording`.

#### Architecture impact

- Added centralized defaults: `RELEASE_INCLUDES` and `RECORDING_INCLUDES` in `MusicBrainzAPI`.
- Updated `get_release` and `get_recording` to apply these defaults via `kwargs.setdefault("includes", ...)`.
- Removed duplicated include lists from `beetsplug/musicbrainz.py` and simplified call sites to `self.mb_api.get_release(...)` / `self.mb_api.get_recording(...)` without passing includes explicitly.

#### High-level result

- Ensures consistent MusicBrainz payload shape across callers.
- Fixes the `mbpseudo` failure caused by missing `artist_credit` data in some responses.
- Reduces coupling and duplication by making include policy an API-layer concern.
