### PR TITLE
fix: duplicate album merge broken in threaded import mode

### DIFF
--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import contextvars
 import itertools
 import logging
 from typing import TYPE_CHECKING
@@ -390,4 +391,5 @@ def _extend_pipeline(tasks, *stages):
         task_iter = tasks
 
     ipl = pipeline.Pipeline([task_iter, *list(stages)])
-    return pipeline.multiple(ipl.pull())
+    ctx = contextvars.copy_context()
+    return pipeline.multiple(ctx.run(list, ipl.pull()))

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -392,4 +392,13 @@ def _extend_pipeline(tasks, *stages):
 
     ipl = pipeline.Pipeline([task_iter, *list(stages)])
     ctx = contextvars.copy_context()
-    return pipeline.multiple(ctx.run(list, ipl.pull()))
+
+    def _ctx_iter():
+        gen = ipl.pull()
+        while True:
+            try:
+                yield ctx.run(next, gen)
+            except StopIteration:
+                return
+
+    return pipeline.multiple(_ctx_iter())

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -68,9 +68,6 @@ New features
 Bug fixes
 ~~~~~~~~~
 
-- :ref:`import-cmd`: Fix duplicate album merge during import when running in
-  threaded mode. The merge action no longer creates a duplicate folder or
-  reports ``could not get filesize`` errors. :bug:`6601`
 - :ref:`import-cmd`: Multi-disc album detection now recognizes ``cassette``,
   ``digital media``, and ``vinyl`` as disc markers (e.g. ``vinyl 1``, ``12 vinyl
   2``), in addition to the existing ``disc``, ``disk``, and ``cd`` markers.
@@ -95,6 +92,9 @@ Bug fixes
   permissions as potential causes. :bug:`1676`
 - :doc:`plugins/lyrics`: Fix apostrophe handling in the ``musixmatch`` backend
   slug. :bug:`4759`
+- :ref:`import-cmd`: Fix duplicate album merge during import when running in
+  threaded mode. The merge action no longer creates a duplicate folder or
+  reports ``could not get filesize`` errors. :bug:`6601`
 - :ref:`import-cmd`: With ``original_date: yes``, album-level ``year``,
   ``month``, and ``day`` now use the original release date. :bug:`6577`
 - :doc:`plugins/musicbrainz`: Correctly handle release dates where leading or

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,9 @@ New features
 Bug fixes
 ~~~~~~~~~
 
+- :ref:`import-cmd`: Fix duplicate album merge during import when running in
+  threaded mode. The merge action no longer creates a duplicate folder or
+  reports ``could not get filesize`` errors. :bug:`6601`
 - :doc:`plugins/mbpseudo`: Fix crashes when applying a pseudo-release. One in
   ``PseudoAlbumInfo.raw_data`` and a ``sqlite3.ProgrammingError``.
 
@@ -92,9 +95,6 @@ Bug fixes
   permissions as potential causes. :bug:`1676`
 - :doc:`plugins/lyrics`: Fix apostrophe handling in the ``musixmatch`` backend
   slug. :bug:`4759`
-- :ref:`import-cmd`: Fix duplicate album merge during import when running in
-  threaded mode. The merge action no longer creates a duplicate folder or
-  reports ``could not get filesize`` errors. :bug:`6601`
 - :ref:`import-cmd`: With ``original_date: yes``, album-level ``year``,
   ``month``, and ``day`` now use the original release date. :bug:`6577`
 - :doc:`plugins/musicbrainz`: Correctly handle release dates where leading or

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -68,6 +68,9 @@ New features
 Bug fixes
 ~~~~~~~~~
 
+- :ref:`import-cmd`: Fix duplicate album merge during import when running in
+  threaded mode. The merge action no longer creates a duplicate folder or
+  reports ``could not get filesize`` errors. :bug:`6601`
 - :ref:`import-cmd`: Multi-disc album detection now recognizes ``cassette``,
   ``digital media``, and ``vinyl`` as disc markers (e.g. ``vinyl 1``, ``12 vinyl
   2``), in addition to the existing ``disc``, ``disk``, and ``cd`` markers.
@@ -90,9 +93,6 @@ Bug fixes
 - Improve ``DBAccessError`` messages to help users diagnose database permission
   issues more easily. The error message now mentions directory missing and file
   permissions as potential causes. :bug:`1676`
