### PR TITLE
tests: use setup fixture in TestHelper

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -189,3 +189,11 @@ adfb73b66dba0fc799880af176ef6f9ac0a7ee68
 6493d4dd018e08eb5d16d5381ebff47deea98bb1
 # Import everything from parent beets.autotag
 29580d2f00eb02f1ce77ebe3e1435804f7252ba1
+# Add setup fixture to TestHelper
+7bad226c33c2d48b5102cff213c67f16eeb09a7b
+# Fix mbcollection tests
+544ea3af5d85df187e080f407d3aaf84eac4ee63
+# Fix ftintitle tests
+ca8544d4bcab503e1e4c2cd6688655c8211aa7a1
+# Fix autobpm tests
+5804a21620098e8da78b1f4a5f85063033586632

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -162,6 +162,14 @@ class TestHelper(RunMixin, ConfigMixin):
     fixtures.
     """
 
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.setup_beets()
+        try:
+            yield
+        finally:
+            self.teardown_beets()
+
     lib: Library
 
     resource_path = Path(os.fsdecode(_common.RSRC)) / "full.mp3"
@@ -407,26 +415,8 @@ class BeetsTestCase(unittest.TestCase, TestHelper):
     completes. Also provides some additional assertion methods, a
     temporary directory, and a DummyIO.
 
-    DEPRECATED: Use pytest + PytestTestHelper instead.
+    DEPRECATED: Use TestHelper instead.
     """
-
-    def setUp(self):
-        self.setup_beets()
-
-    def tearDown(self):
-        self.teardown_beets()
-
-
-class PytestTestHelper(TestHelper):
-    """Same as the BeetsTestCase unittest setup but for pytest."""
-
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.setup_beets()
-        try:
-            yield
-        finally:
-            self.teardown_beets()
 
 
 class ItemInDBTestCase(BeetsTestCase):
@@ -488,13 +478,13 @@ class PluginMixin(ConfigMixin):
 
 class PluginTestCase(PluginMixin, BeetsTestCase):
     """
-    DEPRECATED: Use pytest + PytestPluginTestHelper instead.
+    DEPRECATED: Use PluginTestHelper instead.
     """
 
     pass
 
 
-class PytestPluginTestHelper(PluginMixin, PytestTestHelper):
+class PluginTestHelper(PluginMixin, TestHelper):
     """Helper mixin for pytest-based plugin tests.
 
     This mixin provides the standard beets test setup and automatically
@@ -502,7 +492,7 @@ class PytestPluginTestHelper(PluginMixin, PytestTestHelper):
 
     .. code-block:: python
 
-        class TestMyPlugin(PytestPluginTestHelper):
+        class TestMyPlugin(PluginTestHelper):
             plugin: ClassVar[str] = "myplugin"
     """
 

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -31,7 +31,7 @@ from beets import config, importer, logging, util
 from beets.autotag import AlbumInfo, AlbumMatch, Distance
 from beets.library import Album
 from beets.test import _common
-from beets.test.helper import FetchImageHelper, PytestTestHelper
+from beets.test.helper import FetchImageHelper, TestHelper
 from beets.util import clean_module_tempdir, syspath
 from beets.util.artresizer import ArtResizer
 from beetsplug import fetchart
@@ -67,7 +67,7 @@ class DummyRemoteArtSource(fetchart.RemoteArtSource):
         return iter(())
 
 
-class UseThePlugin(PytestTestHelper):
+class UseThePlugin(TestHelper):
     modules = (fetchart.__name__, ArtResizer.__module__)
 
     @pytest.fixture(autouse=True)

--- a/test/plugins/test_autobpm.py
+++ b/test/plugins/test_autobpm.py
@@ -1,27 +1,19 @@
 import pytest
 
-from beets.test.helper import ImportHelper, PluginMixin
+from beets.test.helper import ImportHelper, PluginTestHelper
 
 pytestmark = pytest.mark.requires_import("librosa")
 
 
-class TestAutoBPMPlugin(PluginMixin, ImportHelper):
+class TestAutoBPMPlugin(ImportHelper, PluginTestHelper):
     plugin = "autobpm"
 
-    @pytest.fixture(scope="class", name="lib")
-    def fixture_lib(self):
-        self.setup_beets()
-
-        yield self.lib
-
-        self.teardown_beets()
-
-    @pytest.fixture(scope="class")
+    @pytest.fixture
     def item(self):
         return self.add_item_fixture()
 
-    @pytest.fixture(scope="class")
-    def importer(self, lib):
+    @pytest.fixture
+    def importer(self):
         self.import_media = []
         self.prepare_album_for_import(1)
         track = self.import_media[0]
