### PR TITLE
convert: Add types and simplify args parsing

### DIFF
--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -96,6 +96,8 @@ EventType = Literal[
     "pluginload",
     "trackinfo_received",
     "write",
+    # convert plugin
+    "after_convert",
     # smartplaylist plugin
     "smartplaylist_update",
 ]

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -308,9 +308,7 @@ class ConvertPlugin(BeetsPlugin):
             items = task.imported_items()
 
             # Filter items based on should_transcode function
-            items = [
-                item for item in items if self.should_transcode(item, self.fmt)
-            ]
+            items = [item for item in items if self.should_transcode(item)]
 
             self._parallel_convert(items, keep_new=False)
 
@@ -388,9 +386,7 @@ class ConvertPlugin(BeetsPlugin):
         else:
             return False
 
-    def should_transcode(
-        self, item: Item, fmt: str, force: bool = False
-    ) -> bool:
+    def should_transcode(self, item: Item) -> bool:
         """Determine whether the item should be transcoded as part of
         conversion (i.e., its bitrate is high or it has the wrong format).
 
@@ -398,7 +394,7 @@ class ConvertPlugin(BeetsPlugin):
         ``never_convert_lossy_files`` are ignored and the item is always
         transcoded.
         """
-        if force:
+        if self.force:
             return True
         if self.in_no_convert(item) or (
             self.config["never_convert_lossy_files"].get(bool)
@@ -408,7 +404,7 @@ class ConvertPlugin(BeetsPlugin):
         maxbr = self.config["max_bitrate"].get(Optional(int))
         if maxbr is not None and item.bitrate >= 1000 * maxbr:
             return True
-        return fmt.lower() != item.format.lower()
+        return self.fmt != item.format.lower()
 
     def convert_item(
         self, keep_new: bool
@@ -416,11 +412,10 @@ class ConvertPlugin(BeetsPlugin):
         """A pipeline thread that converts `Item` objects from a
         library.
         """
-        fmt, force, pretend = self.fmt, self.force, self.pretend
-        link, hardlink = self.link, self.hardlink
-
+        pretend, link, hardlink = self.pretend, self.link, self.hardlink
         command, ext = self.command
         item, original, converted = None, None, None
+
         while True:
             item = yield (item, original, converted)
             dest = item.destination(
@@ -442,11 +437,11 @@ class ConvertPlugin(BeetsPlugin):
             if keep_new:
                 original = dest
                 converted = item.path
-                if self.should_transcode(item, fmt, force):
+                if self.should_transcode(item):
                     converted = replace_ext(converted, ext)
             else:
                 original = item.path
-                if self.should_transcode(item, fmt, force):
+                if self.should_transcode(item):
                     dest = replace_ext(dest, ext)
                 converted = dest
 
@@ -476,7 +471,7 @@ class ConvertPlugin(BeetsPlugin):
                     )
                     util.move(item.path, original)
 
-            if self.should_transcode(item, fmt, force):
+            if self.should_transcode(item):
                 linked = False
                 try:
                     self.encode(command, original, converted, pretend)
@@ -662,7 +657,6 @@ class ConvertPlugin(BeetsPlugin):
         # copied to the destination.
         pl_normpath = None
         items_paths = None
-        fmt = self.fmt
         if playlist := self.playlist:
             # Playlist paths are understood as relative to the dest directory.
             pl_normpath = util.normpath(playlist)
@@ -675,9 +669,7 @@ class ConvertPlugin(BeetsPlugin):
 
                 # When keeping new files in the library, destination paths
                 # keep original files and extensions.
-                if not opts.keep_new and self.should_transcode(
-                    item, fmt, self.force
-                ):
+                if not opts.keep_new and self.should_transcode(item):
                     item_path = replace_ext(item_path, self.command.ext)
 
                 items_paths.append(os.path.relpath(item_path, pl_dir))
@@ -697,7 +689,7 @@ class ConvertPlugin(BeetsPlugin):
         """Transcode a file automatically after it is imported into the
         library.
         """
-        if self.should_transcode(item, self.fmt):
+        if self.should_transcode(item):
             command, ext = self.command
 
             # Create a temporary file for the conversion.

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -312,26 +312,25 @@ class ConvertPlugin(BeetsPlugin):
     # Utilities converted from functions to methods on logging overhaul
 
     def encode(
-        self, command: bytes, source: bytes, dest: bytes, pretend: bool = False
+        self,
+        command_bytes: bytes,
+        source_bytes: bytes,
+        dest_bytes: bytes,
+        pretend: bool = False,
     ) -> None:
-        """Encode `source` to `dest` using command template `command`.
+        """Encode source to destination using given command template.
 
         Raises `subprocess.CalledProcessError` if the command exited with a
         non-zero status code.
         """
-        # The paths and arguments must be bytes.
-        assert isinstance(command, bytes)
-        assert isinstance(source, bytes)
-        assert isinstance(dest, bytes)
-
         quiet = self.config["quiet"].get(bool)
 
         if not quiet and not pretend:
-            self._log.info("Encoding {}", util.displayable_path(source))
+            self._log.info("Encoding {}", util.displayable_path(source_bytes))
 
-        command = os.fsdecode(command)
-        source = os.fsdecode(source)
-        dest = os.fsdecode(dest)
+        command = os.fsdecode(command_bytes)
+        source = os.fsdecode(source_bytes)
+        dest = os.fsdecode(dest_bytes)
 
         # Substitute $source and $dest in the argument list.
         args = shlex.split(command)
@@ -697,8 +696,8 @@ class ConvertPlugin(BeetsPlugin):
             # Create a temporary file for the conversion.
             tmpdir = self.config["tmpdir"].get()
             if tmpdir:
-                tmpdir = os.fsdecode(util.bytestring_path(tmpdir))
-            fd, dest = tempfile.mkstemp(f".{os.fsdecode(ext)}", dir=tmpdir)
+                tmpdir = util.bytestring_path(tmpdir)
+            fd, dest = tempfile.mkstemp(b"." + ext, dir=tmpdir)
             os.close(fd)
             dest = util.bytestring_path(dest)
             _temp_files.append(dest)  # Delete the transcode later.

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -315,18 +315,14 @@ class ConvertPlugin(BeetsPlugin):
     # Utilities converted from functions to methods on logging overhaul
 
     def encode(
-        self,
-        command_bytes: bytes,
-        source_bytes: bytes,
-        dest_bytes: bytes,
-        pretend: bool = False,
+        self, command_bytes: bytes, source_bytes: bytes, dest_bytes: bytes
     ) -> None:
         """Encode source to destination using given command template.
 
         Raises `subprocess.CalledProcessError` if the command exited with a
         non-zero status code.
         """
-        quiet = self.config["quiet"].get(bool)
+        pretend, quiet = self.pretend, self.config["quiet"].get(bool)
 
         if not quiet and not pretend:
             self._log.info("Encoding {}", util.displayable_path(source_bytes))
@@ -474,7 +470,7 @@ class ConvertPlugin(BeetsPlugin):
             if self.should_transcode(item):
                 linked = False
                 try:
-                    self.encode(command, original, converted, pretend)
+                    self.encode(command, original, converted)
                 except subprocess.CalledProcessError:
                     continue
             else:

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -22,6 +22,7 @@ import shlex
 import subprocess
 import tempfile
 import threading
+from functools import cached_property
 from string import Template
 from typing import TYPE_CHECKING
 
@@ -42,6 +43,7 @@ if TYPE_CHECKING:
 
     from beets.importer import ImportSession, ImportTask
     from beets.library import Album, Library
+    from beets.util.functemplate import Template as FuncTemplate
 
 _fs_lock = threading.Lock()
 # Keep track of temporary transcoded files for deletion.
@@ -214,6 +216,48 @@ class ConvertPlugin(BeetsPlugin):
         cmd.func = self.convert_func
         return [cmd]
 
+    @cached_property
+    def dest(self) -> bytes:
+        dest = self.config["dest"].get()
+        if not dest:
+            raise ui.UserError("no convert destination set")
+        return util.bytestring_path(dest)
+
+    @cached_property
+    def threads(self) -> int:
+        return self.config["threads"].get(int)
+
+    @cached_property
+    def path_formats(self) -> dict[str, FuncTemplate]:
+        return ui.get_path_formats(self.config["paths"] or None)
+
+    @cached_property
+    def fmt(self) -> str:
+        return self.config["format"].as_str().lower()
+
+    @cached_property
+    def playlist(self) -> bytes | None:
+        if (playlist := self.config["playlist"].get()) is not None:
+            return os.path.join(self.dest, util.bytestring_path(playlist))
+
+        return None
+
+    @cached_property
+    def pretend(self) -> bool:
+        return self.config["pretend"].get(bool)
+
+    @cached_property
+    def force(self) -> bool:
+        return self.config["force"].get(bool)
+
+    @cached_property
+    def hardlink(self) -> bool:
+        return self.config["hardlink"].get(bool)
+
+    @cached_property
+    def link(self) -> bool:
+        return not self.hardlink and self.config["link"].get(bool)
+
     def auto_convert(self, session: ImportSession, task: ImportTask) -> None:
         if self.config["auto"]:
             par_map(
@@ -225,35 +269,14 @@ class ConvertPlugin(BeetsPlugin):
         self, session: ImportSession, task: ImportTask
     ) -> None:
         if self.config["auto_keep"]:
-            (
-                dest,
-                threads,
-                path_formats,
-                fmt,
-                pretend,
-                hardlink,
-                link,
-                _,
-                force,
-            ) = self._get_opts_and_config()
-
             items = task.imported_items()
 
             # Filter items based on should_transcode function
-            items = [item for item in items if self.should_transcode(item, fmt)]
+            items = [
+                item for item in items if self.should_transcode(item, self.fmt)
+            ]
 
-            self._parallel_convert(
-                dest,
-                False,
-                path_formats,
-                fmt,
-                pretend,
-                link,
-                hardlink,
-                threads,
-                items,
-                force,
-            )
+            self._parallel_convert(items, keep_new=False)
 
     # Utilities converted from functions to methods on logging overhaul
 
@@ -384,24 +407,21 @@ class ConvertPlugin(BeetsPlugin):
         return fmt.lower() != item.format.lower()
 
     def convert_item(
-        self,
-        dest_dir: bytes,
-        keep_new: bool,
-        path_formats: dict[str, str],
-        fmt: str,
-        pretend: bool = False,
-        link: bool = False,
-        hardlink: bool = False,
-        force: bool = False,
+        self, keep_new: bool
     ) -> Generator[tuple[Item | None, bytes | None, bytes | None], Item, None]:
         """A pipeline thread that converts `Item` objects from a
         library.
         """
+        fmt, force, pretend = self.fmt, self.force, self.pretend
+        link, hardlink = self.link, self.hardlink
+
         command, ext = self.get_format(fmt)
         item, original, converted = None, None, None
         while True:
             item = yield (item, original, converted)
-            dest = item.destination(basedir=dest_dir, path_formats=path_formats)
+            dest = item.destination(
+                basedir=self.dest, path_formats=self.path_formats
+            )
 
             # Ensure that desired item is readable before processing it. Needed
             # to avoid any side-effect of the conversion (linking, keep_new,
@@ -529,15 +549,7 @@ class ConvertPlugin(BeetsPlugin):
                     "after_convert", item=item, dest=converted, keepnew=False
                 )
 
-    def copy_album_art(
-        self,
-        album: Album,
-        dest_dir: bytes,
-        path_formats: dict[str, str],
-        pretend: bool = False,
-        link: bool = False,
-        hardlink: bool = False,
-    ) -> None:
+    def copy_album_art(self, album: Album) -> None:
         """Copies or converts the associated cover art of the album. Album must
         have at least one track.
         """
@@ -552,7 +564,7 @@ class ConvertPlugin(BeetsPlugin):
         # Get the destination of the first item (track) of the album, we use
         # this function to format the path accordingly to path_formats.
         dest = album_item.destination(
-            basedir=dest_dir, path_formats=path_formats
+            basedir=self.dest, path_formats=self.path_formats
         )
 
         # Remove item from the path.
@@ -562,7 +574,7 @@ class ConvertPlugin(BeetsPlugin):
         if album.artpath == dest:
             return
 
-        if not pretend:
+        if not (pretend := self.pretend):
             util.mkdirall(dest)
 
         if os.path.exists(util.syspath(dest)):
@@ -584,6 +596,7 @@ class ConvertPlugin(BeetsPlugin):
             if not pretend:
                 ArtResizer.shared.resize(maxwidth, album.artpath, dest)
         else:
+            link, hardlink = self.link, self.hardlink
             if pretend:
                 msg = "ln" if hardlink else ("ln -s" if link else "cp")
 
@@ -617,17 +630,7 @@ class ConvertPlugin(BeetsPlugin):
         self, lib: Library, opts: optparse.Values, args: list[str]
     ) -> None:
         self.config.set(vars(opts))
-        (
-            dest,
-            threads,
-            path_formats,
-            fmt,
-            pretend,
-            hardlink,
-            link,
-            playlist,
-            force,
-        ) = self._get_opts_and_config()
+        pretend = self.pretend
 
         if opts.album:
             albums = lib.albums(args)
@@ -649,15 +652,14 @@ class ConvertPlugin(BeetsPlugin):
 
         if opts.album and self.config["copy_album_art"]:
             for album in albums:
-                self.copy_album_art(
-                    album, dest, path_formats, pretend, link, hardlink
-                )
+                self.copy_album_art(album)
 
         # If the user supplied a playlist name, create a playlist for files
         # copied to the destination.
         pl_normpath = None
         items_paths = None
-        if playlist:
+        fmt = self.fmt
+        if playlist := self.playlist:
             _, ext = self.get_format(fmt)
             # Playlist paths are understood as relative to the dest directory.
             pl_normpath = util.normpath(playlist)
@@ -665,29 +667,20 @@ class ConvertPlugin(BeetsPlugin):
             items_paths = []
             for item in items:
                 item_path = item.destination(
-                    basedir=dest, path_formats=path_formats
+                    basedir=self.dest, path_formats=self.path_formats
                 )
 
                 # When keeping new files in the library, destination paths
                 # keep original files and extensions.
                 if not opts.keep_new and self.should_transcode(
-                    item, fmt, force
+                    item, fmt, self.force
                 ):
                     item_path = replace_ext(item_path, ext)
 
                 items_paths.append(os.path.relpath(item_path, pl_dir))
 
         self._parallel_convert(
-            dest,
-            opts.keep_new,
-            path_formats,
-            fmt,
-            pretend,
-            link,
-            hardlink,
-            threads,
-            items,
-            force,
+            items, keep_new=self.config["keep_new"].get(bool)
         )
 
         if playlist:
@@ -763,75 +756,10 @@ class ConvertPlugin(BeetsPlugin):
                     util.remove(path)
                 _temp_files.remove(path)
 
-    def _get_opts_and_config(
-        self,
-    ) -> tuple[
-        bytes, int, dict[str, str], str, bool, bool, bool, str | None, bool
-    ]:
-        """Returns parameters needed for convert function.
-        Get parameters from command line if available,
-        default to config if not available.
-        """
-        dest = self.config["dest"].get()
-        if not dest:
-            raise ui.UserError("no convert destination set")
-        dest = util.bytestring_path(dest)
-
-        threads = self.config["threads"].get(int)
-
-        path_formats = ui.get_path_formats(self.config["paths"] or None)
-
-        fmt = self.config["format"].as_str().lower()
-
-        playlist = self.config["playlist"].get()
-        if playlist is not None:
-            playlist = os.path.join(dest, util.bytestring_path(playlist))
-
-        pretend = self.config["pretend"].get(bool)
-
-        hardlink = self.config["hardlink"].get(bool)
-        link = not hardlink and self.config["link"].get(bool)
-        force = self.config["force"].get(bool)
-        return (
-            dest,
-            threads,
-            path_formats,
-            fmt,
-            pretend,
-            hardlink,
-            link,
-            playlist,
-            force,
-        )
-
-    def _parallel_convert(
-        self,
-        dest: bytes,
-        keep_new: bool,
-        path_formats: dict[str, str],
-        fmt: str,
-        pretend: bool,
-        link: bool,
-        hardlink: bool,
-        threads: int,
-        items: list[Item],
-        force: bool,
-    ):
+    def _parallel_convert(self, items: list[Item], keep_new: bool):
         """Run the convert_item function for every items on as many thread as
         defined in threads
         """
-        convert = [
-            self.convert_item(
-                dest,
-                keep_new,
-                path_formats,
-                fmt,
-                pretend,
-                link,
-                hardlink,
-                force,
-            )
-            for _ in range(threads)
-        ]
+        convert = [self.convert_item(keep_new) for _ in range(self.threads)]
         pipe = util.pipeline.Pipeline([iter(items), convert])
         pipe.run_parallel()

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -114,6 +114,8 @@ class ConvertPlugin(BeetsPlugin):
                 "album_art_maxwidth": 0,
                 "delete_originals": False,
                 "playlist": None,
+                "force": False,
+                "keep_new": False,
             }
         )
         self.early_import_stages = [self.auto_convert, self.auto_convert_keep]
@@ -126,6 +128,7 @@ class ConvertPlugin(BeetsPlugin):
             "-p",
             "--pretend",
             action="store_true",
+            default=self.config["pretend"].get(),
             help="show actions but do nothing",
         )
         cmd.parser.add_option(
@@ -133,6 +136,7 @@ class ConvertPlugin(BeetsPlugin):
             "--threads",
             action="store",
             type="int",
+            default=self.config["threads"].get(),
             help=(
                 "change the number of threads, defaults to maximum available"
                 " processors"
@@ -143,37 +147,41 @@ class ConvertPlugin(BeetsPlugin):
             "--keep-new",
             action="store_true",
             dest="keep_new",
+            default=self.config["keep_new"].get(),
             help="keep only the converted and move the old files",
         )
         cmd.parser.add_option(
-            "-d", "--dest", action="store", help="set the destination directory"
+            "-d",
+            "--dest",
+            action="store",
+            default=self.config["dest"].get(),
+            help="set the destination directory",
         )
         cmd.parser.add_option(
             "-f",
             "--format",
             action="store",
-            dest="format",
+            default=self.config["format"].get(),
             help="set the target format of the tracks",
         )
         cmd.parser.add_option(
             "-y",
             "--yes",
             action="store_true",
-            dest="yes",
             help="do not ask for confirmation",
         )
         cmd.parser.add_option(
             "-l",
             "--link",
             action="store_true",
-            dest="link",
+            default=self.config["link"].get(),
             help="symlink files that do not need transcoding.",
         )
         cmd.parser.add_option(
             "-H",
             "--hardlink",
             action="store_true",
-            dest="hardlink",
+            default=self.config["hardlink"].get(),
             help=(
                 "hardlink files that do not need transcoding. Overrides --link."
             ),
@@ -182,6 +190,7 @@ class ConvertPlugin(BeetsPlugin):
             "-m",
             "--playlist",
             action="store",
+            default=self.config["playlist"].get(),
             help="""create an m3u8 playlist file containing
                               the converted files. The playlist file will be
                               saved below the destination directory, thus
@@ -195,7 +204,7 @@ class ConvertPlugin(BeetsPlugin):
             "-F",
             "--force",
             action="store_true",
-            dest="force",
+            default=self.config["force"].get(),
             help=(
                 "force transcoding. Ignores no_convert, "
                 "never_convert_lossy_files, and max_bitrate"
@@ -216,7 +225,6 @@ class ConvertPlugin(BeetsPlugin):
         self, session: ImportSession, task: ImportTask
     ) -> None:
         if self.config["auto_keep"]:
-            empty_opts = self.commands()[0].parser.get_default_values()
             (
                 dest,
                 threads,
@@ -227,7 +235,7 @@ class ConvertPlugin(BeetsPlugin):
                 link,
                 _,
                 force,
-            ) = self._get_opts_and_config(empty_opts)
+            ) = self._get_opts_and_config()
 
             items = task.imported_items()
 
@@ -608,6 +616,7 @@ class ConvertPlugin(BeetsPlugin):
     def convert_func(
         self, lib: Library, opts: optparse.Values, args: list[str]
     ) -> None:
+        self.config.set(vars(opts))
         (
             dest,
             threads,
@@ -618,7 +627,7 @@ class ConvertPlugin(BeetsPlugin):
             link,
             playlist,
             force,
-        ) = self._get_opts_and_config(opts)
+        ) = self._get_opts_and_config()
 
         if opts.album:
             albums = lib.albums(args)
