### PR TITLE
fix(replaygain): clear conflicting tags on write

### DIFF
--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -139,6 +139,7 @@ class RgTask:
 
     def _store_track_gain(self, item: Item, track_gain: Gain):
         """Store track gain for a single item in the database."""
+        item.r128_track_gain = None
         item.rg_track_gain = track_gain.gain
         item.rg_track_peak = track_gain.peak
         item.store()
@@ -152,6 +153,7 @@ class RgTask:
 
         The caller needs to ensure that `self.album_gain is not None`.
         """
+        item.r128_album_gain = None
         item.rg_album_gain = album_gain.gain
         item.rg_album_peak = album_gain.peak
         item.store()
@@ -228,6 +230,8 @@ class R128Task(RgTask):
         super().__init__(items, album, target_level, None, backend_name, log)
 
     def _store_track_gain(self, item: Item, track_gain: Gain):
+        item.rg_track_gain = None
+        item.rg_track_peak = None
         item.r128_track_gain = track_gain.gain
         item.store()
         self._log.debug("applied r128 track gain {.r128_track_gain} LU", item)
@@ -237,6 +241,8 @@ class R128Task(RgTask):
 
         The caller needs to ensure that `self.album_gain is not None`.
         """
+        item.rg_album_gain = None
+        item.rg_album_peak = None
         item.r128_album_gain = album_gain.gain
         item.store()
         self._log.debug("applied r128 album gain {.r128_album_gain} LU", item)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,8 @@ New features
   :doc:`plugins/musicbrainz` now preserves each MusicBrainz ``remixer``,
   ``lyricist``, ``composer``, and ``arranger`` relation as a separate value.
   :bug:`5698`
+- :doc:`plugins/replaygain`: Conflicting replay gain tags are now removed on
+  write. RG_* tags are removed when setting R128_* and vice versa.
 
 Bug fixes
 ~~~~~~~~~

--- a/test/plugins/test_replaygain.py
+++ b/test/plugins/test_replaygain.py
@@ -335,6 +335,40 @@ class ReplayGainCliTest:
             assert item.rg_track_gain is not None
             assert item.rg_album_gain is not None
 
+    def test_clears_wrong_tag_type(self):
+        """Check that items that have tags of the wrong type won't be skipped."""
+        if not self.has_r128_support:
+            # This test is a lot less interesting if the backend cannot write
+            # both tag types.
+            self.skipTest(
+                f"r128 tags for opus not supported on backend {self.backend}"
+            )
+
+        album_rg = self._add_album(1)
+        item_rg = album_rg.items()[0]
+
+        album_r128 = self._add_album(1, ext="opus")
+        item_r128 = album_r128.items()[0]
+
+        item_r128.r128_track_gain = 0.0
+        item_r128.store()
+
+        item_rg.rg_track_gain = 0.0
+        item_rg.rg_track_peak = 42.0
+        item_rg.store()
+
+        self.run_command("replaygain")
+        item_rg.load()
+        item_r128.load()
+
+        assert item_rg.rg_track_gain is not None
+        assert item_rg.rg_track_peak is not None
+        assert item_rg.r128_track_gain is None
+
+        assert item_r128.r128_track_gain is not None
+        assert item_r128.rg_track_gain is None
+        assert item_r128.rg_track_peak is None
+
 
 @unittest.skipIf(not GST_AVAILABLE, "gstreamer cannot be found")
 class ReplayGainGstCliTest(


### PR DESCRIPTION
## Description

There are two ways to store replay gain data on music files: RG_ and R128_ (opus). 
Before this change the beets replaygain plugin simply set the right tag based on file format and r128 config value. there are case, however, when for example an opus files comes with RG_ tags already set. After beet write its replaingain tags the files will contain both RG_ and R128_ tags with possibly conflicting values. 

For example, Navidrome currently always prefers RG_ tags over R128_ regardless of format, leading tags set by beets to be ignored. https://github.com/navidrome/navidrome/blob/23f3556371321faf199866989b906f2ef06a8034/model/metadata/map_mediafile.go#L111

As per RFC 7845: Ogg Encapsulation for the Opus Audio Codec 
https://datatracker.ietf.org/doc/html/rfc7845#section-5.2.1
> To avoid confusion with multiple normalization schemes, an Opus
> comment header SHOULD NOT contain any of the REPLAYGAIN_TRACK_GAIN,
> REPLAYGAIN_TRACK_PEAK, REPLAYGAIN_ALBUM_GAIN, or
> REPLAYGAIN_ALBUM_PEAK tags, unless they are only to be used in some
> context where there is guaranteed to be no such confusion.

Since the replaygain plugin does not support setting both RG_ and R128_ at the same time it doesn't make much sense to keep conflicting tags when writing. These tags are also easy to recalculate if needed either with beets itself (with a different configuration), or by running replaygain commands by hand. no valuable information is lost.

This change makes it so the replagain plugin now deletes conflicting tags when processing library items:
* RG_ are deleted if we set R128_
* R128_ are deleted if we set RG_

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
