### PR TITLE
Reduce smartplaylist complexity

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,8 +37,21 @@ jobs:
 
       - name: Install system dependencies on Windows
         if: matrix.platform == 'windows-latest'
+        shell: pwsh
         run: |
-          choco install mp3gain --allow-empty-checksums -y
+          $maxAttempts = 3
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            # mp3gain's Chocolatey install script pulls from a flaky SourceForge
+            # HTTP URL and has no upstream checksums, so allow it and retry.
+            choco install mp3gain -y --allow-empty-checksums --no-progress
+            if ($LASTEXITCODE -eq 0) {
+              break
+            }
+            if ($attempt -eq $maxAttempts) {
+              throw "mp3gain install failed after $maxAttempts attempts."
+            }
+            Start-Sleep -Seconds 3
+          }
 
       - name: Install system dependencies on Ubuntu
         if: matrix.platform == 'ubuntu-latest'

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -96,6 +96,8 @@ EventType = Literal[
     "pluginload",
     "trackinfo_received",
     "write",
+    # smartplaylist plugin
+    "smartplaylist_update",
 ]
 # Global logger.
 log = logging.getLogger("beets")

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import os
 from collections import defaultdict
+from functools import cached_property
 from shlex import quote as shell_quote
 from typing import TYPE_CHECKING, Any, TypeAlias
 from urllib.parse import quote
@@ -81,6 +82,33 @@ class SmartPlaylistPlugin(BeetsPlugin):
 
         if self.config["auto"]:
             self.register_listener("database_change", self.db_change)
+
+    @cached_property
+    def prefix(self) -> bytes:
+        return bytestring_path(self.config["prefix"].as_str())
+
+    @cached_property
+    def relative_to(self) -> bytes | None:
+        if relative_to := self.config["relative_to"].get():
+            return normpath(relative_to)
+
+        return None
+
+    @cached_property
+    def dest_regen(self) -> bool:
+        return self.config["dest_regen"].get(bool)
+
+    @cached_property
+    def forward_slash(self) -> bool:
+        return self.config["forward_slash"].get(bool)
+
+    @cached_property
+    def urlencode(self) -> bool:
+        return self.config["urlencode"].get(bool)
+
+    @cached_property
+    def uri_format(self) -> str | None:
+        return self.config["uri_format"].get()
 
     def commands(self) -> list[ui.Subcommand]:
         spl_update = ui.Subcommand(
@@ -325,6 +353,22 @@ class SmartPlaylistPlugin(BeetsPlugin):
                 seen_ids.add(item.id)
                 yield item
 
+    def get_item_uri(self, item: Item) -> bytes:
+        item_uri = item.path
+        if uri_format := self.uri_format:
+            return uri_format.replace("$id", str(item.id)).encode("utf-8")
+
+        if self.dest_regen:
+            item_uri = item.destination()
+        if self.relative_to:
+            item_uri = os.path.relpath(item_uri, self.relative_to)
+        if self.forward_slash:
+            item_uri = path_as_posix(item_uri)
+        if self.urlencode:
+            item_uri = bytestring_path(pathname2url(os.fsdecode(item_uri)))
+
+        return self.prefix + item_uri
+
     def write_playlist(
         self, path: bytes, is_extm3u: bool, entries: list[PlaylistItem]
     ) -> None:
@@ -345,10 +389,6 @@ class SmartPlaylistPlugin(BeetsPlugin):
         playlist_dir = bytestring_path(
             self.config["playlist_dir"].as_filename()
         )
-        tpl = self.config["uri_format"].get()
-        prefix = bytestring_path(self.config["prefix"].as_str())
-        if relative_to := self.config["relative_to"].get():
-            relative_to = normpath(relative_to)
 
         # Maps playlist filenames to lists of track entries and URI sets used
         # to deduplicate output lines.
@@ -365,21 +405,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
             for item in items:
                 m3u_name = item.evaluate_template(name, True)
                 m3u_name = sanitize_path(m3u_name, lib.replacements)
-                item_uri = item.path
-                if tpl:
-                    item_uri = tpl.replace("$id", str(item.id)).encode("utf-8")
-                else:
-                    if self.config["dest_regen"].get(bool):
-                        item_uri = item.destination()
-                    if relative_to:
-                        item_uri = os.path.relpath(item_uri, relative_to)
-                    if self.config["forward_slash"].get(bool):
-                        item_uri = path_as_posix(item_uri)
-                    if self.config["urlencode"].get(bool):
-                        item_uri = bytestring_path(
-                            pathname2url(os.fsdecode(item_uri))
-                        )
-                    item_uri = prefix + item_uri
+                item_uri = self.get_item_uri(item)
 
                 if item_uri not in m3u_uris_by_name[m3u_name]:
                     m3u_uris_by_name[m3u_name].add(item_uri)

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -37,6 +37,8 @@ from beets.util import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from beets.library import Library
 
 QueryAndSort = tuple[Query, Sort]
@@ -266,41 +268,56 @@ class SmartPlaylistPlugin(BeetsPlugin):
         self._unmatched_playlists -= self._matched_playlists
 
     @staticmethod
+    def get_queries(
+        query: PlaylistQueryAndSort,
+    ) -> list[tuple[Query, Sort | None]]:
+        """Normalize a playlist query into a flat list of query-sort pairs.
+
+        Handles both compound (list/tuple of pairs) and single query inputs,
+        returning an empty list when no query is present.
+        """
+        q, sort = query
+
+        if isinstance(q, (list, tuple)):
+            return list(q)
+        if q:
+            return [(q, sort)]
+
+        return []
+
+    @classmethod
     def get_playlist_items(
+        cls,
         lib: Library,
         item_q: PlaylistQueryAndSort,
         album_q: PlaylistQueryAndSort,
-    ) -> list[Item]:
-        query, q_sort = item_q
-        album_query, a_q_sort = album_q
-        items = []
+    ) -> Iterator[Item]:
+        """Collect unique items matching the playlist's item and album queries.
 
-        # Handle tuple/list of queries (preserves order)
-        # Track seen items to avoid duplicates when an item matches
-        # multiple queries
-        seen_ids = set()
+        Queries both tracks directly and albums (expanding them to their
+        tracks), then merges the results into a deduplicated list preserving
+        insertion order.
+        """
+        items: list[Item] = []
 