@@ -755,7 +764,7 @@ class ConvertPlugin(BeetsPlugin):
                 _temp_files.remove(path)
 
     def _get_opts_and_config(
-        self, opts: optparse.Values
+        self,
     ) -> tuple[
         bytes, int, dict[str, str], str, bool, bool, bool, str | None, bool
     ]:
@@ -763,36 +772,26 @@ class ConvertPlugin(BeetsPlugin):
         Get parameters from command line if available,
         default to config if not available.
         """
-        dest = opts.dest or self.config["dest"].get()
+        dest = self.config["dest"].get()
         if not dest:
             raise ui.UserError("no convert destination set")
         dest = util.bytestring_path(dest)
 
-        threads = opts.threads or self.config["threads"].get(int)
+        threads = self.config["threads"].get(int)
 
         path_formats = ui.get_path_formats(self.config["paths"] or None)
 
-        fmt = opts.format or self.config["format"].as_str().lower()
+        fmt = self.config["format"].as_str().lower()
 
-        playlist = opts.playlist or self.config["playlist"].get()
+        playlist = self.config["playlist"].get()
         if playlist is not None:
             playlist = os.path.join(dest, util.bytestring_path(playlist))
 
-        if opts.pretend is not None:
-            pretend = opts.pretend
-        else:
-            pretend = self.config["pretend"].get(bool)
+        pretend = self.config["pretend"].get(bool)
 
-        if opts.hardlink is not None:
-            hardlink = opts.hardlink
-            link = False
-        elif opts.link is not None:
-            hardlink = False
-            link = opts.link
-        else:
-            hardlink = self.config["hardlink"].get(bool)
-            link = self.config["link"].get(bool)
-        force = getattr(opts, "force", False)
+        hardlink = self.config["hardlink"].get(bool)
+        link = not hardlink and self.config["link"].get(bool)
+        force = self.config["force"].get(bool)
         return (
             dest,
             threads,

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING
 import mediafile
 from confuse import ConfigTypeError, Optional
 
-from beets import config, plugins, ui, util
+from beets import plugins, ui, util
 from beets.library import Item, parse_query_string
 from beets.plugins import BeetsPlugin
 from beets.util import par_map
@@ -63,68 +63,6 @@ def replace_ext(path: bytes, ext: bytes) -> bytes:
     """
     ext_dot = b"." + ext
     return os.path.splitext(path)[0] + ext_dot
