### PR TITLE
Remove 'slow_test' unittest marker

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -315,13 +315,6 @@ Use ``poe`` to run tests:
 
     $ poe test [pytest options]
 
-You can disable a hand-selected set of "slow" tests by setting the environment
-variable ``SKIP_SLOW_TESTS``, for example:
-
-::
-
-    $ SKIP_SLOW_TESTS=1 poe test
-
 Coverage
 ++++++++
 

--- a/beets/test/_common.py
+++ b/beets/test/_common.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import os
 import sys
-import unittest
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
@@ -232,12 +231,3 @@ def system_mock(name):
         yield
     finally:
         platform.system = old_system
-
-
-def slow_test(unused=None):
-    def _id(obj):
-        return obj
-
-    if "SKIP_SLOW_TESTS" in os.environ:
-        return unittest.skip("test is slow")
-    return _id

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -761,7 +761,6 @@ class FanartTVTest(UseThePlugin):
             next(self.source.get(album, self.settings, []))
 
 
-@_common.slow_test()
 class ArtImporterTest(UseThePlugin):
     def setUp(self):
         super().setUp()

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -71,7 +71,6 @@ class ConvertTestCase(IOMixin, ConvertMixin, PluginTestCase):
     plugin = "convert"
 
 
-@_common.slow_test()
 class ImportConvertTest(AsIsImporterMixin, ImportHelper, ConvertTestCase):
     def setUp(self):
         super().setUp()
@@ -133,7 +132,6 @@ class ConvertCommand:
         return self.run_convert_path(self.item, *args)
 
 
-@_common.slow_test()
 class ConvertCliTest(ConvertTestCase, ConvertCommand):
     def setUp(self):
         super().setUp()
@@ -309,7 +307,6 @@ class ConvertCliTest(ConvertTestCase, ConvertCommand):
         self.assert_playlist_entry("converted.ogg", "--keep-new")
 
 
-@_common.slow_test()
 class NeverConvertLossyFilesTest(ConvertTestCase, ConvertCommand):
     """Test the effect of the `never_convert_lossy_files` option."""
 

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -19,7 +19,6 @@ from unittest.mock import patch
 from beets.dbcore.query import TrueQuery
 from beets.importer import Action
 from beets.library import Item
-from beets.test import _common
 from beets.test.helper import (
     AutotagImportTestCase,
     AutotagStub,
@@ -118,7 +117,6 @@ class EditMixin(PluginMixin):
             self.run_command("edit", *args)
 
 
-@_common.slow_test()
 @patch("beets.library.Item.write")
 class EditCommandTest(IOMixin, EditMixin, BeetsTestCase):
     """Black box tests for `beetsplug.edit`. Command line interaction is
@@ -315,7 +313,6 @@ class EditCommandTest(IOMixin, EditMixin, BeetsTestCase):
         assert mock_write.call_count == 0
 
 
-@_common.slow_test()
 class EditDuringImporterTestCase(
     EditMixin, TerminalImportMixin, AutotagImportTestCase
 ):
@@ -332,7 +329,6 @@ class EditDuringImporterTestCase(
         self.items_orig = [Item.from_path(f.path) for f in self.import_media]
 
 
-@_common.slow_test()
 class EditDuringImporterNonSingletonTest(EditDuringImporterTestCase):
     def setUp(self):
         super().setUp()
@@ -467,7 +463,6 @@ class EditDuringImporterNonSingletonTest(EditDuringImporterTestCase):
         assert all("match " in i.mb_trackid for i in self.lib.items())
 
 
-@_common.slow_test()
 class EditDuringImporterSingletonTest(EditDuringImporterTestCase):
     def setUp(self):
         super().setUp()

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -26,7 +26,6 @@ import pytest
 from beets import dbcore
 from beets.dbcore.db import DBCustomFunctionError, Index
 from beets.library import LibModel
-from beets.test import _common
 from beets.util import cached_classproperty
 
 # Fixture: concrete database and model classes. For migration tests, we
@@ -167,7 +166,6 @@ class ModelFixtureWithGetters(dbcore.Model):
         return {}
 
 
-@_common.slow_test()
 class MigrationTest(unittest.TestCase):
     """Tests the ability to change the database schema between
     versions.

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -72,7 +72,6 @@ class PathsMixin:
         return self.lib_path / "Tag Artist" / "Tag Album" / "Tag Track 1.mp3"
 
 
-@_common.slow_test()
 class NonAutotaggedImportTest(PathsMixin, AsIsImporterMixin, ImportTestCase):
     db_on_disk = True
 

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -10,7 +10,7 @@ import pytest
 
 import beets.logging as blog
 from beets import plugins, ui
-from beets.test import _common, helper
+from beets.test import helper
 from beets.test.helper import AsIsImporterMixin, ImportTestCase, PluginMixin
 
 
@@ -233,7 +233,6 @@ class LoggingLevelTest(AsIsImporterMixin, PluginMixin, ImportTestCase):
         assert "dummy: debug import_stage" in logs
 
 
-@_common.slow_test()
 class ConcurrentEventsTest(AsIsImporterMixin, ImportTestCase):
     """Similar to LoggingLevelTest but lower-level and focused on multiple
     events interaction. Since this is a bit heavy we don't do it in

--- a/test/ui/commands/test_completion.py
+++ b/test/ui/commands/test_completion.py
@@ -12,7 +12,6 @@ from beets.util import syspath
 from ..test_ui import TestPluginTestCase
 
 
-@_common.slow_test()
 @pytest.mark.xfail(
     os.environ.get("GITHUB_ACTIONS") == "true" and sys.platform == "linux",
     reason="Completion is for some reason unhappy on Ubuntu 24.04 in CI",

--- a/test/ui/test_ui.py
+++ b/test/ui/test_ui.py
@@ -80,7 +80,6 @@ class ShowModelChangesTest(IOMixin, BeetsTestCase):
         ]
 
 
-@_common.slow_test()
 class TestPluginTestCase(PluginTestCase):
     plugin = "test"
 
@@ -361,7 +360,6 @@ class PathFormatTest(unittest.TestCase):
         assert pf[1:] == default_formats
 
 
-@_common.slow_test()
 class PluginTest(TestPluginTestCase):
     def test_plugin_command_from_pluginpath(self):
         self.run_command("test")


### PR DESCRIPTION
## Remove `slow_test` unittest marker

Removes the `slow_test` decorator and its supporting `SKIP_SLOW_TESTS` env-var mechanism entirely. All previously "slow" test classes now run unconditionally.

**Changes:**
- Deletes `slow_test()` helper from `beets/test/_common.py`
- Removes all `@_common.slow_test()` usages across test files
- Updates `CONTRIBUTING.rst` to drop the `SKIP_SLOW_TESTS` documentation

Just doing some plumbing removing some unused noise from tests.
