### PR TITLE
refactor: Removed `ImportTestCase` in favor of `ImportHelper`

### DIFF
--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -122,8 +122,8 @@ class ConfigMixin:
         return config
 
 
-NEEDS_REFLINK = unittest.skipUnless(
-    check_reflink_support(gettempdir()), "no reflink support for libdir"
+NEEDS_REFLINK = pytest.mark.skipif(
+    not check_reflink_support(gettempdir()), reason="need reflink"
 )
 
 

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -615,10 +615,6 @@ class AsIsImporterMixin:
         return importer
 
 
-class ImportTestCase(ImportHelper, BeetsTestCase):
-    pass
-
-
 class ImportSessionFixture(ImportSession):
     """ImportSession that can be controlled programaticaly.
 
@@ -829,7 +825,7 @@ class AutotagStub:
         )
 
 
-class AutotagImportTestCase(ImportTestCase):
+class AutotagImportTestCase(ImportHelper, BeetsTestCase):
     matching = AutotagStub.IDENT
 
     def setUp(self):

--- a/test/plugins/test_chroma.py
+++ b/test/plugins/test_chroma.py
@@ -19,7 +19,7 @@ import pytest
 from beets import metadata_plugins
 from beets.autotag import AlbumInfo, TrackInfo
 from beets.library import Item
-from beets.test.helper import ImportTestCase, IOMixin, PluginMixin
+from beets.test.helper import ImportHelper, IOMixin, PluginMixin
 from beetsplug import chroma
 
 TEST_TITLE_1 = "TEST_TITLE_1"
@@ -30,7 +30,7 @@ FINGERPRINT_2 = "FP_2"
 
 
 @patch("acoustid.compare_fingerprints")
-class ChromaTest(IOMixin, PluginMixin, ImportTestCase):
+class TestChroma(IOMixin, PluginMixin, ImportHelper):
     plugin = "chroma"
 
     def setup_lib(self):

--- a/test/plugins/test_filefilter.py
+++ b/test/plugins/test_filefilter.py
@@ -14,16 +14,16 @@
 
 """Tests for the `filefilter` plugin."""
 
-from beets.test.helper import ImportTestCase, PluginMixin
+from beets.test.helper import ImportHelper, PluginMixin
 from beets.util import bytestring_path
 
 
-class FileFilterPluginMixin(PluginMixin, ImportTestCase):
+class FileFilterPluginHelper(PluginMixin, ImportHelper):
     plugin = "filefilter"
     preload_plugin = False
 
-    def setUp(self):
-        super().setUp()
+    def setup_beets(self):
+        super().setup_beets()
         self.prepare_tracks_for_import()
 
     def prepare_tracks_for_import(self):
@@ -49,9 +49,9 @@ class FileFilterPluginMixin(PluginMixin, ImportTestCase):
         assert {i.path for i in self.lib.items()} == expected_paths
 
 
-class FileFilterPluginNonSingletonTest(FileFilterPluginMixin):
-    def setUp(self):
-        super().setUp()
+class TestFileFilterPluginNonSingleton(FileFilterPluginHelper):
+    def setup_beets(self):
+        super().setup_beets()
         self.importer = self.setup_importer(autotag=False, copy=False)
 
     def test_import_default(self):
@@ -76,9 +76,9 @@ class FileFilterPluginNonSingletonTest(FileFilterPluginMixin):
         self._run({"singleton_path": ".*other_album.*"}, 3, self.all_tracks)
 
 
-class FileFilterPluginSingletonTest(FileFilterPluginMixin):
-    def setUp(self):
-        super().setUp()
+class TestFileFilterPluginSingleton(FileFilterPluginHelper):
+    def setup_beets(self):
+        super().setup_beets()
         self.importer = self.setup_singleton_importer(autotag=False, copy=False)
 
     def test_global_config(self):

--- a/test/plugins/test_keyfinder.py
+++ b/test/plugins/test_keyfinder.py
@@ -17,11 +17,11 @@ from unittest.mock import patch
 
 from beets import util
 from beets.library import Item
-from beets.test.helper import AsIsImporterMixin, ImportTestCase, PluginMixin
+from beets.test.helper import AsIsImporterMixin, ImportHelper, PluginMixin
 
 
 @patch("beets.util.command_output")
-class KeyFinderTest(AsIsImporterMixin, PluginMixin, ImportTestCase):
+class TestKeyFinder(AsIsImporterMixin, PluginMixin, ImportHelper):
     plugin = "keyfinder"
 
     def test_add_key(self, command_output):

--- a/test/plugins/test_permissions.py
+++ b/test/plugins/test_permissions.py
@@ -4,8 +4,10 @@ import os
 import platform
 from unittest.mock import Mock, patch
 
+import pytest
+
 from beets.test._common import touch
-from beets.test.helper import AsIsImporterMixin, ImportTestCase, PluginMixin
+from beets.test.helper import AsIsImporterMixin, ImportHelper, PluginMixin
 from beetsplug.permissions import (
     check_permissions,
     convert_perm,
@@ -13,12 +15,11 @@ from beetsplug.permissions import (
 )
 
 
-class PermissionsPluginTest(AsIsImporterMixin, PluginMixin, ImportTestCase):
+class TestPermissionsPlugin(AsIsImporterMixin, PluginMixin, ImportHelper):
     plugin = "permissions"
 
-    def setUp(self):
-        super().setUp()
-
+    def setup_beets(self):
+        super().setup_beets()
         self.config["permissions"] = {"file": "777", "dir": "777"}
 
     def test_permissions_on_album_imported(self):
@@ -30,7 +31,7 @@ class PermissionsPluginTest(AsIsImporterMixin, PluginMixin, ImportTestCase):
 
     def import_and_check_permissions(self):
         if platform.system() == "Windows":
-            self.skipTest("permissions not available on Windows")
+            pytest.skip("permissions not available on Windows")
 
         track_file = os.path.join(self.import_dir, b"album", b"track_1.mp3")
         assert os.stat(track_file).st_mode & 0o777 != 511
@@ -57,7 +58,7 @@ class PermissionsPluginTest(AsIsImporterMixin, PluginMixin, ImportTestCase):
 
     def do_set_art(self, expect_success):
         if platform.system() == "Windows":
-            self.skipTest("permissions not available on Windows")
+            pytest.skip("permissions not available on Windows")
         self.run_asis_importer()
         album = self.lib.albums().get()
         artpath = os.path.join(self.temp_dir, b"cover.jpg")

--- a/test/plugins/test_replaygain.py
+++ b/test/plugins/test_replaygain.py
@@ -13,7 +13,7 @@
 # included in all copies or substantial portions of the Software.
 
 
-import unittest
+from abc import ABC, abstractmethod
 from typing import Any, ClassVar
 
 import pytest
@@ -21,7 +21,7 @@ from mediafile import MediaFile
 
 from beets.test.helper import (
     AsIsImporterMixin,
-    ImportTestCase,
+    ImportHelper,
     PluginMixin,
     has_program,
 )
@@ -62,7 +62,7 @@ def reset_replaygain(item):
     item.store()
 
 
-class ReplayGainTestCase(PluginMixin, ImportTestCase):
+class ReplayGainPluginHelper(PluginMixin, ImportHelper):
     db_on_disk = True
     plugin = "replaygain"
     preload_plugin = False
@@ -73,26 +73,27 @@ class ReplayGainTestCase(PluginMixin, ImportTestCase):
     def backend(self):
         return self.plugin_config["backend"]
 
-    def setUp(self):
+    def setup_beets(self):
         # Implemented by Mixins, see above. This may decide to skip the test.
         self.test_backend()
 
-        super().setUp()
+        super().setup_beets()
         self.config["replaygain"].set(self.plugin_config)
 
         self.load_plugins()
 
 
 class ThreadedImportMixin:
-    def setUp(self):
-        super().setUp()
+    def setup_beets(self):
+        super().setup_beets()
         self.config["threaded"] = True
 
 
-class BackendMixin:
+class BackendMixin(ABC):
     plugin_config: ClassVar[dict[str, Any]]
     has_r128_support: bool
 
+    @abstractmethod
     def test_backend(self):
         """Check whether the backend actually has all required functionality."""
 
@@ -110,7 +111,7 @@ class GstBackendMixin(BackendMixin):
             GStreamerBackend(self.config["replaygain"], None)
         except FatalGstreamerPluginReplayGainError as e:
             # Skip the test if plugins could not be loaded.
-            self.skipTest(str(e))
+            pytest.skip(str(e))
 
 
 class CmdBackendMixin(BackendMixin):
@@ -155,7 +156,7 @@ class ReplayGainCliTest:
             i.rg_track_peak is None and i.rg_track_gain is None
             for i in self.lib.items()
         ):
-            self.skipTest("decoder plugins could not be loaded.")
+            pytest.skip("decoder plugins could not be loaded.")
 
         for item in self.lib.items():
             assert item.rg_track_peak is not None
@@ -214,7 +215,7 @@ class ReplayGainCliTest:
         if not self.has_r128_support:
             # This test is a lot less interesting if the backend cannot write
             # both tag types.
-            self.skipTest(
+            pytest.skip(
                 f"r128 tags for opus not supported on backend {self.backend}"
             )
 
@@ -271,7 +272,7 @@ class ReplayGainCliTest:
 
     def test_cli_writes_only_r128_tags(self):
         if not self.has_r128_support:
-            self.skipTest(
+            pytest.skip(
                 f"r128 tags for opus not supported on backend {self.backend}"
             )
 
@@ -305,7 +306,7 @@ class ReplayGainCliTest:
 
     def test_r128_targetlevel_has_effect(self):
         if not self.has_r128_support:
-            self.skipTest(
+            pytest.skip(
                 f"r128 tags for opus not supported on backend {self.backend}"
             )
 
@@ -338,9 +339,7 @@ class ReplayGainCliTest:
     def test_clears_wrong_tag_type(self):
         """Check that items that have tags of the wrong type won't be skipped."""
         if not self.has_r128_support:
-            # This test is a lot less interesting if the backend cannot write
-            # both tag types.
-            self.skipTest(
+            pytest.skip(
                 f"r128 tags for opus not supported on backend {self.backend}"
             )
 
@@ -370,30 +369,30 @@ class ReplayGainCliTest:
         assert item_r128.rg_track_peak is None
 
 
-@unittest.skipIf(not GST_AVAILABLE, "gstreamer cannot be found")
-class ReplayGainGstCliTest(
-    ReplayGainCliTest, ReplayGainTestCase, GstBackendMixin
+@pytest.mark.skipif(not GST_AVAILABLE, reason="gstreamer cannot be found")
+class TestReplayGainGstCli(
+    ReplayGainCliTest, ReplayGainPluginHelper, GstBackendMixin
 ):
     FNAME = "full"  # file contains only silence
 
 
-@unittest.skipIf(not GAIN_PROG, "no *gain command found")
-class ReplayGainCmdCliTest(
-    ReplayGainCliTest, ReplayGainTestCase, CmdBackendMixin
+@pytest.mark.skipif(not GAIN_PROG, reason="no *gain command found")
+class TestReplayGainCmdCli(
+    ReplayGainCliTest, ReplayGainPluginHelper, CmdBackendMixin
 ):
     FNAME = "full"  # file contains only silence
 
 
-@unittest.skipIf(not FFMPEG_AVAILABLE, "ffmpeg cannot be found")
-class ReplayGainFfmpegCliTest(
-    ReplayGainCliTest, ReplayGainTestCase, FfmpegBackendMixin
+@pytest.mark.skipif(not FFMPEG_AVAILABLE, reason="ffmpeg cannot be found")
+class TestReplayGainFfmpegCli(
+    ReplayGainCliTest, ReplayGainPluginHelper, FfmpegBackendMixin
 ):
     FNAME = "full"  # file contains only silence
 
 
-@unittest.skipIf(not FFMPEG_AVAILABLE, "ffmpeg cannot be found")
-class ReplayGainFfmpegNoiseCliTest(
-    ReplayGainCliTest, ReplayGainTestCase, FfmpegBackendMixin
+@pytest.mark.skipif(not FFMPEG_AVAILABLE, reason="ffmpeg cannot be found")
+class TestReplayGainFfmpegNoiseCli(
+    ReplayGainCliTest, ReplayGainPluginHelper, FfmpegBackendMixin
 ):
     FNAME = "whitenoise"
 
@@ -409,25 +408,29 @@ class ImportTest(AsIsImporterMixin):
             assert item.rg_album_gain is not None
 
 
-@unittest.skipIf(not GST_AVAILABLE, "gstreamer cannot be found")
-class ReplayGainGstImportTest(ImportTest, ReplayGainTestCase, GstBackendMixin):
-    pass
-
-
-@unittest.skipIf(not GAIN_PROG, "no *gain command found")
-class ReplayGainCmdImportTest(ImportTest, ReplayGainTestCase, CmdBackendMixin):
-    pass
-
-
-@unittest.skipIf(not FFMPEG_AVAILABLE, "ffmpeg cannot be found")
-class ReplayGainFfmpegImportTest(
-    ImportTest, ReplayGainTestCase, FfmpegBackendMixin
+@pytest.mark.skipif(not GST_AVAILABLE, reason="gstreamer cannot be found")
+class TestReplayGainGstImport(
+    ImportTest, ReplayGainPluginHelper, GstBackendMixin
 ):
     pass
 
 
-@unittest.skipIf(not FFMPEG_AVAILABLE, "ffmpeg cannot be found")
-class ReplayGainFfmpegThreadedImportTest(
-    ThreadedImportMixin, ImportTest, ReplayGainTestCase, FfmpegBackendMixin
+@pytest.mark.skipif(not GAIN_PROG, reason="no *gain command found")
+class TestReplayGainCmdImport(
+    ImportTest, ReplayGainPluginHelper, CmdBackendMixin
+):
+    pass
+
+
+@pytest.mark.skipif(not FFMPEG_AVAILABLE, reason="ffmpeg cannot be found")
+class TestReplayGainFfmpegImport(
+    ImportTest, ReplayGainPluginHelper, FfmpegBackendMixin
+):
+    pass
+
+
+@pytest.mark.skipif(not FFMPEG_AVAILABLE, reason="ffmpeg cannot be found")
+class TestReplayGainFfmpegThreadedImport(
+    ThreadedImportMixin, ImportTest, ReplayGainPluginHelper, FfmpegBackendMixin
 ):
     pass

--- a/test/plugins/test_scrub.py
+++ b/test/plugins/test_scrub.py
@@ -2,10 +2,10 @@ import os
 
 from mediafile import MediaFile
 
-from beets.test.helper import AsIsImporterMixin, ImportTestCase, PluginMixin
+from beets.test.helper import AsIsImporterMixin, ImportHelper, PluginMixin
 
 
-class ScrubbedImportTest(AsIsImporterMixin, PluginMixin, ImportTestCase):
+class TestScrubbedImport(AsIsImporterMixin, PluginMixin, ImportHelper):
     db_on_disk = True
     plugin = "scrub"
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -45,9 +45,10 @@ from beets.test.helper import (
     AutotagImportTestCase,
     AutotagStub,
     BeetsTestCase,
-    ImportTestCase,
+    ImportHelper,
     IOMixin,
     PluginMixin,
+    TestHelper,
     capture_log,
     has_program,
 )
@@ -71,7 +72,7 @@ class PathsMixin:
         return self.lib_path / "Tag Artist" / "Tag Album" / "Tag Track 1.mp3"
 
 
-class NonAutotaggedImportTest(PathsMixin, AsIsImporterMixin, ImportTestCase):
+class TestNonAutotaggedImport(PathsMixin, AsIsImporterMixin, ImportHelper):
     db_on_disk = True
 
     def test_album_created_with_track_artist(self):
@@ -125,7 +126,7 @@ class NonAutotaggedImportTest(PathsMixin, AsIsImporterMixin, ImportTestCase):
         album = self.lib.albums()[0]
         assert album.mb_albumartistids == album.items()[0].mb_albumartistids
 
-    @unittest.skipUnless(_common.HAVE_SYMLINK, "need symlinks")
+    @pytest.mark.skipif(not _common.HAVE_SYMLINK, reason="need symlinks")
     def test_import_link_arrives(self):
         self.run_asis_importer(link=True)
 
@@ -133,7 +134,7 @@ class NonAutotaggedImportTest(PathsMixin, AsIsImporterMixin, ImportTestCase):
         assert self.track_lib_path.is_symlink()
         assert self.track_lib_path.resolve() == self.track_import_path.resolve()
 
-    @unittest.skipUnless(_common.HAVE_HARDLINK, "need hardlinks")
+    @pytest.mark.skipif(not _common.HAVE_HARDLINK, reason="need hardlinks")
     def test_import_hardlink_arrives(self):
         self.run_asis_importer(hardlink=True)
 
@@ -168,13 +169,13 @@ def create_archive(session):
     return bytestring_path(path)
 
 
-class RmTempTest(BeetsTestCase):
+class TestRmTemp(TestHelper):
     """Tests that temporarily extracted archives are properly removed
     after usage.
     """
 
-    def setUp(self):
-        super().setUp()
+    def setup_beets(self):
+        super().setup_beets()
         self.want_resume = False
         self.config["incremental"] = False
         self.config["copy"] = False
@@ -234,7 +235,7 @@ class RmTempTest(BeetsTestCase):
             )
 
 
-class ImportZipTest(AsIsImporterMixin, ImportTestCase):
+class TestImportZip(AsIsImporterMixin, ImportHelper):
     def test_import_zip(self):
         zip_path = create_archive(self)
         assert len(self.lib.items()) == 0
@@ -245,7 +246,7 @@ class ImportZipTest(AsIsImporterMixin, ImportTestCase):
         assert len(self.lib.albums()) == 1
 
 
-class ImportTarTest(ImportZipTest):
+class TestImportTar(TestImportZip):
     def create_archive(self):
         (handle, path) = mkstemp(dir=syspath(self.temp_dir))
         path = bytestring_path(path)
@@ -258,19 +259,19 @@ class ImportTarTest(ImportZipTest):
         return path
 
 
-@unittest.skipIf(not has_program("unrar"), "unrar program not found")
-class ImportRarTest(ImportZipTest):
+@pytest.mark.skipif(not has_program("unrar"), reason="unrar program not found")
+class TestImportRar(TestImportZip):
     def create_archive(self):
         return os.path.join(_common.RSRC, b"archive.rar")
 
 
-class Import7zTest(ImportZipTest):
+class TestImport7z(TestImportZip):
     def create_archive(self):
         return os.path.join(_common.RSRC, b"archive.7z")
 
 
-@unittest.skip("Implement me!")
-class ImportPasswordRarTest(ImportZipTest):
+@pytest.mark.skip(reason="Implement me!")
+class TestImportPasswordRar(TestImportZip):
     def create_archive(self):
         return os.path.join(_common.RSRC, b"password.rar")
 
@@ -385,16 +386,17 @@ class ImportSingletonTest(AutotagImportTestCase):
 
 
 @pytest.mark.skipif(
-    not has_program("ffprobe", ["-L"]), "need ffprobe for format recognition"
+    not has_program("ffprobe", ["-L"]),
+    reason="need ffprobe for format recognition",
 )
-class ImportFormatTest:
+class TestImportFormat(ImportHelper):
     """Test fix_extension during import."""
 
     def test_recognize_format(self):
         resource_src = os.path.join(_common.RSRC, b"no_ext")
         resource_path = os.path.join(self.import_dir, b"no_ext")
         util.copy(resource_src, resource_path)
-        self.setup_importer()
+        self.setup_importer(autotag=False)
         self.importer.paths = [resource_path]
         self.importer.run()
         assert self.lib.items().get().path.endswith(b".mp3")
@@ -405,7 +407,7 @@ class ImportFormatTest:
         util.copy(resource_path, temp_resource_path)
         new_path = os.path.join(self.temp_dir, b"no_ext.mp3")
         util.copy(temp_resource_path, new_path)
-        self.setup_importer()
+        self.setup_importer(autotag=False)
         self.importer.paths = [temp_resource_path]
         with capture_log() as logs:
             self.importer.run()
@@ -414,7 +416,7 @@ class ImportFormatTest:
 
     def test_recognize_format_not_music(self):
         resource_path = os.path.join(_common.RSRC, b"no_ext_not_music")
-        self.setup_importer()
+        self.setup_importer(autotag=False)
         self.importer.paths = [resource_path]
         self.importer.run()
         assert len(self.lib.items()) == 0
@@ -424,7 +426,7 @@ class ImportFormatTest:
         resource_src = os.path.join(_common.RSRC, b"no_ext")
         resource_path = os.path.join(self.temp_dir, b"no_ext")
         util.copy(resource_src, resource_path)
-        self.setup_importer()
+        self.setup_importer(autotag=False)
         self.importer.paths = [resource_path]
         self.importer.run()
         assert not Path(os.path.join(self.temp_dir_path, "no_ext")).exists()
@@ -434,7 +436,7 @@ class ImportFormatTest:
         resource_src = os.path.join(_common.RSRC, b"no_ext")
         resource_path = os.path.join(self.temp_dir, b"no_ext")
         util.copy(resource_src, resource_path)
-        self.setup_importer()
+        self.setup_importer(autotag=False)
         self.importer.paths = [resource_path]
         self.importer.run()
         assert Path(os.path.join(self.temp_dir_path, "no_ext")).exists()
@@ -1022,12 +1024,11 @@ def album_candidates_mock(*args, **kwargs):
 @patch(
     "beets.metadata_plugins.candidates", Mock(side_effect=album_candidates_mock)
 )
-class ImportDuplicateAlbumTest(PluginMixin, ImportTestCase):
+class TestImportDuplicateAlbum(PluginMixin, ImportHelper):
     plugin = "musicbrainz"
 
-    def setUp(self):
-        super().setUp()
-
+    def setup_beets(self):
+        super().setup_beets()
         # Original album
         self.add_album_fixture(albumartist="artist", album="album")
 
@@ -1121,7 +1122,7 @@ class ImportDuplicateAlbumTest(PluginMixin, ImportTestCase):
         assert len(self.lib.albums()) == 1
 
     def test_twice_in_import_dir(self):
-        self.skipTest("write me")
+        pytest.skip(reason="write me")
 
     def test_keep_when_extra_key_is_different(self):
         config["import"]["duplicate_keys"]["album"] = "albumartist album flex"
@@ -1153,7 +1154,7 @@ class ImportDuplicateAlbumTest(PluginMixin, ImportTestCase):
 @patch(
     "beets.metadata_plugins.candidates", Mock(side_effect=album_candidates_mock)
 )
-class ImportDuplicateAlbumThreadedTest(PluginMixin, ImportTestCase):
+class TestImportDuplicateAlbumThreaded(PluginMixin, ImportHelper):
     """Regression test for #6601: threaded merge must propagate context vars."""
 
     plugin = "musicbrainz"
@@ -1161,8 +1162,8 @@ class ImportDuplicateAlbumThreadedTest(PluginMixin, ImportTestCase):
     # empty DB, so we need a real file that all threads share.
     db_on_disk = True
 
-    def setUp(self):
-        super().setUp()
+    def setup_beets(self):
+        super().setup_beets()
         self.add_album_fixture(albumartist="artist", album="album")
         self.prepare_album_for_import(1)
         self.importer = self.setup_importer(
@@ -1202,10 +1203,9 @@ def item_candidates_mock(*args, **kwargs):
     "beets.metadata_plugins.item_candidates",
     Mock(side_effect=item_candidates_mock),
 )
-class ImportDuplicateSingletonTest(ImportTestCase):
-    def setUp(self):
-        super().setUp()
-
+class TestImportDuplicateSingleton(ImportHelper):
+    def setup_beets(self):
+        super().setup_beets()
         # Original file in library
         self.add_item_fixture(
             artist="artist", title="title", mb_trackid="old trackid"
@@ -1288,7 +1288,7 @@ class ImportDuplicateSingletonTest(ImportTestCase):
         assert self.lib.items().get().mb_trackid == "new trackid"
 
     def test_twice_in_import_dir(self):
-        self.skipTest("write me")
+        pytest.skip(reason="write me")
 
     def add_item_fixture(self, **kwargs):
         # Move this to TestHelper
@@ -1314,7 +1314,7 @@ class TagLogTest(unittest.TestCase):
         assert "status caf\xe9" in sio.getvalue()
 
 
-class ResumeImportTest(ImportTestCase):
+class TestResumeImport(ImportHelper):
     @patch("beets.plugins.send")
     def test_resume_album(self, plugins_send):
         self.prepare_albums_for_import(2)
@@ -1360,7 +1360,7 @@ class ResumeImportTest(ImportTestCase):
         assert self.lib.items("title:'Track 1'").get() is not None
 
 
-class IncrementalImportTest(AsIsImporterMixin, ImportTestCase):
+class TestIncrementalImport(AsIsImporterMixin, ImportHelper):
     def test_incremental_album(self):
         importer = self.run_asis_importer(incremental=True)
 
@@ -1768,8 +1768,8 @@ def mocked_get_albums_by_ids(ids):
     """
     # Map IDs to (release title, artist), so the distances are different.
     album_artist_map = {
-        ImportIdTest.ID_RELEASE_0: ("VALID_RELEASE_0", "TAG ARTIST"),
-        ImportIdTest.ID_RELEASE_1: ("VALID_RELEASE_1", "DISTANT_MATCH"),
+        TestImportId.ID_RELEASE_0: ("VALID_RELEASE_0", "TAG ARTIST"),
+        TestImportId.ID_RELEASE_1: ("VALID_RELEASE_1", "DISTANT_MATCH"),
     }
 
     for id_ in ids:
@@ -1803,8 +1803,8 @@ def mocked_get_tracks_by_ids(ids):
     """
     # Map IDs to (recording title, artist), so the distances are different.
     title_artist_map = {
-        ImportIdTest.ID_RECORDING_0: ("VALID_RECORDING_0", "TAG ARTIST"),
-        ImportIdTest.ID_RECORDING_1: ("VALID_RECORDING_1", "DISTANT_MATCH"),
+        TestImportId.ID_RECORDING_0: ("VALID_RECORDING_0", "TAG ARTIST"),
+        TestImportId.ID_RECORDING_1: ("VALID_RECORDING_1", "DISTANT_MATCH"),
     }
 
     for id_ in ids:
@@ -1826,14 +1826,14 @@ def mocked_get_tracks_by_ids(ids):
     "beets.metadata_plugins.albums_for_ids",
     Mock(side_effect=mocked_get_albums_by_ids),
 )
-class ImportIdTest(ImportTestCase):
+class TestImportId(ImportHelper):
     ID_RELEASE_0 = "00000000-0000-0000-0000-000000000000"
     ID_RELEASE_1 = "11111111-1111-1111-1111-111111111111"
     ID_RECORDING_0 = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
     ID_RECORDING_1 = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 
-    def setUp(self):
-        super().setUp()
+    def setup_beets(self):
+        super().setup_beets()
         self.prepare_album_for_import(1)
 
     def test_one_mbid_one_album(self):
@@ -1893,7 +1893,7 @@ class ImportIdTest(ImportTestCase):
         }
 
 
-class MpeglayerWavImportTest(AsIsImporterMixin, ImportTestCase):
+class TestMpeglayerWavImport(AsIsImporterMixin, ImportHelper):
     """Test remuxing of WAVE_FORMAT_MPEGLAYER3 WAV files."""
 
     def test_remux_mpeglayer3_wav(self):

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -11,12 +11,7 @@ import pytest
 import beets.logging as blog
 from beets import plugins, ui
 from beets.test import helper
-from beets.test.helper import (
-    AsIsImporterMixin,
-    ImportHelper,
-    PluginMixin,
-    PluginTestHelper,
-)
+from beets.test.helper import AsIsImporterMixin, ImportHelper, PluginMixin
 
 
 class TestStrFormatLogger:

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -11,7 +11,12 @@ import pytest
 import beets.logging as blog
 from beets import plugins, ui
 from beets.test import helper
-from beets.test.helper import AsIsImporterMixin, ImportTestCase, PluginMixin
+from beets.test.helper import (
+    AsIsImporterMixin,
+    ImportHelper,
+    PluginMixin,
+    PluginTestHelper,
+)
 
 
 class TestStrFormatLogger:
@@ -149,16 +154,13 @@ class DummyModule(ModuleType):
         self.DummyPlugin = self.DummyPlugin
 
 
-class LoggingLevelTest(AsIsImporterMixin, PluginMixin, ImportTestCase):
+class TestLoggingLevel(AsIsImporterMixin, PluginMixin, ImportHelper):
     plugin = "dummy"
 
-    @classmethod
-    def setUpClass(cls):
-        patcher = patch.dict(sys.modules, {"beetsplug.dummy": DummyModule()})
-        patcher.start()
-        cls.addClassCleanup(patcher.stop)
-
-        super().setUpClass()
+    @pytest.fixture(autouse=True, scope="class")
+    def _patch_dummy_module(self):
+        with patch.dict(sys.modules, {"beetsplug.dummy": DummyModule()}):
+            yield
 
     def test_command_level0(self):
         self.config["verbose"] = 0
@@ -233,7 +235,7 @@ class LoggingLevelTest(AsIsImporterMixin, PluginMixin, ImportTestCase):
         assert "dummy: debug import_stage" in logs
 
 
-class ConcurrentEventsTest(AsIsImporterMixin, ImportTestCase):
+class TestConcurrentEvents(AsIsImporterMixin, ImportHelper):
     """Similar to LoggingLevelTest but lower-level and focused on multiple
     events interaction. Since this is a bit heavy we don't do it in
     LoggingLevelTest.

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -4,7 +4,6 @@ import logging as log
 import sys
 import threading
 from types import ModuleType
-from unittest.mock import patch
 
 import pytest
 
@@ -152,10 +151,9 @@ class DummyModule(ModuleType):
 class TestLoggingLevel(AsIsImporterMixin, PluginMixin, ImportHelper):
     plugin = "dummy"
 
-    @pytest.fixture(autouse=True, scope="class")
-    def _patch_dummy_module(self):
-        with patch.dict(sys.modules, {"beetsplug.dummy": DummyModule()}):
-            yield
+    @pytest.fixture(autouse=True)
+    def _patch_dummy_module(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "beetsplug.dummy", DummyModule())
 
     def test_command_level0(self):
         self.config["verbose"] = 0

--- a/test/ui/test_ui_importer.py
+++ b/test/ui/test_ui_importer.py
@@ -23,7 +23,7 @@ from test import test_importer
 
 
 class NonAutotaggedImportTest(
-    TerminalImportMixin, test_importer.NonAutotaggedImportTest
+    TerminalImportMixin, test_importer.TestNonAutotaggedImport
 ):
     pass
 

--- a/test/ui/test_ui_importer.py
+++ b/test/ui/test_ui_importer.py
@@ -22,7 +22,7 @@ from beets.test.helper import TerminalImportMixin
 from test import test_importer
 
 
-class NonAutotaggedImportTest(
+class TestNonAutotaggedImport(
     TerminalImportMixin, test_importer.TestNonAutotaggedImport
 ):
     pass


### PR DESCRIPTION
## Description

This PR removes `ImportTestCase` and replaces all occurrences with  `ImportHelper` + `pytest`.

This touches:
- `test_scrub`
- `test_filefilter`
- `test_replaygain`
- `test_chroma`
- `test_import`

TODOs:
- [x] ~~Changelog~~ Not needed as this is an internal refactor only
---
This is related to the multi-step efforts to improve logging in beets https://github.com/beetbox/beets/issues/6553
