### PR TITLE
fromfilename: Support 'track' prefix when parsing track number

### DIFF
--- a/beetsplug/fromfilename.py
+++ b/beetsplug/fromfilename.py
@@ -32,7 +32,7 @@ PATTERNS = [
     r"^(?P<artist>.+?)\s*-\s*(?P<title>.+?)(\s*-\s*(?P<tag>.*))?$",
     r"^(?P<track>\d+)\.?[\s_-]+(?P<title>.+)$",
     r"^(?P<title>.+) by (?P<artist>.+)$",
-    r"^(?P<track>\d+).*$",
+    r"^(track ?)?(?P<track>\d+).*$",
     r"^(?P<title>.+)$",
 ]
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,8 @@ New features
   Archives are preserved if any file in the archive was not imported (e.g.
   skipped as a duplicate, or the import was aborted), and in non-move import
   modes.
+- :doc:`plugins/fromfilename`: Support ``track`` prefix when parsing the track
+  number from the filename (e.g., ``track01.m4a``).
 
 ..
     Bug fixes

--- a/test/plugins/test_fromfilename.py
+++ b/test/plugins/test_fromfilename.py
@@ -70,6 +70,10 @@ class Task:
             ("/tmp/Song One.m4a", 0, "", "Song One"),
             ("/tmp/Song Two.m4a", 0, "", "Song Two"),
         ),
+        (
+            ("/tmp/track01.m4a", 1, "", "track01"),
+            ("/tmp/track 2.m4a", 2, "", "track 2"),
+        ),
     ],
 )
 def test_fromfilename(song1, song2):


### PR DESCRIPTION
## `fromfilename`: Support `"track"` prefix in track number parsing

The `fromfilename` plugin's filename-matching regex is extended to recognise filenames like `track01.m4a` or `track 2.m4a`, where a literal `"track"` prefix precedes the track number.
