### PR TITLE
feat(duplicates): add chroma plugin integration

### DIFF
--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -501,6 +501,17 @@ def find_plugins() -> Iterable[BeetsPlugin]:
     return _instances
 
 
+U = TypeVar("U", bound=BeetsPlugin)
+
+
+def find_plugin(plugin_type: type[U]) -> U | None:
+    for plugin in find_plugins():
+        if isinstance(plugin, plugin_type):
+            return plugin
+
+    return None
+
+
 # Communication with plugins.
 
 

--- a/beetsplug/chroma.py
+++ b/beetsplug/chroma.py
@@ -369,6 +369,34 @@ class AcoustidPlugin(MetadataSourcePlugin):
 
         return cmd
 
+    def compare_items(
+        self, a: Item, b: Item, write: bool = False
+    ) -> float | None:
+        def item_fingerprint(item: Item) -> str | None:
+            fp = fingerprint_item(
+                self._log,
+                item,
+                write=write,
+                quiet=True,
+            )
+            if fp is None:
+                self._log.warning(f"{item}: could not compute fingerprint")
+
+            return fp
+
+        fp_a = item_fingerprint(a)
+        if fp_a is None:
+            return None
+
+        fp_b = item_fingerprint(b)
+        if fp_b is None:
+            return None
+
+        return acoustid.compare_fingerprints(
+            (0, fp_a.encode("utf-8")),
+            (0, fp_b.encode("utf-8")),
+        )
+
 
 # Hooks into import process.
 

--- a/beetsplug/duplicates.py
+++ b/beetsplug/duplicates.py
@@ -14,11 +14,13 @@
 
 """List duplicate tracks or albums."""
 
+import itertools
 import os
 import shlex
 
+from beets import ui
 from beets.library import Album, Item
-from beets.plugins import BeetsPlugin
+from beets.plugins import BeetsPlugin, find_plugin
 from beets.ui import Subcommand, UserError, print_
 from beets.util import (
     MoveOperation,
@@ -27,6 +29,7 @@ from beets.util import (
     displayable_path,
     subprocess,
 )
+from beetsplug import chroma
 
 PLUGIN = "duplicates"
 
@@ -41,6 +44,8 @@ class DuplicatesPlugin(BeetsPlugin):
             {
                 "album": False,
                 "checksum": "",
+                "chroma_threshold": 0.90,
+                "chroma": False,
                 "copy": "",
                 "count": False,
                 "delete": False,
@@ -57,95 +62,13 @@ class DuplicatesPlugin(BeetsPlugin):
             }
         )
 
-        self._command = Subcommand("duplicates", help=__doc__, aliases=["dup"])
-        self._command.parser.add_option(
-            "-c",
-            "--count",
-            dest="count",
-            action="store_true",
-            help="show duplicate counts",
-        )
-        self._command.parser.add_option(
-            "-C",
-            "--checksum",
-            dest="checksum",
-            action="store",
-            metavar="PROG",
-            help="report duplicates based on arbitrary command",
-        )
-        self._command.parser.add_option(
-            "-d",
-            "--delete",
-            dest="delete",
-            action="store_true",
-            help="delete items from library and disk",
-        )
-        self._command.parser.add_option(
-            "-F",
-            "--full",
-            dest="full",
-            action="store_true",
-            help="show all versions of duplicate tracks or albums",
-        )
-        self._command.parser.add_option(
-            "-s",
-            "--strict",
-            dest="strict",
-            action="store_true",
-            help="report duplicates only if all attributes are set",
-        )
-        self._command.parser.add_option(
-            "-k",
-            "--key",
-            dest="keys",
-            action="append",
-            metavar="KEY",
-            help="report duplicates based on keys (use multiple times)",
-        )
-        self._command.parser.add_option(
-            "-M",
-            "--merge",
-            dest="merge",
-            action="store_true",
-            help="merge duplicate items",
-        )
-        self._command.parser.add_option(
-            "-m",
-            "--move",
-            dest="move",
-            action="store",
-            metavar="DEST",
-            help="move items to dest",
-        )
-        self._command.parser.add_option(
-            "-o",
-            "--copy",
-            dest="copy",
-            action="store",
-            metavar="DEST",
-            help="copy items to dest",
-        )
-        self._command.parser.add_option(
-            "-t",
-            "--tag",
-            dest="tag",
-            action="store",
-            help="tag matched items with 'k=v' attribute",
-        )
-        self._command.parser.add_option(
-            "-r",
-            "--remove",
-            dest="remove",
-            action="store_true",
-            help="remove items from library",
-        )
-        self._command.parser.add_all_common_options()
-
     def commands(self):
         def _dup(lib, opts, args):
             self.config.set_args(opts)
             album = self.config["album"].get(bool)
             checksum = self.config["checksum"].get(str)