-
-
-def get_format(fmt: str | None = None) -> tuple[bytes, bytes]:
-    """Return the command template and the extension from the config."""
-    if not fmt:
-        fmt = config["convert"]["format"].as_str().lower()
-    fmt = ALIASES.get(fmt, fmt)
-
-    try:
-        format_info = config["convert"]["formats"][fmt].get(dict)
-        command = format_info["command"]
-        extension = format_info.get("extension", fmt)
-    except KeyError:
-        raise ui.UserError(f'convert: format {fmt} needs the "command" field')
-    except ConfigTypeError:
-        command = config["convert"]["formats"][fmt].get(str)
-        extension = fmt
-
-    # Convenience and backwards-compatibility shortcuts.
-    keys = config["convert"].keys()
-    if "command" in keys:
-        command = config["convert"]["command"].as_str()
-    elif "opts" in keys:
-        # Undocumented option for backwards compatibility with < 1.3.1.
-        command = (
-            f"ffmpeg -i $source -y {config['convert']['opts'].as_str()} $dest"
-        )
-    if "extension" in keys:
-        extension = config["convert"]["extension"].as_str()
-
-    return (command.encode("utf-8"), extension.encode("utf-8"))
-
-
-def in_no_convert(item: Item) -> bool:
-    no_convert_query = config["convert"]["no_convert"].as_str()
-
-    if no_convert_query:
-        query, _ = parse_query_string(no_convert_query, Item)
-        return query.match(item)
-    else:
-        return False
-
-
-def should_transcode(item: Item, fmt: str, force: bool = False) -> bool:
-    """Determine whether the item should be transcoded as part of
-    conversion (i.e., its bitrate is high or it has the wrong format).
-
-    If ``force`` is True, safety checks like ``no_convert`` and
-    ``never_convert_lossy_files`` are ignored and the item is always
-    transcoded.
-    """
-    if force:
-        return True
-    if in_no_convert(item) or (
-        config["convert"]["never_convert_lossy_files"].get(bool)
-        and item.format.lower() not in LOSSLESS_FORMATS
-    ):
-        return False
-    maxbr = config["convert"]["max_bitrate"].get(Optional(int))
-    if maxbr is not None and item.bitrate >= 1000 * maxbr:
-        return True
-    return fmt.lower() != item.format.lower()
 
 
 class ConvertPlugin(BeetsPlugin):
