### PR TITLE
Move path formats and replacements logic into Library and shared util

### DIFF
--- a/beets/library/library.py
+++ b/beets/library/library.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import re
 from contextlib import contextmanager
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 import platformdirs
@@ -8,6 +10,7 @@ import platformdirs
 import beets
 from beets import context, dbcore
 from beets.dbcore.sort import NullSort
+from beets.exceptions import UserError
 from beets.util import normpath
 
 from . import migrations
@@ -16,6 +19,7 @@ from .queries import PF_KEY_DEFAULT, parse_query_parts, parse_query_string
 
 if TYPE_CHECKING:
     from beets.dbcore import Results
+    from beets.util import Replacements
 
 
 class Library(dbcore.Database):
@@ -31,13 +35,27 @@ class Library(dbcore.Database):
         (migrations.MultiArrangerFieldMigration, (Item,)),
         (migrations.RelativePathMigration, (Item, Album)),
     )
+    replacements: Replacements
+
+    @staticmethod
+    def get_replacements() -> Replacements:
+        """Build regex/string replacement pairs from config."""
+        replacements = []
+        for pattern, repl in beets.config["replace"].get(dict).items():
+            repl = repl or ""
+            try:
+                replacements.append((re.compile(pattern), repl))
+            except re.error:
+                raise UserError(
+                    f"Malformed regular expression in replace: {pattern}"
+                )
+        return replacements
 
     def __init__(
         self,
         path="library.blb",
         directory: str | None = None,
         path_formats=((PF_KEY_DEFAULT, "$artist/$album/$track $title"),),
-        replacements=None,
         set_music_dir: bool = True,
     ):
         timeout = beets.config["timeout"].as_number()
@@ -48,7 +66,7 @@ class Library(dbcore.Database):
         super().__init__(path, timeout=timeout)
 
         self.path_formats = path_formats
-        self.replacements = replacements
+        self.replacements = self.get_replacements()
 
         # Used for template substitution performance.
         self._memotable: dict[tuple[str, ...], str] = {}

--- a/beets/library/library.py
+++ b/beets/library/library.py
@@ -20,6 +20,7 @@ from .queries import PF_KEY_DEFAULT, parse_query_parts, parse_query_string
 if TYPE_CHECKING:
     from beets.dbcore import Results
     from beets.util import Replacements
+    from beets.util.functemplate import Template
 
 
 class Library(dbcore.Database):
@@ -55,7 +56,7 @@ class Library(dbcore.Database):
         self,
         path="library.blb",
         directory: str | None = None,
-        path_formats=((PF_KEY_DEFAULT, "$artist/$album/$track $title"),),
+        path_formats: list[tuple[str, Template]] | None = None,
         set_music_dir: bool = True,
     ):
         timeout = beets.config["timeout"].as_number()

--- a/beets/library/library.py
+++ b/beets/library/library.py
@@ -8,19 +8,20 @@ from typing import TYPE_CHECKING
 import platformdirs
 
 import beets
-from beets import context, dbcore
+from beets import config, context, dbcore
 from beets.dbcore.sort import NullSort
 from beets.exceptions import UserError
 from beets.util import normpath
+from beets.util.pathformats import get_path_formats
 
 from . import migrations
 from .models import Album, Item
-from .queries import PF_KEY_DEFAULT, parse_query_parts, parse_query_string
+from .queries import parse_query_parts, parse_query_string
 
 if TYPE_CHECKING:
     from beets.dbcore import Results
     from beets.util import Replacements
-    from beets.util.functemplate import Template
+    from beets.util.pathformats import PathFormat
 
 
 class Library(dbcore.Database):
@@ -37,6 +38,10 @@ class Library(dbcore.Database):
         (migrations.RelativePathMigration, (Item, Album)),
     )
     replacements: Replacements
+
+    @cached_property
+    def path_formats(self) -> list[PathFormat]:
+        return get_path_formats(config["paths"])
 
     @staticmethod
     def get_replacements() -> Replacements:
@@ -56,17 +61,14 @@ class Library(dbcore.Database):
         self,
         path="library.blb",
         directory: str | None = None,
-        path_formats: list[tuple[str, Template]] | None = None,
         set_music_dir: bool = True,
     ):
-        timeout = beets.config["timeout"].as_number()
         self.directory = normpath(directory or platformdirs.user_music_path())
         if set_music_dir:
             context.set_music_dir(self.directory)
 
