### PR TITLE
Remove `lib` parameter from `_raw_main` and `_setup`

### DIFF
--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -126,7 +126,7 @@ NEEDS_REFLINK = unittest.skipUnless(
 
 
 class RunMixin:
-    lib: Library | None = None
+    lib: Library
 
     def run_command(self, *args, lib: Library | None = None):
         """Run a beets command with an arbitrary amount of arguments. The
@@ -135,7 +135,6 @@ class RunMixin:
         """
         sys.argv = ["beet", *args]  # avoid leakage from test suite args
         lib = lib or self.lib
-        assert lib is not None, "Lib required"
 
         with (
             patch.object(lib, "_close", Mock()),

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -38,7 +38,7 @@ from functools import cached_property
 from pathlib import Path
 from tempfile import gettempdir, mkdtemp, mkstemp
 from typing import Any, ClassVar
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 import responses
@@ -126,17 +126,22 @@ NEEDS_REFLINK = unittest.skipUnless(
 
 
 class RunMixin:
-    def run_command(self, *args, **kwargs):
+    lib: Library | None = None
+
+    def run_command(self, *args, lib: Library | None = None):
         """Run a beets command with an arbitrary amount of arguments. The
         Library` defaults to `self.lib`, but can be overridden with
         the keyword argument `lib`.
         """
-        sys.argv = ["beet"]  # avoid leakage from test suite args
-        lib = None
-        if hasattr(self, "lib"):
-            lib = self.lib
-        lib = kwargs.get("lib", lib)
-        beets.ui._raw_main(list(args), lib)
+        sys.argv = ["beet", *args]  # avoid leakage from test suite args
+        lib = lib or self.lib
+        assert lib is not None, "Lib required"
+
+        with (
+            patch.object(lib, "_close", Mock()),
+            patch("beets.ui._open_library", return_value=lib),
+        ):
+            beets.ui._raw_main(list(args))
 
 
 @pytest.mark.usefixtures("io")

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -805,7 +805,7 @@ optparse.Option.ALWAYS_TYPED_ACTIONS += ("callback",)
 
 
 def _setup(
-    options: optparse.Values, lib: library.Library | None
+    options: optparse.Values,
 ) -> tuple[list[Subcommand], library.Library]:
     """Prepare and global state and updates it with command line options.
 
@@ -821,9 +821,8 @@ def _setup(
     subcommands = list(default_commands)
     subcommands.extend(plugins.commands())
 
-    if lib is None:
-        lib = _open_library(config)
-        plugins.send("library_opened", lib=lib)
+    lib = _open_library(config)
+    plugins.send("library_opened", lib=lib)
 
     return subcommands, lib
 
@@ -903,7 +902,7 @@ def _open_library(config: confuse.LazyConfig) -> library.Library:
     return lib
 
 
-def _raw_main(args: list[str], lib=None) -> None:
+def _raw_main(args: list[str]) -> None:
     """A helper function for `main` without top-level exception
     handling.
     """
@@ -984,20 +983,17 @@ def _raw_main(args: list[str], lib=None) -> None:
 
         return config_edit(options)
 
-    test_lib = bool(lib)
-    subcommands, lib = _setup(options, lib)
+    subcommands, lib = _setup(options)
     parser.add_subcommand(*subcommands)
 
     subcommand, suboptions, subargs = parser.parse_subcommand(subargs)
     subcommand.func(lib, suboptions, subargs)
 
     plugins.send("cli_exit", lib=lib)
-    if not test_lib:
-        # Clean up the library unless it came from the test harness.
-        lib._close()
+    lib._close()
 
 
-def main(args=None):
+def main(args: list[str]) -> None:
     """Run the main command-line interface for beets. Includes top-level
     exception handlers that print friendly error messages.
     """

--- a/test/ui/commands/test_completion.py
+++ b/test/ui/commands/test_completion.py
@@ -47,7 +47,7 @@ class CompletionTest(IOMixin, TestPluginTestCase):
             self.skipTest("could not read bash-completion script")
 
         # Load completion script.
-        self.run_command("completion", lib=None)
+        self.run_command("completion")
         completion_script = self.io.getoutput().encode("utf-8")
         tester.stdin.writelines(completion_script.splitlines(True))
 

--- a/test/ui/test_ui.py
+++ b/test/ui/test_ui.py
@@ -27,7 +27,7 @@ from confuse import ConfigError
 from beets import config, plugins, ui
 from beets.test import _common
 from beets.test.helper import BeetsTestCase, IOMixin, PluginTestCase
-from beets.ui import commands
+from beets.ui import _open_library, commands
 from beets.util import syspath
 
 
@@ -126,6 +126,12 @@ class ConfigTest(IOMixin, TestPluginTestCase):
 
         self._reset_config()
 
+    def run_command(self, *args, **kwargs):
+        # We need to reload the lib based on the
+        # current config
+        self.lib = _open_library(self.config)
+        super().run_command(*args, **kwargs)
+
     def tearDown(self):
         self.env_patcher.stop()
         commands.default_commands.pop()
@@ -155,7 +161,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
         with self.write_config_file() as config:
             config.write("paths: {x: y}")
 
-        self.run_command("test", lib=None)
+        self.run_command("test")
         key, template = self.test_cmd.lib.path_formats[0]
         assert key == "x"
         assert template.original == "y"
@@ -166,7 +172,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
         self._reset_config()
         with self.write_config_file() as config:
             config.write("paths: {x: y}")
-        self.run_command("test", lib=None)
+        self.run_command("test")
         key, template = self.test_cmd.lib.path_formats[0]
         assert key == "x"
         assert template.original == "y"
@@ -178,20 +184,20 @@ class ConfigTest(IOMixin, TestPluginTestCase):
 
         self.io.addinput("n")
         with pytest.raises(ui.UserError):
-            self.run_command("test", lib=None)
+            self.run_command("test")
 
     def test_user_config_file(self):
         with self.write_config_file() as file:
             file.write("anoption: value")
 
-        self.run_command("test", lib=None)
+        self.run_command("test")
         assert config["anoption"].get() == "value"
 
     def test_replacements_parsed(self):
         with self.write_config_file() as config:
             config.write("replace: {'[xy]': z}")
 
-        self.run_command("test", lib=None)
+        self.run_command("test")
         replacements = self.test_cmd.lib.replacements
         repls = [(p.pattern, s) for p, s in replacements]  # Compare patterns.
         assert repls == [("[xy]", "z")]
@@ -199,7 +205,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
     def test_multiple_replacements_parsed(self):
         with self.write_config_file() as config:
             config.write("replace: {'[xy]': z, foo: bar}")
-        self.run_command("test", lib=None)
+        self.run_command("test")
         replacements = self.test_cmd.lib.replacements
         repls = [(p.pattern, s) for p, s in replacements]
         assert repls == [("[xy]", "z"), ("foo", "bar")]
@@ -207,7 +213,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
     def test_cli_config_option(self):
         with open(self.cli_config_path, "w") as file:
             file.write("anoption: value")
-        self.run_command("--config", self.cli_config_path, "test", lib=None)
+        self.run_command("--config", self.cli_config_path, "test")
         assert config["anoption"].get() == "value"
 
     def test_cli_config_file_overwrites_user_defaults(self):
@@ -216,7 +222,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
 
         with open(self.cli_config_path, "w") as file:
             file.write("anoption: cli overwrite")
-        self.run_command("--config", self.cli_config_path, "test", lib=None)
+        self.run_command("--config", self.cli_config_path, "test")
         assert config["anoption"].get() == "cli overwrite"
 
     def test_cli_config_file_overwrites_beetsdir_defaults(self):
@@ -226,7 +232,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
 
         with open(self.cli_config_path, "w") as file:
             file.write("anoption: cli overwrite")
-        self.run_command("--config", self.cli_config_path, "test", lib=None)
+        self.run_command("--config", self.cli_config_path, "test")
         assert config["anoption"].get() == "cli overwrite"
 
     #    @unittest.skip('Difficult to implement with optparse')
@@ -241,7 +247,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
     #            file.write('second: value')
     #
     #        self.run_command('--config', cli_config_path_1,
-    #                      '--config', cli_config_path_2, 'test', lib=None)
+    #                      '--config', cli_config_path_2, 'test')
     #        assert config['first'].get() == 'value'
     #        assert config['second'].get() == 'value'
     #
@@ -267,7 +273,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
             file.write("library: beets.db\n")
             file.write("statefile: state")
 
-        self.run_command("--config", self.cli_config_path, "test", lib=None)
+        self.run_command("--config", self.cli_config_path, "test")
         assert config["library"].as_path() == self.user_config_dir / "beets.db"
         assert config["statefile"].as_path() == self.user_config_dir / "state"
 
@@ -278,14 +284,14 @@ class ConfigTest(IOMixin, TestPluginTestCase):
             file.write("library: beets.db\n")
             file.write("statefile: state")
 
-        self.run_command("--config", self.cli_config_path, "test", lib=None)
+        self.run_command("--config", self.cli_config_path, "test")
         assert config["library"].as_path() == self.beetsdir / "beets.db"
         assert config["statefile"].as_path() == self.beetsdir / "state"
 
     def test_command_line_option_relative_to_working_dir(self):
         config.read()
         os.chdir(syspath(self.temp_dir))
-        self.run_command("--library", "foo.db", "test", lib=None)
+        self.run_command("--library", "foo.db", "test")
         assert config["library"].as_path() == Path.cwd() / "foo.db"
 
     def test_cli_config_file_loads_plugin_commands(self):
@@ -293,7 +299,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
             file.write(f"pluginpath: {_common.PLUGINPATH}\n")
             file.write("plugins: test")
 
-        self.run_command("--config", self.cli_config_path, "plugin", lib=None)
+        self.run_command("--config", self.cli_config_path, "plugin")
         plugs = plugins.find_plugins()
         assert len(plugs) == 1
         assert plugs[0].is_test_plugin
@@ -358,7 +364,7 @@ class PathFormatTest(unittest.TestCase):
 @_common.slow_test()
 class PluginTest(TestPluginTestCase):
     def test_plugin_command_from_pluginpath(self):
-        self.run_command("test", lib=None)
+        self.run_command("test")
 
 
 class CommonOptionsParserCliTest(IOMixin, BeetsTestCase):


### PR DESCRIPTION
## Description


The `lib` parameter on `_raw_main` and `_setup` was only used by the test harness. Rather than keep testing-specific logic in production code, this PR removes the parameter and updates the test harness to patch `_open_library` instead.


- [x] ~~Changelog.~~ (Not needed as this is a purely internal factor imo)

