### PR TITLE
docs: adding beets-getlrc to the 'other plugins' list

### DIFF
--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -501,6 +501,10 @@ beetFs_
     Is a FUSE filesystem for browsing the music in your beets library. (Might be
     out of date.)
 
+beets-getlrc_
+    Fetches synced and non-synced lyrics and creates .lrc files to be used by
+    compatible music players.
+
 beets-goingrunning_
     Generates playlists to go with your running sessions.
 
@@ -620,6 +624,8 @@ beets-youtube_
 .. _beets-fillmissing: https://github.com/amiv1/beets-fillmissing
 
 .. _beets-follow: https://github.com/nolsto/beets-follow
+
+.. _beets-getlrc: https://github.com/jaedonswanson/beets-getlrc
 
 .. _beets-goingrunning: https://pypi.org/project/beets-goingrunning
 


### PR DESCRIPTION
## Description

I added a plugin i made to the docs (index.rst). I made sure to add a link to my github repo for the project. Nothing else was changed.