### PR TITLE
importer: improve handling of duplicates

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -159,6 +159,8 @@ c46069654628040316dea9db85d01b263db3ba9e
 bc71ec308eb938df1d349f6857634ddf2a82e339
 
 # 2026
+# Move changelog note under Unreleased section
+1fe5bad4b27d2845aad16f0afae91fe389f299fb
 # Replace http URLs with https
 3d0d032987c4c2e9550529fd25e79581b06ade73
 # Fix broken URLs

--- a/beets/importer/__init__.py
+++ b/beets/importer/__init__.py
@@ -20,6 +20,7 @@ from .session import ImportAbortError, ImportSession
 from .tasks import (
     Action,
     ArchiveImportTask,
+    DuplicateAction,
     ImportTask,
     SentinelImportTask,
     SingletonImportTask,
@@ -30,6 +31,7 @@ from .tasks import (
 __all__ = [
     "Action",
     "ArchiveImportTask",
+    "DuplicateAction",
     "ImportAbortError",
     "ImportSession",
     "ImportTask",

--- a/beets/importer/__init__.py
+++ b/beets/importer/__init__.py
@@ -16,11 +16,10 @@
 autotagging music files.
 """
 
+from .actions import Action, DuplicateAction
 from .session import ImportAbortError, ImportSession
 from .tasks import (
-    Action,
     ArchiveImportTask,
-    DuplicateAction,
     ImportTask,
     SentinelImportTask,
     SingletonImportTask,

--- a/beets/importer/actions.py
+++ b/beets/importer/actions.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from typing_extensions import Self
+
+
+class Action(Enum):
+    """Enumeration of possible actions for an import task."""
+
+    SKIP = "SKIP"
+    ASIS = "ASIS"
+    TRACKS = "TRACKS"
+    APPLY = "APPLY"
+    ALBUMS = "ALBUMS"
+    RETAG = "RETAG"
+    # The RETAG action represents "don't apply any match, but do record
+    # new metadata". It's not reachable via the standard command prompt but
+    # can be used by plugins.
+
+
+class DuplicateAction(str, Enum):
+    text: str
+
+    def __new__(cls, code: str, text: str) -> Self:
+        obj = str.__new__(cls, code)
+        obj._value_ = code
+        obj.text = text
+        return obj
+
+    @classmethod
+    def options(cls) -> list[str]:
+        return [d.text for d in cls]
+
+    @classmethod
+    def strict_options(cls) -> list[str]:
+        return [d.text for d in set(cls) - {DuplicateAction.ASK}]
+
+    @classmethod
+    def choices(cls) -> dict[str, str]:
+        return {d.name.lower(): d.value for d in cls}
+
+    SKIP = "s", "Skip new"
+    MERGE = "m", "Merge all"
+    REMOVE = "r", "Remove old"
+    KEEP = "k", "Keep all"
+    ASK = "a", "Ask"

--- a/beets/importer/session.py
+++ b/beets/importer/session.py
@@ -18,10 +18,10 @@ import time
 from typing import TYPE_CHECKING
 
 from beets import config, logging, plugins, util
-from beets.importer.tasks import Action
 from beets.util import displayable_path, normpath, pipeline, syspath
 
 from . import stages as stagefuncs
+from .actions import Action
 from .state import ImportState
 
 if TYPE_CHECKING:

--- a/beets/importer/session.py
+++ b/beets/importer/session.py
@@ -166,13 +166,13 @@ class ImportSession:
                 self.tag_log("duplicate-replace", paths)
             elif task.choice_flag in (Action.ASIS, Action.APPLY):
                 self.tag_log("duplicate-keep", paths)
-            elif task.choice_flag is Action.SKIP:
+            elif task.skip:
                 self.tag_log("duplicate-skip", paths)
         else:
             # Non-duplicate: log "skip" and "asis" choices.
             if task.choice_flag is Action.ASIS:
                 self.tag_log("asis", paths)
-            elif task.choice_flag is Action.SKIP:
+            elif task.skip:
                 self.tag_log("skip", paths)
 
     def should_resume(self, path: PathBytes):
@@ -192,9 +192,6 @@ class ImportSession:
         task.duplicate_action = DuplicateAction(
             self.get_duplicate_action_value(task, found_duplicates)
         )
-        if task.duplicate_action is DuplicateAction.SKIP:
-            # Skip new.
-            task.set_choice(Action.SKIP)
 
     def choose_item(self, task: ImportTask):
         raise NotImplementedError

--- a/beets/importer/session.py
+++ b/beets/importer/session.py
@@ -162,7 +162,7 @@ class ImportSession:
         paths = task.paths
         if duplicate:
             # Duplicate: log all three choices (skip, keep both, and trump).
-            if task.should_remove_duplicates:
+            if task.duplicate_action is DuplicateAction.REMOVE:
                 self.tag_log("duplicate-replace", paths)
             elif task.choice_flag in (Action.ASIS, Action.APPLY):
                 self.tag_log("duplicate-keep", paths)
@@ -189,20 +189,12 @@ class ImportSession:
     def resolve_duplicate(
         self, task: ImportTask, found_duplicates: list[AnyLibModel]
     ) -> None:
-        action = DuplicateAction(
+        task.duplicate_action = DuplicateAction(
             self.get_duplicate_action_value(task, found_duplicates)
         )
-        if action is DuplicateAction.SKIP:
+        if task.duplicate_action is DuplicateAction.SKIP:
             # Skip new.
             task.set_choice(Action.SKIP)
-        elif action is DuplicateAction.KEEP:
-            # Keep both. Do nothing; leave the choice intact.
-            pass
-        elif action is DuplicateAction.REMOVE:
-            # Remove old.
-            task.should_remove_duplicates = True
-        elif action is DuplicateAction.MERGE:
-            task.should_merge_duplicates = True
 
     def choose_item(self, task: ImportTask):
         raise NotImplementedError

--- a/beets/importer/session.py
+++ b/beets/importer/session.py
@@ -21,13 +21,14 @@ from beets import config, logging, plugins, util
 from beets.util import displayable_path, normpath, pipeline, syspath
 
 from . import stages as stagefuncs
-from .actions import Action
+from .actions import Action, DuplicateAction
 from .state import ImportState
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from beets import dbcore, library
+    from beets.library import AnyLibModel
     from beets.util import PathBytes
 
     from .tasks import ImportTask
@@ -180,8 +181,28 @@ class ImportSession:
     def choose_match(self, task: ImportTask):
         raise NotImplementedError
 
-    def resolve_duplicate(self, task: ImportTask, found_duplicates):
+    def get_duplicate_action_value(
+        self, task: ImportTask, found_duplicates: list[AnyLibModel]
+    ) -> str:
         raise NotImplementedError
+
+    def resolve_duplicate(
+        self, task: ImportTask, found_duplicates: list[AnyLibModel]
+    ) -> None:
+        action = DuplicateAction(
+            self.get_duplicate_action_value(task, found_duplicates)
+        )
+        if action is DuplicateAction.SKIP:
+            # Skip new.
+            task.set_choice(Action.SKIP)
+        elif action is DuplicateAction.KEEP:
+            # Keep both. Do nothing; leave the choice intact.
+            pass
+        elif action is DuplicateAction.REMOVE:
+            # Remove old.
+            task.should_remove_duplicates = True
+        elif action is DuplicateAction.MERGE:
+            task.should_merge_duplicates = True
 
     def choose_item(self, task: ImportTask):
         raise NotImplementedError

--- a/beets/importer/session.py
+++ b/beets/importer/session.py
@@ -181,17 +181,15 @@ class ImportSession:
     def choose_match(self, task: ImportTask):
         raise NotImplementedError
 
-    def get_duplicate_action_value(
+    def get_duplicate_action(
         self, task: ImportTask, found_duplicates: list[AnyLibModel]
-    ) -> str:
-        raise NotImplementedError
-
-    def resolve_duplicate(
-        self, task: ImportTask, found_duplicates: list[AnyLibModel]
-    ) -> None:
-        task.duplicate_action = DuplicateAction(
-            self.get_duplicate_action_value(task, found_duplicates)
+    ) -> DuplicateAction:
+        """Get the configured duplicate action."""
+        choice = config["import"]["duplicate_action"].as_choice(
+            DuplicateAction.choices()
         )
+        log.debug("default action for duplicates: {}", choice)
+        return DuplicateAction(choice)  # type: ignore[call-arg]
 
     def choose_item(self, task: ImportTask):
         raise NotImplementedError

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -24,6 +24,7 @@ from beets.util import MoveOperation, displayable_path, pipeline
 
 from .tasks import (
     Action,
+    DuplicateAction,
     ImportTask,
     ImportTaskFactory,
     SentinelImportTask,
@@ -343,27 +344,22 @@ def _resolve_duplicates(session: ImportSession, task: ImportTask):
             log.debug("found duplicates: {}", [o.id for o in found_duplicates])
 
             # Get the default action to follow from config.
-            duplicate_action = config["import"]["duplicate_action"].as_choice(
-                {
-                    "skip": "s",
-                    "keep": "k",
-                    "remove": "r",
-                    "merge": "m",
-                    "ask": "a",
-                }
+            default_choice = config["import"]["duplicate_action"].as_choice(
+                DuplicateAction.choices()
             )
-            log.debug("default action for duplicates: {}", duplicate_action)
+            log.debug("default action for duplicates: {}", default_choice)
 
-            if duplicate_action == "s":
+            action = DuplicateAction(default_choice)
+            if action is DuplicateAction.SKIP:
                 # Skip new.
                 task.set_choice(Action.SKIP)
-            elif duplicate_action == "k":
+            elif action is DuplicateAction.KEEP:
                 # Keep both. Do nothing; leave the choice intact.
                 pass
-            elif duplicate_action == "r":
+            elif action is DuplicateAction.REMOVE:
                 # Remove old.
                 task.should_remove_duplicates = True
-            elif duplicate_action == "m":
+            elif action is DuplicateAction.MERGE:
                 # Merge duplicates together
                 task.should_merge_duplicates = True
             else:

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -349,10 +349,7 @@ def _resolve_duplicates(session: ImportSession, task: ImportTask):
             log.debug("default action for duplicates: {}", default_choice)
 
             task.duplicate_action = DuplicateAction(default_choice)
-            if (action := task.duplicate_action) is DuplicateAction.SKIP:
-                # Skip new.
-                task.set_choice(Action.SKIP)
-            elif action is DuplicateAction.ASK:
+            if task.duplicate_action is DuplicateAction.ASK:
                 # No default action set; ask the session.
                 session.resolve_duplicate(task, found_duplicates)
 

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -22,9 +22,8 @@ from typing import TYPE_CHECKING
 from beets import config, plugins
 from beets.util import MoveOperation, displayable_path, pipeline
 
+from .actions import Action, DuplicateAction
 from .tasks import (
-    Action,
-    DuplicateAction,
     ImportTask,
     ImportTaskFactory,
     SentinelImportTask,

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -342,16 +342,9 @@ def _resolve_duplicates(session: ImportSession, task: ImportTask):
         if found_duplicates:
             log.debug("found duplicates: {}", [o.id for o in found_duplicates])
 
-            # Get the default action to follow from config.
-            default_choice = config["import"]["duplicate_action"].as_choice(
-                DuplicateAction.choices()
+            task.duplicate_action = session.get_duplicate_action(
+                task, found_duplicates
             )
-            log.debug("default action for duplicates: {}", default_choice)
-
-            task.duplicate_action = DuplicateAction(default_choice)
-            if task.duplicate_action is DuplicateAction.ASK:
-                # No default action set; ask the session.
-                session.resolve_duplicate(task, found_duplicates)
 
             session.log_choice(task, True)
 

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -195,7 +195,7 @@ def user_query(session: ImportSession, task: ImportTask):
 
     _resolve_duplicates(session, task)
 
-    if task.should_merge_duplicates:
+    if task.duplicate_action is DuplicateAction.MERGE:
         # Create a new task for tagging the current items
         # and duplicates together
         duplicate_items = task.duplicate_items(session.lib)
@@ -280,7 +280,7 @@ def manipulate_files(session: ImportSession, task: ImportTask):
     finalizes each task.
     """
     if not task.skip:
-        if task.should_remove_duplicates:
+        if task.duplicate_action is DuplicateAction.REMOVE:
             task.remove_duplicates(session.lib)
 
         if session.config["move"]:
@@ -348,20 +348,11 @@ def _resolve_duplicates(session: ImportSession, task: ImportTask):
             )
             log.debug("default action for duplicates: {}", default_choice)
 
-            action = DuplicateAction(default_choice)
-            if action is DuplicateAction.SKIP:
+            task.duplicate_action = DuplicateAction(default_choice)
+            if (action := task.duplicate_action) is DuplicateAction.SKIP:
                 # Skip new.
                 task.set_choice(Action.SKIP)
-            elif action is DuplicateAction.KEEP:
-                # Keep both. Do nothing; leave the choice intact.
-                pass
-            elif action is DuplicateAction.REMOVE:
-                # Remove old.
-                task.should_remove_duplicates = True
-            elif action is DuplicateAction.MERGE:
-                # Merge duplicates together
-                task.should_merge_duplicates = True
-            else:
+            elif action is DuplicateAction.ASK:
                 # No default action set; ask the session.
                 session.resolve_duplicate(task, found_duplicates)
 

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -26,6 +26,7 @@ from tempfile import mkdtemp
 from typing import TYPE_CHECKING, Any
 
 import mediafile
+from typing_extensions import Self
 
 from beets import config, library, plugins, util
 from beets.autotag import AlbumMatch, tag_album, tag_item
@@ -70,6 +71,34 @@ REIMPORT_FRESH_FIELDS_ALBUM = [*REIMPORT_FRESH_FIELDS_ITEM, "media"]
 
 # Global logger.
 log = logging.getLogger("beets")
+
+
+class DuplicateAction(str, Enum):
+    text: str
+
+    def __new__(cls, code: str, text: str) -> Self:
+        obj = str.__new__(cls, code)
+        obj._value_ = code
+        obj.text = text
+        return obj
+
+    @classmethod
+    def options(cls) -> list[str]:
+        return [d.text for d in cls]
+
+    @classmethod
+    def strict_options(cls) -> list[str]:
+        return [d.text for d in set(cls) - {DuplicateAction.ASK}]
+
+    @classmethod
+    def choices(cls) -> dict[str, str]:
+        return {d.name.lower(): d.value for d in cls}
+
+    SKIP = "s", "Skip new"
+    MERGE = "m", "Merge all"
+    REMOVE = "r", "Remove old"
+    KEEP = "k", "Keep all"
+    ASK = "a", "Ask"
 
 
 class ImportAbortError(Exception):

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -21,12 +21,10 @@ import shutil
 import time
 from collections import defaultdict
 from collections.abc import Callable
-from enum import Enum
 from tempfile import mkdtemp
 from typing import TYPE_CHECKING, Any
 
 import mediafile
-from typing_extensions import Self
 
 from beets import config, library, plugins, util
 from beets.autotag import AlbumMatch, tag_album, tag_item
@@ -34,6 +32,7 @@ from beets.dbcore.query import PathQuery
 from beets.util import extension
 from beets.util.extension import remux_mpeglayer3_wav
 
+from .actions import Action
 from .state import ImportState
 
 if TYPE_CHECKING:
@@ -73,50 +72,8 @@ REIMPORT_FRESH_FIELDS_ALBUM = [*REIMPORT_FRESH_FIELDS_ITEM, "media"]
 log = logging.getLogger("beets")
 
 
-class DuplicateAction(str, Enum):
-    text: str
-
-    def __new__(cls, code: str, text: str) -> Self:
-        obj = str.__new__(cls, code)
-        obj._value_ = code
-        obj.text = text
-        return obj
-
-    @classmethod
-    def options(cls) -> list[str]:
-        return [d.text for d in cls]
-
-    @classmethod
-    def strict_options(cls) -> list[str]:
-        return [d.text for d in set(cls) - {DuplicateAction.ASK}]
-
-    @classmethod
-    def choices(cls) -> dict[str, str]:
-        return {d.name.lower(): d.value for d in cls}
-
-    SKIP = "s", "Skip new"
-    MERGE = "m", "Merge all"
-    REMOVE = "r", "Remove old"
-    KEEP = "k", "Keep all"
-    ASK = "a", "Ask"
-
-
 class ImportAbortError(Exception):
     """Raised when the user aborts the tagging operation."""
-
-
-class Action(Enum):
-    """Enumeration of possible actions for an import task."""
-
-    SKIP = "SKIP"
-    ASIS = "ASIS"
-    TRACKS = "TRACKS"
-    APPLY = "APPLY"
-    ALBUMS = "ALBUMS"
-    RETAG = "RETAG"
-    # The RETAG action represents "don't apply any match, but do record
-    # new metadata". It's not reachable via the standard command prompt but
-    # can be used by plugins.
 
 
 class BaseImportTask:

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -32,7 +32,7 @@ from beets.dbcore.query import PathQuery
 from beets.util import extension
 from beets.util.extension import remux_mpeglayer3_wav
 
-from .actions import Action
+from .actions import Action, DuplicateAction
 from .state import ImportState
 
 if TYPE_CHECKING:
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
 
     from beets.autotag import Recommendation, TrackMatch
 
-    from .actions import DuplicateAction
     from .session import ImportSession
 
 # Global logger.
@@ -207,8 +206,11 @@ class ImportTask(BaseImportTask):
         return self.choice_flag == Action.APPLY
 
     @property
-    def skip(self):
-        return self.choice_flag == Action.SKIP
+    def skip(self) -> bool:
+        return (
+            self.choice_flag == Action.SKIP
+            or self.duplicate_action is DuplicateAction.SKIP
+        )
 
     # Convenient data.
 

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 
     from beets.autotag import Recommendation, TrackMatch
 
+    from .actions import DuplicateAction
     from .session import ImportSession
 
 # Global logger.
@@ -153,6 +154,7 @@ class ImportTask(BaseImportTask):
     cur_artist: str | None = None
     candidates: Sequence[AlbumMatch | TrackMatch] | None = None
     rec: Recommendation | None = None
+    duplicate_action: DuplicateAction | None = None
 
     def __init__(
         self,
@@ -161,8 +163,6 @@ class ImportTask(BaseImportTask):
         items: Iterable[library.Item] | None,
     ):
         super().__init__(toppath, paths, items)
-        self.should_remove_duplicates = False
-        self.should_merge_duplicates = False
         self.is_album = True
 
     def set_choice(self, choice: Action | AlbumMatch | TrackMatch):
@@ -777,7 +777,6 @@ class SentinelImportTask(ImportTask):
     def __init__(self, toppath, paths):
         super().__init__(toppath, paths, ())
         # TODO Remove the remaining attributes eventually
-        self.should_remove_duplicates = False
         self.is_album = True
         self.choice_flag = None
 

--- a/beets/library/__init__.py
+++ b/beets/library/__init__.py
@@ -2,7 +2,7 @@ from beets.util.deprecation import deprecate_imports
 
 from .exceptions import FileOperationError, ReadError, WriteError
 from .library import Library
-from .models import Album, Item, LibModel
+from .models import Album, AnyLibModel, Item, LibModel
 from .queries import parse_query_parts, parse_query_string
 
 NEW_MODULE_BY_NAME = dict.fromkeys(
@@ -18,6 +18,7 @@ def __getattr__(name: str):
 
 __all__ = [
     "Album",
+    "AnyLibModel",
     "FileOperationError",
     "Item",
     "LibModel",

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -8,7 +8,7 @@ import unicodedata
 from contextlib import suppress
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, TypeVar
 
 from mediafile import MediaFile, UnreadableFileError
 
@@ -43,6 +43,8 @@ if TYPE_CHECKING:
     from .library import Library  # noqa: F401
 
 log = logging.getLogger("beets")
+
+AnyLibModel = TypeVar("AnyLibModel", "Album", "Item")
 
 
 class LibModel(dbcore.Model["Library"]):

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -61,6 +61,8 @@ from beets.util import (
 if TYPE_CHECKING:
     from requests_mock.mocker import Mocker
 
+    from beets.library import AnyLibModel
+
 RUNNING_IN_CI = os.environ.get("GITHUB_ACTIONS") == "true"
 
 
@@ -650,17 +652,12 @@ class ImportSessionFixture(ImportSession):
 
     choose_item = choose_match
 
-    def resolve_duplicate(self, task, found_duplicates):
-        res = DuplicateAction(
-            self.config["duplicate_action"].as_choice(DuplicateAction.choices())
+    def get_duplicate_action_value(
+        self, task: importer.ImportTask, found_duplicates: list[AnyLibModel]
+    ) -> str:
+        return self.config["duplicate_action"].as_choice(
+            DuplicateAction.choices()
         )
-
-        if res is DuplicateAction.SKIP:
-            task.set_choice(importer.Action.SKIP)
-        elif res is DuplicateAction.REMOVE:
-            task.should_remove_duplicates = True
-        elif res is DuplicateAction.MERGE:
-            task.should_merge_duplicates = True
 
 
 class TerminalImportSessionFixture(TerminalImportSession):

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -47,7 +47,7 @@ import beets
 import beets.plugins
 from beets import importer, util
 from beets.autotag import AlbumInfo, TrackInfo
-from beets.importer import DuplicateAction, ImportSession
+from beets.importer import ImportSession
 from beets.library import Item, Library
 from beets.test import _common
 from beets.ui.commands.import_.session import TerminalImportSession
@@ -60,8 +60,6 @@ from beets.util import (
 
 if TYPE_CHECKING:
     from requests_mock.mocker import Mocker
-
-    from beets.library import AnyLibModel
 
 RUNNING_IN_CI = os.environ.get("GITHUB_ACTIONS") == "true"
 
@@ -651,13 +649,6 @@ class ImportSessionFixture(ImportSession):
         return choice
 
     choose_item = choose_match
-
-    def get_duplicate_action_value(
-        self, task: importer.ImportTask, found_duplicates: list[AnyLibModel]
-    ) -> str:
-        return self.config["duplicate_action"].as_choice(
-            DuplicateAction.choices()
-        )
 
 
 class TerminalImportSessionFixture(TerminalImportSession):

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -34,7 +34,6 @@ import sys
 import unittest
 from contextlib import contextmanager
 from dataclasses import dataclass
-from enum import Enum
 from functools import cache, cached_property
 from pathlib import Path
 from tempfile import gettempdir, mkdtemp, mkstemp
@@ -48,7 +47,7 @@ import beets
 import beets.plugins
 from beets import importer, util
 from beets.autotag import AlbumInfo, TrackInfo
-from beets.importer import ImportSession
+from beets.importer import DuplicateAction, ImportSession
 from beets.library import Item, Library
 from beets.test import _common
 from beets.ui.commands.import_.session import TerminalImportSession
@@ -496,7 +495,7 @@ class ImportHelper(TestHelper):
     autotagging library and several assertions for the library.
     """
 
-    default_import_config: ClassVar[dict[str, bool]] = {
+    default_import_config: ClassVar[dict[str, Any]] = {
         "autotag": True,
         "copy": True,
         "hardlink": False,
@@ -651,18 +650,16 @@ class ImportSessionFixture(ImportSession):
 
     choose_item = choose_match
 
-    Resolution = Enum("Resolution", "REMOVE SKIP KEEPBOTH MERGE")
-
-    default_resolution = "REMOVE"
-
     def resolve_duplicate(self, task, found_duplicates):
-        res = self.default_resolution
+        res = DuplicateAction(
+            self.config["duplicate_action"].as_choice(DuplicateAction.choices())
+        )
 
-        if res == self.Resolution.SKIP:
+        if res is DuplicateAction.SKIP:
             task.set_choice(importer.Action.SKIP)
-        elif res == self.Resolution.REMOVE:
+        elif res is DuplicateAction.REMOVE:
             task.should_remove_duplicates = True
-        elif res == self.Resolution.MERGE:
+        elif res is DuplicateAction.MERGE:
             task.should_merge_duplicates = True
 
 

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -628,7 +628,6 @@ class ImportSessionFixture(ImportSession):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._choices = []
-        self._resolutions = []
 
     default_choice = importer.Action.APPLY
 
@@ -657,10 +656,7 @@ class ImportSessionFixture(ImportSession):
     default_resolution = "REMOVE"
 
     def resolve_duplicate(self, task, found_duplicates):
-        try:
-            res = self._resolutions.pop(0)
-        except IndexError:
-            res = self.default_resolution
+        res = self.default_resolution
 
         if res == self.Resolution.SKIP:
             task.set_choice(importer.Action.SKIP)

--- a/beets/ui/commands/import_/session.py
+++ b/beets/ui/commands/import_/session.py
@@ -12,6 +12,7 @@ from beets.autotag import (
     tag_album,
     tag_item,
 )
+from beets.importer import DuplicateAction
 from beets.util import PromptChoice, displayable_path
 from beets.util.color import colorize
 from beets.util.units import human_bytes, human_seconds_short
@@ -186,23 +187,20 @@ class TerminalImportSession(importer.ImportSession):
                 for item in task.imported_items():
                     print(f"  {item}")
 
-            sel = ui.input_options(
-                ("Skip new", "Keep all", "Remove old", "Merge all")
-            )
+            sel = ui.input_options(DuplicateAction.strict_options())
 
-        if sel == "s":
+        action = DuplicateAction(sel)
+        if action is DuplicateAction.SKIP:
             # Skip new.
             task.set_choice(importer.Action.SKIP)
-        elif sel == "k":
+        elif action is DuplicateAction.KEEP:
             # Keep both. Do nothing; leave the choice intact.
             pass
-        elif sel == "r":
+        elif action is DuplicateAction.REMOVE:
             # Remove old.
             task.should_remove_duplicates = True
-        elif sel == "m":
+        elif action is DuplicateAction.MERGE:
             task.should_merge_duplicates = True
-        else:
-            assert False
 
     def should_resume(self, path):
         return ui.input_yn(

--- a/beets/ui/commands/import_/session.py
+++ b/beets/ui/commands/import_/session.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import Counter
 from itertools import chain
+from typing import TYPE_CHECKING
 
 from beets import config, importer, logging, plugins, ui
 from beets.autotag import (
@@ -18,6 +19,9 @@ from beets.util.color import colorize
 from beets.util.units import human_bytes, human_seconds_short
 
 from .display import show_change, show_item_change
+
+if TYPE_CHECKING:
+    from beets.library import AnyLibModel
 
 # Global logger.
 log = logging.getLogger("beets")
@@ -144,7 +148,9 @@ class TerminalImportSession(importer.ImportSession):
                 assert isinstance(choice, TrackMatch)
                 return choice
 
-    def resolve_duplicate(self, task, found_duplicates):
+    def get_duplicate_action_value(
+        self, task: importer.ImportTask, found_duplicates: list[AnyLibModel]
+    ) -> str:
         """Decide what to do when a new album or item seems similar to one
         that's already in the library.
         """
@@ -156,51 +162,32 @@ class TerminalImportSession(importer.ImportSession):
         if config["import"]["quiet"]:
             # In quiet mode, don't prompt -- just skip.
             log.info("Skipping.")
-            sel = "s"
-        else:
-            # Print some detail about the existing and new items so the
-            # user can make an informed decision.
-            for duplicate in found_duplicates:
-                ui.print_(
-                    "Old: "
-                    + summarize_items(
-                        (
-                            list(duplicate.items())
-                            if task.is_album
-                            else [duplicate]
-                        ),
-                        not task.is_album,
-                    )
-                )
-                if config["import"]["duplicate_verbose_prompt"]:
-                    if task.is_album:
-                        for dup in duplicate.items():
-                            print(f"  {dup}")
-                    else:
-                        print(f"  {duplicate}")
-
+            return "s"
+        # Print some detail about the existing and new items so the
+        # user can make an informed decision.
+        for duplicate in found_duplicates:
             ui.print_(
-                "New: "
-                + summarize_items(task.imported_items(), not task.is_album)
+                "Old: "
+                + summarize_items(
+                    (list(duplicate.items()) if task.is_album else [duplicate]),
+                    not task.is_album,
+                )
             )
             if config["import"]["duplicate_verbose_prompt"]:
-                for item in task.imported_items():
-                    print(f"  {item}")
+                if task.is_album:
+                    for dup in duplicate.items():
+                        print(f"  {dup}")
+                else:
+                    print(f"  {duplicate}")
 
-            sel = ui.input_options(DuplicateAction.strict_options())
+        ui.print_(
+            "New: " + summarize_items(task.imported_items(), not task.is_album)
+        )
+        if config["import"]["duplicate_verbose_prompt"]:
+            for item in task.imported_items():
+                print(f"  {item}")
 
-        action = DuplicateAction(sel)
-        if action is DuplicateAction.SKIP:
-            # Skip new.
-            task.set_choice(importer.Action.SKIP)
-        elif action is DuplicateAction.KEEP:
-            # Keep both. Do nothing; leave the choice intact.
-            pass
-        elif action is DuplicateAction.REMOVE:
-            # Remove old.
-            task.should_remove_duplicates = True
-        elif action is DuplicateAction.MERGE:
-            task.should_merge_duplicates = True
+        return ui.input_options(DuplicateAction.strict_options())
 
     def should_resume(self, path):
         return ui.input_yn(

--- a/beets/ui/commands/import_/session.py
+++ b/beets/ui/commands/import_/session.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import Counter
 from itertools import chain
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from beets import config, importer, logging, plugins, ui
 from beets.autotag import (
@@ -14,6 +14,7 @@ from beets.autotag import (
     tag_item,
 )
 from beets.importer import DuplicateAction
+from beets.library import Album
 from beets.util import PromptChoice, displayable_path
 from beets.util.color import colorize
 from beets.util.units import human_bytes, human_seconds_short
@@ -21,7 +22,7 @@ from beets.util.units import human_bytes, human_seconds_short
 from .display import show_change, show_item_change
 
 if TYPE_CHECKING:
-    from beets.library import AnyLibModel
+    from beets.library import AnyLibModel, Item
 
 # Global logger.
 log = logging.getLogger("beets")
@@ -148,15 +149,24 @@ class TerminalImportSession(importer.ImportSession):
                 assert isinstance(choice, TrackMatch)
                 return choice
 
+    def _report_item_summary(
+        self, prefix: Literal["Old", "New"], items: list[Item], is_album: bool
+    ) -> None:
+        ui.print_(f"{prefix}: {summarize_items(items, not is_album)}")
+        if self.config["duplicate_verbose_prompt"].get(bool):
+            for dup in items:
+                print(f"  {dup}")
+
     def get_duplicate_action_value(
         self, task: importer.ImportTask, found_duplicates: list[AnyLibModel]
     ) -> str:
         """Decide what to do when a new album or item seems similar to one
         that's already in the library.
         """
+        is_album = task.is_album
         log.warning(
             "This {} is already in the library!",
-            ("album" if task.is_album else "item"),
+            ("album" if is_album else "item"),
         )
 
         if config["import"]["quiet"]:
@@ -166,26 +176,17 @@ class TerminalImportSession(importer.ImportSession):
         # Print some detail about the existing and new items so the
         # user can make an informed decision.
         for duplicate in found_duplicates:
-            ui.print_(
-                "Old: "
-                + summarize_items(
-                    (list(duplicate.items()) if task.is_album else [duplicate]),
-                    not task.is_album,
-                )
+            self._report_item_summary(
+                "Old",
+                (
+                    list(duplicate.items())
+                    if isinstance(duplicate, Album)
+                    else [duplicate]
+                ),
+                is_album,
             )
-            if config["import"]["duplicate_verbose_prompt"]:
-                if task.is_album:
-                    for dup in duplicate.items():
-                        print(f"  {dup}")
-                else:
-                    print(f"  {duplicate}")
 
-        ui.print_(
-            "New: " + summarize_items(task.imported_items(), not task.is_album)
-        )
-        if config["import"]["duplicate_verbose_prompt"]:
-            for item in task.imported_items():
-                print(f"  {item}")
+        self._report_item_summary("New", task.imported_items(), is_album)
 
         return ui.input_options(DuplicateAction.strict_options())
 

--- a/beets/ui/commands/import_/session.py
+++ b/beets/ui/commands/import_/session.py
@@ -157,7 +157,7 @@ class TerminalImportSession(importer.ImportSession):
             for dup in items:
                 print(f"  {dup}")
 
-    def get_duplicate_action_value(
+    def _get_duplicate_action_from_user(
         self, task: importer.ImportTask, found_duplicates: list[AnyLibModel]
     ) -> str:
         """Decide what to do when a new album or item seems similar to one
@@ -189,6 +189,17 @@ class TerminalImportSession(importer.ImportSession):
         self._report_item_summary("New", task.imported_items(), is_album)
 
         return ui.input_options(DuplicateAction.strict_options())
+
+    def get_duplicate_action(
+        self, task: importer.ImportTask, found_duplicates: list[AnyLibModel]
+    ) -> DuplicateAction:
+        action = super().get_duplicate_action(task, found_duplicates)
+        if action is DuplicateAction.ASK:
+            return DuplicateAction(
+                self._get_duplicate_action_from_user(task, found_duplicates)
+            )  # type: ignore[call-arg]
+
+        return action
 
     def should_resume(self, path):
         return ui.input_yn(

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -92,6 +92,8 @@ For plugin developers
 - Plugin authors can import all autotagger helpers directly from
   ``beets.autotag``, including match classes, distance helpers, and
   ``assign_items``, without relying on lower-level autotag modules.
+- Introduced ``beets.importer.DuplicateAction`` to simplify handling of
+  duplicates.
 
 Other changes
 ~~~~~~~~~~~~~

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1049,7 +1049,7 @@ class TestImportDuplicateAlbum(PluginMixin, ImportHelper):
         assert item.title == "t\xeftle 0"
         assert item.filepath.exists()
 
-        self.importer.default_resolution = self.importer.Resolution.REMOVE
+        self.config["import"]["duplicate_action"] = "remove"
         self.importer.run()
 
         assert not item.filepath.exists()
@@ -1067,7 +1067,7 @@ class TestImportDuplicateAlbum(PluginMixin, ImportHelper):
 
         assert old_artpath.exists()
 
-        self.importer.default_resolution = self.importer.Resolution.REMOVE
+        self.config["import"]["duplicate_action"] = "remove"
         self.importer.run()
 
         assert not old_artpath.exists()
@@ -1093,7 +1093,7 @@ class TestImportDuplicateAlbum(PluginMixin, ImportHelper):
         import_file.title = "new title"
         import_file.save()
 
-        self.importer.default_resolution = self.importer.Resolution.REMOVE
+        self.config["import"]["duplicate_action"] = "remove"
         self.importer.run()
 
         # Old duplicate should be removed, new one imported
@@ -1103,7 +1103,7 @@ class TestImportDuplicateAlbum(PluginMixin, ImportHelper):
         assert self.lib.items().get().title == "new title"
 
     def test_keep_duplicate_album(self):
-        self.importer.default_resolution = self.importer.Resolution.KEEPBOTH
+        self.config["import"]["duplicate_action"] = "keep"
         self.importer.run()
 
         assert len(self.lib.albums()) == 2
@@ -1113,7 +1113,7 @@ class TestImportDuplicateAlbum(PluginMixin, ImportHelper):
         item = self.lib.items().get()
         assert item.title == "t\xeftle 0"
 
-        self.importer.default_resolution = self.importer.Resolution.SKIP
+        self.config["import"]["duplicate_action"] = "skip"
         self.importer.run()
 
         assert len(self.lib.albums()) == 1
@@ -1122,7 +1122,7 @@ class TestImportDuplicateAlbum(PluginMixin, ImportHelper):
         assert item.title == "t\xeftle 0"
 
     def test_merge_duplicate_album(self):
-        self.importer.default_resolution = self.importer.Resolution.MERGE
+        self.config["import"]["duplicate_action"] = "merge"
         self.importer.run()
 
         assert len(self.lib.albums()) == 1
@@ -1143,7 +1143,7 @@ class TestImportDuplicateAlbum(PluginMixin, ImportHelper):
         import_file.title = item["title"]
         import_file.flex = "different"
 
-        self.importer.default_resolution = self.importer.Resolution.SKIP
+        self.config["import"]["duplicate_action"] = "skip"
         self.importer.run()
 
         assert len(self.lib.albums()) == 2
@@ -1184,7 +1184,7 @@ class TestImportDuplicateAlbumThreaded(PluginMixin, ImportHelper):
 
     def test_merge_duplicate_album_threaded(self):
         self.config["threaded"] = True
-        self.importer.default_resolution = self.importer.Resolution.MERGE
+        self.config["import"]["duplicate_action"] = "merge"
         self.importer.run()
 
         assert len(self.lib.albums()) == 1
@@ -1228,7 +1228,7 @@ class TestImportDuplicateSingleton(ImportHelper):
         assert item.mb_trackid == "old trackid"
         assert item.filepath.exists()
 
-        self.importer.default_resolution = self.importer.Resolution.REMOVE
+        self.config["import"]["duplicate_action"] = "remove"
         self.importer.run()
 
         assert not item.filepath.exists()
@@ -1239,7 +1239,7 @@ class TestImportDuplicateSingleton(ImportHelper):
     def test_keep_duplicate(self):
         assert len(self.lib.items()) == 1
 
-        self.importer.default_resolution = self.importer.Resolution.KEEPBOTH
+        self.config["import"]["duplicate_action"] = "keep"
         self.importer.run()
 
         assert len(self.lib.items()) == 2
@@ -1248,7 +1248,7 @@ class TestImportDuplicateSingleton(ImportHelper):
         item = self.lib.items().get()
         assert item.mb_trackid == "old trackid"
 
-        self.importer.default_resolution = self.importer.Resolution.SKIP
+        self.config["import"]["duplicate_action"] = "skip"
         self.importer.run()
 
         assert len(self.lib.items()) == 1
@@ -1262,7 +1262,7 @@ class TestImportDuplicateSingleton(ImportHelper):
         item.store()
         assert len(self.lib.items()) == 1
 
-        self.importer.default_resolution = self.importer.Resolution.SKIP
+        self.config["import"]["duplicate_action"] = "skip"
         self.importer.run()
 
         assert len(self.lib.items()) == 2
@@ -1285,7 +1285,7 @@ class TestImportDuplicateSingleton(ImportHelper):
         import_file.mb_trackid = "new trackid"
         import_file.save()
 
-        self.importer.default_resolution = self.importer.Resolution.REMOVE
+        self.config["import"]["duplicate_action"] = "remove"
         self.importer.run()
 
         # Old duplicate should be removed, new one imported


### PR DESCRIPTION
This change centralizes duplicate handling in the import pipeline.

- `ImportTask` now carries a single `duplicate_action` state instead of separate duplicate flags, so duplicate decisions are represented in one place.
- `ImportSession.get_duplicate_action()` becomes the shared entry point for resolving the configured duplicate policy.
- `TerminalImportSession` now only prompts the user when the configured action is `ASK`; otherwise it reuses the shared session logic.
- Duplicate resolution in `beets/importer/stages.py` is simplified to call the session API instead of re-implementing config lookup and branching.

## High-level impact

- Makes duplicate behavior more consistent across importer stages and UI sessions.
- Reduces duplicated logic between core importer flow, terminal prompting, and test fixtures.
- Simplifies future changes to duplicate handling because policy resolution now lives behind one session-level interface.
- Cleans up tests to use real config-driven duplicate behavior instead of custom fixture-only overrides.
