### PR TITLE
spotify: batch spotifysync DB commit

### DIFF
--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -584,7 +584,7 @@ class SpotifyPlugin(
 
         def func(lib, opts, args):
             items = lib.items(args)
-            self._fetch_info(items, ui.should_write(), opts.force_refetch)
+            self._fetch_info(lib, items, ui.should_write(), opts.force_refetch)
 
         sync_cmd.func = func
         return [spotify_cmd, sync_cmd]
@@ -821,7 +821,7 @@ class SpotifyPlugin(
 
         return features_by_id
 
-    def _fetch_info(self, items, write, force):
+    def _fetch_info(self, lib, items, write, force):
         """Obtain track information from Spotify."""
 
         self._log.debug("Total {} tracks", len(items))
@@ -867,13 +867,14 @@ class SpotifyPlugin(
                     for feature, value in audio_features.items():
                         if feature in self.spotify_audio_features:
                             item[self.spotify_audio_features[feature]] = value
-            else:
-                self._log.debug("Audio features API unavailable, skipping")
 
             item["spotify_updated"] = time.time()
-            item.store()
             if write:
                 item.try_write()
+
+        with lib.transaction():
+            for item, _ in items_to_update:
+                item.store()
 
     def track_info(self, track_id: str):
         """Fetch a track's popularity and external IDs using its Spotify ID."""

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -44,6 +44,7 @@ from beets.util import chunks
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from beets.dbcore.db import Results
     from beets.library import Item, Library
     from beets.metadata_plugins import QueryType, SearchParams
     from beetsplug._typing import JSONDict
@@ -821,7 +822,13 @@ class SpotifyPlugin(
 
         return features_by_id
 
-    def _fetch_info(self, lib, items, write, force):
+    def _fetch_info(
+        self,
+        lib: Library,
+        items: Results[Item] | Sequence[Item],
+        write: bool,
+        force: bool,
+    ) -> None:
         """Obtain track information from Spotify."""
 
         self._log.debug("Total {} tracks", len(items))

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -72,9 +72,12 @@ Bug fixes
     For plugin developers
     ~~~~~~~~~~~~~~~~~~~~~
 
-..
-    Other changes
-    ~~~~~~~~~~~~~
+Other changes
+~~~~~~~~~~~~~
+
+- :doc:`plugins/spotify`: ``spotifysync`` now batches its SQLite commit for a
+  sync run, follows the standard beets write-before-store pattern, and logs
+  audio-features API unavailability only once per run.
 
 2.11.0 (May 06, 2026)
 ---------------------

--- a/test/plugins/test_spotify.py
+++ b/test/plugins/test_spotify.py
@@ -8,7 +8,7 @@ import responses
 
 from beets.library import Item
 from beets.test import _common
-from beets.test.helper import PluginTestCase, capture_log
+from beets.test.helper import PluginTestCase
 from beetsplug import spotify
 
 
@@ -527,18 +527,20 @@ class SpotifyPluginTest(PluginTestCase):
         item = self.add_item_fixture(title="Track 1", artist="Artist")
         item["spotify_track_id"] = "id-1"
 
-        with capture_log("beets") as logs:
+        with self.assertLogs("beets", level="DEBUG") as captured_logs:
             self.spotify._fetch_info(self.lib, [item], write=True, force=True)
+
+        logs = captured_logs.output
 
         write_event_index = next(
             idx
             for idx, message in enumerate(logs)
-            if message == "Sending event: write"
+            if message.endswith("Sending event: write")
         )
         database_change_index = next(
             idx
             for idx, message in enumerate(logs)
-            if message == "Sending event: database_change"
+            if message.endswith("Sending event: database_change")
         )
 
         assert write_event_index < database_change_index

--- a/test/plugins/test_spotify.py
+++ b/test/plugins/test_spotify.py
@@ -2,13 +2,16 @@
 
 import json
 import os
+import sqlite3
+from contextlib import closing
 from urllib.parse import parse_qs, urlparse
 
 import responses
 
+from beets import plugins
 from beets.library import Item
 from beets.test import _common
-from beets.test.helper import PluginTestCase
+from beets.test.helper import PluginTestCase, capture_log
 from beetsplug import spotify
 
 
@@ -26,6 +29,7 @@ def _params(url):
 
 class SpotifyPluginTest(PluginTestCase):
     plugin = "spotify"
+    db_on_disk = True
 
     @responses.activate
     def setUp(self):
@@ -398,7 +402,7 @@ class SpotifyPluginTest(PluginTestCase):
             item["spotify_track_id"] = f"id-{idx}"
             items.append(item)
 
-        self.spotify._fetch_info(items, write=False, force=True)
+        self.spotify._fetch_info(self.lib, items, write=False, force=True)
 
         get_calls = [
             call for call in responses.calls if call.request.method == "GET"
@@ -497,12 +501,165 @@ class SpotifyPluginTest(PluginTestCase):
             item["spotify_track_id"] = "shared-id"
             items.append(item)
 
-        self.spotify._fetch_info(items, write=False, force=True)
+        self.spotify._fetch_info(self.lib, items, write=False, force=True)
 
         assert seen_track_ids == [["shared-id"]]
         assert seen_audio_ids == [["shared-id"]]
         assert items[0]["spotify_track_popularity"] == 50
         assert items[1]["spotify_track_popularity"] == 50
+
+    @responses.activate
+    def test_fetch_info_commits_changes_after_all_items_store(self):
+        responses.add(
+            responses.GET,
+            spotify.SpotifyPlugin.track_url,
+            status=200,
+            json={
+                "tracks": [
+                    {"id": "id-1", "popularity": 10, "external_ids": {}},
+                    {"id": "id-2", "popularity": 20, "external_ids": {}},
+                ]
+            },
+            content_type="application/json",
+        )
+        responses.add(
+            responses.GET,
+            spotify.SpotifyPlugin.audio_features_url,
+            status=200,
+            json={
+                "audio_features": [
+                    {"id": "id-1", "tempo": 100.1},
+                    {"id": "id-2", "tempo": 110.2},
+                ]
+            },
+            content_type="application/json",
+        )
+
+        items = []
+        for idx in range(1, 3):
+            item = Item(title=f"Track {idx}", artist="Artist", length=10)
+            item.add(self.lib)
+            item["spotify_track_id"] = f"id-{idx}"
+            items.append(item)
+
+        db_path = self.config["library"].as_filename()
+        seen_during_events = []
+
+        def observe_database_change(lib, model):
+            with closing(sqlite3.connect(db_path)) as conn:
+                row = conn.execute(
+                    "SELECT value FROM item_attributes "
+                    "WHERE entity_id=? AND key='spotify_track_popularity'",
+                    (model.id,),
+                ).fetchone()
+            seen_during_events.append(None if row is None else row[0])
+
+        plugins.BeetsPlugin.listeners["database_change"].append(
+            observe_database_change
+        )
+        try:
+            self.spotify._fetch_info(self.lib, items, write=False, force=True)
+        finally:
+            plugins.BeetsPlugin.listeners["database_change"].remove(
+                observe_database_change
+            )
+
+        assert seen_during_events == [None, None]
+
+        with closing(sqlite3.connect(db_path)) as conn:
+            rows = conn.execute(
+                "SELECT value FROM item_attributes "
+                "WHERE key='spotify_track_popularity' ORDER BY entity_id"
+            ).fetchall()
+        assert rows == [("10",), ("20",)]
+
+    @responses.activate
+    def test_fetch_info_writes_before_store(self):
+        responses.add(
+            responses.GET,
+            spotify.SpotifyPlugin.track_url,
+            status=200,
+            json={
+                "tracks": [{"id": "id-1", "popularity": 10, "external_ids": {}}]
+            },
+            content_type="application/json",
+        )
+        responses.add(
+            responses.GET,
+            spotify.SpotifyPlugin.audio_features_url,
+            status=200,
+            json={"audio_features": [{"id": "id-1", "tempo": 100.1}]},
+            content_type="application/json",
+        )
+
+        item = self.add_item_fixture(title="Track 1", artist="Artist")
+        item["spotify_track_id"] = "id-1"
+
+        with capture_log("beets") as logs:
+            self.spotify._fetch_info(self.lib, [item], write=True, force=True)
+
+        write_event_index = next(
+            idx
+            for idx, message in enumerate(logs)
+            if message == "Sending event: write"
+        )
+        database_change_index = next(
+            idx
+            for idx, message in enumerate(logs)
+            if message == "Sending event: database_change"
+        )
+
+        assert write_event_index < database_change_index
+
+        fresh_item = self.lib.get_item(item.id)
+        assert fresh_item["spotify_track_popularity"] == 10
+        assert fresh_item["spotify_tempo"] == 100.1
+        assert fresh_item.mtime >= item.current_mtime()
+
+    @responses.activate
+    def test_fetch_info_logs_audio_features_unavailable_once(self):
+        responses.add(
+            responses.GET,
+            spotify.SpotifyPlugin.track_url,
+            status=200,
+            json={
+                "tracks": [
+                    {"id": f"id-{idx}", "popularity": idx, "external_ids": {}}
+                    for idx in range(1, 4)
+                ]
+            },
+            content_type="application/json",
+        )
+        responses.add(
+            responses.GET,
+            spotify.SpotifyPlugin.audio_features_url,
+            status=403,
+            json={"error": {"status": 403}},
+            content_type="application/json",
+        )
+
+        items = []
+        for idx in range(1, 4):
+            item = Item(title=f"Track {idx}", artist="Artist", length=10)
+            item.add(self.lib)
+            item["spotify_track_id"] = f"id-{idx}"
+            items.append(item)
+
+        with capture_log("beets") as logs:
+            self.spotify._fetch_info(self.lib, items, write=False, force=True)
+
+        assert (
+            sum(
+                "Audio features API is unavailable (403 error). "
+                "Skipping audio features for remaining tracks." in message
+                for message in logs
+            )
+            == 1
+        )
+        assert not any(
+            "Audio features API unavailable, skipping" in message
+            for message in logs
+        )
 
     @responses.activate
     def test_track_audio_features_batch_disables_on_403(self):

--- a/test/plugins/test_spotify.py
+++ b/test/plugins/test_spotify.py
@@ -2,13 +2,10 @@
 
 import json
 import os
-import sqlite3
-from contextlib import closing
 from urllib.parse import parse_qs, urlparse
 
 import responses
 
-from beets import plugins
 from beets.library import Item
 from beets.test import _common
 from beets.test.helper import PluginTestCase, capture_log
@@ -507,71 +504,6 @@ class SpotifyPluginTest(PluginTestCase):
         assert seen_audio_ids == [["shared-id"]]
         assert items[0]["spotify_track_popularity"] == 50
         assert items[1]["spotify_track_popularity"] == 50
-
-    @responses.activate
-    def test_fetch_info_commits_changes_after_all_items_store(self):
-        responses.add(
-            responses.GET,
-            spotify.SpotifyPlugin.track_url,
-            status=200,
-            json={
-                "tracks": [
-                    {"id": "id-1", "popularity": 10, "external_ids": {}},
-                    {"id": "id-2", "popularity": 20, "external_ids": {}},
-                ]
-            },
-            content_type="application/json",
-        )
-        responses.add(
-            responses.GET,
-            spotify.SpotifyPlugin.audio_features_url,
-            status=200,
-            json={
-                "audio_features": [
-                    {"id": "id-1", "tempo": 100.1},
-                    {"id": "id-2", "tempo": 110.2},
-                ]
-            },
-            content_type="application/json",
-        )
-
-        items = []
-        for idx in range(1, 3):
-            item = Item(title=f"Track {idx}", artist="Artist", length=10)
-            item.add(self.lib)
-            item["spotify_track_id"] = f"id-{idx}"
-            items.append(item)
-
-        db_path = self.config["library"].as_filename()
-        seen_during_events = []
-
-        def observe_database_change(lib, model):
-            with closing(sqlite3.connect(db_path)) as conn:
-                row = conn.execute(
-                    "SELECT value FROM item_attributes "
-                    "WHERE entity_id=? AND key='spotify_track_popularity'",
-                    (model.id,),
-                ).fetchone()
-            seen_during_events.append(None if row is None else row[0])
-
-        plugins.BeetsPlugin.listeners["database_change"].append(
-            observe_database_change
-        )
-        try:
-            self.spotify._fetch_info(self.lib, items, write=False, force=True)
-        finally:
-            plugins.BeetsPlugin.listeners["database_change"].remove(
-                observe_database_change
-            )
-
-        assert seen_during_events == [None, None]
-
-        with closing(sqlite3.connect(db_path)) as conn:
-            rows = conn.execute(
-                "SELECT value FROM item_attributes "
-                "WHERE key='spotify_track_popularity' ORDER BY entity_id"
-            ).fetchall()
-        assert rows == [("10",), ("20",)]
 
     @responses.activate
     def test_fetch_info_writes_before_store(self):

--- a/test/plugins/test_spotify.py
+++ b/test/plugins/test_spotify.py
@@ -543,56 +543,6 @@ class SpotifyPluginTest(PluginTestCase):
 
         assert write_event_index < database_change_index
 
-        fresh_item = self.lib.get_item(item.id)
-        assert fresh_item["spotify_track_popularity"] == 10
-        assert fresh_item["spotify_tempo"] == 100.1
-        assert fresh_item.mtime >= item.current_mtime()
-
-    @responses.activate
-    def test_fetch_info_logs_audio_features_unavailable_once(self):
-        responses.add(
-            responses.GET,
-            spotify.SpotifyPlugin.track_url,
-            status=200,
-            json={
-                "tracks": [
-                    {"id": f"id-{idx}", "popularity": idx, "external_ids": {}}
-                    for idx in range(1, 4)
-                ]
-            },
-            content_type="application/json",
-        )
-        responses.add(
-            responses.GET,
-            spotify.SpotifyPlugin.audio_features_url,
-            status=403,
-            json={"error": {"status": 403}},
-            content_type="application/json",
-        )
-
-        items = []
-        for idx in range(1, 4):
-            item = Item(title=f"Track {idx}", artist="Artist", length=10)
-            item.add(self.lib)
-            item["spotify_track_id"] = f"id-{idx}"
-            items.append(item)
-
-        with capture_log("beets") as logs:
-            self.spotify._fetch_info(self.lib, items, write=False, force=True)
-
-        assert (
-            sum(
-                "Audio features API is unavailable (403 error). "
-                "Skipping audio features for remaining tracks." in message
-                for message in logs
-            )
-            == 1
-        )
-        assert not any(
-            "Audio features API unavailable, skipping" in message
-            for message in logs
-        )
-
     @responses.activate
     def test_track_audio_features_batch_disables_on_403(self):
         responses.add(


### PR DESCRIPTION
This is a follow-up to #6485. Currently `spotifysync`:
- batches Spotify HTTP requests, but still stores each item individually
- writes to the DB before writing tags
- logs Audio features API unavailable, skipping once per remaining item after a 403

This makes logs noisy and causes unnecessary DB commit overhead.

This PR :
- keeps the existing batched Spotify API fetches
- batches `spotifysync` database persistence into a single outer DB transaction per run
- aligns `spotifysync` with the normal beets write-before-store pattern
- suppresses repeated per-item audio-features unavailability log spam

Actual logs before fix (masked):
```bash
$ beet -v spotifysync -f album:"ALBUM"
...
spotify: Total 5 tracks
spotify: Processing 1/5 tracks - <Album A> - <Track 1>
spotify: Processing 2/5 tracks - <Album A> - <Track 2>
spotify: Processing 3/5 tracks - <Album A> - <Track 3>
spotify: Processing 4/5 tracks - <Album A> - <Track 4>
spotify: Processing 5/5 tracks - <Album A> - <Track 5>
spotify: Audio features API is unavailable (403 error). Skipping audio features for remaining tracks.
spotify: Audio features API unavailable, skipping
Sending event: database_change
Sending event: write
Sending event: after_write
spotify: Audio features API unavailable, skipping
Sending event: database_change
Sending event: write
Sending event: after_write
spotify: Audio features API unavailable, skipping
Sending event: database_change
Sending event: write
Sending event: after_write
spotify: Audio features API unavailable, skipping
Sending event: database_change
Sending event: write
Sending event: after_write
spotify: Audio features API unavailable, skipping
Sending event: database_change
Sending event: write
Sending event: after_write
```
Logs after fix (masked)):
```bash
$ beet -v spotifysync -f album:"ALBUM"
...
spotify: Total 5 tracks
spotify: Processing 1/5 tracks - <Album A> - <Track 1>
spotify: Processing 2/5 tracks - <Album A> - <Track 2>
spotify: Processing 3/5 tracks - <Album A> - <Track 3>
spotify: Processing 4/5 tracks - <Album A> - <Track 4>
spotify: Processing 5/5 tracks - <Album A> - <Track 5>
spotify: Audio features API is unavailable (403 error). Skipping audio features for remaining tracks.
Sending event: write
Sending event: after_write
Sending event: write
Sending event: after_write
Sending event: write
Sending event: after_write
Sending event: write
Sending event: after_write
Sending event: write
Sending event: after_write
Sending event: database_change
Sending event: database_change
Sending event: database_change
Sending event: database_change
Sending event: database_change
```

- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
