### PR TITLE
Improve SearchApiMetadataSourcePlugin interface

### DIFF
--- a/beets/metadata_plugins.py
+++ b/beets/metadata_plugins.py
@@ -390,21 +390,24 @@ class SearchApiMetadataSourcePlugin(
         """
 
     @abc.abstractmethod
-    def get_search_response(self, params: SearchParams) -> Sequence[R]:
+    def get_search_response(
+        self, params: SearchParams
+    ) -> tuple[int, Iterable[R]]:
         """Fetch raw search results for a provider request.
 
         Implementations should return records containing source IDs so shared
         candidate resolution can perform ID-based album and track lookups.
 
         :param params: :py:namedtuple:`~SearchParams` named tuple
-        :return: Sequence of IDResponse dicts containing at least an "id" key for each
+        :return: Tuple of (``total`` number of results, ``results`` Iterable of
+        IDResponse dicts containing at least an "id" key for each)
         """
 
         raise NotImplementedError
 
     def _search_api(
         self, query_type: QueryType, query: str, filters: dict[str, str]
-    ) -> Sequence[R]:
+    ) -> tuple[int, Iterable[R]]:
         """Run shared provider search orchestration and return ID-bearing results.
 
         This path applies optional query normalization and default limits, then
@@ -419,27 +422,27 @@ class SearchApiMetadataSourcePlugin(
 
         self._log.debug("Searching for '{}' with {}", query, filters)
         try:
-            response_data = self.get_search_response(params)
+            total, response_data = self.get_search_response(params)
         except Exception as e:
             if config["raise_on_error"].get(bool):
                 raise
             self._log.error(
                 "Error searching {.data_source}: {}", self, e, exc_info=True
             )
-            return ()
+            return 0, ()
 
-        self._log.debug("Found {} result(s)", len(response_data))
-        return response_data
+        self._log.debug("Found {} result(s)", total)
+        return total, response_data
 
     def _get_candidates(
         self, query_type: QueryType, *args, **kwargs
-    ) -> Sequence[R]:
+    ) -> Iterable[R]:
         """Resolve query hooks and execute one provider search request."""
 
         return self._search_api(
             query_type,
             *self.get_search_query_with_filters(query_type, *args, **kwargs),
-        )
+        )[1]
 
     def get_candidates_from_results(
         self, results: Iterable[R]

--- a/beets/metadata_plugins.py
+++ b/beets/metadata_plugins.py
@@ -12,17 +12,11 @@ import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from functools import cache, cached_property, wraps
-from typing import (
-    TYPE_CHECKING,
-    Generic,
-    Literal,
-    NamedTuple,
-    TypedDict,
-    TypeVar,
-)
+from typing import TYPE_CHECKING, Generic, Literal, NamedTuple, TypeVar
 
 import unidecode
 from confuse import NotFoundError
+from typing_extensions import TypedDict
 
 from beets import config, logging
 from beets.util import cached_classproperty

--- a/beets/metadata_plugins.py
+++ b/beets/metadata_plugins.py
@@ -12,6 +12,7 @@ import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from functools import cache, cached_property, wraps
+from operator import itemgetter
 from typing import TYPE_CHECKING, Generic, Literal, NamedTuple, TypeVar
 
 import unidecode
@@ -440,6 +441,22 @@ class SearchApiMetadataSourcePlugin(
             *self.get_search_query_with_filters(query_type, *args, **kwargs),
         )
 
+    def get_candidates_from_results(
+        self, results: Iterable[R]
+    ) -> Iterable[AlbumInfo]:
+        """Convert results of album search queries to AlbumInfo objects"""
+        yield from filter(
+            None, self.albums_for_ids(map(itemgetter("id"), results))
+        )
+
+    def get_item_candidates_from_results(
+        self, results: Iterable[R]
+    ) -> Iterable[TrackInfo]:
+        """Convert results of track search queries to TrackInfo objects"""
+        yield from filter(
+            None, self.tracks_for_ids(map(itemgetter("id"), results))
+        )
+
     def candidates(
         self,
         items: Sequence[Item],
@@ -448,10 +465,10 @@ class SearchApiMetadataSourcePlugin(
         va_likely: bool,
     ) -> Iterable[AlbumInfo]:
         results = self._get_candidates("album", items, artist, album, va_likely)
-        return filter(None, self.albums_for_ids(r["id"] for r in results))
+        yield from self.get_candidates_from_results(results)
 
     def item_candidates(
         self, item: Item, artist: str, title: str
     ) -> Iterable[TrackInfo]:
         results = self._get_candidates("track", [item], artist, title, False)
-        return filter(None, self.tracks_for_ids(r["id"] for r in results))
+        yield from self.get_item_candidates_from_results(results)

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -238,7 +238,9 @@ class DeezerPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
 
         return query, {}
 
-    def get_search_response(self, params: SearchParams) -> list[IDResponse]:
+    def get_search_response(
+        self, params: SearchParams
+    ) -> tuple[int, list[IDResponse]]:
         """Search Deezer and return the raw result payload entries."""
 
         response = requests.get(
@@ -251,7 +253,8 @@ class DeezerPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
             timeout=10,
         )
         response.raise_for_status()
-        return response.json()["data"]
+        json = response.json()["data"]
+        return len(json), json
 
     def deezerupdate(self, items: Sequence[Item], write: bool):
         """Obtain rank information from Deezer."""

--- a/beetsplug/discogs/__init__.py
+++ b/beetsplug/discogs/__init__.py
@@ -306,11 +306,14 @@ class DiscogsPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
 
         return query, filters
 
-    def get_search_response(self, params: SearchParams) -> Sequence[IDResponse]:
+    def get_search_response(
+        self, params: SearchParams
+    ) -> tuple[int, Sequence[IDResponse]]:
         """Search Discogs releases and return raw result mappings with IDs."""
         results = self.discogs_client.search(params.query, **params.filters)
         results.per_page = params.limit
-        return [r.data for r in results.page(1)]
+        data = [r.data for r in results.page(1)]
+        return len(data), data
 
     @cache
     def get_master_year(self, master_id: str) -> int | None:

--- a/beetsplug/musicbrainz.py
+++ b/beetsplug/musicbrainz.py
@@ -761,15 +761,18 @@ class MusicBrainzPlugin(
             k: _v for k, v in criteria.items() if (_v := v.lower().strip())
         }
 
-    def get_search_response(self, params: SearchParams) -> Sequence[IDResponse]:
+    def get_search_response(
+        self, params: SearchParams
+    ) -> tuple[int, Sequence[IDResponse]]:
         """Search MusicBrainz and return release or recording result mappings."""
 
         mb_entity: Literal["release", "recording"] = (
             "release" if params.query_type == "album" else "recording"
         )
-        return self.mb_api.search(
+        results = self.mb_api.search(
             mb_entity, dict(params.filters), limit=params.limit
         )
+        return len(results), results
 
     def album_for_id(self, album_id: str) -> AlbumInfo | None:
         """Fetches an album by its MusicBrainz ID and returns an AlbumInfo

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -512,7 +512,7 @@ class SpotifyPlugin(
 
     def get_search_response(
         self, params: SearchParams
-    ) -> Sequence[SearchResponseAlbums | SearchResponseTracks]:
+    ) -> tuple[int, Sequence[SearchResponseAlbums | SearchResponseTracks]]:
         """Search Spotify and return raw album or track result items.
 
         Unauthorized responses trigger one token refresh attempt before the
@@ -537,14 +537,14 @@ class SpotifyPlugin(
                     self._authenticate()
                     continue
                 raise
-
-            return (
+            results = (
                 response.json()
                 .get(f"{params.query_type}s", {})
                 .get("items", [])
             )
+            return len(results), results
 
-        return ()
+        return 0, []
 
     def commands(self) -> list[ui.Subcommand]:
         # autotagger import command
@@ -663,7 +663,7 @@ class SpotifyPlugin(
             if album:
                 query += f" album:'{album}'"
 
-            response_data_tracks = self._search_api("track", query, {})
+            total, response_data_tracks = self._search_api("track", query, {})
             if not response_data_tracks:
                 failures.append(query)
                 continue
@@ -677,21 +677,18 @@ class SpotifyPlugin(
                     if region_filter in track_data["available_markets"]
                 ]
 
-            if (
-                len(response_data_tracks) == 1
-                or self.config["tiebreak"].get() == "first"
-            ):
+            if total == 1 or self.config["tiebreak"].get() == "first":
                 self._log.debug(
                     "{.data_source} track(s) found, count: {}",
                     self,
-                    len(response_data_tracks),
+                    total,
                 )
-                chosen_result = response_data_tracks[0]
+                chosen_result = next(iter(response_data_tracks))
             else:
                 # Use the popularity filter
                 self._log.debug(
                     "Most popular track chosen, count: {}",
-                    len(response_data_tracks),
+                    total,
                 )
                 chosen_result = max(
                     response_data_tracks,

--- a/test/test_metadata_plugins.py
+++ b/test/test_metadata_plugins.py
@@ -116,7 +116,7 @@ class TestSearchApiMetadataSourcePlugin(PluginMixin):
     ):
         config["raise_on_error"] = False
 
-        assert search_plugin._search_api("track", "query", {}) == ()
+        assert search_plugin._search_api("track", "query", {}) == (0, ())
         assert "Search failure" in caplog.text
 
     def test_search_api_raises_when_raise_on_error_enabled(


### PR DESCRIPTION
## Description

I'd like to refactor [beets-vocadb](https://github.com/prTopi/beets-vocadb/tree/experimental) to be a `SearchApiMetadataSourcePlugin`, but it serializes api responses to dataclass-like [msgspec structs](https://jcristharif.com/msgspec/structs.html) rather than TypedDicts, making it impossible to follow the class signature. Therefore, I removed the constraint from the type variable to allow plugin developers to use any type of data structure for search search results and instead have them implement custom logic to extract the id from a search result. For example, in beets-vocadb, I'd return `result.id` instead of `result["id"]`.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [ ] Tests. (Very much encouraged but not strictly required.)
