### PR TITLE
feat(lastgenre): Add fallback_original

### DIFF
--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -106,6 +106,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 "min_weight": 10,
                 "count": 1,
                 "fallback": None,
+                "fallback_original": False,
                 "canonical": False,
                 "cleanup_existing": False,
                 "source": "album",
@@ -404,8 +405,14 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 if result := _try_resolve_stage("cleanup", keep_genres, []):
                     return result
 
-                # Return fallback string (None if not set).
-                return self.config["fallback"].get(), "fallback"
+                # If configured, keep the original genre information if the genres
+                # could not be resolved/cleaned up or nothing survived the whitelist.
+                #
+                # Otherwise return the fallback string (None if not set).
+                if self.config["fallback_original"]:
+                    return genres, "fallback + original, no-force"
+                else:
+                    return self.config["fallback"].get(), "fallback + no-force"
 
             # If cleanup_existing is not set, the pre-populated tags are
             # returned as-is.
@@ -494,6 +501,11 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 "original fallback", keep_genres, []
             ):
                 return result
+
+        # If configured, keep the original genre information if the genres
+        # could not be resolved/cleaned up or nothing survived the whitelist.
+        if genres and self.config["force"] and self.config["fallback_original"]:
+            return genres, "fallback + original, force"
 
         # Return fallback as a list.
         if fallback := self.config["fallback"].get():

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,9 @@ Unreleased
 New features
 ~~~~~~~~~~~~
 
+- :doc:`plugins/lastgenre`: Added ``fallback_original`` configuration flag. This
+  allows users to keep the original genre information, if no genres remain after
+  canonicalization and whitelisting.
 - :doc:`plugins/lastgenre`: Added ``cleanup_existing`` configuration flag to
   allow whitelist canonicalization of existing genres.
 - Add native support for multiple genres per album/track. The ``genres`` field

--- a/docs/plugins/lastgenre.rst
+++ b/docs/plugins/lastgenre.rst
@@ -173,12 +173,15 @@ file. The available options are:
 - **cleanup_existing**: This option only takes effect with ``force: no``,
   Setting this to ``yes`` will result in cleanup of existing genres. That
   includes canonicalization and whitelisting, if enabled. If no matching genre
-  can be determined, the ``fallback`` is used instead. Default: ``no``
-  (disabled).
+  can be determined, the ``fallback`` is used instead, or ``fallback_original``,
+  if set. Default: ``no`` (disabled).
 - **count**: Number of genres to fetch. Default: 1
 - **fallback**: A string to use as a fallback genre when no genre is found
   ``or`` the original genre is not desired to be kept (``keep_existing: no``).
   You can use the empty string ``''`` to reset the genre. Default: None.
+- **fallback_original**: Setting this to ``yes`` will preserve existing genres
+  instead of deleting them or setting them to ``fallback`` when no genres are
+  found or when none match the canonical whitelist. Default: ``no``.
 - **force**: By default, lastgenre will fetch new genres for empty tags only,
   enable this option to always try to fetch new last.fm genres. Enable the
   ``keep_existing`` option to combine existing and new genres. (see `Handling

--- a/test/plugins/test_lastgenre.py
+++ b/test/plugins/test_lastgenre.py
@@ -419,7 +419,40 @@ def config(config):
             },
             (["fallback genre"], "fallback"),
         ),
-        # fallback to fallback if no original
+        # Keep the original genre when force is on, whitelist is enabled,
+        # but no valid genre can be found and fallback_original is on.
+        (
+            {
+                "force": True,
+                "keep_existing": False,
+                "source": "track",
+                "whitelist": True,
+                "canonical": True,
+                "fallback_original": True,
+            },
+            ["Jazzers-invalid"],
+            {
+                "track": None,
+                "album": None,
+                "artist": None,
+            },
+            (["Jazzers-invalid"], "fallback + original, force"),
+        ),
+        # Keep the original genre when force is off, whitelist and cleanup_existing is
+        # enabled, but no valid genre can be found and fallback_original is on.
+        (
+            {
+                "force": False,
+                "cleanup_existing": True,
+                "whitelist": True,
+                "fallback_original": True,
+                "canonical": True,
+            },
+            ["Jazzers-invalid"],
+            {},
+            (["Jazzers-invalid"], "fallback + original, no-force"),
+        ),
+        # Fallback to fallback if no original
         (
             {
                 "force": True,


### PR DESCRIPTION
## Description

Fixes #6318

Adds the `fallback_original` flag.

When no genres can be found or no genres match the canonical whitelist, setting this to `yes` will result in existing genres to be preserved, instead of deleting them or setting them to `fallback`.

This is for people that would rather have a bit of non-canonicalized genre info than fully loose the existing genre data.

---

@JOJ0  This is the last feature pull request I have in the pipeline ;D 
This is more of a QoL feature that is nice to have, but not super important.

In case you think this is too specific, feel free to close the MR and the related issue :)   

Cheers and thanks for your work and the reviews!

## To Do

- [x] Documentation.
- [x] Changelog.
- [x] Tests.