### PR TITLE
Add `skip-magic-trailing-comma` ruff format setting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -181,3 +181,5 @@ b8def07121431421118ff7d569f8187aae0520f2
 d4fd36a03384b0f71144932833d9c633c1f9545f
 # sort: Update dotted sort references
 0cd20798aa585f162433423f767c047b7474a70e
+# Reformat using skip-magic-trailing-comma
+adfb73b66dba0fc799880af176ef6f9ac0a7ee68

--- a/beets/__init__.py
+++ b/beets/__init__.py
@@ -26,9 +26,7 @@ __author__ = "Adrian Sampson <adrian@radbox.org>"
 def __getattr__(name: str):
     """Handle deprecated imports."""
     return deprecate_imports(
-        __name__,
-        {"art": "beetsplug._utils", "vfs": "beetsplug._utils"},
-        name,
+        __name__, {"art": "beetsplug._utils", "vfs": "beetsplug._utils"}, name
     )
 
 

--- a/beets/autotag/distance.py
+++ b/beets/autotag/distance.py
@@ -41,9 +41,7 @@ SD_PATTERNS = [
     (r"(, )?(pt\.|part) .+", 0.2),
 ]
 # Replacements to use before testing distance.
-SD_REPLACE = [
-    (r"&", "and"),
-]
+SD_REPLACE = [(r"&", "and")]
 
 
 def _string_dist_basic(str1: str, str2: str) -> float:
@@ -279,10 +277,7 @@ class Distance:
         self._penalties.setdefault(key, []).append(dist)
 
     def add_equality(
-        self,
-        key: str,
-        value: Any,
-        options: list[Any] | tuple[Any, ...] | Any,
+        self, key: str, value: Any, options: list[Any] | tuple[Any, ...] | Any
     ):
         """Adds a distance penalty of 1.0 if `value` doesn't match any
         of the values in `options`. If an option is a compiled regular
@@ -322,10 +317,7 @@ class Distance:
             self.add(key, 0.0)
 
     def add_priority(
-        self,
-        key: str,
-        value: Any,
-        options: list[Any] | tuple[Any, ...] | Any,
+        self, key: str, value: Any, options: list[Any] | tuple[Any, ...] | Any
     ):
         """Adds a distance penalty that corresponds to the position at
         which `value` appears in `options`. A distance penalty of 0.0
@@ -344,12 +336,7 @@ class Distance:
             dist = 1.0
         self.add(key, dist)
 
-    def add_ratio(
-        self,
-        key: str,
-        number1: int | float,
-        number2: int | float,
-    ):
+    def add_ratio(self, key: str, number1: int | float, number2: int | float):
         """Adds a distance penalty for `number1` as a ratio of `number2`.
         `number1` is bound at 0 and `number2`.
         """
@@ -394,9 +381,7 @@ def track_index_changed(item: Item, track_info: TrackInfo) -> bool:
 
 
 def track_distance(
-    item: Item,
-    track_info: TrackInfo,
-    incl_artist: bool = False,
+    item: Item, track_info: TrackInfo, incl_artist: bool = False
 ) -> Distance:
     """Determines the significance of a track metadata change. Returns a
     Distance object. `incl_artist` indicates that a distance component should

--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -635,7 +635,7 @@ class AlbumMatch(Match):
                 f"{mediums}x{self.info.media}"
                 if (mediums := self.info.mediums) and mediums > 1
                 else self.info.media
-            ),
+            )
         }
 
     @property

--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -73,8 +73,7 @@ class Proposal(NamedTuple):
 
 
 def assign_items(
-    items: Sequence[Item],
-    tracks: Sequence[TrackInfo],
+    items: Sequence[Item], tracks: Sequence[TrackInfo]
 ) -> tuple[list[tuple[Item, TrackInfo]], list[Item], list[TrackInfo]]:
     """Given a list of Items and a list of TrackInfo objects, find the
     best mapping between them. Returns a mapping from Items to TrackInfo
@@ -184,9 +183,7 @@ def _sort_candidates(candidates: Iterable[AnyMatch]) -> Sequence[AnyMatch]:
 
 
 def _add_candidate(
-    items: Sequence[Item],
-    results: Candidates[AlbumMatch],
-    info: AlbumInfo,
+    items: Sequence[Item], results: Candidates[AlbumMatch], info: AlbumInfo
 ):
     """Given a candidate AlbumInfo object, attempt to add the candidate
     to the output dictionary of AlbumMatch objects. This involves

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -144,9 +144,7 @@ class FormattedMapping(Mapping[str, str]):
     # The following signature is incompatible with `Mapping[str, str]`, since
     # the return type doesn't include `None` (but `default` can be `None`).
     def get(  # type: ignore
-        self,
-        key: str,
-        default: str | None = None,
+        self, key: str, default: str | None = None
     ) -> str:
         """Similar to Mapping.get(key, default), but always formats to str."""
         if default is None:
@@ -724,9 +722,7 @@ class Model(ABC, Generic[D]):
     _formatter = FormattedMapping
 
     def formatted(
-        self,
-        included_keys: str = _formatter.ALL_KEYS,
-        for_path: bool = False,
+        self, included_keys: str = _formatter.ALL_KEYS, for_path: bool = False
     ) -> FormattedMapping:
         """Get a mapping containing all values on this object formatted
         as human-readable unicode strings.
@@ -734,9 +730,7 @@ class Model(ABC, Generic[D]):
         return self._formatter(self, included_keys, for_path)
 
     def evaluate_template(
-        self,
-        template: str | functemplate.Template,
-        for_path: bool = False,
+        self, template: str | functemplate.Template, for_path: bool = False
     ) -> str:
         """Evaluate a template (a string or a `Template` object) using
         the object's fields. If `for_path` is true, then no new path
@@ -1371,11 +1365,7 @@ class Database:
                     ON {flex_table} (entity_id);
                 """)
 
-    def _create_indices(
-        self,
-        table: str,
-        indices: Sequence[Index],
-    ):
+    def _create_indices(self, table: str, indices: Sequence[Index]):
         """Create indices for the given table if they don't exist."""
         with self.transaction() as tx:
             for index in indices:

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -237,11 +237,7 @@ class StringFieldQuery(FieldQuery[P]):
         )
 
     @classmethod
-    def string_match(
-        cls,
-        pattern: P,
-        value: str,
-    ) -> bool:
+    def string_match(cls, pattern: P, value: str) -> bool:
         """Determine whether the value matches the pattern. Both
         arguments are strings. Subclasses implement this method.
         """
@@ -422,12 +418,7 @@ class BooleanQuery(MatchQuery[int]):
     string reflecting a boolean.
     """
 
-    def __init__(
-        self,
-        field_name: str,
-        pattern: bool,
-        fast: bool = True,
-    ):
+    def __init__(self, field_name: str, pattern: bool, fast: bool = True):
         if isinstance(pattern, str):
             pattern = util.str2bool(pattern)
 
@@ -560,8 +551,7 @@ class CollectionQuery(Query):
         return subq in self.subqueries
 
     def clause_with_joiner(
-        self,
-        joiner: str,
+        self, joiner: str
     ) -> tuple[str | None, Sequence[SQLiteType]]:
         """Return a clause created by joining together the clauses of
         all subqueries with the string joiner (padded by spaces).