-        super().__init__(path, timeout=timeout)
+        super().__init__(path, timeout=beets.config["timeout"].as_number())
 
-        self.path_formats = path_formats
         self.replacements = self.get_replacements()
 
         # Used for template substitution performance.

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -27,10 +27,11 @@ from beets.util import (
 )
 from beets.util.deprecation import maybe_replace_legacy_field
 from beets.util.functemplate import Template, template
+from beets.util.pathformats import PF_KEY_DEFAULT
 
 from .exceptions import FileOperationError, ReadError, WriteError
 from .fields import TYPE_BY_FIELD
-from .queries import PF_KEY_DEFAULT, parse_query_string
+from .queries import parse_query_string
 
 if TYPE_CHECKING:
     from beets.dbcore.query import FieldQuery, FieldQueryType

--- a/beets/library/queries.py
+++ b/beets/library/queries.py
@@ -8,9 +8,6 @@ from beets import dbcore, logging, plugins
 log = logging.getLogger("beets")
 
 
-# Special path format key.
-PF_KEY_DEFAULT = "default"
-
 # Query construction helpers.
 
 

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -224,7 +224,9 @@ class TestHelper(RunMixin, ConfigMixin):
             dbpath = util.bytestring_path(self.config["library"].as_filename())
         else:
             dbpath = ":memory:"
-        self.lib = Library(dbpath, self.libdir)
+        self.lib = Library(
+            dbpath, self.libdir, path_formats=beets.ui.get_path_formats()
+        )
 
     def teardown_beets(self):
         self.env_patcher.stop()

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -224,9 +224,7 @@ class TestHelper(RunMixin, ConfigMixin):
             dbpath = util.bytestring_path(self.config["library"].as_filename())
         else:
             dbpath = ":memory:"
-        self.lib = Library(
-            dbpath, self.libdir, path_formats=beets.ui.get_path_formats()
-        )
+        self.lib = Library(dbpath, self.libdir)
 
     def teardown_beets(self):
         self.env_patcher.stop()

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import errno
 import optparse
 import os.path
-import re
 import shutil
 import sqlite3
 import sys
@@ -432,20 +431,6 @@ def get_path_formats(subview=None):
         query = PF_KEY_QUERIES.get(query, query)  # Expand common queries.
         path_formats.append((query, template(view.as_str())))
     return path_formats
-
-
-def get_replacements():
-    """Confuse validation function that reads regex/string pairs."""
-    replacements = []
-    for pattern, repl in config["replace"].get(dict).items():
-        repl = repl or ""
-        try:
-            replacements.append((re.compile(pattern), repl))
-        except re.error:
-            raise UserError(
-                f"malformed regular expression in replace: {pattern}"
-            )
-    return replacements
 
 
 @cache
@@ -877,7 +862,6 @@ def _open_library(config: confuse.LazyConfig) -> library.Library:
             dbpath,
             config["directory"].as_filename(),
             get_path_formats(),
-            get_replacements(),
         )
         lib.get_item(0)  # Test database connection.
     except (sqlite3.OperationalError, sqlite3.DatabaseError) as db_error:

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -40,7 +40,6 @@ from beets.util import as_string
 from beets.util.color import colorize
 from beets.util.deprecation import deprecate_for_maintainers
 from beets.util.diff import get_model_changes
-from beets.util.functemplate import template
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -60,9 +59,6 @@ log = logging.getLogger("beets")
 if not log.handlers:
     log.addHandler(logging.StreamHandler())
 log.propagate = False  # Don't propagate to root handler.
-
-
-PF_KEY_QUERIES = {"comp": "comp:true", "singleton": "singleton:true"}
 
 
 # Encoding utilities.
@@ -419,18 +415,6 @@ def input_select_objects(prompt, objs, rep, prompt_all=None):
 
     else:  # No.
         return []
-
-
-def get_path_formats(subview=None):
-    """Get the configuration's path formats as a list of query/template
-    pairs.
-    """
-    path_formats = []
-    subview = subview or config["paths"]
-    for query, view in subview.items():
-        query = PF_KEY_QUERIES.get(query, query)  # Expand common queries.
-        path_formats.append((query, template(view.as_str())))
-    return path_formats
 
 
 @cache
@@ -858,11 +842,7 @@ def _open_library(config: confuse.LazyConfig) -> library.Library:
     dbpath = util.bytestring_path(config["library"].as_filename())
     _ensure_db_directory_exists(dbpath)
     try:
-        lib = library.Library(
-            dbpath,
-            config["directory"].as_filename(),
-            get_path_formats(),
-        )
+        lib = library.Library(dbpath, config["directory"].as_filename())
         lib.get_item(0)  # Test database connection.
     except (sqlite3.OperationalError, sqlite3.DatabaseError) as db_error:
         log.debug("{}", traceback.format_exc())

--- a/beets/util/pathformats.py
+++ b/beets/util/pathformats.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .functemplate import template
+
+if TYPE_CHECKING:
+    import confuse
+
+    from .functemplate import Template
+
+    PathFormat = tuple[str, Template]
+
+
+# Special path format key.
+PF_KEY_DEFAULT = "default"
+PF_KEY_QUERIES = {"comp": "comp:true", "singleton": "singleton:true"}
+
+
+def get_path_formats(subview: confuse.Subview) -> list[PathFormat]:
+    """Get the configured path formats as a list of query/template pairs."""
+    return [
+        (PF_KEY_QUERIES.get(q, q), template(v.as_str()))
+        for q, v in subview.items()
+    ]

--- a/beets/util/pathformats.py
+++ b/beets/util/pathformats.py
@@ -18,7 +18,13 @@ PF_KEY_QUERIES = {"comp": "comp:true", "singleton": "singleton:true"}
 
 
 def get_path_formats(subview: confuse.Subview) -> list[PathFormat]:
-    """Get the configured path formats as a list of query/template pairs."""
+    """Build ordered query/template pairs from layered path-format settings.
+
+    The mapping is read through Confuse's ``items()`` view so keys from lower-
+    priority sources remain visible when higher-priority config only overrides
+    part of ``paths``. This keeps inherited defaults such as ``default``,
+    ``comp``, and ``singleton`` available unless they are explicitly replaced.
+    """
     return [
         (PF_KEY_QUERIES.get(q, q), template(v.as_str()))
         for q, v in subview.items()

--- a/beetsplug/bench.py
+++ b/beetsplug/bench.py
@@ -17,10 +17,11 @@
 import cProfile
 import timeit
 
-from beets import importer, library, plugins, ui
+from beets import importer, plugins, ui
 from beets.autotag.match import tag_album
 from beets.plugins import BeetsPlugin
 from beets.util.functemplate import Template
+from beets.util.pathformats import PF_KEY_DEFAULT
 from beetsplug._utils import vfs
 
 
@@ -31,7 +32,7 @@ def aunique_benchmark(lib, prof):
     # Measure path generation performance with %aunique{} included.
     lib.path_formats = [
         (
-            library.PF_KEY_DEFAULT,
+            PF_KEY_DEFAULT,
             Template("$albumartist/$album%aunique{}/$track $title"),
         )
     ]
@@ -46,12 +47,9 @@ def aunique_benchmark(lib, prof):
         interval = timeit.timeit(_build_tree, number=1)
         print("With %aunique:", interval)
 
-    # And with %aunique replaceed with a "cheap" no-op function.
+    # And with %aunique replaced with a "cheap" no-op function.
     lib.path_formats = [
-        (
-            library.PF_KEY_DEFAULT,
-            Template("$albumartist/$album%lower{}/$track $title"),
-        )
+        (PF_KEY_DEFAULT, Template("$albumartist/$album%lower{}/$track $title"))
     ]
     if prof:
         cProfile.runctx(

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -36,6 +36,7 @@ from beets.plugins import BeetsPlugin
 from beets.util import par_map
 from beets.util.artresizer import ArtResizer
 from beets.util.m3u import M3UFile
+from beets.util.pathformats import get_path_formats
 from beetsplug._utils import art
 
 if TYPE_CHECKING:
@@ -43,7 +44,7 @@ if TYPE_CHECKING:
 
     from beets.importer import ImportSession, ImportTask
     from beets.library import Album, Library
-    from beets.util.functemplate import Template as FuncTemplate
+    from beets.util.pathformats import PathFormat
 
 _fs_lock = threading.Lock()
 # Keep track of temporary transcoded files for deletion.
@@ -230,8 +231,8 @@ class ConvertPlugin(BeetsPlugin):
         return self.config["threads"].get(int)
 
     @cached_property
-    def path_formats(self) -> dict[str, FuncTemplate]:
-        return ui.get_path_formats(self.config["paths"] or None)
+    def path_formats(self) -> list[PathFormat]:
+        return get_path_formats(self.config["paths"])
 
     @cached_property
     def fmt(self) -> str:

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -394,15 +394,18 @@ class ConvertPlugin(BeetsPlugin):
             return True
         return self.fmt != item.format.lower()
 
+    def get_item_destination(self, item: Item) -> bytes:
+        return item.destination(
+            basedir=self.dest, path_formats=self.path_formats
+        )
+
     @util.pipeline.mutator_stage
     def convert_item(self, keep_new: bool, item: Item) -> None:
         """Convert an Item from the library."""
         pretend, link, hardlink = self.pretend, self.link, self.hardlink
         command, ext = self.command
 
-        dest = item.destination(
-            basedir=self.dest, path_formats=self.path_formats
-        )
+        dest = self.get_item_destination(item)
 
         # Ensure that desired item is readable before processing it. Needed
         # to avoid any side-effect of the conversion (linking, keep_new,
@@ -536,9 +539,7 @@ class ConvertPlugin(BeetsPlugin):
 
         # Get the destination of the first item (track) of the album, we use
         # this function to format the path accordingly to path_formats.
-        dest = album_item.destination(
-            basedir=self.dest, path_formats=self.path_formats
-        )
+        dest = self.get_item_destination(album_item)
 
         # Remove item from the path.
         dest = os.path.join(*util.components(dest)[:-1])
@@ -603,7 +604,7 @@ class ConvertPlugin(BeetsPlugin):
         self, lib: Library, opts: optparse.Values, args: list[str]
     ) -> None:
         self.config.set(vars(opts))
-        dest, pretend = self.dest, self.pretend
+        pretend = self.pretend
 
         if opts.album:
             albums = lib.albums(args)
@@ -637,9 +638,7 @@ class ConvertPlugin(BeetsPlugin):
             pl_dir = os.path.dirname(pl_normpath)
             items_paths = []
             for item in items:
-                item_path = item.destination(
-                    basedir=dest, path_formats=self.path_formats
-                )
+                item_path = self.get_item_destination(item)
 
                 # When keeping new files in the library, destination paths
                 # keep original files and extensions.

--- a/test/plugins/test_bpd.py
+++ b/test/plugins/test_bpd.py
@@ -363,13 +363,7 @@ class BPDTestHelper(PluginTestCase):
     def _bpd_add(self, client, *items, **kwargs):
         """Add the given item to the BPD playlist or queue."""
         paths = [
-            "/".join(
-                [
-                    item.artist,
-                    item.album,
-                    os.fsdecode(os.path.basename(item.path)),
-                ]
-            )
+            os.fsdecode(item.destination(relative_to_libdir=True))
             for item in items
         ]
         playlist = kwargs.get("playlist")

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -246,6 +246,7 @@ class DestinationTest(BeetsTestCase):
         assert self.i.destination() == np("base/0001-02-03")
 
     def test_destination_escapes_slashes(self):
+        self.lib.path_formats = [("default", "$artist/$album/$track $title")]
         self.i.album = "one/two"
         dest = self.i.destination()
         assert b"one" in dest
@@ -253,12 +254,14 @@ class DestinationTest(BeetsTestCase):
         assert b"one/two" not in dest
 
     def test_destination_escapes_leading_dot(self):
+        self.lib.path_formats = [("default", "$artist/$album/$track $title")]
         self.i.album = ".something"
         dest = self.i.destination()
         assert b"something" in dest
         assert b"/.something" not in dest
 
     def test_destination_preserves_legitimate_slashes(self):
+        self.lib.path_formats = [("default", "$artist/$album/$track $title")]
         self.i.artist = "one"
         self.i.album = "two"
         dest = self.i.destination()
@@ -1043,6 +1046,7 @@ class ArtDestinationTest(BeetsTestCase):
         config["art_filename"] = "artimage"
         config["replace"] = {"X": "Y"}
         self.lib.replacements = [(re.compile("X"), "Y")]
+        self.lib.path_formats = [("default", "$artist/$album/$track $title")]
         self.i = item(self.lib)
         self.i.path = self.i.destination()
         self.ai = self.lib.add_album((self.i,))

--- a/test/ui/test_ui.py
+++ b/test/ui/test_ui.py
@@ -30,7 +30,6 @@ from beets.test import _common
 from beets.test.helper import BeetsTestCase, IOMixin, PluginTestCase
 from beets.ui import _open_library, commands
 from beets.util import syspath
-from beets.util.functemplate import get_path_formats
 
 
 class PrintTest(IOMixin, unittest.TestCase):
@@ -166,18 +165,6 @@ class ConfigTest(IOMixin, TestPluginTestCase):
         key, template = self.test_cmd.lib.path_formats[0]
         assert key == "x"
         assert template.original == "y"
-
-    def test_default_paths_preserved(self):
-        default_formats = get_path_formats()
-
-        self._reset_config()
-        with self.write_config_file() as config:
-            config.write("paths: {x: y}")
-        self.run_command("test")
-        key, template = self.test_cmd.lib.path_formats[0]
-        assert key == "x"
-        assert template.original == "y"
-        assert self.test_cmd.lib.path_formats[1:] == default_formats
 
     def test_nonexistant_db(self):
         with self.write_config_file() as config:
@@ -348,18 +335,6 @@ class ConfigTest(IOMixin, TestPluginTestCase):
         config.read()
         assert config["library"].as_path() == self.beetsdir / "beets.db"
         assert config["statefile"].as_path() == self.beetsdir / "state"
-
-
-class PathFormatTest(unittest.TestCase):
-    def test_custom_paths_prepend(self):
-        default_formats = get_path_formats()
-
-        config["paths"] = {"foo": "bar"}
-        pf = get_path_formats()
-        key, tmpl = pf[0]
-        assert key == "foo"
-        assert tmpl.original == "bar"
-        assert pf[1:] == default_formats
 
 
 class PluginTest(TestPluginTestCase):

--- a/test/ui/test_ui.py
+++ b/test/ui/test_ui.py
@@ -30,6 +30,7 @@ from beets.test import _common
 from beets.test.helper import BeetsTestCase, IOMixin, PluginTestCase
 from beets.ui import _open_library, commands
 from beets.util import syspath
+from beets.util.functemplate import get_path_formats
 
 
 class PrintTest(IOMixin, unittest.TestCase):
@@ -167,7 +168,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
         assert template.original == "y"
 
     def test_default_paths_preserved(self):
-        default_formats = ui.get_path_formats()
+        default_formats = get_path_formats()
 
         self._reset_config()
         with self.write_config_file() as config:
@@ -351,10 +352,10 @@ class ConfigTest(IOMixin, TestPluginTestCase):
 
 class PathFormatTest(unittest.TestCase):
     def test_custom_paths_prepend(self):
-        default_formats = ui.get_path_formats()
+        default_formats = get_path_formats()
 
         config["paths"] = {"foo": "bar"}
-        pf = ui.get_path_formats()
+        pf = get_path_formats()
         key, tmpl = pf[0]
         assert key == "foo"
         assert tmpl.original == "bar"

--- a/test/util/test_pathformats.py
+++ b/test/util/test_pathformats.py
@@ -1,0 +1,17 @@
+from beets.util.pathformats import get_path_formats
+
+
+def test_get_path_formats(config):
+    """Ensure the function prepends custom and preserves defaults."""
+    # override the default 'singleton' path and add a new one
+    config["paths"].set({"singleton": "bar", "new": "hello"})
+
+    path_formats = get_path_formats(config["paths"])
+    actual_path_formats = [(key, tmpl.original) for key, tmpl in path_formats]
+    assert actual_path_formats == [
+        ("singleton:true", "bar"),
+        ("new", "hello"),
+        # defaults
+        ("default", "$albumartist/$album%aunique{}/$track $title"),
+        ("comp:true", "Compilations/$album%aunique{}/$track $title"),
+    ]


### PR DESCRIPTION
## Summary
This PR moves path format and replacement retrieval out of `beets.ui` into library/shared utilities.

## Changes
- Added `beets/util/pathformats.py` with `PF_KEY_DEFAULT`, `PF_KEY_QUERIES`, and `get_path_formats(subview)`.
- Added `Library.path_formats` and `Library.replacements` as `cached_property` values derived from config.
- Removed UI-owned `get_path_formats`/`get_replacements` and simplified `_open_library()` to construct `Library` without passing those values.
- Updated consumers (`beets/library/models.py`, `beetsplug/bench.py`, `beetsplug/convert.py`) to use the shared path-format utility.
- Refactored convert destination path calls through `ConvertPlugin.get_item_destination`.
- Replaced redundant UI tests with focused coverage in `test/util/test_pathformats.py`.
- Updated `.git-blame-ignore-revs`.

## Why
- Keeps path/replacement behavior close to library internals instead of CLI orchestration.
- Preserves layered `paths` defaults by iterating config via Confuse `items()`.
- Reduces duplication in convert destination handling.
