### PR TITLE
fetchart: handle sources config given as plain string

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -1413,6 +1413,13 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             if s_cls.available(self._log, self.config)
             for c in s_cls.VALID_MATCHING_CRITERIA
         ]
+        # When 'sources' is given as a plain string (e.g. "sources: filesystem"
+        # instead of "sources: [filesystem]"), confuse's Pairs template
+        # iterates over individual characters instead of treating it as a
+        # single-item list. Normalize to a list first via as_str_seq().
+        raw_sources = self.config["sources"].get()
+        if isinstance(raw_sources, str):
+            self.config["sources"].set(raw_sources.split())
         sources = sanitize_pairs(
             self.config["sources"].as_pairs(default_value="*"),
             available_sources,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -36,6 +36,9 @@ Bug fixes
 - :ref:`replace`: Made ``drive_sep_replace`` regex logic more precise to prevent
   edge-case mismatches (e.g., a song titled "1:00 AM" would incorrectly be
   considered a Windows drive path).
+- :doc:`plugins/fetchart`: Fix ``sources`` config given as a plain string
+  (e.g. ``sources: filesystem``) being parsed character-by-character instead of
+  as a single source name. :bug:`6336`
 - :doc:`plugins/fish`: Fix AttributeError. :bug:`6340`
 - :ref:`import-cmd` Autotagging by explicit release or recording IDs now keeps
   candidates from all enabled metadata sources instead of dropping matches when

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -1047,3 +1047,28 @@ class EnforceRatioConfigTest(unittest.TestCase):
     def test_percent(self):
         self._load_with_config("0% 0.00% 5.1% 5% 100%".split(), False)
         self._load_with_config("00% 1.234% foo5% 100.1%".split(), True)
+
+
+class SourcesConfigTest(unittest.TestCase):
+    """Test that the 'sources' config option handles both list and plain
+    string values correctly.
+    """
+
+    def test_sources_as_list(self):
+        config["fetchart"]["sources"] = ["filesystem"]
+        plugin = fetchart.FetchArtPlugin()
+        assert len(plugin.sources) == 1
+        assert isinstance(plugin.sources[0], fetchart.FileSystem)
+
+    def test_sources_as_string(self):
+        config["fetchart"]["sources"] = "filesystem"
+        plugin = fetchart.FetchArtPlugin()
+        assert len(plugin.sources) == 1
+        assert isinstance(plugin.sources[0], fetchart.FileSystem)
+
+    def test_sources_as_space_separated_string(self):
+        config["fetchart"]["sources"] = "filesystem coverart"
+        plugin = fetchart.FetchArtPlugin()
+        ids = [type(s).ID for s in plugin.sources]
+        assert "filesystem" in ids
+        assert "coverart" in ids


### PR DESCRIPTION
## Summary
- Fix `fetchart` failing with "no art found" when `sources` is configured as a plain string (e.g. `sources: filesystem`) instead of a list (`sources: [filesystem]`).
- In confuse 2.2.0, the `Pairs` template no longer inherits `StrSeq`'s string-to-list normalization, so a bare string gets iterated character by character. This normalizes the value to a list before passing it to `as_pairs()`.
- Adds tests for both string and list forms of the `sources` config.

Fixes #6336
Related: #5962

## Test plan
- [x] Existing fetchart tests pass
- [ ] New tests verify `sources: filesystem` (string), `sources: [filesystem]` (list), and `sources: filesystem coverart` (space-separated string) all produce the correct source objects