### PR TITLE
Rename play_count -> lastfm_play_count in lastimport due to clash with mpdstats

### DIFF
--- a/beetsplug/lastimport.py
+++ b/beetsplug/lastimport.py
@@ -40,7 +40,7 @@ class LastImportPlugin(plugins.BeetsPlugin):
             }
         )
         self.item_types = {
-            "play_count": types.INTEGER,
+            "lastfm_play_count": types.INTEGER,
         }
 
     def commands(self):
@@ -265,16 +265,16 @@ def process_tracks(lib, tracks, log):
             song = lib.items(query).get()
 
         if song is not None:
-            count = int(song.get("play_count", 0))
-            new_count = int(tracks[num].get("playcount", 1))
+            count = int(song.get("lastfm_play_count", 0))
+            new_count = int(tracks[num]["playcount"])
             log.debug(
                 "match: {0.artist} - {0.title} ({0.album}) updating:"
-                " play_count {1} => {2}",
+                " lastfm_play_count {1} => {2}",
                 song,
                 count,
                 new_count,
             )
-            song["play_count"] = new_count
+            song["lastfm_play_count"] = new_count
             song.store()
             total_found += 1
         else:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -51,6 +51,11 @@ Bug fixes
 - :ref:`config-cmd` on Windows now uses ``cmd /c start ""`` for the default
   editor fallback so ``beet config -e`` works when ``VISUAL`` and ``EDITOR`` are
   unset. :bug:`6436`
+- :doc:`plugins/lastimport`: Rename flexible field ``play_count`` to
+  ``lastfm_play_count`` to avoid conflicts with :doc:`plugins/mpdstats`.
+  **Migration**: This cannot be migrated automatically because of the field
+  clash. If you use ``lastimport`` without ``mpdstats``, migrate manually with
+  ``beet modify lastfm_play_count='$play_count'``.
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/plugins/lastimport.rst
+++ b/docs/plugins/lastimport.rst
@@ -3,8 +3,8 @@ LastImport Plugin
 
 The ``lastimport`` plugin downloads play-count data from your Last.fm_ library
 into beets' database. You can later create :doc:`smart playlists
-</plugins/smartplaylist>` by querying ``play_count`` and do other fun stuff with
-this field.
+</plugins/smartplaylist>` by querying ``lastfm_play_count`` and do other fun
+stuff with this field.
 
 .. _last.fm: https://www.last.fm/
 
@@ -32,16 +32,21 @@ Simply run ``beet lastimport`` and wait for the plugin to request tracks from
 Last.fm and match them to your beets library. (You will be notified of tracks in
 your Last.fm profile that do not match any songs in your library.)
 
-Then, your matched tracks will be populated with the ``play_count`` field, which
-you can use in any query or template. For example:
+Then, your matched tracks will be populated with the ``lastfm_play_count``
+field, which you can use in any query or template. For example:
 
 ::
 
-    $ beet ls -f '$title: $play_count' play_count:5..
+    $ beet ls -f '$title: $lastfm_play_count' lastfm_play_count:5..
     Eple (Melody A.M.): 60
 
 To see more information (namely, the specific play counts for matched tracks),
 use the ``-v`` option.
+
+.. versionchanged:: 2.8.0
+
+    The ``play_count`` field was renamed to ``lastfm_play_count`` to avoid
+    confusion with ``play_count`` field populated by :doc:`mpdstats` plugin.
 
 Configuration
 -------------


### PR DESCRIPTION
## `lastimport`: Rename `play_count` field to `lastfm_play_count`

Renames the flexible field written by the `lastimport` plugin from `play_count` to `lastfm_play_count` to avoid a silent collision with the same-named field written by the `mpdstats` plugin.

### Impact

- **Breaking change**: existing databases with `play_count` populated by `lastimport` must be migrated manually — automatic migration is not possible due to the field name clash. Users are instructed to run `beet modify lastfm_play_count='$play_count'`.
