### PR TITLE
refactor: Pytest based setup for `test_art` and `test_embedart`

### DIFF
--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -878,11 +878,7 @@ class ImageRequestMocker:
             content = content.encode()
 
         self.mocker.get(
-            url,
-            headers={
-                "Content-Type": content_type,
-            },
-            content=content,
+            url, headers={"Content-Type": content_type}, content=content
         )
 
 

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -37,11 +37,10 @@ from enum import Enum
 from functools import cached_property
 from pathlib import Path
 from tempfile import gettempdir, mkdtemp, mkstemp
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 from unittest.mock import Mock, patch
 
 import pytest
-import responses
 from mediafile import Image, MediaFile
 
 import beets
@@ -58,6 +57,9 @@ from beets.util import (
     clean_module_tempdir,
     syspath,
 )
+
+if TYPE_CHECKING:
+    from requests_mock.mocker import Mocker
 
 
 class LogCapture(logging.Handler):
@@ -404,6 +406,8 @@ class BeetsTestCase(unittest.TestCase, TestHelper):
     modifications that will then be automatically removed when the test
     completes. Also provides some additional assertion methods, a
     temporary directory, and a DummyIO.
+
+    DEPRECATED: Use pytest + PytestTestHelper instead.
     """
 
     def setUp(self):
@@ -831,9 +835,10 @@ class AutotagImportTestCase(ImportTestCase):
 
 
 @dataclass(slots=True)
-class ImageResponseMocker:
-    responses_mock: responses.RequestsMock
+class ImageRequestMocker:
+    mocker: Mocker
 
+    # Image types and their file headers
     IMAGE_HEADERS: ClassVar[dict[str, bytes]] = {
         "image/jpeg": b"\xff\xd8\xff\x00\x00\x00JFIF",
         "image/png": b"\211PNG\r\n\032\n",
@@ -846,19 +851,21 @@ class ImageResponseMocker:
         ),
     }
 
-    def add(
+    def get(
         self,
         url: str,
         *,
         content_type: str = "image/jpeg",
         file_type: str | None = None,
-        body: str | bytes | None = None,
+        content: str | bytes | None = None,
     ) -> None:
         actual_file_type = file_type or content_type
 
-        if body is None:
+        if content is None:
             try:
-                body = self.IMAGE_HEADERS[actual_file_type].ljust(32, b"\x00")
+                content = self.IMAGE_HEADERS[actual_file_type].ljust(
+                    32, b"\x00"
+                )
             except KeyError as exc:
                 # If we can't return a file that looks like real file of the requested
                 # type, better fail the test than returning something else, which might
@@ -867,11 +874,15 @@ class ImageResponseMocker:
                     f"Mocking {actual_file_type!r} responses not supported"
                 ) from exc
 
-        self.responses_mock.add(
-            responses.GET,
+        if isinstance(content, str):
+            content = content.encode()
+
+        self.mocker.get(
             url,
-            content_type=content_type,
-            body=body,
+            headers={
+                "Content-Type": content_type,
+            },
+            content=content,
         )
 
 
@@ -879,11 +890,8 @@ class FetchImageHelper:
     """Pytest mixin providing image response mocking utilities."""
 
     @pytest.fixture
-    def image_response_mocker(self):
-        with responses.RequestsMock(
-            assert_all_requests_are_fired=False
-        ) as rsps:
-            yield ImageResponseMocker(rsps)
+    def image_request_mock(self, requests_mock):
+        return ImageRequestMocker(requests_mock)
 
 
 class CleanupModulesMixin:

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -413,6 +413,18 @@ class BeetsTestCase(unittest.TestCase, TestHelper):
         self.teardown_beets()
 
 
+class PytestTestHelper(TestHelper):
+    """Same as the BeetsTestCase unittest setup but for pytest."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.setup_beets()
+        try:
+            yield
+        finally:
+            self.teardown_beets()
+
+
 class ItemInDBTestCase(BeetsTestCase):
     """A test case that includes an in-memory library object (`lib`) and
     an item added to the library (`i`).

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -818,16 +818,11 @@ class AutotagImportTestCase(ImportTestCase):
         self.addCleanup(self.matcher.restore)
 
 
-class FetchImageHelper:
-    """Helper mixin for mocking requests when fetching images
-    with remote art sources.
-    """
+@dataclass(slots=True)
+class ImageResponseMocker:
+    responses_mock: responses.RequestsMock
 
-    @responses.activate
-    def run(self, *args, **kwargs):
-        super().run(*args, **kwargs)
-
-    IMAGEHEADER: ClassVar[dict[str, bytes]] = {
+    IMAGE_HEADERS: ClassVar[dict[str, bytes]] = {
         "image/jpeg": b"\xff\xd8\xff\x00\x00\x00JFIF",
         "image/png": b"\211PNG\r\n\032\n",
         "image/gif": b"GIF89a",
@@ -839,29 +834,44 @@ class FetchImageHelper:
         ),
     }
 
-    def mock_response(
+    def add(
         self,
         url: str,
+        *,
         content_type: str = "image/jpeg",
-        file_type: None | str = None,
+        file_type: str | None = None,
+        body: str | bytes | None = None,
     ) -> None:
-        # Potentially return a file of a type that differs from the
-        # server-advertised content type to mimic misbehaving servers.
-        if file_type is None:
-            file_type = content_type
+        actual_file_type = file_type or content_type
 
-        try:
-            # imghdr reads 32 bytes
-            header = self.IMAGEHEADER[file_type].ljust(32, b"\x00")
-        except KeyError:
-            # If we can't return a file that looks like real file of the requested
-            # type, better fail the test than returning something else, which might
-            # violate assumption made when writing a test.
-            raise AssertionError(f"Mocking {file_type} responses not supported")
+        if body is None:
+            try:
+                body = self.IMAGE_HEADERS[actual_file_type].ljust(32, b"\x00")
+            except KeyError as exc:
+                # If we can't return a file that looks like real file of the requested
+                # type, better fail the test than returning something else, which might
+                # violate assumption made when writing a test.
+                raise AssertionError(
+                    f"Mocking {actual_file_type!r} responses not supported"
+                ) from exc
 
-        responses.add(
-            responses.GET, url, content_type=content_type, body=header
+        self.responses_mock.add(
+            responses.GET,
+            url,
+            content_type=content_type,
+            body=body,
         )
+
+
+class FetchImageHelper:
+    """Pytest mixin providing image response mocking utilities."""
+
+    @pytest.fixture
+    def image_response_mocker(self):
+        with responses.RequestsMock(
+            assert_all_requests_are_fired=False
+        ) as rsps:
+            yield ImageResponseMocker(rsps)
 
 
 class CleanupModulesMixin:

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -85,11 +85,7 @@ class UseThePlugin(PytestTestHelper):
         # requests_mock.get("https://example.com/health", json={"status": "ok"})
 
         # Optional: disable any URL not explicitly mocked
-        requests_mock.register_uri(
-            ANYREEQUEST,
-            ANYREEQUEST,
-            exc=NoMockAddress,
-        )
+        requests_mock.register_uri(ANYREEQUEST, ANYREEQUEST, exc=NoMockAddress)
 
     @pytest.fixture(autouse=True, scope="class")
     def cleanup(self):
@@ -244,10 +240,7 @@ class TestFetchImage(UseThePlugin, FetchImageHelper):
     def test_jpeg_type_returns_path(
         self, source, candidate, settings, image_request_mock
     ) -> None:
-        image_request_mock.get(
-            self.URL,
-            content_type="image/jpeg",
-        )
+        image_request_mock.get(self.URL, content_type="image/jpeg")
         source.fetch_image(candidate, settings)
         assert candidate.path is not None
 
@@ -340,9 +333,7 @@ class TestFSArt(UseThePlugin):
 
     @patch("os.path.samefile")
     def test_is_candidate_fallback_os_error(
-        self,
-        mock_samefile,
-        source,
+        self, mock_samefile, source
     ) -> None:
         mock_samefile.side_effect = OSError("os error")
         fallback = os.path.join(self.temp_dir, b"a.jpg")
@@ -365,10 +356,7 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
         os.mkdir(syspath(dpath))
         return dpath
 
-    def test_main_interface_returns_amazon_art(
-        self,
-        image_request_mock,
-    ):
+    def test_main_interface_returns_amazon_art(self, image_request_mock):
         image_request_mock.get(self.AMAZON_URL)
         album = Album(asin=self.ASIN)
         candidate = self.plugin.art_for_album(album, None)
@@ -562,11 +550,7 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
         assert expected in caplog.messages[1]
 
     def test_itunesstore_fallback_match(
-        self,
-        source: fetchart.ITunesStore,
-        settings,
-        album,
-        image_request_mock,
+        self, source: fetchart.ITunesStore, settings, album, image_request_mock
     ):
         json = """{
                     "results":

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -655,59 +655,74 @@ class GoogleImageTest(UseThePlugin):
             next(self.source.get(album, self.settings, []))
 
 
-class CoverArtArchiveTest(UseThePlugin, CAAHelper):
-    def setUp(self):
-        super().setUp()
-        self.source = fetchart.CoverArtArchive(logger, self.plugin.config)
-        self.settings = Settings(maxwidth=0)
+class TestCoverArtArchive(UseThePlugin, FetchImageHelper, CAAData):
+    @pytest.fixture
+    def settings(self) -> Settings:
+        return Settings(maxwidth=0)
 
-    @responses.activate
-    def run(self, *args, **kwargs):
-        super().run(*args, **kwargs)
+    @pytest.fixture
+    def source(self) -> fetchart.CoverArtArchive:
+        return fetchart.CoverArtArchive(logger, self.plugin.config)
 
-    def test_caa_finds_image(self):
+    def test_caa_finds_image(
+        self,
+        source: fetchart.CoverArtArchive,
+        settings: Settings,
+        image_response_mocker: ImageResponseMocker,
+    ):
         album = _common.Bag(
             mb_albumid=self.MBID_RELASE, mb_releasegroupid=self.MBID_GROUP
         )
-        self.mock_caa_response(self.RELEASE_URL, self.RESPONSE_RELEASE)
-        self.mock_caa_response(self.GROUP_URL, self.RESPONSE_GROUP)
-        candidates = list(self.source.get(album, self.settings, []))
+        image_response_mocker.add(self.RELEASE_URL, body=self.RESPONSE_RELEASE)
+        image_response_mocker.add(self.GROUP_URL, body=self.RESPONSE_GROUP)
+        candidates = list(source.get(album, settings, []))
         assert len(candidates) == 3
-        assert len(responses.calls) == 2
-        assert responses.calls[0].request.url == self.RELEASE_URL
+        assert len(image_response_mocker.responses_mock.calls) == 2
+        assert (
+            image_response_mocker.responses_mock.calls[0].request.url
+            == self.RELEASE_URL
+        )
 
-    def test_fetchart_uses_caa_pre_sized_maxwidth_thumbs(self):
+    def test_fetchart_uses_caa_pre_sized_maxwidth_thumbs(
+        self,
+        source: fetchart.CoverArtArchive,
+        image_response_mocker: ImageResponseMocker,
+    ):
         # CAA provides pre-sized thumbnails of width 250px, 500px, and 1200px
         # We only test with one of them here
         maxwidth = 1200
-        self.settings = Settings(maxwidth=maxwidth)
+        settings = Settings(maxwidth=maxwidth)
 
         album = _common.Bag(
             mb_albumid=self.MBID_RELASE, mb_releasegroupid=self.MBID_GROUP
         )
-        self.mock_caa_response(self.RELEASE_URL, self.RESPONSE_RELEASE)
-        self.mock_caa_response(self.GROUP_URL, self.RESPONSE_GROUP)
-        candidates = list(self.source.get(album, self.settings, []))
+        image_response_mocker.add(self.RELEASE_URL, body=self.RESPONSE_RELEASE)
+        image_response_mocker.add(self.GROUP_URL, body=self.RESPONSE_GROUP)
+        candidates = list(source.get(album, settings, []))
         assert len(candidates) == 3
         for candidate in candidates:
             assert f"-{maxwidth}.jpg" in candidate.url
 
-    def test_caa_finds_image_if_maxwidth_is_set_and_thumbnails_is_empty(self):
+    def test_caa_finds_image_if_maxwidth_is_set_and_thumbnails_is_empty(
+        self,
+        source: fetchart.CoverArtArchive,
+        image_response_mocker: ImageResponseMocker,
+    ):
         # CAA provides pre-sized thumbnails of width 250px, 500px, and 1200px
         # We only test with one of them here
         maxwidth = 1200
-        self.settings = Settings(maxwidth=maxwidth)
+        settings = Settings(maxwidth=maxwidth)
 
         album = _common.Bag(
             mb_albumid=self.MBID_RELASE, mb_releasegroupid=self.MBID_GROUP
         )
-        self.mock_caa_response(
-            self.RELEASE_URL, self.RESPONSE_RELEASE_WITHOUT_THUMBNAILS
+        image_response_mocker.add(
+            self.RELEASE_URL, body=self.RESPONSE_RELEASE_WITHOUT_THUMBNAILS
         )
-        self.mock_caa_response(
-            self.GROUP_URL, self.RESPONSE_GROUP_WITHOUT_THUMBNAILS
+        image_response_mocker.add(
+            self.GROUP_URL, body=self.RESPONSE_GROUP_WITHOUT_THUMBNAILS
         )
-        candidates = list(self.source.get(album, self.settings, []))
+        candidates = list(source.get(album, settings, []))
         assert len(candidates) == 3
         for candidate in candidates:
             assert f"-{maxwidth}.jpg" not in candidate.url

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -523,8 +523,8 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
 
 
 class TestAAO(UseThePlugin, FetchImageHelper):
-    ASIN: str = "xxxx"
-    AAO_URL: str = f"https://www.albumart.org/index_detail.php?asin={ASIN}"
+    ASIN = "xxxx"
+    AAO_URL = f"https://www.albumart.org/index_detail.php?asin={ASIN}"
 
     @pytest.fixture
     def settings(self) -> Settings:

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -728,7 +728,7 @@ class TestCoverArtArchive(UseThePlugin, FetchImageHelper, CAAData):
             assert f"-{maxwidth}.jpg" not in candidate.url
 
 
-class FanartTVTest(UseThePlugin):
+class TestFanartTV(UseThePlugin, FetchImageHelper):
     RESPONSE_MULTIPLE = """{
         "name": "artistname",
         "mbid_id": "artistid",
@@ -786,56 +786,74 @@ class FanartTVTest(UseThePlugin):
     }"""
     RESPONSE_MALFORMED = "bla blup"
 
-    def setUp(self):
-        super().setUp()
-        self.source = fetchart.FanartTV(logger, self.plugin.config)
-        self.settings = Settings()
+    @pytest.fixture
+    def settings(self):
+        return Settings(maxwidth=0)
 
-    @responses.activate
-    def run(self, *args, **kwargs):
-        super().run(*args, **kwargs)
+    @pytest.fixture
+    def source(self):
+        return fetchart.FanartTV(logger, self.plugin.config)
 
-    def mock_response(self, url, json):
-        responses.add(
-            responses.GET, url, body=json, content_type="application/json"
-        )
-
-    def test_fanarttv_finds_image(self):
+    def test_fanarttv_finds_image(
+        self,
+        source: fetchart.FanartTV,
+        settings: Settings,
+        image_response_mocker: ImageResponseMocker,
+    ):
         album = _common.Bag(mb_releasegroupid="thereleasegroupid")
-        self.mock_response(
+        image_response_mocker.add(
             f"{fetchart.FanartTV.API_ALBUMS}thereleasegroupid",
-            self.RESPONSE_MULTIPLE,
+            body=self.RESPONSE_MULTIPLE,
+            content_type="application/json",
         )
-        candidate = next(self.source.get(album, self.settings, []))
+        candidate = next(source.get(album, settings, []))
         assert candidate.url == "http://example.com/1.jpg"
 
-    def test_fanarttv_returns_no_result_when_error_received(self):
+    def test_fanarttv_returns_no_result_when_error_received(
+        self,
+        source: fetchart.FanartTV,
+        settings: Settings,
+        image_response_mocker: ImageResponseMocker,
+    ):
         album = _common.Bag(mb_releasegroupid="thereleasegroupid")
-        self.mock_response(
+        image_response_mocker.add(
             f"{fetchart.FanartTV.API_ALBUMS}thereleasegroupid",
-            self.RESPONSE_ERROR,
+            body=self.RESPONSE_ERROR,
+            content_type="application/json",
         )
         with pytest.raises(StopIteration):
-            next(self.source.get(album, self.settings, []))
+            next(source.get(album, settings, []))
 
-    def test_fanarttv_returns_no_result_with_malformed_response(self):
+    def test_fanarttv_returns_no_result_with_malformed_response(
+        self,
+        source: fetchart.FanartTV,
+        settings: Settings,
+        image_response_mocker: ImageResponseMocker,
+    ):
         album = _common.Bag(mb_releasegroupid="thereleasegroupid")
-        self.mock_response(
+        image_response_mocker.add(
             f"{fetchart.FanartTV.API_ALBUMS}thereleasegroupid",
-            self.RESPONSE_MALFORMED,
+            body=self.RESPONSE_MALFORMED,
+            content_type="application/json",
         )
         with pytest.raises(StopIteration):
-            next(self.source.get(album, self.settings, []))
+            next(source.get(album, settings, []))
 
-    def test_fanarttv_only_other_images(self):
+    def test_fanarttv_only_other_images(
+        self,
+        source: fetchart.FanartTV,
+        settings: Settings,
+        image_response_mocker: ImageResponseMocker,
+    ):
         # The source used to fail when there were images present, but no cover
         album = _common.Bag(mb_releasegroupid="thereleasegroupid")
-        self.mock_response(
+        image_response_mocker.add(
             f"{fetchart.FanartTV.API_ALBUMS}thereleasegroupid",
-            self.RESPONSE_NO_ART,
+            body=self.RESPONSE_NO_ART,
+            content_type="application/json",
         )
         with pytest.raises(StopIteration):
-            next(self.source.get(album, self.settings, []))
+            next(source.get(album, settings, []))
 
 
 class ArtImporterTest(UseThePlugin):

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -29,6 +29,7 @@ import responses
 from beets import config, importer, logging, util
 from beets.autotag.distance import Distance
 from beets.autotag.hooks import AlbumInfo, AlbumMatch
+from beets.library import Album
 from beets.test import _common
 from beets.test.helper import FetchImageHelper, TestHelper
 from beets.util import clean_module_tempdir, syspath
@@ -37,15 +38,15 @@ from beetsplug import fetchart
 
 logger = logging.getLogger("beets.test_art")
 
+
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
     from unittest.mock import MagicMock
 
-    from beets.library import Album
     from beets.test.helper import ImageResponseMocker
 
 
-class Settings:
+class Settings(fetchart.FetchArtPlugin):
     """Used to pass settings to the ArtSources when the plugin isn't fully
     instantiated.
     """
@@ -258,6 +259,7 @@ class TestFetchImage(UseThePlugin, FetchImageHelper):
     ) -> None:
         image_response_mocker.add(self.URL, content_type="image/png")
         source.fetch_image(candidate, settings)
+        assert candidate.path is not None
         assert os.path.splitext(candidate.path)[1] == b".png"
         assert Path(os.fsdecode(candidate.path)).exists()
 
@@ -272,6 +274,7 @@ class TestFetchImage(UseThePlugin, FetchImageHelper):
             self.URL, content_type="image/jpeg", file_type="image/png"
         )
         source.fetch_image(candidate, settings)
+        assert candidate.path is not None
         assert os.path.splitext(candidate.path)[1] == b".png"
         assert Path(os.fsdecode(candidate.path)).exists()
 
@@ -298,7 +301,7 @@ class TestFSArt(UseThePlugin):
         settings: Settings,
     ) -> None:
         _common.touch(os.path.join(dpath, b"a.jpg"))
-        candidate = next(source.get(None, settings, [dpath]))
+        candidate = next(source.get(Album(), settings, [dpath]))
         assert candidate.path == os.path.join(dpath, b"a.jpg")
 
     def test_appropriately_named_file_takes_precedence(
@@ -309,7 +312,7 @@ class TestFSArt(UseThePlugin):
     ) -> None:
         _common.touch(os.path.join(dpath, b"a.jpg"))
         _common.touch(os.path.join(dpath, b"art.jpg"))
-        candidate = next(source.get(None, settings, [dpath]))
+        candidate = next(source.get(Album(), settings, [dpath]))
         assert candidate.path == os.path.join(dpath, b"art.jpg")
 
     def test_non_image_file_not_identified(
@@ -320,7 +323,7 @@ class TestFSArt(UseThePlugin):
     ) -> None:
         _common.touch(os.path.join(dpath, b"a.txt"))
         with pytest.raises(StopIteration):
-            next(source.get(None, settings, [dpath]))
+            next(source.get(Album(), settings, [dpath]))
 
     def test_cautious_skips_fallback(
         self,
@@ -331,7 +334,7 @@ class TestFSArt(UseThePlugin):
         _common.touch(os.path.join(dpath, b"a.jpg"))
         settings.cautious = True
         with pytest.raises(StopIteration):
-            next(source.get(None, settings, [dpath]))
+            next(source.get(Album(), settings, [dpath]))
 
     def test_configured_fallback_is_used(
         self,
@@ -341,8 +344,8 @@ class TestFSArt(UseThePlugin):
     ) -> None:
         fallback = os.path.join(self.temp_dir, b"a.jpg")
         _common.touch(fallback)
-        settings.fallback = fallback
-        candidate = next(source.get(None, settings, [dpath]))
+        settings.fallback = fallback  # type: ignore
+        candidate = next(source.get(Album(), settings, [dpath]))
         assert candidate.path == fallback
 
     def test_empty_dir(
@@ -352,7 +355,7 @@ class TestFSArt(UseThePlugin):
         settings: Settings,
     ) -> None:
         with pytest.raises(StopIteration):
-            next(source.get(None, settings, [dpath]))
+            next(source.get(Album(), settings, [dpath]))
 
     def test_precedence_amongst_correct_files(
         self,
@@ -364,9 +367,10 @@ class TestFSArt(UseThePlugin):
         paths = [os.path.join(dpath, i) for i in images]
         for p in paths:
             _common.touch(p)
-        settings.cover_names = ["cover", "front", "back"]
+        settings.cover_names = [b"cover", b"front", b"back"]
         candidates = [
-            candidate.path for candidate in source.get(None, settings, [dpath])
+            candidate.path
+            for candidate in source.get(Album(), settings, [dpath])
         ]
         assert candidates == paths
 
@@ -378,7 +382,7 @@ class TestFSArt(UseThePlugin):
     ) -> None:
         mock_samefile.side_effect = OSError("os error")
         fallback = os.path.join(self.temp_dir, b"a.jpg")
-        self.plugin.fallback = fallback
+        self.plugin.fallback = str(fallback)
         candidate = fetchart.Candidate(logger, source.ID, fallback)
         result = self.plugin._is_candidate_fallback(candidate)
         mock_samefile.assert_called_once()
@@ -402,12 +406,12 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
         image_response_mocker: ImageResponseMocker,
     ):
         image_response_mocker.add(self.AMAZON_URL)
-        album = _common.Bag(asin=self.ASIN)
+        album = Album(asin=self.ASIN)
         candidate = self.plugin.art_for_album(album, None)
         assert candidate is not None
 
     def test_main_interface_returns_none_for_missing_asin_and_path(self):
-        album = _common.Bag()
+        album = Album()
         candidate = self.plugin.art_for_album(album, None)
         assert candidate is None
 
@@ -418,7 +422,7 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
     ):
         _common.touch(os.path.join(dpath, b"art.jpg"))
         image_response_mocker.add(self.AMAZON_URL)
-        album = _common.Bag(asin=self.ASIN)
+        album = Album(asin=self.ASIN)
         candidate = self.plugin.art_for_album(album, [dpath])
         assert candidate is not None
         assert candidate.path == os.path.join(dpath, b"art.jpg")
@@ -429,7 +433,7 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
         image_response_mocker: ImageResponseMocker,
     ):
         image_response_mocker.add(self.AMAZON_URL)
-        album = _common.Bag(asin=self.ASIN)
+        album = Album(asin=self.ASIN)
         candidate = self.plugin.art_for_album(album, [dpath])
         assert candidate is not None
         assert not candidate.path.startswith(dpath)
@@ -440,7 +444,7 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
         image_response_mocker: ImageResponseMocker,
     ):
         image_response_mocker.add(self.AMAZON_URL)
-        album = _common.Bag(asin=self.ASIN)
+        album = Album(asin=self.ASIN)
         self.plugin.art_for_album(album, [dpath])
         assert len(image_response_mocker.responses_mock.calls) == 1
         assert (
@@ -454,7 +458,7 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
         image_response_mocker: ImageResponseMocker,
     ):
         image_response_mocker.add(self.AMAZON_URL, content_type="text/html")
-        album = _common.Bag(asin=self.ASIN)
+        album = Album(asin=self.ASIN)
         self.plugin.art_for_album(album, [dpath])
         assert (
             image_response_mocker.responses_mock.calls[-1].request.url
@@ -475,7 +479,7 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
             "http://coverartarchive.org/release/rid/12345.jpg",
             content_type="image/jpeg",
         )
-        album = _common.Bag(
+        album = Album(
             mb_albumid=self.MBID_RELASE,
             mb_releasegroupid=self.MBID_GROUP,
             asin=self.ASIN,
@@ -492,7 +496,7 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
         self,
         image_response_mocker: ImageResponseMocker,
     ):
-        album = _common.Bag(mb_albumid=self.MBID, asin=self.ASIN)
+        album = Album(mb_albumid=self.MBID, asin=self.ASIN)
         self.plugin.art_for_album(album, None, local_only=True)
         assert len(image_response_mocker.responses_mock.calls) == 0
 
@@ -502,7 +506,7 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
         image_response_mocker: ImageResponseMocker,
     ):
         _common.touch(os.path.join(dpath, b"art.jpg"))
-        album = _common.Bag(mb_albumid=self.MBID, asin=self.ASIN)
+        album = Album(mb_albumid=self.MBID, asin=self.ASIN)
         candidate = self.plugin.art_for_album(album, [dpath], local_only=True)
         assert candidate is not None
         assert candidate.path == os.path.join(dpath, b"art.jpg")
@@ -537,7 +541,7 @@ class TestAAO(UseThePlugin, FetchImageHelper):
         image_response_mocker.add(
             self.AAO_URL, body=body, content_type="text/html"
         )
-        album = _common.Bag(asin=self.ASIN)
+        album = Album(asin=self.ASIN)
         candidate = next(source.get(album, settings, []))
         assert candidate.url == "TARGET_URL"
 
@@ -550,7 +554,7 @@ class TestAAO(UseThePlugin, FetchImageHelper):
         image_response_mocker.add(
             self.AAO_URL, body="blah blah", content_type="text/html"
         )
-        album = _common.Bag(asin=self.ASIN)
+        album = Album(asin=self.ASIN)
         with pytest.raises(StopIteration):
             next(source.get(album, settings, []))
 
@@ -566,13 +570,13 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
 
     @pytest.fixture
     def album(self):
-        return _common.Bag(albumartist="some artist", album="some album")
+        return Album(albumartist="some artist", album="some album")
 
     def test_itunesstore_finds_image(
         self,
         source: fetchart.ITunesStore,
         settings: Settings,
-        album: _common.Bag,
+        album,
         image_response_mocker: ImageResponseMocker,
     ):
         json = """{
@@ -598,7 +602,7 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
         self,
         source: fetchart.ITunesStore,
         settings: Settings,
-        album: _common.Bag,
+        album: Album,
         image_response_mocker: ImageResponseMocker,
         caplog: pytest.LogCaptureFixture,
     ):
@@ -619,7 +623,7 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
         self,
         source: fetchart.ITunesStore,
         settings: Settings,
-        album: _common.Bag,
+        album: Album,
         image_response_mocker: ImageResponseMocker,
         caplog: pytest.LogCaptureFixture,
     ):
@@ -640,7 +644,7 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
         self,
         source: fetchart.ITunesStore,
         settings: Settings,
-        album: _common.Bag,
+        album: Album,
         image_response_mocker: ImageResponseMocker,
     ):
         json = """{
@@ -665,7 +669,7 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
         self,
         source: fetchart.ITunesStore,
         settings: Settings,
-        album: _common.Bag,
+        album: Album,
         image_response_mocker: ImageResponseMocker,
         caplog: pytest.LogCaptureFixture,
     ):
@@ -694,7 +698,7 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
         self,
         source: fetchart.ITunesStore,
         settings: Settings,
-        album: _common.Bag,
+        album: Album,
         image_response_mocker: ImageResponseMocker,
         caplog: pytest.LogCaptureFixture,
     ):
