### PR TITLE
Filter out zero penalty for cli display

### DIFF
--- a/beets/autotag/distance.py
+++ b/beets/autotag/distance.py
@@ -146,6 +146,7 @@ class Distance:
         return [
             k.replace("album_", "").replace("track_", "").replace("_", " ")
             for k in self._penalties
+            if self[k]
         ]
 
     # Access the components and their aggregates.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,14 +25,12 @@ New features
   skipped as a duplicate, or the import was aborted), and in non-move import
   modes.
 
-
 Bug fixes
 ~~~~~~~~~
 
 - :ref:`import-cmd`: Tags with a zero distance penalty are no longer shown as
   differences in the match display. Previously, custom ``distance_weights``
   could cause fields with no actual mismatch to appear in the ``≠`` line.
-
 
 ..
     For plugin developers

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,9 +25,14 @@ New features
   skipped as a duplicate, or the import was aborted), and in non-move import
   modes.
 
-..
-    Bug fixes
-    ~~~~~~~~~
+
+Bug fixes
+~~~~~~~~~
+
+- :ref:`import-cmd`: Tags with a zero distance penalty are no longer shown as
+  differences in the match display. Previously, custom ``distance_weights``
+  could cause fields with no actual mismatch to appear in the ``≠`` line.
+
 
 ..
     For plugin developers

--- a/test/autotag/test_distance.py
+++ b/test/autotag/test_distance.py
@@ -124,6 +124,12 @@ class TestDistance:
         dist.add("medium", 0.75)
         assert dist.items() == [("album", 0.25), ("medium", 0.25)]
 
+    def test_generic_penalty_keys_excludes_zero_penalties(self, dist):
+        dist.add("album", 0.5)
+        dist.add("label", 0.0)
+        dist.add("medium", 0.25)
+        assert dist.generic_penalty_keys == ["album", "medium"]
+
     def test_update(self, dist):
         dist1 = dist
         dist1.add("album", 0.5)


### PR DESCRIPTION
## Description

Fixes #6555

`generic_penalty_keys` at `beets/autotag/distance.py:145` returns all keys in `_penalties` without filtering for non-zero values. 

I think this is a regression. 

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation~
- [x] Changelog
- [x] Tests