@@ -29,27 +21,27 @@ class TestAutoBPMPlugin(PluginMixin, ImportHelper):
         track.save()
         return self.setup_importer(autotag=False)
 
-    def test_command(self, lib, item):
+    def test_command(self, item):
         item.bpm = None
         item.store()
-        self.run_command("autobpm", lib=lib)
+        self.run_command("autobpm")
 
         item.load()
         assert item.bpm == 117
 
-    def test_command_force(self, lib, item):
+    def test_command_force(self, item):
         item.bpm = 10
         item.store()
 
-        self.run_command("autobpm", lib=lib)
+        self.run_command("autobpm")
         item.load()
         assert item.bpm == 10
 
-        self.run_command("autobpm", "--force", lib=lib)
+        self.run_command("autobpm", "--force")
         item.load()
         assert item.bpm == 117
 
-    def test_command_overwrite(self, lib, item):
+    def test_command_overwrite(self, item):
         item.bpm = 10
         item.store()
 
@@ -57,23 +49,23 @@ class TestAutoBPMPlugin(PluginMixin, ImportHelper):
         self.config[self.plugin]["overwrite"] = True
         self.load_plugins()
 
-        self.run_command("autobpm", lib=lib)
+        self.run_command("autobpm")
         item.load()
         assert item.bpm == 117
 
-    def test_command_quiet(self, lib, item, caplog):
+    def test_command_quiet(self, item, caplog):
         item.bpm = 10
         item.store()
 
         with caplog.at_level("DEBUG"):
-            self.run_command("autobpm", "--quiet", lib=lib)
+            self.run_command("autobpm", "--quiet")
         assert not any("already exists" in msg for msg in caplog.messages)
 
         with caplog.at_level("DEBUG"):
-            self.run_command("autobpm", lib=lib)
+            self.run_command("autobpm")
         assert any("already exists" in msg for msg in caplog.messages)
 
-    def test_import(self, lib, importer):
+    def test_import(self, importer):
         importer.run()
 
-        assert lib.items().get().bpm == 117
+        assert self.lib.items().get().bpm == 117

--- a/test/plugins/test_discogs.py
+++ b/test/plugins/test_discogs.py
@@ -37,20 +37,8 @@ def _artist(name: str, **kwargs):
     } | kwargs
 
 
-class PytestTestHelper(TestHelper):
-    """Same as the BeetsTestCase unittest setup but for pytest."""
-
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.setup_beets()
-        try:
-            yield
-        finally:
-            self.teardown_beets()
-
-
 @patch("beetsplug.discogs.DiscogsPlugin.setup", Mock())