@@ -833,9 +823,7 @@ class DateInterval:
 
     @classmethod
     def from_periods(
-        cls,
-        start: Period | None,
-        end: Period | None,
+        cls, start: Period | None, end: Period | None
     ) -> DateInterval:
         """Create an interval with two Periods as the endpoints."""
         end_date = end.open_right_endpoint() if end is not None else None

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -113,9 +113,7 @@ def parse_query_part(
 
 
 def construct_query_part(
-    model_cls: type[LibModel],
-    prefixes: Prefixes,
-    query_part: str,
+    model_cls: type[LibModel], prefixes: Prefixes, query_part: str
 ) -> query.Query:
     """Parse a *query part* string and return a :class:`Query` object.
 
@@ -184,9 +182,7 @@ def query_from_strings(
 
 
 def construct_sort_part(
-    model_cls: type[LibModel],
-    part: str,
-    case_insensitive: bool = True,
+    model_cls: type[LibModel], part: str, case_insensitive: bool = True
 ) -> sort.Sort:
     """Create a `Sort` from a single string criterion.
 

--- a/beets/dbcore/sort.py
+++ b/beets/dbcore/sort.py
@@ -117,10 +117,7 @@ class FieldSort(Sort):
     """
 
     def __init__(
-        self,
-        field: str,
-        ascending: bool = True,
-        case_insensitive: bool = True,
+        self, field: str, ascending: bool = True, case_insensitive: bool = True
     ):
         self.field = field
         self.ascending = ascending

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -299,9 +299,7 @@ def manipulate_files(session: ImportSession, task: ImportTask):
             operation = None
 
         task.manipulate_files(
-            session=session,
-            operation=operation,
-            write=session.config["write"],
+            session=session, operation=operation, write=session.config["write"]
         )
 
     # Progress, cleanup, and event.

--- a/beets/importer/state.py
+++ b/beets/importer/state.py
@@ -73,9 +73,7 @@ class ImportState:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self._save()
 
-    def _open(
-        self,
-    ):
+    def _open(self):
         try:
             with open(self.path, "rb") as f:
                 state = pickle.load(f)

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -1144,10 +1144,7 @@ class Item(LibModel):
     # Templating.
 
     def destination(
-        self,
-        relative_to_libdir=False,
-        basedir=None,
-        path_formats=None,
+        self, relative_to_libdir=False, basedir=None, path_formats=None
     ) -> bytes:
         """Return the path in the library directory designated for the item
         (i.e., where the file ought to be).
@@ -1405,15 +1402,7 @@ class DefaultTemplateFunctions:
         return (name, keys, disam, item_id)
 
     def _tmpl_unique(
-        self,
-        name,
-        keys,
-        disam,
-        bracket,
-        item_id,
-        db_item,
-        item_keys,
-        skip_item,
+        self, name, keys, disam, bracket, item_id, db_item, item_keys, skip_item
     ):
         """Generate a string that is guaranteed to be unique among all items of
         the same type as "db_item" who share the same set of keys.

--- a/beets/logging.py
+++ b/beets/logging.py
@@ -115,12 +115,7 @@ class StrFormatLogger(Logger):
     """
 
     class _LogMessage:
-        def __init__(
-            self,
-            msg: str,
-            args: _ArgsType,
-            kwargs: dict[str, Any],
-        ):
+        def __init__(self, msg: str, args: _ArgsType, kwargs: dict[str, Any]):
             self.msg = msg
             self.args = args
             self.kwargs = kwargs

--- a/beets/metadata_plugins.py
+++ b/beets/metadata_plugins.py
@@ -219,11 +219,7 @@ class MetadataSourcePlugin(BeetsPlugin, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def candidates(
-        self,
-        items: Sequence[Item],
-        artist: str,
-        album: str,
-        va_likely: bool,
+        self, items: Sequence[Item], artist: str, album: str, va_likely: bool
     ) -> Iterable[AlbumInfo]:
         """Return :py:class:`AlbumInfo` candidates that match the given album.
 
@@ -365,11 +361,7 @@ class SearchApiMetadataSourcePlugin(
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.config.add(
-            {
-                "search_query_ascii": False,
-            }
-        )
+        self.config.add({"search_query_ascii": False})
 
     @abc.abstractmethod
     def get_search_query_with_filters(
@@ -447,11 +439,7 @@ class SearchApiMetadataSourcePlugin(
         )
 
     def candidates(
-        self,
-        items: Sequence[Item],
-        artist: str,
-        album: str,
-        va_likely: bool,
+        self, items: Sequence[Item], artist: str, album: str, va_likely: bool
     ) -> Iterable[AlbumInfo]:
         results = self._get_candidates("album", items, artist, album, va_likely)
         return filter(None, self.albums_for_ids(r["id"] for r in results))

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -284,8 +284,7 @@ class BeetsPlugin(metaclass=BeetsPluginMeta):
         return ()
 
     def _set_stage_log_level(
-        self,
-        stages: list[ImportStageFunc],
+        self, stages: list[ImportStageFunc]
     ) -> list[ImportStageFunc]:
         """Adjust all the stages in `stages` to WARNING logging level."""
         return [
@@ -314,9 +313,7 @@ class BeetsPlugin(metaclass=BeetsPluginMeta):
         return self._set_stage_log_level(self.import_stages)
 
     def _set_log_level_and_params(
-        self,
-        base_log_level: int,
-        func: Callable[P, Ret],
+        self, base_log_level: int, func: Callable[P, Ret]
     ) -> Callable[P, Ret]:
         """Wrap `func` to temporarily set this plugin's logger level to
         `base_log_level` + config options (and restore it to its previous

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -316,17 +316,12 @@ class TestHelper(RunMixin, ConfigMixin):
         return items
 
     def add_album_fixture(
-        self,
-        track_count=1,
-        fname="full",
-        ext="mp3",
-        disc_count=1,
+        self, track_count=1, fname="full", ext="mp3", disc_count=1
     ):
         """Add an album with files to the database."""
         items = []
         path = os.path.join(
-            _common.RSRC,
-            util.bytestring_path(f"{fname}.{ext}"),
+            _common.RSRC, util.bytestring_path(f"{fname}.{ext}")
         )
         for discnumber in range(1, disc_count + 1):
             for i in range(track_count):
@@ -519,10 +514,7 @@ class ImportHelper(TestHelper):
         ]
 
     def prepare_track_for_import(
-        self,
-        track_id: int,
-        album_path: Path,
-        album_id: int | None = None,
+        self, track_id: int, album_path: Path, album_id: int | None = None
     ) -> Path:
         track_path = album_path / f"track_{track_id}.mp3"
         shutil.copy(self.resource_path, track_path)
@@ -577,10 +569,7 @@ class ImportHelper(TestHelper):
 
     def _get_import_session(self, import_dir: bytes) -> ImportSession:
         return ImportSessionFixture(
-            self.lib,
-            loghandler=None,
-            query=None,
-            paths=[import_dir],
+            self.lib, loghandler=None, query=None, paths=[import_dir]
         )
 
     def setup_importer(
@@ -871,10 +860,7 @@ class FetchImageHelper:
             raise AssertionError(f"Mocking {file_type} responses not supported")
 
         responses.add(
-            responses.GET,
-            url,
-            content_type=content_type,
-            body=header,
+            responses.GET, url, content_type=content_type, body=header
         )
 
 

--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -63,10 +63,7 @@ if not log.handlers:
 log.propagate = False  # Don't propagate to root handler.
 
 
-PF_KEY_QUERIES = {
-    "comp": "comp:true",
-    "singleton": "singleton:true",
-}
+PF_KEY_QUERIES = {"comp": "comp:true", "singleton": "singleton:true"}
 
 
 # Encoding utilities.

--- a/beets/ui/commands/import_/session.py
+++ b/beets/ui/commands/import_/session.py
@@ -174,10 +174,7 @@ class TerminalImportSession(importer.ImportSession):
 
             ui.print_(
                 "New: "
-                + summarize_items(
-                    task.imported_items(),
-                    not task.is_album,
-                )
+                + summarize_items(task.imported_items(), not task.is_album)
             )
             if config["import"]["duplicate_verbose_prompt"]:
                 for item in task.imported_items():
@@ -339,10 +336,7 @@ def _summary_judgment(rec: Recommendation) -> importer.Action | None:
             return importer.Action.APPLY
         else:
             action = config["import"]["quiet_fallback"].as_choice(
-                {
-                    "skip": importer.Action.SKIP,
-                    "asis": importer.Action.ASIS,
-                }
+                {"skip": importer.Action.SKIP, "asis": importer.Action.ASIS}
             )
     elif config["import"]["timid"]:
         return None
@@ -487,12 +481,7 @@ def choose_candidate(
 
         # Ask for confirmation.
         default = config["import"]["default_action"].as_choice(
-            {
-                "apply": "a",
-                "skip": "s",
-                "asis": "u",
-                "none": None,
-            }
+            {"apply": "a", "skip": "s", "asis": "u", "none": None}
         )
         if default is None:
             require = True

--- a/beets/ui/commands/update.py
+++ b/beets/ui/commands/update.py
@@ -149,12 +149,7 @@ def update_func(lib, opts, args):
 
 
 update_cmd = ui.Subcommand(
-    "update",
-    help="update the library",
-    aliases=(
-        "upd",
-        "up",
-    ),
+    "update", help="update the library", aliases=("upd", "up")
 )
 update_cmd.parser.add_album_option()
 update_cmd.parser.add_format_option()

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -609,10 +609,7 @@ def hardlink(path: bytes, dest: bytes, replace: bool = False):
 
 
 def reflink(
-    path: bytes,
-    dest: bytes,
-    replace: bool = False,
-    fallback: bool = False,
+    path: bytes, dest: bytes, replace: bool = False, fallback: bool = False
 ):
     """Create a reflink from `dest` to `path`.
 

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -50,10 +50,7 @@ def resize_url(url: str, maxwidth: int, quality: int = 0) -> str:
     """Return a proxied image URL that resizes the original image to
     maxwidth (preserving aspect ratio).
     """
-    params = {
-        "url": url.replace("http://", ""),
-        "w": maxwidth,
-    }
+    params = {"url": url.replace("http://", ""), "w": maxwidth}
 
     if quality > 0:
         params["q"] = quality
@@ -117,9 +114,7 @@ class LocalBackend(ABC):
 
     @abstractmethod
     def deinterlace(
-        self,
-        path_in: bytes,
-        path_out: bytes | None = None,
+        self, path_in: bytes, path_out: bytes | None = None
     ) -> bytes:
         """Remove interlacing from an image and return the output path.
 
@@ -134,10 +129,7 @@ class LocalBackend(ABC):
 
     @abstractmethod
     def convert_format(
-        self,
-        source: bytes,
-        target: bytes,
-        deinterlaced: bool,
+        self, source: bytes, target: bytes, deinterlaced: bool
     ) -> bytes:
         """Convert an image to a new format and return the new file path.
 
@@ -151,10 +143,7 @@ class LocalBackend(ABC):
         return False
 
     def compare(
-        self,
-        im1: bytes,
-        im2: bytes,
-        compare_threshold: float,
+        self, im1: bytes, im2: bytes, compare_threshold: float
     ) -> bool | None:
         """Compare two images and return `True` if they are similar enough, or
         `None` if there is an error.
@@ -332,9 +321,7 @@ class IMBackend(LocalBackend):
         return size
 
     def deinterlace(
-        self,
-        path_in: bytes,
-        path_out: bytes | None = None,
+        self, path_in: bytes, path_out: bytes | None = None
     ) -> bytes:
         if not path_out:
             path_out = get_temp_filename(__name__, "deinterlace_IM_", path_in)
@@ -367,10 +354,7 @@ class IMBackend(LocalBackend):
             return None
 
     def convert_format(
-        self,
-        source: bytes,
-        target: bytes,
-        deinterlaced: bool,
+        self, source: bytes, target: bytes, deinterlaced: bool
     ) -> bytes:
         cmd = [
             *self.convert_cmd,
@@ -393,10 +377,7 @@ class IMBackend(LocalBackend):
         return self.version() > (6, 8, 7)
 
     def compare(
-        self,
-        im1: bytes,
-        im2: bytes,
-        compare_threshold: float,
+        self, im1: bytes, im2: bytes, compare_threshold: float
     ) -> bool | None:
         is_windows = platform.system() == "Windows"
 
@@ -605,9 +586,7 @@ class PILBackend(LocalBackend):
             return None
 
     def deinterlace(
-        self,
-        path_in: bytes,
-        path_out: bytes | None = None,
+        self, path_in: bytes, path_out: bytes | None = None
     ) -> bytes:
         if not path_out:
             path_out = get_temp_filename(__name__, "deinterlace_PIL_", path_in)
@@ -638,10 +617,7 @@ class PILBackend(LocalBackend):
             return None
 
     def convert_format(
-        self,
-        source: bytes,
-        target: bytes,
-        deinterlaced: bool,
+        self, source: bytes, target: bytes, deinterlaced: bool
     ) -> bytes:
         from PIL import Image, UnidentifiedImageError
 
@@ -664,10 +640,7 @@ class PILBackend(LocalBackend):
         return False
 
     def compare(
-        self,
-        im1: bytes,
-        im2: bytes,
-        compare_threshold: float,
+        self, im1: bytes, im2: bytes, compare_threshold: float
     ) -> bool | None:
         # It is an error to call this when ArtResizer.can_compare is not True.
         raise NotImplementedError()
@@ -688,10 +661,7 @@ class PILBackend(LocalBackend):
         im.save(os.fsdecode(file), "PNG", pnginfo=meta)
 
 
-BACKEND_CLASSES: list[type[LocalBackend]] = [
-    IMBackend,
-    PILBackend,
-]
+BACKEND_CLASSES: list[type[LocalBackend]] = [IMBackend, PILBackend]
 
 
 class ArtResizer:
@@ -758,9 +728,7 @@ class ArtResizer:
             return path_in
 
     def deinterlace(
-        self,
-        path_in: bytes,
-        path_out: bytes | None = None,
+        self, path_in: bytes, path_out: bytes | None = None
     ) -> bytes:
         """Deinterlace an image.
 
@@ -815,10 +783,7 @@ class ArtResizer:
             return None
 
     def reformat(
-        self,
-        path_in: bytes,
-        new_format: str,
-        deinterlaced: bool = True,
+        self, path_in: bytes, new_format: str, deinterlaced: bool = True
     ) -> bytes:
         """Converts image to desired format, updating its extension, but
         keeping the same filename.
@@ -831,9 +796,7 @@ class ArtResizer:
 
         new_format = new_format.lower()
         # A nonexhaustive map of image "types" to extensions overrides
-        new_format = {
-            "jpeg": "jpg",
-        }.get(new_format, new_format)
+        new_format = {"jpeg": "jpg"}.get(new_format, new_format)
 
         fname, _ = os.path.splitext(path_in)
         path_new = fname + b"." + new_format.encode("utf8")
@@ -861,10 +824,7 @@ class ArtResizer:
             return False
 
     def compare(
-        self,
-        im1: bytes,
-        im2: bytes,
-        compare_threshold: float,
+        self, im1: bytes, im2: bytes, compare_threshold: float
     ) -> bool | None:
         """Return a boolean indicating whether two images are similar.
 

--- a/beets/util/deprecation.py
+++ b/beets/util/deprecation.py
@@ -13,9 +13,7 @@ if TYPE_CHECKING:
     from logging import Logger
 
 
-ALBUM_LEGACY_TO_LIST_FIELD = {
-    "genre": "genres",
-}
+ALBUM_LEGACY_TO_LIST_FIELD = {"genre": "genres"}
 ITEM_LEGACY_TO_LIST_FIELD = {
     "genre": "genres",
     "arranger": "arrangers",

--- a/beets/util/diff.py
+++ b/beets/util/diff.py
@@ -85,9 +85,7 @@ def _field_diff(
 
 
 def get_model_changes(
-    new: LibModel,
-    old: LibModel,
-    fields: Iterable[str] | None,
+    new: LibModel, old: LibModel, fields: Iterable[str] | None
 ) -> list[str]:
     """Compute human-readable diff lines for changed fields between two models.
 

--- a/beets/util/functemplate.py
+++ b/beets/util/functemplate.py
@@ -99,10 +99,7 @@ def compile_func(arg_names, statements, name="_the_func", debug=False):
     args = ast.arguments(**args_fields)
 
     func_def = ast.FunctionDef(
-        name=name,
-        args=args,
-        body=statements,
-        decorator_list=[],
+        name=name, args=args, body=statements, decorator_list=[]
     )
 
     mod = ast.Module([func_def], [])
@@ -558,8 +555,7 @@ class Template:
             argnames.append(f"{FUNCTION_PREFIX}{funcname}")
 
         func = compile_func(
-            argnames,
-            [ast.Return(ast.List(expressions, ast.Load()))],
+            argnames, [ast.Return(ast.List(expressions, ast.Load()))]
         )
 
         def wrapper_func(values={}, functions={}):

--- a/beets/util/layout.py
+++ b/beets/util/layout.py
@@ -181,11 +181,7 @@ def split_into_lines(string: str, first_width: int, width: int) -> list[str]:
 
 
 def get_column_layout(
-    indent_str: str,
-    left: Side,
-    right: Side,
-    max_width: int,
-    separator: str,
+    indent_str: str, left: Side, right: Side, max_width: int, separator: str
 ) -> Iterator[str]:
     """Print left & right data, with separator inbetween
     'left' and 'right' have a structure of:
@@ -294,11 +290,7 @@ def get_column_layout(
 
 
 def get_newline_layout(
-    indent_str: str,
-    left: Side,
-    right: Side,
-    max_width: int,
-    separator: str,
+    indent_str: str, left: Side, right: Side, max_width: int, separator: str
 ) -> Iterator[str]:
     """Prints using a newline separator between left & right if
     they go over their allocated widths. The datastructures are
@@ -317,9 +309,7 @@ def get_newline_layout(
     width_without_double_prefix = max_width - 2 * len(indent_str)
     # On lower lines we will double the indent for clarity
     left_split = split_into_lines(
-        left.rendered,
-        width_without_prefix,
-        width_without_double_prefix,
+        left.rendered, width_without_prefix, width_without_double_prefix
     )
     # Repeat calculations for rhs, including separator on first line
     right_split = split_into_lines(
@@ -347,10 +337,7 @@ def get_layout_method() -> Callable[[str, Side, Side, int, str], Iterator[str]]:
 
 
 def get_layout_lines(
-    indent_str: str,
-    left: Side,
-    right: Side,
-    max_width: int,
+    indent_str: str, left: Side, right: Side, max_width: int
 ) -> Iterator[str]:
     # No right hand information, so we don't need a separator.
     separator = "" if right.rendered == "" else " -> "

--- a/beets/util/pipeline.py
+++ b/beets/util/pipeline.py
@@ -170,12 +170,7 @@ T = TypeVar("T")  # Type of the task
 R = TypeVar("R")
 
 
-def stage(
-    func: Callable[
-        [Unpack[A], T],
-        R | None,
-    ],
-):
+def stage(func: Callable[[Unpack[A], T], R | None]):
     """Decorate a function to become a simple stage.
 
     >>> @stage
@@ -444,11 +439,7 @@ class Pipeline:
             for coro in self.stages[i]:
                 threads.append(
                     MiddlePipelineThread(
-                        coro,
-                        queues[i - 1],
-                        queues[i],
-                        threads,
-                        base_ctx.copy(),
+                        coro, queues[i - 1], queues[i], threads, base_ctx.copy()
                     )
                 )
 

--- a/beetsplug/_utils/art.py
+++ b/beetsplug/_utils/art.py
@@ -150,11 +150,7 @@ def resize_image(log, imagepath, maxwidth, quality):
 
 
 def check_art_similarity(
-    log,
-    item,
-    imagepath,
-    compare_threshold,
-    artresizer=None,
+    log, item, imagepath, compare_threshold, artresizer=None
 ):
     """A boolean indicating if an image is similar to embedded item art.
 
@@ -190,9 +186,7 @@ def extract(log, outpath, item):
     outpath += bytestring_path(f".{ext}")
 
     log.info(
-        "Extracting album art from: {} to: {}",
-        item,
-        displayable_path(outpath),
+        "Extracting album art from: {} to: {}", item, displayable_path(outpath)
     )
     with open(syspath(outpath), "wb") as f:
         f.write(art)

--- a/beetsplug/absubmit.py
+++ b/beetsplug/absubmit.py
@@ -200,10 +200,7 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
         mbid = item["mb_trackid"]
         headers = {"Content-Type": "application/json"}
         response = requests.post(
-            self.url.format(mbid=mbid),
-            json=data,
-            headers=headers,
-            timeout=10,
+            self.url.format(mbid=mbid), json=data, headers=headers, timeout=10
         )
         # Test that request was successful and raise an error on failure.
         if response.status_code != 200:
@@ -219,6 +216,5 @@ class AcousticBrainzSubmitPlugin(plugins.BeetsPlugin):
             )
         else:
             self._log.debug(
-                "Successfully submitted AcousticBrainz analysis for {}.",
-                item,
+                "Successfully submitted AcousticBrainz analysis for {}.", item
             )

--- a/beetsplug/advancedrewrite.py
+++ b/beetsplug/advancedrewrite.py
@@ -70,7 +70,7 @@ class AdvancedRewritePlugin(BeetsPlugin):
                     {
                         "match": str,
                         "replacements": confuse.MappingValues(
-                            confuse.OneOf([str, confuse.Sequence(str)]),
+                            confuse.OneOf([str, confuse.Sequence(str)])
                         ),
                     },
                 ]
@@ -132,10 +132,7 @@ class AdvancedRewritePlugin(BeetsPlugin):
                         "Advanced rewrites must have at least one replacement"
                     )
                 query = query_from_strings(
-                    AndQuery,
-                    Item,
-                    prefixes={},
-                    query_parts=shlex.split(match),
+                    AndQuery, Item, prefixes={}, query_parts=shlex.split(match)
                 )
                 for fieldname, replacement in replacements.items():
                     if fieldname not in Item._fields:

--- a/beetsplug/bareasc.py
+++ b/beetsplug/bareasc.py
@@ -58,11 +58,7 @@ class BareascPlugin(BeetsPlugin):
     def __init__(self):
         """Default prefix for selecting bare-ASCII matching is #."""
         super().__init__()
-        self.config.add(
-            {
-                "prefix": "#",
-            }
-        )
+        self.config.add({"prefix": "#"})
 
     def queries(self):
         """Register bare-ASCII matching."""

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -118,18 +118,12 @@ class BeatportClient:
 
     @overload
     def search(
-        self,
-        query: str,
-        release_type: Literal["release"],
-        details: bool = True,
+        self, query: str, release_type: Literal["release"], details: bool = True
     ) -> Iterator[BeatportRelease]: ...
 
     @overload
     def search(
-        self,
-        query: str,
-        release_type: Literal["track"],
-        details: bool = True,
+        self, query: str, release_type: Literal["track"], details: bool = True
     ) -> Iterator[BeatportTrack]: ...
 
     def search(
@@ -385,11 +379,7 @@ class BeatportPlugin(MetadataSourcePlugin):
         return self.config["tokenfile"].get(confuse.Filename(in_app_dir=True))
 
     def candidates(
-        self,
-        items: Sequence[Item],
-        artist: str,
-        album: str,
-        va_likely: bool,
+        self, items: Sequence[Item], artist: str, album: str, va_likely: bool
     ) -> Iterator[AlbumInfo]:
         if va_likely:
             query = album

--- a/beetsplug/bench.py
+++ b/beetsplug/bench.py
@@ -33,7 +33,7 @@ def aunique_benchmark(lib, prof):
         (
             library.PF_KEY_DEFAULT,
             Template("$albumartist/$album%aunique{}/$track $title"),
-        ),
+        )
     ]
     if prof:
         cProfile.runctx(
@@ -51,7 +51,7 @@ def aunique_benchmark(lib, prof):
         (
             library.PF_KEY_DEFAULT,
             Template("$albumartist/$album%lower{}/$track $title"),
-        ),
+        )
     ]
     if prof:
         cProfile.runctx(

--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -1009,8 +1009,7 @@ class Command:
         # If the command accepts a variable number of arguments skip the check.
         if wrong_num and not argspec.varargs:
             raise TypeError(
-                f'wrong number of arguments for "{self.name}"',
-                self.name,
+                f'wrong number of arguments for "{self.name}"', self.name
             )
 
         return func
@@ -1518,11 +1517,7 @@ class Server(BaseServer):
 
     def cmd_outputs(self, conn):
         """List the available outputs."""
-        yield (
-            "outputid: 0",
-            "outputname: gstreamer",
-            "outputenabled: 1",
-        )
+        yield ("outputid: 0", "outputname: gstreamer", "outputenabled: 1")
 
     def cmd_enableoutput(self, conn, output_id):
         output_id = cast_arg(int, output_id)

--- a/beetsplug/bpm.py
+++ b/beetsplug/bpm.py
@@ -47,12 +47,7 @@ def bpm(max_strokes):
 class BPMPlugin(BeetsPlugin):
     def __init__(self):
         super().__init__()
-        self.config.add(
-            {
-                "max_strokes": 3,
-                "overwrite": True,
-            }
-        )
+        self.config.add({"max_strokes": 3, "overwrite": True})
 
     def commands(self):
         cmd = ui.Subcommand(

--- a/beetsplug/chroma.py
+++ b/beetsplug/chroma.py
@@ -186,11 +186,7 @@ def _all_releases(items):
 class AcoustidPlugin(MetadataSourcePlugin):
     def __init__(self):
         super().__init__()
-        self.config.add(
-            {
-                "auto": True,
-            }
-        )
+        self.config.add({"auto": True})
         config["acoustid"]["apikey"].redact = True
 
         if self.config["auto"]:
@@ -412,10 +408,7 @@ def submit_items(log, userkey, items, chunksize=64):
         fp = fingerprint_item(log, item, write=ui.should_write())
 
         # Construct a submission dictionary for this item.
-        item_data = {
-            "duration": int(item.length),
-            "fingerprint": fp,
-        }
+        item_data = {"duration": int(item.length), "fingerprint": fp}
         if item.mb_trackid:
             item_data["mbid"] = item.mb_trackid
             log.debug("submitting MBID")

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -50,10 +50,7 @@ _fs_lock = threading.Lock()
 _temp_files: list[bytes] = []
 
 # Some convenient alternate names for formats.
-ALIASES = {
-    "windows media": "wma",
-    "vorbis": "ogg",
-}
+ALIASES = {"windows media": "wma", "vorbis": "ogg"}
 
 LOSSLESS_FORMATS = ["ape", "flac", "alac", "wave", "aiff"]
 
@@ -334,10 +331,7 @@ class ConvertPlugin(BeetsPlugin):
         encode_cmd = []
         for i, arg in enumerate(args):
             args[i] = Template(arg).safe_substitute(
-                {
-                    "source": source,
-                    "dest": dest,
-                }
+                {"source": source, "dest": dest}
             )
             encode_cmd.append(os.fsdecode(args[i]))
 
@@ -447,9 +441,7 @@ class ConvertPlugin(BeetsPlugin):
         if keep_new:
             if pretend:
                 self._log.info(
-                    "mv {.filepath} {}",
-                    item,
-                    util.displayable_path(original),
+                    "mv {.filepath} {}", item, util.displayable_path(original)
                 )
             else:
                 self._log.info("Moving to {}", util.displayable_path(original))

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -112,10 +112,7 @@ class DeezerPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
         if not tracks_data:
             return None
         while "next" in tracks_obj:
-            tracks_obj = requests.get(
-                tracks_obj["next"],
-                timeout=10,
-            ).json()
+            tracks_obj = requests.get(tracks_obj["next"], timeout=10).json()
             tracks_data.extend(tracks_obj["data"])
 
         tracks = []

--- a/beetsplug/discogs/__init__.py
+++ b/beetsplug/discogs/__init__.py
@@ -242,9 +242,7 @@ class DiscogsPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
         except DiscogsAPIError as e:
             if e.status_code != 404:
                 self._log.debug(
-                    "API Error: {} (query: {})",
-                    e,
-                    result.data["resource_url"],
+                    "API Error: {} (query: {})", e, result.data["resource_url"]
                 )
                 if e.status_code == 401:
                     self.reset_auth()
@@ -325,9 +323,7 @@ class DiscogsPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
         except DiscogsAPIError as e:
             if e.status_code != 404:
                 self._log.debug(
-                    "API Error: {} (query: {})",
-                    e,
-                    result.data["resource_url"],
+                    "API Error: {} (query: {})", e, result.data["resource_url"]
                 )
                 if e.status_code == 401:
                     self.reset_auth()
@@ -360,8 +356,7 @@ class DiscogsPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
                 result.refresh()
             except CONNECTION_ERRORS:
                 self._log.debug(
-                    "Connection error in release lookup: {0}",
-                    result,
+                    "Connection error in release lookup: {0}", result
                 )
                 return None
 
@@ -487,9 +482,7 @@ class DiscogsPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
         return None
 
     def get_tracks(
-        self,
-        tracklist: list[Track],
-        albumartistinfo: ArtistState,
+        self, tracklist: list[Track], albumartistinfo: ArtistState
     ) -> list[TrackInfo]:
         """Returns a list of TrackInfo objects for a discogs tracklist."""
         try:
@@ -614,9 +607,7 @@ class DiscogsPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
         return tracklist
 
     def _add_merged_subtracks(
-        self,
-        tracklist: list[Track],
-        subtracks: list[Track],
+        self, tracklist: list[Track], subtracks: list[Track]
     ) -> None:
         """Modify `tracklist` in place, merging a list of `subtracks` into
         a single track into `tracklist`."""

--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -58,11 +58,7 @@ def edit(filename, log):
 
 def dump(arg):
     """Dump a sequence of dictionaries as YAML for editing."""
-    return yaml.safe_dump_all(
-        arg,
-        allow_unicode=True,
-        default_flow_style=False,
-    )
+    return yaml.safe_dump_all(arg, allow_unicode=True, default_flow_style=False)
 
 
 def load(s):
@@ -171,10 +167,7 @@ class EditPlugin(plugins.BeetsPlugin):
             help="edit this field also",
         )
         edit_command.parser.add_option(
-            "--all",
-            action="store_true",
-            dest="all",
-            help="edit all fields",
+            "--all", action="store_true", dest="all", help="edit all fields"
         )
         edit_command.parser.add_album_option()
         edit_command.func = self._edit_command

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -194,13 +194,10 @@ class EmbedCoverArtPlugin(BeetsPlugin):
 
         # Extract command.
         extract_cmd = ui.Subcommand(
-            "extractart",
-            help="extract an image from file metadata",
+            "extractart", help="extract an image from file metadata"
         )
         extract_cmd.parser.add_option(
-            "-o",
-            dest="outpath",
-            help="image output file",
+            "-o", dest="outpath", help="image output file"
         )
         extract_cmd.parser.add_option(
             "-n",
@@ -241,8 +238,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
 
         # Clear command.
         clear_cmd = ui.Subcommand(
-            "clearart",
-            help="remove images from file metadata",
+            "clearart", help="remove images from file metadata"
         )
         clear_cmd.parser.add_option(
             "-y", "--yes", action="store_true", help="skip confirmation"

--- a/beetsplug/embyupdate.py
+++ b/beetsplug/embyupdate.py
@@ -109,12 +109,7 @@ def get_token(host, port, headers, auth_data):
     :rtype: str
     """
     url = api_url(host, port, "/Users/AuthenticateByName")
-    r = requests.post(
-        url,
-        headers=headers,
-        data=auth_data,
-        timeout=10,
-    )
+    r = requests.post(url, headers=headers, data=auth_data, timeout=10)
 
     return r.json().get("AccessToken")
 
@@ -204,11 +199,7 @@ class EmbyUpdate(BeetsPlugin):
 
         # Trigger the Update.
         url = api_url(host, port, "/Library/Refresh")
-        r = requests.post(
-            url,
-            headers=headers,
-            timeout=10,
-        )
+        r = requests.post(url, headers=headers, timeout=10)
         if r.status_code != 204:
             self._log.warning("Update could not be triggered")
         else:

--- a/beetsplug/export.py
+++ b/beetsplug/export.py
@@ -142,11 +142,7 @@ class ExportPlugin(BeetsPlugin):
             included_keys.extend(keys.split(","))
 
         items = []
-        for data_emitter in data_collector(
-            lib,
-            args,
-            album=opts.album,
-        ):
+        for data_emitter in data_collector(lib, args, album=opts.album):
             try:
                 data, _ = data_emitter(included_keys or "*")
             except (mediafile.UnreadableFileError, OSError) as ex:

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -543,8 +543,7 @@ class CoverArtArchive(RemoteArtSource):
         """
 
         def get_image_urls(
-            url: str,
-            preferred_width: None | str = None,
+            url: str, preferred_width: None | str = None
         ) -> Iterator[str]:
             try:
                 response = self.request(url)
@@ -739,11 +738,7 @@ class FanartTV(RemoteArtSource):
 
     @staticmethod
     def add_default_config(config: confuse.ConfigView):
-        config.add(
-            {
-                "fanarttv_key": None,
-            }
-        )
+        config.add({"fanarttv_key": None})
         config["fanarttv_key"].redact = True
 
     def get(
@@ -1153,11 +1148,7 @@ class LastFM(RemoteArtSource):
 
     @staticmethod
     def add_default_config(config: confuse.ConfigView) -> None:
-        config.add(
-            {
-                "lastfm_key": None,
-            }
-        )
+        config.add({"lastfm_key": None})
         config["lastfm_key"].redact = True
 
     @classmethod
@@ -1452,9 +1443,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
 
         try:
             sources = sanitize_pairs(
-                cfg_sources,
-                available_sources,
-                raise_on_unknown=True,
+                cfg_sources, available_sources, raise_on_unknown=True
             )
 
             if len(sources) == 0:
@@ -1604,11 +1593,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         return out
 
     def batch_fetch_art(
-        self,
-        lib: Library,
-        albums: Iterable[Album],
-        force: bool,
-        quiet: bool,
+        self, lib: Library, albums: Iterable[Album], force: bool, quiet: bool
     ) -> None:
         """Fetch album art for each of the albums. This implements the manual
         fetchart CLI command.

--- a/beetsplug/fish.py
+++ b/beetsplug/fish.py
@@ -214,9 +214,7 @@ def get_subcommands(cmd_name_and_help, nobasicfields, extravalues):
 
         if nobasicfields is False:
             word += BL_USE3.format(
-                cmdname,
-                f"-a {wrap('$FIELDS')}",
-                f"-d {wrap('fieldname')}",
+                cmdname, f"-a {wrap('$FIELDS')}", f"-d {wrap('fieldname')}"
             )
 
         if extravalues:
@@ -224,9 +222,7 @@ def get_subcommands(cmd_name_and_help, nobasicfields, extravalues):
                 setvar = wrap(f"${f.upper()}S")
                 word += " ".join(
                     BL_EXTRA3.format(
-                        f"{cmdname} {f}:",
-                        f"-f -A -a {setvar}",
-                        f"-d {wrap(f)}",
+                        f"{cmdname} {f}:", f"-f -A -a {setvar}", f"-d {wrap(f)}"
                     ).split()
                 )
                 word += "\n"
@@ -277,9 +273,7 @@ def get_all_commands(beetcmds):
                 word += "\n"
 
             word = word + BL_USE3.format(
-                name,
-                "-s h -l help",
-                f"-d {wrap('print help')}",
+                name, "-s h -l help", f"-d {wrap('print help')}"
             )
     return word
 

--- a/beetsplug/fromfilename.py
+++ b/beetsplug/fromfilename.py
@@ -37,9 +37,7 @@ PATTERNS = [
 ]
 
 # Titles considered "empty" and in need of replacement.
-BAD_TITLE_PATTERNS = [
-    r"^$",
-]
+BAD_TITLE_PATTERNS = [r"^$"]
 
 
 def equal(seq):

--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -52,9 +52,7 @@ DEFAULT_BRACKET_KEYWORDS: tuple[str, ...] = (
 
 
 def split_on_feat(
-    artist: str,
-    for_artist: bool = True,
-    custom_words: list[str] | None = None,
+    artist: str, for_artist: bool = True, custom_words: list[str] | None = None
 ) -> tuple[str, str | None]:
     """Given an artist string, split the "main" artist from any artist
     on the right-hand side of a string like "feat". Return the main
@@ -103,9 +101,7 @@ def contains_feat(title: str, custom_words: list[str] | None = None) -> bool:
 
 
 def find_feat_part(
-    artist: str,
-    albumartist: str | None,
-    custom_words: list[str] | None = None,
+    artist: str, albumartist: str | None, custom_words: list[str] | None = None
 ) -> str | None:
     """Attempt to find featured artists in the item's artist fields and
     return the results. Returns None if no featured artist found.

--- a/beetsplug/fuzzy.py
+++ b/beetsplug/fuzzy.py
@@ -51,12 +51,7 @@ class FuzzyQuery(StringFieldQuery[str]):
 class FuzzyPlugin(BeetsPlugin):
     def __init__(self) -> None:
         super().__init__()
-        self.config.add(
-            {
-                "prefix": "~",
-                "threshold": 0.7,
-            }
-        )
+        self.config.add({"prefix": "~", "threshold": 0.7})
 
     def queries(self):
         prefix = self.config["prefix"].as_str()

--- a/beetsplug/ihate.py
+++ b/beetsplug/ihate.py
@@ -39,12 +39,7 @@ class IHatePlugin(BeetsPlugin):
         self.register_listener(
             "import_task_choice", self.import_task_choice_event
         )
-        self.config.add(
-            {
-                "warn": [],
-                "skip": [],
-            }
-        )
+        self.config.add({"warn": [], "skip": []})
 
     @classmethod
     def do_i_hate_this(cls, task, action_patterns):
@@ -54,8 +49,7 @@ class IHatePlugin(BeetsPlugin):
         if action_patterns:
             for query_string in action_patterns:
                 query, _ = parse_query_string(
-                    query_string,
-                    Album if task.is_album else Item,
+                    query_string, Album if task.is_album else Item
                 )
                 if any(query.match(item) for item in task.imported_items()):
                     return True

--- a/beetsplug/importadded.py
+++ b/beetsplug/importadded.py
@@ -14,10 +14,7 @@ class ImportAddedPlugin(BeetsPlugin):
     def __init__(self):
         super().__init__()
         self.config.add(
-            {
-                "preserve_mtimes": False,
-                "preserve_write_mtimes": False,
-            }
+            {"preserve_mtimes": False, "preserve_write_mtimes": False}
         )
 
         # item.id for new items that were reimported

--- a/beetsplug/importfeeds.py
+++ b/beetsplug/importfeeds.py
@@ -49,8 +49,7 @@ def _build_m3u_filename(basename):
     date = datetime.datetime.now().strftime("%Y%m%d_%Hh%M")
     path = normpath(
         os.path.join(
-            config["importfeeds"]["dir"].as_filename(),
-            f"{date}_{basename}.m3u",
+            config["importfeeds"]["dir"].as_filename(), f"{date}_{basename}.m3u"
         )
     )
     return path

--- a/beetsplug/importsource.py
+++ b/beetsplug/importsource.py
@@ -20,11 +20,7 @@ class ImportSourcePlugin(BeetsPlugin):
     def __init__(self):
         """Initialize the plugin and read configuration."""
         super().__init__()
-        self.config.add(
-            {
-                "suggest_removal": False,
-            }
-        )
+        self.config.add({"suggest_removal": False})
         self.import_stages = [self.import_stage]
         self.register_listener("item_removed", self.suggest_removal)
         # In order to stop future removal suggestions for an album we keep
@@ -114,10 +110,7 @@ class ImportSourcePlugin(BeetsPlugin):
 
         # Handle user response
         if resp == "d":
-            self._log.info(
-                "Deleting the item's source file: {}",
-                srcpath,
-            )
+            self._log.info("Deleting the item's source file: {}", srcpath)
             srcpath.unlink()
 
         elif resp == "r":
@@ -146,8 +139,7 @@ class ImportSourcePlugin(BeetsPlugin):
 
             if continue_resp == "y":
                 self._log.info(
-                    "Deleting the item's source directory: {}",
-                    srcpath.parent,
+                    "Deleting the item's source directory: {}", srcpath.parent
                 )
                 rmtree(srcpath.parent)
 
@@ -157,8 +149,7 @@ class ImportSourcePlugin(BeetsPlugin):
 
             elif continue_resp == "f":
                 self._log.info(
-                    "removing just the item's original source: {}",
-                    srcpath,
+                    "removing just the item's original source: {}", srcpath
                 )
                 srcpath.unlink()
 

--- a/beetsplug/info.py
+++ b/beetsplug/info.py
@@ -176,10 +176,7 @@ class InfoPlugin(BeetsPlugin):
             help="comma separated list of keys to show",
         )
         cmd.parser.add_option(
-            "-k",
-            "--keys-only",
-            action="store_true",
-            help="show only the keys",
+            "-k", "--keys-only", action="store_true", help="show only the keys"
         )
         cmd.parser.add_format_option(target="item")
         return [cmd]
@@ -211,11 +208,7 @@ class InfoPlugin(BeetsPlugin):
 
         first = True
         summary = {}
-        for data_emitter in data_collector(
-            lib,
-            args,
-            album=opts.album,
-        ):
+        for data_emitter in data_collector(lib, args, album=opts.album):
             try:
                 data, item = data_emitter(included_keys or "*")
             except (mediafile.UnreadableFileError, OSError) as ex:

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -25,12 +25,7 @@ from beets.plugins import BeetsPlugin
 class IPFSPlugin(BeetsPlugin):
     def __init__(self):
         super().__init__()
-        self.config.add(
-            {
-                "auto": True,
-                "nocopy": False,
-            }
-        )
+        self.config.add({"auto": True, "nocopy": False})
 
         if self.config["auto"]:
             self.import_stages = [self.auto_add]

--- a/beetsplug/keyfinder.py
+++ b/beetsplug/keyfinder.py
@@ -24,13 +24,7 @@ from beets.plugins import BeetsPlugin
 class KeyFinderPlugin(BeetsPlugin):
     def __init__(self):
         super().__init__()
-        self.config.add(
-            {
-                "bin": "KeyFinder",
-                "auto": True,
-                "overwrite": False,
-            }
-        )
+        self.config.add({"bin": "KeyFinder", "auto": True, "overwrite": False})
 
         if self.config["auto"].get(bool):
             self.import_stages = [self.imported]

--- a/beetsplug/kodiupdate.py
+++ b/beetsplug/kodiupdate.py
@@ -40,11 +40,7 @@ def update_kodi(host, port, user, password):
     # Create the payload. Id seems to be mandatory.
     payload = {"jsonrpc": "2.0", "method": "AudioLibrary.Scan", "id": 1}
     r = requests.post(
-        url,
-        auth=(user, password),
-        json=payload,
-        headers=headers,
-        timeout=10,
+        url, auth=(user, password), json=payload, headers=headers, timeout=10
     )
 
     return r

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -62,9 +62,7 @@ if TYPE_CHECKING:
 
 
 def flatten_tree(
-    elem: dict[Any, Any] | list[Any] | str,
-    path: list[str],
-    branches: CanonTree,
+    elem: dict[Any, Any] | list[Any] | str, path: list[str], branches: CanonTree
 ) -> None:
     """Flatten nested lists/dictionaries into lists of strings
     (branches).
@@ -302,8 +300,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 # multiple parents
                 if self.whitelist:
                     parents = self._filter_valid(
-                        find_parents(tag, self.c14n_branches),
-                        artist=artist,
+                        find_parents(tag, self.c14n_branches), artist=artist
                     )
                 else:
                     # No whitelist: take only the oldest ancestor, skipping it
@@ -506,8 +503,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                     )
                     for albumartist in obj.albumartists:
                         self._log.extra_debug(
-                            'Fetching artist genre for "{}"',
-                            albumartist,
+                            'Fetching artist genre for "{}"', albumartist
                         )
                         new_genres += self.client.fetch(
                             "album_artist", obj, albumartist

--- a/beetsplug/lastimport.py
+++ b/beetsplug/lastimport.py
@@ -34,23 +34,11 @@ API_URL = "https://ws.audioscrobbler.com/2.0/"
 class LastImportPlugin(plugins.BeetsPlugin):
     def __init__(self):
         super().__init__()
-        config["lastfm"].add(
-            {
-                "user": "",
-                "api_key": plugins.LASTFM_KEY,
-            }
-        )
+        config["lastfm"].add({"user": "", "api_key": plugins.LASTFM_KEY})
         config["lastfm"]["user"].redact = True
         config["lastfm"]["api_key"].redact = True
-        self.config.add(
-            {
-                "per_page": 500,
-                "retry_limit": 3,
-            }
-        )
-        self.item_types = {
-            "lastfm_play_count": types.INTEGER,
-        }
+        self.config.add({"per_page": 500, "retry_limit": 3})
+        self.item_types = {"lastfm_play_count": types.INTEGER}
 
     def commands(self):
         cmd = ui.Subcommand("lastimport", help="import last.fm play-count")

--- a/beetsplug/listenbrainz.py
+++ b/beetsplug/listenbrainz.py
@@ -111,10 +111,7 @@ class ListenBrainzPlugin(MusicBrainzAPIMixin, BeetsPlugin):
         """
         try:
             response = self.session.get(
-                url=url,
-                headers=self.AUTH_HEADER,
-                timeout=10,
-                params=params,
+                url=url, headers=self.AUTH_HEADER, timeout=10, params=params
             )
             response.raise_for_status()
             remaining = response.headers.get("X-RateLimit-Remaining")

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -460,8 +460,7 @@ class Html:
     remove_aside = partial(re.compile("<aside .+?</aside>").sub, "")
     #: remove adslot-Content_1 div from the lyrics text (paroles.net)
     remove_adslot = partial(
-        re.compile(r"\n</div>[^\n]+-- Content_\d+ --.*?\n<div>", re.S).sub,
-        "\n",
+        re.compile(r"\n</div>[^\n]+-- Content_\d+ --.*?\n<div>", re.S).sub, "\n"
     )
     #: remove text formatting (azlyrics.com, lacocinelle.net)
     remove_formatting = partial(
@@ -909,10 +908,7 @@ class RestFiles:
             conf_file.write_text(self.REST_CONF_TEMPLATE)
 
     def write_artist(self, artist: str, items: Iterable[Item]) -> None:
-        parts = [
-            f"{artist}\n{'=' * len(artist)}",
-            ".. contents::\n   :local:",
-        ]
+        parts = [f"{artist}\n{'=' * len(artist)}", ".. contents::\n   :local:"]
         for album, items in groupby(items, key=lambda i: i.album):
             parts.append(f"{album}\n{'-' * len(album)}")
             parts.extend(

--- a/beetsplug/mbcollection.py
+++ b/beetsplug/mbcollection.py
@@ -152,13 +152,7 @@ class MBCollection:
 class MusicBrainzCollectionPlugin(BeetsPlugin):
     def __init__(self) -> None:
         super().__init__()
-        self.config.add(
-            {
-                "auto": False,
-                "collection": "",
-                "remove": False,
-            }
-        )
+        self.config.add({"auto": False, "collection": "", "remove": False})
         if self.config["auto"]:
             self.import_stages = [self.imported]
 

--- a/beetsplug/mbpseudo.py
+++ b/beetsplug/mbpseudo.py
@@ -115,11 +115,7 @@ class MusicBrainzPseudoReleasePlugin(MusicBrainzPlugin):
 
     @override
     def candidates(
-        self,
-        items: Sequence[Item],
-        artist: str,
-        album: str,
-        va_likely: bool,
+        self, items: Sequence[Item], artist: str, album: str, va_likely: bool
     ) -> Iterable[AlbumInfo]:
         if len(self._scripts) == 0:
             yield from super().candidates(items, artist, album, va_likely)
@@ -190,9 +186,7 @@ class MusicBrainzPseudoReleasePlugin(MusicBrainzPlugin):
             return False
 
     def _wanted_pseudo_release_id(
-        self,
-        album_id: str,
-        relation: ReleaseRelation,
+        self, album_id: str, relation: ReleaseRelation
     ) -> str | None:
         if (
             len(self._scripts) == 0
@@ -247,9 +241,7 @@ class MusicBrainzPseudoReleasePlugin(MusicBrainzPlugin):
                         track.artist = alias
 
     def _add_custom_tags(
-        self,
-        official_release: AlbumInfo,
-        pseudo_release: AlbumInfo,
+        self, official_release: AlbumInfo, pseudo_release: AlbumInfo
     ):
         for tag_key, pseudo_key in (
             self.config["album_custom_tags"].get().items()
@@ -298,10 +290,7 @@ class PseudoAlbumInfo(AlbumInfo):
     """
 
     def __init__(
-        self,
-        pseudo_release: AlbumInfo,
-        official_release: AlbumInfo,
-        **kwargs,
+        self, pseudo_release: AlbumInfo, official_release: AlbumInfo, **kwargs
     ):
         super().__init__(pseudo_release.tracks, **kwargs)
         self.__dict__["_pseudo_source"] = True

--- a/beetsplug/metasync/__init__.py
+++ b/beetsplug/metasync/__init__.py
@@ -31,10 +31,7 @@ if TYPE_CHECKING:
 METASYNC_MODULE = "beetsplug.metasync"
 
 # Dictionary to map the MODULE and the CLASS NAME of meta sources
-SOURCES = {
-    "amarok": "Amarok",
-    "itunes": "Itunes",
-}
+SOURCES = {"amarok": "Amarok", "itunes": "Itunes"}
 
 
 class MetaSource(metaclass=ABCMeta):

--- a/beetsplug/missing.py
+++ b/beetsplug/missing.py
@@ -115,9 +115,7 @@ def _item(track_info, album_info, album_id):
 class MissingPlugin(MusicBrainzAPIMixin, BeetsPlugin):
     """List missing tracks"""
 
-    album_types: ClassVar[dict[str, types.Type]] = {
-        "missing": types.INTEGER,
-    }
+    album_types: ClassVar[dict[str, types.Type]] = {"missing": types.INTEGER}
 
     def __init__(self):
         super().__init__()
@@ -233,8 +231,7 @@ class MissingPlugin(MusicBrainzAPIMixin, BeetsPlugin):
         for (artist, artist_id), album_ids in album_ids_by_artist.items():
             try:
                 resp = self.mb_api.browse_release_groups(
-                    artist=artist_id,
-                    type="|".join(release_types),
+                    artist=artist_id, type="|".join(release_types)
                 )
             except requests.exceptions.RequestException:
                 self._log.info(

--- a/beetsplug/musicbrainz.py
+++ b/beetsplug/musicbrainz.py
@@ -293,7 +293,7 @@ class MusicBrainzPlugin(
                     "tidal": False,
                 },
                 "extra_tags": [],
-            },
+            }
         )
         # TODO: Remove in 3.0.0
         with suppress(NotFoundError):
@@ -690,11 +690,7 @@ class MusicBrainzPlugin(
         info.year, info.month, info.day = (
             _get_date(release_date)
             if release_date
-            else (
-                info.original_year,
-                info.original_month,
-                info.original_day,
-            )
+            else (info.original_year, info.original_month, info.original_day)
         )
 
         extra_albumdatas = plugins.send("mb_album_extract", data=release)

--- a/beetsplug/parentwork.py
+++ b/beetsplug/parentwork.py
@@ -35,12 +35,7 @@ class ParentWorkPlugin(MusicBrainzAPIMixin, BeetsPlugin):
     def __init__(self):
         super().__init__()
 
-        self.config.add(
-            {
-                "auto": False,
-                "force": False,
-            }
-        )
+        self.config.add({"auto": False, "force": False})
 
         if self.config["auto"]:
             self.import_stages = [self.imported]

--- a/beetsplug/permissions.py
+++ b/beetsplug/permissions.py
@@ -57,12 +57,7 @@ class Permissions(BeetsPlugin):
         super().__init__()
 
         # Adding defaults.
-        self.config.add(
-            {
-                "file": "644",
-                "dir": "755",
-            }
-        )
+        self.config.add({"file": "644", "dir": "755"})
 
         self.register_listener("item_imported", self.fix)
         self.register_listener("album_imported", self.fix)
@@ -99,8 +94,7 @@ class Permissions(BeetsPlugin):
         for path in files:
             # Changing permissions on the destination file.
             self._log.debug(
-                "setting file permissions on {}",
-                displayable_path(path),
+                "setting file permissions on {}", displayable_path(path)
             )
             if not check_permissions(path, file_perm):
                 os.chmod(syspath(path), file_perm)
@@ -112,8 +106,7 @@ class Permissions(BeetsPlugin):
         for path in dirs:
             # Changing permissions on the destination directory.
             self._log.debug(
-                "setting directory permissions on {}",
-                displayable_path(path),
+                "setting directory permissions on {}", displayable_path(path)
             )
             if not check_permissions(path, dir_perm):
                 os.chmod(syspath(path), dir_perm)

--- a/beetsplug/playlist.py
+++ b/beetsplug/playlist.py
@@ -46,8 +46,7 @@ class PlaylistQuery(InQuery[bytes]):
             pattern,
             os.path.abspath(
                 os.path.join(
-                    config["playlist_dir"].as_filename(),
-                    f"{pattern}.m3u",
+                    config["playlist_dir"].as_filename(), f"{pattern}.m3u"
                 )
             ),
         )

--- a/beetsplug/plexupdate.py
+++ b/beetsplug/plexupdate.py
@@ -25,11 +25,7 @@ def get_music_section(
     url = urljoin(f"{get_protocol(secure)}://{host}:{port}", api_endpoint)
 
     # Sends request.
-    r = requests.get(
-        url,
-        verify=not ignore_cert_errors,
-        timeout=10,
-    )
+    r = requests.get(url, verify=not ignore_cert_errors, timeout=10)
 
     # Parse xml tree and extract music section key.
     tree = ElementTree.fromstring(r.content)
@@ -55,11 +51,7 @@ def update_plex(host, port, token, library_name, secure, ignore_cert_errors):
     url = urljoin(f"{get_protocol(secure)}://{host}:{port}", api_endpoint)
 
     # Sends request and returns requests object.
-    r = requests.get(
-        url,
-        verify=not ignore_cert_errors,
-        timeout=10,
-    )
+    r = requests.get(url, verify=not ignore_cert_errors, timeout=10)
     return r
 
 

--- a/beetsplug/random.py
+++ b/beetsplug/random.py
@@ -109,10 +109,7 @@ def _equal_chance_permutation(
             del groups[group]
 
 
-def _take_time(
-    iter: Iterable[LibModel],
-    secs: float,
-) -> Iterable[LibModel]:
+def _take_time(iter: Iterable[LibModel], secs: float) -> Iterable[LibModel]:
     """Return a list containing the first values in `iter`, which should
     be Item or Album objects, that add up to the given amount of time in
     seconds.

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -321,10 +321,7 @@ class FfmpegBackend(Backend):
         """
         task.track_gains = [
             self._analyse_item(
-                item,
-                task.target_level,
-                task.peak_method,
-                count_blocks=False,
+                item, task.target_level, task.peak_method, count_blocks=False
             )[0]  # take only the gain, discarding number of gating blocks
             for item in task.items
         ]
@@ -341,10 +338,7 @@ class FfmpegBackend(Backend):
         # Gives a list of tuples (track_gain, track_n_blocks)
         track_results: list[tuple[Gain, int]] = [
             self._analyse_item(
-                item,
-                task.target_level,
-                task.peak_method,
-                count_blocks=True,
+                item, task.target_level, task.peak_method, count_blocks=True
             )
             for item in task.items
         ]
@@ -449,13 +443,7 @@ class FfmpegBackend(Backend):
                 step_size=-1,
             )
             peak = self._parse_float(
-                output[
-                    self._find_line(
-                        output,
-                        b"    Peak:",
-                        line_peak,
-                    )
-                ]
+                output[self._find_line(output, b"    Peak:", line_peak)]
             )
             # convert TPFS -> part of FS
             peak = 10 ** (peak / 20)
@@ -467,13 +455,7 @@ class FfmpegBackend(Backend):
             step_size=-1,
         )
         gain = self._parse_float(
-            output[
-                self._find_line(
-                    output,
-                    b"    I:",
-                    line_integrated_loudness,
-                )
-            ]
+            output[self._find_line(output, b"    I:", line_integrated_loudness)]
         )
         # convert LUFS -> LU from target level
         gain = target_level_lufs - gain
@@ -568,12 +550,7 @@ class CommandBackend(Backend):
 
     def __init__(self, config: ConfigView, log: Logger):
         super().__init__(config, log)
-        config.add(
-            {
-                "command": "",
-                "noclip": True,
-            }
-        )
+        config.add({"command": "", "noclip": True})
 
         cmd_path: Path = Path(config["command"].as_str())
         supported_tools = set(self.SUPPORTED_FORMATS_BY_TOOL)
@@ -627,10 +604,7 @@ class CommandBackend(Backend):
         return item.format in self.SUPPORTED_FORMATS_BY_TOOL[self.cmd_name]
 
     def compute_gain(
-        self,
-        items: Sequence[Item],
-        target_level: float,
-        is_album: bool,
+        self, items: Sequence[Item], target_level: float, is_album: bool
     ) -> list[Gain]:
         """Computes the track or album gain of a list of items, returns
         a list of TrackGain objects.
@@ -1312,10 +1286,7 @@ class ReplayGainPlugin(BeetsPlugin):
         return False
 
     def create_task(
-        self,
-        items: Sequence[Item],
-        use_r128: bool,
-        album: Album | None = None,
+        self, items: Sequence[Item], use_r128: bool, album: Album | None = None
     ) -> RgTask:
         if use_r128:
             return R128Task(
@@ -1456,9 +1427,7 @@ class ReplayGainPlugin(BeetsPlugin):
                 return ctx.run(handle_exc, exc)
 
             self.pool.apply_async(
-                run_func,
-                callback=run_callback,
-                error_callback=run_handle_exc,
+                run_func, callback=run_callback, error_callback=run_handle_exc
             )
         else:
             callback(func(*args, **kwds))
@@ -1519,10 +1488,7 @@ class ReplayGainPlugin(BeetsPlugin):
                 self.handle_track(task.item, False, self.force_on_import)
 
     def command_func(
-        self,
-        lib: Library,
-        opts: optparse.Values,
-        args: list[str],
+        self, lib: Library, opts: optparse.Values, args: list[str]
     ):
         try:
             write = ui.should_write(opts.write)

--- a/beetsplug/scrub.py
+++ b/beetsplug/scrub.py
@@ -46,11 +46,7 @@ class ScrubPlugin(BeetsPlugin):
 
     def __init__(self):
         super().__init__()
-        self.config.add(
-            {
-                "auto": True,
-            }
-        )
+        self.config.add({"auto": True})
 
         if self.config["auto"]:
             self.register_listener("import_task_files", self.import_task_files)

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -276,10 +276,7 @@ class SpotifyPlugin(
                 )
                 self._authenticate()
                 return self._handle_response(
-                    method,
-                    url,
-                    params=params,
-                    retry_count=retry_count + 1,
+                    method, url, params=params, retry_count=retry_count + 1
                 )
             elif e.response.status_code == 404:
                 raise APIError(
@@ -306,10 +303,7 @@ class SpotifyPlugin(
                 )
                 time.sleep(int(seconds) + 1)
                 return self._handle_response(
-                    method,
-                    url,
-                    params=params,
-                    retry_count=retry_count + 1,
+                    method, url, params=params, retry_count=retry_count + 1
                 )
             elif e.response.status_code == 503:
                 self._log.error("Service Unavailable.")
@@ -774,9 +768,7 @@ class SpotifyPlugin(
         details_by_id: dict[str, TrackDetails] = {}
         for chunk in chunks(track_ids, 50):
             track_data = self._handle_response(
-                "get",
-                self.track_url,
-                params={"ids": ",".join(chunk)},
+                "get", self.track_url, params={"ids": ",".join(chunk)}
             )
 
             for idx, track in enumerate(track_data.get("tracks", [])):

--- a/beetsplug/subsonicupdate.py
+++ b/beetsplug/subsonicupdate.py
@@ -133,11 +133,7 @@ class SubsonicUpdate(BeetsPlugin):
         else:
             return
         try:
-            response = requests.get(
-                url,
-                params=payload,
-                timeout=10,
-            )
+            response = requests.get(url, params=payload, timeout=10)
             json = response.json()
 
             if (

--- a/beetsplug/the.py
+++ b/beetsplug/the.py
@@ -55,8 +55,7 @@ class ThePlugin(BeetsPlugin):
                 else:
                     if not (p.startswith("^") or p.endswith("$")):
                         self._log.warning(
-                            'warning: "{}" will not match string start/end',
-                            p,
+                            'warning: "{}" will not match string start/end', p
                         )
         if self.config["a"]:
             self.patterns = [PATTERN_A, *self.patterns]

--- a/beetsplug/thumbnails.py
+++ b/beetsplug/thumbnails.py
@@ -40,13 +40,7 @@ LARGE_DIR = bytestring_path(os.path.join(BASE_DIR, "large"))
 class ThumbnailsPlugin(BeetsPlugin):
     def __init__(self):
         super().__init__()
-        self.config.add(
-            {
-                "auto": True,
-                "force": False,
-                "dolphin": False,
-            }
-        )
+        self.config.add({"auto": True, "force": False, "dolphin": False})
 
         if self.config["auto"] and self._check_local_ok():
             self.register_listener("art_set", self.process_album)

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -40,10 +40,7 @@ class TidalPlugin(MetadataSourcePlugin):
         super().__init__()
 
         self.config.add(
-            {
-                "client_id": "mcjmpl1bPATJXcBT",
-                "tokenfile": "tidal_token.json",
-            }
+            {"client_id": "mcjmpl1bPATJXcBT", "tokenfile": "tidal_token.json"}
         )
         self.config["client_id"].redact = True
 
@@ -129,7 +126,7 @@ class TidalPlugin(MetadataSourcePlugin):
         )
         if barcodes and (
             candidates := list(
-                filter(None, self.search_albums_by_ids(barcode_ids=barcodes)),
+                filter(None, self.search_albums_by_ids(barcode_ids=barcodes))
             )
         ):
             return candidates
@@ -179,10 +176,7 @@ class TidalPlugin(MetadataSourcePlugin):
 
     def search_tracks_by_query(self, query: str) -> Iterable[TrackInfo]:
         """Search for tracks given a string query."""
-        search_doc = self.api.search_results(
-            query,
-            include=["tracks.artists"],
-        )
+        search_doc = self.api.search_results(query, include=["tracks.artists"])
         track_by_id: dict[str, TidalTrack] = {
             item["id"]: item
             for item in search_doc.get("included", [])
@@ -198,8 +192,7 @@ class TidalPlugin(MetadataSourcePlugin):
                 yield self._get_track_info(track, artist_by_id=artist_by_id)
             else:
                 log.warning(
-                    "Track with id {0} not found in lookup",
-                    track_rel["id"],
+                    "Track with id {0} not found in lookup", track_rel["id"]
                 )
 
     def search_albums_by_query(self, query: str) -> Iterable[AlbumInfo]:
@@ -246,9 +239,7 @@ class TidalPlugin(MetadataSourcePlugin):
             _ids = list(map(self._extract_id, ids))
 
         tracks_doc = self.api.get_tracks(
-            ids=list(filter(None, _ids)),
-            isrcs=isrcs,
-            include=["artists"],
+            ids=list(filter(None, _ids)), isrcs=isrcs, include=["artists"]
         )
         track_by_id: dict[str, TidalTrack] = {
             item["id"]: item
@@ -328,9 +319,7 @@ class TidalPlugin(MetadataSourcePlugin):
         for _id in _ids:
             if _id is not None and (album := album_by_id.get(_id)):
                 yield self._get_album_info(
-                    album,
-                    track_by_id=track_by_id,
-                    artist_by_id=artist_by_id,
+                    album, track_by_id=track_by_id, artist_by_id=artist_by_id
                 )
             else:
                 yield None
@@ -367,8 +356,7 @@ class TidalPlugin(MetadataSourcePlugin):
                 track_infos.append(track_info)
 
         artist_names, artist_ids = self._parse_artists(
-            album["relationships"]["artists"]["data"],
-            artist_by_id,
+            album["relationships"]["artists"]["data"], artist_by_id
         )
         date_parts = self._parse_release_date(album["attributes"])
         return AlbumInfo(
@@ -392,13 +380,10 @@ class TidalPlugin(MetadataSourcePlugin):
         )
 
     def _get_track_info(
-        self,
-        track: TidalTrack,
-        artist_by_id: dict[str, TidalArtist],
+        self, track: TidalTrack, artist_by_id: dict[str, TidalArtist]
     ) -> TrackInfo:
         artist_names, artist_ids = self._parse_artists(
-            track["relationships"]["artists"]["data"],
-            artist_by_id,
+            track["relationships"]["artists"]["data"], artist_by_id
         )
 
         return TrackInfo(
@@ -434,8 +419,7 @@ class TidalPlugin(MetadataSourcePlugin):
                 artist_names.append(artist["attributes"]["name"])
             else:
                 log.warning(
-                    "Artist with id {0} not found in lookup",
-                    artist_rel["id"],
+                    "Artist with id {0} not found in lookup", artist_rel["id"]
                 )
 
         return artist_names, artist_ids

--- a/beetsplug/tidal/api.py
+++ b/beetsplug/tidal/api.py
@@ -86,10 +86,7 @@ class TidalAPI(RequestHandler):
 
         # Tidal allows at max 20 filters per request. This needs a bit of extra
         # logic sadly.
-        doc: TrackDocument = {
-            "data": [],
-            "included": [],
-        }
+        doc: TrackDocument = {"data": [], "included": []}
         for id_batch, isrc_batch in zip_longest(
             _batched(ids, MAX_FILTER_SIZE),
             _batched(isrcs, MAX_FILTER_SIZE),
@@ -126,10 +123,7 @@ class TidalAPI(RequestHandler):
 
         # Tidal allows at max 20 filters per request. This needs a bit of extra
         # logic sadly.
-        doc: AlbumDocument = {
-            "data": [],
-            "included": [],
-        }
+        doc: AlbumDocument = {"data": [], "included": []}
         for id_batch, barcode_batch in zip_longest(
             _batched(ids, MAX_FILTER_SIZE),
             _batched(barcode_ids, MAX_FILTER_SIZE),
@@ -175,8 +169,7 @@ class TidalAPI(RequestHandler):
 
     @staticmethod
     def merge_multiresource_pagination(
-        a: Document[list[T]],
-        b: Document[list[T]],
+        a: Document[list[T]], b: Document[list[T]]
     ) -> Document[list[T]]:
         """
         Merge of b into a, following JSON:API spec rules.
@@ -223,9 +216,7 @@ class TidalAPI(RequestHandler):
 
         while next := doc.get("links", {}).get("next"):
             page_doc = self.get_json(
-                url=next,
-                params={**params, "include": include},
-                **kwargs,
+                url=next, params={**params, "include": include}, **kwargs
             )
             doc = self.merge_multiresource_pagination(doc, page_doc)
 

--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -425,12 +425,7 @@ def stats():
     with g.lib.transaction() as tx:
         item_rows = tx.query("SELECT COUNT(*) FROM items")
         album_rows = tx.query("SELECT COUNT(*) FROM albums")
-    return flask.jsonify(
-        {
-            "items": item_rows[0][0],
-            "albums": album_rows[0][0],
-        }
-    )
+    return flask.jsonify({"items": item_rows[0][0], "albums": album_rows[0][0]})
 
 
 # UI.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ autosummary_context = {
             "beetsplug._utils.musicbrainz.BrowseKwargs",
             "beetsplug._utils.musicbrainz.BrowseRecordingsKwargs",
             "beetsplug._utils.musicbrainz.BrowseReleaseGroupsKwargs",
-        ],
+        ]
     }
 }
 autodoc_member_order = "bysource"
