### PR TITLE
Parallelize candidate lookup for metadata plugins.

### DIFF
--- a/beets/metadata_plugins.py
+++ b/beets/metadata_plugins.py
@@ -80,9 +80,7 @@ def _yield_from_plugins(
 
     @wraps(func)
     def wrapper(*args, **kwargs) -> Iterator[Ret]:
-        # Run all metadata source plugins in parallel threads.
-        # Each plugin executes its lookup/search concurrently, so I/O-bound API calls
-        # complete faster than sequential.
+        # Run plugin methods concurrently for faster I/O-bound lookups.
         with ThreadPoolExecutor() as executor:
             futures = {
                 executor.submit(

--- a/beets/metadata_plugins.py
+++ b/beets/metadata_plugins.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import abc
 import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from functools import cache, cached_property, wraps
 from typing import (
@@ -79,10 +80,30 @@ def _yield_from_plugins(
 
     @wraps(func)
     def wrapper(*args, **kwargs) -> Iterator[Ret]:
-        for plugin in find_metadata_source_plugins():
-            method = getattr(plugin, method_name)
-            with maybe_handle_plugin_error(plugin, method_name):
-                yield from filter(None, method(*args, **kwargs))
+        # Run all metadata source plugins in parallel threads.
+        # Each plugin executes its lookup/search concurrently, so I/O-bound API calls
+        # complete faster than sequential.
+        with ThreadPoolExecutor() as executor:
+            futures = {
+                executor.submit(
+                    # Evaluate iterator with list such that results are ready when
+                    # future.result() is called.
+                    lambda *args, **kwargs: list(
+                        getattr(plugin, method_name)(
+                            *args,
+                            **kwargs,
+                        )
+                    ),
+                    *args,
+                    **kwargs,
+                ): plugin
+                for plugin in find_metadata_source_plugins()
+            }
+
+            for future in as_completed(futures):
+                plugin = futures[future]
+                with maybe_handle_plugin_error(plugin, method_name):
+                    yield from filter(None, future.result())
 
     return wrapper
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,8 +35,8 @@ New features
   CLI flag to skip re-fetching lyrics for tracks that already have synced
   lyrics, even when ``force`` is enabled. :bug:`5249`
 - :doc:`plugins/musicbrainz`: Use aliases for artist credit.
-- Execute metadata source plugin searches and lookups concurrently, reducing
-  total wait time when multiple plugins (e.g. MusicBrainz and Spotify) are
+- Metadata source plugin searches and lookups are now executed concurrently,
+  speeding up lookups when multiple plugins (e.g. MusicBrainz and Spotify) are
   enabled.
 
 Bug fixes

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,9 @@ New features
   CLI flag to skip re-fetching lyrics for tracks that already have synced
   lyrics, even when ``force`` is enabled. :bug:`5249`
 - :doc:`plugins/musicbrainz`: Use aliases for artist credit.
+- Execute metadata source plugin searches and lookups concurrently, reducing
+  total wait time when multiple plugins (e.g. MusicBrainz and Spotify) are
+  enabled.
 
 Bug fixes
 ~~~~~~~~~


### PR DESCRIPTION
This pull request introduces concurrent execution of metadata source plugin searches and lookups, which significantly improves performance when multiple plugins are enabled. Instead of running each plugin sequentially, the code now uses threads to perform plugin lookups in parallel, reducing overall wait time for I/O-bound operations.

For me this improved lookup times by up to 5s each! The improvement should roughly scale linear with the number of enabled metadata plugins. 