### PR TITLE
Fix concurrent plugin execution

### DIFF
--- a/beets/metadata_plugins.py
+++ b/beets/metadata_plugins.py
@@ -78,6 +78,12 @@ def _yield_from_plugins(
 ) -> Callable[..., Iterator[Ret]]:
     method_name = func.__name__
 
+    def materialize(
+        plugin: MetadataSourcePlugin, method_name: str, *args, **kwargs
+    ) -> list[Ret]:
+        method = getattr(plugin, method_name)
+        return list(method(*args, **kwargs))
+
     @wraps(func)
     def wrapper(*args, **kwargs) -> Iterator[Ret]:
         # Run plugin methods concurrently for faster I/O-bound lookups.
@@ -86,12 +92,9 @@ def _yield_from_plugins(
                 executor.submit(
                     # Evaluate iterator with list such that results are ready when
                     # future.result() is called.
-                    lambda *args, **kwargs: list(
-                        getattr(plugin, method_name)(
-                            *args,
-                            **kwargs,
-                        )
-                    ),
+                    materialize,
+                    plugin,
+                    method_name,
                     *args,
                     **kwargs,
                 ): plugin

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -59,6 +59,8 @@ Bug fixes
 - :doc:`plugins/discogs`: Prevent duplicate featured artists in track artist
   fields when the same artist is credited both in ``artists`` (for example with
   ``Feat.`` join text) and ``extraartists`` as ``Featuring``. :bug:`6166`
+- :ref:`import-cmd` Metadata source plugin ID lookups now correctly call each
+  plugin's own lookup method when running in parallel. :bug:`6583`
 
 ..
     For plugin developers

--- a/test/test_metadata_plugins.py
+++ b/test/test_metadata_plugins.py
@@ -1,4 +1,6 @@
 from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor as BaseThreadPoolExecutor
+from threading import Event
 
 import pytest
 
@@ -124,3 +126,62 @@ class TestSearchApiMetadataSourcePlugin(PluginMixin):
 
         with pytest.raises(ValueError, match="Search failure"):
             search_plugin._search_api("track", "query", {})
+
+
+@pytest.mark.xfail(reason="Currently only the last plugin is called")
+def test_albums_for_ids_calls_each_plugin_once(monkeypatch):
+    start_workers = Event()
+
+    class Plugin:
+        def __init__(self, name):
+            self.data_source = name
+            self.calls: list[list[str]] = []
+
+        def albums_for_ids(self, ids):
+            self.calls.append(list(ids))
+            return [self.data_source]
+
+    plugins = [Plugin("discogs"), Plugin("musicbrainz"), Plugin("tidal")]
+
+    class PluginSequence:
+        def __iter__(self):
+            yield from plugins
+            start_workers.set()
+
+    class DelayedStartExecutor:
+        def __init__(self):
+            self._executor = BaseThreadPoolExecutor(max_workers=1)
+
+        def submit(self, fn, *args, **kwargs):
+            return self._executor.submit(self._run, fn, args, kwargs)
+
+        def _run(self, fn, args, kwargs):
+            start_workers.wait()
+            return fn(*args, **kwargs)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self._executor.shutdown(wait=True)
+            return False
+
+    monkeypatch.setattr(
+        metadata_plugins,
+        "find_metadata_source_plugins",
+        lambda: PluginSequence(),
+    )
+    monkeypatch.setattr(
+        metadata_plugins, "ThreadPoolExecutor", DelayedStartExecutor
+    )
+
+    assert set(metadata_plugins.albums_for_ids(["42"])) == {
+        "discogs",
+        "musicbrainz",
+        "tidal",
+    }
+    assert [plugin.calls for plugin in plugins] == [
+        [["42"]],
+        [["42"]],
+        [["42"]],
+    ]

--- a/test/test_metadata_plugins.py
+++ b/test/test_metadata_plugins.py
@@ -128,7 +128,6 @@ class TestSearchApiMetadataSourcePlugin(PluginMixin):
             search_plugin._search_api("track", "query", {})
 
 
-@pytest.mark.xfail(reason="Currently only the last plugin is called")
 def test_albums_for_ids_calls_each_plugin_once(monkeypatch):
     start_workers = Event()
 


### PR DESCRIPTION
## Fix lambda closure bug in concurrent plugin method execution

Fixes a classic Python closure-over-loop-variable bug in `_yield_from_plugins`, where all `ThreadPoolExecutor` futures ended up calling the **last** plugin's method instead of their respective plugin.

### Root cause

The inline `lambda` captured `plugin` by reference. By the time the executor ran the futures, the loop had finished and all lambdas resolved `getattr(plugin, method_name)` to the final loop value.

### Fix

Extracts a named `materialize(method, *args, **kwargs)` helper. The plugin method is now **passed as an argument** to `executor.submit`, so each future holds its own reference — no closure over the loop variable.

### Testing

A regression test (`test_albums_for_ids_calls_each_plugin_once`) was added first to reproduce the bug, then `xfail` removed once fixed. The test uses a `DelayedStartExecutor` to force all submissions to complete before any worker starts, reliably triggering the original race.

Fixes: #6583 