@@ -82,7 +82,7 @@ htmlhelp_basename = "beetsdoc"
 
 # Options for LaTeX output
 latex_documents = [
-    ("index", "beets.tex", "beets Documentation", AUTHOR, "manual"),
+    ("index", "beets.tex", "beets Documentation", AUTHOR, "manual")
 ]
 
 # Options for manual page output

--- a/docs/extensions/conf.py
+++ b/docs/extensions/conf.py
@@ -28,7 +28,7 @@ class Conf(ObjectDescription[str]):
     """Directive for documenting a single configuration value."""
 
     option_spec: ClassVar[OptionSpec] = {  # type: ignore[misc]
-        "default": directives.unchanged,
+        "default": directives.unchanged
     }
 
     def handle_signature(self, sig: str, signode: desc_signature) -> str:

--- a/extra/release.py
+++ b/extra/release.py
@@ -115,10 +115,7 @@ def create_rst_replacements() -> list[Replacement]:
     return [
         # Replace explicitly defined substitutions from rst_epilog
         #    |BeetsPlugin| -> :class:`beets.plugins.BeetsPlugin`
-        (
-            r"\|\w[^ ]*\|",
-            lambda m: explicit_replacements.get(m[0], m[0]),
-        ),
+        (r"\|\w[^ ]*\|", lambda m: explicit_replacements.get(m[0], m[0])),
         # Replace Sphinx directives by documentation URLs, e.g.,
         #   :ref:`/plugins/autobpm` -> [AutoBPM Plugin](DOCS/plugins/autobpm.html)  # noqa: E501
         #   :ref:`list-cmd` -> [list command](DOCS/reference/cli.html#list-cmd)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -305,6 +305,9 @@ extend-exclude = [
 target-version = "py310"
 line-length = 80
 
+[tool.ruff.format]
+skip-magic-trailing-comma = true
+
 [tool.ruff.lint]
 future-annotations = true
 select = [

--- a/test/autotag/test_hooks.py
+++ b/test/autotag/test_hooks.py
@@ -63,13 +63,7 @@ _p = pytest.param
             ["list value"],
             id="list value wins, warning raised",
         ),
-        _p(
-            None,
-            None,
-            does_not_warn(),
-            None,
-            id="no str value, no warning",
-        ),
+        _p(None, None, does_not_warn(), None, id="no str value, no warning"),
     ],
 )
 class TestLegacyStringField:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -60,8 +60,7 @@ def pytest_collection_modifyitems(
 
 def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
-        "markers",
-        "integration_test: mark a test as an integration test",
+        "markers", "integration_test: mark a test as an integration test"
     )
     config.addinivalue_line(
         "markers",

--- a/test/library/test_migrations.py
+++ b/test/library/test_migrations.py
@@ -26,8 +26,7 @@ class TestMultiGenreFieldMigration:
             {**Album._fields, "genre": types.STRING},
         )
         monkeypatch.setattr(
-            "beets.library.models.Album.item_keys",
-            {*Album.item_keys, "genre"},
+            "beets.library.models.Album.item_keys", {*Album.item_keys, "genre"}
         )
         helper = TestHelper()
         helper.setup_beets()

