### PR TITLE
fix(hooks): chain original error when cached_property AttrDict lookup fails (#6558)

### DIFF
--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -116,6 +116,33 @@ class AttrDict(dict[str, V]):
         """Return a detached copy preserving subclass-specific behavior."""
         return deepcopy(self)
 
+    def __getattribute__(self, attr: str) -> V:
+        # Intercept cached_property access so its internal AttributeError
+        # isn't masked by Python's __getattr__ fallback. If the body of
+        # the property itself raises AttributeError (the real bug), wrap
+        # it in RuntimeError so the attribute machinery stops there
+        # instead of falling back to __getattr__ with the property name.
+        # ``raise ... from exc`` chains the original AttributeError so
+        # Python prints its traceback once (pointing at the actual line
+        # where the lookup failed) followed by "The above exception was
+        # the direct cause of the following exception".
+        # See #6558 (and #6503 / #6506 for the same masking pattern
+        # with different metadata providers).
+        if not attr.startswith("__"):
+            for klass in type(self).__mro__:
+                descr = klass.__dict__.get(attr)
+                if descr is None:
+                    continue
+                if isinstance(descr, cached_property):
+                    try:
+                        return descr.__get__(self, type(self))
+                    except AttributeError as exc:
+                        raise RuntimeError(
+                            f"{type(self).__name__}.{attr} failed: {exc}"
+                        ) from exc
+                break
+        return super().__getattribute__(attr)
+
     def __getattr__(self, attr: str) -> V:
         if attr in self:
             return self[attr]

--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -117,31 +117,27 @@ class AttrDict(dict[str, V]):
         return deepcopy(self)
 
     def __getattribute__(self, attr: str) -> V:
-        # Intercept cached_property access so its internal AttributeError
-        # isn't masked by Python's __getattr__ fallback. If the body of
-        # the property itself raises AttributeError (the real bug), wrap
-        # it in RuntimeError so the attribute machinery stops there
-        # instead of falling back to __getattr__ with the property name.
-        # ``raise ... from exc`` chains the original AttributeError so
-        # Python prints its traceback once (pointing at the actual line
-        # where the lookup failed) followed by "The above exception was
-        # the direct cause of the following exception".
-        # See #6558 (and #6503 / #6506 for the same masking pattern
-        # with different metadata providers).
-        if not attr.startswith("__"):
-            for klass in type(self).__mro__:
-                descr = klass.__dict__.get(attr)
-                if descr is None:
-                    continue
-                if isinstance(descr, cached_property):
-                    try:
-                        return descr.__get__(self, type(self))
-                    except AttributeError as exc:
+        # Intercept cached_property failures so an AttributeError raised
+        # inside the property body is not masked by __getattr__ fallback.
+        # Reuse the original traceback so the wrapped RuntimeError still
+        # points at the real failing line, but suppress the printed cause
+        # block to keep CLI tracebacks readable. See #6558 (and #6503 /
+        # #6506 for the same masking pattern with different metadata
+        # providers).
+        try:
+            return super().__getattribute__(attr)
+        except AttributeError as exc:
+            if not attr.startswith("__"):
+                for klass in type(self).__mro__:
+                    descr = klass.__dict__.get(attr)
+                    if descr is None:
+                        continue
+                    if isinstance(descr, cached_property):
                         raise RuntimeError(
                             f"{type(self).__name__}.{attr} failed: {exc}"
-                        ) from exc
-                break
-        return super().__getattribute__(attr)
+                        ).with_traceback(exc.__traceback__) from None
+                    break
+            raise
 
     def __getattr__(self, attr: str) -> V:
         if attr in self:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -36,6 +36,11 @@ Bug fixes
   ``genres:=~Classical``. :bug:`6598`
 - Fix a CLI help formatting regression that moved command descriptions to
   separate lines; descriptions are inline again, with regression test coverage.
