### PR TITLE
Return keysview from keys methods

### DIFF
--- a/beets/autotag/distance.py
+++ b/beets/autotag/distance.py
@@ -13,7 +13,7 @@ from beets.util import as_string, cached_classproperty, get_most_common_tags
 from beets.util.color import colorize
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Sequence
+    from collections.abc import Iterator, KeysView, Sequence
 
     from beets.library import Item
     from beets.util.color import ColorName
@@ -243,8 +243,8 @@ class Distance:
     def __len__(self) -> int:
         return len(self.items())
 
-    def keys(self) -> list[str]:
-        return [key for key, _ in self.items()]
+    def keys(self) -> KeysView[str]:
+        return dict.fromkeys(key for key, _ in self.items()).keys()
 
     def update(self, dist: Distance):
         """Adds all the distance penalties from `dist`."""

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -736,11 +736,12 @@ class Model(ABC, Generic[D]):
             self.store()
 
     # Formatting and templating.
-
-    _formatter = FormattedMapping
+    _formatter: type[FormattedMapping]
 
     def formatted(
-        self, included_keys: str = _formatter.ALL_KEYS, for_path: bool = False
+        self,
+        included_keys: str = FormattedMapping.ALL_KEYS,
+        for_path: bool = False,
     ) -> FormattedMapping:
         """Get a mapping containing all values on this object formatted
         as human-readable unicode strings.

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -60,6 +60,7 @@ if TYPE_CHECKING:
         Generator,
         Iterable,
         Iterator,
+        KeysView,
         Sequence,
     )
     from sqlite3 import Connection
@@ -112,22 +113,24 @@ class FormattedMapping(Mapping[str, str]):
     """
 
     model: Model
+    model_keys: set[str]
 
     ALL_KEYS = "*"
 
     def __init__(
         self,
         model: Model,
-        included_keys: str = ALL_KEYS,
+        included_keys: str | list[str] = ALL_KEYS,
         for_path: bool = False,
-    ):
+    ) -> None:
         self.for_path = for_path
         self.model = model
-        if included_keys == self.ALL_KEYS:
+        self.model_keys = set(
             # Performance note: this triggers a database query.
-            self.model_keys = self.model.keys(True)
-        else:
-            self.model_keys = included_keys
+            self.model.keys(True)
+            if included_keys == self.ALL_KEYS
+            else included_keys
+        )
 
     def __getitem__(self, key: str) -> str:
         if key in self.model_keys:
@@ -575,23 +578,23 @@ class Model(ABC, Generic[D]):
         else:
             raise KeyError(f"no such field {key}")
 
-    def keys(self, computed: bool = False):
+    def keys(self, computed: bool = False) -> KeysView[str]:
         """Get a list of available field names for this object. The
         `computed` parameter controls whether computed (plugin-provided)
         fields are included in the key list.
         """
-        base_keys = list(self._fields) + list(self._values_flex.keys())
+        keys = {*self._fields, *self._values_flex}
         if computed:
-            return base_keys + list(self._getters().keys())
-        else:
-            return base_keys
+            keys.update(self._getters())
+
+        return dict.fromkeys(keys).keys()
 
     @classmethod
-    def all_keys(cls):
+    def all_keys(cls) -> KeysView[str]:
         """Get a list of available keys for objects of this type.
         Includes fixed and computed fields.
         """
-        return list(cls._fields) + list(cls._getters().keys())
+        return dict.fromkeys({*cls._fields, *cls._getters()}).keys()
 
     # Act like a dictionary.
 

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -15,6 +15,7 @@ from mediafile import MediaFile, UnreadableFileError
 import beets
 from beets import dbcore, logging, plugins, util
 from beets.dbcore import types
