### PR TITLE
docs: fix received spelling in docs

### DIFF
--- a/docs/plugins/titlecase.rst
+++ b/docs/plugins/titlecase.rst
@@ -166,7 +166,7 @@ Default
 
      By default, titlecase runs on the candidates that are received, adjusting them before
      you make your selection and creating different weight calculations. If you'd rather
-     see the data as recieved from the database, set this to true to run after you make
+     see the data as received from the database, set this to true to run after you make
      your tag choice.
 
 Dangerous Fields


### PR DESCRIPTION
Changes:
- `recieved` -> `received` in `docs/plugins/titlecase.rst` (1 occurrence(s), preserving capitalization where applicable)

Verification:
- Applied an exact spelling-only replacement against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked open PR titles and my open PRs before opening this PR.