--- a/test/plugins/test_advancedrewrite.py
+++ b/test/plugins/test_advancedrewrite.py
@@ -31,8 +31,7 @@ class AdvancedRewritePluginTest(PluginTestCase):
             [{"artist ODD EYE CIRCLE": "이달의 소녀 오드아이써클"}]
         ):
             item = self.add_item(
-                artist="ODD EYE CIRCLE",
-                albumartist="ODD EYE CIRCLE",
+                artist="ODD EYE CIRCLE", albumartist="ODD EYE CIRCLE"
             )
 
             assert item.artist == "이달의 소녀 오드아이써클"
@@ -52,7 +51,7 @@ class AdvancedRewritePluginTest(PluginTestCase):
                         "artist": "이달의 소녀 오드아이써클",
                         "artist_sort": "LOONA / ODD EYE CIRCLE",
                     },
-                },
+                }
             ]
         ):
             item_a = self.add_item(
@@ -82,12 +81,11 @@ class AdvancedRewritePluginTest(PluginTestCase):
                 {
                     "match": "artist:배유빈 feat. 김미현",
                     "replacements": {"artists": ["유빈", "미미"]},
-                },
+                }
             ]
         ):
             item = self.add_item(
-                artist="배유빈 feat. 김미현",
-                artists=["배유빈", "김미현"],
+                artist="배유빈 feat. 김미현", artists=["배유빈", "김미현"]
             )
 
             assert item.artists == ["유빈", "미미"]
