### PR TITLE
Fix discogs double featuring credits

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install system dependencies on Windows
         if: matrix.platform == 'windows-latest'
         run: |
-          choco install mp3gain -y
+          choco install mp3gain --allow-empty-checksums -y
 
       - name: Install system dependencies on Ubuntu
         if: matrix.platform == 'ubuntu-latest'

--- a/beetsplug/discogs/states.py
+++ b/beetsplug/discogs/states.py
@@ -22,6 +22,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, NamedTuple
 
 from beets import config
+from beets.util import unique_list
 
 from .types import ArtistInfo
 
@@ -60,6 +61,15 @@ class ArtistState:
         credit: str
         join: str
         role: str
+
+        def __hash__(self) -> int:
+            return hash(self.id)
+
+        def __eq__(self, other: object) -> bool:
+            if isinstance(other, self.__class__):
+                return self.id == other.id
+
+            return False
 
         def get_artist(self, property_name: str) -> str:
             """Return the requested display field with its trailing join token.
@@ -122,9 +132,10 @@ class ArtistState:
     @property
     def main_artists(self) -> list[ValidArtist]:
         """Return the per-artist display names used for the 'artist' field."""
-        return [
+        artists = [
             a for a in self.valid_artists if not a.role or "featuring" in a.role
         ]
+        return unique_list(artists)
 
     @property
     def artists_ids(self) -> list[str]:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -56,6 +56,9 @@ Bug fixes
   created when re-importing albums with the :doc:`plugins/fetchart` plugin
   enabled. Old album art is now properly removed when replacing duplicate albums
   during import. :bug:`1264` :bug:`6205`
+- :doc:`plugins/discogs`: Prevent duplicate featured artists in track artist
+  fields when the same artist is credited both in ``artists`` (for example with
+  ``Feat.`` join text) and ``extraartists`` as ``Featuring``. :bug:`6166`
 
 ..
     For plugin developers

--- a/test/plugins/test_discogs.py
+++ b/test/plugins/test_discogs.py
@@ -48,7 +48,7 @@ class DGAlbumInfoTest(BeetsTestCase):
             "uri": "https://www.discogs.com/release/release/13633721",
             "title": "ALBUM TITLE",
             "year": "3001",
-            "artists": [_artist("ARTIST NAME", id="ARTIST ID", join=",")],
+            "artists": [_artist("ARTIST NAME", join=",")],
             "formats": [
                 {
                     "descriptions": ["FORMAT DESC 1", "FORMAT DESC 2"],
@@ -402,7 +402,7 @@ class DGAlbumInfoTest(BeetsTestCase):
             ],
             "artists": [
                 _artist("ARTIST NAME (2)", id=321, join="&"),
-                _artist("OTHER ARTIST (5)", id=321),
+                _artist("OTHER ARTIST (5)", id=322),
             ],
             "title": "title",
             "labels": [
@@ -420,7 +420,7 @@ class DGAlbumInfoTest(BeetsTestCase):
         d = DiscogsPlugin().get_album_info(release)
         assert d.artist == "ARTIST NAME & OTHER ARTIST"
         assert d.artists == ["ARTIST NAME", "OTHER ARTIST"]
-        assert d.artists_ids == ["321", "321"]
+        assert d.artists_ids == ["321", "322"]
         assert d.tracks[0].artist == "TEST ARTIST"
         assert d.tracks[0].artists == ["TEST ARTIST"]
         assert d.tracks[0].artist_id == "11146"
@@ -444,7 +444,7 @@ class DGAlbumInfoTest(BeetsTestCase):
             ],
             "artists": [
                 _artist("ARTIST NAME (2)", id=321, join="&"),
-                _artist("OTHER ARTIST (5)", id=321),
+                _artist("OTHER ARTIST (5)", id=322),
             ],
             "title": "title",
             "labels": [
@@ -571,7 +571,6 @@ class TestAnv:
             ),
         ],
     )
-    @pytest.mark.xfail(reason="ft artist is doubled")
     def test_track_artist_fields(self, album_info, expected_track_fields):
         self._assert_fields(album_info.tracks[0], expected_track_fields)
 
@@ -602,7 +601,6 @@ class TestAnv:
             ),
         ],
     )
-    @pytest.mark.xfail(reason="ft artist is doubled")
     def test_artist_credit_fields(
         self, album_info, expected_album_fields, expected_track_fields
     ):

--- a/test/plugins/test_discogs.py
+++ b/test/plugins/test_discogs.py
@@ -519,7 +519,10 @@ class TestAnv:
                     "position": "A",
                     "type_": "track",
                     "duration": "5:44",
-                    "artists": [_artist("ARTIST", id=11146, anv="ART")],
+                    "artists": [
+                        _artist("ARTIST", id=11146, anv="ART", join="Feat."),
+                        _artist("PERFORMER", id=787),
+                    ],
                     "extraartists": [
                         _artist("PERFORMER", id=787, role="Featuring")
                     ],
@@ -568,6 +571,7 @@ class TestAnv:
             ),
         ],
     )
+    @pytest.mark.xfail(reason="ft artist is doubled")
     def test_track_artist_fields(self, album_info, expected_track_fields):
         self._assert_fields(album_info.tracks[0], expected_track_fields)
 
@@ -598,6 +602,7 @@ class TestAnv:
             ),
         ],
     )
+    @pytest.mark.xfail(reason="ft artist is doubled")
     def test_artist_credit_fields(
         self, album_info, expected_album_fields, expected_track_fields
     ):


### PR DESCRIPTION
## Fix duplicate featured artists in Discogs track fields

Fixes a bug where a featured artist could appear twice in track `artist`/`artists` fields when credited both in `artists` (with `Feat.` join text) and in `extraartists` as `Featuring`.

### What changed

- `ValidArtist` gains a `__hash__` and `__eq__` methods (based on Discogs artist `id`) so instances are comparable by identity.
- `main_artists` property now wraps its result in `unique_list(...)`, deduplicating artists that appear in both sources.

Fixes: #6166
