### PR TITLE
template evaluation: feed all templates into evaluate_fmt as strings

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -48,8 +48,9 @@ from typing_extensions import (
 from unidecode import unidecode
 
 import beets
+from beets.util import cached_classproperty
+from beets.util.functemplate import get_template
 
-from ..util import cached_classproperty, functemplate
 from . import types
 from .query import MatchQuery, TrueQuery
 from .sort import NullSort
@@ -690,20 +691,13 @@ class Model(ABC, Generic[D]):
         """
         return self._formatter(self, included_keys, for_path)
 
-    def evaluate_template(
-        self, template: str | functemplate.Template, for_path: bool = False
-    ) -> str:
-        """Evaluate a template (a string or a `Template` object) using
-        the object's fields. If `for_path` is true, then no new path
-        separators will be added to the template.
+    def evaluate_fmt(self, fmt: str, for_path: bool = False) -> str:
+        """Evaluate a format string using the object's fields.
+
+        If `for_path` is true, then no new path separators are added to the template.
         """
         # Perform substitution.
-        if isinstance(template, str):
-            t = functemplate.template(template)
-        else:
-            # Help out mypy
-            t = template
-        return t.substitute(
+        return get_template(fmt).substitute(
             self.formatted(for_path=for_path), self._template_funcs()
         )
 

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -27,7 +27,6 @@ from beets.util import (
     syspath,
 )
 from beets.util.deprecation import maybe_replace_legacy_field
-from beets.util.functemplate import Template, template
 from beets.util.pathformats import PF_KEY_DEFAULT
 
 from .exceptions import FileOperationError, ReadError, WriteError
@@ -39,6 +38,7 @@ if TYPE_CHECKING:
 
     from beets.dbcore.query import FieldQuery, FieldQueryType
     from beets.dbcore.sort import FieldSort
+    from beets.util.pathformats import PathFormat
 
     from .library import Library  # noqa: F401
 
@@ -101,10 +101,9 @@ class LibModel(dbcore.Model["Library"]):
         super().add(lib)
 
     def __format__(self, spec):
-        if not spec:
-            spec = beets.config[self._format_config_key].as_str()
-        assert isinstance(spec, str)
-        return self.evaluate_template(spec)
+        return self.evaluate_fmt(
+            spec or beets.config[self._format_config_key].as_str()
+        )
 
     def __str__(self):
         return format(self)
@@ -526,8 +525,9 @@ class Album(LibModel):
         image = bytestring_path(image)
         item_dir = item_dir or self.item_dir()
 
-        filename_tmpl = template(beets.config["art_filename"].as_str())
-        subpath = self.evaluate_template(filename_tmpl, True)
+        subpath = self.evaluate_fmt(
+            beets.config["art_filename"].as_str(), for_path=True
+        )
         if beets.config["asciify_paths"]:
             subpath = util.asciify_path(
                 subpath, beets.config["path_sep_replace"].as_str()
@@ -1182,7 +1182,10 @@ class Item(LibModel):
     # Templating.
 
     def destination(
-        self, relative_to_libdir=False, basedir=None, path_formats=None
+        self,
+        relative_to_libdir=False,
+        basedir=None,
+        path_formats: list[PathFormat] | None = None,
     ) -> bytes:
         """Return the path in the library directory designated for the item
         (i.e., where the file ought to be).
@@ -1212,13 +1215,8 @@ class Item(LibModel):
                     break
             else:
                 assert False, "no default path format"
-        if isinstance(path_format, Template):
-            subpath_tmpl = path_format
-        else:
-            subpath_tmpl = template(path_format)
-
         # Evaluate the selected template.
-        subpath = self.evaluate_template(subpath_tmpl, True)
+        subpath = self.evaluate_fmt(path_format, True)
 
         # Prepare path for output: normalize Unicode characters.
         if sys.platform == "darwin":

--- a/beets/ui/commands/modify.py
+++ b/beets/ui/commands/modify.py
@@ -2,7 +2,6 @@
 
 from beets import library, ui
 from beets.exceptions import UserError
-from beets.util import functemplate
 from beets.util.deprecation import maybe_replace_legacy_field
 
 from .utils import do_query
@@ -26,13 +25,10 @@ def modify_items(lib, mods, dels, query, write, move, album, confirm, inherit):
     # objects.
     ui.print_(f"Modifying {len(objs)} {'album' if album else 'item'}s.")
     changed = []
-    templates = {
-        key: functemplate.template(value) for key, value in mods.items()
-    }
     for obj in objs:
         obj_mods = {
-            key: model_cls._parse(key, obj.evaluate_template(templates[key]))
-            for key in mods.keys()
+            key: model_cls._parse(key, obj.evaluate_fmt(fmt))
+            for key, fmt in mods.items()
         }
         if print_and_modify(obj, obj_mods, dels) and obj not in changed:
             changed.append(obj)

--- a/beets/util/functemplate.py
+++ b/beets/util/functemplate.py
@@ -26,6 +26,8 @@ This is sort of like a tiny, horrible degeneration of a real templating
 engine like Jinja2 or Mustache.
 """
 
+from __future__ import annotations
+
 import ast
 import dis
 import functools
@@ -509,7 +511,7 @@ def _parse(template):
 
 
 @functools.lru_cache(maxsize=128)
-def template(fmt):
+def get_template(fmt: str) -> Template:
     return Template(fmt)
 
 

--- a/beets/util/pathformats.py
+++ b/beets/util/pathformats.py
@@ -2,14 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .functemplate import template
-
 if TYPE_CHECKING:
     import confuse
 
-    from .functemplate import Template
-
-    PathFormat = tuple[str, Template]
+    PathFormat = tuple[str, str]
 
 
 # Special path format key.
@@ -25,7 +21,4 @@ def get_path_formats(subview: confuse.Subview) -> list[PathFormat]:
     part of ``paths``. This keeps inherited defaults such as ``default``,
     ``comp``, and ``singleton`` available unless they are explicitly replaced.
     """
-    return [
-        (PF_KEY_QUERIES.get(q, q), template(v.as_str()))
-        for q, v in subview.items()
-    ]
+    return [(PF_KEY_QUERIES.get(q, q), v.as_str()) for q, v in subview.items()]

--- a/beetsplug/bench.py
+++ b/beetsplug/bench.py
@@ -20,7 +20,6 @@ import timeit
 from beets import importer, plugins, ui
 from beets.autotag import tag_album
 from beets.plugins import BeetsPlugin
-from beets.util.functemplate import Template
 from beets.util.pathformats import PF_KEY_DEFAULT
 from beetsplug._utils import vfs
 
@@ -31,10 +30,7 @@ def aunique_benchmark(lib, prof):
 
     # Measure path generation performance with %aunique{} included.
     lib.path_formats = [
-        (
-            PF_KEY_DEFAULT,
-            Template("$albumartist/$album%aunique{}/$track $title"),
-        )
+        (PF_KEY_DEFAULT, "$albumartist/$album%aunique{}/$track $title")
     ]
     if prof:
         cProfile.runctx(
@@ -49,7 +45,7 @@ def aunique_benchmark(lib, prof):
 
     # And with %aunique replaced with a "cheap" no-op function.
     lib.path_formats = [
-        (PF_KEY_DEFAULT, Template("$albumartist/$album%lower{}/$track $title"))
+        (PF_KEY_DEFAULT, "$albumartist/$album%lower{}/$track $title")
     ]
     if prof:
         cProfile.runctx(

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -403,7 +403,7 @@ class SmartPlaylistPlugin(plugins.BeetsPlugin):
             # the items and generate the correct m3u file names.
             matched_items: list[Item] = []
             for item in items:
-                m3u_name = item.evaluate_template(name, True)
+                m3u_name = item.evaluate_fmt(name, True)
                 m3u_name = sanitize_path(m3u_name, lib.replacements)
                 item_uri = self.get_item_uri(item)
 
@@ -417,7 +417,7 @@ class SmartPlaylistPlugin(plugins.BeetsPlugin):
             )
             for item in matched_items:
                 self._log.debug(
-                    item.evaluate_template(self.config["format"].as_str())
+                    item.evaluate_fmt(self.config["format"].as_str())
                 )
 
         if self.config["pretend"].get():

--- a/test/plugins/test_inline.py
+++ b/test/plugins/test_inline.py
@@ -39,7 +39,7 @@ class TestInlineRecursion(PluginTestCase):
             disctotal=1,
         )
 
-        out = item.evaluate_template("$track_no")
+        out = item.evaluate_fmt("$track_no")
 
         assert out == "01"
 

--- a/test/plugins/test_rewrite.py
+++ b/test/plugins/test_rewrite.py
@@ -21,7 +21,7 @@ class RewritePluginTest(PluginTestCase):
 
             assert item.artist == "Jimi Hendrix"
             assert item.albumartist == "Jimi Hendrix"
-            assert album.evaluate_template("$albumartist") == "Jimi Hendrix"
+            assert album.evaluate_fmt("$albumartist") == "Jimi Hendrix"
 
     def test_rewrite_all_matching_rules(self):
         with self.configure_plugin(

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -174,9 +174,9 @@ class SmartPlaylistTest(BeetsTestCase):
         spl = SmartPlaylistPlugin()
 
         i = Mock(path=b"/tagada.mp3")
-        i.evaluate_template.side_effect = lambda pl, *_: os.fsdecode(
-            pl
-        ).replace("$title", "ta:ga:da")
+        i.evaluate_fmt.side_effect = lambda pl, *_: os.fsdecode(pl).replace(
+            "$title", "ta:ga:da"
+        )
 
         lib = Mock()
         lib.replacements = CHAR_REPLACE
@@ -215,9 +215,9 @@ class SmartPlaylistTest(BeetsTestCase):
         type(i).title = PropertyMock(return_value="fake title")
         type(i).length = PropertyMock(return_value=300.123)
         type(i).path = PropertyMock(return_value=b"/tagada.mp3")
-        i.evaluate_template.side_effect = lambda pl, *_: os.fsdecode(
-            pl
-        ).replace("$title", "ta:ga:da")
+        i.evaluate_fmt.side_effect = lambda pl, *_: os.fsdecode(pl).replace(
+            "$title", "ta:ga:da"
+        )
 
         lib = Mock()
         lib.replacements = CHAR_REPLACE
@@ -264,9 +264,9 @@ class SmartPlaylistTest(BeetsTestCase):
         type(i).path = PropertyMock(return_value=b"/tagada.mp3")
         a = {"id": 456, "genres": ["Rock", "Pop"]}
         i.__getitem__.side_effect = a.__getitem__
-        i.evaluate_template.side_effect = lambda pl, *_: os.fsdecode(
-            pl
-        ).replace("$title", "ta:ga:da")
+        i.evaluate_fmt.side_effect = lambda pl, *_: os.fsdecode(pl).replace(
+            "$title", "ta:ga:da"
+        )
 
         lib = Mock()
         lib.replacements = CHAR_REPLACE

--- a/test/plugins/test_types_plugin.py
+++ b/test/plugins/test_types_plugin.py
@@ -155,20 +155,20 @@ class TypesPluginTest(IOMixin, PluginTestCase):
         without_fields = self.add_item(artist="britney")
 
         int_template = "%ifdef{playcount,Play count: $playcount,Not played}"
-        assert with_fields.evaluate_template(int_template) == "Play count: 10"
-        assert without_fields.evaluate_template(int_template) == "Not played"
+        assert with_fields.evaluate_fmt(int_template) == "Play count: 10"
+        assert without_fields.evaluate_fmt(int_template) == "Not played"
 
         float_template = "%ifdef{rating,Rating: $rating,Not rated}"
-        assert with_fields.evaluate_template(float_template) == "Rating: 5.0"
-        assert without_fields.evaluate_template(float_template) == "Not rated"
+        assert with_fields.evaluate_fmt(float_template) == "Rating: 5.0"
+        assert without_fields.evaluate_fmt(float_template) == "Not rated"
 
         bool_template = "%ifdef{starred,Starred: $starred,Not starred}"
-        assert with_fields.evaluate_template(bool_template).lower() in (
+        assert with_fields.evaluate_fmt(bool_template).lower() in (
             "starred: true",
             "starred: yes",
             "starred: y",
         )
-        assert without_fields.evaluate_template(bool_template) == "Not starred"
+        assert without_fields.evaluate_fmt(bool_template) == "Not starred"
 
     def modify(self, *args):
         return self.run_with_output(

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1246,13 +1246,13 @@ class TestTemplate(PytestItemHelper):
     def test_year_formatted_in_template(self, item_in_db):
         item_in_db.year = 123
         item_in_db.store()
-        assert item_in_db.evaluate_template("$year") == "0123"
+        assert item_in_db.evaluate_fmt("$year") == "0123"
 
     def test_album_flexattr_appears_in_item_template(self, item_in_db):
         self.album = self.lib.add_album([item_in_db])
         self.album.foo = "baz"
         self.album.store()
-        assert item_in_db.evaluate_template("$foo") == "baz"
+        assert item_in_db.evaluate_fmt("$foo") == "baz"
 
     def test_album_and_item_format(self, item_in_db):
         config["format_album"] = "foö $foo"

--- a/test/ui/test_ui.py
+++ b/test/ui/test_ui.py
@@ -162,9 +162,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
             config.write("paths: {x: y}")
 
         self.run_command("test")
-        key, template = self.test_cmd.lib.path_formats[0]
-        assert key == "x"
-        assert template.original == "y"
+        assert self.test_cmd.lib.path_formats[0] == ("x", "y")
 
     def test_nonexistant_db(self):
         with self.write_config_file() as config:

--- a/test/util/test_pathformats.py
+++ b/test/util/test_pathformats.py
@@ -6,9 +6,7 @@ def test_get_path_formats(config):
     # override the default 'singleton' path and add a new one
     config["paths"].set({"singleton": "bar", "new": "hello"})
 
-    path_formats = get_path_formats(config["paths"])
-    actual_path_formats = [(key, tmpl.original) for key, tmpl in path_formats]
-    assert actual_path_formats == [
+    assert get_path_formats(config["paths"]) == [
         ("singleton:true", "bar"),
         ("new", "hello"),
         # defaults


### PR DESCRIPTION
This change standardizes template handling around `evaluate_fmt`, so callers now pass plain format strings everywhere instead of a mix of strings and precompiled `Template` objects.

At a high level, it:
- centralizes template compilation in `get_template`
- keeps `path_formats` as simple `(query, "format string")` pairs
- removes template parsing from models, commands, plugins, and tests

Architecturally, this makes formatting flow through one consistent path: string in, `evaluate_fmt` handles compilation and evaluation. The result is a simpler API, fewer special cases at call sites, and easier reasoning about how path and display formatting works across the codebase.