@@ -113,7 +111,7 @@ class AdvancedRewritePluginTest(PluginTestCase):
                     {
                         "match": "artist:'A & B'",
                         "replacements": {"artist": ["C", "D"]},
-                    },
+                    }
                 ]
             ),
         ):

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -642,8 +642,7 @@ class CoverArtArchiveTest(UseThePlugin, CAAHelper):
             self.RELEASE_URL, self.RESPONSE_RELEASE_WITHOUT_THUMBNAILS
         )
         self.mock_caa_response(
-            self.GROUP_URL,
-            self.RESPONSE_GROUP_WITHOUT_THUMBNAILS,
+            self.GROUP_URL, self.RESPONSE_GROUP_WITHOUT_THUMBNAILS
         )
         candidates = list(self.source.get(album, self.settings, []))
         assert len(candidates) == 3
@@ -770,9 +769,7 @@ class ArtImporterTest(UseThePlugin):
         self.art_file.touch()
         self.old_afa = self.plugin.art_for_album
         self.afa_response = fetchart.Candidate(
-            logger,
-            source_name="test",
-            path=self.art_file,
+            logger, source_name="test", path=self.art_file
         )
 
         def art_for_album(i, p, local_only=False):
@@ -784,8 +781,7 @@ class ArtImporterTest(UseThePlugin):
         os.mkdir(syspath(os.path.join(self.libdir, b"album")))
         itempath = os.path.join(self.libdir, b"album", b"test.mp3")
         shutil.copyfile(
-            syspath(os.path.join(_common.RSRC, b"full.mp3")),
-            syspath(itempath),
+            syspath(os.path.join(_common.RSRC, b"full.mp3")), syspath(itempath)
         )
         self.i = _common.item()
         self.i.path = itempath
@@ -859,9 +855,7 @@ class ArtImporterTest(UseThePlugin):
         artdest = os.path.join(os.path.dirname(self.i.path), b"cover.jpg")
         shutil.copyfile(self.art_file, syspath(artdest))
         self.afa_response = fetchart.Candidate(
-            logger,
-            source_name="test",
-            path=artdest,
+            logger, source_name="test", path=artdest
         )
         self._fetch_art(True)
 

--- a/test/plugins/test_beatport.py
+++ b/test/plugins/test_beatport.py
@@ -559,14 +559,7 @@ class BeatportTest(BeetsTestCase):
 
     def test_track_url_applied(self):
         # Specify beatport ids here because an 'item.id' is beets-internal.
-        ids = [
-            7817567,
-            7817568,
-            7817569,
-            7817570,
-            7817571,
-            7817572,
-        ]
+        ids = [7817567, 7817568, 7817569, 7817570, 7817571, 7817572]
         # Concatenate with 'id' to pass strict equality test.
         for track, test_track, id in zip(self.tracks, self.test_tracks, ids):
             assert (

--- a/test/plugins/test_bpd.py
+++ b/test/plugins/test_bpd.py
@@ -288,10 +288,7 @@ class BPDTestHelper(PluginTestCase):
         if password:
             config["bpd"]["password"] = password
         config_file = tempfile.NamedTemporaryFile(
-            mode="wb",
-            dir=str(self.temp_dir_path),
-            suffix=".yaml",
-            delete=False,
+            mode="wb", dir=str(self.temp_dir_path), suffix=".yaml", delete=False
         )
         config_file.write(
             yaml.dump(config, Dumper=confuse.Dumper, encoding="utf-8")
@@ -416,11 +413,7 @@ class BPDTest(BPDTestHelper):
 
 
 class BPDQueryTest(BPDTestHelper):
-    test_implements_query = implements(
-        {
-            "clearerror",
-        }
-    )
+    test_implements_query = implements({"clearerror"})
 
     def test_cmd_currentsong(self):
         with self.run_bpd() as client:
@@ -534,11 +527,7 @@ class BPDQueryTest(BPDTestHelper):
 
 
 class BPDPlaybackTest(BPDTestHelper):
-    test_implements_playback = implements(
-        {
-            "random",
-        }
-    )
+    test_implements_playback = implements({"random"})
 
     def test_cmd_consume(self):
         with self.run_bpd() as client:
@@ -727,12 +716,7 @@ class BPDPlaybackTest(BPDTestHelper):
 
 class BPDControlTest(BPDTestHelper):
     test_implements_control = implements(
-        {
-            "seek",
-            "seekid",
-            "seekcur",
-        },
-        fail=True,
+        {"seek", "seekid", "seekcur"}, fail=True
     )
 
     def test_cmd_play(self):
@@ -1013,32 +997,16 @@ class BPDDatabaseTest(BPDTestHelper):
 
 class BPDMountsTest(BPDTestHelper):
     test_implements_mounts = implements(
-        {
-            "mount",
-            "unmount",
-            "listmounts",
-            "listneighbors",
-        },
-        fail=True,
+        {"mount", "unmount", "listmounts", "listneighbors"}, fail=True
     )
 
 
 class BPDStickerTest(BPDTestHelper):
-    test_implements_stickers = implements(
-        {
-            "sticker",
-        },
-        fail=True,
-    )
+    test_implements_stickers = implements({"sticker"}, fail=True)
 
 
 class BPDConnectionTest(BPDTestHelper):
-    test_implements_connection = implements(
-        {
-            "close",
-            "kill",
-        }
-    )
+    test_implements_connection = implements({"close", "kill"})
 
     ALL_MPD_TAGTYPES: ClassVar[set[str]] = {
         "Artist",
@@ -1106,36 +1074,19 @@ class BPDConnectionTest(BPDTestHelper):
 
 class BPDPartitionTest(BPDTestHelper):
     test_implements_partitions = implements(
-        {
-            "partition",
-            "listpartitions",
-            "newpartition",
-        },
-        fail=True,
+        {"partition", "listpartitions", "newpartition"}, fail=True
     )
 
 
 class BPDDeviceTest(BPDTestHelper):
     test_implements_devices = implements(
-        {
-            "disableoutput",
-            "enableoutput",
-            "toggleoutput",
-            "outputs",
-        },
-        fail=True,
+        {"disableoutput", "enableoutput", "toggleoutput", "outputs"}, fail=True
     )
 
 
 class BPDReflectionTest(BPDTestHelper):
     test_implements_reflection = implements(
-        {
-            "config",
-            "commands",
-            "notcommands",
-            "urlhandlers",
-        },
-        fail=True,
+        {"config", "commands", "notcommands", "urlhandlers"}, fail=True
     )
 
     @patch(
@@ -1153,12 +1104,6 @@ class BPDReflectionTest(BPDTestHelper):
 
 class BPDPeersTest(BPDTestHelper):
     test_implements_peers = implements(
-        {
-            "subscribe",
-            "unsubscribe",
-            "channels",
-            "readmessages",
-            "sendmessage",
-        },
+        {"subscribe", "unsubscribe", "channels", "readmessages", "sendmessage"},
         fail=True,
     )

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -320,9 +320,7 @@ class NeverConvertLossyFilesTest(ConvertTestCase, ConvertCommand):
             "paths": {"default": "converted"},
             "never_convert_lossy_files": True,
             "format": "mp3",
-            "formats": {
-                "mp3": self.tagged_copy_cmd("mp3"),
-            },
+            "formats": {"mp3": self.tagged_copy_cmd("mp3")},
         }
 
     def test_transcode_from_lossless(self):

--- a/test/plugins/test_discogs.py
+++ b/test/plugins/test_discogs.py
@@ -71,12 +71,7 @@ class TestDGAlbumInfo(PytestTestHelper):
             # genres and styles are reversed in Discogs
             "genres": ["STYLE1", "STYLE2"],
             "styles": ["GENRE1", "GENRE2"],
-            "labels": [
-                {
-                    "name": "LABEL NAME",
-                    "catno": "CATALOG NUMBER",
-                }
-            ],
+            "labels": [{"name": "LABEL NAME", "catno": "CATALOG NUMBER"}],
             "tracklist": [],
         }
 
@@ -419,12 +414,7 @@ class TestDGAlbumInfo(PytestTestHelper):
                 _artist("OTHER ARTIST (5)", id=322),
             ],
             "title": "title",
-            "labels": [
-                {
-                    "name": "LABEL NAME (5)",
-                    "catno": "catalog number",
-                }
-            ],
+            "labels": [{"name": "LABEL NAME (5)", "catno": "catalog number"}],
         }
         release = Bag(
             data=data,
@@ -461,12 +451,7 @@ class TestDGAlbumInfo(PytestTestHelper):
                 _artist("OTHER ARTIST (5)", id=322),
             ],
             "title": "title",
-            "labels": [
-                {
-                    "name": "LABEL NAME (5)",
-                    "catno": "catalog number",
-                }
-            ],
+            "labels": [{"name": "LABEL NAME (5)", "catno": "catalog number"}],
         }
         release = Bag(
             data=data,
@@ -712,7 +697,7 @@ def test_anv_album_artist():
             ["NEW ARTIST", "VOCALIST", "SOLOIST", "PERFORMER", "MUSICIAN"],
             ["11146", "344", "3", "5", "10"],
             ["RANDOM"],
-        ),
+        )
     ],
 )
 @patch("beetsplug.discogs.DiscogsPlugin.setup", Mock())

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -188,9 +188,7 @@ class EditCommandTest(IOMixin, EditMixin, BeetsTestCase):
 
         assert mock_write.call_count == self.TRACK_COUNT
         self.assertItemFieldsModified(
-            self.album.items(),
-            self.items_orig,
-            ["title", "mtime"],
+            self.album.items(), self.items_orig, ["title", "mtime"]
         )
 
     def test_title_edit_keep_editing_then_cancel(self, mock_write):
@@ -202,11 +200,7 @@ class EditCommandTest(IOMixin, EditMixin, BeetsTestCase):
         )
 
         assert mock_write.call_count == 0
-        self.assertItemFieldsModified(
-            self.album.items(),
-            self.items_orig,
-            [],
-        )
+        self.assertItemFieldsModified(self.album.items(), self.items_orig, [])
 
     def test_noedit(self, mock_write):
         """Do not edit anything."""

