### PR TITLE
fix(MusicBrainz): date parsing fix

### DIFF
--- a/beetsplug/musicbrainz.py
+++ b/beetsplug/musicbrainz.py
@@ -198,7 +198,13 @@ def _get_date(date_str: str) -> tuple[int | None, int | None, int | None]:
     if not date_str:
         return None, None, None
 
-    parts = list(map(int, date_str.split("-")))
+    def _parse_part(part: str) -> int | None:
+        try:
+            return int(part)
+        except ValueError:
+            return None
+
+    parts = list(map(_parse_part, date_str.split("-")))
 
     return (
         parts[0] if len(parts) > 0 else None,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -68,6 +68,8 @@ Bug fixes
   slug. :bug:`4759`
 - :ref:`import-cmd`: With ``original_date: yes``, album-level ``year``,
   ``month``, and ``day`` now use the original release date. :bug:`6577`
+- :doc:`plugins/musicbrainz`: Correctly handle release dates where leading or
+  intermediate components are missing, e.g. 2008-??-02
 
 ..
     For plugin developers

--- a/test/plugins/test_musicbrainz.py
+++ b/test/plugins/test_musicbrainz.py
@@ -885,3 +885,20 @@ class TestMusicBrainzPlugin(MusicBrainzPluginTestMixin):
 
         # Ensure the exact error is propagated, not swallowed
         assert excinfo.value is error
+
+    @pytest.mark.parametrize(
+        "input,expected",
+        [
+            ("??-??-??", (None, None, None)),
+            ("??-01-??", (None, 1, None)),
+            ("??-??-02", (None, None, 2)),
+            ("??-01-02", (None, 1, 2)),
+            ("2010-??-01", (2010, None, 1)),
+            ("2010-01-not_an_int", (2010, 1, None)),
+            ("2010", (2010, None, None)),
+            ("2010-01", (2010, 1, None)),
+            ("2010-01-02", (2010, 1, 2)),
+        ],
+    )
+    def test_get_date(self, input, expected):
+        assert musicbrainz._get_date(input) == expected


### PR DESCRIPTION
## Description

Correctly handle release dates where leading or intermediate components are missing, e.g. 2008-??-02

Without this fix parsing of these releases fail with:
```Error in 'MusicBrainz.albums_for_ids': invalid literal for int() with base 10: '??'```

While cases like that are rare in MusicBrainz they do exist and we should support them.
example: https://musicbrainz.org/release/18295b5f-3150-4086-9095-7497c261e6ce

## To Do

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
