### PR TITLE
zero: treat images and art as aliases in keep_fields

### DIFF
--- a/beetsplug/zero.py
+++ b/beetsplug/zero.py
@@ -67,7 +67,7 @@ class ZeroPlugin(BeetsPlugin):
         # Whitelist mode.
         elif self.config["keep_fields"]:
             keep = set(self.config["keep_fields"].as_str_seq())
-            # 'images' and 'art' both refer to embedded artwork
+            # ensure that all artwork fields are added when at least one of them is present
             if keep & ARTWORK_FIELDS:
                 keep.update(ARTWORK_FIELDS)
             for field in MediaFile.fields():

--- a/beetsplug/zero.py
+++ b/beetsplug/zero.py
@@ -63,12 +63,16 @@ class ZeroPlugin(BeetsPlugin):
                 self._set_pattern(field)
         # Whitelist mode.
         elif self.config["keep_fields"]:
+            keep = set(self.config["keep_fields"].as_str_seq())
+            # 'images' and 'art' both refer to embedded artwork
+            if "images" in keep:
+                keep.add("art")
+            if "art" in keep:
+                keep.add("images")
             for field in MediaFile.fields():
                 if (
-                    field not in self.config["keep_fields"].as_str_seq()
-                    and
-                    # These fields should always be preserved.
-                    field not in ("id", "path", "album_id")
+                    field not in keep
+                    and field not in ("id", "path", "album_id")
                 ):
                     self._set_pattern(field)
 

--- a/beetsplug/zero.py
+++ b/beetsplug/zero.py
@@ -67,7 +67,8 @@ class ZeroPlugin(BeetsPlugin):
         # Whitelist mode.
         elif self.config["keep_fields"]:
             keep = set(self.config["keep_fields"].as_str_seq())
-            # ensure that all artwork fields are added when at least one of them is present
+            # ensure that all artwork fields are added when at least
+            # one of them is present
             if keep & ARTWORK_FIELDS:
                 keep.update(ARTWORK_FIELDS)
             for field in MediaFile.fields():

--- a/beetsplug/zero.py
+++ b/beetsplug/zero.py
@@ -71,9 +71,10 @@ class ZeroPlugin(BeetsPlugin):
             if keep & ARTWORK_FIELDS:
                 keep.update(ARTWORK_FIELDS)
             for field in MediaFile.fields():
-                if (
-                    field not in keep
-                    and field not in ("id", "path", "album_id")
+                if field not in keep and field not in (
+                    "id",
+                    "path",
+                    "album_id",
                 ):
                     self._set_pattern(field)
 

--- a/beetsplug/zero.py
+++ b/beetsplug/zero.py
@@ -26,6 +26,9 @@ from beets.ui import Subcommand, input_yn
 __author__ = "baobab@heresiarch.info"
 
 
+ARTWORK_FIELDS = {"images", "art"}
+
+
 class ZeroPlugin(BeetsPlugin):
     def __init__(self):
         super().__init__()
@@ -65,15 +68,12 @@ class ZeroPlugin(BeetsPlugin):
         elif self.config["keep_fields"]:
             keep = set(self.config["keep_fields"].as_str_seq())
             # 'images' and 'art' both refer to embedded artwork
-            if "images" in keep:
-                keep.add("art")
-            if "art" in keep:
-                keep.add("images")
+            if keep & ARTWORK_FIELDS:
+                keep.update(ARTWORK_FIELDS)
             for field in MediaFile.fields():
-                if field not in keep and field not in (
-                    "id",
-                    "path",
-                    "album_id",
+                if (
+                    field not in keep
+                    and field not in ("id", "path", "album_id")
                 ):
                     self._set_pattern(field)
 

--- a/beetsplug/zero.py
+++ b/beetsplug/zero.py
@@ -70,9 +70,10 @@ class ZeroPlugin(BeetsPlugin):
             if "art" in keep:
                 keep.add("images")
             for field in MediaFile.fields():
-                if (
-                    field not in keep
-                    and field not in ("id", "path", "album_id")
+                if field not in keep and field not in (
+                    "id",
+                    "path",
+                    "album_id",
                 ):
                     self._set_pattern(field)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -60,10 +60,6 @@ Bug fixes
   fields when the same artist is credited both in ``artists`` (for example with
   ``Feat.`` join text) and ``extraartists`` as ``Featuring``. :bug:`6166`
 
-- :doc:`plugins/zero`: When using ``keep_fields``, listing ``images`` now
-  correctly preserves embedded album art. Previously, ``art`` also needed to
-  be listed explicitly. :bug:`3532`
-
 ..
     For plugin developers
     ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -60,6 +60,10 @@ Bug fixes
   fields when the same artist is credited both in ``artists`` (for example with
   ``Feat.`` join text) and ``extraartists`` as ``Featuring``. :bug:`6166`
 
+- :doc:`plugins/zero`: When using ``keep_fields``, listing ``images`` now
+  correctly preserves embedded album art. Previously, ``art`` also needed to
+  be listed explicitly. :bug:`3532`
+
 ..
     For plugin developers
     ~~~~~~~~~~~~~~~~~~~~~

--- a/test/plugins/test_zero.py
+++ b/test/plugins/test_zero.py
@@ -315,3 +315,17 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
         assert mf.year == 2016
         assert mf.comments == "test comment"
         assert item["comments"] == "test comment"
+
+    def test_keep_fields_images_preserves_art(self):
+        """Regression test for #3532: 'images' in keep_fields should
+        preserve embedded album art."""
+        path = self.create_mediafile_fixture(images=["jpg"])
+        item = Item.from_path(path)
+
+        with self.configure_plugin(
+            {"fields": None, "keep_fields": ["images"]}
+        ):
+            item.write()
+
+        mf = MediaFile(syspath(path))
+        assert mf.images, "images should be preserved when 'images' is in keep_fields"

--- a/test/plugins/test_zero.py
+++ b/test/plugins/test_zero.py
@@ -317,8 +317,6 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
         assert item["comments"] == "test comment"
 
     def test_keep_fields_images_preserves_art(self):
-        """Regression test for #3532: 'images' in keep_fields should
-        preserve embedded album art."""
         path = self.create_mediafile_fixture(images=["jpg"])
         item = Item.from_path(path)
 

--- a/test/plugins/test_zero.py
+++ b/test/plugins/test_zero.py
@@ -320,10 +320,10 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
         path = self.create_mediafile_fixture(images=["jpg"])
         item = Item.from_path(path)
 
-        with self.configure_plugin(
-            {"fields": None, "keep_fields": ["images"]}
-        ):
+        with self.configure_plugin({"fields": None, "keep_fields": ["images"]}):
             item.write()
 
         mf = MediaFile(syspath(path))
-        assert mf.images, "images should be preserved when 'images' is in keep_fields"
+        assert mf.images, (
+            "images should be preserved when 'images' is in keep_fields"
+        )


### PR DESCRIPTION
## Description

Fixes #3532

When `images` is listed in `keep_fields`, embedded album art was still being removed because the zero plugin didn't recognize `art` as an alias for `images`. Both field names map to the same underlying data in mediafile, so specifying either one in `keep_fields` should protect embedded art.

This PR adds aliasing logic in the `keep_fields` block. If either `images` or `art` appears in `keep_fields`, the other is automatically added to the keep set.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation~
- [x] ~Changelog~ (Will add after review to avoid conflicts.)
- [x] ~Tests~ (Regression test `test_keep_fields_images_preserves_art` added to `test/plugins/test_zero.py`.)
