### PR TITLE
Use aliases for artist credit

### DIFF
--- a/beetsplug/musicbrainz.py
+++ b/beetsplug/musicbrainz.py
@@ -314,9 +314,8 @@ class MusicBrainzPlugin(
         - Parallel lists that keep the per-artist granularity for callers that
           need to reason about individual credited artists.
 
-        When available, a preferred alias is used for the canonical artist name
-        and sort name, while the credit name preserves the exact credited text
-        from the release.
+        When available, a preferred alias is used for the canonical artist name,
+        sort name and the credit name.
         """
         artist_parts: list[str] = []
         artist_sort_parts: list[str] = []

--- a/beetsplug/musicbrainz.py
+++ b/beetsplug/musicbrainz.py
@@ -330,12 +330,17 @@ class MusicBrainzPlugin(
             artists_ids.append(el["artist"]["id"])
             alias = _preferred_alias(el["artist"].get("aliases", []))
             artist_object = alias or el["artist"]
+            credit_artist_object = alias or el
 
             joinphrase = el["joinphrase"]
             for name, parts, multi in (
                 (artist_object["name"], artist_parts, artists),
                 (artist_object["sort_name"], artist_sort_parts, artists_sort),
-                (el["name"], artist_credit_parts, artists_credit),
+                (
+                    credit_artist_object["name"],
+                    artist_credit_parts,
+                    artists_credit,
+                ),
             ):
                 parts.extend([name, joinphrase])
                 multi.append(name)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,7 @@ New features
 - :doc:`plugins/lyrics`: Add ``keep_synced`` config option and ``--keep-synced``
   CLI flag to skip re-fetching lyrics for tracks that already have synced
   lyrics, even when ``force`` is enabled. :bug:`5249`
+- :doc:`plugins/musicbrainz`: Use aliases for artist credit.
 
 Bug fixes
 ~~~~~~~~~

--- a/test/plugins/factories/musicbrainz.py
+++ b/test/plugins/factories/musicbrainz.py
@@ -60,6 +60,15 @@ class ArtistFactory(_SortNameFactory, _IdFactory):
     name = "Artist"
     type = "Person"
     type_id = "b6e035f4-3ce9-331c-97df-83397230b0df"
+    aliases = factory.List(
+        [
+            factory.SubFactory(
+                AliasFactory,
+                type="Artist name",
+                prefix=factory.SelfAttribute("...name"),
+            )
+        ]
+    )
 
 
 class ArtistCreditFactory(factory.DictFactory):

--- a/test/plugins/test_musicbrainz.py
+++ b/test/plugins/test_musicbrainz.py
@@ -653,32 +653,75 @@ class TestParseRelease(MusicBrainzPluginTestMixin):
         assert mb.album_info(release_factory()).genres == expected_genres
 
     @pytest.mark.parametrize(
-        "languages_config, expected_titles",
+        "languages_config, is_aliased",
         [
-            _p([], ("Album", "Release Group", "Recording"), id="no aliases"),
+            _p(
+                [],
+                False,
+                id="no aliases",
+            ),
             _p(
                 ["en"],
-                (
-                    "Album Alias en",
-                    "Release Group Alias en",
-                    "Recording Alias en",
-                ),
+                True,
                 id="aliases",
             ),
         ],
     )
-    def test_parse_titles(self, config, mb, languages_config, expected_titles):
+    def test_parse_titles(
+        self,
+        config,
+        mb: MusicBrainzPlugin,
+        languages_config: list[str],
+        is_aliased: bool,
+    ):
         release = release_factory()
 
         config["import"]["languages"] = languages_config
 
-        album, release_group_title, track_title = expected_titles
+        def aliased_name(name: str) -> str:
+            return f"{name} Alias en" if is_aliased else name
 
         d = mb.album_info(release)
 
-        assert d.album == album
-        assert d.release_group_title == release_group_title
-        assert d.tracks[0].title == track_title
+        assert d.album == aliased_name("Album")
+        assert d.release_group_title == aliased_name("Release Group")
+        assert d.tracks[0].title == aliased_name("Recording")
+
+        album_artist = aliased_name("Artist")
+        assert d.artist == album_artist
+        assert d.artists == [album_artist]
+
+        # There is no artist credit specific alias
+        album_artist_credit = album_artist if is_aliased else "Artist Credit"
+        assert d.artist_credit == album_artist_credit
+        assert d.artists_credit == [album_artist_credit]
+
+        album_artist_sort = (
+            "Artist Alias en, The" if is_aliased else "Artist, The"
+        )
+        assert d.artist_sort == album_artist_sort
+        assert d.artists_sort == [album_artist_sort]
+
+        first_track = d.tracks[0]
+
+        track_artist = aliased_name("Recording Artist")
+        assert first_track.artist == track_artist
+        assert first_track.artists == [track_artist]
+
+        # There is no artist credit specific alias
+        track_artist_credit = (
+            track_artist if is_aliased else "Recording Artist Credit"
+        )
+        assert first_track.artist_credit == track_artist_credit
+        assert first_track.artists_credit == [track_artist_credit]
+
+        track_artist_sort = (
+            "Recording Artist Alias en, The"
+            if is_aliased
+            else "Recording Artist, The"
+        )
+        assert first_track.artist_sort == track_artist_sort
+        assert first_track.artists_sort == [track_artist_sort]
 
     def test_ensure_complete_recordings(self, monkeypatch, mb):
         titles = ["Recording", "Other Recording"]

--- a/test/plugins/test_musicbrainz.py
+++ b/test/plugins/test_musicbrainz.py
@@ -652,74 +652,38 @@ class TestParseRelease(MusicBrainzPluginTestMixin):
     def test_genres(self, mb, expected_genres):
         assert mb.album_info(release_factory()).genres == expected_genres
 
-    @pytest.mark.parametrize(
-        "languages_config, is_aliased",
-        [
-            _p(
-                [],
-                False,
-                id="no aliases",
-            ),
-            _p(
-                ["en"],
-                True,
-                id="aliases",
-            ),
-        ],
-    )
-    def test_parse_titles(
-        self,
-        config,
-        mb: MusicBrainzPlugin,
-        languages_config: list[str],
-        is_aliased: bool,
-    ):
+    def test_parse_aliased_titles(self, config, mb: MusicBrainzPlugin):
         release = release_factory()
 
-        config["import"]["languages"] = languages_config
-
-        def aliased_name(name: str) -> str:
-            return f"{name} Alias en" if is_aliased else name
+        config["import"]["languages"] = ["en"]
 
         d = mb.album_info(release)
 
-        assert d.album == aliased_name("Album")
-        assert d.release_group_title == aliased_name("Release Group")
-        assert d.tracks[0].title == aliased_name("Recording")
+        assert d.album == "Album Alias en"
+        assert d.release_group_title == "Release Group Alias en"
+        assert d.tracks[0].title == "Recording Alias en"
 
-        album_artist = aliased_name("Artist")
+        album_artist = "Artist Alias en"
         assert d.artist == album_artist
         assert d.artists == [album_artist]
-
         # There is no artist credit specific alias
-        album_artist_credit = album_artist if is_aliased else "Artist Credit"
-        assert d.artist_credit == album_artist_credit
-        assert d.artists_credit == [album_artist_credit]
+        assert d.artist_credit == album_artist
+        assert d.artists_credit == [album_artist]
 
-        album_artist_sort = (
-            "Artist Alias en, The" if is_aliased else "Artist, The"
-        )
+        album_artist_sort = "Artist Alias en, The"
         assert d.artist_sort == album_artist_sort
         assert d.artists_sort == [album_artist_sort]
 
         first_track = d.tracks[0]
 
-        track_artist = aliased_name("Recording Artist")
+        track_artist = "Recording Artist Alias en"
         assert first_track.artist == track_artist
         assert first_track.artists == [track_artist]
-
         # There is no artist credit specific alias
-        track_artist_credit = (
-            track_artist if is_aliased else "Recording Artist Credit"
-        )
-        assert first_track.artist_credit == track_artist_credit
-        assert first_track.artists_credit == [track_artist_credit]
+        assert first_track.artist_credit == track_artist
+        assert first_track.artists_credit == [track_artist]
 
-        track_artist_sort = (
-            "Recording Artist Alias en, The"
-            if is_aliased
-            else "Recording Artist, The"
-        )
+        track_artist_sort = "Recording Artist Alias en, The"
         assert first_track.artist_sort == track_artist_sort
         assert first_track.artists_sort == [track_artist_sort]
 


### PR DESCRIPTION
## Description

The `*_credit` fields for album and track are also aliased.

Follow up of https://github.com/beetbox/beets/pull/6231. I wanted to `mbsync` my library but then I realized that `*_credit` fields were reverted to non-alias if already aliased.

I don't how I got those aliased in the first place as the code is not using them since years. Also, I had 2 albums added the same day and one was with aliased credit and the other one not.

Discussed here: https://github.com/beetbox/beets/issues/6358#issuecomment-4274747610

## To Do

- [X] Documentation (nothing to add since it is already said that artist is aliased)
- [X] Changelog.
- [X] Tests. (Somehow artist aliased assertion were missing so I add them as well)
