### PR TITLE
Remove (some) capture_log occurences

### DIFF
--- a/test/plugins/test_autobpm.py
+++ b/test/plugins/test_autobpm.py
@@ -1,6 +1,6 @@
 import pytest
 
-from beets.test.helper import ImportHelper, PluginMixin, capture_log
+from beets.test.helper import ImportHelper, PluginMixin
 
 pytestmark = pytest.mark.requires_import("librosa")
 
@@ -61,19 +61,17 @@ class TestAutoBPMPlugin(PluginMixin, ImportHelper):
         item.load()
         assert item.bpm == 117
 
-    def test_command_quiet(self, lib, item):
+    def test_command_quiet(self, lib, item, caplog):
         item.bpm = 10
         item.store()
 
-        with capture_log() as logs:
+        with caplog.at_level("DEBUG"):
             self.run_command("autobpm", "--quiet", lib=lib)
+        assert not any("already exists" in msg for msg in caplog.messages)
 
-        assert not any("already exists" in log for log in logs)
-
-        with capture_log() as logs:
+        with caplog.at_level("DEBUG"):
             self.run_command("autobpm", lib=lib)
-
-        assert any("already exists" in log for log in logs)
+        assert any("already exists" in msg for msg in caplog.messages)
 
     def test_import(self, lib, importer):
         importer.run()

--- a/test/plugins/test_discogs.py
+++ b/test/plugins/test_discogs.py
@@ -21,7 +21,7 @@ import pytest
 from beets import config
 from beets.library import Item
 from beets.test._common import Bag
-from beets.test.helper import BeetsTestCase, capture_log
+from beets.test.helper import TestHelper
 from beetsplug.discogs import ArtistState, DiscogsPlugin
 
 
@@ -37,8 +37,20 @@ def _artist(name: str, **kwargs):
     } | kwargs
 
 
+class PytestTestHelper(TestHelper):
+    """Same as the BeetsTestCase unittest setup but for pytest."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.setup_beets()
+        try:
+            yield
+        finally:
+            self.teardown_beets()
+
+
 @patch("beetsplug.discogs.DiscogsPlugin.setup", Mock())
-class DGAlbumInfoTest(BeetsTestCase):
+class TestDGAlbumInfo(PytestTestHelper):
     def _make_release(self, tracks=None):
         """Returns a Bag that mimics a discogs_client.Release. The list
         of elements on the returned Bag is incomplete, including just
@@ -350,14 +362,16 @@ class DGAlbumInfoTest(BeetsTestCase):
         assert d.album == "TITLE"
         assert len(d.tracks) == 1
 
-    def test_parse_release_without_required_fields(self):
+    def test_parse_release_without_required_fields(self, caplog):
         """Test parsing of a release that does not have the required fields."""
         release = Bag(data={}, refresh=lambda *args: None)
-        with capture_log() as logs:
+        with caplog.at_level("DEBUG"):
             d = DiscogsPlugin().get_album_info(release)
 
         assert d is None
-        assert "Release does not contain the required fields" in logs[0]
+        assert (
+            "Release does not contain the required fields" in caplog.messages[0]
+        )
 
     def test_default_genre_style_settings(self):
         """Test genre default settings, genres to genre, styles to style"""
@@ -469,7 +483,7 @@ class DGAlbumInfoTest(BeetsTestCase):
 
 
 @patch("beetsplug.discogs.DiscogsPlugin.setup", Mock())
-class DGSearchQueryTest(BeetsTestCase):
+class TestDGSearchQuery(PytestTestHelper):
     def test_default_search_filters_without_extra_tags(self):
         """Discogs search uses only the type filter when no extra_tags are set."""
         plugin = DiscogsPlugin()

--- a/test/plugins/utils/test_playcount.py
+++ b/test/plugins/utils/test_playcount.py
@@ -2,7 +2,7 @@ import pytest
 
 from beets import logging
 from beets.library import Item
-from beets.test.helper import TestHelper, capture_log
+from beets.test.helper import TestHelper
 from beetsplug._utils.playcount import (
     get_items,
     process_track,
@@ -196,7 +196,12 @@ class TestPlayCount:
         ],
     )
     def test_update_play_counts_counts_and_logs_summary(
-        self, tracks, expected_counts, expected_summary, expected_playcount
+        self,
+        tracks,
+        expected_counts,
+        expected_summary,
+        expected_playcount,
+        caplog,
     ):
         item = self.add_item(
             title="Known Song",
@@ -204,7 +209,7 @@ class TestPlayCount:
             play_count=1,
         )
 
-        with capture_log(LOGGER_NAME) as logs:
+        with caplog.at_level("DEBUG", logger=LOGGER_NAME):
             assert (
                 update_play_counts(
                     self.lib,
@@ -216,11 +221,11 @@ class TestPlayCount:
             )
 
         assert any(
-            f"Received {len(tracks)} tracks in this page, processing..." in log
-            for log in logs
+            f"Received {len(tracks)} tracks in this page, processing..." in msg
+            for msg in caplog.messages
         )
         if expected_summary is None:
-            assert not any("Acquired" in log for log in logs)
+            assert not any("Acquired" in msg for msg in caplog.messages)
         else:
-            assert expected_summary in logs
+            assert expected_summary in caplog.text
             assert self.get_playcount(item.id) == expected_playcount


### PR DESCRIPTION
This pull request refactors several test files by replacing the custom `capture_log` context manager with pytest’s built-in `caplog` fixture. Using `caplog` improves clarity, aligns with standard pytest practices, and makes the tests more reliable and easier to maintain.


Note: A few usages of `capture_log` still remain. These cases are more complex and will be addressed separately in a follow-up PR.

---

This is part of the multi-step efforts to improve logging in beets https://github.com/beetbox/beets/issues/6553