### PR TITLE
fetchart: catch FilesystemError in _set_art instead of crashing

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -1510,7 +1510,16 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
     def _set_art(
         self, album: Album, candidate: Candidate, delete: bool = False
     ) -> None:
-        album.set_art(candidate.path, delete)
+        try:
+            album.set_art(candidate.path, delete)
+        except util.FilesystemError as exc:
+            self._log.warning(
+                "fetchart: could not save artwork for {0.albumartist} - "
+                "{0.album}: {1}",
+                album,
+                exc,
+            )
+            return
         if self.store_source:
             # store the source of the chosen artwork in a flexible field
             self._log.debug(


### PR DESCRIPTION
Fixes #6193

## Problem

When `fetchart` tries to save artwork and the destination file is locked by another process (e.g. foobar2000 on Windows), a `FilesystemError` propagates uncaught from `_set_art` → `album.set_art()` → `util.move()`, crashing the entire import pipeline with an unhelpful traceback.

## Fix

Wrap `album.set_art()` in a `try/except util.FilesystemError` block in `_set_art()`. On failure, log a `warning` with the album name and error message, then return early so the rest of the import continues.

This also covers the manual `beet fetchart` command path, which goes through the same `_set_art()` method.

## Behaviour change

Before: import crashes with an unhandled exception.
After: a warning is logged ("fetchart: could not save artwork for ...") and the import continues.