### PR TITLE
Clarify changelog notes that the genre field is gone

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -135,10 +135,10 @@ New features
   allow whitelist canonicalization of existing genres.
 - Add native support for multiple genres per album/track. The ``genres`` field
   now stores genres as a list and is written to files as multiple individual
-  genre tags (e.g., separate GENRE tags for FLAC/MP3). The
-  :doc:`plugins/musicbrainz`, :doc:`plugins/beatport`, :doc:`plugins/discogs`
-  and :doc:`plugins/lastgenre` plugins have been updated to populate the
-  ``genres`` field as a list.
+  genre tags (e.g., separate GENRE tags for FLAC/MP3) while the singular
+  ``genre`` field has been removed. The :doc:`plugins/musicbrainz`,
+  :doc:`plugins/beatport`, :doc:`plugins/discogs` and :doc:`plugins/lastgenre`
+  plugins have been updated to populate the ``genres`` field as a list.
 
   **Migration**: Existing libraries with comma-separated, semicolon-separated,
   or slash-separated genre strings (e.g., ``"Rock, Alternative, Indie"``) are
@@ -149,8 +149,8 @@ New features
   command that writes tags (such as ``beet write`` or during import). No manual
   action or ``mbsync`` is required.
 
-  The ``genre`` field is split by the first separator found in the string, in
-  the following order of precedence:
+  The existing values in the legacy ``genre`` field are split by the first
+  separator found in the string, in the following order of precedence:
 
   1. :doc:`plugins/lastgenre` ``separator`` configuration
   2. Semicolon followed by a space


### PR DESCRIPTION
Added a sentence to clarify that `genre` field has been removed.
