### PR TITLE
Add keep_synced option to lyrics plugin

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -995,6 +995,7 @@ class LyricsPlugin(LyricsRequestHandler, plugins.BeetsPlugin):
                 ),
                 "fallback": None,
                 "force": False,
+                "keep_synced": False,
                 "local": False,
                 "print": False,
                 "synced": False,
@@ -1039,6 +1040,12 @@ class LyricsPlugin(LyricsRequestHandler, plugins.BeetsPlugin):
             action="store_true",
             default=self.config["force"].get(),
             help="always re-download lyrics",
+        )
+        cmd.parser.add_option(
+            "--keep-synced",
+            action="store_true",
+            default=self.config["keep_synced"].get(),
+            help="re-download only unsynced lyrics",
         )
         cmd.parser.add_option(
             "-l",
@@ -1100,6 +1107,10 @@ class LyricsPlugin(LyricsRequestHandler, plugins.BeetsPlugin):
             return
 
         existing_lyrics = Lyrics.from_item(item)
+        if self.config["keep_synced"] and existing_lyrics.synced:
+            self.info("🔵 Keeping synced lyrics: {}", item)
+            return
+
         if new_lyrics := self.find_lyrics(item):
             self.info("🟢 Found lyrics: {}", item)
             if translator := self.translator:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,9 @@ New features
 - :doc:`plugins/discogs`: Import Discogs remixer, lyricist, composer, and
   arranger credits into the multi-value ``remixers``, ``lyricists``,
   ``composers``, and ``arrangers`` fields. :bug:`6380`
+- :doc:`plugins/lyrics`: Add ``keep_synced`` config option and ``--keep-synced``
+  CLI flag to skip re-fetching lyrics for tracks that already have synced
+  lyrics, even when ``force`` is enabled. :bug:`5249`
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -55,6 +55,7 @@ Default configuration:
         dist_thresh: 0.11
         fallback: null
         force: no
+        keep_synced: no
         google_API_key: null
         google_engine_ID: 009217259823014548361:lndtuqkycfu
         print: no
@@ -96,6 +97,10 @@ The available options are:
   found. Use the empty string ``''`` to reset the lyrics in such a case.
 - **force**: By default, beets won't fetch lyrics if the files already have
   ones. To instead always fetch lyrics, set the ``force`` option to ``yes``.
+- **keep_synced**: When enabled, tracks that already have synced lyrics are
+  skipped even when ``force`` is set. Useful when re-fetching lyrics for a
+  library that contains a mix of synced and plain lyrics and you only want to
+  fill in the gaps. Default: ``no``.
 - **google_API_key**: Your Google API key (to enable the Google Custom Search
   backend).
 - **google_engine_ID**: The custom search engine to use. Default: The `beets
@@ -129,6 +134,10 @@ to the console so you can view the fetched (or previously-stored) lyrics.
 
 The ``-f, --force`` option forces the command to fetch lyrics, even for tracks
 that already have lyrics.
+
+The ``--keep-synced`` option skips tracks that already have synced lyrics,
+regardless of the ``force`` flag. This is handy when you want to re-fetch plain
+lyrics without touching tracks that already have a synced version.
 
 Inversely, the ``-l, --local`` option restricts operations to lyrics that are
 locally available, which show lyrics faster without using the network at all.

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -317,6 +317,13 @@ class TestLyricsPlugin(LyricsPluginMixin):
                 "new plain",
                 id="replace-with-unsynced-lyrics-when-disabled",
             ),
+            pytest.param(
+                {"force": True, "keep_synced": True},
+                "[00:00.00] old synced",
+                "new",
+                "[00:00.00] old synced",
+                id="keep_synced_keeps_old_synced",
+            ),
         ],
     )
     def test_overwrite_config(


### PR DESCRIPTION
## `lyrics`: Add `keep_synced` option to protect synced lyrics from being overwritten

Adds a `keep_synced` config option and `--keep-synced` CLI flag to the lyrics plugin. When enabled, tracks that already have synced lyrics are skipped during fetching — even if `force` is set.

**Motivation:** Libraries with a mix of synced and plain lyrics can use `force` to fill gaps without risking overwriting the higher-quality synced entries.

Fixes: #5249

This is another widely requested issue with many reactions from users.