@@ -715,7 +719,7 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
         self,
         source: fetchart.ITunesStore,
         settings: Settings,
-        album: _common.Bag,
+        album: Album,
         image_response_mocker: ImageResponseMocker,
         caplog: pytest.LogCaptureFixture,
     ):
@@ -748,7 +752,7 @@ class TestGoogleImage(UseThePlugin, FetchImageHelper):
         settings: Settings,
         image_response_mocker: ImageResponseMocker,
     ):
-        album = _common.Bag(albumartist="some artist", album="some album")
+        album = Album(albumartist="some artist", album="some album")
         json = '{"items": [{"link": "url_to_the_image"}]}'
         image_response_mocker.add(
             fetchart.GoogleImages.URL,
@@ -764,7 +768,7 @@ class TestGoogleImage(UseThePlugin, FetchImageHelper):
         settings: Settings,
         image_response_mocker: ImageResponseMocker,
     ):
-        album = _common.Bag(albumartist="some artist", album="some album")
+        album = Album(albumartist="some artist", album="some album")
         json = '{"error": {"errors": [{"reason": "some reason"}]}}'
         image_response_mocker.add(
             fetchart.GoogleImages.URL,
@@ -780,7 +784,7 @@ class TestGoogleImage(UseThePlugin, FetchImageHelper):
         settings: Settings,
         image_response_mocker: ImageResponseMocker,
     ):
-        album = _common.Bag(albumartist="some artist", album="some album")
+        album = Album(albumartist="some artist", album="some album")
         json = """bla blup"""
         image_response_mocker.add(
             fetchart.GoogleImages.URL,
@@ -806,7 +810,7 @@ class TestCoverArtArchive(UseThePlugin, FetchImageHelper, CAAData):
         settings: Settings,
         image_response_mocker: ImageResponseMocker,
     ):
