### PR TITLE
Handle TEXT path values when migrating to relative paths

### DIFF
--- a/beets/library/migrations.py
+++ b/beets/library/migrations.py
@@ -237,7 +237,13 @@ class RelativePathMigration(Migration):
         table = model_cls._table
 
         with self.db.transaction() as tx:
-            rows = tx.query(f"SELECT id, {field} FROM {table}")  # type: ignore[assignment]
+            rows = tx.query(
+                f"""
+                SELECT id, {field}
+                FROM {table}
+                WHERE {field} IS NOT NULL
+                """
+            )
 
         total = len(rows)
         to_migrate = [r for r in rows if r[field] and os.path.isabs(r[field])]
@@ -249,7 +255,9 @@ class RelativePathMigration(Migration):
             tx.mutate_many(
                 f"UPDATE {table} SET {field} = ? WHERE id = ?",
                 [
-                    (normalize_path_for_db(r[field]), r["id"])
+                    # Convert to bytes in case a user has manually set paths to
+                    # a TEXT value
+                    (normalize_path_for_db(os.fsencode(r[field])), r["id"])
                     for r in to_migrate
                 ],
             )

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -44,6 +44,10 @@ Bug fixes
 - :ref:`import-cmd`: Tags with a zero distance penalty are no longer shown as
   differences in the match display. Previously, custom ``distance_weights``
   could cause fields with no actual mismatch to appear in the ``≠`` line.
+- Library path migration now also handles manually edited database rows where
+  item or album-art paths were stored as SQLite ``TEXT`` values instead of
+  bytes, so upgrading to the portable-path storage format no longer fails for
+  those libraries. :bug:`6561`
 
 ..
     For plugin developers

--- a/test/library/test_migrations.py
+++ b/test/library/test_migrations.py
@@ -247,18 +247,24 @@ class TestRelativePathMigration:
 
     def test_migrate(self, helper: TestHelper):
         relative_path = os.path.join("foo", "bar", "baz.mp3")
-        absolute_path = os.fsencode(helper.lib_path / relative_path)
+        abs_string_path = str(helper.lib_path / relative_path)
+        abs_bytes_path = os.fsencode(abs_string_path)
 
         # need to insert the path directly into the database to bypass the path setter
-        helper.lib._connection().execute(
-            "INSERT INTO items (id, path) VALUES (?, ?)", (1, absolute_path)
+        helper.lib._connection().executemany(
+            "INSERT INTO items (id, path) VALUES (?, ?)",
+            (
+                (1, abs_bytes_path),
+                # add a string path to ensure the migration handles it
+                (2, abs_string_path),
+            ),
         )
         old_stored_path = (
             helper.lib._connection()
             .execute("select path from items where id=?", (1,))
             .fetchone()[0]
         )
-        assert old_stored_path == absolute_path
+        assert old_stored_path == abs_bytes_path
 
         helper.lib._migrate()
 
@@ -273,4 +279,9 @@ class TestRelativePathMigration:
         )
         assert stored_path == path_as_posix(os.fsencode(relative_path))
         # and the item.path property still returns an absolute path
-        assert item.path == absolute_path
+        assert item.path == abs_bytes_path
+
+        # also check the string path was migrated correctly
+        str_item = helper.lib.get_item(2)
+        assert str_item
+        assert str_item.path == abs_bytes_path


### PR DESCRIPTION
## Handle `TEXT` paths in library path migration

Fixes a crash during library migration for users who manually edited their beets SQLite database and stored item or album-art paths as `TEXT` instead of `BLOB`/`bytes`.

### Changes

- **`migrations.py`**: The relative-to-portable path migration now skips `NULL` rows (avoids unnecessary work) and wraps each path value with `os.fsencode()` before passing it to `normalize_path_for_db()`. This ensures `TEXT` paths are coerced to `bytes` before the update, matching the expected storage format.
- **`test_migrations.py`**: The migration test now inserts both a `bytes` path and a `str` path, asserting both are correctly migrated to relative `bytes` posix paths.

### Impact

Low-risk, targeted fix. No changes to the happy path for users with well-formed databases — `os.fsencode()` on `bytes` is a no-op, so existing behaviour is preserved.

Fixes: #6561
