### PR TITLE
Fix #6059 - Allow for multiple Vinyl, Cassette, Digitial Media releases

### DIFF
--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -1161,8 +1161,18 @@ class ImportTaskFactory:
                 pass
 
 
-MULTIDISC_MARKERS = (rb"dis[ck]", rb"cd", rb"cassette", rb"digital\s+media", rb"vinyl")
-MULTIDISC_PAT_FMT = rb"^(.*%s[\W_]*)\d"
+_MULTIDISC_MARKERS = (
+    rb"dis[ck]",
+    rb"cd",
+    rb"cassette",
+    rb"digital\s+media",
+    rb"vinyl",
+)
+
+MULTIDISC_PATTERNS = [
+    re.compile(rb"^(.*" + marker + rb"[\W_]*)\d", re.I)
+    for marker in _MULTIDISC_MARKERS
+]
 
 
 def is_subdir_of_any_in_list(path, dirs):
@@ -1215,10 +1225,7 @@ def albums_in_dir(path: util.PathBytes):
         # 1") or it contains no items but only directories that are
         # named in this way.
         start_collapsing = False
-        for marker in MULTIDISC_MARKERS:
-            # We're using replace on %s due to lack of .format() on bytestrings
-            p = MULTIDISC_PAT_FMT.replace(b"%s", marker)
-            marker_pat = re.compile(p, re.I)
+        for marker_pat in MULTIDISC_PATTERNS:
             match = marker_pat.match(os.path.basename(root))
 
             # Is this directory the root of a nested multi-disc album?

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -1161,7 +1161,7 @@ class ImportTaskFactory:
                 pass
 
 
-MULTIDISC_MARKERS = (rb"dis[ck]", rb"cd")
+MULTIDISC_MARKERS = (rb"dis[ck]", rb"cd", rb"cassette", rb"digital\s+media", rb"vinyl")
 MULTIDISC_PAT_FMT = rb"^(.*%s[\W_]*)\d"
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -42,9 +42,8 @@ Bug fixes
 ~~~~~~~~~
 
 - :ref:`import-cmd`: Multi-disc album detection now recognizes ``cassette``,
-  ``digital media``, and ``vinyl`` as disc markers (e.g. ``vinyl 1``,
-  ``12 vinyl 2``), in addition to the existing ``disc``, ``disk``, and ``cd``
-  markers.
+  ``digital media``, and ``vinyl`` as disc markers (e.g. ``vinyl 1``, ``12 vinyl
+  2``), in addition to the existing ``disc``, ``disk``, and ``cd`` markers.
 - :ref:`import-cmd`: Tags with a zero distance penalty are no longer shown as
   differences in the match display. Previously, custom ``distance_weights``
   could cause fields with no actual mismatch to appear in the ``≠`` line.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -41,6 +41,10 @@ New features
 Bug fixes
 ~~~~~~~~~
 
+- :ref:`import-cmd`: Multi-disc album detection now recognizes ``cassette``,
+  ``digital media``, and ``vinyl`` as disc markers (e.g. ``vinyl 1``,
+  ``12 vinyl 2``), in addition to the existing ``disc``, ``disk``, and ``cd``
+  markers.
 - :ref:`import-cmd`: Tags with a zero distance penalty are no longer shown as
   differences in the match display. Previously, custom ``distance_weights``
   could cause fields with no actual mismatch to appear in the ``≠`` line.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -79,8 +79,9 @@ items in the subdirectories into a single release for tagging.
 The heuristic works by looking at the names of directories. If multiple
 subdirectories of a common parent directory follow the pattern "(title) disc
 (number) (...)" and the *prefix* (everything up to the number) is the same, the
-directories are collapsed together. One of the key words "disc" or "CD" must be
-present to make this work.
+directories are collapsed together. One of the following key words must be
+present to make this work: "disc", "disk", "CD", "cassette", "digital media",
+or "vinyl".
 
 If you have trouble tagging a multi-disc album, consider the ``--flat`` flag
 (which treats a whole tree as a single album) or just putting all the tracks

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -80,8 +80,8 @@ The heuristic works by looking at the names of directories. If multiple
 subdirectories of a common parent directory follow the pattern "(title) disc
 (number) (...)" and the *prefix* (everything up to the number) is the same, the
 directories are collapsed together. One of the following key words must be
-present to make this work: "disc", "disk", "CD", "cassette", "digital media",
-or "vinyl".
+present to make this work: "disc", "disk", "CD", "cassette", "digital media", or
+"vinyl".
 
 If you have trouble tagging a multi-disc album, consider the ``--flat`` flag
 (which treats a whole tree as a single album) or just putting all the tracks

--- a/docs/guides/tagger.rst
+++ b/docs/guides/tagger.rst
@@ -50,8 +50,8 @@ all of these limitations.
 
   First, directories that look like separate parts of a *multi-disc album* are
   tagged together as a single release. If two adjacent albums have a common
