### PR TITLE
limit: Fix HeadQuery + SlowFieldSort applying limit before sort

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -877,8 +877,26 @@ class Results(Generic[AnyModel]):
         """
         if self.sort:
             # Slow sort. Must build the full list first.
-            objects = self.sort.sort(list(self._get_objects()))
-            return iter(objects)
+            # When a slow query is also present (e.g., HeadQuery),
+            # apply it AFTER sorting: slow queries may be order-sensitive
+            # (HeadQuery counts items and stops at N),
+            # so limiting before sorting would produce wrong results.
+            # Temporarily suppress the slow query to materialize all rows,
+            # sort them, then filter.
+            if self.query:
+                slow_query = self.query
+                self.query = None
+                try:
+                    all_objects = list(self._get_objects())
+                finally:
+                    self.query = slow_query
+                sorted_objects = self.sort.sort(all_objects)
+                return iter(
+                    obj for obj in sorted_objects if slow_query.match(obj)
+                )
+            else:
+                objects = self.sort.sort(list(self._get_objects()))
+                return iter(objects)
 
         else:
             # Objects are pre-sorted (i.e., by the database).

--- a/test/plugins/test_limit.py
+++ b/test/plugins/test_limit.py
@@ -92,3 +92,31 @@ class LimitPluginTest(IOMixin, PluginTestCase):
         incorrect_order = f"{self.num_limit_prefix} {self.track_tail_range}"
         result = self.lib.items(incorrect_order)
         assert len(result) == 0
+
+    def test_prefix_with_slow_sort(self):
+        """
+        HeadQuery combined with a slow sort returns the correct top-N items.
+
+        Regression test for https://github.com/beetbox/beets/issues/5076:
+        when a flexible (non-DB) field is used for sorting,
+        the limit must be applied AFTER sorting, not before.
+        """
+        # Assign a flexible attribute so items get SlowFieldSort.
+        # Use 0-indexed single-digit ratings to avoid lexicographic-vs-numeric
+        # ordering issues (flexible attrs are stored as strings).
+        for rating, item in enumerate(
+            sorted(self.lib.items(), key=lambda i: i.track)
+        ):
+            item["rating"] = rating  # 0..num_test_items-1
+            item.store()
+
+        # Top num_limit items by rating descending must be the highest-rated ones.
+        result = list(self.lib.items(f"rating- {self.num_limit_prefix}"))
+        assert len(result) == self.num_limit
+
+        # Flexible attrs come back as strings; single-digit values compare
+        # identically as int and as string, so casting is safe here.
+        ratings = [int(item["rating"]) for item in result]
+        max_rating = self.num_test_items - 1
+        expected = list(range(max_rating, max_rating - self.num_limit, -1))
+        assert ratings == expected, f"Expected {expected}, got {ratings}"


### PR DESCRIPTION
## Description
When `Results.__iter__()` has both a slow sort and a slow query active, the slow query was applied during row materialization (inside `_get_objects()`), before `sort.sort()` ran.
Because `HeadQuery` is order-sensitive (it counts items and stops at N), it was capping the result set to N unsorted rows, which were then sorted. The fix temporarily suppresses the slow query while fetching all rows, sorts them, and only then applies the query to the sorted sequence.

A regression test is added in `test/plugins/test_limit.py`.

Fixes #5076.

## To Do

- [X] ~~Documentation.~~
- [ ] Changelog (will be added once reviewed & approved).
- [X] Tests.