### PR TITLE
chroma: gate candidates on musicbrainz plugin being enabled

### DIFF
--- a/beetsplug/chroma.py
+++ b/beetsplug/chroma.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import heapq
 import re
 from collections import defaultdict
-from functools import partial
+from functools import cached_property, partial
 from typing import TYPE_CHECKING
 
 import acoustid
@@ -196,8 +196,9 @@ class AcoustidPlugin(MetadataSourcePlugin):
             self.register_listener("import_task_start", self.fingerprint_task)
         self.register_listener("import_task_apply", apply_acoustid_metadata)
 
-    def _get_musicbrainz(self) -> MusicBrainzPlugin | None:
-        """Return the loaded MusicBrainz plugin, or ``None``.
+    @cached_property
+    def mb(self) -> MusicBrainzPlugin | None:
+        """The loaded MusicBrainz plugin, or ``None``.
 
         Acoustid lookups return MusicBrainz IDs, so chroma needs the
         ``musicbrainz`` plugin to resolve them into album/track
@@ -230,13 +231,12 @@ class AcoustidPlugin(MetadataSourcePlugin):
         return dist
 
     def candidates(self, items, artist, album, va_likely):
-        mb = self._get_musicbrainz()
-        if mb is None:
+        if self.mb is None:
             return []
 
         albums = []
         for relid in prefix(_all_releases(items), MAX_RELEASES):
-            album = mb.album_for_id(relid)
+            album = self.mb.album_for_id(relid)
             if album:
                 albums.append(album)
 
@@ -247,14 +247,13 @@ class AcoustidPlugin(MetadataSourcePlugin):
         if item.path not in _matches:
             return []
 
-        mb = self._get_musicbrainz()
-        if mb is None:
+        if self.mb is None:
             return []
 
         recording_ids, _ = _matches[item.path]
         tracks = []
         for recording_id in prefix(recording_ids, MAX_RECORDINGS):
-            track = mb.track_for_id(recording_id)
+            track = self.mb.track_for_id(recording_id)
             if track:
                 tracks.append(track)
         self._log.debug("acoustid item candidates: {}", len(tracks))

--- a/beetsplug/chroma.py
+++ b/beetsplug/chroma.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import heapq
 import re
 from collections import defaultdict
-from functools import cached_property, partial
+from functools import partial
 from typing import TYPE_CHECKING
 
 import acoustid
@@ -29,15 +29,15 @@ import confuse
 
 from beets import config, ui, util
 from beets.autotag.distance import Distance
-from beets.metadata_plugins import MetadataSourcePlugin
+from beets.metadata_plugins import MetadataSourcePlugin, get_metadata_source
 from beets.util.color import colorize
-from beetsplug.musicbrainz import MusicBrainzPlugin
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
     from beets.autotag.hooks import TrackInfo
     from beets.library.models import Item
+    from beetsplug.musicbrainz import MusicBrainzPlugin
 
 API_KEY = "1vOwZtEn"
 SCORE_THRESH = 0.5
@@ -196,9 +196,25 @@ class AcoustidPlugin(MetadataSourcePlugin):
             self.register_listener("import_task_start", self.fingerprint_task)
         self.register_listener("import_task_apply", apply_acoustid_metadata)
 
-    @cached_property
-    def mb(self) -> MusicBrainzPlugin:
-        return MusicBrainzPlugin()
+    def _get_musicbrainz(self) -> MusicBrainzPlugin | None:
+        """Return the loaded MusicBrainz plugin, or ``None``.
+
+        Acoustid lookups return MusicBrainz IDs, so chroma needs the
+        ``musicbrainz`` plugin to resolve them into album/track
+        candidates. When the user has not enabled ``musicbrainz``,
+        chroma must not produce any candidates.
+
+        Uses the plugin registry so that any plugin that swaps the
+        musicbrainz instance at runtime (e.g. :doc:`plugins/mbpseudo`)
+        is respected.
+        """
+        plugin = get_metadata_source("musicbrainz")
+        if plugin is None:
+            self._log.debug(
+                "musicbrainz plugin not enabled; "
+                "acoustid matches will not produce candidates"
+            )
+        return plugin  # type: ignore[return-value]
 
     def fingerprint_task(self, task, session):
         return fingerprint_task(self._log, task, session)
