### PR TITLE
Replace old cover art instead of creating suffixed new entries / fetchart

### DIFF
--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -270,15 +270,30 @@ class ImportTask(BaseImportTask):
         return duplicate_items
 
     def remove_duplicates(self, lib: library.Library):
-        duplicate_items = self.duplicate_items(lib)
-        log.debug("removing {} old duplicated items", len(duplicate_items))
-        for item in duplicate_items:
-            item.remove()
-            if lib.directory in util.ancestry(item.path):
-                log.debug("deleting duplicate {.filepath}", item)
-                util.remove(item.path)
+        duplicate_albums = self.find_duplicates(lib)
+        log.debug("removing {} old duplicate albums", len(duplicate_albums))
+
+        for album in duplicate_albums:
+            artpath = album.artpath
+
+            for item in album.items():
+                item.remove(with_album=False)
+                if lib.directory in util.ancestry(item.path):
+                    log.debug("deleting duplicate {.filepath}", item)
+                    util.remove(item.path)
+                    util.prune_dirs(
+                        os.path.dirname(item.path),
+                        lib.directory,
+                        clutter=config["clutter"].as_str_seq(),
+                    )
+
+            album.remove(with_items=False)
+
+            if artpath and lib.directory in util.ancestry(artpath):
+                log.debug("deleting duplicate album art {}", artpath)
+                util.remove(artpath)
                 util.prune_dirs(
-                    os.path.dirname(item.path),
+                    os.path.dirname(artpath),
                     lib.directory,
                     clutter=config["clutter"].as_str_seq(),
                 )
@@ -715,6 +730,20 @@ class SingletonImportTask(ImportTask):
         return found_items
 
     duplicate_items = find_duplicates
+
+    def remove_duplicates(self, lib: library.Library):
+        duplicate_items = self.find_duplicates(lib)
+        log.debug("removing {} old duplicated items", len(duplicate_items))
+        for item in duplicate_items:
+            item.remove()
+            if lib.directory in util.ancestry(item.path):
+                log.debug("deleting duplicate {.filepath}", item)
+                util.remove(item.path)
+                util.prune_dirs(
+                    os.path.dirname(item.path),
+                    lib.directory,
+                    clutter=config["clutter"].as_str_seq(),
+                )
 
     def add(self, lib):
         with lib.transaction():

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -540,9 +540,9 @@ class Album(LibModel):
             return
 
         # Normal operation.
-        if oldart == artdest:
+        if oldart:
             util.remove(oldart)
-        artdest = util.unique_path(artdest)
+        util.remove(artdest)
         if copy:
             util.copy(path, artdest)
         else:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -48,6 +48,10 @@ Bug fixes
   item or album-art paths were stored as SQLite ``TEXT`` values instead of
   bytes, so upgrading to the portable-path storage format no longer fails for
   those libraries. :bug:`6561`
+- :ref:`import-cmd` Fix duplicate album art files (e.g. ``cover.2.jpg``) being
+  created when re-importing albums with the :doc:`plugins/fetchart` plugin
+  enabled. Old album art is now properly removed when replacing duplicate albums
+  during import. :bug:`1264` :bug:`6205`
 
 ..
     For plugin developers

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -414,7 +414,10 @@ class ArtFileTest(BeetsTestCase):
         ai.set_art(artdest)
         assert ai.art_filepath.exists()
 
-    def test_setart_to_conflicting_file_gets_new_path(self):
+    @pytest.mark.xfail(
+        reason="set_art should replace conflicting file, not create suffixed duplicate"
+    )
+    def test_setart_to_conflicting_file_replaces_it(self):
         newart = os.path.join(self.libdir, b"newart.jpg")
         touch(newart)
         i2 = item()
@@ -427,10 +430,36 @@ class ArtFileTest(BeetsTestCase):
         artdest = ai.art_destination(newart)
         touch(artdest)
 
-        # Set the art.
+        # Set the art - should replace the existing file, not create a suffixed
+        # duplicate like cover.2.jpg.
         ai.set_art(newart)