@@ -294,7 +232,7 @@ class ConvertPlugin(BeetsPlugin):
             items = task.imported_items()
 
             # Filter items based on should_transcode function
-            items = [item for item in items if should_transcode(item, fmt)]
+            items = [item for item in items if self.should_transcode(item, fmt)]
 
             self._parallel_convert(
                 dest,
@@ -374,6 +312,69 @@ class ConvertPlugin(BeetsPlugin):
                 "Finished encoding {}", util.displayable_path(source)
             )
 
+    def get_format(self, fmt: str | None = None) -> tuple[bytes, bytes]:
+        """Return the command template and the extension from the config."""
+        if not fmt:
+            fmt = self.config["format"].as_str().lower()
+        fmt = ALIASES.get(fmt, fmt)
+
+        try:
+            format_info = self.config["formats"][fmt].get(dict)
+            command = format_info["command"]
+            extension = format_info.get("extension", fmt)
+        except KeyError:
+            raise ui.UserError(
+                f'convert: format {fmt} needs the "command" field'
+            )
+        except ConfigTypeError:
+            command = self.config["formats"][fmt].get(str)
+            extension = fmt
+
+        # Convenience and backwards-compatibility shortcuts.
+        keys = self.config.keys()
+        if "command" in keys:
+            command = self.config["command"].as_str()
+        elif "opts" in keys:
+            # Undocumented option for backwards compatibility with < 1.3.1.
+            command = (
+                f"ffmpeg -i $source -y {self.config['opts'].as_str()} $dest"
+            )
+        if "extension" in keys:
+            extension = self.config["extension"].as_str()
+
+        return (command.encode("utf-8"), extension.encode("utf-8"))
+
+    def in_no_convert(self, item: Item) -> bool:
+        no_convert_query = self.config["no_convert"].as_str()
+
+        if no_convert_query:
+            query, _ = parse_query_string(no_convert_query, Item)
+            return query.match(item)
+        else:
+            return False
+
+    def should_transcode(
+        self, item: Item, fmt: str, force: bool = False
+    ) -> bool:
+        """Determine whether the item should be transcoded as part of
+        conversion (i.e., its bitrate is high or it has the wrong format).
+
+        If ``force`` is True, safety checks like ``no_convert`` and
+        ``never_convert_lossy_files`` are ignored and the item is always
+        transcoded.
+        """
+        if force:
+            return True
+        if self.in_no_convert(item) or (
+            self.config["never_convert_lossy_files"].get(bool)
+            and item.format.lower() not in LOSSLESS_FORMATS
+        ):
+            return False
+        maxbr = self.config["max_bitrate"].get(Optional(int))
+        if maxbr is not None and item.bitrate >= 1000 * maxbr:
+            return True
+        return fmt.lower() != item.format.lower()
+
     def convert_item(
         self,
         dest_dir: bytes,
@@ -388,7 +389,7 @@ class ConvertPlugin(BeetsPlugin):
         """A pipeline thread that converts `Item` objects from a
         library.
         """
-        command, ext = get_format(fmt)
+        command, ext = self.get_format(fmt)
         item, original, converted = None, None, None
         while True:
             item = yield (item, original, converted)
@@ -409,11 +410,11 @@ class ConvertPlugin(BeetsPlugin):
             if keep_new:
                 original = dest
                 converted = item.path
-                if should_transcode(item, fmt, force):
+                if self.should_transcode(item, fmt, force):
                     converted = replace_ext(converted, ext)
             else:
                 original = item.path
-                if should_transcode(item, fmt, force):
+                if self.should_transcode(item, fmt, force):
                     dest = replace_ext(dest, ext)
                 converted = dest
 
@@ -443,7 +444,7 @@ class ConvertPlugin(BeetsPlugin):
                     )
                     util.move(item.path, original)
 