--- a/test/plugins/test_embedart.py
+++ b/test/plugins/test_embedart.py
@@ -59,14 +59,10 @@ def require_artresizer_compare(test):
         compare_threshold = 20
 
         similar_compares_ok = ArtResizer.shared.compare(
-            abbey_artpath,
-            abbey_similarpath,
-            compare_threshold,
+            abbey_artpath, abbey_similarpath, compare_threshold
         )
         different_compares_ok = ArtResizer.shared.compare(
-            abbey_artpath,
-            abbey_differentpath,
-            compare_threshold,
+            abbey_artpath, abbey_differentpath, compare_threshold
         )
         if not similar_compares_ok or different_compares_ok:
             raise unittest.SkipTest("IM version with broken compare")
@@ -333,11 +329,7 @@ class ArtSimilarityTest(unittest.TestCase):
 
     def _similarity(self, threshold):
         return art.check_art_similarity(
-            self.log,
-            self.item,
-            b"path",
-            threshold,
-            artresizer=self.artresizer,
+            self.log, self.item, b"path", threshold, artresizer=self.artresizer
         )
 
     def _popen(self, status=0, stdout="", stderr=""):

--- a/test/plugins/test_filefilter.py
+++ b/test/plugins/test_filefilter.py
@@ -63,16 +63,12 @@ class FileFilterPluginNonSingletonTest(FileFilterPluginMixin):
 
     def test_global_config(self):
         self._run(
-            {"path": ".*album.*"},
-            2,
-            {self.album_track, self.other_album_track},
+            {"path": ".*album.*"}, 2, {self.album_track, self.other_album_track}
         )
 
     def test_album_config(self):
         self._run(
-            {"album_path": ".*other_album.*"},
-            1,
-            {self.other_album_track},
+            {"album_path": ".*other_album.*"}, 1, {self.other_album_track}
         )
 
     def test_singleton_config(self):

--- a/test/plugins/test_ftintitle.py
+++ b/test/plugins/test_ftintitle.py
@@ -47,8 +47,7 @@ def env() -> Generator[FtInTitlePluginFunctional, None, None]:
 
 
 def set_config(
-    env: FtInTitlePluginFunctional,
-    cfg: dict[str, ConfigValue] | None,
+    env: FtInTitlePluginFunctional, cfg: dict[str, ConfigValue] | None
 ) -> None:
     cfg = {} if cfg is None else cfg
     defaults = {
@@ -206,50 +205,35 @@ def add_item(
                 "keep_in_artist": True,
                 "custom_words": ["med"],
             },
-            (
-                "ftintitle",
-                "-d",
-            ),
+            ("ftintitle", "-d"),
             ("Alice med Bob", "Song 1", "Alice"),
             ("Alice med Bob", "Song 1"),
             id="custom-feat-words-keep-in-artists-drop-from-title",
         ),
         # ---- preserve_album_artist variants ----
         pytest.param(
-            {
-                "format": "feat. {}",
-                "preserve_album_artist": True,
-            },
+            {"format": "feat. {}", "preserve_album_artist": True},
             ("ftintitle",),
             ("Alice feat. Bob", "Song 1", "Alice"),
             ("Alice", "Song 1 feat. Bob"),
             id="skip-if-artist-and-album-artists-is-the-same-different-match",
         ),
         pytest.param(
-            {
-                "format": "feat. {}",
-                "preserve_album_artist": False,
-            },
+            {"format": "feat. {}", "preserve_album_artist": False},
             ("ftintitle",),
             ("Alice feat. Bob", "Song 1", "Alice"),
             ("Alice", "Song 1 feat. Bob"),
             id="skip-if-artist-and-album-artists-is-the-same-different-match-b",
         ),
         pytest.param(
-            {
-                "format": "feat. {}",
-                "preserve_album_artist": True,
-            },
+            {"format": "feat. {}", "preserve_album_artist": True},
             ("ftintitle",),
             ("Alice feat. Bob", "Song 1", "Alice feat. Bob"),
             ("Alice feat. Bob", "Song 1"),
             id="skip-if-artist-and-album-artists-is-the-same-matching-match",
         ),
         pytest.param(
-            {
-                "format": "feat. {}",
-                "preserve_album_artist": False,
-            },
+            {"format": "feat. {}", "preserve_album_artist": False},
             ("ftintitle",),
             ("Alice feat. Bob", "Song 1", "Alice feat. Bob"),
             ("Alice", "Song 1 feat. Bob"),
@@ -309,9 +293,7 @@ def test_ftintitle_functional(
     ],
 )
 def test_find_feat_part(
-    artist: str,
-    albumartist: str,
-    expected: str | None,
+    artist: str, albumartist: str, expected: str | None
 ) -> None:
     assert ftintitle.find_feat_part(artist, albumartist) == expected
 
@@ -338,10 +320,7 @@ def test_find_feat_part(
         ("Alice and Bob feat Charlie", ("Alice and Bob", "Charlie")),
     ],
 )
-def test_split_on_feat(
-    given: str,
-    expected: tuple[str, str | None],
-) -> None:
+def test_split_on_feat(given: str, expected: tuple[str, str | None]) -> None:
     assert ftintitle.split_on_feat(given) == expected
 
 
@@ -393,9 +372,7 @@ def test_split_on_feat(
     ],
 )  # fmt: skip
 def test_insert_ft_into_title(
-    given: str,
-    keywords: list[str] | None,
-    expected: str,
+    given: str, keywords: list[str] | None, expected: str
 ) -> None:
     assert (
         ftintitle.FtInTitlePlugin.insert_ft_into_title(

--- a/test/plugins/test_hook.py
+++ b/test/plugins/test_hook.py
@@ -54,9 +54,7 @@ class TestHookLogs(HookTestCase):
     def _configure_hook(self, command: str) -> None:
         config = {"hooks": [self._get_hook(self.HOOK, command)]}
 
-        with (
-            self.configure_plugin(config),
-        ):
+        with self.configure_plugin(config):
             plugins.send(self.HOOK)
 
     def test_hook_empty_command(self, caplog: pytest.LogCaptureFixture):

--- a/test/plugins/test_lastgenre.py
+++ b/test/plugins/test_lastgenre.py
@@ -242,10 +242,7 @@ class LastGenrePluginTest(IOMixin, PluginTestCase):
         """
         self._setup_config(whitelist=False, canonical=True, count=99)
         self.plugin.ignore_patterns = defaultdict(
-            list,
-            {
-                "the artist": [re.compile(r"^delta blues$", re.IGNORECASE)],
-            },
+            list, {"the artist": [re.compile(r"^delta blues$", re.IGNORECASE)]}
         )
         result = self.plugin._resolve_genres(
             ["delta blues"], artist="the artist"
@@ -261,8 +258,7 @@ class LastGenrePluginTest(IOMixin, PluginTestCase):
         self._setup_config(whitelist=False, canonical=True, count=99)
         # ignorelist targets an unrelated genre — must not affect parent walking
         self.plugin.ignore_patterns = defaultdict(
-            list,
-            {"*": [re.compile(r"^jazz$", re.IGNORECASE)]},
+            list, {"*": [re.compile(r"^jazz$", re.IGNORECASE)]}
         )
         result = self.plugin._resolve_genres(["delta blues"])
         assert result == ["blues"], (
@@ -275,8 +271,7 @@ class LastGenrePluginTest(IOMixin, PluginTestCase):
         """
         self._setup_config(whitelist=False, canonical=True, count=99)
         self.plugin.ignore_patterns = defaultdict(
-            list,
-            {"*": [re.compile(r"^blues$", re.IGNORECASE)]},
+            list, {"*": [re.compile(r"^blues$", re.IGNORECASE)]}
         )
         result = self.plugin._resolve_genres(["delta blues"])
         assert result == [], (
@@ -309,9 +304,7 @@ def config(config):
                 "count": 10,
             },
             ["Blues"],
-            {
-                "album": ["Jazz"],
-            },
+            {"album": ["Jazz"]},
             (["Blues", "Jazz"], "keep + album, whitelist"),
         ),
         # force and keep whitelisted, unknown original
@@ -326,9 +319,7 @@ def config(config):
                 "count": 10,
             },
             ["original unknown", "Blues"],
-            {
-                "album": ["Jazz"],
-            },
+            {"album": ["Jazz"]},
             (["Blues", "Jazz"], "keep + album, whitelist"),
         ),
         # force and keep whitelisted on empty tag
@@ -342,9 +333,7 @@ def config(config):
                 "prefer_specific": False,
             },
             [],
-            {
-                "album": ["Jazz"],
-            },
+            {"album": ["Jazz"]},
             (["Jazz"], "album, whitelist"),
         ),
         # force and keep, artist configured
@@ -359,10 +348,7 @@ def config(config):
                 "count": 10,
             },
             ["original unknown", "Blues"],
-            {
-                "album": ["Jazz"],
-                "artist": ["Pop"],
-            },
+            {"album": ["Jazz"], "artist": ["Pop"]},
             (["Blues", "Pop"], "keep + artist, whitelist"),
         ),
         # don't force, disabled whitelist
@@ -376,9 +362,7 @@ def config(config):
                 "prefer_specific": False,
             },
             ["any genre"],
-            {
-                "album": ["Jazz"],
-            },
+            {"album": ["Jazz"]},
             (["any genre"], "keep any, no-force"),
         ),
         # don't force and empty is regular last.fm fetch; no whitelist too
@@ -392,9 +376,7 @@ def config(config):
                 "prefer_specific": False,
             },
             [],
-            {
-                "album": ["Jazzin"],
-            },
+            {"album": ["Jazzin"]},
             (["Jazzin"], "album, any"),
         ),
         # Canonicalize original genre when force is **off** and
@@ -413,13 +395,8 @@ def config(config):
                 "count": 10,
             },
             ["Cosmic Disco"],
-            {
-                "artist": [],
-            },
-            (
-                ["Disco", "Electronic"],
-                "keep + cleanup, whitelist",
-            ),
+            {"artist": []},
+            (["Disco", "Electronic"], "keep + cleanup, whitelist"),
         ),
         # fallback to next stages until found
         (
@@ -433,11 +410,7 @@ def config(config):
                 "count": 10,
             },
             ["unknown genre"],
-            {
-                "track": None,
-                "album": None,
-                "artist": ["Jazz"],
-            },
+            {"track": None, "album": None, "artist": ["Jazz"]},
             (["Unknown Genre", "Jazz"], "keep + artist, any"),
         ),
         # Keep the original genre when force and keep_existing are on, and
@@ -453,11 +426,7 @@ def config(config):
                 "prefer_specific": False,
             },
             ["any existing"],
-            {
-                "track": None,
-                "album": None,
-                "artist": None,
-            },
+            {"track": None, "album": None, "artist": None},
             (["any existing"], "original fallback"),
         ),
         # Keep the original genre when force and keep_existing are on, and
@@ -473,11 +442,7 @@ def config(config):
                 "prefer_specific": False,
             },
             ["Jazz"],
-            {
-                "track": None,
-                "album": None,
-                "artist": None,
-            },
+            {"track": None, "album": None, "artist": None},
             (["Jazz"], "original fallback"),
         ),
         # Return the configured fallback when force is on but
@@ -493,11 +458,7 @@ def config(config):
                 "prefer_specific": False,
             },
             ["Jazz"],
-            {
-                "track": None,
-                "album": None,
-                "artist": None,
-            },
+            {"track": None, "album": None, "artist": None},
             (["fallback genre"], "fallback"),
         ),
         # fallback to fallback if no original
@@ -512,11 +473,7 @@ def config(config):
                 "prefer_specific": False,
             },
             [],
-            {
-                "track": None,
-                "album": None,
-                "artist": None,
-            },
+            {"track": None, "album": None, "artist": None},
             (["fallback genre"], "fallback"),
         ),
         # limit a lot of results
@@ -531,9 +488,7 @@ def config(config):
                 "prefer_specific": False,
             },
             ["original unknown", "Blues", "Rock", "Folk", "Metal"],
-            {
-                "album": ["Jazz", "Bebop", "Hardbop"],
-            },
+            {"album": ["Jazz", "Bebop", "Hardbop"]},
             (
                 ["Blues", "Rock", "Metal", "Jazz", "Bebop"],
                 "keep + album, whitelist",
@@ -552,11 +507,7 @@ def config(config):
                 "prefer_specific": False,
             },
             ["not whitelisted original"],
-            {
-                "track": None,
-                "album": None,
-                "artist": ["Jazz"],
-            },
+            {"track": None, "album": None, "artist": ["Jazz"]},
             (["Jazz"], "keep + artist, whitelist"),
         ),
         # canonicalization transforms non-whitelisted genres to canonical forms
@@ -574,9 +525,7 @@ def config(config):
                 "count": 10,
             },
             [],
-            {
-                "album": ["acid techno"],
-            },
+            {"album": ["acid techno"]},
             (["Techno", "Electronic"], "album, whitelist"),
         ),
         # canonicalization transforms whitelisted genres to canonical forms and
@@ -597,9 +546,7 @@ def config(config):
                 "extended_debug": True,
             },
             ["detroit techno"],
-            {
-                "album": ["acid house"],
-            },
+            {"album": ["acid house"]},
             (
                 [
                     "Detroit Techno",
@@ -628,9 +575,7 @@ def config(config):
                 "count": 10,
             },
             ["Cosmic Disco"],
-            {
-                "album": ["Detroit Techno"],
-            },
+            {"album": ["Detroit Techno"]},
             (
                 ["Disco", "Electronic", "Detroit Techno", "Techno"],
                 "keep + album, whitelist",
@@ -652,14 +597,8 @@ def config(config):
                 "count": 10,
             },
             ["Cosmic Disco"],
-            {
-                "album": [],
-                "artist": [],
-            },
-            (
-                ["Disco", "Electronic"],
-                "keep + original fallback, whitelist",
-            ),
+            {"album": [], "artist": []},
+            (["Disco", "Electronic"], "keep + original fallback, whitelist"),
         ),
         # Semicolon-delimited genre tag from an external mediafile
         # ("Jazz; Funk; Soul" as a single element) is split by
@@ -677,10 +616,7 @@ def config(config):
                 "count": 10,
             },
             ["Jazz; Funk; Soul"],
-            {
-                "album": [],
-                "artist": [],
-            },
+            {"album": [], "artist": []},
             (["Jazz", "Funk", "Soul"], "original fallback"),
         ),
         # Multiple whitelisted genres in the multi-valued `genres` field must
@@ -698,10 +634,7 @@ def config(config):
                 "prefer_specific": False,
             },
             ["Baroque", "Classical"],
-            {
-                "album": [],
-                "artist": [],
-            },
+            {"album": [], "artist": []},
             (["Baroque", "Classical"], "original fallback"),
         ),
     ],
