### PR TITLE
Support multi-valued fields in rewrite and advancedrewrite plugins

### DIFF
--- a/beetsplug/advancedrewrite.py
+++ b/beetsplug/advancedrewrite.py
@@ -26,6 +26,8 @@ from beets.library import Album, Item
 from beets.plugins import BeetsPlugin
 from beets.ui import UserError
 
+from .rewrite import apply_rewrite_rules
+
 
 def rewriter(field, simple_rules, advanced_rules):
     """Template field function factory.
@@ -38,10 +40,10 @@ def rewriter(field, simple_rules, advanced_rules):
 
     def fieldfunc(item):
         value = item._values_fixed[field]
-        for pattern, replacement in simple_rules:
-            if pattern.match(value.lower()):
-                # Rewrite activated.
-                return replacement
+        if (new_value := apply_rewrite_rules(value, simple_rules)) != value:
+            # Rewrite activated.
+            return new_value
+
         for query, replacement in advanced_rules:
             if query.match(item):
                 # Rewrite activated.

--- a/beetsplug/rewrite.py
+++ b/beetsplug/rewrite.py
@@ -18,9 +18,43 @@ formats.
 
 import re
 from collections import defaultdict
+from functools import singledispatch
+from typing import Any, TypeVar
 
 from beets import library, ui
 from beets.plugins import BeetsPlugin
+
+T = TypeVar("T")
+
+
+@singledispatch
+def rewrite_value(value: Any, pat: re.Pattern[str], repl: str) -> Any:
+    """Rewrite a value if it matches the given pattern."""
+    return value
+
+
+@rewrite_value.register
+def _(value: str, pat: re.Pattern[str], repl: str) -> str:
+    if pat.match(value.lower()):
+        return repl
+    return value
+
+
+@rewrite_value.register(list)
+def _(value: list[str], pat: re.Pattern[str], repl: str) -> list[str]:
+    return [rewrite_value(v, pat, repl) for v in value]
+
+
+def apply_rewrite_rules(
+    value: T, rules: list[tuple[re.Pattern[str], str]]
+) -> T:
+    """Apply the first matching rewrite rule to the given value."""
+    for pattern, replacement in rules:
+        if (new_value := rewrite_value(value, pattern, replacement)) != value:
+            # Rewrite activated.
+            return new_value
+    # Not activated; return original value.
+    return value
 
 
 def rewriter(field, rules):
@@ -30,13 +64,7 @@ def rewriter(field, rules):
     """
 
     def fieldfunc(item):
-        value = item._values_fixed[field]
-        for pattern, replacement in rules:
-            if pattern.match(value.lower()):
-                # Rewrite activated.
-                return replacement
-        # Not activated; return original value.
-        return value
+        return apply_rewrite_rules(item._values_fixed[field], rules)
 
     return fieldfunc
 

--- a/beetsplug/rewrite.py
+++ b/beetsplug/rewrite.py
@@ -48,12 +48,10 @@ def _(value: list[str], pat: re.Pattern[str], repl: str) -> list[str]:
 def apply_rewrite_rules(
     value: T, rules: list[tuple[re.Pattern[str], str]]
 ) -> T:
-    """Apply the first matching rewrite rule to the given value."""
+    """Apply all matching rewrite rules to the given value."""
     for pattern, replacement in rules:
-        if (new_value := rewrite_value(value, pattern, replacement)) != value:
-            # Rewrite activated.
-            return new_value
-    # Not activated; return original value.
+        value = rewrite_value(value, pattern, replacement)
+
     return value
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -80,6 +80,9 @@ Bug fixes
   plural field names. :bug:`6483`
 - :doc:`plugins/fetchart`: Error when a configured source does not exist or
   sources configuration is empty. :bug:`6336`