-- :ref:`import-cmd`: Fix duplicate album merge during import when running in
-  threaded mode. The merge action no longer creates a duplicate folder or
-  reports ``could not get filesize`` errors. :bug:`6601`
 - :doc:`plugins/lyrics`: Fix apostrophe handling in the ``musixmatch`` backend
   slug. :bug:`4759`
 - :ref:`import-cmd`: With ``original_date: yes``, album-level ``year``,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -90,6 +90,9 @@ Bug fixes
 - Improve ``DBAccessError`` messages to help users diagnose database permission
   issues more easily. The error message now mentions directory missing and file
   permissions as potential causes. :bug:`1676`
+- :ref:`import-cmd`: Fix duplicate album merge during import when running in
+  threaded mode. The merge action no longer creates a duplicate folder or
+  reports ``could not get filesize`` errors. :bug:`6601`
 - :doc:`plugins/lyrics`: Fix apostrophe handling in the ``musixmatch`` backend
   slug. :bug:`4759`
 - :ref:`import-cmd`: With ``original_date: yes``, album-level ``year``,

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1163,6 +1163,8 @@ class ImportDuplicateAlbumThreadedTest(PluginMixin, ImportTestCase):
     """Regression test for #6601: threaded merge must propagate context vars."""
 
     plugin = "musicbrainz"
+    # Each thread gets its own connection; :memory: would give each thread an
+    # empty DB, so we need a real file that all threads share.
     db_on_disk = True
 
     def setUp(self):
@@ -1180,13 +1182,18 @@ class ImportDuplicateAlbumThreadedTest(PluginMixin, ImportTestCase):
         return album
 
     def test_merge_duplicate_album_threaded(self):
-        config["threaded"] = True
+        self.config["threaded"] = True
         self.importer.default_resolution = self.importer.Resolution.MERGE
         self.importer.run()
 
         assert len(self.lib.albums()) == 1
         for item in self.lib.items():
             assert item.filepath.exists(), f"item path not found: {item.path}"
+
+        # Without the fix, lost context vars cause relative paths to stay
+        # unresolved, so items land in different (duplicate) directories.
+        album_dirs = {item.filepath.parent for item in self.lib.items()}
+        assert len(album_dirs) == 1, f"expected single album dir, got {album_dirs}"
 
 
 def item_candidates_mock(*args, **kwargs):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1193,7 +1193,9 @@ class ImportDuplicateAlbumThreadedTest(PluginMixin, ImportTestCase):
         # Without the fix, lost context vars cause relative paths to stay
         # unresolved, so items land in different (duplicate) directories.
         album_dirs = {item.filepath.parent for item in self.lib.items()}
-        assert len(album_dirs) == 1, f"expected single album dir, got {album_dirs}"
+        assert len(album_dirs) == 1, (
+            f"expected single album dir, got {album_dirs}"
+        )
 
 
 def item_candidates_mock(*args, **kwargs):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1156,6 +1156,39 @@ class ImportDuplicateAlbumTest(PluginMixin, ImportTestCase):
         return album
 
 