+from beets.dbcore.db import FormattedMapping
 from beets.dbcore.pathutils import normalize_path_for_db
 from beets.dbcore.sort import SmartArtistSort
 from beets.util import (
@@ -313,6 +314,8 @@ class Album(LibModel):
     @cached_classproperty
     def _types(cls) -> dict[str, types.Type]:
         return {**super()._types, "path": TYPE_BY_FIELD["path"]}
+
+    _formatter = FormattedMapping
 
     _sorts: ClassVar[dict[str, type[FieldSort]]] = {
         "albumartist": SmartArtistSort,

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -34,6 +34,8 @@ from .fields import TYPE_BY_FIELD
 from .queries import parse_query_string
 
 if TYPE_CHECKING:
+    from collections.abc import KeysView
+
     from beets.dbcore.query import FieldQuery, FieldQueryType
     from beets.dbcore.sort import FieldSort
 
@@ -167,16 +169,22 @@ class FormattedItemMapping(dbcore.db.FormattedMapping):
 
     ALL_KEYS = "*"
 
-    def __init__(self, item, included_keys=ALL_KEYS, for_path=False):
+    def __init__(
+        self,
+        item: Item,
+        included_keys: str | list[str] = ALL_KEYS,
+        for_path: bool = False,
+    ) -> None:
         # We treat album and item keys specially here,
         # so exclude transitive album keys from the model's keys.
         super().__init__(item, included_keys=[], for_path=for_path)
         self.included_keys = included_keys
-        if included_keys == self.ALL_KEYS:
+        self.model_keys = set(
             # Performance note: this triggers a database query.
-            self.model_keys = item.keys(computed=True, with_album=False)
-        else:
-            self.model_keys = included_keys
+            item.keys(computed=True, with_album=False)
+            if included_keys == self.ALL_KEYS
+            else included_keys
+        )
         self.item = item
 
     @cached_property
@@ -806,17 +814,16 @@ class Item(LibModel):
             f"({', '.join(f'{k}={self[k]!r}' for k in self.keys(with_album=False))})"
         )
 
-    def keys(self, computed=False, with_album=True):
+    def keys(self, computed=False, with_album=True) -> KeysView[str]:
         """Get a list of available field names.
 
         `with_album` controls whether the album's fields are included.
         """
         keys = super().keys(computed=computed)
         if with_album and self._cached_album:
-            keys = set(keys)
-            keys.update(self._cached_album.keys(computed=computed))
-            keys = list(keys)
-        return keys
+            keys |= self._cached_album.keys(computed=computed)
+
+        return dict.fromkeys(keys).keys()
 
     def get(self, key, default=None, with_album=True):
         """Get the value for a given key or `default` if it does not

--- a/beets/ui/commands/fields.py
+++ b/beets/ui/commands/fields.py
@@ -15,8 +15,7 @@ def _print_keys(query):
 
 def fields_func(lib, opts, args):
     def _print_rows(names):
-        names.sort()
-        ui.print_(textwrap.indent("\n".join(names), "  "))
+        ui.print_(textwrap.indent("\n".join(sorted(names)), "  "))
 
     ui.print_("Item fields:")
     _print_rows(library.Item.all_keys())

--- a/beetsplug/fish.py
+++ b/beetsplug/fish.py
@@ -82,7 +82,7 @@ class FishPlugin(BeetsPlugin):
             "--extravalues",
             action="append",
             type="choice",
-            choices=library.Item.all_keys() + library.Album.all_keys(),
+            choices=library.Item.all_keys() | library.Album.all_keys(),
             help="include specified field *values* in completions",
         )
         cmd.parser.add_option(
@@ -114,7 +114,7 @@ class FishPlugin(BeetsPlugin):
             (commands.default_commands + plugins.commands()),
             key=attrgetter("name"),
         )
-        fields = sorted(set(library.Album.all_keys() + library.Item.all_keys()))
+        fields = sorted(library.Album.all_keys() | library.Item.all_keys())
         # Collect commands, their aliases, and their help text
         cmd_names_help = []
         for cmd in beetcmds:

--- a/test/test_dbcore.py
+++ b/test/test_dbcore.py
@@ -25,7 +25,7 @@ import pytest
 
 from beets import dbcore
 from beets.dbcore import query, sort, types
-from beets.dbcore.db import DBCustomFunctionError, Index
+from beets.dbcore.db import DBCustomFunctionError, FormattedMapping, Index
 from beets.library import Album, Item, LibModel
 from beets.util import cached_classproperty
 
@@ -68,6 +68,7 @@ class ModelFixture1(LibModel):
         "some_sort": SortFixture
     }
     _indices = (Index("field_one_index", ("field_one",)),)
+    _formatter = FormattedMapping
 
     @cached_classproperty
     def _types(cls):

--- a/test/ui/commands/test_fields.py
+++ b/test/ui/commands/test_fields.py
@@ -4,21 +4,14 @@ from beets.ui.commands.fields import fields_func
 
 
 class FieldsTest(IOMixin, ItemInDBTestCase):
-    def remove_keys(self, keys, text):
-        for i in text:
-            try:
-                keys.remove(i)
-            except ValueError:
-                pass
-
     def test_fields_func(self):
         fields_func(self.lib, [], [])
         items = library.Item.all_keys()
         albums = library.Album.all_keys()
 
-        output = self.io.getoutput().split()
-        self.remove_keys(items, output)
-        self.remove_keys(albums, output)
+        output = set(self.io.getoutput().split())
+        items -= output
+        albums -= output
 
         assert len(items) == 0
         assert len(albums) == 0


### PR DESCRIPTION
### PR summary

This change makes field/key handling more consistent and better typed across the model layer.

- `Model.keys()` and `all_keys()` now return `KeysView`-style set-like views instead of lists, and related code is updated to use set operations like `|` and `sorted(...)`.
- `FormattedMapping` and `FormattedItemMapping` now store included keys as sets internally, which matches the new key semantics and simplifies membership checks.
- The formatter plumbing in `beets.dbcore.db` is tightened for mypy: `_formatter` is explicitly typed, `formatted()` now forwards arguments generically, and `Album` opts into the base `FormattedMapping` explicitly.

### High-level impact

- Standardizes the architecture around "keys are a set of field names", not an ordered mutable list.
- Reduces duplicate/merge logic at call sites and makes intent clearer.
- Fixes typing issues without changing the user-facing behavior of commands like `fields`; most changes are internal API cleanup and consistency work.
