### PR TITLE
Correct MusicBrainz extra_tags default documentation

### DIFF
--- a/docs/plugins/musicbrainz.rst
+++ b/docs/plugins/musicbrainz.rst
@@ -86,9 +86,10 @@ Default
 .. conf:: extra_tags
     :default: []
 
-    By default, beets will use only the artist, album, and track count to query
-    MusicBrainz. Additional tags to be queried can be supplied with the
-    ``extra_tags`` setting.
+    By default, beets will use only the album and either artist or
+    the MusicBrainz Various Artists ID to query MusicBrainz. Additional
+    tags, including track count, can be queried by using the ``extra_tags``
+    setting.
 
     This setting should improve the autotagger results if the metadata with the
     given tags match the metadata returned by MusicBrainz.


### PR DESCRIPTION
## Description

The MusicBrainz plugin currently defaults `extra_tags` to an empty list. Album search criteria are built from the release title plus either the artist name or the MusicBrainz Various Artists ID; track count is only added when `tracks` is configured in `musicbrainz.extra_tags`.

This updates the `extra_tags` documentation to match the current plugin behavior.

Refs #6073.

## Validation

- Checked `MusicBrainzPlugin.get_album_criteria` and `MusicBrainzAPI.search` against the documented behavior.
- Parsed the edited RST block and ran `git diff --check`.

## To Do

- [x] Documentation
- [x] ~Changelog~ Documentation clarification only.
- [x] ~Tests~ No code behavior changed.