### PR TITLE
fetchart: handle FilesystemError when setting album art

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -1525,7 +1525,11 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             candidate = self.art_candidates.pop(task)
             removal_enabled = self._is_source_file_removal_enabled()
 
-            self._set_art(task.album, candidate, not removal_enabled)
+            try:
+                self._set_art(task.album, candidate, not removal_enabled)
+            except util.FilesystemError as exc:
+                self._log.warning("error setting art: {}", exc)
+                return  # No art was set, so skip the prune step below.
 
             if removal_enabled and not self._is_candidate_fallback(candidate):
                 task.prune(candidate.path)
@@ -1629,8 +1633,13 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
 
                 candidate = self.art_for_album(album, local_paths)
                 if candidate:
-                    self._set_art(album, candidate)
-                    message = colorize("text_success", "found album art")
+                    try:
+                        self._set_art(album, candidate)
+                    except util.FilesystemError as exc:
+                        self._log.warning("error setting art: {}", exc)
+                        message = colorize("text_error", "error setting art")
+                    else:
+                        message = colorize("text_success", "found album art")
                 else:
                     message = colorize("text_error", "no art found")
                 ui.print_(f"{album}: {message}")

--- a/test/plugins/test_fetchart.py
+++ b/test/plugins/test_fetchart.py
@@ -16,6 +16,7 @@
 import ctypes
 import os
 import sys
+from unittest.mock import patch
 
 from beets import util
 from beets.test.helper import IOMixin, PluginTestCase
@@ -118,6 +119,43 @@ class FetchartCliTest(IOMixin, PluginTestCase):
         self.config["ui"]["color"] = True
         out = self.run_with_output("fetchart")
         assert " - the älbum: \x1b[1;31mno art found\x1b[39;49;00m\n" == out
+
+    def test_batch_fetch_filesystem_error(self):
+        """When _set_art raises FilesystemError (e.g. permissions), the
+        fetchart command should log a warning instead of crashing."""
+        self.touch(b"c\xc3\xb6ver.jpg", dir=self.album.path, content="IMAGE")
+
+        exc = util.FilesystemError(
+            reason=PermissionError("mocked permission error"),
+            verb="move",
+            paths=[b"/src", b"/dst"],
+        )
+        with patch(
+            "beetsplug.fetchart.FetchArtPlugin._set_art",
+            side_effect=exc,
+        ):
+            out = self.run_with_output("fetchart")
+
+        assert "error setting art" in out
+
+    def test_assign_art_filesystem_error(self):
+        """When _set_art raises FilesystemError during import, the import
+        should continue instead of crashing."""
+        exc = util.FilesystemError(
+            reason=PermissionError("mocked permission error"),
+            verb="move",
+            paths=[b"/src", b"/dst"],
+        )
+        fa = FetchArtPlugin()
+        # Simulate an import task with a queued candidate
+        task = type("FakeTask", (), {"album": self.album})()
+        fa.art_candidates[task] = type(
+            "FakeCandidate", (), {"path": b"/tmp/art.jpg", "source_name": "test"}
+        )()
+
+        with patch.object(fa, "_set_art", side_effect=exc):
+            # Should not raise
+            fa.assign_art(session=None, task=task)
 
     def test_sources_is_a_string(self):
         self.config["fetchart"].set({"sources": "filesystem"})


### PR DESCRIPTION
## Description

Fixes #6193.

## Problem

When `fetchart` encounters a `FilesystemError` during `set_art` (e.g. a file locked by another process on Windows, or a cross-device move permission error), the unhandled exception crashes the import session or the `fetchart` CLI command.

The `cleanup` method at line ~520 already catches `FilesystemError` and logs it gracefully, but the two `_set_art` call sites don't.

## Fix

Wrap both `_set_art` call sites in `try/except util.FilesystemError`:

- **`assign_art()`** (import pipeline): log the error and return early, skipping the prune step since no art was set.
- **`batch_fetch_art()`** (CLI command): log the error and show "error setting art" in the output instead of crashing.

## Tests

Added two tests covering both error paths:
- `test_batch_fetch_filesystem_error` — verifies the CLI command reports the error message instead of crashing.
- `test_assign_art_filesystem_error` — verifies the import path returns gracefully on error.

All existing fetchart tests pass.

## To Do

- [x] ~Changelog~
- [x] Tests
- [x] ~Documentation~