### PR TITLE
fix(deezer): use artist ID to detect Various Artists releases

### DIFF
--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -22,10 +22,12 @@ from typing import TYPE_CHECKING, ClassVar
 
 import requests
 
-from beets import ui
+from beets import config, ui
 from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.dbcore import types
 from beets.metadata_plugins import IDResponse, SearchApiMetadataSourcePlugin
+
+VARIOUS_ARTISTS_ID = 5080
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -125,19 +127,23 @@ class DeezerPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
         for track in tracks:
             track.medium_total = medium_totals[track.medium]
 
+        is_va = str(album_data["artist"]["id"]) == str(VARIOUS_ARTISTS_ID)
+        if is_va:
+            va_name = config["va_name"].as_str()
+            artist = va_name
+
         return AlbumInfo(
             album=album_data["title"],
             album_id=deezer_id,
             deezer_album_id=deezer_id,
             artist=artist,
-            artist_credit=self.get_artist([album_data["artist"]])[0],
+            artist_credit=(
+                artist if is_va else self.get_artist([album_data["artist"]])[0]
+            ),
             artist_id=artist_id,
             tracks=tracks,
             albumtype=album_data["record_type"],
-            va=(
-                len(album_data["contributors"]) == 1
-                and (artist or "").lower() == "various artists"
-            ),
+            va=is_va,
             year=year,
             month=month,
             day=day,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -41,6 +41,9 @@ New features
 Bug fixes
 ~~~~~~~~~
 
+- :doc:`plugins/deezer`: Fix Various Artists albums being tagged with a
+  localized string instead of the configured ``va_name``. Detection now uses
+  Deezer's artist ID rather than the artist name string. :bug:`4956`
 - Correctly handle semicolon-delimited genre values from externally-tagged
   files. :bug:`6450`
 - :doc:`plugins/listenbrainz`: Fix ``lbimport`` crashing when ListenBrainz


### PR DESCRIPTION
## Description

Fixes #4956

The Deezer API apparently uses IP geolocation to return a localized “Various Artists” name (e.g. “Verschiedene Interpreten” in German), causing VA releases to match poorly and display the wrong artist name.

This implements the approach suggested by @sampsyo in [beetbox/beets#4956](https://github.com/beetbox/beets/issues/4956#issuecomment-1773281190): detect VA releases using Deezer’s (hopefully) stable various artists ID (5080) instead of a string comparison, then replace the localized name with the user’s configured `va_name`, mirroring what the MusicBrainz plugin already does with its own `VARIOUS_ARTISTS_ID`.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation.
- [x] Changelog.
- [ ] Tests.
