### PR TITLE
Added notes on AI usage to contribution guide.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -393,6 +393,18 @@ beets also defines custom pytest markers in ``test/conftest.py``:
     @pytest.mark.requires_import("librosa", force_ci=False)
     def test_autobpm_command(): ...
 
+Notes on AI Usage
+-----------------
+
+We are not opposed to AI-generated contributions, but communication should be
+handled by a real person. We will likely have questions about your PR, and we
+need you to understand the proposed changes in order to discuss with us what the
+implications are. If a contribution is mostly AI-generated, we also expect this
+information to be disclosed upfront.
+
+> Currently we value human oversight and accountability, AI as a tool, not a
+contributor.
+
 .. _codecov: https://app.codecov.io/github/beetbox/beets
 
 .. _discussion board: https://github.com/beetbox/beets/discussions

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -399,8 +399,7 @@ Notes on AI Usage
 We are not opposed to AI-generated contributions, but communication should be
 handled by a real person. We will likely have questions about your PR, and we
 need you to understand the proposed changes in order to discuss with us what the
-implications are. If a contribution is mostly AI-generated, we also expect this
-information to be disclosed upfront.
+implications are.
 
 > Currently we value human oversight and accountability, AI as a tool, not a
 contributor.


### PR DESCRIPTION
This pull request adds a new section to the `CONTRIBUTING.rst` file to clarify the project's stance on AI-generated contributions. 

@beetbox/maintainers Do any of you have another stance? Am very happy to iterate on the exact wording if some of you see need for change. 