-            if should_transcode(item, fmt, force):
+            if self.should_transcode(item, fmt, force):
                 linked = False
                 try:
                     self.encode(command, original, converted, pretend)
@@ -648,7 +649,7 @@ class ConvertPlugin(BeetsPlugin):
         pl_normpath = None
         items_paths = None
         if playlist:
-            _, ext = get_format(fmt)
+            _, ext = self.get_format(fmt)
             # Playlist paths are understood as relative to the dest directory.
             pl_normpath = util.normpath(playlist)
             pl_dir = os.path.dirname(pl_normpath)
@@ -660,7 +661,9 @@ class ConvertPlugin(BeetsPlugin):
 
                 # When keeping new files in the library, destination paths
                 # keep original files and extensions.
-                if not opts.keep_new and should_transcode(item, fmt, force):
+                if not opts.keep_new and self.should_transcode(
+                    item, fmt, force
+                ):
                     item_path = replace_ext(item_path, ext)
 
                 items_paths.append(os.path.relpath(item_path, pl_dir))
@@ -690,8 +693,8 @@ class ConvertPlugin(BeetsPlugin):
         library.
         """
         fmt = self.config["format"].as_str().lower()
-        if should_transcode(item, fmt):
-            command, ext = get_format()
+        if self.should_transcode(item, fmt):
+            command, ext = self.get_format()
 
             # Create a temporary file for the conversion.
             tmpdir = self.config["tmpdir"].get()

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -39,7 +39,6 @@ from beetsplug._utils import art
 
 if TYPE_CHECKING:
     import optparse
-    from collections.abc import Generator
 
     from beets.importer import ImportSession, ImportTask
     from beets.library import Album, Library
@@ -402,147 +401,135 @@ class ConvertPlugin(BeetsPlugin):
             return True
         return self.fmt != item.format.lower()
 
-    def convert_item(
-        self, keep_new: bool
-    ) -> Generator[tuple[Item | None, bytes | None, bytes | None], Item, None]:
-        """A pipeline thread that converts `Item` objects from a
-        library.
-        """
+    @util.pipeline.mutator_stage
+    def convert_item(self, keep_new: bool, item: Item) -> None:
+        """Convert an Item from the library."""
         pretend, link, hardlink = self.pretend, self.link, self.hardlink
         command, ext = self.command
-        item, original, converted = None, None, None
 
-        while True:
-            item = yield (item, original, converted)
-            dest = item.destination(
-                basedir=self.dest, path_formats=self.path_formats
-            )
+        dest = item.destination(
+            basedir=self.dest, path_formats=self.path_formats
+        )
 
-            # Ensure that desired item is readable before processing it. Needed
-            # to avoid any side-effect of the conversion (linking, keep_new,
-            # refresh) if we already know that it will fail.
-            try:
-                mediafile.MediaFile(util.syspath(item.path))
-            except mediafile.UnreadableFileError as exc:
-                self._log.error("Could not open file to convert: {}", exc)
-                continue
+        # Ensure that desired item is readable before processing it. Needed
+        # to avoid any side-effect of the conversion (linking, keep_new,
+        # refresh) if we already know that it will fail.
+        try:
+            mediafile.MediaFile(util.syspath(item.path))
+        except mediafile.UnreadableFileError as exc:
+            self._log.error("Could not open file to convert: {}", exc)
+            return
 
-            # When keeping the new file in the library, we first move the
-            # current (pristine) file to the destination. We'll then copy it
-            # back to its old path or transcode it to a new path.
-            if keep_new:
-                original = dest
-                converted = item.path
-                if self.should_transcode(item):
-                    converted = replace_ext(converted, ext)
-            else:
-                original = item.path
-                if self.should_transcode(item):
-                    dest = replace_ext(dest, ext)
-                converted = dest
-
-            # Ensure that only one thread tries to create directories at a
-            # time. (The existence check is not atomic with the directory
-            # creation inside this function.)
-            if not pretend:
-                with _fs_lock:
-                    util.mkdirall(dest)
-
-            if os.path.exists(util.syspath(dest)):
-                self._log.info(
-                    "Skipping {.filepath} (target file exists)", item
-                )
-                continue
-
-            if keep_new:
-                if pretend:
-                    self._log.info(
-                        "mv {.filepath} {}",
-                        item,
-                        util.displayable_path(original),
-                    )
-                else:
-                    self._log.info(
-                        "Moving to {}", util.displayable_path(original)
-                    )
-                    util.move(item.path, original)
-
+        # When keeping the new file in the library, we first move the
+        # current (pristine) file to the destination. We'll then copy it
+        # back to its old path or transcode it to a new path.
+        if keep_new:
+            original = dest
+            converted = item.path
             if self.should_transcode(item):
-                linked = False
-                try:
-                    self.encode(command, original, converted)
-                except subprocess.CalledProcessError:
-                    continue
-            else:
-                linked = link or hardlink
-                if pretend:
-                    msg = "ln" if hardlink else ("ln -s" if link else "cp")
+                converted = replace_ext(converted, ext)
+        else:
+            original = item.path
+            if self.should_transcode(item):
+                dest = replace_ext(dest, ext)
+            converted = dest
 
-                    self._log.info(
-                        "{} {} {}",
-                        msg,
-                        util.displayable_path(original),
-                        util.displayable_path(converted),
-                    )
-                else:
-                    # No transcoding necessary.
-                    msg = (
-                        "Hardlinking"
-                        if hardlink
-                        else ("Linking" if link else "Copying")
-                    )
+        # Ensure that only one thread tries to create directories at a
+        # time. (The existence check is not atomic with the directory
+        # creation inside this function.)
+        if not pretend:
+            with _fs_lock:
+                util.mkdirall(dest)
 
-                    self._log.info("{} {.filepath}", msg, item)
+        if os.path.exists(util.syspath(dest)):
+            self._log.info("Skipping {.filepath} (target file exists)", item)
+            return
 
-                    if hardlink:
-                        util.hardlink(original, converted)
-                    elif link:
-                        util.link(original, converted)
-                    else:
-                        util.copy(original, converted)
-
+        if keep_new:
             if pretend:
-                continue
-
-            id3v23 = self.config["id3v23"].as_choice([True, False, "inherit"])
-            if id3v23 == "inherit":
-                id3v23 = None
-
-            # Write tags from the database to the file if requested
-            if self.config["write_metadata"].get(bool):
-                item.try_write(path=converted, id3v23=id3v23)
-
-            if keep_new:
-                # If we're keeping the transcoded file, read it again (after
-                # writing) to get new bitrate, duration, etc.
-                item.path = converted
-                item.read()
-                item.store()  # Store new path and audio data.
-
-            if self.config["embed"] and not linked:
-                album = item._cached_album
-                if album and album.artpath:
-                    maxwidth = self._get_art_resize(album.artpath)
-                    self._log.debug(
-                        "embedding album art from {.art_filepath}", album
-                    )
-                    art.embed_item(
-                        self._log,
-                        item,
-                        album.artpath,
-                        maxwidth,
-                        itempath=converted,
-                        id3v23=id3v23,
-                    )
-
-            if keep_new:
-                plugins.send(
-                    "after_convert", item=item, dest=dest, keepnew=True
+                self._log.info(
+                    "mv {.filepath} {}",
+                    item,
+                    util.displayable_path(original),
                 )
             else:
-                plugins.send(
-                    "after_convert", item=item, dest=converted, keepnew=False
+                self._log.info("Moving to {}", util.displayable_path(original))
+                util.move(item.path, original)
+
+        if self.should_transcode(item):
+            linked = False
+            try:
+                self.encode(command, original, converted)
+            except subprocess.CalledProcessError:
+                return
+        else:
+            linked = link or hardlink
+            if pretend:
+                msg = "ln" if hardlink else ("ln -s" if link else "cp")
+
+                self._log.info(
+                    "{} {} {}",
+                    msg,
+                    util.displayable_path(original),
+                    util.displayable_path(converted),
                 )
+            else:
+                # No transcoding necessary.
+                msg = (
+                    "Hardlinking"
+                    if hardlink
+                    else ("Linking" if link else "Copying")
+                )
+
+                self._log.info("{} {.filepath}", msg, item)
+
+                if hardlink:
+                    util.hardlink(original, converted)
+                elif link:
+                    util.link(original, converted)
+                else:
+                    util.copy(original, converted)
+
+        if pretend:
+            return
+
+        id3v23 = self.config["id3v23"].as_choice([True, False, "inherit"])
+        if id3v23 == "inherit":
+            id3v23 = None
+
+        # Write tags from the database to the file if requested
+        if self.config["write_metadata"].get(bool):
+            item.try_write(path=converted, id3v23=id3v23)
+
+        if keep_new:
+            # If we're keeping the transcoded file, read it again (after
+            # writing) to get new bitrate, duration, etc.
+            item.path = converted
+            item.read()
+            item.store()  # Store new path and audio data.
+
+        if self.config["embed"] and not linked:
+            album = item._cached_album
+            if album and album.artpath:
+                maxwidth = self._get_art_resize(album.artpath)
+                self._log.debug(
+                    "embedding album art from {.art_filepath}", album
+                )
+                art.embed_item(
+                    self._log,
+                    item,
+                    album.artpath,
+                    maxwidth,
+                    itempath=converted,
+                    id3v23=id3v23,
+                )
+
+        if keep_new:
+            plugins.send("after_convert", item=item, dest=dest, keepnew=True)
+        else:
+            plugins.send(
+                "after_convert", item=item, dest=converted, keepnew=False
+            )
 
     def copy_album_art(self, album: Album) -> None:
         """Copies or converts the associated cover art of the album. Album must

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -24,7 +24,7 @@ import tempfile
 import threading
 from functools import cached_property
 from string import Template
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import mediafile
 from confuse import ConfigTypeError, Optional
