### PR TITLE
Fix: browse recordings missing aliases for releases with more than 500 tracks

### DIFF
--- a/beetsplug/musicbrainz.py
+++ b/beetsplug/musicbrainz.py
@@ -592,7 +592,9 @@ class MusicBrainzPlugin(
             recording["artist_credit"] = (
                 track["artist_credit"] or recording["artist_credit"]
             )
-            if track["title"] and not _preferred_alias(recording.get("aliases", [])):
+            if track["title"] and not _preferred_alias(
+                recording.get("aliases", [])
+            ):
                 recording["title"] = track["title"]
 
             ti = self.track_info(recording)

--- a/beetsplug/musicbrainz.py
+++ b/beetsplug/musicbrainz.py
@@ -71,6 +71,7 @@ FIELDS_TO_MB_KEYS = {
 
 BROWSE_INCLUDES = [
     "artist-credits",
+    "aliases",
     "work-rels",
     "artist-rels",
     "recording-rels",
@@ -591,7 +592,7 @@ class MusicBrainzPlugin(
             recording["artist_credit"] = (
                 track["artist_credit"] or recording["artist_credit"]
             )
-            if track["title"] and not _preferred_alias(recording["aliases"]):
+            if track["title"] and not _preferred_alias(recording.get("aliases", [])):
                 recording["title"] = track["title"]
 
             ti = self.track_info(recording)

--- a/beetsplug/musicbrainz.py
+++ b/beetsplug/musicbrainz.py
@@ -592,9 +592,7 @@ class MusicBrainzPlugin(
             recording["artist_credit"] = (
                 track["artist_credit"] or recording["artist_credit"]
             )
-            if track["title"] and not _preferred_alias(
-                recording.get("aliases", [])
-            ):
+            if track["title"] and not _preferred_alias(recording["aliases"]):
                 recording["title"] = track["title"]
 
             ti = self.track_info(recording)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -55,6 +55,8 @@ Bug fixes
   during ``mbupdate`` without crashing, and log a clearer message that points
   users to ``musicbrainz.user`` and ``musicbrainz.pass`` configuration.
   :bug:`6651`
+- :doc:`plugins/musicbrainz`: Fix ``KeyError: 'aliases'`` crash when looking up
+  releases with more than 500 tracks.
 
 ..
     For plugin developers

--- a/test/plugins/test_musicbrainz.py
+++ b/test/plugins/test_musicbrainz.py
@@ -672,39 +672,34 @@ class TestParseRelease(MusicBrainzPluginTestMixin):
         ]
         assert new_recordings == complete_recordings
 
-    def test_album_info_browse_recordings_without_aliases(
-        self, monkeypatch, mb
+    def test_album_info_browse_recordings_prefers_alias_over_track_title(
+        self, config, monkeypatch, mb
     ):
-        """Recordings fetched via browse_recordings may lack 'aliases' if the
-        API includes were missing; album_info must not raise KeyError."""
-        initial_recordings = [recording_factory(index=idx) for idx in range(2)]
-        # Simulate browse_recordings returning recordings without 'aliases'
-        browsed_recordings = [
-            {k: v for k, v in r.items() if k != "aliases"}
-            for r in initial_recordings
-        ]
+        config["import"]["languages"] = ["en"]
+
+        recording = recording_factory(
+            title="Recording Title",
+            aliases=[alias_factory(type="Recording name", locale="en")],
+        )
+        browsed_recording = {**recording, "url_relations": [url_relation_factory()]}
 
         monkeypatch.setattr("beetsplug.musicbrainz.BROWSE_CHUNKSIZE", 1)
-        monkeypatch.setattr("beetsplug.musicbrainz.BROWSE_MAXTRACKS", 1)
+        monkeypatch.setattr("beetsplug.musicbrainz.BROWSE_MAXTRACKS", 0)
         monkeypatch.setattr(
             mb.mb_api,
             "browse_recordings",
-            lambda offset=0, **__: (
-                [browsed_recordings[offset]]
-                if offset < len(browsed_recordings)
-                else []
-            ),
+            lambda offset=0, **__: [browsed_recording] if offset == 0 else [],
         )
 
         release = release_factory(
             media__0__tracks=[
-                track_factory(recording=r) for r in initial_recordings
+                track_factory(recording=recording, title="Track Title")
             ]
         )
 
-        # Should not raise KeyError: 'aliases'
         album = mb.album_info(release)
-        assert len(album.tracks) == 2
+
+        assert album.tracks[0].title == "Alias en"
 
 
 class TestPseudoRelease(MusicBrainzPluginTestMixin):

--- a/test/plugins/test_musicbrainz.py
+++ b/test/plugins/test_musicbrainz.py
@@ -672,6 +672,38 @@ class TestParseRelease(MusicBrainzPluginTestMixin):
         ]
         assert new_recordings == complete_recordings
 
+    def test_album_info_browse_recordings_without_aliases(
+        self, monkeypatch, mb
+    ):
+        """Recordings fetched via browse_recordings may lack 'aliases' if the
+        API include was missing; album_info must not raise KeyError."""
+        initial_recordings = [
+            recording_factory(index=idx) for idx in range(2)
+        ]
+        # Simulate browse_recordings returning recordings without 'aliases'
+        browsed_recordings = [
+            {k: v for k, v in r.items() if k != "aliases"}
+            for r in initial_recordings
+        ]
+
+        monkeypatch.setattr("beetsplug.musicbrainz.BROWSE_CHUNKSIZE", 1)
+        monkeypatch.setattr("beetsplug.musicbrainz.BROWSE_MAXTRACKS", 1)
+        monkeypatch.setattr(
+            mb.mb_api,
+            "browse_recordings",
+            lambda offset=0, **__: [browsed_recordings[offset]],
+        )
+
+        release = release_factory(
+            media__0__tracks=[
+                track_factory(recording=r) for r in initial_recordings
+            ]
+        )
+
+        # Should not raise KeyError: 'aliases'
+        album = mb.album_info(release)
+        assert len(album.tracks) == 2
+
 
 class TestPseudoRelease(MusicBrainzPluginTestMixin):
     ACTUAL_RELEASE = release_factory(index=1, country="US")

--- a/test/plugins/test_musicbrainz.py
+++ b/test/plugins/test_musicbrainz.py
@@ -681,7 +681,10 @@ class TestParseRelease(MusicBrainzPluginTestMixin):
             title="Recording Title",
             aliases=[alias_factory(type="Recording name", locale="en")],
         )
-        browsed_recording = {**recording, "url_relations": [url_relation_factory()]}
+        browsed_recording = {
+            **recording,
+            "url_relations": [url_relation_factory()],
+        }
 
         monkeypatch.setattr("beetsplug.musicbrainz.BROWSE_CHUNKSIZE", 1)
         monkeypatch.setattr("beetsplug.musicbrainz.BROWSE_MAXTRACKS", 0)

--- a/test/plugins/test_musicbrainz.py
+++ b/test/plugins/test_musicbrainz.py
@@ -676,10 +676,8 @@ class TestParseRelease(MusicBrainzPluginTestMixin):
         self, monkeypatch, mb
     ):
         """Recordings fetched via browse_recordings may lack 'aliases' if the
-        API include was missing; album_info must not raise KeyError."""
-        initial_recordings = [
-            recording_factory(index=idx) for idx in range(2)
-        ]
+        API includes were missing; album_info must not raise KeyError."""
+        initial_recordings = [recording_factory(index=idx) for idx in range(2)]
         # Simulate browse_recordings returning recordings without 'aliases'
         browsed_recordings = [
             {k: v for k, v in r.items() if k != "aliases"}
@@ -691,7 +689,11 @@ class TestParseRelease(MusicBrainzPluginTestMixin):
         monkeypatch.setattr(
             mb.mb_api,
             "browse_recordings",
-            lambda offset=0, **__: [browsed_recordings[offset]],
+            lambda offset=0, **__: (
+                [browsed_recordings[offset]]
+                if offset < len(browsed_recordings)
+                else []
+            ),
         )
 
         release = release_factory(


### PR DESCRIPTION
## Description

When a release exceeds BROWSE_MAXTRACKS tracks, _ensure_complete_recordings
fetches recordings via browse_recordings. BROWSE_INCLUDES was missing "aliases",
so the API never returned alias data, causing a KeyError in get_tracks_from_medium.

Add "aliases" to BROWSE_INCLUDES and defensively use .get("aliases", []) at the
access site, consistent with all other alias lookups in the file.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)~
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