-        if isinstance(query, (list, tuple)):
-            for q, sort in query:
-                for item in lib.items(q, sort):
-                    if item.id not in seen_ids:
-                        items.append(item)
-                        seen_ids.add(item.id)
-        elif query:
-            items.extend(lib.items(query, q_sort))
+        for q, sort in cls.get_queries(item_q):
+            items.extend(lib.items(q, sort))
 
-        if isinstance(album_query, (list, tuple)):
-            for q, sort in album_query:
-                for album in lib.albums(q, sort):
-                    for item in album.items():
-                        if item.id not in seen_ids:
-                            items.append(item)
-                            seen_ids.add(item.id)
-        elif album_query:
-            for album in lib.albums(album_query, a_q_sort):
+        albums: list[Album] = []
+        for q, sort in cls.get_queries(album_q):
+            albums.extend(lib.albums(q, sort))
+
+        seen_album_ids = set()
+        for album in albums:
+            if album.id not in seen_album_ids:
+                seen_album_ids.add(album.id)
                 items.extend(album.items())
 
-        return items
+        seen_ids = set()
+        for item in items:
+            if item.id not in seen_ids:
+                seen_ids.add(item.id)
+                yield item
 
     def update_playlists(self, lib: Library) -> None:
         playlist_count = len(self._matched_playlists)

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -275,9 +275,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
         )
         tpl = self.config["uri_format"].get()
         prefix = bytestring_path(self.config["prefix"].as_str())
-        dest_regen = self.config["dest_regen"].get(bool)
-        relative_to = self.config["relative_to"].get()
-        if relative_to:
+        if relative_to := self.config["relative_to"].get():
             relative_to = normpath(relative_to)
 
         # Maps playlist filenames to lists of track entries and URI sets used
@@ -328,7 +326,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
                 if tpl:
                     item_uri = tpl.replace("$id", str(item.id)).encode("utf-8")
                 else:
-                    if dest_regen is True:
+                    if self.config["dest_regen"].get(bool):
                         item_uri = item.destination()
                     if relative_to:
                         item_uri = os.path.relpath(item_uri, relative_to)

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -26,11 +26,9 @@ from urllib.request import pathname2url
 
 import confuse
 
-from beets import ui
+from beets import plugins, ui
 from beets.dbcore.query import ParsingError, Query, Sort
 from beets.library import Album, Item, parse_query_string
