### PR TITLE
listenbrainz: add option to import listens from ListenBrainz data export zip

### DIFF
--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -236,7 +236,7 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
         for track in listens:
             if track["track_metadata"].get("release_name") is None:
                 continue
-            mbid_mapping = track["track_metadata"].get("mbid_mapping", {})
+            mbid_mapping = track["track_metadata"].get("mbid_mapping", {}) or {}
             mbid = mbid_mapping.get("recording_mbid")
             tracks.append(
                 {

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -21,6 +21,8 @@ from ._utils.playcount import update_play_counts
 from ._utils.requests import TimeoutAndRetrySession
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from ._utils.playcount import Track
 
 
@@ -164,7 +166,7 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
             self._log.debug("Invalid Search Error: {}", e)
             return None
 
-    def import_listenbrainz_data_export(self, export_file: str):
+    def import_listenbrainz_data_export(self, export_file: str | Path):
         """Import ListenBrainz data from a .zip file."""
         export_file = syspath(normpath(export_file))
 

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -26,6 +26,27 @@ if TYPE_CHECKING:
     from ._utils.playcount import Track
 
 
+class Listen(TypedDict):
+    listened_at: int
+    track_metadata: TrackMetadata
+
+
+class TrackMetadata(TypedDict, total=False):
+    artist_name: str
+    track_name: str
+    release_name: str | None
+    additional_info: AdditionalInfo
+    mbid_mapping: MbidMapping | None
+
+
+class AdditionalInfo(TypedDict, total=False):
+    recording_mbid: str | None
+
+
+class MbidMapping(TypedDict, total=False):
+    recording_mbid: str | None
+
+
 class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
     """A Beets plugin for interacting with ListenBrainz."""
 
@@ -420,24 +441,3 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
         # Fetch and return tracks from the selected playlist
         playlist = self.get_playlist(selected_playlist.get("identifier"))
         return self.get_tracks_from_playlist(playlist)
-
-
-class Listen(TypedDict):
-    listened_at: int
-    track_metadata: TrackMetadata
-
-
-class TrackMetadata(TypedDict, total=False):
-    artist_name: str
-    track_name: str
-    release_name: str | None
-    additional_info: AdditionalInfo
-    mbid_mapping: MbidMapping | None
-
-
-class AdditionalInfo(TypedDict, total=False):
-    recording_mbid: str | None
-
-
-class MbidMapping(TypedDict, total=False):
-    recording_mbid: str | None

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -14,7 +14,7 @@ import requests
 from beets import config, ui
 from beets.dbcore import types
 from beets.plugins import BeetsPlugin
-from beets.util import syspath, normpath
+from beets.util import displayable_path, normpath, syspath
 
 from ._utils.musicbrainz import MusicBrainzAPIMixin
 from ._utils.playcount import update_play_counts
@@ -48,18 +48,21 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
             "lbimport", help="Import ListenBrainz history"
         )
         lbupdate_cmd.parser.add_option(
+            "-f",
             "--export-file",
             dest="export_file",
             metavar="PATH",
             default=None,
-            help="path to a ListenBrainz data export .zip file (instead of fetching from the API)",
+            help="path to a ListenBrainz data export .zip file "
+            "(instead of fetching from the API)",
         )
         lbupdate_cmd.parser.add_option(
             "--max",
             dest="max_listens",
             type="int",
             default=None,
-            help="maximum number of listens to fetch (default: all)",
+            help="maximum number of listens to fetch via the API (default: all). "
+            "This option does not apply when importing a file via -f/--export-file.",
         )
 
         def func(lib, opts, args):
@@ -77,6 +80,10 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
         """Update play counts from ListenBrainz listening history."""
         if export_file is not None:
             log.info("Importing ListenBrainz data from {}...", export_file)
+            if max_listens is not None:
+                log.warning(
+                    "Ignoring superfluous --max flag when importing from file."
+                )
             listens = self.import_listenbrainz_data_export(log, export_file)
         else:
             log.info("Fetching ListenBrainz history...")
@@ -152,18 +159,32 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
 
         all_listens = []
 
-        with zipfile.ZipFile(export_file, "r") as zip_file:
-            for file_name in zip_file.namelist():
-                if file_name.startswith("listens/") and file_name.endswith(
-                    ".jsonl"
-                ):
-                    log.info("Reading listens from {}", file_name)
-                    with zip_file.open(file_name) as file:
-                        data = file.read()
-                        listens = [
-                            json.loads(line) for line in data.splitlines()
-                        ]
-                        all_listens.extend(listens)
+        try:
+            with zipfile.ZipFile(export_file, "r") as zip_file:
+                for file_name in zip_file.namelist():
+                    if file_name.startswith("listens/") and file_name.endswith(
+                        ".jsonl"
+                    ):
+                        log.info(
+                            "Reading listens from {}",
+                            displayable_path(file_name),
+                        )
+                        with zip_file.open(file_name) as file:
+                            for line in file:
+                                if not line.strip():
+                                    continue
+                                try:
+                                    all_listens.append(json.loads(line))
+                                except json.JSONDecodeError as err:
+                                    log.error(
+                                        "Invalid JSON in {}: {}",
+                                        displayable_path(file_name),
+                                        err,
+                                    )
+        except OSError as err:
+            raise ui.UserError(
+                f"unreadable export file {displayable_path(export_file)}: {err}"
+            ) from err
         return all_listens
 
     def get_listens(self, min_ts=None, max_ts=None, count=None, max_total=None):
@@ -237,7 +258,7 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
             track_metadata = track["track_metadata"]
             if track_metadata.get("release_name") is None:
                 continue
-            additional_info = track.get("additional_info", {})
+            additional_info = track_metadata.get("additional_info", {})
             recording_mbid = additional_info.get("recording_mbid")
             if recording_mbid is None:
                 mbid_mapping = track_metadata.get("mbid_mapping", {}) or {}

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -72,9 +72,7 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
 
         def func(lib, opts, args):
             self._lbupdate(
-                lib,
-                export_file=opts.export_file,
-                max_listens=opts.max_listens,
+                lib, export_file=opts.export_file, max_listens=opts.max_listens
             )
 
         lbupdate_cmd.func = func

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -7,7 +7,7 @@ import json
 import time
 import zipfile
 from collections import Counter
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import requests
 
@@ -166,7 +166,9 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
             self._log.debug("Invalid Search Error: {}", e)
             return None
 
-    def import_listenbrainz_data_export(self, export_file: str | Path):
+    def import_listenbrainz_data_export(
+        self, export_file: str | Path
+    ) -> list[Any]:
         """Import ListenBrainz data from a .zip file."""
         export_file = syspath(normpath(export_file))
 

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -234,22 +234,20 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
         """Returns a list of tracks from a list of listens."""
         tracks: list[Track] = []
         for track in listens:
-            if track["track_metadata"].get("release_name") is None:
+            track_metadata = track["track_metadata"]
+            if track_metadata.get("release_name") is None:
                 continue
-            mbid_mapping = track["track_metadata"].get("mbid_mapping", {}) or {}
-            mbid = mbid_mapping.get("recording_mbid")
+            additional_info = track.get("additional_info", {})
+            recording_mbid = additional_info.get("recording_mbid")
+            if recording_mbid is None:
+                mbid_mapping = track_metadata.get("mbid_mapping", {}) or {}
+                recording_mbid = mbid_mapping.get("recording_mbid")
             tracks.append(
                 {
-                    "album": (
-                        track["track_metadata"].get("release_name") or ""
-                    ).strip(),
-                    "name": (
-                        track["track_metadata"].get("track_name") or ""
-                    ).strip(),
-                    "artist": (
-                        track["track_metadata"].get("artist_name") or ""
-                    ).strip(),
-                    "mbid": mbid,
+                    "album": (track_metadata.get("release_name") or "").strip(),
+                    "name": (track_metadata.get("track_name") or "").strip(),
+                    "artist": (track_metadata.get("artist_name") or "").strip(),
+                    "mbid": recording_mbid,
                     "playcount": 1,
                 }
             )

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -53,22 +53,26 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
             dest="export_file",
             metavar="PATH",
             default=None,
-            help="path to a ListenBrainz data export .zip file "
-            "(instead of fetching from the API)",
+            help=(
+                "path to a ListenBrainz data export .zip file"
+                " (instead of fetching from the API)"
+            ),
         )
         lbupdate_cmd.parser.add_option(
             "--max",
             dest="max_listens",
             type="int",
             default=None,
-            help="maximum number of listens to fetch via the API (default: all). "
-            "This option does not apply when importing a file via -f/--export-file.",
+            help=(
+                "maximum number of listens to fetch via the API (default: all)."
+                " This option does not apply when importing a file via"
+                " -f/--export-file."
+            ),
         )
 
         def func(lib, opts, args):
             self._lbupdate(
                 lib,
-                self._log,
                 export_file=opts.export_file,
                 max_listens=opts.max_listens,
             )
