### PR TITLE
Extend the default `ruff` config instead of replacing it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -306,7 +306,7 @@ line-length = 80
 
 [tool.ruff.lint]
 future-annotations = true
-select = [
+extend-select = [
     # "ARG", # flake8-unused-arguments
     # "C4", # flake8-comprehensions
     "E", # pycodestyle


### PR DESCRIPTION
## Description

Instead of choosing specifically what to enable, choose which extra options to enable on top of the default settings. 

## To Do

* Test how much code breaks

- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