-from beets.plugins import BeetsPlugin
-from beets.plugins import send as send_event
 from beets.util import (
     bytestring_path,
     mkdirall,
@@ -53,7 +51,7 @@ PlaylistMatch: TypeAlias = tuple[
 ]
 
 
-class SmartPlaylistPlugin(BeetsPlugin):
+class SmartPlaylistPlugin(plugins.BeetsPlugin):
     def __init__(self) -> None:
         super().__init__()
         self.config.add(
@@ -432,7 +430,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
                 self.write_playlist(m3u_path, is_extm3u, entries)
 
             # Send an event when playlists were updated.
-            send_event("smartplaylist_update")  # type: ignore
+            plugins.send("smartplaylist_update")
             self._log.info("{} playlists updated", playlist_count)
 
 

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -41,10 +41,9 @@ if TYPE_CHECKING:
 
 QueryAndSort = tuple[Query, Sort]
 PlaylistQuery = Query | tuple[QueryAndSort, ...] | None
+PlaylistQueryAndSort = tuple[PlaylistQuery, Sort | None]
 PlaylistMatch: TypeAlias = tuple[
-    str,
-    tuple[PlaylistQuery, Sort | None],
-    tuple[PlaylistQuery, Sort | None],
+    str, PlaylistQueryAndSort, PlaylistQueryAndSort
 ]
 
 
@@ -266,6 +265,43 @@ class SmartPlaylistPlugin(BeetsPlugin):
 
         self._unmatched_playlists -= self._matched_playlists
 
+    @staticmethod
+    def get_playlist_items(
+        lib: Library,
+        item_q: PlaylistQueryAndSort,
+        album_q: PlaylistQueryAndSort,
+    ) -> list[Item]:
+        query, q_sort = item_q
+        album_query, a_q_sort = album_q
+        items = []
+
+        # Handle tuple/list of queries (preserves order)
+        # Track seen items to avoid duplicates when an item matches
+        # multiple queries
+        seen_ids = set()
+
+        if isinstance(query, (list, tuple)):
+            for q, sort in query:
+                for item in lib.items(q, sort):
+                    if item.id not in seen_ids:
+                        items.append(item)
+                        seen_ids.add(item.id)
+        elif query:
+            items.extend(lib.items(query, q_sort))
+
+        if isinstance(album_query, (list, tuple)):
+            for q, sort in album_query:
+                for album in lib.albums(q, sort):
+                    for item in album.items():
+                        if item.id not in seen_ids:
+                            items.append(item)
+                            seen_ids.add(item.id)
+        elif album_query:
+            for album in lib.albums(album_query, a_q_sort):
+                items.extend(album.items())
+
+        return items
+
     def update_playlists(self, lib: Library) -> None:
         playlist_count = len(self._matched_playlists)
         self._log.info("Updating {} smart playlists...", playlist_count)
@@ -284,38 +320,13 @@ class SmartPlaylistPlugin(BeetsPlugin):
         m3u_uris_by_name: dict[str, set[Any]] = {}
 
         for playlist in self._matched_playlists:
-            matched_count = 0
-            name, (query, q_sort), (album_query, a_q_sort) = playlist
-            items = []
-
-            # Handle tuple/list of queries (preserves order)
-            # Track seen items to avoid duplicates when an item matches
-            # multiple queries
-            seen_ids = set()
-
-            if isinstance(query, (list, tuple)):
-                for q, sort in query:
-                    for item in lib.items(q, sort):
-                        if item.id not in seen_ids:
-                            items.append(item)
-                            seen_ids.add(item.id)
-            elif query:
-                items.extend(lib.items(query, q_sort))
-
-            if isinstance(album_query, (list, tuple)):
-                for q, sort in album_query:
-                    for album in lib.albums(q, sort):
-                        for item in album.items():
-                            if item.id not in seen_ids:
-                                items.append(item)
-                                seen_ids.add(item.id)
-            elif album_query:
-                for album in lib.albums(album_query, a_q_sort):
-                    items.extend(album.items())
+            name, item_q, album_q = playlist
+            items = self.get_playlist_items(lib, item_q, album_q)
 
             # As we allow tags in the m3u names, we'll need to iterate through
             # the items and generate the correct m3u file names.
             matched_items: list[tuple[Any, Any]] = []
+            matched_count = 0
             for item in items:
                 m3u_name = item.evaluate_template(name, True)
                 m3u_name = sanitize_path(m3u_name, lib.replacements)
@@ -347,7 +358,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
             self._log.info(
                 "Creating playlist {}: {} tracks.", name, matched_count
             )
-            for item, item_uri in matched_items:
+            for item, _ in matched_items:
                 self._log.debug(
                     item.evaluate_template(self.config["format"].as_str())
                 )

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -401,20 +401,8 @@ class SmartPlaylistPlugin(BeetsPlugin):
                         keys = self.config["fields"].get(list)
                         f.write(b"#EXTM3U\n")
                     for entry in entries:
-                        item = entry.item
-                        comment = ""
-                        if extm3u:
-                            attr = [(k, entry.item[k]) for k in keys]
-                            al = [
-                                f' {k}="{quote("; ".join(v) if isinstance(v, list) else str(v), safe="/:")}"'  # noqa: E501
-                                for k, v in attr
-                            ]
-                            attrs = "".join(al)
-                            comment = (
-                                f"#EXTINF:{int(item.length)}{attrs},"
-                                f"{item.artist} - {item.title}\n"
-                            )
-                        f.write(comment.encode("utf-8") + entry.uri + b"\n")
+                        f.write(entry.get_comment(extm3u, keys))
+
             # Send an event when playlists were updated.
             send_event("smartplaylist_update")  # type: ignore
             self._log.info("{} playlists updated", playlist_count)
@@ -424,3 +412,19 @@ class PlaylistItem:
     def __init__(self, item: Item, uri: bytes) -> None:
         self.item = item
         self.uri = uri
+
+    def get_comment(self, is_extm3u: bool, fields: list[str]) -> bytes:
+        comment = ""
+        if is_extm3u:
+            attr = [(k, self.item[k]) for k in fields]
+            al = [
+                f' {k}="{quote("; ".join(v) if isinstance(v, list) else str(v), safe="/:")}"'  # noqa: E501
+                for k, v in attr
+            ]
+            attrs = "".join(al)
+            comment = (
+                f"#EXTINF:{int(self.item.length)}{attrs},"
+                f"{self.item.artist} - {self.item.title}\n"
+            )
+
+        return comment.encode("utf-8") + self.uri + b"\n"

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -267,10 +267,8 @@ class SmartPlaylistPlugin(BeetsPlugin):
         self._unmatched_playlists -= self._matched_playlists
 
     def update_playlists(self, lib: Library) -> None:
-        self._log.info(
-            "Updating {} smart playlists...",
-            len(self._matched_playlists),
-        )
+        playlist_count = len(self._matched_playlists)
+        self._log.info("Updating {} smart playlists...", playlist_count)
 
         playlist_dir = bytestring_path(
             self.config["playlist_dir"].as_filename()
@@ -357,10 +355,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
                 )
 
         if self.config["pretend"].get():
-            self._log.info(
-                "{} playlists would be updated",
-                len(self._matched_playlists),
-            )
+            self._log.info("{} playlists would be updated", playlist_count)
         else:
             # Write all of the accumulated track lists to files.
             for m3u, entries in m3us.items():
@@ -396,7 +391,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
                         f.write(comment.encode("utf-8") + entry.uri + b"\n")
             # Send an event when playlists were updated.
             send_event("smartplaylist_update")  # type: ignore
-            self._log.info("{} playlists updated", len(self._matched_playlists))
+            self._log.info("{} playlists updated", playlist_count)
 
 
 class PlaylistItem:

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -65,6 +65,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
                 "urlencode": False,
                 "format": "$artist - $title",
                 "output": "m3u",
+                "pretend": False,
             }
         )
 