@@ -76,31 +80,40 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
         lbupdate_cmd.func = func
         return [lbupdate_cmd]
 
-    def _lbupdate(self, lib, log, export_file=None, max_listens=None):
+    def _lbupdate(
+        self,
+        lib,
+        export_file: str | None = None,
+        max_listens: int | None = None,
+    ):
         """Update play counts from ListenBrainz listening history."""
         if export_file is not None:
-            log.info("Importing ListenBrainz data from {}...", export_file)
+            self._log.info(
+                "Importing ListenBrainz data from {}...", export_file
+            )
             if max_listens is not None:
-                log.warning(
+                self._log.warning(
                     "Ignoring superfluous --max flag when importing from file."
                 )
-            listens = self.import_listenbrainz_data_export(log, export_file)
+            listens = self.import_listenbrainz_data_export(export_file)
         else:
-            log.info("Fetching ListenBrainz history...")
+            self._log.info("Fetching ListenBrainz history...")
             listens = self.get_listens(max_total=max_listens)
         if listens is None:
-            log.error("Failed to fetch listens from ListenBrainz.")
+            self._log.error("Failed to fetch listens from ListenBrainz.")
             return
         if not listens:
-            log.info("No listens found.")
+            self._log.info("No listens found.")
             return
-        log.info("Found {} listens", len(listens))
+        self._log.info("Found {} listens", len(listens))
         tracks = self._aggregate_listens(self.get_tracks_from_listens(listens))
-        log.info("Aggregated into {} unique tracks", len(tracks))
-        found, unknown = update_play_counts(lib, tracks, log, "listenbrainz")
-        log.info("... done!")
-        log.info("{} unknown play-counts", unknown)
-        log.info("{} play-counts imported", found)
+        self._log.info("Aggregated into {} unique tracks", len(tracks))
+        found, unknown = update_play_counts(
+            lib, tracks, self._log, "listenbrainz"
+        )
+        self._log.info("... done!")
+        self._log.info("{} unknown play-counts", unknown)
+        self._log.info("{} play-counts imported", found)
 
     @staticmethod
     def _aggregate_listens(tracks: list[Track]) -> list[Track]:
@@ -153,7 +166,7 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
             self._log.debug("Invalid Search Error: {}", e)
             return None
 
-    def import_listenbrainz_data_export(self, log, export_file):
+    def import_listenbrainz_data_export(self, export_file: str):
         """Import ListenBrainz data from a .zip file."""
         export_file = syspath(normpath(export_file))
 
@@ -165,7 +178,7 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
                     if file_name.startswith("listens/") and file_name.endswith(
                         ".jsonl"
                     ):
-                        log.info(
+                        self._log.info(
                             "Reading listens from {}",
                             displayable_path(file_name),
                         )
@@ -176,7 +189,7 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
                                 try:
                                     all_listens.append(json.loads(line))
                                 except json.JSONDecodeError as err:
-                                    log.error(
+                                    self._log.error(
                                         "Invalid JSON in {}: {}",
                                         displayable_path(file_name),
                                         err,

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import datetime
+import json
 import time
+import zipfile
 from collections import Counter
 from typing import TYPE_CHECKING, ClassVar
 
@@ -12,6 +14,7 @@ import requests
 from beets import config, ui
 from beets.dbcore import types
 from beets.plugins import BeetsPlugin
+from beets.util import syspath, normpath
 
 from ._utils.musicbrainz import MusicBrainzAPIMixin
 from ._utils.playcount import update_play_counts
@@ -45,6 +48,13 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
             "lbimport", help="Import ListenBrainz history"
         )
         lbupdate_cmd.parser.add_option(
+            "--export-file",
+            dest="export_file",
+            metavar="PATH",
+            default=None,
+            help="path to a ListenBrainz data export .zip file (instead of fetching from the API)",
+        )
+        lbupdate_cmd.parser.add_option(
             "--max",
             dest="max_listens",
             type="int",
@@ -53,14 +63,24 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
         )
 
         def func(lib, opts, args):
-            self._lbupdate(lib, self._log, max_listens=opts.max_listens)
+            self._lbupdate(
+                lib,
+                self._log,
+                export_file=opts.export_file,
+                max_listens=opts.max_listens,
+            )
 
         lbupdate_cmd.func = func
         return [lbupdate_cmd]
 
-    def _lbupdate(self, lib, log, max_listens=None):
-        """Obtain play counts from ListenBrainz."""
-        listens = self.get_listens(max_total=max_listens)
+    def _lbupdate(self, lib, log, export_file=None, max_listens=None):
+        """Update play counts from ListenBrainz listening history."""
+        if export_file is not None:
+            log.info("Importing ListenBrainz data from {}...", export_file)
+            listens = self.import_listenbrainz_data_export(log, export_file)
+        else:
+            log.info("Fetching ListenBrainz history...")
+            listens = self.get_listens(max_total=max_listens)
         if listens is None:
             log.error("Failed to fetch listens from ListenBrainz.")
             return
@@ -126,8 +146,28 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
             self._log.debug("Invalid Search Error: {}", e)
             return None
 
+    def import_listenbrainz_data_export(self, log, export_file):
+        """Import ListenBrainz data from a .zip file."""
+        export_file = syspath(normpath(export_file))
+
+        all_listens = []
+
+        with zipfile.ZipFile(export_file, "r") as zip_file:
+            for file_name in zip_file.namelist():
+                if file_name.startswith("listens/") and file_name.endswith(
+                    ".jsonl"
+                ):
+                    log.info("Reading listens from {}", file_name)
+                    with zip_file.open(file_name) as file:
+                        data = file.read()
+                        listens = [
+                            json.loads(line) for line in data.splitlines()
+                        ]
+                        all_listens.extend(listens)
+        return all_listens
+
     def get_listens(self, min_ts=None, max_ts=None, count=None, max_total=None):
-        """Gets the listen history of a given user.
+        """Gets the listening history of a given user from the ListenBrainz API.
 
         Paginates through all available listens using the max_ts parameter.
 

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -7,7 +7,7 @@ import json
 import time
 import zipfile
 from collections import Counter
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, ClassVar, TypedDict
 
 import requests
 
@@ -87,6 +87,7 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
         max_listens: int | None = None,
     ):
         """Update play counts from ListenBrainz listening history."""
+        listens: list[Listen] | None
         if export_file is not None:
             self._log.info(
                 "Importing ListenBrainz data from {}...", export_file
@@ -99,9 +100,9 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
         else:
             self._log.info("Fetching ListenBrainz history...")
             listens = self.get_listens(max_total=max_listens)
-        if listens is None:
-            self._log.error("Failed to fetch listens from ListenBrainz.")
-            return
+            if listens is None:
+                self._log.error("Failed to fetch listens from ListenBrainz.")
+                return
         if not listens:
             self._log.info("No listens found.")
             return
@@ -168,7 +169,7 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
 
     def import_listenbrainz_data_export(
         self, export_file: str | Path
-    ) -> list[Any]:
+    ) -> list[Listen]:
         """Import ListenBrainz data from a .zip file."""
         export_file = syspath(normpath(export_file))
 
@@ -202,7 +203,9 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
             ) from err
         return all_listens
 
-    def get_listens(self, min_ts=None, max_ts=None, count=None, max_total=None):
+    def get_listens(
+        self, min_ts=None, max_ts=None, count=None, max_total=None
+    ) -> list[Listen] | None:
         """Gets the listening history of a given user from the ListenBrainz API.
 
         Paginates through all available listens using the max_ts parameter.
@@ -223,7 +226,7 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
 
         per_page = min(count or 1000, 1000)
         url = f"{self.ROOT}/user/{self.username}/listens"
-        all_listens = []
+        all_listens: list[Listen] = []
 
         while True:
             if max_total is not None:
@@ -266,7 +269,7 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
 
         return all_listens
 
-    def get_tracks_from_listens(self, listens) -> list[Track]:
+    def get_tracks_from_listens(self, listens: list[Listen]) -> list[Track]:
         """Returns a list of tracks from a list of listens."""
         tracks: list[Track] = []
         for track in listens:
@@ -276,8 +279,9 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
             additional_info = track_metadata.get("additional_info", {})
             recording_mbid = additional_info.get("recording_mbid")
             if recording_mbid is None:
-                mbid_mapping = track_metadata.get("mbid_mapping", {}) or {}
-                recording_mbid = mbid_mapping.get("recording_mbid")
+                mbid_mapping = track_metadata.get("mbid_mapping")
+                if mbid_mapping is not None:
+                    recording_mbid = mbid_mapping.get("recording_mbid")
             tracks.append(
                 {
                     "album": (track_metadata.get("release_name") or "").strip(),
@@ -416,3 +420,24 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
         # Fetch and return tracks from the selected playlist
         playlist = self.get_playlist(selected_playlist.get("identifier"))
         return self.get_tracks_from_playlist(playlist)
+
+
+class Listen(TypedDict):
+    listened_at: int
+    track_metadata: TrackMetadata
+
+
+class TrackMetadata(TypedDict, total=False):
+    artist_name: str
+    track_name: str
+    release_name: str | None
+    additional_info: AdditionalInfo
+    mbid_mapping: MbidMapping | None
+
+
+class AdditionalInfo(TypedDict, total=False):
+    recording_mbid: str | None
+
+
+class MbidMapping(TypedDict, total=False):
+    recording_mbid: str | None

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,9 @@ New features
   also available as config options via ``force`` and ``keep_new``.
 - :ref:`import-cmd`: The ``--nomove`` / ``-M`` CLI flag can now be used to
   override the ``move: yes`` config option during import.
+- :doc:`plugins/listenbrainz`: Add support for importing ListenBrainz listening
+  history from an export file. Use the ``-f`` / ``--export-file`` flag to
+  specify the path to the ListenBrainz export file.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/plugins/listenbrainz.rst
+++ b/docs/plugins/listenbrainz.rst
@@ -32,6 +32,14 @@ Usage
 Once the plugin is enabled, you can import the listening history using the
 ``lbimport`` command in beets.
 
+The command has two command-line options:
+
+- To import the listening history from a ListenBrainz export file, use the
+  ``-f`` (``--export-file``) flag followed by the path to the export file.
+- To limit the number of listens fetched via the API during import, the
+  ``--max`` flag can be used. By default, the plugin will fetch all listens.
+  This option will be ignored when an export file is provided.
+
 Matched tracks are populated with the ``listenbrainz_play_count`` field, which
 you can use in queries and templates. For example:
 

--- a/test/plugins/test_listenbrainz.py
+++ b/test/plugins/test_listenbrainz.py
@@ -1,9 +1,22 @@
-from unittest.mock import patch
+import io
+import json
+import zipfile
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from beets import ui
 from beets.test.helper import ConfigMixin
 from beetsplug.listenbrainz import ListenBrainzPlugin
+
+
+def _make_zip(files: dict[str, str]) -> bytes:
+    """Build an in-memory zip with the given {name: content} entries."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, content in files.items():
+            zf.writestr(name, content)
+    return buf.getvalue()
 
 
 class TestListenBrainzPlugin(ConfigMixin):
@@ -292,3 +305,64 @@ class TestListenBrainzPlugin(ConfigMixin):
         tracks = plugin.get_tracks_from_listens(listens)
         assert tracks[0]["mbid"] == "rec-mbid-123"
         assert tracks[0]["playcount"] == 1
+
+    def test_import_file_returns_listens(self, plugin, tmp_path):
+        listen = {
+            "listened_at": 1778946700,
+            "track_metadata": {"track_name": "S"},
+        }
+        zip_path = tmp_path / "export.zip"
+        zip_path.write_bytes(
+            _make_zip({"listens/2026.jsonl": json.dumps(listen) + "\n"})
+        )
+
+        result = plugin.import_listenbrainz_data_export(MagicMock(), zip_path)
+
+        assert result == [listen]
+
+    def test_import_file_ignores_non_listens_entries(self, plugin, tmp_path):
+        listen = {"listened_at": 1778946700, "track_metadata": {}}
+        zip_path = tmp_path / "export.zip"
+        zip_path.write_bytes(
+            _make_zip(
+                {
+                    "listens/2026.jsonl": json.dumps(listen) + "\n",
+                    "other/data.jsonl": '{"should": "be ignored"}\n',
+                    "listens/readme.txt": "not a jsonl file\n",
+                }
+            )
+        )
+
+        result = plugin.import_listenbrainz_data_export(MagicMock(), zip_path)
+
+        assert result == [listen]
+
+    def test_import_file_skips_empty_lines(self, plugin, tmp_path):
+        listen = {"listened_at": 1778946700, "track_metadata": {}}
+        content = "\n" + json.dumps(listen) + "\n\n"
+        zip_path = tmp_path / "export.zip"
+        zip_path.write_bytes(_make_zip({"listens/2026.jsonl": content}))
+
+        result = plugin.import_listenbrainz_data_export(MagicMock(), zip_path)
+
+        assert result == [listen]
+
+    def test_import_file_skips_invalid_json_and_logs_error(
+        self, plugin, tmp_path
+    ):
+        listen = {"listened_at": 1778946700, "track_metadata": {}}
+        content = "not valid json\n" + json.dumps(listen) + "\n"
+        zip_path = tmp_path / "export.zip"
+        zip_path.write_bytes(_make_zip({"listens/2026.jsonl": content}))
+        log = MagicMock()
+
+        result = plugin.import_listenbrainz_data_export(log, zip_path)
+
+        assert result == [listen]
+        log.error.assert_called_once()
+
+    def test_import_file_raises_on_missing_file(self, plugin, tmp_path):
+        with pytest.raises(ui.UserError):
+            plugin.import_listenbrainz_data_export(
+                MagicMock(), tmp_path / "nonexistent.zip"
+            )

--- a/test/plugins/test_listenbrainz.py
+++ b/test/plugins/test_listenbrainz.py
@@ -292,9 +292,7 @@ class TestListenBrainzPlugin(ConfigMixin):
                     "track_name": "Song",
                     "artist_name": "Artist",
                     "release_name": "Album",
-                    "additional_info": {
-                        "recording_mbid": "rec-mbid-123",
-                    },
+                    "additional_info": {"recording_mbid": "rec-mbid-123"},
                     "mbid_mapping": {
                         "recording_mbid": "rec-mbid-456",
                         "release_mbid": "rel-mbid",

--- a/test/plugins/test_listenbrainz.py
+++ b/test/plugins/test_listenbrainz.py
@@ -253,3 +253,42 @@ class TestListenBrainzPlugin(ConfigMixin):
         assert isinstance(t["artist"], str)
         assert isinstance(t["name"], str)
         assert t["album"] == "Album"
+
+    def test_get_tracks_from_listens_null_mbid_mapping(self, plugin):
+        listens = [
+            {
+                "listened_at": 1000,
+                "track_metadata": {
+                    "track_name": "Song",
+                    "artist_name": "Artist",
+                    "release_name": "Album",
+                    "mbid_mapping": None,
+                },
+            }
+        ]
+        tracks = plugin.get_tracks_from_listens(listens)  # should not raise
+        assert tracks[0]["mbid"] is None
+
+    def test_get_tracks_from_listens_prefers_additional_info_recording_mbid(
+        self, plugin
+    ):
+        listens = [
+            {
+                "listened_at": 1000,
+                "track_metadata": {
+                    "track_name": "Song",
+                    "artist_name": "Artist",
+                    "release_name": "Album",
+                    "additional_info": {
+                        "recording_mbid": "rec-mbid-123",
+                    },
+                    "mbid_mapping": {
+                        "recording_mbid": "rec-mbid-456",
+                        "release_mbid": "rel-mbid",
+                    },
+                },
+            }
+        ]
+        tracks = plugin.get_tracks_from_listens(listens)
+        assert tracks[0]["mbid"] == "rec-mbid-123"
+        assert tracks[0]["playcount"] == 1

--- a/test/plugins/test_listenbrainz.py
+++ b/test/plugins/test_listenbrainz.py
@@ -1,7 +1,7 @@
 import io
 import json
 import zipfile
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -314,7 +314,7 @@ class TestListenBrainzPlugin(ConfigMixin):
             _make_zip({"listens/2026.jsonl": json.dumps(listen) + "\n"})
         )
 
-        result = plugin.import_listenbrainz_data_export(MagicMock(), zip_path)
+        result = plugin.import_listenbrainz_data_export(zip_path)
 
         assert result == [listen]
 
@@ -331,7 +331,7 @@ class TestListenBrainzPlugin(ConfigMixin):
             )
         )
 
