### PR TITLE
lastgenre: replace built-in genre list with improved hierarchy

### DIFF
--- a/beetsplug/lastgenre/genres-tree.yaml
+++ b/beetsplug/lastgenre/genres-tree.yaml
@@ -1,793 +1,12306 @@
-- african:
-    - african heavy metal
-    - african hip hop
-    - afrobeat
-    - apala
-    - benga
-    - bikutsi
-    - bongo flava
-    - cape jazz
-    - chimurenga
-    - coupé-décalé
-    - egyptian
-    - fuji music
-    - genge
-    - highlife
-    - hiplife
-    - isicathamiya
-    - jit
-    - jùjú
-    - kapuka
-    - kizomba
-    - kuduro
-    - kwaito
-    - kwela
-    - makossa
-    - maloya
-    - marrabenta
-    - mbalax
-    - mbaqanga
-    - mbube
-    - morna
-    - museve
-    - palm-wine
-    - raï
-    - sakara
-    - sega
-    - seggae
-    - semba
-    - shangaan electro
-    - soukous
-    - taarab
-    - zouglou
-- asian:
-    - east asian:
-        - anison
-        - c-pop
-        - cantopop
-        - enka
-        - hong kong english pop
-        - j-pop
-        - k-pop
-        - kayōkyoku
-        - korean pop
-        - mandopop
-        - onkyokei
-        - taiwanese pop
-    - fann at-tanbura
-    - fijiri
-    - khaliji
-    - liwa
-    - sawt
-    - south and southeast asian:
-        - baila
-        - bhangra
-        - bhojpuri
-        - dangdut
-        - filmi
-        - indian pop
-        - lavani
-        - luk thung:
-            - luk krung
-        - manila sound
-        - morlam
-        - pinoy pop
-        - pop sunda
-        - ragini
-        - thai pop
-- avant-garde:
-    - experimental music
-    - lo-fi
-    - musique concrète
-- blues:
-    - african blues
-    - blues rock
-    - blues shouter
-    - british blues
-    - canadian blues
-    - chicago blues
-    - classic female blues
-    - contemporary r&b
-    - country blues
-    - delta blues
-    - detroit blues
-    - electric blues
-    - gospel blues
-    - hill country blues
-    - hokum blues
-    - jazz blues
-    - jump blues
-    - kansas city blues
-    - louisiana blues
-    - memphis blues
-    - piano blues
-    - piedmont blues
-    - punk blues
-    - soul blues
-    - st. louis blues
-    - swamp blues
-    - texas blues
-    - west coast blues
-- caribbean and latin american:
-    - bachata
-    - baithak gana
-    - bolero
-    - brazilian:
-        - axé
-        - bossa nova
-        - brazilian rock
-        - brega
-        - choro
-        - forró
-        - frevo
-        - funk carioca
-        - lambada
-        - maracatu
-        - música popular brasileira
-        - música sertaneja
-        - pagode
-        - samba
-        - samba rock
-        - tecnobrega
-        - tropicalia
-        - zouk-lambada
-    - calypso
-    - chutney
-    - chutney soca
-    - compas
-    - folklore argentino
-    - mambo
-    - merengue
-    - méringue
-    - other latin:
-        - chicha
-        - criolla
-        - cumbia
-        - huayno
-        - mariachi
-        - ranchera
-        - tejano
-    - punta
-    - punta rock
-    - rasin
-    - reggaeton
-    - salsa
-    - soca
-    - son
-    - timba
-    - twoubadou
-    - zouk
-- classical:
-    - ballet
-    - baroque:
-        - baroque music
-    - cantata
-    - chamber music:
-        - string quartet
-    - classical music
-    - concerto:
-        - concerto grosso
-    - contemporary classical
-    - modern classical
-    - opera
-    - oratorio
-    - orchestra:
-        - orchestral
-        - symphonic
-        - symphony
-    - organum
-    - mass:
-        - requiem
-    - sacred music:
-        - cantique
-        - gregorian chant
-    - sonata
-- comedy:
-    - comedy music
-    - comedy rock
-    - humor
-    - parody music
-    - stand-up
-    - kabarett
-- country:
-    - alternative country:
-        - cowpunk
-    - americana
-    - australian country music
-    - bakersfield sound
-    - bluegrass:
-        - progressive bluegrass
-        - reactionary bluegrass
-    - blues country
-    - cajun:
-        - cajun fiddle tunes
-    - christian country music
-    - classic country
-    - close harmony
-    - country pop
-    - country rap
-    - country rock
-    - country soul
-    - cowboy/western music
-    - dansband music
-    - franco-country
-    - gulf and western
-    - hellbilly music
-    - hokum
-    - honky tonk
-    - instrumental country
-    - lubbock sound
-    - nashville sound
-    - neotraditional country
-    - outlaw country
-    - progressive country
-    - psychobilly/punkabilly
-    - red dirt
-    - rockabilly
-    - sertanejo
-    - texas country
-    - traditional country music
-    - truck-driving country
-    - western swing
-    - zydeco
-- easy listening:
-    - background music
-    - beautiful music
-    - elevator music
-    - furniture music
-    - lounge music
-    - middle of the road
-    - new-age music
-- electronic:
-    - ambient:
-        - ambient dub
-        - ambient house
-        - ambient techno
-        - dark ambient
-        - drone music
-        - illbient
-        - isolationism
-        - lowercase
-    - asian underground
-    - breakbeat:
-        - 4-beat
-        - acid breaks
-        - baltimore club
-        - big beat
-        - broken beat
-        - florida breaks
-        - nu skool breaks
-    - chiptune:
-        - bitpop
-        - game boy music
-        - nintendocore
-        - video game music
-        - yorkshire bleeps and bass
-    - disco:
-        - cosmic disco
-        - disco polo
-            - euro disco
-        - italo disco
-        - nu-disco
-        - space disco
-    - downtempo:
-        - acid jazz
-        - balearic beat
-        - chill out
-        - dub music
+- Ambient:
+  - ambient
+  - ambient music
+  - Ambient Americana:
+    - ambient americana
+    - ambient country
+  - Ambient Fusion:
+    - ambient fusion
+    - Ambient Dub:
+      - ambient dub
+      - Dubtronica:
         - dubtronica
-        - ethnic electronica
-        - moombahton
-        - nu jazz
-        - trip hop
-    - drum and bass:
-        - darkcore
-        - darkstep
-        - drumfunk
-        - drumstep
-        - hardstep
-        - intelligent drum and bass
-        - jump-up
-        - liquid funk
-        - neurofunk
-        - jungle:
-            - darkside jungle
-            - ragga jungle
-            - oldschool jungle
-        - raggacore
-        - sambass
-        - techstep
-        - leftfield
-        - halftime
-    - electro:
-        - crunk
-        - electro backbeat
-        - electro-grime
-        - electropop
-    - electroacoustic:
-        - acousmatic music
-        - computer music
-        - electroacoustic improvisation
-        - field recording
-        - live coding
-        - live electronics
-        - soundscape composition
-        - tape music
-    - electronic rock:
-        - alternative dance:
-            - baggy
-            - madchester
-        - dance-punk
-        - dance-rock
-        - dark wave
-        - electroclash
-        - electronicore
-        - electropunk
-        - ethereal wave
-        - indietronica
-        - new rave
-        - space rock
-        - synthpop
-        - synthpunk
-    - electronica:
-        - berlin school
-        - chillwave
-        - electronic art music
-        - electronic dance music
-        - folktronica
-        - freestyle music
-        - glitch
-        - idm
-        - laptronica
-        - skweee
-        - sound art
-        - synthcore
-    - eurodance:
-        - bubblegum dance
-        - italo dance
-        - turbofolk
-    - hardcore:
-        - bouncy house
-        - bouncy techno
+    - Ambient House:
+      - ambient house
+    - Ambient Trance:
+      - ambient trance
+    - Psybient:
+      - psybient
+      - psychedelic ambient
+      - psychill
+      - Psydub:
+        - psydub
+        - psy dub
+        - psy-dub
+        - psychedelic dub
+  - Dark Ambient:
+    - dark ambient
+    - ambient industrial
+    - Black Ambient:
+      - black ambient
+      - blackened ambient
+    - Ritual Ambient:
+      - ritual ambient
+      - dark ritual ambient
+      - ritual dark ambient
+  - Hauntology:
+    - hauntology
+    - memoradelia
+  - Space Ambient:
+    - space ambient
+    - space
+    - space music
+    - spacemusic
+  - Tribal Ambient:
+    - tribal ambient
+    - ethnic ambient
+    - ethno ambient
+    - organic ambient
+    - organic ambient music
+    - techno tribal
+    - techno-tribal
+- Audio Media:
+  - audio media
+  - ASMR:
+    - asmr
+    - autonomous sensory meridian response
+  - Audio Drama:
+    - audio drama
+    - audio play
+    - audio theater
+    - audio theatre
+    - drama
+    - hoerspiel
+    - hoorspel
+    - hörspiel
+    - horspiel
+    - kuunnelma
+    - radio drama
+    - radio play
+    - radio plays
+    - radio theater
+    - radio theatre
+    - radioteatret
+    - teatr wyobraźni
+    - ボイスドラマ
+    - teatr wyobrazni
+  - Dialogue:
+    - dialogue
+    - Interview:
+      - interview
+      - conversation
+      - conversations
+      - interviews
+  - Documentary:
+    - documentary
+    - audio documentary
+    - radio documentary
+  - Educational:
+    - educational
+    - education
+    - educational audio
+    - instructional
+    - Language Learning:
+      - language learning
+      - language course
+      - language course audio
+      - language instruction
+      - language instruction audio
+      - language learning audio
+      - language practice
+  - Field Recording:
+    - field recording
+    - field recordings
+    - Nature Recordings:
+      - nature recordings
+      - natural sounds
+      - nature sounds
+      - Animal Sounds:
+        - animal sounds
+        - animal music
+        - animal recordings
+        - Bird Sounds:
+          - bird sounds
+          - bird call
+          - bird calls
+        - Insect Sounds:
+          - insect sounds
+          - bug sounds
+          - insect recordings
+        - Whale Song:
+          - whale song
+      - Rain Sounds:
+        - rain sounds
+        - rain recordings
+      - Water Sounds:
+        - water sounds
+        - ocean sounds
+        - sea sounds
+        - water recordings
+        - wave sounds
+      - Weather Sounds:
+        - weather sounds
+        - storm sounds
+        - thunderstorm sounds
+        - wind sounds
+    - Soundscape:
+      - soundscape
+      - soundscape recording
+      - soundscape recordings
+      - soundscapes
+  - Podcast:
+    - podcast
+    - podcast episode
+    - podcast episodes
+    - podcasts
+  - Public Broadcast:
+    - public broadcast
+    - public broadcast recording
+    - public broadcast recordings
+    - radio broadcast
+    - radio broadcast recording
+    - radio broadcast recordings
+    - radio show
+    - radio shows
+    - News Broadcast:
+      - news broadcast
+      - news
+      - news broadcasts
+    - Old Time Radio:
+      - old time radio
+      - otr
+    - Public Service Announcement:
+      - public service announcement
+      - psa
+      - psas
+      - public service announcements
+    - Talk Radio:
+      - talk radio
+      - radio talk show
+      - talk show
+      - talk shows
+      - Shock Jock:
+        - shock jock
+  - Sound Effects:
+    - sound effects
+    - audio effect
+    - audio effects
+    - fx
+    - movie effects
+    - sample library
+    - sample pack
+    - samples
+    - sfx
+    - sound effect
+    - sound effects library
+    - sound fx
+    - sound libraries
+    - sound library
+    - special effects
+    - special fx
+    - Battle Record:
+      - battle record
+      - battle breaks
+      - battle tool
+      - dj battle tool
+      - scratch record
+      - scratch vinyl
+    - Foley:
+      - foley
+      - foley effects
+      - foley sounds
+    - Jingle:
+      - jingle
+      - jingles
+    - White Noise:
+      - white noise
+      - brown noise
+      - brownian noise
+      - gray noise
+      - grey noise
+      - pink noise
+  - Speech:
+    - speech
+    - speeches
+    - Debate:
+      - debate
+      - debates
+      - political debate
+      - political debates
+    - Lecture:
+      - lecture
+      - lectures
+    - Monologue:
+      - monologue
+      - monolog
+    - Sermon:
+      - sermon
+      - sermons
+    - Therapeutic Audio:
+      - therapeutic audio
+      - therapeutic
+      - therapy
+      - Guided Meditation:
+        - guided meditation
+        - meditation
+        - meditation music
+      - Hypnosis:
+        - hypnosis
+        - hypnotherapy
+  - Sports Commentary:
+    - sports commentary
+    - sport
+    - sport commentaries
+    - sport commentary
+    - sports
+    - sports commentaries
+  - Storytelling:
+    - storytelling
+    - stories
+    - story
+    - Audiobook:
+      - audiobook
+      - audio book
+      - audio books
+      - audiobooks
+      - book on tape
+      - books on tape
+    - Children's Storytelling:
+      - children's storytelling
+      - children's stories
+      - Bedtime Story:
+        - bedtime story
+        - bedtime stories
+      - Fairy Tales:
+        - fairy tales
+        - fairy tale
+    - Folktale:
+      - folktale
+      - folktales
+- Blues:
+  - blues
+  - Acoustic Blues:
+    - acoustic blues
+    - early acoustic blues
+    - pre-war blues
+    - traditional blues
+    - Acoustic Chicago Blues:
+      - acoustic chicago blues
+      - pre-electric chicago blues
+    - Jug Band:
+      - jug band
+      - acoustic jug band
+    - Piedmont Blues:
+      - piedmont blues
+      - east coast blues
+      - ragtime blues
+  - Blues Ballad:
+    - blues ballad
+  - Canadian Blues:
+    - canadian blues
+  - Country Blues:
+    - country blues
+    - downhome blues
+    - folk blues
+    - folk-blues
+    - pre-war country blues
+    - rural blues
+    - Delta Blues:
+      - delta blues
+      - mississippi delta blues
+    - Hill Country Blues:
+      - hill country blues
+      - north mississippi hill country blues
+    - Songster:
+      - songster
+  - Desert Blues:
+    - desert blues
+    - assouf
+    - ishumar music
+    - mali blues
+    - saharan rock
+    - tichumaren
+    - tishoumaren
+    - tuareg blues
+    - tuareg rock
+  - Electric Blues:
+    - electric blues
+    - contemporary blues
+    - modern blues
+    - modern electric blues
+    - urban blues
+    - British Blues:
+      - british blues
+    - Chicago Blues:
+      - chicago blues
+      - electric chicago blues
+    - Detroit Blues:
+      - detroit blues
+    - Juke Joint Blues:
+      - juke joint blues
+    - Slide Guitar Blues:
+      - slide guitar blues
+    - Swamp Blues:
+      - swamp blues
+  - Fife and Drum Blues:
+    - fife and drum blues
+    - fife and drum band
+  - Gospel Blues:
+    - gospel blues
+    - blues gospel
+    - holy blues
+    - pre-war gospel blues
+  - Harmonica Blues:
+    - harmonica blues
+    - electric harmonica blues
+  - Jump Blues:
+    - jump blues
+    - rnb/swing
+    - swing blues
+    - Jazz Blues:
+      - jazz blues
+    - West Coast Blues:
+      - west coast blues
+  - Kansas City Blues:
+    - kansas city blues
+  - Louisiana Blues:
+    - louisiana blues
+  - Memphis Blues:
+    - memphis blues
+  - New Orleans Blues:
+    - new orleans blues
+  - Piano Blues:
+    - piano blues
+    - blues piano
+    - Boogie Woogie:
+      - boogie woogie
+      - boogie-woogie
+    - St. Louis Blues:
+      - st. louis blues
+      - saint louis blues
+      - st louis blues
+  - Soul Blues:
+    - soul blues
+    - soul-blues
+  - Texas Blues:
+    - texas blues
+    - Acoustic Texas Blues:
+      - acoustic texas blues
+    - Electric Texas Blues:
+      - electric texas blues
+  - Vaudeville Blues:
+    - vaudeville blues
+    - classic blues vocals
+    - classic female blues
+    - Hokum:
+      - hokum
+      - hokum blues
+- Children:
+  - children
+  - children's music
+  - children's songs
+  - childrens music
+  - childrens songs
+  - kids music
+  - kids songs
+  - kids' music
+  - Lullaby:
+    - lullaby
+    - lullabies
+  - Nursery Rhyme:
+    - nursery rhyme
+    - nursery
+    - nursery rhymes
+    - nursery song
+    - nursery songs
+- Classical:
+  - classical
+  - classical music
+  - formal music
+  - African Court Music:
+    - african court music
+    - Buganda Royal Court:
+      - buganda royal court
+      - buganda royal court music
+      - buganda royal music
+    - Inkiranya:
+      - inkiranya
+    - Kete:
+      - kete
+  - Asian Classical:
+    - asian classical
+    - asian classical music
+    - East Asian Classical:
+      - east asian classical
+      - east asian classical music
+      - Chinese Classical:
+        - chinese classical
+        - chinese classical music
+        - Chinese Literati:
+          - chinese literati
+          - chinese literati music
+          - chinese scholar music
+          - qin
+          - qin music
+          - wenren yinyue
+          - 文人音乐
+          - 文人音樂
+        - Naxi:
+          - naxi
+          - nakhi music
+          - naxi ancient music
+          - nàxī gǔ yuè
+          - naxi gu yue
+          - naxi music
+          - 纳西古乐
+          - Baisha xiyue:
+            - baisha xiyue
+            - baisha fine music
+            - baisha orchestral music
+            - baisha traditional music
+            - 白沙细乐
+          - Dongjing:
+            - dongjing
+            - dongjing yinyue
+            - donjiang
+            - 洞經音樂
+            - 洞经音乐
+        - Yayue:
+          - yayue
+          - 雅樂
+      - Chinese Opera:
+        - chinese opera
+        - xiqu
+        - xìqǔ
+        - 戏曲
+        - 戲曲
+        - Cantonese Opera:
+          - cantonese opera
+          - daai6 hei3
+          - jyut6 kek6
+          - 大戲
+          - 粵劇
+        - Henan Opera:
+          - henan opera
+          - henan bangzi
+          - henan gaodiao
+          - yu opera
+          - yuju
+          - 河南梆子
+          - 河南高調
+          - 河南高调
+          - 豫剧
+          - 豫劇
+        - Kunqu Opera:
+          - kunqu opera
+          - kun opera
+          - kunju
+          - kunqu
+          - kunqu theatre
+          - 崑劇
+          - 崑曲
+          - 昆剧
+          - 昆山腔
+          - 昆曲
+          - 昆腔
+        - Peking Opera:
+          - peking opera
+          - beijing opera
+          - guójù
+          - guoju
+          - jīngjù
+          - jingju
+          - 京剧
+          - 京劇
+          - 國劇
+          - Revolutionary Opera:
+            - revolutionary opera
+            - model opera
+            - yangban xi
+            - 样板戏
+        - Shaoxing Opera:
+          - shaoxing opera
+          - shaoxing literal opera
+          - yue opera
+          - yuèjù
+          - yueju
+          - 绍兴文戏
+          - 越剧
+          - 越劇
+        - Sichuan Opera:
+          - sichuan opera
+          - chuānjù
+          - chuanju
+          - cuan ju
+          - 川剧
+          - 川劇
+          - 川戏
+          - 川戲
+        - Yangzhou Opera:
+          - yangzhou opera
+          - weiyangxi
+          - yangju
+          - yangzhouxi
+          - 扬剧
+          - 扬州戏
+          - 维扬戏
+      - Japanese Classical:
+        - japanese classical
+        - japanese classical music
+        - Gagaku:
+          - gagaku
+          - 雅楽
+          - Komagaku:
+            - komagaku
+            - koma-gaku
+            - komagaku music
+            - 高麗楽
+        - Heikyoku:
+          - heikyoku
+          - heike biwa
+          - heike katari
+          - 平曲
+        - Honkyoku:
+          - honkyoku
+          - 本曲
+        - Jiuta:
+          - jiuta
+        - Jōruri:
+          - jōruri
+          - joruri
+          - 浄瑠璃
+        - Meiji shinkyoku:
+          - meiji shinkyoku
+          - 明治新曲
+        - Nagauta:
+          - nagauta
+          - 長唄
+        - Noh:
+          - noh
+          - nō
+          - nogaku
+          - 能
+          - 能楽
+        - Shōka:
+          - shōka
+          - shoka
+          - shōka music
+          - shoka music
+          - 唱歌
+        - Shōmyō:
+          - shōmyō
+          - shomyo
+          - shoumyou
+          - 声明
+        - Sōkyoku:
+          - sōkyoku
+          - sokyoku
+          - soukyoku
+          - 筝曲
+          - Danmono:
+            - danmono
+            - 段物
+          - Kumiuta:
+            - kumiuta
+            - kumi-uta
+      - Korean Classical:
+        - korean classical
+        - korean classical music
+        - Korean Court:
+          - korean court
+          - korean court music
+          - Aak:
+            - aak
+            - 아악
+          - Dang-ak:
+            - dang-ak
+            - dang ak
+            - tang-ak
+            - tangak
+            - tanguk
+            - 당악
+            - 唐樂
+          - Hyang-ak:
+            - hyang-ak
+            - hyang ak
+            - hyangak
+            - 향악
+            - 鄕樂
+          - Jeong-ak:
+            - jeong-ak
+            - chŏngak
+            - chongak
+            - jeong ak
+            - 정악
+            - 正樂
+            - Gagok:
+              - gagok
+              - kagok
+              - 가곡
+              - 歌曲
+        - Korean Revolutionary Opera:
+          - korean revolutionary opera
+          - 조선혁명가극
+      - Minyue:
+        - minyue
+        - chinese national music
+        - guo yue
+        - guoyue
+        - guoyue music
+        - huayue
+        - 国乐
+        - 國樂
+        - 民乐
+        - 民樂
+        - 華樂
+      - Sizhu:
+        - sizhu
+        - silk and bamboo
+        - silk and bamboo music
+        - sizhu music
+        - 丝竹
+        - 丝竹乐
+        - 絲竹
+        - 絲竹樂
+        - Guangdong yinyue:
+          - guangdong yinyue
+          - cantonese instrumental music
+          - guangdong instrumental music
+          - gwóng-dūng yām-ngohk
+          - gwong-dung yam-ngohk
+          - 广东音乐
+          - 廣東音樂
+        - Nanyin:
+          - nanyin
+          - langjunyue
+          - nan-kouan
+          - nanguan
+          - nanguan music
+          - nanqu
+          - nanyue
+          - xianguan
+          - 南乐
+          - 南曲
+          - 南管
+          - 南音
+          - 弦管
+          - 郎君乐
+      - Vietnamese Court:
+        - vietnamese court
+        - nhã nhạc
+        - nha nhac
+        - nhạc cung đình
+        - nhac cung đinh
+        - vietnamese court music
+        - Vietnamese Opera:
+          - vietnamese opera
+          - hát bội
+          - hat boi
+          - hát bôi
+          - hát tuồng
+          - hat tuong
+    - South Asian Classical:
+      - south asian classical
+      - indian classical
+      - indian classical music
+      - south asian classical music
+      - Carnatic Classical:
+        - carnatic classical
+        - carnatic
+        - carnatic classical music
+        - carnatic music
+        - karnatak music
+        - karṇāṭaka sangīta
+        - karnataka sangita
+        - karṇāṭaka sangītam
+        - karnataka sangitam
+        - karnatik classical music
+        - karnatik music
+        - Konnakol:
+          - konnakol
+          - konakkol
+          - konnakkol
+          - konokol
+          - கொன்னக்கோல்
+          - വായ്ത്താരി
+        - Kriti:
+          - kriti
+          - carnatic kriti
+          - krithi
+          - krti
+        - Thillana:
+          - thillana
+          - tillana
+      - Hindustani Classical:
+        - hindustani classical
+        - hindustani
+        - hindustani classical music
+        - north indian classical music
+        - ہندوستانی کلاسیکی موسیقی
+        - हिन्दुस्तानी शास्त्रीय संगीत
+        - ভারতীয় শাস্ত্রীয় সংগীত
+        - Bangladeshi Classical:
+          - bangladeshi classical
+          - bangladeshi classical music
+        - Dadra:
+          - dadra
+          - dadra music
+        - Dhrupad:
+          - dhrupad
+          - Dhamar:
+            - dhamar
+            - dhamar taal
+            - dhamar tala
+        - Dhun:
+          - dhun
+        - Kafi:
+          - kafi
+          - kāfī
+          - waee
+        - Khayal:
+          - khayal
+          - khyal
+          - خیال
+          - ख़याल
+        - Klasik:
+          - klasik
+        - Qawwali:
+          - qawwali
+          - قوّالی
+          - क़व्वाली
+          - কাওয়ালি
+          - ਕ਼ੱਵਾਲੀ
+        - Tarana:
+          - tarana
+        - Thumri:
+          - thumri
+          - thumree
+      - Odissi Classical:
+        - odissi classical
+        - odissi classical music
+        - odissi music
+        - odramagadhi classical music
+        - orisi music
+        - ଓଡ଼ିଶୀ ସଙ୍ଗୀତ
+      - Panchavadyam:
+        - panchavadyam
+        - panchavadyam music
+    - Southeast Asian Classical:
+      - southeast asian classical
+      - gong chime
+      - gong chime ensemble
+      - gong chime music
+      - gong-chime ensemble
+      - gong-chime music
+      - gong-chime orchestras
+      - southeast asian classical music
+      - Burmese Classical:
+        - burmese classical
+        - burmese classical music
+        - myanmar classical music
+      - Cambodian Classical:
+        - cambodian classical
+        - cambodian classical music
+      - Gamelan:
+        - gamelan
+        - Balinese Gamelan:
+          - balinese gamelan
+          - gambelan
+          - gambelan bali
+          - karawitan bali
+          - Gamelan angklung:
+            - gamelan angklung
+          - Gamelan bebonangan:
+            - gamelan bebonangan
+          - Gamelan beleganjur:
+            - gamelan beleganjur
+            - gamelan baleganjur
+            - gamelan belaganjur
+          - Gamelan gender wayang:
+            - gamelan gender wayang
+            - gamelan gendér wayang
+            - gamelan gendèr wayang
+            - gamelan gěndèr wayang
+            - gender wayang
+          - Gamelan gong gede:
+            - gamelan gong gede
+            - gamelan gong gde
+            - gamelan gong gedé
+          - Gamelan gong kebyar:
+            - gamelan gong kebyar
+            - kebyar
+          - Gamelan jegog:
+            - gamelan jegog
+            - gamelan djegog
+            - jegog
+          - Gamelan selonding:
+            - gamelan selonding
+            - gamelan selunding
+          - Gamelan semar pegulingan:
+            - gamelan semar pegulingan
+        - Gamelan degung:
+          - gamelan degung
+          - degung
+        - Gamelan salendro:
+          - gamelan salendro
+        - Javanese Gamelan:
+          - javanese gamelan
+          - gendhing jawa
+          - gending jawa
+          - karawitan jawa
+          - Gamelan sekaten:
+            - gamelan sekaten
+          - Solonese Gamelan:
+            - solonese gamelan
+            - gamelan solo
+            - gamelan surakarta
+            - karawitan gaya surakarta
+            - surakartan gamelan
+        - Malay Gamelan:
+          - malay gamelan
+          - gamelan melayu
+          - ݢاميلن ملايو
+      - Kacapi suling:
+        - kacapi suling
+        - katjapi soeling
+        - ketjapi soeling
+      - Kakawin:
+        - kakawin
+        - kekawin
+        - ᬓᬓᬯᬶᬦ᭄
+        - ꦏꦏꦮꦶꦤ꧀
+      - Kulintang:
+        - kulintang
+        - kolintang
+        - kulintangan
+        - totobuang
+      - Mahori:
+        - mahori
+        - mahoree
+        - mohowrri
+      - Malay Classical:
+        - malay classical
+        - malay classical music
+      - Philippine Classical:
+        - philippine classical
+        - philippine classical music
+      - Pinpeat:
+        - pinpeat
+      - Saluang klasik:
+        - saluang klasik
+      - Tai tu:
+        - tai tu
+        - don ca tai tu
+        - nhac tai tu
+        - nhạc tài tử
+        - tài tử
+        - tai tu music
+        - đờn ca tài tử
+      - Talempong:
+        - talempong
+        - cak lempong
+        - calempong
+        - talèmpong
+        - tilempong
+      - Tembang Sunda Cianjuran:
+        - tembang sunda cianjuran
+        - cianjuran
+        - seni mamaos cianjuran
+        - tembang soenda
+        - tembang sunda
+        - tembang tjiandjuran
+        - Panambih:
+          - panambih
+          - tembang sunda panambih
+      - Thai Classical:
+        - thai classical
+        - siamese classical music
+        - thai classical music
+        - ดนตรีไทยเดิม
+        - Fon leb:
+          - fon leb
+          - nail dance
+          - ฟ้อนเล็บ
+        - Khrueang sai:
+          - khrueang sai
+          - khruang sai
+          - khryang sai
+          - wong khrueang sai
+          - วงเครื่องสาย
+        - Piphat:
+          - piphat
+          - pi phat
+          - ปี่พาทย์
+        - Pleng Thai sakorn:
+          - pleng thai sakorn
+          - phleng thai sakon
+          - phleng thai sakorn
+          - pleng thai sakon
+    - Tibetan Buddhist Chant:
+      - tibetan buddhist chant
+      - tibetan chordal chant
+  - Maqāmic Classical:
+    - maqāmic classical
+    - islamicate classical music
+    - maqām
+    - maqam
+    - maqām-based music
+    - maqam-based music
+    - maqāmic
+    - maqamic classical
+    - maqāmic music
+    - maqamic music
+    - middle eastern classical music
+    - مقام
+    - maqamic
+    - Arabic Classical:
+      - arabic classical
+      - arabic classical music
+      - Andalusian Classical:
+        - andalusian classical
+        - andalus classical
+        - andalusian classical music
+        - arab-andalusian classical music
+        - arabic-andalusian classical music
+        - arabo-andalusian classical music
+        - moussiqua al-âla
+        - moussiqua al-ala
+        - Muwashshah:
+          - muwashshah
+          - muwashah
+          - muwashshah music
+          - muwashshahat
+          - موشح
+      - Iraqi Maqam:
+        - iraqi maqam
+        - iraqi classical music
+        - maqam al-iraqi
+        - الـمـقـام الـعـراقـي
+      - Sawt:
+        - sawt
+        - ṣawt
+        - sout
+        - sowt
+        - صوت
+    - Azerbaijani Mugham:
+      - azerbaijani mugham
+      - muğam
+      - mugam
+      - mugham
+      - موغام
+    - Persian Classical:
+      - persian classical
+      - iranian classical music
+      - musiqi-e assil-e irani
+      - musiqi-e sonati-e irani
+      - persian classical music
+    - Shashmaqam:
+      - shashmaqam
+      - shashmaqom
+    - Sufiana kalam:
+      - sufiana kalam
+      - kashmiri classical music
+      - sufiana mausiqi
+      - sufyana kalam
+      - صفیانہ موسیقی
+      - صفیانہ کلام
+    - Turkish Classical:
+      - turkish classical
+      - ottoman classical
+      - ottoman classical music
+      - saray musikisi
+      - türk sanat müziği
+      - turk sanat muzigi
+      - turkish classical music
+      - Turkish Mevlevi:
+        - turkish mevlevi
+        - tasavvuf music
+        - tasavvuf musikisi
+        - türk tasavvuf musikisi
+        - turk tasavvuf musikisi
+        - türk tasavvuf müziği
+        - turk tasavvuf muzigi
+        - türk tasavvufi sanat müziği
+        - turk tasavvufi sanat muzigi
+        - turkish mevlevi music
+        - turkish tasavvuf music
+    - Twelve Muqam:
+      - twelve muqam
+      - 12 muqam
+      - on ikki muqam
+      - ئون ئىككى مۇقامى
+      - 维吾尔十二木卡姆
+  - Western Classical:
+    - western classical
+    - european classical music
+    - western art music
+    - western classical music
+    - Art Song:
+      - art song
+      - kunstlied
+      - Lied:
+        - lied
+        - lieder
+      - Mélodie:
+        - mélodie
+        - melodie
+      - Orchestral Song:
+        - orchestral song
+        - orchestral lieder
+    - Bagatelle:
+      - bagatelle
+    - Ballet:
+      - ballet
+      - Ballet de cour:
+        - ballet de cour
+        - court ballet
+      - Comédie-ballet:
+        - comédie-ballet
+        - comédie ballet
+        - comédie galante
+        - comedie galante
+        - comedie-ballet
+        - comic ballet
+        - tragédie-ballet
+        - tragedie-ballet
+        - tragicomédie et ballet
+        - tragicomedie et ballet
+        - comedie ballet
+      - Opéra-ballet:
+        - opéra-ballet
+        - opéra ballet
+        - opera-ballet
+        - opera ballet
+    - Brazilian Classical:
+      - brazilian classical
+      - brazilian classical music
+      - música erudita brasileira
+      - musica erudita brasileira
+      - Valsa brasileira:
+        - valsa brasileira
+        - brazilian waltz
+        - valsinha brasileira
+    - Byzantine:
+      - byzantine
+      - byzantine music
+      - Byzantine Chant:
+        - byzantine chant
+        - chant of constantinople
+    - Cantata:
+      - cantata
+    - Canzona:
+      - canzona
+      - canzon
+      - canzone
+    - Capriccio:
+      - capriccio
+      - caprice
+    - Chamber Music:
+      - chamber music
+      - chamber
+      - Divertimento:
+        - divertimento
+      - Divertissement:
+        - divertissement
+      - String Quartet:
+        - string quartet
+    - Character Piece:
+      - character piece
+      - characteristic piece
+      - charakterstück
+      - charakterstuck
+      - genrestück
+      - genrestuck
+      - lyric piece
+      - Nocturne:
+        - nocturne
+        - notturno
+    - Choral:
+      - choral
+      - Choral Concerto:
+        - choral concerto
+        - church concerto
+        - sacred concerto
+        - vocal concerto
+        - хоровий концерт
+        - хоровой концерт
+    - Cinematic Classical:
+      - cinematic classical
+      - cinematic music
+      - Epic:
+        - epic
+        - epic cinematic music
+        - epic music
+        - trailer music
+      - Spaghetti Western:
+        - spaghetti western
+        - italo-western
+    - Classic Ragtime:
+      - classic ragtime
+      - classic rag
+      - classical rag
+      - classical ragtime
+    - Classical Period:
+      - classical period
+      - classical era
+      - classical music era
+      - Galant:
+        - galant
+        - galant style
+        - style galant
+    - Concert Band:
+      - concert band
+      - band music
+      - symphonic band
+      - symphonic wind ensemble
+      - symphonic winds
+      - wind band
+      - wind ensemble
+      - wind orchestra
+      - wind symphony
+    - Concerto:
+      - concerto
+      - Concerto for Orchestra:
+        - concerto for orchestra
+        - concert for orchestra
+      - Concerto grosso:
+        - concerto grosso
+        - grand concerto
+    - Early Music:
+      - early music
+      - early
+      - Baroque:
+        - baroque
+        - baroque music
+        - baroque period
+        - Baroque Suite:
+          - baroque suite
+          - baroque dance suite
+          - ordre
+          - parthia
+          - parthie
+          - partia
+          - partie
+          - partita
+          - suite
+        - Chorale:
+          - chorale
+          - chorale setting
+          - Chorale Cantata:
+            - chorale cantata
+          - Chorale Concerto:
+            - chorale concerto
+          - Chorale Fantasia:
+            - chorale fantasia
+          - Chorale Monody:
+            - chorale monody
+          - Chorale Motet:
+            - chorale motet
+          - Chorale Partita:
+            - chorale partita
+          - Chorale Prelude:
+            - chorale prelude
+          - Lutheran Chorale:
+            - lutheran chorale
+            - lutheran hymn
+      - Medieval Classical:
+        - medieval classical
+        - medieval
+        - medieval classical music
+        - medieval music
+        - Ars antiqua:
+          - ars antiqua
+          - ars veterum
+          - ars vetus
+        - Ars nova:
+          - ars nova
+          - new art
+        - Ars subtilior:
+          - ars subtilior
+          - ars subtilissima
+          - artem magis subtiliter
+          - post modum subtiliorem comparantes
+        - Ballata:
+          - ballata
+        - Cantiga:
+          - cantiga
+        - Contenance angloise:
+          - contenance angloise
+          - english manner
+        - Lauda:
+          - lauda
+          - lauda spirituale
+        - Medieval Lyric Poetry:
+          - medieval lyric poetry
+          - troubadour lyric poetry
+          - troubadour songs
+        - Neo-Medieval:
+          - neo-medieval
+          - neo medieval
+          - neo medieval classical
+          - neo medieval music
+          - neo-medieval classical
+          - neo-medieval music
+        - Organum:
+          - organum
+          - new technique
+        - Plainsong:
+          - plainsong
+          - plainchant
+          - Ambrosian Chant:
+            - ambrosian chant
+            - milanese chant
+          - Canto beneventano:
+            - canto beneventano
+            - beneventan chant
+          - Canto mozárabe:
+            - canto mozárabe
+            - ancient spanish chant
+            - canto mozarabe
+            - hispanic chant
+            - mozarabic chant
+            - old hispanic chant
+            - old spanish chant
+            - visigothic chant
+          - Celtic Chant:
+            - celtic chant
+            - insular chant
+          - Gallican Chant:
+            - gallican chant
+            - gallic chant
+          - Gregorian Chant:
+            - gregorian chant
+            - Sarum Chant:
+              - sarum chant
+          - Old Roman Chant:
+            - old roman chant
+        - Rondeau:
+          - rondeau
+          - rondeaux
+        - Virelai:
+          - virelai
+      - Renaissance:
+        - renaissance
+        - renaissance music
+        - Burgundian School:
+          - burgundian school
+          - burgundian music
+          - burgundian school music
+        - Elizabethan Song:
+          - elizabethan song
+          - air de cour
+          - ayre
+          - consort song
+          - jacobean song
+          - lute song
+        - Franco-Flemish School:
+          - franco-flemish school
+          - dutch school
+          - flemish school
+          - franco flemish school
+          - franco-netherlandish school
+          - low countries school
+          - netherlandish school
+          - northern school
+        - Villanella:
+          - villanella
+    - English Pastoral School:
+      - english pastoral school
+      - english nationalist school
+    - Fantasia:
+      - fantasia
+      - fancy
+      - fantasy
+      - fantazy
+      - phantasy
+    - Fugue:
+      - fugue
+      - fuga
+      - fuge
+    - Impromptu:
+      - impromptu
+    - Latin American Classical:
+      - latin american classical
+      - latin american classical music
+    - Madrigal:
+      - madrigal
+    - March:
+      - march
+      - marches
+      - martial music
+      - military march music
+      - military music
+      - Bandas de viento de México:
+        - bandas de viento de méxico
+        - bandas de viento de mexico
+        - música de viento de méxico
+        - musica de viento de mexico
+        - Banda sinaloense:
+          - banda sinaloense
+          - tambora
+      - Brass Band:
+        - brass band
+        - brass
+        - brass music
+        - British Brass Band:
+          - british brass band
+          - prize band
+          - silver band
+        - Dechovka:
+          - dechovka
+          - dechová hudba
+          - dechova hudba
+          - dychovka
+      - Bugle Call:
+        - bugle call
+      - Circus March:
+        - circus march
+        - screamer
+      - Dobrado:
+        - dobrado
+      - Fanfare:
+        - fanfare
+      - Funeral March:
+        - funeral march
+        - dead march
+      - Gunka:
+        - gunka
+        - gunka music
+        - japanese military songs
+        - 軍歌
+      - Marching Band:
+        - marching band
+        - Beni:
+          - beni
+        - Drum and Bugle Corps:
+          - drum and bugle corps
+        - Drumline:
+          - drumline
+          - battery
+          - drum corps
+          - marching percussion
+        - Fife and Drum Corps:
+          - fife and drum corps
+        - Guggenmusik:
+          - guggenmusik
+          - guggemusig
+        - Pep Band:
+          - pep band
+          - academic marching band
+          - athletic marching band
+          - show band
+          - Fight Song:
+            - fight song
+            - college fight song
+            - fight songs
+            - games song
+            - school fight song
+            - team anthem
+            - team song
+          - Military Marching Band:
+            - military marching band
+            - military
+            - military band
+      - Ottoman Military:
+        - ottoman military
+        - janissary music
+        - mehter
+        - mehter music
+        - mehteran
+        - mehterhane
+        - ottoman janissary band
+        - ottoman military band
+        - ottoman military music
+      - Tanjidor:
+        - tanjidor
+    - Modern Classical:
+      - modern classical
+      - 20th century classical
+      - 20th century classical music
+      - 20th-century classical
+      - 20th-century classical music
+      - contemporary classical
+      - modern classical music
+      - American Gamelan:
+        - american gamelan
+        - new gamelan
+      - Avant-Garde Classical:
+        - avant-garde classical
+        - avant-garde classical music
+      - Darmstadt School:
+        - darmstadt school
+        - darmstädter schule
+        - darmstadter schule
+      - Expressionism:
+        - expressionism
+      - Impressionism:
+        - impressionism
+        - impressionist
+        - impressionist music
+      - Late Romanticism:
+        - late romanticism
+        - late romantic
+        - post-romanticism
+        - Second Viennese School:
+          - second viennese school
+          - neue wiener schule
+          - new viennese school
+          - wiener atonale schule
+          - wiener schule der moderne
+          - zweite wiener schule
+      - Microtonal Classical:
+        - microtonal classical
+        - microtonal
+        - microtonal music
+      - Minimalism:
+        - minimalism
+        - minimalist classical
+        - Holy Minimalism:
+          - holy minimalism
+          - european mysticism
+          - mystic minimalism
+          - sacred minimalism
+          - spiritual minimalism
+      - Musique concrète instrumentale:
+        - musique concrète instrumentale
+        - instrumental concrete music
+        - musique concrete instrumentale
+        - post-lachenmann
+      - Neoromanticism:
+        - neoromanticism
+        - neo-romantic
+        - neo-romanticism
+        - neoconservative postmodernism
+        - neoromantic
+      - New Complexity:
+        - new complexity
+        - the new complexity
+      - New York School:
+        - new york school
+      - Post-Minimalism:
+        - post-minimalism
+        - post minimalism
+        - Totalism:
+          - totalism
+      - Process Music:
+        - process music
+        - process
+        - process-generated
+        - process-generated music
+      - Serialism:
+        - serialism
+        - serial
+        - twelve-tone
+        - Integral Serialism:
+          - integral serialism
+          - pointillism
+          - punctualism
+          - total serialism
+      - Sonorism:
+        - sonorism
+        - sonorystyka
+      - Spectralism:
+        - spectralism
+        - spectral music
+      - Stochastic:
+        - stochastic
+        - stochastic music
+        - stochasticism
+        - stochastism
+    - Motet:
+      - motet
+      - madrigali spirituali
+    - Neoclassicism:
+      - neoclassicism
+      - neo-classical
+      - neoclassical
+      - neoclassical music
+    - Opera:
+      - opera
+      - european opera
+      - western classical opera
+      - Ballad Opera:
+        - ballad opera
+      - Bel Canto:
+        - bel canto
+      - Comic Opera:
+        - comic opera
+      - Grand opéra:
+        - grand opéra
+        - grand opera
+      - Monodrama:
+        - monodrama
+        - mono-opera
+        - monologue lyrique
+        - musical monologue
+      - Opera buffa:
+        - opera buffa
+        - commedia per musica
+        - dramma giocoso per musica
+        - italian comic opera
+        - italian light opera
+      - Opera semiseria:
+        - opera semiseria
+        - drammi eroicocomici
+        - semi-serious opera
+      - Opera seria:
+        - opera seria
+        - dramma per musica
+        - melodramma serio
+        - neapolitan opera
+        - serious opera
+      - Operetta:
+        - operetta
+        - operette
+        - Kalon'ny fahiny:
+          - kalon'ny fahiny
+          - malagasy operetta
+          - opérette malgache
+          - operette malgache
+      - Opéra-comique:
+        - opéra-comique
+        - opéra comique
+        - opera-comique
+        - opera comique
+      - Romantische Oper:
+        - romantische oper
+        - german romantic opera
+      - Singspiel:
+        - singspiel
+      - Tragédie en musique:
+        - tragédie en musique
+        - tragédie
+        - tragedie
+        - tragedie en musique
+        - tragédie lyrique
+        - tragedie lyrique
+      - Verismo:
+        - verismo
+      - Zarzuela:
+        - zarzuela
+        - sarsuela
+        - zartzuela
+        - zarzuelta
+        - Género chico:
+          - género chico
+          - genero chico
+          - zarzuela chica
+          - zarzuela por hora
+          - zarzuela por seccion
+          - zarzuelita
+        - Zarzuela barroca:
+          - zarzuela barroca
+          - baroque zarzuela
+        - Zarzuela grande:
+          - zarzuela grande
+          - género grande
+          - genero grande
+      - Zeitoper:
+        - zeitoper
+        - now opera
+    - Oratorio:
+      - oratorio
+    - Orchestral:
+      - orchestral
+      - orchestra
+      - orchestral music
+      - Symphonic Mugham:
+        - symphonic mugham
+        - simfonik muğam
+        - simfonik mugam
+        - симфонический мугам
+      - Tone Poem:
+        - tone poem
+        - musical tableau
+        - symphonic poem
+    - Overture:
+      - overture
+      - einleitung
+      - introduction
+      - sinfonia
+      - vorspiel
+    - Passion:
+      - passion
+      - passion music
+      - passion setting
+    - Prelude:
+      - prelude
+      - praeludium
+      - preamble
+    - Pìobaireachd:
+      - pìobaireachd
+      - ceòl mòr
+      - ceòl mór
+      - ceol mor
+      - pibroch
+      - piobaireachd
+    - Ricercar:
+      - ricercar
+      - recercar
+      - recercare
+      - ricercare
+      - ricercata
+    - Roman School:
+      - roman school
+      - later roman school
+    - Romanticism:
+      - romanticism
+      - romantic
+      - romantic classical
+      - romantic music
+      - romantic period
+      - Absolute Music:
+        - absolute music
+        - absolute
+        - abstract music
+      - Moscow School:
+        - moscow school
+        - moscow school of composition
+        - московская школа композиторов
+      - Młoda Polska:
+        - młoda polska
+      - New German School:
+        - new german school
+        - music of the future
+        - neo-german school
+        - neudeutsche schule
+        - new weimar school
+        - weimar school
+        - zukunftsmusik
+      - Program Music:
+        - program music
+        - program
+      - Saint Petersburg School:
+        - saint petersburg school
+        - russian national school
+        - russian nationalist school
+        - st. petersburg compositional school
+        - петербургская школа композиторов
+    - Serenade:
+      - serenade
+      - nachtmusik
+      - serenata
+    - Sonata:
+      - sonata
+    - Spanish Classical:
+      - spanish classical
+      - música clásica española
+      - musica clasica espanola
+      - spanish classical music
+    - Symphony:
+      - symphony
+      - Choral Symphony:
+        - choral symphony
+      - Sinfonia concertante:
+        - sinfonia concertante
+        - concertante symphony
+        - symphonie concertante
+        - symphony-concerto
+    - Theme and Variation:
+      - theme and variation
+      - theme and variations
+      - variations on a theme
+    - Tientos:
+      - tientos
+      - tiento
+    - Toccata:
+      - toccata
+      - toccare
+      - toccatina
+      - tochata
+    - Étude:
+      - étude
+      - etude
+      - exercise
+      - lesson
+      - study
+- Country:
+  - country
+  - country and western
+  - country music
+  - Alternative Country:
+    - alternative country
+    - alt country
+    - alt-country
+    - Gothic Country:
+      - gothic country
+      - dark country
+      - death country
+      - denver sound
+      - gothic americana
+      - southern gothic
+      - southern gothic music
+  - Australian Country:
+    - australian country
+    - australian country music
+  - Bluegrass:
+    - bluegrass
+    - bluegrass music
+    - Contemporary Bluegrass:
+      - contemporary bluegrass
+      - Progressive Bluegrass:
+        - progressive bluegrass
+        - newgrass
+    - Czech Bluegrass:
+      - czech bluegrass
+    - Traditional Bluegrass:
+      - traditional bluegrass
+      - truegrass
+      - Bluegrass Gospel:
+        - bluegrass gospel
+        - bluegrass-gospel
+        - gospel bluegrass
+  - Contemporary Country:
+    - contemporary country
+    - Boyfriend Country:
+      - boyfriend country
+    - Bro-Country:
+      - bro-country
+      - bro country
+    - Neo-Traditionalist Country:
+      - neo-traditionalist country
+      - neo traditionalist country
+      - neo-traditional country
+      - neotraditional country
+      - new traditionalist
+  - Country & Irish:
+    - country & irish
+  - Country Folk:
+    - country folk
+    - country-folk
+  - Country Pop:
+    - country pop
+    - country-pop
+    - Nashville Sound:
+      - nashville sound
+      - Countrypolitan:
+        - countrypolitan
+    - Urban Cowboy:
+      - urban cowboy
+  - Honky Tonk:
+    - honky tonk
+    - honky-tonk
+    - Bakersfield Sound:
+      - bakersfield sound
+    - Truck Driving Country:
+      - truck driving country
+      - truck-driving country
+      - trucking country
+      - trucking music
+  - Progressive Country:
+    - progressive country
+    - Outlaw Country:
+      - outlaw country
+  - Red Dirt:
+    - red dirt
+  - Traditional Country:
+    - traditional country
+    - classic country
+    - hillbilly music
+    - Close Harmony:
+      - close harmony
+      - brother duets
+    - Country Boogie:
+      - country boogie
+      - hillbilly boogie
+    - Country Gospel:
+      - country gospel
+      - christian country
+      - christian country music
+      - gospel country
+    - Country Yodeling:
+      - country yodeling
+  - Western:
+    - western
+    - Cowboy Country:
+      - cowboy country
+  - Western Swing:
+    - western swing
+    - western-swing
+- Dance:
+  - dance
+  - club music
+  - dance music
+  - dances
+  - African Dance:
+    - african dance
+    - Afoxé:
+      - afoxé
+      - afoxe
+      - candomblé de rua
+      - candomble de rua
+    - Alloukou:
+      - alloukou
+      - alloucou
+      - alloukou tchatcha
+      - aloucou
+      - aloukou
+      - biho
+      - toumba
+    - Assiko:
+      - assiko
+    - Bend-skin:
+      - bend-skin
+      - ben skin
+      - bend shin
+      - bend skin
+      - courbez l'échine
+      - courbez l'echine
+    - Bikutsi:
+      - bikutsi
+      - bikut-si
+    - Congolese Rumba:
+      - congolese rumba
+      - rumba congolaise
+      - rumba lingala
+    - Dhaanto:
+      - dhaanto
+    - Funaná:
+      - funaná
+      - badju l’ gaita
+      - fuc-fuc
+      - funana
+    - Highlife:
+      - highlife
+      - hi-life
+      - osibi
+      - Burger-Highlife:
+        - burger-highlife
+        - burger highlife
+        - burgher-highlife
+    - Jit:
+      - jit
+      - harare beat
+      - jit-jive
+      - jiti
+    - Kalindula:
+      - kalindula
+    - Kizomba:
+      - kizomba
+      - Tarraxinha:
+        - tarraxinha
+        - tarraxa
+        - tarraxo
+    - Kpanlogo:
+      - kpanlogo
+      - kpanlogo music
+    - Makossa:
+      - makossa
+    - Mapouka:
+      - mapouka
+      - macouka
+      - mapouka dance
+    - Marrabenta:
+      - marrabenta
+    - Mbalax:
+      - mbalax
+      - mbalakh
+    - Mbolé:
+      - mbolé
+      - mbole
+    - Mchiriku:
+      - mchiriku
+      - mnanda
+    - Muziki wa dansi:
+      - muziki wa dansi
+      - dansi
+    - Puxa:
+      - puxa
+    - Salegy:
+      - salegy
+    - Semba:
+      - semba
+    - Soukous:
+      - soukous
+      - Kwassa kwassa:
+        - kwassa kwassa
+        - kwasa kwasa
+      - Ndombolo:
+        - ndombolo
+    - Township Jive:
+      - township jive
+      - jaiva
+    - Tsonga Disco:
+      - tsonga disco
+    - Ziglibithy:
+      - ziglibithy
+    - Zouglou:
+      - zouglou
+  - Ballroom Dance:
+    - ballroom dance
+    - Foxtrot:
+      - foxtrot
+    - Mazurka:
+      - mazurka
+      - mazurek
+      - Mazur:
+        - mazur
+        - wielki
+    - Polonaise:
+      - polonaise
+      - polacco
+      - polonez
+    - Schottische:
+      - schottische
+      - chotis
+      - schottisch
+    - Waltz:
+      - waltz
+      - valse
+      - walzer
+      - Vals venezolano:
+        - vals venezolano
+        - valse venezolano
+        - venezuelan waltz
+  - Dance-Pop:
+    - dance-pop
+    - dance pop
+    - Bubblegum Dance:
+      - bubblegum dance
+    - Disco polo:
+      - disco polo
+      - muzyka chodnikowa
+      - piosenka chodnikowa
+    - Freestyle:
+      - freestyle
+      - freestyle music
+      - Latin Freestyle:
+        - latin freestyle
+    - Funk melody:
+      - funk melody
+    - Romanian Popcorn:
+      - romanian popcorn
+      - popcorn
+      - romanian house
+    - Tecnorumba:
+      - tecnorumba
+    - Township Bubblegum:
+      - township bubblegum
+    - Vietnamese New Wave:
+      - vietnamese new wave
+      - new wave việt nam
+      - new wave viet nam
+      - newave
+  - Disco:
+    - disco
+    - Boogie:
+      - boogie
+      - disco boogie
+    - Electro-Disco:
+      - electro-disco
+      - electro disco
+      - Hi-NRG:
+        - hi-nrg
+        - hi nrg
+        - high energy
+        - high nrg
+        - high-energy
+        - high-nrg
+      - Italo-Disco:
+        - italo-disco
+        - italo disco
+        - spaghetti disco
+        - spaghetti-dance
+        - Spacesynth:
+          - spacesynth
+          - spacedance
+          - synthdance
+          - synthesizer dance
+      - Red Disco:
+        - red disco
+        - cooperative disco
+        - cooperative pops
+        - perestroika disco
+        - soviet disco
+        - диско перестройки
+        - кооперативное диско
+        - кооперативный попс
+        - красное диско
+        - перестроечное диско
+        - ред-диско
+        - советское диско
+      - Space Disco:
+        - space disco
+    - Euro-Disco:
+      - euro-disco
+      - euro disco
+      - eurodisco
+    - Latin Disco:
+      - latin disco
+    - Mutant Disco:
+      - mutant disco
+      - disco-not-disco
+    - Nu-Disco:
+      - nu-disco
+      - neo disco
+      - neo-disco
+      - nu disco
+    - Post-Disco:
+      - post-disco
+      - post disco
+      - postdisco
+  - Latin Dance:
+    - latin dance
+    - música tropical
+    - musica tropical
+    - tropical
+    - tropical latin
+    - tropical music
+    - Axé:
+      - axé
+      - axe
+      - Samba-reggae:
+        - samba-reggae
+        - samba reggae
+    - Bachata:
+      - bachata
+      - amargue
+    - Beguine:
+      - beguine
+    - Biguine:
+      - biguine
+      - beguine moderne
+      - beguine vide
+    - Bouyon:
+      - bouyon
+    - Cadence:
+      - cadence
+      - Cadence lypso:
+        - cadence lypso
+        - cadence-lypso
+        - kadans lypso
+      - Cadence rampa:
+        - cadence rampa
+        - cadence rempa
+        - kadans
+        - kadans rampa
+    - Carimbó:
+      - carimbó
+      - baião típico de marajó
+      - baiao tipico de marajo
+      - carimbo
+      - pau e corda
+      - samba de roda do marajó
+      - samba de roda do marajo
+    - Champeta:
+      - champeta
+    - Combined Rhythm:
+      - combined rhythm
+      - ritmo kombina
+    - Compas:
+      - compas
+      - compas direct
+      - kompa
+      - konpa
+      - konpa dirèk
+      - konpa direk
+      - Mini-jazz:
+        - mini-jazz
+        - compas mini-jazz
+        - mini djaz
+        - mini jazz
+        - mini-djaz
+    - Conga:
+      - conga
+    - Cuarteto:
+      - cuarteto
+      - cuartetazo
+    - Cuban Dance:
+      - cuban dance
+      - Chachachá:
+        - chachachá
+        - cha cha
+        - cha cha chá
+        - cha cha cha
+        - cha-cha
+        - cha-cha-chá
+        - cha-cha-cha
+        - chachacha
+      - Charanga:
+        - charanga
+      - Contradanza:
+        - contradanza
+        - contradanza criolla
+      - Danzón:
+        - danzón
+        - danzon
+      - Mambo:
+        - mambo
+        - Mambo chileno:
+          - mambo chileno
+          - mambo 569
+      - Rumba:
+        - rumba
+    - Cumbia:
+      - cumbia
+      - Cumbia argentina:
+        - cumbia argentina
+        - argentine cumbia
+        - bailanta
+        - Cumbia santafesina:
+          - cumbia santafesina
+        - Cumbia turra:
+          - cumbia turra
+          - música turra
+          - musica turra
+          - onda turra
+        - Cumbia villera:
+          - cumbia villera
+        - RKT:
+          - rkt
+      - Cumbia chilena:
+        - cumbia chilena
+        - chilean cumbia
+        - Nueva cumbia chilena:
+          - nueva cumbia chilena
+          - cumbia rock
+      - Cumbia colombiana:
+        - cumbia colombiana
+        - colombian cumbia
+      - Cumbia mexicana:
+        - cumbia mexicana
+        - mexican cumbia
+        - mexican-cumbia
+        - Cumbia sonidera:
+          - cumbia sonidera
+          - sonidero
+          - sonidero cumbia
+          - sonideros
+          - Cumbia rebajada:
+            - cumbia rebajada
+      - Cumbia peruana:
+        - cumbia peruana
+        - peruvian cumbia
+        - Chicha:
+          - chicha
+          - cumbia andina
+          - cumbia tropical andina
+        - Cumbia amazónica:
+          - cumbia amazónica
+          - cumbia amazonica
+          - cumbia selvática
+          - cumbia selvatica
+        - Cumbia norteña peruana:
+          - cumbia norteña peruana
+          - cumbia nortena peruana
+          - cumbia piurana
+      - Cumbia salvadoreña:
+        - cumbia salvadoreña
+        - cumbia salvadorena
+        - salvadoran cumbia
+      - Tropicanibalismo:
+        - tropicanibalismo
+    - Danza:
+      - danza
+      - danza puertorriqueña
+      - puerto rican danza
+      - danza puertorriquena
+    - Forró:
+      - forró
+      - arrasta-pé
+      - arrasta-pe
+      - bate-chinela
+      - fobó
+      - fobo
+      - forro
+      - forrodobó
+      - forrodobo
+      - Forró eletrônico:
+        - forró eletrônico
+        - forro eletronico
+        - forró estilizado
+        - forro estilizado
+        - Forró de favela:
+          - forró de favela
+          - forró das comunidades
+          - forro das comunidades
+          - forro de favela
+          - forró de periferia
+          - forro de periferia
+          - forró romântico
+          - forro romantico
+        - Piseiro:
+          - piseiro
+          - pisadinha
+      - Forró universitário:
+        - forró universitário
+        - forro universitario
+    - Frevo:
+      - frevo
+      - Frevo de bloco:
+        - frevo de bloco
+        - marcha de bloco
+        - marcha regresso
+      - Frevo de rua:
+        - frevo de rua
+      - Frevo elétrico:
+        - frevo elétrico
+        - frevo baiano
+        - frevo eletrico
+      - Frevo-canção:
+        - frevo-canção
+        - frevo canção
+        - frevo-cancao
+        - frevo cancao
+    - Habanera:
+      - habanera
+      - cuban contradanza
+    - Junkanoo:
+      - junkanoo
+    - Kaseko:
+      - kaseko
+    - Lambada:
+      - lambada
+      - Guitarrada:
+        - guitarrada
+        - lambada instrumental
+    - Maxixe:
+      - maxixe
+      - brazilian tango
+      - mattchiche
+    - Merengue:
+      - merengue
+      - merengue music
+      - Mambo urbano:
+        - mambo urbano
+        - mambero
+        - mambo [merengue]
+        - mambo dominicano
+        - mambo merengue
+        - merengue callejero
+        - merengue de calle
+        - merengue de mambo
+        - merengue urbano
+        - pakipá
+        - pakipa
+      - Merecumbé:
+        - merecumbé
+        - merecumbe
+      - Merengue típico:
+        - merengue típico
+        - merengue cibaeño
+        - merengue cibaeno
+        - merengue tipico
+        - perico ripiao
+        - traditional merengue
+      - Merenhouse:
+        - merenhouse
+        - merengue hip hop
+        - merengue hip-hop
+        - merengue house
+        - merenrap
+      - Tecnomerengue:
+        - tecnomerengue
+    - Mozambique:
+      - mozambique
+    - Pachanga:
+      - pachanga
+      - pachangueo
+    - Palo de mayo:
+      - palo de mayo
+    - Pasillo:
+      - pasillo
+      - vals
+    - Pilón:
+      - pilón
+      - pilon
+    - Porro:
+      - porro
+    - Punta:
+      - punta
+    - Rhumba:
+      - rhumba
+      - ballroom rumba
+      - international rumba
+    - Ringbang:
+      - ringbang
+      - ring bang
+    - Salsa:
+      - salsa
+      - new york salsa
+      - salsa music
+      - Salsa choke:
+        - salsa choke
+        - salsa choque
+      - Salsa dura:
+        - salsa dura
+        - classic salsa
+        - salsa brava
+        - salsa clásica
+        - salsa clasica
+      - Salsa romántica:
+        - salsa romántica
+        - salsa erótica
+        - salsa erotica
+        - salsa romantica
+      - Songo-Salsa:
+        - songo-salsa
+        - songo salsa
+    - Samba:
+      - samba
+      - Batucada:
+        - batucada
+        - samba batucada
+      - Marchinha:
+        - marchinha
+        - marcha carnavalesca
+        - marchinha de carnaval
+      - Pagode:
+        - pagode
+        - pagode de raiz
+        - Pagode romântico:
+          - pagode romântico
+          - neo-pagode
+          - novo pagode
+          - pagode paulista
+          - pagode romantico
+        - Pagodão:
+          - pagodão
+          - pagodao
+          - pagode baiano
+          - quebradeira
+          - samba reggaeton
+          - swingueira
+      - Partido alto:
+        - partido alto
+        - samba de partido alto
+      - Samba de breque:
+        - samba de breque
+      - Samba de gafieira:
+        - samba de gafieira
+        - gafieira
+        - gafieira samba
+      - Samba de terreiro:
+        - samba de terreiro
+        - samba de quadra
+      - Samba-canção:
+        - samba-canção
+        - samba canção
+        - samba-cancao
+        - samba cancao
+      - Samba-enredo:
+        - samba-enredo
+        - samba enredo
+      - Samba-exaltação:
+        - samba-exaltação
+        - samba exaltação
+        - samba-exaltacao
+        - samba exaltacao
+      - Samba-joia:
+        - samba-joia
+        - samba joia
+        - sambão
+        - sambao
+        - sambão-joia
+        - sambao-joia
+      - Samba-rock:
+        - samba-rock
+        - samba rock
+        - samba-suingue
+        - suingue
+        - Samba Soul:
+          - samba soul
+          - brazilian soul
+          - samba-soul
+      - Sambalanço:
+        - sambalanço
+        - sambalanco
+        - swing samba
+    - Soca:
+      - soca
+      - sokah
+      - the soul of calypso
+      - Bashment Soca:
+        - bashment soca
+      - Dennery Segment:
+        - dennery segment
+        - lucian kuduro
+      - Power Soca:
+        - power soca
+        - jump and wave soca
+        - jumpy soca
+      - Rapso:
+        - rapso
+    - Son cubano:
+      - son cubano
+      - cuban son
+      - modern son
+      - son
+      - sonero
+      - Bolero son:
+        - bolero son
+        - bolero-son
+      - Son montuno:
+        - son montuno
+        - montuno
+      - Son-batá:
+        - son-batá
+        - son bata
+        - son batá
+        - son-bata
+    - Steel Band:
+      - steel band
+      - steel drum band
+      - steel pan music
+      - steelband
+    - Tamborera:
+      - tamborera
+    - Tango:
+      - tango
+      - tango music
+      - Electrotango:
+        - electrotango
+        - electronic tango
+        - tango electrónico
+        - tango electronico
+        - tango fusión
+        - tango fusion
+      - Finnish Tango:
+        - finnish tango
+      - Tango nuevo:
+        - tango nuevo
+        - nuevo tango
+    - Timba:
+      - timba
+      - salsa cubana
+    - Tumbélé:
+      - tumbélé
+      - tumbele
+    - Xote:
+      - xote
+      - chóte
+      - chote
+      - chótis
+      - xótis
+      - xotis
+    - Xuc:
+      - xuc
+    - Zouk:
+      - zouk
+      - Cabo-Zouk:
+        - cabo-zouk
+        - cabo zouk
+        - cabo-love
+      - Zouk Love:
+        - zouk love
+        - zouklove
+  - South Asian Dance:
+    - south asian dance
+    - Baila:
+      - baila
+      - Calypso-Style Baila:
+        - calypso-style baila
+        - calypso baila
+        - calypso style baila
+    - Bhangra:
+      - bhangra
+      - بھنگڑا
+      - ਭੰਗੜਾ
+      - Bhangraton:
+        - bhangraton
+      - Folkhop:
+        - folkhop
+        - bhangra rap
+        - folk hop
+        - folk rap
+        - folk-hop
+  - Southeast Asian Dance:
+    - southeast asian dance
+    - southeast asian dance music
+    - Jaipongan:
+      - jaipongan
+      - jaipong
+  - Zydeco:
+    - zydeco
+    - Nouveau zydeco:
+      - nouveau zydeco
+      - new zydeco
+      - zydeco nouveau
+- Easy Listening:
+  - easy listening
+  - Instrumental Pop:
+    - instrumental pop
+  - Light Music:
+    - light music
+    - concert music
+    - light
+    - mood music
+    - Furniture Music:
+      - furniture music
+      - furnishing music
+      - furniture
+      - musique d'ameublement
+    - Parlour:
+      - parlour
+      - parlor music
+      - parlour music
+      - salon music
+  - Lounge:
+    - lounge
+    - lounge music
+    - Beautiful Music:
+      - beautiful music
+      - b/ez
+      - beautiful
+      - bm
+      - bm/ez
+    - Cocktail Nation:
+      - cocktail nation
+      - cocktail
+    - Exotica:
+      - exotica
+      - Sitarsploitation:
+        - sitarsploitation
+        - sitar exploitation
+        - sitarploitation
+    - Muzak:
+      - muzak
+      - elevator music
+      - lift music
+      - piped music
+    - Space Age Pop:
+      - space age pop
+      - sabpm
+      - space age
+      - space age bachelor pad music
+      - space-age
+      - space-age pop
+  - Pops Orchestra:
+    - pops orchestra
+    - popular orchestra
+- Electronic:
+  - electronic
+  - electronic music
+  - Acholitronix:
+    - acholitronix
+    - electro acholi
+  - Algorave:
+    - algorave
+    - algorithmic rave
+    - live coded dance music
+    - live-coded dance music
+  - Binaural Beats:
+    - binaural beats
+    - Bit Music:
+      - bit music
+      - bit
+      - Chiptune:
+        - chiptune
+        - 8-bit
+        - chip music
+        - chiptunes
+        - Nintendocore:
+          - nintendocore
+          - nerdcore
+          - nescore
+      - Demoscene:
+        - demoscene
+        - demoparties
+        - Demostyle:
+          - demostyle
+          - demo style
+          - demoscene style
+          - Doskpop:
+            - doskpop
+        - Warez Scene:
+          - warez scene
+          - 7h3 w4r3z 5c3n3
+          - cracker d00dz
+          - cracker scene
+          - cracking scene
+          - warez d00dz
+      - Digital Fusion:
+        - digital fusion
+        - digifu
+        - post-chiptune
+      - FM Synthesis:
+        - fm synthesis
+        - fm
+        - fm synth
+        - frequency modulation synthesis
+      - MIDI:
+        - midi
+        - midi music
+        - Black MIDI:
+          - black midi
+          - impossible music
+          - kuro gakufu
+      - Sequencer & Tracker:
+        - sequencer & tracker
+        - 16-bit:
+          - 16-bit
+          - 16 bit
+        - Tracker:
+          - tracker
+          - keygen music
+          - mod music
+          - mods
+          - modscene
+          - module files
+          - modules
+          - tracked music
+          - tracker music
+          - Amigacore:
+            - amigacore
+            - amiga hardcore
+  - Drift Phonk:
+    - drift phonk
+    - drift music
+    - phonk drift
+    - дрифт-фонк
+    - фонк
+    - фонк-дрифт
+    - Brazilian Phonk:
+      - brazilian phonk
+      - phonk baile
+      - phonk carioca
+    - Phonk House:
+      - phonk house
+      - cowbell house
+      - drift house
+      - house phonk
+      - фонк-хаус
+      - хаус-фонк
+  - Dungeon Synth:
+    - dungeon synth
+    - dark dungeon music
+    - dark medieval
+    - fantasy music
+    - Comfy Synth:
+      - comfy synth
+      - cosy synth
+      - cozy synth
+    - Winter Synth:
+      - winter synth
+  - Electro Hop:
+    - electro hop
+    - electro-hop
+  - Electro-Industrial:
+    - electro-industrial
+    - electro industrial
+    - elektro
+  - Electronic Dance Music:
+    - electronic dance music
+    - edm
+    - electronic dance
+    - Artcore:
+      - artcore
+      - japanese artcore
+      - アートコア
+    - Balani Show:
+      - balani show
+      - balani
+    - Breakbeat:
+      - breakbeat
+      - breakbeats
+      - breaks
+      - Acid Breaks:
+        - acid breaks
+        - acid breakbeat
+      - Baltimore Club:
+        - baltimore club
+        - bmore
+        - bmore club
+        - bmore house
+      - Big Beat:
+        - big beat
+        - chemical breaks
+      - Breakbeat Hardcore:
         - breakbeat hardcore
-        - breakcore
-        - digital hardcore
-        - doomcore
-        - dubstyle
-        - gabber
-        - happy hardcore
-        - hardstyle
-        - jumpstyle
-        - makina
-        - speedcore
-        - terrorcore
-        - uk hardcore
-    - hi-nrg:
-        - eurobeat
-        - hard nrg
-        - new beat
-    - house:
-        - acid house
-        - chicago house
-        - deep house
-        - diva house
-        - dutch house
-        - electro house
-        - freestyle house
-        - french house
-        - funky house
-        - ghetto house
-        - hardbag
-        - hip house
-        - italo house
-        - latin house
-        - minimal house
-        - progressive house
-        - rave music
-        - swing house
-        - tech house
-        - tribal house
-        - uk hard house
-        - us garage
-        - vocal house
-    - industrial:
-        - aggrotech
-        - coldwave
-        - cybergrind
-        - dark electro
-        - death industrial
-        - electro-industrial
-        - electronic body music:
-            - futurepop
-        - industrial metal:
-            - neue deutsche härte
-        - industrial rock
-        - noise:
-            - japanoise
-            - power electronics
-            - power noise
-        - witch house
-    - juke:
-        - footwork
-    - post-disco:
-        - boogie
-        - dance-pop
-    - progressive:
-        - progressive house/trance:
-            - disco house
-            - dream house
-            - space house
+        - oldskool hardcore
+        - oldskool rave
+        - Darkside:
+          - darkside
+        - Hardcore Breaks:
+          - hardcore breaks
+      - Breakbeat Kota:
+        - breakbeat kota
+        - breakbeat indo
+        - breakbeat indonesia
+        - breakfunk
+        - indonesian breakbeat
+        - Jungle Dutch:
+          - jungle dutch
+          - breakbeat jungle dutch
+      - Florida Breaks:
+        - florida breaks
+        - orlando breaks
+        - tampa breaks
+        - the orlando sound
+      - Funky Breaks:
+        - funky breaks
+        - funk breaks
+        - funky breakbeat
+      - Nu Skool Breaks:
+        - nu skool breaks
+        - nu breaks
+        - nu skool breakbeat
+        - nu skool breakz
+        - nu-skool breaks
+      - Progressive Breaks:
         - progressive breaks
-        - progressive drum & bass
-        - progressive techno
-    - techno:
-        - acid techno
-        - detroit techno
-        - dub techno
-        - free tekno
-        - ghettotech
-        - minimal
-        - nortec
-        - schranz
-        - techno-dnb
-        - technopop
-        - tecno brega
-        - toytown techno
-    - trance:
-        - acid trance
-        - classic trance
-        - dream trance
-        - goa trance:
-            - dark psytrance
-            - full on
-            - psybreaks
-            - psyprog
-            - suomisaundi
-        - hard trance
-        - tech trance
-        - uplifting trance:
-            - orchestral uplifting
-        - vocal trance
-    - uk garage:
-        - 2-step
-        - 4x4
-        - bassline
-        - breakstep
-        - dubstep
-        - funky
-        - grime
-        - speed garage
-        - trap
-- folk:
-    - american folk revival
-    - anti-folk
-    - british folk revival
-    - celtic music
-    - contemporary folk
-    - filk music
-    - freak folk
-    - indie folk
-    - industrial folk
-    - neofolk
-    - progressive folk
-    - psychedelic folk
-    - sung poetry
-    - techno-folk
-- hip hop:
-    - alternative hip hop
-    - avant-garde hip hop
-    - chap hop
-    - christian hip hop
-    - conscious hip hop
-    - crunkcore
-    - cumbia rap
-    - east coast hip hop:
+        - atmospheric breaks
+        - prog breaks
+        - progressive breakbeat
+      - Psybreaks:
+        - psybreaks
+        - psy tech-funk
+        - psy-breaks
+        - psychedelic breaks
+      - West Coast Breaks:
+        - west coast breaks
+        - funky desert breaks
+        - west coast breakbeat
+    - Broken Beat:
+      - broken beat
+      - bruk
+    - Bubblegum Bass:
+      - bubblegum bass
+      - pc music
+    - Budots:
+      - budots
+    - Bérite Club:
+      - bérite club
+      - bérite
+      - berite
+      - berite club
+    - Coupé-décalé:
+      - coupé-décalé
+      - coupé décalé
+      - coupe-decale
+      - coupe decale
+      - Logobi:
+        - logobi
+        - logobie
+    - Cruise:
+      - cruise
+      - freebeat
+      - mara
+    - Dariacore:
+      - dariacore
+      - hyperflip
+      - hyperphonics
+    - Deconstructed Club:
+      - deconstructed club
+      - avant-club
+      - club-not-club
+      - experimental club
+      - post-club
+    - Dek Bass:
+      - dek bass
+      - humming
+      - humming bass
+      - power bass
+      - power music
+      - sound battle music
+    - Digital Cumbia:
+      - digital cumbia
+      - electro cumbia
+      - electro-cumbia
+      - electronic cumbia
+    - Drum & Bass:
+      - drum & bass
+      - d 'n' b
+      - d&b
+      - dnb
+      - drum 'n' bass
+      - drum and bass
+      - drum n bass
+      - drum&bass
+      - drum'n'bass
+      - Atmospheric Drum & Bass:
+        - atmospheric drum & bass
+        - ambient jungle
+        - artcore d 'n' b
+        - artcore d&b
+        - artcore dnb
+        - artcore drum & bass
+        - artcore drum 'n' bass
+        - artcore drum and bass
+        - artcore drum n bass
+        - artcore drum&bass
+        - artcore drum'n'bass
+        - atmospheric d 'n' b
+        - atmospheric d&b
+        - atmospheric dnb
+        - atmospheric drum 'n' bass
+        - atmospheric drum and bass
+        - atmospheric drum n bass
+        - atmospheric drum&bass
+        - atmospheric drum'n'bass
+        - intelligent d 'n' b
+        - intelligent d&b
+        - intelligent dnb
+        - intelligent drum & bass
+        - intelligent drum 'n' bass
+        - intelligent drum and bass
+        - intelligent drum n bass
+        - intelligent drum&bass
+        - intelligent drum'n'bass
+      - Dancefloor Drum & Bass:
+        - dancefloor drum & bass
+        - dancefloor d 'n' b
+        - dancefloor d&b
+        - dancefloor dnb
+        - dancefloor drum 'n' bass
+        - dancefloor drum and bass
+        - dancefloor drum n bass
+        - dancefloor drum&bass
+        - dancefloor drum'n'bass
+      - Darkstep:
+        - darkstep
+        - Crossbreed:
+          - crossbreed
+          - brokencore
+          - core & bass
+          - core n bass
+          - core'n'bass
+          - drum & core
+          - drum'n'core
+          - hardcore d 'n' b
+          - hardcore d&b
+          - hardcore dnb
+          - hardcore drum & bass
+          - hardcore drum 'n' bass
+          - hardcore drum and bass
+          - hardcore drum n bass
+          - hardcore drum&bass
+          - hardcore drum'n'bass
+        - Skullstep:
+          - skullstep
+      - Deep Drum & Bass:
+        - deep drum & bass
+        - deep d 'n' b
+        - deep d&b
+        - deep dnb
+        - deep drum 'n' bass
+        - deep drum and bass
+        - deep drum n bass
+        - deep drum&bass
+        - deep drum'n'bass
+      - Drumfunk:
+        - drumfunk
+        - choppage
+        - edits
+      - Drumstep:
+        - drumstep
+        - dnbstep
+      - Dubwise Drum & Bass:
+        - dubwise drum & bass
+        - dubwise
+        - dubwise d 'n' b
+        - dubwise d&b
+        - dubwise dnb
+        - dubwise drum 'n' bass
+        - dubwise drum and bass
+        - dubwise drum n bass
+        - dubwise drum&bass
+        - dubwise drum'n'bass
+        - dubwize
+        - dubwize d 'n' b
+        - dubwize d&b
+        - dubwize dnb
+        - dubwize drum & bass
+        - dubwize drum 'n' bass
+        - dubwize drum and bass
+        - dubwize drum n bass
+        - dubwize drum&bass
+        - dubwize drum'n'bass
+        - ragga d 'n' b
+        - ragga d&b
+        - ragga dnb
+        - ragga drum & bass
+        - ragga drum 'n' bass
+        - ragga drum and bass
+        - ragga drum n bass
+        - ragga drum&bass
+        - ragga drum'n'bass
+        - reggae d 'n' b
+        - reggae d&b
+        - reggae dnb
+        - reggae drum & bass
+        - reggae drum 'n' bass
+        - reggae drum and bass
+        - reggae drum n bass
+        - reggae drum&bass
+        - reggae drum'n'bass
+      - Halftime:
+        - halftime
+        - halftime d 'n' b
+        - halftime d&b
+        - halftime dnb
+        - halftime drum & bass
+        - halftime drum 'n' bass
+        - halftime drum and bass
+        - halftime drum n bass
+        - halftime drum&bass
+        - halftime drum'n'bass
+        - halftime neurofunk
+      - Hardstep:
+        - hardstep
+      - Industrial Drum & Bass:
+        - industrial drum & bass
+        - industrial d 'n' b
+        - industrial d&b
+        - industrial dnb
+        - industrial drum 'n' bass
+        - industrial drum and bass
+        - industrial drum n bass
+        - industrial drum&bass
+        - industrial drum'n'bass
+      - Jazzstep:
+        - jazzstep
+        - jazz and bass
+        - jazzy jungle
+      - Jump-Up:
+        - jump-up
+        - jump up
+      - Jungle:
+        - jungle
+        - jungle music
+        - Ragga Jungle:
+          - ragga jungle
+      - Liquid Drum & Bass:
+        - liquid drum & bass
+        - liquid
+        - liquid d 'n' b
+        - liquid d&b
+        - liquid dnb
+        - liquid drum 'n' bass
+        - liquid drum&bass
+        - liquid drum and bass
+        - liquid drum n bass
+        - liquid drum'n'bass
+        - liquid funk
+        - Sambass:
+          - sambass
+          - brazilian d 'n' b
+          - brazilian d&b
+          - brazilian dnb
+          - brazilian drum & bass
+          - brazilian drum 'n' bass
+          - brazilian drum and bass
+          - brazilian drum n bass
+          - brazilian drum&bass
+          - brazilian drum'n'bass
+          - brazilian sound
+          - drum & bossa
+          - drum 'n' bossa
+      - Minimal Drum & Bass:
+        - minimal drum & bass
+        - minimal d 'n' b
+        - minimal d&b
+        - minimal dnb
+        - minimal drum 'n' bass
+        - minimal drum and bass
+        - minimal drum n bass
+        - minimal drum&bass
+        - minimal drum'n'bass
+        - Autonomic:
+          - autonomic
+          - autonomic d 'n' b
+          - autonomic d&b
+          - autonomic dnb
+          - autonomic drum & bass
+          - autonomic drum 'n' bass
+          - autonomic drum and bass
+          - autonomic drum n bass
+          - autonomic drum&bass
+          - autonomic drum'n'bass
+          - halfstep
+        - Microfunk:
+          - microfunk
+          - click and bass
+          - click n bass
+          - click'n'bass
+          - микрофанк
+      - Neurofunk:
+        - neurofunk
+        - neuro
+      - Technoid:
+        - technoid
+        - techno d 'n' b
+        - techno d&b
+        - techno dnb
+        - techno drum & bass
+        - techno drum 'n' bass
+        - techno drum and bass
+        - techno drum n bass
+        - techno drum&bass
+        - techno drum'n'bass
+      - Techstep:
+        - techstep
+      - Trancestep:
+        - trancestep
+        - trance and bass
+    - Dubstep:
+      - dubstep
+      - Brostep:
+        - brostep
+        - filthstep
+        - Briddim:
+          - briddim
+        - Colour Bass:
+          - colour bass
+          - color bass
+        - Deathstep:
+          - deathstep
+          - Minatory:
+            - minatory
+      - Chillstep:
+        - chillstep
+        - liquid dubstep
+      - Dungeon Sound:
+        - dungeon sound
+        - dark dubstep
+        - dungeon
+      - Melodic Dubstep:
+        - melodic dubstep
+        - lovestep
+      - Purple Sound:
+        - purple sound
+        - purple funk
+        - purple wow
+      - Riddim:
+        - riddim
+        - riddim dubstep
+        - swamp
+        - trench
+        - Future Riddim:
+          - future riddim
+          - melodic riddim
+        - Liquid Riddim:
+          - liquid riddim
+      - Tearout:
+        - tearout
+    - East Coast Club:
+      - east coast club
+      - east coast club music
+      - Jersey Club:
+        - jersey club
         - brick city club
-        - hardcore hip hop
-        - mafioso rap
-        - new jersey hip hop
-    - electro music
-    - freestyle rap
-    - g-funk
-    - gangsta rap
-    - glitch hop
-    - golden age hip hop
-    - hip hop soul
-    - hip pop
-    - hyphy
-    - industrial hip hop
-    - instrumental hip hop
-    - jazz rap
-    - low bap
-    - lyrical hip hop
-    - merenrap
-    - midwest hip hop:
-        - chicago hip hop
-        - detroit hip hop
-        - horrorcore
-        - st. louis hip hop
-        - twin cities hip hop
-    - motswako
-    - nerdcore
-    - new jack swing
-    - new school hip hop
-    - old school hip hop
-    - political hip hop
-    - rap opera
-    - rap rock:
-        - rap metal
-        - rapcore
-    - songo-salsa
-    - southern hip hop:
-        - atlanta hip hop:
-            - snap music
-        - bounce music
-        - houston hip hop:
-            - chopped and screwed
-        - miami bass
-    - turntablism
-    - underground hip hop
-    - urban pasifika
-    - west coast hip hop:
-        - chicano rap
-        - jerkin'
-    - austrian hip hop
-    - german hip hop
-- jazz:
-    - asian american jazz
-    - avant-garde jazz
-    - bebop
-    - boogie-woogie
-    - brass band
-    - british dance band
-    - chamber jazz
-    - continental jazz
-    - cool jazz
-    - crossover jazz
-    - cubop
-    - dixieland
-    - ethno jazz
-    - european free jazz
-    - free funk
-    - free improvisation
-    - free jazz
-    - gypsy jazz
-    - hard bop
-    - jazz fusion
-    - jazz rock
-    - jazz-funk
-    - kansas city jazz
-    - latin jazz
+      - Philly Club:
+        - philly club
+        - philly party music
+    - Electro:
+      - electro
+      - electro-boogie
+      - electro-funk
+      - electrofunk
+    - Electro latino:
+      - electro latino
+    - Electro Swing:
+      - electro swing
+      - electro-swing
+    - Electronic Body:
+      - electronic body
+      - ebm
+      - electronic body music
+      - Dark Electro:
+        - dark electro
+      - Futurepop:
+        - futurepop
+      - New Beat:
+        - new beat
+        - belgian new beat
+        - newbeat
+        - Hard Beat:
+          - hard beat
+          - hardbeat
+    - Eurobeat:
+      - eurobeat
+      - J-Euro:
+        - j-euro
+        - j euro
+        - j-eurobeat
+    - Eurodance:
+      - eurodance
+      - euro dance
+      - euro-dance
+      - euro-nrg
+      - Italo Dance:
+        - italo dance
+        - italodance
+        - nu italo
+        - nu italo disco
+        - nu-italo
+    - Footwork:
+      - footwork
+      - Footwork Jungle:
+        - footwork jungle
+        - future juke
+        - jungle footwork
+        - jungle juke
+    - Funk mandelão:
+      - funk mandelão
+      - funk mandela
+      - funk mandelao
+      - mandela
+      - mandela funk
+      - mandelão
+      - mandelao
+      - Beat bruxaria:
+        - beat bruxaria
+        - bruxaria
+        - estoura tímpano
+        - estoura timpano
+        - estraga fone
+        - funk bruxaria
+        - sangra tímpano
+        - sangra timpano
+      - Funk automotivo:
+        - funk automotivo
+        - automotivo
+        - beat automotivo
+      - Ritmada:
+        - ritmada
+        - beat zn
+        - funk ritmado
+        - ritmado zona norte
+    - Funkot:
+      - funkot
+      - funky kota
+      - hardfunk
+      - house kota
+      - indonesian hardcore
+      - indonesian house
+      - ファンキー・コタ
+      - ファンコット
+    - Future Bass:
+      - future bass
+      - Kawaii Future Bass:
+        - kawaii future bass
+        - dofflin
+        - kawaii bass
+    - Future Rave:
+      - future rave
+    - Ghettotech:
+      - ghettotech
+      - detroit bass
+      - Ghetto Funk:
+        - ghetto funk
+        - ghetto-funk
+      - Neurohop:
+        - neurohop
+    - Grime:
+      - grime
+      - Neo-Grime:
+        - neo-grime
+        - neo grime
+        - neogrime
+        - uk wave
+      - Rhythm & Grime:
+        - rhythm & grime
+        - r&g
+        - rhythm and grime
+      - Weightless:
+        - weightless
+        - weightless grime
+    - Hard Dance:
+      - hard dance
+      - hard dance music
+      - hard edm
+      - hard electronic dance music
+      - hdm
+      - Hardstyle:
+        - hardstyle
+        - Dubstyle:
+          - dubstyle
+        - Early Hardstyle:
+          - early hardstyle
+        - Euphoric Hardstyle:
+          - euphoric hardstyle
+          - melodic hardstyle
+          - uplifting hardstyle
+        - Nustyle:
+          - nustyle
+        - Psystyle:
+          - psystyle
+          - psy hardstyle
+        - Rawstyle:
+          - rawstyle
+          - raw hardstyle
+          - Rawphoric:
+            - rawphoric
+            - euphoraw
+            - euphoric rawstyle
+            - melodic raw hardstyle
+            - melodic rawstyle
+            - rawphoric hardstyle
+      - Hardtek:
+        - hardtek
+        - modern hardtek
+        - newstyle hardtek
+        - Raggatek:
+          - raggatek
+      - Jumpstyle:
+        - jumpstyle
+        - jump
+      - Lento violento:
+        - lento violento
+        - hard slowstyle
+        - lento
+        - slowstyle
+    - House:
+      - house
+      - house music
+      - Acid House:
+        - acid house
+        - acid
+      - Afro House:
+        - afro house
+        - afrohouse
+        - 3-Step:
+          - 3-step
+          - 3 step
+        - Afro Tech:
+          - afro tech
+          - afro tech house
+          - afro-tech
+          - afrotech
+      - Amapiano:
+        - amapiano
+        - Afropiano:
+          - afropiano
+      - Ballroom:
+        - ballroom
+        - ballroom beats
+        - vogue beats
+      - Bass House:
+        - bass house
+      - Big Room House:
+        - big room house
+        - big room
+        - bigroom
+        - bigroom house
+        - festival house
+      - Brazilian Bass:
+        - brazilian bass
+        - Mega funk:
+          - mega funk
+          - mega-funk
+      - Bubbling House:
+        - bubbling house
+      - Changa tuki:
+        - changa tuki
+        - changa
+        - raptor house
+      - Chicago House:
+        - chicago house
+      - Deep House:
+        - deep house
+        - Lo-fi House:
+          - lo-fi house
+          - lo fi house
+          - lofi house
+          - low-fi house
+      - Diva House:
+        - diva house
+        - handbag house
+        - Hardbag:
+          - hardbag
+          - hardbag house
+      - Electro House:
+        - electro house
+        - Bloghouse:
+          - bloghouse
+          - bloghaus
+        - Complextro:
+          - complextro
+        - Dutch House:
+          - dutch house
+          - dirty dutch
+          - Noiadance:
+            - noiadance
+            - dutch funk
+            - leskerray
+            - noia dance
+        - Fidget House:
+          - fidget house
+        - French Electro:
+          - french electro
+          - french electro house
+          - french touch 2.0
+        - Melbourne Bounce:
+          - melbourne bounce
+          - melbourne sound
+      - Eletrofunk:
+        - eletrofunk
+        - eletro funk
+      - Euro House:
+        - euro house
+        - euro-house
+        - eurohouse
+      - Festival Progressive House:
+        - festival progressive house
+        - big room progressive house
+        - festival prog house
+        - progressive big room
+        - swedish house
+        - swedish progressive house
+      - French House:
+        - french house
+        - filter house
+        - french touch
+        - neu-disco
+        - tek funk
+      - Funky House:
+        - funky house
+      - Future House:
+        - future house
+        - Future Bounce:
+          - future bounce
+        - Slap House:
+          - slap house
+          - lithuanian bass
+      - G-House:
+        - g-house
+        - g house
+        - gangsta house
+      - Garage House:
+        - garage house
+        - garage
+        - new york garage
+        - new york house
+        - us garage
+        - Gospel House:
+          - gospel house
+        - Jersey Sound:
+          - jersey sound
+          - jersey house
+          - new jersey sound
+          - zanzibar music
+      - Ghetto House:
+        - ghetto house
+        - booty house
+        - Juke:
+          - juke
+          - juke house
+          - jukin' house
+      - Gqom:
+        - gqom
+        - gqomu
+        - igqom
+        - Gqom Trap:
+          - gqom trap
+          - gqom-trap
+      - Hard Drum:
+        - hard drum
+        - heavy perx
+      - Hard House:
+        - hard house
+        - Chicago Hard House:
+          - chicago hard house
+          - LA Hard House:
+            - la hard house
+            - los angeles hard house
+        - UK Hard House:
+          - uk hard house
+          - NRG:
+            - nrg
+            - hard nrg
+            - nu nrg
+          - Scouse House:
+            - scouse house
+            - bouncy house
+            - donk
+            - hard bounce
+            - scouse
+            - uk bounce
+            - Pumping House:
+              - pumping house
+              - bumping
+              - Hardbass:
+                - hardbass
+                - hard bass
+                - russian hard bass
+                - russian hardbass
+                - хард басс
+                - хардбасс
+          - Speed House:
+            - speed house
+      - Hip House:
+        - hip house
+        - house rap
+      - Italo House:
+        - italo house
+      - Jackin' House:
+        - jackin' house
+        - jackin house
+      - Jazz House:
+        - jazz house
+        - jazz-house
+      - Kwaito:
+        - kwaito
+        - Bacardi:
+          - bacardi
+          - bacardi house
+          - rekere
+      - Latin House:
+        - latin house
+        - Tribal Guarachero:
+          - tribal guarachero
+          - 3ball
+          - trival
+      - Melodic House:
+        - melodic house
+      - Microhouse:
+        - microhouse
+        - minimal house
+      - Organic House:
+        - organic house
+        - organica
+        - playa tech
+        - spiritual house
+      - Outsider House:
+        - outsider house
+        - hipster house
+        - outsider dance
+        - raw house
+      - Progressive House:
+        - progressive house
+        - prog house
+      - Stutter House:
+        - stutter house
+        - flutter house
+        - tremolo house
+      - Tech House:
+        - tech house
+        - tech-house
+        - Deep Tech:
+          - deep tech
+          - low-tech
+          - urban house
+        - Rominimal:
+          - rominimal
+      - Tribal House:
+        - tribal house
+        - tribal
+      - Tropical House:
+        - tropical house
+        - summer house
+        - trop house
+      - UK Jackin':
+        - uk jackin'
+        - house & bass
+        - jackin bass house
+        - uk jackin
+        - uk jackin house
+        - uk jacking
+        - uk jacking house
+        - uk jackin' house
+      - Vinahouse:
+        - vinahouse
+        - vina house
+      - Vixa:
+        - vixa
+        - klubowe
+        - pompa
+        - wiksa
+        - wixa
+    - Hardcore:
+      - hardcore
+      - hardcore edm
+      - hardcore techno
+      - Acidcore:
+        - acidcore
+        - hardcore acid
+      - Breakcore:
+        - breakcore
+        - Lolicore:
+          - lolicore
+        - Mashcore:
+          - mashcore
+          - happy breakcore
+          - ravecore
+          - Dancecore:
+            - dancecore
+        - Raggacore:
+          - raggacore
+          - speedhall
+          - yardcore
+      - Darkcore:
+        - darkcore
+        - darkcore hardcore
+      - Deathchant Hardcore:
+        - deathchant hardcore
+        - deathchant sound
+        - deathchant uk hardcore
+      - Doomcore:
+        - doomcore
+        - gloomcore
+      - Frapcore:
+        - frapcore
+      - Freeform Hardcore:
+        - freeform hardcore
+        - freeform
+        - trancecore [edm]
+      - Frenchcore:
+        - frenchcore
+      - Gabber:
+        - gabber
+        - gabba
+        - rotterdam hardcore
+        - Industrial Hardcore:
+          - industrial hardcore
+        - Nu Style Gabber:
+          - nu style gabber
+          - mainstream hardcore
+          - mainstyle
+          - newstyle hardcore
+      - Happy Hardcore:
+        - happy hardcore
+        - happy rave
+        - happycore
+        - 4-Beat:
+          - 4-beat
+          - 4 beat
+          - four beat
+          - four-beat
+        - Bouncy Techno:
+          - bouncy techno
+          - tartan techno
+        - J-core:
+          - j-core
+          - j core
+          - japanese hardcore techno
+        - UK Hardcore:
+          - uk hardcore
+          - Future Core:
+            - future core
+            - future-core
+          - Powerstomp:
+            - powerstomp
+            - power stomp
+            - powerbounce
+      - Speedcore:
+        - speedcore
+        - Extratone:
+          - extratone
+        - Splittercore:
+          - splittercore
+          - splitter
+      - Terrorcore:
+        - terrorcore
+        - terror
+      - Uptempo Hardcore:
+        - uptempo hardcore
+        - uptempo
+    - Hypertechno:
+      - hypertechno
+      - hyper rave
+      - hyper techno
+      - stutter techno
+      - ハイパーテクノ
+    - Jungle Terror:
+      - jungle terror
+    - Kuduro:
+      - kuduro
+      - kuduru
+      - Batida:
+        - batida
+    - Makina:
+      - makina
+      - bacalao
+      - bakalao
+      - mákina
+      - máquina
+      - maquina
+    - Manyao:
+      - manyao
+      - man yao
+      - 慢摇
+    - Melodic Bass:
+      - melodic bass
+    - Midtempo Bass:
+      - midtempo bass
+      - midtempo
+      - midtempo electro
+    - Moombahcore:
+      - moombahcore
+      - moombahstep
+    - Moombahton:
+      - moombahton
+    - Nerdcore Techno:
+      - nerdcore techno
+      - sampling techno
+      - ナードコア
+      - ナードコアテクノ
+    - Ori deck:
+      - ori deck
+      - sapa’u
+    - Post-Dubstep:
+      - post-dubstep
+      - post dubstep
+    - Shangaan Electro:
+      - shangaan electro
+    - Singeli:
+      - singeli
+    - Skweee:
+      - skweee
+      - conflict r&b
+      - scandinavian funk
+    - Slimepunk:
+      - slimepunk
+    - Techno:
+      - techno
+      - Acid Techno:
+        - acid techno
+      - Ambient Techno:
+        - ambient techno
+      - Belgian Techno:
+        - belgian techno
+        - belgian hardcore
+        - belgian rave
+        - bretter tekkno
+        - juliana's techno
+        - julitech
+        - rave techno
+        - techno rave
+      - Bleep Techno:
+        - bleep techno
+        - bleep
+        - bleep and bass
+        - yorkshire bass
+        - yorkshire bleep and bass
+      - Deep Techno:
+        - deep techno
+      - Detroit Techno:
+        - detroit techno
+        - First Wave of Detroit Techno:
+          - first wave of detroit techno
+        - Second Wave of Detroit Techno:
+          - second wave of detroit techno
+      - Freetekno:
+        - freetekno
+        - free tekno
+        - tekno
+        - tribe
+      - Hard Techno:
+        - hard techno
+        - hardtechno
+        - Schranz:
+          - schranz
+      - Hardgroove Techno:
+        - hardgroove techno
+        - hard groove
+        - hardgroove
+        - tribal techno
+      - Industrial Techno:
+        - industrial techno
+        - Birmingham Sound:
+          - birmingham sound
+          - birmingham techno
+      - Melodic Techno:
+        - melodic techno
+      - Minimal Techno:
+        - minimal techno
+        - Dub Techno:
+          - dub techno
+          - techno dub
+          - techno-dub
+      - Peak Time Techno:
+        - peak time techno
+        - peak-time techno
+      - West Coast Sound of Holland:
+        - west coast sound of holland
+        - westcoast electro sound of holland
+      - Wonky Techno:
+        - wonky techno
+        - experimental techno
+    - Trance:
+      - trance
+      - trance music
+      - Acid Trance:
+        - acid trance
+      - Big Room Trance:
+        - big room trance
+      - Dream Trance:
+        - dream trance
+        - dream dance
+        - dream house
+      - Euro Trance:
+        - euro trance
+        - eurotrance
+        - Hands Up:
+          - hands up
+          - hands-up
+          - handz up
+          - Buchiage Trance:
+            - buchiage trance
+            - age-kei trance
+            - gyaru trance
+            - hime trance
+            - アゲ系トランス
+            - ギャルトランス
+            - ブチアゲトランス
+            - 姫トランス
+      - Hard Trance:
+        - hard trance
+      - Hi-Tech Full-On:
+        - hi-tech full-on
+        - hi tech full on
+        - hitech
+        - japanese hi-tech
+      - Ibiza Trance:
+        - ibiza trance
+        - balearic trance
+      - Progressive Trance:
+        - progressive trance
+        - neo trance
+        - neotrance
+        - nu trance
+        - prog trance
+      - Psytrance:
+        - psytrance
+        - psychedelic trance
+        - Dark Psytrance:
+          - dark psytrance
+          - dark psychedelic trance
+          - darkpsy
+          - horror trance
+          - Hi-Tech Psytrance:
+            - hi-tech psytrance
+            - hi tech psytrance
+            - hi-tech
+            - hitek psy
+          - Psycore:
+            - psycore
+        - Forest Psytrance:
+          - forest psytrance
+          - forest psy
+          - forest psychedelic
+        - Full-On Psytrance:
+          - full-on psytrance
+          - full on
+          - full on psytrance
+          - full-on
+          - fullon
+        - Goa Trance:
+          - goa trance
+          - '604'
+          - goa
+          - Nitzhonot:
+            - nitzhonot
+            - ניצחונות
+        - Progressive Psytrance:
+          - progressive psytrance
+          - minimal psytrance
+          - progpsy
+          - psygressive
+          - psyprog
+          - Zenonesque:
+            - zenonesque
+            - zenon
+            - zenon sound
+        - Suomisaundi:
+          - suomisaundi
+          - spugedelic trance
+      - Tech Trance:
+        - tech trance
+      - Uplifting Trance:
+        - uplifting trance
+        - anthem trance
+        - emotional trance
+        - epic trance
+        - euphoric trance
+        - melodic trance
+      - Vocal Trance:
+        - vocal trance
+    - Trap EDM:
+      - trap edm
+      - acid trap
+      - edm trap
+      - edm trap music
+      - trap (edm)
+      - trapstep
+      - Festival Trap:
+        - festival trap
+      - Hard Trap:
+        - hard trap
+        - hardtrap
+      - Heaven Trap:
+        - heaven trap
+        - progressive trap
+      - Hybrid Trap:
+        - hybrid trap
+        - hybrid
+      - Twerk:
+        - twerk
+        - 100 bpm
+    - UK Bass:
+      - uk bass
+    - UK Funky:
+      - uk funky
+      - funky
+      - uk funky house
+      - ukf
+    - UK Garage:
+      - uk garage
+      - ukg
+      - 2-Step:
+        - 2-step
+        - 2 step
+        - 2 step garage
+        - 2-step garage
+        - two step
+        - two step garage
+        - two-step
+        - two-step garage
+      - Bassline:
+        - bassline
+        - bassline house
+        - niche
+      - Breakstep:
+        - breakstep
+        - breakbeat garage
+      - Future Garage:
+        - future garage
+        - atmospheric garage
+        - minimal garage
+        - nu-garage
+        - post-garage
+        - space garage
+      - Speed Garage:
+        - speed garage
+    - Wonky:
+      - wonky
+      - street bass
+      - Aquacrunk:
+        - aquacrunk
+        - aqua crunk
+        - lazer bass
+  - Electronica:
+    - electronica
+    - electronica music
+    - Asian Underground:
+      - asian underground
+      - new asian kool
+    - Celtic Electronica:
+      - celtic electronica
+      - acid croft
+      - celtic electronic
+      - electro-celtic
+      - gaelictronica
+    - Chillout:
+      - chillout
+      - chill out
+      - chill-out
+      - chill-out music
+      - Balearic Beat:
+        - balearic beat
+        - balearic
+      - Barber Beats:
+        - barber beats
+      - Downtempo:
+        - downtempo
+        - downbeat
+        - downtempo electronic
+        - downtempo electronica
+        - Mushroom Jazz:
+          - mushroom jazz
+        - Trip Hop:
+          - trip hop
+          - trip-hop
+          - Bristol Sound:
+            - bristol sound
+            - bristol scene
+            - bristol underground scene
+      - Lo-fi:
+        - lo-fi
+        - lo fi
+        - lo-fi music
+        - lofi
+        - low fi
+        - low fidelity
+        - low-fi
+    - Folktronica:
+      - folktronica
+      - laptop folk
+    - Glitch Hop:
+      - glitch hop
+      - glitch-hop
+    - IDM:
+      - idm
+      - braindance
+      - electronic listening music
+      - intelligent dance music
+      - Drill and Bass:
+        - drill and bass
+        - drill & bass
+        - drill 'n' bass
+        - drill d&b
+        - drill dnb
+        - drill n bass
+        - drill'n'bass
+    - Illbient:
+      - illbient
+    - Microsound:
+      - microsound
+    - Nortec:
+      - nortec
+      - nor-tec
+      - nortech
+    - Nu Jazz:
+      - nu jazz
+      - electro jazz
+      - electro-jazz
+      - future jazz
+      - jazztronica
+      - nu-jazz
+  - Epadunk:
+    - epadunk
+    - epa-dunk
+    - raggardunk
+  - Flashcore:
+    - flashcore
+  - Funktronica:
+    - funktronica
+  - HexD:
+    - hexd
+    - hex
+    - hexxed
+    - Krushclub:
+      - krushclub
+      - krushklub
+  - Horror Synth:
+    - horror synth
+    - electronic horror
+  - Livetronica:
     - livetronica
-    - m-base
-    - mainstream jazz
-    - modal jazz
-    - neo-bop jazz
-    - neo-swing
-    - novelty ragtime
-    - orchestral jazz
-    - post-bop
-    - punk jazz
-    - ragtime
-    - shibuya-kei
-    - ska jazz
-    - smooth jazz
-    - soul jazz
-    - straight-ahead jazz
-    - stride jazz
-    - swing
-    - third stream
-    - trad jazz
-    - vocal jazz
-    - west coast gypsy jazz
-    - west coast jazz
-- kids music:
-    - kinderlieder
-- pop:
-    - adult contemporary
-    - arab pop
-    - baroque pop
-    - bubblegum pop
-    - christian pop
-    - classical crossover
-    - europop:
-        - austropop
-        - balkan pop
-        - french pop
-        - latin pop
-        - laïkó
-        - nederpop
-        - russian pop
-    - iranian pop
-    - jangle pop
-    - latin ballad
-    - levenslied
-    - louisiana swamp pop
-    - mexican pop
-    - motorpop
-    - new romanticism
+    - jamtronica
+    - Electro-Soul:
+      - electro-soul
+      - electro soul
+  - Maloya électronique:
+    - maloya électronique
+    - électro-maloya
+    - electro-maloya
+    - maloya electronique
+    - maloya-électro
+    - maloya-electro
+  - Minimal Wave:
+    - minimal wave
+    - minimal-wave
+    - synth wave
+    - Minimal Synth:
+      - minimal synth
+  - Moogsploitation:
+    - moogsploitation
+    - moog music
+    - switched-on
+  - Nightcore:
+    - nightcore
+    - nxc
+  - Novo Dub:
+    - novo dub
+    - alternative novo-dub
+  - Progressive Electronic:
+    - progressive electronic
+    - prog electronic
+    - progressive electronic music
+    - Berlin School:
+      - berlin school
+      - berlin school of electronic music
+  - Russemusikk:
+    - russemusikk
+    - russ music
+    - russelåt
+    - russelat
+    - russelåter
+    - russelater
+    - russesang
+    - russesanger
+  - Slowed & Reverb:
+    - slowed & reverb
+  - Synthwave:
+    - synthwave
+    - neo 80s
+    - outrun electro
+    - retro electro
+    - retrowave
+    - Darksynth:
+      - darksynth
+      - dark synth
+      - dreadwave
+    - Dreamwave:
+      - dreamwave
+    - Sovietwave:
+      - sovietwave
+      - советвейв
+  - Tecnobrega:
+    - tecnobrega
+    - brega de aparelhagem
+    - tecnomelody
+    - Tecnofunk:
+      - tecnofunk
+      - rock doido
+  - Vapor:
+    - vapor
+    - vapour
+    - Dreampunk:
+      - dreampunk
+      - dream music
+    - Future Funk:
+      - future funk
+      - future-funk
+      - japanese disco
+      - vaporboogie
+    - Hardvapour:
+      - hardvapour
+      - hardvapor
+    - Seapunk:
+      - seapunk
+      - '#seapunk'
+    - Utopian Virtual:
+      - utopian virtual
+      - midijams
+      - muzakcore
+    - Vapornoise:
+      - vapornoise
+      - noisewave
+      - vapournoise
+    - Vaportrap:
+      - vaportrap
+    - Vaporwave:
+      - vaporwave
+      - vapourwave
+      - Broken Transmission:
+        - broken transmission
+        - signalwave
+      - Eccojams:
+        - eccojams
+        - echo jams
+      - Mallsoft:
+        - mallsoft
+        - mallwave
+      - Slushwave:
+        - slushwave
+        - dreamtone
+        - phaserwave
+  - Wave:
+    - wave
+    - dark trap
+    - euro bass
+    - Hardwave:
+      - hardwave
+      - hard wave
+  - Witch House:
+    - witch house
+    - crunk shoegaze
+    - drag
+    - haunted house
+    - screwgaze
+- Experimental:
+  - experimental
+  - avant garde
+  - avant garde music
+  - avant-garde
+  - avant-garde music
+  - experimental music
+  - Biomusic:
+    - biomusic
+  - Danger Music:
+    - danger music
+    - anti music
+    - anti-music
+    - danger
+  - Data Sonification:
+    - data sonification
+    - data-driven music
+    - sonification
+  - Drone:
+    - drone
+    - drone music
+  - Electroacoustic:
+    - electroacoustic
+    - computer music
+    - ea
+    - electro-acoustic
+    - Acousmatic:
+      - acousmatic
+      - acousmatic music
+    - EAI:
+      - eai
+      - electroacoustic improv
+      - electroacoustic improvisation
+    - Graphical Sound:
+      - graphical sound
+      - drawn sound
+      - ornamental sound
+      - графический звук
+      - орнаментальный звук
+      - рисованный звук
+    - Micromontage:
+      - micromontage
+    - Musique concrète:
+      - musique concrète
+      - concrete music
+      - musique concrete
+    - Tape Music:
+      - tape music
+      - tape
+  - Experimental Improvisation:
+    - experimental improvisation
+    - experimental improv
+    - improvised music
+    - structured improvisation
+    - Conducted Improvisation:
+      - conducted improvisation
+      - conducted improv
+      - conduction
+    - Free Improvisation:
+      - free improvisation
+      - free improv
+      - free music
+      - non-idiomatic improvisation
+      - open improvisation
+      - total improvisation
+    - Modern Creative:
+      - modern creative
+      - aacm-style improvisation
+      - creative music
+  - Futurism:
+    - futurism
+    - futurist music
+    - musica futurista
+  - Glitch:
+    - glitch
+    - clicks & cuts
+    - clicks n cuts
+    - clicks 'n' cuts
+    - clicks and cuts
+  - Indeterminacy:
+    - indeterminacy
+    - aleatoric music
+    - chance music
+    - indeterminate music
+  - Mechanical:
+    - mechanical
+    - automatic music
+    - mechanical music
+  - Noise:
+    - noise
+    - noise music
+    - Ambient Noise Wall:
+      - ambient noise wall
+      - anw
+    - Black Noise:
+      - black noise
+      - blackened noise
+    - Gorenoise:
+      - gorenoise
+      - vomitnoise
+    - Harsh Noise:
+      - harsh noise
+      - Harsh Noise Wall:
+        - harsh noise wall
+        - hnw
+    - Japanoise:
+      - japanoise
+      - japanese noise
+      - ジャパノイズ
+    - Power Electronics:
+      - power electronics
+      - heavy electronics
+      - Death Industrial:
+        - death industrial
+        - dark noise
+    - Power Noise:
+      - power noise
+      - distorted beat music
+      - noize
+      - rhythm & noise
+      - rhythm 'n' noise
+      - rhythm n noise
+      - rhythmic noise
+  - Outsider Music:
+    - outsider music
+    - incorrect music
+    - outsider
+    - outsider art
+  - Plunderphonics:
+    - plunderphonics
+    - High Quality Rip:
+      - high quality rip
+    - Mashup:
+      - mashup
+      - bastard pop
+    - Sampledelia:
+      - sampledelia
+      - sampledelic music
+      - sampledelica
+    - SoundClown:
+      - soundclown
+      - weird soundcloud
+    - YTPMV:
+      - ytpmv
+      - youtube poop music video
+      - OtoMAD:
+        - otomad
+        - mad
+        - 音mad
+        - 鬼畜
+  - Reductionism:
+    - reductionism
+    - Lowercase:
+      - lowercase
+    - Onkyo:
+      - onkyo
+      - onkyo-kei
+      - onkyokei
+      - 音響系
+  - Sound Art:
+    - sound art
+    - sonic art
+    - sound installation & sculpture
+    - sound sculpture
+  - Sound Collage:
+    - sound collage
+    - sonic collage
+    - sound montage
+    - Epic Collage:
+      - epic collage
+  - Sound Poetry:
+    - sound poetry
+  - Toypop:
+    - toypop
+    - toy music
+    - トイポップ
+  - Turntable Music:
+    - turntable music
+    - cut-up
+    - cut-up/dj
+    - experimental turntable music
+    - experimental turntablism
+    - turntable
+- Folk:
+  - folk
+  - Ancient:
+    - ancient
+    - ancient music
+    - Ancient Chinese:
+      - ancient chinese
+      - ancient chinese music
+    - Ancient Egyptian:
+      - ancient egyptian
+      - ancient egyptian music
+    - Ancient Greek:
+      - ancient greek
+      - ancient greek music
+    - Ancient Levitical:
+      - ancient levitical
+      - ancient levitical music
+    - Ancient Roman:
+      - ancient roman
+      - ancient roman music
+    - Mesopotamian:
+      - mesopotamian
+      - mesopotamian music
+    - Prehistoric:
+      - prehistoric
+      - prehistoric music
+  - Contemporary Folk:
+    - contemporary folk
+    - alt folk
+    - alternative folk
+    - american folk music revival
+    - american folk revival
+    - american folk-music revival
+    - contemporary folk music
+    - contemporary-folk
+    - folk revival
+    - neo-traditional folk
+    - neotraditional folk
+    - Adhunik geet:
+      - adhunik geet
+      - adhuneek geet
+      - adhunik git
+      - आधुनिक गीत
+    - American Primitivism:
+      - american primitivism
+      - american primitive guitar
+    - Americana:
+      - americana
+    - Anti-Folk:
+      - anti-folk
+      - anti folk
+    - Authenticité:
+      - authenticité
+      - authenticite
+    - Avant-Folk:
+      - avant-folk
+      - avant folk
+      - avant-garde folk
+      - Free Folk:
+        - free folk
+        - free-folk
+      - New Weird America:
+        - new weird america
+        - nwa
+    - Baião:
+      - baião
+      - baiano
+      - baiao
+    - Bernese Dialect Scene:
+      - bernese dialect scene
+      - berner mundartszene
+    - Brukdown:
+      - brukdown
+      - brokdown
+      - bruckdown
+      - brukdon
+      - brukdong
+    - Cajun:
+      - cajun
+      - cajun music
+      - musique cadienne
+    - Calypso:
+      - calypso
+      - calypso music
+      - Calipso venezolano:
+        - calipso venezolano
+        - calipso callaoense
+        - calipso de el callao
+        - calipso guayanés
+        - calipso guayanes
+      - Extempo:
+        - extempo
+        - extempo calypso
+    - Campursari:
+      - campursari
+      - tjampursari
+    - Campus Folk:
+      - campus folk
+      - campus folk song
+      - campus-folk
+      - taiwan campus folk
+      - 校园民歌
+      - 校园民谣
+      - 民歌運動
+    - Celtic Fusion:
+      - celtic fusion
+    - Chamber Folk:
+      - chamber folk
+      - chamber-folk
+    - Changjak gugak:
+      - changjak gugak
+      - creative gugak
+      - shin gugak
+      - 신국악
+      - 창작국악
+    - Chimurenga:
+      - chimurenga
+    - Chutney:
+      - chutney
+      - chutney music
+      - Chut-kai-pang:
+        - chut-kai-pang
+        - chut kai pang
+      - Chutney Soca:
+        - chutney soca
+        - chatnee soca
+        - chutney-soca
+    - Coco:
+      - coco
+      - Ciranda:
+        - ciranda
+      - Embolada:
+        - embolada
+        - coco-de-desafio
+        - coco-de-embolada
+    - Coladeira:
+      - coladeira
+      - colinha
+      - koladera
+    - Corrido:
+      - corrido
+      - Movimiento alterado:
+        - movimiento alterado
+    - Cuban Charanga:
+      - cuban charanga
+    - Dondang sayang:
+      - dondang sayang
+    - Famo:
+      - famo
+    - Filk:
+      - filk
+      - filk music
+      - filksong
+      - Brony:
+        - brony
+        - brony music
+        - mlp fan music
+        - my little pony fan music
+        - pony music
+      - Wizard Rock:
+        - wizard rock
+        - wizard-rock
+        - wrock
+    - Folk Baroque:
+      - folk baroque
+    - Folk Pop:
+      - folk pop
+      - folk-pop
+      - Stomp and Holler:
+        - stomp and holler
+        - stomp & holler
+        - stomp clap
+        - stomp clap hey
+        - stomp folk
+    - Fusion Gugak:
+      - fusion gugak
+      - 퓨전국악
+    - Gaita zuliana:
+      - gaita zuliana
+      - gaita
+    - Greenwich Village Scene:
+      - greenwich village scene
+      - greenwich village folk scene
+    - Guajira:
+      - guajira
+      - cuban country
+    - Guaracha:
+      - guaracha
+    - Guarania:
+      - guarania
+    - Hưng ca:
+      - hưng ca
+      - hung ca
+    - Indie Folk:
+      - indie folk
+      - indie-folk
+    - Isicathamiya:
+      - isicathamiya
+      - cothoza mfana
+    - Kadongo kamu:
+      - kadongo kamu
+    - Kalattut:
+      - kalattut
+      - greenlandic polka
+    - Kaneka:
+      - kaneka
+      - kanéka
+    - Keroncong:
+      - keroncong
+      - kroncong
+      - krontjong
+      - Cilokaq:
+        - cilokaq
+        - ciloka
+        - giciloka
+      - Langgam Jawa:
+        - langgam jawa
+        - langgam djawa
+    - Kidumbak:
+      - kidumbak
+      - kidumbaki
+      - kitaarab
+    - Koche bazari:
+      - koche bazari
+      - kooche bazari
+      - lalehzari
+      - sharghi khani/khooni
+      - موسیقی کوچه بازاری
+    - Kundiman:
+      - kundiman
+    - Loner Folk:
+      - loner folk
+      - downer folk
+      - loner-folk
+      - outsider folk
+    - Maskandi:
+      - maskandi
+      - maskanda
+      - zulu blues
+    - Mbube:
+      - mbube
+      - ibombing
+      - isikambula
+      - isikhwela jo
+      - isikhwela joe
+    - Mono:
+      - mono
+      - kalabaw
+    - Morna:
+      - morna
+    - Música gaúcha:
+      - música gaúcha
+      - bailão
+      - bailao
+      - gaucho
+      - musica gaucha
+      - música nativista
+      - musica nativista
+      - tchê music
+      - tche music
+      - Vanera:
+        - vanera
+        - vanerão
+        - vanerao
+        - vanerinha
+    - Neofolk:
+      - neofolk
+      - apocalyptic folk
+      - Dark Folk:
+        - dark folk
+        - dark-folk
+    - Neofolklore:
+      - neofolklore
+      - neofolclor
+    - Neue Volksmusik:
+      - neue volksmusik
+      - volxmusik
+    - New Acoustic:
+      - new acoustic
+      - new acoustic music
+    - Nhạc đỏ:
+      - nhạc đỏ
+      - nhac đo
+    - Omutibo:
+      - omutibo
+    - Onda nueva:
+      - onda nueva
+    - Palm Wine:
+      - palm wine
+      - maringa
+      - palm wine guitar
+      - palm wine music
+      - palm-wine
+    - Parang:
+      - parang
+    - Progressive Folk:
+      - progressive folk
+      - prog folk
+      - progressive folk music
+      - progressive-folk
+    - Protest Folk:
+      - protest folk
+      - political folk
+      - protest song
+      - protest songs
+    - Psychedelic Folk:
+      - psychedelic folk
+      - acid folk
+      - psych folk
+      - psychedelic-folk
+      - Freak Folk:
+        - freak folk
+        - freak-folk
+      - New Weird Finland:
+        - new weird finland
+      - Udigrudi:
+        - udigrudi
+        - psicodelia pernambucana
+        - psicodelia recifense
+        - udigrudi recifense
+      - Wyrd Folk:
+        - wyrd folk
+        - wyrd-folk
+    - Rabòday:
+      - rabòday
+      - raboday
+    - Rasin:
+      - rasin
+      - mizik rasin
+    - Scottish Folk Revival:
+      - scottish folk revival
+      - modern scottish folk song revival
+      - scottish folk song revival
+    - Second British Folk Revival:
+      - second british folk revival
+    - Skiffle:
+      - skiffle
+      - skiffle revival
+    - Slack-Key Guitar:
+      - slack-key guitar
+      - kihoalu
+      - slack key guitar
+    - Son de pascua:
+      - son de pascua
+    - Son nica:
+      - son nica
+    - Staïfi:
+      - staïfi
+      - staifi
+      - سطايفي
+    - Sungura:
+      - sungura
+    - Taarab:
+      - taarab
+      - tarab
+      - tarabu
+      - طرب
+    - Tecnobanda:
+      - tecnobanda
+      - technobanda
+    - Tizita:
+      - tizita
+      - tezeta
+      - ትዝታ
+    - Tradi-moderne congolais:
+      - tradi-moderne congolais
+      - congolese tradi-modern
+      - congotronics
+      - tradi moderne congolais
+    - Tradi-moderne ivoirien:
+      - tradi-moderne ivoirien
+      - tradi moderne ivoirien
+    - Trampská hudba:
+      - trampská hudba
+      - czech tramping music
+      - trampska hudba
+    - Tsapiky:
+      - tsapiky
+      - tsapika
+    - Tân cổ giao duyên:
+      - tân cổ giao duyên
+      - tân cổ
+      - tan co
+      - tan co giao duyen
+    - Vaigat:
+      - vaigat
+      - vaigat music
+    - Vallenato:
+      - vallenato
+      - Charanga-Vallenata:
+        - charanga-vallenata
+        - charanga vallenata
+      - Puya:
+        - puya
+        - aire de puya
+        - puya vallenata
+        - vallenato puya
+    - Women's Music:
+      - women's music
+      - wimmin's music
+      - women's music movement
+      - womyn's music
+    - Xinyao:
+      - xinyao
+      - xinjiapo geyao
+      - xinjiapo nianqingren zichuang geyao
+      - 新加坡年轻人自创歌谣
+      - 新加坡歌谣
+      - 新谣
+    - Zoblazo:
+      - zoblazo
+  - Religious:
+    - religious
+    - religious music
+    - Abakuá:
+      - abakuá
+      - abakuá music
+      - abakua music
+      - música carabalí
+      - musica carabali
+      - música ñáñiga
+      - musica naniga
+      - abakua
+    - Bhajan:
+      - bhajan
+      - بھجن
+      - भजन
+      - ভজন
+      - ਭਜਨ
+      - ભજન
+      - ଭଜନ
+      - பஜனை
+      - భజన
+      - ಭಜನೆ
+      - ഭജൻ
+    - Buddhist:
+      - buddhist
+      - buddhist music
+      - Beompae:
+        - beompae
+        - beom-eum
+        - beom-pae
+        - eo-san
+        - in-do
+        - korean buddhist music
+        - pompae
+        - 범음
+        - 범패
+        - 어산
+        - 인도
+        - 印度
+        - 引導
+        - 梵唄
+        - 梵音
+        - 魚山
+      - Chöd:
+        - chöd
+        - chö
+        - cho
+        - chod
+        - cutting through ego
+        - གཅོད
+    - Christian:
+      - christian
+      - christian music
+      - Christian Liturgical:
+        - christian liturgical
+        - christian liturgical music
+        - Anglican Chant:
+          - anglican chant
+          - english chant
+        - Armenian Church:
+          - armenian church
+          - armenian chant
+          - armenian church music
+          - armenian liturgical chant
+          - armenian liturgical music
+          - armenian sacred chant
+          - armenian sacred music
+          - sharakan
+          - sharakans
+          - հայ եկեղեցական երաժշտություն
+          - հայ հոգևոր երաժշտություն
+        - Coptic:
+          - coptic
+          - coptic music
+        - Ethiopian Church:
+          - ethiopian church
+          - ethiopian chant
+          - ethiopian church music
+          - ethiopian liturgical chant
+          - ethiopian orthodox tewahedo church music
+          - zema
+          - ተዋህዶ ሙዚቃ
+        - Gelineau Psalmody:
+          - gelineau psalmody
+        - Kyivan Chant:
+          - kyivan chant
+          - kievan chant
+          - киевский распев
+          - київський розспів
+        - Mass:
+          - mass
+          - mass setting
+          - missa
+          - Requiem:
+            - requiem
+            - funeral mass
+            - mass for the dead
+            - mass of the dead
+            - missa defunctorum
+            - missa pro defunctis
+            - missa pro mortuis
+            - requiem mass
+            - requiem setting
+        - Obikhod:
+          - obikhod
+          - obihod
+          - obikhod chant
+          - obikhod church singing
+          - обиход церковного пения
+        - Prostopinije:
+          - prostopinije
+          - carpatho-rusyn chant
+          - prostopenie
+          - prostopenije
+        - Syriac Chant:
+          - syriac chant
+          - syrian chant
+          - تراتيل سريانية
+        - Znamenny Chant:
+          - znamenny chant
+          - znamenny raspev
+          - знаменный распев
+      - Hymns:
+        - hymns
+        - hymnody
+        - Christmas Carol:
+          - christmas carol
+          - christmas carols
+          - noel
+          - noels
+        - Tamil Christian Keerthanai:
+          - tamil christian keerthanai
+          - christian keerthanai
+      - LDS Music:
+        - lds music
+        - latter day saint
+        - latter day saint music
+        - latter day saints
+        - latter day saints music
+        - latter-day saint
+        - latter-day saint music
+        - latter-day saints music
+        - lds
+        - mormon music
+        - mormons
+      - Purísima:
+        - purísima
+        - purisima
+      - Shaker:
+        - shaker
+        - shaker music
+        - shaker spirituals
+    - Holiday:
+      - holiday
+    - Islamic:
+      - islamic
+      - islamic religious music & recitation
+      - Ginan:
+        - ginan
+        - گنان
+        - ગિનાન
+      - Maddahi:
+        - maddahi
+        - Shoor:
+          - shoor
+          - شور
+      - Mataali:
+        - mataali
+      - Nasheed:
+        - nasheed
+        - na'at
+        - naat
+        - nashid
+        - أناشيد
+        - نشيد
+        - نعت
+      - Qasidah modern:
+        - qasidah modern
+        - qasidah modéren
+        - qasidah moderen
+      - Sufi:
+        - sufi
+        - sufi music
+        - موسيقى صوفية
+        - Banga:
+          - banga
+        - Jilala:
+          - jilala
+          - jilala music
+          - موسيقى جيلالة
+        - Manzuma:
+          - manzuma
+          - menzuma
+          - መንዙማ
+        - Rapai dabõih:
+          - rapai dabõih
+          - rapa'i dabõih
+          - rapa'i daboih
+          - rapai dabõh
+          - rapai daboh
+          - rapai daboih
+    - Jewish:
+      - jewish
+      - jewish music
+      - Hasidic:
+        - hasidic
+        - chasidic music
+        - chassidic
+        - chassidic music
+        - hasidic music
+        - hassidic music
+        - חסידישע מיוזיק
+        - מוזיקה חסידית
+        - Nigun:
+          - nigun
+          - chassidic nigun
+          - hasidic nigun
+          - niggun
+          - חסידישע ניגון
+          - ניגון
+          - ניגון חסידי
+      - Jewish Liturgical:
+        - jewish liturgical
+        - jewish liturgical music
+        - Ashkenazi Cantorial:
+          - ashkenazi cantorial
+          - ashkenazi cantorial music
+          - ashkenazi chazzanut
+          - מוזיקת חזנות אשכנזית
+        - Baqashot:
+          - baqashot
+          - שירת הבקשות
+        - Chazzanut:
+          - chazzanut
+          - cantorial
+          - chazanut
+          - ḥazanut
+          - hazanut
+          - ḥazzanut
+          - hazzanut
+          - khazanut
+          - khazzanut
+          - nusach
+          - nusakh
+          - חזנות
+          - נוסח
+        - Kriyat haTorah:
+          - kriyat hatorah
+          - cantillation
+          - keri'at hatorah
+          - keriyat hatorah
+          - kri'at hatorah
+          - krias hatora
+          - kriyas hatora
+          - qeri'at ha-torah
+          - qeriyat ha-torah
+          - torah reading
+          - קריאה בתורה
+          - קריאת התורה
+        - Maftirim:
+          - maftirim
+          - maftarim
+        - Piyyut:
+          - piyyut
+          - piyut
+          - פיוט
+      - Muzika yehudit mekorit:
+        - muzika yehudit mekorit
+        - authentic jewish music
+        - neo-hasidic music
+        - new israeli-jewish music
+        - מוזיקה יהודית מקורית
+        - מוזיקה יהודית-ישראלית מתחדשת
+        - מוזיקה ניאו-חסידית
+    - Nyahbinghi:
+      - nyahbinghi
+      - binghi
+      - nyabinghi
+      - nyahbinghi drum music
+    - Sacred Singing Circle:
+      - sacred singing circle
+      - sacred singing
+      - sacred song circle
+      - singing circle
+      - song circle
+      - מעגל שירה
+      - מעגל שירה מקודשת
+      - שירה מקודשת
+    - Santería:
+      - santería
+      - lucumí music
+      - lucumi music
+      - lukumí music
+      - lukumi music
+      - santería music
+      - santeria music
+      - santeria
+    - Taoist Ritual:
+      - taoist ritual
+      - chinese taoist music
+      - daoist music
+      - daojiao yinyue
+      - dàojiào yīnyuè
+      - taoist music
+      - taoist ritual music
+      - zhongguo daojiao yinyue
+      - zhōngguó dàojiào yīnyuè
+      - 中国道教音乐
+      - 中國道教音樂
+      - 道教音乐
+      - 道教音樂
+  - Traditional Folk:
+    - traditional folk
+    - folk music
+    - folk song
+    - folk songs
+    - folksong
+    - folksongs
+    - traditional folk music
+    - traditional-folk
+    - world
+    - world music
+    - African Folk:
+      - african folk
+      - african folk music
+      - african traditional music
+      - Agbadza:
+        - agbadza
+        - agbadja
+      - Agbekor:
+        - agbekor
+        - agbekɔ
+        - atamga
+        - atamuga
+        - atsiagbekor
+        - atsiagbekɔ
+      - Ahwash:
+        - ahwash
+        - a7wach
+        - ahouach
+        - ahwach
+        - aḥwash
+        - أحواش
+        - ⴰⵃⵡⴰⵛ
+      - Ambasse bey:
+        - ambasse bey
+        - ambas-i-bay
+      - Apala:
+        - apala
+        - akpala
+        - àpàlà
+      - Bajourou:
+        - bajourou
+      - Banda:
+        - banda
+        - banda music
+      - Bantowbol:
+        - bantowbol
+        - bantubol
+      - Batuque:
+        - batuque
+        - batuk
+        - batuku
+      - Belwo:
+        - belwo
+        - balwo
+      - Dagomba:
+        - dagomba
+        - dagbamba music
+        - dagomba music
+      - Gnawa:
+        - gnawa
+        - gnaoua
+        - gnawa music
+        - غناوة
+      - Gumbe:
+        - gumbe
+      - Haqibah:
+        - haqibah
+      - Igbo:
+        - igbo
+        - igbo music
+      - Izlan:
+        - izlan
+      - Kabye Folk:
+        - kabye folk
+        - kabiyé folk music
+        - kabiye folk music
+        - kabye folk music
+      - Kilapanga:
+        - kilapanga
+      - Malagasy Folk:
+        - malagasy folk
+        - malagasy folk music
+        - Hiragasy:
+          - hiragasy
+          - hira gasy
+      - Mangambeu:
+        - mangambeu
+        - mamgambeu
+        - mangabeu
+        - tchatcho
+      - Mascarene Islands Folk:
+        - mascarene islands folk
+        - mascarene islands folk music
+        - Maloya:
+          - maloya
+          - Maloya élektrik:
+            - maloya élektrik
+            - electric maloya
+            - maloya électrique
+            - maloya electrique
+            - maloya elektrik
+            - maloya fizyon
+            - maloya fusion
+            - maloya moden
+            - maloya moderne
+        - Santé engagé:
+          - santé engagé
+          - sante engage
+          - santé engazé
+          - sante engaze
+        - Séga:
+          - séga
+          - sega
+          - sega music
+          - Traditional Séga:
+            - traditional séga
+            - séga tipik (mauritius)
+            - sega tipik (mauritius)
+            - traditional sega
+        - Traditional Maloya:
+          - traditional maloya
+      - Mbenga-Mbuti:
+        - mbenga-mbuti
+        - mbenga mbuti
+        - mbenga-mbuti music
+        - mbenga-mbuti pygmy music
+        - mbuti choral
+      - Mezwed:
+        - mezwed
+        - mezoued
+        - mezwed music
+        - mizwad music
+      - Moutya:
+        - moutya
+        - montea
+      - Ngoma:
+        - ngoma
+        - Chakacha:
+          - chakacha
+          - chakacha music
+        - Unyago:
+          - unyago
+      - Ogene:
+        - ogene
+        - egwu ogene
+        - égwú ógēnè
+        - ogene music
+      - Qaraami:
+        - qaraami
+      - Sabar:
+        - sabar
+        - sabar dance
+        - sabar drumming
+        - sabar music
+      - Southern African Folk:
+        - southern african folk
+        - southern african folk music
+        - Afrikaner Folk:
+          - afrikaner folk
+          - afrikaans folk music
+          - afrikaner folk music
+          - boer folk music
+        - Khoisan Folk:
+          - khoisan folk
+          - khoisan folk music
+        - Nguni Folk:
+          - nguni folk
+          - nguni folk music
+        - Shona Mbira:
+          - shona mbira
+          - shona mbira music
+        - Sotho-Tswana Folk:
+          - sotho-tswana folk
+          - sotho tswana folk
+          - sotho-tswana folk music
+        - Timbila:
+          - timbila
+      - Takamba:
+        - takamba
+        - takanba
+      - Tchinkoumé:
+        - tchinkoumé
+        - tchingoumé
+        - tchingoume
+        - tchingoumin
+        - tchinkoume
+        - tchinkoumey
+        - tchinkoumin
+      - Waka:
+        - waka
+        - wákà
+      - Were music:
+        - were music
+        - ajiwere
+        - oniwere
+        - were
+      - Zinli:
+        - zinli
+    - American Folk:
+      - american folk
+      - american folk music
+      - american roots music
+      - united states folk
+      - usa folk music
+      - Appalachian Folk:
+        - appalachian folk
+        - appalachian folk music
+        - appalachian music
+        - Old-Time:
+          - old-time
+          - hillbilly
+          - old time
+          - old-time music
+          - old-timey
+      - Barbershop:
+        - barbershop
+        - barbershop harmony
+        - barbershop music
+        - barbershop quartet
+        - barbershop quartets
+      - Barn Dance:
+        - barn dance
+        - barndance
+      - Creole:
+        - creole
+        - creole music
+      - New Mexico:
+        - new mexico
+        - música nuevomexicana
+        - musica nuevomexicana
+        - new mexico music
+      - Pennsylvania Dutch Folk:
+        - pennsylvania dutch folk
+        - pennsylvania dutch folk music
+      - Pueblo:
+        - pueblo
+        - pueblo music
+        - puebloan music
+      - Ring Shout:
+        - ring shout
+        - shout songs
+      - Sacred Harp:
+        - sacred harp
+        - fasola
+        - sacred harp singing
+        - shape note singing
+        - shape-note singing
+      - Spirituals:
+        - spirituals
+        - african american spiritual
+        - black spiritual
+        - negro spiritual
+      - Talking Blues:
+        - talking blues
+      - Traditional Cajun:
+        - traditional cajun
+        - traditional cajun music
+    - Arabic Folk:
+      - arabic folk
+      - arabic folk music
+      - Aita:
+        - aita
+        - âita
+        - aïta
+        - "'aiṭa"
+        - "'âita"
+        - "'aita"
+        - al 'âita
+        - al 'aita
+        - al-aita
+        - عيطة
+      - Algerian Chaabi:
+        - algerian chaabi
+        - الشعبي الجزائري
+      - Arabic Bellydance:
+        - arabic bellydance
+        - arabic bellydance music
+        - belly dancing
+        - Raqs baladi:
+          - raqs baladi
+          - balady
+          - beledi
+          - beledy
+          - بلدي
+          - رقص بلدي  baladi
+      - Ayyalah:
+        - ayyalah
+        - al-ayala
+        - al-ayyalah
+        - al-yola
+        - al-yowlah
+        - ayala
+        - yola
+        - yowlah
+        - العيالة
+        - اليولة
+      - Bedouin:
+        - bedouin
+        - bedouin music
+        - beduin music
+        - الموسيقى البدوية
+      - Dabke:
+        - dabke
+        - dabka
+        - dabkeh
+        - دبكة
+      - Fijiri:
+        - fijiri
+        - al-fijiri
+        - fidjeri
+        - fijri
+        - الفجيري
+        - لفجري
+      - Khaliji:
+        - khaliji
+        - gulf music
+        - khaleeji
+        - khaleeji music
+        - khaliji music
+        - الفن الخليجي
+        - الموسيقى الخليجية
+        - Samri:
+          - samri
+          - سامري
+        - Shehhi:
+          - shehhi
+          - al-shihiya
+          - shehhi music
+          - shihhi music
+          - shihiya
+          - shihuh music
+          - الفن الشحي
+          - المسيقى الشحية
+          - مسيقى الشحوح
+        - Shilla:
+          - shilla
+          - al-shilla
+          - shayla
+          - shaylat
+          - sheila
+          - sheilat
+          - shila
+          - shillat
+          - شيلات
+          - شيلة
+          - فن الشيلة
+      - Liwa:
+        - liwa
+        - al-laywah
+        - laywah
+        - الليوة
+        - فن الليوة
+      - Malhun:
+        - malhun
+        - al-malḥūn
+        - al-malhun
+        - malhoun
+        - melhoun
+        - الملحون
+      - Moroccan Chaabi:
+        - moroccan chaabi
+        - cha3bi maghribi
+        - cha3by maghribi
+        - chaabi maghribi
+        - chaabi marocain
+        - moroccan chaâbi
+        - شعبي مغربي
+      - Nuban:
+        - nuban
+        - al nuban
+        - nūbān
+        - النوبان
+        - فن النوبان
+        - نوبان
+      - Qasidah:
+        - qasidah
+        - qasida
+        - qasidah music
+      - Sa'idi:
+        - sa'idi
+        - saidi
+        - صعيدي
+    - Australian Folk:
+      - australian folk
+      - aboriginal
+      - australian folk music
+      - bush ballads
+      - bush songs
+      - Bush Ballad:
+        - bush ballad
+    - Bayawan:
+      - bayawan
+      - dolan muqam
+      - 巴亚宛
+    - Brazilian Folk:
+      - brazilian folk
+      - brazilian folk music
+      - música folclórica brasileira
+      - musica folclorica brasileira
+      - música tradicional brasileira
+      - musica tradicional brasileira
+      - Banda de pífano:
+        - banda de pífano
+        - banda de couros
+        - banda de pifano
+        - banda de pifes
+        - cabaçal
+        - cabacal
+        - esquenta-muié
+        - esquenta-muie
+        - terno
+        - zabumba
+      - Bandinha:
+        - bandinha
+        - banda de baile
+        - bandinha alemã
+        - bandinha alema
+        - conjunto de baile
+        - música de bandinha
+        - musica de bandinha
+      - Boi:
+        - boi
+      - Caipira:
+        - caipira
+        - música caipira
+        - musica caipira
+      - Candomblé:
+        - candomblé
+        - candomblé music
+        - candomble music
+        - candomble
+      - Cantoria:
+        - cantoria
+        - cantoria de viola
+        - Repente:
+          - repente
+          - desafio
+          - repentismo
+      - Capoeira:
+        - capoeira
+        - capoeira music
+        - música de capoeira
+        - musica de capoeira
+      - Fandango caiçara:
+        - fandango caiçara
+        - fandango caicara
+      - Jongo:
+        - jongo
+        - caxambu
+        - Ponto de umbanda:
+          - ponto de umbanda
+          - ponto cantado
+      - Lundu:
+        - lundu
+        - landum
+        - londu
+        - lundum
+      - Maracatu:
+        - maracatu
+      - Modinha:
+        - modinha
+        - moda brasileira
+        - modinha brasileira
+        - modinha de salão
+        - modinha de salao
+        - modinha imperial
+      - Rasqueado:
+        - rasqueado
+      - Samba de roda:
+        - samba de roda
+      - Seresta:
+        - seresta
+      - Sertanejo de raiz:
+        - sertanejo de raiz
+        - Moda de viola:
+          - moda de viola
+      - Toada de Boi:
+        - toada de boi
+        - toada do boi
+      - Xaxado:
+        - xaxado
+    - Canadian Folk:
+      - canadian folk
+      - canadian folk music
+      - canadian traditional music
+      - musique folklorique du canada
+      - musique traditionnelle du canada
+      - Canadian Maritime Folk:
+        - canadian maritime folk
+        - maritime traditional folk music
+        - maritime traditional music
+      - French-Canadian Folk:
+        - french-canadian folk
+        - french canadian folk
+        - french-canadian folk music
+        - french-canadian traditional music
+        - musique traditionnelle du canada français
+        - musique traditionnelle du canada francais
+      - Métis:
+        - métis
+        - métis music
+        - metis music
+        - metis
+        - Métis Fiddling:
+          - métis fiddling
+          - métis fiddle
+          - metis fiddle
+          - metis fiddling
+      - Newfoundland Folk:
+        - newfoundland folk
+        - newfoundland folk music
+    - Caribbean Folk:
+      - caribbean folk
+      - caribbean folk music
+      - Aguinaldo:
+        - aguinaldo
+      - Aleke:
+        - aleke
+      - Bahamian Rhyming Spiritual:
+        - bahamian rhyming spiritual
+        - rhyming spiritual
+      - Baithak gana:
+        - baithak gana
+        - बैठक गाना
+      - Balakadri:
+        - balakadri
+      - Bele:
+        - bele
+        - bel-air
+        - belair
+        - bélé
+        - bèlè
+        - fine-air
+      - Benna:
+        - benna
+        - bennah
+        - ditti
+      - Bomba:
+        - bomba
+      - Bullerengue:
+        - bullerengue
+        - bullarengue
+      - Calinda:
+        - calinda
+        - calenda
+        - kalenda
+        - kalinda
+      - Changüí:
+        - changüí
+        - changuí
+        - changui
+      - Chouval bwa:
+        - chouval bwa
+        - chouval bwa music
+        - chouval-bwa
+      - Fungi:
+        - fungi
+        - quelbe
+        - scratch band music
+      - Garifuna:
+        - garifuna
+        - garifuna music
+        - garinagu music
+        - Charikawi:
+          - charikawi
+        - Chumba:
+          - chumba
+        - Eremwu eu:
+          - eremwu eu
+        - Gunchei:
+          - gunchei
+        - Hunguhungu:
+          - hunguhungu
+          - fedu
+          - hungu hungu
+          - hungu-hungu
+        - Matamuerte:
+          - matamuerte
+        - Paranda:
+          - paranda
+          - garifuna paranda
+          - paranda music
+      - Goombay:
+        - goombay
+      - Gwo ka:
+        - gwo ka
+        - gro ka
+        - Gwo ka moderne:
+          - gwo ka moderne
+      - Haitian Vodou Drumming:
+        - haitian vodou drumming
+        - haitian vodoun drumming
+        - haitian voodoo drumming
+        - vodou drumming
+        - vodoun drumming
+      - Jamaican Folk:
+        - jamaican folk
+        - jamaican folk music
+      - Jibaro:
+        - jibaro
+        - jíbaro music
+        - jibaro music
+        - Seis:
+          - seis
+          - seis puertorriqueño
+          - seis puertorriqueno
+      - Jing ping:
+        - jing ping
+        - jing ping band
+      - Kaiso:
+        - kaiso
+        - caïso
+        - caiso
+        - cariso
+      - Kitchen Dance:
+        - kitchen dance
+        - caymanian folk music
+        - kitchen band music
+        - kitchen dance music
+      - Mento:
+        - mento
+      - Méringue:
+        - méringue
+        - haitian méringue
+        - haitian meringue
+        - mereng
+        - meringue
+      - Plena:
+        - plena
+      - Rara:
+        - rara
+      - Ripsaw:
+        - ripsaw
+        - combina music
+        - Rake-and-Scrape:
+          - rake-and-scrape
+          - rake 'n' scrape
+          - rake and scrape
+          - rake n scrape
+          - ripsaw music
+      - Rumba cubana:
+        - rumba cubana
+        - afro-cuban rumba
+        - cuban rhumba
+        - cuban rumba
+        - Batá-rumba:
+          - batá-rumba
+          - bata rumba
+          - batá rumba
+          - bata-rumba
+        - Guaguancó:
+          - guaguancó
+          - guaguanco
+          - rumba guaguancó
+          - rumba guaguanco
+      - Tambu:
+        - tambu
+        - tambú
+        - tambu music
+      - Tassa:
+        - tassa
+      - Tumba:
+        - tumba
+      - Tumba francesa:
+        - tumba francesa
+        - french drum
+      - Virgin Islander Cariso:
+        - virgin islander cariso
+    - Caucasian Folk:
+      - caucasian folk
+      - caucasian folk music
+      - Abkhazian Folk:
+        - abkhazian folk
+        - abkhazian folk music
+        - аԥсуа жәлар рмузыка
+      - Chechen Folk:
+        - chechen folk
+        - chechen folk music
+        - нохчийн халкъан илли
+        - нохчийн халкъан мукъам
+        - нохчийн халкъан эшар
+        - чеченская народная музыка
+      - Circassian Folk:
+        - circassian folk
+        - adyghe folk music
+        - circassian folk music
+        - адыгейская народная музыка
+        - адыгэ макъамэ
+        - адыгэ цiыхубэ макъамэ
+        - черкесская народная музыка
+      - Dagestani Folk:
+        - dagestani folk
+        - dagestani folk music
+        - музыка народов дагестана
+        - Avar Folk:
+          - avar folk
+          - avar folk music
+          - аваразул халкъияб музыка
+          - аварская народная музыка
+          - магiарул халкъияб кечi
+          - магiарул халкъияб музыка
+      - Georgian Folk:
+        - georgian folk
+        - georgian folk music
+        - ქართული ხალხური მუსიკა
+        - Batonebi Songs:
+          - batonebi songs
+          - iavnana
+          - mobodishneba
+          - nanina
+          - sabodisho
+          - იავნანა
+          - ნანა
+          - ნანინა
+        - Georgian Polyphony:
+          - georgian polyphony
+          - georgian choir
+          - georgian choral music
+      - Ossetian Folk:
+        - ossetian folk
+        - ossetian folk music
+        - ирон адæмон музыкæ
+        - ирыстоны адæмон музыкæ
+        - осетинская народная музыка
+    - Central Asian Folk:
+      - central asian folk
+      - central asian folk music
+      - Karakalpak Traditional:
+        - karakalpak traditional
+        - karakalpak traditional music
+        - qaraqalpaq traditional music
+      - Kyrgyz Traditional:
+        - kyrgyz traditional
+        - kirghiz traditional music
+        - kirghizstani traditional music
+        - kyrgyz traditional music
+        - Manaschi:
+          - manaschi
+          - manas recitation
+          - manaschy
+          - manasci
+    - Central Asian Throat Singing:
+      - central asian throat singing
+      - overtone singing
+      - Kai:
+        - kai
+        - kay
+        - khai
+        - khay
+        - кай
+      - Tuvan Throat Singing:
+        - tuvan throat singing
+        - khoomei
+        - khöömii
+        - khoomii
+        - mongolian overtone singing
+        - mongolian throat singing
+        - tuvan overtone singing
+        - tuvan throat-singing
+        - xöömej
+        - xoomej
+        - xoomii
+        - xöömii
+        - хөөмий
+        - Chylandyk:
+          - chylandyk
+        - Kargyraa:
+          - kargyraa
+        - Sygyt:
+          - sygyt
+    - Chukchi Folk:
+      - chukchi folk
+      - chukchi folk music
+      - народная музыка чукчей
+    - Dirge:
+      - dirge
+      - funeral dirge
+      - lament
+    - East Asian Folk:
+      - east asian folk
+      - east asian folk music
+      - Ainu:
+        - ainu
+        - ainu music
+        - Upopo:
+          - upopo
+          - ウポポ
+        - Yukar:
+          - yukar
+          - ユーカラ
+      - Amami shimauta:
+        - amami shimauta
+        - shima uta
+        - shima-uta
+        - shimauta
+        - 奄美島唄
+        - 島唄
+      - Bogino duu:
+        - bogino duu
+        - mongolian short song
+        - short song
+        - богино дуу
+        - ᠪᠣᠭᠣᠨᠢ ᠳᠠᠭᠤᠤ
+      - Chinese Folk:
+        - chinese folk
+        - chinese folk music
+        - zhōngguó mínjiān yīnyuè
+        - zhongguo minjian yinyue
+        - 中国民间音乐
+        - 中國民間音樂
+        - Beiguan:
+          - beiguan
+          - beiguan music
+        - Chaozhou xianshi:
+          - chaozhou xianshi
+          - chaozhou xianyue
+          - teochew string music
+          - xianshiyue
+          - 弦诗乐
+          - 潮州弦乐
+          - 潮州弦诗
+        - Han Folk:
+          - han folk
+          - ethnic han music
+          - han chinese folk music
+          - han folk music
+        - Jiangnan sizhu:
+          - jiangnan sizhu
+          - jiāngnán sīzhú
+          - 江南丝竹
+          - 江南絲竹
+      - Indigenous Taiwanese:
+        - indigenous taiwanese
+        - aboriginal taiwanese music
+        - indigenous taiwanese music
+      - Japanese Folk:
+        - japanese folk
+        - japanese folk music
+        - Kagura:
+          - kagura
+          - kamikura
+          - shinto ceremonial music
+        - Kouta:
+          - kouta
+          - 小唄
+        - Min'yō:
+          - min'yō
+          - min'yo
+          - minyō
+          - minyo
+          - 民謡
+        - Ondō:
+          - ondō
+          - ondo
+          - 音頭
+          - Goshu ondo:
+            - goshu ondo
+            - gōshū ondo
+            - goshu ondō
+            - 江州音頭
+          - Kawachi ondo:
+            - kawachi ondo
+        - Rōkyoku:
+          - rōkyoku
+          - naniwa-bushi
+          - rokyoku
+          - 浪曲
+          - 浪花節
+        - Taiko:
+          - taiko
+          - kumi-daiko
+          - 太鼓
+          - 組太鼓
+        - Tsugaru shamisen:
+          - tsugaru shamisen
+          - tsugaru-jamisen
+          - tsugaru-shamisen
+          - 津軽三味線
+      - Korean Folk:
+        - korean folk
+        - korean folk music
+        - minsogak
+        - Muak:
+          - muak
+          - korean shamanistic music
+          - musok eumak
+          - 무속음악
+          - 무악
+          - 巫俗音樂
+          - 巫樂
+        - Pansori:
+          - pansori
+          - korean epic chants
+          - p'ansori
+          - 판소리
+        - Pungmul:
+          - pungmul
+          - nongak
+          - 농악
+          - 풍물
+          - 風物
+        - Sanjo:
+          - sanjo
+          - 산조
+          - 散調
+        - Sinawi:
+          - sinawi
+          - shinawi
+          - 시나위
+      - Nakasi:
+        - nakasi
+        - nagashi
+        - nagashi music
+        - nakashi
+        - nakashi music
+        - nakasi music
+        - 那卡西
+      - Ryukyuan:
+        - ryukyuan
+        - nantō kayō
+        - nanto kayo
+        - ryūkyū ongaku
+        - ryukyu ongaku
+        - ryukyuan music
+        - 南島歌謡
+        - 琉球音楽
+        - Okinawan:
+          - okinawan
+          - okinawa ongaku
+          - okinawan music
+          - okinawan traditional
+          - uchinā ungaku
+          - uchina ungaku
+          - ウチナー音楽
+          - 沖縄音楽
+          - Kachāshī:
+            - kachāshī
+            - kachashi
+      - Zohioliin duu:
+        - zohioliin duu
+        - niitiin duu
+        - zokhiolyn duu
+        - zoxiolyn duu
+        - зохиолын дуу
+        - нийтийн дуу
+    - European Folk:
+      - european folk
+      - european folk music
+      - traditional european folk
+      - Alpine Folk:
+        - alpine folk
+        - alpenländische volksmusik
+        - alpenlandische volksmusik
+        - alpine folk music
+        - Canto degli Alpini:
+          - canto degli alpini
+          - alpini song
+          - canto alpino
+        - Ländler:
+          - ländler
+          - hudigääggeler
+          - hudigaaggeler
+          - landler
+          - ländler-fox
+          - landler-fox
+          - ländlermusik
+          - landlermusik
+      - Balkan Folk:
+        - balkan folk
+        - balkan folk music
+        - Albanian Folk:
+          - albanian folk
+          - albanian folk music
+          - muzika folklorike shqiptare
+          - Lab Polyphony:
+            - lab polyphony
+          - Shota:
+            - shota
+          - Tosk Polyphony:
+            - tosk polyphony
+        - Aromanian Folk:
+          - aromanian folk
+          - aromanian folk music
+          - muzica tradițională armãneascã
+          - muzica traditionala armaneasca
+        - Balkan Brass:
+          - balkan brass
+          - balkan brass band
+          - serbian brass
+          - serbian brass band
+          - truba
+        - Csango Folk:
+          - csango folk
+          - csango folk music
+          - csángó muzsika
+          - csango muzsika
+          - muzică ceangăiască
+          - muzica ceangaiasca
+        - Gagauz Folk:
+          - gagauz folk
+          - gagauz folk music
+        - Greek Folk:
+          - greek folk
+          - greek folk music
+          - ελληνική δημοτική μουσική
+          - Aegean Islands Folk:
+            - aegean islands folk
+            - aegean islands folk music
+            - νησιώτικα αιγαίου
+          - Cretan Folk:
+            - cretan folk
+            - cretan
+            - cretan folk music
+            - cretan music
+            - kritika
+            - κρητικά
+            - Rizitika:
+              - rizitika
+              - ριζίτικα
+          - Dimotika:
+            - dimotika
+            - dimotiko
+            - δημοτικά
+          - Hasapiko:
+            - hasapiko
+            - hasapikos
+            - hasaposerviko
+            - hasaposérviko
+          - Ionian Islands Folk:
+            - ionian islands folk
+            - ionian islands folk music
+            - νησιώτικα ιονίου
+          - Kalamatianó:
+            - kalamatianó
+            - kalamatiano
+            - kalamatianos
+            - kalamatianos dance
+          - Nisiotika:
+            - nisiotika
+            - nisiótika
+          - Rembetika:
+            - rembetika
+            - rebetika
+            - rebetiko
+            - rembetiko
+            - ρεμπέτικα
+            - ρεμπέτικο
+            - Zeibekiko:
+              - zeibekiko
+              - zeimbekiko
+              - zembekiko
+              - zeybekiko
+        - Izvorna:
+          - izvorna
+        - Kolo:
+          - kolo
+        - Narodna muzika:
+          - narodna muzika
+      - Baltic Folk:
+        - baltic folk
+        - baltic folk music
+        - Latvian Folk:
+          - latvian folk
+          - dainas
+          - latvian folk music
+          - latviešu tautas dziesmas
+          - latviesu tautas dziesmas
+          - latviešu tautas mūzika
+          - latviesu tautas muzika
+        - Lithuanian Folk:
+          - lithuanian folk
+          - lietuvių liaudies muzika
+          - lietuviu liaudies muzika
+          - lietuvių muzikinis folkloras
+          - lietuviu muzikinis folkloras
+          - lithuanian folk music
+          - lithuanian traditional music
+          - Daina:
+            - daina
+          - Sutartinės:
+            - sutartinės
+            - sutartines
+      - Balto-Finnic Folk:
+        - balto-finnic folk
+        - balto finnic folk
+        - balto-finnic folk music
+        - finnic folk music
+        - Estonian Folk:
+          - estonian folk
+          - eesti folkmuusika
+          - eesti pärimusmuusika
+          - eesti parimusmuusika
+          - eesti rahvamuusika
+          - estonian folk music
+        - Finnish Folk:
+          - finnish folk
+          - finnish folk music
+          - suomalainen kansanmusiikki
+          - Jenkka:
+            - jenkka
+            - finnish schottische
+            - Letkajenkka:
+              - letkajenkka
+              - letkis
+              - letkiss
+          - Pelimanni music:
+            - pelimanni music
+            - pelimanni
+          - Rekilaulu:
+            - rekilaulu
+        - Karelian Folk:
+          - karelian folk
+          - karelian folk music
+        - Livonian Folk:
+          - livonian folk
+          - līvõkīel lōlõd
+          - livokiel lolod
+          - livonian folk music
+        - Rune Singing:
+          - rune singing
+          - regilaul
+          - runesang
+          - runo song
+          - runolaul
+          - runolaulu
+          - Seto leelo:
+            - seto leelo
+      - Basque Folk:
+        - basque folk
+        - basque
+        - basque folk music
+        - basque music
+        - euskal herriko folk musika
+        - Trikitixa:
+          - trikitixa
+          - trikiti
+      - Catalan Folk:
+        - catalan folk
+        - catalan
+        - catalan folk music
+        - catalan music
+        - catalonian folk music
+        - Sardana:
+          - sardana
+          - cobla
+      - Celtic Folk:
+        - celtic folk
+        - celtic
+        - celtic folk music
+        - Breton Celtic Folk:
+          - breton celtic folk
+          - breton celtic folk music
+          - musique folklorique celtique bretonne
+          - sonerezh folklorel keltiek breizhek
+          - Bagad:
+            - bagad
+            - bagadoù
+            - bagadou
+        - Cape Breton Folk:
+          - cape breton folk
+          - cape breton folk music
+          - Cape Breton Fiddling:
+            - cape breton fiddling
+        - Cornish Folk:
+          - cornish folk
+          - cornish folk music
+          - ilow kernow
+        - Hornpipe:
+          - hornpipe
+      - Concertina Band:
+        - concertina band
+      - Dutch Folk:
+        - dutch folk
+        - dutch folk music
+        - nederlandse volksmuziek
+      - English Folk:
+        - english folk
+        - english folk music
+        - Northumbrian Folk:
+          - northumbrian folk
+          - northumbrian folk music
+        - Scrumpy and Western:
+          - scrumpy and western
+      - Flemish Folk:
+        - flemish folk
+        - flemish folk music
+      - French Folk:
+        - french folk
+        - french folk music
+        - Alsatian Folk:
+          - alsatian folk
+          - alsatian folk music
+          - elsässische volksmusik
+          - elsassische volksmusik
+          - musique folklorique alsacienne
+          - musique traditionnelle alsacienne
+        - Breton Folk:
+          - breton folk
+          - breton
+          - breton folk music
+          - breton music
+          - musique folklorique bretonne
+          - sonerezh folklorel breizhek
+          - Kan ha diskan:
+            - kan ha diskan
+        - Corsican Folk:
+          - corsican folk
+          - corsican folk music
+          - musique corse
+          - Paghjella:
+            - paghjella
+            - cantu in paghjella
+        - Musette:
+          - musette
+          - bal-musette
+          - Swing musette:
+            - swing musette
+            - jazz musette
+            - musette swing
+            - valse-swing
+        - Occitan Folk:
+          - occitan folk
+          - musica folclorica occitana
+          - musica tradicionala occitana
+          - musique folk occitane
+          - musique traditionnelle occitane
+          - occitan
+          - occitan folk music
+          - Auvergnat Folk:
+            - auvergnat folk
+            - auvergnat folk music
+            - musica folk auvernhata
+            - musica tradicionala auvernhata
+            - musique folklorique auvergnate
+            - musique traditionnelle auvergnate
+          - Gascon Folk:
+            - gascon folk
+            - gascon folk music
+            - musique gasconne
+      - German Folk:
+        - german folk
+        - german folk music
+        - volksmusik
+        - Gstanzl:
+          - gstanzl
+          - schamperliedlein
+          - schandliedlein
+          - schelmenliedlein
+          - schlumperliedl
+          - schnaderhacki
+          - schnaderhüpfel
+          - schnaderhupfel
+          - schnatterliedl
+          - trutzgsangl
+          - trutzliedl
+          - vierzeiler
+      - Għana:
+        - għana
+        - ghana
+        - maltese ghana
+      - Hungarian Folk:
+        - hungarian folk
+        - hungarian folk music
+        - magyar népzene
+        - magyar nepzene
+        - népzene
+        - nepzene
+        - Csárdás:
+          - csárdás
+          - csardas
+          - czárdás
+          - czardas
+        - Legényes:
+          - legényes
+          - feciorească
+          - fecioreasca
+          - legenyes
+        - Magyar nóta:
+          - magyar nóta
+          - magyar nota
+          - nóta
+          - nota
+        - Pásztordal:
+          - pásztordal
+          - pasztordal
+          - pásztornóta
+          - pasztornota
+        - Táncház:
+          - táncház
+          - dance house
+          - dance-house
+          - tanchaz
+      - Irish Folk:
+        - irish folk
+        - celtic folk
+        - celtic music
+        - ceol traidisiúnta na héireann
+        - ceol traidisiunta na heireann
+        - irish folk music
+        - irish trad
+        - irish traditional music
+        - traditional irish folk
+        - Donegal Fiddle:
+          - donegal fiddle
+          - donegal fiddle music
+          - donegal fiddle tradition
+        - Irish Rebel:
+          - irish rebel
+          - irish rebel music
+        - Jig:
+          - jig
+        - Manx Folk:
+          - manx folk
+          - kiaull vannin
+          - manx folk music
+        - Scottish Folk:
+          - scottish folk
+          - ceòl folk
+          - ceol folk
+          - ceòl traidiseanta na h-alba
+          - ceol traidiseanta na h-alba
+          - mouth music
+          - scots fowk music
+          - scottish folk music
+          - traditional scottish folk
+          - Bothy Ballad:
+            - bothy ballad
+          - Pipe Band:
+            - pipe band
+            - còmhlan-pìoba
+            - comhlan-pioba
+            - pìob is drumaichean
+            - piob is drumaichean
+            - pipe & drum
+            - pipe and drum
+            - pipe bands
+            - pipes and drums
+          - Scots Song:
+            - scots song
+            - scots folk song
+            - scots folksong
+            - scots sang
+            - scots traditional song
+          - Scottish Country Dance:
+            - scottish country dance
+            - scottish country dance band
+            - scottish country dance music
+          - Shetland & Orkney Folk:
+            - shetland & orkney folk
+            - shetland & orkney folk music
+          - Òrain Ghàidhlig:
+            - òrain ghàidhlig
+            - gaelic song
+            - orain ghaidhlig
+            - òran gàidhlig
+            - oran gaidhlig
+            - scottish gaelic song
+            - seinn dùthchasach
+            - seinn duthchasach
+            - Seinn nan salm:
+              - seinn nan salm
+              - gaelic psalm
+              - gaelic psalm singing
+              - gaelic psalmody
+              - salmadaireachd
+              - salmaireachd
+            - Òrain luaidh:
+              - òrain luaidh
+              - milling song
+              - orain luaidh
+              - òrain luathaidh
+              - orain luathaidh
+              - waulking song
+        - Sean-nós:
+          - sean-nós
+          - old style irish song
+          - sean nós
+          - sean nos singing
+          - sean nós singing
+          - sean-nos
+          - sean-nós singing
+          - sean-nos singing
+          - sean-nós song
+          - sean-nos song
+          - sean nos
+        - Welsh Folk:
+          - welsh folk
+          - traditional welsh music
+          - welsh folk music
+      - Istrian Folk:
+        - istrian folk
+        - istrian folk music
+      - Italian Folk:
+        - italian folk
+        - italian folk music
+        - Canzone napoletana:
+          - canzone napoletana
+          - neapolitan song
+        - Liscio:
+          - liscio
+          - musica da ballo romagnola
+        - Sardinian Folk:
+          - sardinian folk
+          - musica folcloristica sarda
+          - sardinian folk music
+          - Cantu a chiterra:
+            - cantu a chiterra
+          - Cantu a tenore:
+            - cantu a tenore
+        - Stornello:
+          - stornello
+        - Tarantella:
+          - tarantella
+          - Pizzica:
+            - pizzica
+            - taranta
+          - Tammurriata:
+            - tammurriata
+        - Trallalero:
+          - trallalero
+          - tralalêro
+          - tralalero
+          - trallallero
+      - Luxembourgish Folk:
+        - luxembourgish folk
+        - lëtzebuerger volleksmusek
+        - letzebuerger volleksmusek
+        - luxembourgish folk music
+      - Neo-Medieval Folk:
+        - neo-medieval folk
+        - medieval folk music
+        - neo medieval folk
+        - Bardcore:
+          - bardcore
+          - tavernwave
+      - Neo-Pagan Folk:
+        - neo-pagan folk
+        - neo pagan folk
+        - neo-pagan
+        - neopagan
+        - neopagan folk
+        - pagan folk
+      - Nordic Folk:
+        - nordic folk
+        - nordic folk music
+        - Danish Folk:
+          - danish folk
+          - danish folk music
+          - dansk folkemusik
+        - Faroese Folk:
+          - faroese folk
+          - faroese folk music
+          - fólkatónleikur í føroyum
+          - folkatonleikur i føroyum
+          - Kvæði:
+            - kvæði
+            - faroese ballad
+            - faroese ballads
+            - kvaedi
+            - kvøðing
+        - Icelandic Folk:
+          - icelandic folk
+          - icelandic folk music
+          - íslensk þjóðlagatónlist
+          - islensk þjoðlagatonlist
+          - Rímur:
+            - rímur
+            - rimur
+        - Joik:
+          - joik
+          - juoigan
+          - juoiggus
+          - luohti
+          - sámi
+          - sami
+          - yoik
+        - Nordic Old Time Dance:
+          - nordic old time dance
+          - gammaldans
+          - nordic dance music
+          - nordic old time dance music
+          - pelimannimusiikki
+          - spelmansmusik
+          - traditional nordic dance
+          - traditional nordic dance music
+          - Polska:
+            - polska
+            - pols
+            - polsk
+            - springar
+            - springlek
+            - Hambo:
+              - hambo
+        - Norwegian Folk:
+          - norwegian folk
+          - norsk folkemusikk
+          - norwegian folk music
+          - Halling:
+            - halling
+        - Swedish Folk:
+          - swedish folk
+          - svensk folkmusik
+          - swedish folk music
+        - Visa:
+          - visa
+          - vísa
+          - vise
+      - Polka:
+        - polka
+        - Chicago Polka:
+          - chicago polka
+          - chicago-style polka
+          - polka chicagowska
+        - Eastern-Style Polka:
+          - eastern-style polka
+          - eastern style polka
+        - Polka peruana:
+          - polka peruana
+          - polka criolla
+      - Portuguese Folk:
+        - portuguese folk
+        - portuguese folk music
+        - portuguese traditional music
+        - Cante alentejano:
+          - cante alentejano
+          - canto alentejano
+        - Chamarrita açoriana:
+          - chamarrita açoriana
+          - chamarrita acoriana
+        - Chula:
+          - chula
+          - chula music
+          - portuguese chula
+        - Desgarrada:
+          - desgarrada
+          - cantares ao desafio
+          - cantigas à desgarrada
+          - cantigas a desgarrada
+          - cantigas ao desafio
+          - desgarradas
+        - Fado:
+          - fado
+          - Fado de Coimbra:
+            - fado de coimbra
+            - canção de coimbra
+            - cancao de coimbra
+        - Trás-os-Montes Folk:
+          - trás-os-montes folk
+          - trás os montes folk
+          - trás-os-montes folk music
+          - tras-os-montes folk music
+          - trás-os-montes traditional music
+          - tras-os-montes traditional music
+          - tras os montes folk
+          - tras-os-montes folk
+        - Vira:
+          - vira
+          - vira do minho
+          - vira português
+          - vira portugues
+      - Romanian Folk:
+        - romanian folk
+        - muzica tradițională românească
+        - muzica traditionala romaneasca
+        - romanian folk music
+        - Bocet:
+          - bocet
+          - jelanie
+        - Colinde:
+          - colinde
+          - colind
+          - colindã
+          - colinda
+          - colinduri
+        - Doină:
+          - doină
+          - doina
+          - Ca din tulnic:
+            - ca din tulnic
+            - doina ca din tulnic
+            - tulnic doina
+        - Muzică lăutărească:
+          - muzică lăutărească
+          - muzica lautareasca
+        - Sârbă:
+          - sârbă
+          - sarba
+      - Slavic Folk:
+        - slavic folk
+        - slavic folk music
+        - slavonic folk music
+        - Belarusian Folk:
+          - belarusian folk
+          - belarusian folk music
+        - Bosnian Folk:
+          - bosnian folk
+          - bosnian folk music
+          - Izvorna bosanska muzika:
+            - izvorna bosanska muzika
+            - bosnian root music
+            - изворна босанска музика
+          - Sevdalinka:
+            - sevdalinka
+            - sevdah
+        - Bulgarian Folk:
+          - bulgarian folk
+          - bulgarian folk music
+        - Croatian Folk:
+          - croatian folk
+          - croatian folk music
+          - hrvatska narodna glazba
+          - Klapa:
+            - klapa
+            - klape
+            - klapsko pjevanje
+        - Czech Folk:
+          - czech folk
+          - česká lidová hudba
+          - ceska lidova hudba
+          - czech folk music
+        - Ganga:
+          - ganga
+        - Goral:
+          - goral
+          - goral folk music
+          - goral music
+          - goralská ľudová hudba
+          - goralska ludova hudba
+          - muzyka góralska
+          - muzyka goralska
+          - гуральская музыка
+          - Polish Goral:
+            - polish goral
+            - polish goral music
+        - Macedonian Folk:
+          - macedonian folk
+          - macedonian folk music
+          - Čalgija:
+            - čalgija
+            - calgija
+        - Montenegrin Folk:
+          - montenegrin folk
+          - montenegrin folk music
+        - Moravian Folk:
+          - moravian folk
+          - moravian folk music
+          - moravian traditional music
+          - moravská lidová hudba
+          - moravska lidova hudba
+        - Polish Folk:
+          - polish folk
+          - polish folk music
+          - polska muzyka ludowa
+          - Folklor miejski:
+            - folklor miejski
+            - polish urban folk music
+            - Warsaw City Folk:
+              - warsaw city folk
+              - warsaw folk music
+              - warszawski folklor
+          - Kashubian Folk:
+            - kashubian folk
+            - kashubian folk music
+            - muzyka kaszubska
+          - Krakowiak:
+            - krakowiak
+            - cracovienne
+            - krakauer
+          - Kujawiak:
+            - kujawiak
+            - gładki
+            - kolebany
+            - kouiaviak
+            - ksebka
+            - kujaviak
+            - odsibka
+            - okrągły
+            - okragły
+            - owczarek
+            - śpiący
+            - spiacy
+          - Kujon:
+            - kujon
+          - Kurpian Folk:
+            - kurpian folk
+            - kurpian folk music
+            - muzyka kurpiowska
+          - Oberek:
+            - oberek
+            - drobny
+            - drygant
+            - ober
+            - obertany
+            - obertas
+            - okrąglak
+            - okraglak
+            - okrąglok
+            - okraglok
+            - owijas
+            - owijok
+            - przewracany
+            - swijok
+            - wykrętacz
+            - wykretacz
+            - wyrwas
+            - wyrywany
+            - wyrywas
+            - zawijacz
+            - zawijany
+            - zwijacz
+            - zwijas
+        - Russian Folk:
+          - russian folk
+          - russian folk music
+          - русская народная музыка
+          - Bard:
+            - bard
+            - amateur song
+            - bard song
+            - bardovskaya pesnya
+          - Barynya:
+            - barynya
+          - Chastushka:
+            - chastushka
+            - chastushka song
+            - chastushki
+        - Serbian Folk:
+          - serbian folk
+          - serbian folk music
+          - srpska narodna muzika
+          - српска народна музика
+        - Slovak Folk:
+          - slovak folk
+          - slovak folk music
+          - slovenská ľudová hudba
+          - slovenska ludova hudba
+        - Slovenian Folk:
+          - slovenian folk
+          - slovenian folk music
+          - slovenska ljudska glasba
+          - Narodno zabavna glasba:
+            - narodno zabavna glasba
+            - govedna
+            - goveja muska
+            - narodnozabavna glasba
+            - oberkrainer
+        - Starogradska muzika:
+          - starogradska muzika
+        - Ukrainian Folk:
+          - ukrainian folk
+          - ukrainian folk music
+          - ukrainian traditional music
+          - українська народна музика
+          - Duma:
+            - duma
+          - Hutsul Folk:
+            - hutsul folk
+            - hutsul folk music
+            - гуцульська народна музика
+            - Kolomyjka:
+              - kolomyjka
+      - Spanish Folk:
+        - spanish folk
+        - spanish folk music
+        - Andalusian Folk:
+          - andalusian folk
+          - andalusian folk music
+          - música folclórica andaluza
+          - musica folclorica andaluza
+          - Saeta:
+            - saeta
+          - Sevillanas:
+            - sevillanas
+        - Aragonese Folk:
+          - aragonese folk
+          - aragonese folk music
+          - jota
+          - música folklórica aragonesa
+          - musica folklorica aragonesa
+        - Asturian Folk:
+          - asturian folk
+          - asturian folk music
+          - asturian traditional music
+          - música tradicional asturiana
+          - musica tradicional asturiana
+        - Bolero español:
+          - bolero español
+          - bolero espanol
+          - spanish bolero
+        - Canarian Folk:
+          - canarian folk
+          - canarian folk music
+          - música folklórica canaria
+          - musica folklorica canaria
+        - Chotis madrileño:
+          - chotis madrileño
+          - chotis madrileno
+          - schotis madrileño
+          - schotis madrileno
+        - Copla:
+          - copla
+        - Flamenco:
+          - flamenco
+          - Bulería:
+            - bulería
+            - buleria
+            - bulerías
+            - bulerias
+            - flamenco bulería
+            - flamenco buleria
+          - Cante chico:
+            - cante chico
+            - cante chico flamenco
+          - Cante jondo:
+            - cante jondo
+            - cante grande
+            - cante jondo flamenco
+            - deep song
+          - Cantiñas:
+            - cantiñas
+            - cantiña
+            - cantina
+            - cantinas
+            - cantinas flamencas
+          - Cartageneras:
+            - cartageneras
+            - cartagenera
+            - cartageneras flamencas
+          - Farruca:
+            - farruca
+            - farruca flamenca
+          - Flamenco nuevo:
+            - flamenco nuevo
+            - contemporary flamenco
+            - new flamenco
+            - nuevo flamenco
+          - Martinetes:
+            - martinetes
+            - martinete
+            - martinetes flamencos
+          - Rumba flamenca:
+            - rumba flamenca
+            - flamenco rumba
+            - rumba flamenco
+        - Galician Folk:
+          - galician folk
+          - galician
+          - galician folk music
+          - galician traditional
+        - Pasodoble:
+          - pasodoble
+          - paso doble
+        - Romance:
+          - romance
+        - Valencian Folk:
+          - valencian folk
+          - música popular valenciana
+          - musica popular valenciana
+          - música tradicional valenciana
+          - musica tradicional valenciana
+          - valencian folk music
+        - Villancico:
+          - villancico
+          - vilancete
+          - vilancico
+          - vilhancico
+          - villancet
+          - villançete
+          - villancete
+          - villancicos
+      - Volga-Ural Folk:
+        - volga-ural folk
+        - volga ural folk
+        - volga-kama-belaya folk music
+        - volga-ural folk music
+        - Bashkir Folk:
+          - bashkir folk
+          - bashkir folk music
+          - башкирская народная музыка
+          - башкирская народная песня
+          - башҡорт халыҡ йырҙары
+          - башҡорт халыҡ музыкаһы
+        - Chuvash Folk:
+          - chuvash folk
+          - chuvash folk music
+          - чăваш халăх мусăкĕ
+          - чувашская народная музыка
+        - Komi Folk:
+          - komi folk
+          - komi folk music
+          - коми народная музыка
+        - Mari Folk:
+          - mari folk
+          - mari folk music
+          - марий калык сем
+          - марийская народная музыка
+          - мары калык сем
+        - Mordvin Folk:
+          - mordvin folk
+          - mordvin folk music
+          - mordvinian folk music
+          - мокшень ломаттнень мора
+          - мордовская народная музыка
+          - эрзянь раскень седямось
+        - Udmurt Folk:
+          - udmurt folk
+          - udmurt folk music
+          - votyak folk music
+          - вотякская народная музыка
+          - удмуртская народная музыка
+        - Volga Tatar Folk:
+          - volga tatar folk
+          - volga tatar folk music
+      - Walloon Folk:
+        - walloon folk
+        - musique folklorique wallone
+        - muzike do foclore walone
+        - walloon folk music
+      - White Voice:
+        - white voice
+        - biały głos
+        - biały śpiew
+        - biały spiew
+        - śpiewokrzyk
+        - spiewokrzyk
+        - white singing
+        - білий голос
+        - білий спів
+      - Yiddish Folksong:
+        - yiddish folksong
+        - yiddisch folksong
+        - yiddish folk
+        - yiddish folk music
+        - yiddish folk song
+        - יידישע פאלק
+        - יידישע פאלק לידער
+    - Falak:
+      - falak
+      - aflak
+      - falak music
+      - фалак
+      - فلک
+    - Football Chant:
+      - football chant
+      - football terrace chant
+      - soccer chant
+    - Griot:
+      - griot
+      - griot music
+    - Hazara Folk:
+      - hazara folk
+      - hazara folk music
+      - hazaragi folk music
+    - Hispanic American Folk:
+      - hispanic american folk
+      - hispanic american folk music
+      - hispanic american folklore
+      - Andean Folk:
+        - andean folk
+        - andean folk music
+        - andean music
+        - quechua
+        - Baguala:
+          - baguala
+        - Bailecito:
+          - bailecito
+          - bailecito de la tierra
+        - Caporal:
+          - caporal
+          - caporal-saya
+          - caporales
+          - negritos
+          - saya caporal
+          - tundiqui
+          - tuntuna
+        - Carnaval cruceño:
+          - carnaval cruceño
+          - carnaval
+          - carnaval cruceno
+          - carnavalito cruceño
+          - carnavalito cruceno
+        - Chuntunqui romántico:
+          - chuntunqui romántico
+          - chuntunqui
+          - chuntunqui romantico
+        - Conjunto andino:
+          - conjunto andino
+          - andean conjunto
+          - neo-folklore
+          - pan-andean band
+        - Diablada:
+          - diablada
+        - Harawi:
+          - harawi
+          - arawi
+        - Huaylarsh:
+          - huaylarsh
+          - huaylars
+          - huaylas
+          - huaylash
+        - Huayno:
+          - huayno
+          - huaino
+          - huaiño
+          - huayño
+          - huaynu
+          - huayñu
+          - wayno
+          - wayño
+          - waynu
+          - wayñu
+          - Bolivian Huayño:
+            - bolivian huayño
+            - bolivian huaino
+            - bolivian huaiño
+            - bolivian huayno
+            - bolivian huaynu
+            - bolivian huayñu
+            - bolivian wayno
+            - bolivian wayño
+            - bolivian waynu
+            - bolivian wayñu
+            - huaino boliviano
+            - huaiño boliviano
+            - huayño boliviano
+            - huayno boliviano
+            - huaynu boliviano
+            - huayñu boliviano
+            - wayno boliviano
+            - wayño boliviano
+            - waynu boliviano
+            - wayñu boliviano
+          - Carnavalito:
+            - carnavalito
+          - Chimaychi:
+            - chimaychi
+            - chimaiche
+            - chimayche
+        - Morenada:
+          - morenada
+          - danza de los morenos
+        - Muliza:
+          - muliza
+        - Tinku:
+          - tinku
+        - Tunantada:
+          - tunantada
+        - Yaraví:
+          - yaraví
+          - triste
+          - yaravi
+      - Bambuco:
+        - bambuco
+      - Candombe:
+        - candombe
+      - Carranga:
+        - carranga
+        - guasca
+      - Chacarera:
+        - chacarera
+      - Chamamé:
+        - chamamé
+        - chamame
+        - Chamamé tropical:
+          - chamamé tropical
+          - chamame tropical
+      - Chamarrita rioplatense:
+        - chamarrita rioplatense
+        - chamarrita
+        - chimarrita
+      - Chilean Folk:
+        - chilean folk
+        - chilean folk music
+        - Canto a lo poeta:
+          - canto a lo poeta
+        - Chilena:
+          - chilena
+        - Chilote:
+          - chilote
+          - chilote music
+          - música chilota
+          - musica chilota
+        - Cueca:
+          - cueca
+        - Música típica chilena:
+          - música típica chilena
+          - musica tipica chilena
+        - Tonada chilena:
+          - tonada chilena
+        - Zamacueca:
+          - zamacueca
+      - Currulao:
+        - currulao
+        - bambuco viejo
+      - Décima:
+        - décima
+        - decima
+        - decima music
+        - décima music
+      - Guaracha santiagueña:
+        - guaracha santiagueña
+        - guaracha de santiago del estero
+        - guaracha del estero
+        - guaracha santiaguena
+        - guarachaca
+      - Malambo:
+        - malambo
+        - argentine malambo
+        - malambo music
+      - Mexican Folk:
+        - mexican folk
+        - mexican folk music
+      - Milonga:
+        - milonga
+        - habanera pobre
+        - Gato:
+          - gato
+      - Murga:
+        - murga
+        - chirigota
+        - Murga uruguaya:
+          - murga uruguaya
+      - Música criolla peruana:
+        - música criolla peruana
+        - música criolla
+        - musica criolla
+        - musica criolla peruana
+        - peruvian creole music
+        - Festejo:
+          - festejo
+        - Landó:
+          - landó
+          - lando
+          - zamba landó
+          - zamba lando
+        - Marinera:
+          - marinera
+        - Tondero:
+          - tondero
+        - Vals criollo:
+          - vals criollo
+          - vals peruano
+      - Norteño:
+        - norteño
+        - mexican folk
+        - Canto cardenche:
+          - canto cardenche
+          - corrido acardenchando
+        - Cumbia norteña mexicana:
+          - cumbia norteña mexicana
+          - cumbia nortena mexicana
+        - Duranguense:
+          - duranguense
+          - pasito duranguense
+        - Jarana yucateca:
+          - jarana yucateca
+          - yucatecan jarana
+        - Mariachi:
+          - mariachi
+        - Narcocorrido:
+          - narcocorrido
+          - narco corrido
+          - narco corridos
+          - narco-corrido
+          - narcocorridos
+        - Pirekua:
+          - pirekua
+        - Ranchera:
+          - ranchera
+          - canción ranchera
+          - cancion ranchera
+        - Sierreño:
+          - sierreño
+          - conjunto
+          - la musica norteña
+          - la musica nortena
+          - norteña
+          - nortena
+          - norteno
+          - Corrido tumbado:
+            - corrido tumbado
+            - alternative corridos
+            - campirano
+            - sierreno
+          - Waila:
+            - waila
+            - chicken scratch
+            - o'odham waila
+        - Son calentano:
+          - son calentano
+        - Son huasteco:
+          - son huasteco
+          - huapango
+        - Son istmeño:
+          - son istmeño
+          - sandunga
+          - son istmeno
+          - son oaxaqueño
+          - son oaxaqueno
+        - Son jarocho:
+          - son jarocho
+          - jarocho
+        - Trova yucateca:
+          - trova yucateca
+          - canción yucateca
+          - cancion yucateca
+      - Polka paraguaya:
+        - polka paraguaya
+        - paraguayan polka
+      - Saya:
+        - saya
+        - afro-bolivian saya
+        - saya afroboliviana
+      - Tamborito:
+        - tamborito
+        - Mejoranera:
+          - mejoranera
+      - Taquirari:
+        - taquirari
+        - takirari
+      - Venezuelan Folk:
+        - venezuelan folk
+        - venezuelan folk music
+        - Joropo:
+          - joropo
+        - Malagueña venezolana:
+          - malagueña venezolana
+          - malagueña oriental
+          - malaguena oriental
+          - malaguena venezolana
+        - Música llanera:
+          - música llanera
+          - llanero music
+          - musica llanera
+          - musica llanero
+        - Parranda:
+          - parranda
+        - Polo:
+          - polo
+        - Tambor:
+          - tambor
+          - tambor venezolano
+      - Zamba:
+        - zamba
+    - Indigenous American Traditional:
+      - indigenous american traditional
+      - american indian traditional music
+      - indigenous american traditional music
+      - indigenous music of north america
+      - native american traditional music
+      - traditional native american
+      - Athabaskan Fiddling:
+        - athabaskan fiddling
+        - dene fiddling
+      - Icaro:
+        - icaro
+      - Inuit Vocal Games:
+        - inuit vocal games
+        - iirngaaq
+        - katadjak
+        - katajjaq
+        - nipaquhiit
+        - piqqusiraarniq
+        - pirkusirtuk
+        - qiarvaaqtuq
+      - James Bay Fiddling:
+        - james bay fiddling
+        - james bay cree fiddling
+        - james bay fiddle
+      - Mapuche Folk:
+        - mapuche folk
+        - mapuche folk music
+        - Loncomeo:
+          - loncomeo
+      - Peyote Song:
+        - peyote song
+        - peyote
+        - peyote music
+        - peyote songs
+      - Powwow:
+        - powwow
+        - pau wau music
+        - pow wow
+        - pow wow music
+        - pow-wow
+        - powwow music
+      - Tonada potosina:
+        - tonada potosina
+        - norte potosina
+        - tonada nor potosina
+        - tonada tinku
+        - tunada
+      - Unakesa:
+        - unakesa
+        - cafurna
+    - Indigenous Australian Traditional:
+      - indigenous australian traditional
+      - aboriginal australian and torres strait islander traditional music
+      - indigenous australian traditional music
+      - Djanba:
+        - djanba
+        - dhanba
+        - djunba
+        - thanba
+        - thanpa
+      - Wangga:
+        - wangga
+    - Industrial Folk Song:
+      - industrial folk song
+      - industrial folk music
+      - industrial work song
+    - Inuit:
+      - inuit
+      - inuit music
+      - Tivaner inngernerlu:
+        - tivaner inngernerlu
+        - drum song
+        - drumdancing and drumsinging
+        - east greenlandic drum dance
+        - inngerutit
+        - qilaat music
+      - Uaajeerneq:
+        - uaajeerneq
+        - greenlandic mask dance
+    - Jewish Folk:
+      - jewish folk
+      - Ashkenazi:
+        - ashkenazi
+        - ashkenazi jewish music
+        - ashkenazi music
+      - Klezmer:
+        - klezmer
+        - kleizmer
+        - כליזמר
+        - קלעזמער
+      - Oriental Jewish:
+        - oriental jewish
+        - eastern jewish music
+        - mizrahi jewish music
+        - oriental jewish music
+        - Yemenite:
+          - yemenite
+          - memanim
+          - yemeni jewish
+          - yemenite jewish
+          - yemenite music
+      - Sephardic:
+        - sephardic
+        - muzika sefaradit
+        - muzika sepharadit
+        - muzika sfaradit
+        - muzika spharadit
+        - sefaradic music
+        - sefardi music
+        - sefardic music
+        - sepharadic music
+        - sephardi music
+        - sephardic music
+        - מוזיקה ספרדית
+    - Khakas Traditional:
+      - khakas traditional
+      - khakas traditional music
+      - khakass traditional music
+    - Ladino Folksong:
+      - ladino folksong
+      - ladino folk music
+      - ladino folk song
+      - ladino music
+      - muzikat ladino
+      - shirey ladino
+      - מוזיקת לאדינו
+      - מוזיקת לדינו
+      - שירי לאדינו
+      - שירי לדינו
+    - Mesoamerican Folk:
+      - mesoamerican folk
+      - mesoamerican folk music
+      - Maya:
+        - maya
+        - maya music
+        - mayan music
+      - Nahua:
+        - nahua
+        - aztec music
+        - música azteca
+        - musica azteca
+        - música náhua
+        - musica nahua
+        - música náhuatl
+        - musica nahuatl
+        - nahua music
+        - nahuatl music
+    - Ob-Ugric Folk:
+      - ob-ugric folk
+      - ob ugric folk
+      - ob-ugrian folk music
+      - ob-ugric folk music
+      - народная музыка обско-угорских народов
+      - Payada:
+        - payada
+        - pajada
+        - pallada
+        - paya
+    - Oceanian Folk:
+      - oceanian folk
+      - oceanian folk music
+      - pacific
+      - Hawaiian:
+        - hawaiian
+        - hawai'ian music
+        - hawaiian music
+        - Hula:
+          - hula
+        - Kanikapila:
+          - kanikapila
+      - Himene tarava:
+        - himene tarava
+      - Kantan Chamorrita:
+        - kantan chamorrita
+        - ayotte
+        - chamorrita singing
+      - Māori:
+        - māori
+        - māori music
+        - maori music
+        - pūoro māori
+        - puoro maori
+        - waiata
+        - maori
+      - Papuan Folk:
+        - papuan folk
+        - papuan folk music
+      - Vude:
+        - vude
+    - Polyphonic Chant:
+      - polyphonic chant
+      - polyphonic singing
+    - Quyi:
+      - quyi
+      - qǔyì
+      - shuochang yishu
+      - shuōchàng yìshù
+      - 曲艺
+      - 曲藝
+      - 說唱藝術
+      - 说唱艺术
+    - Romani Folk:
+      - romani folk
+      - gypsy folk music
+      - romani
+      - romani folk music
+      - Hora:
+        - hora
+      - Hora lungă:
+        - hora lungă
+        - hora lunga
+    - Sakha Traditional:
+      - sakha traditional
+      - sakha traditional music
+      - yakut traditional music
+      - Olonkho:
+        - olonkho
+    - Samoyedic Folk:
+      - samoyedic folk
+      - samoyedic folk music
+    - South Asian Folk:
+      - south asian folk
+      - south asian folk music
+      - Assamese Folk:
+        - assamese folk
+        - assamese folk music
+        - Bihu:
+          - bihu
+          - bihu geet
+          - bihu music
+          - bihu naas
+          - bihu songs
+      - Bengali Folk:
+        - bengali folk
+        - bangla folk music
+        - bengali
+        - bengali folk music
+        - bengali geet
+        - bengali music
+        - geet
+        - Baul gaan:
+          - baul gaan
+          - baul
+          - baul gan
+          - baul music
+          - baul sangeet
+          - baul song
+          - বাউল গান
+          - বাউল সঙ্গীত
+      - Bhojpuri Folk:
+        - bhojpuri folk
+        - bhojpuri folk music
+        - bhojpuri lok geet
+        - भोजपुरी लोकगीत
+        - Biraha:
+          - biraha
+          - birha
+          - बिरहा
+        - Chowtal:
+          - chowtal
+          - chautal
+          - chawtal
+          - chowtal music
+      - Boduberu:
+        - boduberu
+        - baburu lava
+        - bodu beru
+        - ބޮޑުބެރު
+      - Burushaski Folk:
+        - burushaski folk
+        - burushaski folk music
+        - hunza folk music
+      - Gar:
+        - gar
+      - Gujarati Folk:
+        - gujarati folk
+        - gujarati folk music
+        - gujarati lok sangeet
+        - sugam sangeet
+        - ગુજરાતી લોકસંગીત
+        - Garba:
+          - garba
+          - garba music
+          - raas garba
+          - गरबा
+          - ગર્બા
+      - Kannada Folk:
+        - kannada folk
+        - janapada geethe
+        - janapada sangeeta
+        - kannada folk music
+        - kannadigaru folk music
+        - ಜಾನಪದ ಸಂಗೀತ
+      - Kirtan:
+        - kirtan
+        - Shabad kirtan:
+          - shabad kirtan
+          - gurbani kirtan
+          - gurmat sangeet
+          - sikh kirtan
+          - ਸ਼ਬਦ ਕੀਰਤਨ
+      - Malayali Folk:
+        - malayali folk
+        - kerala folk music
+        - malayali folk music
+        - Mappila:
+          - mappila
+          - malabar muslim folk
+          - mappila folk
+          - mappila pattu
+          - mappila songs
+        - Melam:
+          - melam
+          - chenda melam
+          - melam music
+      - Mantra:
+        - mantra
+        - mantram
+        - mantras
+        - मन्त्रम्
+        - Vedic Chant:
+          - vedic chant
+          - ved paath
+          - vedic mantra
+          - vedic paath
+          - वैदिक पाठ
+          - वैदिक मंत्र
+          - বৈদিক স্তোত্র
+          - வேத மந்திரங்கள்
+          - వేద మంత్రోచ్ఛారణ
+      - Marathi Folk:
+        - marathi folk
+        - maharashtrian folk music
+        - marathi folk music
+        - Dhol tasha:
+          - dhol tasha
+        - Lavani:
+          - lavani
+          - lavani music
+          - lavani song
+        - Powada:
+          - powada
+      - Nangma:
+        - nangma
+      - Nepali Folk:
+        - nepali folk
+        - nepalese folk music
+        - nepali folk music
+        - nepali lok geet
+        - Panche Baja:
+          - panche baja
+          - pancai baja
+          - panchai baaja
+          - panchai baja
+          - panche baaja
+          - panchje baja
+          - पञ्चे बाजा
+      - Newa Folk:
+        - newa folk
+        - newa folk music
+        - newar folk music
+        - newari folk music
+      - Odia Folk:
+        - odia folk
+        - odia folk music
+        - oriya folk music
+      - Pashto Folk:
+        - pashto folk
+        - pashto folk music
+        - pashtun folk music
+      - Punjabi Folk:
+        - punjabi folk
+        - punjabi folk music
+        - punjabi lok geet
+        - پنجابی لوک گیت
+        - ਪੰਜਾਬੀ ਲੋਕ ਗੀਤ
+        - ਪੰਜਾਬੀ ਲੋਕ ਸੰਗੀਤ
+        - Giddha:
+          - giddha
+      - Rajasthani Folk:
+        - rajasthani folk
+        - rajasthani folk music
+        - rajasthani lok geet
+        - rajasthani lok sangeet
+        - राजस्थानी लोक संगीत
+        - Ravanahatha:
+          - ravanahatha
+          - ravan hatta
+          - ravan hattha
+          - ravana hasta veena
+          - ravanahatta
+          - ravanastron
+          - ravanhatha
+          - ravanhatta
+          - rawanhattha
+      - Sinhalese Folk:
+        - sinhalese folk
+        - sinhala folk music
+        - sinhalese folk music
+        - Sarala gee:
+          - sarala gee
+      - Tamil Folk:
+        - tamil folk
+        - tamil folk music
+        - கிராமிய இசை
+        - Dappankuthu:
+          - dappankuthu
+          - dappan kuthu
+          - kuthu
+        - Gaana:
+          - gaana
+          - gānā
+          - gana
+          - paattu
+          - கானா பாடல்
+        - Urumi melam:
+          - urumi melam
+          - urumee melam
+          - உறுமி மேளம்
+      - Telugu Folk:
+        - telugu folk
+        - janapada geetalu
+        - telugu folk music
+        - జానపద గీతాలు
+        - Burrakatha:
+          - burrakatha
+          - బుర్రకథ
+      - Toeshey:
+        - toeshey
+      - Zhabdro gorgom:
+        - zhabdro gorgom
+        - bödra
+        - bodra
+        - boedra
+        - drukdra
+        - gorgom
+    - Southeast Asian Folk:
+      - southeast asian folk
+      - southeast asian folk music
+      - Balitaw:
+        - balitaw
+      - Bamar Folk:
+        - bamar folk
+        - bamar folk music
+        - burmese folk music
+      - Bantengan:
+        - bantengan
+      - Celempungan:
+        - celempungan
+        - celempung
+        - celempung music
+        - sundanese celempungan
+      - Gambang kromong:
+        - gambang kromong
+        - gambang keromong
+      - Gandrung:
+        - gandrung
+        - gandrung banyuwangi
+        - tari gandrung
+      - Gondang:
+        - gondang
+        - batak folk music
+        - gendang
+      - Harana:
+        - harana
+      - Hmong Folk:
+        - hmong folk
+        - hmong folk music
+      - Joged:
+        - joged
+        - joged dance
+        - Joged bumbung:
+          - joged bumbung
+          - gamelan joged bumbung
+      - Ketuk tilu:
+        - ketuk tilu
+      - Khene:
+        - khene
+        - kaen
+        - ken
+        - khaen
+        - khaen music
+        - khen
+        - khene music
+        - lao khaen
+        - lao khene
+        - แคน
+        - ແຄນ
+      - Khmer Folk:
+        - khmer folk
+        - cambodian folk music
+        - khmer folk music
+        - Kantruem:
+          - kantruem
+          - kantrum
+          - กันตรึม
+          - កន្រ្តឹម
+      - Kliningan:
+        - kliningan
+      - Kuda kepang:
+        - kuda kepang
+        - ebeg
+        - jaran kepang
+        - jaranan
+        - jathilan
+        - sang hyang jaran
+      - Lao Folk:
+        - lao folk
+        - lao folk music
+        - lao music
+        - laotian folk music
+      - Malay Folk:
+        - malay folk
+        - malay folk music
+        - Dikir barat:
+          - dikir barat
+        - Kertok:
+          - kertok
+        - Ronggeng:
+          - ronggeng
+        - Silat:
+          - silat
+          - gendang silat
+          - pencak silat music
+        - Zapin:
+          - zapin
+          - japin
+          - jepen
+          - jepin
+          - zafin
+      - Molam:
+        - molam
+        - maw lam
+        - maw lum
+        - mhor lum
+        - moh lam
+        - mor lam
+        - หมอลำ
+        - ລຳ
+        - Molam sing:
+          - molam sing
+          - lam sing
+          - mor lam sing
+      - Orkes gambus:
+        - orkes gambus
+        - o.g.
+      - Pakacaping:
+        - pakacaping
+        - hasapi
+        - kacapi
+        - kecapi
+        - pakacaping music
+        - sape
+      - Philippine Rondalla:
+        - philippine rondalla
+        - rondalla
+        - rondalya
+      - Tarawangsa:
+        - tarawangsa
+      - Thai Folk:
+        - thai folk
+        - thai folk music
+      - Vietnamese Folk:
+        - vietnamese folk
+        - vietnamese folk music
+        - Ca trù:
+          - ca trù
+          - ca tru
+          - hát ả đào
+          - hat a đao
+          - hát ca trù
+          - hat ca tru
+          - hát chơi
+          - hat choi
+          - hát cô đào
+          - hat co đao
+          - 歌籌
+        - Chèo:
+          - chèo
+          - cheo
+        - Chầu văn:
+          - chầu văn
+          - chau van
+          - hát chầu văn
+          - hát chau van
+          - hat chau van
+          - hát văn
+          - hat van
+        - Ngâm thơ:
+          - ngâm thơ
+          - ngam tho
+          - thơ ngâm
+          - tho ngam
+        - Quan họ:
+          - quan họ
+          - quan ho
+        - Xẩm:
+          - xẩm
+          - hát xẩm
+          - hat xam
+          - xam
+          - 咭眈
+          - 眈
+    - Urtiin duu:
+      - urtiin duu
+      - long song
+      - long-song
+      - urtin duu
+      - urtyn duu
+      - уртын дуу
+      - 长调
+    - Wassoulou:
+      - wassoulou
+      - wassoulou music
+    - West Asian Folk:
+      - west asian folk
+      - middle eastern folk music
+      - southwest asian folk music
+      - traditional middle eastern folk
+      - west asian folk music
+      - Alevi Folk:
+        - alevi folk
+        - alevi deyişi
+        - alevi deyisi
+        - alevi folk music
+        - alevi halk müziği
+        - alevi halk muzigi
+        - alevi music
+        - alevi müziği
+        - alevi muzigi
+        - alevi türküsü
+        - alevi turkusu
+      - Armenian Folk:
+        - armenian folk
+        - armenian folk music
+        - հայկական ժողովրդական երաժշտություն
+        - Kef:
+          - kef
+          - kef music
+          - kef time
+          - քէֆ
+        - Shalakho:
+          - shalakho
+      - Assyrian Folk:
+        - assyrian folk
+        - assyrian folk music
+        - syriac folk music
+        - موسيقى شعبية آشورية سريانية
+        - ܡܘܣܝܩܝ ܣܦܝܢܘܬܐ ܐܬܘܪܝܬܐ
+        - ܡܘܣܝܩܝ ܣܦܝܢܘܬܐ ܣܘܪܝܝܬܐ
+      - Israeli Folk:
+        - israeli folk
+        - israeli folk music
+        - shirei eretz yisra'el
+        - שירי ארץ ישראל
+        - Zemer Ivri:
+          - zemer ivri
+      - Luri Folk:
+        - luri folk
+        - luri folk music
+      - Meyxana:
+        - meyxana
+        - meykhana
+      - Persian Folk:
+        - persian folk
+        - musiqi-e mahali
+        - persian folk music
+        - موسیقی محلی
+        - Bandari:
+          - bandari
+          - بندری
+      - Turkish Folk:
+        - turkish folk
+        - türk halk müziği
+        - turk halk muzigi
+        - turkish folk music
+        - türkü
+        - turku
+        - Ashik:
+          - ashik
+          - ashiq
+          - ashugh
+          - asik
+          - aşık
+          - saz poet
+        - Turkish Black Sea Region Folk:
+          - turkish black sea region folk
+          - black sea folk music
+          - black sea region folk music
+          - karadeniz bölgesi halk müziği
+          - karadeniz bolgesi halk muzigi
+          - karadeniz halk müziği
+          - karadeniz halk muzigi
+          - turkish black sea region folk music
+        - Uzun Hava:
+          - uzun hava
+          - long tune
+          - turkish long melody
+        - Zeybek:
+          - zeybek
+    - Work Song:
+      - work song
+      - work songs
+      - Aboio:
+        - aboio
+        - Aboio cantado:
+          - aboio cantado
+          - aboio em versos
+      - Field Hollers:
+        - field hollers
+        - field calls
+      - Haozi:
+        - haozi
+        - hàozǐ
+        - láodòng hàozǐ
+        - laodong haozi
+        - 劳动号子
+        - 勞動號子
+        - 号子
+        - 號子
+      - Sea Shanty:
+        - sea shanty
+        - chantey
+        - sea shanties
+        - shanty
+      - Shan'ge:
+        - shan'ge
+        - mountain song
+        - shān'gē
+        - 山歌
+    - Yodeling:
+      - yodeling
+      - jodeling
+      - yodel
+      - Naturjodel:
+        - naturjodel
+        - natural yodel
+- Hip Hop:
+  - hip hop
+  - emceeing
+  - hip hop music
+  - hip-hop
+  - mc-ing
+  - mcing
+  - rap
+  - rapping
+  - Abstract Hip Hop:
+    - abstract hip hop
+    - abstract hip-hop
+  - African Hip Hop:
+    - african hip hop
+    - african hip-hop
+    - african rap
+    - Bongo Flava:
+      - bongo flava
+    - Hipco:
+      - hipco
+      - co
+    - Hiplife:
+      - hiplife
+    - Kapuka:
+      - kapuka
+      - boomba music
+      - Genge:
+        - genge
+        - Gengetone:
+          - gengetone
+    - Motswako:
+      - motswako
+  - Afro Trap:
+    - afro trap
+  - Afroswing:
+    - afroswing
+    - afro bashment
+    - afrowave
+    - uk afrobeats
+  - Alternative Hip Hop:
+    - alternative hip hop
+    - alt hip hop
+    - alt hip-hop
+    - alt rap
+    - alternative hip-hop
+    - alternative rap
+    - underground hip hop
+    - underground hip-hop
+    - underground rap
+    - Zef:
+      - zef
+      - zef music
+      - zef rap
+      - zef rave
+  - Arabesque Rap:
+    - arabesque rap
+    - arabesk rap
+    - arabesque hip hop
+    - arabesque hip-hop
+  - Australian Hip Hop:
+    - australian hip hop
+    - aussie hip hop
+    - aussie hip-hop
+    - aussie rap
+    - australian hip-hop
+    - australian rap
+  - Beatboxing:
+    - beatboxing
+    - beatbox
+  - Boom Bap:
+    - boom bap
+  - Bounce:
+    - bounce
+    - bounce music
+    - new orleans bounce
+    - nola bounce
+    - Sissy Bounce:
+      - sissy bounce
+      - trip out
+  - Chipmunk Soul:
+    - chipmunk soul
+    - chipmunk-soul
+  - Chopped and Screwed:
+    - chopped and screwed
+    - screw
+    - screw music
+    - screwed and chopped
+    - slowed and throwed
+  - Christian Hip Hop:
+    - christian hip hop
+    - christian hip-hop
+    - christian rap
+    - gospel rap
+    - holy hip hop
+    - holy hip-hop
+  - Cloud Rap:
+    - cloud rap
+    - trillwave
+  - Comedy Rap:
+    - comedy rap
+    - comedy hip hop
+    - comedy hip-hop
+    - Chap Hop:
+      - chap hop
+      - chap-hop
+      - gentleman rap
+  - Conscious Hip Hop:
+    - conscious hip hop
+    - conscious
+    - conscious hip-hop
+    - conscious rap
+  - Country Rap:
+    - country rap
+    - hick hop
+    - hick-hop
+    - rural rap
+    - Country Trap:
+      - country trap
+      - country-rap
+      - country-trap
+      - trap country
+  - Crunkcore:
+    - crunkcore
+    - scrunk
+  - Desi Hip Hop:
+    - desi hip hop
+    - bangladeshi hip hop
+    - bangladeshi hip-hop
+    - bangladeshi rap
+    - desi hip-hop
+    - dhh
+    - nepalese hip hop
+    - nepalese hip-hop
+    - nepali hip hop
+    - nepali hip-hop
+    - nepali rap
+    - nephop
+    - pakistani hip hop
+    - pakistani hip-hop
+    - pakistani rap
+    - sri lankan hip hop
+    - sri lankan hip-hop
+    - sri lankan rap
+  - Digicore:
+    - digicore
+    - glitchcore
+  - Dirty Rap:
+    - dirty rap
+    - dirty hip hop
+    - dirty hip-hop
+    - porn rap
+    - porno rap
+    - sex rap
+  - Disco Rap:
+    - disco rap
+  - Drill:
+    - drill
+    - drill music
+    - drill rap
+    - Chicago Drill:
+      - chicago drill
+      - chiraq drill
+      - Bop:
+        - bop
+        - bopping music
+        - chicago bop
+    - Detroit Drill:
+      - detroit drill
+      - detroit drill music
+    - Free Car:
+      - free car
+      - dc drill
+      - dmv drill
+      - free car music
+    - Jersey Drill:
+      - jersey drill
+      - club drill
+      - jersey club drill
+      - jersey club drill rap
+    - New York Drill:
+      - new york drill
+      - ny drill
+      - Sample Drill:
+        - sample drill
+        - soul drill
+      - Sexy Drill:
+        - sexy drill
+    - Philly Drill:
+      - philly drill
+    - UK Drill:
+      - uk drill
+  - Drumless:
+    - drumless
+  - East Coast Hip Hop:
+    - east coast hip hop
+    - east coast hip-hop
+    - east coast rap
+    - Bronx Drill:
+      - bronx drill
+      - bx drill
+    - Brooklyn Drill:
+      - brooklyn drill
+      - bk drill
+    - Jersey Club Rap:
+      - jersey club rap
+    - Philly Club Rap:
+      - philly club rap
+  - Emo Rap:
+    - emo rap
+    - emo hip hop
+    - emo hip-hop
+    - emo trap
+  - Experimental Hip Hop:
+    - experimental hip hop
+    - experimental hip-hop
+    - experimental rap
+    - Industrial Hip Hop:
+      - industrial hip hop
+      - industrial hip-hop
+      - noise rap
+  - French Hip Hop:
+    - french hip hop
+    - french hip-hop
+    - french rap
+    - hip hop français
+    - hip hop francais
+    - hip-hop français
+    - hip-hop francais
+    - rap fr
+    - rap français
+    - rap francais
+  - Funk brasileiro:
+    - funk brasileiro
+    - baile funk
+    - brazilian funk
+    - Arrocha funk:
+      - arrocha funk
+      - arrocha-funk
+      - funk arrochado
+    - Beat bolha:
+      - beat bolha
+      - bubble beat
+      - tambor bolha
+    - Beat fino:
+      - beat fino
+      - beat série gold
+      - beat serie gold
+      - funk capixaba
+      - série gold
+      - serie gold
+    - Funk 150 bpm:
+      - funk 150 bpm
+    - Funk carioca:
+      - funk carioca
+      - favela funk
+      - Funk proibidão:
+        - funk proibidão
+        - funk proibidao
+        - funk realidade
+        - proibidão
+        - proibidao
+    - Funk consciente:
+      - funk consciente
+      - funk de protesto
+    - Funk de BH:
+      - funk de bh
+      - funk de belo horizonte
+      - funk mineiro
+    - Funk ostentação:
+      - funk ostentação
+      - funk ostentacao
+    - Funk Ousadia:
+      - funk ousadia
+      - funk ousadia paulista
+    - Rasteirinha:
+      - rasteirinha
+      - axé funk
+      - axe funk
+      - funk rasteirinha
+      - ragga funk
+    - Trapfunk:
+      - trapfunk
+      - trap funk
+  - Hanmai:
+    - hanmai
+    - 喊麦
+  - Hardcore Hip Hop:
+    - hardcore hip hop
+    - hardcore hip-hop
+    - hardcore rap
+    - Britcore:
+      - britcore
+    - Chopper:
+      - chopper
+      - chopper rap
+      - midwest chopper
+    - Gangsta Rap:
+      - gangsta rap
+      - gangsta
+      - gangster rap
+      - thug
+      - thug rap
+      - Coke Rap:
+        - coke rap
+        - cocaine rap
+      - Mafioso Rap:
+        - mafioso rap
+      - Road Rap:
+        - road rap
+        - gangster grime
+      - Scam Rap:
+        - scam rap
+    - Horrorcore:
+      - horrorcore
+      - horror rap
+      - horrorcore rap
+    - Memphis Rap:
+      - memphis rap
+      - memphis hip hop
+      - memphis hip-hop
+      - Dungeon Rap:
+        - dungeon rap
+      - Phonk:
+        - phonk
+        - trap phonk
+        - Rare Phonk:
+          - rare phonk
+          - chill phonk
+          - cloud phonk
+    - Mid-School Hip Hop:
+      - mid-school hip hop
+      - mid school hip hop
+      - mid-school hip-hop
+      - mid-school rap
+  - Hip-hopolo:
+    - hip-hopolo
+    - hip hopolo
+  - Hookah Rap:
+    - hookah rap
+    - hookah pop
+    - kalyan rap
+    - kalyanny rap
+    - кальянный рэп
+  - Instrumental Hip Hop:
+    - instrumental hip hop
+    - instrumental hip-hop
+    - LA Beat Scene:
+      - la beat scene
+      - los angeles beat scene
+  - Japanese Hip Hop:
+    - japanese hip hop
+    - j hop
+    - j-hop
+    - j-rap
+    - japanese hip-hop
+    - japanese rap
+  - Jazz Rap:
+    - jazz rap
+    - jazz hip hop
+    - jazz hip-hop
+    - jazz hop
+    - jazz-hop
+    - jazz-rap
+    - jazzy hip hop
+    - jazzy hip-hop
+  - Jerk:
+    - jerk
+    - hoodtrap
+    - jerknb
+  - Jigg:
+    - jigg
+  - Korean Hip Hop:
+    - korean hip hop
+    - k hop
+    - k-hip hop
+    - k-hip-hop
+    - k-hop
+    - k-rap
+    - korean hip-hop
+    - korean rap
+  - Latin Rap:
+    - latin rap
+    - latin hip hop
+    - latin hip-hop
+    - rap latino
+    - Chicano Rap:
+      - chicano rap
+  - Lo-fi Hip Hop:
+    - lo-fi hip hop
+    - chill hop
+    - chill-hop
+    - chillhop
+    - lo fi hip hop
+    - lo fi hip-hop
+    - lo-fi hip-hop
+    - lofi hip hop
+    - lofi hip-hop
+    - low-fi hip hop
+    - low-fi hip-hop
+  - Low Bap:
+    - low bap
+  - Midwest Hip Hop:
+    - midwest hip hop
+    - midwest hip-hop
+    - midwest rap
+    - midwestern hip hop
+    - midwestern hip-hop
+    - Detroit Sound:
+      - detroit sound
+      - Flint Sound:
+        - flint sound
+    - Lowend:
+      - lowend
+      - low-end
+  - Mumble Rap:
+    - mumble rap
+    - mumble hip hop
+    - mumble hip-hop
+    - mumble trap
+  - Nerdcore Hip Hop:
+    - nerdcore hip hop
+    - geeksta rap
+    - nerdcore hip-hop
+    - nerdcore rap
+  - Nervous:
+    - nervous
+    - nervous music
+    - traffic music
+  - New School Hip Hop:
+    - new school hip hop
+    - new school hip-hop
+    - new school rap
+    - new-school hip hop
+    - new-school hip-hop
+    - new-school rap
+    - Golden Age Hip Hop:
+      - golden age hip hop
+      - golden age hip-hop
+      - golden age rap
+  - Old-School Hip Hop:
+    - old-school hip hop
+    - old school hip hop
+    - old school hip-hop
+    - old school rap
+    - old skool hip hop
+    - old skool hip-hop
+    - old skool rap
+    - old-school hip-hop
+    - old-school rap
+  - Political Hip Hop:
+    - political hip hop
+    - political hip-hop
+    - political rap
+  - Pop Rap:
     - pop rap
-    - popera
-    - psychedelic pop
-    - schlager
-    - soft rock
-    - sophisti-pop
-    - space age pop
-    - sunshine pop
-    - surf pop
-    - teen pop
-    - traditional pop music
-    - turkish pop
-    - vispop
-    - wonky pop
-- rhythm and blues:
-    - funk:
-        - deep funk
-        - go-go
-        - p-funk
-    - soul:
-        - blue-eyed soul
-        - neo soul
-        - northern soul
-- rock:
-    - alternative rock:
-        - britpop:
-            - post-britpop
-        - dream pop
-        - grunge:
-            - post-grunge
-        - indie pop:
-            - dunedin sound
-            - twee pop
-        - indie rock
-        - noise pop
-        - nu metal
-        - post-punk revival
-        - post-rock:
-            - post-metal
-        - sadcore
-        - shoegaze
-        - slowcore
-    - art rock
-    - beat music
-    - chinese rock
-    - christian rock
-    - classic rock
-    - dark cabaret
-    - desert rock
-    - experimental rock
-    - folk rock
-    - garage rock
-    - glam rock
-    - hard rock
-    - heavy metal:
-        - alternative metal:
-            - funk metal
-        - black metal:
-            - viking metal
-        - christian metal
-        - death metal:
-            - death/doom
-            - goregrind
-            - melodic death metal
-            - technical death metal
-        - doom metal:
-            - epic doom metal
-            - funeral doom
-        - drone metal
-        - epic metal
-        - folk metal:
-            - celtic metal
-            - medieval metal
-            - pagan metal
-        - funk metal
-        - glam metal
-        - gothic metal
-        - industrial metal:
-            - industrial death metal
-        - metalcore:
-            - deathcore
-            - mathcore:
-                - djent
-            - synthcore
-        - neoclassical metal
-        - post-metal
-        - power metal:
-            - progressive power metal
-        - progressive metal
+    - pop-rap
+    - Frat Rap:
+      - frat rap
+      - campus hip hop
+      - campus hip-hop
+      - college rap
+    - Futuristic Swag:
+      - futuristic swag
+      - futuristic
+  - Ragga Hip Hop:
+    - ragga hip hop
+    - ragga hip-hop
+  - Ratchet:
+    - ratchet
+  - Sigilkore:
+    - sigilkore
+  - Southern Hip Hop:
+    - southern hip hop
+    - southern hip-hop
+    - southern rap
+    - texas rap
+    - Atlanta Hip Hop:
+      - atlanta hip hop
+      - atlanta hip-hop
+      - atlanta rap
+    - Crunk:
+      - crunk
+      - get-buck
+    - Dirty South:
+      - dirty south
+    - Houston Sound:
+      - houston sound
+      - houston style
+    - Jook:
+      - jook
+      - jookin'
+    - Miami Bass:
+      - miami bass
+      - bass music
+      - booty bass
+      - booty music
+      - Atlanta Bass:
+        - atlanta bass
+        - atl bass
+      - Florida Fast:
+        - florida fast
+        - broward county fast music
+        - fast music
+        - florida fast music
+        - miami fast music
+      - Tamborzão:
+        - tamborzão
+        - tamborzao
+      - Techno Bass:
+        - techno bass
+        - Car Audio Bass:
+          - car audio bass
+          - audio bass
+    - Snap:
+      - snap
+      - snap music
+    - South Florida SoundCloud Rap:
+      - south florida soundcloud rap
+  - Stoner Rap:
+    - stoner rap
+    - weed rap
+  - Trap:
+    - trap
+    - trap music
+    - trap rap
+    - New Jazz:
+      - new jazz
+      - new-jazz
+    - No Melody:
+      - no melody
+    - Plugg:
+      - plugg
+      - plug
+      - plugg music
+      - Ambient Plugg:
+        - ambient plugg
+        - nod
+      - Dark Plugg:
+        - dark plugg
+        - dark plug
+        - dmv plugg
+        - evil plugg
+      - PluggnB:
+        - pluggnb
+        - plugg&b
+      - Terror Plugg:
+        - terror plugg
+        - alarm plugg
+        - terror bass
+    - Rage:
+      - rage
+      - hypertrap
+      - rage beats
+      - rage music
+      - rage rap
+    - Regalia:
+      - regalia
+    - Trap latino:
+      - trap latino
+      - latin trap
+    - Trap Metal:
+      - trap metal
+      - hardcore trap
+      - industrial trap
+      - trap-metal
+    - Trap shaabi:
+      - trap shaabi
+      - shaabi trap
+      - trap chaabi
+      - trap sha3bi
+      - trap sha3by
+      - trap shaaby
+      - تراب شعبي
+    - Tread:
+      - tread
+      - tread rap
+  - Turntablism:
+    - turntablism
+    - Beat Juggling:
+      - beat juggling
+    - Scratching:
+      - scratching
+      - scratch music
+  - UK Hip Hop:
+    - uk hip hop
+    - brithop
+    - british hip hop
+    - british hip-hop
+    - british rap
+    - uk hip-hop
+    - uk rap
+  - Urban Pasifika:
+    - urban pasifika
+    - urban pacific
+    - urban pacifika
+  - West Coast Hip Hop:
+    - west coast hip hop
+    - bay area rap
+    - west coast hip-hop
+    - west coast rap
+    - G-Funk:
+      - g-funk
+      - g funk
+      - gangsta funk
+    - Hyphy:
+      - hyphy
+      - Jerk Rap:
+        - jerk rap
+        - jerk music
+        - jerkin'
+    - Mobb:
+      - mobb
+      - mobb music
+- Jazz:
+  - jazz
+  - improvised jazz
+  - jas
+  - jass
+  - jazz improv
+  - jazz improvisation
+  - Afro-Jazz:
+    - afro-jazz
+    - african jazz
+    - afro jazz
+  - Arabic Jazz:
+    - arabic jazz
+    - arabic-jazz
+  - Avant-Garde Jazz:
+    - avant-garde jazz
+    - avant garde jazz
+    - avant-garde-jazz
+    - avant-jazz
+    - experimental jazz
+    - Free Funk:
+      - free funk
+      - free-funk
+    - Free Jazz:
+      - free jazz
+      - free-form jazz
+      - free-jazz
+      - modern free
+      - European Free Jazz:
+        - european free jazz
+        - fmp style free jazz
+    - M-Base:
+      - m-base
+      - m base
+      - mbase
+    - Yass:
+      - yass
+  - Bebop:
+    - bebop
+    - bop [jazz]
+  - Big Band:
+    - big band
+    - big band music
+    - modern big band
+    - British Dance Band:
+      - british dance band
+      - british dance bands
+    - Experimental Big Band:
+      - experimental big band
+    - Luk krung:
+      - luk krung
+      - look krung
+      - luk grung
+      - phleng luk krung
+      - thai city music
+      - ลูกกรุง
+      - Lilat:
+        - lilat
+        - leelart
+        - leelat
+        - thai ballroom music
+        - ลีลาศ
+    - Orchestral Jazz:
+      - orchestral jazz
+    - Progressive Big Band:
+      - progressive big band
+      - progressive jazz
+  - Bulawayo Jazz:
+    - bulawayo jazz
+    - bulawayo-jazz
+  - Cape Jazz:
+    - cape jazz
+    - cape-jazz
+  - Cartoon Music:
+    - cartoon music
+    - cartoon
+    - mickey mousing
+    - mickey-mousing
+  - Chamber Jazz:
+    - chamber jazz
+    - chamber-jazz
+  - Contemporary Jazz:
+    - contemporary jazz
+    - contemporary-jazz
+    - ECM Style Jazz:
+      - ecm style jazz
+      - ecm third stream
+      - nordic tone
+      - scandinavian jazz
+    - Jazz Fusion:
+      - jazz fusion
+      - crossover jazz
+      - electric jazz
+      - fusion
+      - fusion jazz
+    - Jazz Pop:
+      - jazz pop
+      - jazz-pop
+      - pop jazz
+      - pop-jazz
+    - Jazz-Funk:
+      - jazz-funk
+      - jazz funk
+    - Smooth Jazz:
+      - smooth jazz
+      - smooth-jazz
+  - Cool Jazz:
+    - cool jazz
+    - cool
+    - cool-jazz
+    - West Coast Jazz:
+      - west coast jazz
+      - west coast cool
+  - Crime Jazz:
+    - crime jazz
+    - crime-jazz
+    - detective music
+    - noir jazz
+  - Dark Jazz:
+    - dark jazz
+    - dark-jazz
+    - doom jazz
+  - Dixieland:
+    - dixieland
+    - dixieland jazz
+    - hot jazz
+    - new orleans jazz
+    - new orleans jazz revival
+    - trad jazz
+    - traditional jazz
+    - British Trad Jazz:
+      - british trad jazz
+      - british traditional jazz
+  - Dutch Jazz:
+    - dutch jazz
+  - Ethio-Jazz:
+    - ethio-jazz
+    - ethio jazz
+    - ethiopian jazz
+  - Flamenco Jazz:
+    - flamenco jazz
+    - flamenco-jazz
+    - jazz flamenco
+  - Folk Jazz:
+    - folk jazz
+    - folk-jazz
+    - jazz folk
+    - jazz-folk
+  - Hard Bop:
+    - hard bop
+    - Neo-Bop:
+      - neo-bop
+      - neo bop
+      - neobop
+  - Harlem Renaissance:
+    - harlem renaissance
+    - new negro movement
+    - new negro renaissance
+  - Indo Jazz:
+    - indo jazz
+    - indian jazz fusion
+    - indo jazz fusion
+    - indo-jazz
+  - Jazz guachaca:
+    - jazz guachaca
+    - jazz huachaca
+  - Jazz manouche:
+    - jazz manouche
+    - gypsy jazz
+    - gypsy swing
+    - hot club jazz
+    - manouche
+    - manouche jazz
+  - Jazz Poetry:
+    - jazz poetry
+  - Kréyol djaz:
+    - kréyol djaz
+    - creole jazz
+    - jazz créole
+    - jazz creole
+    - kreyol djaz
+  - Latin Jazz:
+    - latin jazz
+    - latin-jazz
+    - Afro-Cuban Jazz:
+      - afro-cuban jazz
+      - afro cuban jazz
+      - afro-cuban
+      - afro-cuban-jazz
+    - Bossa nova:
+      - bossa nova
+      - bossa nova jazz
+    - Choro:
+      - choro
+      - chorinho
+      - Samba-choro:
+        - samba-choro
+        - samba choro
+    - Descarga:
+      - descarga
+    - Filin:
+      - filin
+      - bolero jazz
+      - bolero-jazz
+    - Latin Big Band:
+      - latin big band
+      - latin big-band
+    - Samba-jazz:
+      - samba-jazz
+      - jazz-samba
+      - mpm
+      - samba jazz
+    - Songo:
+      - songo
+      - songo music
+  - Loft Jazz:
+    - loft jazz
+    - loft era
+    - loft scene
+    - loft-jazz
+  - New London Jazz:
+    - new london jazz
+    - london jazz scene
+    - new wave of british jazz
+  - New Orleans Brass Band:
+    - new orleans brass band
+    - new orleans brass bands
+  - Pansy Craze:
+    - pansy craze
+  - Post-Bop:
+    - post-bop
+    - post bop
+  - Ragtime:
+    - ragtime
+    - rag
+    - ragtime jazz
+    - Cakewalk:
+      - cakewalk
+    - Honky-Tonk Piano:
+      - honky-tonk piano
+      - honky tonk piano
+    - Novelty Piano:
+      - novelty piano
+      - novelty ragtime
+    - Ragtime Song:
+      - ragtime song
+      - vocal rag
+      - vocal ragtime
+    - Slow Drag:
+      - slow drag
+    - Stride:
+      - stride
+      - harlem stride
+      - harlem stride piano
+      - stride piano
+  - Soul Jazz:
+    - soul jazz
+    - soul jazz groove
+    - soul-jazz
+    - Organ Trio:
+      - organ trio
+      - hammond organ trio
+      - jazz organ trio
+  - Spiritual Jazz:
+    - spiritual jazz
+    - astral jazz
+    - spiritual-jazz
+  - Spy Music:
+    - spy music
+    - spy
+    - spy jazz
+  - Sweet Jazz:
+    - sweet jazz
+    - sweet band
+    - sweet bands
+    - sweet music
+    - sweet orchestra
+    - sweet-jazz
+  - Swing:
+    - swing
+    - jitterbug
+    - jitterbug music
+    - jive
+    - jive dance
+    - jive music
+    - swing music
+    - Swing Revival:
+      - swing revival
+      - neoswing
+      - retro swing
+  - Third Stream:
+    - third stream
+  - Township Jazz:
+    - township jazz
+    - Marabi:
+      - marabi
+      - Kwela:
+        - kwela
+        - pennywhistle kwela
+      - Mbaqanga:
+        - mbaqanga
+        - mbaqanga jazz
+    - Modal Jazz:
+      - modal jazz
+      - modal music
+      - modal-jazz
+      - Jazz Mugham:
+        - jazz mugham
+        - caz-muğam
+        - caz-mugam
+        - mugham jazz
+  - Vocal Jazz:
+    - vocal jazz
+    - bop vocals
+    - contemporary jazz vocals
+    - early jazz vocals
+    - modern jazz vocals
+    - vocal-jazz
+    - Vocalese:
+      - vocalese
+- Metal:
+  - metal
+  - metal music
+  - African Heavy Metal:
+    - african heavy metal
+    - african metal
+  - Alternative Metal:
+    - alternative metal
+    - alt metal
+    - alt-metal
+    - alternative-metal
+    - Funk Metal:
+      - funk metal
+      - funk-metal
+    - Neue Deutsche Härte:
+      - neue deutsche härte
+      - ndh
+      - neue deutsche harte
+      - new german hardness
+      - tanzmetall
+    - Nu Metal:
+      - nu metal
+      - nü metal
+      - nü-metal
+      - nu-metal
+  - Avant-Garde Metal:
+    - avant-garde metal
+    - avant garde metal
+    - avant-garde-metal
+    - avant-metal
+    - avantgarde metal
+    - experimental metal
+  - Christian Metal:
+    - christian metal
+    - heavenly metal
+    - jesus metal
+  - Djent:
+    - djent
+    - math metal
+    - Thall:
+      - thall
+  - Drone Metal:
+    - drone metal
+    - doom drone
+    - drone doom
+    - drone doom metal
+    - drone-metal
+  - Extreme Metal:
+    - extreme metal
+    - Black Metal:
+      - black metal
+      - black-metal
+      - Atmospheric Black Metal:
+        - atmospheric black metal
+        - atmoblack
+        - Blackgaze:
+          - blackgaze
+      - Black 'n' Roll:
+        - black 'n' roll
+      - Cascadian Black Metal:
+        - cascadian black metal
+      - Depressive Suicidal Black Metal:
+        - depressive suicidal black metal
+        - depressive black metal
+        - dsbm
+        - suicidal black metal
+      - Dissonant Black Metal:
+        - dissonant black metal
+        - dissoblack
+      - Hellenic Black Metal:
+        - hellenic black metal
+      - Melodic Black Metal:
+        - melodic black metal
+        - meloblack
+      - Pagan Black Metal:
+        - pagan black metal
+        - pagan black
+      - RABM:
+        - rabm
+        - red and anarchist black metal
+      - Symphonic Black Metal:
+        - symphonic black metal
+      - Unblack Metal:
+        - unblack metal
+        - christian black metal
+        - unblack-metal
+        - unblackened metal
+        - white metal
+      - War Metal:
+        - war metal
+        - bestial black metal
+        - war-metal
+    - Death 'n' Roll:
+      - death 'n' roll
+      - death & roll
+      - Melodic Death Metal:
+        - melodic death metal
+        - mdm
+        - melodeath
+        - Gothenburg Sound:
+          - gothenburg sound
+      - Progressive Death Metal:
+        - progressive death metal
+      - Technical Death Metal:
+        - technical death metal
+        - tech death
+        - Dissonant Death Metal:
+          - dissonant death metal
+          - dissodeath
+          - skronk death metal
+          - skronk-death
+    - Death Metal:
+      - death metal
+      - death-metal
+      - Blackened Death Metal:
+        - blackened death metal
+        - black death metal
+        - black/death metal
+        - death/black metal
+      - Brutal Death Metal:
+        - brutal death metal
+        - Slam Death Metal:
+          - slam death metal
+          - slam metal
+          - slamming brutal death metal
+          - slamming death metal
+    - Doom Metal:
+      - doom metal
+      - doom
+      - doom-metal
+      - Death Doom Metal:
+        - death doom metal
+        - death/doom
+        - death doom
+        - death-doom
+        - doom death
+      - Funeral Doom Metal:
+        - funeral doom metal
+        - funeral doom
+      - Sludge Metal:
         - sludge metal
-        - speed metal
-        - stoner rock:
-            - stoner metal
-        - symphonic metal
-        - thrash metal:
-            - crossover thrash
-            - groove metal
-            - progressive thrash metal
-            - teutonic thrash metal
-        - traditional heavy metal
-    - math rock
-    - new wave:
-        - world fusion
-    - paisley underground
-    - pop rock
-    - post-punk:
-        - gothic rock
-        - no wave
-        - noise rock
-    - power pop
-    - progressive rock:
-        - canterbury scene
-        - krautrock
-        - new prog
-        - rock in opposition
-    - psychedelic rock:
-        - acid rock
-        - freakbeat
-        - neo-psychedelia
-        - raga rock
-    - punk rock:
-        - anarcho punk:
-            - crust punk:
-                - d-beat
-        - art punk
-        - christian punk
-        - deathrock
-        - deutschpunk
-        - folk punk:
-            - celtic punk
-            - gypsy punk
-        - garage punk
-        - grindcore:
-            - crustgrind
-            - noisegrind
-        - hardcore punk:
-            - post-hardcore:
-                - emo:
-                    - screamo
-            - powerviolence
-            - street punk
-            - thrashcore
-        - horror punk
-        - oi!
-        - pop punk
-        - psychobilly
-        - riot grrrl
-        - ska punk:
-            - ska-core
-        - skate punk
-    - rock and roll
-    - southern rock
-    - sufi rock
-    - surf rock
-    - visual kei:
-        - nagoya kei
-- reggae:
-    - roots reggae
-    - reggae fusion
-    - reggae en español:
-        - spanish reggae
-        - reggae 110
-        - reggae bultrón
-        - romantic flow
-    - lovers rock
-    - raggamuffin:
-        - ragga
-    - dancehall
-    - ska:
-        - 2 tone
-        - rocksteady
-    - dub
-- soundtrack:
-- singer-songwriter:
-    - cantautorato
-    - cantautor
-    - cantautora
-    - chanson
-    - canción de autor
-    - nueva canción
-- world:
-    - world dub
-    - world fusion
+        - sludge
+        - sludge-metal
+        - Atmospheric Sludge Metal:
+          - atmospheric sludge metal
+          - atmosludge
+          - atmospheric sludge
+        - NOLA Sludge:
+          - nola sludge
+          - new orleans sludge
+          - nola sludge metal
+          - nola sound
+        - Southern Metal:
+          - southern metal
+          - southern-metal
+      - Stoner Metal:
+        - stoner metal
+        - stoner-metal
+      - Traditional Doom Metal:
+        - traditional doom metal
+        - trad doom
+        - trad doom metal
+        - Epic Doom Metal:
+          - epic doom metal
+          - epic doom
+    - Thrash Metal:
+      - thrash metal
+      - thrash
+      - thrash-metal
+      - Bay Area Thrash Metal:
+        - bay area thrash metal
+        - bay area thrash
+      - Crossover Thrash:
+        - crossover thrash
+        - crossover
+        - crossover thrash metal
+      - Progressive Thrash Metal:
+        - progressive thrash metal
+      - Technical Thrash Metal:
+        - technical thrash metal
+        - technical thrash
+      - Teutonic Thrash Metal:
+        - teutonic thrash metal
+        - german thrash metal
+  - Folk Metal:
+    - folk metal
+    - folk-metal
+    - Celtic Metal:
+      - celtic metal
+      - celtic folk metal
+      - celtic-metal
+    - Mittelalter-Metal:
+      - mittelalter-metal
+      - medieval metal
+      - mittelalter metal
+    - Oriental Metal:
+      - oriental metal
+      - middle eastern metal
+    - Pirate Metal:
+      - pirate metal
+      - pirate-metal
+    - Viking Metal:
+      - viking metal
+      - viking-metal
+  - Gothic Metal:
+    - gothic metal
+    - goth metal
+    - gothic-metal
+  - Grindcore:
+    - grindcore
+    - grind
+    - Cybergrind:
+      - cybergrind
+      - electrogrind
+    - Deathgrind:
+      - deathgrind
+    - Goregrind:
+      - goregrind
+      - Pornogrind:
+        - pornogrind
+        - groovy goregrind
+        - porngrind
+        - pornogore
+    - Mincecore:
+      - mincecore
+      - mince
+    - Noisegrind:
+      - noisegrind
+      - grindnoise
+  - Groove Metal:
+    - groove metal
+    - groove-metal
+    - post-thrash
+  - Heavy Metal:
+    - heavy metal
+    - heavy metal music
+    - heavy-metal
+    - traditional heavy metal
+    - traditional metal
+    - Epic Metal:
+      - epic metal
+      - epic heavy metal
+    - Glam Metal:
+      - glam metal
+      - glam-metal
+      - hair metal
+      - Sleaze Rock:
+        - sleaze rock
+        - sleaze
+        - sleaze glam
+        - sleaze metal
+        - sleaze-rock
+      - Sunset Strip Glam Metal:
+        - sunset strip glam metal
+        - hollywood glam metal
+    - NWOBHM:
+      - nwobhm
+      - new wave of british heavy metal
+    - Speed Metal:
+      - speed metal
+      - speed-metal
+    - US Power Metal:
+      - us power metal
+      - united states power metal
+      - uspm
+  - Industrial Metal:
+    - industrial metal
+    - industrial-metal
+    - Cyber Metal:
+      - cyber metal
+      - cyber-metal
+    - Industrial Death Metal:
+      - industrial death metal
+    - Industrial Thrash Metal:
+      - industrial thrash metal
+  - Kawaii Metal:
+    - kawaii metal
+    - idol metal
+    - kawaii-metal
+    - kawaiicore
+    - かわいいメタル
+  - Latin Metal:
+    - latin metal
+    - heavy metal en español
+    - latin-metal
+    - metal latino
+    - heavy metal en espanol
+  - Metalcore:
+    - metalcore
+    - metallic hardcore
+    - mxc
+    - Deathcore:
+      - deathcore
+      - dxc
+      - Downtempo Deathcore:
+        - downtempo deathcore
+        - funeral deathcore
+        - sludgewave
+    - Holy Terror:
+      - holy terror
+      - holy terror church of final judgement
+    - Mathcore:
+      - mathcore
+    - Melodic Metalcore:
+      - melodic metalcore
+  - Neoclassical Metal:
+    - neoclassical metal
+    - neo classical metal
+    - neo-classical metal
+    - neoclassical-metal
+    - shred metal
+  - Post-Metal:
+    - post-metal
+    - post metal
+    - Doomgaze:
+      - doomgaze
+  - Power Metal:
+    - power metal
+    - eupm
+    - european power metal
+    - power-metal
+    - Symphonic Metal:
+      - symphonic metal
+      - symphonic-metal
+      - Trance Metal:
+        - trance metal
+        - trance-metal
+  - Progressive Metal:
+    - progressive metal
+    - prog metal
+    - progressive-metal
+- New Age:
+  - new age
+  - new age music
+  - new-age
+  - new-age music
+  - Andean New Age:
+    - andean new age
+  - Celtic New Age:
+    - celtic new age
+  - Mystical Minimalism:
+    - mystical minimalism
+  - Native American New Age:
+    - native american new age
+  - Neoclassical New Age:
+    - neoclassical new age
+  - New Age Kirtan:
+    - new age kirtan
+  - Tibetan New Age:
+    - tibetan new age
+- Performance:
+  - performance
+  - audio performance
+  - Cabaret:
+    - cabaret
+    - Dark Cabaret:
+      - dark cabaret
+    - Dutch Cabaret:
+      - dutch cabaret
+    - Kabarett:
+      - kabarett
+    - Punk Cabaret:
+      - punk cabaret
+      - cabaret punk
+  - Change Ringing:
+    - change ringing
+  - Comedy:
+    - comedy
+    - comedy music
+    - spoken comedy
+    - Blue Comedy:
+      - blue comedy
+      - blue humor
+      - blue humour
+    - Break-In:
+      - break-in
+      - break in
+    - Improvisational Comedy:
+      - improvisational comedy
+      - improv
+      - improv comedy
+    - Observational Comedy:
+      - observational comedy
+      - observational humor
+      - observational humour
+    - Parody Music:
+      - parody music
+      - musical parody
+      - parody
+      - song parody
+    - Political Comedy:
+      - political comedy
+    - Prank Calls:
+      - prank calls
+      - crank calls
+    - Rakugo:
+      - rakugo
+    - Satire:
+      - satire
+    - Sketch Comedy:
+      - sketch comedy
+      - skit comedy
+    - Stand-Up Comedy:
+      - stand-up comedy
+      - stand up comedy
+      - stand-up
+      - standup
+      - standup comedy
+    - Vaudeville:
+      - vaudeville
+      - Siffleur:
+        - siffleur
+        - siffleuse
+        - whistling
+  - Incidental Music:
+    - incidental music
+    - incidental
+  - Spoken Word:
+    - spoken word
+    - spoken word performance
+    - spoken-word
+    - Poetry:
+      - poetry
+      - poetry reading
+      - poetry readings
+      - recited poetry
+      - spoken word poetry
+      - Beat Poetry:
+        - beat poetry
+        - beat generation
+        - beat movement
+        - beatnik poetry
+      - Cowboy Poetry:
+        - cowboy poetry
+      - Ottava rima:
+        - ottava rima
+        - ottava rima stanza
+      - Slam Poetry:
+        - slam poetry
+        - poetry slam
+      - Tassu:
+        - tassu
+        - taasu
+        - tasso
+        - tassou
+      - Zajal:
+        - zajal
+        - زجل
+  - Theatre:
+    - theatre
+    - musical theater
+    - musical theatre
+    - plays
+    - theater
+    - theater music
+    - theater performance
+    - theatre music
+    - theatre performance
+    - theatrical
+    - theatrical performance
+    - Bangsawan:
+      - bangsawan
+      - bangsawan theater
+      - bangsawan theatre
+      - malay opera
+    - Bunraku:
+      - bunraku
+      - ningyō jōruri
+      - ningyo joruri
+      - 人形浄瑠璃
+      - 文楽
+    - Circus Music:
+      - circus music
+      - carnival music
+      - circus
+    - Cuplé:
+      - cuplé
+      - cuple
+    - Cải lương:
+      - cải lương
+      - cai luong
+    - Hát lô tô:
+      - hát lô tô
+      - hat lo to
+      - kêu lô tô
+      - keu lo to
+      - lotto singing
+    - Kabuki:
+      - kabuki
+      - kabuki theater
+      - kabuki theatre
+      - 歌舞伎
+    - Kanto:
+      - kanto
+      - canto
+    - Kecak:
+      - kecak
+      - kechak
+      - ketjak
+    - Lhamo:
+      - lhamo
+      - ache lhamo
+      - lha mo
+      - tibetan opera
+      - tibetan theater
+      - tibetan theatre
+    - Minstrelsy:
+      - minstrelsy
+      - blackface minstrelsy
+      - minstrel
+      - minstrel show
+      - minstrel song
+      - Coon Song:
+        - coon song
+    - Music Hall:
+      - music hall
+      - music-hall
+      - variety
+    - Musical:
+      - musical
+      - cast recording
+      - cast recordings
+      - musicals
+      - Industrial Musical:
+        - industrial musical
+        - corporate musical
+        - industrial show
+      - Musical Comedy:
+        - musical comedy
+        - music comedy
+      - Rock Musical:
+        - rock musical
+        - broadway rock
+        - musical theatre rock
+        - rock & roll musical
+      - Show Tunes:
+        - show tunes
+        - show tune
+    - Revue:
+      - revue
+      - revista
+    - Yoruba Folk Opera:
+      - yoruba folk opera
+- Pop:
+  - pop
+  - pop music
+  - popular
+  - popular music
+  - Adult Contemporary:
+    - adult contemporary
+    - adult contemporary music
+  - African Pop:
+    - african pop
+    - african popular
+    - african popular music
+    - african-pop
+    - afro-pop
+    - afropop
+    - Afrobeats:
+      - afrobeats
+      - azonto
+      - Alté:
+        - alté
+        - alte
+    - Benga:
+      - benga
+      - benga music
+    - Fuji:
+      - fuji
+      - fújì
+      - fuji music
+    - Jùjú:
+      - jùjú
+      - juju
+      - jùjú music
+      - juju music
+      - Yo-pop:
+        - yo-pop
+        - yo pop
+    - Kidandali:
+      - kidandali
+    - Tchink System:
+      - tchink system
+      - tchink-system
+    - Urban Grooves:
+      - urban grooves
+      - zim urban grooves
+    - Yoruba:
+      - yoruba
+      - yoruba music
+      - yorùbá music
+  - Alternative Pop:
+    - alternative pop
+    - alt pop
+    - alternative-pop
+    - Wonky Pop:
+      - wonky pop
+  - AM Pop:
+    - am pop
+  - Art Pop:
+    - art pop
+    - art-pop
+    - avant pop
+    - avant-pop
+    - experimental pop
+    - left field pop
+    - left-field pop
+  - Asian Pop:
+    - asian pop
+    - asian-pop
+    - C-Pop:
+      - c-pop
+      - c pop
+      - cpop
+      - chinese pop
+      - chinese popular music
+      - zhōngwén liúxíng yīnyuè
+      - zhongwen liuxing yinyue
+      - 中文流行音乐
+      - 中文流行音樂
+    - Cantopop:
+      - cantopop
+      - cantonese pop
+      - gwongdung go
+      - hk-pop
+      - hong kong and cantonese pop
+      - hong kong pop - jyutyu lauhang jamngok - yueyu liuxing yinyue - 廣東歌 - 
+        粵語流行音樂
+      - Gufeng:
+        - gufeng
+        - guofeng
+        - 古風
+        - 古风
+        - 国风
+        - 國風
+      - Hokkien Pop:
+        - hokkien pop
+        - bân-lâm-gú liû-hîng im-gak
+        - ban-lam-gu liu-hing im-gak
+        - hokkien-pop
+        - minnan pop
+        - mǐnnányǔ liúxíng yīnyuè
+        - minnanyu liuxing yinyue
+        - tai-pop
+        - taiwanese folk
+        - taiwanese hokkien popular music
+        - taiwanese pop
+        - 閩南語流行音樂
+        - 闽南语流行音乐
+        - New Taiwanese Song:
+          - new taiwanese song
+      - Mandopop:
+        - mandopop
+        - huáyǔ liúxíng yīnyuè
+        - huayu liuxing yinyue
+        - mandapop
+        - mandarin pop
+        - mandarin popular music
+        - 华语流行音乐
+        - 華語流行音樂
+      - Zhongguo feng:
+        - zhongguo feng
+        - chinese style
+        - zhōngguó fēng
+        - 中国风
+        - 中國風
+    - Enka:
+      - enka
+      - 演歌
+    - Filmi:
+      - filmi
+      - bollywood
+      - Filmi Ghazal:
+        - filmi ghazal
+        - film ghazal
+        - film-ghazal
+        - filmi-ghazal
+    - Indian Pop:
+      - indian pop
+      - hindi pop
+      - indi-pop
+      - indian-pop
+      - indipop
+      - Bhojpuri Pop:
+        - bhojpuri pop
+        - bhojpuri geet
+        - bhojpuri song
+        - bhojpuri-pop
+        - भोजपुरी के पॉप
+      - Desi:
+        - desi
+        - desi music
+      - Pop Ghazal:
+        - pop ghazal
+      - Tamil Film:
+        - tamil film
+        - tamil film music
+    - J-Pop:
+      - j-pop
+      - anime song
+      - anison
+      - j pop
+      - japanese pop
+      - jpop
+      - jポップ
+      - ジェイポップ
+      - Akishibu-kei:
+        - akishibu-kei
+        - akishibu kei
+        - アキシブ系
+      - City Pop:
+        - city pop
+        - city-pop
+        - Neo-City Pop:
+          - neo-city pop
+          - neo city pop
+          - neo-city-pop
+          - ネオ・シティ・ポップ
+      - Denpa:
+        - denpa
+        - akiba-pop
+        - denpa song
+        - moe song
+        - 萌えソング
+        - 電波
+        - 電波ソング
+      - Doujin:
+        - doujin
+        - dōjin music
+        - dojin music
+        - dōjin ongaku
+        - dojin ongaku
+        - doujin music
+        - doujin ongaku
+        - otokei dōjin
+        - otokei dojin
+        - otokei doujin
+        - 同人音楽
+        - 音系同人
+        - Touhou:
+          - touhou
+          - tōhō dōjin music
+          - toho dojin music
+          - tōhō music
+          - toho music
+          - tōhō project music
+          - toho project music
+          - touhou doujin music
+          - touhou music
+          - touhou project music
+          - 東方project音楽
+          - 東方同人音楽
+          - 東方音楽
+      - Japanese Idol:
+        - japanese idol
+        - heisei idol
+        - j-idol
+        - アイドル
+        - 平成アイドル
+        - Alternative Idol:
+          - alternative idol
+          - alt idol
+          - alt-idol
+          - anti-idol
+          - gakkyoku-ha idol
+          - 楽曲派アイドル
+      - New Music:
+        - new music
+        - new
+        - nyū myūjikku
+        - nyu myujikku
+        - ニューミュージック
+      - Vocaloid Scene:
+        - vocaloid scene
+        - vocalo
+        - vocaloid
+        - ボカロ
+        - ボカロシーン
+        - ボカロ曲
+        - Utaite:
+          - utaite
+          - utattemita
+          - vsinger
+          - youtaite
+          - 歌い手
+          - 歌ってみた
+      - Wa Euro:
+        - wa euro
+        - japanese eurobeat
+        - wasei euro
+        - wasei eurobeat
+        - 和ユーロ
+        - 和製ユーロ
+        - 和製ユーロビート
+        - 日本のユーロビート
+      - Yakousei:
+        - yakousei
+        - night-loving scene
+        - nocturnal scene
+        - yakо̄sei
+        - 夜好性
+        - 夜行性
+    - K-Pop:
+      - k-pop
+      - k pop
+      - kpop
+      - keipab
+      - korean pop
+      - 케이팝
+      - Semi-Trot:
+        - semi-trot
+        - neo-trot
+        - semi teurotteu
+        - semi trot
+        - 세미 트로트
+    - Kayōkyoku:
+      - kayōkyoku
+      - kayō
+      - kayo
+      - kayokyoku
+      - kayou
+      - kayoukyoku
+      - shōwa era pop
+      - showa era pop
+      - standard japanese pop
+      - かようきょく
+      - 歌謡曲
+      - Idol kayō:
+        - idol kayō
+        - aidoru kayō
+        - aidoru kayo
+        - idol kayo
+        - idol kayōkyoku
+        - idol kayokyoku
+        - idol kayou
+        - showa idol kayō
+        - showa idol kayo
+        - アイドル歌謡
+        - 昭和アイドル歌謡
+      - Mood kayō:
+        - mood kayō
+        - mood kayo
+        - ムード歌謡
+      - Techno kayō:
+        - techno kayō
+        - techno kayo
+        - techno kayou
+        - テクノ歌謡
+    - Korean Ballad:
+      - korean ballad
+      - balladeu
+      - k-ballad
+      - 발라드
+      - Oriental Ballad:
+        - oriental ballad
+        - 오리엔탈 발라드
+    - Luk thung:
+      - luk thung
+      - loog thung
+      - thai country music
+      - ลูกทุ่ง
+    - Nhạc vàng:
+      - nhạc vàng
+      - gold music
+      - golden music
+      - nhac vang
+    - Q-Pop:
+      - q-pop
+      - q pop
+      - qazaq pop
+    - Rigsar:
+      - rigsar
+      - རིག་གསར
+    - Ryūkōka:
+      - ryūkōka
+      - ryukoka
+      - ryuukouka
+      - 流行歌
+    - Shidaiqu:
+      - shidaiqu
+      - songs of the era
+      - 廈語時代曲
+      - 時代曲
+      - 粵語時代曲
+    - Southeast Asian Pop:
+      - southeast asian pop
+      - Bolero Việt Nam:
+        - bolero việt nam
+        - bolero viet nam
+        - nhạc bolero
+        - nhac bolero
+        - trữ tình bolero
+        - tru tinh bolero
+        - vietnamese bolero
+      - Cambodian Pop:
+        - cambodian pop
+        - cambodian-pop
+        - khmer pop
+        - Jamrieng samai:
+          - jamrieng samai
+          - chamrieng samai
+          - ចម្រៀងសម័យ
+        - Rom kbach:
+          - rom kbach
+          - ram kbach
+          - ramkbach
+          - រាំក្បាច់
+      - Hmong Pop:
+        - hmong pop
+        - hmong-pop
+      - Indonesian Pop:
+        - indonesian pop
+        - indo pop
+        - indo-pop
+        - indonesian-pop
+        - Dangdut:
+          - dangdut
+          - Dangdut koplo:
+            - dangdut koplo
+            - koplo
+        - Pop Batak:
+          - pop batak
+        - Pop Minang:
+          - pop minang
+          - minang pop
+          - pop minangkabau
+          - Talempong goyang:
+            - talempong goyang
+        - Pop Sunda:
+          - pop sunda
+          - sundanese pop
+      - Manila Sound:
+        - manila sound
+      - Nhạc tiền chiến:
+        - nhạc tiền chiến
+        - nhạc cải cách
+        - nhac cai cach
+        - nhac tien chien
+      - OPM:
+        - opm
+        - original philippine music
+        - original pilipino music
+        - original pinoy music
+      - P-Pop:
+        - p-pop
+        - filipino pop
+        - opm pop
+        - p pop
+        - pinoy pop
+      - Pop Kreatif:
+        - pop kreatif
+        - indonesian city pop
+      - T-Pop:
+        - t-pop
+        - string music
+        - t pop
+        - thai pop
+        - ที-ป็อป
+        - เพลงสตริง
+        - ไทยป็อป
+      - V-Pop:
+        - v-pop
+        - green music
+        - nhạc trẻ
+        - nhac tre
+        - nhạc xanh
+        - nhac xanh
+        - v pop
+        - vietnamese pop
+    - T'ong Guitar:
+      - t'ong guitar
+      - t'ong guitar music
+      - tong guitar
+      - tong guitar music
+    - Tibetan Pop:
+      - tibetan pop
+      - tibetan popular music
+    - Trot:
+      - trot
+      - ppongjjak
+      - ppongtchak
+      - teurotteu
+      - 뽕짝
+      - 트로트
+  - Baroque Pop:
+    - baroque pop
+    - baroque-pop
+  - Bitpop:
+    - bitpop
+  - Boy Band:
+    - boy band
+  - Brill Building:
+    - brill building
+    - brill building pop
+    - brill building sound
+  - Bubblegum:
+    - bubblegum
+    - bubblegum pop
+  - Classical Crossover:
+    - classical crossover
+    - classical pop
+    - Operatic Pop:
+      - operatic pop
+      - operatic pop music
+      - pop opera
+      - pop-opera
+      - popera
+  - Contemporary Christian:
+    - contemporary christian
+    - ccm
+    - contemporary christian music
+    - Jesus Music:
+      - jesus music
+      - gospel beat music
+      - jesus
+      - jesus music movement
+    - Worship:
+      - worship
+      - praise & worship
+      - praise and worship
+      - praise song
+      - praise songs
+  - Electropop:
+    - electropop
+  - Ethno-Pop:
+    - ethno-pop
+    - ethno pop
+  - European Pop:
+    - european pop
+    - european pop music
+    - Austropop:
+      - austropop
+      - austro pop
+    - Balkan Pop-Folk:
+      - balkan pop-folk
+      - balkan pop
+      - balkan pop folk
+      - Chalga:
+        - chalga
+      - Manele:
+        - manele
+        - manea
+      - Modern Laika:
+        - modern laika
+        - contemporary laika
+        - contemporary laïka
+        - contemporary laiko
+        - contemporary laïko
+        - laika pop
+        - laiko pop
+        - laïko pop
+        - laiko-pop
+        - laïko-pop
+        - modern laïka
+        - modern laiko
+        - modern laïko
+        - σύγχρονο λαϊκό
+      - Musika popullore:
+        - musika popullore
+        - muzikë popullore
+        - muzike popullore
+      - Muzică de mahala:
+        - muzică de mahala
+        - muzica de mahala
+        - proto-manele
+      - Romanian Etno:
+        - romanian etno
+        - romanian ethno-pop
+        - romanian etno music
+        - romanian etno-dance
+      - Skiladika:
+        - skiladika
+        - skiladiko
+        - skyladika
+        - skyladiko
+        - σκυλάδικα
+      - Tallava:
+        - tallava
+      - Turbo-Folk:
+        - turbo-folk
+        - turbo folk
+        - turbofolk
+        - турбо-фолк
+    - Dansbandsmusik:
+      - dansbandsmusik
+      - dansband
+      - dansebandmusikk
+      - svensktoppar
+    - Dansktop:
+      - dansktop
+    - Europop:
+      - europop
+      - euro pop
+      - euro-pop
+    - Flamenco Pop:
+      - flamenco pop
+      - flamenco-pop
+      - pop aflamencado
+    - French Pop:
+      - french pop
+      - french-pop
+    - Irish Showband:
+      - irish showband
+      - showband
+    - Italo Pop:
+      - italo pop
+      - canzone leggera italiana
+      - canzone romantica italiana
+      - italian pop
+      - italo-pop
+      - musica leggera italiana
+      - Canzone neomelodica:
+        - canzone neomelodica
+        - musica neomelodica
+        - neomelodic music
+        - neomelodica
+    - Laika:
+      - laika
+      - laïka
+      - laiki
+      - laïki
+      - laïko
+      - laïkó
+      - laiko
+      - λαϊκά
+      - λαϊκή
+      - Entechna laika:
+        - entechna laika
+        - entehna laika
+        - έντεχνα λαϊκά
+        - έντεχνο λαϊκό
+    - Mulatós:
+      - mulatós
+      - mulatos
+    - Nederpop:
+      - nederpop
+      - dutch pop
+      - Palingsound:
+        - palingsound
+        - eelsound
+        - palingpop
+    - Rabiz:
+      - rabiz
+      - rabis
+      - ռաբիզ
+      - ռաբիս
+    - Rumba catalana:
+      - rumba catalana
+      - catalan rumba
+    - Russian Chanson:
+      - russian chanson
+      - blatnaya pesnya
+      - blatnyak
+      - блатная песня
+      - блатняк
+      - русский шансон
+    - Russian Pop:
+      - russian pop
+      - russian-pop
+    - Schlager:
+      - schlager
+      - Humppa:
+        - humppa
+      - Levenslied:
+        - levenslied
+      - Pimba:
+        - pimba
+      - Volkstümliche Musik:
+        - volkstümliche musik
+        - volkstumliche musik
+        - volkstümlicher schlager
+        - volkstumlicher schlager
+      - Yu-Mex:
+        - yu-mex
+        - yu mex
+    - Soviet Estrada:
+      - soviet estrada
+      - estrada
+      - советская эстрада
+      - эстрада
+      - эстрадная песня
+    - Yé-yé:
+      - yé-yé
+      - yé yé
+      - ye-ye
+      - ye ye
+  - Girl Group:
+    - girl group
+    - girl groups
+  - Hapa haole:
+    - hapa haole
+    - hawaiian craze
+  - Hyperpop:
+    - hyperpop
+  - Indie Pop:
+    - indie pop
+    - indie-pop
+    - Bedroom Pop:
+      - bedroom pop
+      - bedroom-pop
+    - Chamber Pop:
+      - chamber pop
+      - chamber-pop
+      - ork-pop
+    - Donosti Sound:
+      - donosti sound
+      - sonido donosti
+    - Shibuya-kei:
+      - shibuya-kei
+      - shibuya kei
+      - 渋谷系
+    - Tontipop:
+      - tontipop
+      - acné pop
+      - acne pop
+      - nocilla pop
+      - ñoñipop
+      - nonipop
+      - nuevo pop cardíaco español
+      - nuevo pop cardiaco espanol
+      - pop naif
+    - Twee Pop:
+      - twee pop
+      - twee
+      - twee-pop
+      - Cuddlecore:
+        - cuddlecore
+        - crush pop
+        - twee punk
+        - tweecore
+  - Latin Pop:
+    - latin pop
+    - latin-pop
+    - pop latino
+    - Bolero:
+      - bolero
+    - Brega:
+      - brega
+      - Arrocha:
+        - arrocha
+        - Arrochadeira:
+          - arrochadeira
+        - Bregadeira:
+          - bregadeira
+      - Brega funk:
+        - brega funk
+        - brega-funk
+        - Batidão romântico:
+          - batidão romântico
+          - batidão
+          - batidao
+          - batidao romantico
+    - Brega calypso:
+      - brega calypso
+      - brega paraense
+      - brega pop
+    - Canción melódica:
+      - canción melódica
+      - balada romántica
+      - balada romantica
+      - canción ligera
+      - cancion ligera
+      - cancion melodica
+      - melódicos
+      - melodicos
+      - Bolero-Beat:
+        - bolero-beat
+        - balada rockmántica
+        - balada rockmantica
+        - bolero beat
+      - Música cebolla:
+        - música cebolla
+        - cebolla
+        - cebollera
+        - musica cebolla
+    - Cumbia pop:
+      - cumbia pop
+      - cumbia canchera
+      - cumbia cheta
+      - cumbia-pop
+    - Grupera:
+      - grupera
+      - grupero
+      - musica grupera
+      - música grupera
+      - onda grupera
+    - MPB:
+      - mpb
+      - brazilian popular music
+      - música popular brasileira
+      - musica popular brasileira
+    - Nueva ola:
+      - nueva ola
+      - la nueva ola
+    - Sertanejo:
+      - sertanejo
+      - música sertaneja
+      - musica sertaneja
+      - sertanejo music
+      - Sertanejo romântico:
+        - sertanejo romântico
+        - sertanejo moderno
+        - sertanejo pop
+        - sertanejo romantico
+      - Sertanejo universitário:
+        - sertanejo universitário
+        - sertanejo universitario
+        - Arrocha sertanejo:
+          - arrocha sertanejo
+          - arrocha universitário
+          - arrocha universitario
+        - Funknejo:
+          - funknejo
+          - pancadão sertanejo
+          - pancadao sertanejo
+    - Tejano:
+      - tejano
+      - música tejana
+      - musica tejana
+      - tejano music
+      - tex mex music
+      - tex-mex music
+    - Tropipop:
+      - tropipop
+  - Lokal musik:
+    - lokal musik
+    - lokal music
+  - Middle Eastern Pop:
+    - middle eastern pop
+    - Al-Jadīd:
+      - al-jadīd
+      - al jadīd
+      - al-jadid
+      - الجديد
+      - al jadid
+    - Arabic Pop:
+      - arabic pop
+      - arab pop
+      - arabic pop music
+      - arabic-pop
+      - Al jeel:
+        - al jeel
+        - al-geel
+        - al-jil
+        - geel
+        - jeel
+        - الجيل
+      - Mūsīqā lubnāniyya:
+        - mūsīqā lubnāniyya
+        - al-ughniyya al-lubnāniyya
+        - al-ughniyya al-lubnaniyya
+        - musiqa lubnaniyya
+        - الأغنية اللبنانية
+        - موسيقى لبنانية
+      - Shaabi:
+        - shaabi
+        - egyptian chaabi
+        - sha'abi
+        - sha'bī
+        - sha'bi
+        - sha3bi
+        - شعبي
+        - Mahraganat:
+          - mahraganat
+          - electro chaabi
+          - electro sha3bi
+          - electro-shaabi
+          - الكترو شعبي
+          - مهرجان
+          - مهرجانات
+    - Assyrian Folk-Pop:
+      - assyrian folk-pop
+      - assyrian folk pop
+      - assyrian folk/pop
+      - assyrian pop
+    - Muzika mizrahit:
+      - muzika mizrahit
+      - mizrahi
+      - musica mizrahit
+      - muzika yam-tichonit
+      - zemer mizrahi
+      - zemer yam-tichoni
+      - זמר ים-תיכוני
+      - זמר מזרחי
+      - מוזיקה ים-תיכונית
+      - מוזיקה מזרחית
+      - Muzikat dika'on:
+        - muzikat dika'on
+        - depression music
+        - depression songs
+        - soul music
+        - מוזיקת דיכאון
+        - מוזיקת נשמה
+        - שירי דיכאון
+        - שירי נשמה
+    - Orthodox Pop:
+      - orthodox pop
+      - chassidic pop
+      - haredi pop
+      - hasidic pop
+      - orthodox-pop
+      - פופ חסידי
+      - פופ חרדי
+    - Persian Pop:
+      - persian pop
+      - farsipop
+      - iranian pop
+      - musiqi-e pop
+      - persian-pop
+      - موسیقی پاپ ایرانی
+    - Turkish Pop:
+      - turkish pop
+      - türk pop
+      - turk pop
+      - türkçe pop
+      - turkce pop
+      - turkish-pop
+      - Arabesk:
+        - arabesk
+        - arabesque
+      - Fantezi:
+        - fantezi
+  - Orchestral Pop:
+    - orchestral pop
+    - orchestral pop music
+    - symphonic pop
+  - Progressive Pop:
+    - progressive pop
+    - prog pop
+    - progressive-pop
+  - Psychedelic Pop:
+    - psychedelic pop
+    - psych pop
+    - psychedelic-pop
+  - Raï:
+    - raï
+    - rai
+    - Pop Raï:
+      - pop raï
+      - pop rai
+    - Traditional Raï:
+      - traditional raï
+      - folk raï
+      - folk rai
+      - traditional rai
+  - Sophisti-Pop:
+    - sophisti-pop
+    - sophisti pop
+  - Sunshine Pop:
+    - sunshine pop
+    - soft pop
+    - sunshine-pop
+  - Synthpop:
+    - synthpop
+    - synth pop
+    - synth-pop
+    - synthesizer pop
+    - technopop
+    - Pon-chak disco:
+      - pon-chak disco
+      - pon chak disco
+      - pon-chak techno
+      - ppongjjak disco
+      - ppongtchak disco
+      - techno-trot
+      - trot medley
+      - 뽕짝 디스코
+      - ポンチャック
+  - Teen Pop:
+    - teen pop
+    - teen-pop
+  - Toytown Pop:
+    - toytown pop
+    - toytown
+    - toytown psych
+    - toytown-pop
+  - Traditional Pop:
+    - traditional pop
+    - classic pop
+    - traditional pop music
+    - traditional-pop
+    - Pop Standards:
+      - pop standards
+      - american popular song
+      - american standards
+      - composer songbook
+      - songbook
+      - standards
+    - Romanţe:
+      - romanţe
+      - romanţă
+      - romanta
+      - romante
+    - Tin Pan Alley:
+      - tin pan alley
+      - tin pan alley pop
+    - Torch Song:
+      - torch song
+      - torch songs
+  - Worldbeat:
     - worldbeat
-
+    - ethnic fusion
+    - global fusion
+    - international fusion
+    - pan global
+    - pan-global
+    - world fusion
+    - world fusion music
+    - worldfusion
+- Psychedelia:
+  - psychedelia
+  - psychedelic music
+  - Neo-Psychedelia:
+    - neo-psychedelia
+    - neo psychedelia
+    - neo-psych
+    - Hypnagogic Pop:
+      - hypnagogic pop
+      - h-pop
+      - hypnagogic-pop
+  - Psychsploitation:
+    - psychsploitation
+    - exploito psych
+    - psych exploitation
+    - psychploitation
+  - Tropicália:
+    - tropicália
+    - tropicalia
+    - tropicalismo
+    - Clube da esquina:
+      - clube da esquina
+    - Vanguarda paulista:
+      - vanguarda paulista
+      - vanguarda paulistana
+      - Nova vanguarda paulistana:
+        - nova vanguarda paulistana
+        - clube da encruza
+        - nova vanguarda paulista
+- Reggae:
+  - reggae
+  - reggay
+  - Celtic Reggae:
+    - celtic reggae
+    - celtic dub
+    - celtic folk reggae
+    - celtic ska
+  - Dancehall:
+    - dancehall
+    - bashment
+    - Bubbling:
+      - bubbling
+      - dutch bubbling
+      - speed bubbling
+    - Dembow:
+      - dembow
+      - dominican dembow
+      - reggaeton
+      - reguetón
+      - regueton
+      - Cubaton:
+        - cubaton
+        - cuban reggaetón
+        - cuban reggaeton
+        - reggaetón cubano
+        - reggaeton cubano
+        - reggaetón de cuba
+        - reggaeton de cuba
+        - Reparto:
+          - reparto
+          - música repartera
+          - musica repartera
+      - Cumbiatón:
+        - cumbiatón
+        - cumbiaton
+      - Doble paso:
+        - doble paso
+      - Neoperreo:
+        - neoperreo
+        - neo-perreo
+      - Reggaetón:
+        - reggaetón
+        - bachateo
+        - bachaton
+        - Alternative Reggaetón:
+          - alternative reggaetón
+          - alt reggaeton
+          - alt reggaetón
+          - alternative reggaeton
+          - reggaetón alternativo
+          - reggaeton alternativo
+        - Bachatón:
+          - bachatón
+      - Romantic Style Reggaetón:
+        - romantic style reggaetón
+        - reggaetón romántico
+        - reggaeton romantico
+        - romantic reggaetón
+        - romantic reggaeton
+        - romantic style
+        - romantic style reggaeton
+        - romantiqueo
+        - romantiqueo reggaetón
+        - romantiqueo reggaeton
+    - Digital Dancehall:
+      - digital dancehall
+      - digital
+      - digital reggae
+    - Flex Dance:
+      - flex dance
+      - fdm
+      - flex dance music
+    - Gommance:
+      - gommance
+    - Ragga:
+      - ragga
+      - raggamuffin
+      - Bhangragga:
+        - bhangragga
+        - bhangra dancehall
+        - bhangra muffin
+        - bhangra reggae
+        - bhangramuffin
+        - ragga bhangra
+    - Shatta:
+      - shatta
+    - Trap Dancehall:
+      - trap dancehall
+      - dancehall trap
+      - traphall
+    - Zess:
+      - zess
+      - steam
+    - Zimdancehall:
+      - zimdancehall
+  - Deejay:
+    - deejay
+    - chatting
+    - deejaying
+    - dj
+    - toasting
+  - Dub:
+    - dub
+    - dub music
+    - dub reggae
+    - Dub Poetry:
+      - dub poetry
+  - Euro Reggae:
+    - euro reggae
+    - european reggae
+  - Lovers Rock:
+    - lovers rock
+    - lovers-rock
+    - smooth reggae
+  - Pacific Reggae:
+    - pacific reggae
+    - pacific island reggae
+    - Jawaiian:
+      - jawaiian
+      - hawaiian reggae
+  - Reggae Fusion:
+    - reggae fusion
+    - reggaefusion
+  - Reggae Gospel:
+    - reggae gospel
+  - Reggae Pop:
+    - reggae pop
+    - pop reggae
+    - reggae-pop
+  - Rocksteady:
+    - rocksteady
+    - rock steady
+  - Roots Reggae:
+    - roots reggae
+    - political reggae
+    - roots rock reggae
+  - Seggae:
+    - seggae
+  - Ska:
+    - ska
+    - blue beat
+    - bluebeat
+    - 2 Tone:
+      - 2 tone
+      - 2-tone
+      - two tone
+      - two-tone
+    - Christian Ska:
+      - christian ska
+      - christian ska punk
+    - Jamaican Ska:
+      - jamaican ska
+      - first wave ska
+    - New Tone:
+      - new tone
+      - new tone ska
+    - Spouge:
+      - spouge
+    - Third Wave Ska:
+      - third wave ska
+      - ska revival
+      - third wave ska revival
+      - Ska Punk:
+        - ska punk
+        - punk ska
+        - ska-punk
+        - Skacore:
+          - skacore
+          - Crack Rock Steady:
+            - crack rock steady
+  - Skinhead Reggae:
+    - skinhead reggae
+    - boss reggae
+- Rhythm & Blues:
+  - rhythm & blues
+  - r 'n' b
+  - r&b
+  - r'n'b
+  - rhythm and blues
+  - rnb
+  - Acid Jazz:
+    - acid jazz
+    - acid-jazz
+    - club jazz
+    - clubjazz
+    - groove jazz
+    - jazz dance
+    - jazzdance
+    - psychedelic jazz
+  - Beach Music:
+    - beach music
+    - beach
+    - beach beat
+    - beach pop
+    - bubblegum beach
+    - carolina beach music
+    - carolina shag music
+    - shag music
+  - British R&B:
+    - british r&b
+    - british r 'n' b
+    - british r'n'b
+    - british rhythm & blues
+    - british rhythm and blues
+    - british rnb
+  - Contemporary R&B:
+    - contemporary r&b
+    - contemporary r 'n' b
+    - contemporary r'n'b
+    - contemporary rhythm & blues
+    - contemporary rhythm and blues
+    - contemporary rnb
+    - Alternative R&B:
+      - alternative r&b
+      - alternative r 'n' b
+      - alternative r'n'b
+      - alternative rhythm & blues
+      - alternative rhythm and blues
+      - alternative rnb
+    - Crunk&B:
+      - crunk&b
+      - crunk and b
+    - Hip Hop Soul:
+      - hip hop soul
+      - hip-hop soul
+    - Latin R&B:
+      - latin r&b
+      - latin r 'n' b
+      - latin r'n'b
+      - latin rhythm & blues
+      - latin rhythm and blues
+      - latin rnb
+      - spanish r 'n' b
+      - spanish r&b
+      - spanish r'n'b
+      - spanish rhythm & blues
+      - spanish rhythm and blues
+      - spanish rnb
+    - New Jack Swing:
+      - new jack swing
+      - new jack
+      - swingbeat
+    - Quiet Storm:
+      - quiet storm
+      - quiet storm music
+    - R&Bass:
+      - r&bass
+      - r 'n' bass
+      - r'n'bass
+      - rhythm & bass
+      - rhythm and bass
+      - rnbass
+    - Snap&B:
+      - snap&b
+      - snap and b
+    - Trap Soul:
+      - trap soul
+      - trap-soul
+      - trapsoul
+    - UK Street Soul:
+      - uk street soul
+      - ground beat
+      - street soul
+  - Doo-Wop:
+    - doo-wop
+    - doo wop
+  - Funk:
+    - funk
+    - Afro-Funk:
+      - afro-funk
+      - afro funk
+      - voodoo funk
+    - Afrobeat:
+      - afrobeat
+      - afro-beat
+    - Afrofuturism:
+      - afrofuturism
+    - Avant-Funk:
+      - avant-funk
+      - agit funk
+      - agit-funk
+      - avant funk
+      - punk funk
+      - punk-funk
+    - Britfunk:
+      - britfunk
+      - brit funk
+      - brit-funk
+    - Deep Funk:
+      - deep funk
+      - deep funk revival
+      - deep-funk
+      - heavy funk
+    - Go-Go:
+      - go-go
+      - go go
+      - Bounce Beat:
+        - bounce beat
+        - dc bounce
+    - Latin Funk:
+      - latin funk
+      - latin-funk
+    - Louisiana Funk:
+      - louisiana funk
+      - bayou funk
+      - louisiana-funk
+    - Porn Groove:
+      - porn groove
+      - porn funk
+      - porno funk
+      - porno groove
+    - Psychedelic Funk:
+      - psychedelic funk
+      - funkadelia
+      - p funk
+      - p-funk
+      - parliament funkadelic
+      - parliament-funkadelic
+    - Synth Funk:
+      - synth funk
+      - naked funk
+      - synth-funk
+      - Minneapolis Sound:
+        - minneapolis sound
+  - Gospel:
+    - gospel
+    - gospel music
+    - Jubilee:
+      - jubilee
+      - jubilee quartet
+    - Praise Break:
+      - praise break
+      - shout
+    - Sacred Steel:
+      - sacred steel
+    - Southern Gospel:
+      - southern gospel
+    - Traditional Black Gospel:
+      - traditional black gospel
+      - black gospel
+      - traditional gospel
+    - Urban Contemporary Gospel:
+      - urban contemporary gospel
+      - contemporary gospel
+      - urban gospel
+  - New Orleans R&B:
+    - new orleans r&b
+    - new orleans r 'n' b
+    - new orleans r'n'b
+    - new orleans rhythm & blues
+    - new orleans rhythm and blues
+    - new orleans rnb
+  - Soul:
+    - soul
+    - Blue-Eyed Soul:
+      - blue-eyed soul
+      - blue eyed soul
+      - blue-eyed-soul
+      - white soul
+    - Brown-Eyed Soul:
+      - brown-eyed soul
+      - brown eyed soul
+      - chicano soul
+      - hispanic soul
+      - latino soul
+      - West Side Sound:
+        - west side sound
+        - westside sound
+    - Chicago Soul:
+      - chicago soul
+      - chi-soul
+      - chicago-soul
+    - Country Soul:
+      - country soul
+      - country-soul
+    - Deep Soul:
+      - deep soul
+      - deep-soul
+    - Latin Soul:
+      - latin soul
+      - latin-soul
+      - Boogaloo:
+        - boogaloo
+        - boogalu
+        - bugalú
+        - bugalu
+        - shing-a-ling
+    - Memphis Soul:
+      - memphis soul
+      - memphis sound
+    - Neo-Soul:
+      - neo-soul
+      - neo soul
+      - nu soul
+    - Northern Soul:
+      - northern soul
+      - northern-soul
+    - Philly Soul:
+      - philly soul
+      - philadelphia soul
+      - philadelphia sound
+      - philly-soul
+      - the sound of philadelphia
+      - tsop
+    - Pop Soul:
+      - pop soul
+      - pop-soul
+      - Motown Sound:
+        - motown sound
+        - motown
+    - Progressive Soul:
+      - progressive soul
+      - prog soul
+      - progressive-soul
+    - Psychedelic Soul:
+      - psychedelic soul
+      - psych soul
+      - psychedelic-soul
+    - Retro-Soul:
+      - retro-soul
+      - retro soul
+      - soul revival
+    - Smooth Soul:
+      - smooth soul
+      - smooth-soul
+    - Southern Soul:
+      - southern soul
+      - southern-soul
+    - Uptown Soul:
+      - uptown soul
+  - Swamp Pop:
+    - swamp pop
+    - louisiana swamp pop
+    - swamp-pop
+- Rock:
+  - rock
+  - rock music
+  - Acoustic Rock:
+    - acoustic rock
+    - acoustic-rock
+  - Afro-Rock:
+    - afro-rock
+    - afro rock
+  - Alternative Rock:
+    - alternative rock
+    - alt rock
+    - alt-rock
+    - alternative-rock
+    - Brno Alternative Scene:
+      - brno alternative scene
+      - brněnská alternativa
+      - brnenska alternativa
+      - brněnská alternativní scéna
+      - brnenska alternativni scena
+      - brněnská nová vlna
+      - brnenska nova vlna
+      - brněnská scéna
+      - brnenska scena
+      - brno alternative
+      - brno new wave
+      - brno scene
+    - Christian Alternative Rock:
+      - christian alternative rock
+      - christian alt rock
+    - College Rock:
+      - college rock
+      - college radio rock
+    - Dream Pop:
+      - dream pop
+      - dream-pop
+      - Ambient Pop:
+        - ambient pop
+        - ambient-pop
+    - Emo-Pop:
+      - emo-pop
+      - emo pop
+      - pop emo
+    - Geek Rock:
+      - geek rock
+      - dork rock
+      - geek-rock
+      - nerd rock
+    - Grunge:
+      - grunge
+      - grunge revival
+      - grunge rock
+      - seattle sound
+    - Hamburger Schule:
+      - hamburger schule
+      - discourse pop
+      - discourse rock
+      - diskurspop
+      - diskursrock
+      - hamburg school
+    - Hoboken Sound:
+      - hoboken sound
+      - hoboken scene
+    - Indie Rock:
+      - indie rock
+      - independent rock
+      - indie-rock
+      - Beijing New Sound:
+        - beijing new sound
+        - beijing xinsheng
+        - new sound of beijing
+        - 北京新声
+        - 北京新聲
+        - 新北京之声
+        - 新北京之聲
+      - C86:
+        - c86
+        - c-86
+      - Dolewave:
+        - dolewave
+        - chillmate
+        - new melbourne jangle
+        - new ordinary
+        - sharehouse-pop
+      - Dunedin Sound:
+        - dunedin sound
+      - Grindie:
+        - grindie
+        - grime indie
+        - grime indie rock
+        - grime-indie
+      - Madchester:
+        - madchester
+        - Baggy:
+          - baggy
+      - Math Pop:
+        - math pop
+        - math-pop
+      - Noise Pop:
+        - noise pop
+        - noise-pop
+      - San Diego Sound:
+        - san diego sound
+      - Slacker Rock:
+        - slacker rock
+        - lo-fi indie rock
+        - slack rock
+        - slacker-rock
+      - Slowcore:
+        - slowcore
+        - sad-core
+        - sadcore
+        - slow-core
+    - Jangle Pop:
+      - jangle pop
+      - jangle
+      - jangle rock
+      - jangle-pop
+      - Neo-Acoustic:
+        - neo-acoustic
+        - neo aco
+        - neo acoustic
+        - neo ako
+        - neo-acoustic pop
+        - neoacoustic
+        - ネオアコ
+        - ネオ・アコースティック
+      - Paisley Underground:
+        - paisley underground
+        - paisley pop
+    - Nova srpska scena:
+      - nova srpska scena
+      - new serbian scene
+    - Novaya scena:
+      - novaya scena
+      - new scene
+      - new stage
+      - новая сцена
+    - Post-Grunge:
+      - post-grunge
+      - post grunge
+    - Scene:
+      - scene
+      - Happy Rock:
+        - happy rock
+        - banda colorida
+        - happy-rock
+    - Shimokita-kei:
+      - shimokita-kei
+      - rockin on-kei
+      - rockin' on-kei
+      - rockin'on-kei
+      - shimokita kei
+      - shimokita-kei guitar rock
+      - ロキノン系
+      - 下北系
+      - 下北系ギターロック
+    - Shoegaze:
+      - shoegaze
+      - shoegazer
+      - shoegazing
+      - wombadelia
+      - Nu Gaze:
+        - nu gaze
+        - nu-gaze
+        - nugaze
+        - second wave shoegaze
+        - second-wave shoegaze
+      - Rock sónico:
+        - rock sónico
+        - movida sónica
+        - movida sonica
+        - nuevo rock argentino
+        - rock sonico
+    - Česká alternativní scéna:
+      - česká alternativní scéna
+      - ceska alternativni scena
+      - czech alternative scene
+      - gray zone
+      - grey zone
+      - šedá zóna
+      - seda zona
+  - Art Rock:
+    - art rock
+    - art-rock
+  - Asian Rock:
+    - asian rock
+    - Anatolian Rock:
+      - anatolian rock
+      - anadolu pop
+      - anadolu rock
+      - anatolian folk rock
+      - anatolian-rock
+    - Chinese Rock:
+      - chinese rock
+      - c rock
+      - c-rock
+      - chinese rock music
+      - zhongguo yaogun
+      - zhongguo yaogun yinyue
+      - 中国摇滚
+      - 中国摇滚音乐
+    - Indian Rock:
+      - indian rock
+      - indian rock music
+    - J-Rock:
+      - j-rock
+      - j rock
+      - j-pop rock
+      - j-poprock
+      - japanese pop rock
+      - japanese poprock
+      - japanese rock
+      - jrock
+    - K-Rock:
+      - k-rock
+      - k rock
+      - korean rock
+    - Pinoy Rock:
+      - pinoy rock
+      - filipino rock
+      - filipino rock music
+    - Sufi Rock:
+      - sufi rock
+      - sufi-rock
+  - Blues Rock:
+    - blues rock
+    - blues-rock
+    - Boogie Rock:
+      - boogie rock
+      - boogie-rock
+      - southern boogie
+  - Cello Rock:
+    - cello rock
+    - cello-rock
+  - Christian Rock:
+    - christian rock
+    - christian-rock
+  - Comedy Rock:
+    - comedy rock
+    - comedy-rock
+  - Country Rock:
+    - country rock
+    - country-rock
+    - Cosmic Country:
+      - cosmic country
+    - Lubbock Sound:
+      - lubbock sound
+  - Electronic Rock:
+    - electronic rock
+    - electro rock
+    - synth rock
+    - Alternative Dance:
+      - alternative dance
+      - Grebo:
+        - grebo
+        - grebo rock
+      - New Rave:
+        - new rave
+        - neu rave
+        - nu rave
+        - rock 'n' rave
+    - Dance-Punk:
+      - dance-punk
+      - dance punk
+      - Dance-Punk Revival:
+        - dance-punk revival
+        - dance punk revival
+    - Dance-Rock:
+      - dance-rock
+      - dance rock
+    - Electroclash:
+      - electroclash
+      - neo-electro
+      - nouveau disco
+    - Electronicore:
+      - electronicore
+      - synthcore
+      - trancecore
+    - Indietronica:
+      - indietronica
+      - indie electronic
+      - indietronics
+      - lap-pop
+      - Chillwave:
+        - chillwave
+        - dream-beat
+        - glo-fi
+        - Chillsynth:
+          - chillsynth
+          - lo-fi synthwave
+      - Glitch Pop:
+        - glitch pop
+        - glitch-pop
+      - Picopop:
+        - picopop
+        - future pop
+        - pico pico pop
+        - pico pop
+        - フューチャーポップ
+    - Industrial Rock:
+      - industrial rock
+      - industrial-rock
+    - Synth-Punk:
+      - synth-punk
+      - electro punk
+      - electropunk
+      - synth punk
+      - synthpunk
+  - European Rock:
+    - european rock
+    - British Rock:
+      - british rock
+      - british invasion
+      - british invasion music
+      - british rock music
+    - Deutschrock:
+      - deutschrock
+    - Miejski folk:
+      - miejski folk
+    - Rock andaluz:
+      - rock andaluz
+  - Experimental Rock:
+    - experimental rock
+    - avant-garde rock
+    - avant-rock
+    - experimental-rock
+    - Krautrock:
+      - krautrock
+      - kosmische musik
+      - kraut rock
+      - Düsseldorf School:
+        - düsseldorf school
+        - dusseldorf school
+        - düsseldorf school of electronic music
+        - dusseldorf school of electronic music
+  - Folk Rock:
+    - folk rock
+    - folk-rock
+    - Alpenrock:
+      - alpenrock
+    - Bard Rock:
+      - bard rock
+      - alt bard music
+      - alt-bard music
+      - alternative bard music
+      - bard-rock
+    - British Folk Rock:
+      - british folk rock
+      - british folk-rock
+      - electric folk
+    - Celtic Rock:
+      - celtic rock
+      - celtic folk rock
+      - celtic-rock
+    - Laurel Canyon Scene:
+      - laurel canyon scene
+    - Medieval Folk Rock:
+      - medieval folk rock
+      - medieval folk
+    - Mittelalter-Rock:
+      - mittelalter-rock
+      - medieval rock
+      - mittelalter rock
+    - Nordic Folk Rock:
+      - nordic folk rock
+    - Pagan Rock:
+      - pagan rock
+    - Phleng phuea chiwit:
+      - phleng phuea chiwit
+      - pleng phua cheewit
+      - เพลงเพื่อชีวิต
+    - Pinoy Folk Rock:
+      - pinoy folk rock
+      - filipino folk rock
+    - Rock rural:
+      - rock rural
+    - Xibei feng:
+      - xibei feng
+      - northwest style
+      - northwest wind
+      - northwestern wave
+      - xīběi fēng
+      - 西北風
+      - 西北风
+  - Funk Rock:
+    - funk rock
+    - funk-rock
+  - Garage Rock:
+    - garage rock
+    - garage-rock
+    - Frat Rock:
+      - frat rock
+      - frat-rock
+      - fraternity rock
+      - party rock
+      - teenbeat
+    - Garage Psych:
+      - garage psych
+      - garage psychedelic rock
+      - garage-psych
+      - psychedelic garage rock
+    - Garage Rock Revival:
+      - garage rock revival
+  - Glam Rock:
+    - glam rock
+    - glam
+    - glam-rock
+    - glitter
+    - glitter rock
+    - neo glam
+    - neo-glam
+  - Hard Rock:
+    - hard rock
+    - classic rock
+    - hard-rock
+    - Arena Rock:
+      - arena rock
+      - adult oriented rock
+      - album rock
+      - aor
+      - arena-rock
+      - melodic rock
+      - stadium rock
+    - Occult Rock:
+      - occult rock
+      - doom rock
+      - occult-rock
+    - Stoner Rock:
+      - stoner rock
+      - stoner-rock
+      - Palm Desert Scene:
+        - palm desert scene
+        - desert rock
+  - Heartland Rock:
+    - heartland rock
+    - heartland-rock
+    - Jersey Shore Sound:
+      - jersey shore sound
+  - Indigenous Rock:
+    - indigenous rock
+    - aboriginal rock
+    - indigenous rock music
+  - Industrial:
+    - industrial
+    - industrial music
+    - Post-Industrial:
+      - post-industrial
+      - post industrial
+      - Martial Industrial:
+        - martial industrial
+        - martial pop
+        - military pop
+  - Instrumental Rock:
+    - instrumental rock
+    - instrumental rock music
+  - Jam Band:
+    - jam band
+    - jam bands
+    - jam rock
+    - jam session
+    - jamming
+    - Jamgrass:
+      - jamgrass
+  - Jazz-Rock:
+    - jazz-rock
+    - jazz rock
+    - Punk Jazz:
+      - punk jazz
+      - jazz punk
+      - punk-jazz
+  - Kiwi Rock:
+    - kiwi rock
+    - kiwi rock music
+    - new zealand rock
+    - new zealand rock music
+  - Latin American Rock:
+    - latin american rock
+    - Argentine Rock:
+      - argentine rock
+      - argentine rock music
+      - rock argentino
+      - rock nacional
+      - Rock barrial:
+        - rock barrial
+        - rock chabón
+        - rock chabon
+        - rock rolinga
+        - rock stone
+    - Candombe beat:
+      - candombe beat
+    - Latin Alternative:
+      - latin alternative
+      - alterlatino
+      - música latina alternativa
+      - musica latina alternativa
+    - Latin Rock:
+      - latin rock
+      - belizean punta rock
+      - latin-rock
+      - punta-rock
+      - Chicano Rock:
+        - chicano rock
+        - chicano rock and roll
+        - chicano rock music
+      - Punta Rock:
+        - punta rock
+    - Manguebeat:
+      - manguebeat
+      - mangue bit
+      - manguebit
+    - Mexican Rock:
+      - mexican rock
+      - mexican rock music
+      - rock mexicano
+      - Rock urbano mexicano:
+        - rock urbano mexicano
+        - rock ñero
+        - rock nero
+    - Rock andino:
+      - rock andino
+      - andean rock
+  - Math Rock:
+    - math rock
+    - math-rock
+  - New Wave:
+    - new wave
+    - new wave music
+    - new-wave
+    - Akron Sound:
+      - akron sound
+      - akron punk
+      - akron scene
+      - rubber city punk
+    - Beat Rock:
+      - beat rock
+      - beat-rock
+      - ビートロック
+    - BRock:
+      - brock
+    - Friese bries:
+      - friese bries
+    - Mod Revival:
+      - mod revival
+      - new mod
+    - Movida madrileña:
+      - movida madrileña
+      - la movida
+      - la movida madrileña
+      - la movida madrilena
+      - movida madrilena
+      - the madrilenian scene
+    - Neue Deutsche Welle:
+      - neue deutsche welle
+      - ndw
+      - new german wave
+    - New Pop:
+      - new pop
+      - new music [american usage]
+      - new-pop
+    - New Primitivism:
+      - new primitivism
+      - new primitives
+      - novi primitivisti
+      - novi primitivizam
+    - New Romantic:
+      - new romantic
+      - new romanticism
+    - New Wave of New Wave:
+      - new wave of new wave
+      - nwonw
+    - Yugoslav New Wave:
+      - yugoslav new wave
+      - novi talas
+      - novi val
+      - нов бран
+      - нови вал
+      - нови талас
+    - Zolo:
+      - zolo
+    - Česká nová vlna:
+      - česká nová vlna
+      - ceska nova vlna
+      - czech new wave
+  - Noise Rock:
+    - noise rock
+    - noise-rock
+    - Fort Thunder Scene:
+      - fort thunder scene
+    - Free Noise:
+      - free noise
+      - free noise movement
+      - new zealand free noise
+      - nz free noise
+    - Shitgaze:
+      - shitgaze
+  - Pop Rock:
+    - pop rock
+    - pop-rock
+    - Beat:
+      - beat
+      - beat music
+      - Freakbeat:
+        - freakbeat
+      - Group Sounds:
+        - group sounds
+        - gs
+        - グループ・サウンズ
+      - Jovem Guarda:
+        - jovem guarda
+        - iê-iê-iê
+        - ie-ie-ie
+      - Merseybeat:
+        - merseybeat
+        - mersey sound
+      - Mod:
+        - mod
+      - Nederbeat:
+        - nederbeat
+        - dutch beat
+        - nederbiet
+    - Big:
+      - big
+      - big music
+      - big rock
+      - big sound
+      - the big music
+      - the big sound
+    - Britpop:
+      - britpop
+      - Post-Britpop:
+        - post-britpop
+        - post britpop
+    - New Partisans:
+      - new partisans
+    - Piano Rock:
+      - piano rock
+      - piano pop
+      - piano-rock
+    - Pop Yeh-Yeh:
+      - pop yeh-yeh
+      - pop yeh yeh
+    - Power Pop:
+      - power pop
+      - power-pop
+    - Rock Opera:
+      - rock opera
+    - Soft Rock:
+      - soft rock
+      - soft-rock
+      - Tropical Rock:
+        - tropical rock
+        - gulf & western
+        - trop rock
+        - tropical-rock
+      - Yacht Rock:
+        - yacht rock
+        - west coast sound
+        - yacht-rock
+    - Stereo:
+      - stereo
+  - Post-Rock:
+    - post-rock
+    - post rock
+    - Chicago School:
+      - chicago school
+      - chicago acoustic school
+      - chicago post-rock
+      - chicago school of post-rock
+      - windy city post-rock
+      - シカゴ音響派
+    - Maidcore:
+      - maidcore
+      - maid core
+      - maid rock
+      - мейдкор
+  - Progressive Rock:
+    - progressive rock
+    - prog
+    - prog rock
+    - prog-rock
+    - progressive-rock
+    - Avant-Prog:
+      - avant-prog
+      - avant prog
+      - avant-garde progressive rock
+      - Brutal Prog:
+        - brutal prog
+      - Rock in Opposition:
+        - rock in opposition
+        - rio
+      - Zeuhl:
+        - zeuhl
+    - Canterbury Scene:
+      - canterbury scene
+      - canterbury sound
+      - Neo-Canterbury:
+        - neo-canterbury
+        - neo canterbury
+        - neo-canterbury sound
+    - Neo-Prog:
+      - neo-prog
+      - neo prog
+      - neo-progressive rock
+    - New Prog:
+      - new prog
+      - nu prog
+      - nü prog
+      - post-progressive
+      - post-progressive rock
+    - Progg:
+      - progg
+      - alternativa musikrörelsen
+      - alternativa musikrorelsen
+      - musikrörelsen
+      - musikrorelsen
+      - svensk progg
+      - svenska alternativa musikrörelsen
+      - svenska alternativa musikrorelsen
+      - svenska musikrörelsen
+      - svenska musikrorelsen
+      - swedish alternative music movement
+      - swedish music movement
+      - swedish progg
+      - swedish progressive music movement
+    - Symphonic Prog:
+      - symphonic prog
+      - symphonic progressive rock
+  - Psychedelic Rock:
+    - psychedelic rock
+    - psych rock
+    - psychedelic-rock
+    - Acid Rock:
+      - acid rock
+      - acid-rock
+    - Bosstown Sound:
+      - bosstown sound
+      - boston sound
+    - English Underground:
+      - english underground
+      - english counterculture
+      - london counterculture
+      - london underground
+      - Ladbroke Grove Scene:
+        - ladbroke grove scene
+    - Heavy Psych:
+      - heavy psych
+      - hard psych
+    - Psichedelia occulta italiana:
+      - psichedelia occulta italiana
+      - iop
+      - italian occult psychedelia
+      - poi
+    - Raga Rock:
+      - raga rock
+      - raga-rock
+    - San Francisco Sound:
+      - san francisco sound
+      - Haight-Ashbury Scene:
+        - haight-ashbury scene
+        - haight ashbury scene
+    - Space Rock:
+      - space rock
+      - space-rock
+      - Space Rock Revival:
+        - space rock revival
+    - Texas Psychedelia:
+      - texas psychedelia
+      - "'60s texas psychedelic scene"
+      - texas psych
+    - Xian Psych:
+      - xian psych
+      - christian psych
+      - christian psychedelia
+      - jesus rock
+    - Zamrock:
+      - zamrock
+  - Pub Rock:
+    - pub rock
+    - pub-rock
+    - Aussie Pub Rock:
+      - aussie pub rock
+      - australian pub rock
+      - pub rock [australian usage]
+  - Punk:
+    - punk
+    - Art Punk:
+      - art punk
+      - art-punk
+      - avant punk
+      - avant-punk
+      - avant-punk rock
+      - Egg Punk:
+        - egg punk
+        - devocore
+        - egg-punk
+        - eggpunk
+    - Christian Punk:
+      - christian punk
+      - christian punk rock
+    - Cowpunk:
+      - cowpunk
+      - country punk
+    - Emo:
+      - emo
+      - Emo Revival:
+        - emo revival
+      - Emocore:
+        - emocore
+        - emotional hardcore
+      - Mall Screamo:
+        - mall screamo
+        - mtv screamo
+        - pop screamo
+      - Midwest Emo:
+        - midwest emo
+        - indie emo
+        - midwestern emo
+        - post-emo indie rock
+      - Screamo:
+        - screamo
+        - skramz
+        - Emoviolence:
+          - emoviolence
+    - Folk Punk:
+      - folk punk
+      - folk-punk
+      - Celtic Punk:
+        - celtic punk
+        - celtcore
+        - celtic-punk
+        - jig punk
+        - paddybeat
+        - rock and reel
+      - Gypsy Punk:
+        - gypsy punk
+        - gypsy-punk
+    - Glam Punk:
+      - glam punk
+      - glam-punk
+    - Latino Punk:
+      - latino punk
+      - latin american punk
+      - latin punk
+    - Noisecore:
+      - noisecore
+    - Pigfuck:
+      - pigfuck
+      - pigfucker
+    - Post-Punk:
+      - post-punk
+      - new musick
+      - post punk
+      - Coldwave:
+        - coldwave
+        - cold wave
+      - Gothic Rock:
+        - gothic rock
+        - goth rock
+        - gothic-rock
+        - Darkwave:
+          - darkwave
+          - dark wave
+          - Ethereal Wave:
+            - ethereal wave
+            - ethereal
+            - ethereal dark wave
+            - ethereal darkwave
+            - ethereal goth
+            - ethereal-wave
+          - Neoclassical Darkwave:
+            - neoclassical darkwave
+            - neoclassical dark wave
+          - Neue Deutsche Todeskunst:
+            - neue deutsche todeskunst
+            - ndt
+            - new german death art
+        - Deathrock:
+          - deathrock
+          - death punk
+          - death rock
+          - goth punk
+          - gothic punk
+        - Northern Gothic:
+          - northern gothic
+        - Positive Punk:
+          - positive punk
+          - positive-punk
+        - Visual kei:
+          - visual kei
+          - v-kei
+          - vijuaru kei
+          - vk
+          - v系
+          - ヴィジュアル系
+          - Kote kei:
+            - kote kei
+            - kotebi
+            - kotekote kei
+            - kotevi
+            - matina kei
+            - matina 系
+            - コテヴィ
+            - コテコテ系
+            - コテビ
+            - コテ系
+          - Nagoya kei:
+            - nagoya kei
+            - 名古屋系
+          - Oshare Kei:
+            - oshare kei
+            - お洒落系
+          - Soft Visual:
+            - soft visual
+            - soft visual kei
+            - sofubi
+            - sofvi
+            - ソフトヴィジュアル系
+            - ソフビ
+            - ソフビ系
+      - Leningrad Rock Club Scene:
+        - leningrad rock club scene
+        - leningrad rock club
+        - leningrad rock club wave
+        - ленинградский рок-клуб
+        - ленклуб любителей музыки
+        - ленрокклуб
+      - Little Band Scene:
+        - little band scene
+        - north fitzroy beat
+      - New Way of Danish Fuck You:
+        - new way of danish fuck you
+        - new wave of danish fuck you
+      - No Wave:
+        - no wave
+        - no-wave
+        - Chicago No Wave:
+          - chicago no wave
+        - Kansai No Wave:
+          - kansai no wave
+          - 関西no wave
+          - 関西ノー・ウェイヴ
+      - Post-Punk Revival:
+        - post-punk revival
+        - new wave revival
+        - post punk revival
+      - Ultra:
+        - ultra
+        - ultramodernen
+      - Windmill Scene:
+        - windmill scene
+        - the speedy scene
+        - windmill-core
+    - Proto-Punk:
+      - proto-punk
+      - proto punk
+      - protopunk
+    - Punk Blues:
+      - punk blues
+      - blues punk
+    - Punk Rock:
+      - punk rock
+      - punk-rock
+      - Anarcho-Punk:
+        - anarcho-punk
+        - anarchist punk
+        - anarcho punk
+      - CBGB Scene:
+        - cbgb scene
+        - cbgb punk
+      - Chikipunk:
+        - chikipunk
+        - chiki punk
+        - chiki-punk
+        - punk melódico
+        - punk melodico
+      - Cleveland Punk:
+        - cleveland punk
+        - cle punk
+        - cleveland scene
+        - cleveland-punk
+      - Deutschpunk:
+        - deutschpunk
+      - Garage Punk:
+        - garage punk
+        - garage-punk
+      - Hardcore Punk:
+        - hardcore punk
+        - hardcore-punk
+        - hxc
+        - Beatdown Hardcore:
+          - beatdown hardcore
+          - beatdown
+          - heavy hardcore
+          - heavy hardcore punk
+          - tough guy hardcore
+        - Christian Hardcore:
+          - christian hardcore
+        - Crust Punk:
+          - crust punk
+          - crust
+          - crust-punk
+          - Blackened Crust:
+            - blackened crust
+            - blackened crust punk
+          - Neocrust:
+            - neocrust
+            - melodic crust
+            - neo crust
+            - neo-crust
+          - Stenchcore:
+            - stenchcore
+            - stench
+        - D-Beat:
+          - d-beat
+          - d beat
+          - discore
+          - kängpunk
+          - kangpunk
+        - Digital Hardcore:
+          - digital hardcore
+        - Japanese Hardcore:
+          - japanese hardcore
+          - Burning Spirits:
+            - burning spirits
+            - burning spirits hardcore
+        - Melodic Hardcore:
+          - melodic hardcore
+        - Nardcore:
+          - nardcore
+          - oxnard hardcore
+        - New York Hardcore:
+          - new york hardcore
+          - nyhc
+        - Post-Hardcore:
+          - post-hardcore
+          - post hardcore
+          - Louisville Sound:
+            - louisville sound
+          - Revolution Summer:
+            - revolution summer
+          - Swancore:
+            - swancore
+            - progcore
+            - progressive post-hardcore
+          - The Wave:
+            - the wave
+            - new wave of post-hardcore
+            - the-wave
+        - Riot Grrrl:
+          - riot grrrl
+          - riot girl
+          - riot grrl
+        - Straight Edge:
+          - straight edge
+          - straight edge hardcore
+          - straight-edge
+          - straight-edge hardcore
+          - sxe
+          - Krishnacore:
+            - krishnacore
+            - krishna conscious hardcore
+          - Vegan Straight Edge:
+            - vegan straight edge
+            - vegan straightedge
+            - xvx
+            - H8000:
+              - h8000
+            - Hardline:
+              - hardline
+              - hardline straight edge
+              - vegan hardline
+          - Youth Crew:
+            - youth crew
+            - youth crew hardcore
+        - Thrashcore:
+          - thrashcore
+          - fastcore
+          - Powerviolence:
+            - powerviolence
+            - pv
+      - Horror Punk:
+        - horror punk
+        - horror rock
+        - horror-punk
+      - J-Punk:
+        - j-punk
+        - j punk
+        - japanese punk
+        - japanese punk rock
+      - Könsrock:
+        - könsrock
+        - konsrock
+      - New Brunswick Basement Scene:
+        - new brunswick basement scene
+        - new brunswick underground
+        - rutgers basement scene
+        - rutgers underground
+      - Oi!:
+        - oi!
+        - oi
+      - Pop-Punk:
+        - pop-punk
+        - pop punk
+        - punk pop
+        - Easycore:
+          - easycore
+          - popcore
+          - softcore
+        - Seishun Punk:
+          - seishun punk
+          - seishun punk rock
+          - seishun-punk
+          - seisyun punk
+          - 青春パンク
+          - 青春パンクロック
+      - Queercore:
+        - queercore
+        - homocore
+      - Rock radical vasco:
+        - rock radical vasco
+        - basque radical rock
+        - euskal herriko rock erradikala
+        - euskal rock erradikala
+        - rrv
+      - Rock subterráneo:
+        - rock subterráneo
+        - movida subte
+        - rock subte
+        - rock subterraneo
+      - Rock urbano español:
+        - rock urbano español
+        - rock urbano
+        - rock urbano espanol
+      - Siberian Punk:
+        - siberian punk
+        - siberian-punk
+        - sibpunk
+        - сибирский панк
+        - сибпанк
+      - Skate Punk:
+        - skate punk
+        - skate rock
+        - skate-punk
+        - skatepunk
+      - Street Punk:
+        - street punk
+        - street-punk
+        - streetpunk
+      - Taqwacore:
+        - taqwacore
+      - UK82:
+        - uk82
+      - Vikingarock:
+        - vikingarock
+        - viking rock
+      - Voëlvry Movement:
+        - voëlvry movement
+        - die voëlvry-beweging
+        - die voelvry-beweging
+        - voelvry movement
+    - Sass:
+      - sass
+      - sasscore
+      - sassy screamo
+    - Český underground:
+      - český underground
+      - český hudební underground
+      - cesky hudebni underground
+      - cesky underground
+      - czech music underground
+      - czech rock underground
+      - czech underground
+      - prague underground
+      - pražský underground
+      - prazsky underground
+  - Rap Rock:
+    - rap rock
+    - rap-rock
+    - Rap Metal:
+      - rap metal
+      - rap-metal
+      - Rapcore:
+        - rapcore
+  - Reggae Rock:
+    - reggae rock
+    - reggae-rock
+  - Rock & Roll:
+    - rock & roll
+    - rock 'n' roll
+    - rock and roll
+    - rock n roll
+    - rock'n'roll
+    - British Rock & Roll:
+      - british rock & roll
+      - british rock 'n' roll
+      - british rock and roll
+      - british rock n roll
+      - british rock'n'roll
+    - Indorock:
+      - indorock
+      - indo rock
+    - Mentai Rock:
+      - mentai rock
+      - mentai beat
+      - mentai-rock
+      - めんたいビート
+      - めんたいロック
+      - 博多のロック
+    - Rockabilly:
+      - rockabilly
+      - rockabilly revival
+      - Gothabilly:
+        - gothabilly
+        - gothic rockabilly
+        - gothic rockabilly music
+      - Psychobilly:
+        - psychobilly
+    - Twist:
+      - twist
+  - Roots Rock:
+    - roots rock
+    - roots-rock
+    - Swamp Rock:
+      - swamp rock
+      - swamp-rock
+    - Tex-Mex:
+      - tex-mex
+      - tex mex
+  - Southern Rock:
+    - southern rock
+    - southern-rock
+  - Surf:
+    - surf
+    - surf music
+    - Hot Rod:
+      - hot rod
+      - drag racing
+      - drag rock
+      - drag surf
+      - hot rod music
+      - hot rod rock
+      - hot rod surf
+      - surf & drag
+    - Indie Surf:
+      - indie surf
+      - indie beach
+      - indie beach rock
+      - indie surf rock
+    - Surf Punk:
+      - surf punk
+      - surf-punk
+    - Surf Rock:
+      - surf rock
+      - surf revival
+      - surf-rock
+    - Vocal Surf:
+      - vocal surf
+      - surf pop
+      - surf vocal
+      - Eleki:
+        - eleki
+        - eleki buumu
+        - エレキ
+      - Rautalanka:
+        - rautalanka
+        - pigtrådsmusik
+        - pigtradsmusik
+        - ståltrådsmusik
+        - staltradsmusik
+        - taggtrådsmusik
+        - taggtradsmusik
+      - Wong shadow:
+        - wong shadow
+        - shadow music
+        - วงชาโดว์
+  - Symphonic Rock:
+    - symphonic rock
+    - symphonic-rock
+  - Tolai Rock:
+    - tolai rock
+    - tolai-rock
+- Singer-Songwriter:
+  - singer-songwriter
+  - singer songwriter
+  - singer/songwriter
+  - Azmari:
+    - azmari
+    - አዝማሪ
+  - European Singer-Songwriter:
+    - european singer-songwriter
+    - european singer songwriter
+    - Avtorskaya pesnya:
+      - avtorskaya pesnya
+      - author song
+      - bard music
+      - авторская песня
+      - бардовская песня
+    - Canzone d'autore:
+      - canzone d'autore
+      - musica d'autore
+    - Chanson:
+      - chanson
+      - french chanson
+      - Chanson alternative:
+        - chanson alternative
+      - Chanson québécoise:
+        - chanson québécoise
+        - chanson quebecoise
+        - québécois chanson
+        - quebecois chanson
+      - Chanson réaliste:
+        - chanson réaliste
+        - chanson realiste
+      - Chanson à texte:
+        - chanson à texte
+        - chanson a texte
+      - Nouvelle chanson:
+        - nouvelle chanson
+        - new chanson
+        - nouvelle chanson française
+        - nouvelle chanson francaise
+        - nouvelle scène
+        - nouvelle scene
+        - nouvelle scène française
+        - nouvelle scene francaise
+    - Euskal kantagintza berria:
+      - euskal kantagintza berria
+      - euskal kanta berria
+    - Kleinkunst:
+      - kleinkunst
+      - luisterlied
+    - Liedermacher:
+      - liedermacher
+    - Música de intervenção:
+      - música de intervenção
+      - canção de esquerda
+      - cancao de esquerda
+      - canção de protesto
+      - cancao de protesto
+      - canto colectivo
+      - canto livre
+      - musica de intervencao
+      - música de resistência
+      - musica de resistencia
+    - Nova cançó:
+      - nova cançó
+      - nova canco
+    - Nòva cançon:
+      - nòva cançon
+      - nova cancon
+      - nòva canson
+      - nova canson
+      - nòva chançon
+      - nova chancon
+    - Poezja śpiewana:
+      - poezja śpiewana
+      - poezja spiewana
+      - polish sung poetry
+    - Russian Romance:
+      - russian romance
+      - русский романс
+    - Éntekhno:
+      - éntekhno
+      - entechna
+      - entekhno
+      - Néo kýma:
+        - néo kýma
+        - greek new wave
+        - neo kyma
+        - νέο κύμα
+    - Özgün Müzik:
+      - özgün müzik
+      - özgün
+      - ozgun
+      - ozgun muzik
+  - Ghazal:
+    - ghazal
+    - gazel
+    - qəzəl
+    - غزل
+    - ग़ज़ल
+    - गजल
+    - গ়জ়ল
+    - ਗ਼ਜ਼ਲ
+    - ગ઼ઝલ
+  - Latin American Singer-Songwriter:
+    - latin american singer-songwriter
+    - latin american singer songwriter
+    - Nueva canción:
+      - nueva canción
+      - nueva cancion
+      - Nueva canción española:
+        - nueva canción española
+        - canción del pueblo
+        - cancion del pueblo
+        - manifiesto canción del sur
+        - manifiesto cancion del sur
+        - nueva canción aragonesa
+        - nueva cancion aragonesa
+        - nueva canción canaria
+        - nueva cancion canaria
+        - nueva canción castellana
+        - nueva cancion castellana
+        - nueva cancion espanola
+      - Nueva canción latinoamericana:
+        - nueva canción latinoamericana
+        - nueva cancion latinoamericana
+        - Nueva canción chilena:
+          - nueva canción chilena
+          - nueva cancion chilena
+        - Nuevo Cancionero:
+          - nuevo cancionero
+          - movimiento del nuevo cancionero
+    - Trova:
+      - trova
+      - canción trovadoresca cubana
+      - cancion trovadoresca cubana
+      - cuban trova
+      - trova cubana
+      - Nueva trova:
+        - nueva trova
+        - nueva trova cubana
+    - Trova rosarina:
+      - trova rosarina
+    - Twoubadou:
+      - twoubadou
+      - misik twoubadou

--- a/beetsplug/lastgenre/genres.txt
+++ b/beetsplug/lastgenre/genres.txt
@@ -1,1546 +1,2985 @@
-2 tone
-2-step garage
-4-beat
-4x4 garage
-8-bit
-acapella
-acid
-acid breaks
-acid house
-acid jazz
-acid rock
-acoustic music
-acousticana
-adult contemporary music
-african popular music
-african rumba
-afrobeat
-aleatoric music
-alternative country
-alternative dance
-alternative hip hop
-alternative metal
-alternative rock
-ambient
-ambient house
-ambient music
-americana
-anarcho punk
-anti-folk
-apala
-ape haters
-arab pop
-arabesque
-arabic pop
-argentine rock
-ars antiqua
-ars nova
-art punk
-art rock
-ashiq
-asian american jazz
-australian country music
-australian hip hop
-australian pub rock
-austropop
-avant-garde
-avant-garde jazz
-avant-garde metal
-avant-garde music
-axé
-bac-bal
-bachata
-baggy
-baila
-baile funk
-baisha xiyue
-baithak gana
-baião
-bajourou
-bakersfield sound
-bakou
-bakshy
-bal-musette
-balakadri
-balinese gamelan
-balkan pop
-ballad
-ballata
-ballet
-bamboo band
-bambuco
-banda
-bangsawan
-bantowbol
-barbershop music
-barndance
-baroque
-baroque music
-baroque pop
-bass music
-batcave
-batucada
-batuco
-batá-rumba
-beach music
-beat
-beatboxing
-beautiful music
-bebop
-beiguan
-bel canto
-bend-skin
-benga
-berlin school of electronic music
-bhajan
-bhangra
-bhangra-wine
-bhangragga
-bhangramuffin
-big band
-big band music
-big beat
-biguine
-bihu
-bikutsi
-biomusic
-bitcore
-bitpop
-black metal
-blackened death metal
-blue-eyed soul
-bluegrass
-blues
-blues ballad
-blues-rock
-boogie
-boogie woogie
-boogie-woogie
-bossa nova
-brass band
-brazilian funk
-brazilian jazz
-breakbeat
-breakbeat hardcore
-breakcore
-breton music
-brill building pop
-britfunk
-british blues
-british invasion
-britpop
-broken beat
-brown-eyed soul
-brukdown
-brutal death metal
-bubblegum dance
-bubblegum pop
-bulerias
-bumba-meu-boi
-bunraku
-burger-highlife
-burgundian school
-byzantine chant
-ca din tulnic
-ca pe lunca
-ca trù
-cabaret
-cadence
-cadence rampa
-cadence-lypso
-café-aman
-cai luong
-cajun music
-cakewalk
-calenda
-calentanos
-calgia
-calypso
-calypso jazz
-calypso-style baila
-campursari
-canatronic
-canción de autor
-candombe
-canon
-canrock
-cantata
-cantautorato
-cantautor
-cantautora
-cante chico
-cante jondo
-canterbury scene
-cantiga
-cantique
-cantiñas
-canto livre
-canto nuevo
-canto popular
-cantopop
-canzone napoletana
-cape jazz
-capoeira music
-caracoles
-carceleras
-cardas
-cardiowave
-carimbó
-cariso
-carnatic music
-carol
-cartageneras
-cassette culture
-casséy-co
-cavacha
-caveman
-caña
-celempungan
-cello rock
-celtic
-celtic fusion
-celtic metal
-celtic punk
-celtic reggae
-celtic rock
-cha-cha-cha
-chakacha
-chalga
-chamamé
-chamber jazz
-chamber music
-chamber pop
-champeta
-changuí
-chanson
-chant
-charanga
-charanga-vallenata
-charikawi
-chastushki
-chau van
-chemical breaks
-chicago blues
-chicago house
-chicago soul
-chicano rap
-chicha
-chicken scratch
-children's music
-chillout
-chillwave
-chimurenga
-chinese music
-chinese pop
-chinese rock
-chip music
-cho-kantrum
-chongak
-chopera
-chorinho
-choro
-chouval bwa
-chowtal
-christian alternative
-christian black metal
-christian electronic music
-christian hardcore
-christian hip hop
-christian industrial
-christian metal
-christian music
-christian punk
-christian r&b
-christian rock
-christian ska
-christmas carol
-christmas music
-chumba
-chut-kai-pang
-chutney
-chutney soca
-chutney-bhangra
-chutney-hip hop
-chutney-soca
-chylandyk
-chzalni
-chèo
-cigányzene
-classic
-classic country
-classic female blues
-classic rock
-classical
-classical music
-classical music era
-clicks n cuts
-close harmony
-club music
-cocobale
-coimbra fado
-coladeira
-colombianas
-combined rhythm
-comedy
-comedy rap
-comedy rock
-comic opera
-comparsa
-compas direct
-compas meringue
-concert overture
-concerto
-concerto grosso
-congo
-conjunto
-contemporary christian
-contemporary christian music
-contemporary classical
-contemporary r&b
-contonbley
-contradanza
-cool jazz
-corrido
-corsican polyphonic song
-cothoza mfana
-country
-country blues
-country gospel
-country music
-country pop
-country r&b
-country rock
-country-rap
-countrypolitan
-couple de sonneurs
-coupé-décalé
-cowpunk
-cretan music
-crossover jazz
-crossover music
-crossover thrash
-crossover thrash metal
-crunk
-crunk&b
-crunkcore
-crust punk
-csárdás
-cuarteto
-cuban rumba
-cuddlecore
-cueca
-cumbia
-cumbia villera
-cybergrind
-dabka
-dadra
-daina
-dalauna
-dance
-dance music
-dance-pop
-dance-punk
-dance-rock
-dancehall
-dangdut
-danger music
-dansband
-danza
-danzón
-dark ambient
-dark cabaret
-dark pop
-darkcore
-darkstep
-darkwave
-de ascultat la servici
-de codru
-de dragoste
-de jale
-de pahar
-death industrial
-death metal
-death rock
-death/doom
-deathcore
-deathgrind
-deathrock
-deep funk
-deep house
-deep soul
-degung
-delta blues
-dementia
-desert rock
-desi
-detroit blues
-detroit techno
-dub techno
-dhamar
-dhimotiká
-dhrupad
-dhun
-digital hardcore
-dirge
-dirty dutch
-dirty rap
-dirty rap/pornocore
-dirty south
-disco
-disco house
-disco polo
-disney
-disney hardcore
-disney pop
-diva house
-divine rock
-dixieland
-dixieland jazz
-djambadon
-djent
-dodompa
-doina
-dombola
-dondang sayang
-donegal fiddle tradition
-dongjing
-doo wop
-doom metal
-doomcore
-downtempo
-drag
-dream pop
-drone doom
-drone metal
-drone music
-dronology
-drum and bass
-dub
-dub house
-dubanguthu
-dubstep
-dubtronica
-dunedin sound
-dunun
-dutch jazz
-décima
-early music
-east coast blues
-east coast hip hop
-easy listening
-electric blues
-electric folk
-electro
-electro backbeat
-electro hop
-electro house
-electro punk
-electro-industrial
-electro-swing
-electroclash
-electrofunk
-electronic
-electronic art music
-electronic body music
-electronic dance
-electronic luk thung
-electronic music
-electronic rock
-electronica
-electropop
-elevator music
-emo
-emo pop
-emo rap
-emocore
-emotronic
-enka
-epic doom metal
-epic metal
-eremwu eu
-ethereal pop
-ethereal wave
-euro
-euro disco
-eurobeat
-eurodance
-europop
-eurotrance
-eurourban
-exotica
-experimental music
-experimental noise
-experimental pop
-experimental rock
-extreme metal
-ezengileer
-fado
-falak
-fandango
-farruca
-fife and drum blues
-filk
-film score
-filmi
-filmi-ghazal
-finger-style
-fjatpangarri
-flamenco
-flamenco rumba
-flower power
-foaie verde
-fofa
-folk hop
-folk metal
-folk music
-folk pop
-folk punk
-folk rock
-folktronica
-forró
-franco-country
-freak-folk
-freakbeat
-free improvisation
-free jazz
-free music
-freestyle
-freestyle house
-freetekno
-french pop
-frenchcore
-frevo
-fricote
-fuji
-fuji music
-fulia
-full on
-funaná
-funeral doom
-funk
-funk metal
-funk rock
-funkcore
-funky house
-furniture music
-fusion jazz
-g-funk
-gaana
-gabba
-gabber
-gagaku
-gaikyoku
-gaita
-galant
-gamad
-gambang kromong
-gamelan
-gamelan angklung
-gamelan bang
-gamelan bebonangan
-gamelan buh
-gamelan degung
-gamelan gede
-gamelan kebyar
-gamelan salendro
-gamelan selunding
-gamelan semar pegulingan
-gamewave
-gammeldans
-gandrung
-gangsta rap
-gar
-garage rock
-garrotin
-gavotte
-gelugpa chanting
-gender wayang
-gending
-german folk music
-gharbi
-gharnati
-ghazal
-ghazal-song
-ghetto house
-ghettotech
-girl group
-glam metal
-glam punk
-glam rock
-glitch
-gnawa
-go-go
-goa
-goa trance
-gong-chime music
-goombay
-goregrind
-goshu ondo
-gospel music
-gothic metal
-gothic rock
-granadinas
-grebo
-gregorian chant
-grime
-grindcore
-groove metal
-group sounds
-grunge
-grupera
-guaguanbo
-guajira
-guasca
-guitarra baiana
-guitarradas
-gumbe
-gunchei
-gunka
-guoyue
-gwo ka
-gwo ka moderne
-gypsy jazz
-gypsy punk
-gypsybilly
-gyu ke
-habanera
-hajnali
-hakka
-halling
-hambo
-hands up
-hapa haole
-happy hardcore
-haqibah
-hard
-hard bop
-hard house
-hard rock
-hard trance
-hardcore hip hop
-hardcore metal
-hardcore punk
-hardcore techno
-hardstyle
-harepa
-harmonica blues
-hasaposérviko
-heart attack
-heartland rock
-heavy beat
-heavy metal
-hesher
-hi-nrg
-highlands
-highlife
-highlife fusion
-hillybilly music
-hindustani classical music
-hip hop
-hip hop & rap
-hip hop soul
-hip house
-hiplife
-hiragasy
-hiva usu
-hong kong and cantonese pop
-hong kong english pop
-honky tonk
-honkyoku
-hora lunga
-hornpipe
-horror punk
-horrorcore
-horrorcore rap
-house
-house music
-hua'er
-huasteco
-huayno
-hula
-humor
-humppa
-hunguhungu
-hyangak
-hymn
-hyphy
-hát chau van
-hát chèo
-hát cãi luong
-hát tuồng
-ibiza music
-icaro
-idm
-igbo music
-ijexá
-ilahije
-illbient
-impressionist music
-improvisational
-incidental music
-indian pop
-indie folk
-indie music
-indie pop
-indie rock
-indietronica
-indo jazz
-indo rock
-indonesian pop
-indoyíftika
-industrial death metal
-industrial hip hop
-industrial metal
-industrial music
-industrial musical
-industrial rock
-instrumental rock
-intelligent dance music
-international latin
-inuit music
-iranian pop
-irish folk
-irish rebel music
-iscathamiya
-isicathamiya
-isikhwela jo
-island
-isolationist
-italo dance
-italo disco
-italo house
-itsmeños
-izvorna bosanska muzika
-j'ouvert
-j-fusion
-j-pop
-j-rock
-jaipongan
-jaliscienses
-jam band
-jam rock
-jamana kura
-jamrieng samai
-jangle pop
-japanese pop
-jarana
-jariang
-jarochos
-jawaiian
-jazz
-jazz blues
-jazz fusion
-jazz metal
-jazz rap
-jazz-funk
-jazz-rock
-jegog
-jenkka
-jesus music
-jibaro
-jig
-jig punk
-jing ping
-jingle
-jit
-jitterbug
-jive
-joged
-joged bumbung
-joik
-jonnycore
-joropo
-jota
-jtek
-jug band
-jujitsu
-juju
-juke joint blues
-jump blues
-jumpstyle
-jungle
-junkanoo
-juré
-jùjú
-k-pop
-kaba
-kabuki
-kachāshī
-kadans
-kagok
-kagyupa chanting
-kaiso
-kalamatianó
-kalattuut
-kalinda
-kamba pop
-kan ha diskan
-kansas city blues
-kantrum
-kantádhes
-kargyraa
-karma
-kaseko
-katajjaq
-kawachi ondo
-kayōkyoku
-ke-kwe
-kebyar
-kecak
-kecapi suling
-kertok
-khaleeji
-khap
-khelimaski djili
-khene
-khoomei
-khorovodi
-khplam wai
-khrung sai
-khyal
-kilapanda
-kinko
-kirtan
-kiwi rock
-kizomba
-klape
-klasik
-klezmer
-kliningan
-kléftiko
-kochare
-kolomyjka
-komagaku
-kompa
-konpa
-korean pop
-koumpaneia
-kpanlogo
-krakowiak
-krautrock
-kriti
-kroncong
-krump
-krzesany
-kuduro
-kulintang
-kulning
-kumina
-kun-borrk
-kundere
-kundiman
-kussundé
-kutumba wake
-kveding
-kvæði
-kwaito
-kwassa kwassa
-kwela
-käng
-kélé
-kĩkũyũ pop
-la la
-latin american
-latin jazz
-latin pop
-latin rap
-lavway
-laïko
-laïkó
-le leagan
-legényes
-lelio
-letkajenkka
-levenslied
-lhamo
-lieder
-light music
-light rock
-likanos
-liquid drum&bass
-liquid funk
-liquindi
-llanera
-llanto
-lo-fi
-lo-fi music
-loki djili
-long-song
-louisiana blues
-louisiana swamp pop
-lounge music
-lovers rock
-lowercase
-lubbock sound
-lucknavi thumri
-luhya omutibo
-luk grung
-lullaby
-lundu
-lundum
-m-base
-madchester
-madrigal
-mafioso rap
-maglaal
-magnificat
-mahori
-mainstream jazz
-makossa
-makossa-soukous
-malagueñas
-malawian jazz
-malhun
-maloya
-maluf
-maluka
-mambo
-manaschi
-mandarin pop
-manding swing
-mango
-mangue bit
-mangulina
-manikay
-manila sound
-manouche
-manzuma
-mapouka
-mapouka-serré
-marabi
-maracatu
-marga
-mariachi
-marimba
-marinera
-marrabenta
-martial industrial
-martinetes
-maskanda
-mass
-matamuerte
-math rock
-mathcore
-matt bello
-maxixe
-mazurka
-mbalax
-mbaqanga
-mbube
-mbumba
-medh
-medieval folk rock
-medieval metal
-medieval music
-meditation
-mejorana
-melhoun
-melhûn
-melodic black metal
-melodic death metal
-melodic hardcore
-melodic metalcore
-melodic music
-melodic trance
-memphis blues
-memphis rap
-memphis soul
-mento
-merengue
-merengue típico moderno
-merengue-bomba
-meringue
-merseybeat
-metal
-metalcore
-metallic hardcore
-mexican pop
-mexican rock
-mexican son
-meykhana
-mezwed
-miami bass
-microhouse
-middle of the road
-midwest hip hop
-milonga
-min'yo
-mineras
-mini compas
-mini-jazz
-minimal techno
-minimalist music
-minimalist trance
-minneapolis sound
-minstrel show
-minuet
-mirolóyia
-modal jazz
-modern classical
-modern classical music
-modern laika
-modern rock
-modinha
-mohabelo
-montuno
-monumental dance
-mor lam
-mor lam sing
-morna
-motorpop
-motown
-mozambique
-mpb
-mugam
-multicultural
-murga
-musette
-museve
-mushroom jazz
-music drama
-music hall
-musiqi-e assil
-musique concrète
-mutuashi
-muwashshah
-muzak
-méringue
-música campesina
-música criolla
-música de la interior
-música llanera
-música nordestina
-música popular brasileira
-música tropical
-nagauta
-nakasi
-nangma
-nanguan
-narcocorrido
-nardcore
-narodna muzika
-nasheed
-nashville sound
-nashville sound/countrypolitan
-national socialist black metal
-naturalismo
-nederpop
-neo soul
-neo-classical metal
-neo-medieval
-neo-prog
-neo-psychedelia
-neoclassical
-neoclassical metal
-neoclassical music
-neofolk
-neotraditional country
-nerdcore
-neue deutsche härte
-neue deutsche welle
-new age music
-new beat
-new instrumental
-new jack swing
-new orleans blues
-new orleans jazz
-new pop
-new prog
-new rave
-new romantic
-new school hip hop
-new taiwanese song
-new wave
-new wave of british heavy metal
-new wave of new wave
-new weird america
-new york blues
-new york house
-newgrass
-nganja
-nightcore
-nintendocore
-nisiótika
-no wave
-noh
-noise music
-noise pop
-noise rock
-nongak
-norae undong
-nordic folk dance music
-nordic folk music
-nortec
-norteño
-northern soul
-nota
-nu jazz
-nu metal
-nu soul
-nu skool breaks
-nueva canción
-nyatiti
-néo kýma
-obscuro
-oi!
-old school hip hop
-old-time
-oldies
-olonkho
-oltului
-ondo
-opera
-operatic pop
-oratorio
-orchestra
-orchestral
-organ trio
-organic ambient
-organum
-orgel
-oriental metal
-ottava rima
-outlaw country
-outsider music
-p-funk
-pagan metal
-pagan rock
-pagode
-paisley underground
-palm wine
-palm-wine
-pambiche
-panambih
-panchai baja
-panchavadyam
-pansori
-paranda
-parang
-parody
-parranda
-partido alto
-pasillo
-patriotic
-peace punk
-pelimanni music
-petenera
-peyote song
-philadelphia soul
-piano blues
-piano rock
-piedmont blues
-pimba
-pinoy pop
-pinoy rock
-pinpeat orchestra
-piphat
-piyyutim
-plainchant
-plena
-pleng phua cheewit
-pleng thai sakorn
-political hip hop
-polka
-polo
-polonaise
-pols
-polska
-pong lang
-pop
-pop folk
-pop music
-pop punk
-pop rap
-pop rock
-pop sunda
-pornocore
-porro
-post disco
-post-britpop
-post-disco
-post-grunge
-post-hardcore
-post-industrial
-post-metal
-post-minimalism
-post-punk
-post-rock
-post-romanticism
-pow-wow
-power electronics
-power metal
-power noise
-power pop
-powerviolence
-ppongtchak
-praise song
-program symphony
-progressive bluegrass
-progressive country
-progressive death metal
-progressive electronic
-progressive electronic music
-progressive folk
-progressive folk music
-progressive house
-progressive metal
-progressive power metal
-progressive rock
-progressive trance
-progressive thrash metal
-protopunk
-psych folk
-psychedelic music
-psychedelic pop
-psychedelic rock
-psychedelic trance
-psychobilly
-punk blues
-punk cabaret
-punk jazz
-punk rock
-punta
-punta rock
-qasidah
-qasidah modern
-qawwali
-quadrille
-quan ho
-queercore
-quiet storm
-rada
-raga
-raga rock
-ragga
-ragga jungle
-raggamuffin
-ragtime
-rai
-rake-and-scrape
-ramkbach
-ramvong
-ranchera
-rap
-rap metal
-rap rock
-rapcore
-rara
-rare groove
-rasiya
-rave
-raw rock
-raï
-rebetiko
-red dirt
-reel
-reggae
-reggae 110
-reggae bultrón
-reggae en español
-reggae fusion
-reggae highlife
-reggaefusion
-reggaeton
-rekilaulu
-relax music
-religious
-rembetiko
-renaissance music
-requiem
-rhapsody
-rhyming spiritual
-rhythm & blues
-rhythm and blues
-ricercar
-riot grrrl
-rock
-rock and roll
-rock en español
-rock opera
-rockabilly
-rocksteady
-rococo
-romantic flow
-romantic period in music
-rondeaux
-ronggeng
-roots reggae
-roots rock
-roots rock reggae
-rumba
-russian pop
-rímur
-sabar
-sacred harp
-sacred music
-sadcore
-saibara
-sakara
-salegy
-salsa
-salsa erotica
-salsa romantica
-saltarello
-samba
-samba-canção
-samba-reggae
-samba-rock
-sambai
-sanjo
-sato kagura
-sawt
-saya
-scat
-schlager
-schottisch
-schranz
-scottish baroque music
-screamo
-scrumpy and western
-sea shanty
-sean nós
-second viennese school
-sega music
-seggae
-seis
-semba
-sephardic music
-serialism
-set dance
-sevdalinka
-sevillana
-shabab
-shabad
-shalako
-shan'ge
-shango
-shape note
-shibuya-kei
-shidaiqu
-shima uta
-shock rock
-shoegaze
-shoegazer
-shoka
-shomyo
-show tune
-sica
-siguiriyas
-silat
-sinawi
-situational
-ska
-ska punk
-skacore
-skald
-skate punk
-skiffle
-slack-key guitar
-slide
-slowcore
-sludge metal
-slängpolska
-smooth jazz
-soca
-soft rock
-son
-son montuno
-son-batá
-sonata
-songo
-songo-salsa
-sophisti-pop
-soukous
-soul
-soul blues
-soul jazz
-soul music
-southern gospel
-southern harmony
-southern hip hop
-southern metal
-southern rock
-southern soul
-space age pop
-space music
-space rock
-spectralism
-speed garage
-speed metal
-speedcore
-spirituals
-spouge
-sprechgesang
-square dance
-squee
-st. louis blues
-stand-up
-steelband
-stoner metal
-stoner rock
-straight edge
-strathspeys
-stride
-string
-string quartet
-sufi music
-suite
-sunshine pop
-suomirock
-super eurobeat
-surf ballad
-surf instrumental
-surf music
-surf pop
-surf rock
-swamp blues
-swamp pop
-swamp rock
-swing
-swing music
-swingbeat
-sygyt
-symphonic
-symphonic black metal
-symphonic metal
-symphonic poem
-symphonic rock
-symphony
-synthcore
-synthpop
-synthpunk
-t'ong guitar
-taarab
-tai tu
-taiwanese pop
-tala
-talempong
-tambu
-tamburitza
-tamil christian keerthanai
-tango
-tanguk
-tappa
-tarana
-tarantella
-taranto
-tech
-tech house
-tech trance
-technical death metal
-technical metal
-techno
-technoid
-technopop
-techstep
-techtonik
-teen pop
-tejano
-tejano music
-tekno
-tembang sunda
-teutonic thrash metal
-texas blues
-thai pop
-thillana
-thrash metal
-thrashcore
-thumri
-tibetan pop
-tiento
-timbila
-tin pan alley
-tinga
-tinku
-toeshey
-togaku
-trad jazz
-traditional bluegrass
-traditional heavy metal
-traditional pop music
-trallalero
-trance
-tribal house
-trikitixa
-trip hop
-trip rock
-tropicalia
-tropicalismo
-tropipop
-truck-driving country
-tumba
-turbo-folk
-turkish music
-turkish pop
-turntablism
-tuvan throat-singing
-twee pop
-twist
-two tone
-táncház
-uk garage
-uk pub rock
-unblack metal
-underground music
-uplifting
-uplifting trance
-urban cowboy
-urban folk
-urban jazz
-vallenato
-vaudeville
-venezuela
-verbunkos
-verismo
-viking metal
-villanella
-virelai
-vispop
-visual kei
-visual music
-vocal
-vocal house
-vocal jazz
-vocal music
-volksmusik
-waila
-waltz
-wangga
-warabe uta
-wassoulou
-weld
-were music
-west coast hip hop
-west coast jazz
-western
-western blues
-western swing
-witch house
-wizard rock
-women's music
-wong shadow
-wonky pop
-wood
-work song
-world fusion
-world fusion music
-world music
-worldbeat
-xhosa music
-xoomii
-yo-pop
-yodeling
-yukar
-yé-yé
-zajal
-zapin
-zarzuela
-zeibekiko
-zeuhl
-ziglibithy
-zouglou
-zouk
-zouk chouv
-zouklove
-zulu music
-zydeco
+16-bit
+2 Tone
+2-Step
+3-Step
+4-Beat
+Aak
+Abakuá
+Abkhazian Folk
+Aboio
+Aboio cantado
+Absolute Music
+Abstract Hip Hop
+Acholitronix
+Acid Breaks
+Acid House
+Acid Jazz
+Acid Rock
+Acid Techno
+Acid Trance
+Acidcore
+Acousmatic
+Acoustic Blues
+Acoustic Chicago Blues
+Acoustic Rock
+Acoustic Texas Blues
+Adhunik geet
+Adult Contemporary
+Aegean Islands Folk
+Afoxé
+African Court Music
+African Dance
+African Folk
+African Heavy Metal
+African Hip Hop
+African Pop
+Afrikaner Folk
+Afro House
+Afro Tech
+Afro Trap
+Afro-Cuban Jazz
+Afro-Funk
+Afro-Jazz
+Afro-Rock
+Afrobeat
+Afrobeats
+Afrofuturism
+Afropiano
+Afroswing
+Agbadza
+Agbekor
+Aguinaldo
+Ahwash
+Ainu
+Aita
+Akishibu-kei
+Akron Sound
+Al jeel
+Al-Jadīd
+Albanian Folk
+Aleke
+Alevi Folk
+Algerian Chaabi
+Algorave
+Alloukou
+Alpenrock
+Alpine Folk
+Alsatian Folk
+Alternative Country
+Alternative Dance
+Alternative Hip Hop
+Alternative Idol
+Alternative Metal
+Alternative Pop
+Alternative R&B
+Alternative Reggaetón
+Alternative Rock
+Alté
+AM Pop
+Amami shimauta
+Amapiano
+Ambasse bey
+Ambient
+Ambient Americana
+Ambient Dub
+Ambient Fusion
+Ambient House
+Ambient Noise Wall
+Ambient Plugg
+Ambient Pop
+Ambient Techno
+Ambient Trance
+Ambrosian Chant
+American Folk
+American Gamelan
+American Primitivism
+Americana
+Amigacore
+Anarcho-Punk
+Anatolian Rock
+Ancient
+Ancient Chinese
+Ancient Egyptian
+Ancient Greek
+Ancient Levitical
+Ancient Roman
+Andalusian Classical
+Andalusian Folk
+Andean Folk
+Andean New Age
+Anglican Chant
+Animal Sounds
+Anti-Folk
+Apala
+Appalachian Folk
+Aquacrunk
+Arabesk
+Arabesque Rap
+Arabic Bellydance
+Arabic Classical
+Arabic Folk
+Arabic Jazz
+Arabic Pop
+Aragonese Folk
+Arena Rock
+Argentine Rock
+Armenian Church
+Armenian Folk
+Aromanian Folk
+Arrocha
+Arrocha funk
+Arrocha sertanejo
+Arrochadeira
+Ars antiqua
+Ars nova
+Ars subtilior
+Art Pop
+Art Punk
+Art Rock
+Art Song
+Artcore
+Ashik
+Ashkenazi
+Ashkenazi Cantorial
+Asian Classical
+Asian Pop
+Asian Rock
+Asian Underground
+ASMR
+Assamese Folk
+Assiko
+Assyrian Folk
+Assyrian Folk-Pop
+Asturian Folk
+Athabaskan Fiddling
+Atlanta Bass
+Atlanta Hip Hop
+Atmospheric Black Metal
+Atmospheric Drum & Bass
+Atmospheric Sludge Metal
+Audio Drama
+Audio Media
+Audiobook
+Aussie Pub Rock
+Australian Country
+Australian Folk
+Australian Hip Hop
+Austropop
+Authenticité
+Autonomic
+Auvergnat Folk
+Avant-Folk
+Avant-Funk
+Avant-Garde Classical
+Avant-Garde Jazz
+Avant-Garde Metal
+Avant-Prog
+Avar Folk
+Avtorskaya pesnya
+Axé
+Ayyalah
+Azerbaijani Mugham
+Azmari
+Bacardi
+Bachata
+Bachatón
+Bagad
+Bagatelle
+Baggy
+Baguala
+Bahamian Rhyming Spiritual
+Baila
+Bailecito
+Baisha xiyue
+Baithak gana
+Baião
+Bajourou
+Bakersfield Sound
+Balakadri
+Balani Show
+Balearic Beat
+Balinese Gamelan
+Balitaw
+Balkan Brass
+Balkan Folk
+Balkan Pop-Folk
+Ballad Opera
+Ballata
+Ballet
+Ballet de cour
+Ballroom
+Ballroom Dance
+Baltic Folk
+Baltimore Club
+Balto-Finnic Folk
+Bamar Folk
+Bambuco
+Banda
+Banda de pífano
+Banda sinaloense
+Bandari
+Bandas de viento de México
+Bandinha
+Banga
+Bangladeshi Classical
+Bangsawan
+Bantengan
+Bantowbol
+Baqashot
+Barber Beats
+Barbershop
+Bard
+Bard Rock
+Bardcore
+Barn Dance
+Baroque
+Baroque Pop
+Baroque Suite
+Barynya
+Bashkir Folk
+Bashment Soca
+Basque Folk
+Bass House
+Bassline
+Batida
+Batidão romântico
+Batonebi Songs
+Battle Record
+Batucada
+Batuque
+Batá-rumba
+Baul gaan
+Bay Area Thrash Metal
+Bayawan
+Beach Music
+Beat
+Beat bolha
+Beat bruxaria
+Beat fino
+Beat Juggling
+Beat Poetry
+Beat Rock
+Beatboxing
+Beatdown Hardcore
+Beautiful Music
+Bebop
+Bedouin
+Bedroom Pop
+Bedtime Story
+Beguine
+Beiguan
+Beijing New Sound
+Bel Canto
+Belarusian Folk
+Bele
+Belgian Techno
+Belwo
+Bend-skin
+Benga
+Bengali Folk
+Beni
+Benna
+Beompae
+Berlin School
+Bernese Dialect Scene
+Bhajan
+Bhangra
+Bhangragga
+Bhangraton
+Bhojpuri Folk
+Bhojpuri Pop
+Big
+Big Band
+Big Beat
+Big Room House
+Big Room Trance
+Biguine
+Bihu
+Bikutsi
+Binaural Beats
+Biomusic
+Biraha
+Bird Sounds
+Birmingham Sound
+Bit Music
+Bitpop
+Black 'n' Roll
+Black Ambient
+Black Metal
+Black MIDI
+Black Noise
+Blackened Crust
+Blackened Death Metal
+Blackgaze
+Bleep Techno
+Bloghouse
+Blue Comedy
+Blue-Eyed Soul
+Bluegrass
+Bluegrass Gospel
+Blues
+Blues Ballad
+Blues Rock
+Bocet
+Boduberu
+Bogino duu
+Boi
+Bolero
+Bolero español
+Bolero son
+Bolero Việt Nam
+Bolero-Beat
+Bolivian Huayño
+Bomba
+Bongo Flava
+Boogaloo
+Boogie
+Boogie Rock
+Boogie Woogie
+Boom Bap
+Bop
+Bosnian Folk
+Bossa nova
+Bosstown Sound
+Bothy Ballad
+Bounce
+Bounce Beat
+Bouncy Techno
+Bouyon
+Boy Band
+Boyfriend Country
+Brass Band
+Brazilian Bass
+Brazilian Classical
+Brazilian Folk
+Brazilian Phonk
+Break-In
+Breakbeat
+Breakbeat Hardcore
+Breakbeat Kota
+Breakcore
+Breakstep
+Brega
+Brega calypso
+Brega funk
+Bregadeira
+Breton Celtic Folk
+Breton Folk
+Briddim
+Brill Building
+Bristol Sound
+Britcore
+Britfunk
+British Blues
+British Brass Band
+British Dance Band
+British Folk Rock
+British R&B
+British Rock
+British Rock & Roll
+British Trad Jazz
+Britpop
+Brno Alternative Scene
+Bro-Country
+BRock
+Broken Beat
+Broken Transmission
+Bronx Drill
+Brony
+Brooklyn Drill
+Brostep
+Brown-Eyed Soul
+Brukdown
+Brutal Death Metal
+Brutal Prog
+Bubblegum
+Bubblegum Bass
+Bubblegum Dance
+Bubbling
+Bubbling House
+Buchiage Trance
+Buddhist
+Budots
+Buganda Royal Court
+Bugle Call
+Bulawayo Jazz
+Bulería
+Bulgarian Folk
+Bullerengue
+Bunraku
+Burger-Highlife
+Burgundian School
+Burmese Classical
+Burning Spirits
+Burrakatha
+Burushaski Folk
+Bush Ballad
+Byzantine
+Byzantine Chant
+Bérite Club
+C-Pop
+C86
+Ca din tulnic
+Ca trù
+Cabaret
+Cabo-Zouk
+Cadence
+Cadence lypso
+Cadence rampa
+Caipira
+Cajun
+Cakewalk
+Calinda
+Calipso venezolano
+Calypso
+Calypso-Style Baila
+Cambodian Classical
+Cambodian Pop
+Campursari
+Campus Folk
+Canadian Blues
+Canadian Folk
+Canadian Maritime Folk
+Canarian Folk
+Canción melódica
+Candombe
+Candombe beat
+Candomblé
+Cantata
+Cante alentejano
+Cante chico
+Cante jondo
+Canterbury Scene
+Cantiga
+Cantiñas
+Canto a lo poeta
+Canto beneventano
+Canto cardenche
+Canto degli Alpini
+Canto mozárabe
+Cantonese Opera
+Cantopop
+Cantoria
+Cantu a chiterra
+Cantu a tenore
+Canzona
+Canzone d'autore
+Canzone napoletana
+Canzone neomelodica
+Cape Breton Fiddling
+Cape Breton Folk
+Cape Jazz
+Capoeira
+Caporal
+Capriccio
+Car Audio Bass
+Caribbean Folk
+Carimbó
+Carnatic Classical
+Carnaval cruceño
+Carnavalito
+Carranga
+Cartageneras
+Cartoon Music
+Cascadian Black Metal
+Catalan Folk
+Caucasian Folk
+CBGB Scene
+Celempungan
+Cello Rock
+Celtic Chant
+Celtic Electronica
+Celtic Folk
+Celtic Fusion
+Celtic Metal
+Celtic New Age
+Celtic Punk
+Celtic Reggae
+Celtic Rock
+Central Asian Folk
+Central Asian Throat Singing
+Chacarera
+Chachachá
+Chakacha
+Chalga
+Chamamé
+Chamamé tropical
+Chamarrita açoriana
+Chamarrita rioplatense
+Chamber Folk
+Chamber Jazz
+Chamber Music
+Chamber Pop
+Champeta
+Changa tuki
+Change Ringing
+Changjak gugak
+Changüí
+Chanson
+Chanson alternative
+Chanson québécoise
+Chanson réaliste
+Chanson à texte
+Chaozhou xianshi
+Chap Hop
+Character Piece
+Charanga
+Charanga-Vallenata
+Charikawi
+Chastushka
+Chazzanut
+Chechen Folk
+Chicago Blues
+Chicago Drill
+Chicago Hard House
+Chicago House
+Chicago No Wave
+Chicago Polka
+Chicago School
+Chicago Soul
+Chicano Rap
+Chicano Rock
+Chicha
+Chikipunk
+Children
+Children's Storytelling
+Chilean Folk
+Chilena
+Chillout
+Chillstep
+Chillsynth
+Chillwave
+Chilote
+Chimaychi
+Chimurenga
+Chinese Classical
+Chinese Folk
+Chinese Literati
+Chinese Opera
+Chinese Rock
+Chipmunk Soul
+Chiptune
+Chopped and Screwed
+Chopper
+Choral
+Choral Concerto
+Choral Symphony
+Chorale
+Chorale Cantata
+Chorale Concerto
+Chorale Fantasia
+Chorale Monody
+Chorale Motet
+Chorale Partita
+Chorale Prelude
+Choro
+Chotis madrileño
+Chouval bwa
+Chowtal
+Christian
+Christian Alternative Rock
+Christian Hardcore
+Christian Hip Hop
+Christian Liturgical
+Christian Metal
+Christian Punk
+Christian Rock
+Christian Ska
+Christmas Carol
+Chukchi Folk
+Chula
+Chumba
+Chuntunqui romántico
+Chut-kai-pang
+Chutney
+Chutney Soca
+Chuvash Folk
+Chylandyk
+Chèo
+Chöd
+Chầu văn
+Cilokaq
+Cinematic Classical
+Ciranda
+Circassian Folk
+Circus March
+Circus Music
+City Pop
+Classic Ragtime
+Classical
+Classical Crossover
+Classical Period
+Cleveland Punk
+Close Harmony
+Cloud Rap
+Clube da esquina
+Cocktail Nation
+Coco
+Coke Rap
+Coladeira
+Coldwave
+Colinde
+College Rock
+Colour Bass
+Combined Rhythm
+Comedy
+Comedy Rap
+Comedy Rock
+Comfy Synth
+Comic Opera
+Compas
+Complextro
+Comédie-ballet
+Concert Band
+Concertina Band
+Concerto
+Concerto for Orchestra
+Concerto grosso
+Conducted Improvisation
+Conga
+Congolese Rumba
+Conjunto andino
+Conscious Hip Hop
+Contemporary Bluegrass
+Contemporary Christian
+Contemporary Country
+Contemporary Folk
+Contemporary Jazz
+Contemporary R&B
+Contenance angloise
+Contradanza
+Cool Jazz
+Coon Song
+Copla
+Coptic
+Cornish Folk
+Corrido
+Corrido tumbado
+Corsican Folk
+Cosmic Country
+Country
+Country & Irish
+Country Blues
+Country Boogie
+Country Folk
+Country Gospel
+Country Pop
+Country Rap
+Country Rock
+Country Soul
+Country Trap
+Country Yodeling
+Countrypolitan
+Coupé-décalé
+Cowboy Country
+Cowboy Poetry
+Cowpunk
+Crack Rock Steady
+Creole
+Cretan Folk
+Crime Jazz
+Croatian Folk
+Crossbreed
+Crossover Thrash
+Cruise
+Crunk
+Crunk&B
+Crunkcore
+Crust Punk
+Csango Folk
+Csárdás
+Cuarteto
+Cuban Charanga
+Cuban Dance
+Cubaton
+Cuddlecore
+Cueca
+Cumbia
+Cumbia amazónica
+Cumbia argentina
+Cumbia chilena
+Cumbia colombiana
+Cumbia mexicana
+Cumbia norteña mexicana
+Cumbia norteña peruana
+Cumbia peruana
+Cumbia pop
+Cumbia rebajada
+Cumbia salvadoreña
+Cumbia santafesina
+Cumbia sonidera
+Cumbia turra
+Cumbia villera
+Cumbiatón
+Cuplé
+Currulao
+Cyber Metal
+Cybergrind
+Czech Bluegrass
+Czech Folk
+Cải lương
+D-Beat
+Dabke
+Dadra
+Dagestani Folk
+Dagomba
+Daina
+Dance
+Dance-Pop
+Dance-Punk
+Dance-Punk Revival
+Dance-Rock
+Dancecore
+Dancefloor Drum & Bass
+Dancehall
+Dang-ak
+Dangdut
+Dangdut koplo
+Danger Music
+Danish Folk
+Danmono
+Dansbandsmusik
+Dansktop
+Danza
+Danzón
+Dappankuthu
+Dariacore
+Dark Ambient
+Dark Cabaret
+Dark Electro
+Dark Folk
+Dark Jazz
+Dark Plugg
+Dark Psytrance
+Darkcore
+Darkside
+Darkstep
+Darksynth
+Darkwave
+Darmstadt School
+Data Sonification
+Death 'n' Roll
+Death Doom Metal
+Death Industrial
+Death Metal
+Deathchant Hardcore
+Deathcore
+Deathgrind
+Deathrock
+Deathstep
+Debate
+Dechovka
+Deconstructed Club
+Deejay
+Deep Drum & Bass
+Deep Funk
+Deep House
+Deep Soul
+Deep Tech
+Deep Techno
+Dek Bass
+Delta Blues
+Dembow
+Demoscene
+Demostyle
+Dennery Segment
+Denpa
+Depressive Suicidal Black Metal
+Descarga
+Desert Blues
+Desgarrada
+Desi
+Desi Hip Hop
+Detroit Blues
+Detroit Drill
+Detroit Sound
+Detroit Techno
+Deutschpunk
+Deutschrock
+Dhaanto
+Dhamar
+Dhol tasha
+Dhrupad
+Dhun
+Diablada
+Dialogue
+Digicore
+Digital Cumbia
+Digital Dancehall
+Digital Fusion
+Digital Hardcore
+Dikir barat
+Dimotika
+Dirge
+Dirty Rap
+Dirty South
+Disco
+Disco polo
+Disco Rap
+Dissonant Black Metal
+Dissonant Death Metal
+Diva House
+Divertimento
+Divertissement
+Dixieland
+Djanba
+Djent
+Doble paso
+Dobrado
+Documentary
+Doină
+Dolewave
+Dondang sayang
+Donegal Fiddle
+Dongjing
+Donosti Sound
+Doo-Wop
+Doom Metal
+Doomcore
+Doomgaze
+Doskpop
+Doujin
+Downtempo
+Downtempo Deathcore
+Dream Pop
+Dream Trance
+Dreampunk
+Dreamwave
+Drift Phonk
+Drill
+Drill and Bass
+Drone
+Drone Metal
+Drum & Bass
+Drum and Bugle Corps
+Drumfunk
+Drumless
+Drumline
+Drumstep
+Dub
+Dub Poetry
+Dub Techno
+Dubstep
+Dubstyle
+Dubtronica
+Dubwise Drum & Bass
+Duma
+Dunedin Sound
+Dungeon Rap
+Dungeon Sound
+Dungeon Synth
+Duranguense
+Dutch Cabaret
+Dutch Folk
+Dutch House
+Dutch Jazz
+Décima
+Düsseldorf School
+EAI
+Early Hardstyle
+Early Music
+East Asian Classical
+East Asian Folk
+East Coast Club
+East Coast Hip Hop
+Eastern-Style Polka
+Easy Listening
+Easycore
+Eccojams
+ECM Style Jazz
+Educational
+Egg Punk
+Electric Blues
+Electric Texas Blues
+Electro
+Electro Hop
+Electro House
+Electro latino
+Electro Swing
+Electro-Disco
+Electro-Industrial
+Electro-Soul
+Electroacoustic
+Electroclash
+Electronic
+Electronic Body
+Electronic Dance Music
+Electronic Rock
+Electronica
+Electronicore
+Electropop
+Electrotango
+Eleki
+Eletrofunk
+Elizabethan Song
+Embolada
+Emo
+Emo Rap
+Emo Revival
+Emo-Pop
+Emocore
+Emoviolence
+English Folk
+English Pastoral School
+English Underground
+Enka
+Entechna laika
+Epadunk
+Epic
+Epic Collage
+Epic Doom Metal
+Epic Metal
+Eremwu eu
+Estonian Folk
+Ethereal Wave
+Ethio-Jazz
+Ethiopian Church
+Ethno-Pop
+Euphoric Hardstyle
+Euro House
+Euro Reggae
+Euro Trance
+Euro-Disco
+Eurobeat
+Eurodance
+European Folk
+European Free Jazz
+European Pop
+European Rock
+European Singer-Songwriter
+Europop
+Euskal kantagintza berria
+Exotica
+Experimental
+Experimental Big Band
+Experimental Hip Hop
+Experimental Improvisation
+Experimental Rock
+Expressionism
+Extempo
+Extratone
+Extreme Metal
+Fado
+Fado de Coimbra
+Fairy Tales
+Falak
+Famo
+Fandango caiçara
+Fanfare
+Fantasia
+Fantezi
+Faroese Folk
+Farruca
+Festejo
+Festival Progressive House
+Festival Trap
+Fidget House
+Field Hollers
+Field Recording
+Fife and Drum Blues
+Fife and Drum Corps
+Fight Song
+Fijiri
+Filin
+Filk
+Filmi
+Filmi Ghazal
+Finnish Folk
+Finnish Tango
+First Wave of Detroit Techno
+Flamenco
+Flamenco Jazz
+Flamenco nuevo
+Flamenco Pop
+Flashcore
+Flemish Folk
+Flex Dance
+Flint Sound
+Florida Breaks
+Florida Fast
+FM Synthesis
+Foley
+Folk
+Folk Baroque
+Folk Jazz
+Folk Metal
+Folk Pop
+Folk Punk
+Folk Rock
+Folkhop
+Folklor miejski
+Folktale
+Folktronica
+Fon leb
+Football Chant
+Footwork
+Footwork Jungle
+Forest Psytrance
+Forró
+Forró de favela
+Forró eletrônico
+Forró universitário
+Fort Thunder Scene
+Foxtrot
+Franco-Flemish School
+Frapcore
+Frat Rap
+Frat Rock
+Freak Folk
+Freakbeat
+Free Car
+Free Folk
+Free Funk
+Free Improvisation
+Free Jazz
+Free Noise
+Freeform Hardcore
+Freestyle
+Freetekno
+French Electro
+French Folk
+French Hip Hop
+French House
+French Pop
+French-Canadian Folk
+Frenchcore
+Frevo
+Frevo de bloco
+Frevo de rua
+Frevo elétrico
+Frevo-canção
+Friese bries
+Fugue
+Fuji
+Full-On Psytrance
+Funaná
+Funeral Doom Metal
+Funeral March
+Fungi
+Funk
+Funk 150 bpm
+Funk automotivo
+Funk brasileiro
+Funk carioca
+Funk consciente
+Funk de BH
+Funk mandelão
+Funk melody
+Funk Metal
+Funk ostentação
+Funk Ousadia
+Funk proibidão
+Funk Rock
+Funknejo
+Funkot
+Funktronica
+Funky Breaks
+Funky House
+Furniture Music
+Fusion Gugak
+Future Bass
+Future Bounce
+Future Core
+Future Funk
+Future Garage
+Future House
+Future Rave
+Future Riddim
+Futurepop
+Futurism
+Futuristic Swag
+G-Funk
+G-House
+Gaana
+Gabber
+Gagaku
+Gagauz Folk
+Gagok
+Gaita zuliana
+Galant
+Galician Folk
+Gallican Chant
+Gambang kromong
+Gamelan
+Gamelan angklung
+Gamelan bebonangan
+Gamelan beleganjur
+Gamelan degung
+Gamelan gender wayang
+Gamelan gong gede
+Gamelan gong kebyar
+Gamelan jegog
+Gamelan salendro
+Gamelan sekaten
+Gamelan selonding
+Gamelan semar pegulingan
+Gandrung
+Ganga
+Gangsta Rap
+Gar
+Garage House
+Garage Psych
+Garage Punk
+Garage Rock
+Garage Rock Revival
+Garba
+Garifuna
+Gascon Folk
+Gato
+Geek Rock
+Gelineau Psalmody
+Genge
+Gengetone
+Georgian Folk
+Georgian Polyphony
+German Folk
+Ghazal
+Ghetto Funk
+Ghetto House
+Ghettotech
+Giddha
+Ginan
+Girl Group
+Glam Metal
+Glam Punk
+Glam Rock
+Glitch
+Glitch Hop
+Glitch Pop
+Gnawa
+Go-Go
+Goa Trance
+Golden Age Hip Hop
+Gommance
+Gondang
+Goombay
+Goral
+Goregrind
+Gorenoise
+Goshu ondo
+Gospel
+Gospel Blues
+Gospel House
+Gothabilly
+Gothenburg Sound
+Gothic Country
+Gothic Metal
+Gothic Rock
+Gqom
+Gqom Trap
+Grand opéra
+Graphical Sound
+Grebo
+Greek Folk
+Greenwich Village Scene
+Gregorian Chant
+Grime
+Grindcore
+Grindie
+Griot
+Groove Metal
+Group Sounds
+Grunge
+Grupera
+Gstanzl
+Guaguancó
+Guajira
+Guangdong yinyue
+Guaracha
+Guaracha santiagueña
+Guarania
+Gufeng
+Guggenmusik
+Guided Meditation
+Guitarrada
+Gujarati Folk
+Gumbe
+Gunchei
+Gunka
+Gwo ka
+Gwo ka moderne
+Gypsy Punk
+Género chico
+Għana
+H8000
+Habanera
+Haight-Ashbury Scene
+Haitian Vodou Drumming
+Halftime
+Halling
+Hambo
+Hamburger Schule
+Han Folk
+Hands Up
+Hanmai
+Haozi
+Hapa haole
+Happy Hardcore
+Happy Rock
+Haqibah
+Harana
+Harawi
+Hard Beat
+Hard Bop
+Hard Dance
+Hard Drum
+Hard House
+Hard Rock
+Hard Techno
+Hard Trance
+Hard Trap
+Hardbag
+Hardbass
+Hardcore
+Hardcore Breaks
+Hardcore Hip Hop
+Hardcore Punk
+Hardgroove Techno
+Hardline
+Hardstep
+Hardstyle
+Hardtek
+Hardvapour
+Hardwave
+Harlem Renaissance
+Harmonica Blues
+Harsh Noise
+Harsh Noise Wall
+Hasapiko
+Hasidic
+Hauntology
+Hawaiian
+Hazara Folk
+Heartland Rock
+Heaven Trap
+Heavy Metal
+Heavy Psych
+Heikyoku
+Hellenic Black Metal
+Henan Opera
+HexD
+Hi-NRG
+Hi-Tech Full-On
+Hi-Tech Psytrance
+High Quality Rip
+Highlife
+Hill Country Blues
+Himene tarava
+Hindustani Classical
+Hip Hop
+Hip Hop Soul
+Hip House
+Hip-hopolo
+Hipco
+Hiplife
+Hiragasy
+Hispanic American Folk
+Hmong Folk
+Hmong Pop
+Hoboken Sound
+Hokkien Pop
+Hokum
+Holiday
+Holy Minimalism
+Holy Terror
+Honky Tonk
+Honky-Tonk Piano
+Honkyoku
+Hookah Rap
+Hora
+Hora lungă
+Hornpipe
+Horror Punk
+Horror Synth
+Horrorcore
+Hot Rod
+House
+Houston Sound
+Huaylarsh
+Huayno
+Hula
+Humppa
+Hungarian Folk
+Hunguhungu
+Hutsul Folk
+Hyang-ak
+Hybrid Trap
+Hymns
+Hyperpop
+Hypertechno
+Hyphy
+Hypnagogic Pop
+Hypnosis
+Hát lô tô
+Hưng ca
+Ibiza Trance
+Icaro
+Icelandic Folk
+IDM
+Idol kayō
+Igbo
+Illbient
+Impressionism
+Impromptu
+Improvisational Comedy
+Incidental Music
+Indeterminacy
+Indian Pop
+Indian Rock
+Indie Folk
+Indie Pop
+Indie Rock
+Indie Surf
+Indietronica
+Indigenous American Traditional
+Indigenous Australian Traditional
+Indigenous Rock
+Indigenous Taiwanese
+Indo Jazz
+Indonesian Pop
+Indorock
+Industrial
+Industrial Death Metal
+Industrial Drum & Bass
+Industrial Folk Song
+Industrial Hardcore
+Industrial Hip Hop
+Industrial Metal
+Industrial Musical
+Industrial Rock
+Industrial Techno
+Industrial Thrash Metal
+Inkiranya
+Insect Sounds
+Instrumental Hip Hop
+Instrumental Pop
+Instrumental Rock
+Integral Serialism
+Interview
+Inuit
+Inuit Vocal Games
+Ionian Islands Folk
+Iraqi Maqam
+Irish Folk
+Irish Rebel
+Irish Showband
+Isicathamiya
+Islamic
+Israeli Folk
+Istrian Folk
+Italian Folk
+Italo Dance
+Italo House
+Italo Pop
+Italo-Disco
+Izlan
+Izvorna
+Izvorna bosanska muzika
+J-core
+J-Euro
+J-Pop
+J-Punk
+J-Rock
+Jackin' House
+Jaipongan
+Jam Band
+Jamaican Folk
+Jamaican Ska
+James Bay Fiddling
+Jamgrass
+Jamrieng samai
+Jangle Pop
+Japanese Classical
+Japanese Folk
+Japanese Hardcore
+Japanese Hip Hop
+Japanese Idol
+Japanoise
+Jarana yucateca
+Javanese Gamelan
+Jawaiian
+Jazz
+Jazz Blues
+Jazz Fusion
+Jazz guachaca
+Jazz House
+Jazz manouche
+Jazz Mugham
+Jazz Poetry
+Jazz Pop
+Jazz Rap
+Jazz-Funk
+Jazz-Rock
+Jazzstep
+Jenkka
+Jeong-ak
+Jerk
+Jerk Rap
+Jersey Club
+Jersey Club Rap
+Jersey Drill
+Jersey Shore Sound
+Jersey Sound
+Jesus Music
+Jewish
+Jewish Folk
+Jewish Liturgical
+Jiangnan sizhu
+Jibaro
+Jig
+Jigg
+Jilala
+Jing ping
+Jingle
+Jit
+Jiuta
+Joged
+Joged bumbung
+Joik
+Jongo
+Jook
+Joropo
+Jovem Guarda
+Jubilee
+Jug Band
+Juke
+Juke Joint Blues
+Jump Blues
+Jump-Up
+Jumpstyle
+Jungle
+Jungle Dutch
+Jungle Terror
+Junkanoo
+Jùjú
+Jōruri
+K-Pop
+K-Rock
+Kabarett
+Kabuki
+Kabye Folk
+Kacapi suling
+Kachāshī
+Kadongo kamu
+Kafi
+Kagura
+Kai
+Kaiso
+Kakawin
+Kalamatianó
+Kalattut
+Kalindula
+Kalon'ny fahiny
+Kan ha diskan
+Kaneka
+Kanikapila
+Kannada Folk
+Kansai No Wave
+Kansas City Blues
+Kantan Chamorrita
+Kanto
+Kantruem
+Kapuka
+Karakalpak Traditional
+Karelian Folk
+Kargyraa
+Kaseko
+Kashubian Folk
+Kawachi ondo
+Kawaii Future Bass
+Kawaii Metal
+Kayōkyoku
+Kecak
+Kef
+Keroncong
+Kertok
+Kete
+Ketuk tilu
+Khakas Traditional
+Khaliji
+Khayal
+Khene
+Khmer Folk
+Khoisan Folk
+Khrueang sai
+Kidandali
+Kidumbak
+Kilapanga
+Kirtan
+Kitchen Dance
+Kiwi Rock
+Kizomba
+Klapa
+Klasik
+Kleinkunst
+Klezmer
+Kliningan
+Koche bazari
+Kolo
+Kolomyjka
+Komagaku
+Komi Folk
+Konnakol
+Korean Ballad
+Korean Classical
+Korean Court
+Korean Folk
+Korean Hip Hop
+Korean Revolutionary Opera
+Kote kei
+Kouta
+Kpanlogo
+Krakowiak
+Krautrock
+Krishnacore
+Kriti
+Kriyat haTorah
+Krushclub
+Kréyol djaz
+Kuda kepang
+Kuduro
+Kujawiak
+Kujon
+Kulintang
+Kumiuta
+Kundiman
+Kunqu Opera
+Kurpian Folk
+Kvæði
+Kwaito
+Kwassa kwassa
+Kwela
+Kyivan Chant
+Kyrgyz Traditional
+Könsrock
+LA Beat Scene
+LA Hard House
+Lab Polyphony
+Ladbroke Grove Scene
+Ladino Folksong
+Laika
+Lambada
+Landó
+Langgam Jawa
+Language Learning
+Lao Folk
+Late Romanticism
+Latin Alternative
+Latin American Classical
+Latin American Rock
+Latin American Singer-Songwriter
+Latin Big Band
+Latin Dance
+Latin Disco
+Latin Freestyle
+Latin Funk
+Latin House
+Latin Jazz
+Latin Metal
+Latin Pop
+Latin R&B
+Latin Rap
+Latin Rock
+Latin Soul
+Latino Punk
+Latvian Folk
+Lauda
+Laurel Canyon Scene
+Lavani
+LDS Music
+Lecture
+Legényes
+Leningrad Rock Club Scene
+Lento violento
+Letkajenkka
+Levenslied
+Lhamo
+Lied
+Liedermacher
+Light Music
+Lilat
+Liquid Drum & Bass
+Liquid Riddim
+Liscio
+Lithuanian Folk
+Little Band Scene
+Livetronica
+Livonian Folk
+Liwa
+Lo-fi
+Lo-fi Hip Hop
+Lo-fi House
+Loft Jazz
+Logobi
+Lokal musik
+Lolicore
+Loncomeo
+Loner Folk
+Louisiana Blues
+Louisiana Funk
+Louisville Sound
+Lounge
+Lovers Rock
+Low Bap
+Lowend
+Lowercase
+Lubbock Sound
+Luk krung
+Luk thung
+Lullaby
+Lundu
+Luri Folk
+Lutheran Chorale
+Luxembourgish Folk
+Ländler
+M-Base
+Macedonian Folk
+Madchester
+Maddahi
+Madrigal
+Mafioso Rap
+Maftirim
+Magyar nóta
+Mahori
+Mahraganat
+Maidcore
+Makina
+Makossa
+Malagasy Folk
+Malagueña venezolana
+Malambo
+Malay Classical
+Malay Folk
+Malay Gamelan
+Malayali Folk
+Malhun
+Mall Screamo
+Mallsoft
+Maloya
+Maloya électronique
+Maloya élektrik
+Mambo
+Mambo chileno
+Mambo urbano
+Manaschi
+Mandopop
+Manele
+Mangambeu
+Manguebeat
+Manila Sound
+Mantra
+Manx Folk
+Manyao
+Manzuma
+Mapouka
+Mappila
+Mapuche Folk
+Maqāmic Classical
+Marabi
+Maracatu
+Marathi Folk
+March
+Marching Band
+Marchinha
+Mari Folk
+Mariachi
+Marinera
+Marrabenta
+Martial Industrial
+Martinetes
+Mascarene Islands Folk
+Mashcore
+Mashup
+Maskandi
+Mass
+Mataali
+Matamuerte
+Math Pop
+Math Rock
+Mathcore
+Maxixe
+Maya
+Mazur
+Mazurka
+Mbalax
+Mbaqanga
+Mbenga-Mbuti
+Mbolé
+Mbube
+Mchiriku
+Mechanical
+Medieval Classical
+Medieval Folk Rock
+Medieval Lyric Poetry
+Mega funk
+Meiji shinkyoku
+Mejoranera
+Melam
+Melbourne Bounce
+Melodic Bass
+Melodic Black Metal
+Melodic Death Metal
+Melodic Dubstep
+Melodic Hardcore
+Melodic House
+Melodic Metalcore
+Melodic Techno
+Memphis Blues
+Memphis Rap
+Memphis Soul
+Mentai Rock
+Mento
+Merecumbé
+Merengue
+Merengue típico
+Merenhouse
+Merseybeat
+Mesoamerican Folk
+Mesopotamian
+Metal
+Metalcore
+Mexican Folk
+Mexican Rock
+Meyxana
+Mezwed
+Miami Bass
+Microfunk
+Microhouse
+Micromontage
+Microsound
+Microtonal Classical
+Mid-School Hip Hop
+Middle Eastern Pop
+MIDI
+Midtempo Bass
+Midwest Emo
+Midwest Hip Hop
+Miejski folk
+Military Marching Band
+Milonga
+Min'yō
+Minatory
+Mincecore
+Mini-jazz
+Minimal Drum & Bass
+Minimal Synth
+Minimal Techno
+Minimal Wave
+Minimalism
+Minneapolis Sound
+Minstrelsy
+Minyue
+Mittelalter-Metal
+Mittelalter-Rock
+Mobb
+Mod
+Mod Revival
+Moda de viola
+Modal Jazz
+Modern Classical
+Modern Creative
+Modern Laika
+Modinha
+Molam
+Molam sing
+Mono
+Monodrama
+Monologue
+Montenegrin Folk
+Mood kayō
+Moogsploitation
+Moombahcore
+Moombahton
+Moravian Folk
+Mordvin Folk
+Morenada
+Morna
+Moroccan Chaabi
+Moscow School
+Motet
+Motown Sound
+Motswako
+Moutya
+Movida madrileña
+Movimiento alterado
+Mozambique
+MPB
+Muak
+Mulatós
+Muliza
+Mumble Rap
+Murga
+Murga uruguaya
+Musette
+Mushroom Jazz
+Music Hall
+Musical
+Musical Comedy
+Musika popullore
+Musique concrète
+Musique concrète instrumentale
+Mutant Disco
+Muwashshah
+Muzak
+Muzică de mahala
+Muzică lăutărească
+Muzika mizrahit
+Muzika yehudit mekorit
+Muzikat dika'on
+Muziki wa dansi
+Mystical Minimalism
+Mélodie
+Méringue
+Métis
+Métis Fiddling
+Música cebolla
+Música criolla peruana
+Música de intervenção
+Música gaúcha
+Música llanera
+Música típica chilena
+Māori
+Młoda Polska
+Mūsīqā lubnāniyya
+Nagauta
+Nagoya kei
+Nahua
+Nakasi
+Nangma
+Nanyin
+Narcocorrido
+Nardcore
+Narodna muzika
+Narodno zabavna glasba
+Nasheed
+Nashville Sound
+Native American New Age
+Nature Recordings
+Naturjodel
+Naxi
+Ndombolo
+Nederbeat
+Nederpop
+Neo-Acoustic
+Neo-Bop
+Neo-Canterbury
+Neo-City Pop
+Neo-Grime
+Neo-Medieval
+Neo-Medieval Folk
+Neo-Pagan Folk
+Neo-Prog
+Neo-Psychedelia
+Neo-Soul
+Neo-Traditionalist Country
+Neoclassical Darkwave
+Neoclassical Metal
+Neoclassical New Age
+Neoclassicism
+Neocrust
+Neofolk
+Neofolklore
+Neoperreo
+Neoromanticism
+Nepali Folk
+Nerdcore Hip Hop
+Nerdcore Techno
+Nervous
+Neue Deutsche Härte
+Neue Deutsche Todeskunst
+Neue Deutsche Welle
+Neue Volksmusik
+Neurofunk
+Neurohop
+New Acoustic
+New Age
+New Age Kirtan
+New Beat
+New Brunswick Basement Scene
+New Complexity
+New German School
+New Jack Swing
+New Jazz
+New London Jazz
+New Mexico
+New Music
+New Orleans Blues
+New Orleans Brass Band
+New Orleans R&B
+New Partisans
+New Pop
+New Primitivism
+New Prog
+New Rave
+New Romantic
+New School Hip Hop
+New Taiwanese Song
+New Tone
+New Wave
+New Wave of New Wave
+New Way of Danish Fuck You
+New Weird America
+New Weird Finland
+New York Drill
+New York Hardcore
+New York School
+Newa Folk
+Newfoundland Folk
+News Broadcast
+Ngoma
+Nguni Folk
+Ngâm thơ
+Nhạc tiền chiến
+Nhạc vàng
+Nhạc đỏ
+Nightcore
+Nigun
+Nintendocore
+Nisiotika
+Nitzhonot
+No Melody
+No Wave
+Nocturne
+Noh
+Noiadance
+Noise
+Noise Pop
+Noise Rock
+Noisecore
+Noisegrind
+NOLA Sludge
+Nordic Folk
+Nordic Folk Rock
+Nordic Old Time Dance
+Nortec
+Norteño
+Northern Gothic
+Northern Soul
+Northumbrian Folk
+Norwegian Folk
+Nouveau zydeco
+Nouvelle chanson
+Nova cançó
+Nova srpska scena
+Nova vanguarda paulistana
+Novaya scena
+Novelty Piano
+Novo Dub
+NRG
+Nu Gaze
+Nu Jazz
+Nu Metal
+Nu Skool Breaks
+Nu Style Gabber
+Nu-Disco
+Nuban
+Nueva canción
+Nueva canción chilena
+Nueva canción española
+Nueva canción latinoamericana
+Nueva cumbia chilena
+Nueva ola
+Nueva trova
+Nuevo Cancionero
+Nursery Rhyme
+Nustyle
+NWOBHM
+Nyahbinghi
+Néo kýma
+Nòva cançon
+Ob-Ugric Folk
+Oberek
+Obikhod
+Observational Comedy
+Occitan Folk
+Occult Rock
+Oceanian Folk
+Odia Folk
+Odissi Classical
+Ogene
+Oi!
+Okinawan
+Old Roman Chant
+Old Time Radio
+Old-School Hip Hop
+Old-Time
+Olonkho
+Omutibo
+Onda nueva
+Ondō
+Onkyo
+Opera
+Opera buffa
+Opera semiseria
+Opera seria
+Operatic Pop
+Operetta
+OPM
+Opéra-ballet
+Opéra-comique
+Oratorio
+Orchestral
+Orchestral Jazz
+Orchestral Pop
+Orchestral Song
+Organ Trio
+Organic House
+Organum
+Ori deck
+Oriental Ballad
+Oriental Jewish
+Oriental Metal
+Orkes gambus
+Orthodox Pop
+Oshare Kei
+Ossetian Folk
+OtoMAD
+Ottava rima
+Ottoman Military
+Outlaw Country
+Outsider House
+Outsider Music
+Overture
+P-Pop
+Pachanga
+Pacific Reggae
+Pagan Black Metal
+Pagan Rock
+Paghjella
+Pagode
+Pagode romântico
+Pagodão
+Paisley Underground
+Pakacaping
+Palingsound
+Palm Desert Scene
+Palm Wine
+Palo de mayo
+Panambih
+Panchavadyam
+Panche Baja
+Pansori
+Pansy Craze
+Papuan Folk
+Paranda
+Parang
+Parlour
+Parody Music
+Parranda
+Partido alto
+Pashto Folk
+Pasillo
+Pasodoble
+Passion
+Payada
+Peak Time Techno
+Peking Opera
+Pelimanni music
+Pennsylvania Dutch Folk
+Pep Band
+Performance
+Persian Classical
+Persian Folk
+Persian Pop
+Peyote Song
+Philippine Classical
+Philippine Rondalla
+Philly Club
+Philly Club Rap
+Philly Drill
+Philly Soul
+Phleng phuea chiwit
+Phonk
+Phonk House
+Piano Blues
+Piano Rock
+Picopop
+Piedmont Blues
+Pigfuck
+Pilón
+Pimba
+Pinoy Folk Rock
+Pinoy Rock
+Pinpeat
+Pipe Band
+Piphat
+Pirate Metal
+Pirekua
+Piseiro
+Piyyut
+Pizzica
+Plainsong
+Plena
+Pleng Thai sakorn
+Plugg
+PluggnB
+Plunderphonics
+Podcast
+Poetry
+Poezja śpiewana
+Polish Folk
+Polish Goral
+Political Comedy
+Political Hip Hop
+Polka
+Polka paraguaya
+Polka peruana
+Polo
+Polonaise
+Polska
+Polyphonic Chant
+Pon-chak disco
+Ponto de umbanda
+Pop
+Pop Batak
+Pop Ghazal
+Pop Kreatif
+Pop Minang
+Pop Rap
+Pop Raï
+Pop Rock
+Pop Soul
+Pop Standards
+Pop Sunda
+Pop Yeh-Yeh
+Pop-Punk
+Pops Orchestra
+Porn Groove
+Pornogrind
+Porro
+Portuguese Folk
+Positive Punk
+Post-Bop
+Post-Britpop
+Post-Disco
+Post-Dubstep
+Post-Grunge
+Post-Hardcore
+Post-Industrial
+Post-Metal
+Post-Minimalism
+Post-Punk
+Post-Punk Revival
+Post-Rock
+Powada
+Power Electronics
+Power Metal
+Power Noise
+Power Pop
+Power Soca
+Powerstomp
+Powerviolence
+Powwow
+Praise Break
+Prank Calls
+Prehistoric
+Prelude
+Process Music
+Progg
+Program Music
+Progressive Big Band
+Progressive Bluegrass
+Progressive Breaks
+Progressive Country
+Progressive Death Metal
+Progressive Electronic
+Progressive Folk
+Progressive House
+Progressive Metal
+Progressive Pop
+Progressive Psytrance
+Progressive Rock
+Progressive Soul
+Progressive Thrash Metal
+Progressive Trance
+Prostopinije
+Protest Folk
+Proto-Punk
+Psichedelia occulta italiana
+Psybient
+Psybreaks
+Psychedelia
+Psychedelic Folk
+Psychedelic Funk
+Psychedelic Pop
+Psychedelic Rock
+Psychedelic Soul
+Psychobilly
+Psychsploitation
+Psycore
+Psydub
+Psystyle
+Psytrance
+Pub Rock
+Public Broadcast
+Public Service Announcement
+Pueblo
+Pumping House
+Pungmul
+Punjabi Folk
+Punk
+Punk Blues
+Punk Cabaret
+Punk Jazz
+Punk Rock
+Punta
+Punta Rock
+Purple Sound
+Purísima
+Puxa
+Puya
+Pásztordal
+Pìobaireachd
+Q-Pop
+Qaraami
+Qasidah
+Qasidah modern
+Qawwali
+Quan họ
+Queercore
+Quiet Storm
+Quyi
+R&Bass
+Rabiz
+RABM
+Rabòday
+Raga Rock
+Rage
+Ragga
+Ragga Hip Hop
+Ragga Jungle
+Raggacore
+Raggatek
+Ragtime
+Ragtime Song
+Rain Sounds
+Rajasthani Folk
+Rake-and-Scrape
+Rakugo
+Ranchera
+Rap Metal
+Rap Rock
+Rapai dabõih
+Rapcore
+Rapso
+Raqs baladi
+Rara
+Rare Phonk
+Rasin
+Rasqueado
+Rasteirinha
+Ratchet
+Rautalanka
+Ravanahatha
+Rawphoric
+Rawstyle
+Raï
+Red Dirt
+Red Disco
+Reductionism
+Regalia
+Reggae
+Reggae Fusion
+Reggae Gospel
+Reggae Pop
+Reggae Rock
+Reggaetón
+Rekilaulu
+Religious
+Rembetika
+Renaissance
+Reparto
+Repente
+Requiem
+Retro-Soul
+Revolution Summer
+Revolutionary Opera
+Revue
+Rhumba
+Rhythm & Blues
+Rhythm & Grime
+Ricercar
+Riddim
+Rigsar
+Ring Shout
+Ringbang
+Riot Grrrl
+Ripsaw
+Ritmada
+Ritual Ambient
+Rizitika
+RKT
+Road Rap
+Rock
+Rock & Roll
+Rock andaluz
+Rock andino
+Rock barrial
+Rock in Opposition
+Rock Musical
+Rock Opera
+Rock radical vasco
+Rock rural
+Rock subterráneo
+Rock sónico
+Rock urbano español
+Rock urbano mexicano
+Rockabilly
+Rocksteady
+Rom kbach
+Roman School
+Romance
+Romani Folk
+Romanian Etno
+Romanian Folk
+Romanian Popcorn
+Romantic Style Reggaetón
+Romanticism
+Romantische Oper
+Romanţe
+Rominimal
+Rondeau
+Ronggeng
+Roots Reggae
+Roots Rock
+Rumba
+Rumba catalana
+Rumba cubana
+Rumba flamenca
+Rune Singing
+Russemusikk
+Russian Chanson
+Russian Folk
+Russian Pop
+Russian Romance
+Ryukyuan
+Ryūkōka
+Rímur
+Rōkyoku
+Sa'idi
+Sabar
+Sacred Harp
+Sacred Singing Circle
+Sacred Steel
+Saeta
+Saint Petersburg School
+Sakha Traditional
+Salegy
+Salsa
+Salsa choke
+Salsa dura
+Salsa romántica
+Saluang klasik
+Samba
+Samba de breque
+Samba de gafieira
+Samba de roda
+Samba de terreiro
+Samba Soul
+Samba-canção
+Samba-choro
+Samba-enredo
+Samba-exaltação
+Samba-jazz
+Samba-joia
+Samba-reggae
+Samba-rock
+Sambalanço
+Sambass
+Samoyedic Folk
+Sample Drill
+Sampledelia
+Samri
+San Diego Sound
+San Francisco Sound
+Sanjo
+Santería
+Santé engagé
+Sarala gee
+Sardana
+Sardinian Folk
+Sarum Chant
+Sass
+Satire
+Sawt
+Saya
+Scam Rap
+Scene
+Schlager
+Schottische
+Schranz
+Scots Song
+Scottish Country Dance
+Scottish Folk
+Scottish Folk Revival
+Scouse House
+Scratching
+Screamo
+Scrumpy and Western
+Sea Shanty
+Sean-nós
+Seapunk
+Second British Folk Revival
+Second Viennese School
+Second Wave of Detroit Techno
+Seggae
+Seinn nan salm
+Seis
+Seishun Punk
+Semba
+Semi-Trot
+Sephardic
+Sequencer & Tracker
+Serbian Folk
+Serenade
+Seresta
+Serialism
+Sermon
+Sertanejo
+Sertanejo de raiz
+Sertanejo romântico
+Sertanejo universitário
+Seto leelo
+Sevdalinka
+Sevillanas
+Sexy Drill
+Shaabi
+Shabad kirtan
+Shaker
+Shalakho
+Shan'ge
+Shangaan Electro
+Shaoxing Opera
+Shashmaqam
+Shatta
+Shehhi
+Shetland & Orkney Folk
+Shibuya-kei
+Shidaiqu
+Shilla
+Shimokita-kei
+Shitgaze
+Shock Jock
+Shoegaze
+Shona Mbira
+Shoor
+Shota
+Show Tunes
+Shōka
+Shōmyō
+Siberian Punk
+Sichuan Opera
+Sierreño
+Siffleur
+Sigilkore
+Silat
+Sinawi
+Sinfonia concertante
+Singeli
+Singer-Songwriter
+Singspiel
+Sinhalese Folk
+Sissy Bounce
+Sitarsploitation
+Sizhu
+Ska
+Ska Punk
+Skacore
+Skate Punk
+Sketch Comedy
+Skiffle
+Skiladika
+Skinhead Reggae
+Skullstep
+Skweee
+Slack-Key Guitar
+Slacker Rock
+Slam Death Metal
+Slam Poetry
+Slap House
+Slavic Folk
+Sleaze Rock
+Slide Guitar Blues
+Slimepunk
+Slovak Folk
+Slovenian Folk
+Slow Drag
+Slowcore
+Slowed & Reverb
+Sludge Metal
+Slushwave
+Smooth Jazz
+Smooth Soul
+Snap
+Snap&B
+Soca
+Soft Rock
+Soft Visual
+Solonese Gamelan
+Son calentano
+Son cubano
+Son de pascua
+Son huasteco
+Son istmeño
+Son jarocho
+Son montuno
+Son nica
+Son-batá
+Sonata
+Songo
+Songo-Salsa
+Songster
+Sonorism
+Sophisti-Pop
+Sotho-Tswana Folk
+Soukous
+Soul
+Soul Blues
+Soul Jazz
+Sound Art
+Sound Collage
+Sound Effects
+Sound Poetry
+SoundClown
+Soundscape
+South Asian Classical
+South Asian Dance
+South Asian Folk
+South Florida SoundCloud Rap
+Southeast Asian Classical
+Southeast Asian Dance
+Southeast Asian Folk
+Southeast Asian Pop
+Southern African Folk
+Southern Gospel
+Southern Hip Hop
+Southern Metal
+Southern Rock
+Southern Soul
+Soviet Estrada
+Sovietwave
+Space Age Pop
+Space Ambient
+Space Disco
+Space Rock
+Space Rock Revival
+Spacesynth
+Spaghetti Western
+Spanish Classical
+Spanish Folk
+Spectralism
+Speech
+Speed Garage
+Speed House
+Speed Metal
+Speedcore
+Spiritual Jazz
+Spirituals
+Splittercore
+Spoken Word
+Sports Commentary
+Spouge
+Spy Music
+St. Louis Blues
+Stand-Up Comedy
+Starogradska muzika
+Staïfi
+Steel Band
+Stenchcore
+Stereo
+Stochastic
+Stomp and Holler
+Stoner Metal
+Stoner Rap
+Stoner Rock
+Stornello
+Storytelling
+Straight Edge
+Street Punk
+Stride
+String Quartet
+Stutter House
+Sufi
+Sufi Rock
+Sufiana kalam
+Sungura
+Sunset Strip Glam Metal
+Sunshine Pop
+Suomisaundi
+Surf
+Surf Punk
+Surf Rock
+Sutartinės
+Swamp Blues
+Swamp Pop
+Swamp Rock
+Swancore
+Swedish Folk
+Sweet Jazz
+Swing
+Swing musette
+Swing Revival
+Sygyt
+Symphonic Black Metal
+Symphonic Metal
+Symphonic Mugham
+Symphonic Prog
+Symphonic Rock
+Symphony
+Synth Funk
+Synth-Punk
+Synthpop
+Synthwave
+Syriac Chant
+Sârbă
+Séga
+Sōkyoku
+T'ong Guitar
+T-Pop
+Taarab
+Tai tu
+Taiko
+Takamba
+Talempong
+Talempong goyang
+Talk Radio
+Talking Blues
+Tallava
+Tambor
+Tamborera
+Tamborito
+Tamborzão
+Tambu
+Tamil Christian Keerthanai
+Tamil Film
+Tamil Folk
+Tammurriata
+Tango
+Tango nuevo
+Tanjidor
+Taoist Ritual
+Tape Music
+Taquirari
+Taqwacore
+Tarana
+Tarantella
+Tarawangsa
+Tarraxinha
+Tassa
+Tassu
+Tchink System
+Tchinkoumé
+Tearout
+Tech House
+Tech Trance
+Technical Death Metal
+Technical Thrash Metal
+Techno
+Techno Bass
+Techno kayō
+Technoid
+Techstep
+Tecnobanda
+Tecnobrega
+Tecnofunk
+Tecnomerengue
+Tecnorumba
+Teen Pop
+Tejano
+Telugu Folk
+Tembang Sunda Cianjuran
+Terror Plugg
+Terrorcore
+Teutonic Thrash Metal
+Tex-Mex
+Texas Blues
+Texas Psychedelia
+Thai Classical
+Thai Folk
+Thall
+The Wave
+Theatre
+Theme and Variation
+Therapeutic Audio
+Thillana
+Third Stream
+Third Wave Ska
+Thrash Metal
+Thrashcore
+Thumri
+Tibetan Buddhist Chant
+Tibetan New Age
+Tibetan Pop
+Tientos
+Timba
+Timbila
+Tin Pan Alley
+Tinku
+Tivaner inngernerlu
+Tizita
+Toada de Boi
+Toccata
+Toeshey
+Tolai Rock
+Tonada chilena
+Tonada potosina
+Tondero
+Tone Poem
+Tontipop
+Torch Song
+Tosk Polyphony
+Totalism
+Touhou
+Township Bubblegum
+Township Jazz
+Township Jive
+Toypop
+Toytown Pop
+Tracker
+Tradi-moderne congolais
+Tradi-moderne ivoirien
+Traditional Black Gospel
+Traditional Bluegrass
+Traditional Cajun
+Traditional Country
+Traditional Doom Metal
+Traditional Folk
+Traditional Maloya
+Traditional Pop
+Traditional Raï
+Traditional Séga
+Tragédie en musique
+Trallalero
+Trampská hudba
+Trance
+Trance Metal
+Trancestep
+Trap
+Trap Dancehall
+Trap EDM
+Trap latino
+Trap Metal
+Trap shaabi
+Trap Soul
+Trapfunk
+Tread
+Tribal Ambient
+Tribal Guarachero
+Tribal House
+Trikitixa
+Trip Hop
+Tropical House
+Tropical Rock
+Tropicanibalismo
+Tropicália
+Tropipop
+Trot
+Trova
+Trova rosarina
+Trova yucateca
+Truck Driving Country
+Trás-os-Montes Folk
+Tsapiky
+Tsonga Disco
+Tsugaru shamisen
+Tumba
+Tumba francesa
+Tumbélé
+Tunantada
+Turbo-Folk
+Turkish Black Sea Region Folk
+Turkish Classical
+Turkish Folk
+Turkish Mevlevi
+Turkish Pop
+Turntable Music
+Turntablism
+Tuvan Throat Singing
+Twee Pop
+Twelve Muqam
+Twerk
+Twist
+Twoubadou
+Táncház
+Tân cổ giao duyên
+Uaajeerneq
+Udigrudi
+Udmurt Folk
+UK Bass
+UK Drill
+UK Funky
+UK Garage
+UK Hard House
+UK Hardcore
+UK Hip Hop
+UK Jackin'
+UK Street Soul
+UK82
+Ukrainian Folk
+Ultra
+Unakesa
+Unblack Metal
+Unyago
+Uplifting Trance
+Upopo
+Uptempo Hardcore
+Uptown Soul
+Urban Contemporary Gospel
+Urban Cowboy
+Urban Grooves
+Urban Pasifika
+Urtiin duu
+Urumi melam
+US Power Metal
+Utaite
+Utopian Virtual
+Uzun Hava
+V-Pop
+Vaigat
+Valencian Folk
+Vallenato
+Vals criollo
+Vals venezolano
+Valsa brasileira
+Vanera
+Vanguarda paulista
+Vapor
+Vapornoise
+Vaportrap
+Vaporwave
+Vaudeville
+Vaudeville Blues
+Vedic Chant
+Vegan Straight Edge
+Venezuelan Folk
+Verismo
+Vietnamese Court
+Vietnamese Folk
+Vietnamese New Wave
+Vietnamese Opera
+Viking Metal
+Vikingarock
+Villancico
+Villanella
+Vinahouse
+Vira
+Virelai
+Virgin Islander Cariso
+Visa
+Visual kei
+Vixa
+Vocal Jazz
+Vocal Surf
+Vocal Trance
+Vocalese
+Vocaloid Scene
+Volga Tatar Folk
+Volga-Ural Folk
+Volkstümliche Musik
+Voëlvry Movement
+Vude
+Wa Euro
+Waila
+Waka
+Walloon Folk
+Waltz
+Wangga
+War Metal
+Warez Scene
+Warsaw City Folk
+Wassoulou
+Water Sounds
+Wave
+Weather Sounds
+Weightless
+Welsh Folk
+Were music
+West Asian Folk
+West Coast Blues
+West Coast Breaks
+West Coast Hip Hop
+West Coast Jazz
+West Coast Sound of Holland
+West Side Sound
+Western
+Western Classical
+Western Swing
+Whale Song
+White Noise
+White Voice
+Windmill Scene
+Winter Synth
+Witch House
+Wizard Rock
+Women's Music
+Wong shadow
+Wonky
+Wonky Pop
+Wonky Techno
+Work Song
+Worldbeat
+Worship
+Wyrd Folk
+Xaxado
+Xian Psych
+Xibei feng
+Xinyao
+Xote
+Xuc
+Xẩm
+Yacht Rock
+Yakousei
+Yangzhou Opera
+Yaraví
+Yass
+Yayue
+Yemenite
+Yiddish Folksong
+Yo-pop
+Yodeling
+Yoruba
+Yoruba Folk Opera
+Youth Crew
+YTPMV
+Yu-Mex
+Yugoslav New Wave
+Yukar
+Yé-yé
+Zajal
+Zamacueca
+Zamba
+Zamrock
+Zapin
+Zarzuela
+Zarzuela barroca
+Zarzuela grande
+Zef
+Zeibekiko
+Zeitoper
+Zemer Ivri
+Zenonesque
+Zess
+Zeuhl
+Zeybek
+Zhabdro gorgom
+Zhongguo feng
+Ziglibithy
+Zimdancehall
+Zinli
+Znamenny Chant
+Zoblazo
+Zohioliin duu
+Zolo
+Zouglou
+Zouk
+Zouk Love
+Zydeco
+Éntekhno
+Étude
+Òrain Ghàidhlig
+Òrain luaidh
+Özgün Müzik
+Čalgija
+Česká alternativní scéna
+Česká nová vlna
+Český underground


### PR DESCRIPTION
## Description
The current genre list is alright but not very extensive, and also contains some oddities.

Replaces genres-tree.yaml and genres.txt with a significantly expanded and restructured genre hierarchy.
- 2,984 'main' (whitelisted) genres, up from ~740
  - Includes some much needed additions like 'Vaporwave', 'Hyperpop', 'Phonk', 'Cloud Rap', 'Midwest Emo', etc.
  - Also includes very extensive entries for 'world music' (which is not itself a genre). E.g., 'Singeli' (African), 'Son Cubano' (Latin American), 'Mandopop' (Asian), 'Klezmer' (Jewish), etc.
  - Properly lists actual genres from non-Western regions under their real _genre_ instead of just a region. E.g., the current hierarchy lists genres like 'blues' and 'classical', but then also treats 'african' and 'asian' as genres. In my hierarchy, such music will be listed under their proper genre, not just a region. E.g., 'K-Pop' will be listed under `Pop → Asian Pop → K-Pop`, not `asian → east asian → k-pop`.
  - Excludes some vague/nonsensical entries, e.g., 'acoustic music' (not a genre--can be any genre), 'cassette culture' (also not a genre), 'dementia' (???), etc.
- Many aliases supported (9,300+, up from 1546), will all refer to a standardised 'main' entry. E.g., 'hip-hop' will map to 'Hip Hop', 'dnb' will map to 'Drum & Bass'.
  - Also includes basic ascii aliases. E.g., both 'candomblé' and 'candomble' will map to 'Candomblé'.
- Much work was put into organising the tree correctly, meaning that a proper hierarchy of a genre can be traced. Some examples:
  1. `Electronic → Electronic Dance Music → House → Hard House → UK Hard House → Scouse House → Pumping House → Hardbass`
  2. `Classical → Asian Classical → East Asian Classical → Korean Classical → Korean Court → Jeong-ak → Gagok`
  3. `Folk → Traditional Folk → European Folk → Balkan Folk → Greek Folk → Cretan Folk → Rizitika`
- Proper Case genre names. Also supports proper case if other letters than the first one need capitalisation, e.g., 'IDM', 'HexD', etc. Or will lowercase if needed, e.g., 'Lo-fi' instead of 'Lo-Fi'.
  - Will need some work changing the current capitalisation logic to actually produce this as output, but at least we have a good source for proper capitalisation to work with now.

Sources used:
- [RateYourMusic](https://rateyourmusic.com)
- [Wikipedia List of Music Genres](https://en.wikipedia.org/wiki/Lists_of_music_genres)
- [Discogs](https://www.discogs.com)
- [AllMusic](https://www.allmusic.com)

Fixes #6628

## To Do
- [ ] Documentation. _The proposed hierarchy comes properly capitalised by default. I think ideally, when capitalisation is activated, it will use use the untouched terminology, and otherwise just lowercase everything. Currently the setup is different, just applying Proper Case to any lowercase default value._ If that logic is altered, we will need new documentation, but as it is no new documentation is required.
- [ ] Changelog. _Will add this once it's approved._
- [X] Tests. _I use this hierarchy myself._


I don't know if my PR is even appreciated, but a lack of extensive genre maintenance was bothering me personally. The default list seems to be based on some very old extraction of Wikipedia and isn't necessarily of high quality. So I put a lot of effort into building this for personal use and I thought I'd at least offer to share. Please let me know if anything more would be required from my side.