-  prefix, followed by "disc," "disk," or "CD" and then a number, they are tagged
-  together.
+  prefix, followed by "disc," "disk," "CD," "cassette," "digital media," or
+  "vinyl" and then a number, they are tagged together.
 
   Second, if you have jumbled directories containing more than one album, you
   can ask beets to split them apart for you based on their metadata. Use either

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1540,12 +1540,7 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
         ]:
             with self.subTest(marker=marker, suffix1=suffix1, suffix2=suffix2):
                 base = os.path.abspath(
-                    os.path.join(
-                        self.temp_dir,
-                        b"marker_"
-                        + marker.replace(b" ", b"_")
-                        + suffix1.replace(b" ", b"_"),
-                    )
+                    os.path.join(self.temp_dir, b"marker " + marker)
                 )
                 os.mkdir(syspath(base))
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1528,19 +1528,23 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
         assert len(items) == 3
 
     def test_coalesce_markers(self):
-        for marker in [
-            b"Disc",  # titlecase
-            b"disk 757",  # lowercase, numerical suffix
-            b"CD",  # uppercase
-            b"cAsSeTtE",  # mixed case
-            b"Digital   Media",  # multiple spaces
-            b"vinyl",  # lowercase
-            b"12 vinyl",  # common prefix
+        for marker, suffix1, suffix2 in [
+            (b"Disc", b" 1", b" 02"),  # titlecase, space-separated
+            (b"disk 757", b" 1", b" 02"),  # lowercase, numerical suffix
+            (b"CD", b"01", b"02"),  # uppercase, no space (e.g. CD01)
+            (b"disc", b"_1", b"_2"),  # underscore separator (e.g. disc_1)
+            (b"cAsSeTtE", b" 1", b" 02"),  # mixed case
+            (b"Digital   Media", b" 1", b" 02"),  # multiple spaces
+            (b"vinyl", b" 1", b" 02"),  # lowercase
+            (b"12 vinyl", b" 1", b" 02"),  # common prefix
         ]:
-            with self.subTest(marker=marker):
+            with self.subTest(marker=marker, suffix1=suffix1, suffix2=suffix2):
                 base = os.path.abspath(
                     os.path.join(
-                        self.temp_dir, b"marker_" + marker.replace(b" ", b"_")
+                        self.temp_dir,
+                        b"marker_"
+                        + marker.replace(b" ", b"_")
+                        + suffix1.replace(b" ", b"_"),
                     )
                 )
                 os.mkdir(syspath(base))
@@ -1549,7 +1553,7 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
                 os.mkdir(syspath(album_dir))
 
                 discs = []
-                for suffix in (b" 1", b" 02"):
+                for suffix in (suffix1, suffix2):
                     disc = os.path.join(album_dir, marker + suffix)
                     os.mkdir(syspath(disc))
                     _mkmp3(syspath(os.path.join(disc, b"song.mp3")))
@@ -1561,6 +1565,23 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
                 for disc in discs:
                     assert disc in root
                 assert len(items) == 2
+
+    def test_no_coalesce_mismatched_prefixes(self):
+        # "CD 02" and "Enhanced CD 01" share the "cd" marker but have
+        # different prefixes, so they should not be collapsed.
+        base = os.path.abspath(os.path.join(self.temp_dir, b"mismatched"))
+        os.mkdir(syspath(base))
+
+        album_dir = os.path.join(base, b"Album Name")
+        os.mkdir(syspath(album_dir))
+
+        for subdir in (b"CD 02", b"Enhanced CD 01"):
+            d = os.path.join(album_dir, subdir)
+            os.mkdir(syspath(d))
+            _mkmp3(syspath(os.path.join(d, b"song.mp3")))
+
+        albums = list(albums_in_dir(base))
+        assert len(albums) == 2
 
 
 class ReimportTest(AutotagImportTestCase):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1539,7 +1539,9 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
         ]:
             with self.subTest(marker=marker):
                 base = os.path.abspath(
-                    os.path.join(self.temp_dir, b"marker_" + marker.replace(b" ", b"_"))
+                    os.path.join(
+                        self.temp_dir, b"marker_" + marker.replace(b" ", b"_")
+                    )
                 )
                 os.mkdir(syspath(base))
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1528,19 +1528,21 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
         assert len(items) == 3
 
     def test_coalesce_markers(self):