@@ -881,25 +814,13 @@ class TestIgnorelist:
         "invalid_config, expected_error_message",
         [
             # A plain string (e.g. accidental file path) instead of a mapping
-            (
-                "/path/to/ignorelist.txt",
-                "must be a dict",
-            ),
+            ("/path/to/ignorelist.txt", "must be a dict"),
             # An integer instead of a mapping
-            (
-                42,
-                "must be a dict",
-            ),
+            (42, "must be a dict"),
             # A list of strings instead of a mapping
-            (
-                ["spoken word", "comedy"],
-                "must be a dict",
-            ),
+            (["spoken word", "comedy"], "must be a dict"),
             # A mapping with a non-list value
-            (
-                {"metallica": "metal"},
-                "must be a list",
-            ),
+            ({"metallica": "metal"}, "must be a list"),
         ],
     )
     def test_ignorelist_config_format_errors(
@@ -933,10 +854,9 @@ class TestIgnorelist:
         def fake_fetch(_, kind, obj, *args):
             if kind == "album_artist" and args:
                 album_artist = args[0]
-                return {
-                    "Artist A": ["Rock"],
-                    "Artist B": ["Metal", "Jazz"],
-                }[album_artist]
+                return {"Artist A": ["Rock"], "Artist B": ["Metal", "Jazz"]}[
+                    album_artist
+                ]
             return []
 
         monkeypatch.setattr(

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -265,13 +265,7 @@ class TestLyricsPlugin(LyricsPluginMixin):
     @pytest.mark.parametrize(
         "plugin_config, old_lyrics, found, expected",
         [
-            pytest.param(
-                {},
-                "old",
-                "new",
-                "old",
-                id="no_force_keeps_old",
-            ),
+            pytest.param({}, "old", "new", "old", id="no_force_keeps_old"),
             pytest.param(
                 {"force": True},
                 "old",
@@ -338,13 +332,7 @@ class TestLyricsPlugin(LyricsPluginMixin):
         ],
     )
     def test_overwrite_config(
-        self,
-        monkeypatch,
-        helper,
-        lyrics_plugin,
-        old_lyrics,
-        found,
-        expected,
+        self, monkeypatch, helper, lyrics_plugin, old_lyrics, found, expected
     ):
         monkeypatch.setattr(
             lyrics_plugin,
@@ -386,9 +374,7 @@ class TestLyricsPlugin(LyricsPluginMixin):
             item.lyrics_translation_language
 
     def test_imported_skips_auto_ignored_items(
-        self,
-        lyrics_plugin,
-        monkeypatch,
+        self, lyrics_plugin, monkeypatch
     ):
         lyrics_plugin.config["auto_ignore"].set("album:Greatest Hits")
         items = [
@@ -639,15 +625,9 @@ class TestLRCLibLyrics(LyricsBackendTest):
         "response_data, expected_lyrics",
         [
             pytest.param([], None, id="handle non-matching lyrics"),
+            pytest.param([lyrics_match()], SYNCED, id="synced when available"),
             pytest.param(
-                [lyrics_match()],
-                SYNCED,
-                id="synced when available",
-            ),
-            pytest.param(
-                [lyrics_match(duration=1)],
-                None,
-                id="none: duration too short",
+                [lyrics_match(duration=1)], None, id="none: duration too short"
             ),
             pytest.param(
                 [lyrics_match(instrumental=True)],
@@ -679,8 +659,7 @@ class TestLRCLibLyrics(LyricsBackendTest):
                         plainLyrics="valid plain",
                     ),
                     lyrics_match(
-                        duration=1,
-                        syncedLyrics="synced with invalid duration",
+                        duration=1, syncedLyrics="synced with invalid duration"
                     ),
                 ],
                 "valid plain",

--- a/test/plugins/test_mbpseudo.py
+++ b/test/plugins/test_mbpseudo.py
@@ -140,9 +140,7 @@ class TestMBPseudoPlugin(TestMBPseudoMixin):
         ],
     )
     def test_extract_id_uses_music_brainz_pattern(
-        self,
-        mbpseudo_plugin: MusicBrainzPseudoReleasePlugin,
-        album_id: str,
+        self, mbpseudo_plugin: MusicBrainzPseudoReleasePlugin, album_id: str
     ):
         if album_id.startswith("-"):
             assert mbpseudo_plugin._extract_id(album_id) is None
@@ -159,14 +157,7 @@ class TestMBPseudoPlugin(TestMBPseudoMixin):
         assert album_info.data_source == "MusicBrainzPseudoRelease"
         assert album_info.albumstatus == _STATUS_PSEUDO
 
-    @pytest.mark.parametrize(
-        "json_key",
-        [
-            "type",
-            "direction",
-            "release",
-        ],
-    )
+    @pytest.mark.parametrize("json_key", ["type", "direction", "release"])
     def test_interception_skip_when_rel_values_dont_match(
         self,
         mbpseudo_plugin: MusicBrainzPseudoReleasePlugin,
@@ -202,8 +193,7 @@ class TestMBPseudoPlugin(TestMBPseudoMixin):
         assert album_info.data_source == "MusicBrainzPseudoRelease"
 
     def test_final_adjustment_skip(
-        self,
-        mbpseudo_plugin: MusicBrainzPseudoReleasePlugin,
+        self, mbpseudo_plugin: MusicBrainzPseudoReleasePlugin
     ):
         match = AlbumMatch(
             distance=Distance(),

--- a/test/plugins/test_mbsync.py
+++ b/test/plugins/test_mbsync.py
@@ -84,9 +84,7 @@ class TestMbsyncCli(PytestPluginTestHelper):
         for item in [
             Item(artist="albumartist", album="no id"),
             Item(
-                artist="albumartist",
-                album="invalid id",
-                mb_albumid="a1b2c3d4",
+                artist="albumartist", album="invalid id", mb_albumid="a1b2c3d4"
             ),
         ]:
             self.lib.add_album([item])

--- a/test/plugins/test_missing.py
+++ b/test/plugins/test_missing.py
@@ -119,10 +119,7 @@ class TestMissingAlbums(IOMixin, PluginMixin):
 
         with self.configure_plugin({}):
             output = self.run_with_output(
-                "missing",
-                "-a",
-                "--release-types",
-                "compilation,album",
+                "missing", "-a", "--release-types", "compilation,album"
             )
 
         assert "artist - compilation" in output
@@ -141,8 +138,7 @@ class TestMissingAlbums(IOMixin, PluginMixin):
             )
         )
         adapter = requests_mock.get(
-            re.compile(r"/ws/2/release-group"),
-            json={"release-groups": []},
+            re.compile(r"/ws/2/release-group"), json={"release-groups": []}
         )
 
         with self.configure_plugin({"release_types": []}):
@@ -188,10 +184,7 @@ class TestMissingTracks(IOMixin, PluginMixin):
 
     @pytest.mark.parametrize(
         "total,count,expected",
-        [
-            (True, False, "1\n"),
-            (False, True, "artist - album: 1"),
-        ],
+        [(True, False, "1\n"), (False, True, "artist - album: 1")],
     )
     @patch("beets.metadata_plugins.album_for_id")
     def test_missing_tracks(self, album_for_id, total, count, expected):

--- a/test/plugins/test_musicbrainz.py
+++ b/test/plugins/test_musicbrainz.py
@@ -250,10 +250,7 @@ class TestParseRecording(MusicBrainzPluginTestMixin):
 
         assert mb.track_info(recording) == {
             "album": None,
-            "arrangers": [
-                "Recording Arranger",
-                "Another Recording Arranger",
-            ],
+            "arrangers": ["Recording Arranger", "Another Recording Arranger"],
             "arrangers_ids": [
                 "00000000-0000-0000-0000-000000000002",
                 "00000000-0000-0000-0000-000000000003",
@@ -262,24 +259,13 @@ class TestParseRecording(MusicBrainzPluginTestMixin):
             "artist_credit": "Recording Artist Credit",
             "artist_id": "00000000-0000-0000-0000-000000000001",
             "artist_sort": "Recording Artist, The",
-            "artists": [
-                "Recording Artist",
-            ],
-            "artists_credit": [
-                "Recording Artist Credit",
-            ],
-            "artists_ids": [
-                "00000000-0000-0000-0000-000000000001",
-            ],
-            "artists_sort": [
-                "Recording Artist, The",
-            ],
+            "artists": ["Recording Artist"],
+            "artists_credit": ["Recording Artist Credit"],
+            "artists_ids": ["00000000-0000-0000-0000-000000000001"],
+            "artists_sort": ["Recording Artist, The"],
             "bpm": None,
             "composer_sort": "Recording Composer, The, Another Recording Composer, The",
-            "composers": [
-                "Recording Composer",
-                "Another Recording Composer",
-            ],
+            "composers": ["Recording Composer", "Another Recording Composer"],
             "composers_ids": [
                 "00000000-0000-0000-0000-000000000006",
                 "00000000-0000-0000-0000-000000000007",
@@ -292,10 +278,7 @@ class TestParseRecording(MusicBrainzPluginTestMixin):
             "initial_key": None,
             "isrc": None,
             "length": None,
-            "lyricists": [
-                "Recording Lyricist",
-                "Another Recording Lyricist",
-            ],
+            "lyricists": ["Recording Lyricist", "Another Recording Lyricist"],
             "lyricists_ids": [
                 "00000000-0000-0000-0000-000000000004",
                 "00000000-0000-0000-0000-000000000005",
@@ -306,12 +289,8 @@ class TestParseRecording(MusicBrainzPluginTestMixin):
             "medium_index": None,
             "medium_total": None,
             "release_track_id": None,
-            "remixers": [
-                "Recording Remixer",
-            ],
-            "remixers_ids": [
-                "00000000-0000-0000-0000-000000000001",
-            ],
+            "remixers": ["Recording Remixer"],
+            "remixers_ids": ["00000000-0000-0000-0000-000000000001"],
             "title": "Recording",
             "track_alt": None,
             "track_id": "00000000-0000-0000-0000-000000001001",
@@ -384,26 +363,23 @@ class TestParseMedia(MusicBrainzPluginTestMixin):
                     length=1000.0,
                     artist_credit=[
                         artist_credit_factory(
-                            artist__name="Track Artist",
-                            joinphrase=" & ",
+                            artist__name="Track Artist", joinphrase=" & "
                         ),
                         artist_credit_factory(
-                            artist__name="Other Track Artist",
-                            artist__index=2,
+                            artist__name="Other Track Artist", artist__index=2
                         ),
                     ],
                     recording__length=2000.0,
                     recording__artist_credit=[
                         artist_credit_factory(
-                            artist__name="Recording Artist",
-                            joinphrase=" & ",
+                            artist__name="Recording Artist", joinphrase=" & "
                         ),
                         artist_credit_factory(
                             artist__name="Other Recording Artist",
                             artist__index=2,
                         ),
                     ],
-                ),
+                )
             ]
         )
 
@@ -462,10 +438,7 @@ class TestParseMedia(MusicBrainzPluginTestMixin):
                 id="include data tracks",
             ),
             _p(
-                {
-                    "ignore_data_tracks": False,
-                    "ignore_video_tracks": False,
-                },
+                {"ignore_data_tracks": False, "ignore_video_tracks": False},
                 ("Audio", "Video: Video", "Data"),
                 id="include data and video tracks",
             ),
@@ -480,9 +453,7 @@ class TestParseMedia(MusicBrainzPluginTestMixin):
                 track_factory(recording__title="[data track]"),
                 track_factory(recording__title="Video", recording__video=True),
             ],
-            data_tracks=[
-                track_factory(recording__title="Data"),
-            ],
+            data_tracks=[track_factory(recording__title="Data")],
         )
         release = release_factory(media=[medium])
 
@@ -512,10 +483,10 @@ class TestParseRelease(MusicBrainzPluginTestMixin):
                     url__resource="https://discogs.com/release/123456"
                 ),
                 url_relation_factory(
-                    url__resource="https://open.spotify.com/album/ABCDab2ImQyHZ9sXCXFyZ8",
+                    url__resource="https://open.spotify.com/album/ABCDab2ImQyHZ9sXCXFyZ8"
                 ),
                 url_relation_factory(
-                    url__resource="https://somemusic.bandcamp.com/album/somealbum",
+                    url__resource="https://somemusic.bandcamp.com/album/somealbum"
                 ),
             ]
         )
@@ -527,25 +498,15 @@ class TestParseRelease(MusicBrainzPluginTestMixin):
             "albumdisambig": "Album Disambiguation",
             "albumstatus": "Official",
             "albumtype": "album",
-            "albumtypes": [
-                "album",
-            ],
+            "albumtypes": ["album"],
             "artist": "Artist",
             "artist_credit": "Artist Credit",
             "artist_id": "00000000-0000-0000-0000-000000000011",
             "artist_sort": "Artist, The",
-            "artists": [
-                "Artist",
-            ],
-            "artists_credit": [
-                "Artist Credit",
-            ],
-            "artists_ids": [
-                "00000000-0000-0000-0000-000000000011",
-            ],
-            "artists_sort": [
-                "Artist, The",
-            ],
+            "artists": ["Artist"],
+            "artists_credit": ["Artist Credit"],
+            "artists_ids": ["00000000-0000-0000-0000-000000000011"],
+            "artists_sort": ["Artist, The"],
             "asin": "Album Asin",
             "bandcamp_album_id": "https://somemusic.bandcamp.com/album/somealbum",
             "barcode": "0000000000000",
@@ -581,18 +542,10 @@ class TestParseRelease(MusicBrainzPluginTestMixin):
                     "artist_credit": "Recording Artist Credit",
                     "artist_id": "00000000-0000-0000-0000-000000000001",
                     "artist_sort": "Recording Artist, The",
-                    "artists": [
-                        "Recording Artist",
-                    ],
-                    "artists_credit": [
-                        "Recording Artist Credit",
-                    ],
-                    "artists_ids": [
-                        "00000000-0000-0000-0000-000000000001",
-                    ],
-                    "artists_sort": [
-                        "Recording Artist, The",
-                    ],
+                    "artists": ["Recording Artist"],
+                    "artists_credit": ["Recording Artist Credit"],
+                    "artists_ids": ["00000000-0000-0000-0000-000000000001"],
+                    "artists_sort": ["Recording Artist, The"],
                     "bpm": None,
                     "composer_sort": None,
                     "composers": None,
@@ -621,7 +574,7 @@ class TestParseRelease(MusicBrainzPluginTestMixin):
                     "trackdisambig": None,
                     "work": None,
                     "work_disambig": None,
-                },
+                }
             ],
             "va": False,
             "year": 2020,

--- a/test/plugins/test_play.py
+++ b/test/plugins/test_play.py
@@ -140,9 +140,7 @@ class PlayPluginTest(IOMixin, CleanupModulesMixin, PluginTestCase):
 
         self.io.addinput("a")
         self.run_and_assert(
-            open_mock,
-            ["-y", "NiceTitle"],
-            expected_playlist=expected_playlist,
+            open_mock, ["-y", "NiceTitle"], expected_playlist=expected_playlist
         )
 
     def _playlist_lines(self, open_mock):

--- a/test/plugins/test_playlist.py
+++ b/test/plugins/test_playlist.py
@@ -32,12 +32,7 @@ class PlaylistTestCase(PluginTestCase):
 
         i1 = _common.item()
         i1.path = beets.util.normpath(
-            os.path.join(
-                self.music_dir,
-                "a",
-                "b",
-                "c.mp3",
-            )
+            os.path.join(self.music_dir, "a", "b", "c.mp3")
         )
         i1.title = "some item"
         i1.album = "some album"
@@ -46,12 +41,7 @@ class PlaylistTestCase(PluginTestCase):
 
         i2 = _common.item()
         i2.path = beets.util.normpath(
-            os.path.join(
-                self.music_dir,
-                "d",
-                "e",
-                "f.mp3",
-            )
+            os.path.join(self.music_dir, "d", "e", "f.mp3")
         )
         i2.title = "another item"
         i2.album = "another album"
@@ -60,12 +50,7 @@ class PlaylistTestCase(PluginTestCase):
 
         i3 = _common.item()
         i3.path = beets.util.normpath(
-            os.path.join(
-                self.music_dir,
-                "x",
-                "y",
-                "z.mp3",
-            )
+            os.path.join(self.music_dir, "x", "y", "z.mp3")
         )
         i3.title = "yet another item"
         i3.album = "yet another album"

--- a/test/plugins/test_rewrite.py
+++ b/test/plugins/test_rewrite.py
@@ -37,15 +37,12 @@ class RewritePluginTest(PluginTestCase):
 
             assert item.artist == "Experience catalog"
 
-    def test_rewrite_is_case_insensitive_and_leaves_non_matches_unchanged(
-        self,
-    ):
+    def test_rewrite_is_case_insensitive_and_leaves_non_matches_unchanged(self):
         with self.configure_plugin(
             {"artist odd eye circle": "LOONA / ODD EYE CIRCLE"}
         ):
             matching_item = self.add_item(
-                artist="ODD EYE CIRCLE",
-                albumartist="ODD EYE CIRCLE",
+                artist="ODD EYE CIRCLE", albumartist="ODD EYE CIRCLE"
             )
             other_item = self.add_item(artist="ARTMS", albumartist="ARTMS")
 

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -328,10 +328,7 @@ class TestGetItemURI:
 
     @pytest.fixture
     def plugin(self, config, plugin_config):
-        plugin_config = {
-            "prefix": "http://beets:8337/files",
-            **plugin_config,
-        }
+        plugin_config = {"prefix": "http://beets:8337/files", **plugin_config}
         config["smartplaylist"].set(plugin_config)
 
         return SmartPlaylistPlugin()

--- a/test/plugins/test_spotify.py
+++ b/test/plugins/test_spotify.py
@@ -214,11 +214,7 @@ class SpotifyPluginTest(PluginTestCase):
 
         # Search without ascii encoding
 
-        with self.configure_plugin(
-            {
-                "search_query_ascii": False,
-            }
-        ):
+        with self.configure_plugin({"search_query_ascii": False}):
             assert self.spotify.config["search_query_ascii"].get() is False
             # Call the method to match library tracks
             results = self.spotify._match_library_tracks(self.lib, item.title)
@@ -239,11 +235,7 @@ class SpotifyPluginTest(PluginTestCase):
             assert not query.isascii()
 
         # Is not found in the library if ascii encoding is enabled
-        with self.configure_plugin(
-            {
-                "search_query_ascii": True,
-            }
-        ):
+        with self.configure_plugin({"search_query_ascii": True}):
             assert self.spotify.config["search_query_ascii"].get() is True
             results = self.spotify._match_library_tracks(self.lib, item.title)
             params = _params(responses.calls[1].request.url)

--- a/test/plugins/test_substitute.py
+++ b/test/plugins/test_substitute.py
@@ -29,12 +29,7 @@ class SubstitutePluginTest(PluginTestCase):
 
     def test_simple_substitute(self):
         self.run_substitute(
-            {
-                "a": "x",
-                "b": "y",
-                "c": "z",
-            },
-            [("a", "x"), ("b", "y"), ("c", "z")],
+            {"a": "x", "b": "y", "c": "z"}, [("a", "x"), ("b", "y"), ("c", "z")]
         )
 
     def test_case_insensitivity(self):
@@ -70,23 +65,10 @@ class SubstitutePluginTest(PluginTestCase):
 
     def test_rules_applied_in_definition_order(self):
         self.run_substitute(
-            {
-                "a": "x",
-                "[ab]": "y",
-                "b": "z",
-            },
-            [
-                ("a", "x"),
-                ("b", "y"),
-            ],
+            {"a": "x", "[ab]": "y", "b": "z"}, [("a", "x"), ("b", "y")]
         )
 
     def test_rules_applied_in_sequence(self):
         self.run_substitute(
-            {"a": "b", "b": "c", "d": "a"},
-            [
-                ("a", "c"),
-                ("b", "c"),
-                ("d", "a"),
-            ],
+            {"a": "b", "b": "c", "d": "a"}, [("a", "c"), ("b", "c"), ("d", "a")]
         )

--- a/test/plugins/test_thumbnails.py
+++ b/test/plugins/test_thumbnails.py
@@ -47,8 +47,7 @@ class ThumbnailsTest(BeetsTestCase):
 
         metadata = {"Thumb::URI": "COVER_URI", "Thumb::MTime": "12345"}
         mock_artresizer.shared.write_metadata.assert_called_once_with(
-            b"/path/to/thumbnail",
-            metadata,
+            b"/path/to/thumbnail", metadata
         )
         mock_stat.assert_called_once_with(syspath(album.artpath))
 

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -106,7 +106,7 @@ def _make_track(
                     {"id": aid, "type": "artists"} for aid in (artist_ids or [])
                 ],
                 "links": {},
-            },
+            }
         },
     }
 
@@ -144,11 +144,7 @@ class TestAlbumParsing(TidalPluginTest):
             "al2", "Album Two", tracks, ["a1"]
         )
 
-        info = self.tidal._get_album_info(
-            album,
-            track_lookup,
-            artist_lookup,
-        )
+        info = self.tidal._get_album_info(album, track_lookup, artist_lookup)
 
         assert len(info.tracks) == 2
         assert info.tracks[0].index == 1