@@ -214,9 +230,13 @@ class AcoustidPlugin(MetadataSourcePlugin):
         return dist
 
     def candidates(self, items, artist, album, va_likely):
+        mb = self._get_musicbrainz()
+        if mb is None:
+            return []
+
         albums = []
         for relid in prefix(_all_releases(items), MAX_RELEASES):
-            album = self.mb.album_for_id(relid)
+            album = mb.album_for_id(relid)
             if album:
                 albums.append(album)
 
@@ -227,10 +247,14 @@ class AcoustidPlugin(MetadataSourcePlugin):
         if item.path not in _matches:
             return []
 
+        mb = self._get_musicbrainz()
+        if mb is None:
+            return []
+
         recording_ids, _ = _matches[item.path]
         tracks = []
         for recording_id in prefix(recording_ids, MAX_RECORDINGS):
-            track = self.mb.track_for_id(recording_id)
+            track = mb.track_for_id(recording_id)
             if track:
                 tracks.append(track)
         self._log.debug("acoustid item candidates: {}", len(tracks))

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -130,6 +130,11 @@ Bug fixes
   multi-valued fields such as ``genres`` by applying rules to each matching list
   entry. Additionally, apply rewrite rules in config order, so that multiple
   rules can be applied to the same field. :bug:`6515`
+- :doc:`plugins/chroma`: Do not produce MusicBrainz-sourced autotagger
+  candidates when the :doc:`plugins/musicbrainz` plugin is not enabled. The
+  chroma plugin now looks up the musicbrainz plugin through the metadata-source
+  registry instead of unconditionally instantiating its own private instance.
+  :bug:`6212`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -37,8 +37,9 @@ Bug fixes
 - :doc:`plugins/chroma`: Do not produce MusicBrainz-sourced autotagger
   candidates when the :doc:`plugins/musicbrainz` plugin is not enabled. The
   chroma plugin now looks up the musicbrainz plugin through the metadata-source
-  registry instead of unconditionally instantiating its own private instance.
-  :bug:`6212`
+  registry instead of unconditionally instantiating its own private instance,
+  which also restores compatibility with :doc:`plugins/mbpseudo` for
+  chroma-triggered lookups. :bug:`6212` :bug:`6441`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,11 @@ Bug fixes
   silently importing them with incorrect metadata. :bug:`6455`
 - :doc:`plugins/listenbrainz`: Retry listenbrainz requests for temporary
   failures.
+- :doc:`plugins/chroma`: Do not produce MusicBrainz-sourced autotagger
+  candidates when the :doc:`plugins/musicbrainz` plugin is not enabled. The
+  chroma plugin now looks up the musicbrainz plugin through the metadata-source
+  registry instead of unconditionally instantiating its own private instance.
+  :bug:`6212`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~
@@ -130,11 +135,6 @@ Bug fixes
   multi-valued fields such as ``genres`` by applying rules to each matching list
   entry. Additionally, apply rewrite rules in config order, so that multiple
   rules can be applied to the same field. :bug:`6515`
-- :doc:`plugins/chroma`: Do not produce MusicBrainz-sourced autotagger
-  candidates when the :doc:`plugins/musicbrainz` plugin is not enabled. The
-  chroma plugin now looks up the musicbrainz plugin through the metadata-source
-  registry instead of unconditionally instantiating its own private instance.
-  :bug:`6212`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/plugins/chroma.rst
+++ b/docs/plugins/chroma.rst
@@ -122,6 +122,16 @@ library.) The generated fingerprints will be stored in the library database. If
 you have the ``import.write`` config option enabled, they will also be written
 to files' metadata.
 
+.. note::
+
+    The ``chroma`` plugin turns Acoustid fingerprint matches into autotagger
+    candidates by resolving them through the :doc:`musicbrainz` plugin, so you
+    need to enable ``musicbrainz`` alongside ``chroma`` to get album and track
+    candidates from acoustid lookups. If ``musicbrainz`` is not enabled, the
+    ``chroma`` plugin will still fingerprint your files and store the
+    ``acoustid_id`` and ``acoustid_fingerprint`` fields, but it will not
+    contribute candidates during autotagging.
+
 .. _submitfp:
 
 Configuration

