### PR TITLE
Fix path format queries for multi-valued fields

### DIFF
--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -198,9 +198,7 @@ class MatchQuery(FieldQuery[AnySQLiteType]):
 
     @classmethod
     def value_match(cls, pattern: AnySQLiteType, value: Any) -> bool:
-        if isinstance(value, Sequence) and not isinstance(
-            value, (str, bytes, memoryview)
-        ):
+        if isinstance(value, list):
             return pattern in value
         return pattern == value
 
@@ -231,14 +229,12 @@ class StringFieldQuery(FieldQuery[P]):
         """Determine whether the value matches the pattern. The value
         may have any type.
         """
-        if isinstance(value, Sequence) and not isinstance(
-            value, (str, bytes, memoryview)
-        ):
-            return any(
-                cls.string_match(pattern, util.as_string(item))
-                for item in value
-            )
-        return cls.string_match(pattern, util.as_string(value))
+        if not isinstance(value, list):
+            value = [value]
+
+        return any(
+            cls.string_match(pattern, util.as_string(item)) for item in value
+        )
 
     @classmethod
     def string_match(

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -198,6 +198,10 @@ class MatchQuery(FieldQuery[AnySQLiteType]):
 
     @classmethod
     def value_match(cls, pattern: AnySQLiteType, value: Any) -> bool:
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, memoryview)
+        ):
+            return pattern in value
         return pattern == value
 
 
@@ -227,6 +231,13 @@ class StringFieldQuery(FieldQuery[P]):
         """Determine whether the value matches the pattern. The value
         may have any type.
         """
+        if isinstance(value, Sequence) and not isinstance(
+            value, (str, bytes, memoryview)
+        ):
+            return any(
+                cls.string_match(pattern, util.as_string(item))
+                for item in value
+            )
         return cls.string_match(pattern, util.as_string(value))
 
     @classmethod

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,9 @@ Bug fixes
 
 - :doc:`plugins/mbpseudo`: Fix crashes when applying a pseudo-release. One in
   ``PseudoAlbumInfo.raw_data`` and a ``sqlite3.ProgrammingError``.
+- Path format queries now correctly match multi-value fields such as
+  ``genres`` when using exact string matches like ``genres:=Classical`` or
+  ``genres:=~Classical``.
 
 ..
     For plugin developers

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,7 +30,7 @@ Bug fixes
   ``requests-oauthlib`` is installed. :bug:`6633`
 - Path format queries now correctly match multi-value fields such as ``genres``
   when using exact string matches like ``genres:=Classical`` or
-  ``genres:=~Classical``.
+  ``genres:=~Classical``. :bug:`6598`
 
 ..
     For plugin developers

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,8 +28,8 @@ Bug fixes
   when ``import.from_scratch`` is enabled. :bug:`6613`
 - :doc:`plugins/tidal`: add ``tidal`` dependency extra to make sure
   ``requests-oauthlib`` is installed. :bug:`6633`
-- Path format queries now correctly match multi-value fields such as
-  ``genres`` when using exact string matches like ``genres:=Classical`` or
+- Path format queries now correctly match multi-value fields such as ``genres``
+  when using exact string matches like ``genres:=Classical`` or
   ``genres:=~Classical``.
 
 ..

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -1187,6 +1187,9 @@ config file like this:
 will place soundtrack albums in a separate directory. The queries are tested in
 the order they appear in the configuration file, meaning that if an item matches
 multiple queries, beets will use the path format for the *first* matching query.
+Queries on multi-value fields, such as ``genres``, match each individual value,
+so an exact string query like ``genres:=Classical`` can match an item whose
+genres are ``Classical`` and ``Baroque`` without also matching ``Neoclassical``.
 
 Note that the special ``singleton`` and ``comp`` path format conditions are, in
 fact, just shorthand for the explicit queries ``singleton:true`` and

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -337,6 +337,33 @@ class DestinationTest(BeetsTestCase):
         self.lib.path_formats = [("default", "two"), ("comp:true", "three")]
         assert self.i.destination() == np("one/three")
 
+    def test_multi_value_string_query_path(self):
+        self.i.genres = ["Classical"]
+        self.lib.directory = b"one"
+        self.lib.path_formats = [
+            ("default", "two"),
+            ("genres:=~Classical", "three"),
+        ]
+        assert self.i.destination() == np("one/three")
+
+    def test_multi_value_match_query_path(self):
+        self.i.genres = ["Classical"]
+        self.lib.directory = b"one"
+        self.lib.path_formats = [
+            ("default", "two"),
+            ("genres:=Classical", "three"),
+        ]
+        assert self.i.destination() == np("one/three")
+
+    def test_multi_value_string_query_path_no_substring_match(self):
+        self.i.genres = ["Neoclassical"]
+        self.lib.directory = b"one"
+        self.lib.path_formats = [
+            ("default", "two"),
+            ("genres:=~Classical", "three"),
+        ]
+        assert self.i.destination() == np("one/two")
+
     def test_albumtype_query_path(self):
         self.i.comp = True
         self.lib.add_album([self.i])

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -272,7 +272,13 @@ class TestGet:
 class TestMatch:
     @pytest.fixture(scope="class")
     def item(self):
-        return _common.item(album="the album", disc=6, year=1, bitrate=128000)
+        return _common.item(
+            album="the album",
+            disc=6,
+            year=1,
+            bitrate=128000,
+            genres=["Classical", "Baroque"],
+        )
 
     @pytest.mark.parametrize(
         "q, should_match",
@@ -286,6 +292,10 @@ class TestMatch:
             (StringQuery("album", "the album"), True),
             (StringQuery("album", "THE ALBUM"), True),
             (StringQuery("album", "album"), False),
+            (MatchQuery("genres", "Classical"), True),
+            (MatchQuery("genres", "Neoclassical"), False),
+            (StringQuery("genres", "classical"), True),
+            (StringQuery("genres", "neoclassical"), False),
             (NumericQuery("year", "1"), True),
             (NumericQuery("year", "10"), False),
             (NumericQuery("bitrate", "100000..200000"), True),


### PR DESCRIPTION
## Description

Fixes #6598.


(...)

## To Do

the issue was that path format queries are evaluated against an in-memory Item using query.match(), where multi-valued fields such as genres are represented as lists, e.g. ["Classical"]. Before this change, string/exact matching treated that list as one whole value, so a path rule like genres:=~Classical: _Classical/... failed to match and fell back to the default path format, even though beet list genres:=~Classical worked through the database query path. This change updates in-memory matching so sequence-like field values are matched element by element, while excluding strings and byte-like values from sequence handling. I added regression tests for genres:=~Classical, genres:=Classical, avoiding a false positive for Neoclassical, and direct query.match() behavior on multi-valued fields. Manual verification showed the original version returned match: False and destination: ...\one\two, while the fixed version returns match: True and destination: ...\one\three.
-->
[yes]This is a bug fix for existing behavior and does not add or change user-facing configuration.
 [no]Changelog. I can add an entry after review if maintainers prefer.
 [yes]Tests.
## Summary

This fixes path format selection for multi-valued fields such as `genres`.

Path format queries are evaluated against an in-memory `Item` via `query.match()`.
For multi-valued fields, the in-memory value is a list, for example:

```python
genres = ["Classical"]