-        assert artdest != ai.artpath
-        assert os.path.dirname(artdest) == os.path.dirname(ai.artpath)
+        assert artdest == ai.artpath
+
+    @pytest.mark.xfail(
+        reason="set_art should replace old art, even if it has a different extension"
+    )
+    def test_setart_replaces_old_art_at_different_path(self):
+        newart = os.path.join(self.libdir, b"newart.png")
+        touch(newart)
+        i2 = item()
+        i2.path = self.i.path
+        i2.artist = "someArtist"
+        ai = self.lib.add_album((i2,))
+        i2.move(operation=MoveOperation.COPY)
+
+        # Set initial art.
+        ai.set_art(newart)
+        old_artpath = ai.artpath
+        assert os.path.exists(syspath(old_artpath))
+
+        # Set new art with a different extension.
+        another_art = os.path.join(self.libdir, b"another.jpg")
+        touch(another_art)
+        ai.set_art(another_art)
+
+        # Old art should be removed.
+        assert not os.path.exists(syspath(old_artpath))
+        assert ai.art_filepath.exists()
 
     def test_setart_sets_permissions(self):
         util.remove(self.art)

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -414,9 +414,6 @@ class ArtFileTest(BeetsTestCase):
         ai.set_art(artdest)
         assert ai.art_filepath.exists()
 
-    @pytest.mark.xfail(
-        reason="set_art should replace conflicting file, not create suffixed duplicate"
-    )
     def test_setart_to_conflicting_file_replaces_it(self):
         newart = os.path.join(self.libdir, b"newart.jpg")
         touch(newart)
@@ -435,9 +432,6 @@ class ArtFileTest(BeetsTestCase):
         ai.set_art(newart)
         assert artdest == ai.artpath
 
-    @pytest.mark.xfail(
-        reason="set_art should replace old art, even if it has a different extension"
-    )
     def test_setart_replaces_old_art_at_different_path(self):
         newart = os.path.join(self.libdir, b"newart.png")
         touch(newart)

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1058,9 +1058,6 @@ class ImportDuplicateAlbumTest(PluginMixin, ImportTestCase):
         item = self.lib.items().get()
         assert item.title == "new title"
 
-    @pytest.mark.xfail(
-        reason="cover art should be removed when album is removed"
-    )
     def test_remove_duplicate_album_deletes_art(self):
         album = self.lib.albums().get()
         art_source = os.path.join(_common.RSRC, b"abbey.jpg")

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1058,6 +1058,24 @@ class ImportDuplicateAlbumTest(PluginMixin, ImportTestCase):
         item = self.lib.items().get()
         assert item.title == "new title"
 
+    @pytest.mark.xfail(
+        reason="cover art should be removed when album is removed"
+    )
+    def test_remove_duplicate_album_deletes_art(self):
+        album = self.lib.albums().get()
+        art_source = os.path.join(_common.RSRC, b"abbey.jpg")
+        album.set_art(art_source)
+        album.store()
+        old_artpath = album.art_filepath
+
+        assert old_artpath.exists()
+
+        self.importer.default_resolution = self.importer.Resolution.REMOVE
+        self.importer.run()
+
+        assert not old_artpath.exists()
+        assert len(self.lib.albums()) == 1
+
     def test_no_autotag_removes_duplicate_album(self):
         config["import"]["autotag"] = False
         album = self.lib.albums().get()


### PR DESCRIPTION
## Summary

- Fix duplicate album art files (`cover.2.jpg`, `cover.3.jpg`, ...) accumulating when re-importing albums with the fetchart plugin enabled.
- `ImportTask.remove_duplicates` now operates at the album level and explicitly deletes album art files from disk when removing duplicate albums during import.
- `Album.set_art` now unconditionally removes old art and any existing file at the destination, instead of appending a numeric suffix via `unique_path`. This matches the method's documented behavior of "replacing any existing art".
- `SingletonImportTask` gets its own `remove_duplicates` override preserving the original item-level behavior, since `find_duplicates` returns items (not albums) for singletons.

## Root cause

Two issues contributed to the bug:

**1. `remove_duplicates` never deleted album art files.**

When a user imports a duplicate album and chooses "Remove old", `remove_duplicates` iterated over items and called `item.remove()`. When the last item was removed, this cascaded to `Album.remove(delete=False)`, which skipped art deletion due to `delete=False`. The old `cover.jpg` remained on disk as an orphan.

**2. `set_art` created unique paths instead of replacing.**

`set_art` only removed the old art file when `oldart == artdest` (exact byte equality). When `oldart` was `None` (new album, no inherited artpath) or pointed to a different path (e.g. different extension), the existing file was left in place and `unique_path` generated `cover.2.jpg`.

Fixes #6205
