### PR TITLE
play: Add -R/--randomize option to `play` plugin

### DIFF
--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -14,6 +14,7 @@
 
 """Send the results of a query to the configured music player as a playlist."""
 
+import random
 import shlex
 import subprocess
 from os.path import relpath
@@ -93,6 +94,12 @@ class PlayPlugin(BeetsPlugin):
             help="add additional arguments to the command",
         )
         play_command.parser.add_option(
+            "-R",
+            "--randomize",
+            action="store_true",
+            help="randomize the order of playlist entries",
+        )
+        play_command.parser.add_option(
             "-y",
             "--yes",
             action="store_true",
@@ -135,6 +142,9 @@ class PlayPlugin(BeetsPlugin):
         if not selection:
             ui.print_(colorize("text_warning", f"No {item_type} to play."))
             return
+
+        if opts.randomize:
+            random.shuffle(paths)
 
         open_args = self._playlist_or_paths(paths)
         open_args_str = [

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,8 @@ New features
   specify MusicBrainz release types to show using the ``--release-type`` flag.
   The default behavior is also changed to just show releases of type ``album``.
   :bug:`2661`
+- :doc:`plugins/play`: Added ``-R``/``--randomize`` flag to shuffle the playlist
+  order before passing it to the player.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/plugins/play.rst
+++ b/docs/plugins/play.rst
@@ -120,6 +120,13 @@ The ``--yes`` (or ``-y``) flag to the ``play`` command will skip the warning
 message if you choose to play more items than the **warning_threshold** value
 usually allows.
 
+The ``--randomize`` (or ``-R``) flag shuffles the order of playlist entries
+before passing it to the player:
+
+::
+
+    $ beet play --randomize my query
+
 Note on the Leakage of the Generated Playlists
 ----------------------------------------------
 

--- a/test/plugins/test_play.py
+++ b/test/plugins/test_play.py
@@ -145,6 +145,38 @@ class PlayPluginTest(IOMixin, CleanupModulesMixin, PluginTestCase):
             expected_playlist=expected_playlist,
         )
 
+    def _playlist_lines(self, open_mock):
+        """Read the playlist file passed to interactive_open and return its lines."""
+        # interactive_open is called as: interactive_open([playlist_path], command)
+        playlist_path = open_mock.call_args[0][0][0]
+        with open(playlist_path, "rb") as playlist:
+            return playlist.read().decode("utf-8").splitlines()
+
+    def _add_many_ordered_items(self, *, count, album):
+        items = []
+        for track in range(1, count + 1):
+            items.append(
+                self.add_item(
+                    album=album,
+                    artist="randomize artist",
+                    title=f"randomize {track:03d}",
+                    track=track,
+                )
+            )
+        return items
+
+    def test_randomize(self, open_mock):
+        album = "randomize_test"
+        items = self._add_many_ordered_items(count=100, album=album)
+        baseline = [str(item.filepath) for item in items]
+
+        self.run_command("play", "-R", f"album:{album}")
+        lines = self._playlist_lines(open_mock)
+        assert sorted(lines) == sorted(baseline), (
+            "playlist items are not the same"
+        )
+        assert lines != baseline, "playlist order hasn't changed"
+
     def test_command_failed(self, open_mock):
         open_mock.side_effect = OSError("some reason")
 


### PR DESCRIPTION
## Description

I really wanted to combine `random` with `play` to shuffle tracks in a temporary playlist, but couldn't find easy way to do it. I'd like to introduce a new flag `-R / --randomize` to the `play` plugin to shuffle tracks before passing them to the player.

I couldn't really decide between `-r` and `-R`, not sure if there's any rule there. If you believe lower case would be better, just let me know.

## To Do

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