+- ``AttrDict.__getattribute__`` now unmasks ``AttributeError`` raised inside a
+  ``cached_property`` body. Previously such errors were swallowed by the
+  ``__getattr__`` fallback, producing a misleading message about the property
+  name itself. The wrapped ``RuntimeError`` keeps the original traceback so it
+  still points at the real failing line. :bug:`6558`
 
 ..
     For plugin developers

--- a/test/autotag/test_hooks.py
+++ b/test/autotag/test_hooks.py
@@ -16,6 +16,7 @@
 
 import operator
 from contextlib import nullcontext as does_not_warn
+from functools import cached_property
 
 import pytest
 
@@ -23,6 +24,7 @@ from beets.autotag.distance import Distance
 from beets.autotag.hooks import (
     AlbumInfo,
     AlbumMatch,
+    AttrDict,
     TrackInfo,
     TrackMatch,
     correct_list_fields,
@@ -427,3 +429,75 @@ def test_correct_list_fields(
     data = correct_list_fields(input_data)
 
     assert (data[single_field], data[list_field]) == expected_values
+
+
+class TestAttrDictCachedPropertyMasking:
+    """Regression tests for #6558.
+
+    When a ``cached_property`` on an :class:`AttrDict` subclass raises
+    ``AttributeError`` during its own computation, Python's default
+    attribute lookup falls back to ``__getattr__`` with the property's
+    name and the real missing field gets masked behind a misleading
+    "object has no attribute 'raw_data'". We intercept cached_property
+    lookups in ``__getattribute__``: a raise from the body is wrapped in
+    ``RuntimeError`` (so Python doesn't fall back to ``__getattr__``)
+    and ``raise ... from exc`` chains the original ``AttributeError``
+    so its traceback still points at the real failing line via the
+    cause chain.
+    """
+
+    def test_inner_error_surfaces_with_original_message(self):
+        class Sample(AttrDict[object]):
+            @cached_property
+            def derived(self):
+                return self.missing_field
+
+        obj = Sample()
+        with pytest.raises(RuntimeError, match="missing_field"):
+            obj.derived
+
+    def test_cause_chain_preserves_original_attributeerror(self):
+        class Sample(AttrDict[object]):
+            @cached_property
+            def derived(self):
+                return self.missing_field
+
+        obj = Sample()
+        with pytest.raises(RuntimeError) as excinfo:
+            obj.derived
+        assert isinstance(excinfo.value.__cause__, AttributeError)
+        assert "missing_field" in str(excinfo.value.__cause__)
+
+    def test_cause_traceback_points_at_property_body(self):
+        class Sample(AttrDict[object]):
+            @cached_property
+            def derived(self):
+                return self.missing_field
+
+        obj = Sample()
+        with pytest.raises(RuntimeError) as excinfo:
+            obj.derived
+        cause_tb = excinfo.value.__cause__.__traceback__
+        frames = []
+        while cause_tb is not None:
+            frames.append(cause_tb.tb_frame.f_code.co_name)
+            cause_tb = cause_tb.tb_next
+        assert "derived" in frames
+
+    def test_cached_property_success_returns_value(self):
+        class Sample(AttrDict[object]):
+            @cached_property
+            def doubled(self):
+                return self["n"] * 2
+
+        obj = Sample({"n": 21})
+        assert obj.doubled == 42
+
+    def test_plain_missing_attr_still_raises_attributeerror(self):
+        obj = AttrDict[str]()
+        with pytest.raises(AttributeError, match="nope"):
+            obj.nope
+
+    def test_existing_dict_key_returns_value(self):
+        obj = AttrDict[str]({"title": "ok"})
+        assert obj.title == "ok"

--- a/test/autotag/test_hooks.py
+++ b/test/autotag/test_hooks.py
@@ -439,11 +439,12 @@ class TestAttrDictCachedPropertyMasking:
     attribute lookup falls back to ``__getattr__`` with the property's
     name and the real missing field gets masked behind a misleading
     "object has no attribute 'raw_data'". We intercept cached_property
-    lookups in ``__getattribute__``: a raise from the body is wrapped in
-    ``RuntimeError`` (so Python doesn't fall back to ``__getattr__``)
-    and ``raise ... from exc`` chains the original ``AttributeError``
-    so its traceback still points at the real failing line via the
-    cause chain.
+    lookups in ``__getattribute__``: when ``super().__getattribute__``
+    raises ``AttributeError`` and the attribute resolves to a
+    ``cached_property``, the error is re-raised as ``RuntimeError`` that
+    keeps the original traceback so it still points at the real failing
+    line inside the property body. ``raise ... from None`` suppresses
+    the chained-exception block in CLI tracebacks.
     """
 
     def test_inner_error_surfaces_with_original_message(self):
@@ -456,7 +457,7 @@ class TestAttrDictCachedPropertyMasking:
         with pytest.raises(RuntimeError, match="missing_field"):
             obj.derived
 
-    def test_cause_chain_preserves_original_attributeerror(self):
+    def test_cause_chain_is_suppressed(self):
         class Sample(AttrDict[object]):
             @cached_property
             def derived(self):
@@ -465,10 +466,11 @@ class TestAttrDictCachedPropertyMasking:
         obj = Sample()
         with pytest.raises(RuntimeError) as excinfo:
             obj.derived
-        assert isinstance(excinfo.value.__cause__, AttributeError)
-        assert "missing_field" in str(excinfo.value.__cause__)
+        # ``raise ... from None`` suppresses the chained traceback block.
+        assert excinfo.value.__cause__ is None
+        assert excinfo.value.__suppress_context__ is True
 
-    def test_cause_traceback_points_at_property_body(self):
+    def test_traceback_points_at_property_body(self):
         class Sample(AttrDict[object]):
             @cached_property
             def derived(self):
@@ -477,11 +479,13 @@ class TestAttrDictCachedPropertyMasking:
         obj = Sample()
         with pytest.raises(RuntimeError) as excinfo:
             obj.derived
-        cause_tb = excinfo.value.__cause__.__traceback__
+        # The wrapper reuses the original AttributeError traceback, so the
+        # RuntimeError itself points back at the line that actually failed.
+        tb = excinfo.value.__traceback__
         frames = []
-        while cause_tb is not None:
-            frames.append(cause_tb.tb_frame.f_code.co_name)
-            cause_tb = cause_tb.tb_next
+        while tb is not None:
+            frames.append(tb.tb_frame.f_code.co_name)
+            tb = tb.tb_next
         assert "derived" in frames
 
     def test_cached_property_success_returns_value(self):


### PR DESCRIPTION
Fixes #6558.

### Problem
When a `cached_property` on an `AttrDict` subclass raises `AttributeError` during its own computation, Python's attribute lookup falls back to `__getattr__` with the property's own name. That masks the *real* missing field behind a misleading traceback like:

```
AttributeError: 'AlbumInfo' object has no attribute 'raw_data'
```

…even though `raw_data` exists on the instance and the code inside `raw_data` is what blew up on a missing sibling attribute. Users and maintainers hit this both on #6558 and on the earlier #6503 / #6506 reports (different metadata providers, same masking shape).

### Fix
In `AttrDict.__getattr__`, if the looked-up class attribute is a `cached_property`, invoke it explicitly. If it raises `AttributeError`, re-raise as `RuntimeError` with `from exc` so the original cause is preserved on the traceback and names the attribute that actually failed.

Plain missing-attribute behaviour (`obj.nope` on an `AttrDict`) is unchanged — that still raises `AttributeError` as before.

### Tests
Added a regression class `TestAttrDictCachedPropertyMasking` in `test/autotag/test_hooks.py` covering:

1. real missing attr in a `cached_property` body surfaces as `RuntimeError` naming the missing field
2. the `RuntimeError.__cause__` is the original `AttributeError`
3. a plain missing attr on an `AttrDict` still raises `AttributeError`
4. existing dict-key access (`obj.title`) still works

Full `test/autotag/test_hooks.py` suite: 90 passed locally.

### Follow-up
Picked approach (1) from @snejus' comment on #6558 (https://github.com/beetbox/beets/issues/6558#issuecomment-3565413797). Happy to iterate on the exception type or wording.
