### PR TITLE
Support += and -= for multi-value fields in modify

### DIFF
--- a/beets/ui/commands/modify.py
+++ b/beets/ui/commands/modify.py
@@ -1,11 +1,53 @@
 """The `modify` command: change metadata fields."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NamedTuple
+
 from beets import library, ui
+from beets.dbcore import types
 from beets.exceptions import UserError
 from beets.util import functemplate
 from beets.util.deprecation import maybe_replace_legacy_field
 
 from .utils import do_query
+
+if TYPE_CHECKING:
+    from beets.library import LibModel
+
+
+class ModifyOperation(NamedTuple):
+    operator: str | None
+    value: str
+
+    def apply(
+        self, obj: LibModel, field: str, new_values: list[str]
+    ) -> list[str]:
+        if self.operator is None:
+            return new_values
+
+        current = list(obj[field])
+
+        if self.operator == "+":
+            return current + [
+                item for item in new_values if item not in current
+            ]
+
+        return [item for item in current if item not in new_values]
+
+
+def _is_multi_value_field(model_cls: type[LibModel], field: str) -> bool:
+    return isinstance(model_cls._type(field), types.DelimitedString)
+
+
+def _check_modify_operations(
+    model_cls: type[LibModel], mods: dict[str, ModifyOperation]
+) -> None:
+    for field, mod in mods.items():
+        if mod.operator and not _is_multi_value_field(model_cls, field):
+            raise UserError(
+                f"field {field!r} does not support the {mod.operator}= operator"
+            )
 
 
 def modify_items(lib, mods, dels, query, write, move, album, confirm, inherit):
@@ -17,6 +59,7 @@ def modify_items(lib, mods, dels, query, write, move, album, confirm, inherit):
     """
     # Parse key=value specifications into a dictionary.
     model_cls = library.Album if album else library.Item
+    _check_modify_operations(model_cls, mods)
 
     # Get the items to modify.
     items, albums = do_query(lib, query, album, False)
@@ -26,14 +69,16 @@ def modify_items(lib, mods, dels, query, write, move, album, confirm, inherit):
     # objects.
     ui.print_(f"Modifying {len(objs)} {'album' if album else 'item'}s.")
     changed = []
-    templates = {
-        key: functemplate.template(value) for key, value in mods.items()
-    }
+    templates = {}
+    for key, mod in mods.items():
+        templates[key] = functemplate.template(mod.value)
     for obj in objs:
-        obj_mods = {
-            key: model_cls._parse(key, obj.evaluate_template(templates[key]))
-            for key in mods.keys()
-        }
+        obj_mods = {}
+        for key, mod in mods.items():
+            parsed_value = model_cls._parse(
+                key, obj.evaluate_template(templates[key])
+            )
+            obj_mods[key] = mod.apply(obj, key, parsed_value)
         if print_and_modify(obj, obj_mods, dels) and obj not in changed:
             changed.append(obj)
 
@@ -97,8 +142,11 @@ def modify_parse_args(args, is_album: bool):
             dels.append(arg[:-1])  # Strip trailing !.
         elif "=" in arg and ":" not in arg.split("=", 1)[0]:
             key, val = arg.split("=", 1)
+            operator = None
+            if key.endswith(("+", "-")):
+                key, operator = key[:-1], key[-1]
             key = maybe_replace_legacy_field(key, is_album, modify=True)
-            mods[key] = val
+            mods[key] = ModifyOperation(operator, val)
         else:
             query.append(arg)
     return query, mods, dels

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,9 @@ New features
 - :doc:`plugins/tidal`: Add cover art support. Album metadata now includes
   ``cover_art_url`` from Tidal's ``coverArt`` relationship, which the
   :doc:`plugins/fetchart` plugin can retrieve.
+- :ref:`modify-cmd`: Support ``+=`` and ``-=`` operators to add or remove
+  individual values from multi-valued fields without replacing the whole field.
+  :bug:`6587`
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -259,7 +259,7 @@ modify
 
 ::
 