-        album = _common.Bag(
+        album = Album(
             mb_albumid=self.MBID_RELASE, mb_releasegroupid=self.MBID_GROUP
         )
         image_response_mocker.add(self.RELEASE_URL, body=self.RESPONSE_RELEASE)
@@ -829,7 +833,7 @@ class TestCoverArtArchive(UseThePlugin, FetchImageHelper, CAAData):
         maxwidth = 1200
         settings = Settings(maxwidth=maxwidth)
 
-        album = _common.Bag(
+        album = Album(
             mb_albumid=self.MBID_RELASE, mb_releasegroupid=self.MBID_GROUP
         )
         image_response_mocker.add(self.RELEASE_URL, body=self.RESPONSE_RELEASE)
@@ -837,6 +841,7 @@ class TestCoverArtArchive(UseThePlugin, FetchImageHelper, CAAData):
         candidates = list(source.get(album, settings, []))
         assert len(candidates) == 3
         for candidate in candidates:
+            assert candidate.url is not None
             assert f"-{maxwidth}.jpg" in candidate.url
 
     def test_caa_finds_image_if_maxwidth_is_set_and_thumbnails_is_empty(
@@ -849,7 +854,7 @@ class TestCoverArtArchive(UseThePlugin, FetchImageHelper, CAAData):
         maxwidth = 1200
         settings = Settings(maxwidth=maxwidth)
 
-        album = _common.Bag(
+        album = Album(
             mb_albumid=self.MBID_RELASE, mb_releasegroupid=self.MBID_GROUP
         )
         image_response_mocker.add(
@@ -861,6 +866,7 @@ class TestCoverArtArchive(UseThePlugin, FetchImageHelper, CAAData):
         candidates = list(source.get(album, settings, []))
         assert len(candidates) == 3
         for candidate in candidates:
+            assert candidate.url is not None
             assert f"-{maxwidth}.jpg" not in candidate.url
 
 
@@ -936,7 +942,7 @@ class TestFanartTV(UseThePlugin, FetchImageHelper):
         settings: Settings,
         image_response_mocker: ImageResponseMocker,
     ):
-        album = _common.Bag(mb_releasegroupid="thereleasegroupid")
+        album: Album = Album(mb_releasegroupid="thereleasegroupid")
         image_response_mocker.add(
             f"{fetchart.FanartTV.API_ALBUMS}thereleasegroupid",
             body=self.RESPONSE_MULTIPLE,
@@ -951,7 +957,7 @@ class TestFanartTV(UseThePlugin, FetchImageHelper):
         settings: Settings,
         image_response_mocker: ImageResponseMocker,
     ):
-        album = _common.Bag(mb_releasegroupid="thereleasegroupid")
+        album = Album(mb_releasegroupid="thereleasegroupid")
         image_response_mocker.add(
             f"{fetchart.FanartTV.API_ALBUMS}thereleasegroupid",
             body=self.RESPONSE_ERROR,
@@ -966,7 +972,7 @@ class TestFanartTV(UseThePlugin, FetchImageHelper):
         settings: Settings,
         image_response_mocker: ImageResponseMocker,
     ):
-        album = _common.Bag(mb_releasegroupid="thereleasegroupid")
+        album = Album(mb_releasegroupid="thereleasegroupid")
         image_response_mocker.add(
             f"{fetchart.FanartTV.API_ALBUMS}thereleasegroupid",
             body=self.RESPONSE_MALFORMED,
@@ -982,7 +988,7 @@ class TestFanartTV(UseThePlugin, FetchImageHelper):
         image_response_mocker: ImageResponseMocker,
     ):
         # The source used to fail when there were images present, but no cover
-        album = _common.Bag(mb_releasegroupid="thereleasegroupid")
+        album = Album(mb_releasegroupid="thereleasegroupid")
         image_response_mocker.add(
             f"{fetchart.FanartTV.API_ALBUMS}thereleasegroupid",
             body=self.RESPONSE_NO_ART,
@@ -1129,7 +1135,7 @@ class AlbumArtOperationMixin(UseThePlugin):
             yield
 
     def get_album_art(self):
-        return self.plugin.art_for_album(_common.Bag(), [""], True)
+        return self.plugin.art_for_album(Album(), [""], True)
 
 
 class TestAlbumArtOperationConfiguration(AlbumArtOperationMixin):

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -211,8 +211,7 @@ class CAAData:
     }"""
 
 
-
-class TestFetchImage(FetchImageTestCase):
+class TestFetchImage(UseThePlugin, FetchImageHelper):
     URL: str = "http://example.com/test.jpg"
 
     @pytest.fixture
@@ -232,8 +231,9 @@ class TestFetchImage(FetchImageTestCase):
         source: DummyRemoteArtSource,
         candidate: fetchart.Candidate,
         settings: Settings,
+        image_response_mocker: ImageResponseMocker,
     ) -> None:
-        self.mock_response(self.URL, "image/watercolour")
+        image_response_mocker.add(self.URL, content_type="image/watercolour")
         source.fetch_image(candidate, settings)
         assert candidate.path is None
 
@@ -242,8 +242,9 @@ class TestFetchImage(FetchImageTestCase):
         source: DummyRemoteArtSource,
         candidate: fetchart.Candidate,
         settings: Settings,
+        image_response_mocker: ImageResponseMocker,
     ) -> None:
-        self.mock_response(self.URL, "image/jpeg")
+        image_response_mocker.add(self.URL, content_type="image/jpeg")
         source.fetch_image(candidate, settings)
         assert candidate.path is not None
 
@@ -252,8 +253,9 @@ class TestFetchImage(FetchImageTestCase):
         source: DummyRemoteArtSource,
         candidate: fetchart.Candidate,
         settings: Settings,
+        image_response_mocker: ImageResponseMocker,
     ) -> None:
-        self.mock_response(self.URL, "image/png")
+        image_response_mocker.add(self.URL, content_type="image/png")
         source.fetch_image(candidate, settings)
         assert os.path.splitext(candidate.path)[1] == b".png"
         assert Path(os.fsdecode(candidate.path)).exists()
@@ -263,8 +265,11 @@ class TestFetchImage(FetchImageTestCase):
         source: DummyRemoteArtSource,
         candidate: fetchart.Candidate,
         settings: Settings,
+        image_response_mocker: ImageResponseMocker,
     ) -> None:
-        self.mock_response(self.URL, "image/jpeg", "image/png")
+        image_response_mocker.add(
+            self.URL, content_type="image/jpeg", file_type="image/png"
+        )
         source.fetch_image(candidate, settings)
         assert os.path.splitext(candidate.path)[1] == b".png"
         assert Path(os.fsdecode(candidate.path)).exists()

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -290,68 +290,110 @@ class TestFetchImage(FetchImageTestCase):
         assert Path(os.fsdecode(candidate.path)).exists()
 
 
-class FSArtTest(UseThePlugin):
-    def setUp(self):
-        super().setUp()
-        self.dpath = os.path.join(self.temp_dir, b"arttest")
-        os.mkdir(syspath(self.dpath))
+class TestFSArt(UseThePlugin):
+    @pytest.fixture
+    def settings(self) -> Settings:
+        return Settings(cautious=False, cover_names=("art",), fallback=None)
 
-        self.source = fetchart.FileSystem(logger, self.plugin.config)
-        self.settings = Settings(
-            cautious=False, cover_names=("art",), fallback=None
-        )
+    @pytest.fixture
+    def dpath(self) -> bytes:
+        dpath = os.path.join(self.temp_dir, b"arttest")
+        os.mkdir(syspath(dpath))
+        return dpath
 
-    def test_finds_jpg_in_directory(self):
-        _common.touch(os.path.join(self.dpath, b"a.jpg"))
-        candidate = next(self.source.get(None, self.settings, [self.dpath]))
-        assert candidate.path == os.path.join(self.dpath, b"a.jpg")
+    @pytest.fixture
+    def source(self) -> fetchart.FileSystem:
+        return fetchart.FileSystem(logger, self.plugin.config)
 
-    def test_appropriately_named_file_takes_precedence(self):
-        _common.touch(os.path.join(self.dpath, b"a.jpg"))
-        _common.touch(os.path.join(self.dpath, b"art.jpg"))
-        candidate = next(self.source.get(None, self.settings, [self.dpath]))
-        assert candidate.path == os.path.join(self.dpath, b"art.jpg")
+    def test_finds_jpg_in_directory(
+        self,
+        source: fetchart.FileSystem,
+        dpath: bytes,
+        settings: Settings,
+    ) -> None:
+        _common.touch(os.path.join(dpath, b"a.jpg"))
+        candidate = next(source.get(None, settings, [dpath]))
+        assert candidate.path == os.path.join(dpath, b"a.jpg")
 
-    def test_non_image_file_not_identified(self):
-        _common.touch(os.path.join(self.dpath, b"a.txt"))
+    def test_appropriately_named_file_takes_precedence(
+        self,
+        source: fetchart.FileSystem,
+        dpath: bytes,
+        settings: Settings,
+    ) -> None:
+        _common.touch(os.path.join(dpath, b"a.jpg"))
+        _common.touch(os.path.join(dpath, b"art.jpg"))
+        candidate = next(source.get(None, settings, [dpath]))
+        assert candidate.path == os.path.join(dpath, b"art.jpg")
+
+    def test_non_image_file_not_identified(
+        self,
+        source: fetchart.FileSystem,
+        dpath: bytes,
+        settings: Settings,
+    ) -> None:
+        _common.touch(os.path.join(dpath, b"a.txt"))
         with pytest.raises(StopIteration):
-            next(self.source.get(None, self.settings, [self.dpath]))
+            next(source.get(None, settings, [dpath]))
 
-    def test_cautious_skips_fallback(self):
-        _common.touch(os.path.join(self.dpath, b"a.jpg"))
-        self.settings.cautious = True
+    def test_cautious_skips_fallback(
+        self,
+        source: fetchart.FileSystem,
+        dpath: bytes,
+        settings: Settings,
+    ) -> None:
+        _common.touch(os.path.join(dpath, b"a.jpg"))
+        settings.cautious = True
         with pytest.raises(StopIteration):
-            next(self.source.get(None, self.settings, [self.dpath]))
+            next(source.get(None, settings, [dpath]))
 
-    def test_configured_fallback_is_used(self):
+    def test_configured_fallback_is_used(
+        self,
+        source: fetchart.FileSystem,
+        dpath: bytes,
+        settings: Settings,
+    ) -> None:
         fallback = os.path.join(self.temp_dir, b"a.jpg")
         _common.touch(fallback)
-        self.settings.fallback = fallback
-        candidate = next(self.source.get(None, self.settings, [self.dpath]))
+        settings.fallback = fallback
+        candidate = next(source.get(None, settings, [dpath]))
         assert candidate.path == fallback
 
-    def test_empty_dir(self):
+    def test_empty_dir(
+        self,
+        source: fetchart.FileSystem,
+        dpath: bytes,
+        settings: Settings,
+    ) -> None:
         with pytest.raises(StopIteration):
-            next(self.source.get(None, self.settings, [self.dpath]))
+            next(source.get(None, settings, [dpath]))
 
-    def test_precedence_amongst_correct_files(self):
+    def test_precedence_amongst_correct_files(
+        self,
+        source: fetchart.FileSystem,
+        dpath: bytes,
+        settings: Settings,
+    ) -> None:
         images = [b"front-cover.jpg", b"front.jpg", b"back.jpg"]
-        paths = [os.path.join(self.dpath, i) for i in images]
+        paths = [os.path.join(dpath, i) for i in images]
         for p in paths:
             _common.touch(p)
-        self.settings.cover_names = ["cover", "front", "back"]
+        settings.cover_names = ["cover", "front", "back"]
         candidates = [
-            candidate.path
-            for candidate in self.source.get(None, self.settings, [self.dpath])
+            candidate.path for candidate in source.get(None, settings, [dpath])
         ]
         assert candidates == paths
 
     @patch("os.path.samefile")
-    def test_is_candidate_fallback_os_error(self, mock_samefile):
+    def test_is_candidate_fallback_os_error(
+        self,
+        mock_samefile,
+        source: fetchart.FileSystem,
+    ) -> None:
         mock_samefile.side_effect = OSError("os error")
         fallback = os.path.join(self.temp_dir, b"a.jpg")
         self.plugin.fallback = fallback
-        candidate = fetchart.Candidate(logger, self.source.ID, fallback)
+        candidate = fetchart.Candidate(logger, source.ID, fallback)
         result = self.plugin._is_candidate_fallback(candidate)
         mock_samefile.assert_called_once()
         assert not result

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import os
 import shutil
-import unittest
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import patch
@@ -31,7 +30,7 @@ from beets import config, importer, logging, util
 from beets.autotag.distance import Distance
 from beets.autotag.hooks import AlbumInfo, AlbumMatch
 from beets.test import _common
-from beets.test.helper import CleanupModulesMixin, FetchImageHelper, TestHelper
+from beets.test.helper import FetchImageHelper, TestHelper
 from beets.util import clean_module_tempdir, syspath
 from beets.util.artresizer import ArtResizer
 from beetsplug import fetchart
@@ -40,8 +39,10 @@ logger = logging.getLogger("beets.test_art")
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
+    from unittest.mock import MagicMock
 
     from beets.library import Album
+    from beets.test.helper import ImageResponseMocker
 
 
 class Settings:
@@ -524,6 +525,7 @@ class TestAAO(UseThePlugin, FetchImageHelper):
         self,
         source: fetchart.AlbumArtOrg,
         settings: Settings,
+        image_response_mocker: ImageResponseMocker,
     ) -> None:
         body = """
         <br />
@@ -532,7 +534,9 @@ class TestAAO(UseThePlugin, FetchImageHelper):
         <img src="http://www.albumart.org/images/zoom-icon.jpg"
              alt="View larger image" width="17" height="15" border="0"/></a>
         """
-        self.mock_response(self.AAO_URL, body=body, content_type="text/html")
+        image_response_mocker.add(
+            self.AAO_URL, body=body, content_type="text/html"
+        )
         album = _common.Bag(asin=self.ASIN)
         candidate = next(source.get(album, settings, []))
         assert candidate.url == "TARGET_URL"
@@ -541,8 +545,9 @@ class TestAAO(UseThePlugin, FetchImageHelper):
         self,
         source: fetchart.AlbumArtOrg,
         settings: Settings,
+        image_response_mocker: ImageResponseMocker,
     ) -> None:
-        self.mock_response(
+        image_response_mocker.add(
             self.AAO_URL, body="blah blah", content_type="text/html"
         )
         album = _common.Bag(asin=self.ASIN)

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -232,39 +232,62 @@ class CAAHelper:
         )
 
 
-class FetchImageTest(FetchImageTestCase):
-    URL = "http://example.com/test.jpg"
+class TestFetchImage(FetchImageTestCase):
+    URL: str = "http://example.com/test.jpg"
 
-    def setUp(self):
-        super().setUp()
-        self.dpath = os.path.join(self.temp_dir, b"arttest")
-        self.source = DummyRemoteArtSource(logger, self.plugin.config)
-        self.settings = Settings(maxwidth=0)
-        self.candidate = fetchart.Candidate(
-            logger, self.source.ID, url=self.URL
-        )
+    @pytest.fixture
+    def settings(self) -> Settings:
+        return Settings(maxwidth=0)
 
-    def test_invalid_type_returns_none(self):
+    @pytest.fixture
+    def source(self) -> DummyRemoteArtSource:
+        return DummyRemoteArtSource(logger, self.plugin.config)
+
+    @pytest.fixture
+    def candidate(self, source: DummyRemoteArtSource) -> fetchart.Candidate:
+        return fetchart.Candidate(logger, source.ID, url=self.URL)
+
+    def test_invalid_type_returns_none(
+        self,
+        source: DummyRemoteArtSource,
+        candidate: fetchart.Candidate,
+        settings: Settings,
+    ) -> None:
         self.mock_response(self.URL, "image/watercolour")
-        self.source.fetch_image(self.candidate, self.settings)
-        assert self.candidate.path is None
+        source.fetch_image(candidate, settings)
+        assert candidate.path is None
 
-    def test_jpeg_type_returns_path(self):
+    def test_jpeg_type_returns_path(
+        self,
+        source: DummyRemoteArtSource,
+        candidate: fetchart.Candidate,
+        settings: Settings,
+    ) -> None:
         self.mock_response(self.URL, "image/jpeg")
-        self.source.fetch_image(self.candidate, self.settings)
-        assert self.candidate.path is not None
+        source.fetch_image(candidate, settings)
+        assert candidate.path is not None
 
-    def test_extension_set_by_content_type(self):
+    def test_extension_set_by_content_type(
+        self,
+        source: DummyRemoteArtSource,
+        candidate: fetchart.Candidate,
+        settings: Settings,
+    ) -> None:
         self.mock_response(self.URL, "image/png")
-        self.source.fetch_image(self.candidate, self.settings)
-        assert os.path.splitext(self.candidate.path)[1] == b".png"
-        assert Path(os.fsdecode(self.candidate.path)).exists()
+        source.fetch_image(candidate, settings)
+        assert os.path.splitext(candidate.path)[1] == b".png"
+        assert Path(os.fsdecode(candidate.path)).exists()
 
-    def test_does_not_rely_on_server_content_type(self):
+    def test_does_not_rely_on_server_content_type(
+        self,
+        source: DummyRemoteArtSource,
+        candidate: fetchart.Candidate,
+        settings: Settings,
+    ) -> None:
         self.mock_response(self.URL, "image/jpeg", "image/png")
-        self.source.fetch_image(self.candidate, self.settings)
-        assert os.path.splitext(self.candidate.path)[1] == b".png"
-        assert Path(os.fsdecode(self.candidate.path)).exists()
+        source.fetch_image(candidate, settings)
+        assert os.path.splitext(candidate.path)[1] == b".png"
+        assert Path(os.fsdecode(candidate.path)).exists()
 
 
 class FSArtTest(UseThePlugin):

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -486,40 +486,46 @@ class CombinedTest(FetchImageTestCase, CAAHelper):
         assert len(responses.calls) == 0
 
 
-class AAOTest(UseThePlugin):
-    ASIN = "xxxx"
-    AAO_URL = f"https://www.albumart.org/index_detail.php?asin={ASIN}"
+class TestAAO(UseThePlugin, FetchImageHelper):
+    ASIN: str = "xxxx"
+    AAO_URL: str = f"https://www.albumart.org/index_detail.php?asin={ASIN}"
 
-    def setUp(self):
-        super().setUp()
-        self.source = fetchart.AlbumArtOrg(logger, self.plugin.config)
-        self.settings = Settings()
+    @pytest.fixture
+    def settings(self) -> Settings:
+        return Settings()
 
-    @responses.activate
-    def run(self, *args, **kwargs):
-        super().run(*args, **kwargs)
+    @pytest.fixture
+    def source(self) -> fetchart.AlbumArtOrg:
+        return fetchart.AlbumArtOrg(logger, self.plugin.config)
 
-    def mock_response(self, url, body):
-        responses.add(responses.GET, url, body=body, content_type="text/html")
-
-    def test_aao_scraper_finds_image(self):
+    def test_aao_scraper_finds_image(
+        self,
+        source: fetchart.AlbumArtOrg,
+        settings: Settings,
+    ) -> None:
         body = """
         <br />
-        <a href=\"TARGET_URL\" title=\"View larger image\"
-           class=\"thickbox\" style=\"color: #7E9DA2; text-decoration:none;\">
-        <img src=\"http://www.albumart.org/images/zoom-icon.jpg\"
-       alt=\"View larger image\" width=\"17\" height=\"15\"  border=\"0\"/></a>
+        <a href="TARGET_URL" title="View larger image"
+           class="thickbox" style="color: #7E9DA2; text-decoration:none;">
+        <img src="http://www.albumart.org/images/zoom-icon.jpg"
+             alt="View larger image" width="17" height="15" border="0"/></a>
         """
-        self.mock_response(self.AAO_URL, body)
+        self.mock_response(self.AAO_URL, body=body, content_type="text/html")
         album = _common.Bag(asin=self.ASIN)
-        candidate = next(self.source.get(album, self.settings, []))
+        candidate = next(source.get(album, settings, []))
         assert candidate.url == "TARGET_URL"
 
-    def test_aao_scraper_returns_no_result_when_no_image_present(self):
-        self.mock_response(self.AAO_URL, "blah blah")
+    def test_aao_scraper_returns_no_result_when_no_image_present(
+        self,
+        source: fetchart.AlbumArtOrg,
+        settings: Settings,
+    ) -> None:
+        self.mock_response(
+            self.AAO_URL, body="blah blah", content_type="text/html"
+        )
         album = _common.Bag(asin=self.ASIN)
         with pytest.raises(StopIteration):
-            next(self.source.get(album, self.settings, []))
+            next(source.get(album, settings, []))
 
 
 class ITunesStoreTest(UseThePlugin):

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -24,7 +24,8 @@ from unittest.mock import patch
 
 import confuse
 import pytest
-import responses
+from requests_mock import ANY as ANYREEQUEST
+from requests_mock.exceptions import NoMockAddress
 
 from beets import config, importer, logging, util
 from beets.autotag.distance import Distance
@@ -43,7 +44,9 @@ if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
     from unittest.mock import MagicMock
 
-    from beets.test.helper import ImageResponseMocker
+    from requests_mock.mocker import Mocker
+
+    from beets.test.helper import ImageRequestMocker
 
 
 class Settings(fetchart.FetchArtPlugin):
@@ -75,6 +78,22 @@ class UseThePlugin(PytestTestHelper):
     @pytest.fixture(autouse=True)
     def setup_plugin(self, setup):
         self.plugin = fetchart.FetchArtPlugin()
+
+    @pytest.fixture(autouse=True)
+    def requests_mock_all(self, requests_mock):
+        """Will disable all outgoing requests and raise an error!
+
+        Tests need to mock all requests!
+        """
+        # Register some “safe” mocks you actually want to allow, if any:
+        # requests_mock.get("https://example.com/health", json={"status": "ok"})
+
+        # Optional: disable any URL not explicitly mocked
+        requests_mock.register_uri(
+            ANYREEQUEST,
+            ANYREEQUEST,
+            exc=NoMockAddress,
+        )
 
     @pytest.fixture(autouse=True, scope="class")
     def cleanup(self):
@@ -205,7 +224,7 @@ class CAAData:
 
 
 class TestFetchImage(UseThePlugin, FetchImageHelper):
-    URL: str = "http://example.com/test.jpg"
+    URL = "http://example.com/test.jpg"
 
     @pytest.fixture
     def settings(self) -> Settings:
@@ -224,9 +243,9 @@ class TestFetchImage(UseThePlugin, FetchImageHelper):
         source: DummyRemoteArtSource,
         candidate: fetchart.Candidate,
         settings: Settings,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ) -> None:
-        image_response_mocker.add(self.URL, content_type="image/watercolour")
+        image_request_mock.get(self.URL, content_type="image/watercolour")
         source.fetch_image(candidate, settings)
         assert candidate.path is None
 
@@ -235,9 +254,12 @@ class TestFetchImage(UseThePlugin, FetchImageHelper):
         source: DummyRemoteArtSource,
         candidate: fetchart.Candidate,
         settings: Settings,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ) -> None:
-        image_response_mocker.add(self.URL, content_type="image/jpeg")
+        image_request_mock.get(
+            self.URL,
+            content_type="image/jpeg",
+        )
         source.fetch_image(candidate, settings)
         assert candidate.path is not None
 
@@ -246,9 +268,9 @@ class TestFetchImage(UseThePlugin, FetchImageHelper):
         source: DummyRemoteArtSource,
         candidate: fetchart.Candidate,
         settings: Settings,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ) -> None:
-        image_response_mocker.add(self.URL, content_type="image/png")
+        image_request_mock.get(self.URL, content_type="image/png")
         source.fetch_image(candidate, settings)
         assert candidate.path is not None
         assert os.path.splitext(candidate.path)[1] == b".png"
@@ -259,9 +281,9 @@ class TestFetchImage(UseThePlugin, FetchImageHelper):
         source: DummyRemoteArtSource,
         candidate: fetchart.Candidate,
         settings: Settings,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ) -> None:
-        image_response_mocker.add(
+        image_request_mock.get(
             self.URL, content_type="image/jpeg", file_type="image/png"
         )
         source.fetch_image(candidate, settings)
@@ -394,9 +416,9 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
 
     def test_main_interface_returns_amazon_art(
         self,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ):
-        image_response_mocker.add(self.AMAZON_URL)
+        image_request_mock.get(self.AMAZON_URL)
         album = Album(asin=self.ASIN)
         candidate = self.plugin.art_for_album(album, None)
         assert candidate is not None
@@ -409,10 +431,10 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
     def test_main_interface_gives_precedence_to_fs_art(
         self,
         dpath: bytes,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ):
         _common.touch(os.path.join(dpath, b"art.jpg"))
-        image_response_mocker.add(self.AMAZON_URL)
+        image_request_mock.get(self.AMAZON_URL)
         album = Album(asin=self.ASIN)
         candidate = self.plugin.art_for_album(album, [dpath])
         assert candidate is not None
@@ -421,9 +443,9 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
     def test_main_interface_falls_back_to_amazon(
         self,
         dpath: bytes,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ):
-        image_response_mocker.add(self.AMAZON_URL)
+        image_request_mock.get(self.AMAZON_URL)
         album = Album(asin=self.ASIN)
         candidate = self.plugin.art_for_album(album, [dpath])
         assert candidate is not None
@@ -432,41 +454,38 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
     def test_main_interface_tries_amazon_before_aao(
         self,
         dpath: bytes,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ):
-        image_response_mocker.add(self.AMAZON_URL)
+        image_request_mock.get(self.AMAZON_URL)
         album = Album(asin=self.ASIN)
         self.plugin.art_for_album(album, [dpath])
-        assert len(image_response_mocker.responses_mock.calls) == 1
+        assert image_request_mock.mocker.called_once
         assert (
-            image_response_mocker.responses_mock.calls[0].request.url
-            == self.AMAZON_URL
+            image_request_mock.mocker.request_history[0].url == self.AMAZON_URL
         )
 
     def test_main_interface_falls_back_to_aao(
         self,
         dpath: bytes,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ):
-        image_response_mocker.add(self.AMAZON_URL, content_type="text/html")
+        image_request_mock.get(self.AMAZON_URL, content_type="text/html")
+        image_request_mock.get(self.AAO_URL, content_type="image/jpeg")
         album = Album(asin=self.ASIN)
         self.plugin.art_for_album(album, [dpath])
-        assert (
-            image_response_mocker.responses_mock.calls[-1].request.url
-            == self.AAO_URL
-        )
+        assert image_request_mock.mocker.request_history[-1].url == self.AAO_URL
 
     def test_main_interface_uses_caa_when_mbid_available(
         self,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ):
-        image_response_mocker.add(self.RELEASE_URL, body=self.RESPONSE_RELEASE)
-        image_response_mocker.add(self.GROUP_URL, body=self.RESPONSE_GROUP)
-        image_response_mocker.add(
+        image_request_mock.get(self.RELEASE_URL, content=self.RESPONSE_RELEASE)
+        image_request_mock.get(self.GROUP_URL, content=self.RESPONSE_GROUP)
+        image_request_mock.get(
             "http://coverartarchive.org/release/rid/12345.gif",
             content_type="image/gif",
         )
-        image_response_mocker.add(
+        image_request_mock.get(
             "http://coverartarchive.org/release/rid/12345.jpg",
             content_type="image/jpeg",
         )
@@ -477,31 +496,30 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
         )
         candidate = self.plugin.art_for_album(album, None)
         assert candidate is not None
-        assert len(image_response_mocker.responses_mock.calls) == 3
+        assert image_request_mock.mocker.call_count == 3
         assert (
-            image_response_mocker.responses_mock.calls[0].request.url
-            == self.RELEASE_URL
+            image_request_mock.mocker.request_history[0].url == self.RELEASE_URL
         )
 
     def test_local_only_does_not_access_network(
         self,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ):
         album = Album(mb_albumid=self.MBID, asin=self.ASIN)
         self.plugin.art_for_album(album, None, local_only=True)
-        assert len(image_response_mocker.responses_mock.calls) == 0
+        assert not image_request_mock.mocker.called
 
     def test_local_only_gets_fs_image(
         self,
         dpath: bytes,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ):
         _common.touch(os.path.join(dpath, b"art.jpg"))
         album = Album(mb_albumid=self.MBID, asin=self.ASIN)
         candidate = self.plugin.art_for_album(album, [dpath], local_only=True)
         assert candidate is not None
         assert candidate.path == os.path.join(dpath, b"art.jpg")
-        assert len(image_response_mocker.responses_mock.calls) == 0
+        assert not image_request_mock.mocker.called
 
 
 class TestAAO(UseThePlugin, FetchImageHelper):
@@ -520,7 +538,7 @@ class TestAAO(UseThePlugin, FetchImageHelper):
         self,
         source: fetchart.AlbumArtOrg,
         settings: Settings,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ) -> None:
         body = """
         <br />
@@ -529,8 +547,8 @@ class TestAAO(UseThePlugin, FetchImageHelper):
         <img src="http://www.albumart.org/images/zoom-icon.jpg"
              alt="View larger image" width="17" height="15" border="0"/></a>
         """
-        image_response_mocker.add(
-            self.AAO_URL, body=body, content_type="text/html"
+        image_request_mock.get(
+            self.AAO_URL, content=body, content_type="text/html"
         )
         album = Album(asin=self.ASIN)
         candidate = next(source.get(album, settings, []))
@@ -540,10 +558,10 @@ class TestAAO(UseThePlugin, FetchImageHelper):
         self,
         source: fetchart.AlbumArtOrg,
         settings: Settings,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ) -> None:
-        image_response_mocker.add(
-            self.AAO_URL, body="blah blah", content_type="text/html"
+        image_request_mock.get(
+            self.AAO_URL, content="blah blah", content_type="text/html"
         )
         album = Album(asin=self.ASIN)
         with pytest.raises(StopIteration):
@@ -568,7 +586,7 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
         source: fetchart.ITunesStore,
         settings: Settings,
         album,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ):
         json = """{
                     "results":
@@ -580,9 +598,9 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
                             }
                         ]
                   }"""
-        image_response_mocker.add(
+        image_request_mock.get(
             fetchart.ITunesStore.API_URL,
-            body=json,
+            content=json,
             content_type="application/json",
         )
         candidate = next(source.get(album, settings, []))
@@ -594,13 +612,13 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
         source: fetchart.ITunesStore,
         settings: Settings,
         album: Album,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
         caplog: pytest.LogCaptureFixture,
     ):
         json = '{"results": []}'
-        image_response_mocker.add(
+        image_request_mock.get(
             fetchart.ITunesStore.API_URL,
-            body=json,
+            content=json,
             content_type="application/json",
         )
         expected = "got no results"
@@ -615,14 +633,13 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
         source: fetchart.ITunesStore,
         settings: Settings,
         album: Album,
-        image_response_mocker: ImageResponseMocker,
+        requests_mock: Mocker,
         caplog: pytest.LogCaptureFixture,
     ):
-        image_response_mocker.responses_mock.add(
-            responses.GET,
+        requests_mock.get(
             fetchart.ITunesStore.API_URL,
             json={"error": "not found"},
-            status=404,
+            status_code=404,
         )
         expected = "iTunes search failed: 404 Client Error"
 
@@ -636,7 +653,7 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
         source: fetchart.ITunesStore,
         settings: Settings,
         album: Album,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ):
         json = """{
                     "results":
@@ -647,9 +664,9 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
                             }
                         ]
                   }"""
-        image_response_mocker.add(
+        image_request_mock.get(
             fetchart.ITunesStore.API_URL,
-            body=json,
+            content=json,
             content_type="application/json",
         )
         candidate = next(source.get(album, settings, []))
@@ -661,7 +678,7 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
         source: fetchart.ITunesStore,
         settings: Settings,
         album: Album,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
         caplog: pytest.LogCaptureFixture,
     ):
         json = """{
@@ -673,9 +690,9 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
                             }
                         ]
                   }"""
-        image_response_mocker.add(
+        image_request_mock.get(
             fetchart.ITunesStore.API_URL,
-            body=json,
+            content=json,
             content_type="application/json",
         )
         expected = "Malformed itunes candidate"
@@ -690,13 +707,13 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
         source: fetchart.ITunesStore,
         settings: Settings,
         album: Album,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
         caplog: pytest.LogCaptureFixture,
     ):
         json = '{"error": {"errors": [{"reason": "some reason"}]}}'
-        image_response_mocker.add(
+        image_request_mock.get(
             fetchart.ITunesStore.API_URL,
-            body=json,
+            content=json,
             content_type="application/json",
         )
         expected = "not found in json. Fields are"
@@ -711,13 +728,13 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
         source: fetchart.ITunesStore,
         settings: Settings,
         album: Album,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
         caplog: pytest.LogCaptureFixture,
     ):
         json = """bla blup"""
-        image_response_mocker.add(
+        image_request_mock.get(
             fetchart.ITunesStore.API_URL,
-            body=json,
+            content=json,
             content_type="application/json",
         )
         expected = "Could not decode json response:"
@@ -741,13 +758,13 @@ class TestGoogleImage(UseThePlugin, FetchImageHelper):
         self,
         source: fetchart.GoogleImages,
         settings: Settings,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ):
         album = Album(albumartist="some artist", album="some album")
         json = '{"items": [{"link": "url_to_the_image"}]}'
-        image_response_mocker.add(
+        image_request_mock.get(
             fetchart.GoogleImages.URL,
-            body=json,
+            content=json,
             content_type="application/json",
         )
         candidate = next(source.get(album, settings, []))
@@ -757,13 +774,13 @@ class TestGoogleImage(UseThePlugin, FetchImageHelper):
         self,
         source: fetchart.GoogleImages,
         settings: Settings,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ):
         album = Album(albumartist="some artist", album="some album")
         json = '{"error": {"errors": [{"reason": "some reason"}]}}'
-        image_response_mocker.add(
+        image_request_mock.get(
             fetchart.GoogleImages.URL,
-            body=json,
+            content=json,
             content_type="application/json",
         )
         with pytest.raises(StopIteration):
@@ -773,13 +790,13 @@ class TestGoogleImage(UseThePlugin, FetchImageHelper):
         self,
         source: fetchart.GoogleImages,
         settings: Settings,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ):
         album = Album(albumartist="some artist", album="some album")
         json = """bla blup"""
-        image_response_mocker.add(
+        image_request_mock.get(
             fetchart.GoogleImages.URL,
-            body=json,
+            content=json,
             content_type="application/json",
         )
         with pytest.raises(StopIteration):
@@ -799,25 +816,24 @@ class TestCoverArtArchive(UseThePlugin, FetchImageHelper, CAAData):
         self,
         source: fetchart.CoverArtArchive,
         settings: Settings,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ):
         album = Album(
             mb_albumid=self.MBID_RELASE, mb_releasegroupid=self.MBID_GROUP
         )
-        image_response_mocker.add(self.RELEASE_URL, body=self.RESPONSE_RELEASE)
-        image_response_mocker.add(self.GROUP_URL, body=self.RESPONSE_GROUP)
+        image_request_mock.get(self.RELEASE_URL, content=self.RESPONSE_RELEASE)
+        image_request_mock.get(self.GROUP_URL, content=self.RESPONSE_GROUP)
         candidates = list(source.get(album, settings, []))
         assert len(candidates) == 3
-        assert len(image_response_mocker.responses_mock.calls) == 2
+        assert image_request_mock.mocker.call_count == 2
         assert (
-            image_response_mocker.responses_mock.calls[0].request.url
-            == self.RELEASE_URL
+            image_request_mock.mocker.request_history[0].url == self.RELEASE_URL
         )
 
     def test_fetchart_uses_caa_pre_sized_maxwidth_thumbs(
         self,
         source: fetchart.CoverArtArchive,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ):
         # CAA provides pre-sized thumbnails of width 250px, 500px, and 1200px
         # We only test with one of them here
@@ -827,8 +843,8 @@ class TestCoverArtArchive(UseThePlugin, FetchImageHelper, CAAData):
         album = Album(
             mb_albumid=self.MBID_RELASE, mb_releasegroupid=self.MBID_GROUP
         )
-        image_response_mocker.add(self.RELEASE_URL, body=self.RESPONSE_RELEASE)
-        image_response_mocker.add(self.GROUP_URL, body=self.RESPONSE_GROUP)
+        image_request_mock.get(self.RELEASE_URL, content=self.RESPONSE_RELEASE)
+        image_request_mock.get(self.GROUP_URL, content=self.RESPONSE_GROUP)
         candidates = list(source.get(album, settings, []))
         assert len(candidates) == 3
         for candidate in candidates:
@@ -838,7 +854,7 @@ class TestCoverArtArchive(UseThePlugin, FetchImageHelper, CAAData):
     def test_caa_finds_image_if_maxwidth_is_set_and_thumbnails_is_empty(
         self,
         source: fetchart.CoverArtArchive,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ):
         # CAA provides pre-sized thumbnails of width 250px, 500px, and 1200px
         # We only test with one of them here
@@ -848,11 +864,11 @@ class TestCoverArtArchive(UseThePlugin, FetchImageHelper, CAAData):
         album = Album(
             mb_albumid=self.MBID_RELASE, mb_releasegroupid=self.MBID_GROUP
         )
-        image_response_mocker.add(
-            self.RELEASE_URL, body=self.RESPONSE_RELEASE_WITHOUT_THUMBNAILS
+        image_request_mock.get(
+            self.RELEASE_URL, content=self.RESPONSE_RELEASE_WITHOUT_THUMBNAILS
         )
-        image_response_mocker.add(
-            self.GROUP_URL, body=self.RESPONSE_GROUP_WITHOUT_THUMBNAILS
+        image_request_mock.get(
+            self.GROUP_URL, content=self.RESPONSE_GROUP_WITHOUT_THUMBNAILS
         )
         candidates = list(source.get(album, settings, []))
         assert len(candidates) == 3
@@ -931,12 +947,12 @@ class TestFanartTV(UseThePlugin, FetchImageHelper):
         self,
         source: fetchart.FanartTV,
         settings: Settings,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ):
         album: Album = Album(mb_releasegroupid="thereleasegroupid")
-        image_response_mocker.add(
+        image_request_mock.get(
             f"{fetchart.FanartTV.API_ALBUMS}thereleasegroupid",
-            body=self.RESPONSE_MULTIPLE,
+            content=self.RESPONSE_MULTIPLE,
             content_type="application/json",
         )
         candidate = next(source.get(album, settings, []))
@@ -946,12 +962,12 @@ class TestFanartTV(UseThePlugin, FetchImageHelper):
         self,
         source: fetchart.FanartTV,
         settings: Settings,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ):
         album = Album(mb_releasegroupid="thereleasegroupid")
-        image_response_mocker.add(
+        image_request_mock.get(
             f"{fetchart.FanartTV.API_ALBUMS}thereleasegroupid",
-            body=self.RESPONSE_ERROR,
+            content=self.RESPONSE_ERROR,
             content_type="application/json",
         )
         with pytest.raises(StopIteration):
@@ -961,12 +977,12 @@ class TestFanartTV(UseThePlugin, FetchImageHelper):
         self,
         source: fetchart.FanartTV,
         settings: Settings,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ):
         album = Album(mb_releasegroupid="thereleasegroupid")
-        image_response_mocker.add(
+        image_request_mock.get(
             f"{fetchart.FanartTV.API_ALBUMS}thereleasegroupid",
-            body=self.RESPONSE_MALFORMED,
+            content=self.RESPONSE_MALFORMED,
             content_type="application/json",
         )
         with pytest.raises(StopIteration):
@@ -976,13 +992,13 @@ class TestFanartTV(UseThePlugin, FetchImageHelper):
         self,
         source: fetchart.FanartTV,
         settings: Settings,
-        image_response_mocker: ImageResponseMocker,
+        image_request_mock: ImageRequestMocker,
     ):
         # The source used to fail when there were images present, but no cover
         album = Album(mb_releasegroupid="thereleasegroupid")
-        image_response_mocker.add(
+        image_request_mock.get(
             f"{fetchart.FanartTV.API_ALBUMS}thereleasegroupid",
-            body=self.RESPONSE_NO_ART,
+            content=self.RESPONSE_NO_ART,
             content_type="application/json",
         )
         with pytest.raises(StopIteration):

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -44,10 +44,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
     from unittest.mock import MagicMock
 
-    from requests_mock.mocker import Mocker
-
-    from beets.test.helper import ImageRequestMocker
-
 
 class Settings(fetchart.FetchArtPlugin):
     """Used to pass settings to the ArtSources when the plugin isn't fully