+- :doc:`plugins/rewrite` :doc:`plugins/advancedrewrite`: Fix rewriting
+  multi-valued fields such as ``genres`` by applying rules to each matching list
+  entry. :bug:`6515`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -82,7 +82,8 @@ Bug fixes
   sources configuration is empty. :bug:`6336`
 - :doc:`plugins/rewrite` :doc:`plugins/advancedrewrite`: Fix rewriting
   multi-valued fields such as ``genres`` by applying rules to each matching list
-  entry. :bug:`6515`
+  entry. Additionally, apply rewrite rules in config order, so that multiple
+  rules can be applied to the same field. :bug:`6515`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/plugins/advancedrewrite.rst
+++ b/docs/plugins/advancedrewrite.rst
@@ -28,6 +28,9 @@ replace a single field:
     advancedrewrite:
       - artist ODD EYE CIRCLE: 이달의 소녀 오드아이써클
 
+As with :doc:`/plugins/rewrite`, simple rules applied to a multi-valued field
+rewrite only the matching list entries.
+
 The advanced syntax consists of a query to match against, as well as a map of
 replacements to apply. For example, to credit all songs of ODD EYE CIRCLE before
 2023 to their original group name, you can use the following rule:

--- a/docs/plugins/rewrite.rst
+++ b/docs/plugins/rewrite.rst
@@ -30,6 +30,15 @@ might use:
     rewrite:
         artist .*jimi hendrix.*: Jimi Hendrix
 
+Rules also apply to matching elements in multi-valued fields. For example, this
+rewrites the ``rock`` entry in ``genres`` while leaving other genre values
+unchanged:
+
+::
+
+    rewrite:
+        genres rock: Classic Rock
+
 As a convenience, the plugin applies patterns for the ``artist`` field to the
 ``albumartist`` field as well. (Otherwise, you would probably want to duplicate
 every rule for ``artist`` and ``albumartist``.)

--- a/docs/plugins/rewrite.rst
+++ b/docs/plugins/rewrite.rst
@@ -39,6 +39,18 @@ unchanged:
     rewrite:
         genres rock: Classic Rock
 
+Rules are applied in the order they appear in the config. This means a
+multi-valued field can have several entries rewritten by different rules:
+
+::
+
+    rewrite:
+        genres rock: Classic Rock
+        genres pop: Pop
+
+With this configuration, a ``genres`` value such as ``rock; pop; techno`` is
+rewritten to ``Classic Rock; Pop; techno``.
+
 As a convenience, the plugin applies patterns for the ``artist`` field to the
 ``albumartist`` field as well. (Otherwise, you would probably want to duplicate
 every rule for ``artist`` and ``albumartist``.)

--- a/test/plugins/test_advancedrewrite.py
+++ b/test/plugins/test_advancedrewrite.py
@@ -37,6 +37,15 @@ class AdvancedRewritePluginTest(PluginTestCase):
 
             assert item.artist == "이달의 소녀 오드아이써클"
 
