### PR TITLE
Retry listenbrainz requests

### DIFF
--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -15,6 +15,7 @@ from beets.plugins import BeetsPlugin
 
 from ._utils.musicbrainz import MusicBrainzAPIMixin
 from ._utils.playcount import update_play_counts
+from ._utils.requests import TimeoutAndRetrySession
 
 if TYPE_CHECKING:
     from ._utils.playcount import Track
@@ -34,6 +35,7 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
         super().__init__()
         self.token = self.config["token"].get()
         self.username = self.config["username"].get()
+        self.session = TimeoutAndRetrySession()
         self.AUTH_HEADER = {"Authorization": f"Token {self.token}"}
         config["listenbrainz"]["token"].redact = True
 
@@ -108,7 +110,7 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
         returning, so the next call is guaranteed a fresh quota.
         """
         try:
-            response = requests.get(
+            response = self.session.get(
                 url=url,
                 headers=self.AUTH_HEADER,
                 timeout=10,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,9 +26,11 @@ New features
       after upgrading to trigger the migration. Only then you can safely move
       the library to a new location.
 
-..
-    Bug fixes
-    ~~~~~~~~~
+Bug fixes
+~~~~~~~~~
+
+- :doc:`plugins/listenbrainz`: Retry listenbrainz requests for temporary
+  failures.
 
 ..
     For plugin developers


### PR DESCRIPTION
## Description

Fixes problems with not all listens being fetched when encountering temporary network failures.

I don't think we have a way to simulate network failures in tests, but I might be wrong about that.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