@@ -65,7 +61,7 @@ class DummyRemoteArtSource(fetchart.RemoteArtSource):
 
     def get(
         self,
-        album: Album,
+        album,
         plugin: fetchart.FetchArtPlugin,
         paths: None | Sequence[bytes],
     ) -> Iterator[fetchart.Candidate]:
@@ -239,22 +235,14 @@ class TestFetchImage(UseThePlugin, FetchImageHelper):
         return fetchart.Candidate(logger, source.ID, url=self.URL)
 
     def test_invalid_type_returns_none(
-        self,
-        source: DummyRemoteArtSource,
-        candidate: fetchart.Candidate,
-        settings: Settings,
-        image_request_mock: ImageRequestMocker,
+        self, source, candidate, settings, image_request_mock
     ) -> None:
         image_request_mock.get(self.URL, content_type="image/watercolour")
         source.fetch_image(candidate, settings)
         assert candidate.path is None
 
     def test_jpeg_type_returns_path(
-        self,
-        source: DummyRemoteArtSource,
-        candidate: fetchart.Candidate,
-        settings: Settings,
-        image_request_mock: ImageRequestMocker,
+        self, source, candidate, settings, image_request_mock
     ) -> None:
         image_request_mock.get(
             self.URL,
@@ -264,11 +252,7 @@ class TestFetchImage(UseThePlugin, FetchImageHelper):
         assert candidate.path is not None
 
     def test_extension_set_by_content_type(
-        self,
-        source: DummyRemoteArtSource,
-        candidate: fetchart.Candidate,
-        settings: Settings,
-        image_request_mock: ImageRequestMocker,
+        self, source, candidate, settings, image_request_mock
     ) -> None:
         image_request_mock.get(self.URL, content_type="image/png")
         source.fetch_image(candidate, settings)
@@ -277,11 +261,7 @@ class TestFetchImage(UseThePlugin, FetchImageHelper):
         assert Path(os.fsdecode(candidate.path)).exists()
 
     def test_does_not_rely_on_server_content_type(
-        self,
-        source: DummyRemoteArtSource,
-        candidate: fetchart.Candidate,
-        settings: Settings,
-        image_request_mock: ImageRequestMocker,
+        self, source, candidate, settings, image_request_mock
     ) -> None:
         image_request_mock.get(
             self.URL, content_type="image/jpeg", file_type="image/png"
@@ -307,21 +287,13 @@ class TestFSArt(UseThePlugin):
     def source(self) -> fetchart.FileSystem:
         return fetchart.FileSystem(logger, self.plugin.config)
 
-    def test_finds_jpg_in_directory(
-        self,
-        source: fetchart.FileSystem,
-        dpath: bytes,
-        settings: Settings,
-    ) -> None:
+    def test_finds_jpg_in_directory(self, source, dpath, settings) -> None:
         _common.touch(os.path.join(dpath, b"a.jpg"))
         candidate = next(source.get(Album(), settings, [dpath]))
         assert candidate.path == os.path.join(dpath, b"a.jpg")
 
     def test_appropriately_named_file_takes_precedence(
-        self,
-        source: fetchart.FileSystem,
-        dpath: bytes,
-        settings: Settings,
+        self, source, dpath, settings
     ) -> None:
         _common.touch(os.path.join(dpath, b"a.jpg"))
         _common.touch(os.path.join(dpath, b"art.jpg"))
@@ -329,52 +301,31 @@ class TestFSArt(UseThePlugin):
         assert candidate.path == os.path.join(dpath, b"art.jpg")
 
     def test_non_image_file_not_identified(
-        self,
-        source: fetchart.FileSystem,
-        dpath: bytes,
-        settings: Settings,
+        self, source, dpath, settings
     ) -> None:
         _common.touch(os.path.join(dpath, b"a.txt"))
         with pytest.raises(StopIteration):
             next(source.get(Album(), settings, [dpath]))
 
-    def test_cautious_skips_fallback(
-        self,
-        source: fetchart.FileSystem,
-        dpath: bytes,
-        settings: Settings,
-    ) -> None:
+    def test_cautious_skips_fallback(self, source, dpath, settings) -> None:
         _common.touch(os.path.join(dpath, b"a.jpg"))
         settings.cautious = True
         with pytest.raises(StopIteration):
             next(source.get(Album(), settings, [dpath]))
 
-    def test_configured_fallback_is_used(
-        self,
-        source: fetchart.FileSystem,
-        dpath: bytes,
-        settings: Settings,
-    ) -> None:
+    def test_configured_fallback_is_used(self, source, dpath, settings) -> None:
         fallback = os.path.join(self.temp_dir, b"a.jpg")
         _common.touch(fallback)
         settings.fallback = fallback  # type: ignore
         candidate = next(source.get(Album(), settings, [dpath]))
         assert candidate.path == fallback
 
-    def test_empty_dir(
-        self,
-        source: fetchart.FileSystem,
-        dpath: bytes,
-        settings: Settings,
-    ) -> None:
+    def test_empty_dir(self, source, dpath, settings) -> None:
         with pytest.raises(StopIteration):
             next(source.get(Album(), settings, [dpath]))
 
     def test_precedence_amongst_correct_files(
-        self,
-        source: fetchart.FileSystem,
-        dpath: bytes,
-        settings: Settings,
+        self, source, dpath, settings
     ) -> None:
         images = [b"front-cover.jpg", b"front.jpg", b"back.jpg"]
         paths = [os.path.join(dpath, i) for i in images]
@@ -391,7 +342,7 @@ class TestFSArt(UseThePlugin):
     def test_is_candidate_fallback_os_error(
         self,
         mock_samefile,
-        source: fetchart.FileSystem,
+        source,
     ) -> None:
         mock_samefile.side_effect = OSError("os error")
         fallback = os.path.join(self.temp_dir, b"a.jpg")
@@ -416,7 +367,7 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
 
     def test_main_interface_returns_amazon_art(
         self,
-        image_request_mock: ImageRequestMocker,
+        image_request_mock,
     ):
         image_request_mock.get(self.AMAZON_URL)
         album = Album(asin=self.ASIN)
@@ -430,8 +381,8 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
 
     def test_main_interface_gives_precedence_to_fs_art(
         self,
-        dpath: bytes,
-        image_request_mock: ImageRequestMocker,
+        dpath,
+        image_request_mock,
     ):
         _common.touch(os.path.join(dpath, b"art.jpg"))
         image_request_mock.get(self.AMAZON_URL)
@@ -442,8 +393,8 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
 
     def test_main_interface_falls_back_to_amazon(
         self,
-        dpath: bytes,
-        image_request_mock: ImageRequestMocker,
+        dpath,
+        image_request_mock,
     ):
         image_request_mock.get(self.AMAZON_URL)
         album = Album(asin=self.ASIN)
@@ -453,8 +404,8 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
 
     def test_main_interface_tries_amazon_before_aao(
         self,
-        dpath: bytes,
-        image_request_mock: ImageRequestMocker,
+        dpath,
+        image_request_mock,
     ):
         image_request_mock.get(self.AMAZON_URL)
         album = Album(asin=self.ASIN)
@@ -464,11 +415,7 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
             image_request_mock.mocker.request_history[0].url == self.AMAZON_URL
         )
 
-    def test_main_interface_falls_back_to_aao(
-        self,
-        dpath: bytes,
-        image_request_mock: ImageRequestMocker,
-    ):
+    def test_main_interface_falls_back_to_aao(self, dpath, image_request_mock):
         image_request_mock.get(self.AMAZON_URL, content_type="text/html")
         image_request_mock.get(self.AAO_URL, content_type="image/jpeg")
         album = Album(asin=self.ASIN)
@@ -476,8 +423,7 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
         assert image_request_mock.mocker.request_history[-1].url == self.AAO_URL
 
     def test_main_interface_uses_caa_when_mbid_available(
-        self,
-        image_request_mock: ImageRequestMocker,
+        self, image_request_mock
     ):
         image_request_mock.get(self.RELEASE_URL, content=self.RESPONSE_RELEASE)
         image_request_mock.get(self.GROUP_URL, content=self.RESPONSE_GROUP)
@@ -501,19 +447,12 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
             image_request_mock.mocker.request_history[0].url == self.RELEASE_URL
         )
 