@@ -181,7 +182,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
             self._matched_playlists = self._unmatched_playlists
 
         self.config.set(vars(opts))
-        self.update_playlists(lib, opts.pretend)
+        self.update_playlists(lib)
 
     def _parse_one_query(
         self, playlist: dict[str, Any], key: str, model_cls: type
@@ -265,7 +266,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
 
         self._unmatched_playlists -= self._matched_playlists
 
-    def update_playlists(self, lib: Library, pretend: bool = False) -> None:
+    def update_playlists(self, lib: Library) -> None:
         self._log.info(
             "Updating {} smart playlists...",
             len(self._matched_playlists),
@@ -355,7 +356,12 @@ class SmartPlaylistPlugin(BeetsPlugin):
                     item.evaluate_template(self.config["format"].as_str())
                 )
 
-        if not pretend:
+        if self.config["pretend"].get():
+            self._log.info(
+                "{} playlists would be updated",
+                len(self._matched_playlists),
+            )
+        else:
             # Write all of the accumulated track lists to files.
             for m3u, entries in m3us.items():
                 m3u_path = normpath(
@@ -390,13 +396,6 @@ class SmartPlaylistPlugin(BeetsPlugin):
                         f.write(comment.encode("utf-8") + entry.uri + b"\n")
             # Send an event when playlists were updated.
             send_event("smartplaylist_update")  # type: ignore
-
-        if pretend:
-            self._log.info(
-                "{} playlists would be updated",
-                len(self._matched_playlists),
-            )
-        else:
             self._log.info("{} playlists updated", len(self._matched_playlists))
 
 

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -22,6 +22,8 @@ from typing import TYPE_CHECKING, Any, TypeAlias
 from urllib.parse import quote
 from urllib.request import pathname2url
 
+import confuse
+
 from beets import ui
 from beets.dbcore.query import ParsingError, Query, Sort
 from beets.library import Album, Item, parse_query_string
@@ -73,6 +75,8 @@ class SmartPlaylistPlugin(BeetsPlugin):
         self.config["prefix"].redact = True  # May contain username/password.
         self._matched_playlists: set[PlaylistMatch] = set()
         self._unmatched_playlists: set[PlaylistMatch] = set()
+        # validate output format
+        self.config["output"].get(confuse.Choice(["m3u", "extm3u"]))
 
         if self.config["auto"]:
             self.register_listener("database_change", self.db_change)
@@ -149,7 +153,8 @@ class SmartPlaylistPlugin(BeetsPlugin):
         )
         spl_update.parser.add_option(
             "--output",
-            type="string",
+            type="choice",
+            choices=["m3u", "extm3u"],
             default=self.config["output"].get(),
             help="specify the playlist format: m3u|extm3u.",
         )
@@ -389,12 +394,7 @@ class SmartPlaylistPlugin(BeetsPlugin):
                     os.path.join(playlist_dir, bytestring_path(m3u))
                 )
                 mkdirall(m3u_path)