+    @pytest.mark.xfail(
+        reason="advancedrewrite currently assumes scalar field values",
+    )
+    def test_list_field(self):
+        with self.configure_plugin([{"genres rock": "techno"}]):
+            item = self.add_item(genres=["rock", "pop"])
+
+            assert item.genres == ["techno", "pop"]
+
     def test_advanced_rewrite_example(self):
         with self.configure_plugin(
             [

--- a/test/plugins/test_advancedrewrite.py
+++ b/test/plugins/test_advancedrewrite.py
@@ -37,9 +37,6 @@ class AdvancedRewritePluginTest(PluginTestCase):
 
             assert item.artist == "이달의 소녀 오드아이써클"
 
-    @pytest.mark.xfail(
-        reason="advancedrewrite currently assumes scalar field values",
-    )
     def test_list_field(self):
         with self.configure_plugin([{"genres rock": "techno"}]):
             item = self.add_item(genres=["rock", "pop"])

--- a/test/plugins/test_rewrite.py
+++ b/test/plugins/test_rewrite.py
@@ -52,9 +52,6 @@ class RewritePluginTest(PluginTestCase):
             assert matching_item.artist == "LOONA / ODD EYE CIRCLE"
             assert other_item.artist == "ARTMS"
 
-    @pytest.mark.xfail(
-        reason="rewrite currently assumes scalar field values",
-    )
     def test_genres_rewrite_applies_to_matching_list_values(self):
         with self.configure_plugin({"genres rock": "Classic Rock"}):
             item = self.add_item(genres=["rock", "pop"])

--- a/test/plugins/test_rewrite.py
+++ b/test/plugins/test_rewrite.py
@@ -52,6 +52,17 @@ class RewritePluginTest(PluginTestCase):
             assert matching_item.artist == "LOONA / ODD EYE CIRCLE"
             assert other_item.artist == "ARTMS"
 
+    @pytest.mark.xfail(
+        reason="rewrite currently assumes scalar field values",
+    )
+    def test_genres_rewrite_applies_to_matching_list_values(self):
+        with self.configure_plugin({"genres rock": "Classic Rock"}):
+            item = self.add_item(genres=["rock", "pop"])
+            album = self.lib.add_album([item])
+
+            assert item.genres == ["Classic Rock", "pop"]
+            assert album.evaluate_template("$genres") == "Classic Rock; pop"
+
     def test_invalid_rewrite_spec_raises_user_error(self):
         self.config[self.plugin].set({"artist": "Jimi Hendrix"})
 

--- a/test/plugins/test_rewrite.py
+++ b/test/plugins/test_rewrite.py
@@ -23,11 +23,11 @@ class RewritePluginTest(PluginTestCase):
             assert item.albumartist == "Jimi Hendrix"
             assert album.evaluate_template("$albumartist") == "Jimi Hendrix"
 
-    def test_rewrite_uses_first_matching_rule(self):
+    def test_rewrite_all_matching_rules(self):
         with self.configure_plugin(
             {
-                "artist .*hendrix.*": "Hendrix catalog",
-                "artist the jimi hendrix experience": "Experience catalog",
+                "artist .*hendrix.*": "hendrix catalog",
+                "artist .*catalog.*": "Experience catalog",
             }
         ):
             item = self.add_item(
@@ -35,7 +35,7 @@ class RewritePluginTest(PluginTestCase):
                 albumartist="The Jimi Hendrix Experience",
             )
 
-            assert item.artist == "Hendrix catalog"
+            assert item.artist == "Experience catalog"
 
     def test_rewrite_is_case_insensitive_and_leaves_non_matches_unchanged(
         self,
@@ -52,7 +52,6 @@ class RewritePluginTest(PluginTestCase):
             assert matching_item.artist == "LOONA / ODD EYE CIRCLE"
             assert other_item.artist == "ARTMS"
 
-    @pytest.mark.xfail(reason="only the first pattern applied")
     def test_rewrite_applied_to_all_list_values(self):
         with self.configure_plugin(
             {"genres rock": "Classic Rock", "genres pop": "Pop"}

--- a/test/plugins/test_rewrite.py
+++ b/test/plugins/test_rewrite.py
@@ -52,13 +52,14 @@ class RewritePluginTest(PluginTestCase):
             assert matching_item.artist == "LOONA / ODD EYE CIRCLE"
             assert other_item.artist == "ARTMS"
 
-    def test_genres_rewrite_applies_to_matching_list_values(self):
-        with self.configure_plugin({"genres rock": "Classic Rock"}):
-            item = self.add_item(genres=["rock", "pop"])
-            album = self.lib.add_album([item])
+    @pytest.mark.xfail(reason="only the first pattern applied")
+    def test_rewrite_applied_to_all_list_values(self):
+        with self.configure_plugin(
+            {"genres rock": "Classic Rock", "genres pop": "Pop"}
+        ):
+            item = self.add_item(genres=["rock", "pop", "techno"])
 
-            assert item.genres == ["Classic Rock", "pop"]
-            assert album.evaluate_template("$genres") == "Classic Rock; pop"
+            assert item.genres == ["Classic Rock", "Pop", "techno"]
 
     def test_invalid_rewrite_spec_raises_user_error(self):
         self.config[self.plugin].set({"artist": "Jimi Hendrix"})

--- a/test/plugins/test_rewrite.py
+++ b/test/plugins/test_rewrite.py
@@ -1,0 +1,67 @@
+import pytest
+
+from beets.test.helper import PluginTestCase
+from beets.ui import UserError
+from beetsplug.rewrite import RewritePlugin
+
+
+class RewritePluginTest(PluginTestCase):
+    plugin = "rewrite"
+    preload_plugin = False
+
+    def test_artist_rewrite_applies_to_artist_albumartist_and_album_fields(
+        self,
+    ):
+        with self.configure_plugin({"artist .*jimi hendrix.*": "Jimi Hendrix"}):
+            item = self.add_item(
+                artist="The Jimi Hendrix Experience",
+                albumartist="The Jimi Hendrix Experience",
+            )
+            album = self.lib.add_album([item])
+
+            assert item.artist == "Jimi Hendrix"
+            assert item.albumartist == "Jimi Hendrix"
+            assert album.evaluate_template("$albumartist") == "Jimi Hendrix"
+
+    def test_rewrite_uses_first_matching_rule(self):
+        with self.configure_plugin(
+            {
+                "artist .*hendrix.*": "Hendrix catalog",
+                "artist the jimi hendrix experience": "Experience catalog",
+            }
+        ):
+            item = self.add_item(
+                artist="The Jimi Hendrix Experience",
+                albumartist="The Jimi Hendrix Experience",
+            )
+
+            assert item.artist == "Hendrix catalog"
+
+    def test_rewrite_is_case_insensitive_and_leaves_non_matches_unchanged(
+        self,
+    ):
+        with self.configure_plugin(
+            {"artist odd eye circle": "LOONA / ODD EYE CIRCLE"}
+        ):
+            matching_item = self.add_item(
+                artist="ODD EYE CIRCLE",
+                albumartist="ODD EYE CIRCLE",
+            )
+            other_item = self.add_item(artist="ARTMS", albumartist="ARTMS")
+
+            assert matching_item.artist == "LOONA / ODD EYE CIRCLE"
+            assert other_item.artist == "ARTMS"
+
+    def test_invalid_rewrite_spec_raises_user_error(self):
+        self.config[self.plugin].set({"artist": "Jimi Hendrix"})
+
+        with pytest.raises(UserError, match="invalid rewrite specification"):
+            RewritePlugin()
+
+    def test_invalid_field_name_raises_user_error(self):
+        self.config[self.plugin].set({"not_a_field rock": "Classic Rock"})
+
+        with pytest.raises(
+            UserError, match="invalid field name \\(not_a_field\\) in rewriter"
+        ):
+            RewritePlugin()


### PR DESCRIPTION
## Fix rewriting of multi-valued fields (`rewrite` / `advancedrewrite` plugins)

**Bug:** Both `rewrite` and `advancedrewrite` plugins assumed all field values are scalars, so list-type fields (e.g. `genres`) were not rewritten correctly. Additionally, only the first matching rule was ever applied to a field.

---

### What changed

**Core logic (`beetsplug/rewrite.py`):**

- Introduced a `rewrite_value` `singledispatch` function to handle both `str` and `list[str]` values. For lists, each element is rewritten individually.
- Extracted `apply_rewrite_rules` as a shared utility — now applies **all** matching rules in config order (previously stopped at the first match).

**`advancedrewrite` plugin:**

- Replaced its own inline rule-matching loop with a call to the shared `apply_rewrite_rules`, fixing list field support there too.

**Behaviour change — rule application order:**

Previously, only the first matching rule was applied. Now, all rules run in config order, allowing chained rewrites. For example:

```yaml
rewrite:
    artist .*hendrix.*: hendrix catalog
    artist .*catalog.*: Experience catalog
```

This now produces `"Experience catalog"` instead of `"hendrix catalog"`.

Fixes: #6515 