+            chroma = self.config["chroma"].get(bool)
+            chroma_threshold = self.config["chroma_threshold"].get(float)
             copy = bytestring_path(self.config["copy"].as_str())
             count = self.config["count"].get(bool)
             delete = self.config["delete"].get(bool)
@@ -159,6 +82,9 @@ class DuplicatesPlugin(BeetsPlugin):
             tiebreak = self.config["tiebreak"].get(dict)
             strict = self.config["strict"].get(bool)
             tag = self.config["tag"].get(str)
+
+            if album and chroma:
+                raise ui.UserError("cannot use chroma for albums")
 
             if album:
                 if not keys:
@@ -194,6 +120,8 @@ class DuplicatesPlugin(BeetsPlugin):
                 strict=strict,
                 tiebreak=tiebreak,
                 merge=merge,
+                chroma=chroma,
+                chroma_thresh=chroma_threshold,
             ):
                 if obj_id:  # Skip empty IDs.
                     for o in objs:
@@ -211,8 +139,108 @@ class DuplicatesPlugin(BeetsPlugin):
                             ),
                         )
 
-        self._command.func = _dup
-        return [self._command]
+        command = Subcommand("duplicates", help=__doc__, aliases=["dup"])
+        command.parser.add_option(
+            "-c",
+            "--count",
+            dest="count",
+            action="store_true",
+            help="show duplicate counts",
+        )
+        command.parser.add_option(
+            "-C",
+            "--checksum",
+            dest="checksum",
+            action="store",
+            metavar="PROG",
+            help="report duplicates based on arbitrary command",
+        )
+
+        if self._chroma_plug() is not None:
+            command.parser.add_option(
+                "--chroma",
+                dest="chroma",
+                action="store_true",
+                help="check duplicates similarity with the chroma plugin",
+            )
+            command.parser.add_option(
+                "--chroma-threshold",
+                dest="chroma_threshold",
+                action="store",
+                type=float,
+                help="minimum score to consider items equal",
+            )
+
+        command.parser.add_option(
+            "-d",
+            "--delete",
+            dest="delete",
+            action="store_true",
+            help="delete items from library and disk",
+        )
+        command.parser.add_option(
+            "-F",
+            "--full",
+            dest="full",
+            action="store_true",
+            help="show all versions of duplicate tracks or albums",
+        )
+        command.parser.add_option(
+            "-s",
+            "--strict",
+            dest="strict",
+            action="store_true",
+            help="report duplicates only if all attributes are set",
+        )
+        command.parser.add_option(
+            "-k",
+            "--key",
+            dest="keys",
+            action="append",
+            metavar="KEY",
+            help="report duplicates based on keys (use multiple times)",
+        )
+        command.parser.add_option(
+            "-M",
+            "--merge",
+            dest="merge",
+            action="store_true",
+            help="merge duplicate items",
+        )
+        command.parser.add_option(
+            "-m",
+            "--move",
+            dest="move",
+            action="store",
+            metavar="DEST",
+            help="move items to dest",
+        )
+        command.parser.add_option(
+            "-o",
+            "--copy",
+            dest="copy",
+            action="store",
+            metavar="DEST",
+            help="copy items to dest",
+        )
+        command.parser.add_option(
+            "-t",
+            "--tag",
+            dest="tag",
+            action="store",
+            help="tag matched items with 'k=v' attribute",
+        )
+        command.parser.add_option(
+            "-r",
+            "--remove",
+            dest="remove",
+            action="store_true",
+            help="remove items from library",
+        )
+        command.parser.add_all_common_options()
+
+        command.func = _dup
+        return [command]
 
     def _process_item(
         self,
@@ -402,12 +430,36 @@ class DuplicatesPlugin(BeetsPlugin):
             objs = self._merge_albums(objs)
         return objs
 
-    def _duplicates(self, objs, keys, full, strict, tiebreak, merge):
+    def _duplicates(
+        self, objs, keys, full, strict, tiebreak, merge, chroma, chroma_thresh
+    ):
         """Generate triples of keys, duplicate counts, and constituent objects."""
         offset = 0 if full else 1
         for k, objs in self._group_by(objs, keys, strict).items():
-            if len(objs) > 1:
-                objs = self._order(objs, tiebreak)
-                if merge:
-                    objs = self._merge(objs)
-                yield (k, len(objs) - offset, objs[offset:])
+            if len(objs) <= 1:
+                continue
+
+            objs = self._order(objs, tiebreak)
+
+            if chroma:
+                objs = self._chroma_filter_dups(objs, chroma_thresh)
+                if len(objs) <= 1:
+                    continue
+
+            if merge:
+                objs = self._merge(objs)
+            yield (k, len(objs) - offset, objs[offset:])
+
+    def _chroma_filter_dups(self, items, chroma_thresh):
+        choma_plug = self._chroma_plug()
+        res = [items[0]]
+
+        for a, b in itertools.pairwise(items):
+            score = choma_plug.compare_items(a, b)
+            if score is None or score < chroma_thresh:
+                res.append(b)
+
+        return res
+
+    def _chroma_plug(self):
+        return find_plugin(chroma.AcoustidPlugin)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,9 @@ New features
   also available as config options via ``force`` and ``keep_new``.
 - :ref:`import-cmd`: The ``--nomove`` / ``-M`` CLI flag can now be used to
   override the ``move: yes`` config option during import.
+- :doc:`plugins/duplicates`: Add integration with the :doc:`plugins/chroma`
+  plugin to allow using audio fingerprints for narrowing down results. See
+  :ref:`duplicates-chroma` for more details.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/plugins/duplicates.rst
+++ b/docs/plugins/duplicates.rst
@@ -86,6 +86,26 @@ file. The available options mirror the command-line options:
 - **remove**: Remove matched items from the library, but not from the disk.
   Default: ``no``.
 
+.. _duplicates-chroma:
+
+Chroma
+------
+
+When the :doc:`chroma` is enabled, the duplicates plugin can make use of its
+sonic fingerprinting capabilities to compare the tracks audio in addition of
+their ``keys``. This is especially useful when multiple versions of a song, such
+as live or remixes exist in the library.
+
+When the option is enabled, tracks with the same ``keys`` but different audio
+will be excluded from the results.
+
+The following additional options are available when the :doc:`chroma` is
+enabled:
+
+- **chroma**: Enable fingerprint comparison during duplicate search
+- **chroma_threshold**: Threshold, from 0 to 1, to consider track audio the
+  same. 1 means an exact match; 0 nothing alike. Default: ``0.9``.
+
 Examples
 --------
 

--- a/test/plugins/test_duplicates.py
+++ b/test/plugins/test_duplicates.py
@@ -12,17 +12,20 @@
 # included in all copies or substantial portions of the Software.
 
 
+from unittest.mock import patch
+
 import pytest
 
 from beets.test.helper import IOMixin, PluginMixin, TestHelper
 
 
 class TestDuplicatesPlugin(PluginMixin, TestHelper, IOMixin):
-    plugin = "duplicates"
+    preload_plugin = False
 
     @pytest.fixture(autouse=True)
     def setup(self):
         self.setup_beets()
+        self.load_plugins("duplicates", "chroma")
         self.dup_item = self.create_item(
             album="Pretend Album",
             albumartist="Pretend Artist",
@@ -31,6 +34,7 @@ class TestDuplicatesPlugin(PluginMixin, TestHelper, IOMixin):
             genres=["Original Genre"],
             mb_trackid="abc",
             mb_albumid="def",
+            length=123,
         )
         try:
             yield
@@ -38,18 +42,22 @@ class TestDuplicatesPlugin(PluginMixin, TestHelper, IOMixin):
             self.teardown_beets()
             self.dup_item = None
 
-    def run_cmd(self, count=False, path=False) -> str:
+    def run_cmd(self, count=False, path=False, chroma=False) -> str:
         args = ["duplicates"]
         if count:
             args.append("--count")
         if path:
             args.append("--path")
+        if chroma:
+            args.append("--chroma")
 
         return self.run_with_output(*args).strip()
 
     def create_dups(self, count: int):
-        for _ in range(count):
-            self.lib.add(self.dup_item)
+        for i in range(count):
+            item = self.dup_item
+            item.acoustid_fingerprint = f"FP_{i}"
+            self.lib.add(item)
 
     def test_duplicate(self):
         self.create_dups(2)
@@ -80,3 +88,19 @@ class TestDuplicatesPlugin(PluginMixin, TestHelper, IOMixin):
 
         assert self.dup_item.path.decode() in out
         assert out.endswith("5")
+
+    @patch("acoustid.compare_fingerprints", return_value=0.99)
+    def test_duplicate_chroma_similar(self, cf):
+        self.create_dups(2)
+        out = self.run_cmd(chroma=True)
+
+        assert out == ""
+
+    @patch("acoustid.compare_fingerprints", return_value=0.5)
+    def test_duplicate_chroma_dissimilar(self, cf):
+        self.create_dups(2)
+        out = self.run_cmd(chroma=True)
+
+        assert self.dup_item.artist in out
+        assert self.dup_item.album in out
+        assert self.dup_item.title in out


### PR DESCRIPTION
## Description

When the chroma plugin is enabled, the duplicates plugin can now make use of
its sonic fingerprinting capabilities to compare the tracks audio in addition of
their ``keys``. This is especially useful when multiple versions of a song, such
as live or remixes exist in the library.

When the option is enabled, tracks with the same ``keys`` but different audio
will be excluded from the results.

The following additional options are available when the chroma plugin is
enabled:

- **chroma**: Enable fingerprint comparison during duplicate search
- **chroma_threshold**: Threshold, from 0 to 1, to consider track audio the
  same. 1 means an exact match; 0 nothing alike. Default: ``0.9``.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
