### PR TITLE
Fix Windows fallback for beet config -e when no editor is set

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -934,7 +934,8 @@ def open_anything() -> str:
     if sys_name == "Darwin":
         base_cmd = "open"
     elif sys_name == "Windows":
-        base_cmd = "start"
+        # `start` is a cmd.exe builtin, so invoke it through the shell.
+        base_cmd = 'cmd /c start ""'
     else:  # Assume Unix
         base_cmd = "xdg-open"
     return base_cmd

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -49,8 +49,8 @@ Bug fixes
 - :doc:`plugins/beatport`: Use ``va_name`` config for the album artist on VA
   releases instead of hardcoded "Various Artists". :bug:`6316`
 - :ref:`config-cmd` on Windows now uses ``cmd /c start ""`` for the default
-  editor fallback so ``beet config -e`` works when ``VISUAL`` and ``EDITOR``
-  are unset. :bug:`6436`
+  editor fallback so ``beet config -e`` works when ``VISUAL`` and ``EDITOR`` are
+  unset. :bug:`6436`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -48,6 +48,9 @@ Bug fixes
   :bug:`6316`
 - :doc:`plugins/beatport`: Use ``va_name`` config for the album artist on VA
   releases instead of hardcoded "Various Artists". :bug:`6316`
+- :ref:`config-cmd` on Windows now uses ``cmd /c start ""`` for the default
+  editor fallback so ``beet config -e`` works when ``VISUAL`` and ``EDITOR``
+  are unset. :bug:`6436`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -31,7 +31,7 @@ from beets.test import _common
 class UtilTest(unittest.TestCase):
     def test_open_anything(self):
         with _common.system_mock("Windows"):
-            assert util.open_anything() == "start"
+            assert util.open_anything() == 'cmd /c start ""'
 
         with _common.system_mock("Darwin"):
             assert util.open_anything() == "open"
@@ -49,6 +49,13 @@ class UtilTest(unittest.TestCase):
 
         util.interactive_open(["foo"], "bar")
         mock_execlp.assert_called_once_with("bar", "bar", "foo")
+
+    @patch("os.execlp")
+    def test_interactive_open_windows_start_command(self, mock_execlp):
+        util.interactive_open(["foo"], 'cmd /c start ""')
+        mock_execlp.assert_called_once_with(
+            "cmd", "cmd", "/c", "start", "", "foo"
+        )
 
     def test_sanitize_unix_replaces_leading_dot(self):
         with _common.platform_posix():

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -50,13 +50,6 @@ class UtilTest(unittest.TestCase):
         util.interactive_open(["foo"], "bar")
         mock_execlp.assert_called_once_with("bar", "bar", "foo")
 
-    @patch("os.execlp")
-    def test_interactive_open_windows_start_command(self, mock_execlp):
-        util.interactive_open(["foo"], 'cmd /c start ""')
-        mock_execlp.assert_called_once_with(
-            "cmd", "cmd", "/c", "start", "", "foo"
-        )
-
     def test_sanitize_unix_replaces_leading_dot(self):
         with _common.platform_posix():
             p = util.sanitize_path("one/.two/three")

--- a/test/ui/commands/test_config.py
+++ b/test/ui/commands/test_config.py
@@ -5,6 +5,7 @@ import pytest
 import yaml
 
 from beets import config, ui
+from beets.test import _common
 from beets.test.helper import BeetsTestCase, IOMixin
 
 
@@ -108,6 +109,22 @@ class ConfigCommandTest(IOMixin, BeetsTestCase):
                 self.run_command("config", "-e")
         execlp.assert_called_once_with(
             "please_open", "please_open", self.config_path
+        )
+
+    def test_edit_config_with_windows_default_open(self):
+        with (
+            _common.system_mock("Windows"),
+            patch("os.execlp") as execlp,
+        ):
+            self.run_command("config", "-e")
+
+        execlp.assert_called_once_with(
+            "cmd",
+            "cmd",
+            "/c",
+            "start",
+            "",
+            self.config_path,
         )
 
     def test_config_editor_not_found(self):

--- a/test/ui/commands/test_config.py
+++ b/test/ui/commands/test_config.py
@@ -5,7 +5,6 @@ import pytest
 import yaml
 
 from beets import config, ui
-from beets.test import _common
 from beets.test.helper import BeetsTestCase, IOMixin
 
 
@@ -109,22 +108,6 @@ class ConfigCommandTest(IOMixin, BeetsTestCase):
                 self.run_command("config", "-e")
         execlp.assert_called_once_with(
             "please_open", "please_open", self.config_path
-        )
-
-    def test_edit_config_with_windows_default_open(self):
-        with (
-            _common.system_mock("Windows"),
-            patch("os.execlp") as execlp,
-        ):
-            self.run_command("config", "-e")
-
-        execlp.assert_called_once_with(
-            "cmd",
-            "cmd",
-            "/c",
-            "start",
-            "",
-            self.config_path,
         )
 
     def test_config_editor_not_found(self):


### PR DESCRIPTION
## Description

Fixes #6436.

On Windows, `beet config -e` falls back to `open_anything()` when `VISUAL`/`EDITOR` are unset. That fallback returned `start`, but `start` is a `cmd.exe` builtin (not an executable), so `os.execlp()` raised `FileNotFoundError`.

This changes the Windows fallback command to `cmd /c start ""` so the builtin is invoked via the shell and file opening works as intended.

## Changes

- Update `open_anything()` Windows fallback to `cmd /c start ""`.
- Add regression test for `interactive_open()` with the Windows fallback command.
- Add regression test for `beet config -e` on simulated Windows with no editor env vars.
- Add changelog entry under Unreleased bug fixes.

## To Do

- [x] ~Documentation~
- [x] Changelog
- [x] Tests
