### PR TITLE
feat(chroma): add chromasearch command

### DIFF
--- a/beetsplug/chroma.py
+++ b/beetsplug/chroma.py
@@ -18,6 +18,7 @@ autotagger. Requires the pyacoustid library.
 
 from __future__ import annotations
 
+import heapq
 import re
 from collections import defaultdict
 from functools import cached_property, partial
@@ -29,12 +30,14 @@ import confuse
 from beets import config, ui, util
 from beets.autotag.distance import Distance
 from beets.metadata_plugins import MetadataSourcePlugin
+from beets.util.color import colorize
 from beetsplug.musicbrainz import MusicBrainzPlugin
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Iterator
 
     from beets.autotag.hooks import TrackInfo
+    from beets.library.models import Item
 
 API_KEY = "1vOwZtEn"
 SCORE_THRESH = 0.5
@@ -265,7 +268,83 @@ class AcoustidPlugin(MetadataSourcePlugin):
 
         fingerprint_cmd.func = fingerprint_cmd_func
 
-        return [submit_cmd, fingerprint_cmd]
+        return [submit_cmd, fingerprint_cmd, self.chromasearch_cmd()]
+
+    def chromasearch_cmd(self):
+        cmd = ui.Subcommand(
+            "chromasearch", help="search local database by chroma fingerprint"
+        )
+        cmd.parser.add_path_option()
+        cmd.parser.add_format_option()
+        cmd.parser.add_option(
+            "-s",
+            "--search",
+            dest="search",
+            action="store",
+            help="Fingerprint to search for (from the output of fpcalc -plain)",
+        )
+        cmd.parser.add_option(
+            "-c",
+            "--count",
+            dest="count",
+            action="store",
+            default=5,
+            type=int,
+            help="Number of items in result",
+        )
+        cmd.parser.add_option(
+            "--full",
+            dest="full",
+            action="store_true",
+            help="Don't stop searching once we found an exact match",
+        )
+        cmd.parser.add_option(
+            "-w",
+            "--write",
+            dest="write",
+            action="store_true",
+            help="Write computed fingerprints to files",
+        )
+
+        def search_cmd_func(lib, opts, args):
+            if not opts.search:
+                raise ui.UserError("no --search provided")
+            if opts.count <= 0:
+                raise ui.UserError("--count must be > 0")
+
+            target = (0, opts.search.encode("utf-8"))
+            top = TopN(opts.count)
+
+            for item in lib.items(args):
+                fp = fingerprint_item(
+                    self._log,
+                    item,
+                    write=ui.should_write(opts.write),
+                    quiet=True,
+                )
+                if fp is None:
+                    self._log.warning(f"{item}: could not compute fingerprint")
+                    continue
+
+                score = acoustid.compare_fingerprints(
+                    target, (0, fp.encode("utf-8"))
+                )
+
+                if score == 1 and not opts.full:
+                    ui.print_(
+                        f"{colorize('text_success', 'Found exact match')}: {item}"
+                    )
+                    return
+
+                if score > 0:
+                    top.add(ScoredItem(item, score))
+
+            for item in top:
+                ui.print_(str(item))
+
+        cmd.func = search_cmd_func
+
+        return cmd
 
 
 # Hooks into import process.
@@ -340,7 +419,7 @@ def submit_items(log, userkey, items, chunksize=64):
         submit_chunk()
 
 