@@ -56,6 +56,11 @@ ALIASES = {
 }
 
 LOSSLESS_FORMATS = ["ape", "flac", "alac", "wave", "aiff"]
+
+
+class FormatCommand(NamedTuple):
+    command: bytes
+    ext: bytes
 
 
 def replace_ext(path: bytes, ext: bytes) -> bytes:
@@ -258,6 +263,37 @@ class ConvertPlugin(BeetsPlugin):
     def link(self) -> bool:
         return not self.hardlink and self.config["link"].get(bool)
 
+    @cached_property
+    def command(self) -> FormatCommand:
+        """Return the command template and the extension from the config."""
+        fmt = ALIASES.get(self.fmt, self.fmt)
+
+        try:
+            format_info = self.config["formats"][fmt].get(dict)
+            command = format_info["command"]
+            extension = format_info.get("extension", fmt)
+        except KeyError:
+            raise ui.UserError(
+                f'convert: format {fmt} needs the "command" field'
+            )
+        except ConfigTypeError:
+            command = self.config["formats"][fmt].get(str)
+            extension = fmt
+
+        # Convenience and backwards-compatibility shortcuts.
+        keys = self.config.keys()
+        if "command" in keys:
+            command = self.config["command"].as_str()
+        elif "opts" in keys:
+            # Undocumented option for backwards compatibility with < 1.3.1.
+            command = (
+                f"ffmpeg -i $source -y {self.config['opts'].as_str()} $dest"
+            )
+        if "extension" in keys:
+            extension = self.config["extension"].as_str()
+
+        return FormatCommand(command.encode("utf-8"), extension.encode("utf-8"))
+
     def auto_convert(self, session: ImportSession, task: ImportTask) -> None:
         if self.config["auto"]:
             par_map(
@@ -343,38 +379,6 @@ class ConvertPlugin(BeetsPlugin):
                 "Finished encoding {}", util.displayable_path(source)
             )
 
-    def get_format(self, fmt: str | None = None) -> tuple[bytes, bytes]:
-        """Return the command template and the extension from the config."""
-        if not fmt:
-            fmt = self.config["format"].as_str().lower()
-        fmt = ALIASES.get(fmt, fmt)
-
-        try:
-            format_info = self.config["formats"][fmt].get(dict)
-            command = format_info["command"]
-            extension = format_info.get("extension", fmt)
-        except KeyError:
-            raise ui.UserError(
-                f'convert: format {fmt} needs the "command" field'
-            )
-        except ConfigTypeError:
-            command = self.config["formats"][fmt].get(str)
-            extension = fmt
-
-        # Convenience and backwards-compatibility shortcuts.
-        keys = self.config.keys()
-        if "command" in keys:
-            command = self.config["command"].as_str()
-        elif "opts" in keys:
-            # Undocumented option for backwards compatibility with < 1.3.1.
-            command = (
-                f"ffmpeg -i $source -y {self.config['opts'].as_str()} $dest"
-            )
-        if "extension" in keys:
-            extension = self.config["extension"].as_str()
-
-        return (command.encode("utf-8"), extension.encode("utf-8"))
-
     def in_no_convert(self, item: Item) -> bool:
         no_convert_query = self.config["no_convert"].as_str()
 
@@ -415,7 +419,7 @@ class ConvertPlugin(BeetsPlugin):
         fmt, force, pretend = self.fmt, self.force, self.pretend
         link, hardlink = self.link, self.hardlink
 
-        command, ext = self.get_format(fmt)
+        command, ext = self.command
         item, original, converted = None, None, None
         while True:
             item = yield (item, original, converted)
@@ -630,7 +634,7 @@ class ConvertPlugin(BeetsPlugin):
         self, lib: Library, opts: optparse.Values, args: list[str]
     ) -> None:
         self.config.set(vars(opts))
-        pretend = self.pretend
+        dest, pretend = self.dest, self.pretend
 
         if opts.album:
             albums = lib.albums(args)
@@ -660,14 +664,13 @@ class ConvertPlugin(BeetsPlugin):
         items_paths = None
         fmt = self.fmt
         if playlist := self.playlist:
-            _, ext = self.get_format(fmt)
             # Playlist paths are understood as relative to the dest directory.
             pl_normpath = util.normpath(playlist)
             pl_dir = os.path.dirname(pl_normpath)
             items_paths = []
             for item in items:
                 item_path = item.destination(
-                    basedir=self.dest, path_formats=self.path_formats
+                    basedir=dest, path_formats=self.path_formats
                 )
 
                 # When keeping new files in the library, destination paths
@@ -675,7 +678,7 @@ class ConvertPlugin(BeetsPlugin):
                 if not opts.keep_new and self.should_transcode(
                     item, fmt, self.force
                 ):
-                    item_path = replace_ext(item_path, ext)
+                    item_path = replace_ext(item_path, self.command.ext)
 
                 items_paths.append(os.path.relpath(item_path, pl_dir))
 
