### PR TITLE
Fix KeyError when Spotify album response lacks 'label' field

### DIFF
--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -412,7 +412,7 @@ class SpotifyPlugin(
             year=year,
             month=month,
             day=day,
-            label=album_data["label"],
+            label=album_data.get("label"),
             mediums=max(filter(None, medium_totals.keys())),
             data_source=self.data_source,
             data_url=album_data["external_urls"]["spotify"],

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -71,6 +71,8 @@ Bug fixes
   longer omit the opening verse or include non-lyric page content.
 - :doc:`plugins/convert`: Tidy the ``--playlist`` help text so it no longer has
   awkward indentation in CLI output.
+- :doc:`plugins/spotify`: Improved Spotify API parsing to handle missing label
+  data :bug:`6679`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Description

Fixes #6679

Changed the way label data is parsed from Spotify API in Spotify plugin.

Now if label data is absent from API response, plugin is still working and can be used to match release.