### PR TITLE
library: include path and reason in ReadError/WriteError messages

### DIFF
--- a/beets/library/exceptions.py
+++ b/beets/library/exceptions.py
@@ -28,11 +28,15 @@ class ReadError(FileOperationError):
     """An error while reading a file (i.e. in `Item.read`)."""
 
     def __str__(self):
-        return f"error reading {super()}"
+        # Formatting super() directly stringifies the proxy object, so call
+        # __str__ explicitly to forward to FileOperationError.__str__.
+        return f"error reading {super().__str__()}"
 
 
 class WriteError(FileOperationError):
     """An error while writing a file (i.e. in `Item.write`)."""
 
     def __str__(self):
-        return f"error writing {super()}"
+        # Formatting super() directly stringifies the proxy object, so call
+        # __str__ explicitly to forward to FileOperationError.__str__.
+        return f"error writing {super().__str__()}"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -45,6 +45,9 @@ Bug fixes
   ``__getattr__`` fallback, producing a misleading message about the property
   name itself. The wrapped ``RuntimeError`` keeps the original traceback so it
   still points at the real failing line. :bug:`6558`
+- ``ReadError`` and ``WriteError`` now include the file path and the underlying
+  reason in their message instead of a ``<super: ...>`` object representation.
+  :bug:`6560`
 
 ..
     For plugin developers

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1271,8 +1271,9 @@ class WriteTest(BeetsTestCase):
         os.chmod(path, stat.S_IRUSR)
 
         try:
-            with pytest.raises(beets.library.WriteError):
+            with pytest.raises(beets.library.WriteError) as exc_info:
                 item.write()
+            assert "super:" not in str(exc_info.value)
 
         finally:
             # Restore write permissions so the file can be cleaned up.
@@ -1337,6 +1338,15 @@ class ItemReadTest(unittest.TestCase):
         item = beets.library.Item()
         with pytest.raises(beets.library.ReadError):
             item.read("/thisfiledoesnotexist")
+
+    def test_read_error_str_includes_reason(self):
+        unreadable = os.path.join(_common.RSRC, b"image-2x3.png")
+        item = beets.library.Item()
+        with pytest.raises(beets.library.ReadError) as exc_info:
+            item.read(unreadable)
+        message = str(exc_info.value)
+        assert "super:" not in message
+        assert str(exc_info.value.reason) in message
 
 
 class ItemReadGenreTest(BeetsTestCase):


### PR DESCRIPTION
## Description

`ReadError.__str__` and `WriteError.__str__` put `super()` straight into an f-string, so a failed read or write printed `error reading <super: <class 'ReadError'>, <ReadError object>>` and the actual path and reason were lost. Calling `super().__str__()` returns the `FileOperationError` message with the path and underlying reason. The reported `beet import` case now logs the file path and the failure reason.

Fixes #6560.

## To Do

- [ ] ~Documentation~
- [x] Changelog
- [x] Tests
