### PR TITLE
Remove dead code identified by static analysis

### DIFF
--- a/beets/dbcore/types.py
+++ b/beets/dbcore/types.py
@@ -204,14 +204,6 @@ class PaddedInt(BasePaddedInt[int]):
     pass
 
 
-class NullPaddedInt(BasePaddedInt[None]):
-    """Same as `PaddedInt`, but does not normalize `None` to `0`."""
-
-    @property
-    def null(self) -> None:
-        return None
-
-
 class ScaledInt(Integer):
     """An integer whose formatting operation scales the number by a
     constant and adds a suffix. Good for units with large magnitudes.

--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -343,17 +343,6 @@ class FtInTitlePlugin(plugins.BeetsPlugin):
         )
         return True
 
-    @staticmethod
-    def find_bracket_position(
-        title: str, keywords: list[str] | None = None
-    ) -> int | None:
-        normalized = (
-            DEFAULT_BRACKET_KEYWORDS if keywords is None else tuple(keywords)
-        )
-        pattern = FtInTitlePlugin._bracket_position_pattern(normalized)
-        m: re.Match[str] | None = pattern.search(title)
-        return m.start() if m else None
-
     @classmethod
     def insert_ft_into_title(
         cls, title: str, feat_part: str, keywords: list[str] | None = None

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -257,15 +257,3 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
         # Fetch and return tracks from the selected playlist
         playlist = self.get_playlist(selected_playlist.get("identifier"))
         return self.get_tracks_from_playlist(playlist)
-
-    def get_weekly_exploration(self):
-        return self.get_weekly_playlist("Exploration", most_recent=True)
-
-    def get_weekly_jams(self):
-        return self.get_weekly_playlist("Jams", most_recent=True)
-
-    def get_last_weekly_exploration(self):
-        return self.get_weekly_playlist("Exploration", most_recent=False)
-
-    def get_last_weekly_jams(self):
-        return self.get_weekly_playlist("Jams", most_recent=False)

--- a/beetsplug/mbcollection.py
+++ b/beetsplug/mbcollection.py
@@ -148,13 +148,6 @@ class MBCollection:
             self.mb_api.delete(f"{self.releases_url}/{'%3B'.join(chunk)}")
 
 
-def submit_albums(collection: MBCollection, release_ids):
-    """Add all of the release IDs to the indicated collection. Multiple
-    requests are made if there are many release IDs to submit.
-    """
-    collection.add_releases(release_ids)
-
-
 class MusicBrainzCollectionPlugin(BeetsPlugin):
     def __init__(self) -> None:
         super().__init__()


### PR DESCRIPTION
Hi! Just doing some cleanup.. 

## Description

Remove unused functions, methods, and classes with zero callers, identified by [Skylos](https://github.com/duriantaco/skylos)

**Removed:**

- `ListenBrainzPlugin.get_weekly_exploration`, `get_weekly_jams`, `get_last_weekly_exploration`, `get_last_weekly_jams`:  unused convenience wrappers in `beetsplug/listenbrainz.py` (never called anywhere in the codebase)
- `FtInTitlePlugin.find_bracket_position`: unused static method in `beetsplug/ftintitle.py`
- `submit_albums()`: unused standalone function in `beetsplug/mbcollection.py` (superseded by `MBCollection.add_releases()`)
- `NullPaddedInt`: unused class in `beets/dbcore/types.py` (never imported or instantiated)

0 additions, 38 deletions across 4 files. We ran `grep` to do a second layer of verification. 

## To Do

This is a pure dead code cleanup (only deleted unused methods, functions and classes), so we believe documentation, changelog, and tests are not required. 

- [x] Documentation
- [x] Changelog
- [x] Tests