### PR TITLE
fix(mbsync): do not clear metadata if import.from_scratch is set

### DIFF
--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -540,8 +540,14 @@ class Match:
         return self.info.type
 
     @cached_property
-    def from_scratch(self) -> bool:
+    def config_from_scratch(self) -> bool:
         return bool(config["import"]["from_scratch"])
+
+    def from_scratch(self, override: bool | None) -> bool:
+        if override is not None:
+            return override
+
+        return self.config_from_scratch
 
     @property
     def disambig_fields(self) -> Sequence[str]:
@@ -617,10 +623,15 @@ class AlbumMatch(Match):
             for i, ti in self.item_info_pairs
         ]
 
-    def apply_metadata(self) -> None:
-        """Apply metadata to each of the items."""
+    def apply_metadata(self, from_scratch: bool | None = None) -> None:
+        """Apply metadata to each of the items.
+
+        If ``from_scratch`` is provided, its value determines whether the
+        items existing metadata are cleared before applying new metadata.
+        Otherwise, the configured ``from_scratch`` setting is used.
+        """
         for item, data in self.merged_pairs:
-            if self.from_scratch:
+            if self.from_scratch(from_scratch):
                 item.clear()
 
             item.update(data)
@@ -655,9 +666,14 @@ class TrackMatch(Match):
             ),
         }
 
-    def apply_metadata(self) -> None:
-        """Apply metadata to the item."""
-        if self.from_scratch:
+    def apply_metadata(self, from_scratch: bool | None = None) -> None:
+        """Apply metadata to the item.
+
+        If ``from_scratch`` is provided, its value determines whether the
+        item's existing metadata is cleared before applying new metadata.
+        Otherwise, the configured ``from_scratch`` setting is used.
+        """
+        if self.from_scratch(from_scratch):
             self.item.clear()
 
         self.item.update(self.info.item_data)

--- a/beetsplug/bpsync.py
+++ b/beetsplug/bpsync.py
@@ -95,7 +95,9 @@ class BPSyncPlugin(BeetsPlugin):
             # Apply.
             trackinfo = self.beatport_plugin.track_for_id(item.mb_trackid)
             with lib.transaction():
-                TrackMatch(Distance(), trackinfo, item).apply_metadata()
+                TrackMatch(Distance(), trackinfo, item).apply_metadata(
+                    from_scratch=False
+                )
                 apply_item_changes(lib, item, move, pretend, write)
 
     @staticmethod
@@ -162,7 +164,7 @@ class BPSyncPlugin(BeetsPlugin):
             with lib.transaction():
                 AlbumMatch(
                     Distance(), albuminfo, dict(item_info_pairs)
-                ).apply_metadata()
+                ).apply_metadata(from_scratch=False)
                 changed = False
                 # Find any changed item to apply Beatport changes to album.
                 any_changed_item = items[0]

--- a/beetsplug/mbsync.py
+++ b/beetsplug/mbsync.py
@@ -92,7 +92,9 @@ class MBSyncPlugin(BeetsPlugin):
 
             # Apply.
             with lib.transaction():
-                TrackMatch(Distance(), track_info, item).apply_metadata()
+                TrackMatch(Distance(), track_info, item).apply_metadata(
+                    from_scratch=False
+                )
                 apply_item_changes(lib, item, move, pretend, write)
 
     def albums(self, lib, query, move, pretend, write):
@@ -160,7 +162,7 @@ class MBSyncPlugin(BeetsPlugin):
             with lib.transaction():
                 AlbumMatch(
                     Distance(), album_info, dict(item_info_pairs)
-                ).apply_metadata()
+                ).apply_metadata(from_scratch=False)
                 changed = False
                 # Find any changed item to apply changes to album.
                 any_changed_item = items[0]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,8 @@ Bug fixes
   ``PseudoAlbumInfo.raw_data`` and a ``sqlite3.ProgrammingError``.
 - :doc:`plugins/duplicates`: Fix plugin output: information about duplicate
   items was not displayed by default. --count option was ignored :bug:`6476`
+- :doc:`plugins/mbsync` / :doc:`plugins/bpsync`: Do not clear items metadata
+  when ``import.from_scratch`` is enabled. :bug:`6613`
 
 ..
     For plugin developers

--- a/test/plugins/test_mbsync.py
+++ b/test/plugins/test_mbsync.py
@@ -16,10 +16,10 @@ from unittest.mock import Mock, patch
 
 from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.library import Item
-from beets.test.helper import PluginTestCase, capture_log
+from beets.test.helper import ConfigMixin, PluginTestCase, capture_log
 
 
-class MbsyncCliTest(PluginTestCase):
+class MbsyncCliTest(PluginTestCase, ConfigMixin):
     plugin = "mbsync"
 
     @patch(
@@ -88,3 +88,51 @@ class MbsyncCliTest(PluginTestCase):
 
         assert "mbsync: Skipping album with no mb_albumid: 'no id'" in logs
         assert "mbsync: Skipping singleton with no mb_trackid: 'no id'" in logs
+
+    @patch(
+        "beets.metadata_plugins.album_for_id",
+        Mock(
+            side_effect=lambda *_: AlbumInfo(
+                album_id="album id",
+                album="new album",
+                tracks=[TrackInfo(track_id="track id", title="new title")],
+            )
+        ),
+    )
+    @patch(
+        "beets.metadata_plugins.track_for_id",
+        Mock(
+            side_effect=lambda *_: TrackInfo(
+                track_id="singleton id", title="new title"
+            )
+        ),
+    )
+    def test_update_library_from_scratch_set(self):
+        self.config["import"]["from_scratch"] = True
+
+        test_lyrics = "Hello"
+
+        album_item = Item(
+            album="old album",
+            mb_albumid="album id",
+            mb_trackid="track id",
+            data_source="data_source",
+            lyrics=test_lyrics,
+        )
+        self.lib.add_album([album_item])
+
+        singleton = Item(
+            title="old title",
+            mb_trackid="singleton id",
+            data_source="data_source",
+            lyrics=test_lyrics,
+        )
+        self.lib.add(singleton)
+
+        self.run_command("mbsync")
+
+        singleton.load()
+        assert singleton.lyrics == test_lyrics
+
+        album_item.load()
+        assert album_item.lyrics == test_lyrics


### PR DESCRIPTION
## Description

if import.from_scratch was set in the config, runnning mbsync would clear any metadata not provided by MBz (replay gain, lyrics, genres...). we now ignore this setting when running mbsync to preserve metadata.

Fixes: #6613

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
