### PR TITLE
mbcollection: handle MB Unauthorized error

### DIFF
--- a/beetsplug/_utils/musicbrainz.py
+++ b/beetsplug/_utils/musicbrainz.py
@@ -14,15 +14,24 @@ import operator
 import re
 from dataclasses import dataclass, field
 from functools import cached_property, singledispatchmethod, wraps
+from http import HTTPStatus
 from itertools import groupby, starmap
-from typing import TYPE_CHECKING, Any, Literal, ParamSpec, TypedDict, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Literal,
+    ParamSpec,
+    TypedDict,
+    TypeVar,
+)
 
 from requests_ratelimiter import LimiterMixin
 from typing_extensions import NotRequired, Unpack
 
 from beets import config, logging
 
-from .requests import RequestHandler, TimeoutAndRetrySession
+from .requests import BeetsHTTPError, RequestHandler, TimeoutAndRetrySession
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -539,6 +548,19 @@ def require_one_of(*keys: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
     return deco
 
 
+class UnauthorizedMBError(BeetsHTTPError):
+    """Raised when the MusicBrainz API returns a 401 Unauthorized response."""
+
+    STATUS = HTTPStatus.UNAUTHORIZED
+
+    def __init__(self, *args, message: str | None = None, **kwargs) -> None:
+        message = (
+            f"HTTP Error: {self.STATUS.value} {self.STATUS.phrase}."
+            " Check your musicbrainz.user and musicbrainz.pass configuration"
+        )
+        super().__init__(*args, message=message, **kwargs)
+
+
 @dataclass
 class MusicBrainzAPI(RequestHandler):
     """High-level interface to the MusicBrainz WS/2 API.
@@ -552,6 +574,11 @@ class MusicBrainzAPI(RequestHandler):
 
     Documentation: https://musicbrainz.org/doc/MusicBrainz_API
     """
+
+    explicit_http_errors: ClassVar[list[type[BeetsHTTPError]]] = [
+        *RequestHandler.explicit_http_errors,
+        UnauthorizedMBError,
+    ]
 
     api_host: str = field(init=False)
     rate_limit: float = field(init=False)

--- a/beetsplug/_utils/requests.py
+++ b/beetsplug/_utils/requests.py
@@ -21,12 +21,11 @@ if TYPE_CHECKING:
 class BeetsHTTPError(requests.exceptions.HTTPError):
     STATUS: ClassVar[HTTPStatus]
 
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(
-            f"HTTP Error: {self.STATUS.value} {self.STATUS.phrase}",
-            *args,
-            **kwargs,
-        )
+    def __init__(self, *args, message: str | None = None, **kwargs) -> None:
+        if not message:
+            message = f"HTTP Error: {self.STATUS.value} {self.STATUS.phrase}"
+
+        super().__init__(message, *args, **kwargs)
 
 
 class HTTPNotFoundError(BeetsHTTPError):

--- a/beetsplug/mbcollection.py
+++ b/beetsplug/mbcollection.py
@@ -28,6 +28,7 @@ from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand
 
 from ._utils.musicbrainz import MusicBrainzAPI
+from ._utils.requests import BeetsHTTPError
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -212,17 +213,24 @@ class MusicBrainzCollectionPlugin(BeetsPlugin):
         self, lib: Library, albums: Iterable[Album], remove_missing: bool
     ) -> None:
         """Update the MusicBrainz collection from a list of Beets albums"""
-        collection = self.collection
+        try:
+            collection = self.collection
 
-        # Get a list of all the album IDs.
-        album_ids = [id_ for a in albums if UUID_PAT.match(id_ := a.mb_albumid)]
+            # Get a list of all the album IDs.
+            album_ids = [
+                id_ for a in albums if UUID_PAT.match(id_ := a.mb_albumid)
+            ]
 
-        # Submit to MusicBrainz.
-        self._log.info("Updating MusicBrainz collection {}...", collection.id)
-        collection.add_releases(album_ids)
-        if remove_missing:
-            lib_ids = {x.mb_albumid for x in lib.albums()}
-            albums_in_collection = {r["id"] for r in collection.releases}
-            collection.remove_releases(list(albums_in_collection - lib_ids))
+            # Submit to MusicBrainz.
+            self._log.info(
+                "Updating MusicBrainz collection {}...", collection.id
+            )
+            collection.add_releases(album_ids)
+            if remove_missing:
+                lib_ids = {x.mb_albumid for x in lib.albums()}
+                albums_in_collection = {r["id"] for r in collection.releases}
+                collection.remove_releases(list(albums_in_collection - lib_ids))
 
-        self._log.info("...MusicBrainz collection updated.")
+            self._log.info("...MusicBrainz collection updated.")
+        except BeetsHTTPError as exc:
+            self._log.error("Failed to update MusicBrainz collection: {}", exc)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -51,6 +51,10 @@ Bug fixes
 - ``ReadError`` and ``WriteError`` now include the file path and the underlying
   reason in their message instead of a ``<super: ...>`` object representation.
   :bug:`6560`
+- :doc:`plugins/mbcollection`: Handle MusicBrainz ``401 Unauthorized`` errors
+  during ``mbupdate`` without crashing, and log a clearer message that points
+  users to ``musicbrainz.user`` and ``musicbrainz.pass`` configuration.
+  :bug:`6651`
 
 ..
     For plugin developers

--- a/test/plugins/test_mbcollection.py
+++ b/test/plugins/test_mbcollection.py
@@ -3,6 +3,7 @@ import uuid
 from contextlib import nullcontext as does_not_raise
 
 import pytest
+import requests
 
 from beets.library import Album
 from beets.test.helper import PluginMixin, TestHelper
@@ -140,3 +141,23 @@ class TestMbCollectionPlugin(PluginMixin, TestHelper):
         helper.run_command("mbupdate", "--remove")
 
         assert requests_mock.call_count == 6
+
+    def test_mbupdate_logs_unauthorized_errors(
+        self, helper, requests_mock, caplog
+    ):
+        response = requests.Response()
+        response.status_code = 401
+        requests_mock.get(
+            "/ws/2/collection",
+            exc=requests.exceptions.HTTPError(response=response),
+        )
+
+        with caplog.at_level("ERROR", logger="beets.mbcollection"):
+            helper.run_command("mbupdate")
+
+        expected_message = (
+            "Failed to update MusicBrainz collection: HTTP Error: 401"
+            " Unauthorized. Check your musicbrainz.user and musicbrainz.pass"
+            " configuration"
+        )
+        assert expected_message in caplog.text


### PR DESCRIPTION
### PR Summary

This change makes `mbupdate` fail gracefully when MusicBrainz returns `401 Unauthorized`.

#### High-level impact
- Adds a MusicBrainz-specific HTTP error, `UnauthorizedMBError`, on top of the shared `BeetsHTTPError` request layer.
- Registers that error in `MusicBrainzAPI`, so authentication failures are translated into a clearer domain-specific exception.
- Updates `beetsplug/mbcollection.py` to catch `BeetsHTTPError` during collection sync and log a user-friendly error instead of crashing.
- Adds a regression test covering the unauthorized case and documents the behavior in `docs/changelog.rst`.

#### Architectural effect
- Keeps HTTP-to-domain error mapping centralized in `beetsplug/_utils/musicbrainz.py` and `beetsplug/_utils/requests.py`.
- Keeps `mbcollection` focused on sync flow and error handling, rather than raw HTTP details.
- Improves resilience of the `mbcollection` plugin without changing the normal successful update path.

Fixes #6651