-def fingerprint_item(log, item, write=False):
+def fingerprint_item(log, item, write=False, quiet=False):
     """Get the fingerprint for an Item. If the item already has a
     fingerprint, it is not regenerated. If fingerprint generation fails,
     return None. If the items are associated with a library, they are
@@ -351,10 +430,11 @@ def fingerprint_item(log, item, write=False):
     if not item.length:
         log.info("{.filepath}: no duration available", item)
     elif item.acoustid_fingerprint:
-        if write:
-            log.info("{.filepath}: fingerprint exists, skipping", item)
-        else:
-            log.info("{.filepath}: using existing fingerprint", item)
+        if not quiet:
+            if write:
+                log.info("{.filepath}: fingerprint exists, skipping", item)
+            else:
+                log.info("{.filepath}: using existing fingerprint", item)
         return item.acoustid_fingerprint
     else:
         log.info("{.filepath}: fingerprinting", item)
@@ -369,3 +449,45 @@ def fingerprint_item(log, item, write=False):
             return item.acoustid_fingerprint
         except acoustid.FingerprintGenerationError as exc:
             log.info("fingerprint generation failed: {}", exc)
+
+
+# Classes for search.
+
+
+class ScoredItem:
+    def __init__(self, item: Item, score: float):
+        self.item = item
+        self.score = score
+
+    def __lt__(self, other):
+        return self.score < other.score
+
+    def __gt__(self, other):
+        return self.score > other.score
+
+    def __str__(self):
+        percent = f"{round(self.score * 100, 2)}%".rjust(6)
+        if self.score >= 0.95:
+            percent = colorize("text_success", percent)
+        elif self.score >= 0.85:
+            percent = colorize("text_warning", percent)
+        else:
+            percent = colorize("text_error", percent)
+
+        return f"[{percent}] {self.item}"
+
+
+class TopN:
+    def __init__(self, n: int):
+        self.n = n
+        self.heap: list[ScoredItem] = []
+
+    def add(self, value: ScoredItem):
+        if len(self.heap) < self.n:
+            heapq.heappush(self.heap, value)
+        else:
+            if value > self.heap[0]:
+                heapq.heapreplace(self.heap, value)
+
+    def __iter__(self) -> Iterator[ScoredItem]:
+        return iter(sorted(self.heap, reverse=True))

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,8 @@ New features
   unknown playlist name is passed as an argument is now sorted alphabetically
   and printed space-delimited and POSIX shell-quoted when required. This makes
   it easier to copy and paste multiple playlists for further use in the shell.
+- :doc:`plugins/chroma`: Add new command ``chromasearch`` to search the local
+  library by chromaprint fingerprint.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/plugins/chroma.rst
+++ b/docs/plugins/chroma.rst
@@ -155,3 +155,43 @@ your library.) The command will use stored fingerprints if they're available;
 otherwise it will fingerprint each file before submitting it.
 
 .. _get an api key: https://acoustid.org/api-key
+
+Fingerprint Search
+------------------
+
+The ``chromasearch`` command lets you search your local beets library for tracks
+with similar audio fingerprints. This is useful for identifying duplicate files,
+finding alternate encodings of the same recording, or locating tracks when
+metadata is missing or incorrect.
+
+To perform a search, run:
+
+.. code-block:: shell
+
+    beet chromasearch -s FINGERPRINT
+
+The fingerprint must be provided using the ``-s`` (``--search``) option. You can
+generate a fingerprint using the external ``fpcalc`` tool from the Chromaprint_
+project. For example:
+
+.. code-block:: shell
+
+    fpcalc -plain somefile.mp3
+
+By default the whole library is searched, use a :doc:`query </reference/query>`
+to restrict the search:
+
+.. code-block:: shell
+
+    beet chromasearch -s FINGERPRINT artist:"rolling stones"
+
+By default, the command returns the top 5 closest matches in your library. You
+can change the number of results using the ``-c`` (``--count``) option.
+
+When an exact match is found, the search normally stops early. To continue
+searching for additional similar items even after an exact match, use the
+``--full`` flag.
+
+The ``-w`` (``--write``) option causes the plugin to store fingerprints for
+files that do not already have them. This can improve search results over time
+by ensuring more items in your library are indexed.

--- a/test/plugins/test_chroma.py
+++ b/test/plugins/test_chroma.py
@@ -1,0 +1,79 @@
+# This file is part of beets.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+
+from unittest.mock import patch
+
+from beets.library import Item
+from beets.test.helper import ImportTestCase, IOMixin, PluginMixin
+
+TEST_TITLE_1 = "TEST_TITLE_1"
+TEST_TITLE_2 = "TEST_TITLE_2"
+FINGERPRINT_1 = "FP_1"
+FINGERPRINT_1_CLOSE = "FP_1_CLOSE"
+FINGERPRINT_2 = "FP_2"
+
+
+@patch("acoustid.compare_fingerprints")
+class ChromaTest(IOMixin, PluginMixin, ImportTestCase):
+    plugin = "chroma"
+
+    def setup_lib(self):
+        item1 = Item(path="/file")
+        item1.length = 30
+        item1.title = TEST_TITLE_1
+        item1.acoustid_fingerprint = FINGERPRINT_1
+        item1.add(self.lib)
+
+        item2 = Item(path="/file")
+        item2.length = 30
+        item2.title = TEST_TITLE_2
+        item2.acoustid_fingerprint = FINGERPRINT_2
+        item2.add(self.lib)
+
+    def run_search(self, fp):
+        return self.run_with_output("chromasearch", "-s", fp, "-f", "$title")
+
+    def line_count(self, str):
+        return len(
+            [line for line in str.split("\n") if line.strip(" \n") != ""]
+        )
+
+    def compare_fingerprints(self, *args, **kwargs):
+        if args[0][1] == args[1][1]:
+            return 1
+
+        if args[0][1] == FINGERPRINT_1_CLOSE and args[1][1] == FINGERPRINT_1:
+            return 0.9
+
+        return 0.1
+
+    def test_chroma_search_exact(self, compare_fingerprints):
+        self.setup_lib()
+        compare_fingerprints.side_effect = self.compare_fingerprints
+
+        output = self.run_search(FINGERPRINT_2)
+        assert self.line_count(output) == 1
+        assert TEST_TITLE_2 in output
+
+        output = self.run_search(FINGERPRINT_1)
+        assert self.line_count(output) == 1
+        assert TEST_TITLE_1 in output
+
+    def test_chroma_search_close(self, compare_fingerprints):
+        self.setup_lib()
+        compare_fingerprints.side_effect = self.compare_fingerprints
+
+        output = self.run_search(FINGERPRINT_1_CLOSE)
+        assert self.line_count(output) == 2
+        assert TEST_TITLE_1 in output.split("\n")[0]


### PR DESCRIPTION
## Description

Add a new command to the `chroma` plugin: `chromasearch`.
 
This command lets user search the database by chromaprint fingerprint similarity.
Database item fingerprints are computed on the fly if needed. This is useful for example to check if an unknown / untagged audio file already exists in the database.

Will update changelog and doc once naming & co are sorted.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
