### PR TITLE
Fix album modify splitting multi-value field strings into individual characters

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -492,8 +492,23 @@ class Model(ABC, Generic[D]):
 
         If the field has no explicit type, it is given the base `Type`,
         which does no conversion.
+
+        For models with a related model (e.g. Album <-> Item), fall back
+        to the related model's field and type definitions for fields not
+        defined on this model. This avoids descending into the sibling's
+        `_type` method to prevent infinite recursion between reciprocal
+        relations.
         """
-        return cls._fields.get(key) or cls._types.get(key) or types.DEFAULT
+        typ = cls._fields.get(key) or cls._types.get(key)
+        if typ is not None:
+            return typ
+        if cls._relation is not cls:
+            typ = cls._relation._fields.get(key) or cls._relation._types.get(
+                key
+            )
+            if typ is not None:
+                return typ
+        return types.DEFAULT
 
     def _get(self, key, default: Any = None, raise_: bool = False):
         """Get the value for a field, or `default`. Alternatively,

--- a/beets/dbcore/types.py
+++ b/beets/dbcore/types.py
@@ -331,6 +331,8 @@ class DelimitedString(BaseString[list, list]):  # type: ignore[type-arg]
                 else:
                     result.append(item)
             return result
+        if isinstance(value, str):
+            return self.parse(value)
         return self.model_type(value)
 
     def to_sql(self, model_value: list[str]):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -36,6 +36,10 @@ Bug fixes
   ``genres:=~Classical``. :bug:`6598`
 - Fix a CLI help formatting regression that moved command descriptions to
   separate lines; descriptions are inline again, with regression test coverage.
+- :ref:`modify-cmd`: Fix ``beet modify -a`` splitting multi-value field strings
+  (like ``artists``, ``genres``) into individual characters when modifying
+  albums. Album field types now fall back to the corresponding item field type
+  definitions. :bug:`5690`
 
 ..
     For plugin developers

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -278,6 +278,10 @@ To adjust a multi-valued field, such as ``genres``, ``remixers``, ``lyricists``,
 ``composers``, or ``arrangers``, separate the values with |semicolon_space|. For
 example, ``beet modify genres="rock; pop"``.
 
+When modifying albums with ``-a``, multi-valued fields such as ``artists``,
+``genres``, ``composers`` are also supported with the same semicolon-separated
+syntax.
+
 For compatibility, ``modify`` assignments and query expressions still accept
 legacy singular names such as ``genre``, ``composer``, ``lyricist``,
 ``remixer``, and ``arranger``, but beets will warn and translate them to the

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -24,8 +24,9 @@ from typing import ClassVar
 import pytest
 
 from beets import dbcore
+from beets.dbcore import types
 from beets.dbcore.db import DBCustomFunctionError, Index
-from beets.library import LibModel
+from beets.library import Album, Item, LibModel
 from beets.util import cached_classproperty
 
 # Fixture: concrete database and model classes. For migration tests, we
@@ -541,6 +542,31 @@ class ParseTest(unittest.TestCase):
     def test_parse_untyped_field(self):
         value = ModelFixture1._parse("field_nine", "2")
         assert value == "2"
+
+
+# --- Model._type fallback tests ---
+
+
+def test_album_type_falls_back_to_item_type():
+    typ = Album._type("artists")
+    assert isinstance(typ, types.DelimitedString)
+    assert typ is types.MULTI_VALUE_DSV
+
+
+def test_album_type_falls_back_to_item_type_other_list_fields():
+    for field in ["genres", "composers", "artists_sort"]:
+        typ = Album._type(field)
+        assert isinstance(typ, types.DelimitedString), field
+
+
+def test_item_type_does_not_change():
+    typ = Item._type("artists")
+    assert isinstance(typ, types.DelimitedString)
+
+
+def test_unknown_key_falls_through_to_default():
+    typ = Album._type("nonexistent_field_xyz")
+    assert isinstance(typ, types.Default)
 
 
 class QueryParseTest(unittest.TestCase):

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -544,29 +544,24 @@ class ParseTest(unittest.TestCase):
         assert value == "2"
 
 
