### PR TITLE
Add optional id extractor pattern attribute to metadata plugins

### DIFF
--- a/beets/metadata_plugins.py
+++ b/beets/metadata_plugins.py
@@ -35,6 +35,7 @@ QueryType = Literal["album", "track"]
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator, Sequence
+    from typing import ClassVar
 
     from .autotag.hooks import AlbumInfo, Item, TrackInfo
 
@@ -178,6 +179,8 @@ class MetadataSourcePlugin(BeetsPlugin, metaclass=abc.ABCMeta):
 
     DEFAULT_DATA_SOURCE_MISMATCH_PENALTY = 0.5
 
+    id_extractor_pattern: ClassVar[re.Pattern[str] | None] = None
+
     @cached_classproperty
     def data_source(cls) -> str:
         """The data source name for this plugin.
@@ -278,6 +281,10 @@ class MetadataSourcePlugin(BeetsPlugin, metaclass=abc.ABCMeta):
         Uses the plugin's data source name to determine the ID format and
         extracts the ID from a given URL.
         """
+        if self.id_extractor_pattern:
+            if m := self.id_extractor_pattern.search(url):
+                return m[1]
+            return None
         return extract_release_id(self.data_source, url)
 
     @staticmethod

--- a/beets/util/id_extractors.py
+++ b/beets/util/id_extractors.py
@@ -17,34 +17,71 @@
 from __future__ import annotations
 
 import re
+from enum import Enum, auto
+from functools import cache
+
+from typing_extensions import override
 
 from beets import logging
 
 log = logging.getLogger("beets")
 
 
-PATTERN_BY_SOURCE = {
-    "spotify": re.compile(r"(?:^|open\.spotify\.com/[^/]+/)([0-9A-Za-z]{22})"),
-    "deezer": re.compile(r"(?:^|deezer\.com/)(?:[a-z]*/)?(?:[^/]+/)?(\d+)"),
-    "beatport": re.compile(r"(?:^|beatport\.com/release/.+/)(\d+)$"),
-    "musicbrainz": re.compile(r"(\w{8}(?:-\w{4}){3}-\w{12})"),
-    # - plain integer, optionally wrapped in brackets and prefixed by an
-    #   'r', as this is how discogs displays the release ID on its webpage.
-    # - legacy url format: discogs.com/<name of release>/release/<id>
-    # - legacy url short format: discogs.com/release/<id>
-    # - current url format: discogs.com/release/<id>-<name of release>
-    # See #291, #4080 and #4085 for the discussions leading up to these
-    # patterns.
-    "discogs": re.compile(
-        r"(?:^|\[?r|discogs\.com/(?:[^/]+/)?release/)(\d+)\b"
-    ),
-    # There is no such thing as a Bandcamp album or artist ID, the URL can be
-    # used as the identifier. The Bandcamp metadata source plugin works that way
-    # - https://github.com/snejus/beetcamp. Bandcamp album URLs usually look
-    # like: https://nameofartist.bandcamp.com/album/nameofalbum
-    "bandcamp": re.compile(r"(.+)"),
-    "tidal": re.compile(r"(?:^|tidal\.com/(?:browse/)?(?:album|track)/)(\d+)"),
-}
+class UrlSource(str, Enum):
+    @staticmethod
+    @override
+    def _generate_next_value_(
+        name: str, start: int, count: int, last_values: list[str]
+    ) -> str:
+        return name.lower()
+
+    DISCOGS = auto()
+    BANDCAMP = auto()
+    SPOTIFY = auto()
+    DEEZER = auto()
+    TIDAL = auto()
+    BEATPORT = auto()
+    MUSICBRAINZ = auto()
+
+    @classmethod
+    def _missing_(cls, value: object) -> UrlSource | None:
+        if isinstance(value, str):
+            value = value.lower()
+            for member in cls:
+                if member.value == value:
+                    return member
+        return None
+
+
+@cache
+def pattern_by_source(source: UrlSource) -> re.Pattern[str]:
+    match source:
+        case UrlSource.SPOTIFY:
+            pattern: str = r"(?:^|open\.spotify\.com/[^/]+/)([0-9A-Za-z]{22})"
+        case UrlSource.DEEZER:
+            pattern = r"(?:^|deezer\.com/)(?:[a-z]*/)?(?:[^/]+/)?(\d+)"
+        case UrlSource.BEATPORT:
+            pattern = r"(?:^|beatport\.com/release/.+/)(\d+)$"
+        case UrlSource.MUSICBRAINZ:
+            pattern = r"(\w{8}(?:-\w{4}){3}-\w{12})"
+        case UrlSource.DISCOGS:
+            # - plain integer, optionally wrapped in brackets and prefixed by an
+            #   'r', as this is how discogs displays the release ID on its webpage.
+            # - legacy url format: discogs.com/<name of release>/release/<id>
+            # - legacy url short format: discogs.com/release/<id>
+            # - current url format: discogs.com/release/<id>-<name of release>
+            # See #291, #4080 and #4085 for the discussions leading up to these
+            # patterns.
+            pattern = r"(?:^|\[?r|discogs\.com/(?:[^/]+/)?release/)(\d+)\b"
+        case UrlSource.BANDCAMP:
+            # There is no such thing as a Bandcamp album or artist ID, the URL can be
+            # used as the identifier. The Bandcamp metadata source plugin works that way
+            # - https://github.com/snejus/beetcamp. Bandcamp album URLs usually look
+            # like: https://nameofartist.bandcamp.com/album/nameofalbum
+            pattern = r"(.+)"
+        case UrlSource.TIDAL:
+            pattern = r"(?:^|tidal\.com/(?:browse/)?(?:album|track)/)(\d+)"
+    return re.compile(pattern)
 
 
 def extract_release_id(source: str, id_: str) -> str | None:
@@ -55,7 +92,7 @@ def extract_release_id(source: str, id_: str) -> str | None:
     `source` provided.
     """
     try:
-        source_pattern = PATTERN_BY_SOURCE[source.lower()]
+        source_pattern = pattern_by_source(UrlSource(source))
     except KeyError:
         log.debug(
             "Unknown source '{}' for ID extraction. Returning id/url as-is.",

--- a/beetsplug/musicbrainz.py
+++ b/beetsplug/musicbrainz.py
@@ -30,7 +30,7 @@ from beets import config, plugins, util
 from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.metadata_plugins import IDResponse, SearchApiMetadataSourcePlugin
 from beets.util.deprecation import deprecate_for_user
-from beets.util.id_extractors import extract_release_id
+from beets.util.id_extractors import UrlSource, extract_release_id
 
 from ._utils.musicbrainz import MusicBrainzAPIMixin
 from ._utils.requests import HTTPNotFoundError
@@ -78,11 +78,6 @@ BROWSE_INCLUDES = [
 ]
 BROWSE_CHUNKSIZE = 100
 BROWSE_MAXTRACKS = 500
-
-
-UrlSource = Literal[
-    "discogs", "bandcamp", "spotify", "deezer", "tidal", "beatport"
-]
 
 
 class ArtistInfo(TypedDict):
@@ -541,7 +536,7 @@ class MusicBrainzPlugin(
         """
         external_ids = self.config["external_ids"].get()
         wanted_sources: set[UrlSource] = {
-            site for site, wanted in external_ids.items() if wanted
+            UrlSource(site) for site, wanted in external_ids.items() if wanted
         }
         url_by_source: dict[UrlSource, str] = {}
         for source, url_relation in product(wanted_sources, url_relations):


### PR DESCRIPTION
## Description

Allows external `MetadataSourcePlugin`s to supply a custom pattern to be used in `_extract_id`.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
