### PR TITLE
docs: Update links to `pipx` installation guide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -74,7 +74,7 @@ virtual environment, where its dependencies will not interfere with your system
 and other CLI tools.
 
 If you do not have pipx_ installed in your system, follow `pipx installation
-instructions <https://pipx.pypa.io/stable/installation/>`__ or
+instructions <https://pipx.pypa.io/stable/how-to/install-pipx/>`__ or
 
 .. code-block:: sh
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -88,6 +88,8 @@ Other changes
   management with pipx and move package manager instructions to the FAQ.
 - :doc:`guides/main`: Update quick installation section to reflect current
   installation guide structure.
+- :doc:`guides/installation`: Update pipx installation guide link
+- :doc:`contributing`: Update pipx installation guide link
 
 2.7.1 (March 08, 2026)
 ----------------------

--- a/docs/guides/installation.rst
+++ b/docs/guides/installation.rst
@@ -43,7 +43,7 @@ installation page`_ to get it set up.
 
 .. _pipx: https://pipx.pypa.io/stable
 
-.. _pipx installation page: https://pipx.pypa.io/stable/installation/
+.. _pipx installation page: https://pipx.pypa.io/stable/how-to/install-pipx/
 
 Managing Plugins with ``pipx``
 ------------------------------


### PR DESCRIPTION
## Description

The [old link](https://pipx.pypa.io/stable/installation/) now responds with 404.

## To Do

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] ~~Tests. (Very much encouraged but not strictly required.)~~