@@ -202,10 +198,7 @@ class TestTrackForID(TidalPluginTest):
         artist = _make_artist("a1", "API Artist")
 
         self.tidal.api.get_tracks = Mock(
-            return_value={
-                "data": [track],
-                "included": [artist],
-            }
+            return_value={"data": [track], "included": [artist]}
         )
 
         info = self.tidal.track_for_id("https://tidal.com/track/490839595")
@@ -240,10 +233,7 @@ class TestTracksForIDs(TidalPluginTest):
         artist = _make_artist("a1", "API Artist")
 
         self.tidal.api.get_tracks = Mock(
-            return_value={
-                "data": [track1, track2],
-                "included": [artist],
-            }
+            return_value={"data": [track1, track2], "included": [artist]}
         )
 
         results = list(
@@ -267,18 +257,12 @@ class TestTracksForIDs(TidalPluginTest):
         artist = _make_artist("a1", "API Artist")
 
         self.tidal.api.get_tracks = Mock(
-            return_value={
-                "data": [track],
-                "included": [artist],
-            }
+            return_value={"data": [track], "included": [artist]}
         )
 
         results = list(
             self.tidal.tracks_for_ids(
-                [
-                    "https://tidal.com/track/490839595",
-                    "does_not_exist",
-                ]
+                ["https://tidal.com/track/490839595", "does_not_exist"]
             )
         )
 
@@ -345,10 +329,7 @@ class TestAlbumsForIDs(TidalPluginTest):
         ]
 
         self.tidal.api.get_albums = Mock(
-            return_value={
-                "data": [album1, album2],
-                "included": all_included,
-            }
+            return_value={"data": [album1, album2], "included": all_included}
         )
 
         results = list(
@@ -384,10 +365,7 @@ class TestAlbumsForIDs(TidalPluginTest):
 
         results = list(
             self.tidal.albums_for_ids(
-                [
-                    "https://tidal.com/album/226495055",
-                    "does_not_exist",
-                ]
+                ["https://tidal.com/album/226495055", "does_not_exist"]
             )
         )
 
@@ -434,11 +412,9 @@ class TestCandidates(TidalPluginTest):
             return_value={
                 "data": {
                     "relationships": {
-                        "albums": {
-                            "data": [{"id": "al1", "type": "albums"}],
-                        },
-                    },
-                },
+                        "albums": {"data": [{"id": "al1", "type": "albums"}]}
+                    }
+                }
             }
         )
 
@@ -475,10 +451,7 @@ class TestItemCandidates(TidalPluginTest):
         artist = _make_artist("a1", "ISRC Artist")
 
         self.tidal.api.get_tracks = Mock(
-            return_value={
-                "data": [track],
-                "included": [artist],
-            }
+            return_value={"data": [track], "included": [artist]}
         )
 
         item = Item(isrc="ISRC001")
@@ -498,9 +471,9 @@ class TestItemCandidates(TidalPluginTest):
                 "data": {
                     "relationships": {
                         "tracks": {
-                            "data": [{"id": "490839595", "type": "tracks"}],
-                        },
-                    },
+                            "data": [{"id": "490839595", "type": "tracks"}]
+                        }
+                    }
                 },
                 "included": [
                     _make_track(

--- a/test/plugins/test_titlecase.py
+++ b/test/plugins/test_titlecase.py
@@ -51,7 +51,7 @@ titlecase_fields_testcases = [
             album="Blackbox",
             title="Khameleon",
         ),
-    ),
+    )
 ]
 
 
@@ -308,21 +308,9 @@ class TestTitlecasePlugin(PluginTestCase):
             ),
             # Test with the_artist disabled
             (
-                {
-                    "the_artist": False,
-                    "fields": [
-                        "artist",
-                        "artists_sort",
-                    ],
-                },
-                Item(
-                    artists_sort=["b-52s, the"],
-                    artist="a day in the park",
-                ),
-                Item(
-                    artists_sort=["B-52s, The"],
-                    artist="A Day in the Park",
-                ),
+                {"the_artist": False, "fields": ["artist", "artists_sort"]},
+                Item(artists_sort=["b-52s, the"], artist="a day in the park"),
+                Item(artists_sort=["B-52s, The"], artist="A Day in the Park"),
             ),
             # Test to make sure preserve and the_artist
             # dont target the middle of sentences

--- a/test/plugins/test_zero.py
+++ b/test/plugins/test_zero.py
@@ -14,10 +14,7 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
 
     def test_no_patterns(self):
         item = self.add_item_fixture(
-            comments="test comment",
-            title="Title",
-            month=1,
-            year=2000,
+            comments="test comment", title="Title", month=1, year=2000
         )
         item.write()
 
@@ -124,11 +121,7 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
         item_id = item.id
 
         with self.configure_plugin(
-            {
-                "fields": ["comments"],
-                "update_database": False,
-                "auto": False,
-            }
+            {"fields": ["comments"], "update_database": False, "auto": False}
         ):
             self.io.addinput("y")
             self.run_command("zero")
@@ -213,10 +206,7 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
 
     def test_keep_fields(self):
         item = self.add_item_fixture(year=2016, comments="test comment")
-        tags = {
-            "comments": "test comment",
-            "year": 2016,
-        }
+        tags = {"comments": "test comment", "year": 2016}
 
         with self.configure_plugin(
             {"fields": None, "keep_fields": ["year"], "update_database": True}

--- a/test/plugins/utils/test_musicbrainz.py
+++ b/test/plugins/utils/test_musicbrainz.py
@@ -97,16 +97,12 @@ def test_normalize_data():
                         {
                             "type": "composer",
                             "type_id": "d59d99ea-23d4-4a80-b066-edca32ee158f",
-                            "artist": {
-                                "name": "幾田りら",
-                            },
+                            "artist": {"name": "幾田りら"},
                         },
                         {
                             "type": "lyricist",
                             "type_id": "3e48faba-ec01-47fd-8e89-30e81161661c",
-                            "artist": {
-                                "name": "幾田りら",
-                            },
+                            "artist": {"name": "幾田りら"},
                         },
                     ],
                     "url_relations": [
@@ -128,7 +124,7 @@ def test_normalize_data():
                     "title": "百花繚乱",
                     "type": "Song",
                 },
-            },
+            }
         ],
     }
 

--- a/test/plugins/utils/test_playcount.py
+++ b/test/plugins/utils/test_playcount.py
@@ -52,10 +52,7 @@ class TestPlayCount:
         source="lastfm",
     ):
         item = Item(
-            title=title,
-            artist=artist,
-            album=album,
-            mb_trackid=mb_trackid,
+            title=title, artist=artist, album=album, mb_trackid=mb_trackid
         )
         self.lib.add(item)
 
@@ -113,25 +110,14 @@ class TestPlayCount:
 
     def test_process_track_updates_every_matching_song(self):
         first = self.add_item(
-            title="Song",
-            artist="Artist",
-            album="First Album",
-            play_count=1,
+            title="Song", artist="Artist", album="First Album", play_count=1
         )
         second = self.add_item(
-            title="Song",
-            artist="Artist",
-            album="Second Album",
-            play_count=9,
+            title="Song", artist="Artist", album="Second Album", play_count=9
         )
 
         assert (
-            process_track(
-                self.lib,
-                self.track(playcount=0),
-                self.log,
-                "lastfm",
-            )
+            process_track(self.lib, self.track(playcount=0), self.log, "lastfm")
             is True
         )
 
@@ -177,11 +163,7 @@ class TestPlayCount:
             pytest.param([], (0, 0), None, None, id="empty-page"),
             pytest.param(
                 [
-                    {
-                        "artist": "Artist",
-                        "name": "Known Song",
-                        "playcount": 8,
-                    },
+                    {"artist": "Artist", "name": "Known Song", "playcount": 8},
                     {
                         "artist": "Missing Artist",
                         "name": "Missing Song",
@@ -203,11 +185,7 @@ class TestPlayCount:
         expected_playcount,
         caplog,
     ):
-        item = self.add_item(
-            title="Known Song",
-            artist="Artist",
-            play_count=1,
-        )
+        item = self.add_item(title="Known Song", artist="Artist", play_count=1)
 
         with caplog.at_level("DEBUG", logger=LOGGER_NAME):
             assert (

--- a/test/plugins/utils/test_requests.py
+++ b/test/plugins/utils/test_requests.py
@@ -16,10 +16,7 @@ def _prepared_request(
 class TestRateLimitAdapter:
     @pytest.mark.parametrize(
         "last_request_time, now, expected_sleep",
-        [
-            (100.0, 100.0, 0.25),
-            (100.0, 100.1, 0.15),
-        ],
+        [(100.0, 100.0, 0.25), (100.0, 100.1, 0.15)],
     )
     def test_send_sleeps_for_remaining_time(
         self, monkeypatch, last_request_time, now, expected_sleep
@@ -33,8 +30,7 @@ class TestRateLimitAdapter:
         )
 
         monkeypatch.setattr(
-            "beetsplug._utils.requests.time.monotonic",
-            lambda: now,
+            "beetsplug._utils.requests.time.monotonic", lambda: now
         )
 
         sleep_mock = MagicMock()

--- a/test/test_art_resize.py
+++ b/test/test_art_resize.py
@@ -60,10 +60,7 @@ class ArtResizerFileSizeTest(CleanupModulesMixin, BeetsTestCase):
         """Test resizing based on file size, given a resize_func."""
         # Check quality setting unaffected by new parameter
         im_95_qual = backend.resize(
-            225,
-            self.IMG_225x225,
-            quality=95,
-            max_filesize=0,
+            225, self.IMG_225x225, quality=95, max_filesize=0
         )
         # check valid path returned - max_filesize hasn't broken resize command
         assert Path(os.fsdecode(im_95_qual)).exists()
@@ -84,10 +81,7 @@ class ArtResizerFileSizeTest(CleanupModulesMixin, BeetsTestCase):
 
         # Attempt with lower initial quality
         im_75_qual = backend.resize(
-            225,
-            self.IMG_225x225,
-            quality=75,
-            max_filesize=0,
+            225, self.IMG_225x225, quality=75, max_filesize=0
         )
         assert Path(os.fsdecode(im_75_qual)).exists()
 

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -65,21 +65,17 @@ class ModelFixture1(LibModel):
     }
 
     _sorts: ClassVar[dict[str, type[sort.FieldSort]]] = {
-        "some_sort": SortFixture,
+        "some_sort": SortFixture
     }
     _indices = (Index("field_one_index", ("field_one",)),)
 
     @cached_classproperty
     def _types(cls):
-        return {
-            "some_float_field": dbcore.types.FLOAT,
-        }
+        return {"some_float_field": dbcore.types.FLOAT}
 
     @cached_classproperty
     def _queries(cls):
-        return {
-            "some_query": QueryFixture,
-        }
+        return {"some_query": QueryFixture}
 
     @classmethod
     def _getters(cls):
@@ -547,9 +543,7 @@ class ParseTest(unittest.TestCase):
 class QueryParseTest(unittest.TestCase):
     def pqp(self, part):
         return dbcore.queryparse.parse_query_part(
-            part,
-            {"year": query.NumericQuery},
-            {":": query.RegexpQuery},
+            part, {"year": query.NumericQuery}, {":": query.RegexpQuery}
         )[:-1]  # remove the negate flag
 
     def test_one_basic_term(self):
@@ -606,10 +600,7 @@ class QueryParseTest(unittest.TestCase):
 class QueryFromStringsTest(unittest.TestCase):
     def qfs(self, strings):
         return dbcore.queryparse.query_from_strings(
-            query.AndQuery,
-            ModelFixture1,
-            {":": query.RegexpQuery},
-            strings,
+            query.AndQuery, ModelFixture1, {":": query.RegexpQuery}, strings
         )
 
     def test_zero_parts(self):
@@ -640,10 +631,7 @@ class QueryFromStringsTest(unittest.TestCase):
 
 class SortFromStringsTest(unittest.TestCase):
     def sfs(self, strings):
-        return dbcore.queryparse.sort_from_strings(
-            ModelFixture1,
-            strings,
-        )
+        return dbcore.queryparse.sort_from_strings(ModelFixture1, strings)
 
     def test_zero_parts(self):
         s = self.sfs([])
@@ -676,10 +664,7 @@ class SortFromStringsTest(unittest.TestCase):
 
 class ParseSortedQueryTest(unittest.TestCase):
     def psq(self, parts):
-        return dbcore.parse_sorted_query(
-            ModelFixture1,
-            parts.split(),
-        )
+        return dbcore.parse_sorted_query(ModelFixture1, parts.split())
 
     def test_and_query(self):
         q, s = self.psq("foo bar")

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -335,10 +335,7 @@ class ImportSingletonTest(AutotagImportTestCase):
         single_path = os.path.join(self.import_dir, b"track_2.mp3")
 
         util.copy(resource_path, single_path)
-        import_files = [
-            os.path.join(self.import_dir, b"album"),
-            single_path,
-        ]
+        import_files = [os.path.join(self.import_dir, b"album"), single_path]
         self.setup_importer()
         self.importer.paths = import_files
 
@@ -390,8 +387,7 @@ class ImportSingletonTest(AutotagImportTestCase):
 
 
 @pytest.mark.skipif(
-    not has_program("ffprobe", ["-L"]),
-    "need ffprobe for format recognition",
+    not has_program("ffprobe", ["-L"]), "need ffprobe for format recognition"
 )
 class ImportFormatTest:
     """Test fix_extension during import."""
@@ -1200,10 +1196,7 @@ class ImportDuplicateAlbumThreadedTest(PluginMixin, ImportTestCase):
 
 def item_candidates_mock(*args, **kwargs):
     yield TrackInfo(
-        artist="artist",
-        title="title",
-        track_id="new trackid",
-        index=0,
+        artist="artist", title="title", track_id="new trackid", index=0
     )
 
 
@@ -1403,8 +1396,7 @@ class IncrementalImportTest(AsIsImporterMixin, ImportTestCase):
 
 def _mkmp3(path):
     shutil.copyfile(
-        syspath(os.path.join(_common.RSRC, b"min.mp3")),
-        syspath(path),
+        syspath(os.path.join(_common.RSRC, b"min.mp3")), syspath(path)
     )
 
 

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -129,11 +129,7 @@ class AddTest(BeetsTestCase):
         """Test library.add emits only one database_change event."""
         self.item = _common.item()
         self.item.path = beets.util.normpath(
-            os.path.join(
-                self.temp_dir,
-                b"a",
-                b"b.mp3",
-            )
+            os.path.join(self.temp_dir, b"a", b"b.mp3")
         )
         self.item.album = "a"
         self.item.title = "b"
@@ -925,21 +921,15 @@ class PluginDestinationTest(BeetsTestCase):
         self._assert_dest(b"the artist $foo")
 
     def test_plugin_value_not_substituted(self):
-        self._tv_map = {
-            "foo": "bar",
-        }
+        self._tv_map = {"foo": "bar"}
         self._assert_dest(b"the artist bar")
 
     def test_plugin_value_overrides_attribute(self):
-        self._tv_map = {
-            "artist": "bar",
-        }
+        self._tv_map = {"artist": "bar"}
         self._assert_dest(b"bar $foo")
 
     def test_plugin_value_sanitized(self):
-        self._tv_map = {
-            "foo": "bar/baz",
-        }
+        self._tv_map = {"foo": "bar/baz"}
         self._assert_dest(b"the artist bar_baz")
 
 

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -225,14 +225,8 @@ class ParseTest(unittest.TestCase):
 
 class EvalTest(unittest.TestCase):
     def _eval(self, template):
-        values = {
-            "foo": "bar",
-            "baz": "BaR",
-        }
-        functions = {
-            "lower": str.lower,
-            "len": len,
-        }
+        values = {"foo": "bar", "baz": "BaR"}
+        functions = {"lower": str.lower, "len": len}
         return functemplate.Template(template).substitute(values, functions)
 
     def test_plain_text(self):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -111,11 +111,7 @@ class UtilTest(unittest.TestCase):
         assert exc_info.value.cmd == "taga \xc3\xa9"
 
     def test_case_sensitive_default(self):
-        path = util.bytestring_path(
-            util.normpath(
-                "/this/path/does/not/exist",
-            )
-        )
+        path = util.bytestring_path(util.normpath("/this/path/does/not/exist"))
 
         assert util.case_sensitive(path) == (platform.system() != "Windows")
 

--- a/test/ui/commands/test_utils.py
+++ b/test/ui/commands/test_utils.py
@@ -15,8 +15,7 @@ class QueryTest(BeetsTestCase):
     def add_item(self, filename=b"srcfile", templatefile=b"full.mp3"):
         itempath = os.path.join(self.libdir, filename)
         shutil.copy(
-            syspath(os.path.join(_common.RSRC, templatefile)),
-            syspath(itempath),
+            syspath(os.path.join(_common.RSRC, templatefile)), syspath(itempath)
         )
         item = library.Item.from_path(itempath)
         self.lib.add(item)

--- a/test/util/test_config.py
+++ b/test/util/test_config.py
@@ -24,18 +24,8 @@ def test_sanitize_pairs():
             ("*", "*"),
             ("discard", "bye"),
         ],
-        [
-            ("foo", "bar"),
-            ("foo", "baz"),
-            ("foo", "foobar"),
-            ("key", "value"),
-        ],
-    ) == [
-        ("foo", "baz"),
-        ("foo", "bar"),
-        ("key", "value"),
-        ("foo", "foobar"),
-    ]
+        [("foo", "bar"), ("foo", "baz"), ("foo", "foobar"), ("key", "value")],
+    ) == [("foo", "baz"), ("foo", "bar"), ("key", "value"), ("foo", "foobar")]
 
 
 def test_sanitize_pairs_unknown_key():


### PR DESCRIPTION
This PR enables Ruff’s `skip-magic-trailing-comma` setting in the formatter configuration and applies formatting across the codebase.

Specifically:

* Enables `skip-magic-trailing-comma` in Ruff format settings
* Re-formats the codebase using `ruff format`

This aligns trailing comma usage with line length. As a result:

* Trailing commas are only preserved when they meaningfully support multiline formatting
* Single-line expressions are kept clean without unnecessary trailing commas
* Formatting becomes more consistent and deterministic across the project