### PR TITLE
fix(update): persist mtime to DB after reading file tags (#6603)

### DIFF
--- a/beets/ui/commands/update.py
+++ b/beets/ui/commands/update.py
@@ -89,14 +89,15 @@ def update_items(lib, query, album, move, pretend, fields, exclude_fields=None):
                     if move and lib.directory in ancestry(item.path):
                         item.move(store=False)
 
-                    item.store(fields=item_fields)
+                    # Include mtime explicitly to persist the updated timestamp.
+                    item.store(fields=set(item_fields) | {"mtime"})
                     affected_albums.add(item.album_id)
                 else:
                     # The file's mtime was different, but there were no
                     # changes to the metadata. Store the new mtime,
                     # which is set in the call to read(), so we don't
                     # check this again in the future.
-                    item.store(fields=item_fields)
+                    item.store(fields=["mtime"])
 
         # Skip album changes while pretending.
         if pretend:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -68,6 +68,9 @@ Bug fixes
   slug. :bug:`4759`
 - :ref:`import-cmd`: With ``original_date: yes``, album-level ``year``,
   ``month``, and ``day`` now use the original release date. :bug:`6577`
+- :ref:`update-cmd`: Fix ``beet update`` re-reporting the same metadata changes
+  on every run by persisting the updated ``mtime`` to the database after reading
+  file tags. :bug:`6603`
 
 ..
     For plugin developers

--- a/test/ui/commands/test_update.py
+++ b/test/ui/commands/test_update.py
@@ -196,6 +196,29 @@ class UpdateTest(IOMixin, BeetsTestCase):
         assert album.albumtype == correct_albumtype
         assert album.albumtypes == correct_albumtypes
 
+    def test_mtime_persisted_when_metadata_changed(self):
+        """mtime must be saved to DB when metadata changes, preventing
+        reprocessing on subsequent runs (github.com/beetbox/beets/issues/6603).
+        """
+        mf = MediaFile(syspath(self.i.path))
+        mf.title = "differentTitle"
+        mf.save()
+        self._update()
+
+        item = self.lib.get_item(self.i.id)
+        assert item.title == "differentTitle"
+        assert item.mtime == item.current_mtime()
+
+    def test_mtime_persisted_when_no_metadata_changes(self):
+        """mtime must be saved to DB even when no metadata changed, preventing
+        reprocessing on subsequent runs (github.com/beetbox/beets/issues/6603).
+        """
+        # _update sets DB mtime=0 by default, so the file will be re-read.
+        self._update()
+
+        item = self.lib.get_item(self.i.id)
+        assert item.mtime == item.current_mtime()
+
     def test_modified_metadata_excluded(self):
         mf = MediaFile(syspath(self.i.path))
         mf.lyrics = "new lyrics"


### PR DESCRIPTION
## Description

Fixes #6603

- `beet update` was re-reporting the same metadata changes on every run because `mtime` is not in `Item._media_fields`, so `item.store(fields=item_fields)` never wrote the updated `mtime` to the database. `store()` then calls `clear_dirty()` at the end, silently discarding the in-memory update without persisting it.
- Fix: explicitly include `"mtime"` in the `store()` call — merged with `item_fields` when metadata changed, or stored alone when only `mtime` differed.
- Two regression tests added to verify `mtime` is persisted in both cases.


- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)

Tested it locally. Here's the result after the fix (note that the track was skipped the second time):
```bash
arsaboo@arsmusic:~$ beet update

...
Jaanwar (1999) - Jaanewale
  arrangers:
    +
  lyricists:
    +
^C^C^C
arsaboo@arsmusic:~$ ^C

arsaboo@arsmusic:~$ beet -vv update
user configuration: /home/arsaboo/.config/beets/config.yaml
data directory: /home/arsaboo/.config/beets
plugin paths: []
Loading plugins: badfiles, convert, deezer, discogs, duplicates, edit, embedart, fetchart, gaana, importreplace, info, inline, lastgenre, lastimport, limit, listenbrainz, lyrics, mbsubmit, mbsync, missing, musicbrainz, plexsync, rewrite, scrub, spotify, subsonic, types, web, xtractor, youtube
fetchart: google: Disabling art source due to missing key
lastgenre: Loading whitelist ~/.config/beets/genres/genres.txt
lastgenre: Loading canonicalization tree ~/.config/beets/genres/genres-trees.yaml
rewrite: adding template field artist Rahul Dev Burman
inline: adding item field initial_char
inline: adding item field folder
inline: adding item field clean_comments
inline: adding album field format
inline: adding album field alb_data_source
inline: adding album field alb_spotify_album_id
inline: adding album field alb_mtime
inline: adding album field plex_matched
Initializing cache at: /home/arsaboo/.config/beets/plexsync_cache.db
Cache database initialized successfully
Spotify cache tables verified
Sending event: pluginload
library database: /home/arsaboo/.config/beets/musiclibrary.blb
library directory: /data/music
Sending event: library_opened
Parsed query: AndQuery([TrueQuery()])
Parsed sort: NullSort()
....
skipping /data/music/Hindi Music/J/Jaanwar (1999)/Jaanwar (1999) - Jaanewale.flac because mtime is up to date (1768355318.0)
```