### PR TITLE
Moved PytestPluginTestHelper class into test_helper.

### DIFF
--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -487,7 +487,24 @@ class PluginMixin(ConfigMixin):
 
 
 class PluginTestCase(PluginMixin, BeetsTestCase):
+    """
+    DEPRECATED: Use pytest + PytestPluginTestHelper instead.
+    """
+
     pass
+
+
+class PytestPluginTestHelper(PluginMixin, PytestTestHelper):
+    """Helper mixin for pytest-based plugin tests.
+
+    This mixin provides the standard beets test setup and automatically
+    initializes and tears down plugin state for each test.
+
+    .. code-block:: python
+
+        class TestMyPlugin(PytestPluginTestHelper):
+            plugin: ClassVar[str] = "myplugin"
+    """
 
 
 class ImportHelper(TestHelper):

--- a/test/plugins/test_embedart.py
+++ b/test/plugins/test_embedart.py
@@ -32,8 +32,7 @@ from beets.test.helper import (
     FetchImageHelper,
     ImportHelper,
     IOMixin,
-    PluginMixin,
-    TestHelper,
+    PytestPluginTestHelper,
 )
 from beets.util import bytestring_path, displayable_path, syspath
 from beets.util.artresizer import ArtResizer
@@ -76,18 +75,6 @@ def require_artresizer_compare(test):
 
     wrapper.__name__ = test.__name__
     return wrapper
-
-
-class PytestPluginTestHelper(PluginMixin, TestHelper):
-    """Same as the BeetsTestCase unittest setup but for pytest."""
-
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.setup_beets()
-        try:
-            yield
-        finally:
-            self.teardown_beets()
 
 
 class PytestImportHelper(PytestPluginTestHelper, ImportHelper):

--- a/test/plugins/test_hook.py
+++ b/test/plugins/test_hook.py
@@ -22,22 +22,10 @@ from typing import TYPE_CHECKING, ClassVar
 import pytest
 
 from beets import plugins
-from beets.test.helper import PluginMixin, TestHelper
+from beets.test.helper import PytestPluginTestHelper
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-
-
-class PytestPluginTestHelper(PluginMixin, TestHelper):
-    """Same as the BeetsTestCase unittest setup but for pytest."""
-
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.setup_beets()
-        try:
-            yield
-        finally:
-            self.teardown_beets()
 
 
 class HookTestCase(PytestPluginTestHelper):

--- a/test/plugins/test_mbsync.py
+++ b/test/plugins/test_mbsync.py
@@ -14,23 +14,9 @@
 
 from unittest.mock import Mock, patch
 
-import pytest
-
 from beets.autotag.hooks import AlbumInfo, TrackInfo
 from beets.library import Item
-from beets.test.helper import PluginMixin, TestHelper
-
-
-class PytestPluginTestHelper(PluginMixin, TestHelper):
-    """Same as the BeetsTestCase unittest setup but for pytest."""
-
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.setup_beets()
-        try:
-            yield
-        finally:
-            self.teardown_beets()
+from beets.test.helper import PytestPluginTestHelper
 
 
 class TestMbsyncCli(PytestPluginTestHelper):


### PR DESCRIPTION
This PR moved the `PytestPluginTestHelper` which was duplicated in quite a few test files into the `beets/test/helper.py` file.