### PR TITLE
badfiles: respect import.quiet during import hook

### DIFF
--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -169,9 +169,10 @@ class BadFiles(BeetsPlugin):
             task._badfiles_checks_failed = checks_failed
 
     def on_import_task_before_choice(self, task, session):
+        if config["import"]["quiet"]:
+            return None
+
         if hasattr(task, "_badfiles_checks_failed"):
-            if config["import"]["quiet"]:
-                return None
             ui.print_(
                 f"{colorize('text_warning', 'BAD')} one or more files failed checks:"
             )

--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -22,7 +22,7 @@ from subprocess import STDOUT, CalledProcessError, check_output, list2cmdline
 
 import confuse
 
-from beets import importer, ui
+from beets import config, importer, ui
 from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand
 from beets.util import displayable_path, par_map
@@ -170,6 +170,8 @@ class BadFiles(BeetsPlugin):
 
     def on_import_task_before_choice(self, task, session):
         if hasattr(task, "_badfiles_checks_failed"):
+            if config["import"]["quiet"]:
+                return None
             ui.print_(
                 f"{colorize('text_warning', 'BAD')} one or more files failed checks:"
             )

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -68,6 +68,9 @@ Bug fixes
   slug. :bug:`4759`
 - :ref:`import-cmd`: With ``original_date: yes``, album-level ``year``,
   ``month``, and ``day`` now use the original release date. :bug:`6577`
+- :doc:`plugins/badfiles`: Respect quiet mode (the ``--quiet`` flag or
+  ``import.quiet: yes`` config) during import so the corrupt-file prompt is
+  suppressed in non-interactive imports. :bug:`4736`
 
 ..
     For plugin developers

--- a/test/plugins/test_badfiles.py
+++ b/test/plugins/test_badfiles.py
@@ -1,0 +1,51 @@
+# This file is part of beets.
+# Copyright 2026, Eyup Akman.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+"""Tests for the 'badfiles' plugin."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from beets.test.helper import PluginTestCase
+from beetsplug.badfiles import BadFiles
+
+
+class BadFilesPluginTest(PluginTestCase):
+    plugin = "badfiles"
+
+    def test_quiet_import_skips_prompt(self):
+        plugin = BadFiles()
+        task = SimpleNamespace(_badfiles_checks_failed=[["bad: error"]])
+
+        self.config["import"]["quiet"] = True
+
+        with patch("beetsplug.badfiles.ui.input_options") as mock_input:
+            result = plugin.on_import_task_before_choice(task, session=None)
+
+        mock_input.assert_not_called()
+        assert result is None
+
+    def test_non_quiet_import_calls_prompt(self):
+        plugin = BadFiles()
+        task = SimpleNamespace(_badfiles_checks_failed=[["bad: error"]])
+
+        self.config["import"]["quiet"] = False
+
+        with patch(
+            "beetsplug.badfiles.ui.input_options", return_value="c"
+        ) as mock_input:
+            result = plugin.on_import_task_before_choice(task, session=None)
+
+        mock_input.assert_called_once()
+        assert result is None

--- a/test/plugins/test_badfiles.py
+++ b/test/plugins/test_badfiles.py
@@ -17,6 +17,7 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from beets import importer
 from beets.test.helper import PluginTestCase
 from beetsplug.badfiles import BadFiles
 
@@ -30,10 +31,9 @@ class BadFilesPluginTest(PluginTestCase):
 
         self.config["import"]["quiet"] = True
 
-        with patch("beetsplug.badfiles.ui.input_options") as mock_input:
+        with patch("beetsplug.badfiles.ui.input_options", return_value="s"):
             result = plugin.on_import_task_before_choice(task, session=None)
 
-        mock_input.assert_not_called()
         assert result is None
 
     def test_non_quiet_import_calls_prompt(self):
@@ -42,10 +42,7 @@ class BadFilesPluginTest(PluginTestCase):
 
         self.config["import"]["quiet"] = False
 
-        with patch(
-            "beetsplug.badfiles.ui.input_options", return_value="c"
-        ) as mock_input:
+        with patch("beetsplug.badfiles.ui.input_options", return_value="s"):
             result = plugin.on_import_task_before_choice(task, session=None)
 
-        mock_input.assert_called_once()
-        assert result is None
+        assert result == importer.Action.SKIP


### PR DESCRIPTION
## Description

The badfiles plugin's `on_import_task_before_choice` hook prompted for input even when quiet mode was active. Non-interactive imports stalled on the corrupt-file dialog. The hook now returns early when `import.quiet` is set, so the importer falls back to its summary judgment under both the `--quiet` flag and the `import.quiet: yes` config key.

Fixes #4736.

## To Do

- [ ] ~Documentation~
- [x] Changelog
- [x] Tests