-                pl_format = self.config["output"].get()
-                if pl_format != "m3u" and pl_format != "extm3u":
-                    msg = "Unsupported output format '{}' provided! "
-                    msg += "Supported: m3u, extm3u"
-                    raise Exception(msg.format(pl_format))
-                extm3u = pl_format == "extm3u"
+                extm3u = self.config["output"].get() == "extm3u"
                 with open(syspath(m3u_path), "wb") as f:
                     keys = []
                     if extm3u:

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -324,6 +324,19 @@ class SmartPlaylistPlugin(BeetsPlugin):
                 seen_ids.add(item.id)
                 yield item
 
+    def write_playlist(
+        self, path: bytes, is_extm3u: bool, entries: list[PlaylistItem]
+    ) -> None:
+        """Write a playlist file with the given entries."""
+        mkdirall(path)
+        with open(syspath(path), "wb") as f:
+            keys = []
+            if is_extm3u:
+                keys = self.config["fields"].get(list)
+                f.write(b"#EXTM3U\n")
+            for entry in entries:
+                f.write(entry.get_comment(is_extm3u, keys))
+
     def update_playlists(self, lib: Library) -> None:
         playlist_count = len(self._matched_playlists)
         self._log.info("Updating {} smart playlists...", playlist_count)
@@ -389,19 +402,12 @@ class SmartPlaylistPlugin(BeetsPlugin):
             self._log.info("{} playlists would be updated", playlist_count)
         else:
             # Write all of the accumulated track lists to files.
+            is_extm3u = self.config["output"].get() == "extm3u"
             for m3u, entries in m3us.items():
                 m3u_path = normpath(
                     os.path.join(playlist_dir, bytestring_path(m3u))
                 )
-                mkdirall(m3u_path)
-                extm3u = self.config["output"].get() == "extm3u"
-                with open(syspath(m3u_path), "wb") as f:
-                    keys = []
-                    if extm3u:
-                        keys = self.config["fields"].get(list)
-                        f.write(b"#EXTM3U\n")
-                    for entry in entries:
-                        f.write(entry.get_comment(extm3u, keys))
+                self.write_playlist(m3u_path, is_extm3u, entries)
 
             # Send an event when playlists were updated.
             send_event("smartplaylist_update")  # type: ignore

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import os
+from collections import defaultdict
 from shlex import quote as shell_quote
 from typing import TYPE_CHECKING, Any, TypeAlias
 from urllib.parse import quote
@@ -351,8 +352,8 @@ class SmartPlaylistPlugin(BeetsPlugin):
 
         # Maps playlist filenames to lists of track entries and URI sets used
         # to deduplicate output lines.
-        m3us: dict[str, list[PlaylistItem]] = {}
-        m3u_uris_by_name: dict[str, set[Any]] = {}
+        m3us: dict[str, list[PlaylistItem]] = defaultdict(list)
+        m3u_uris_by_name: dict[str, set[bytes]] = defaultdict(set)
 
         for playlist in self._matched_playlists:
             name, item_q, album_q = playlist
@@ -360,14 +361,10 @@ class SmartPlaylistPlugin(BeetsPlugin):
 
             # As we allow tags in the m3u names, we'll need to iterate through
             # the items and generate the correct m3u file names.
-            matched_items: list[tuple[Any, Any]] = []
-            matched_count = 0
+            matched_items: list[Item] = []
             for item in items:
                 m3u_name = item.evaluate_template(name, True)
                 m3u_name = sanitize_path(m3u_name, lib.replacements)
-                if m3u_name not in m3us:
-                    m3us[m3u_name] = []
-                    m3u_uris_by_name[m3u_name] = set()
                 item_uri = item.path
                 if tpl:
                     item_uri = tpl.replace("$id", str(item.id)).encode("utf-8")
@@ -387,13 +384,12 @@ class SmartPlaylistPlugin(BeetsPlugin):
                 if item_uri not in m3u_uris_by_name[m3u_name]:
                     m3u_uris_by_name[m3u_name].add(item_uri)
                     m3us[m3u_name].append(PlaylistItem(item, item_uri))
-                    matched_items.append((item, item_uri))
-                    matched_count += 1
+                    matched_items.append(item)
 
             self._log.info(
-                "Creating playlist {}: {} tracks.", name, matched_count
+                "Creating playlist {}: {} tracks.", name, len(matched_items)
             )