-        for marker, suffix1, suffix2 in [
-            (b"Disc", b" 1", b" 02"),  # titlecase, space-separated
-            (b"disk 757", b" 1", b" 02"),  # lowercase, numerical suffix
-            (b"CD", b"01", b"02"),  # uppercase, no space (e.g. CD01)
-            (b"disc", b"_1", b"_2"),  # underscore separator (e.g. disc_1)
-            (b"cAsSeTtE", b" 1", b" 02"),  # mixed case
-            (b"Digital   Media", b" 1", b" 02"),  # multiple spaces
-            (b"vinyl", b" 1", b" 02"),  # lowercase
-            (b"12 vinyl", b" 1", b" 02"),  # common prefix
-        ]:
+        for i, (marker, suffix1, suffix2) in enumerate(
+            [
+                (b"Disc", b" 1", b" 02"),  # titlecase, space-separated
+                (b"disk 757", b" 1", b" 02"),  # lowercase, numerical suffix
+                (b"CD", b"01", b"02"),  # uppercase, no space (e.g. CD01)
+                (b"disc", b"_1", b"_2"),  # underscore separator (e.g. disc_1)
+                (b"cAsSeTtE", b" 1", b" 02"),  # mixed case
+                (b"Digital   Media", b" 1", b" 02"),  # multiple spaces
+                (b"vinyl", b" 1", b" 02"),  # lowercase
+                (b"12 vinyl", b" 1", b" 02"),  # common prefix
+            ]
+        ):
             with self.subTest(marker=marker, suffix1=suffix1, suffix2=suffix2):
                 base = os.path.abspath(
-                    os.path.join(self.temp_dir, b"marker " + marker)
+                    os.path.join(self.temp_dir, b"marker_" + str(i).encode())
                 )
                 os.mkdir(syspath(base))
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1527,6 +1527,40 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
         assert root == self.dirs[0:3]
         assert len(items) == 3
 
+    def test_coalesce_markers(self):
+        for marker in [
+            b"disc",
+            b"disk",
+            b"cd",
+            b"cassette",
+            b"digital media",
+            b"vinyl",
+            b"12 vinyl",
+        ]:
+            with self.subTest(marker=marker):
+                base = os.path.abspath(
+                    os.path.join(self.temp_dir, b"marker_" + marker.replace(b" ", b"_"))
+                )
+                os.mkdir(syspath(base))
+
+                album_dir = os.path.join(base, b"Album Name")
+                os.mkdir(syspath(album_dir))
+
+                disc1 = os.path.join(album_dir, marker + b" 1")
+                disc2 = os.path.join(album_dir, marker + b" 2")
+                os.mkdir(syspath(disc1))
+                os.mkdir(syspath(disc2))
+
+                _mkmp3(syspath(os.path.join(disc1, b"song1.mp3")))
+                _mkmp3(syspath(os.path.join(disc2, b"song2.mp3")))
+
+                albums = list(albums_in_dir(base))
+                assert len(albums) == 1
+                root, items = albums[0]
+                assert disc1 in root
+                assert disc2 in root
+                assert len(items) == 2
+
 
 class ReimportTest(AutotagImportTestCase):
     """Test "re-imports", in which the autotagging machinery is used for

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1529,13 +1529,13 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
 
     def test_coalesce_markers(self):
         for marker in [
-            b"disc",
-            b"disk",
-            b"cd",
-            b"cassette",
-            b"digital media",
-            b"vinyl",
-            b"12 vinyl",
+            b"Disc",  # titlecase
+            b"disk 757",  # lowercase, numerical suffix
+            b"CD",  # uppercase
+            b"cAsSeTtE",  # mixed case
+            b"Digital   Media",  # multiple spaces
+            b"vinyl",  # lowercase
+            b"12 vinyl",  # common prefix
         ]:
             with self.subTest(marker=marker):
                 base = os.path.abspath(
@@ -1548,19 +1548,18 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
                 album_dir = os.path.join(base, b"Album Name")
                 os.mkdir(syspath(album_dir))
 
-                disc1 = os.path.join(album_dir, marker + b" 1")
-                disc2 = os.path.join(album_dir, marker + b" 2")
-                os.mkdir(syspath(disc1))
-                os.mkdir(syspath(disc2))
-
-                _mkmp3(syspath(os.path.join(disc1, b"song1.mp3")))
-                _mkmp3(syspath(os.path.join(disc2, b"song2.mp3")))
+                discs = []
+                for suffix in (b" 1", b" 02"):
+                    disc = os.path.join(album_dir, marker + suffix)
+                    os.mkdir(syspath(disc))
+                    _mkmp3(syspath(os.path.join(disc, b"song.mp3")))
+                    discs.append(disc)
 
                 albums = list(albums_in_dir(base))
                 assert len(albums) == 1
                 root, items = albums[0]
-                assert disc1 in root
-                assert disc2 in root
+                for disc in discs:
+                    assert disc in root
                 assert len(items) == 2
 
 


### PR DESCRIPTION
## Description

Fixes https://github.com/beetbox/beets/issues/6059

I chose to include "Cassette", "Digital Media", and "Vinyl" as those are used by `lidarr` by default. "12 Vinyl" is handled as a general case for "Vinyl"

I can make this a more general feature where this functionality is exposed to the config.yaml, but that seemed to be more complicated than necessary.

grug suggested that I pre-compile the regex, which seemed reasonable. I've also made sure the docs are updated.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
