### PR TITLE
fix(library): pass clutter to move command

### DIFF
--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -277,7 +277,11 @@ class ImportTask(BaseImportTask):
             if lib.directory in util.ancestry(item.path):
                 log.debug("deleting duplicate {.filepath}", item)
                 util.remove(item.path)
-                util.prune_dirs(os.path.dirname(item.path), lib.directory)
+                util.prune_dirs(
+                    os.path.dirname(item.path),
+                    lib.directory,
+                    clutter=config["clutter"].as_str_seq(),
+                )
 
     def set_fields(self, lib: library.Library):
         """Sets the fields given at CLI or configuration to the specified

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -448,7 +448,11 @@ class Album(LibModel):
         )
         if operation == MoveOperation.MOVE:
             util.move(old_art, new_art)
-            util.prune_dirs(os.path.dirname(old_art), self._db.directory)
+            util.prune_dirs(
+                os.path.dirname(old_art),
+                self._db.directory,
+                clutter=beets.config["clutter"].as_str_seq(),
+            )
         elif operation == MoveOperation.COPY:
             util.copy(old_art, new_art)
         elif operation == MoveOperation.LINK:
@@ -1154,7 +1158,11 @@ class Item(LibModel):
         # Delete the associated file.
         if delete:
             util.remove(self.path)
-            util.prune_dirs(os.path.dirname(self.path), self._db.directory)
+            util.prune_dirs(
+                os.path.dirname(self.path),
+                self._db.directory,
+                clutter=beets.config["clutter"].as_str_seq(),
+            )
 
         self._db._memotable = {}
 
@@ -1207,7 +1215,11 @@ class Item(LibModel):
 
         # Prune vacated directory.
         if operation == MoveOperation.MOVE:
-            util.prune_dirs(os.path.dirname(old_path), self._db.directory)
+            util.prune_dirs(
+                os.path.dirname(old_path),
+                self._db.directory,
+                clutter=beets.config["clutter"].as_str_seq(),
+            )
 
     # Templating.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -49,6 +49,7 @@ Bug fixes
   registry instead of unconditionally instantiating its own private instance,
   which also restores compatibility with :doc:`plugins/mbpseudo` for
   chroma-triggered lookups. :bug:`6212` :bug:`6441`
+- :ref:`import-cmd` Remove clutter from imported album folders. :bug:`5016`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1343,6 +1343,42 @@ class FilesizeTest(BeetsTestCase):
         assert item.filesize == 0
 
 
+class ItemPruneDirsClutterTest(BeetsTestCase):
+    """Regression tests: prune_dirs respects config["clutter"] during move/remove."""
+
+    def _drop_clutter(self, directory, filename=b"unwanted.log"):
+        """Create a clutter file in *directory* (bytes path)."""
+        path = os.path.join(directory, filename)
+        with open(syspath(path), "w"):
+            pass
+        return path
+
+    def test_move_prunes_dir_with_config_clutter(self):
+        """After moving an item, old dir is removed even when only clutter remains."""
+        config["clutter"] = ["*.log"]
+        item = self.add_item_fixture()
+        old_dir = os.path.dirname(item.path)
+        self._drop_clutter(old_dir)
+
+        # Change artist so the destination path differs, forcing a real move.
+        item.artist = "new artist"
+        item.store()
+        item.move()
+
+        assert not os.path.exists(syspath(old_dir))
+
+    def test_remove_prunes_dir_with_config_clutter(self):
+        """After deleting an item, its dir is removed even when only clutter remains."""
+        config["clutter"] = ["*.log"]
+        item = self.add_item_fixture()
+        old_dir = os.path.dirname(item.path)
+        self._drop_clutter(old_dir)
+
+        item.remove(delete=True)
+
+        assert not os.path.exists(syspath(old_dir))
+
+
 class ParseQueryTest(unittest.TestCase):
     def test_parse_invalid_query_string(self):
         with pytest.raises(beets.dbcore.query.ParsingError):


### PR DESCRIPTION
## Description

This change fixes move and ensures that `clutter` options are correctly passed through allowing beets to prune dirs with clutter in them.

Fixes: #5016 

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)~
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
