### PR TITLE
fetchart: catch OSError in _set_art for graceful permission error handling

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -1498,8 +1498,20 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
 
     def _set_art(
         self, album: Album, candidate: Candidate, delete: bool = False
-    ) -> None:
-        album.set_art(candidate.path, delete)
+    ) -> bool:
+        """Set album art from candidate. Returns True on success, False on
+        failure (e.g. permission errors when writing the art file).
+        """
+        try:
+            album.set_art(candidate.path, delete)
+        except OSError as exc:
+            self._log.warning(
+                "fetchart: could not write art for {0.albumartist} - "
+                "{0.album}: {1}",
+                album,
+                exc,
+            )
+            return False
         if self.store_source:
             # store the source of the chosen artwork in a flexible field
             self._log.debug(
@@ -1507,6 +1519,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             )
             album.art_source = candidate.source_name
         album.store()
+        return True
 
     # Synchronous; after music files are put in place.
     def assign_art(self, session: ImportSession, task: ImportTask):
@@ -1615,8 +1628,12 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
 
                 candidate = self.art_for_album(album, local_paths)
                 if candidate:
-                    self._set_art(album, candidate)
-                    message = colorize("text_success", "found album art")
+                    if self._set_art(album, candidate):
+                        message = colorize("text_success", "found album art")
+                    else:
+                        message = colorize(
+                            "text_error", "error writing album art"
+                        )
                 else:
                     message = colorize("text_error", "no art found")
                 ui.print_(f"{album}: {message}")

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -59,6 +59,9 @@ Bug fixes
   during ``mbupdate`` without crashing, and log a clearer message that points
   users to ``musicbrainz.user`` and ``musicbrainz.pass`` configuration.
   :bug:`6651`
+- :doc:`plugins/fetchart`: Catch ``OSError`` in ``_set_art`` so that permission
+  errors (e.g. a file locked by another process) are logged as warnings instead
+  of crashing beets. :bug:`6193`
 
 ..
     For plugin developers

--- a/test/plugins/test_fetchart.py
+++ b/test/plugins/test_fetchart.py
@@ -16,6 +16,7 @@
 import ctypes
 import os
 import sys
+from unittest import mock
 
 from beets import util
 from beets.test.helper import IOMixin, PluginTestCase
@@ -118,6 +119,20 @@ class FetchartCliTest(IOMixin, PluginTestCase):
         self.config["ui"]["color"] = True
         out = self.run_with_output("fetchart")
         assert " - the älbum: \x1b[1;31mno art found\x1b[39;49;00m\n" == out
+
+    def test_set_art_oserror_is_handled_gracefully(self):
+        """OSError (e.g. PermissionError) in set_art is logged as a warning,
+        not an unhandled crash. Regression test for #6193.
+        """
+        self.touch(b"c\xc3\xb6ver.jpg", dir=self.album.path, content="IMAGE")
+        with mock.patch(
+            "beets.library.Album.set_art",
+            side_effect=PermissionError("[WinError 32] file in use"),
+        ):
+            out = self.run_with_output("fetchart")
+        self.album.load()
+        assert "error writing album art" in out
+        assert self.album["artpath"] is None
 
     def test_sources_is_a_string(self):
         self.config["fetchart"].set({"sources": "filesystem"})


### PR DESCRIPTION
﻿## Problem

When fetchart moves album art to the destination folder, a `PermissionError`
(or other `OSError`) can crash beets with an unhandled traceback. This happens
when a file is locked by another process, such as foobar2000 scanning the folder
during import.

Example traceback from #6193:

`PermissionError: [WinError 32] The process cannot access the file because it is being used by another process`

## Fix

Wrap `album.set_art()` in a `try/except OSError` block inside `_set_art`.
On failure, log a warning and return `False` instead of crashing. The
`batch_fetch_art` CLI path now checks the return value and reports
`"error writing album art"` instead of a traceback.

## Changes

- `beetsplug/fetchart.py`: `_set_art` now returns `bool`; catches `OSError` with a warning log
- `test/plugins/test_fetchart.py`: new test `test_set_art_oserror_is_handled_gracefully` verifies graceful handling when `Album.set_art` raises `PermissionError`
- `docs/changelog.rst`: bug fix entry added

Fixes #6193
