### PR TITLE
Use url to override lyrics

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -1140,7 +1140,11 @@ class LyricsPlugin(LyricsRequestHandler, plugins.BeetsPlugin):
             return
 
         existing_lyrics = Lyrics.from_item(item)
-        if self.config["keep_synced"] and existing_lyrics.synced and not item.get("lyrics_url"):
+        if (
+            self.config["keep_synced"]
+            and existing_lyrics.synced
+            and not item.get("lyrics_url")
+        ):
             self.info("🔵 Keeping synced lyrics: {}", item)
             return
 
@@ -1153,7 +1157,12 @@ class LyricsPlugin(LyricsRequestHandler, plugins.BeetsPlugin):
 
             is_override = bool(item.get("lyrics_url"))
             synced_mode = self.config["synced"].get(bool)
-            if synced_mode and existing_lyrics.synced and not new_lyrics.synced and not is_override:
+            if (
+                synced_mode
+                and existing_lyrics.synced
+                and not new_lyrics.synced
+                and not is_override
+            ):
                 self.info(
                     "🔴 Not updating synced lyrics with non-synced ones: {}",
                     item,

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -1054,6 +1054,14 @@ class LyricsPlugin(LyricsRequestHandler, plugins.BeetsPlugin):
             default=self.config["local"].get(),
             help="do not fetch missing lyrics",
         )
+        cmd.parser.add_option(
+            "-u",
+            "--lyrics-url",
+            dest="lyrics_url",
+            action="store",
+            default=None,
+            help="override lyrics source with URL",
+        )
 
         def func(lib: Library, opts, args) -> None:
             # The "write to files" option corresponds to the
@@ -1061,6 +1069,9 @@ class LyricsPlugin(LyricsRequestHandler, plugins.BeetsPlugin):
             self.config.set(vars(opts))
             items = list(lib.items(args))
             for item in items:
+                if opts.lyrics_url:
+                    item.lyrics_url = opts.lyrics_url
+                    item.store()
                 self.add_item_lyrics(item, ui.should_write())
                 if item.lyrics and opts.print:
                     ui.print_(item.lyrics)
@@ -1095,10 +1106,32 @@ class LyricsPlugin(LyricsRequestHandler, plugins.BeetsPlugin):
 
         return next(filter(None, matches), None)
 
-    def add_item_lyrics(self, item: Item, write: bool) -> None:
-        """Fetch and store lyrics for a single item. If ``write``, then the
-        lyrics will also be written to the file itself.
-        """
+    def fetch_url_override(self, item: Item) -> Lyrics | None:
+        """Fetch lyrics from the URL stored in item.lyrics_url, if present."""
+        override_url = item.get("lyrics_url")
+        if not override_url:
+            return None
+
+        self.debug("Using override URL: {}", override_url)
+
+        # detect lrclib API URLs and use proper JSON parsing
+        if re.search(r"lrclib\.net/api/get/\d+", override_url):
+            with self.handle_request():
+                candidate = self.get_json(override_url)
+                lrc = LRCLyrics.make(candidate, round(item.length))
+                lyrics_text = lrc.get_text(self.config["synced"].get(bool))
+                return Lyrics(lyrics_text, "lrclib", override_url)
+            return None
+
+        # fallback: treat URL as plain text (e.g. raw lyrics page)
+        with self.handle_request():
+            text = self.get_text(override_url)
+            if text:
+                return Lyrics(text, "override", override_url)
+
+        return None
+
+def add_item_lyrics(self, item: Item, write: bool) -> None:
         if self.config["local"]:
             return
 
@@ -1107,22 +1140,16 @@ class LyricsPlugin(LyricsRequestHandler, plugins.BeetsPlugin):
             return
 
         existing_lyrics = Lyrics.from_item(item)
-        if self.config["keep_synced"] and existing_lyrics.synced:
+        if self.config["keep_synced"] and existing_lyrics.synced and not item.get("lyrics_url"):
             self.info("🔵 Keeping synced lyrics: {}", item)
             return
 
-        if new_lyrics := self.find_lyrics(item):
+        if new_lyrics := self.fetch_url_override(item) or self.find_lyrics(
+            item
+        ):
             self.info("🟢 Found lyrics: {}", item)
             if translator := self.translator:
                 new_lyrics = translator.translate(new_lyrics, existing_lyrics)
-
-            synced_mode = self.config["synced"].get(bool)
-            if synced_mode and existing_lyrics.synced and not new_lyrics.synced:
-                self.info(
-                    "🔴 Not updating synced lyrics with non-synced ones: {}",
-                    item,
-                )
-                return
 
             for key in ("backend", "url", "language", "translation_language"):
                 item_key = f"lyrics_{key}"

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -1131,7 +1131,7 @@ class LyricsPlugin(LyricsRequestHandler, plugins.BeetsPlugin):
 
         return None
 
-def add_item_lyrics(self, item: Item, write: bool) -> None:
+    def add_item_lyrics(self, item: Item, write: bool) -> None:
         if self.config["local"]:
             return
 
@@ -1150,6 +1150,15 @@ def add_item_lyrics(self, item: Item, write: bool) -> None:
             self.info("🟢 Found lyrics: {}", item)
             if translator := self.translator:
                 new_lyrics = translator.translate(new_lyrics, existing_lyrics)
+
+            is_override = bool(item.get("lyrics_url"))
+            synced_mode = self.config["synced"].get(bool)
+            if synced_mode and existing_lyrics.synced and not new_lyrics.synced and not is_override:
+                self.info(
+                    "🔴 Not updating synced lyrics with non-synced ones: {}",
+                    item,
+                )
+                return
 
             for key in ("backend", "url", "language", "translation_language"):
                 item_key = f"lyrics_{key}"


### PR DESCRIPTION
## Description

Fixes #6439
These changes will allow users to override lyrics by adding a -u or --lyrics-url CLI flag to redirect lyric retrieval from the specified URL

**What Was The Problem?**
For some songs, LRCLib has multiple versions and there was no way to choose which lyrics would get pulled. 

**What Is The Solution?**
Allows user to determine which source LRCLib API URL they want the lyrics to get chosen from: 
beet lyrics -f -u "https://lrclib.net/api/get/26627014" "song title"

The URL is stored on the item as the lyrics_url flex attribute and takes priority over the normal search flow. If the override URL fails then the plugin falls back to normal source search automatically.