-class TestDGAlbumInfo(PytestTestHelper):
+class TestDGAlbumInfo(TestHelper):
     def _make_release(self, tracks=None):
         """Returns a Bag that mimics a discogs_client.Release. The list
         of elements on the returned Bag is incomplete, including just
@@ -468,7 +456,7 @@ class TestDGAlbumInfo(PytestTestHelper):
 
 
 @patch("beetsplug.discogs.DiscogsPlugin.setup", Mock())
-class TestDGSearchQuery(PytestTestHelper):
+class TestDGSearchQuery(TestHelper):
     def test_default_search_filters_without_extra_tags(self):
         """Discogs search uses only the type filter when no extra_tags are set."""
         plugin = DiscogsPlugin()

--- a/test/plugins/test_embedart.py
+++ b/test/plugins/test_embedart.py
@@ -32,7 +32,7 @@ from beets.test.helper import (
     FetchImageHelper,
     ImportHelper,
     IOMixin,
-    PytestPluginTestHelper,
+    PluginTestHelper,
 )
 from beets.util import bytestring_path, displayable_path, syspath
 from beets.util.artresizer import ArtResizer
@@ -77,7 +77,7 @@ def require_artresizer_compare(test):
     return wrapper
 
 
-class PytestImportHelper(PytestPluginTestHelper, ImportHelper):
+class PytestImportHelper(PluginTestHelper, ImportHelper):
     @pytest.fixture(autouse=True)
     def setup_import_helper(self, setup):
         self.import_media = []

--- a/test/plugins/test_ftintitle.py
+++ b/test/plugins/test_ftintitle.py
@@ -16,265 +16,228 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeAlias
-
 import pytest
 
 from beets.library.models import Album
-from beets.test.helper import PluginTestCase
+from beets.test.helper import PluginTestHelper
 from beetsplug import ftintitle
 
-if TYPE_CHECKING:
-    from collections.abc import Generator
 
-    from beets.library.models import Item
-
-ConfigValue: TypeAlias = str | bool | list[str]
-
-
-class FtInTitlePluginFunctional(PluginTestCase):
+class TestFtInTitlePluginFunctional(PluginTestHelper):
     plugin = "ftintitle"
 
-
-@pytest.fixture
-def env() -> Generator[FtInTitlePluginFunctional, None, None]:
-    case = FtInTitlePluginFunctional(methodName="runTest")
-    case.setUp()
-    try:
-        yield case
-    finally:
-        case.tearDown()
-
-
-def set_config(
-    env: FtInTitlePluginFunctional, cfg: dict[str, ConfigValue] | None
-) -> None:
-    cfg = {} if cfg is None else cfg
-    defaults = {
-        "drop": False,
-        "auto": True,
-        "keep_in_artist": False,
-        "custom_words": [],
-    }
-    env.config["ftintitle"].set(defaults)
-    env.config["ftintitle"].set(cfg)
-
-
-def add_item(
-    env: FtInTitlePluginFunctional,
-    path: str,
-    artist: str,
-    title: str,
-    albumartist: str | None,
-) -> Item:
-    return env.add_item(
-        path=path,
-        artist=artist,
-        artist_sort=artist,
-        title=title,
-        albumartist=albumartist,
+    @pytest.mark.parametrize(
+        "cfg, cmd_args, given, expected",
+        [
+            pytest.param(
+                {},
+                ("ftintitle",),
+                ("Alice", "Song 1", "Alice"),
+                ("Alice", "Song 1"),
+                id="no-featured-artist",
+            ),
+            pytest.param(
+                {"format": "feat {0}"},
+                ("ftintitle",),
+                ("Alice ft. Bob", "Song 1", None),
+                ("Alice", "Song 1 feat Bob"),
+                id="no-albumartist-custom-format",
+            ),
+            pytest.param(
+                {},
+                ("ftintitle",),
+                ("Alice", "Song 1", None),
+                ("Alice", "Song 1"),
+                id="no-albumartist-no-feature",
+            ),
+            pytest.param(
+                {"format": "featuring {0}"},
+                ("ftintitle",),
+                ("Alice ft Bob", "Song 1", "George"),
+                ("Alice", "Song 1 featuring Bob"),
+                id="guest-artist-custom-format",
+            ),
+            pytest.param(
+                {},
+                ("ftintitle",),
+                ("Alice", "Song 1", "George"),
+                ("Alice", "Song 1"),
+                id="guest-artist-no-feature",
+            ),
+            # ---- drop (-d) variants ----
+            pytest.param(
+                {},
+                ("ftintitle", "-d"),
+                ("Alice ft Bob", "Song 1", "Alice"),
+                ("Alice", "Song 1"),
+                id="drop-self-ft",
+            ),
+            pytest.param(
+                {},
+                ("ftintitle", "-d"),
+                ("Alice", "Song 1", "Alice"),
+                ("Alice", "Song 1"),
+                id="drop-self-no-ft",
+            ),
+            pytest.param(
+                {},
+                ("ftintitle", "-d"),
+                ("Alice ft Bob", "Song 1", "George"),
+                ("Alice", "Song 1"),
+                id="drop-guest-ft",
+            ),
+            pytest.param(
+                {},
+                ("ftintitle", "-d"),
+                ("Alice", "Song 1", "George"),
+                ("Alice", "Song 1"),
+                id="drop-guest-no-ft",
+            ),
+            # ---- custom format variants ----
+            pytest.param(
+                {"format": "feat. {}"},
+                ("ftintitle",),
+                ("Alice ft Bob", "Song 1", "Alice"),
+                ("Alice", "Song 1 feat. Bob"),
+                id="custom-format-feat-dot",
+            ),
+            pytest.param(
+                {"format": "featuring {}"},
+                ("ftintitle",),
+                ("Alice feat. Bob", "Song 1", "Alice"),
+                ("Alice", "Song 1 featuring Bob"),
+                id="custom-format-featuring",
+            ),
+            pytest.param(
+                {"format": "with {}"},
+                ("ftintitle",),
+                ("Alice feat Bob", "Song 1", "Alice"),
+                ("Alice", "Song 1 with Bob"),
+                id="custom-format-with",
+            ),
+            # ---- keep_in_artist variants ----
+            pytest.param(
+                {"format": "feat. {}", "keep_in_artist": True},
+                ("ftintitle",),
+                ("Alice ft Bob", "Song 1", "Alice"),
+                ("Alice ft Bob", "Song 1 feat. Bob"),
+                id="keep-in-artist-add-to-title",
+            ),
+            pytest.param(
+                {"format": "feat. {}", "keep_in_artist": True},
+                ("ftintitle", "-d"),
+                ("Alice ft Bob", "Song 1", "Alice"),
+                ("Alice ft Bob", "Song 1"),
+                id="keep-in-artist-drop-from-title",
+            ),
+            # ---- custom_words variants ----
+            pytest.param(
+                {"format": "featuring {}", "custom_words": ["med"]},
+                ("ftintitle",),
+                ("Alice med Bob", "Song 1", "Alice"),
+                ("Alice", "Song 1 featuring Bob"),
+                id="custom-feat-words",
+            ),
+            pytest.param(
+                {
+                    "format": "featuring {}",
+                    "keep_in_artist": True,
+                    "custom_words": ["med"],
+                },
+                ("ftintitle",),
+                ("Alice med Bob", "Song 1", "Alice"),
+                ("Alice med Bob", "Song 1 featuring Bob"),
+                id="custom-feat-words-keep-in-artists",
+            ),
+            pytest.param(
+                {
+                    "format": "featuring {}",
+                    "keep_in_artist": True,
+                    "custom_words": ["med"],
+                },
+                ("ftintitle", "-d"),
+                ("Alice med Bob", "Song 1", "Alice"),
+                ("Alice med Bob", "Song 1"),
+                id="custom-feat-words-keep-in-artists-drop-from-title",
+            ),
+            # ---- preserve_album_artist variants ----
+            pytest.param(
+                {"format": "feat. {}", "preserve_album_artist": True},
+                ("ftintitle",),
+                ("Alice feat. Bob", "Song 1", "Alice"),
+                ("Alice", "Song 1 feat. Bob"),
+                id="skip-if-artist-and-album-artists-is-the-same-different-match",
+            ),
+            pytest.param(
+                {"format": "feat. {}", "preserve_album_artist": False},
+                ("ftintitle",),
+                ("Alice feat. Bob", "Song 1", "Alice"),
+                ("Alice", "Song 1 feat. Bob"),
+                id="skip-if-artist-and-album-artists-is-the-same-different-match-b",
+            ),
+            pytest.param(
+                {"format": "feat. {}", "preserve_album_artist": True},
+                ("ftintitle",),
+                ("Alice feat. Bob", "Song 1", "Alice feat. Bob"),
+                ("Alice feat. Bob", "Song 1"),
+                id="skip-if-artist-and-album-artists-is-the-same-matching-match",
+            ),
+            pytest.param(
+                {"format": "feat. {}", "preserve_album_artist": False},
+                ("ftintitle",),
+                ("Alice feat. Bob", "Song 1", "Alice feat. Bob"),
+                ("Alice", "Song 1 feat. Bob"),
+                id="skip-if-artist-and-album-artists-is-the-same-matching-match-b",
+            ),
+            # ---- titles with brackets/parentheses ----
+            pytest.param(
+                {"format": "ft. {}", "bracket_keywords": ["mix"]},
+                ("ftintitle",),
+                ("Alice ft. Bob", "Song 1 (Club Mix)", "Alice"),
+                ("Alice", "Song 1 ft. Bob (Club Mix)"),
+                id="ft-inserted-before-matching-bracket-keyword",
+            ),
+            pytest.param(
+                {"format": "ft. {}", "bracket_keywords": ["nomatch"]},
+                ("ftintitle",),
+                ("Alice ft. Bob", "Song 1 (Club Remix)", "Alice"),
+                ("Alice", "Song 1 (Club Remix) ft. Bob"),
+                id="ft-inserted-at-end-no-bracket-keyword-match",
+            ),
+        ],
     )
+    def test_ftintitle_functional(
+        self,
+        cfg: dict[str, str | bool | list[str]],
+        cmd_args: tuple[str, ...],
+        given: tuple[str, str, str | None],
+        expected: tuple[str, str],
+    ) -> None:
+        config = {
+            "drop": False,
+            "auto": True,
+            "keep_in_artist": False,
+            "custom_words": [],
+            **cfg,
+        }
 
+        artist, title, albumartist = given
+        item = self.add_item(
+            path="/",
+            artist=artist,
+            artist_sort=artist,
+            title=title,
+            albumartist=albumartist,
+        )
 
-@pytest.mark.parametrize(
-    "cfg, cmd_args, given, expected",
-    [
-        pytest.param(
-            None,
-            ("ftintitle",),
-            ("Alice", "Song 1", "Alice"),
-            ("Alice", "Song 1"),
-            id="no-featured-artist",
-        ),
-        pytest.param(
-            {"format": "feat {0}"},
-            ("ftintitle",),
-            ("Alice ft. Bob", "Song 1", None),
-            ("Alice", "Song 1 feat Bob"),
-            id="no-albumartist-custom-format",
-        ),
-        pytest.param(
-            None,
-            ("ftintitle",),
-            ("Alice", "Song 1", None),
-            ("Alice", "Song 1"),
-            id="no-albumartist-no-feature",
-        ),
-        pytest.param(
-            {"format": "featuring {0}"},
-            ("ftintitle",),
-            ("Alice ft Bob", "Song 1", "George"),
-            ("Alice", "Song 1 featuring Bob"),
-            id="guest-artist-custom-format",
-        ),
-        pytest.param(
-            None,
-            ("ftintitle",),
-            ("Alice", "Song 1", "George"),
-            ("Alice", "Song 1"),
-            id="guest-artist-no-feature",
-        ),
-        # ---- drop (-d) variants ----
-        pytest.param(
-            None,
-            ("ftintitle", "-d"),
-            ("Alice ft Bob", "Song 1", "Alice"),
-            ("Alice", "Song 1"),
-            id="drop-self-ft",
-        ),
-        pytest.param(
-            None,
-            ("ftintitle", "-d"),
-            ("Alice", "Song 1", "Alice"),
-            ("Alice", "Song 1"),
-            id="drop-self-no-ft",
-        ),
-        pytest.param(
-            None,
-            ("ftintitle", "-d"),
-            ("Alice ft Bob", "Song 1", "George"),
-            ("Alice", "Song 1"),
-            id="drop-guest-ft",
-        ),
-        pytest.param(
-            None,
-            ("ftintitle", "-d"),
-            ("Alice", "Song 1", "George"),
-            ("Alice", "Song 1"),
-            id="drop-guest-no-ft",
-        ),
-        # ---- custom format variants ----
-        pytest.param(
-            {"format": "feat. {}"},
-            ("ftintitle",),
-            ("Alice ft Bob", "Song 1", "Alice"),
-            ("Alice", "Song 1 feat. Bob"),
-            id="custom-format-feat-dot",
-        ),
-        pytest.param(
-            {"format": "featuring {}"},
-            ("ftintitle",),
-            ("Alice feat. Bob", "Song 1", "Alice"),
-            ("Alice", "Song 1 featuring Bob"),
-            id="custom-format-featuring",
-        ),
-        pytest.param(
-            {"format": "with {}"},
-            ("ftintitle",),
-            ("Alice feat Bob", "Song 1", "Alice"),
-            ("Alice", "Song 1 with Bob"),
-            id="custom-format-with",
-        ),
-        # ---- keep_in_artist variants ----
-        pytest.param(
-            {"format": "feat. {}", "keep_in_artist": True},
-            ("ftintitle",),
-            ("Alice ft Bob", "Song 1", "Alice"),
-            ("Alice ft Bob", "Song 1 feat. Bob"),
-            id="keep-in-artist-add-to-title",
-        ),
-        pytest.param(
-            {"format": "feat. {}", "keep_in_artist": True},
-            ("ftintitle", "-d"),
-            ("Alice ft Bob", "Song 1", "Alice"),
-            ("Alice ft Bob", "Song 1"),
-            id="keep-in-artist-drop-from-title",
-        ),
-        # ---- custom_words variants ----
-        pytest.param(
-            {"format": "featuring {}", "custom_words": ["med"]},
-            ("ftintitle",),
-            ("Alice med Bob", "Song 1", "Alice"),
-            ("Alice", "Song 1 featuring Bob"),
-            id="custom-feat-words",
-        ),
-        pytest.param(
-            {
-                "format": "featuring {}",
-                "keep_in_artist": True,
-                "custom_words": ["med"],
-            },
-            ("ftintitle",),
-            ("Alice med Bob", "Song 1", "Alice"),
-            ("Alice med Bob", "Song 1 featuring Bob"),
-            id="custom-feat-words-keep-in-artists",
-        ),
-        pytest.param(
-            {
-                "format": "featuring {}",
-                "keep_in_artist": True,
-                "custom_words": ["med"],
-            },
-            ("ftintitle", "-d"),
-            ("Alice med Bob", "Song 1", "Alice"),
-            ("Alice med Bob", "Song 1"),
-            id="custom-feat-words-keep-in-artists-drop-from-title",
-        ),
-        # ---- preserve_album_artist variants ----
-        pytest.param(
-            {"format": "feat. {}", "preserve_album_artist": True},
-            ("ftintitle",),
-            ("Alice feat. Bob", "Song 1", "Alice"),
-            ("Alice", "Song 1 feat. Bob"),
-            id="skip-if-artist-and-album-artists-is-the-same-different-match",
-        ),
-        pytest.param(
-            {"format": "feat. {}", "preserve_album_artist": False},
-            ("ftintitle",),
-            ("Alice feat. Bob", "Song 1", "Alice"),
-            ("Alice", "Song 1 feat. Bob"),
-            id="skip-if-artist-and-album-artists-is-the-same-different-match-b",
-        ),
-        pytest.param(
-            {"format": "feat. {}", "preserve_album_artist": True},
-            ("ftintitle",),
-            ("Alice feat. Bob", "Song 1", "Alice feat. Bob"),
-            ("Alice feat. Bob", "Song 1"),
-            id="skip-if-artist-and-album-artists-is-the-same-matching-match",
-        ),
-        pytest.param(
-            {"format": "feat. {}", "preserve_album_artist": False},
-            ("ftintitle",),
-            ("Alice feat. Bob", "Song 1", "Alice feat. Bob"),
-            ("Alice", "Song 1 feat. Bob"),
-            id="skip-if-artist-and-album-artists-is-the-same-matching-match-b",
-        ),
-        # ---- titles with brackets/parentheses ----
-        pytest.param(
-            {"format": "ft. {}", "bracket_keywords": ["mix"]},
-            ("ftintitle",),
-            ("Alice ft. Bob", "Song 1 (Club Mix)", "Alice"),
-            ("Alice", "Song 1 ft. Bob (Club Mix)"),
-            id="ft-inserted-before-matching-bracket-keyword",
-        ),
-        pytest.param(
-            {"format": "ft. {}", "bracket_keywords": ["nomatch"]},
-            ("ftintitle",),
-            ("Alice ft. Bob", "Song 1 (Club Remix)", "Alice"),
-            ("Alice", "Song 1 (Club Remix) ft. Bob"),
-            id="ft-inserted-at-end-no-bracket-keyword-match",
-        ),
-    ],
-)
-def test_ftintitle_functional(
-    env: FtInTitlePluginFunctional,
-    cfg: dict[str, str | bool | list[str]] | None,
-    cmd_args: tuple[str, ...],
-    given: tuple[str, str, str | None],
-    expected: tuple[str, str],
-) -> None:
-    set_config(env, cfg)
-    ftintitle.FtInTitlePlugin()
+        with self.configure_plugin(config):
+            self.run_command(*cmd_args)
 
-    artist, title, albumartist = given
-    item = add_item(env, "/", artist, title, albumartist)
+        item.load()
 
-    env.run_command(*cmd_args)
-    item.load()
-
-    expected_artist, expected_title = expected
-    assert item["artist"] == expected_artist
-    assert item["title"] == expected_title
+        expected_artist, expected_title = expected
+        assert item["artist"] == expected_artist
+        assert item["title"] == expected_title
 
 
 @pytest.mark.parametrize(

--- a/test/plugins/test_hook.py
+++ b/test/plugins/test_hook.py
@@ -22,13 +22,13 @@ from typing import TYPE_CHECKING, ClassVar
 import pytest
 
 from beets import plugins
-from beets.test.helper import PytestPluginTestHelper
+from beets.test.helper import PluginTestHelper
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-class HookTestCase(PytestPluginTestHelper):
+class HookTestCase(PluginTestHelper):
     plugin = "hook"
     preload_plugin = False
 

--- a/test/plugins/test_mbcollection.py
+++ b/test/plugins/test_mbcollection.py
@@ -24,14 +24,6 @@ class TestMbCollectionPlugin(PluginMixin, TestHelper):
         self.config["musicbrainz"]["pass"] = "testpass"
         self.config["mbcollection"]["collection"] = self.COLLECTION_ID
 
-    @pytest.fixture(autouse=True)
-    def helper(self):
-        self.setup_beets()
-
-        yield self
-
-        self.teardown_beets()
-
     @pytest.mark.parametrize(
         "user_collections,expectation",
         [
@@ -66,7 +58,7 @@ class TestMbCollectionPlugin(PluginMixin, TestHelper):
         with expectation:
             mbcollection.MusicBrainzCollectionPlugin().collection
 
-    def test_mbupdate(self, helper, requests_mock, monkeypatch):
+    def test_mbupdate(self, requests_mock, monkeypatch):
         """Verify mbupdate sync of a MusicBrainz collection with the library.
 
         This test ensures that the command:
@@ -85,7 +77,7 @@ class TestMbCollectionPlugin(PluginMixin, TestHelper):
             "00000000-0000-0000-0000-000000000001",
             "00000000-0000-0000-0000-000000000002",
         ]:
-            helper.lib.add(Album(mb_albumid=mb_albumid))
+            self.lib.add(Album(mb_albumid=mb_albumid))
 
         # The relevant collection
         requests_mock.get(
@@ -138,13 +130,11 @@ class TestMbCollectionPlugin(PluginMixin, TestHelper):
             re.compile(rf".*{collection_releases}/not_in_library")
         )
 
-        helper.run_command("mbupdate", "--remove")
+        self.run_command("mbupdate", "--remove")
 
         assert requests_mock.call_count == 6
 
-    def test_mbupdate_logs_unauthorized_errors(
-        self, helper, requests_mock, caplog
-    ):
+    def test_mbupdate_logs_unauthorized_errors(self, requests_mock, caplog):
         response = requests.Response()
         response.status_code = 401
         requests_mock.get(
@@ -153,7 +143,7 @@ class TestMbCollectionPlugin(PluginMixin, TestHelper):
         )
 
         with caplog.at_level("ERROR", logger="beets.mbcollection"):
-            helper.run_command("mbupdate")
+            self.run_command("mbupdate")
 
         expected_message = (
             "Failed to update MusicBrainz collection: HTTP Error: 401"

--- a/test/plugins/test_mbsync.py
+++ b/test/plugins/test_mbsync.py
@@ -16,10 +16,10 @@ from unittest.mock import Mock, patch
 
 from beets.autotag import AlbumInfo, TrackInfo
 from beets.library import Item
-from beets.test.helper import PytestPluginTestHelper
+from beets.test.helper import PluginTestHelper
 
 
-class TestMbsyncCli(PytestPluginTestHelper):
+class TestMbsyncCli(PluginTestHelper):
     plugin = "mbsync"
 
     @patch(

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -34,7 +34,7 @@ from beets import config, plugins, util
 from beets.library import Album
 from beets.test import _common
 from beets.test._common import item
-from beets.test.helper import PytestTestHelper
+from beets.test.helper import TestHelper
 from beets.util import (
     as_string,
     bytestring_path,
@@ -47,7 +47,7 @@ from beets.util import (
 np = util.normpath
 
 
-class PytestItemHelper(PytestTestHelper):
+class PytestItemHelper(TestHelper):
     def get_first_item(self):
         """Retrieve first item from library."""
         return next(iter(self.lib.items()))
@@ -616,7 +616,7 @@ class PathFormattingMixin:
         assert actual == dest
 
 
-class TestDestinationFunction(PytestTestHelper, PathFormattingMixin):
+class TestDestinationFunction(TestHelper, PathFormattingMixin):
     @pytest.fixture(autouse=True)
     def item(self, setup):
         self.lib.directory = b"/base"
@@ -724,7 +724,7 @@ class TestDestinationFunction(PytestTestHelper, PathFormattingMixin):
         self._assert_dest(b"/base/Alice & Bob", item)
 
 
-class TestDisambiguation(PytestTestHelper, PathFormattingMixin):
+class TestDisambiguation(TestHelper, PathFormattingMixin):
     @pytest.fixture(autouse=True)
     def items(self, setup):
         self.lib.directory = b"/base"
@@ -819,7 +819,7 @@ class TestDisambiguation(PytestTestHelper, PathFormattingMixin):
         self._assert_dest(b"/base/foo/the title", i1)
 
 
-class TestSingletonDisambiguation(PytestTestHelper, PathFormattingMixin):
+class TestSingletonDisambiguation(TestHelper, PathFormattingMixin):
     @pytest.fixture(autouse=True)
     def items(self, setup):
         self.lib.directory = b"/base"
@@ -911,7 +911,7 @@ class TestSingletonDisambiguation(PytestTestHelper, PathFormattingMixin):
         self._assert_dest(b"/base/foo/the title", i1)
 
 
-class TestPluginDestination(PytestTestHelper):
+class TestPluginDestination(TestHelper):
     @pytest.fixture(autouse=True)
     def item(self, setup):
         # Mock beets.plugins.item_field_getters.
@@ -1055,7 +1055,7 @@ class TestAlbumInfo(PytestItemHelper):
         assert item.album == ai.album
 
 
-class TestArtDestination(PytestTestHelper):
+class TestArtDestination(TestHelper):
     @pytest.fixture(autouse=True)
     def item_and_album(self, setup):
         config["art_filename"] = "artimage"
@@ -1185,7 +1185,7 @@ class TestPathString(PytestItemHelper):
         assert album.path == os.path.dirname(absolute_path)
 
 
-class TestMtime(PytestTestHelper):
+class TestMtime(TestHelper):
     @pytest.fixture(autouse=True)
     def item(self, setup):
         self.ipath = os.path.join(self.temp_dir, b"testfile.mp3")
@@ -1220,7 +1220,7 @@ class TestMtime(PytestTestHelper):
         assert item.mtime >= self._mtime()
 
 
-class TestImportTime(PytestTestHelper):
+class TestImportTime(TestHelper):
     def added(self):
         self.track = item()
         self.album = self.lib.add_album((self.track,))
@@ -1273,7 +1273,7 @@ class TestUnicodePath(PytestItemHelper):
         item_in_db.write()
 
 
-class TestWrite(PytestTestHelper):
+class TestWrite(TestHelper):
     def test_write_nonexistant(self):
         item = self.create_item()
         item.path = b"/path/does/not/exist"
@@ -1361,7 +1361,7 @@ class TestItemRead(PytestItemHelper):
         assert str(exc_info.value.reason) in message
 
 
-class TestItemReadGenre(PytestTestHelper):
+class TestItemReadGenre(TestHelper):
     def test_read_semicolon_delimited_genres(self):
         """Semicolon-delimited genre tags are split into individual genres on read."""
         path = self.create_mediafile_fixture()
@@ -1372,7 +1372,7 @@ class TestItemReadGenre(PytestTestHelper):
         assert item.genres == ["Jazz", "Funk", "Soul"]
 
 
-class TestFilesize(PytestTestHelper):
+class TestFilesize(TestHelper):
     def test_filesize(self):
         item = self.add_item_fixture()
         assert item.filesize != 0
@@ -1382,7 +1382,7 @@ class TestFilesize(PytestTestHelper):
         assert item.filesize == 0
 
 
-class TestItemPruneDirsClutter(PytestTestHelper):
+class TestItemPruneDirsClutter(TestHelper):
     """Regression tests: prune_dirs respects config["clutter"] during move/remove."""
 
     def _drop_clutter(self, directory, filename=b"unwanted.log"):

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -39,13 +39,13 @@ from beets.test.helper import (
     ImportHelper,
     IOMixin,
     PluginMixin,
-    PytestPluginTestHelper,
+    PluginTestHelper,
     TerminalImportMixin,
 )
 from beets.util import PromptChoice, displayable_path, syspath
 
 
-class TestPluginRegistration(IOMixin, PytestPluginTestHelper):
+class TestPluginRegistration(IOMixin, PluginTestHelper):
     class RatingPlugin(plugins.BeetsPlugin):
         item_types: ClassVar[dict[str, types.Type]] = {
             "rating": types.Float(),
@@ -97,7 +97,7 @@ class TestPluginRegistration(IOMixin, PytestPluginTestHelper):
         assert out == "one; two; three\n"
 
 
-class PytestImportHelper(ImportHelper, PytestPluginTestHelper):
+class PytestImportHelper(ImportHelper, PluginTestHelper):
     @pytest.fixture(autouse=True)
     def setup_import_helper(self, setup):
         self.import_media = []
@@ -179,7 +179,7 @@ class TestEvents(PytestImportHelper):
         ]
 
 
-class TestListeners(PytestPluginTestHelper):
+class TestListeners(PluginTestHelper):
     def test_register(self):
         class DummyPlugin(plugins.BeetsPlugin):
             def __init__(self):


### PR DESCRIPTION
## PR Summary

grug see this PR as test-helper cleanup with small architecture shift.

- Move pytest setup/teardown into shared `TestHelper` via an autouse `setup` fixture.
- Collapse old pytest-specific helpers into the main helpers by using `TestHelper` and `PluginTestHelper` as the standard test base classes.
- Update plugin and library tests to use the new shared lifecycle instead of custom fixtures or manual `setUp`/`tearDown`.
- Rewrite `test/plugins/test_ftintitle.py` to use `PluginTestHelper` and `configure_plugin`, which removes manual environment wiring and makes the test flow match other plugin tests.
- Simplify `test/plugins/test_mbcollection.py` by dropping its local helper fixture and relying on the shared test setup.

## High-level impact

- Test architecture becomes more consistent: one shared pytest setup path instead of many local patterns.
- Boilerplate goes down across the test suite, so future tests should be easier to write and maintain.
- Deprecated helper split is reduced, which makes test utilities simpler to understand.
- Main behavior change is in test infrastructure, and it fixes the failing `ftintitle` and `mbcollection` tests without changing production plugin logic.