@@ -694,9 +697,8 @@ class ConvertPlugin(BeetsPlugin):
         """Transcode a file automatically after it is imported into the
         library.
         """
-        fmt = self.config["format"].as_str().lower()
-        if self.should_transcode(item, fmt):
-            command, ext = self.get_format()
+        if self.should_transcode(item, self.fmt):
+            command, ext = self.command
 
             # Create a temporary file for the conversion.
             tmpdir = self.config["tmpdir"].get()

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -14,6 +14,8 @@
 
 """Converts tracks or albums to external directory"""
 
+from __future__ import annotations
+
 import logging
 import os
 import shlex
@@ -21,6 +23,7 @@ import subprocess
 import tempfile
 import threading
 from string import Template
+from typing import TYPE_CHECKING
 
 import mediafile
 from confuse import ConfigTypeError, Optional
@@ -33,8 +36,16 @@ from beets.util.artresizer import ArtResizer
 from beets.util.m3u import M3UFile
 from beetsplug._utils import art
 
+if TYPE_CHECKING:
+    import optparse
+    from collections.abc import Generator
+
+    from beets.importer import ImportSession, ImportTask
+    from beets.library import Album, Library
+
 _fs_lock = threading.Lock()
-_temp_files = []  # Keep track of temporary transcoded files for deletion.
+# Keep track of temporary transcoded files for deletion.
+_temp_files: list[bytes] = []
 
 # Some convenient alternate names for formats.
 ALIASES = {
@@ -45,7 +56,7 @@ ALIASES = {
 LOSSLESS_FORMATS = ["ape", "flac", "alac", "wave", "aiff"]
 
 
-def replace_ext(path, ext):
+def replace_ext(path: bytes, ext: bytes) -> bytes:
     """Return the path with its extension replaced by `ext`.
 
     The new extension must not contain a leading dot.
@@ -54,7 +65,7 @@ def replace_ext(path, ext):
     return os.path.splitext(path)[0] + ext_dot
 
 
-def get_format(fmt=None):
+def get_format(fmt: str | None = None) -> tuple[bytes, bytes]:
     """Return the command template and the extension from the config."""
     if not fmt:
         fmt = config["convert"]["format"].as_str().lower()
@@ -95,7 +106,7 @@ def in_no_convert(item: Item) -> bool:
         return False
 
 
-def should_transcode(item, fmt, force: bool = False):
+def should_transcode(item: Item, fmt: str, force: bool = False) -> bool:
     """Determine whether the item should be transcoded as part of
     conversion (i.e., its bitrate is high or it has the wrong format).
 
@@ -117,7 +128,7 @@ def should_transcode(item, fmt, force: bool = False):
 
 
 class ConvertPlugin(BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.config.add(
             {
@@ -171,7 +182,7 @@ class ConvertPlugin(BeetsPlugin):
 
         self.register_listener("import_task_files", self._cleanup)
 
-    def commands(self):
+    def commands(self) -> list[ui.Subcommand]:
         cmd = ui.Subcommand("convert", help="convert to external location")
         cmd.parser.add_option(
             "-p",
@@ -256,14 +267,16 @@ class ConvertPlugin(BeetsPlugin):
         cmd.func = self.convert_func
         return [cmd]
 
-    def auto_convert(self, config, task):
+    def auto_convert(self, session: ImportSession, task: ImportTask) -> None:
         if self.config["auto"]:
             par_map(
-                lambda item: self.convert_on_import(config.lib, item),
+                lambda item: self.convert_on_import(session.lib, item),
                 task.imported_items(),
             )
 
-    def auto_convert_keep(self, config, task):
+    def auto_convert_keep(
+        self, session: ImportSession, task: ImportTask
+    ) -> None:
         if self.config["auto_keep"]:
             empty_opts = self.commands()[0].parser.get_default_values()
             (
@@ -298,7 +311,9 @@ class ConvertPlugin(BeetsPlugin):
 
     # Utilities converted from functions to methods on logging overhaul
 
-    def encode(self, command, source, dest, pretend=False):
+    def encode(
+        self, command: bytes, source: bytes, dest: bytes, pretend: bool = False
+    ) -> None:
         """Encode `source` to `dest` using command template `command`.
 
         Raises `subprocess.CalledProcessError` if the command exited with a
@@ -362,15 +377,15 @@ class ConvertPlugin(BeetsPlugin):
 
     def convert_item(
         self,
-        dest_dir,
-        keep_new,
-        path_formats,
-        fmt,
-        pretend=False,
-        link=False,
-        hardlink=False,
-        force=False,
-    ):
+        dest_dir: bytes,
+        keep_new: bool,
+        path_formats: dict[str, str],
+        fmt: str,
+        pretend: bool = False,
+        link: bool = False,
+        hardlink: bool = False,
+        force: bool = False,
+    ) -> Generator[tuple[Item | None, bytes | None, bytes | None], Item, None]:
         """A pipeline thread that converts `Item` objects from a
         library.
         """
@@ -508,13 +523,13 @@ class ConvertPlugin(BeetsPlugin):
 
     def copy_album_art(
         self,
-        album,
-        dest_dir,
-        path_formats,
-        pretend=False,
-        link=False,
-        hardlink=False,
-    ):
+        album: Album,
+        dest_dir: bytes,
+        path_formats: dict[str, str],
+        pretend: bool = False,
+        link: bool = False,
+        hardlink: bool = False,
+    ) -> None:
         """Copies or converts the associated cover art of the album. Album must
         have at least one track.
         """
@@ -590,7 +605,9 @@ class ConvertPlugin(BeetsPlugin):
                 else:
                     util.copy(album.artpath, dest)
 
-    def convert_func(self, lib, opts, args):
+    def convert_func(
+        self, lib: Library, opts: optparse.Values, args: list[str]
+    ) -> None:
         (
             dest,
             threads,
@@ -669,7 +686,7 @@ class ConvertPlugin(BeetsPlugin):
                 m3ufile.set_contents(items_paths)
                 m3ufile.write()
 
-    def convert_on_import(self, lib, item):
+    def convert_on_import(self, _: Library, item: Item) -> None:
         """Transcode a file automatically after it is imported into the
         library.
         """
@@ -708,7 +725,7 @@ class ConvertPlugin(BeetsPlugin):
                 )
                 util.remove(source_path, False)
 
-    def _get_art_resize(self, artpath):
+    def _get_art_resize(self, artpath: bytes) -> int | None:
         """For a given piece of album art, determine whether or not it needs
         to be resized according to the user's settings. If so, returns the
         new size. If not, returns None.
@@ -728,14 +745,18 @@ class ConvertPlugin(BeetsPlugin):
                 )
         return newwidth
 
-    def _cleanup(self, task, session):
+    def _cleanup(self, task: ImportTask, session: ImportSession) -> None:
         for path in task.old_paths:
             if path in _temp_files:
                 if os.path.isfile(util.syspath(path)):
                     util.remove(path)
                 _temp_files.remove(path)
 
-    def _get_opts_and_config(self, opts):
+    def _get_opts_and_config(
+        self, opts: optparse.Values
+    ) -> tuple[
+        bytes, int, dict[str, str], str, bool, bool, bool, str | None, bool
+    ]:
         """Returns parameters needed for convert function.
         Get parameters from command line if available,
         default to config if not available.
@@ -784,16 +805,16 @@ class ConvertPlugin(BeetsPlugin):
 
     def _parallel_convert(
         self,
-        dest,
-        keep_new,
-        path_formats,
-        fmt,
-        pretend,
-        link,
-        hardlink,
-        threads,
-        items,
-        force,
+        dest: bytes,
+        keep_new: bool,
+        path_formats: dict[str, str],
+        fmt: str,
+        pretend: bool,
+        link: bool,
+        hardlink: bool,
+        threads: int,
+        items: list[Item],
+        force: bool,
     ):
         """Run the convert_item function for every items on as many thread as
         defined in threads

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,9 +9,11 @@ below!
 Unreleased
 ----------
 
-..
-    New features
-    ~~~~~~~~~~~~
+New features
+~~~~~~~~~~~~
+
+- :doc:`plugins/convert`: The ``--force`` and ``--keep-new`` CLI flags are now
+  also available as config options via ``force`` and ``keep_new``.
 
 ..
     Bug fixes

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -54,7 +54,8 @@ embedding is disabled for files that are linked. Refer to the ``link`` and
 The ``-F`` (or ``--force``) option forces transcoding even when safety options
 such as ``no_convert``, ``never_convert_lossy_files``, or ``max_bitrate`` would
 normally cause a file to be copied or skipped instead. This can be combined with
-``--format`` to explicitly transcode lossy inputs to a chosen target format.
+``--format`` to explicitly transcode lossy inputs to a chosen target format. The
+default value for this flag comes from the ``force`` configuration option.
 
 The ``-m`` (or ``--playlist``) option enables the plugin to create an m3u8
 playlist file in the destination folder given by the ``-d`` (``--dest``) option
@@ -81,7 +82,8 @@ The available options are:
   them to your library. Default: ``no``.
 - **auto_keep**: Convert your files automatically on import to **dest** but
   import the non transcoded version. It uses the default format you have defined
-  in your config file. Default: ``no``.
+  in your config file. Default: ``no``. This import behavior is fixed and is not
+  affected by ``keep_new``.
 
   .. note::
 
@@ -109,21 +111,30 @@ The available options are:
   with high bitrates, even if they are already in the same format as the output.
   Note that this does not guarantee that all converted files will have a lower
   bitrate---that depends on the encoder and its configuration. Default: none.
-  This option will be overridden by the ``--force`` flag
+  This option is ignored when ``force`` is enabled (via config or ``--force``).
 - **no_convert**: Does not transcode items matching the query string provided
   (see :doc:`/reference/query`). For example, to not convert AAC or WMA formats,
   you can use ``format:AAC, format:WMA`` or ``path::\.(m4a|wma)$``. If you only
   want to transcode WMA format, you can use a negative query, e.g.,
   ``^path::\.(wma)$``, to not convert any other format except WMA. This option
-  will be overridden by the ``--force`` flag
+  is ignored when ``force`` is enabled (via config or ``--force``).
 - **never_convert_lossy_files**: Cross-conversions between lossy codecs---such
   as mp3, ogg vorbis, etc.---makes little sense as they will decrease quality
   even further. If set to ``yes``, lossy files are always copied. Default:
   ``no``. When ``never_convert_lossy_files`` is enabled, lossy source files (for
   example MP3 or Ogg Vorbis) are normally not transcoded and are instead copied
   or linked as-is. To explicitly transcode lossy files in spite of this, use the
-  ``--force`` option with the ``convert`` command (optionally together with
-  ``--format`` to choose a target format)
+  ``force`` setting (from config or ``--force``) with the ``convert`` command
+  (optionally together with ``--format`` to choose a target format)
+- **force**: Force transcoding by default. When enabled, items are transcoded
+  even when ``no_convert``, ``never_convert_lossy_files``, or ``max_bitrate``
+  would otherwise copy or skip them. This applies to both ``beet convert`` and
+  automatic conversion during import (``auto`` and ``auto_keep``). Default:
+  ``false``.
+- **keep_new**: Enable ``--keep-new`` behavior by default for ``beet convert``.
+  Converted files stay in your library and originals are moved to the external
+  destination. This option applies only to ``beet convert`` and does not change
+  ``auto_keep`` import semantics. Default: ``false``.
 - **paths**: The directory structure and naming scheme for the converted files.
   Uses the same format as the top-level ``paths`` section (see
   :ref:`path-format-config`). Default: Reuse your top-level path format

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -30,6 +30,7 @@ from beets.test.helper import (
     AsIsImporterMixin,
     ImportHelper,
     IOMixin,
+    PluginMixin,
     PluginTestCase,
     capture_log,
 )
@@ -360,8 +361,16 @@ class NeverConvertLossyFilesTest(ConvertTestCase, ConvertCommand):
         assert self.file_endswith(converted, "opus")
 
 
-class TestNoConvert:
+class TestNoConvert(PluginMixin):
     """Test the effect of the `no_convert` option."""
+
+    plugin = "convert"
+
+    @pytest.fixture(autouse=True)
+    def cleanup_plugins(self):
+        """Make sure hooks are cleared after each test."""
+        yield
+        self.unload_plugins()
 
     @pytest.mark.parametrize(
         "config_value, should_skip",
@@ -372,7 +381,7 @@ class TestNoConvert:
             ("bitrate:320 , format:ogg", True),
         ],
     )
-    def test_no_convert_skip(self, config_value, should_skip):
+    def test_no_convert_skip(self, config, config_value, should_skip):
         item = Item(format="ogg", bitrate=256)
-        convert.config["convert"]["no_convert"] = config_value
-        assert convert.in_no_convert(item) == should_skip
+        config["convert"]["no_convert"] = config_value
+        assert convert.ConvertPlugin().in_no_convert(item) == should_skip


### PR DESCRIPTION
## Refactor `ConvertPlugin` to use instance attributes instead of parameter threading

This PR cleans up the `ConvertPlugin` class by eliminating the pattern of passing config values as explicit parameters through the call chain.

### What changed

- **Removed `_get_opts_and_config`** — a method that returned a 9-tuple of config values. All callers unpacked and re-passed these values explicitly.
- **Config values are now `@cached_property` attributes** on `ConvertPlugin`: `dest`, `fmt`, `force`, `pretend`, `link`, `hardlink`, `threads`, `playlist`, `path_formats`.
- **CLI option defaults now set from config**, so `self.config.set(vars(opts))` in `convert_func` is sufficient to merge CLI overrides — no more `opts.x or config["x"]` branching in `_get_opts_and_config`.
- **`get_format` → `command` cached property** returning a typed `FormatCommand` `NamedTuple`, replacing a free function that accessed the global `config`.
- **`should_transcode` and `encode`** signatures simplified — `fmt`, `force`, and `pretend` no longer passed as arguments; methods read from `self`.
- **`_parallel_convert` and `convert_item`** reduced to `(items, keep_new)` signatures.
- **Free module-level functions** (`get_format`, `in_no_convert`, `should_transcode`) removed; equivalent logic now lives as methods, removing the dependency on the global `config` object.
- Types and `TYPE_CHECKING` imports added throughout; `after_convert` event registered in `plugins.py`.

### Impact

No behaviour change. The refactor reduces argument surface area significantly, makes the config read path explicit and testable per-instance, and eliminates a source of subtle bugs where CLI flags could silently fall back to wrong defaults.
