### PR TITLE
core/structure: move UserError to beets.exceptions

### DIFF
--- a/beets/exceptions.py
+++ b/beets/exceptions.py
@@ -1,0 +1,4 @@
+class UserError(Exception):
+    """UI exception. Commands should throw this in order to display
+    nonrecoverable errors to the user.
+    """

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -36,6 +36,7 @@ import confuse
 from beets import config, library, logging, plugins, util
 from beets.dbcore import db
 from beets.dbcore import query as db_query
+from beets.exceptions import UserError
 from beets.util import as_string
 from beets.util.color import colorize
 from beets.util.deprecation import deprecate_for_maintainers
@@ -66,12 +67,6 @@ PF_KEY_QUERIES = {
     "comp": "comp:true",
     "singleton": "singleton:true",
 }
-
-
-class UserError(Exception):
-    """UI exception. Commands should throw this in order to display
-    nonrecoverable errors to the user.
-    """
 
 
 # Encoding utilities.

--- a/beets/ui/commands/config.py
+++ b/beets/ui/commands/config.py
@@ -3,6 +3,7 @@
 import os
 
 from beets import config, ui
+from beets.exceptions import UserError
 from beets.util import displayable_path, editor_command, interactive_open
 
 
@@ -52,7 +53,7 @@ def config_edit(cli_options):
     editor = editor_command()
 
     if not editor:
-        raise ui.UserError(
+        raise UserError(
             "Please set the VISUAL or EDITOR environment variable to edit"
             " configuration."
         )
@@ -61,9 +62,9 @@ def config_edit(cli_options):
             open(path, "w+").close()
         interactive_open([path], editor)
     except FileNotFoundError:
-        raise ui.UserError(f"Editor {editor!r} not found.")
+        raise UserError(f"Editor {editor!r} not found.")
     except OSError as exc:
-        raise ui.UserError(f"Could not edit configuration: {exc}")
+        raise UserError(f"Could not edit configuration: {exc}")
 
 
 config_cmd = ui.Subcommand("config", help="show or edit the user configuration")

--- a/beets/ui/commands/help.py
+++ b/beets/ui/commands/help.py
@@ -1,6 +1,7 @@
 """The 'help' command: show help information for commands."""
 
 from beets import ui
+from beets.exceptions import UserError
 
 
 class HelpCommand(ui.Subcommand):
@@ -16,7 +17,7 @@ class HelpCommand(ui.Subcommand):
             cmdname = args[0]
             helpcommand = self.root_parser._subcommand_for_name(cmdname)
             if not helpcommand:
-                raise ui.UserError(f"unknown command '{cmdname}'")
+                raise UserError(f"unknown command '{cmdname}'")
             helpcommand.print_help()
         else:
             self.root_parser.print_help()

--- a/beets/ui/commands/import_/__init__.py
+++ b/beets/ui/commands/import_/__init__.py
@@ -3,6 +3,7 @@
 import os
 
 from beets import config, logging, plugins, ui
+from beets.exceptions import UserError
 from beets.util import displayable_path, normpath, syspath
 
 from .session import TerminalImportSession
@@ -37,11 +38,11 @@ def parse_logfiles(logfiles):
         try:
             yield from paths_from_logfile(syspath(normpath(logfile)))
         except ValueError as err:
-            raise ui.UserError(
+            raise UserError(
                 f"malformed logfile {displayable_path(logfile)}: {err}"
             ) from err
         except OSError as err:
-            raise ui.UserError(
+            raise UserError(
                 f"unreadable logfile {displayable_path(logfile)}: {err}"
             ) from err
 
@@ -52,7 +53,7 @@ def import_files(lib, paths: list[bytes], query):
     """
     # Check parameter consistency.
     if config["import"]["quiet"] and config["import"]["timid"]:
-        raise ui.UserError("can't be both quiet and timid")
+        raise UserError("can't be both quiet and timid")
 
     # Open the log.
     if config["import"]["log"].get() is not None:
@@ -60,7 +61,7 @@ def import_files(lib, paths: list[bytes], query):
         try:
             loghandler = logging.FileHandler(logpath, encoding="utf-8")
         except OSError:
-            raise ui.UserError(
+            raise UserError(
                 "Could not open log file for writing:"
                 f" {displayable_path(logpath)}"
             )
@@ -98,7 +99,7 @@ def import_func(lib, opts, args: list[str]):
         paths_from_logfiles = list(parse_logfiles(opts.from_logfiles or []))
 
         if not paths and not paths_from_logfiles:
-            raise ui.UserError("no path specified")
+            raise UserError("no path specified")
 
         byte_paths = [os.fsencode(p) for p in paths]
         paths_from_logfiles = [os.fsencode(p) for p in paths_from_logfiles]
@@ -106,7 +107,7 @@ def import_func(lib, opts, args: list[str]):
         # Check the user-specified directories.
         for path in byte_paths:
             if not os.path.exists(syspath(normpath(path))):
-                raise ui.UserError(
+                raise UserError(
                     f"no such file or directory: {displayable_path(path)}"
                 )
 
@@ -126,7 +127,7 @@ def import_func(lib, opts, args: list[str]):
         # If all paths were read from a logfile, and none of them exist, throw
         # an error
         if not byte_paths:
-            raise ui.UserError("none of the paths are importable")
+            raise UserError("none of the paths are importable")
 
     import_files(lib, byte_paths, query)
 
@@ -150,7 +151,7 @@ def _store_dict(option, opt_str, value, parser):
         if not (key and value):
             raise ValueError
     except ValueError:
-        raise ui.UserError(
+        raise UserError(
             f"supplied argument `{value}' is not of the form `key=value'"
         )
 

--- a/beets/ui/commands/modify.py
+++ b/beets/ui/commands/modify.py
@@ -1,6 +1,7 @@
 """The `modify` command: change metadata fields."""
 
 from beets import library, ui
+from beets.exceptions import UserError
 from beets.util import functemplate
 from beets.util.deprecation import maybe_replace_legacy_field
 
@@ -106,7 +107,7 @@ def modify_parse_args(args, is_album: bool):
 def modify_func(lib, opts, args):
     query, mods, dels = modify_parse_args(args, is_album=opts.album)
     if not mods and not dels:
-        raise ui.UserError("no modifications specified")
+        raise UserError("no modifications specified")
     modify_items(
         lib,
         mods,

--- a/beets/ui/commands/move.py
+++ b/beets/ui/commands/move.py
@@ -6,6 +6,7 @@ import os
 from typing import TYPE_CHECKING
 
 from beets import logging, ui
+from beets.exceptions import UserError
 from beets.util import MoveOperation, displayable_path, normpath, syspath
 from beets.util.diff import colordiff
 
@@ -151,7 +152,7 @@ def move_func(lib, opts, args):
     if dest is not None:
         dest = normpath(dest)
         if not os.path.isdir(syspath(dest)):
-            raise ui.UserError(f"no such directory: {displayable_path(dest)}")
+            raise UserError(f"no such directory: {displayable_path(dest)}")
 
     move_items(
         lib,

--- a/beets/ui/commands/utils.py
+++ b/beets/ui/commands/utils.py
@@ -1,6 +1,6 @@
 """Utility functions for beets UI commands."""
 
-from beets import ui
+from beets.exceptions import UserError
 
 
 def do_query(lib, query, album, also_items=True):
@@ -22,8 +22,8 @@ def do_query(lib, query, album, also_items=True):
         items = list(lib.items(query))
 
     if album and not albums:
-        raise ui.UserError("No matching albums found.")
+        raise UserError("No matching albums found.")
     elif not album and not items:
-        raise ui.UserError("No matching items found.")
+        raise UserError("No matching items found.")
 
     return items, albums

--- a/beetsplug/absubmit.py
+++ b/beetsplug/absubmit.py
@@ -25,6 +25,7 @@ import tempfile
 import requests
 
 from beets import plugins, ui, util
+from beets.exceptions import UserError
 
 # We use this field to check whether AcousticBrainz info is present.
 PROBE_FIELD = "mood_acoustic"
@@ -60,7 +61,7 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
             self.extractor = util.normpath(self.extractor)
             # Explicit path to extractor
             if not os.path.isfile(self.extractor):
-                raise ui.UserError(
+                raise UserError(
                     f"Extractor command does not exist: {self.extractor}."
                 )
         else:
@@ -69,7 +70,7 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
             try:
                 call([self.extractor])
             except OSError:
-                raise ui.UserError(
+                raise UserError(
                     "No extractor command found: please install the extractor"
                     " binary from https://essentia.upf.edu/"
                 )
@@ -92,7 +93,7 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
         base_url = self.config["base_url"].as_str()
         if base_url:
             if not base_url.startswith("http"):
-                raise ui.UserError(
+                raise UserError(
                     "AcousticBrainz server base URL must start "
                     "with an HTTP scheme"
                 )
@@ -128,7 +129,7 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
 
     def command(self, lib, opts, args):
         if not self.url:
-            raise ui.UserError(
+            raise UserError(
                 "This plugin is deprecated since AcousticBrainz no longer "
                 "accepts new submissions. See the base_url configuration "
                 "option."

--- a/beetsplug/acousticbrainz.py
+++ b/beetsplug/acousticbrainz.py
@@ -21,6 +21,7 @@ import requests
 
 from beets import plugins, ui
 from beets.dbcore import types
+from beets.exceptions import UserError
 
 LEVELS = ["/low-level", "/high-level"]
 ABSCHEME = {
@@ -93,7 +94,7 @@ class AcousticPlugin(plugins.BeetsPlugin):
         self.base_url = self.config["base_url"].as_str()
         if self.base_url:
             if not self.base_url.startswith("http"):
-                raise ui.UserError(
+                raise UserError(
                     "AcousticBrainz server base URL must start "
                     "with an HTTP scheme"
                 )
@@ -133,7 +134,7 @@ class AcousticPlugin(plugins.BeetsPlugin):
 
     def _get_data(self, mbid):
         if not self.base_url:
-            raise ui.UserError(
+            raise UserError(
                 "This plugin is deprecated since AcousticBrainz has shut "
                 "down. See the base_url configuration option."
             )

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -33,6 +33,7 @@ import beets
 import beets.ui
 from beets import config
 from beets.autotag.hooks import AlbumInfo, TrackInfo
+from beets.exceptions import UserError
 from beets.metadata_plugins import MetadataSourcePlugin
 from beets.util import unique_list
 from beets.util.deprecation import deprecate_for_user
@@ -359,7 +360,7 @@ class BeatportPlugin(MetadataSourcePlugin):
             url = auth_client.get_authorize_url()
         except AUTH_ERRORS as e:
             self._log.debug("authentication error: {}", e)
-            raise beets.ui.UserError("communication with Beatport failed")
+            raise UserError("communication with Beatport failed")
 
         beets.ui.print_("To authenticate with Beatport, visit:")
         beets.ui.print_(url)
@@ -370,7 +371,7 @@ class BeatportPlugin(MetadataSourcePlugin):
             token, secret = auth_client.get_access_token(data)
         except AUTH_ERRORS as e:
             self._log.debug("authentication error: {}", e)
-            raise beets.ui.UserError("Beatport token request failed")
+            raise UserError("Beatport token request failed")
 
         # Save the token for later use.
         self._log.debug("Beatport token {}, secret {}", token, secret)

--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, ClassVar
 import beets
 import beets.ui
 from beets import dbcore
+from beets.exceptions import UserError
 from beets.library import Item
 from beets.plugins import BeetsPlugin
 from beets.util import as_string, bluelet
@@ -1618,7 +1619,7 @@ class BPDPlugin(BeetsPlugin):
             else:
                 ctrl_port = self.config["control_port"].get(int)
             if args:
-                raise beets.ui.UserError("too many arguments")
+                raise UserError("too many arguments")
             password = self.config["password"].as_str()
             volume = self.config["volume"].get(int)
             self.start_bpd(

--- a/beetsplug/bpd/gstplayer.py
+++ b/beetsplug/bpd/gstplayer.py
@@ -25,7 +25,7 @@ import urllib
 
 import gi
 
-from beets import ui
+from beets.exceptions import UserError
 
 try:
     gi.require_version("Gst", "1.0")
@@ -78,12 +78,12 @@ class GstPlayer:
         self.player = Gst.ElementFactory.make("playbin", "player")
 
         if self.player is None:
-            raise ui.UserError("Could not create playbin")
+            raise UserError("Could not create playbin")
 
         fakesink = Gst.ElementFactory.make("fakesink", "fakesink")
 
         if fakesink is None:
-            raise ui.UserError("Could not create fakesink")
+            raise UserError("Could not create fakesink")
 
         self.player.set_property("video-sink", fakesink)
         bus = self.player.get_bus()

--- a/beetsplug/bucket.py
+++ b/beetsplug/bucket.py
@@ -19,7 +19,8 @@ import string
 from datetime import datetime
 from itertools import tee
 
-from beets import plugins, ui
+from beets import plugins
+from beets.exceptions import UserError
 
 ASCII_DIGITS = string.digits + string.ascii_lowercase
 
@@ -54,13 +55,13 @@ def span_from_str(span_str):
 
     years = [int(x) for x in re.findall(r"\d+", span_str)]
     if not years:
-        raise ui.UserError(
+        raise UserError(
             f"invalid range defined for year bucket {span_str!r}: no year found"
         )
     try:
         years = [normalize_year(x, years[0]) for x in years]
     except BucketError as exc:
-        raise ui.UserError(
+        raise UserError(
             f"invalid range defined for year bucket {span_str!r}: {exc}"
         )
 
@@ -163,7 +164,7 @@ def build_alpha_spans(alpha_spans_str, alpha_regexs):
                 begin_index = ASCII_DIGITS.index(bucket[0])
                 end_index = ASCII_DIGITS.index(bucket[-1])
             else:
-                raise ui.UserError(
+                raise UserError(
                     "invalid range defined for alpha bucket "
                     f"'{elem}': no alphanumeric character found"
                 )

--- a/beetsplug/chroma.py
+++ b/beetsplug/chroma.py
@@ -29,6 +29,7 @@ import confuse
 
 from beets import config, ui, util
 from beets.autotag.distance import Distance
+from beets.exceptions import UserError
 from beets.metadata_plugins import MetadataSourcePlugin, get_metadata_source
 from beets.util.color import colorize
 
@@ -276,7 +277,7 @@ class AcoustidPlugin(MetadataSourcePlugin):
             try:
                 apikey = config["acoustid"]["apikey"].as_str()
             except confuse.NotFoundError:
-                raise ui.UserError("no Acoustid user API key provided")
+                raise UserError("no Acoustid user API key provided")
             submit_items(self._log, apikey, lib.items(args))
 
         submit_cmd.func = submit_cmd_func
@@ -331,9 +332,9 @@ class AcoustidPlugin(MetadataSourcePlugin):
 
         def search_cmd_func(lib, opts, args):
             if not opts.search:
-                raise ui.UserError("no --search provided")
+                raise UserError("no --search provided")
             if opts.count <= 0:
-                raise ui.UserError("--count must be > 0")
+                raise UserError("--count must be > 0")
 
             target = (0, opts.search.encode("utf-8"))
             top = TopN(opts.count)

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -30,6 +30,7 @@ import mediafile
 from confuse import ConfigTypeError, Optional
 
 from beets import plugins, ui, util
+from beets.exceptions import UserError
 from beets.library import Item, parse_query_string
 from beets.plugins import BeetsPlugin
 from beets.util import par_map
@@ -224,7 +225,7 @@ class ConvertPlugin(BeetsPlugin):
     def dest(self) -> bytes:
         dest = self.config["dest"].get()
         if not dest:
-            raise ui.UserError("no convert destination set")
+            raise UserError("no convert destination set")
         return util.bytestring_path(dest)
 
     @cached_property
@@ -272,9 +273,7 @@ class ConvertPlugin(BeetsPlugin):
             command = format_info["command"]
             extension = format_info.get("extension", fmt)
         except KeyError:
-            raise ui.UserError(
-                f'convert: format {fmt} needs the "command" field'
-            )
+            raise UserError(f'convert: format {fmt} needs the "command" field')
         except ConfigTypeError:
             command = self.config["formats"][fmt].get(str)
             extension = fmt
@@ -363,7 +362,7 @@ class ConvertPlugin(BeetsPlugin):
             util.prune_dirs(os.path.dirname(dest))
             raise
         except OSError as exc:
-            raise ui.UserError(
+            raise UserError(
                 f"convert: couldn't invoke {' '.join(args)!r}: {exc}"
             )
 

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -25,6 +25,7 @@ import requests
 from beets import config, ui
 from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.dbcore import types
+from beets.exceptions import UserError
 from beets.metadata_plugins import IDResponse, SearchApiMetadataSourcePlugin
 
 VARIOUS_ARTISTS_ID = 5080
@@ -96,7 +97,7 @@ class DeezerPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
             month = None
             day = None
         else:
-            raise ui.UserError(
+            raise UserError(
                 f"Invalid `release_date` returned by {self.data_source} API: "
                 f"{release_date!r}"
             )

--- a/beetsplug/discogs/__init__.py
+++ b/beetsplug/discogs/__init__.py
@@ -39,6 +39,7 @@ import beets.ui
 from beets import config, util
 from beets.autotag.distance import string_dist
 from beets.autotag.hooks import AlbumInfo, TrackInfo
+from beets.exceptions import UserError
 from beets.metadata_plugins import IDResponse, SearchApiMetadataSourcePlugin
 
 from .states import DISAMBIGUATION_RE, ArtistState, TracklistState
@@ -178,7 +179,7 @@ class DiscogsPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
             _, _, url = auth_client.get_authorize_url()
         except CONNECTION_ERRORS as e:
             self._log.debug("connection error: {}", e)
-            raise beets.ui.UserError("communication with Discogs failed")
+            raise UserError("communication with Discogs failed")
 
         beets.ui.print_("To authenticate with Discogs, visit:")
         beets.ui.print_(url)
@@ -188,10 +189,10 @@ class DiscogsPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
         try:
             token, secret = auth_client.get_access_token(code)
         except DiscogsAPIError:
-            raise beets.ui.UserError("Discogs authorization failed")
+            raise UserError("Discogs authorization failed")
         except CONNECTION_ERRORS as e:
             self._log.debug("connection error: {}", e)
-            raise beets.ui.UserError("Discogs token request failed")
+            raise UserError("Discogs token request failed")
 
         # Save the token for later use.
         self._log.debug("Discogs token {}, secret {}", token, secret)

--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -24,6 +24,7 @@ import yaml
 
 from beets import plugins, ui, util
 from beets.dbcore import types
+from beets.exceptions import UserError
 from beets.importer import Action
 from beets.ui.commands.utils import do_query
 from beets.util import PromptChoice
@@ -52,7 +53,7 @@ def edit(filename, log):
     try:
         subprocess.call(cmd)
     except OSError as exc:
-        raise ui.UserError(f"could not run editor command {cmd[0]!r}: {exc}")
+        raise UserError(f"could not run editor command {cmd[0]!r}: {exc}")
 
 
 def dump(arg):

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -21,6 +21,7 @@ from mimetypes import guess_extension
 import requests
 
 from beets import config, ui
+from beets.exceptions import UserError
 from beets.plugins import BeetsPlugin
 from beets.ui import print_
 from beets.util import bytestring_path, displayable_path, normpath, syspath
@@ -115,7 +116,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
             if opts.file:
                 imagepath = normpath(opts.file)
                 if not os.path.isfile(syspath(imagepath)):
-                    raise ui.UserError(
+                    raise UserError(
                         f"image file {displayable_path(imagepath)} not found"
                     )
 

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -30,6 +30,7 @@ import requests
 from mediafile import image_mime_type
 
 from beets import config, importer, plugins, ui, util
+from beets.exceptions import UserError
 from beets.util import bytestring_path, get_temp_filename, sorted_walk, syspath
 from beets.util.artresizer import ArtResizer
 from beets.util.color import colorize
@@ -1457,11 +1458,11 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             )
 
             if len(sources) == 0:
-                raise ui.UserError("fetchart: no sources defined in config")
+                raise UserError("fetchart: no sources defined in config")
 
             return sources
         except UnknownPairError as e:
-            raise ui.UserError(e)
+            raise UserError(e)
 
     @staticmethod
     def _is_source_file_removal_enabled() -> bool:

--- a/beetsplug/lastimport.py
+++ b/beetsplug/lastimport.py
@@ -21,6 +21,7 @@ from pylast import TopItem, _extract, _number
 
 from beets import config, plugins, ui
 from beets.dbcore import types
+from beets.exceptions import UserError
 
 from ._utils.playcount import update_play_counts
 
@@ -126,7 +127,7 @@ def import_lastfm(lib, log):
     per_page = config["lastimport"]["per_page"].get(int)
 
     if not user:
-        raise ui.UserError("You must specify a user name for lastimport")
+        raise UserError("You must specify a user name for lastimport")
 
     log.info("Fetching last.fm library for @{}", user)
 
@@ -147,7 +148,7 @@ def import_lastfm(lib, log):
             tracks, page_total = fetch_tracks(user, page_current + 1, per_page)
             if page_total < 1:
                 # It means nothing to us!
-                raise ui.UserError("Last.fm reported no data.")
+                raise UserError("Last.fm reported no data.")
 
             if tracks:
                 found, unknown = update_play_counts(lib, tracks, log, "lastfm")

--- a/beetsplug/mbcollection.py
+++ b/beetsplug/mbcollection.py
@@ -22,7 +22,8 @@ from typing import TYPE_CHECKING, ClassVar
 
 from requests.auth import HTTPDigestAuth
 
-from beets import __version__, config, ui
+from beets import __version__, config
+from beets.exceptions import UserError
 from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand
 
@@ -168,7 +169,7 @@ class MusicBrainzCollectionPlugin(BeetsPlugin):
     @cached_property
     def collection(self) -> MBCollection:
         if not (collections := self.mb_api.browse_collections()):
-            raise ui.UserError("no collections exist for user")
+            raise UserError("no collections exist for user")
 
         # Get all release collection IDs, avoiding event collections
         if not (
@@ -176,12 +177,12 @@ class MusicBrainzCollectionPlugin(BeetsPlugin):
                 c["id"]: c for c in collections if c["entity_type"] == "release"
             }
         ):
-            raise ui.UserError("No release collection found.")
+            raise UserError("No release collection found.")
 
         # Check that the collection exists so we can present a nice error
         if collection_id := self.config["collection"].as_str():
             if not (collection := collection_by_id.get(collection_id)):
-                raise ui.UserError(f"invalid collection ID: {collection_id}")
+                raise UserError(f"invalid collection ID: {collection_id}")
         else:
             # No specified collection. Just return the first collection ID
             collection = next(iter(collection_by_id.values()))

--- a/beetsplug/mpdstats.py
+++ b/beetsplug/mpdstats.py
@@ -22,6 +22,7 @@ import mpd
 from beets import config, plugins, ui
 from beets.dbcore import types
 from beets.dbcore.query import PathQuery
+from beets.exceptions import UserError
 from beets.util import displayable_path
 
 # If we lose the connection, how many times do we want to retry and how
@@ -69,14 +70,14 @@ class MPDClientWrapper:
         try:
             self.client.connect(host, port)
         except OSError as e:
-            raise ui.UserError(f"could not connect to MPD: {e}")
+            raise UserError(f"could not connect to MPD: {e}")
 
         password = mpd_config["password"].as_str()
         if password:
             try:
                 self.client.password(password)
             except mpd.CommandError as e:
-                raise ui.UserError(f"could not authenticate to MPD: {e}")
+                raise UserError(f"could not authenticate to MPD: {e}")
 
     def disconnect(self):
         """Disconnect from the MPD."""
@@ -94,7 +95,7 @@ class MPDClientWrapper:
 
         if retries <= 0:
             # if we exited without breaking, we couldn't reconnect in time :(
-            raise ui.UserError("communication with MPD server failed")
+            raise UserError("communication with MPD server failed")
 
         time.sleep(RETRY_INTERVAL)
 

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -20,6 +20,7 @@ import subprocess
 from os.path import relpath
 
 from beets import config, ui, util
+from beets.exceptions import UserError
 from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand
 from beets.util import PromptChoice, get_temp_filename
@@ -60,7 +61,7 @@ def play(
         else:
             util.interactive_open(open_args, command_str)
     except OSError as exc:
-        raise ui.UserError(f"Could not play the query: {exc}")
+        raise UserError(f"Could not play the query: {exc}")
 
 
 class PlayPlugin(BeetsPlugin):

--- a/beetsplug/replace.py
+++ b/beetsplug/replace.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import mediafile
 
 from beets import ui, util
+from beets.exceptions import UserError
 from beets.plugins import BeetsPlugin
 
 if TYPE_CHECKING:
@@ -23,7 +24,7 @@ class ReplacePlugin(BeetsPlugin):
 
     def run(self, lib: Library, args: list[str]) -> None:
         if len(args) < 2:
-            raise ui.UserError("Usage: beet replace <query> <new_file_path>")
+            raise UserError("Usage: beet replace <query> <new_file_path>")
 
         new_file_path: Path = Path(args[-1])
         item_query: list[str] = args[:-1]
@@ -33,7 +34,7 @@ class ReplacePlugin(BeetsPlugin):
         item_list = list(lib.items(item_query))
 
         if not item_list:
-            raise ui.UserError("No matching songs found.")
+            raise UserError("No matching songs found.")
 
         song = self.select_song(item_list)
 
@@ -50,14 +51,14 @@ class ReplacePlugin(BeetsPlugin):
     def file_check(self, filepath: Path) -> None:
         """Check if the file exists and is supported"""
         if not filepath.is_file():
-            raise ui.UserError(
+            raise UserError(
                 f"'{util.displayable_path(filepath)}' is not a valid file."
             )
 
         try:
             mediafile.MediaFile(util.syspath(filepath))
         except mediafile.FileTypeError as fte:
-            raise ui.UserError(fte)
+            raise UserError(fte)
 
     def select_song(self, items: list[Item]):
         """Present a menu of matching songs and get user selection."""
@@ -89,7 +90,7 @@ class ReplacePlugin(BeetsPlugin):
         original_file_path: Path = Path(song.path.decode())
 
         if not original_file_path.exists():
-            raise ui.UserError("The original song file was not found.")
+            raise UserError("The original song file was not found.")
 
         ui.print_(
             f"\nReplacing: {util.displayable_path(new_file_path)} "
@@ -110,7 +111,7 @@ class ReplacePlugin(BeetsPlugin):
         try:
             shutil.move(util.syspath(new_file_path), util.syspath(dest))
         except Exception as e:
-            raise ui.UserError(f"Error replacing file: {e}")
+            raise UserError(f"Error replacing file: {e}")
 
         if (
             new_file_path.suffix != original_file_path.suffix
@@ -119,7 +120,7 @@ class ReplacePlugin(BeetsPlugin):
             try:
                 original_file_path.unlink()
             except Exception as e:
-                raise ui.UserError(f"Could not delete original file: {e}")
+                raise UserError(f"Could not delete original file: {e}")
 
         song.path = str(dest).encode()
         song.store()

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -34,6 +34,7 @@ from threading import Event, Thread
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar
 
 from beets import ui
+from beets.exceptions import UserError
 from beets.plugins import BeetsPlugin
 from beets.util import command_output, syspath
 
@@ -1226,7 +1227,7 @@ class ReplayGainPlugin(BeetsPlugin):
         self.backend_name = self.config["backend"].as_str()
 
         if self.backend_name not in BACKENDS:
-            raise ui.UserError(
+            raise UserError(
                 f"Selected ReplayGain backend {self.backend_name} is not"
                 f" supported. Please select one of: {', '.join(BACKENDS)}"
             )
@@ -1235,7 +1236,7 @@ class ReplayGainPlugin(BeetsPlugin):
         # and deprecating the old name 'peak'.
         peak_method = self.config["peak"].as_str()
         if peak_method not in PeakMethod.__members__:
-            raise ui.UserError(
+            raise UserError(
                 f"Selected ReplayGain peak method {peak_method} is not"
                 " supported. Please select one of:"
                 f" {', '.join(PeakMethod.__members__)}"
@@ -1258,7 +1259,7 @@ class ReplayGainPlugin(BeetsPlugin):
                 self.config, self._log
             )
         except (ReplayGainError, FatalReplayGainError) as e:
-            raise ui.UserError(f"replaygain initialization failed: {e}")
+            raise UserError(f"replaygain initialization failed: {e}")
 
     def should_use_r128(self, item: Item) -> bool:
         """Checks the plugin setting to decide whether the calculation
@@ -1381,7 +1382,7 @@ class ReplayGainPlugin(BeetsPlugin):
             except ReplayGainError as e:
                 self._log.info("ReplayGain error: {}", e)
             except FatalReplayGainError as e:
-                raise ui.UserError(f"Fatal replay gain error: {e}")
+                raise UserError(f"Fatal replay gain error: {e}")
 
     def handle_track(self, item: Item, write: bool, force: bool = False):
         """Compute track replay gain and store it in the item.
@@ -1410,7 +1411,7 @@ class ReplayGainPlugin(BeetsPlugin):
         except ReplayGainError as e:
             self._log.info("ReplayGain error: {}", e)
         except FatalReplayGainError as e:
-            raise ui.UserError(f"Fatal replay gain error: {e}")
+            raise UserError(f"Fatal replay gain error: {e}")
 
     def open_pool(self, threads: int):
         """Open a `ThreadPool` instance in `self.pool`"""

--- a/beetsplug/rewrite.py
+++ b/beetsplug/rewrite.py
@@ -21,7 +21,8 @@ from collections import defaultdict
 from functools import singledispatch
 from typing import Any, TypeVar
 
-from beets import library, ui
+from beets import library
+from beets.exceptions import UserError
 from beets.plugins import BeetsPlugin
 
 T = TypeVar("T")
@@ -80,11 +81,9 @@ class RewritePlugin(BeetsPlugin):
             try:
                 fieldname, pattern = key.split(None, 1)
             except ValueError:
-                raise ui.UserError("invalid rewrite specification")
+                raise UserError("invalid rewrite specification")
             if fieldname not in library.Item._fields:
-                raise ui.UserError(
-                    f"invalid field name ({fieldname}) in rewriter"
-                )
+                raise UserError(f"invalid field name ({fieldname}) in rewriter")
             self._log.debug("adding template field {}", key)
             pattern = re.compile(pattern.lower())
             rules[fieldname].append((pattern, value))

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -28,6 +28,7 @@ import confuse
 
 from beets import plugins, ui
 from beets.dbcore.query import ParsingError, Query, Sort
+from beets.exceptions import UserError
 from beets.library import Album, Item, parse_query_string
 from beets.util import (
     bytestring_path,
@@ -205,7 +206,7 @@ class SmartPlaylistPlugin(plugins.BeetsPlugin):
                 unmatched = [name for name, _, _ in self._unmatched_playlists]
                 unmatched.sort()
                 quoted_names = " ".join(shell_quote(name) for name in unmatched)
-                raise ui.UserError(
+                raise UserError(
                     f"No playlist matching any of {quoted_names} found"
                 )
 

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -36,6 +36,7 @@ import requests
 from beets import ui
 from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.dbcore import types
+from beets.exceptions import UserError
 from beets.library import Library
 from beets.metadata_plugins import IDResponse, SearchApiMetadataSourcePlugin
 from beets.util import chunks
@@ -218,7 +219,7 @@ class SpotifyPlugin(
         try:
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
-            raise ui.UserError(
+            raise UserError(
                 f"Spotify authorization failed: {e}\n{response.text}"
             )
         self.access_token = response.json()["access_token"]
@@ -379,7 +380,7 @@ class SpotifyPlugin(
             month = None
             day = None
         else:
-            raise ui.UserError(
+            raise UserError(
                 "Invalid `release_date_precision` returned "
                 f"by {self.data_source} API: '{release_date_precision}'"
             )

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -10,6 +10,7 @@ import confuse
 
 from beets import ui
 from beets.autotag.hooks import AlbumInfo, TrackInfo
+from beets.exceptions import UserError
 from beets.logging import getLogger
 from beets.metadata_plugins import MetadataSourcePlugin
 
@@ -63,7 +64,7 @@ class TidalPlugin(MetadataSourcePlugin):
 
     def require_authentication(self):
         if not os.path.isfile(self._tokenfile()):
-            raise ui.UserError(
+            raise UserError(
                 "Please login to TIDAL"
                 " using `beet tidal --auth` or disable tidal plugin"
             )

--- a/test/plugins/test_bucket.py
+++ b/test/plugins/test_bucket.py
@@ -18,7 +18,8 @@ from datetime import datetime
 
 import pytest
 
-from beets import config, ui
+from beets import config
+from beets.exceptions import UserError
 from beets.test.helper import BeetsTestCase
 from beetsplug import bucket
 
@@ -140,21 +141,21 @@ class BucketPluginTest(BeetsTestCase):
 
     def test_bad_alpha_range_def(self):
         """If bad alpha range definition, a UserError is raised."""
-        with pytest.raises(ui.UserError):
+        with pytest.raises(UserError):
             self._setup_config(bucket_alpha=["$%"])
 
     def test_bad_year_range_def_no4digits(self):
         """If bad year range definition, a UserError is raised.
         Range origin must be expressed on 4 digits.
         """
-        with pytest.raises(ui.UserError):
+        with pytest.raises(UserError):
             self._setup_config(bucket_year=["62-64"])
 
     def test_bad_year_range_def_nodigits(self):
         """If bad year range definition, a UserError is raised.
         At least the range origin must be declared.
         """
-        with pytest.raises(ui.UserError):
+        with pytest.raises(UserError):
             self._setup_config(bucket_year=["nodigits"])
 
     def check_span_from_str(self, sstr, dfrom, dto):

--- a/test/plugins/test_embedart.py
+++ b/test/plugins/test_embedart.py
@@ -23,7 +23,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from mediafile import MediaFile
 
-from beets import config, logging, ui
+from beets import config, logging
+from beets.exceptions import UserError
 from beets.test import _common
 from beets.test.helper import (
     BeetsTestCase,
@@ -154,7 +155,7 @@ class EmbedartCliTest(
     def test_art_file_missing(self):
         self.add_album_fixture()
         logging.getLogger("beets.embedart").setLevel(logging.DEBUG)
-        with pytest.raises(ui.UserError):
+        with pytest.raises(UserError):
             self.run_command("embedart", "-y", "-f", "/doesnotexist")
 
     def test_embed_non_image_file(self):

--- a/test/plugins/test_replace.py
+++ b/test/plugins/test_replace.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from mediafile import MediaFile
 
-from beets import ui
+from beets.exceptions import UserError
 from beets.test import _common
 from beetsplug.replace import ReplacePlugin
 
@@ -23,13 +23,13 @@ class TestReplace:
     def test_path_is_dir(self):
         fake_directory = self.fake_dir / "fakeDir"
         fake_directory.mkdir()
-        with pytest.raises(ui.UserError):
+        with pytest.raises(UserError):
             replace.file_check(fake_directory)
 
     def test_path_is_unsupported_file(self):
         fake_file = self.fake_file / "fakefile.txt"
         fake_file.write_text("test", encoding="utf-8")
-        with pytest.raises(ui.UserError):
+        with pytest.raises(UserError):
             replace.file_check(fake_file)
 
     def test_path_is_supported_file(self):
@@ -89,7 +89,7 @@ class TestReplace:
 
         song = Song()
 
-        with pytest.raises(ui.UserError):
+        with pytest.raises(UserError):
             replace.confirm_replacement("test", song)
 
     def test_confirm_replacement_yes(self, monkeypatch):

--- a/test/ui/commands/test_config.py
+++ b/test/ui/commands/test_config.py
@@ -4,7 +4,8 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from beets import config, ui
+from beets import config
+from beets.exceptions import UserError
 from beets.test.helper import BeetsTestCase, IOMixin
 
 
@@ -114,7 +115,7 @@ class ConfigCommandTest(IOMixin, BeetsTestCase):
         msg_match = "Could not edit configuration.*here is problem"
         with (
             patch("os.execlp", side_effect=OSError("here is problem")),
-            pytest.raises(ui.UserError, match=msg_match),
+            pytest.raises(UserError, match=msg_match),
         ):
             self.run_command("config", "-e")
 

--- a/test/ui/commands/test_import.py
+++ b/test/ui/commands/test_import.py
@@ -4,9 +4,10 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from beets import config, library, ui
+from beets import config, library
 from beets.autotag.hooks import AlbumInfo, AlbumMatch, TrackInfo
 from beets.autotag.match import distance
+from beets.exceptions import UserError
 from beets.test import _common
 from beets.test.helper import BeetsTestCase, IOMixin
 from beets.ui.commands.import_ import import_files, paths_from_logfile
@@ -18,7 +19,7 @@ class ImportTest(BeetsTestCase):
     def test_quiet_timid_disallowed(self):
         config["import"]["quiet"] = True
         config["import"]["timid"] = True
-        with pytest.raises(ui.UserError):
+        with pytest.raises(UserError):
             import_files(None, [], None)
 
     def test_parse_paths_from_logfile(self):

--- a/test/ui/commands/test_utils.py
+++ b/test/ui/commands/test_utils.py
@@ -3,7 +3,8 @@ import shutil
 
 import pytest
 
-from beets import library, ui
+from beets import library
+from beets.exceptions import UserError
 from beets.test import _common
 from beets.test.helper import BeetsTestCase
 from beets.ui.commands.utils import do_query
@@ -33,11 +34,11 @@ class QueryTest(BeetsTestCase):
         assert len(albums) == num_albums
 
     def test_query_empty(self):
-        with pytest.raises(ui.UserError):
+        with pytest.raises(UserError):
             do_query(self.lib, (), False)
 
     def test_query_empty_album(self):
-        with pytest.raises(ui.UserError):
+        with pytest.raises(UserError):
             do_query(self.lib, (), True)
 
     def test_query_item(self):

--- a/test/ui/test_ui.py
+++ b/test/ui/test_ui.py
@@ -25,6 +25,7 @@ import pytest
 from confuse import ConfigError
 
 from beets import config, plugins, ui
+from beets.exceptions import UserError
 from beets.test import _common
 from beets.test.helper import BeetsTestCase, IOMixin, PluginTestCase
 from beets.ui import _open_library, commands
@@ -182,7 +183,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
             config.write("library: /xxx/yyy/not/a/real/path")
 
         self.io.addinput("n")
-        with pytest.raises(ui.UserError):
+        with pytest.raises(UserError):
             self.run_command("test")
 
     def test_user_config_file(self):
@@ -420,7 +421,7 @@ class CommonOptionsParserCliTest(IOMixin, BeetsTestCase):
         output = self.run_with_output("help", "list")
         assert "Usage:" in output
 
-        with pytest.raises(ui.UserError):
+        with pytest.raises(UserError):
             self.run_command("help", "this.is.not.a.real.command")
 
     def test_stats(self):

--- a/test/ui/test_ui_init.py
+++ b/test/ui/test_ui_init.py
@@ -21,6 +21,7 @@ from copy import deepcopy
 from random import random
 
 from beets import config, ui
+from beets.exceptions import UserError
 from beets.test import _common
 from beets.test.helper import BeetsTestCase, IOMixin
 
@@ -111,7 +112,7 @@ class ParentalDirCreation(IOMixin, BeetsTestCase):
         self.io.addinput("n")
         try:
             lib = ui._open_library(test_config)
-        except ui.UserError:
+        except UserError:
             if os.path.exists(non_exist_path_parent):
                 shutil.rmtree(non_exist_path_parent)
                 raise OSError("Parent directories should not be created.")


### PR DESCRIPTION
Update all references in core, plugins, and tests to import UserError
from the new location. This centralizes exception handling and improves
code organization.