-    def test_local_only_does_not_access_network(
-        self,
-        image_request_mock: ImageRequestMocker,
-    ):
+    def test_local_only_does_not_access_network(self, image_request_mock):
         album = Album(mb_albumid=self.MBID, asin=self.ASIN)
         self.plugin.art_for_album(album, None, local_only=True)
         assert not image_request_mock.mocker.called
 
-    def test_local_only_gets_fs_image(
-        self,
-        dpath: bytes,
-        image_request_mock: ImageRequestMocker,
-    ):
+    def test_local_only_gets_fs_image(self, dpath, image_request_mock):
         _common.touch(os.path.join(dpath, b"art.jpg"))
         album = Album(mb_albumid=self.MBID, asin=self.ASIN)
         candidate = self.plugin.art_for_album(album, [dpath], local_only=True)
@@ -535,10 +474,7 @@ class TestAAO(UseThePlugin, FetchImageHelper):
         return fetchart.AlbumArtOrg(logger, self.plugin.config)
 
     def test_aao_scraper_finds_image(
-        self,
-        source: fetchart.AlbumArtOrg,
-        settings: Settings,
-        image_request_mock: ImageRequestMocker,
+        self, source, settings, image_request_mock
     ) -> None:
         body = """
         <br />
@@ -555,10 +491,7 @@ class TestAAO(UseThePlugin, FetchImageHelper):
         assert candidate.url == "TARGET_URL"
 
     def test_aao_scraper_returns_no_result_when_no_image_present(
-        self,
-        source: fetchart.AlbumArtOrg,
-        settings: Settings,
-        image_request_mock: ImageRequestMocker,
+        self, source, settings, image_request_mock
     ) -> None:
         image_request_mock.get(
             self.AAO_URL, content="blah blah", content_type="text/html"
@@ -570,23 +503,19 @@ class TestAAO(UseThePlugin, FetchImageHelper):
 
 class TestITunesStore(UseThePlugin, FetchImageHelper):
     @pytest.fixture
-    def settings(self):
+    def settings(self) -> Settings:
         return Settings()
 
     @pytest.fixture
-    def source(self):
+    def source(self) -> fetchart.ITunesStore:
         return fetchart.ITunesStore(logger, self.plugin.config)
 
     @pytest.fixture
-    def album(self):
+    def album(self) -> Album:
         return Album(albumartist="some artist", album="some album")
 
     def test_itunesstore_finds_image(
-        self,
-        source: fetchart.ITunesStore,
-        settings: Settings,
-        album,
-        image_request_mock: ImageRequestMocker,
+        self, source, settings, album, image_request_mock
     ):
         json = """{
                     "results":
@@ -608,12 +537,7 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
         assert candidate.match == fetchart.MetadataMatch.EXACT
 
     def test_itunesstore_no_result(
-        self,
-        source: fetchart.ITunesStore,
-        settings: Settings,
-        album: Album,
-        image_request_mock: ImageRequestMocker,
-        caplog: pytest.LogCaptureFixture,
+        self, source, settings, album, image_request_mock, caplog
     ):
         json = '{"results": []}'
         image_request_mock.get(
@@ -629,12 +553,7 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
         assert expected in caplog.messages[1]
 
     def test_itunesstore_requestexception(
-        self,
-        source: fetchart.ITunesStore,
-        settings: Settings,
-        album: Album,
-        requests_mock: Mocker,
-        caplog: pytest.LogCaptureFixture,
+        self, source, settings, album, requests_mock, caplog
     ):
         requests_mock.get(
             fetchart.ITunesStore.API_URL,
@@ -651,9 +570,9 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
     def test_itunesstore_fallback_match(
         self,
         source: fetchart.ITunesStore,
-        settings: Settings,
-        album: Album,
-        image_request_mock: ImageRequestMocker,
+        settings,
+        album,
+        image_request_mock,
     ):
         json = """{
                     "results":
@@ -674,12 +593,7 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
         assert candidate.match == fetchart.MetadataMatch.FALLBACK
 
     def test_itunesstore_returns_result_without_artwork(
-        self,
-        source: fetchart.ITunesStore,
-        settings: Settings,
-        album: Album,
-        image_request_mock: ImageRequestMocker,
-        caplog: pytest.LogCaptureFixture,
+        self, source, settings, album, image_request_mock, caplog
     ):
         json = """{
                     "results":
@@ -703,12 +617,7 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
         assert expected in caplog.messages[1]
 
     def test_itunesstore_returns_no_result_when_error_received(
-        self,
-        source: fetchart.ITunesStore,
-        settings: Settings,
-        album: Album,
-        image_request_mock: ImageRequestMocker,
-        caplog: pytest.LogCaptureFixture,
+        self, source, settings, album, image_request_mock, caplog
     ):
         json = '{"error": {"errors": [{"reason": "some reason"}]}}'
         image_request_mock.get(
@@ -724,12 +633,7 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
         assert expected in caplog.messages[1]
 
     def test_itunesstore_returns_no_result_with_malformed_response(
-        self,
-        source: fetchart.ITunesStore,
-        settings: Settings,
-        album: Album,
-        image_request_mock: ImageRequestMocker,
-        caplog: pytest.LogCaptureFixture,
+        self, source, settings, album, image_request_mock, caplog
     ):
         json = """bla blup"""
         image_request_mock.get(
@@ -747,19 +651,14 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
 
 class TestGoogleImage(UseThePlugin, FetchImageHelper):
     @pytest.fixture
-    def settings(self):
+    def settings(self) -> Settings:
         return Settings()
 
     @pytest.fixture
-    def source(self):
+    def source(self) -> fetchart.GoogleImages:
         return fetchart.GoogleImages(logger, self.plugin.config)
 
-    def test_google_art_finds_image(
-        self,
-        source: fetchart.GoogleImages,
-        settings: Settings,
-        image_request_mock: ImageRequestMocker,
-    ):
+    def test_google_art_finds_image(self, source, settings, image_request_mock):
         album = Album(albumartist="some artist", album="some album")
         json = '{"items": [{"link": "url_to_the_image"}]}'
         image_request_mock.get(
@@ -771,10 +670,7 @@ class TestGoogleImage(UseThePlugin, FetchImageHelper):
         assert candidate.url == "url_to_the_image"
 
     def test_google_art_returns_no_result_when_error_received(
-        self,
-        source: fetchart.GoogleImages,
-        settings: Settings,
-        image_request_mock: ImageRequestMocker,
+        self, source, settings, image_request_mock
     ):
         album = Album(albumartist="some artist", album="some album")
         json = '{"error": {"errors": [{"reason": "some reason"}]}}'
@@ -787,10 +683,7 @@ class TestGoogleImage(UseThePlugin, FetchImageHelper):
             next(source.get(album, settings, []))
 
     def test_google_art_returns_no_result_with_malformed_response(
-        self,
-        source: fetchart.GoogleImages,
-        settings: Settings,
-        image_request_mock: ImageRequestMocker,
+        self, source, settings, image_request_mock
     ):
         album = Album(albumartist="some artist", album="some album")
         json = """bla blup"""
@@ -812,12 +705,7 @@ class TestCoverArtArchive(UseThePlugin, FetchImageHelper, CAAData):
     def source(self) -> fetchart.CoverArtArchive:
         return fetchart.CoverArtArchive(logger, self.plugin.config)
 
-    def test_caa_finds_image(
-        self,
-        source: fetchart.CoverArtArchive,
-        settings: Settings,
-        image_request_mock: ImageRequestMocker,
-    ):
+    def test_caa_finds_image(self, source, settings, image_request_mock):
         album = Album(
             mb_albumid=self.MBID_RELASE, mb_releasegroupid=self.MBID_GROUP
         )
@@ -831,9 +719,7 @@ class TestCoverArtArchive(UseThePlugin, FetchImageHelper, CAAData):
         )
 
     def test_fetchart_uses_caa_pre_sized_maxwidth_thumbs(
-        self,
-        source: fetchart.CoverArtArchive,
-        image_request_mock: ImageRequestMocker,
+        self, source, image_request_mock
     ):
         # CAA provides pre-sized thumbnails of width 250px, 500px, and 1200px
         # We only test with one of them here
@@ -852,9 +738,7 @@ class TestCoverArtArchive(UseThePlugin, FetchImageHelper, CAAData):
             assert f"-{maxwidth}.jpg" in candidate.url
 
     def test_caa_finds_image_if_maxwidth_is_set_and_thumbnails_is_empty(
-        self,
-        source: fetchart.CoverArtArchive,
-        image_request_mock: ImageRequestMocker,
+        self, source, image_request_mock
     ):
         # CAA provides pre-sized thumbnails of width 250px, 500px, and 1200px
         # We only test with one of them here
@@ -943,13 +827,8 @@ class TestFanartTV(UseThePlugin, FetchImageHelper):
     def source(self):
         return fetchart.FanartTV(logger, self.plugin.config)
 
-    def test_fanarttv_finds_image(
-        self,
-        source: fetchart.FanartTV,
-        settings: Settings,
-        image_request_mock: ImageRequestMocker,
-    ):
-        album: Album = Album(mb_releasegroupid="thereleasegroupid")
+    def test_fanarttv_finds_image(self, source, settings, image_request_mock):
+        album = Album(mb_releasegroupid="thereleasegroupid")
         image_request_mock.get(
             f"{fetchart.FanartTV.API_ALBUMS}thereleasegroupid",
             content=self.RESPONSE_MULTIPLE,
@@ -959,10 +838,7 @@ class TestFanartTV(UseThePlugin, FetchImageHelper):
         assert candidate.url == "http://example.com/1.jpg"
 
     def test_fanarttv_returns_no_result_when_error_received(
-        self,
-        source: fetchart.FanartTV,
-        settings: Settings,
-        image_request_mock: ImageRequestMocker,
+        self, source, settings, image_request_mock
     ):
         album = Album(mb_releasegroupid="thereleasegroupid")
         image_request_mock.get(
@@ -974,10 +850,7 @@ class TestFanartTV(UseThePlugin, FetchImageHelper):
             next(source.get(album, settings, []))
 
     def test_fanarttv_returns_no_result_with_malformed_response(
-        self,
-        source: fetchart.FanartTV,
-        settings: Settings,
-        image_request_mock: ImageRequestMocker,
+        self, source, settings, image_request_mock
     ):
         album = Album(mb_releasegroupid="thereleasegroupid")
         image_request_mock.get(
@@ -989,10 +862,7 @@ class TestFanartTV(UseThePlugin, FetchImageHelper):
             next(source.get(album, settings, []))
 
     def test_fanarttv_only_other_images(
-        self,
-        source: fetchart.FanartTV,
-        settings: Settings,
-        image_request_mock: ImageRequestMocker,
+        self, source, settings, image_request_mock
     ):
         # The source used to fail when there were images present, but no cover
         album = Album(mb_releasegroupid="thereleasegroupid")
@@ -1190,59 +1060,57 @@ class TestAlbumArtPerformOperation(AlbumArtOperationMixin):
     """Test that the art is resized and deinterlaced if necessary."""
 
     @pytest.fixture
-    def resizer_mock(self):
+    def resizer_mock(self) -> Iterator[MagicMock]:
         with patch.object(
             ArtResizer.shared, "resize", return_value=self.IMAGE_PATH
         ) as mocked:
             yield mocked
 
     @pytest.fixture
-    def deinterlacer_mock(self):
+    def deinterlacer_mock(self) -> Iterator[MagicMock]:
         with patch.object(
             ArtResizer.shared, "deinterlace", return_value=self.IMAGE_PATH
         ) as mocked:
             yield mocked
 
-    def test_resize(self, resizer_mock: MagicMock):
+    def test_resize(self, resizer_mock):
         self.plugin.maxwidth = self.IMAGE_WIDTH / 2
         assert self.get_album_art()
         resizer_mock.assert_called_once()
 
-    def test_file_resized(self, resizer_mock: MagicMock):
+    def test_file_resized(self, resizer_mock):
         self.plugin.max_filesize = self.IMAGE_FILESIZE // 2
         assert self.get_album_art()
         resizer_mock.assert_called_once()
 
-    def test_file_not_resized(self, resizer_mock: MagicMock):
+    def test_file_not_resized(self, resizer_mock):
         self.plugin.max_filesize = self.IMAGE_FILESIZE
         assert self.get_album_art()
         resizer_mock.assert_not_called()
 
-    def test_file_resized_but_not_scaled(self, resizer_mock: MagicMock):
+    def test_file_resized_but_not_scaled(self, resizer_mock):
         self.plugin.maxwidth = self.IMAGE_WIDTH * 2
         self.plugin.max_filesize = self.IMAGE_FILESIZE // 2
         assert self.get_album_art()
         resizer_mock.assert_called_once()
 
-    def test_file_resized_and_scaled(self, resizer_mock: MagicMock):
+    def test_file_resized_and_scaled(self, resizer_mock):
         self.plugin.maxwidth = self.IMAGE_WIDTH / 2
         self.plugin.max_filesize = self.IMAGE_FILESIZE // 2
         assert self.get_album_art()
         assert resizer_mock.call_count == 2
 
-    def test_deinterlaced(self, deinterlacer_mock: MagicMock):
+    def test_deinterlaced(self, deinterlacer_mock):
         self.plugin.deinterlace = True
         assert self.get_album_art()
         deinterlacer_mock.assert_called_once()
 
-    def test_not_deinterlaced(self, deinterlacer_mock: MagicMock):
+    def test_not_deinterlaced(self, deinterlacer_mock):
         self.plugin.deinterlace = False
         assert self.get_album_art()
         deinterlacer_mock.assert_not_called()
 
-    def test_deinterlaced_and_resized(
-        self, resizer_mock: MagicMock, deinterlacer_mock: MagicMock
-    ):
+    def test_deinterlaced_and_resized(self, resizer_mock, deinterlacer_mock):
         self.plugin.maxwidth = self.IMAGE_WIDTH / 2
         self.plugin.deinterlace = True
         assert self.get_album_art()

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -31,7 +31,7 @@ from beets.autotag.distance import Distance
 from beets.autotag.hooks import AlbumInfo, AlbumMatch
 from beets.library import Album
 from beets.test import _common
-from beets.test.helper import FetchImageHelper, TestHelper
+from beets.test.helper import FetchImageHelper, PytestTestHelper
 from beets.util import clean_module_tempdir, syspath
 from beets.util.artresizer import ArtResizer
 from beetsplug import fetchart
@@ -67,18 +67,6 @@ class DummyRemoteArtSource(fetchart.RemoteArtSource):
         paths: None | Sequence[bytes],
     ) -> Iterator[fetchart.Candidate]:
         return iter(())
-
-
-class PytestTestHelper(TestHelper):
-    """Same as the BeetsTestCase unittest setup but for pytest."""
-
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.setup_beets()
-        try:
-            yield
-        finally:
-            self.teardown_beets()
 
 
 class UseThePlugin(PytestTestHelper):

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -1090,7 +1090,7 @@ class TestAlbumArtPerformOperation(AlbumArtOperationMixin):
         resizer_mock.assert_called_once()
 
 
-class DeprecatedConfigTest(unittest.TestCase):
+class TestDeprecatedConfig:
     """While refactoring the plugin, the remote_priority option was deprecated,
     and a new codepath should translate its effect. Check that it actually does
     so.
@@ -1099,8 +1099,8 @@ class DeprecatedConfigTest(unittest.TestCase):
     # If we subclassed UseThePlugin, the configuration change would either be
     # overwritten by BeetsTestCase or be set after constructing the
     # plugin object
-    def setUp(self):
-        super().setUp()
+    @pytest.fixture(autouse=True)
+    def setup(self):
         config["fetchart"]["remote_priority"] = True
         self.plugin = fetchart.FetchArtPlugin()
 
@@ -1108,7 +1108,7 @@ class DeprecatedConfigTest(unittest.TestCase):
         assert isinstance(self.plugin.sources[-1], fetchart.FileSystem)
 
 
-class EnforceRatioConfigTest(unittest.TestCase):
+class TestEnforceRatioConfig:
     """Throw some data at the regexes."""
 
     def _load_with_config(self, values, should_raise):

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -886,7 +886,7 @@ class ArtImporterTest(UseThePlugin):
         assert self.album.art_filepath.exists()
 
 
-class AlbumArtOperationTestCase(UseThePlugin):
+class AlbumArtOperationMixin(UseThePlugin):
     """Base test case for album art operations.
 
     Provides common setup for testing album art processing operations by setting
@@ -899,24 +899,22 @@ class AlbumArtOperationTestCase(UseThePlugin):
     IMAGE_HEIGHT = 490
     IMAGE_WIDTH_HEIGHT_DIFF = IMAGE_WIDTH - IMAGE_HEIGHT
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
+    @pytest.fixture(autouse=True, scope="class")
+    def fs_mock(self, cleanup):
         def fs_source_get(_self, album, settings, paths):
             if paths:
                 yield fetchart.Candidate(
-                    logger, source_name=_self.ID, path=cls.IMAGE_PATH
+                    logger, source_name=_self.ID, path=self.IMAGE_PATH
                 )
 
-        patch("beetsplug.fetchart.FileSystem.get", fs_source_get).start()
-        cls.addClassCleanup(patch.stopall)
+        with patch("beetsplug.fetchart.FileSystem.get", fs_source_get):
+            yield
 
     def get_album_art(self):
         return self.plugin.art_for_album(_common.Bag(), [""], True)
 
 
-class AlbumArtOperationConfigurationTest(AlbumArtOperationTestCase):
+class TestAlbumArtOperationConfiguration(AlbumArtOperationMixin):
     """Check that scale & filesize configuration is respected.
 
     Depending on `minwidth`, `enforce_ratio`, `margin_px`, and `margin_percent`

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -987,9 +987,9 @@ class TestFanartTV(UseThePlugin, FetchImageHelper):
             next(source.get(album, settings, []))
 
 
-class ArtImporterTest(UseThePlugin):
-    def setUp(self):
-        super().setUp()
+class TestArtImporter(UseThePlugin):
+    @pytest.fixture(autouse=True)
+    def _setup(self, setup_plugin):
 
         # Mock the album art fetcher to always return our test file.
         self.art_file = self.temp_dir_path / "tmpcover.jpg"
@@ -1030,9 +1030,7 @@ class ArtImporterTest(UseThePlugin):
             tracks=[],
         )
         self.task.set_choice(AlbumMatch(Distance(), info, {}))
-
-    def tearDown(self):
-        super().tearDown()
+        yield
         self.plugin.art_for_album = self.old_afa
 
     def _fetch_art(self, should_exist):

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -508,23 +508,26 @@ class TestAAO(UseThePlugin, FetchImageHelper):
             next(source.get(album, settings, []))
 
 
-class ITunesStoreTest(UseThePlugin):
-    def setUp(self):
-        super().setUp()
-        self.source = fetchart.ITunesStore(logger, self.plugin.config)
-        self.settings = Settings()
-        self.album = _common.Bag(albumartist="some artist", album="some album")
+class TestITunesStore(UseThePlugin, FetchImageHelper):
+    @pytest.fixture
+    def settings(self):
+        return Settings()
 
-    @responses.activate
-    def run(self, *args, **kwargs):
-        super().run(*args, **kwargs)
+    @pytest.fixture
+    def source(self):
+        return fetchart.ITunesStore(logger, self.plugin.config)
 
-    def mock_response(self, url, json):
-        responses.add(
-            responses.GET, url, body=json, content_type="application/json"
-        )
+    @pytest.fixture
+    def album(self):
+        return _common.Bag(albumartist="some artist", album="some album")
 
-    def test_itunesstore_finds_image(self):
+    def test_itunesstore_finds_image(
+        self,
+        source: fetchart.ITunesStore,
+        settings: Settings,
+        album: _common.Bag,
+        image_response_mocker: ImageResponseMocker,
+    ):
         json = """{
                     "results":
                         [
@@ -535,23 +538,45 @@ class ITunesStoreTest(UseThePlugin):
                             }
                         ]
                   }"""
-        self.mock_response(fetchart.ITunesStore.API_URL, json)
-        candidate = next(self.source.get(self.album, self.settings, []))
+        image_response_mocker.add(
+            fetchart.ITunesStore.API_URL,
+            body=json,
+            content_type="application/json",
+        )
+        candidate = next(source.get(album, settings, []))
         assert candidate.url == "url_to_the_image"
         assert candidate.match == fetchart.MetadataMatch.EXACT
 
-    def test_itunesstore_no_result(self):
+    def test_itunesstore_no_result(
+        self,
+        source: fetchart.ITunesStore,
+        settings: Settings,
+        album: _common.Bag,
+        image_response_mocker: ImageResponseMocker,
+        caplog: pytest.LogCaptureFixture,
+    ):
         json = '{"results": []}'
-        self.mock_response(fetchart.ITunesStore.API_URL, json)
+        image_response_mocker.add(
+            fetchart.ITunesStore.API_URL,
+            body=json,
+            content_type="application/json",
+        )
         expected = "got no results"
 
-        with capture_log("beets.test_art") as logs:
+        with caplog.at_level("DEBUG", logger="beets.test_art"):
             with pytest.raises(StopIteration):
-                next(self.source.get(self.album, self.settings, []))
-        assert expected in logs[1]
+                next(source.get(album, settings, []))
+        assert expected in caplog.messages[1]
 
-    def test_itunesstore_requestexception(self):
-        responses.add(
+    def test_itunesstore_requestexception(
+        self,
+        source: fetchart.ITunesStore,
+        settings: Settings,
+        album: _common.Bag,
+        image_response_mocker: ImageResponseMocker,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        image_response_mocker.responses_mock.add(
             responses.GET,
             fetchart.ITunesStore.API_URL,
             json={"error": "not found"},
@@ -559,12 +584,18 @@ class ITunesStoreTest(UseThePlugin):
         )
         expected = "iTunes search failed: 404 Client Error"
 
-        with capture_log("beets.test_art") as logs:
+        with caplog.at_level("DEBUG", logger="beets.test_art"):
             with pytest.raises(StopIteration):
-                next(self.source.get(self.album, self.settings, []))
-        assert expected in logs[1]
+                next(source.get(album, settings, []))
+        assert expected in caplog.messages[1]
 
-    def test_itunesstore_fallback_match(self):
+    def test_itunesstore_fallback_match(
+        self,
+        source: fetchart.ITunesStore,
+        settings: Settings,
+        album: _common.Bag,
+        image_response_mocker: ImageResponseMocker,
+    ):
         json = """{
                     "results":
                         [
@@ -574,12 +605,23 @@ class ITunesStoreTest(UseThePlugin):
                             }
                         ]
                   }"""
-        self.mock_response(fetchart.ITunesStore.API_URL, json)
-        candidate = next(self.source.get(self.album, self.settings, []))
+        image_response_mocker.add(
+            fetchart.ITunesStore.API_URL,
+            body=json,
+            content_type="application/json",
+        )
+        candidate = next(source.get(album, settings, []))
         assert candidate.url == "url_to_the_image"
         assert candidate.match == fetchart.MetadataMatch.FALLBACK
 
-    def test_itunesstore_returns_result_without_artwork(self):
+    def test_itunesstore_returns_result_without_artwork(
+        self,
+        source: fetchart.ITunesStore,
+        settings: Settings,
+        album: _common.Bag,
+        image_response_mocker: ImageResponseMocker,
+        caplog: pytest.LogCaptureFixture,
+    ):
         json = """{
                     "results":
                         [
@@ -589,33 +631,59 @@ class ITunesStoreTest(UseThePlugin):
                             }
                         ]
                   }"""
-        self.mock_response(fetchart.ITunesStore.API_URL, json)
+        image_response_mocker.add(
+            fetchart.ITunesStore.API_URL,
+            body=json,
+            content_type="application/json",
+        )
         expected = "Malformed itunes candidate"
 
-        with capture_log("beets.test_art") as logs:
+        with caplog.at_level("DEBUG", logger="beets.test_art"):
             with pytest.raises(StopIteration):
-                next(self.source.get(self.album, self.settings, []))
-        assert expected in logs[1]
+                next(source.get(album, settings, []))
+        assert expected in caplog.messages[1]
 
-    def test_itunesstore_returns_no_result_when_error_received(self):
+    def test_itunesstore_returns_no_result_when_error_received(
+        self,
+        source: fetchart.ITunesStore,
+        settings: Settings,
+        album: _common.Bag,
+        image_response_mocker: ImageResponseMocker,
+        caplog: pytest.LogCaptureFixture,
+    ):
         json = '{"error": {"errors": [{"reason": "some reason"}]}}'
-        self.mock_response(fetchart.ITunesStore.API_URL, json)
+        image_response_mocker.add(
+            fetchart.ITunesStore.API_URL,
+            body=json,
+            content_type="application/json",
+        )
         expected = "not found in json. Fields are"
 
-        with capture_log("beets.test_art") as logs:
+        with caplog.at_level("DEBUG", logger="beets.test_art"):
             with pytest.raises(StopIteration):
-                next(self.source.get(self.album, self.settings, []))
-        assert expected in logs[1]
+                next(source.get(album, settings, []))
+        assert expected in caplog.messages[1]
 
-    def test_itunesstore_returns_no_result_with_malformed_response(self):
+    def test_itunesstore_returns_no_result_with_malformed_response(
+        self,
+        source: fetchart.ITunesStore,
+        settings: Settings,
+        album: _common.Bag,
+        image_response_mocker: ImageResponseMocker,
+        caplog: pytest.LogCaptureFixture,
+    ):
         json = """bla blup"""
-        self.mock_response(fetchart.ITunesStore.API_URL, json)
+        image_response_mocker.add(
+            fetchart.ITunesStore.API_URL,
+            body=json,
+            content_type="application/json",
+        )
         expected = "Could not decode json response:"
 
-        with capture_log("beets.test_art") as logs:
+        with caplog.at_level("DEBUG", logger="beets.test_art"):
             with pytest.raises(StopIteration):
-                next(self.source.get(self.album, self.settings, []))
-        assert expected in logs[1]
+                next(source.get(album, settings, []))
+        assert expected in caplog.messages[1]
 
 
 class GoogleImageTest(UseThePlugin):

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -92,11 +92,7 @@ class UseThePlugin(PytestTestHelper):
             clean_module_tempdir(module)
 
 
-class FetchImageTestCase(FetchImageHelper, UseThePlugin):
-    pass
-
-
-class CAAHelper:
+class CAAData:
     """Helper mixin for mocking requests to the Cover Art Archive."""
 
     MBID_RELASE = "rid"
@@ -109,81 +105,73 @@ class CAAHelper:
     GROUP_URL = f"https://{GROUP_URL}"
 
     RESPONSE_RELEASE = """{
-    "images": [
-      {
-        "approved": false,
-        "back": false,
-        "comment": "GIF",
-        "edit": 12345,
-        "front": true,
-        "id": 12345,
-        "image": "http://coverartarchive.org/release/rid/12345.gif",
-        "thumbnails": {
-          "1200": "http://coverartarchive.org/release/rid/12345-1200.jpg",
-          "250": "http://coverartarchive.org/release/rid/12345-250.jpg",
-          "500": "http://coverartarchive.org/release/rid/12345-500.jpg",
-          "large": "http://coverartarchive.org/release/rid/12345-500.jpg",
-          "small": "http://coverartarchive.org/release/rid/12345-250.jpg"
+        "images": [
+        {
+            "approved": false,
+            "back": false,
+            "comment": "GIF",
+            "edit": 12345,
+            "front": true,
+            "id": 12345,
+            "image": "http://coverartarchive.org/release/rid/12345.gif",
+            "thumbnails": {
+                "1200": "http://coverartarchive.org/release/rid/12345-1200.jpg",
+                "250": "http://coverartarchive.org/release/rid/12345-250.jpg",
+                "500": "http://coverartarchive.org/release/rid/12345-500.jpg",
+                "large": "http://coverartarchive.org/release/rid/12345-500.jpg",
+                "small": "http://coverartarchive.org/release/rid/12345-250.jpg"
+            },
+            "types": ["Front"]
         },
-        "types": [
-          "Front"
-        ]
-      },
-      {
-        "approved": false,
-        "back": false,
-        "comment": "",
-        "edit": 12345,
-        "front": false,
-        "id": 12345,
-        "image": "http://coverartarchive.org/release/rid/12345.jpg",
-        "thumbnails": {
-          "1200": "http://coverartarchive.org/release/rid/12345-1200.jpg",
-          "250": "http://coverartarchive.org/release/rid/12345-250.jpg",
-          "500": "http://coverartarchive.org/release/rid/12345-500.jpg",
-          "large": "http://coverartarchive.org/release/rid/12345-500.jpg",
-          "small": "http://coverartarchive.org/release/rid/12345-250.jpg"
-        },
-        "types": [
-          "Front"
-        ]
-      }
-    ],
-    "release": "https://musicbrainz.org/release/releaseid"
-}"""
+        {
+            "approved": false,
+            "back": false,
+            "comment": "",
+            "edit": 12345,
+            "front": false,
+            "id": 12345,
+            "image": "http://coverartarchive.org/release/rid/12345.jpg",
+            "thumbnails": {
+                "1200": "http://coverartarchive.org/release/rid/12345-1200.jpg",
+                "250": "http://coverartarchive.org/release/rid/12345-250.jpg",
+                "500": "http://coverartarchive.org/release/rid/12345-500.jpg",
+                "large": "http://coverartarchive.org/release/rid/12345-500.jpg",
+                "small": "http://coverartarchive.org/release/rid/12345-250.jpg"
+            },
+            "types": ["Front"]
+        }
+        ],
+        "release": "https://musicbrainz.org/release/releaseid"
+    }"""
     RESPONSE_RELEASE_WITHOUT_THUMBNAILS = """{
-    "images": [
-      {
-        "approved": false,
-        "back": false,
-        "comment": "GIF",
-        "edit": 12345,
-        "front": true,
-        "id": 12345,
-        "image": "http://coverartarchive.org/release/rid/12345.gif",
-        "types": [
-          "Front"
-        ]
-      },
-      {
-        "approved": false,
-        "back": false,
-        "comment": "",
-        "edit": 12345,
-        "front": false,
-        "id": 12345,
-        "image": "http://coverartarchive.org/release/rid/12345.jpg",
-        "thumbnails": {
-            "large": "http://coverartarchive.org/release/rgid/12345-500.jpg",
-            "small": "http://coverartarchive.org/release/rgid/12345-250.jpg"
+        "images": [
+        {
+            "approved": false,
+            "back": false,
+            "comment": "GIF",
+            "edit": 12345,
+            "front": true,
+            "id": 12345,
+            "image": "http://coverartarchive.org/release/rid/12345.gif",
+            "types": ["Front"]
         },
-        "types": [
-          "Front"
-        ]
-      }
-    ],
-    "release": "https://musicbrainz.org/release/releaseid"
-}"""
+        {
+            "approved": false,
+            "back": false,
+            "comment": "",
+            "edit": 12345,
+            "front": false,
+            "id": 12345,
+            "image": "http://coverartarchive.org/release/rid/12345.jpg",
+            "thumbnails": {
+                "large": "http://coverartarchive.org/release/rgid/12345-500.jpg",
+                "small": "http://coverartarchive.org/release/rgid/12345-250.jpg"
+            },
+            "types": ["Front"]
+        }
+        ],
+        "release": "https://musicbrainz.org/release/releaseid"
+    }"""
     RESPONSE_GROUP = """{
         "images": [
           {
@@ -201,9 +189,7 @@ class CAAHelper:
               "large": "http://coverartarchive.org/release/rgid/12345-500.jpg",
               "small": "http://coverartarchive.org/release/rgid/12345-250.jpg"
             },
-            "types": [
-              "Front"
-            ]
+            "types": ["Front"]
           }
         ],
         "release": "https://musicbrainz.org/release/release-id"
@@ -218,18 +204,12 @@ class CAAHelper:
             "front": true,
             "id": 12345,
             "image": "http://coverartarchive.org/release/releaseid/12345.jpg",
-            "types": [
-              "Front"
-            ]
+            "types": ["Front"]
           }
         ],
         "release": "https://musicbrainz.org/release/release-id"
     }"""
 
-    def mock_caa_response(self, url, json):
-        responses.add(
-            responses.GET, url, body=json, content_type="application/json"
-        )
 
 
 class TestFetchImage(FetchImageTestCase):

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -90,8 +90,11 @@ class UseThePlugin(PytestTestHelper):
 
     @pytest.fixture(autouse=True, scope="class")
     def cleanup(self):
-        for module in self.modules:
-            clean_module_tempdir(module)
+        try:
+            yield
+        finally:
+            for module in self.modules:
+                clean_module_tempdir(module)
 
 
 class CAAData:

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -31,13 +31,8 @@ from beets import config, importer, logging, util
 from beets.autotag.distance import Distance
 from beets.autotag.hooks import AlbumInfo, AlbumMatch
 from beets.test import _common
-from beets.test.helper import (
-    BeetsTestCase,
-    CleanupModulesMixin,
-    FetchImageHelper,
-    capture_log,
-)
-from beets.util import syspath
+from beets.test.helper import CleanupModulesMixin, FetchImageHelper, TestHelper
+from beets.util import clean_module_tempdir, syspath
 from beets.util.artresizer import ArtResizer
 from beetsplug import fetchart
 
@@ -72,12 +67,29 @@ class DummyRemoteArtSource(fetchart.RemoteArtSource):
         return iter(())
 
 
-class UseThePlugin(CleanupModulesMixin, BeetsTestCase):
+class PytestTestHelper(TestHelper):
+    """Same as the BeetsTestCase unittest setup but for pytest."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.setup_beets()
+        try:
+            yield
+        finally:
+            self.teardown_beets()
+
+
+class UseThePlugin(PytestTestHelper):
     modules = (fetchart.__name__, ArtResizer.__module__)
 
-    def setUp(self):
-        super().setUp()
+    @pytest.fixture(autouse=True)
+    def setup_plugin(self, setup):
         self.plugin = fetchart.FetchArtPlugin()
+
+    @pytest.fixture(autouse=True, scope="class")
+    def cleanup(self):
+        for module in self.modules:
+            clean_module_tempdir(module)
 
 
 class FetchImageTestCase(FetchImageHelper, UseThePlugin):

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -686,41 +686,62 @@ class TestITunesStore(UseThePlugin, FetchImageHelper):
         assert expected in caplog.messages[1]
 
 
-class GoogleImageTest(UseThePlugin):
-    def setUp(self):
-        super().setUp()
-        self.source = fetchart.GoogleImages(logger, self.plugin.config)
-        self.settings = Settings()
+class TestGoogleImage(UseThePlugin, FetchImageHelper):
+    @pytest.fixture
+    def settings(self):
+        return Settings()
 
-    @responses.activate
-    def run(self, *args, **kwargs):
-        super().run(*args, **kwargs)
+    @pytest.fixture
+    def source(self):
+        return fetchart.GoogleImages(logger, self.plugin.config)
 
-    def mock_response(self, url, json):
-        responses.add(
-            responses.GET, url, body=json, content_type="application/json"
-        )
-
-    def test_google_art_finds_image(self):
+    def test_google_art_finds_image(
+        self,
+        source: fetchart.GoogleImages,
+        settings: Settings,
+        image_response_mocker: ImageResponseMocker,
+    ):
         album = _common.Bag(albumartist="some artist", album="some album")
         json = '{"items": [{"link": "url_to_the_image"}]}'
-        self.mock_response(fetchart.GoogleImages.URL, json)
-        candidate = next(self.source.get(album, self.settings, []))
+        image_response_mocker.add(
+            fetchart.GoogleImages.URL,
+            body=json,
+            content_type="application/json",
+        )
+        candidate = next(source.get(album, settings, []))
         assert candidate.url == "url_to_the_image"
 
-    def test_google_art_returns_no_result_when_error_received(self):
+    def test_google_art_returns_no_result_when_error_received(
+        self,
+        source: fetchart.GoogleImages,
+        settings: Settings,
+        image_response_mocker: ImageResponseMocker,
+    ):
         album = _common.Bag(albumartist="some artist", album="some album")
         json = '{"error": {"errors": [{"reason": "some reason"}]}}'
-        self.mock_response(fetchart.GoogleImages.URL, json)
+        image_response_mocker.add(
+            fetchart.GoogleImages.URL,
+            body=json,
+            content_type="application/json",
+        )
         with pytest.raises(StopIteration):
-            next(self.source.get(album, self.settings, []))
+            next(source.get(album, settings, []))
 
-    def test_google_art_returns_no_result_with_malformed_response(self):
+    def test_google_art_returns_no_result_with_malformed_response(
+        self,
+        source: fetchart.GoogleImages,
+        settings: Settings,
+        image_response_mocker: ImageResponseMocker,
+    ):
         album = _common.Bag(albumartist="some artist", album="some album")
         json = """bla blup"""
-        self.mock_response(fetchart.GoogleImages.URL, json)
+        image_response_mocker.add(
+            fetchart.GoogleImages.URL,
+            body=json,
+            content_type="application/json",
+        )
         with pytest.raises(StopIteration):
-            next(self.source.get(album, self.settings, []))
+            next(source.get(album, settings, []))
 
 
 class TestCoverArtArchive(UseThePlugin, FetchImageHelper, CAAData):

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -380,9 +380,7 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
         assert candidate is None
 
     def test_main_interface_gives_precedence_to_fs_art(
-        self,
-        dpath,
-        image_request_mock,
+        self, dpath, image_request_mock
     ):
         _common.touch(os.path.join(dpath, b"art.jpg"))
         image_request_mock.get(self.AMAZON_URL)
@@ -392,9 +390,7 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
         assert candidate.path == os.path.join(dpath, b"art.jpg")
 
     def test_main_interface_falls_back_to_amazon(
-        self,
-        dpath,
-        image_request_mock,
+        self, dpath, image_request_mock
     ):
         image_request_mock.get(self.AMAZON_URL)
         album = Album(asin=self.ASIN)
@@ -403,9 +399,7 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
         assert not candidate.path.startswith(dpath)
 
     def test_main_interface_tries_amazon_before_aao(
-        self,
-        dpath,
-        image_request_mock,
+        self, dpath, image_request_mock
     ):
         image_request_mock.get(self.AMAZON_URL)
         album = Album(asin=self.ASIN)

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -955,61 +955,68 @@ class TestAlbumArtOperationConfiguration(AlbumArtOperationMixin):
         assert self.get_album_art()
 
 
-class AlbumArtPerformOperationTest(AlbumArtOperationTestCase):
+class TestAlbumArtPerformOperation(AlbumArtOperationMixin):
     """Test that the art is resized and deinterlaced if necessary."""
 
-    def setUp(self):
-        super().setUp()
-        self.resizer_mock = patch.object(
+    @pytest.fixture
+    def resizer_mock(self):
+        with patch.object(
             ArtResizer.shared, "resize", return_value=self.IMAGE_PATH
-        ).start()
-        self.deinterlacer_mock = patch.object(
-            ArtResizer.shared, "deinterlace", return_value=self.IMAGE_PATH
-        ).start()
+        ) as mocked:
+            yield mocked
 
-    def test_resize(self):
+    @pytest.fixture
+    def deinterlacer_mock(self):
+        with patch.object(
+            ArtResizer.shared, "deinterlace", return_value=self.IMAGE_PATH
+        ) as mocked:
+            yield mocked
+
+    def test_resize(self, resizer_mock: MagicMock):
         self.plugin.maxwidth = self.IMAGE_WIDTH / 2
         assert self.get_album_art()
-        assert self.resizer_mock.called
+        resizer_mock.assert_called_once()
 
-    def test_file_resized(self):
+    def test_file_resized(self, resizer_mock: MagicMock):
         self.plugin.max_filesize = self.IMAGE_FILESIZE // 2
         assert self.get_album_art()
-        assert self.resizer_mock.called
+        resizer_mock.assert_called_once()
 
-    def test_file_not_resized(self):
+    def test_file_not_resized(self, resizer_mock: MagicMock):
         self.plugin.max_filesize = self.IMAGE_FILESIZE
         assert self.get_album_art()
-        assert not self.resizer_mock.called
+        resizer_mock.assert_not_called()
 
-    def test_file_resized_but_not_scaled(self):
+    def test_file_resized_but_not_scaled(self, resizer_mock: MagicMock):
         self.plugin.maxwidth = self.IMAGE_WIDTH * 2
         self.plugin.max_filesize = self.IMAGE_FILESIZE // 2
         assert self.get_album_art()
-        assert self.resizer_mock.called
+        resizer_mock.assert_called_once()
 
-    def test_file_resized_and_scaled(self):
+    def test_file_resized_and_scaled(self, resizer_mock: MagicMock):
         self.plugin.maxwidth = self.IMAGE_WIDTH / 2
         self.plugin.max_filesize = self.IMAGE_FILESIZE // 2
         assert self.get_album_art()
-        assert self.resizer_mock.called
+        assert resizer_mock.call_count == 2
 
-    def test_deinterlaced(self):
+    def test_deinterlaced(self, deinterlacer_mock: MagicMock):
         self.plugin.deinterlace = True
         assert self.get_album_art()
-        assert self.deinterlacer_mock.called
+        deinterlacer_mock.assert_called_once()
 
-    def test_not_deinterlaced(self):
+    def test_not_deinterlaced(self, deinterlacer_mock: MagicMock):
         self.plugin.deinterlace = False
         assert self.get_album_art()
-        assert not self.deinterlacer_mock.called
+        deinterlacer_mock.assert_not_called()
 
-    def test_deinterlaced_and_resized(self):
+    def test_deinterlaced_and_resized(
+        self, resizer_mock: MagicMock, deinterlacer_mock: MagicMock
+    ):
         self.plugin.maxwidth = self.IMAGE_WIDTH / 2
         self.plugin.deinterlace = True
         assert self.get_album_art()
-        assert self.deinterlacer_mock.called
-        assert self.resizer_mock.called
+        deinterlacer_mock.assert_called_once()
+        resizer_mock.assert_called_once()
 
 
 class DeprecatedConfigTest(unittest.TestCase):

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -384,19 +384,23 @@ class TestFSArt(UseThePlugin):
         assert not result
 
 
-class CombinedTest(FetchImageTestCase, CAAHelper):
+class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
     ASIN = "xxxx"
     MBID = "releaseid"
     AMAZON_URL = f"https://images.amazon.com/images/P/{ASIN}.01.LZZZZZZZ.jpg"
     AAO_URL = f"https://www.albumart.org/index_detail.php?asin={ASIN}"
 
-    def setUp(self):
-        super().setUp()
-        self.dpath = os.path.join(self.temp_dir, b"arttest")
-        os.mkdir(syspath(self.dpath))
+    @pytest.fixture
+    def dpath(self):
+        dpath = os.path.join(self.temp_dir, b"arttest")
+        os.mkdir(syspath(dpath))
+        return dpath
 
-    def test_main_interface_returns_amazon_art(self):
-        self.mock_response(self.AMAZON_URL)
+    def test_main_interface_returns_amazon_art(
+        self,
+        image_response_mocker: ImageResponseMocker,
+    ):
+        image_response_mocker.add(self.AMAZON_URL)
         album = _common.Bag(asin=self.ASIN)
         candidate = self.plugin.art_for_album(album, None)
         assert candidate is not None
@@ -406,42 +410,67 @@ class CombinedTest(FetchImageTestCase, CAAHelper):
         candidate = self.plugin.art_for_album(album, None)
         assert candidate is None
 
-    def test_main_interface_gives_precedence_to_fs_art(self):
-        _common.touch(os.path.join(self.dpath, b"art.jpg"))
-        self.mock_response(self.AMAZON_URL)
+    def test_main_interface_gives_precedence_to_fs_art(
+        self,
+        dpath: bytes,
+        image_response_mocker: ImageResponseMocker,
+    ):
+        _common.touch(os.path.join(dpath, b"art.jpg"))
+        image_response_mocker.add(self.AMAZON_URL)
         album = _common.Bag(asin=self.ASIN)
-        candidate = self.plugin.art_for_album(album, [self.dpath])
+        candidate = self.plugin.art_for_album(album, [dpath])
         assert candidate is not None
-        assert candidate.path == os.path.join(self.dpath, b"art.jpg")
+        assert candidate.path == os.path.join(dpath, b"art.jpg")
 
-    def test_main_interface_falls_back_to_amazon(self):
-        self.mock_response(self.AMAZON_URL)
+    def test_main_interface_falls_back_to_amazon(
+        self,
+        dpath: bytes,
+        image_response_mocker: ImageResponseMocker,
+    ):
+        image_response_mocker.add(self.AMAZON_URL)
         album = _common.Bag(asin=self.ASIN)
-        candidate = self.plugin.art_for_album(album, [self.dpath])
+        candidate = self.plugin.art_for_album(album, [dpath])
         assert candidate is not None
-        assert not candidate.path.startswith(self.dpath)
+        assert not candidate.path.startswith(dpath)
 
-    def test_main_interface_tries_amazon_before_aao(self):
-        self.mock_response(self.AMAZON_URL)
+    def test_main_interface_tries_amazon_before_aao(
+        self,
+        dpath: bytes,
+        image_response_mocker: ImageResponseMocker,
+    ):
+        image_response_mocker.add(self.AMAZON_URL)
         album = _common.Bag(asin=self.ASIN)
-        self.plugin.art_for_album(album, [self.dpath])
-        assert len(responses.calls) == 1
-        assert responses.calls[0].request.url == self.AMAZON_URL
+        self.plugin.art_for_album(album, [dpath])
+        assert len(image_response_mocker.responses_mock.calls) == 1
+        assert (
+            image_response_mocker.responses_mock.calls[0].request.url
+            == self.AMAZON_URL
+        )
 
-    def test_main_interface_falls_back_to_aao(self):
-        self.mock_response(self.AMAZON_URL, content_type="text/html")
+    def test_main_interface_falls_back_to_aao(
+        self,
+        dpath: bytes,
+        image_response_mocker: ImageResponseMocker,
+    ):
+        image_response_mocker.add(self.AMAZON_URL, content_type="text/html")
         album = _common.Bag(asin=self.ASIN)
-        self.plugin.art_for_album(album, [self.dpath])
-        assert responses.calls[-1].request.url == self.AAO_URL
+        self.plugin.art_for_album(album, [dpath])
+        assert (
+            image_response_mocker.responses_mock.calls[-1].request.url
+            == self.AAO_URL
+        )
 
-    def test_main_interface_uses_caa_when_mbid_available(self):
-        self.mock_caa_response(self.RELEASE_URL, self.RESPONSE_RELEASE)
-        self.mock_caa_response(self.GROUP_URL, self.RESPONSE_GROUP)
-        self.mock_response(
+    def test_main_interface_uses_caa_when_mbid_available(
+        self,
+        image_response_mocker: ImageResponseMocker,
+    ):
+        image_response_mocker.add(self.RELEASE_URL, body=self.RESPONSE_RELEASE)
+        image_response_mocker.add(self.GROUP_URL, body=self.RESPONSE_GROUP)
+        image_response_mocker.add(
             "http://coverartarchive.org/release/rid/12345.gif",
             content_type="image/gif",
         )
-        self.mock_response(
+        image_response_mocker.add(
             "http://coverartarchive.org/release/rid/12345.jpg",
             content_type="image/jpeg",
         )
@@ -452,23 +481,31 @@ class CombinedTest(FetchImageTestCase, CAAHelper):
         )
         candidate = self.plugin.art_for_album(album, None)
         assert candidate is not None
-        assert len(responses.calls) == 3
-        assert responses.calls[0].request.url == self.RELEASE_URL
+        assert len(image_response_mocker.responses_mock.calls) == 3
+        assert (
+            image_response_mocker.responses_mock.calls[0].request.url
+            == self.RELEASE_URL
+        )
 
-    def test_local_only_does_not_access_network(self):
+    def test_local_only_does_not_access_network(
+        self,
+        image_response_mocker: ImageResponseMocker,
+    ):
         album = _common.Bag(mb_albumid=self.MBID, asin=self.ASIN)
         self.plugin.art_for_album(album, None, local_only=True)
-        assert len(responses.calls) == 0
+        assert len(image_response_mocker.responses_mock.calls) == 0
 
-    def test_local_only_gets_fs_image(self):
-        _common.touch(os.path.join(self.dpath, b"art.jpg"))
+    def test_local_only_gets_fs_image(
+        self,
+        dpath: bytes,
+        image_response_mocker: ImageResponseMocker,
+    ):
+        _common.touch(os.path.join(dpath, b"art.jpg"))
         album = _common.Bag(mb_albumid=self.MBID, asin=self.ASIN)
-        candidate = self.plugin.art_for_album(
-            album, [self.dpath], local_only=True
-        )
+        candidate = self.plugin.art_for_album(album, [dpath], local_only=True)
         assert candidate is not None
-        assert candidate.path == os.path.join(self.dpath, b"art.jpg")
-        assert len(responses.calls) == 0
+        assert candidate.path == os.path.join(dpath, b"art.jpg")
+        assert len(image_response_mocker.responses_mock.calls) == 0
 
 
 class TestAAO(UseThePlugin, FetchImageHelper):

--- a/test/plugins/test_embedart.py
+++ b/test/plugins/test_embedart.py
@@ -41,7 +41,7 @@ from beetsplug._utils import art
 from test.test_art_resize import DummyIMBackend
 
 if TYPE_CHECKING:
-    from beets.test.helper import ImageResponseMocker
+    from beets.test.helper import ImageRequestMocker
 
 
 def require_artresizer_compare(test):
@@ -278,43 +278,43 @@ class TestEmbedartCli(PytestImportHelper, IOMixin, FetchImageHelper):
         assert mediafile.images[0].data == self.image_data
 
     def test_embed_art_from_url_with_yes_input(
-        self, image_response_mocker: ImageResponseMocker
+        self, image_request_mock: ImageRequestMocker
     ):
         self._setup_data()
         album = self.add_album_fixture()
         item = album.items()[0]
-        image_response_mocker.add(
+        image_request_mock.get(
             "http://example.com/test.jpg", content_type="image/jpeg"
         )
         self.io.addinput("y")
         self.run_command("embedart", "-u", "http://example.com/test.jpg")
         mediafile = MediaFile(syspath(item.path))
-        assert mediafile.images[0].data == image_response_mocker.IMAGE_HEADERS[
+        assert mediafile.images[0].data == image_request_mock.IMAGE_HEADERS[
             "image/jpeg"
         ].ljust(32, b"\x00")
 
     def test_embed_art_from_url_png(
-        self, image_response_mocker: ImageResponseMocker
+        self, image_request_mock: ImageRequestMocker
     ):
         self._setup_data()
         album = self.add_album_fixture()
         item = album.items()[0]
-        image_response_mocker.add(
+        image_request_mock.get(
             "http://example.com/test.png", content_type="image/png"
         )
         self.run_command("embedart", "-y", "-u", "http://example.com/test.png")
         mediafile = MediaFile(syspath(item.path))
-        assert mediafile.images[0].data == image_response_mocker.IMAGE_HEADERS[
+        assert mediafile.images[0].data == image_request_mock.IMAGE_HEADERS[
             "image/png"
         ].ljust(32, b"\x00")
 
     def test_embed_art_from_url_not_image(
-        self, image_response_mocker: ImageResponseMocker
+        self, image_request_mock: ImageRequestMocker
     ):
         self._setup_data()
         album = self.add_album_fixture()
         item = album.items()[0]
-        image_response_mocker.add(
+        image_request_mock.get(
             "http://example.com/test.html", content_type="text/html"
         )
         self.run_command("embedart", "-y", "-u", "http://example.com/test.html")

--- a/test/plugins/test_embedart.py
+++ b/test/plugins/test_embedart.py
@@ -289,11 +289,9 @@ class TestEmbedartCli(PytestImportHelper, IOMixin, FetchImageHelper):
         self.io.addinput("y")
         self.run_command("embedart", "-u", "http://example.com/test.jpg")
         mediafile = MediaFile(syspath(item.path))
-        assert mediafile.images[
-            0
-        ].data == image_response_mocker.IMAGE_HEADERS.get("image/jpeg").ljust(
-            32, b"\x00"
-        )
+        assert mediafile.images[0].data == image_response_mocker.IMAGE_HEADERS[
+            "image/jpeg"
+        ].ljust(32, b"\x00")
 
     def test_embed_art_from_url_png(
         self, image_response_mocker: ImageResponseMocker
@@ -306,11 +304,9 @@ class TestEmbedartCli(PytestImportHelper, IOMixin, FetchImageHelper):
         )
         self.run_command("embedart", "-y", "-u", "http://example.com/test.png")
         mediafile = MediaFile(syspath(item.path))
-        assert mediafile.images[
-            0
-        ].data == image_response_mocker.IMAGE_HEADERS.get("image/png").ljust(
-            32, b"\x00"
-        )
+        assert mediafile.images[0].data == image_response_mocker.IMAGE_HEADERS[
+            "image/png"
+        ].ljust(32, b"\x00")
 
     def test_embed_art_from_url_not_image(
         self, image_response_mocker: ImageResponseMocker

--- a/test/plugins/test_embedart.py
+++ b/test/plugins/test_embedart.py
@@ -12,12 +12,14 @@
 # The above copyright notice and this permission notice shall be
 # included in all copies or substantial portions of the Software.
 
+from __future__ import annotations
 
 import os
 import os.path
 import shutil
 import tempfile
 import unittest
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -27,16 +29,19 @@ from beets import config, logging
 from beets.exceptions import UserError
 from beets.test import _common
 from beets.test.helper import (
-    BeetsTestCase,
     FetchImageHelper,
     ImportHelper,
     IOMixin,
     PluginMixin,
+    TestHelper,
 )
 from beets.util import bytestring_path, displayable_path, syspath
 from beets.util.artresizer import ArtResizer
 from beetsplug._utils import art
 from test.test_art_resize import DummyIMBackend
+
+if TYPE_CHECKING:
+    from beets.test.helper import ImageResponseMocker
 
 
 def require_artresizer_compare(test):
@@ -73,9 +78,30 @@ def require_artresizer_compare(test):
     return wrapper
 
 
-class EmbedartCliTest(
-    ImportHelper, IOMixin, PluginMixin, FetchImageHelper, BeetsTestCase
-):
+class PytestPluginTestHelper(PluginMixin, TestHelper):
+    """Same as the BeetsTestCase unittest setup but for pytest."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.setup_beets()
+        try:
+            yield
+        finally:
+            self.teardown_beets()
+
+
+class PytestImportHelper(PytestPluginTestHelper, ImportHelper):
+    @pytest.fixture(autouse=True)
+    def setup_import_helper(self, setup):
+        self.import_media = []
+        self.lib.path_formats = [
+            ("default", os.path.join("$artist", "$album", "$title")),
+            ("singleton:true", os.path.join("singletons", "$title")),
+            ("comp:true", os.path.join("compilations", "$album", "$title")),
+        ]
+
+
+class TestEmbedartCli(PytestImportHelper, IOMixin, FetchImageHelper):
     plugin = "embedart"
     small_artpath = os.path.join(_common.RSRC, b"image-2x3.jpg")
     abbey_artpath = os.path.join(_common.RSRC, b"abbey.jpg")
@@ -144,7 +170,7 @@ class EmbedartCliTest(
 
         if os.path.isfile(syspath(tmp_path)):
             os.remove(syspath(tmp_path))
-            self.fail(
+            pytest.fail(
                 f"Artwork file {displayable_path(tmp_path)} was not deleted"
             )
 
@@ -251,34 +277,50 @@ class EmbedartCliTest(
         mediafile = MediaFile(syspath(item.path))
         assert mediafile.images[0].data == self.image_data
 
-    def test_embed_art_from_url_with_yes_input(self):
+    def test_embed_art_from_url_with_yes_input(
+        self, image_response_mocker: ImageResponseMocker
+    ):
         self._setup_data()
         album = self.add_album_fixture()
         item = album.items()[0]
-        self.mock_response("http://example.com/test.jpg", "image/jpeg")
+        image_response_mocker.add(
+            "http://example.com/test.jpg", content_type="image/jpeg"
+        )
         self.io.addinput("y")
         self.run_command("embedart", "-u", "http://example.com/test.jpg")
         mediafile = MediaFile(syspath(item.path))
-        assert mediafile.images[0].data == self.IMAGEHEADER.get(
-            "image/jpeg"
-        ).ljust(32, b"\x00")
+        assert mediafile.images[
+            0
+        ].data == image_response_mocker.IMAGE_HEADERS.get("image/jpeg").ljust(
+            32, b"\x00"
+        )
 
-    def test_embed_art_from_url_png(self):
+    def test_embed_art_from_url_png(
+        self, image_response_mocker: ImageResponseMocker
+    ):
         self._setup_data()
         album = self.add_album_fixture()
         item = album.items()[0]
-        self.mock_response("http://example.com/test.png", "image/png")
+        image_response_mocker.add(
+            "http://example.com/test.png", content_type="image/png"
+        )
         self.run_command("embedart", "-y", "-u", "http://example.com/test.png")
         mediafile = MediaFile(syspath(item.path))
-        assert mediafile.images[0].data == self.IMAGEHEADER.get(
-            "image/png"
-        ).ljust(32, b"\x00")
+        assert mediafile.images[
+            0
+        ].data == image_response_mocker.IMAGE_HEADERS.get("image/png").ljust(
+            32, b"\x00"
+        )
 
-    def test_embed_art_from_url_not_image(self):
+    def test_embed_art_from_url_not_image(
+        self, image_response_mocker: ImageResponseMocker
+    ):
         self._setup_data()
         album = self.add_album_fixture()
         item = album.items()[0]
-        self.mock_response("http://example.com/test.html", "text/html")
+        image_response_mocker.add(
+            "http://example.com/test.html", content_type="text/html"
+        )
         self.run_command("embedart", "-y", "-u", "http://example.com/test.html")
         mediafile = MediaFile(syspath(item.path))
         assert not mediafile.images


### PR DESCRIPTION
This pull request refactors the image response mocking utilities used in tests, transitioning from a unittest-based mixin (`FetchImageHelper`) to a more flexible, pytest-compatible fixture approach. It introduces a new `ImageResponseMocker` class, updates test helpers to use pytest fixtures, and adapts the embedart plugin tests to leverage these changes for clearer and more maintainable test code.

This is quite a big one, sorry about that but there was not really a way to make this more digestible. The testing mixin hierachy we had before the refactor got quite convoluted over the years. It is still not perfect imo but it is a big step up.


TODOs:
- [x] ~~Changelog~~ Not needed as this is an internal refactor only

---

This is related to the multi-step efforts to improve logging in beets https://github.com/beetbox/beets/issues/6553