-            for item, _ in matched_items:
+            for item in matched_items:
                 self._log.debug(
                     item.evaluate_template(self.config["format"].as_str())
                 )

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -25,10 +25,13 @@ import pytest
 from beets import config
 from beets.dbcore.query import FixedFieldSort, MultipleSort, NullSort
 from beets.library import Album, Item, parse_query_string
+from beets.test._common import item
 from beets.test.helper import BeetsTestCase, IOMixin, PluginTestCase
 from beets.ui import UserError
 from beets.util import CHAR_REPLACE, syspath
 from beetsplug.smartplaylist import SmartPlaylistPlugin
+
+_p = pytest.param
 
 
 class SmartPlaylistTest(BeetsTestCase):
@@ -300,50 +303,6 @@ class SmartPlaylistTest(BeetsTestCase):
             b"/tagada.mp3\n"
         )
 
-    def test_playlist_update_uri_format(self):
-        spl = SmartPlaylistPlugin()
-
-        i = MagicMock()
-        type(i).id = PropertyMock(return_value=3)
-        type(i).path = PropertyMock(return_value=b"/tagada.mp3")
-        i.evaluate_template.side_effect = lambda pl, *_: os.fsdecode(
-            pl
-        ).replace("$title", "ta:ga:da")
-
-        lib = Mock()
-        lib.replacements = CHAR_REPLACE
-        lib.items.return_value = [i]
-        lib.albums.return_value = []
-
-        q = Mock()
-        a_q = Mock()
-        pl = b"$title-my<playlist>.m3u", (q, None), (a_q, None)
-        spl._matched_playlists = {pl}
-
-        dir = mkdtemp()
-        tpl = "http://beets:8337/item/$id/file"
-        config["smartplaylist"]["uri_format"] = tpl
-        config["smartplaylist"]["playlist_dir"] = dir
-        # The following options should be ignored when uri_format is set
-        config["smartplaylist"]["relative_to"] = "/data"
-        config["smartplaylist"]["prefix"] = "/prefix"
-        config["smartplaylist"]["urlencode"] = True
-        try:
-            spl.update_playlists(lib)
-        except Exception:
-            rmtree(syspath(dir))
-            raise
-
-        lib.items.assert_called_once_with(q, None)
-        lib.albums.assert_called_once_with(a_q, None)
-
-        m3u_filepath = Path(dir, "ta_ga_da-my_playlist_.m3u")
-        assert m3u_filepath.exists()
-        content = m3u_filepath.read_bytes()
-        rmtree(syspath(dir))
-
-        assert content == b"http://beets:8337/item/3/file\n"
-
     def test_get_playlist_items(self):
         """Test get playlist items.
 
@@ -361,86 +320,61 @@ class SmartPlaylistTest(BeetsTestCase):
 
         assert [i.id for i in actual_items] == [3, 2, 1]
 
-    def test_playlist_update_dest_regen(self):
-        spl = SmartPlaylistPlugin()
 
-        i = MagicMock()
-        type(i).artist = PropertyMock(return_value="fake artist")
-        type(i).title = PropertyMock(return_value="fake title")
-        type(i).length = PropertyMock(return_value=300.123)
-        # Set a path which is not equal to the one returned by `item.destination`.
-        type(i).path = PropertyMock(
-            return_value=b"/imported/path/with/dont/move/tagada.mp3"
-        )
-        # Set a path which would be equal to the one returned by `item.destination`.
-        type(i).destination = PropertyMock(return_value=lambda: b"/tagada.mp3")
-        i.evaluate_template.side_effect = lambda pl, *_: os.fsdecode(
-            pl
-        ).replace("$title", "ta:ga:da")
+class TestGetItemURI:
+    @pytest.fixture
+    def plugin_config(self):
+        return {}
 
-        lib = Mock()
-        lib.replacements = CHAR_REPLACE
-        lib.items.return_value = [i]
-        lib.albums.return_value = []
+    @pytest.fixture
+    def plugin(self, config, plugin_config):
+        plugin_config = {
+            "prefix": "http://beets:8337/files",
+            **plugin_config,
+        }
+        config["smartplaylist"].set(plugin_config)
 
-        q = Mock()
-        a_q = Mock()
-        pl = b"$title-my<playlist>.m3u", (q, None), (a_q, None)
-        spl._matched_playlists = {pl}
+        return SmartPlaylistPlugin()
 
-        dir = mkdtemp()
-        config["smartplaylist"]["output"] = "extm3u"
-        config["smartplaylist"]["prefix"] = "http://beets:8337/files"
-        config["smartplaylist"]["relative_to"] = False
-        config["smartplaylist"]["playlist_dir"] = str(dir)
+    @pytest.fixture(autouse=True)
+    def _setup(self, monkeypatch):
+        monkeypatch.setattr(Item, "destination", lambda _: b"/tagada.mp3")
 
-        # Test when `dest_regen` is set to True:
-        # Intended behavior is to use the path of `i.destination`.
-
-        config["smartplaylist"]["dest_regen"] = True
-        try:
-            spl.update_playlists(lib)
-        except Exception:
-            rmtree(syspath(dir))
-            raise
-
-        lib.items.assert_called_once_with(q, None)
-        lib.albums.assert_called_once_with(a_q, None)
-
-        m3u_filepath = Path(dir, "ta_ga_da-my_playlist_.m3u")
-        assert m3u_filepath.exists()
-        with open(syspath(m3u_filepath), "rb") as f:
-            content = f.read()
-        rmtree(syspath(dir))
-
-        assert content == (
-            b"#EXTM3U\n"
-            b"#EXTINF:300,fake artist - fake title\n"
-            b"http://beets:8337/files/tagada.mp3\n"
+    @pytest.fixture
+    def item(self):
+        return item(
+            id=3,
+            artist="fake artist",
+            title="fake title",
+            length=300.123,
+            path=b"/imported/path/with/dont/move/tagada.mp3",
         )
 
-        # Test when `dest_regen` is set to False:
-        # Intended behavior is to use the path of `i.path`.
-
-        config["smartplaylist"]["dest_regen"] = False
-
-        try:
-            spl.update_playlists(lib)
-        except Exception:
-            rmtree(syspath(dir))
-            raise
-
-        m3u_filepath = Path(dir, "ta_ga_da-my_playlist_.m3u")
-        assert m3u_filepath.exists()
-        with open(syspath(m3u_filepath), "rb") as f:
-            content = f.read()
-        rmtree(syspath(dir))
-
-        assert content == (
-            b"#EXTM3U\n"
-            b"#EXTINF:300,fake artist - fake title\n"
-            b"http://beets:8337/files/imported/path/with/dont/move/tagada.mp3\n"
-        )
+    @pytest.mark.parametrize(
+        "plugin_config, expected_uri",
+        [
+            _p(
+                {},
+                b"http://beets:8337/files/imported/path/with/dont/move/tagada.mp3",
+                id="path by default",
+            ),
+            _p(
+                {"dest_regen": True},
+                b"http://beets:8337/files/tagada.mp3",
+                id="dest_regen uses item destination",
+            ),
+            _p(
+                {
+                    "uri_format": "http://beets:8337/item/$id/file",
+                    "dest_regen": True,
+                },
+                b"http://beets:8337/item/3/file",
+                id="uri_format takes precedence",
+            ),
+        ],
+    )
+    def test_get_item_uri(self, plugin, item, expected_uri):
+        assert plugin.get_item_uri(item) == expected_uri
 
 
 class SmartPlaylistCLITest(IOMixin, PluginTestCase):

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -344,117 +344,22 @@ class SmartPlaylistTest(BeetsTestCase):
 
         assert content == b"http://beets:8337/item/3/file\n"
 
-    def test_playlist_update_multiple_queries_preserve_order(self):
-        """Test that multiple queries preserve their order in the playlist."""
-        spl = SmartPlaylistPlugin()
+    def test_get_playlist_items(self):
+        """Test get playlist items.
 
