### PR TITLE
fix(autotag): only write mb_* fields when data source is MusicBrainz

### DIFF
--- a/beets/autotag/__init__.py
+++ b/beets/autotag/__init__.py
@@ -63,6 +63,9 @@ __all__ = [
 # Global logger.
 log = logging.getLogger("beets")
 
+# The data_source value produced by MusicBrainzPlugin.
+_MUSICBRAINZ_SOURCE = "MusicBrainz"
+
 # Metadata fields that are already hardcoded, or where the tag name changes.
 SPECIAL_FIELDS = {
     "album": (
@@ -199,12 +202,18 @@ def apply_item_metadata(item: Item, track_info: TrackInfo):
     item.artist_credit = track_info.artist_credit
     item.artists_credit = track_info.artists_credit
     item.title = track_info.title
-    item.mb_trackid = track_info.track_id
-    item.mb_releasetrackid = track_info.release_track_id
-    if track_info.artist_id:
-        item.mb_artistid = track_info.artist_id
-    if track_info.artists_ids:
-        item.mb_artistids = track_info.artists_ids
+    if track_info.data_source == _MUSICBRAINZ_SOURCE:
+        item.mb_trackid = track_info.track_id
+        item.mb_releasetrackid = track_info.release_track_id
+        if track_info.artist_id:
+            item.mb_artistid = track_info.artist_id
+        if track_info.artists_ids:
+            item.mb_artistids = track_info.artists_ids
+    else:
+        item.mb_trackid = ""
+        item.mb_releasetrackid = ""
+        item.mb_artistid = ""
+        item.mb_artistids = []
 
     _apply_metadata(track_info, item)
     correct_list_fields(item)
@@ -305,22 +314,37 @@ def apply_metadata(
         item.disc = track_info.medium
         item.disctotal = album_info.mediums
 
-        # MusicBrainz IDs.
-        item.mb_trackid = track_info.track_id
-        item.mb_releasetrackid = track_info.release_track_id or item.mb_trackid
+        # MusicBrainz IDs: only write when the data source is MusicBrainz,
+        # to avoid storing service-specific IDs (Spotify, Deezer, etc.) in
+        # MusicBrainz fields. When the source is not MusicBrainz, clear any
+        # stale values so retagging does not leave invalid IDs behind.
+        if album_info.data_source == _MUSICBRAINZ_SOURCE:
+            item.mb_trackid = track_info.track_id
+            item.mb_releasetrackid = (
+                track_info.release_track_id or item.mb_trackid
+            )
 
-        item.mb_albumid = album_info.album_id
-        item.mb_releasegroupid = album_info.releasegroup_id
+            item.mb_albumid = album_info.album_id
+            item.mb_releasegroupid = album_info.releasegroup_id
 
-        item.mb_albumartistid = album_info.artist_id
-        item.mb_albumartistids = album_info.artists_ids or (
-            [ai] if (ai := item.mb_albumartistid) else []
-        )
+            item.mb_albumartistid = album_info.artist_id
+            item.mb_albumartistids = album_info.artists_ids or (
+                [ai] if (ai := item.mb_albumartistid) else []
+            )
 
-        item.mb_artistid = track_info.artist_id or item.mb_albumartistid
-        item.mb_artistids = track_info.artists_ids or (
-            [iai] if (iai := item.mb_artistid) else []
-        )
+            item.mb_artistid = track_info.artist_id or item.mb_albumartistid
+            item.mb_artistids = track_info.artists_ids or (
+                [iai] if (iai := item.mb_artistid) else []
+            )
+        else:
+            item.mb_trackid = ""
+            item.mb_releasetrackid = ""
+            item.mb_albumid = ""
+            item.mb_releasegroupid = ""
+            item.mb_albumartistid = ""
+            item.mb_albumartistids = []
+            item.mb_artistid = ""
+            item.mb_artistids = []
 
         # Compilation flag.
         item.comp = album_info.va


### PR DESCRIPTION
## Description

Plugins like Spotify and Deezer set `album_id`, `artist_id`, and `track_id` on their `AlbumInfo`/`TrackInfo` objects, which `apply_metadata()` and `apply_item_metadata()` then unconditionally write to `mb_albumid`, `mb_artistid`, etc. This means service-specific IDs end up stored in MusicBrainz fields, breaking clients such as Music Assistant.

This PR adds a guard so that `mb_*` fields are only written when `data_source == "MusicBrainz"`. Let me know if this is a good fix. If so, I’ll update the changelog and add some unit tests.

Note that a broader approach (registering Spotify/Deezer IDs as their own media fields) was explored in #6349, but it turned out to be quite complex, so this PR is just fixing the obvious problem.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation.
- [ ] Changelog.
- [ ] Tests.