-    beet modify [-IMWay] [-f FORMAT] QUERY [FIELD=VALUE...] [FIELD!...]
+    beet modify [-IMWay] [-f FORMAT] QUERY [FIELD=VALUE...] [FIELD+=VALUE...] [FIELD-=VALUE...] [FIELD!...]
 
 Change the metadata for items or albums in the database.
 
@@ -277,6 +277,13 @@ title='$track $title'`` will add track numbers to their title metadata.
 To adjust a multi-valued field, such as ``genres``, ``remixers``, ``lyricists``,
 ``composers``, or ``arrangers``, separate the values with |semicolon_space|. For
 example, ``beet modify genres="rock; pop"``.
+
+For these multi-valued fields, you can also use ``+=`` to add values and ``-=``
+to remove values, instead of replacing the whole field. For example, ``beet
+modify genres+=Funk`` adds "Funk" to the existing genres (without duplicating it
+if already present), and ``beet modify genres-=Pop`` removes "Pop" from the
+list, leaving the other values untouched. These operators are only valid for
+multi-valued fields.
 
 When modifying albums with ``-a``, multi-valued fields such as ``artists``,
 ``genres``, ``composers`` are also supported with the same semicolon-separated

--- a/test/ui/commands/test_modify.py
+++ b/test/ui/commands/test_modify.py
@@ -2,17 +2,15 @@ import pytest
 from mediafile import MediaFile
 
 from beets import logging
-from beets.test.helper import BeetsTestCase, IOMixin
-from beets.ui.commands.modify import modify_parse_args
+from beets.exceptions import UserError
+from beets.test.helper import BeetsTestCase, IOMixin, TestHelper
+from beets.ui.commands.modify import ModifyOperation, modify_parse_args
 from beets.util import syspath
 
+_p = pytest.param
 
-class ModifyTest(IOMixin, BeetsTestCase):
-    def setUp(self):
-        super().setUp()
-        self.album = self.add_album_fixture()
-        [self.item] = self.album.items()
 
+class ModifyHelper(IOMixin):
     def modify_inp(self, inp: list[str], *args):
         for chat in inp:
             self.io.addinput(chat)
@@ -20,6 +18,13 @@ class ModifyTest(IOMixin, BeetsTestCase):
 
     def modify(self, *args):
         self.modify_inp(["y"], *args)
+
+
+class ModifyTest(ModifyHelper, BeetsTestCase):
+    def setUp(self):
+        super().setUp()
+        self.album = self.add_album_fixture()
+        [self.item] = self.album.items()
 
     # Item tests
 
@@ -211,7 +216,7 @@ class ModifyTest(IOMixin, BeetsTestCase):
             ["title:oldTitle", "title=newTitle"], is_album=False
         )
         assert query == ["title:oldTitle"]
-        assert mods == {"title": "newTitle"}
+        assert mods == {"title": ModifyOperation(None, "newTitle")}
 
     def test_arg_parsing_delete(self):
         query, _, dels = modify_parse_args(
@@ -225,22 +230,80 @@ class ModifyTest(IOMixin, BeetsTestCase):
             ["title:oldTitle!", "title=newTitle!"], is_album=False
         )
         assert query == ["title:oldTitle!"]
-        assert mods == {"title": "newTitle!"}
+        assert mods == {"title": ModifyOperation(None, "newTitle!")}
 
     def test_arg_parsing_equals_in_value(self):
         query, mods, _ = modify_parse_args(
             ["title:foo=bar", "title=newTitle"], is_album=False
         )
         assert query == ["title:foo=bar"]