--- a/test/plugins/test_chroma.py
+++ b/test/plugins/test_chroma.py
@@ -12,10 +12,16 @@
 # included in all copies or substantial portions of the Software.
 
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import pytest
+
+import beets.plugins
+from beets import config, metadata_plugins
+from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.library import Item
 from beets.test.helper import ImportTestCase, IOMixin, PluginMixin
+from beetsplug import chroma
 
 TEST_TITLE_1 = "TEST_TITLE_1"
 TEST_TITLE_2 = "TEST_TITLE_2"
@@ -77,3 +83,123 @@ class ChromaTest(IOMixin, PluginMixin, ImportTestCase):
         output = self.run_search(FINGERPRINT_1_CLOSE)
         assert self.line_count(output) == 2
         assert TEST_TITLE_1 in output.split("\n")[0]
+
+
+# -----------------------------------------------------------------------------
+# Regression tests for issue #6212: chroma must respect which metadata source
+# plugins are enabled. When the musicbrainz plugin is not loaded, chroma must
+# not produce any MusicBrainz-sourced candidates.
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def reset_plugin_state():
+    """Fully reset plugin and metadata-plugin state around each test."""
+    beets.plugins.BeetsPlugin.listeners.clear()
+    beets.plugins.BeetsPlugin._raw_listeners.clear()
+    beets.plugins._instances.clear()
+    config["plugins"] = []
+    metadata_plugins.find_metadata_source_plugins.cache_clear()
+    metadata_plugins.get_metadata_source.cache_clear()
+    chroma._matches.clear()
+
+    yield
+
+    chroma._matches.clear()
+    beets.plugins.BeetsPlugin.listeners.clear()
+    beets.plugins.BeetsPlugin._raw_listeners.clear()
+    beets.plugins._instances.clear()
+    config["plugins"] = []
+    metadata_plugins.find_metadata_source_plugins.cache_clear()
+    metadata_plugins.get_metadata_source.cache_clear()
+
+
+def _load_plugins(*names: str) -> None:
+    """Load the given plugins into the global beets plugin registry."""
+    config["plugins"] = list(names)
+    beets.plugins.load_plugins()
+
+
+def _seed_acoustid_match(
+    item_path: bytes = b"/fake/path.mp3",
+    recording_ids: list[str] | None = None,
+    release_ids: list[str] | None = None,
+) -> Item:
+    """Seed the chroma module-level match cache as if acoustid had run."""
+    if recording_ids is None:
+        recording_ids = ["rec-id-1"]
+    if release_ids is None:
+        release_ids = ["rel-id-1", "rel-id-1", "rel-id-1"]
+
+    chroma._matches[item_path] = (recording_ids, release_ids)
+    return Item(path=item_path)
+
+
+@pytest.mark.usefixtures("reset_plugin_state")
+class TestChromaWithoutMusicBrainz:
+    """When musicbrainz is not loaded, chroma must not produce candidates."""
+
+    def test_candidates_returns_empty(self):
+        _load_plugins("chroma")
+        plugin = chroma.AcoustidPlugin()
+        item = _seed_acoustid_match()
+
+        result = plugin.candidates(
+            [item], artist="A", album="B", va_likely=False
+        )
+
+        assert list(result) == []
+
+    def test_item_candidates_returns_empty(self):
+        _load_plugins("chroma")
+        plugin = chroma.AcoustidPlugin()
+        item = _seed_acoustid_match()
+
+        result = plugin.item_candidates(item, artist="A", title="B")
+
+        assert list(result) == []
+
+
+@pytest.mark.usefixtures("reset_plugin_state")
+class TestChromaWithMusicBrainz:
+    """When musicbrainz IS loaded, chroma uses the registry instance."""
+
+    def test_candidates_returns_mb_albums(self, monkeypatch):
+        _load_plugins("chroma", "musicbrainz")
+
+        fake_album = AlbumInfo(
+            tracks=[], album_id="rel-id-1", album="Fake Album"
+        )
+        mb_plugin = metadata_plugins.get_metadata_source("musicbrainz")
+        assert mb_plugin is not None
+        monkeypatch.setattr(
+            mb_plugin, "album_for_id", MagicMock(return_value=fake_album)
+        )
+
+        plugin = chroma.AcoustidPlugin()
+        item = _seed_acoustid_match()
+
+        result = list(
+            plugin.candidates([item], artist="A", album="B", va_likely=False)
+        )
+
+        assert result == [fake_album]
+        mb_plugin.album_for_id.assert_called_with("rel-id-1")
+
+    def test_item_candidates_returns_mb_tracks(self, monkeypatch):
+        _load_plugins("chroma", "musicbrainz")
+
+        fake_track = TrackInfo(title="Fake Track", track_id="rec-id-1")
+        mb_plugin = metadata_plugins.get_metadata_source("musicbrainz")
+        assert mb_plugin is not None
+        monkeypatch.setattr(
+            mb_plugin, "track_for_id", MagicMock(return_value=fake_track)
+        )
+
+        plugin = chroma.AcoustidPlugin()
+        item = _seed_acoustid_match()
+
+        result = list(plugin.item_candidates(item, artist="A", title="B"))
+
+        assert result == [fake_track]
+        mb_plugin.track_for_id.assert_called_with("rec-id-1")

