### PR TITLE
Use va_name config for all artist fields on VA releases

### DIFF
--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -31,6 +31,7 @@ from requests_oauthlib.oauth1_session import (
 
 import beets
 import beets.ui
+from beets import config
 from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.metadata_plugins import MetadataSourcePlugin
 from beets.util import unique_list
@@ -459,7 +460,7 @@ class BeatportPlugin(MetadataSourcePlugin):
         va = release.artists is not None and len(release.artists) > 3
         artist, artist_id = self._get_artist(release.artists)
         if va:
-            artist = "Various Artists"
+            artist = config["va_name"].as_str()
         tracks: list[TrackInfo] = []
         if release.tracks is not None:
             tracks = [self._get_track_info(x) for x in release.tracks]

--- a/beetsplug/musicbrainz.py
+++ b/beetsplug/musicbrainz.py
@@ -572,7 +572,13 @@ class MusicBrainzPlugin(
         )
         info.va = info.artist_id == VARIOUS_ARTISTS_ID
         if info.va:
-            info.artist = config["va_name"].as_str()
+            va_name = config["va_name"].as_str()
+            info.artist = va_name
+            info.artist_sort = va_name
+            info.artists = [va_name]
+            info.artists_sort = [va_name]
+            info.artist_credit = va_name
+            info.artists_credit = [va_name]
         info.asin = release.get("asin")
         info.releasegroup_id = release["release-group"]["id"]
         info.albumstatus = release.get("status")

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,12 @@ Bug fixes
   different providers share the same ID. :bug:`6178` :bug:`6181`
 - :doc:`plugins/mbsync` and :doc:`plugins/missing` now use each item's stored
   ``data_source`` for ID lookups, with a fallback to ``MusicBrainz``.
+- :doc:`plugins/musicbrainz`: Use ``va_name`` config for ``albumartist_sort``,
+  ``albumartists_sort``, ``albumartist_credit``, ``albumartists_credit``, and
+  ``albumartists`` on VA releases instead of hardcoded "Various Artists".
+  :bug:`6316`
+- :doc:`plugins/beatport`: Use ``va_name`` config for the album artist on VA
+  releases instead of hardcoded "Various Artists". :bug:`6316`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

Fixes #6316

When importing compilations/various artists albums, several fields used the
hardcoded string "Various Artists" instead of the user-configured `va_name`
setting:

- In the **musicbrainz plugin**, only `info.artist` was overridden with `va_name`
  when a release was identified as VA. The `artist_sort`, `artists_sort`,
  `artist_credit`, `artists_credit`, and `artists` fields were left with the raw
  MusicBrainz value ("Various Artists"), which then propagated to
  `albumartist_sort`, `albumartists_sort`, `albumartist_credit`,
  `albumartists_credit`, and `albumartists` on items.

- In the **beatport plugin**, the VA artist name was hardcoded to
  "Various Artists" instead of reading from config.

## Changes

- `beetsplug/musicbrainz.py`: When `info.va` is true, override all artist-related
  fields (`artist_sort`, `artists`, `artists_sort`, `artist_credit`,
  `artists_credit`) with `va_name`, not just `artist`.
- `beetsplug/beatport.py`: Replace hardcoded "Various Artists" with
  `config["va_name"].as_str()`.
- `docs/changelog.rst`: Add changelog entries for both fixes.

## Test plan

- Import a VA album from MusicBrainz with a custom `va_name` setting (e.g.,
  `va_name: "Artistes divers"`) and verify that `albumartist_sort`,
  `albumartists_sort`, `albumartist_credit`, `albumartists_credit`, and
  `albumartists` all use the configured value.
- Run `beet mbsync` on an existing VA album after changing `va_name` and verify
  the sort/credit fields update correctly.
- Verify that without a custom `va_name`, the default "Various Artists" is still
  used everywhere (no behavior change for default config).