-        assert mods == {"title": "newTitle"}
+        assert mods == {"title": ModifyOperation(None, "newTitle")}
+
+
+class TestMultiValue(ModifyHelper, TestHelper):
+    @pytest.fixture
+    def item(self):
+        album = self.add_album_fixture()
+        [item] = album.items()
+        return item
+
+    @pytest.mark.parametrize(
+        "initial_genres, modify_arg, expected_genres",
+        [
+            _p([], "genres=Jazz; Blues", ["Jazz", "Blues"], id="assign"),
+            _p(
+                ["Jazz", "Blues"],
+                "genres+=Funk",
+                ["Jazz", "Blues", "Funk"],
+                id="append",
+            ),
+            _p(
+                ["Jazz", "Funk"],
+                "genres+=Funk",
+                ["Jazz", "Funk"],
+                id="append-duplicate",
+            ),
+            _p(
+                ["Jazz", "Blues", "Funk"],
+                "genres-=Blues",
+                ["Jazz", "Funk"],
+                id="remove-exact",
+            ),
+            _p(
+                ["Jazz", "Blues Rock", "Blues"],
+                "genres-=Blues",
+                ["Jazz", "Blues Rock"],
+                id="remove-no-partial-match",
+            ),
+            _p(
+                ["Jazz", "Blues"],
+                "genres+=Funk; Soul",
+                ["Jazz", "Blues", "Funk", "Soul"],
+                id="append-preserves-order",
+            ),
+        ],
+    )
+    def test_modify_multi_value(
+        self, item, initial_genres, modify_arg, expected_genres
+    ):
+        item.genres = initial_genres
+        item.store()
+
+        self.modify("--nowrite", "--nomove", modify_arg)
+        item.load()
+        assert item.genres == expected_genres
+
+    def test_modify_scalar_operator_error(self):
+        with pytest.raises(UserError, match="field 'title' does not support"):
+            self.modify("--nowrite", "--nomove", "title+=foo")
 
 
 @pytest.mark.parametrize(
     "is_album, legacy_field, list_field",
     [
-        pytest.param(True, "genre", "genres", id="album-genre"),
-        pytest.param(False, "genre", "genres", id="item-genre"),
-        pytest.param(False, "composer", "composers", id="item-composer"),
+        _p(True, "genre", "genres", id="album-genre"),
+        _p(False, "genre", "genres", id="item-genre"),
+        _p(False, "composer", "composers", id="item-composer"),
     ],
 )
 def test_arg_parsing_rewrites_legacy_list_fields(
@@ -252,7 +315,7 @@ def test_arg_parsing_rewrites_legacy_list_fields(
         )
 
     assert query == []
-    assert mods == {list_field: "value1; value2"}
+    assert mods == {list_field: ModifyOperation(None, "value1; value2")}
     assert dels == []
     assert caplog.records, "No log records were captured"
     assert len(caplog.records) == 1


### PR DESCRIPTION
## Description

Fixes #6587.

This PR adds `+=` and `-=` support to `beet modify` for multi-value fields.

For example:

```bash
beet modify genres+=Funk
beet modify genres-=Blues
```

With this change, `genres+=Funk` appends `Funk` to the existing `genres` values if it is not already present, while `genres-=Blues` removes only the exact value `Blues` and preserves other values such as `Blues Rock`.

The existing `field=value` replacement behavior is preserved.

Main behavior changes:

- `genres=Jazz; Blues` still replaces the full field value as before.
- `genres+=Funk` appends `Funk` to the existing multi-value field.
- `genres+=Funk` does not create duplicate values.
- `genres-=Blues` removes only the exact value `Blues`.
- Removing `Blues` does not remove partial matches like `Blues Rock`.
- Existing value order is preserved.
- `+=` and `-=` are rejected for scalar fields with a clear user-facing error.

## To Do

- [ ] Documentation. I have not added documentation yet. I can add this to the `modify` command documentation if maintainers prefer.
- [ ] Changelog. I have not added a changelog entry yet and can add one after review if this change is accepted.
- [x] Tests. Added tests for multi-value assignment, append, duplicate prevention, exact removal, partial-match preservation, ordering, and scalar-field operator errors.

## Verification

Ran:

```bash
poetry run pytest test/ui/commands/test_modify.py -q
```