-        result = plugin.import_listenbrainz_data_export(MagicMock(), zip_path)
+        result = plugin.import_listenbrainz_data_export(zip_path)
 
         assert result == [listen]
 
@@ -341,26 +341,20 @@ class TestListenBrainzPlugin(ConfigMixin):
         zip_path = tmp_path / "export.zip"
         zip_path.write_bytes(_make_zip({"listens/2026.jsonl": content}))
 
-        result = plugin.import_listenbrainz_data_export(MagicMock(), zip_path)
+        result = plugin.import_listenbrainz_data_export(zip_path)
 
         assert result == [listen]
 
-    def test_import_file_skips_invalid_json_and_logs_error(
-        self, plugin, tmp_path
-    ):
+    def test_import_file_skips_invalid_json(self, plugin, tmp_path):
         listen = {"listened_at": 1778946700, "track_metadata": {}}
         content = "not valid json\n" + json.dumps(listen) + "\n"
         zip_path = tmp_path / "export.zip"
         zip_path.write_bytes(_make_zip({"listens/2026.jsonl": content}))
-        log = MagicMock()
 
-        result = plugin.import_listenbrainz_data_export(log, zip_path)
+        result = plugin.import_listenbrainz_data_export(zip_path)
 
         assert result == [listen]
-        log.error.assert_called_once()
 
     def test_import_file_raises_on_missing_file(self, plugin, tmp_path):
         with pytest.raises(ui.UserError):
-            plugin.import_listenbrainz_data_export(
-                MagicMock(), tmp_path / "nonexistent.zip"
-            )
+            plugin.import_listenbrainz_data_export(tmp_path / "nonexistent.zip")


### PR DESCRIPTION
## Description

Since importing listens from the API is rather slow and puts unnecessary load on the servers, importing a dump exported from https://listenbrainz.org/settings/export/ should also be possible. This change introduces the `export-file` parameter to the `lbimport` command, which takes all listens from the zipfile to update the play counts.

I also fixed an issue where `mbid_mapping` could be `None` if explicitly set to `null` in the JSON (which happens for these exports sometimes), and changed the recording mbid logic to prefer one explicitly supplied by the player in the `additional_data`, instead of relying on the (sometimes inaccurate) mapper.

Since the `--max` parameter isn't documented either, I'm unsure whether I should add the parameter to the plugin docs. In theory, the `--help` parameter already tells you enough.

I'm also not sure if the `--max` parameter should apply to exported files, especially since the order of zip file entries isn't deterministic.

## To Do

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
