### PR TITLE
Fix original date application

### DIFF
--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -305,6 +305,19 @@ class AlbumInfo(Info):
 
         return data
 
+    @cached_property
+    def item_data(self) -> JSONDict:
+        """Album metadata with optional original-date override."""
+        data = {**super().item_data}
+        if config["original_date"].get(bool) and (
+            original_year := data.get("original_year")
+        ):
+            data["year"] = original_year
+            data["month"] = data.get("original_month") or 0
+            data["day"] = data.get("original_day") or 0
+
+        return data
+
     def __init__(
         self,
         tracks: list[TrackInfo],
@@ -505,15 +518,6 @@ class TrackInfo(Info):
             | {"tracktotal": len(album_info.tracks)}
             | track.item_data
         )
-
-        # When configured, prefer original release date over album date.
-        # This keeps logic local and simple; no need to change AlbumInfo.
-        if config["original_date"].get(bool) and (
-            original_year := merged.get("original_year")
-        ):
-            merged["year"] = original_year
-            merged["month"] = merged.get("original_month") or 0
-            merged["day"] = merged.get("original_day") or 0
         return merged
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -52,20 +52,22 @@ Bug fixes
   item or album-art paths were stored as SQLite ``TEXT`` values instead of
   bytes, so upgrading to the portable-path storage format no longer fails for
   those libraries. :bug:`6561`
-- :ref:`import-cmd` Fix duplicate album art files (e.g. ``cover.2.jpg``) being
+- :ref:`import-cmd`: Fix duplicate album art files (e.g. ``cover.2.jpg``) being
   created when re-importing albums with the :doc:`plugins/fetchart` plugin
   enabled. Old album art is now properly removed when replacing duplicate albums
   during import. :bug:`1264` :bug:`6205`
 - :doc:`plugins/discogs`: Prevent duplicate featured artists in track artist
   fields when the same artist is credited both in ``artists`` (for example with
   ``Feat.`` join text) and ``extraartists`` as ``Featuring``. :bug:`6166`
-- :ref:`import-cmd` Metadata source plugin ID lookups now correctly call each
+- :ref:`import-cmd`: Metadata source plugin ID lookups now correctly call each
   plugin's own lookup method when running in parallel. :bug:`6583`
 - Improve ``DBAccessError`` messages to help users diagnose database permission
   issues more easily. The error message now mentions directory missing and file
   permissions as potential causes. :bug:`1676`
 - :doc:`plugins/lyrics`: Fix apostrophe handling in the ``musixmatch`` backend
   slug. :bug:`4759`
+- :ref:`import-cmd`: With ``original_date: yes``, album-level ``year``,
+  ``month``, and ``day`` now use the original release date. :bug:`6577`
 
 ..
     For plugin developers

--- a/test/autotag/test_hooks.py
+++ b/test/autotag/test_hooks.py
@@ -107,6 +107,7 @@ class ApplyTest(BeetsTestCase):
         self.config["import"]["from_scratch"] = from_scratch
         amatch = AlbumMatch(Distance(), self.info, mapping)
         amatch.apply_metadata()
+        return amatch
 
     def setUp(self):
         super().setUp()
@@ -291,8 +292,7 @@ class ApplyTest(BeetsTestCase):
         assert self.items[0].month == 2
         assert self.items[0].day == 3
 
-    def test_original_date_overrides_release_date(self):
-        self.items = [Item(year=1, month=2, day=3)]
+    def test_original_date_overrides_album_metadata(self):
         self.info.update(
             year=2013,
             month=12,
@@ -301,12 +301,13 @@ class ApplyTest(BeetsTestCase):
             original_month=4,
             original_day=7,
         )
+        match = self._apply(original_date=True)
+        album = self.lib.add_album(self.items)
+        match.apply_album_metadata(album)
 
-        self._apply(original_date=True)
-
-        assert self.items[0].year == 1999
-        assert self.items[0].month == 4
-        assert self.items[0].day == 7
+        assert album.year == 1999
+        assert album.month == 4
+        assert album.day == 7
 
 
 class TestFromScratch:


### PR DESCRIPTION
## `autotag`: Move `original_date` override into `AlbumInfo.item_data`

Previously, the `original_date` year/month/day substitution was applied in `merge_with_album` — meaning only track-level items got the corrected date. Album-level metadata was never updated, causing a mismatch between item and album fields.

This PR moves the logic into a `cached_property` override of `item_data` on `AlbumInfo`, so both item and album metadata consistently reflect the original release date when `original_date: yes` is configured.

**Key changes:**
- New `AlbumInfo.item_data` property applies the `original_date` override before data is consumed by either items or albums.
- `merge_with_album` drops its now-redundant inline override block.
- Test renamed and extended to assert album-level fields (`album.year/month/day`) rather than just item fields.

Fixes #6577.
