### PR TITLE
refactor: log formatter

### DIFF
--- a/beets/logging.py
+++ b/beets/logging.py
@@ -113,7 +113,7 @@ class LegacyFormatter(Formatter):
 
     Usage::
 
-        handler.setFormatter(LegacyFormatter("%(legacy_msg)s"))
+        handler.setFormatter(LegacyFormatter("%(legacy_prefix)s%(message)s"))
 
     The ``legacy_msg`` attribute is attached to the record by
     ``LegacyFormatter.format()``, so the format string above only works
@@ -129,15 +129,9 @@ class LegacyFormatter(Formatter):
 
     def format(self, record):
         parts = record.name.split(".")
-
-        child_name = ".".join(parts[1:]) if len(parts) > 1 else None
-
-        record.legacy_msg = (
-            f"{child_name}: {record.getMessage()}"
-            if child_name
-            else record.getMessage()
+        record.legacy_prefix = (
+            f"{'.'.join(parts[1:])}: " if len(parts) > 1 else ""
         )
-
         return super().format(record)
 
 

--- a/beets/logging.py
+++ b/beets/logging.py
@@ -32,6 +32,7 @@ from logging import (
     WARNING,
     FileHandler,
     Filter,
+    Formatter,
     Handler,
     Logger,
     NullHandler,
@@ -100,6 +101,44 @@ def _logsafe(val: T) -> str | T:
     # Other objects are used as-is so field access, etc., still works in
     # the format string. Relies on a working __str__ implementation.
     return val
+
+
+class LegacyFormatter(Formatter):
+    """A ``logging.Formatter`` that reproduces the pre-3.0 beets output style.
+
+    For every log record, this formatter strips the ``beets.`` prefix from
+    the logger name and prepends the remainder to the message, separated by
+    a colon.  Records from the root logger ("beets") or from loggers not
+    under the ``beets`` namespace are passed through unchanged.
+
+    Usage::
+
+        handler.setFormatter(LegacyFormatter("%(legacy_msg)s"))
+
+    The ``legacy_msg`` attribute is attached to the record by
+    ``LegacyFormatter.format()``, so the format string above only works
+    when this class is the active formatter.  Using it with the stdlib
+    ``logging.Formatter`` will raise ``KeyError`` / ``ValueError``.
+
+    Output examples::
+
+        "beets"                     "msg"
+        "beets.musicbrainz"         "musicbrainz: msg"
+        "beets.musicbrainz.sub"     "musicbrainz.sub: msg"
+    """
+
+    def format(self, record):
+        parts = record.name.split(".")
+
+        child_name = ".".join(parts[1:]) if len(parts) > 1 else None
+
+        record.legacy_msg = (
+            f"{child_name}: {record.getMessage()}"
+            if child_name
+            else record.getMessage()
+        )
+
+        return super().format(record)
 
 
 class StrFormatLogger(Logger):

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -124,23 +124,6 @@ class PluginImportError(ImportError):
         super().__init__(f"Could not import plugin {name}")
 
 
-class PluginLogFilter(logging.Filter):
-    """A logging filter that identifies the plugin that emitted a log
-    message.
-    """
-
-    def __init__(self, plugin):
-        self.prefix = f"{plugin.name}: "
-
-    def filter(self, record):
-        if hasattr(record.msg, "msg") and isinstance(record.msg.msg, str):
-            # A _LogMessage from our hacked-up Logging replacement.
-            record.msg.msg = f"{self.prefix}{record.msg.msg}"
-        elif isinstance(record.msg, str):
-            record.msg = f"{self.prefix}{record.msg}"
-        return True
-
-
 # Managing the plugins themselves.
 
 
@@ -240,8 +223,6 @@ class BeetsPlugin(metaclass=BeetsPluginMeta):
 
         self._log = log.getChild(self.name)
         self._log.setLevel(logging.NOTSET)  # Use `beets` logger level.
-        if not any(isinstance(f, PluginLogFilter) for f in self._log.filters):
-            self._log.addFilter(PluginLogFilter(self))
 
         # In order to verify the config we need to make sure the plugin is fully
         # configured (plugins usually add the default configuration *after*

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -58,7 +58,9 @@ if sys.platform == "win32":
 log = logging.getLogger("beets")
 if not log.handlers:
     handler = logging.StreamHandler()
-    handler.setFormatter(logging.LegacyFormatter("%(legacy_msg)s"))
+    handler.setFormatter(
+        logging.LegacyFormatter("%(legacy_prefix)s%(message)s")
+    )
     log.addHandler(handler)
 log.propagate = False  # Don't propagate to root handler.
 

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -57,7 +57,9 @@ if sys.platform == "win32":
 
 log = logging.getLogger("beets")
 if not log.handlers:
-    log.addHandler(logging.StreamHandler())
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.LegacyFormatter("%(legacy_msg)s"))
+    log.addHandler(handler)
 log.propagate = False  # Don't propagate to root handler.
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -120,6 +120,8 @@ Other changes
   audio-features API unavailability only once per run.
 - :doc:`plugins/titlecase`: Correct the path format example and document the
   ``%titlecase{text}`` template function. :bug:`6697`
+- Log message prefix formatting (``musicbrainz: msg``) moved from a filter to
+  ``LegacyFormatter``, making future customization easier.
 
 2.11.0 (May 06, 2026)
 ---------------------

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -195,7 +195,7 @@ class TestConvertCli(ConvertPluginHelper, ConvertCommand):
     def test_empty_query(self, caplog):
         with caplog.at_level("INFO", logger="beets.convert"):
             self.run_convert("An impossible query")
-        assert caplog.messages[0] == "convert: Empty query result."
+        assert caplog.messages[0] == "Empty query result."
 
     @pytest.mark.parametrize(
         "max_bitrate,convert_format,args,should_transcode",

--- a/test/plugins/test_hook.py
+++ b/test/plugins/test_hook.py
@@ -49,7 +49,7 @@ class TestHookLogs(HookTestCase):
         with caplog.at_level("DEBUG"):
             self._configure_hook("")
 
-        assert 'hook: invalid command ""' in caplog.messages
+        assert 'invalid command ""' in caplog.messages
 
     # FIXME: fails on windows
     @pytest.mark.skipif(sys.platform == "win32", reason="win32")
@@ -57,15 +57,12 @@ class TestHookLogs(HookTestCase):
         with caplog.at_level("DEBUG"):
             self._configure_hook('sh -c "exit 1"')
 
-        assert (
-            f"hook: hook for {self.HOOK} exited with status 1"
-            in caplog.messages
-        )
+        assert f"hook for {self.HOOK} exited with status 1" in caplog.messages
 
     def test_hook_non_existent_command(self, caplog: pytest.LogCaptureFixture):
         with caplog.at_level("DEBUG"):
             self._configure_hook("non-existent-command")
-        assert f"hook: hook for {self.HOOK} failed: " in caplog.text
+        assert f"hook for {self.HOOK} failed: " in caplog.text
         # The error message is different for each OS. Unfortunately the text is
         # different in each case, where the only shared text is the string
         # 'file' and substring 'Err'

--- a/test/plugins/test_mbsync.py
+++ b/test/plugins/test_mbsync.py
@@ -84,13 +84,9 @@ class TestMbsyncCli(PluginTestHelper):
         with caplog.at_level("DEBUG", logger="beets.mbsync"):
             self.run_command("mbsync", "-f", "'%if{$album,$album,$title}'")
 
+        assert "Skipping album with no mb_albumid: 'no id'" in caplog.messages
         assert (
-            "mbsync: Skipping album with no mb_albumid: 'no id'"
-            in caplog.messages
-        )
-        assert (
-            "mbsync: Skipping singleton with no mb_trackid: 'no id'"
-            in caplog.messages
+            "Skipping singleton with no mb_trackid: 'no id'" in caplog.messages
         )
 
     @patch(

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -364,7 +364,7 @@ class TestLegacyFormatter:
         """Root logger passes message unchanged; child loggers get
         ``prefix: msg`` format after the ``beets.`` prefix is stripped.
         """
-        formatter = blog.LegacyFormatter("%(legacy_msg)s")
+        formatter = blog.LegacyFormatter("%(legacy_prefix)s%(message)s")
         record = log.LogRecord(
             logger_name, log.INFO, __file__, 0, "hello world", (), None
         )

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -158,73 +158,73 @@ class TestLoggingLevel(AsIsImporterMixin, PluginMixin, ImportHelper):
         self.config["verbose"] = 0
         with caplog.at_level("DEBUG"):
             self.run_command("dummy")
-        assert "dummy: warning cmd" in caplog.messages
-        assert "dummy: info cmd" in caplog.messages
-        assert "dummy: debug cmd" not in caplog.messages
+        assert "warning cmd" in caplog.messages
+        assert "info cmd" in caplog.messages
+        assert "debug cmd" not in caplog.messages
 
     def test_command_level1(self, caplog):
         self.config["verbose"] = 1
         with caplog.at_level("DEBUG"):
             self.run_command("dummy")
-        assert "dummy: warning cmd" in caplog.messages
-        assert "dummy: info cmd" in caplog.messages
-        assert "dummy: debug cmd" in caplog.messages
+        assert "warning cmd" in caplog.messages
+        assert "info cmd" in caplog.messages
+        assert "debug cmd" in caplog.messages
 
     def test_command_level2(self, caplog):
         self.config["verbose"] = 2
         with caplog.at_level("DEBUG"):
             self.run_command("dummy")
-        assert "dummy: warning cmd" in caplog.messages
-        assert "dummy: info cmd" in caplog.messages
-        assert "dummy: debug cmd" in caplog.messages
+        assert "warning cmd" in caplog.messages
+        assert "info cmd" in caplog.messages
+        assert "debug cmd" in caplog.messages
 
     def test_listener_level0(self, caplog):
         self.config["verbose"] = 0
         with caplog.at_level("DEBUG"):
             plugins.send("dummy_event")
-        assert "dummy: warning listener" in caplog.messages
-        assert "dummy: info listener" not in caplog.messages
-        assert "dummy: debug listener" not in caplog.messages
+        assert "warning listener" in caplog.messages
+        assert "info listener" not in caplog.messages
+        assert "debug listener" not in caplog.messages
 
     def test_listener_level1(self, caplog):
         self.config["verbose"] = 1
         with caplog.at_level("DEBUG"):
             plugins.send("dummy_event")
-        assert "dummy: warning listener" in caplog.messages
-        assert "dummy: info listener" in caplog.messages
-        assert "dummy: debug listener" not in caplog.messages
+        assert "warning listener" in caplog.messages
+        assert "info listener" in caplog.messages
+        assert "debug listener" not in caplog.messages
 
     def test_listener_level2(self, caplog):
         self.config["verbose"] = 2
         with caplog.at_level("DEBUG"):
             plugins.send("dummy_event")
-        assert "dummy: warning listener" in caplog.messages
-        assert "dummy: info listener" in caplog.messages
-        assert "dummy: debug listener" in caplog.messages
+        assert "warning listener" in caplog.messages
+        assert "info listener" in caplog.messages
+        assert "debug listener" in caplog.messages
 
     def test_import_stage_level0(self, caplog):
         self.config["verbose"] = 0
         with caplog.at_level("DEBUG"):
             self.run_asis_importer()
-        assert "dummy: warning import_stage" in caplog.messages
-        assert "dummy: info import_stage" not in caplog.messages
-        assert "dummy: debug import_stage" not in caplog.messages
+        assert "warning import_stage" in caplog.messages
+        assert "info import_stage" not in caplog.messages
+        assert "debug import_stage" not in caplog.messages
 
     def test_import_stage_level1(self, caplog):
         self.config["verbose"] = 1
         with caplog.at_level("DEBUG"):
             self.run_asis_importer()
-        assert "dummy: warning import_stage" in caplog.messages
-        assert "dummy: info import_stage" in caplog.messages
-        assert "dummy: debug import_stage" not in caplog.messages
+        assert "warning import_stage" in caplog.messages
+        assert "info import_stage" in caplog.messages
+        assert "debug import_stage" not in caplog.messages
 
     def test_import_stage_level2(self, caplog):
         self.config["verbose"] = 2
         with caplog.at_level("DEBUG"):
             self.run_asis_importer()
-        assert "dummy: warning import_stage" in caplog.messages
-        assert "dummy: info import_stage" in caplog.messages
-        assert "dummy: debug import_stage" in caplog.messages
+        assert "warning import_stage" in caplog.messages
+        assert "info import_stage" in caplog.messages
+        assert "debug import_stage" in caplog.messages
 
 
 class TestConcurrentEvents(AsIsImporterMixin, ImportHelper):

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -344,3 +344,28 @@ class TestConcurrentEvents(AsIsImporterMixin, ImportHelper):
         with caplog.at_level("DEBUG"):
             self.run_asis_importer()
         assert "Sending event: database_change" in caplog.messages
+
+
+class TestLegacyFormatter:
+    """Tests for ``LegacyFormatter``, which strips the ``beets.`` prefix
+    from logger names and prepends the remainder to the message.
+    """
+
+    @pytest.mark.parametrize(
+        "logger_name, expected",
+        [
+            ("beets", "hello world"),
+            ("beets.musicbrainz", "musicbrainz: hello world"),
+            ("beets.musicbrainz.sub", "musicbrainz.sub: hello world"),
+            ("root.foobar", "foobar: hello world"),
+        ],
+    )
+    def test_format(self, logger_name, expected):
+        """Root logger passes message unchanged; child loggers get
+        ``prefix: msg`` format after the ``beets.`` prefix is stripped.
+        """
+        formatter = blog.LegacyFormatter("%(legacy_msg)s")
+        record = log.LogRecord(
+            logger_name, log.INFO, __file__, 0, "hello world", (), None
+        )
+        assert formatter.format(record) == expected


### PR DESCRIPTION
This pull request refactors how log messages are formatted in the codebase, specifically replacing the use of a logging filter with a custom logging formatter to append plugin names to log messages. This change improves flexibility and future extensibility for logging setups.

This is part of the multi-step efforts to improve logging in beets #6553 

----

This change should yield no visible change for users and is entirely a internal refactor:

```bash
musicbrainz: Searching for '' with {'release': 'somebody that i used to know', 'arid': '89ad4ac3-39f7-470e-963a-56509c546377'}
Searching for MusicBrainz releases with: 'release:(somebody that i used to know) arid:(89ad4ac3\\-39f7\\-470e\\-963a\\-56509c546377)'
musicbrainz: Found 5 result(s)
musicbrainz: Requesting MusicBrainz release 7841a24b-02fc-437e-a146-e59de916f1a2
```