-        # Create three mock items
-        i1 = Mock(path=b"/item1.mp3", id=1)
-        i1.evaluate_template.return_value = "ordered.m3u"
-        i2 = Mock(path=b"/item2.mp3", id=2)
-        i2.evaluate_template.return_value = "ordered.m3u"
-        i3 = Mock(path=b"/item3.mp3", id=3)
-        i3.evaluate_template.return_value = "ordered.m3u"
+        - Items preserve their order in the playlist
+        - There are no duplicates when items match multiple queries
+        """
+        self.add_item(path=b"/item1.mp3", id=1)
+        self.add_item(path=b"/item2.mp3", id=2)
+        self.add_item(path=b"/item3.mp3", id=3)
+        queries_and_sorts = (("path::item id-", None), ("path::item3", None))
 
-        lib = Mock()
-        lib.replacements = CHAR_REPLACE
-        lib.albums.return_value = []
+        actual_items = SmartPlaylistPlugin.get_playlist_items(
+            self.lib, (queries_and_sorts, None), (None, None)
+        )
 
-        # Set up lib.items to return different items for different queries
-        q1 = Mock()
-        q2 = Mock()
-        q3 = Mock()
-
-        def items_side_effect(query, sort):
-            if query == q1:
-                return [i1]
-            elif query == q2:
-                return [i2]
-            elif query == q3:
-                return [i3]
-            return []
-
-        lib.items.side_effect = items_side_effect
-
-        # Create playlist with multiple queries (stored as tuple)
-        queries_and_sorts = ((q1, None), (q2, None), (q3, None))
-        pl = "ordered.m3u", (queries_and_sorts, None), (None, None)
-        spl._matched_playlists = {pl}
-
-        dir = mkdtemp()
-        config["smartplaylist"]["relative_to"] = False
-        config["smartplaylist"]["playlist_dir"] = str(dir)
-        try:
-            spl.update_playlists(lib)
-        except Exception:
-            rmtree(syspath(dir))
-            raise
-
-        # Verify that lib.items was called with queries in the correct order
-        assert lib.items.call_count == 3
-        lib.items.assert_any_call(q1, None)
-        lib.items.assert_any_call(q2, None)
-        lib.items.assert_any_call(q3, None)
-
-        m3u_filepath = Path(dir, "ordered.m3u")
-        assert m3u_filepath.exists()
-        content = m3u_filepath.read_bytes()
-        rmtree(syspath(dir))
-
-        # Items should be in order: i1, i2, i3
-        assert content == b"/item1.mp3\n/item2.mp3\n/item3.mp3\n"
-
-    def test_playlist_update_multiple_queries_no_duplicates(self):
-        """Test that items matching multiple queries only appear once."""
-        spl = SmartPlaylistPlugin()
-
-        # Create two mock items
-        i1 = Mock(path=b"/item1.mp3", id=1)
-        i1.evaluate_template.return_value = "dedup.m3u"
-        i2 = Mock(path=b"/item2.mp3", id=2)
-        i2.evaluate_template.return_value = "dedup.m3u"
-
-        lib = Mock()
-        lib.replacements = CHAR_REPLACE
-        lib.albums.return_value = []
-
-        # Set up lib.items so both queries return overlapping items
-        q1 = Mock()
-        q2 = Mock()
-
-        def items_side_effect(query, sort):
-            if query == q1:
-                return [i1, i2]  # Both items match q1
-            elif query == q2:
-                return [i2]  # Only i2 matches q2
-            return []
-
-        lib.items.side_effect = items_side_effect
-
-        # Create playlist with multiple queries (stored as tuple)
-        queries_and_sorts = ((q1, None), (q2, None))
-        pl = "dedup.m3u", (queries_and_sorts, None), (None, None)
-        spl._matched_playlists = {pl}
-
-        dir = mkdtemp()
-        config["smartplaylist"]["relative_to"] = False
-        config["smartplaylist"]["playlist_dir"] = str(dir)
-        try:
-            spl.update_playlists(lib)
-        except Exception:
-            rmtree(syspath(dir))
-            raise
-
-        m3u_filepath = Path(dir, "dedup.m3u")
-        assert m3u_filepath.exists()
-        content = m3u_filepath.read_bytes()
-        rmtree(syspath(dir))
-
-        # i2 should only appear once even though it matches both queries
-        # Order should be: i1 (from q1), i2 (from q1, skipped in q2)
-        assert content == b"/item1.mp3\n/item2.mp3\n"
-        # Verify i2 is not duplicated
-        assert content.count(b"/item2.mp3") == 1
+        assert [i.id for i in actual_items] == [3, 2, 1]
 
     def test_playlist_update_dest_regen(self):
         spl = SmartPlaylistPlugin()


### PR DESCRIPTION
## Refactor `smartplaylist` plugin internals

This PR incrementally cleans up `smartplaylist.py` with no behaviour changes, splitting a monolithic `update_playlists` method into focused, testable units.

### Key changes

- **`get_item_uri`** — extracts URI resolution logic (prefix, `dest_regen`, `relative_to`, `urlencode`, `uri_format`) out of the update loop into a dedicated method. Config options are now lazily cached as `@cached_property` fields on the plugin instance.
- **`get_playlist_items`** — isolates item/album query resolution into a static/class method returning a deduplicated `Iterator[Item]`. A helper `get_queries` normalises single vs. compound query inputs.
- **`write_playlist`** — extracts file I/O and `#EXTM3U` header writing into its own method.
- **`PlaylistItem.get_comment`** — moves per-entry comment formatting (including `#EXTINF` generation) onto the `PlaylistItem` dataclass.
- **Output format validation** — moved to plugin init using `confuse.Choice`, replacing a manual runtime string check. The CLI `--output` option now uses `type="choice"` accordingly.
- **`pretend` config default** — added to the config schema so `update_playlists` can read it directly, removing the `pretend` parameter from its signature.
- **`defaultdict`** — replaces manual `m3u`/`m3u_uris` dict initialisation in the update loop.

### Test impact

`TestGetItemURI` replaces two large integration-style test methods (`test_playlist_update_uri_format`, `test_playlist_update_dest_regen`) with a focused parametrised class using real `Item` fixtures instead of `MagicMock`. The multi-query ordering and deduplication tests are replaced by a single `test_get_playlist_items` using real library items.


**Before**
```
$ complexipy beetsplug/smartplaylist.py
🧠 Total Cognitive Complexity: 117
```

**After**
```
$ complexipy beetsplug/smartplaylist.py
🧠 Total Cognitive Complexity: 59
```