+@patch(
+    "beets.metadata_plugins.candidates", Mock(side_effect=album_candidates_mock)
+)
+class ImportDuplicateAlbumThreadedTest(PluginMixin, ImportTestCase):
+    """Regression test for #6601: threaded merge must propagate context vars."""
+
+    plugin = "musicbrainz"
+    db_on_disk = True
+
+    def setUp(self):
+        super().setUp()
+        self.add_album_fixture(albumartist="artist", album="album")
+        self.prepare_album_for_import(1)
+        self.importer = self.setup_importer(
+            duplicate_keys={"album": "albumartist album"}
+        )
+
+    def add_album_fixture(self, **kwargs):
+        album = super().add_album_fixture()
+        album.update(kwargs)
+        album.store()
+        return album
+
+    def test_merge_duplicate_album_threaded(self):
+        config["threaded"] = True
+        self.importer.default_resolution = self.importer.Resolution.MERGE
+        self.importer.run()
+
+        assert len(self.lib.albums()) == 1
+        for item in self.lib.items():
+            assert item.filepath.exists(), f"item path not found: {item.path}"
+
+
 def item_candidates_mock(*args, **kwargs):
     yield TrackInfo(
         artist="artist",


### PR DESCRIPTION
Fixes #6601 

Added `import contextvars` and changed `_extend_pipeline` to capture the current context and run the inner pipeline within it to ensure the `music_dir` context variable is available when the inner pipeline resolves paths, preventing the relative-path bug that caused could not get filesize errors and removing 0 old duplicated items during merge.

Works perfectly after the fix:

```bash
arsaboo@arsmusic:~$ beet import -m -I -t ~/shared/music/ --set genre="Filmi" --search-id 7MwKD3kEFMov4LQqyhnmzL

/home/arsaboo/shared/music (1 items)

  Match (75.2%):
  King - Lukkhe
  ≠ artist, tracks
  Spotify, None, 2026, None, Warner Music India, None, None
  https://open.spotify.com/album/7MwKD3kEFMov4LQqyhnmzL
  ≠ Artist: King; OAFF; Savera; Sunny M.R. -> King
  * Album: Lukkhe
     ≠ (#2) Khamoshiyaan (3:03) -> (#2) Khamoshiyaan (feat. Romy & Manreet Khara) (3:03)
Missing tracks (13/14 - 92.9%):
 ! Bulletproof (#1) (3:09)
 ! Jee Lenge (#3) (3:25)
 ! Headshot (#4) (3:10)
 ! Ruh Teri (feat. Manreet Khara & Agrim Joshi) (#5) (2:31)
 ! Roobaroo (#6) (3:17)
 ! Savere (#7) (2:29)
 ! Haal (#8) (3:29)
 ! Haal (The Journey) (#9) (6:13)
 ! Nachdi Shaam (#10) (2:22)
 ! Hoga Bada Mera Naam (#11) (1:58)
 ! All Eyes On Us (#12) (3:13)
 ! Swan Song (Hoya Azaad) (#13) (3:17)
 ! Bhaari Pangey (#14) (2:19)
➜ [A]pply, More candidates, Skip, Use as-is, as Tracks, Group albums,
Enter search, enter Id, aBort, eDit, edit Candidates, Print tracks,
Open files with Picard? a
This album is already in the library!
Old: 3 items, MP3, 320kbps, 9:45, 22.9 MiB
New: 1 items, MP3, 320kbps, 3:03, 7.8 MiB
➜ [S]kip new, Keep all, Remove old, Merge all? m

/home/arsaboo/shared/music
/data/music/Hindi Music/L/Lukkhe [30718] (2026)/Lukkhe (2026) - Bulletproof.mp3
/data/music/Hindi Music/L/Lukkhe [30718] (2026)/Lukkhe (2026) - Headshot.mp3
/data/music/Hindi Music/L/Lukkhe [30718] (2026)/Lukkhe (2026) - Jee Lenge.mp3 (4 items)

  Match (82.6%):
  King - Lukkhe
  ≠ artist, tracks
  Spotify, None, 2026, None, Warner Music India, None, None
  https://open.spotify.com/album/7MwKD3kEFMov4LQqyhnmzL
  ≠ Artist: OAFF; Savera; Ruaa Kayy; Romy; Manreet Khara -> King
  * Album: Lukkhe
     * (#1) Bulletproof (3:09)
     ≠ (#2) Khamoshiyaan (3:03) -> (#2) Khamoshiyaan (feat. Romy & Manreet Khara) (3:03)
     * (#3) Jee Lenge (3:25)
     * (#4) Headshot (3:10)
Missing tracks (10/14 - 71.4%):
 ! Ruh Teri (feat. Manreet Khara & Agrim Joshi) (#5) (2:31)
 ! Roobaroo (#6) (3:17)
 ! Savere (#7) (2:29)
 ! Haal (#8) (3:29)
 ! Haal (The Journey) (#9) (6:13)
 ! Nachdi Shaam (#10) (2:22)
 ! Hoga Bada Mera Naam (#11) (1:58)
 ! All Eyes On Us (#12) (3:13)
 ! Swan Song (Hoya Azaad) (#13) (3:17)
 ! Bhaari Pangey (#14) (2:19)
➜ [A]pply, More candidates, Skip, Use as-is, as Tracks, Group albums,
Enter search, enter Id, aBort, eDit, edit Candidates, Print tracks,
Open files with Picard? a
```

- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x]  Tests. (Very much encouraged but not strictly required.)
