### PR TITLE
docs: Document match.distance_weights in autotagger config

### DIFF
--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -925,7 +925,7 @@ making them more important in the matching decision.
 
 The defaults are:
 
-::
+.. code-block:: yaml
 
     match:
         distance_weights:
@@ -953,7 +953,7 @@ The defaults are:
 For example, if you don't care as much about matching the exact release year,
 you can reduce its weight:
 
-::
+.. code-block:: yaml
 
     match:
         distance_weights:


### PR DESCRIPTION
## Summary

Add documentation for the `match.distance_weights` configuration option in the autotagger matching section of the reference docs.

The section includes:
- Description of what distance weights control
- Complete list of all available fields with their default values
- Example showing how to customize a specific weight
- Note that only overridden fields need to be specified

Closes #6081