### PR TITLE
Clarify %if template behavior

### DIFF
--- a/docs/reference/pathformat.rst
+++ b/docs/reference/pathformat.rst
@@ -62,9 +62,9 @@ These functions are built in to beets:
 - ``%left{text,n}``: Return the first ``n`` characters of ``text``.
 - ``%right{text,n}``: Return the last ``n`` characters of ``text``.
 - ``%if{condition,text}`` or ``%if{condition,truetext,falsetext}``: If
-  ``condition`` is not empty, and not one of the values ``0`` or ``false``
-  (case insensitive), then returns the second argument. Otherwise, returns the
-  third argument if specified (or nothing if ``falsetext`` is left off).
+  ``condition`` is not empty, and not one of the values ``0`` or ``false`` (case
+  insensitive), then returns the second argument. Otherwise, returns the third
+  argument if specified (or nothing if ``falsetext`` is left off).
 - ``%asciify{text}``: Convert non-ASCII characters to their ASCII equivalents.
   For example, "café" becomes "cafe". Uses the mapping provided by the
   `unidecode module`_. See the :ref:`asciify-paths` configuration option.


### PR DESCRIPTION
## Description

Fixes #4991.  <!-- Insert issue number here if applicable. -->

I don't know if there's a single, good workaround for this, so I opted to not add an example solution. 

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
