### PR TITLE
Refactor queryparse

### DIFF
--- a/beets/dbcore/__init__.py
+++ b/beets/dbcore/__init__.py
@@ -12,6 +12,7 @@ from .query import (
     Query,
 )
 from .queryparse import (
+    ModelQuery,
     parse_sorted_query,
     query_from_strings,
     sort_from_strings,
@@ -26,6 +27,7 @@ __all__ = [
     "InvalidQueryError",
     "MatchQuery",
     "Model",
+    "ModelQuery",
     "OrQuery",
     "Query",
     "Results",

--- a/beets/dbcore/__init__.py
+++ b/beets/dbcore/__init__.py
@@ -2,6 +2,8 @@
 Library.
 """
 
+from beets.util.deprecation import deprecate_for_maintainers, deprecate_imports
+
 from .db import Database, Index, Model, Results
 from .query import (
     AndQuery,
@@ -13,11 +15,22 @@ from .query import (
 )
 from .queryparse import (
     ModelQuery,
+    build_and_query,
     parse_sorted_query,
-    query_from_strings,
     sort_from_strings,
 )
 from .types import Type
+
+
+def __getattr__(name: str):
+    if name == "query_from_strings":
+        deprecate_for_maintainers(
+            f"'beets.dbcore.{name}'", "'beets.dbcore.build_and_query'"
+        )
+        return build_and_query
+
+    return deprecate_imports(__name__, {}, name)
+
 
 __all__ = [
     "AndQuery",
@@ -32,7 +45,7 @@ __all__ = [
     "Query",
     "Results",
     "Type",
+    "build_and_query",
     "parse_sorted_query",
-    "query_from_strings",
     "sort_from_strings",
 ]

--- a/beets/dbcore/__init__.py
+++ b/beets/dbcore/__init__.py
@@ -13,21 +13,24 @@ from .query import (
     OrQuery,
     Query,
 )
-from .queryparse import (
-    ModelQuery,
-    build_and_query,
-    parse_sorted_query,
-    sort_from_strings,
-)
+from .queryparse import ModelQuery
 from .types import Type
+
+_NEW_METHOD_BY_OLD_METHOD_NAME = {
+    "query_from_strings": ModelQuery.build_and_query,
+    "sort_from_strings": ModelQuery.get_sort,
+    "parse_sorted_query": ModelQuery.parse,
+}
 
 
 def __getattr__(name: str):
-    if name == "query_from_strings":
-        deprecate_for_maintainers(
-            f"'beets.dbcore.{name}'", "'beets.dbcore.build_and_query'"
-        )
-        return build_and_query
+    for old_method_name, new_method in _NEW_METHOD_BY_OLD_METHOD_NAME.items():
+        if name == old_method_name:
+            deprecate_for_maintainers(
+                f"'beets.dbcore.{name}'",
+                f"'beets.dbcore.{new_method.__qualname__}'",
+            )
+            return new_method
 
     return deprecate_imports(__name__, {}, name)
 
@@ -45,7 +48,4 @@ __all__ = [
     "Query",
     "Results",
     "Type",
-    "build_and_query",
-    "parse_sorted_query",
-    "sort_from_strings",
 ]

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -1373,7 +1373,7 @@ class Database:
 
     # Querying.
 
-    def _fetch(
+    def get_results(
         self,
         model_cls: type[AnyModel],
         query: Query | None = None,
@@ -1433,7 +1433,7 @@ class Database:
 
     def _get(self, model_cls: type[AnyModel], id_: int) -> AnyModel | None:
         """Get a Model object by its id or None if the id does not exist."""
-        return self._fetch(model_cls, MatchQuery("id", id_)).get()
+        return self.get_results(model_cls, MatchQuery("id", id_)).get()
 
 
 class Index(NamedTuple):

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
     from sqlite3 import Connection
     from types import TracebackType
 
-    from .query import FieldQueryType, Query, SQLiteType
+    from .query import Query, QueryByField, SQLiteType
     from .sort import FieldSort, Sort
 
 D = TypeVar("D", bound="Database", default=Any)
@@ -276,7 +276,7 @@ class Model(ABC, Generic[D]):
     """
 
     @cached_classproperty
-    def _queries(cls) -> dict[str, FieldQueryType]:
+    def _queries(cls) -> QueryByField:
         """Named queries that use a field-like `name:value` syntax but which
         do not relate to any specific field.
         """

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -101,6 +101,9 @@ class Query(ABC):
     def __and__(self, other: Query) -> AndQuery:
         return AndQuery([self, other])
 
+    def __or__(self, other: Query) -> OrQuery:
+        return OrQuery([self, other])
+
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}()"
 
@@ -629,6 +632,14 @@ class MutableCollectionQuery(CollectionQuery):
 class AndQuery(MutableCollectionQuery):
     """A conjunction of a list of other queries."""
 
+    def __and__(self, other: Query) -> AndQuery:
+        if isinstance(other, AndQuery):
+            self.subqueries.extend(other.subqueries)
+        else:
+            self.subqueries.append(other)
+
+        return self
+
     def clause(self) -> tuple[str | None, Sequence[SQLiteType]]:
         return self.clause_with_joiner("and")
 
@@ -638,6 +649,14 @@ class AndQuery(MutableCollectionQuery):
 
 class OrQuery(MutableCollectionQuery):
     """A conjunction of a list of other queries."""
+
+    def __or__(self, other: Query) -> OrQuery:
+        if isinstance(other, OrQuery):
+            self.subqueries.extend(other.subqueries)
+        else:
+            self.subqueries.append(other)
+
+        return self
 
     def clause(self) -> tuple[str | None, Sequence[SQLiteType]]:
         return self.clause_with_joiner("or")

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -6,7 +6,7 @@ import os
 import re
 import unicodedata
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
+from collections.abc import MutableMapping, Sequence
 from datetime import datetime, timedelta
 from functools import cached_property, reduce
 from operator import mul, or_
@@ -114,7 +114,7 @@ class Query(ABC):
 
 SQLiteType = str | bytes | float | int | memoryview | None
 AnySQLiteType = TypeVar("AnySQLiteType", bound=SQLiteType)
-FieldQueryType = type["FieldQuery"]
+QueryByField = MutableMapping[str, type["FieldQuery"]]
 
 
 class FieldQuery(Query, Generic[P]):

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -13,7 +13,11 @@ from operator import mul, or_
 from re import Pattern
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
 
+from typing_extensions import Self
+
 from beets import context, util
+from beets.dbcore.pathutils import normalize_path_for_db
+from beets.util.deprecation import maybe_replace_legacy_field
 from beets.util.units import raw_seconds_short
 
 from . import pathutils
@@ -125,6 +129,36 @@ class FieldQuery(Query, Generic[P]):
     same matching functionality in SQLite.
     """
 
+    @classmethod
+    def normalize_pattern(
+        cls, model_cls: type[Model], field: str, pattern: P
+    ) -> P:
+        """Normalize the pattern for this query.
+
+        By default, this does nothing, but subclasses can override it to perform
+        normalization on the pattern before it's used for matching.
+        """
+        return pattern
+
+    @classmethod
+    def from_model(
+        cls, model_cls: type[Model], field_name: str, pattern: P
+    ) -> Self:
+        field = maybe_replace_legacy_field(
+            field_name, model_cls.__name__ == "Album"
+        )
+
+        fast = field in model_cls.all_db_fields
+        if field in model_cls.shared_db_fields:
+            # This field exists in both tables, so SQLite will encounter
+            # an OperationalError if we try to use it in a query.
+            # Using an explicit table name resolves this.
+            field = f"{model_cls._table}.{field}"
+
+        return cls(
+            field, cls.normalize_pattern(model_cls, field, pattern), fast
+        )
+
     @property
     def field(self) -> str:
         return (
@@ -208,6 +242,21 @@ class StringFieldQuery(FieldQuery[P]):
     """A FieldQuery that converts values to strings before matching
     them.
     """
+
+    @classmethod
+    def normalize_pattern(  # type: ignore[override]
+        cls, model_cls: type[Model], field: str, pattern: str
+    ) -> str:
+        """Strip the library prefix to match the stored relative path."""
+        if model_cls._type(field).query is PathQuery:
+            bytes_pattern = normalize_path_for_db(util.bytestring_path(pattern))
+            # do not remove escape chars (`\`) from the pattern, since they are
+            # used for escaping in the SQL query regex
+            if cls is not RegexpQuery:
+                bytes_pattern = util.path_as_posix(bytes_pattern)
+            return os.fsdecode(bytes_pattern)
+
+        return pattern
 
     @classmethod
     def value_match(cls, pattern: P, value: Any):

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import itertools
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 from beets import plugins
 
@@ -171,43 +171,71 @@ def query_from_strings(
     return query_cls(subqueries)
 
 
-def construct_sort_part(model_cls: type[LibModel], part: str) -> sort.FieldSort:
-    """Create a `Sort` from a single string criterion.
+class SortTerm(NamedTuple):
+    """Represents a parsed sort specification with field name and direction."""
 
-    `model_cls` is the `Model` being queried. `part` is a single string
-    ending in ``+`` or ``-`` indicating the sort.
-    """
-    assert part, "part must be a field name and + or -"
-    field = part[:-1]
-    assert field, "field is missing"
-    direction = part[-1]
-    assert direction in ("+", "-"), "part must end with + or -"
-    is_ascending = direction == "+"
+    field: str
+    ascending: bool
 
-    if sort_cls := model_cls._sorts.get(field):
-        if isinstance(sort_cls, sort.SmartArtistSort):
-            field = "albumartist" if model_cls.__name__ == "Album" else "artist"
-    elif field in model_cls._fields:
-        sort_cls = sort.FixedFieldSort
-    else:
-        # Flexible or computed.
-        sort_cls = sort.SlowFieldSort
+    @staticmethod
+    def check_valid(part: str) -> bool:
+        return len(part) > 1 and part.endswith(("+", "-")) and ":" not in part
 
-    return sort_cls(field, is_ascending)
+    @classmethod
+    def make(cls, part: str) -> SortTerm:
+        """Parse a sort specification string into a SortPart instance.
+
+        Recognizes field names suffixed with '+' for ascending or '-' for
+        descending order. Rejects strings containing colons to avoid conflicts
+        with other query syntax.
+        """
+        return cls(part[:-1], part[-1] == "+")
+
+    def get_sort(self, model_cls: type[LibModel]) -> sort.FieldSort:
+        """Create an appropriate FieldSort instance for the target model.
+
+        Selects the optimal sort implementation based on field availability
+        and type, handling special cases like smart artist sorting that maps
+        to different fields depending on the model.
+        """
+        field = self.field
+        if sort_cls := model_cls._sorts.get(field):
+            if sort_cls is sort.SmartArtistSort:
+                field = (
+                    "albumartist" if model_cls.__name__ == "Album" else "artist"
+                )
+        elif field in model_cls._fields:
+            sort_cls = sort.FixedFieldSort
+        else:
+            # Flexible or computed.
+            sort_cls = sort.SlowFieldSort
+
+        return sort_cls(field, self.ascending)
 
 
 def sort_from_strings(
     model_cls: type[LibModel], sort_parts: Sequence[str]
 ) -> sort.Sort:
-    """Create a `Sort` from a list of sort criteria (strings)."""
+    """Construct a Sort object from a sequence of sort field strings.
+
+    Interpret, validate, and translate user-provided sort field strings into
+    a composite sort order for querying the database. It supports multi-field
+    sorting by combining individual sort terms, and ensures that only valid
+    fields are included in the resulting sort.
+
+    The main purpose is to provide a flexible way to specify sorting criteria
+    (such as from command-line arguments or configuration) and convert them
+    into a form that the query engine can use to order results.
+
+    If no valid sort fields are provided, a default "no sort" object is returned.
+    """
     if not sort_parts:
         return sort.NullSort()
-    if len(sort_parts) == 1:
-        return construct_sort_part(model_cls, sort_parts[0])
-    s = sort.MultipleSort()
-    for part in sort_parts:
-        s.add_sort(construct_sort_part(model_cls, part))
-    return s
+
+    terms = map(SortTerm.make, filter(SortTerm.check_valid, sort_parts))
+    sorts = [p.get_sort(model_cls) for p in terms]
+
+    return sort.MultipleSort(sorts) if len(sorts) > 1 else sorts[0]
 
 
 def parse_sorted_query(
@@ -235,13 +263,10 @@ def parse_sorted_query(
                 query_from_strings(query.AndQuery, model_cls, subquery_parts)
             )
             del subquery_parts[:]
+        elif SortTerm.check_valid(part):
+            sort_parts.append(part)
         else:
-            # Sort parts (1) end in + or -, (2) don't have a field, and
-            # (3) consist of more than just the + or -.
-            if part.endswith(("+", "-")) and ":" not in part and len(part) > 1:
-                sort_parts.append(part)
-            else:
-                subquery_parts.append(part)
+            subquery_parts.append(part)
 
     # Avoid needlessly wrapping single statements in an OR
     q = query.OrQuery(query_parts) if len(query_parts) > 1 else query_parts[0]

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -7,6 +7,7 @@ import re
 import shlex
 from dataclasses import dataclass
 from functools import partial, reduce
+from itertools import groupby
 from typing import TYPE_CHECKING, NamedTuple
 
 from typing_extensions import Self
@@ -17,7 +18,7 @@ from beets.util import cached_classproperty
 from . import query, sort
 
 if TYPE_CHECKING:
-    from collections.abc import Collection, Sequence
+    from collections.abc import Iterable, Sequence
 
     from beets.library.models import LibModel
 
@@ -139,7 +140,7 @@ class QueryTerm:
 
 # TYPING ERROR
 def build_and_query(
-    model_cls: type[LibModel], query_parts: Collection[str]
+    model_cls: type[LibModel], query_parts: Iterable[str]
 ) -> query.Query:
     """Build a query by combining search terms with a logical AND."""
     if not query_parts:
@@ -221,31 +222,21 @@ def parse_sorted_query(
     """Given a list of strings, create the `Query` and `Sort` that they
     represent.
     """
-    # Separate query token and sort token.
-    query_parts = []
-    sort_parts = []
+    sort_parts = [p for p in parts if SortTerm.check_valid(p)]
+    query_parts = [p for p in parts if not SortTerm.check_valid(p)]
 
-    # Split up query in to comma-separated subqueries, each representing
-    # an AndQuery, which need to be joined together in one OrQuery
-    subquery_parts = []
-    for part in [*parts, ","]:
-        if part.endswith(","):
-            # Ensure we can catch "foo, bar" as well as "foo , bar"
-            last_subquery_part = part[:-1]
-            if last_subquery_part:
-                subquery_parts.append(last_subquery_part)
-            # Parse the subquery in to a single Query
-            query_parts.append(build_and_query(model_cls, subquery_parts))
-            del subquery_parts[:]
-        elif SortTerm.check_valid(part):
-            sort_parts.append(part)
-        else:
-            subquery_parts.append(part)
+    queries = [
+        build_and_query(model_cls, g)
+        for k, g in groupby(query_parts, lambda p: p == ",")
+        if not k
+    ]
+    if not queries or "," in {query_parts[0], query_parts[-1]}:
+        queries.append(query.TrueQuery())
 
-    # Avoid needlessly wrapping single statements in an OR
-    q = query.OrQuery(query_parts) if len(query_parts) > 1 else query_parts[0]
-    s = sort_from_strings(model_cls, sort_parts)
-    return q, s
+    return (
+        reduce(operator.or_, queries),
+        sort_from_strings(model_cls, sort_parts),
+    )
 
 
 class ModelQuery(NamedTuple):

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-import itertools
 import re
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, NamedTuple
 
 from beets import plugins
+from beets.util import cached_classproperty
 
 from . import query, sort
 
@@ -28,81 +29,82 @@ PARSE_QUERY_PART_REGEX = re.compile(
 )
 
 
-def get_prefixes() -> dict[str, query.FieldQueryType]:
-    """Get query types and their prefix characters."""
-    return {
-        ":": query.RegexpQuery,
-        "=~": query.StringQuery,
-        "=": query.MatchQuery,
-        **plugins.queries(),
-    }
+@dataclass
+class QueryTerm:
+    """Represents a parsed query component with field, operator, and pattern.
 
-
-def parse_query_part(
-    part: str,
-    query_classes: dict[str, query.FieldQueryType] = {},
-    default_class: type[query.SubstringQuery] = query.SubstringQuery,
-) -> tuple[str | None, str, query.FieldQueryType, bool]:
-    """Parse a single *query part*, which is a chunk of a complete query
-    string representing a single criterion.
-
-    A query part is a string consisting of:
-    - A *pattern*: the value to look for.
-    - Optionally, a *field name* preceding the pattern, separated by a
-      colon. So in `foo:bar`, `foo` is the field name and `bar` is the
-      pattern.
-    - Optionally, a *query prefix* just before the pattern (and after the
-      optional colon) indicating the type of query that should be used. For
-      example, in `~foo`, `~` might be a prefix.
-    - Optionally, a negation indicator, `-` or `^`, at the very beginning.
-
-    Both prefixes and the separating `:` character may be escaped with a
-    backslash to avoid their normal meaning.
-
-    The function returns a tuple consisting of:
-    - The field name: a string or None if it's not present.
-    - The pattern, a string.
-    - The query class to use, which inherits from the base
-      :class:`Query` type.
-    - A negation flag, a bool.
-
-    The two optional parameters determine which query class is used (i.e.,
-    the third return value). They are:
-    - `query_classes`, which maps field names to query classes. These
-      are used when no explicit prefix is present.
-    - `default_class`, the fallback when neither the field nor a prefix
-      indicates a query class.
-
-    So the precedence for determining which query class to return is:
-    prefix, followed by field, and finally the default.
-
-    For example, assuming the `:` prefix is used for `RegexpQuery`:
-    - `'stapler'` -> `(None, 'stapler', SubstringQuery, False)`
-    - `'color:red'` -> `('color', 'red', SubstringQuery, False)`
-    - `':^Quiet'` -> `(None, '^Quiet', RegexpQuery, False)`, because
-      the `^` follows the `:`
-    - `'color::b..e'` -> `('color', 'b..e', RegexpQuery, False)`
-    - `'-color:red'` -> `('color', 'red', SubstringQuery, True)`
+    Encapsulates the structure of database query terms, handling negation,
+    field-specific queries, and operator prefixes. Provides the foundation
+    for converting user input into executable database queries.
     """
-    # Apply the regular expression and extract the components.
-    part = part.strip()
-    match = PARSE_QUERY_PART_REGEX.match(part)
 
-    assert match  # Regex should always match
-    negate = bool(match.group(1))
-    key = match.group(2)
-    term = match.group(3).replace("\\:", ":")
+    negate: bool
+    field: str | None
+    prefix: str | None
+    pattern: str
 
-    # Check whether there's a prefix in the query and use the
-    # corresponding query type.
-    for pre, query_class in get_prefixes().items():
-        if term.startswith(pre):
-            return key, term[len(pre) :], query_class, negate
+    @cached_classproperty
+    def query_by_prefix(cls) -> dict[str, query.FieldQueryType]:
+        """Map operator prefixes to their corresponding query class types."""
+        return {
+            ":": query.RegexpQuery,
+            "=~": query.StringQuery,
+            "=": query.MatchQuery,
+            **plugins.queries(),
+        }
 
-    # No matching prefix, so use either the query class determined by
-    # the field or the default as a fallback.
-    query_class = query_classes.get(key, default_class)
-    return key, term, query_class, negate
+    @cached_classproperty
+    def prefix_query_regex(cls) -> re.Pattern[str]:
+        """Compile regex pattern for parsing query syntax components."""
+        return re.compile(
+            rf"""
+    (?P<negate>[-^])?   # Optional negation
+    (                   # Optional field
+        (?P<field>[^:]+?)
+        (?<!\\):        # Needs to end with an unescaped colon
+    )?
+    (                   # Optional prefix
+        (?<!\\)         # Not escaped
+        (?P<prefix>{"|".join(map(re.escape, cls.query_by_prefix))})
+    )?
+    (?P<pattern>.*)     # The query term
+        """,
+            re.I + re.VERBOSE,
+        )
+
+    @classmethod
+    def make(cls, part: str) -> QueryTerm:
+        """Parse a query string into structured query term components."""
+        if query.PathQuery.is_path_query(part):
+            part = f"path:{part}"
+
+        if m := cls.prefix_query_regex.match(part):
+            data = m.groupdict()
+            return cls(
+                negate=bool(data["negate"]),
+                field=data["field"],
+                prefix=data["prefix"],
+                pattern=data["pattern"].replace(r"\:", ":"),
+            )
+
+        raise query.InvalidQueryError(part, "Unrecognised query format")
+
+    def get_query_cls(self, model_cls: type[LibModel]) -> query.FieldQueryType:
+        """Determine the most appropriate query class for filtering this field.
+
+        Resolves query type by checking prefix-specific queries first, then
+        field-specific queries, falling back to substring matching as default.
+        """
+        all_fields = model_cls._fields | model_cls._types
+        model_queries = {
+            **{k: v.query for k, v in all_fields.items()},
+            **model_cls._queries,
+        }
+        return (
+            self.query_by_prefix.get(self.prefix or "")
+            or model_queries.get(self.field)  # type: ignore[arg-type]
+            or query.SubstringQuery
+        )
 
 
 def construct_query_part(
@@ -124,31 +126,21 @@ def construct_query_part(
 
     out_query: query.Query
 
-    # Use `model_cls` to build up a map from field (or query) names to
-    # `Query` classes.
-    query_classes: dict[str, query.FieldQueryType] = {}
-    for k, t in itertools.chain(
-        model_cls._fields.items(), model_cls._types.items()
-    ):
-        query_classes[k] = t.query
-    query_classes.update(model_cls._queries)  # Non-field queries.
-
-    # Parse the string.
-    key, pattern, query_class, negate = parse_query_part(
-        query_part, query_classes
-    )
-
-    if key is None:
+    term = QueryTerm.make(query_part)
+    query_class = term.get_query_cls(model_cls)
+    if not term.field:
         # If there's no key (field name) specified, this is a "match anything"
         # query.
-        out_query = model_cls.any_field_query(pattern, query_class)
+        out_query = model_cls.any_field_query(term.pattern, query_class)
     else:
         # Field queries get constructed according to the name of the field
         # they are querying.
-        out_query = model_cls.field_query(key.lower(), pattern, query_class)
+        out_query = model_cls.field_query(
+            term.field.lower(), term.pattern, query_class
+        )
 
     # Apply negation.
-    if negate:
+    if term.negate:
         return query.NotQuery(out_query)
     return out_query
 

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -147,12 +147,10 @@ def query_from_strings(
     strings in the format used by parse_query_part. `model_cls`
     determines how queries are constructed from strings.
     """
-    subqueries = []
-    for part in query_parts:
-        subqueries.append(QueryTerm.make(part).get_query(model_cls))
-    if not subqueries:  # No terms in query.
-        subqueries = [query.TrueQuery()]
-    return query_cls(subqueries)
+    if not query_parts:
+        return query.TrueQuery()
+    subqueries = [QueryTerm.make(p).get_query(model_cls) for p in query_parts]
+    return query_cls(subqueries) if len(subqueries) > 1 else subqueries[0]
 
 
 class SortTerm(NamedTuple):
@@ -241,8 +239,7 @@ def parse_sorted_query(
             last_subquery_part = part[:-1]
             if last_subquery_part:
                 subquery_parts.append(last_subquery_part)
-            # Parse the subquery in to a single AndQuery
-            # TODO: Avoid needlessly wrapping AndQueries containing 1 subquery?
+            # Parse the subquery in to a single Query
             query_parts.append(
                 query_from_strings(query.AndQuery, model_cls, subquery_parts)
             )

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import re
+import shlex
 from dataclasses import dataclass
+from functools import partial
 from typing import TYPE_CHECKING, NamedTuple
 
-from beets import plugins
+from typing_extensions import Self
+
+from beets import logging, plugins
 from beets.util import cached_classproperty
 
 from . import query, sort
@@ -14,7 +18,7 @@ from . import query, sort
 if TYPE_CHECKING:
     from collections.abc import Collection, Sequence
 
-    from ..library import LibModel
+    from beets.library.models import LibModel
 
 
 PARSE_QUERY_PART_REGEX = re.compile(
@@ -27,6 +31,9 @@ PARSE_QUERY_PART_REGEX = re.compile(
     r"(.*)",  # The term itself.
     re.I,  # Case-insensitive.
 )
+
+log = logging.getLogger(__name__)
+escape_commas = partial(re.compile(r"(?<=\S),(?=\S)").sub, r"\,")
 
 
 @dataclass
@@ -231,7 +238,7 @@ def sort_from_strings(
 
 
 def parse_sorted_query(
-    model_cls: type[LibModel], parts: list[str]
+    model_cls: type[LibModel], parts: Sequence[str]
 ) -> tuple[query.Query, sort.Sort]:
     """Given a list of strings, create the `Query` and `Sort` that they
     represent.
@@ -264,3 +271,53 @@ def parse_sorted_query(
     q = query.OrQuery(query_parts) if len(query_parts) > 1 else query_parts[0]
     s = sort_from_strings(model_cls, sort_parts)
     return q, s
+
+
+class ModelQuery(NamedTuple):
+    """Parses a user-provided string into a query and a sort order.
+
+    The query string can contain both search terms and sorting directives.
+    Search terms are combined with AND, and comma-separated groups of terms are
+    combined with OR. For example, `foo bar, baz` becomes
+    `(foo AND bar) OR baz`.
+
+    Sorting is specified by appending `+` (ascending) or `-` (descending) to a
+    field name, e.g., `artist+ album-`.
+    """
+
+    query: query.Query
+    sort: sort.Sort
+
+    @classmethod
+    def parse(
+        cls, model_cls: type[LibModel], parts: str | Sequence[str] | None = None
+    ) -> Self:
+        """Construct a query and sort object from a variety of inputs.
+
+        Create `ModelQuery` instance to parse the provided string or sequence of
+        strings.
+        """
+        parts = parts or []
+        query_str = (
+            parts
+            if isinstance(parts, str)
+            else " ".join(map(shlex.quote, parts))
+        )
+        if parts:
+            log.debug("Query string: {!r}", query_str)
+
+        lex = shlex.shlex(
+            escape_commas(query_str), punctuation_chars=",", posix=True
+        )
+        lex.commenters = ""  # make sure we keep '#example' as it is
+        lex.whitespace_split = True
+
+        try:
+            _query, _sort = parse_sorted_query(model_cls, list(lex))
+        except ValueError as exc:
+            raise query.InvalidQueryError(query_str, exc) from exc
+
+        if parts:
+            log.debug("Parsed query: {!r}", _query)
+            log.debug("Parsed sort: {!r}", _sort)
+        return cls(_query, _sort)

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -51,7 +51,7 @@ class QueryTerm:
     pattern: str
 
     @cached_classproperty
-    def query_by_prefix(cls) -> dict[str, query.FieldQueryType]:
+    def query_by_prefix(cls) -> query.QueryByField:
         """Map operator prefixes to their corresponding query class types."""
         return {
             ":": query.RegexpQuery,
@@ -96,7 +96,9 @@ class QueryTerm:
 
         raise query.InvalidQueryError(part, "Unrecognised query format")
 
-    def get_query_cls(self, model_cls: type[LibModel]) -> query.FieldQueryType:
+    def get_query_cls(
+        self, model_cls: type[LibModel]
+    ) -> type[query.FieldQuery]:
         """Determine the most appropriate query class for filtering this field.
 
         Resolves query type by checking prefix-specific queries first, then

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -22,6 +22,9 @@ if TYPE_CHECKING:
 
     from beets.library.models import LibModel
 
+    from .query import Query
+    from .sort import Sort
+
 
 PARSE_QUERY_PART_REGEX = re.compile(
     # Non-capturing optional segment for the keyword.
@@ -138,17 +141,6 @@ class QueryTerm:
         return query.NotQuery(out_query) if self.negate else out_query
 
 
-# TYPING ERROR
-def build_and_query(
-    model_cls: type[LibModel], query_parts: Iterable[str]
-) -> query.Query:
-    """Build a query by combining search terms with a logical AND."""
-    if not query_parts:
-        return query.TrueQuery()
-    subqueries = [QueryTerm.make(p).get_query(model_cls) for p in query_parts]
-    return reduce(operator.and_, subqueries)
-
-
 class SortTerm(NamedTuple):
     """Represents a parsed sort specification with field name and direction."""
 
@@ -191,54 +183,6 @@ class SortTerm(NamedTuple):
         return sort_cls(field, self.ascending)
 
 
-def sort_from_strings(
-    model_cls: type[LibModel], sort_parts: Sequence[str]
-) -> sort.Sort:
-    """Construct a Sort object from a sequence of sort field strings.
-
-    Interpret, validate, and translate user-provided sort field strings into
-    a composite sort order for querying the database. It supports multi-field
-    sorting by combining individual sort terms, and ensures that only valid
-    fields are included in the resulting sort.
-
-    The main purpose is to provide a flexible way to specify sorting criteria
-    (such as from command-line arguments or configuration) and convert them
-    into a form that the query engine can use to order results.
-
-    If no valid sort fields are provided, a default "no sort" object is returned.
-    """
-    if not sort_parts:
-        return sort.NullSort()
-
-    terms = map(SortTerm.make, filter(SortTerm.check_valid, sort_parts))
-    sorts = [p.get_sort(model_cls) for p in terms]
-
-    return sort.MultipleSort(sorts) if len(sorts) > 1 else sorts[0]
-
-
-def parse_sorted_query(
-    model_cls: type[LibModel], parts: Sequence[str]
-) -> tuple[query.Query, sort.Sort]:
-    """Given a list of strings, create the `Query` and `Sort` that they
-    represent.
-    """
-    sort_parts = [p for p in parts if SortTerm.check_valid(p)]
-    query_parts = [p for p in parts if not SortTerm.check_valid(p)]
-
-    queries = [
-        build_and_query(model_cls, g)
-        for k, g in groupby(query_parts, lambda p: p == ",")
-        if not k
-    ]
-    if not queries or "," in {query_parts[0], query_parts[-1]}:
-        queries.append(query.TrueQuery())
-
-    return (
-        reduce(operator.or_, queries),
-        sort_from_strings(model_cls, sort_parts),
-    )
-
-
 class ModelQuery(NamedTuple):
     """Parses a user-provided string into a query and a sort order.
 
@@ -251,8 +195,8 @@ class ModelQuery(NamedTuple):
     field name, e.g., `artist+ album-`.
     """
 
-    query: query.Query
-    sort: sort.Sort
+    query: Query
+    sort: Sort
 
     @classmethod
     def parse(
@@ -279,11 +223,58 @@ class ModelQuery(NamedTuple):
         lex.whitespace_split = True
 
         try:
-            _query, _sort = parse_sorted_query(model_cls, list(lex))
+            parts = list(lex)
         except ValueError as exc:
             raise query.InvalidQueryError(query_str, exc) from exc
+
+        _query = cls.get_query(model_cls, parts)
+        _sort = cls.get_sort(model_cls, parts)
 
         if parts:
             log.debug("Parsed query: {!r}", _query)
             log.debug("Parsed sort: {!r}", _sort)
         return cls(_query, _sort)
+
+    @staticmethod
+    def get_sort(model_cls: type[LibModel], parts: Iterable[str]) -> Sort:
+        """Build the final `Sort` object from the extracted directives.
+
+        If no sorting directives are found in the query string,
+        ``sort.NullSort`` is returned.
+        """
+        sort_parts = [p for p in parts if SortTerm.check_valid(p)]
+        if not sort_parts:
+            return sort.NullSort()
+
+        sorts = [SortTerm.make(p).get_sort(model_cls) for p in sort_parts]
+
+        return sort.MultipleSort(sorts) if len(sorts) > 1 else sorts[0]
+
+    @staticmethod
+    def build_and_query(
+        model_cls: type[LibModel], parts: Iterable[str]
+    ) -> Query:
+        """Build a query by combining search terms with a logical AND."""
+        queries = [QueryTerm.make(p).get_query(model_cls) for p in parts]
+        return reduce(operator.and_, queries)
+
+    @classmethod
+    def get_query(
+        cls, model_cls: type[LibModel], parts: Iterable[str]
+    ) -> Query:
+        """Build the final `Query` object from the search terms.
+
+        Terms are grouped by commas, which act as logical OR operators.
+        Within each group, terms are combined with logical AND.
+        """
+        query_parts = [p for p in parts if not SortTerm.check_valid(p)]
+
+        queries = [
+            cls.build_and_query(model_cls, g)
+            for k, g in groupby(query_parts, lambda p: p == ",")
+            if not k
+        ]
+        if not queries or "," in {query_parts[0], query_parts[-1]}:
+            queries.append(query.TrueQuery())
+
+        return reduce(operator.or_, queries)

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -140,12 +140,14 @@ def construct_query_part(
     if not term.field:
         # If there's no key (field name) specified, this is a "match anything"
         # query.
-        out_query = model_cls.any_field_query(term.pattern, query_class)
+        out_query = query.OrQuery(
+            [query_class(f, term.pattern) for f in model_cls._search_fields]
+        )
     else:
         # Field queries get constructed according to the name of the field
         # they are querying.
-        out_query = model_cls.field_query(
-            term.field.lower(), term.pattern, query_class
+        out_query = query_class.from_model(
+            model_cls, term.field.lower(), term.pattern
         )
 
     # Apply negation.

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -138,19 +138,14 @@ class QueryTerm:
 
 
 # TYPING ERROR
-def query_from_strings(
-    query_cls: type[query.CollectionQuery],
-    model_cls: type[LibModel],
-    query_parts: Collection[str],
+def build_and_query(
+    model_cls: type[LibModel], query_parts: Collection[str]
 ) -> query.Query:
-    """Creates a collection query of type `query_cls` from a list of
-    strings in the format used by parse_query_part. `model_cls`
-    determines how queries are constructed from strings.
-    """
+    """Build a query by combining search terms with a logical AND."""
     if not query_parts:
         return query.TrueQuery()
     subqueries = [QueryTerm.make(p).get_query(model_cls) for p in query_parts]
-    return query_cls(subqueries) if len(subqueries) > 1 else subqueries[0]
+    return reduce(operator.and_, subqueries)
 
 
 class SortTerm(NamedTuple):
@@ -240,9 +235,7 @@ def parse_sorted_query(
             if last_subquery_part:
                 subquery_parts.append(last_subquery_part)
             # Parse the subquery in to a single Query
-            query_parts.append(
-                query_from_strings(query.AndQuery, model_cls, subquery_parts)
-            )
+            query_parts.append(build_and_query(model_cls, subquery_parts))
             del subquery_parts[:]
         elif SortTerm.check_valid(part):
             sort_parts.append(part)

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import operator
 import re
 import shlex
 from dataclasses import dataclass
-from functools import partial
+from functools import partial, reduce
 from typing import TYPE_CHECKING, NamedTuple
 
 from typing_extensions import Self
@@ -115,45 +116,25 @@ class QueryTerm:
             or query.SubstringQuery
         )
 
+    def get_query(self, model_cls: type[LibModel]) -> query.Query:
+        """Create an executable query object tailored to the target model."""
+        out_query: query.Query
+        if self.pattern:
+            # Field queries get constructed according to the name of the field
+            # they are querying.
+            fields = (
+                [self.field.lower()] if self.field else model_cls._search_fields
+            )
 
-def construct_query_part(
-    model_cls: type[LibModel], query_part: str
-) -> query.Query:
-    """Parse a *query part* string and return a :class:`Query` object.
+            query_cls = self.get_query_cls(model_cls)
+            queries = [
+                query_cls.from_model(model_cls, f, self.pattern) for f in fields
+            ]
+            out_query = reduce(operator.or_, queries)
+        else:
+            out_query = query.TrueQuery()
 
-    :param model_cls: The :class:`Model` class that this is a query for.
-      This is used to determine the appropriate query types for the
-      model's fields.
-    :param query_part: The string to parse.
-
-    See the documentation for `parse_query_part` for more information on
-    query part syntax.
-    """
-    # A shortcut for empty query parts.
-    if not query_part:
-        return query.TrueQuery()
-
-    out_query: query.Query
-
-    term = QueryTerm.make(query_part)
-    query_class = term.get_query_cls(model_cls)
-    if not term.field:
-        # If there's no key (field name) specified, this is a "match anything"
-        # query.
-        out_query = query.OrQuery(
-            [query_class(f, term.pattern) for f in model_cls._search_fields]
-        )
-    else:
-        # Field queries get constructed according to the name of the field
-        # they are querying.
-        out_query = query_class.from_model(
-            model_cls, term.field.lower(), term.pattern
-        )
-
-    # Apply negation.
-    if term.negate:
-        return query.NotQuery(out_query)
-    return out_query
+        return query.NotQuery(out_query) if self.negate else out_query
 
 
 # TYPING ERROR
@@ -168,7 +149,7 @@ def query_from_strings(
     """
     subqueries = []
     for part in query_parts:
-        subqueries.append(construct_query_part(model_cls, part))
+        subqueries.append(QueryTerm.make(part).get_query(model_cls))
     if not subqueries:  # No terms in query.
         subqueries = [query.TrueQuery()]
     return query_cls(subqueries)

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -6,14 +6,14 @@ import itertools
 import re
 from typing import TYPE_CHECKING
 
+from beets import plugins
+
 from . import query, sort
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Sequence
 
     from ..library import LibModel
-
-    Prefixes = dict[str, query.FieldQueryType]
 
 
 PARSE_QUERY_PART_REGEX = re.compile(
@@ -28,10 +28,19 @@ PARSE_QUERY_PART_REGEX = re.compile(
 )
 
 
+def get_prefixes() -> dict[str, query.FieldQueryType]:
+    """Get query types and their prefix characters."""
+    return {
+        ":": query.RegexpQuery,
+        "=~": query.StringQuery,
+        "=": query.MatchQuery,
+        **plugins.queries(),
+    }
+
+
 def parse_query_part(
     part: str,
     query_classes: dict[str, query.FieldQueryType] = {},
-    prefixes: Prefixes = {},
     default_class: type[query.SubstringQuery] = query.SubstringQuery,
 ) -> tuple[str | None, str, query.FieldQueryType, bool]:
     """Parse a single *query part*, which is a chunk of a complete query
@@ -44,8 +53,7 @@ def parse_query_part(
       pattern.
     - Optionally, a *query prefix* just before the pattern (and after the
       optional colon) indicating the type of query that should be used. For
-      example, in `~foo`, `~` might be a prefix. (The set of prefixes to
-      look for is given in the `prefixes` parameter.)
+      example, in `~foo`, `~` might be a prefix.
     - Optionally, a negation indicator, `-` or `^`, at the very beginning.
 
     Both prefixes and the separating `:` character may be escaped with a
@@ -58,11 +66,10 @@ def parse_query_part(
       :class:`Query` type.
     - A negation flag, a bool.
 
-    The three optional parameters determine which query class is used (i.e.,
+    The two optional parameters determine which query class is used (i.e.,
     the third return value). They are:
     - `query_classes`, which maps field names to query classes. These
       are used when no explicit prefix is present.
-    - `prefixes`, which maps prefix strings to query classes.
     - `default_class`, the fallback when neither the field nor a prefix
       indicates a query class.
 
@@ -88,7 +95,7 @@ def parse_query_part(
 
     # Check whether there's a prefix in the query and use the
     # corresponding query type.
-    for pre, query_class in prefixes.items():
+    for pre, query_class in get_prefixes().items():
         if term.startswith(pre):
             return key, term[len(pre) :], query_class, negate
 
@@ -99,14 +106,13 @@ def parse_query_part(
 
 
 def construct_query_part(
-    model_cls: type[LibModel], prefixes: Prefixes, query_part: str
+    model_cls: type[LibModel], query_part: str
 ) -> query.Query:
     """Parse a *query part* string and return a :class:`Query` object.
 
     :param model_cls: The :class:`Model` class that this is a query for.
       This is used to determine the appropriate query types for the
       model's fields.
-    :param prefixes: A map from prefix strings to :class:`Query` types.
     :param query_part: The string to parse.
 
     See the documentation for `parse_query_part` for more information on
@@ -129,7 +135,7 @@ def construct_query_part(
 
     # Parse the string.
     key, pattern, query_class, negate = parse_query_part(
-        query_part, query_classes, prefixes
+        query_part, query_classes
     )
 
     if key is None:
@@ -151,7 +157,6 @@ def construct_query_part(
 def query_from_strings(
     query_cls: type[query.CollectionQuery],
     model_cls: type[LibModel],
-    prefixes: Prefixes,
     query_parts: Collection[str],
 ) -> query.Query:
     """Creates a collection query of type `query_cls` from a list of
@@ -160,7 +165,7 @@ def query_from_strings(
     """
     subqueries = []
     for part in query_parts:
-        subqueries.append(construct_query_part(model_cls, prefixes, part))
+        subqueries.append(construct_query_part(model_cls, part))
     if not subqueries:  # No terms in query.
         subqueries = [query.TrueQuery()]
     return query_cls(subqueries)
@@ -212,10 +217,7 @@ def sort_from_strings(
 
 
 def parse_sorted_query(
-    model_cls: type[LibModel],
-    parts: list[str],
-    prefixes: Prefixes = {},
-    case_insensitive: bool = True,
+    model_cls: type[LibModel], parts: list[str], case_insensitive: bool = True
 ) -> tuple[query.Query, sort.Sort]:
     """Given a list of strings, create the `Query` and `Sort` that they
     represent.
@@ -236,9 +238,7 @@ def parse_sorted_query(
             # Parse the subquery in to a single AndQuery
             # TODO: Avoid needlessly wrapping AndQueries containing 1 subquery?
             query_parts.append(
-                query_from_strings(
-                    query.AndQuery, model_cls, prefixes, subquery_parts
-                )
+                query_from_strings(query.AndQuery, model_cls, subquery_parts)
             )
             del subquery_parts[:]
         else:

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -171,15 +171,11 @@ def query_from_strings(
     return query_cls(subqueries)
 
 
-def construct_sort_part(
-    model_cls: type[LibModel], part: str, case_insensitive: bool = True
-) -> sort.Sort:
+def construct_sort_part(model_cls: type[LibModel], part: str) -> sort.FieldSort:
     """Create a `Sort` from a single string criterion.
 
     `model_cls` is the `Model` being queried. `part` is a single string
-    ending in ``+`` or ``-`` indicating the sort. `case_insensitive`
-    indicates whether or not the sort should be performed in a case
-    sensitive manner.
+    ending in ``+`` or ``-`` indicating the sort.
     """
     assert part, "part must be a field name and + or -"
     field = part[:-1]
@@ -197,27 +193,25 @@ def construct_sort_part(
         # Flexible or computed.
         sort_cls = sort.SlowFieldSort
 
-    return sort_cls(field, is_ascending, case_insensitive)
+    return sort_cls(field, is_ascending)
 
 
 def sort_from_strings(
-    model_cls: type[LibModel],
-    sort_parts: Sequence[str],
-    case_insensitive: bool = True,
+    model_cls: type[LibModel], sort_parts: Sequence[str]
 ) -> sort.Sort:
     """Create a `Sort` from a list of sort criteria (strings)."""
     if not sort_parts:
         return sort.NullSort()
     if len(sort_parts) == 1:
-        return construct_sort_part(model_cls, sort_parts[0], case_insensitive)
+        return construct_sort_part(model_cls, sort_parts[0])
     s = sort.MultipleSort()
     for part in sort_parts:
-        s.add_sort(construct_sort_part(model_cls, part, case_insensitive))
+        s.add_sort(construct_sort_part(model_cls, part))
     return s
 
 
 def parse_sorted_query(
-    model_cls: type[LibModel], parts: list[str], case_insensitive: bool = True
+    model_cls: type[LibModel], parts: list[str]
 ) -> tuple[query.Query, sort.Sort]:
     """Given a list of strings, create the `Query` and `Sort` that they
     represent.
@@ -251,5 +245,5 @@ def parse_sorted_query(
 
     # Avoid needlessly wrapping single statements in an OR
     q = query.OrQuery(query_parts) if len(query_parts) > 1 else query_parts[0]
-    s = sort_from_strings(model_cls, sort_parts, case_insensitive)
+    s = sort_from_strings(model_cls, sort_parts)
     return q, s

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -16,14 +16,13 @@ from beets import logging, plugins
 from beets.util import cached_classproperty
 
 from . import query, sort
+from .query import Query  # noqa: TC001 required for docs type resolution
+from .sort import Sort  # noqa: TC001 required for docs type resolution
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
     from beets.library.models import LibModel
-
-    from .query import Query
-    from .sort import Sort
 
 
 PARSE_QUERY_PART_REGEX = re.compile(

--- a/beets/dbcore/sort.py
+++ b/beets/dbcore/sort.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+import beets
+from beets.util import cached_classproperty
+
 if TYPE_CHECKING:
     from beets.dbcore.db import AnyModel, Model
 
@@ -103,12 +106,13 @@ class FieldSort(Sort):
     any kind).
     """
 
-    def __init__(
-        self, field: str, ascending: bool = True, case_insensitive: bool = True
-    ):
+    def __init__(self, field: str, ascending: bool = True):
         self.field = field
         self.ascending = ascending
-        self.case_insensitive = case_insensitive
+
+    @cached_classproperty
+    def case_insensitive(cls) -> bool:
+        return beets.config["sort_case_insensitive"].get(bool)
 
     def sort(self, objs: list[AnyModel]) -> list[AnyModel]:
         # TODO: Support flexible attributes with different types (e.g. a mix

--- a/beets/dbcore/sort.py
+++ b/beets/dbcore/sort.py
@@ -8,6 +8,8 @@ import beets
 from beets.util import cached_classproperty
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from beets.dbcore.db import AnyModel, Model
 
 
@@ -45,8 +47,8 @@ class Sort:
 class MultipleSort(Sort):
     """Sort that encapsulates multiple sub-sorts."""
 
-    def __init__(self, sorts: list[Sort] | None = None):
-        self.sorts = sorts or []
+    def __init__(self, sorts: Sequence[Sort] | None = None):
+        self.sorts = list(sorts or [])
 
     def add_sort(self, sort: Sort):
         self.sorts.append(sort)

--- a/beets/dbcore/types.py
+++ b/beets/dbcore/types.py
@@ -49,7 +49,7 @@ class Type(ABC, Generic[T, N]):
     """The SQLite column type for the value.
     """
 
-    query: query.FieldQueryType = query.SubstringQuery
+    query: type[query.FieldQuery] = query.SubstringQuery
     """The `Query` subclass to be used when querying the field.
     """
 
@@ -220,7 +220,7 @@ class BaseFloat(Type[float, N]):
     """
 
     sql = "REAL"
-    query: query.FieldQueryType = query.NumericQuery
+    query: type[query.FieldQuery] = query.NumericQuery
     model_type = float
 
     def __init__(self, digits: int = 1):

--- a/beets/library/library.py
+++ b/beets/library/library.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 import re
 from contextlib import contextmanager
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 import platformdirs
 
 import beets
 from beets import config, context, dbcore
-from beets.dbcore.sort import NullSort
 from beets.exceptions import UserError
 from beets.util import normpath
 from beets.util.pathformats import get_path_formats
@@ -19,9 +18,16 @@ from .models import Album, Item
 from .queries import parse_query_parts, parse_query_string
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from beets.dbcore import Results
+    from beets.dbcore.query import Query, Sort
     from beets.util import Replacements
     from beets.util.pathformats import PathFormat
+
+    from .models import LibModel
+
+    LM = TypeVar("LM", bound=LibModel)
 
 
 class Library(dbcore.Database):
@@ -123,7 +129,12 @@ class Library(dbcore.Database):
 
     # Querying.
 
-    def _fetch(self, model_cls, query, sort=None):
+    def _fetch(
+        self,
+        model_cls: type[LM],
+        query: str | Sequence[str] | Query | None = None,
+        sort: Sort | None = None,
+    ) -> dbcore.Results[LM]:
         """Parse a query and fetch.
 
         If an order specification is present in the query string
@@ -142,34 +153,22 @@ class Library(dbcore.Database):
         except dbcore.query.InvalidQueryArgumentValueError as exc:
             raise dbcore.InvalidQueryError(query, exc)
 
-        # Any non-null sort specified by the parsed query overrides the
-        # provided sort.
-        if parsed_sort and not isinstance(parsed_sort, NullSort):
-            sort = parsed_sort
-
-        return super().get_results(model_cls, query, sort)
-
-    @staticmethod
-    def get_default_album_sort():
-        """Get a :class:`Sort` object for albums from the config option."""
-        return dbcore.sort_from_strings(
-            Album, beets.config["sort_album"].as_str_seq()
+        parsed_sort = parsed_sort or sort
+        return self.get_results(
+            model_cls,
+            query,
+            # Any non-null sort specified by the parsed query overrides the
+            # provided sort.
+            model_cls.default_sort if parsed_sort is None else parsed_sort,
         )
 
-    @staticmethod
-    def get_default_item_sort():
-        """Get a :class:`Sort` object for items from the config option."""
-        return dbcore.sort_from_strings(
-            Item, beets.config["sort_item"].as_str_seq()
-        )
-
-    def albums(self, query=None, sort=None) -> Results[Album]:
+    def albums(self, *args, **kwargs) -> Results[Album]:
         """Get :class:`Album` objects matching the query."""
-        return self._fetch(Album, query, sort or self.get_default_album_sort())
+        return self._fetch(Album, *args, **kwargs)
 
-    def items(self, query=None, sort=None) -> Results[Item]:
+    def items(self, *args, **kwargs) -> Results[Item]:
         """Get :class:`Item` objects matching the query."""
-        return self._fetch(Item, query, sort or self.get_default_item_sort())
+        return self._fetch(Item, *args, **kwargs)
 
     # Convenience accessors.
     def get_item(self, id_: int) -> Item | None:

--- a/beets/library/library.py
+++ b/beets/library/library.py
@@ -9,19 +9,19 @@ import platformdirs
 
 import beets
 from beets import config, context, dbcore
+from beets.dbcore.query import Query
 from beets.exceptions import UserError
 from beets.util import normpath
 from beets.util.pathformats import get_path_formats
 
 from . import migrations
 from .models import Album, Item
-from .queries import parse_query_parts, parse_query_string
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from beets.dbcore import Results
-    from beets.dbcore.query import Query, Sort
+    from beets.dbcore.sort import Sort
     from beets.util import Replacements
     from beets.util.pathformats import PathFormat
 
@@ -146,17 +146,17 @@ class Library(dbcore.Database):
             # Query parsing needs the library root, but keeping it scoped here
             # avoids leaking one Library's directory into another's work.
             with context.music_dir(self.directory):
-                if isinstance(query, str):
-                    query, parsed_sort = parse_query_string(query, model_cls)
-                elif isinstance(query, (list, tuple)):
-                    query, parsed_sort = parse_query_parts(query, model_cls)
+                if isinstance(query, Query):
+                    parsed_query, parsed_sort = query, sort
+                else:
+                    parsed_query, parsed_sort = model_cls.parse_query(query)
         except dbcore.query.InvalidQueryArgumentValueError as exc:
             raise dbcore.InvalidQueryError(query, exc)
 
         parsed_sort = parsed_sort or sort
         return self.get_results(
             model_cls,
-            query,
+            parsed_query,
             # Any non-null sort specified by the parsed query overrides the
             # provided sort.
             model_cls.default_sort if parsed_sort is None else parsed_sort,

--- a/beets/library/library.py
+++ b/beets/library/library.py
@@ -147,7 +147,7 @@ class Library(dbcore.Database):
         if parsed_sort and not isinstance(parsed_sort, NullSort):
             sort = parsed_sort
 
-        return super()._fetch(model_cls, query, sort)
+        return super().get_results(model_cls, query, sort)
 
     @staticmethod
     def get_default_album_sort():

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -86,6 +86,7 @@ class LibModel(dbcore.Model["Library"]):
     def parse_query(
         cls, query: str | Sequence[str] | None = None
     ) -> ModelQuery:
+        """Parse human-readable search and sort syntax for this model."""
         return ModelQuery.parse(cls, query)
 
     @property

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -35,7 +35,7 @@ from .fields import TYPE_BY_FIELD
 if TYPE_CHECKING:
     from collections.abc import KeysView, Sequence
 
-    from beets.dbcore.query import FieldQuery, FieldQueryType
+    from beets.dbcore.query import FieldQuery, QueryByField
     from beets.dbcore.sort import FieldSort, Sort
 
     from .library import Library  # noqa: F401
@@ -68,7 +68,7 @@ class LibModel(dbcore.Model["Library"]):
         }
 
     @cached_classproperty
-    def _queries(cls) -> dict[str, FieldQueryType]:
+    def _queries(cls) -> QueryByField:
         return plugins.named_queries(cls)  # type: ignore[arg-type]
 
     @cached_classproperty
@@ -129,7 +129,7 @@ class LibModel(dbcore.Model["Library"]):
 
     @classmethod
     def field_query(
-        cls, field: str, pattern: str, query_cls: FieldQueryType
+        cls, field: str, pattern: str, query_cls: type[FieldQuery]
     ) -> FieldQuery:
         """Get a `FieldQuery` for the given field on this model."""
         field = maybe_replace_legacy_field(field, cls is Album)
@@ -734,7 +734,7 @@ class Item(LibModel):
     _sorts: ClassVar[dict[str, type[FieldSort]]] = {"artist": SmartArtistSort}
 
     @cached_classproperty
-    def _queries(cls) -> dict[str, FieldQueryType]:
+    def _queries(cls) -> QueryByField:
         return {**super()._queries, "singleton": dbcore.query.SingletonQuery}
 
     _format_config_key = "format_item"

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -14,7 +14,6 @@ import beets
 from beets import dbcore, logging, plugins, util
 from beets.dbcore import types
 from beets.dbcore.db import FormattedMapping
-from beets.dbcore.pathutils import normalize_path_for_db
 from beets.dbcore.queryparse import ModelQuery
 from beets.dbcore.sort import SmartArtistSort
 from beets.util import (
@@ -25,7 +24,6 @@ from beets.util import (
     samefile,
     syspath,
 )
-from beets.util.deprecation import maybe_replace_legacy_field
 from beets.util.functemplate import Template, template
 from beets.util.pathformats import PF_KEY_DEFAULT
 
@@ -128,50 +126,19 @@ class LibModel(dbcore.Model["Library"]):
     # Convenient queries.
 
     @classmethod
-    def field_query(
-        cls, field: str, pattern: str, query_cls: type[FieldQuery]
-    ) -> FieldQuery:
-        """Get a `FieldQuery` for the given field on this model."""
-        field = maybe_replace_legacy_field(field, cls is Album)
-
-        fast = field in cls.all_db_fields
-        if (
-            cls._type(field).query is dbcore.query.PathQuery
-            and query_cls is not dbcore.query.PathQuery
-        ):
-            # Regex, exact, and string queries operate on the raw DB value, so
-            # strip the library prefix to match the stored relative path.
-            bytes_pattern = normalize_path_for_db(util.bytestring_path(pattern))
-            if query_cls is not dbcore.query.RegexpQuery:
-                bytes_pattern = util.path_as_posix(bytes_pattern)
-            pattern = os.fsdecode(bytes_pattern)
-
-        if field in cls.shared_db_fields:
-            # This field exists in both tables, so SQLite will encounter
-            # an OperationalError if we try to use it in a query.
-            # Using an explicit table name resolves this.
-            field = f"{cls._table}.{field}"
-
-        return query_cls(field, pattern, fast)
-
-    @classmethod
-    def any_field_query(cls, *args, **kwargs) -> dbcore.OrQuery:
-        return dbcore.OrQuery(
-            [cls.field_query(f, *args, **kwargs) for f in cls._search_fields]
-        )
-
-    @classmethod
-    def any_writable_media_field_query(cls, *args, **kwargs) -> dbcore.OrQuery:
+    def any_writable_media_field_query(
+        cls, pattern: str, query_cls: type[FieldQuery]
+    ) -> dbcore.OrQuery:
         fields = cls.writable_media_fields
         return dbcore.OrQuery(
-            [cls.field_query(f, *args, **kwargs) for f in fields]
+            [query_cls.from_model(cls, f, pattern) for f in fields]
         )
 
     def duplicates_query(self, fields: list[str]) -> dbcore.AndQuery:
         """Return a query for entities with same values in the given fields."""
         return dbcore.AndQuery(
             [
-                self.field_query(f, self.get(f), dbcore.MatchQuery)
+                dbcore.MatchQuery.from_model(self.__class__, f, self.get(f))
                 for f in fields
             ]
         )

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from collections.abc import KeysView
 
     from beets.dbcore.query import FieldQuery, FieldQueryType
-    from beets.dbcore.sort import FieldSort
+    from beets.dbcore.sort import FieldSort, Sort
 
     from .library import Library  # noqa: F401
 
@@ -74,6 +74,15 @@ class LibModel(dbcore.Model["Library"]):
     @cached_classproperty
     def writable_media_fields(cls) -> set[str]:
         return set(MediaFile.fields()) & cls._fields.keys()
+
+    @cached_classproperty
+    def default_sort(cls) -> Sort:
+        """Get a :class:`beets.dbcore.sort.Sort` for configured fields."""
+        config_key = f"sort_{cls.__name__.lower()}"
+        return dbcore.sort_from_strings(
+            cls,  # type: ignore[arg-type]
+            beets.config[config_key].as_str_seq(),
+        )
 
     @property
     def filepath(self) -> Path:

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -15,6 +15,7 @@ from beets import dbcore, logging, plugins, util
 from beets.dbcore import types
 from beets.dbcore.db import FormattedMapping
 from beets.dbcore.pathutils import normalize_path_for_db
+from beets.dbcore.queryparse import ModelQuery
 from beets.dbcore.sort import SmartArtistSort
 from beets.util import (
     MoveOperation,
@@ -30,10 +31,9 @@ from beets.util.pathformats import PF_KEY_DEFAULT
 
 from .exceptions import FileOperationError, ReadError, WriteError
 from .fields import TYPE_BY_FIELD
-from .queries import parse_query_string
 
 if TYPE_CHECKING:
-    from collections.abc import KeysView
+    from collections.abc import KeysView, Sequence
 
     from beets.dbcore.query import FieldQuery, FieldQueryType
     from beets.dbcore.sort import FieldSort, Sort
@@ -83,6 +83,12 @@ class LibModel(dbcore.Model["Library"]):
             cls,  # type: ignore[arg-type]
             beets.config[config_key].as_str_seq(),
         )
+
+    @classmethod
+    def parse_query(
+        cls, query: str | Sequence[str] | None = None
+    ) -> ModelQuery:
+        return ModelQuery.parse(cls, query)
 
     @property
     def filepath(self) -> Path:
@@ -1202,10 +1208,10 @@ class Item(LibModel):
 
         # Use a path format based on a query, falling back on the
         # default.
-        for query, path_format in path_formats:
-            if query == PF_KEY_DEFAULT:
+        for query_str, path_format in path_formats:
+            if query_str == PF_KEY_DEFAULT:
                 continue
-            query, _ = parse_query_string(query, type(self))
+            query, _ = self.parse_query(query_str)
             if query.match(self):
                 # The query matches the item! Use the corresponding path
                 # format.

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -77,7 +77,7 @@ class LibModel(dbcore.Model["Library"]):
     def default_sort(cls) -> Sort:
         """Get a :class:`beets.dbcore.sort.Sort` for configured fields."""
         config_key = f"sort_{cls.__name__.lower()}"
-        return dbcore.sort_from_strings(
+        return ModelQuery.get_sort(
             cls,  # type: ignore[arg-type]
             beets.config[config_key].as_str_seq(),
         )
@@ -1178,8 +1178,7 @@ class Item(LibModel):
         for query_str, path_format in path_formats:
             if query_str == PF_KEY_DEFAULT:
                 continue
-            query, _ = self.parse_query(query_str)
-            if query.match(self):
+            if self.parse_query(query_str).query.match(self):
                 # The query matches the item! Use the corresponding path
                 # format.
                 break

--- a/beets/library/queries.py
+++ b/beets/library/queries.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import shlex
 
-import beets
 from beets import dbcore, logging
 
 log = logging.getLogger("beets")
@@ -25,9 +24,7 @@ def parse_query_parts(parts, model_cls):
         for s in parts
     ]
 
-    case_insensitive = beets.config["sort_case_insensitive"].get(bool)
-
-    query, sort = dbcore.parse_sorted_query(model_cls, parts, case_insensitive)
+    query, sort = dbcore.parse_sorted_query(model_cls, parts)
     log.debug("Parsed query: {!r}", query)
     log.debug("Parsed sort: {!r}", sort)
     return query, sort

--- a/beets/library/queries.py
+++ b/beets/library/queries.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import shlex
 
 import beets
-from beets import dbcore, logging, plugins
+from beets import dbcore, logging
 
 log = logging.getLogger("beets")
 
@@ -18,14 +18,6 @@ def parse_query_parts(parts, model_cls):
     Like `dbcore.parse_sorted_query`, with beets query prefixes and
     ensuring that implicit path queries are made explicit with 'path::<query>'
     """
-    # Get query types and their prefix characters.
-    prefixes = {
-        ":": dbcore.query.RegexpQuery,
-        "=~": dbcore.query.StringQuery,
-        "=": dbcore.query.MatchQuery,
-    }
-    prefixes.update(plugins.queries())
-
     # Special-case path-like queries, which are non-field queries
     # containing path separators (/).
     parts = [
@@ -35,9 +27,7 @@ def parse_query_parts(parts, model_cls):
 
     case_insensitive = beets.config["sort_case_insensitive"].get(bool)
 
-    query, sort = dbcore.parse_sorted_query(
-        model_cls, parts, prefixes, case_insensitive
-    )
+    query, sort = dbcore.parse_sorted_query(model_cls, parts, case_insensitive)
     log.debug("Parsed query: {!r}", query)
     log.debug("Parsed sort: {!r}", sort)
     return query, sort

--- a/beets/library/queries.py
+++ b/beets/library/queries.py
@@ -17,13 +17,6 @@ def parse_query_parts(parts, model_cls):
     Like `dbcore.parse_sorted_query`, with beets query prefixes and
     ensuring that implicit path queries are made explicit with 'path::<query>'
     """
-    # Special-case path-like queries, which are non-field queries
-    # containing path separators (/).
-    parts = [
-        f"path:{s}" if dbcore.query.PathQuery.is_path_query(s) else s
-        for s in parts
-    ]
-
     query, sort = dbcore.parse_sorted_query(model_cls, parts)
     log.debug("Parsed query: {!r}", query)
     log.debug("Parsed sort: {!r}", sort)

--- a/beets/library/queries.py
+++ b/beets/library/queries.py
@@ -1,11 +1,4 @@
-from __future__ import annotations
-
-import shlex
-
-from beets import dbcore, logging
-
-log = logging.getLogger("beets")
-
+from beets.util.deprecation import deprecate_for_maintainers
 
 # Query construction helpers.
 
@@ -17,10 +10,10 @@ def parse_query_parts(parts, model_cls):
     Like `dbcore.parse_sorted_query`, with beets query prefixes and
     ensuring that implicit path queries are made explicit with 'path::<query>'
     """
-    query, sort = dbcore.parse_sorted_query(model_cls, parts)
-    log.debug("Parsed query: {!r}", query)
-    log.debug("Parsed sort: {!r}", sort)
-    return query, sort
+    deprecate_for_maintainers(
+        "'parse_query_parts'", f"beets.library.{model_cls.__name__}.parse_query"
+    )
+    return model_cls.parse_query(parts)
 
 
 def parse_query_string(s, model_cls):
@@ -29,10 +22,8 @@ def parse_query_string(s, model_cls):
 
     The string is split into components using shell-like syntax.
     """
-    message = f"Query is not unicode: {s!r}"
-    assert isinstance(s, str), message
-    try:
-        parts = shlex.split(s)
-    except ValueError as exc:
-        raise dbcore.InvalidQueryError(s, exc)
-    return parse_query_parts(parts, model_cls)
+    deprecate_for_maintainers(
+        "'parse_query_string'",
+        f"beets.library.{model_cls.__name__}.parse_query",
+    )
+    return model_cls.parse_query(s)

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
     from confuse import Subview
 
-    from beets.dbcore.db import FieldQueryType
+    from beets.dbcore.query import QueryByField
     from beets.dbcore.types import Type
     from beets.importer import ImportSession, ImportTask
     from beets.library import Album, Item, Library
@@ -305,7 +305,7 @@ class BeetsPlugin(metaclass=BeetsPluginMeta):
 
         return wrapper
 
-    def queries(self) -> dict[str, FieldQueryType]:
+    def queries(self) -> QueryByField:
         """Return a dict mapping prefixes to Query subclasses."""
         return {}
 
@@ -475,7 +475,7 @@ def commands() -> list[Subcommand]:
     return out
 
 
-def queries() -> dict[str, FieldQueryType]:
+def queries() -> QueryByField:
     """Return configured query prefixes from all plugins."""
     return {
         p: q for plugin in find_plugins() for p, q in plugin.queries().items()
@@ -499,7 +499,7 @@ def types(model_cls: type[AnyModel]) -> dict[str, Type]:
     return types
 
 
-def named_queries(model_cls: type[AnyModel]) -> dict[str, FieldQueryType]:
+def named_queries(model_cls: type[AnyModel]) -> QueryByField:
     """Return mapping between field names and queries for the given model."""
     attr_name = f"{model_cls.__name__.lower()}_queries"
     return {

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
 
     from confuse import Subview
 
-    from beets.dbcore import Query
     from beets.dbcore.db import FieldQueryType
     from beets.dbcore.types import Type
     from beets.importer import ImportSession, ImportTask
@@ -306,7 +305,7 @@ class BeetsPlugin(metaclass=BeetsPluginMeta):
 
         return wrapper
 
-    def queries(self) -> dict[str, type[Query]]:
+    def queries(self) -> dict[str, FieldQueryType]:
         """Return a dict mapping prefixes to Query subclasses."""
         return {}
 
@@ -476,14 +475,11 @@ def commands() -> list[Subcommand]:
     return out
 
 
-def queries() -> dict[str, type[Query]]:
-    """Returns a dict mapping prefix strings to Query subclasses all loaded
-    plugins.
-    """
-    out: dict[str, type[Query]] = {}
-    for plugin in find_plugins():
-        out.update(plugin.queries())
-    return out
+def queries() -> dict[str, FieldQueryType]:
+    """Return configured query prefixes from all plugins."""
+    return {
+        p: q for plugin in find_plugins() for p, q in plugin.queries().items()
+    }
 
 
 def types(model_cls: type[AnyModel]) -> dict[str, Type]:

--- a/beets/test/_common.py
+++ b/beets/test/_common.py
@@ -19,6 +19,10 @@ from beets.util import syspath
 if TYPE_CHECKING:
     import pytest
 
+# Because the absolute path begins with something like C:, we
+# can't disambiguate it from an ordinary query.
+WIN32_NO_IMPLICIT_PATHS = "Implicit paths are not supported on Windows"
+
 beetsplug.__path__ = [
     os.path.abspath(
         os.path.join(

--- a/beets/test/fixtures.py
+++ b/beets/test/fixtures.py
@@ -6,7 +6,7 @@ exercise metadata registration and model integration.
 
 from typing import ClassVar
 
-from beets.dbcore import sort, types
+from beets.dbcore import query, sort, types
 from beets.dbcore.db import FormattedMapping, Index
 from beets.library import LibModel
 from beets.util import cached_classproperty
@@ -24,6 +24,7 @@ class ModelFixture1(LibModel):
         "id": types.PRIMARY_ID,
         "field_one": types.INTEGER,
         "field_two": types.STRING,
+        "path": types.PathType(),
     }
 
     _sorts: ClassVar[dict[str, type[sort.FieldSort]]] = {
@@ -35,6 +36,10 @@ class ModelFixture1(LibModel):
     @cached_classproperty
     def _types(cls):
         return {"some_float_field": types.FLOAT}
+
+    @cached_classproperty
+    def _queries(cls):
+        return {"year": query.NumericQuery}
 
     @classmethod
     def _getters(cls):

--- a/beets/test/fixtures.py
+++ b/beets/test/fixtures.py
@@ -32,6 +32,7 @@ class ModelFixture1(LibModel):
     }
     _indices = (Index("field_one_index", ("field_one",)),)
     _formatter = FormattedMapping
+    _search_fields = ("artist", "title")
 
     @cached_classproperty
     def _types(cls):

--- a/beetsplug/advancedrewrite.py
+++ b/beetsplug/advancedrewrite.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 import confuse
 
-from beets.dbcore import build_and_query
+from beets.dbcore import ModelQuery
 from beets.dbcore.types import MULTI_VALUE_DSV
 from beets.library import Album, Item
 from beets.plugins import BeetsPlugin
@@ -117,7 +117,7 @@ class AdvancedRewritePlugin(BeetsPlugin):
                     raise UserError(
                         "Advanced rewrites must have at least one replacement"
                     )
-                query = build_and_query(Item, shlex.split(match))
+                query = ModelQuery.build_and_query(Item, shlex.split(match))
                 for fieldname, replacement in replacements.items():
                     if fieldname not in Item._fields:
                         raise UserError(

--- a/beetsplug/advancedrewrite.py
+++ b/beetsplug/advancedrewrite.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 import confuse
 
-from beets.dbcore import AndQuery, query_from_strings
+from beets.dbcore import build_and_query
 from beets.dbcore.types import MULTI_VALUE_DSV
 from beets.library import Album, Item
 from beets.plugins import BeetsPlugin
@@ -117,9 +117,7 @@ class AdvancedRewritePlugin(BeetsPlugin):
                     raise UserError(
                         "Advanced rewrites must have at least one replacement"
                     )
-                query = query_from_strings(
-                    AndQuery, Item, query_parts=shlex.split(match)
-                )
+                query = build_and_query(Item, shlex.split(match))
                 for fieldname, replacement in replacements.items():
                     if fieldname not in Item._fields:
                         raise UserError(

--- a/beetsplug/advancedrewrite.py
+++ b/beetsplug/advancedrewrite.py
@@ -118,7 +118,7 @@ class AdvancedRewritePlugin(BeetsPlugin):
                         "Advanced rewrites must have at least one replacement"
                     )
                 query = query_from_strings(
-                    AndQuery, Item, prefixes={}, query_parts=shlex.split(match)
+                    AndQuery, Item, query_parts=shlex.split(match)
                 )
                 for fieldname, replacement in replacements.items():
                     if fieldname not in Item._fields:

--- a/beetsplug/aura.py
+++ b/beetsplug/aura.py
@@ -169,7 +169,7 @@ class AURADocument:
                 # Add exact match query to list
                 # Use a slow query so it works with all fields
                 queries.append(
-                    self.model_cls.field_query(beets_attr, value, MatchQuery)
+                    MatchQuery.from_model(self.model_cls, beets_attr, value)
                 )
         # NOTE: AURA doesn't officially support multiple queries
         return AndQuery(queries)
@@ -304,7 +304,7 @@ class AURADocument:
             # have a non-empty, non-zero value for that field.
             query.subqueries.extend(
                 NotQuery(
-                    self.model_cls.field_query(s.field, "(^$|^0$)", RegexpQuery)
+                    RegexpQuery.from_model(self.model_cls, s.field, "(^$|^0$)")
                 )
                 for s in sort.sorts
             )

--- a/beetsplug/bpd/__init__.py
+++ b/beetsplug/bpd/__init__.py
@@ -1384,14 +1384,14 @@ class Server(BaseServer):
                     if allow_any_query:
                         queries.append(
                             Item.any_writable_media_field_query(
-                                query_type, value
+                                value, query_type
                             )
                         )
                     else:
                         raise BPDError(ERROR_UNKNOWN, "no such tagtype")
                 else:
                     _, key = self._tagtype_lookup(tag)
-                    queries.append(Item.field_query(key, value, query_type))
+                    queries.append(query_type.from_model(Item, key, value))
             return dbcore.query.AndQuery(queries)
         # No key-value pairs.
         return dbcore.query.TrueQuery()
@@ -1452,7 +1452,7 @@ class Server(BaseServer):
         songs = 0
         playtime = 0.0
         for item in self.lib.items(
-            Item.field_query(key, value, dbcore.query.MatchQuery)
+            dbcore.query.MatchQuery.from_model(Item, key, value)
         ):
             songs += 1
             playtime += item.length

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -369,7 +369,7 @@ class ConvertPlugin(BeetsPlugin):
         no_convert_query = self.config["no_convert"].as_str()
 
         if no_convert_query:
-            query, _ = Item.parse_query(no_convert_query)
+            query = Item.parse_query(no_convert_query).query
             return query.match(item)
         return False
 

--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -17,7 +17,7 @@ from confuse import ConfigTypeError, Optional
 
 from beets import plugins, ui, util
 from beets.exceptions import UserError
-from beets.library import Item, parse_query_string
+from beets.library import Item
 from beets.plugins import BeetsPlugin
 from beets.util import pipeline
 from beets.util.artresizer import ArtResizer
@@ -369,7 +369,7 @@ class ConvertPlugin(BeetsPlugin):
         no_convert_query = self.config["no_convert"].as_str()
 
         if no_convert_query:
-            query, _ = parse_query_string(no_convert_query, Item)
+            query, _ = Item.parse_query(no_convert_query)
             return query.match(item)
         return False
 

--- a/beetsplug/ihate.py
+++ b/beetsplug/ihate.py
@@ -33,7 +33,7 @@ class IHatePlugin(BeetsPlugin):
         if action_patterns:
             for query_string in action_patterns:
                 model_cls = Album if task.is_album else Item
-                query, _ = model_cls.parse_query(query_string)
+                query = model_cls.parse_query(query_string).query
                 if any(query.match(item) for item in task.imported_items()):
                     return True
         return False

--- a/beetsplug/ihate.py
+++ b/beetsplug/ihate.py
@@ -1,7 +1,7 @@
 """Warns you about things you hate (or even blocks import)."""
 
 from beets.importer import Action
-from beets.library import Album, Item, parse_query_string
+from beets.library import Album, Item
 from beets.plugins import BeetsPlugin
 
 __author__ = "baobab@heresiarch.info"
@@ -32,9 +32,8 @@ class IHatePlugin(BeetsPlugin):
         """
         if action_patterns:
             for query_string in action_patterns:
-                query, _ = parse_query_string(
-                    query_string, Album if task.is_album else Item
-                )
+                model_cls = Album if task.is_album else Item
+                query, _ = model_cls.parse_query(query_string)
                 if any(query.match(item) for item in task.imported_items()):
                     return True
         return False

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -24,7 +24,7 @@ from beets import plugins, ui
 from beets.autotag import string_dist
 from beets.dbcore import types
 from beets.dbcore.query import FalseQuery
-from beets.library import Item, parse_query_string
+from beets.library import Item
 from beets.util.config import sanitize_choices
 from beets.util.lyrics import INSTRUMENTAL_LYRICS, Lyrics
 
@@ -1126,7 +1126,7 @@ class LyricsPlugin(LyricsRequestHandler, plugins.BeetsPlugin):
     def imported(self, _, task: ImportTask) -> None:
         """Import hook for fetching lyrics automatically."""
         if query_str := self.config["auto_ignore"].get():
-            query, _ = parse_query_string(query_str, Item)
+            query, _ = Item.parse_query(query_str)
         else:
             # matches nothing, so all items proceed normally
             query = FalseQuery()

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -7,6 +7,7 @@ from os.path import relpath
 
 from beets import config, ui, util
 from beets.exceptions import UserError
+from beets.library import Album
 from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand
 from beets.util import PromptChoice, get_temp_filename
@@ -109,7 +110,7 @@ class PlayPlugin(BeetsPlugin):
             selection = lib.albums(args)
             paths = []
 
-            sort = lib.get_default_album_sort()
+            sort = Album.default_sort
             for album in selection:
                 if use_folders:
                     paths.append(album.item_dir())

--- a/beetsplug/playlist.py
+++ b/beetsplug/playlist.py
@@ -12,7 +12,7 @@ from beets.util import path_as_posix
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from beets.dbcore.query import FieldQueryType
+    from beets.dbcore.query import QueryByField
 
 
 def is_m3u_file(path: str) -> bool:
@@ -74,9 +74,7 @@ class PlaylistQuery(InQuery[bytes]):
 
 
 class PlaylistPlugin(beets.plugins.BeetsPlugin):
-    item_queries: ClassVar[dict[str, FieldQueryType]] = {
-        "playlist": PlaylistQuery
-    }
+    item_queries: ClassVar[QueryByField] = {"playlist": PlaylistQuery}
 
     def __init__(self):
         super().__init__()

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -16,7 +16,7 @@ from beets import plugins, ui
 from beets.dbcore.query import ParsingError, Query
 from beets.dbcore.sort import Sort
 from beets.exceptions import UserError
-from beets.library import Album, Item, parse_query_string
+from beets.library import Album, Item
 from beets.util import (
     bytestring_path,
     mkdirall,
@@ -29,7 +29,7 @@ from beets.util import (
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from beets.library import Library
+    from beets.library import LibModel, Library
 
 QueryAndSort = tuple[Query, Sort]
 PlaylistQuery = Query | tuple[QueryAndSort, ...] | None
@@ -206,18 +206,18 @@ class SmartPlaylistPlugin(plugins.BeetsPlugin):
         self.update_playlists(lib)
 
     def _parse_one_query(
-        self, playlist: dict[str, Any], key: str, model_cls: type
+        self, playlist: dict[str, Any], key: str, model_cls: type[LibModel]
     ) -> tuple[PlaylistQuery, Sort | None]:
         qs = playlist.get(key)
         if qs is None:
             return None, None
         if isinstance(qs, str):
-            return parse_query_string(qs, model_cls)
+            return model_cls.parse_query(qs)
         if len(qs) == 1:
-            return parse_query_string(qs[0], model_cls)
+            return model_cls.parse_query(qs[0])
 
         queries_and_sorts: tuple[QueryAndSort, ...] = tuple(
-            parse_query_string(q, model_cls) for q in qs
+            model_cls.parse_query(q) for q in qs
         )
         return queries_and_sorts, None
 

--- a/docs/_templates/autosummary/namedtuple.rst
+++ b/docs/_templates/autosummary/namedtuple.rst
@@ -3,3 +3,4 @@
 .. currentmodule:: {{ module }}
 
 .. autonamedtuple:: {{ objname }}
+    :members:

--- a/docs/api/database.rst
+++ b/docs/api/database.rst
@@ -43,3 +43,10 @@ Queries
     Query
     FieldQuery
     AndQuery
+
+.. currentmodule:: beets.dbcore.queryparse
+
+.. autosummary::
+    :toctree: generated/
+
+    ModelQuery

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -65,9 +65,15 @@ Bug fixes
   ordered before present ones when sorting ascending and after them when
   descending. :bug:`3461`
 
-..
-    For plugin developers
-    ~~~~~~~~~~~~~~~~~~~~~
+For plugin developers
+~~~~~~~~~~~~~~~~~~~~~
+
+- Query parsing is now available through ``Item.parse_query`` and
+  ``Album.parse_query``, which return a
+  :class:`~beets.dbcore.queryparse.ModelQuery` containing the query and sort
+  order. The ``parse_query_string``, ``parse_query_parts``,
+  ``query_from_strings``, ``sort_from_strings``, and ``parse_sorted_query``
+  helpers are deprecated.
 
 Other changes
 ~~~~~~~~~~~~~

--- a/docs/dev/library.rst
+++ b/docs/dev/library.rst
@@ -237,6 +237,22 @@ There are many different types of queries. Just as an example,
 :class:`CollectionQuery`) takes a set of other query objects and bundles them
 together, matching only albums/items that match all constituent queries.
 
-Beets has a human-writable plain-text query syntax that can be parsed into
-:class:`Query` objects. Calling ``AndQuery.from_strings`` parses a list of query
-parts into a query object that can then be used with |Library| objects.
+Beets has a human-writable plain-text query syntax. The |Library| query methods
+accept this syntax directly:
+
+.. code-block:: python
+
+    items = lib.items('artist:"The Beatles" year-')
+
+When code needs the :class:`Query` and sort objects directly, use
+``Item.parse_query`` for item queries or ``Album.parse_query`` for album
+queries. These class methods accept either a query string or a sequence of query
+parts and return a :class:`~beets.dbcore.queryparse.ModelQuery` containing both
+objects.
+
+Use :meth:`FieldQuery.from_model` when constructing a field query directly. This
+applies the model's field aliases and normalization rules:
+
+.. code-block:: python
+
+    query = MatchQuery.from_model(Item, "artist", "The Beatles")

--- a/test/dbcore/test_db.py
+++ b/test/dbcore/test_db.py
@@ -504,16 +504,16 @@ class ResultsIteratorTest(unittest.TestCase):
         self.db._connection().close()
 
     def test_iterate_once(self):
-        objs = self.db._fetch(ModelFixture1)
+        objs = self.db.get_results(ModelFixture1)
         assert len(list(objs)) == 2
 
     def test_iterate_twice(self):
-        objs = self.db._fetch(ModelFixture1)
+        objs = self.db.get_results(ModelFixture1)
         list(objs)
         assert len(list(objs)) == 2
 
     def test_concurrent_iterators(self):
-        results = self.db._fetch(ModelFixture1)
+        results = self.db.get_results(ModelFixture1)
         it1 = iter(results)
         it2 = iter(results)
         next(it1)
@@ -522,43 +522,45 @@ class ResultsIteratorTest(unittest.TestCase):
 
     def test_slow_query(self):
         q = query.SubstringQuery("foo", "ba", False)
-        objs = self.db._fetch(ModelFixture1, q)
+        objs = self.db.get_results(ModelFixture1, q)
         assert len(list(objs)) == 2
 
     def test_slow_query_negative(self):
         q = query.SubstringQuery("foo", "qux", False)
-        objs = self.db._fetch(ModelFixture1, q)
+        objs = self.db.get_results(ModelFixture1, q)
         assert len(list(objs)) == 0
 
     def test_iterate_slow_sort(self):
         s = sort.SlowFieldSort("foo")
-        res = self.db._fetch(ModelFixture1, sort=s)
+        res = self.db.get_results(ModelFixture1, sort=s)
         objs = list(res)
         assert objs[0].foo == "bar"
         assert objs[1].foo == "baz"
 
     def test_unsorted_subscript(self):
-        objs = self.db._fetch(ModelFixture1)
+        objs = self.db.get_results(ModelFixture1)
         assert objs[0].foo == "baz"
         assert objs[1].foo == "bar"
 
     def test_slow_sort_subscript(self):
         s = sort.SlowFieldSort("foo")
-        objs = self.db._fetch(ModelFixture1, sort=s)
+        objs = self.db.get_results(ModelFixture1, sort=s)
         assert objs[0].foo == "bar"
         assert objs[1].foo == "baz"
 
     def test_length(self):
-        objs = self.db._fetch(ModelFixture1)
+        objs = self.db.get_results(ModelFixture1)
         assert len(objs) == 2
 
     def test_out_of_range(self):
-        objs = self.db._fetch(ModelFixture1)
+        objs = self.db.get_results(ModelFixture1)
         with pytest.raises(IndexError):
             objs[100]
 
     def test_no_results(self):
-        assert self.db._fetch(ModelFixture1, query.FalseQuery()).get() is None
+        assert (
+            self.db.get_results(ModelFixture1, query.FalseQuery()).get() is None
+        )
 
 
 class TestException:

--- a/test/dbcore/test_db.py
+++ b/test/dbcore/test_db.py
@@ -150,7 +150,7 @@ class MigrationTest(unittest.TestCase):
         c.execute("select * from test")
         row = c.fetchone()
         c.connection.close()
-        assert len(row.keys()) == len(ModelFixture2._fields)
+        assert len(row.keys()) == len(ModelFixture1._fields)
 
     def test_open_with_multiple_new_fields(self):
         new_lib = DatabaseFixture4(self.libfile)
@@ -353,9 +353,12 @@ class ModelTest(unittest.TestCase):
     def test_items(self):
         model = ModelFixture1(self.db)
         model.id = 5
-        assert {("id", 5), ("field_one", 0), ("field_two", "")} == set(
-            model.items()
-        )
+        assert {
+            ("id", 5),
+            ("field_one", 0),
+            ("field_two", ""),
+            ("path", b""),
+        } == set(model.items())
 
     def test_delete_internal_field(self):
         model = dbcore.Model()

--- a/test/dbcore/test_query.py
+++ b/test/dbcore/test_query.py
@@ -31,10 +31,6 @@ from beets.dbcore.query import (
 from beets.library import Item
 from beets.test import _common
 
-# Because the absolute path begins with something like C:, we
-# can't disambiguate it from an ordinary query.
-WIN32_NO_IMPLICIT_PATHS = "Implicit paths are not supported on Windows"
-
 _p = pytest.param
 
 
@@ -378,7 +374,9 @@ class TestPathQuery:
 
         assert {i.title for i in lib.items(q)} == {"relative item"}
 
-    @pytest.mark.skipif(sys.platform == "win32", reason=WIN32_NO_IMPLICIT_PATHS)
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason=_common.WIN32_NO_IMPLICIT_PATHS
+    )
     @pytest.mark.parametrize(
         "q, expected_titles",
         [
@@ -416,7 +414,9 @@ class TestPathQuery:
 
     # FIXME: Also create a variant of this test for windows, which tests
     # both os.sep and os.altsep
-    @pytest.mark.skipif(sys.platform == "win32", reason=WIN32_NO_IMPLICIT_PATHS)
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason=_common.WIN32_NO_IMPLICIT_PATHS
+    )
     @pytest.mark.parametrize(
         "q, is_path_query",
         [

--- a/test/dbcore/test_queryparse.py
+++ b/test/dbcore/test_queryparse.py
@@ -78,9 +78,7 @@ class QueryFromStringsTest(unittest.TestCase):
 
     def test_zero_parts(self):
         q = self.qfs([])
-        assert isinstance(q, query.AndQuery)
-        assert len(q.subqueries) == 1
-        assert isinstance(q.subqueries[0], query.TrueQuery)
+        assert isinstance(q, query.TrueQuery)
 
     def test_two_parts(self):
         q = self.qfs(["foo", "bar:baz"])
@@ -91,15 +89,15 @@ class QueryFromStringsTest(unittest.TestCase):
 
     def test_parse_fixed_type_query(self):
         q = self.qfs(["field_one:2..3"])
-        assert isinstance(q.subqueries[0], query.NumericQuery)
+        assert isinstance(q, query.NumericQuery)
 
     def test_parse_flex_type_query(self):
         q = self.qfs(["some_float_field:2..3"])
-        assert isinstance(q.subqueries[0], query.NumericQuery)
+        assert isinstance(q, query.NumericQuery)
 
     def test_empty_query_part(self):
         q = self.qfs([""])
-        assert isinstance(q.subqueries[0], query.TrueQuery)
+        assert isinstance(q, query.TrueQuery)
 
 
 class SortFromStringsTest(unittest.TestCase):
@@ -159,9 +157,9 @@ class ParseSortedQueryTest(unittest.TestCase):
 
     def test_no_spaces_or_query(self):
         q, s = self.psq("foo,bar")
-        assert isinstance(q, query.AndQuery)
+        assert isinstance(q, query.OrQuery)
         assert isinstance(s, sort.NullSort)
-        assert len(q.subqueries) == 1
+        assert len(q.subqueries) == 2
 
     def test_trailing_comma_or_query(self):
         q, s = self.psq("foo , bar ,")
@@ -177,9 +175,8 @@ class ParseSortedQueryTest(unittest.TestCase):
 
     def test_only_direction(self):
         q, s = self.psq("-")
-        assert isinstance(q, query.AndQuery)
+        assert isinstance(q, query.NotQuery)
         assert isinstance(s, sort.NullSort)
-        assert len(q.subqueries) == 1
 
 
 class ParseQueryTest:

--- a/test/dbcore/test_queryparse.py
+++ b/test/dbcore/test_queryparse.py
@@ -4,14 +4,14 @@ import unittest
 
 import pytest
 
-from beets import dbcore
 from beets.dbcore import ModelQuery, query, sort
+from beets.dbcore.queryparse import QueryTerm
 from beets.test.fixtures import ModelFixture1, SortFixture
 
 
 class QueryParseTest(unittest.TestCase):
     def pqp(self, part):
-        term = dbcore.queryparse.QueryTerm.make(part)
+        term = QueryTerm.make(part)
         return term.field, term.pattern, term.get_query_cls(ModelFixture1)
 
     def test_one_basic_term(self):
@@ -66,7 +66,7 @@ class QueryParseTest(unittest.TestCase):
 
     def test_implicit_path(self):
         q = "/tmp"
-        r = ("path", "/tmp", dbcore.query.PathQuery)
+        r = ("path", "/tmp", query.PathQuery)
         assert self.pqp(q) == r
 
 
@@ -179,5 +179,5 @@ class ParseSortedQueryTest(unittest.TestCase):
 
 class ParseQueryTest:
     def test_parse_invalid_query_string(self):
-        with pytest.raises(dbcore.query.ParsingError):
+        with pytest.raises(query.ParsingError):
             ModelQuery.parse(ModelFixture1, 'foo"')

--- a/test/dbcore/test_queryparse.py
+++ b/test/dbcore/test_queryparse.py
@@ -72,7 +72,7 @@ class QueryParseTest(unittest.TestCase):
 
 class QueryFromStringsTest(unittest.TestCase):
     def qfs(self, strings):
-        return dbcore.queryparse.build_and_query(ModelFixture1, strings)
+        return ModelQuery.build_and_query(ModelFixture1, strings)
 
     def test_zero_parts(self):
         q = self.qfs([])
@@ -100,7 +100,7 @@ class QueryFromStringsTest(unittest.TestCase):
 
 class SortFromStringsTest(unittest.TestCase):
     def sfs(self, strings):
-        return dbcore.queryparse.sort_from_strings(ModelFixture1, strings)
+        return ModelQuery.get_sort(ModelFixture1, strings)
 
     def test_zero_parts(self):
         s = self.sfs([])
@@ -133,7 +133,7 @@ class SortFromStringsTest(unittest.TestCase):
 
 class ParseSortedQueryTest(unittest.TestCase):
     def psq(self, parts):
-        return dbcore.parse_sorted_query(ModelFixture1, parts.split())
+        return ModelQuery.parse(ModelFixture1, parts.split())
 
     def test_and_query(self):
         q, s = self.psq("foo bar")
@@ -149,12 +149,9 @@ class ParseSortedQueryTest(unittest.TestCase):
 
     def test_no_space_before_comma_or_query(self):
         q, s = self.psq("foo, bar")
-        assert isinstance(q, query.AndQuery)
-        assert isinstance(q.subqueries[0], query.OrQuery)
-        assert isinstance(q.subqueries[1], query.OrQuery)
-        assert len(q.subqueries[0].subqueries) == 2
-        assert len(q.subqueries[1].subqueries) == 2
+        assert isinstance(q, query.OrQuery)
         assert isinstance(s, sort.NullSort)
+        assert len(q.subqueries) == 4
 
     def test_no_spaces_or_query(self):
         q, s = self.psq("foo,bar")

--- a/test/dbcore/test_queryparse.py
+++ b/test/dbcore/test_queryparse.py
@@ -72,9 +72,7 @@ class QueryParseTest(unittest.TestCase):
 
 class QueryFromStringsTest(unittest.TestCase):
     def qfs(self, strings):
-        return dbcore.queryparse.query_from_strings(
-            query.AndQuery, ModelFixture1, strings
-        )
+        return dbcore.queryparse.build_and_query(ModelFixture1, strings)
 
     def test_zero_parts(self):
         q = self.qfs([])

--- a/test/dbcore/test_queryparse.py
+++ b/test/dbcore/test_queryparse.py
@@ -145,13 +145,16 @@ class ParseSortedQueryTest(unittest.TestCase):
         q, s = self.psq("foo , bar")
         assert isinstance(q, query.OrQuery)
         assert isinstance(s, sort.NullSort)
-        assert len(q.subqueries) == 2
+        assert len(q.subqueries) == 4
 
     def test_no_space_before_comma_or_query(self):
         q, s = self.psq("foo, bar")
-        assert isinstance(q, query.OrQuery)
+        assert isinstance(q, query.AndQuery)
+        assert isinstance(q.subqueries[0], query.OrQuery)
+        assert isinstance(q.subqueries[1], query.OrQuery)
+        assert len(q.subqueries[0].subqueries) == 2
+        assert len(q.subqueries[1].subqueries) == 2
         assert isinstance(s, sort.NullSort)
-        assert len(q.subqueries) == 2
 
     def test_no_spaces_or_query(self):
         q, s = self.psq("foo,bar")
@@ -163,13 +166,13 @@ class ParseSortedQueryTest(unittest.TestCase):
         q, s = self.psq("foo , bar ,")
         assert isinstance(q, query.OrQuery)
         assert isinstance(s, sort.NullSort)
-        assert len(q.subqueries) == 3
+        assert len(q.subqueries) == 5
 
     def test_leading_comma_or_query(self):
         q, s = self.psq(", foo , bar")
         assert isinstance(q, query.OrQuery)
         assert isinstance(s, sort.NullSort)
-        assert len(q.subqueries) == 3
+        assert len(q.subqueries) == 5
 
     def test_only_direction(self):
         q, s = self.psq("-")

--- a/test/dbcore/test_queryparse.py
+++ b/test/dbcore/test_queryparse.py
@@ -2,8 +2,10 @@
 
 import unittest
 
+import pytest
+
 from beets import dbcore
-from beets.dbcore import query, sort
+from beets.dbcore import ModelQuery, query, sort
 from beets.test.fixtures import ModelFixture1, SortFixture
 
 
@@ -178,3 +180,9 @@ class ParseSortedQueryTest(unittest.TestCase):
         assert isinstance(q, query.AndQuery)
         assert isinstance(s, sort.NullSort)
         assert len(q.subqueries) == 1
+
+
+class ParseQueryTest:
+    def test_parse_invalid_query_string(self):
+        with pytest.raises(dbcore.query.ParsingError):
+            ModelQuery.parse(ModelFixture1, 'foo"')

--- a/test/dbcore/test_queryparse.py
+++ b/test/dbcore/test_queryparse.py
@@ -10,7 +10,7 @@ from beets.test.fixtures import ModelFixture1, SortFixture
 class QueryParseTest(unittest.TestCase):
     def pqp(self, part):
         return dbcore.queryparse.parse_query_part(
-            part, {"year": query.NumericQuery}, {":": query.RegexpQuery}
+            part, {"year": query.NumericQuery}
         )[:-1]  # remove the negate flag
 
     def test_one_basic_term(self):
@@ -67,7 +67,7 @@ class QueryParseTest(unittest.TestCase):
 class QueryFromStringsTest(unittest.TestCase):
     def qfs(self, strings):
         return dbcore.queryparse.query_from_strings(
-            query.AndQuery, ModelFixture1, {":": query.RegexpQuery}, strings
+            query.AndQuery, ModelFixture1, strings
         )
 
     def test_zero_parts(self):

--- a/test/dbcore/test_queryparse.py
+++ b/test/dbcore/test_queryparse.py
@@ -1,9 +1,12 @@
 """Tests for dbcore query parsing helpers."""
 
+import sys
+
 import pytest
 
 from beets.dbcore import ModelQuery, query, sort
 from beets.dbcore.queryparse import QueryTerm
+from beets.test._common import WIN32_NO_IMPLICIT_PATHS
 from beets.test.fixtures import ModelFixture1, SortFixture
 
 _p = pytest.param
@@ -26,12 +29,25 @@ class TestQueryTermParsing:
             ("test:", ("test", "", query.SubstringQuery)),
             (r":regexp", (None, "regexp", query.RegexpQuery)),
             (r"test::regexp", ("test", "regexp", query.RegexpQuery)),
-            (r"test\:val", (None, "test:val", query.SubstringQuery)),
+            _p(
+                r"test\:val",
+                (None, "test:val", query.SubstringQuery),
+                marks=pytest.mark.skipif(
+                    sys.platform == "win32",
+                    reason="Backslash is parsed as a path separator in Windows",
+                ),
+            ),
             (r":test\:regexp", (None, "test:regexp", query.RegexpQuery)),
             ("year:1999", ("year", "1999", query.NumericQuery)),
             ("year:1999..2010", ("year", "1999..2010", query.NumericQuery)),
             ("", (None, "", query.SubstringQuery)),
-            ("/tmp", ("path", "/tmp", query.PathQuery)),
+            _p(
+                "/tmp",
+                ("path", "/tmp", query.PathQuery),
+                marks=pytest.mark.skipif(
+                    sys.platform == "win32", reason=WIN32_NO_IMPLICIT_PATHS
+                ),
+            ),
         ],
     )
     def test_query_term_parsing(self, query_string, expected):

--- a/test/dbcore/test_queryparse.py
+++ b/test/dbcore/test_queryparse.py
@@ -9,9 +9,8 @@ from beets.test.fixtures import ModelFixture1, SortFixture
 
 class QueryParseTest(unittest.TestCase):
     def pqp(self, part):
-        return dbcore.queryparse.parse_query_part(
-            part, {"year": query.NumericQuery}
-        )[:-1]  # remove the negate flag
+        term = dbcore.queryparse.QueryTerm.make(part)
+        return term.field, term.pattern, term.get_query_cls(ModelFixture1)
 
     def test_one_basic_term(self):
         q = "test"
@@ -61,6 +60,11 @@ class QueryParseTest(unittest.TestCase):
     def test_empty_query_part(self):
         q = ""
         r = (None, "", query.SubstringQuery)
+        assert self.pqp(q) == r
+
+    def test_implicit_path(self):
+        q = "/tmp"
+        r = ("path", "/tmp", dbcore.query.PathQuery)
         assert self.pqp(q) == r
 
 

--- a/test/dbcore/test_queryparse.py
+++ b/test/dbcore/test_queryparse.py
@@ -1,183 +1,138 @@
 """Tests for dbcore query parsing helpers."""
 
-import unittest
-
 import pytest
 
 from beets.dbcore import ModelQuery, query, sort
 from beets.dbcore.queryparse import QueryTerm
 from beets.test.fixtures import ModelFixture1, SortFixture
 
-
-class QueryParseTest(unittest.TestCase):
-    def pqp(self, part):
-        term = QueryTerm.make(part)
-        return term.field, term.pattern, term.get_query_cls(ModelFixture1)
-
-    def test_one_basic_term(self):
-        q = "test"
-        r = (None, "test", query.SubstringQuery)
-        assert self.pqp(q) == r
-
-    def test_one_keyed_term(self):
-        q = "test:val"
-        r = ("test", "val", query.SubstringQuery)
-        assert self.pqp(q) == r
-
-    def test_colon_at_end(self):
-        q = "test:"
-        r = ("test", "", query.SubstringQuery)
-        assert self.pqp(q) == r
-
-    def test_one_basic_regexp(self):
-        q = r":regexp"
-        r = (None, "regexp", query.RegexpQuery)
-        assert self.pqp(q) == r
-
-    def test_keyed_regexp(self):
-        q = r"test::regexp"
-        r = ("test", "regexp", query.RegexpQuery)
-        assert self.pqp(q) == r
-
-    def test_escaped_colon(self):
-        q = r"test\:val"
-        r = (None, "test:val", query.SubstringQuery)
-        assert self.pqp(q) == r
-
-    def test_escaped_colon_in_regexp(self):
-        q = r":test\:regexp"
-        r = (None, "test:regexp", query.RegexpQuery)
-        assert self.pqp(q) == r
-
-    def test_single_year(self):
-        q = "year:1999"
-        r = ("year", "1999", query.NumericQuery)
-        assert self.pqp(q) == r
-
-    def test_multiple_years(self):
-        q = "year:1999..2010"
-        r = ("year", "1999..2010", query.NumericQuery)
-        assert self.pqp(q) == r
-
-    def test_empty_query_part(self):
-        q = ""
-        r = (None, "", query.SubstringQuery)
-        assert self.pqp(q) == r
-
-    def test_implicit_path(self):
-        q = "/tmp"
-        r = ("path", "/tmp", query.PathQuery)
-        assert self.pqp(q) == r
+_p = pytest.param
 
 
-class QueryFromStringsTest(unittest.TestCase):
-    def qfs(self, strings):
-        return ModelQuery.build_and_query(ModelFixture1, strings)
+def _parse_query_parts(parts: list[str]):
+    return ModelFixture1.parse_query(parts).query
 
-    def test_zero_parts(self):
-        q = self.qfs([])
-        assert isinstance(q, query.TrueQuery)
 
-    def test_two_parts(self):
-        q = self.qfs(["foo", "bar:baz"])
+def _parse_sort_parts(parts: list[str]):
+    return ModelFixture1.parse_query(parts).sort
+
+
+class TestQueryTermParsing:
+    @pytest.mark.parametrize(
+        "query_string,expected",
+        [
+            ("test", (None, "test", query.SubstringQuery)),
+            ("test:val", ("test", "val", query.SubstringQuery)),
+            ("test:", ("test", "", query.SubstringQuery)),
+            (r":regexp", (None, "regexp", query.RegexpQuery)),
+            (r"test::regexp", ("test", "regexp", query.RegexpQuery)),
+            (r"test\:val", (None, "test:val", query.SubstringQuery)),
+            (r":test\:regexp", (None, "test:regexp", query.RegexpQuery)),
+            ("year:1999", ("year", "1999", query.NumericQuery)),
+            ("year:1999..2010", ("year", "1999..2010", query.NumericQuery)),
+            ("", (None, "", query.SubstringQuery)),
+            ("/tmp", ("path", "/tmp", query.PathQuery)),
+        ],
+    )
+    def test_query_term_parsing(self, query_string, expected):
+        """Test that various query strings are parsed correctly."""
+        term = QueryTerm.make(query_string)
+        result = term.field, term.pattern, term.get_query_cls(ModelFixture1)
+        assert result == expected
+
+
+class TestQueryFromParts:
+    @pytest.mark.parametrize(
+        "query_parts,expected_type",
+        [
+            _p([], query.TrueQuery, id="zero_parts"),
+            _p([""], query.TrueQuery, id="empty_query_part"),
+            _p(["field_one:2..3"], query.NumericQuery, id="fixed_type_query"),
+            _p(
+                ["some_float_field:2..3"],
+                query.NumericQuery,
+                id="flex_type_query",
+            ),
+        ],
+    )
+    def test_query_from_parts_types(self, query_parts, expected_type):
+        q = _parse_query_parts(query_parts)
+        assert isinstance(q, expected_type)
+
+    def test_query_from_two_parts_builds_and_query(self):
+        q = _parse_query_parts(["foo", "bar:baz"])
         assert isinstance(q, query.AndQuery)
         assert len(q.subqueries) == 2
         assert isinstance(q.subqueries[0], query.OrQuery)
         assert isinstance(q.subqueries[1], query.SubstringQuery)
 
-    def test_parse_fixed_type_query(self):
-        q = self.qfs(["field_one:2..3"])
-        assert isinstance(q, query.NumericQuery)
 
-    def test_parse_flex_type_query(self):
-        q = self.qfs(["some_float_field:2..3"])
-        assert isinstance(q, query.NumericQuery)
-
-    def test_empty_query_part(self):
-        q = self.qfs([""])
-        assert isinstance(q, query.TrueQuery)
-
-
-class SortFromStringsTest(unittest.TestCase):
-    def sfs(self, strings):
-        return ModelQuery.get_sort(ModelFixture1, strings)
-
-    def test_zero_parts(self):
-        s = self.sfs([])
+class TestSortFromParts:
+    def test_sort_from_zero_parts(self):
+        s = _parse_sort_parts([])
         assert isinstance(s, sort.NullSort)
         assert s == sort.NullSort()
 
-    def test_one_parts(self):
-        s = self.sfs(["field+"])
+    def test_sort_from_one_part(self):
+        s = _parse_sort_parts(["field+"])
         assert isinstance(s, sort.Sort)
 
-    def test_two_parts(self):
-        s = self.sfs(["field+", "another_field-"])
+    def test_sort_from_two_parts(self):
+        s = _parse_sort_parts(["field+", "another_field-"])
         assert isinstance(s, sort.MultipleSort)
         assert len(s.sorts) == 2
 
-    def test_fixed_field_sort(self):
-        s = self.sfs(["field_one+"])
-        assert isinstance(s, sort.FixedFieldSort)
-        assert s == sort.FixedFieldSort("field_one")
-
-    def test_flex_field_sort(self):
-        s = self.sfs(["flex_field+"])
-        assert isinstance(s, sort.SlowFieldSort)
-        assert s == sort.SlowFieldSort("flex_field")
-
-    def test_special_sort(self):
-        s = self.sfs(["some_sort+"])
-        assert isinstance(s, SortFixture)
-
-
-class ParseSortedQueryTest(unittest.TestCase):
-    def psq(self, parts):
-        return ModelQuery.parse(ModelFixture1, parts.split())
-
-    def test_and_query(self):
-        q, s = self.psq("foo bar")
-        assert isinstance(q, query.AndQuery)
-        assert isinstance(s, sort.NullSort)
-        assert len(q.subqueries) == 2
-
-    def test_or_query(self):
-        q, s = self.psq("foo , bar")
-        assert isinstance(q, query.OrQuery)
-        assert isinstance(s, sort.NullSort)
-        assert len(q.subqueries) == 4
-
-    def test_no_space_before_comma_or_query(self):
-        q, s = self.psq("foo, bar")
-        assert isinstance(q, query.OrQuery)
-        assert isinstance(s, sort.NullSort)
-        assert len(q.subqueries) == 4
-
-    def test_no_spaces_or_query(self):
-        q, s = self.psq("foo,bar")
-        assert isinstance(q, query.OrQuery)
-        assert isinstance(s, sort.NullSort)
-        assert len(q.subqueries) == 2
-
-    def test_trailing_comma_or_query(self):
-        q, s = self.psq("foo , bar ,")
-        assert isinstance(q, query.OrQuery)
-        assert isinstance(s, sort.NullSort)
-        assert len(q.subqueries) == 5
-
-    def test_leading_comma_or_query(self):
-        q, s = self.psq(", foo , bar")
-        assert isinstance(q, query.OrQuery)
-        assert isinstance(s, sort.NullSort)
-        assert len(q.subqueries) == 5
-
-    def test_only_direction(self):
-        q, s = self.psq("-")
-        assert isinstance(q, query.NotQuery)
-        assert isinstance(s, sort.NullSort)
+    @pytest.mark.parametrize(
+        "sort_parts,expected_type,expected_sort",
+        [
+            _p(
+                ["field_one+"],
+                sort.FixedFieldSort,
+                sort.FixedFieldSort("field_one"),
+                id="fixed_field_sort",
+            ),
+            _p(
+                ["flex_field+"],
+                sort.SlowFieldSort,
+                sort.SlowFieldSort("flex_field"),
+                id="flex_field_sort",
+            ),
+            _p(["some_sort+"], SortFixture, None, id="special_sort"),
+        ],
+    )
+    def test_sort_from_parts_types(
+        self, sort_parts, expected_type, expected_sort
+    ):
+        s = _parse_sort_parts(sort_parts)
+        assert isinstance(s, expected_type)
+        if expected_sort is not None:
+            assert s == expected_sort
 
 
-class ParseQueryTest:
+class TestParseSortedQuery:
+    @pytest.mark.parametrize(
+        "query_str,expected_type,expected_subqueries",
+        [
+            _p("foo bar", query.AndQuery, 2, id="and_query"),
+            _p("foo , bar", query.OrQuery, 4, id="or_query"),
+            _p("foo, bar", query.OrQuery, 4, id="no_space_before_comma_or_query"),
+            _p("foo,bar", query.OrQuery, 2, id="no_spaces_or_query"),
+            _p("foo , bar ,", query.OrQuery, 5, id="trailing_comma_or_query"),
+            _p(", foo , bar", query.OrQuery, 5, id="leading_comma_or_query"),
+            _p("-", query.NotQuery, None, id="only_direction"),
+        ],
+    )  # fmt: skip
+    def test_parse_sorted_query(
+        self, query_str, expected_type, expected_subqueries
+    ):
+        """Verify that query strings are parsed into the correct query type."""
+        q = _parse_query_parts(query_str.split())
+        assert isinstance(q, expected_type)
+        if expected_subqueries is not None:
+            assert len(q.subqueries) == expected_subqueries
+
+
+class TestModelQueryErrors:
     def test_parse_invalid_query_string(self):
         with pytest.raises(query.ParsingError):
             ModelQuery.parse(ModelFixture1, 'foo"')

--- a/test/dbcore/test_sort.py
+++ b/test/dbcore/test_sort.py
@@ -304,9 +304,7 @@ class TestNonExistingField:
         If a string ends with a sorting suffix, it takes precedence over the
         NotQuery parsing.
         """
-        query, sort = beets.library.parse_query_string(
-            "-bar+", beets.library.Item
-        )
+        query, sort = beets.library.Item.parse_query("-bar+")
         assert len(query.subqueries) == 1
         assert isinstance(query.subqueries[0], TrueQuery)
         assert isinstance(sort, SlowFieldSort)

--- a/test/dbcore/test_sort.py
+++ b/test/dbcore/test_sort.py
@@ -305,7 +305,6 @@ class TestNonExistingField:
         NotQuery parsing.
         """
         query, sort = beets.library.Item.parse_query("-bar+")
-        assert len(query.subqueries) == 1
-        assert isinstance(query.subqueries[0], TrueQuery)
+        assert isinstance(query, TrueQuery)
         assert isinstance(sort, SlowFieldSort)
         assert sort.field == "-bar"

--- a/test/dbcore/test_sort.py
+++ b/test/dbcore/test_sort.py
@@ -160,6 +160,23 @@ class TestCaseSensitivity:
         helper.add_item(artist="artist", flex1="flex1", track=10)
         helper.add_item(artist="Artist", flex1="Flex1", track=2)
 
+    @pytest.fixture
+    def config(self, monkeypatch, config):
+        """Monkeypatch the config to clear the cached sort settings.
+
+        This is needed because ``FieldSort`` is accessed multiple times during
+        the test.
+        """
+
+        def _set_config(_, key, value):
+            """Invalidate cached sort settings before updating the config."""
+            if key == "sort_case_insensitive":
+                util.cached_classproperty.cache.clear()
+            config.set({key: value})
+
+        monkeypatch.setattr("confuse.core.ConfigView.__setitem__", _set_config)
+        return config
+
     @pytest.mark.parametrize(
         "getter,query,attr,expected_insensitive,expected_sensitive",
         [

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -9,7 +9,7 @@ import pytest
 
 from beets import config
 from beets.dbcore.sort import FixedFieldSort, MultipleSort, NullSort
-from beets.library import Album, Item, parse_query_string
+from beets.library import Album, Item
 from beets.test._common import item
 from beets.test.helper import BeetsTestCase, IOMixin, PathsMixin, PluginTestCase
 from beets.ui import UserError
@@ -48,15 +48,11 @@ class SmartPlaylistTest(PlaylistDirMixin, BeetsTestCase):
         )
         spl.build_queries()
         assert spl._matched_playlists == set()
-        foo_foo = parse_query_string("FOO foo", Item)
-        baz_baz = parse_query_string("BAZ baz", Item)
-        baz_baz2 = parse_query_string("BAZ baz", Album)
-        # Multiple queries are now stored as a tuple of (query, sort) tuples
+        foo_foo = Item.parse_query("FOO foo")
+        baz_baz = Item.parse_query("BAZ baz")
+        baz_baz2 = Album.parse_query("BAZ baz")
         bar_queries = tuple(
-            [
-                parse_query_string("BAR bar1", Album),
-                parse_query_string("BAR bar2", Album),
-            ]
+            [Album.parse_query("BAR bar1"), Album.parse_query("BAR bar2")]
         )
         assert spl._unmatched_playlists == {
             ("foo", foo_foo, (None, None)),
@@ -95,10 +91,10 @@ class SmartPlaylistTest(PlaylistDirMixin, BeetsTestCase):
                 sorts[name] = sort
 
         sort = FixedFieldSort  # short cut since we're only dealing with this
-        assert sorts["no_sort"] == NullSort()
+        assert not sorts["no_sort"]
         assert sorts["one_sort"] == sort("year")
         # Multiple queries store individual sorts in the tuple
-        assert all(isinstance(x, NullSort) for x in sorts["only_empty_sorts"])
+        assert not any(x for x in sorts["only_empty_sorts"])
         assert sorts["one_non_empty_sort"] == [sort("year"), NullSort()]
         assert sorts["multiple_sorts"] == [sort("year"), sort("genres", False)]
         assert sorts["mixed"] == [

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -13,7 +13,6 @@ from unittest.mock import patch
 import pytest
 from mediafile import MediaFile, UnreadableFileError
 
-import beets.dbcore.query
 import beets.library
 from beets import config, plugins, util
 from beets.library import Album
@@ -1385,13 +1384,3 @@ class TestItemPruneDirsClutter(TestHelper):
         item.remove(delete=True)
 
         assert not os.path.exists(syspath(old_dir))
-
-
-class TestParseQuery:
-    def test_parse_invalid_query_string(self):
-        with pytest.raises(beets.dbcore.query.ParsingError):
-            beets.library.parse_query_string('foo"', None)
-
-    def test_parse_bytes(self):
-        with pytest.raises(AssertionError):
-            beets.library.parse_query_string(b"query", None)


### PR DESCRIPTION
## Query Parsing Architecture Consolidation

### What this PR does

This PR reshapes query parsing around a single model-level entrypoint and moves parsing/building responsibilities closer to the objects that own them.

At a high level, the change:

1. Replaces scattered query/sort helper functions with `LibModel.parse_query(...)`.
2. Centralizes parsing into `ModelQuery`, `QueryTerm`, and `SortTerm`.
3. Moves field-specific query construction into query classes via `FieldQuery.from_model(...)`.
4. Updates library and plugin call sites to consume the new API consistently.
5. Cleans up and modernizes the test suite around the new parsing model.

---

## Why this matters

**Before**:
- Query parsing logic was split across multiple helper functions.
- Callers had to know which parsing helper to use.
- Field normalization and query construction were partly model-owned, partly parser-owned.
- Tests were spread across unrelated files and still used older `unittest` patterns.

**After**:
- Parsing has one clear entrypoint: `Item.parse_query(...)` / `Album.parse_query(...)`.
- Query terms, sort terms, and final model query assembly each have distinct responsibilities.
- Query classes now own more of their own normalization and construction behavior.
- The parser tokenizes input once and builds both `query` and `sort` from the same token stream.
- Tests better reflect the actual parsing contract.

---

## Architecture changes

### 1. Single parsing entrypoint: `LibModel.parse_query(...)`

The biggest architectural change is that model classes now own parsing through `LibModel.parse_query(...)`, which returns a `ModelQuery` object:

```py
parsed = Item.parse_query('artist:foo year+')
query = parsed.query
sort = parsed.sort
```

This replaces older helper-style flows such as:
- `parse_query_string(...)`
- `parse_query_parts(...)`
- `query_from_strings(...)`
- `sort_from_strings(...)`
- `parse_sorted_query(...)`

### Result

Reviewers can now think about query parsing as:

```text
input -> model.parse_query(...) -> ModelQuery(query, sort)
```

instead of multiple helper paths.

---

### 2. Parsing pipeline is now explicit

The new parsing flow is layered:

```text
raw string / token list
    ->
`ModelQuery.parse(...)`
    ->
tokenization via `shlex`
    ->
`QueryTerm` parses search terms
`SortTerm` parses sort directives
    ->
`ModelQuery.get_query(...)`
`ModelQuery.get_sort(...)`
    ->
final executable `Query` + `Sort`
```

This makes responsibilities much clearer:

- `QueryTerm`: parse one search term like `'year:1999'` or `'/tmp'`
- `SortTerm`: parse one sort directive like `'artist+'`
- `ModelQuery`: orchestrate the full query string

---

### 3. Query construction moved closer to query classes

A second major design improvement is that field-aware query creation now lives in query classes themselves via `FieldQuery.from_model(...)`.

That method now handles concerns that used to be distributed elsewhere:

- legacy field alias replacement
- shared-table field qualification
- path normalization
- query-specific pattern normalization via `normalize_pattern(...)`

### Result

Instead of models and parsers coordinating low-level query setup, the query class now owns how it should be built for a model.

That is a cleaner boundary:

```text
parser decides "what query type"
query class decides "how to build itself correctly"
```

---

### 4. Query composition is simpler and flatter

`Query.__or__` was added, and both `AndQuery` and `OrQuery` now flatten when combined.

This matters because the parser now builds final query trees through operator composition rather than repeatedly wrapping collection queries.

### High-level impact

The resulting query objects are simpler:

- fewer unnecessary one-element wrappers
- more direct `TrueQuery`, `NumericQuery`, etc.
- flatter `AndQuery` / `OrQuery` trees

This is why several tests changed from asserting on nested `subqueries[0]` shapes to asserting directly on the final query type.

---

### 5. Sort handling is centralized and model-driven

Sort parsing now follows the same pattern as query parsing:

- `SortTerm` parses and validates sort tokens
- sort resolution happens against model metadata
- default sort resolution lives on `LibModel.default_sort`

Also, sort case sensitivity is now owned by `FieldSort` rather than threaded through parsing helpers.

### Result

Sorting behavior is:
- easier to reason about
- less coupled to parser plumbing
- more naturally configured at the sort layer

---

## Library and plugin integration impact

This PR updates multiple call sites to use the new model API consistently.

### Before

```py
query, sort = parse_query_string(q, Item)
```

or

```py
query, _ = Item.parse_query(q)
```

### After

```py
parsed = Item.parse_query(q)
query = parsed.query
sort = parsed.sort
```

This affects core library flow and plugin consumers such as:

- `advancedrewrite`
- `convert`
- `ihate`
- `lyrics`
- `smartplaylist`
- `aura`
- `bpd`

### Why this is good

All callers now depend on the same contract:
- models parse queries
- callers consume `.query` and `.sort`

That reduces API surface and keeps parsing behavior consistent across the application.

---

## Data flow after this PR

```text
User/config/plugin query string
    ->
`Item.parse_query(...)` / `Album.parse_query(...)`
    ->
`ModelQuery.parse(...)`
    ->
build `query` and `sort`
    ->
`Library.get_results(...)` / plugin matching logic
```

And inside parsing:

```text
'foo bar, baz year+'
    ->
search terms: `foo`, `bar`, `baz`
sort terms: `year+`
    ->
(`foo` AND `bar`) OR `baz`
+
sort by `year`
```

---

## Behavioral changes reviewers should notice

This is mostly a refactor, but there are a few meaningful parser-contract changes:

### 1. Simpler query object shapes
Empty and single-term parses now often return direct queries like `TrueQuery` or `NumericQuery` instead of wrapper collection queries.

### 2. Parsing happens once
`ModelQuery.parse(...)` tokenizes once and derives both query and sort from the same token stream.

### 3. Implicit path queries are normalized in parser/core flow
Path-like input such as `'/tmp'` becomes a `path` query earlier and more consistently.

### 4. Sort suffix precedence is clearer
Strings ending in `'+'` or `'-'` are treated as sort directives when valid.

### 5. Public helper surface is reduced
Legacy `dbcore` parsing re-exports/helpers are removed in favor of the model API.

---

## Test architecture changes

The test portion of this PR is not just cleanup; it aligns the suite with the new architecture.

### What changed

- Query parsing tests were moved into dedicated `test/dbcore/test_queryparse.py`
- shared test models/sorts/queries were extracted into `beets.test.fixtures`
- older `unittest.TestCase` style tests were rewritten into grouped pytest classes
- many repetitive cases were collapsed into `@pytest.mark.parametrize(...)`

### Why this matters

The tests now mirror the actual parser design:

- `TestQueryTermParsing`
- `TestQueryFromParts`
- `TestSortFromParts`
- `TestParseSortedQuery`
- `TestModelQueryErrors`

That makes the parser contract easier to review and safer to extend.

---

## Reviewer guide

If reviewing for architecture, the most important files are:

- `beets/dbcore/queryparse.py`
- `beets/dbcore/query.py`
- `beets/library/models.py`
- `beets/library/library.py`
- `beets/test/fixtures.py`
- `test/dbcore/test_queryparse.py`

### Suggested review order

1. `beets/dbcore/queryparse.py`
   - new parsing model
2. `beets/dbcore/query.py`
   - query construction and composition changes
3. `beets/library/models.py`
   - new model entrypoint and default sort ownership
4. plugin call sites
   - API adoption
5. tests
   - expected behavior and edge cases

---

## Net effect

This PR is a **query parsing consolidation**.

It moves the system from a helper-driven design to a model-centered parsing API with clearer ownership boundaries:

- models own parsing entrypoints
- parser objects own syntax handling
- query classes own model-aware construction
- sort classes own sort behavior
- callers consume one consistent parsed result

The overall impact is a smaller public surface, clearer layering, and a test suite that better documents the intended behavior.