--- a/test/plugins/test_chroma.py
+++ b/test/plugins/test_chroma.py
@@ -84,13 +84,6 @@ class ChromaTest(IOMixin, PluginMixin, ImportTestCase):
         assert TEST_TITLE_1 in output.split("\n")[0]
 
 
-# -----------------------------------------------------------------------------
-# Regression tests for issue #6212: chroma must respect which metadata source
-# plugins are enabled. When the musicbrainz plugin is not loaded, chroma must
-# not produce any MusicBrainz-sourced candidates.
-# -----------------------------------------------------------------------------
-
-
 def _seed_acoustid_match(
     item_path: bytes = b"/fake/path.mp3",
     recording_ids: list[str] | None = None,
@@ -106,13 +99,20 @@ def _seed_acoustid_match(
     return Item(path=item_path)
 
 
-class ChromaCandidatesTestBase(PluginMixin):
-    """Shared fixture for chroma candidate tests.
+class TestChromaCandidates(PluginMixin):
+    """Regression tests for issue #6212: chroma must respect which metadata
+    source plugins are enabled.
 
-    Subclasses should not set ``plugin`` so that ``load_plugins``
-    accepts explicit plugin-name arguments. The autouse fixture
-    additionally clears the ``@cache``-decorated metadata-source
-    registry and the chroma match state between tests.
+    When the musicbrainz plugin is not loaded, chroma must not produce any
+    MusicBrainz-sourced candidates (via either ``candidates`` or
+    ``item_candidates``). When it IS loaded, chroma resolves acoustid
+    matches through the registered plugin instance.
+
+    ``plugin`` is intentionally not set on the class so that
+    :py:meth:`PluginMixin.load_plugins` honours explicit plugin-name
+    arguments and each test can choose its own combination. The autouse
+    fixture clears the ``@cache``-decorated metadata-source registry and
+    the chroma match state between tests.
     """
 
     preload_plugin = False
@@ -128,11 +128,7 @@ class ChromaCandidatesTestBase(PluginMixin):
         metadata_plugins.find_metadata_source_plugins.cache_clear()
         metadata_plugins.get_metadata_source.cache_clear()
 
-
-class TestChromaWithoutMusicBrainz(ChromaCandidatesTestBase):
-    """When musicbrainz is not loaded, chroma must not produce candidates."""
-
-    def test_candidates_returns_empty(self):
+    def test_candidates_returns_empty_without_musicbrainz(self):
         self.load_plugins("chroma")
         plugin = chroma.AcoustidPlugin()
         item = _seed_acoustid_match()
@@ -143,7 +139,7 @@ class TestChromaWithoutMusicBrainz(ChromaCandidatesTestBase):
 
         assert list(result) == []
 
-    def test_item_candidates_returns_empty(self):
+    def test_item_candidates_returns_empty_without_musicbrainz(self):
         self.load_plugins("chroma")
         plugin = chroma.AcoustidPlugin()
         item = _seed_acoustid_match()
@@ -152,11 +148,7 @@ class TestChromaWithoutMusicBrainz(ChromaCandidatesTestBase):
 
         assert list(result) == []
 
-
-class TestChromaWithMusicBrainz(ChromaCandidatesTestBase):
-    """When musicbrainz IS loaded, chroma uses the registry instance."""
-
-    def test_candidates_returns_mb_albums(self, monkeypatch):
+    def test_candidates_returns_mb_albums_with_musicbrainz(self, monkeypatch):
         self.load_plugins("chroma", "musicbrainz")
 
         fake_album = AlbumInfo(
@@ -178,7 +170,9 @@ class TestChromaWithMusicBrainz(ChromaCandidatesTestBase):
         assert result == [fake_album]
         mb_plugin.album_for_id.assert_called_with("rel-id-1")
 
-    def test_item_candidates_returns_mb_tracks(self, monkeypatch):
+    def test_item_candidates_returns_mb_tracks_with_musicbrainz(
+        self, monkeypatch
+    ):
         self.load_plugins("chroma", "musicbrainz")
 
         fake_track = TrackInfo(title="Fake Track", track_id="rec-id-1")

--- a/test/plugins/test_chroma.py
+++ b/test/plugins/test_chroma.py
@@ -16,8 +16,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-import beets.plugins
-from beets import config, metadata_plugins
+from beets import metadata_plugins
 from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.library import Item
 from beets.test.helper import ImportTestCase, IOMixin, PluginMixin
@@ -92,34 +91,6 @@ class ChromaTest(IOMixin, PluginMixin, ImportTestCase):
 # -----------------------------------------------------------------------------
 
 
-@pytest.fixture
-def reset_plugin_state():
-    """Fully reset plugin and metadata-plugin state around each test."""
-    beets.plugins.BeetsPlugin.listeners.clear()
-    beets.plugins.BeetsPlugin._raw_listeners.clear()
-    beets.plugins._instances.clear()
-    config["plugins"] = []
-    metadata_plugins.find_metadata_source_plugins.cache_clear()
-    metadata_plugins.get_metadata_source.cache_clear()
-    chroma._matches.clear()
-
-    yield
-
-    chroma._matches.clear()
-    beets.plugins.BeetsPlugin.listeners.clear()
-    beets.plugins.BeetsPlugin._raw_listeners.clear()
-    beets.plugins._instances.clear()
-    config["plugins"] = []
-    metadata_plugins.find_metadata_source_plugins.cache_clear()
-    metadata_plugins.get_metadata_source.cache_clear()
-
-
-def _load_plugins(*names: str) -> None:
-    """Load the given plugins into the global beets plugin registry."""
-    config["plugins"] = list(names)
-    beets.plugins.load_plugins()
-
-
 def _seed_acoustid_match(
     item_path: bytes = b"/fake/path.mp3",
     recording_ids: list[str] | None = None,
@@ -135,12 +106,34 @@ def _seed_acoustid_match(
     return Item(path=item_path)
 
 
-@pytest.mark.usefixtures("reset_plugin_state")
-class TestChromaWithoutMusicBrainz:
+class ChromaCandidatesTestBase(PluginMixin):
+    """Shared fixture for chroma candidate tests.
+
+    Subclasses should not set ``plugin`` so that ``load_plugins``
+    accepts explicit plugin-name arguments. The autouse fixture
+    additionally clears the ``@cache``-decorated metadata-source
+    registry and the chroma match state between tests.
+    """
+
+    preload_plugin = False
+
+    @pytest.fixture(autouse=True)
+    def _setup_chroma(self):
+        metadata_plugins.find_metadata_source_plugins.cache_clear()
+        metadata_plugins.get_metadata_source.cache_clear()
+        chroma._matches.clear()
+        yield
+        chroma._matches.clear()
+        self.unload_plugins()
+        metadata_plugins.find_metadata_source_plugins.cache_clear()
+        metadata_plugins.get_metadata_source.cache_clear()
+
+
+class TestChromaWithoutMusicBrainz(ChromaCandidatesTestBase):
     """When musicbrainz is not loaded, chroma must not produce candidates."""
 
     def test_candidates_returns_empty(self):
-        _load_plugins("chroma")
+        self.load_plugins("chroma")
         plugin = chroma.AcoustidPlugin()
         item = _seed_acoustid_match()
 
@@ -151,7 +144,7 @@ class TestChromaWithoutMusicBrainz:
         assert list(result) == []
 
     def test_item_candidates_returns_empty(self):
-        _load_plugins("chroma")
+        self.load_plugins("chroma")
         plugin = chroma.AcoustidPlugin()
         item = _seed_acoustid_match()
 
@@ -160,12 +153,11 @@ class TestChromaWithoutMusicBrainz:
         assert list(result) == []
 
 
-@pytest.mark.usefixtures("reset_plugin_state")
-class TestChromaWithMusicBrainz:
+class TestChromaWithMusicBrainz(ChromaCandidatesTestBase):
     """When musicbrainz IS loaded, chroma uses the registry instance."""
 
     def test_candidates_returns_mb_albums(self, monkeypatch):
-        _load_plugins("chroma", "musicbrainz")
+        self.load_plugins("chroma", "musicbrainz")
 
         fake_album = AlbumInfo(
             tracks=[], album_id="rel-id-1", album="Fake Album"
@@ -187,7 +179,7 @@ class TestChromaWithMusicBrainz:
         mb_plugin.album_for_id.assert_called_with("rel-id-1")
 
     def test_item_candidates_returns_mb_tracks(self, monkeypatch):
-        _load_plugins("chroma", "musicbrainz")
+        self.load_plugins("chroma", "musicbrainz")
 
         fake_track = TrackInfo(title="Fake Track", track_id="rec-id-1")
         mb_plugin = metadata_plugins.get_metadata_source("musicbrainz")


### PR DESCRIPTION
## Summary

Fixes #6212.
Fixes #6441.

Split out from #6522 per @semohr's suggestion.

The ``chroma`` plugin unconditionally instantiated its own private
``MusicBrainzPlugin`` instance and called ``album_for_id`` /
``track_for_id`` on it regardless of the user's plugin configuration.
This meant MusicBrainz-sourced candidates appeared during tagging even
when the user had not enabled the ``musicbrainz`` plugin.

This PR replaces the direct instantiation with a lookup through the
metadata-source registry (``get_metadata_source("musicbrainz")``).
When the musicbrainz plugin is not loaded, both ``candidates`` and
``item_candidates`` short-circuit and return empty. Acoustid
fingerprinting itself is unaffected — ``acoustid_id`` and
``acoustid_fingerprint`` fields are still populated as before.

### Side-effect fix

The previous ``cached_property mb = MusicBrainzPlugin()`` pattern
created a second instance outside the plugin registry. This bypassed
any plugin that swaps the musicbrainz instance at runtime (e.g.
``mbpseudo``). Routing through ``get_metadata_source`` fixes this —
chroma now uses the same shared instance as the rest of beets.

### Scope

This PR is intentionally scoped to the gating fix only. The richer
cross-reference routing (extracting Spotify/Discogs/etc. IDs from
MusicBrainz ``url-relations`` and dispatching to enabled external
plugins) is being developed separately in #6522.

## Test plan

- [x] 4 new tests in ``test/plugins/test_chroma.py``:
  ``candidates`` / ``item_candidates`` × with / without musicbrainz.
- [x] 2 existing ``chromasearch`` tests still pass.
- [x] 144 focused regression tests pass (chroma, musicbrainz,
  metadata_plugins, autotag/match, autotag/distance).
- [x] ``ruff check`` + ``ruff format --check`` clean.
- [x] ``mypy beetsplug/chroma.py`` clean.
- [x] ``sphinx-lint`` + ``docstrfmt`` (Python 3.10) clean.
- [x] Changelog entry + docs note added.