### PR TITLE
feat(import): add --nomove / -M option

### DIFF
--- a/beets/ui/commands/import_/__init__.py
+++ b/beets/ui/commands/import_/__init__.py
@@ -182,6 +182,13 @@ import_cmd.parser.add_option(
     help="move tracks into the library (overrides -c)",
 )
 import_cmd.parser.add_option(
+    "-M",
+    "--nomove",
+    action="store_false",
+    dest="move",
+    help="don't move tracks into the library (overrides -m)",
+)
+import_cmd.parser.add_option(
     "-w",
     "--write",
     action="store_true",

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,8 @@ New features
 
 - :doc:`plugins/convert`: The ``--force`` and ``--keep-new`` CLI flags are now
   also available as config options via ``force`` and ``keep_new``.
+- :ref:`import-cmd`: The ``--nomove`` / ``-M`` CLI flag can now be used to
+  override the ``move: yes`` config option during import.
 
 ..
     Bug fixes

--- a/docs/guides/tagger.rst
+++ b/docs/guides/tagger.rst
@@ -98,6 +98,8 @@ command-line options you should know:
   them where they are
 - ``beet import -m``: move imported files to your music directory (overrides the
   ``-c`` option)
+- ``beet import -M``: don't move imported files to your music directory
+  (overrides the ``-m`` option)
 - ``beet import -l LOGFILE``: write a message to ``LOGFILE`` every time you skip
   an album or choose to take its tags "as-is" (see below) or the album is
   skipped as a duplicate; this lets you come back later and reexamine albums

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -46,7 +46,7 @@ import
 
 ::
 
-    beet import [-CWAPRqst] [-l LOGPATH] PATH...
+    beet import [-CMWAPRqst] [-l LOGPATH] PATH...
     beet import [options] -L QUERY
 
 Add music to your library, attempting to get correct tags for it from
@@ -73,9 +73,9 @@ Optional command flags:
   ID3 tags on your music. In order to move the files, instead of copying, use
   the ``-m`` (move) option. When importing an archive with ``-m``, if all files
   are imported, the archive is removed from disk. If you'd like to leave your
-  music files untouched, try the ``-C`` (don't copy) and ``-W`` (don't write
-  tags) options. You can also disable this behavior by default in the
-  configuration file (below).
+  music files untouched, try the ``-C`` (don't copy), ``-M`` (don't move), and
+  ``-W`` (don't write tags) options. You can also disable this behavior by
+  default in the configuration file (below).
 - Also, you can disable the autotagging behavior entirely using ``-A`` (don't
   autotag)---then your music will be imported with its existing metadata.
 - During a long tagging import, it can be useful to keep track of albums that
@@ -174,6 +174,11 @@ Optional command flags:
     true, of course, if ``move`` is enabled.) That is, your directory
     structure will be updated to reflect the new tags if copying is enabled; you
     never end up with two copies of the file.
+
+    Using ``-C`` (don't copy) in combination with ``-M`` (don't move) will retag
+    music while leaving the files where they are. This is useful for players/music
+    servers that get confused when an item changes path and tags at the same time.
+    One can later use the :ref:`move-cmd` command to move items based on their new tags.
 
     The ``-L`` (``--library``) flag is also useful for retagging. Instead of
     listing paths you want to import on the command line, specify a :doc:`query


### PR DESCRIPTION
## Description

Add `--nomove` / `-M` option to override the `move: yes` config option during import.

This option is especially useful for reimporting when using players / music servers like Navidrome that easily loose track of files when they change path and tags at the same time. 
Now one can retag their files without moving them `beet import -M my-files/`, wait for a rescan, and then `beet move`. 

original idea by @snejus 

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