-# --- Model._type fallback tests ---
+class TestModelTypeFallback:
+    def test_album_type_falls_back_to_item_type(self):
+        typ = Album._type("artists")
+        assert isinstance(typ, types.DelimitedString)
+        assert typ is types.MULTI_VALUE_DSV
 
+    def test_album_type_falls_back_to_item_type_other_list_fields(self):
+        for field in ["genres", "composers", "artists_sort"]:
+            typ = Album._type(field)
+            assert isinstance(typ, types.DelimitedString), field
 
-def test_album_type_falls_back_to_item_type():
-    typ = Album._type("artists")
-    assert isinstance(typ, types.DelimitedString)
-    assert typ is types.MULTI_VALUE_DSV
+    def test_item_type_does_not_change(self):
+        typ = Item._type("artists")
+        assert isinstance(typ, types.DelimitedString)
 
-
-def test_album_type_falls_back_to_item_type_other_list_fields():
-    for field in ["genres", "composers", "artists_sort"]:
-        typ = Album._type(field)
-        assert isinstance(typ, types.DelimitedString), field
-
-
-def test_item_type_does_not_change():
-    typ = Item._type("artists")
-    assert isinstance(typ, types.DelimitedString)
-
-
-def test_unknown_key_falls_through_to_default():
-    typ = Album._type("nonexistent_field_xyz")
-    assert isinstance(typ, types.Default)
+    def test_unknown_key_falls_through_to_default(self):
+        typ = Album._type("nonexistent_field_xyz")
+        assert isinstance(typ, types.Default)
 
 
 class QueryParseTest(unittest.TestCase):

--- a/test/test_types.py
+++ b/test/test_types.py
@@ -73,6 +73,12 @@ def test_durationtype():
         (None, []),
         # no false split: value without "; " is unchanged
         (["Smith, John"], ["Smith, John"]),
+        # plain string gets wrapped (not split into characters)
+        ("Charli XCX", ["Charli XCX"]),
+        # string with delimiter gets split
+        ("Jazz; Folk; Soul", ["Jazz", "Folk", "Soul"]),
+        # empty string
+        ("", []),
     ],
 )
 def test_delimitedstring_normalize(original, expected):

--- a/test/ui/commands/test_modify.py
+++ b/test/ui/commands/test_modify.py
@@ -158,6 +158,21 @@ class ModifyTest(IOMixin, BeetsTestCase):
         item.load()
         assert item.album == f"{orig_album} - append"
 
+    def test_album_modify_artists_not_split(self):
+        self.modify("--album", "artists=Charli XCX")
+        for item in self.lib.items():
+            assert item.artists == ["Charli XCX"], (
+                f"artists should be a list with one element, "
+                f"got {item.artists!r}"
+            )
+
+    def test_album_modify_genres_not_split(self):
+        self.modify("--album", "genres=Rock")
+        for item in self.lib.items():
+            assert item.genres == ["Rock"], (
+                f"genres should be a list with one element, got {item.genres!r}"
+            )
+
     # Misc
 
     def test_write_initial_key_tag(self):


### PR DESCRIPTION
Fixes #5690

## Problem

When running `beet mod -a artists=Charli XCX` in album mode, the `artists` tag value gets split into individual characters on disk. Item mode (`beet mod` without `-a`) works correctly.

## Root Cause

1. `Album._type(artists)` returns `DEFAULT` (artists is not an Album fixed field), so `Album._parse` returns a plain string.
2. When `Album.store()` propagates to items, `MULTI_VALUE_DSV.normalize(value)` falls through to `model_type(value)` = `list(value)`, splitting the string into characters.

## Fix

1. **`DelimitedString.normalize`** (`types.py`): Handle string input by parsing it (splitting by delimiter if present) instead of `list()`. This prevents character-level splitting.
2. **`Model._type`** (`db.py`): Fall back to the related models field definitions so multi-value types (e.g. `MULTI_VALUE_DSV` for `artists`) are recognized on both Album and Item models.

## Tests

456 passed, 0 failed core test suites (dbcore, types, library, query, modify).