### PR TITLE
bpd: enable coverage measurement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,8 @@ addopts =
 data_file = .reports/coverage/data
 branch = true
 relative_files = true
+parallel = true
+sigterm = true
 omit =
     test/*
     beets/test/*

--- a/test/plugins/test_bpd.py
+++ b/test/plugins/test_bpd.py
@@ -339,7 +339,10 @@ class BPDTestHelper(PluginTestCase):
                 sock.close()
         finally:
             server.terminate()
-            server.join(timeout=0.2)
+            server.join(timeout=2)  # give coverage time to write data
+            if server.is_alive():
+                server.kill()  # force kill if still stuck (SIGKILL on POSIX)
+                server.join(timeout=2)
 
     def _assert_ok(self, *responses):
         for response in responses:


### PR DESCRIPTION
- `setup.cfg` now enables coverage collection for subprocess-based test execution by turning on `parallel = true` and `sigterm = true` in `coverage` settings.

- `test/plugins/test_bpd.py` now gives the `bpd` test server more time to shut down cleanly so coverage data can be written before the process exits. If shutdown still hangs, it falls back to a forced kill.

- Architecturally, this change improves how the test suite handles coverage for plugin code that runs in a separate process, without changing plugin behavior itself.

- High-level impact: `bpd` plugin code is now included more reliably in coverage reports, and the test teardown path is more robust against stuck server processes.
