### PR TITLE
Make aliases-as-credits functionality opt-in.

### DIFF
--- a/beetsplug/musicbrainz.py
+++ b/beetsplug/musicbrainz.py
@@ -277,6 +277,10 @@ class MusicBrainzPlugin(
     def ignore_video_tracks(self) -> bool:
         return config["match"]["ignore_video_tracks"].get(bool)
 
+    @cached_property
+    def aliases_as_credits(self) -> bool:
+        return self.config["aliases_as_credits"].get(bool)
+
     def __init__(self) -> None:
         """Set up the python-musicbrainz-ngs module according to settings
         from the beets configuration. This should be called at startup.
@@ -294,6 +298,7 @@ class MusicBrainzPlugin(
                     "tidal": False,
                 },
                 "extra_tags": [],
+                "aliases_as_credits": False,
             }
         )
         # TODO: Remove in 3.0.0
@@ -307,8 +312,9 @@ class MusicBrainzPlugin(
                 "'musicbrainz.search_limit'",
             )
 
-    @staticmethod
-    def _parse_artist_credits(artist_credits: list[ArtistCredit]) -> ArtistInfo:
+    def _parse_artist_credits(
+        self, artist_credits: list[ArtistCredit]
+    ) -> ArtistInfo:
         """Normalize MusicBrainz artist-credit data into tag-friendly fields.
 
         MusicBrainz represents credits as a sequence of credited artists, each
@@ -336,7 +342,9 @@ class MusicBrainzPlugin(
             artists_ids.append(el["artist"]["id"])
             alias = _preferred_alias(el["artist"].get("aliases", []))
             artist_object = alias or el["artist"]
-            credit_artist_object = alias or el
+            credit_artist_object = (
+                alias if (alias and self.aliases_as_credits) else el
+            )
 
             joinphrase = el["joinphrase"]
             for name, parts, multi in (

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,7 @@ New features
 - :doc:`plugins/listenbrainz`: Add support for importing ListenBrainz listening
   history from an export file. Use the ``-f`` / ``--export-file`` flag to
   specify the path to the ListenBrainz export file.
+- :doc:`plugins/musicbrainz`: Make aliases-as-artist-credit optional.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,7 +23,9 @@ New features
 - :doc:`plugins/listenbrainz`: Add support for importing ListenBrainz listening
   history from an export file. Use the ``-f`` / ``--export-file`` flag to
   specify the path to the ListenBrainz export file.
-- :doc:`plugins/musicbrainz`: Make aliases-as-artist-credit optional.
+- :doc:`plugins/musicbrainz`: Introduce
+  :conf:`plugins.musicbrainz:aliases_as_credits` to make
+  aliases-as-artist-credit optional.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/plugins/musicbrainz.rst
+++ b/docs/plugins/musicbrainz.rst
@@ -42,6 +42,7 @@ Default
             tidal: no
         data_source_mismatch_penalty: 0.5
         search_limit: 5
+        aliases_as_credits: no
 
 .. conf:: host
     :default: musicbrainz.org
@@ -150,6 +151,11 @@ Default
 
     Either ``genre`` or ``tag``. Specify ``genre`` to use just musicbrainz genre and
     ``tag`` to use all user-supplied musicbrainz tags.
+
+.. conf:: aliases_as_credits
+    :default: no
+
+    Use the "aliases" data from MusicBrainz as the value for ``*_credit`` fields.
 
 .. include:: ./shared_metadata_source_config.rst
 

--- a/test/plugins/test_musicbrainz.py
+++ b/test/plugins/test_musicbrainz.py
@@ -90,7 +90,7 @@ class TestUtils:
     def test_single_artist(self):
         credit = [artist_credit_factory(artist__name="Artist")]
 
-        assert MusicBrainzPlugin._parse_artist_credits(credit) == {
+        assert MusicBrainzPlugin()._parse_artist_credits(credit) == {
             "artist": "Artist",
             "artist_id": "00000000-0000-0000-0000-000000000001",
             "artist_sort": "Artist, The",
@@ -107,7 +107,7 @@ class TestUtils:
             artist_credit_factory(artist__name="Other Artist", artist__index=2),
         ]
 
-        assert MusicBrainzPlugin._parse_artist_credits(credit) == {
+        assert MusicBrainzPlugin()._parse_artist_credits(credit) == {
             "artist": "Artist AND Other Artist",
             "artist_id": "00000000-0000-0000-0000-000000000001",
             "artist_sort": "Artist, The AND Other Artist, The",
@@ -605,38 +605,58 @@ class TestParseRelease(MusicBrainzPluginTestMixin):
     def test_genres(self, mb, expected_genres):
         assert mb.album_info(release_factory()).genres == expected_genres
 
-    def test_parse_aliased_titles(self, config, mb: MusicBrainzPlugin):
+    @pytest.mark.parametrize(
+        "aliases_as_credits",
+        [_p(False, id="no aliases"), _p(True, id="aliases")],
+    )
+    def test_aliases_as_credits(
+        self, config, mb: MusicBrainzPlugin, aliases_as_credits: bool
+    ):
+        config["import"]["languages"] = ["en"] if aliases_as_credits else []
+        config["musicbrainz"]["aliases_as_credits"] = aliases_as_credits
         release = release_factory()
 
-        config["import"]["languages"] = ["en"]
+        def aliased_name(name: str) -> str:
+            print(aliases_as_credits)
+            return f"{name} Alias en" if aliases_as_credits else name
 
         d = mb.album_info(release)
 
-        assert d.album == "Album Alias en"
-        assert d.release_group_title == "Release Group Alias en"
-        assert d.tracks[0].title == "Recording Alias en"
-
-        album_artist = "Artist Alias en"
+        album_artist = aliased_name("Artist")
         assert d.artist == album_artist
         assert d.artists == [album_artist]
-        # There is no artist credit specific alias
-        assert d.artist_credit == album_artist
-        assert d.artists_credit == [album_artist]
 
-        album_artist_sort = "Artist Alias en, The"
+        # There is no artist credit specific alias
+        album_artist_credit = (
+            album_artist if aliases_as_credits else "Artist Credit"
+        )
+        assert d.artist_credit == album_artist_credit
+        assert d.artists_credit == [album_artist_credit]
+
+        album_artist_sort = (
+            "Artist Alias en, The" if aliases_as_credits else "Artist, The"
+        )
         assert d.artist_sort == album_artist_sort
         assert d.artists_sort == [album_artist_sort]
 
         first_track = d.tracks[0]
 
-        track_artist = "Recording Artist Alias en"
+        track_artist = aliased_name("Recording Artist")
         assert first_track.artist == track_artist
         assert first_track.artists == [track_artist]
-        # There is no artist credit specific alias
-        assert first_track.artist_credit == track_artist
-        assert first_track.artists_credit == [track_artist]
 
-        track_artist_sort = "Recording Artist Alias en, The"
+        # There is no artist credit specific alias
+        track_artist_credit = (
+            track_artist if aliases_as_credits else "Recording Artist Credit"
+        )
+        assert first_track.artist_credit == track_artist_credit
+        assert first_track.artists_credit == [track_artist_credit]
+
+        track_artist_sort = (
+            "Recording Artist Alias en, The"
+            if aliases_as_credits
+            else "Recording Artist, The"
+        )
         assert first_track.artist_sort == track_artist_sort
         assert first_track.artists_sort == [track_artist_sort]
 

--- a/test/plugins/test_musicbrainz.py
+++ b/test/plugins/test_musicbrainz.py
@@ -606,59 +606,146 @@ class TestParseRelease(MusicBrainzPluginTestMixin):
         assert mb.album_info(release_factory()).genres == expected_genres
 
     @pytest.mark.parametrize(
-        "aliases_as_credits",
-        [_p(False, id="no aliases"), _p(True, id="aliases")],
+        "plugin_config", [_p({"aliases_as_credits": True})]
     )
-    def test_aliases_as_credits(
-        self, config, mb: MusicBrainzPlugin, aliases_as_credits: bool
-    ):
-        config["import"]["languages"] = ["en"] if aliases_as_credits else []
-        config["musicbrainz"]["aliases_as_credits"] = aliases_as_credits
+    def test_parse_aliased_titles(self, config, mb: MusicBrainzPlugin):
         release = release_factory()
 
-        def aliased_name(name: str) -> str:
-            print(aliases_as_credits)
-            return f"{name} Alias en" if aliases_as_credits else name
+        config["import"]["languages"] = ["en"]
 
         d = mb.album_info(release)
 
-        album_artist = aliased_name("Artist")
+        assert d.album == "Album Alias en"
+        assert d.release_group_title == "Release Group Alias en"
+        assert d.tracks[0].title == "Recording Alias en"
+
+        album_artist = "Artist Alias en"
         assert d.artist == album_artist
         assert d.artists == [album_artist]
-
         # There is no artist credit specific alias
-        album_artist_credit = (
-            album_artist if aliases_as_credits else "Artist Credit"
-        )
-        assert d.artist_credit == album_artist_credit
-        assert d.artists_credit == [album_artist_credit]
+        assert d.artist_credit == album_artist
+        assert d.artists_credit == [album_artist]
 
-        album_artist_sort = (
-            "Artist Alias en, The" if aliases_as_credits else "Artist, The"
-        )
+        album_artist_sort = "Artist Alias en, The"
         assert d.artist_sort == album_artist_sort
         assert d.artists_sort == [album_artist_sort]
 
         first_track = d.tracks[0]
 
-        track_artist = aliased_name("Recording Artist")
+        track_artist = "Recording Artist Alias en"
         assert first_track.artist == track_artist
         assert first_track.artists == [track_artist]
-
         # There is no artist credit specific alias
-        track_artist_credit = (
-            track_artist if aliases_as_credits else "Recording Artist Credit"
-        )
-        assert first_track.artist_credit == track_artist_credit
-        assert first_track.artists_credit == [track_artist_credit]
+        assert first_track.artist_credit == track_artist
+        assert first_track.artists_credit == [track_artist]
 
-        track_artist_sort = (
-            "Recording Artist Alias en, The"
-            if aliases_as_credits
-            else "Recording Artist, The"
-        )
+        track_artist_sort = "Recording Artist Alias en, The"
         assert first_track.artist_sort == track_artist_sort
         assert first_track.artists_sort == [track_artist_sort]
+
+    @pytest.mark.parametrize(
+        "plugin_config, languages_config, expected_artist_credit",
+        [
+            _p(
+                {"aliases_as_credits": False},
+                [],
+                {
+                    "artist": "Artist",
+                    "artists": ["Artist"],
+                    "album_artist_sort": "Artist, The",
+                    "album_artists_sort": ["Artist, The"],
+                    "track_artist": "Recording Artist",
+                    "track_artists": ["Recording Artist"],
+                    "artist_sort": "Recording Artist, The",
+                    "artists_sort": ["Recording Artist, The"],
+                    "track_artist_credit": "Recording Artist Credit",
+                    "track_artists_credit": ["Recording Artist Credit"],
+                    "artist_credit": "Artist Credit",
+                    "artists_credit": ["Artist Credit"],
+                },
+                id="no aliases",
+            ),
+            _p(
+                {"aliases_as_credits": True},
+                ["en"],
+                {
+                    "artist": "Artist Alias en",
+                    "artists": ["Artist Alias en"],
+                    "album_artist_sort": "Artist Alias en, The",
+                    "album_artists_sort": ["Artist Alias en, The"],
+                    "track_artist": "Recording Artist Alias en",
+                    "track_artists": ["Recording Artist Alias en"],
+                    "artist_sort": "Recording Artist Alias en, The",
+                    "artists_sort": ["Recording Artist Alias en, The"],
+                    "artist_credit": "Artist Alias en",
+                    "artists_credit": ["Artist Alias en"],
+                    "track_artist_credit": "Recording Artist Alias en",
+                    "track_artists_credit": ["Recording Artist Alias en"],
+                },
+                id="aliases",
+            ),
+            _p(
+                {"aliases_as_credits": False},
+                ["en"],
+                {
+                    "artist": "Artist Alias en",
+                    "artists": ["Artist Alias en"],
+                    "album_artist_sort": "Artist Alias en, The",
+                    "album_artists_sort": ["Artist Alias en, The"],
+                    "track_artist": "Recording Artist Alias en",
+                    "track_artists": ["Recording Artist Alias en"],
+                    "artist_sort": "Recording Artist Alias en, The",
+                    "artists_sort": ["Recording Artist Alias en, The"],
+                    "artist_credit": "Artist Credit",
+                    "artists_credit": ["Artist Credit"],
+                    "track_artist_credit": "Recording Artist Credit",
+                    "track_artists_credit": ["Recording Artist Credit"],
+                },
+                id="no aliases, with languages",
+            ),
+        ],
+    )
+    def test_aliases_as_credits(
+        self,
+        config,
+        mb: MusicBrainzPlugin,
+        languages_config,
+        expected_artist_credit,
+    ):
+        config["import"]["languages"] = languages_config
+        release = release_factory()
+
+        d = mb.album_info(release)
+
+        assert d.artist == expected_artist_credit["artist"]
+        assert d.artists == expected_artist_credit["artists"]
+
+        # There is no artist credit specific alias
+        assert d.artist_credit == expected_artist_credit["artist_credit"]
+        assert d.artists_credit == expected_artist_credit["artists_credit"]
+
+        assert d.artist_sort == expected_artist_credit["album_artist_sort"]
+        assert d.artists_sort == expected_artist_credit["album_artists_sort"]
+
+        first_track = d.tracks[0]
+
+        assert first_track.artist == expected_artist_credit["track_artist"]
+        assert first_track.artists == expected_artist_credit["track_artists"]
+
+        # There is no artist credit specific alias
+        assert (
+            first_track.artist_credit
+            == expected_artist_credit["track_artist_credit"]
+        )
+        assert (
+            first_track.artists_credit
+            == expected_artist_credit["track_artists_credit"]
+        )
+
+        assert first_track.artist_sort == expected_artist_credit["artist_sort"]
+        assert (
+            first_track.artists_sort == expected_artist_credit["artists_sort"]
+        )
 
     def test_ensure_complete_recordings(self, monkeypatch, mb):
         titles = ["Recording", "Other Recording"]

--- a/test/plugins/test_musicbrainz.py
+++ b/test/plugins/test_musicbrainz.py
@@ -644,20 +644,11 @@ class TestParseRelease(MusicBrainzPluginTestMixin):
         assert first_track.artists_sort == [track_artist_sort]
 
     @pytest.mark.parametrize(
-        "plugin_config, languages_config, expected_artist_credit",
+        "plugin_config, expected_artist_credit",
         [
             _p(
                 {"aliases_as_credits": False},
-                [],
                 {
-                    "artist": "Artist",
-                    "artists": ["Artist"],
-                    "album_artist_sort": "Artist, The",
-                    "album_artists_sort": ["Artist, The"],
-                    "track_artist": "Recording Artist",
-                    "track_artists": ["Recording Artist"],
-                    "artist_sort": "Recording Artist, The",
-                    "artists_sort": ["Recording Artist, The"],
                     "track_artist_credit": "Recording Artist Credit",
                     "track_artists_credit": ["Recording Artist Credit"],
                     "artist_credit": "Artist Credit",
@@ -667,16 +658,7 @@ class TestParseRelease(MusicBrainzPluginTestMixin):
             ),
             _p(
                 {"aliases_as_credits": True},
-                ["en"],
                 {
-                    "artist": "Artist Alias en",
-                    "artists": ["Artist Alias en"],
-                    "album_artist_sort": "Artist Alias en, The",
-                    "album_artists_sort": ["Artist Alias en, The"],
-                    "track_artist": "Recording Artist Alias en",
-                    "track_artists": ["Recording Artist Alias en"],
-                    "artist_sort": "Recording Artist Alias en, The",
-                    "artists_sort": ["Recording Artist Alias en, The"],
                     "artist_credit": "Artist Alias en",
                     "artists_credit": ["Artist Alias en"],
                     "track_artist_credit": "Recording Artist Alias en",
@@ -684,55 +666,21 @@ class TestParseRelease(MusicBrainzPluginTestMixin):
                 },
                 id="aliases",
             ),
-            _p(
-                {"aliases_as_credits": False},
-                ["en"],
-                {
-                    "artist": "Artist Alias en",
-                    "artists": ["Artist Alias en"],
-                    "album_artist_sort": "Artist Alias en, The",
-                    "album_artists_sort": ["Artist Alias en, The"],
-                    "track_artist": "Recording Artist Alias en",
-                    "track_artists": ["Recording Artist Alias en"],
-                    "artist_sort": "Recording Artist Alias en, The",
-                    "artists_sort": ["Recording Artist Alias en, The"],
-                    "artist_credit": "Artist Credit",
-                    "artists_credit": ["Artist Credit"],
-                    "track_artist_credit": "Recording Artist Credit",
-                    "track_artists_credit": ["Recording Artist Credit"],
-                },
-                id="no aliases, with languages",
-            ),
         ],
     )
     def test_aliases_as_credits(
-        self,
-        config,
-        mb: MusicBrainzPlugin,
-        languages_config,
-        expected_artist_credit,
+        self, config, mb: MusicBrainzPlugin, expected_artist_credit
     ):
-        config["import"]["languages"] = languages_config
+        config["import"]["languages"] = ["en"]
         release = release_factory()
 
         d = mb.album_info(release)
 
-        assert d.artist == expected_artist_credit["artist"]
-        assert d.artists == expected_artist_credit["artists"]
-
-        # There is no artist credit specific alias
         assert d.artist_credit == expected_artist_credit["artist_credit"]
         assert d.artists_credit == expected_artist_credit["artists_credit"]
 
-        assert d.artist_sort == expected_artist_credit["album_artist_sort"]
-        assert d.artists_sort == expected_artist_credit["album_artists_sort"]
-
         first_track = d.tracks[0]
 
-        assert first_track.artist == expected_artist_credit["track_artist"]
-        assert first_track.artists == expected_artist_credit["track_artists"]
-
-        # There is no artist credit specific alias
         assert (
             first_track.artist_credit
             == expected_artist_credit["track_artist_credit"]
@@ -740,11 +688,6 @@ class TestParseRelease(MusicBrainzPluginTestMixin):
         assert (
             first_track.artists_credit
             == expected_artist_credit["track_artists_credit"]
-        )
-
-        assert first_track.artist_sort == expected_artist_credit["artist_sort"]
-        assert (
-            first_track.artists_sort == expected_artist_credit["artists_sort"]
         )
 
     def test_ensure_complete_recordings(self, monkeypatch, mb):


### PR DESCRIPTION
## Description

This feature was introduced in 2.10 but results a lot of data being overwritten with (potentially) incorrect data the next time a user runs `mbsync` over their library.

To make this less of a "breaking" change, make this feature opt-in. The users who want this large change can enable the functionality.

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
