### PR TITLE
Fix lyrics JSON decode error compatibility

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import itertools
+import json
 import math
 import re
 import textwrap
@@ -70,6 +71,15 @@ class CaptchaError(requests.exceptions.HTTPError):
 
 class GeniusHTTPError(requests.exceptions.HTTPError):
     pass
+
+
+def _json_decode_error() -> type[ValueError]:
+    """Return the JSON decode error type exposed by requests."""
+    return getattr(
+        requests,
+        "JSONDecodeError",
+        getattr(requests.compat, "JSONDecodeError", json.JSONDecodeError),
+    )
 
 
 # Utilities.
@@ -226,7 +236,7 @@ class LyricsRequestHandler(RequestHandler):
     def handle_request(self) -> Iterator[None]:
         try:
             yield
-        except requests.JSONDecodeError:
+        except _json_decode_error():
             self.warn("Could not decode response JSON data")
         except requests.RequestException as exc:
             self.warn("Request error: {}", exc)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -69,6 +69,9 @@ Bug fixes
   of crashing beets. :bug:`6193`
 - :doc:`plugins/lyrics`: Improve Musica.com lyric scraping so fetched lyrics no
   longer omit the opening verse or include non-lyric page content.
+- :doc:`plugins/lyrics`: Handle JSON decode failures without crashing on
+  requests versions that do not expose ``JSONDecodeError`` at the top level.
+  :bug:`5998`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 import textwrap
 from functools import partial
@@ -261,6 +262,36 @@ class TestLyricsPlugin(LyricsPluginMixin):
         last_log = caplog.messages[-1]
         assert last_log
         assert re.search(expected_log_match, last_log, re.I)
+
+    def test_error_handling_without_requests_json_decode_error(
+        self, monkeypatch, lyrics_plugin, caplog
+    ):
+        """JSON decode errors are still handled with older requests versions."""
+        monkeypatch.delattr(requests, "JSONDecodeError", raising=False)
+
+        with lyrics_plugin.handle_request():
+            raise json.JSONDecodeError("invalid", "", 0)
+
+        assert caplog.messages
+        last_log = caplog.messages[-1]
+        assert last_log
+        assert re.search(
+            r"LyricsPlugin: Could not decode.*JSON", last_log, re.I
+        )
+
+    def test_request_error_without_requests_json_decode_error(
+        self, monkeypatch, lyrics_plugin, caplog
+    ):
+        """Request errors are handled when requests has no JSONDecodeError."""
+        monkeypatch.delattr(requests, "JSONDecodeError", raising=False)
+
+        with lyrics_plugin.handle_request():
+            raise lyrics.CaptchaError()
+
+        assert caplog.messages
+        last_log = caplog.messages[-1]
+        assert last_log
+        assert "LyricsPlugin: Request error: Captcha is required" in last_log
 
     @pytest.mark.parametrize(
         "plugin_config, old_lyrics, found, expected",


### PR DESCRIPTION
## Description

Fixes #5998.

The lyrics request handler now resolves the JSON decode exception type through a compatibility helper instead of looking up `requests.JSONDecodeError` directly. On installs where requests lacks that top-level alias, request errors can now fall through to the existing request-error handler instead of crashing with `AttributeError` while matching exceptions.

## Testing

- `.venv/bin/python -m pytest test/plugins/test_lyrics.py -q`
- `.venv/bin/python -m ruff check --config=pyproject.toml beetsplug/lyrics.py test/plugins/test_lyrics.py`
- `.venv/bin/python -m ruff format --check --diff beetsplug/lyrics.py test/plugins/test_lyrics.py`
- `git diff --check`

## To Do

- [x] ~Documentation~ (No command-line or configuration docs changed.)
- [x] Changelog.
- [x] Tests.