### PR TITLE
lyrics: handle apostrophes in musixmatch slug

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -399,6 +399,7 @@ class MusiXmatch(Backend):
     URL_TEMPLATE = "https://www.musixmatch.com/lyrics/{}/{}"
 
     REPLACEMENTS: ClassVar[dict[str, str]] = {
+        "['\u2018\u2019]": "-",
         r"\s+": "-",
         "<": "Less_Than",
         ">": "Greater_Than",

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -64,6 +64,8 @@ Bug fixes
 - Improve ``DBAccessError`` messages to help users diagnose database permission
   issues more easily. The error message now mentions directory missing and file
   permissions as potential causes. :bug:`1676`
+- :doc:`plugins/lyrics`: Fix apostrophe handling in the ``musixmatch`` backend
+  slug. :bug:`4759`
 
 ..
     For plugin developers

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -140,6 +140,17 @@ class TestLyricsUtils:
     def test_slug(self, text, expected):
         assert lyrics.slug(text) == expected
 
+    @pytest.mark.parametrize(
+        "text, expected",
+        [
+            ("If They’re Shooting at You", "If-They-re-Shooting-at-You"),
+            ("‘Round Midnight", "-Round-Midnight"),
+            ("Don't Stop", "Don-t-Stop"),
+        ],
+    )
+    def test_musixmatch_encode(self, text, expected):
+        assert lyrics.MusiXmatch.encode(text) == expected
+
 
 class TestHtml:
     def test_scrape_strip_cruft(self):


### PR DESCRIPTION
## Description

`REPLACEMENTS` runs before `unidecode` in the `musixmatch` backend, so curly apostrophes (U+2018, U+2019) survived as raw bytes in the percent-encoded URL and titles like "If They're Shooting at You" produced a lookup that returned nothing. A new entry in `REPLACEMENTS` maps both codepoints to a dash. The shared `slug()` helper avoids the bug because it calls `unidecode` first.

Fixes #4759.

## To Do

- [ ] ~Documentation~
- [x] Changelog
- [x] Tests
