### PR TITLE
typing: add missing types to beets.importer

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -205,3 +205,9 @@ ca8544d4bcab503e1e4c2cd6688655c8211aa7a1
 d0dc5f86a626765c86cdadc348595429f4c6e6ef
 # Enable and fix flake8-builtins
 b7974ace83ab193b6417bdcecaf68a742bf5a1a8
+# Preserve importer config views
+c9ad80dad2528af67cdb76c35d7ba5e4824b7600
+# Type _reduce_and_log
+c070b29e14cd06419e129b76a6d42a82fe51e190
+# Add missing types to importer
+e4baceae1fa03dfd6db9e0bab88ddd2812963ad3

--- a/beets/importer/session.py
+++ b/beets/importer/session.py
@@ -25,15 +25,16 @@ from .actions import Action, DuplicateAction
 from .state import ImportState
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterator, Sequence
 
     import confuse
 
     from beets import dbcore, library
+    from beets.autotag import AlbumMatch, TrackMatch
     from beets.library import AnyLibModel
     from beets.util import PathBytes
 
-    from .tasks import ImportTask
+    from .tasks import ImportTask, SingletonImportTask
 
 
 QUEUE_SIZE = 128
@@ -65,7 +66,7 @@ class ImportSession:
         loghandler: logging.Handler | None,
         paths: Sequence[PathBytes] | None,
         query: dbcore.Query | None,
-    ):
+    ) -> None:
         """Create a session.
 
         Parameters
@@ -90,7 +91,9 @@ class ImportSession:
         # Normalize the paths.
         self.paths = list(map(normpath, paths or []))
 
-    def _setup_logging(self, loghandler: logging.Handler | None):
+    def _setup_logging(
+        self, loghandler: logging.Handler | None
+    ) -> logging.BeetsLogger:
         logger = logging.getLogger(__name__)
         logger.propagate = False
         if not loghandler:
@@ -149,13 +152,13 @@ class ImportSession:
 
         self.want_resume = config["resume"].as_choice([True, False, "ask"])
 
-    def tag_log(self, status, paths: Sequence[PathBytes]):
+    def tag_log(self, status: str, paths: Sequence[PathBytes]) -> None:
         """Log a message about a given album to the importer log. The status
         should reflect the reason the album couldn't be tagged.
         """
         self.logger.info("{} {}", status, displayable_path(paths))
 
-    def log_choice(self, task: ImportTask, duplicate=False):
+    def log_choice(self, task: ImportTask, duplicate: bool = False) -> None:
         """Logs the task's current choice if it should be logged. If
         ``duplicate``, then this is a secondary choice after a duplicate was
         detected and a decision was made.
@@ -176,10 +179,10 @@ class ImportSession:
             elif task.skip:
                 self.tag_log("skip", paths)
 
-    def should_resume(self, path: PathBytes):
+    def should_resume(self, path: PathBytes) -> bool:
         raise NotImplementedError
 
-    def choose_match(self, task: ImportTask):
+    def choose_match(self, task: ImportTask) -> AlbumMatch | Action:
         raise NotImplementedError
 
     def get_duplicate_action(
@@ -192,14 +195,15 @@ class ImportSession:
         log.debug("default action for duplicates: {}", choice)
         return DuplicateAction(choice)  # type: ignore[call-arg]
 
-    def choose_item(self, task: ImportTask):
+    def choose_item(self, task: SingletonImportTask) -> TrackMatch | Action:
         raise NotImplementedError
 
-    def run(self):
+    def run(self) -> None:
         """Run the import task."""
         self.logger.info("import started {}", time.asctime())
         self.set_config(config["import"])
 
+        stages: list[Iterator[stagefuncs.StageMessage]]
         # Set up the pipeline.
         if self.query is None:
             stages = [stagefuncs.read_tasks(self)]
@@ -250,7 +254,9 @@ class ImportSession:
 
     # Incremental and resumed imports
 
-    def already_imported(self, toppath: PathBytes, paths: Sequence[PathBytes]):
+    def already_imported(
+        self, toppath: PathBytes, paths: Sequence[PathBytes]
+    ) -> bool:
         """Returns true if the files belonging to this task have already
         been imported in a previous session.
         """
@@ -272,7 +278,7 @@ class ImportSession:
             self._history_dirs = ImportState().taghistory
         return self._history_dirs
 
-    def already_merged(self, paths: Sequence[PathBytes]):
+    def already_merged(self, paths: Sequence[PathBytes]) -> bool:
         """Returns true if all the paths being imported were part of a merge
         during previous tasks.
         """
@@ -281,7 +287,7 @@ class ImportSession:
                 return False
         return True
 
-    def mark_merged(self, paths: Sequence[PathBytes]):
+    def mark_merged(self, paths: Sequence[PathBytes]) -> None:
         """Mark paths and directories as merged for future reimport tasks."""
         self._merged_items.update(paths)
         dirs = {
@@ -290,14 +296,14 @@ class ImportSession:
         }
         self._merged_dirs.update(dirs)
 
-    def is_resuming(self, toppath: PathBytes):
+    def is_resuming(self, toppath: PathBytes) -> bool:
         """Return `True` if user wants to resume import of this path.
 
         You have to call `ask_resume` first to determine the return value.
         """
         return self._is_resuming.get(toppath, False)
 
-    def ask_resume(self, toppath: PathBytes):
+    def ask_resume(self, toppath: PathBytes) -> None:
         """If import of `toppath` was aborted in an earlier session, ask
         user if they want to resume the import.
 

--- a/beets/importer/session.py
+++ b/beets/importer/session.py
@@ -27,6 +27,8 @@ from .state import ImportState
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    import confuse
+
     from beets import dbcore, library
     from beets.library import AnyLibModel
     from beets.util import PathBytes
@@ -96,14 +98,13 @@ class ImportSession:
         logger.handlers = [loghandler]
         return logger
 
-    def set_config(self, config):
+    def set_config(self, config: confuse.ConfigView) -> None:
         """Set `config` property from global import config and make
         implied changes.
         """
         # FIXME: Maybe this function should not exist and should instead
         # provide "decision wrappers" like "should_resume()", etc.
-        iconfig = dict(config)
-        self.config = iconfig
+        self.config = iconfig = config
 
         # Incremental and progress are mutually exclusive.
         if iconfig["incremental"]:

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -291,7 +291,7 @@ def manipulate_files(session: ImportSession, task: ImportTask):
             operation = MoveOperation.LINK
         elif session.config["hardlink"]:
             operation = MoveOperation.HARDLINK
-        elif session.config["reflink"] == "auto":
+        elif session.config["reflink"].get() == "auto":
             operation = MoveOperation.REFLINK_AUTO
         elif session.config["reflink"]:
             operation = MoveOperation.REFLINK
@@ -299,7 +299,9 @@ def manipulate_files(session: ImportSession, task: ImportTask):
             operation = None
 
         task.manipulate_files(
-            session=session, operation=operation, write=session.config["write"]
+            session=session,
+            operation=operation,
+            write=session.config["write"].get(bool),
         )
 
     # Progress, cleanup, and event.

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import contextvars
 import itertools
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias
 
 from beets import config, plugins
 from beets.util import MoveOperation, displayable_path, pipeline
@@ -31,11 +31,16 @@ from .tasks import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Generator, Iterable, Iterator
 
     from beets import library
 
     from .session import ImportSession
+    from .tasks import BaseImportTask
+
+    StageMessage: TypeAlias = BaseImportTask | pipeline.MultiMessage | None
+    StageCoro: TypeAlias = Generator[StageMessage, ImportTask, None]
+    StageReturn: TypeAlias = ImportTask | pipeline.MultiMessage | str
 
 # Global logger.
 log = logging.getLogger("beets")
@@ -44,7 +49,7 @@ log = logging.getLogger("beets")
 # Functions that are called first i.e. they generate import tasks
 
 
-def read_tasks(session: ImportSession):
+def read_tasks(session: ImportSession) -> Iterator[BaseImportTask]:
     """A generator yielding all the albums (as ImportTask objects) found
     in the user-specified list of paths. In the case of a singleton
     import, yields single-item tasks instead.
@@ -68,12 +73,12 @@ def read_tasks(session: ImportSession):
         log.info("Skipped {} paths.", skipped)
 
 
-def query_tasks(session: ImportSession):
+def query_tasks(session: ImportSession) -> Iterator[BaseImportTask]:
     """A generator that works as a drop-in-replacement for read_tasks.
     Instead of finding files from the filesystem, a query is used to
     match items from the library.
     """
-    task: ImportTask
+    task: BaseImportTask
     if session.config["singletons"]:
         # Search for items.
         for item in session.lib.items(session.query):
@@ -100,7 +105,7 @@ def query_tasks(session: ImportSession):
 # They are chained together in the pipeline e.g. stage2(stage1(task)) -> task
 
 
-def group_albums(session: ImportSession):
+def group_albums(session: ImportSession) -> StageCoro:
     """A pipeline stage that groups the items of each task into albums
     using their metadata.
 
@@ -108,13 +113,14 @@ def group_albums(session: ImportSession):
     pipeline stage emits new album tasks for each discovered group.
     """
 
-    def group(item):
+    def group(item: library.Item) -> tuple[str | None, str | None]:
         return (item.albumartist or item.artist, item.album)
 
-    task = None
+    out: StageMessage = None
     while True:
-        task = yield task
+        task = yield out
         if task.skip:
+            out = task
             continue
         tasks = []
         sorted_items: list[library.Item] = sorted(task.items, key=group)
@@ -124,11 +130,11 @@ def group_albums(session: ImportSession):
             tasks += task.handle_created(session)
         tasks.append(SentinelImportTask(task.toppath, task.paths))
 
-        task = pipeline.multiple(tasks)
+        out = pipeline.multiple(tasks)
 
 
 @pipeline.mutator_stage
-def lookup_candidates(session: ImportSession, task: ImportTask):
+def lookup_candidates(session: ImportSession, task: ImportTask) -> None:
     """A coroutine for performing the initial MusicBrainz lookup for an
     album. It accepts lists of Items and yields
     (items, cur_artist, cur_album, candidates, rec) tuples. If no match
@@ -148,7 +154,7 @@ def lookup_candidates(session: ImportSession, task: ImportTask):
 
 
 @pipeline.stage
-def user_query(session: ImportSession, task: ImportTask):
+def user_query(session: ImportSession, task: ImportTask) -> StageReturn:
     """A coroutine for interfacing with the user about the tagging
     process.
 
@@ -174,7 +180,7 @@ def user_query(session: ImportSession, task: ImportTask):
     # As-tracks: transition to singleton workflow.
     if task.choice_flag is Action.TRACKS:
         # Set up a little pipeline for dealing with the singletons.
-        def emitter(task):
+        def emitter(task: ImportTask) -> Iterator[BaseImportTask]:
             for item in task.items:
                 task = SingletonImportTask(task.toppath, item)
                 yield from task.handle_created(session)
@@ -220,7 +226,7 @@ def user_query(session: ImportSession, task: ImportTask):
 
 
 @pipeline.mutator_stage
-def import_asis(session: ImportSession, task: ImportTask):
+def import_asis(session: ImportSession, task: ImportTask) -> None:
     """Select the `action.ASIS` choice for all tasks.
 
     This stage replaces the initial_lookup and user_query stages
@@ -240,7 +246,7 @@ def plugin_stage(
     session: ImportSession,
     func: Callable[[ImportSession, ImportTask], None],
     task: ImportTask,
-):
+) -> None:
     """A coroutine (pipeline stage) that calls the given function with
     each non-skipped import task. These stages occur between applying
     metadata changes and moving/copying/writing files.
@@ -257,7 +263,7 @@ def plugin_stage(
 
 
 @pipeline.stage
-def log_files(session: ImportSession, task: ImportTask):
+def log_files(session: ImportSession, task: ImportTask) -> None:
     """A coroutine (pipeline stage) to log each file to be imported."""
     if isinstance(task, SingletonImportTask):
         log.info("Singleton: {}", displayable_path(task.item["path"]))
@@ -274,7 +280,7 @@ def log_files(session: ImportSession, task: ImportTask):
 
 
 @pipeline.stage
-def manipulate_files(session: ImportSession, task: ImportTask):
+def manipulate_files(session: ImportSession, task: ImportTask) -> None:
     """A coroutine (pipeline stage) that performs necessary file
     manipulations *after* items have been added to the library and
     finalizes each task.
@@ -312,7 +318,7 @@ def manipulate_files(session: ImportSession, task: ImportTask):
 # Private functions only used in the stages above
 
 
-def _apply_choice(session: ImportSession, task: ImportTask):
+def _apply_choice(session: ImportSession, task: ImportTask) -> None:
     """Apply the task's choice to the Album or Item it contains and add
     it to the library.
     """
@@ -335,7 +341,7 @@ def _apply_choice(session: ImportSession, task: ImportTask):
         task.set_fields(session.lib)
 
 
-def _resolve_duplicates(session: ImportSession, task: ImportTask):
+def _resolve_duplicates(session: ImportSession, task: ImportTask) -> None:
     """Check if a task conflicts with items or albums already imported
     and ask the session to resolve this.
     """
@@ -351,7 +357,7 @@ def _resolve_duplicates(session: ImportSession, task: ImportTask):
             session.log_choice(task, True)
 
 
-def _freshen_items(items):
+def _freshen_items(items: Iterable[library.Item]) -> None:
     # Clear IDs from re-tagged items so they appear "fresh" when
     # we add them back to the library.
     for item in items:
@@ -359,17 +365,14 @@ def _freshen_items(items):
         item.album_id = None
 
 
-def _extend_pipeline(tasks, *stages):
+def _extend_pipeline(
+    tasks: Iterable[BaseImportTask], *stages: StageCoro
+) -> pipeline.MultiMessage:
     # Return pipeline extension for stages with list of tasks
-    if isinstance(tasks, list):
-        task_iter = iter(tasks)
-    else:
-        task_iter = tasks
-
-    ipl = pipeline.Pipeline([task_iter, *list(stages)])
+    ipl = pipeline.Pipeline([iter(tasks), *list(stages)])
     ctx = contextvars.copy_context()
 
-    def _ctx_iter():
+    def _ctx_iter() -> Iterator[StageMessage]:
         gen = ipl.pull()
         while True:
             try:

--- a/beets/importer/state.py
+++ b/beets/importer/state.py
@@ -21,9 +21,13 @@ from bisect import bisect_left, insort
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from typing_extensions import Self
+
 from beets import config
 
 if TYPE_CHECKING:
+    from types import TracebackType
+
     from beets.util import PathBytes
 
 
@@ -61,19 +65,26 @@ class ImportState:
     taghistory: set[tuple[PathBytes, ...]]
     path: PathBytes
 
-    def __init__(self, readonly=False, path: PathBytes | None = None):
+    def __init__(
+        self, readonly: bool = False, path: PathBytes | None = None
+    ) -> None:
         self.path = path or os.fsencode(config["statefile"].as_filename())
         self.tagprogress = {}
         self.taghistory = set()
         self._open()
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         self._save()
 
-    def _open(self):
+    def _open(self) -> None:
         try:
             with open(self.path, "rb") as f:
                 state = pickle.load(f)
@@ -87,7 +98,7 @@ class ImportState:
             # full list!).
             log.debug("state file could not be read: {}", exc)
 
-    def _save(self):
+    def _save(self) -> None:
         try:
             with open(self.path, "wb") as f:
                 pickle.dump(
@@ -102,7 +113,7 @@ class ImportState:
 
     # -------------------------------- Tagprogress ------------------------------- #
 
-    def progress_add(self, toppath: PathBytes, *paths: PathBytes):
+    def progress_add(self, toppath: PathBytes, *paths: PathBytes) -> None:
         """Record that the files under all of the `paths` have been imported
         under `toppath`.
         """
@@ -126,7 +137,7 @@ class ImportState:
         """
         return toppath in self.tagprogress
 
-    def progress_reset(self, toppath: PathBytes | None):
+    def progress_reset(self, toppath: PathBytes | None) -> None:
         """Reset the progress for `toppath`."""
         with self as state:
             if toppath in state.tagprogress:
@@ -134,7 +145,7 @@ class ImportState:
 
     # -------------------------------- Taghistory -------------------------------- #
 
-    def history_add(self, paths: list[PathBytes]):
+    def history_add(self, paths: list[PathBytes]) -> None:
         """Add the paths to the history."""
         with self as state:
             state.taghistory.add(tuple(paths))

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -1074,19 +1074,13 @@ class ImportTaskFactory:
         return None
 
     def album(
-        self,
-        paths: Iterable[util.PathBytes],
-        dirs: list[util.PathBytes] | None = None,
+        self, paths: Iterable[util.PathBytes], dirs: list[util.PathBytes]
     ) -> ImportTask | None:
         """Return a `ImportTask` with all media files from paths.
 
         `dirs` is a list of parent directories used to record already
         imported albums.
         """
-
-        if dirs is None:
-            dirs = list({os.path.dirname(p) for p in paths})
-
         if self.session.already_imported(self.toppath, dirs):
             log.debug(
                 "Skipping previously-imported path: {}",

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -36,7 +36,7 @@ from .actions import Action, DuplicateAction
 from .state import ImportState
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Iterable, Mapping, Sequence
 
     from beets.autotag import Recommendation, TrackMatch
 
@@ -544,7 +544,11 @@ class ImportTask(BaseImportTask):
         albums.
         """
 
-        def _reduce_and_log(new_obj, existing_fields, overwrite_keys):
+        def _reduce_and_log(
+            new_obj: library.LibModel,
+            existing_fields: Mapping[str, Any],
+            overwrite_keys: list[str],
+        ) -> Mapping[str, Any]:
             """Some flexible attributes should be overwritten (rather than
             preserved) on reimports; Copies existing_fields, logs and removes
             entries that should not be preserved and returns a dict containing

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -91,7 +91,7 @@ class BaseImportTask:
         toppath: util.PathBytes | None,
         paths: Iterable[util.PathBytes] | None,
         items: Iterable[library.Item] | None,
-    ):
+    ) -> None:
         """Create a task. The primary fields that define a task are:
 
         * `toppath`: The user-specified base directory that contains the
@@ -160,11 +160,11 @@ class ImportTask(BaseImportTask):
         toppath: util.PathBytes | None,
         paths: Iterable[util.PathBytes] | None,
         items: Iterable[library.Item] | None,
-    ):
+    ) -> None:
         super().__init__(toppath, paths, items)
         self.is_album = True
 
-    def set_choice(self, choice: Action | AlbumMatch | TrackMatch):
+    def set_choice(self, choice: Action | AlbumMatch | TrackMatch) -> None:
         """Given an AlbumMatch or TrackMatch object or an action constant,
         indicates that an action has been selected for this task.
 
@@ -188,21 +188,21 @@ class ImportTask(BaseImportTask):
             self.choice_flag = Action.APPLY  # Implicit choice.
             self.match = choice  # type: ignore[assignment]
 
-    def save_progress(self):
+    def save_progress(self) -> None:
         """Updates the progress state to indicate that this album has
         finished.
         """
         if self.toppath:
             ImportState().progress_add(self.toppath, *self.paths)
 
-    def save_history(self):
+    def save_history(self) -> None:
         """Save the directory in the history for incremental imports."""
         ImportState().history_add(self.paths)
 
     # Logical decisions.
 
     @property
-    def apply(self):
+    def apply(self) -> bool:
         return self.choice_flag == Action.APPLY
 
     @property
@@ -214,7 +214,7 @@ class ImportTask(BaseImportTask):
 
     # Convenient data.
 
-    def chosen_info(self):
+    def chosen_info(self) -> dict[str, Any]:
         """Return a dictionary of metadata about the current choice.
         May only be called when the choice flag is ASIS or RETAG
         (in which case the data comes from the files' current metadata)
@@ -227,7 +227,7 @@ class ImportTask(BaseImportTask):
             return self.match.info.copy()
         assert False
 
-    def imported_items(self):
+    def imported_items(self) -> list[library.Item]:
         """Return a list of Items that should be added to the library.
 
         If the tasks applies an album match the method only returns the
@@ -246,13 +246,13 @@ class ImportTask(BaseImportTask):
         if self.match:  # TODO: redesign to remove the conditional
             self.match.apply_metadata()
 
-    def duplicate_items(self, lib: library.Library):
-        duplicate_items = []
+    def duplicate_items(self, lib: library.Library) -> list[library.Item]:
+        duplicate_items: list[library.Item] = []
         for album in self.find_duplicates(lib):
             duplicate_items += album.items()
         return duplicate_items
 
-    def remove_duplicates(self, lib: library.Library):
+    def remove_duplicates(self, lib: library.Library) -> None:
         duplicate_albums = self.find_duplicates(lib)
         log.debug("removing {} old duplicate albums", len(duplicate_albums))
 
@@ -281,7 +281,7 @@ class ImportTask(BaseImportTask):
                     clutter=config["clutter"].as_str_seq(),
                 )
 
-    def set_fields(self, lib: library.Library):
+    def set_fields(self, lib: library.Library) -> None:
         """Sets the fields given at CLI or configuration to the specified
         values, for both the album and all its items.
         """
@@ -302,7 +302,7 @@ class ImportTask(BaseImportTask):
                 item.store()
             self.album.store()
 
-    def finalize(self, session: ImportSession):
+    def finalize(self, session: ImportSession) -> None:
         """Save progress, clean up files, and emit plugin event."""
         # Update progress.
         if session.want_resume:
@@ -322,7 +322,9 @@ class ImportTask(BaseImportTask):
         if not self.skip:
             self._emit_imported(session.lib)
 
-    def cleanup(self, copy=False, delete=False, move=False):
+    def cleanup(
+        self, copy: bool = False, delete: bool = False, move: bool = False
+    ) -> None:
         """Remove and prune imported paths."""
         # Do not delete any files or prune directories when skipping.
         if self.skip:
@@ -344,22 +346,23 @@ class ImportTask(BaseImportTask):
             for old_path in self.old_paths:
                 self.prune(old_path)
 
-    def _emit_imported(self, lib: library.Library):
+    def _emit_imported(self, lib: library.Library) -> None:
         plugins.send("album_imported", lib=lib, album=self.album)
 
-    def handle_created(self, session: ImportSession):
+    def handle_created(self, session: ImportSession) -> list[ImportTask]:
         """Send the `import_task_created` event for this task. Return a list of
         tasks that should continue through the pipeline. By default, this is a
         list containing only the task itself, but plugins can replace the task
         with new ones.
         """
-        tasks = plugins.send("import_task_created", session=session, task=self)
-        if not tasks:
-            tasks = [self]
-        else:
-            # The plugins gave us a list of lists of tasks. Flatten it.
-            tasks = [t for inner in tasks for t in inner]
-        return tasks
+        plugin_tasks = plugins.send(
+            "import_task_created", session=session, task=self
+        )
+        if not plugin_tasks:
+            return [self]
+
+        # The plugins gave us a list of lists of tasks. Flatten it.
+        return [t for inner in plugin_tasks for t in inner]
 
     def lookup_candidates(self, search_ids: list[str]) -> None:
         """Retrieve and store candidates for this album.
@@ -404,7 +407,7 @@ class ImportTask(BaseImportTask):
 
         return duplicates
 
-    def align_album_level_fields(self):
+    def align_album_level_fields(self) -> None:
         """Make some album fields equal across `self.items`. For the
         RETAG action, we assume that the responsible for returning it
         (ie. a plugin) always ensures that the first item contains
@@ -452,8 +455,8 @@ class ImportTask(BaseImportTask):
         self,
         session: ImportSession,
         operation: util.MoveOperation | None = None,
-        write=False,
-    ):
+        write: bool = False,
+    ) -> None:
         """Copy, move, link, hardlink or reflink (depending on `operation`)
         the files as well as write metadata.
 
@@ -496,7 +499,7 @@ class ImportTask(BaseImportTask):
 
         plugins.send("import_task_files", session=session, task=self)
 
-    def add(self, lib: library.Library):
+    def add(self, lib: library.Library) -> None:
         """Add the items as an album to the library and remove replaced items."""
         self.align_album_level_fields()
         with lib.transaction():
@@ -516,7 +519,7 @@ class ImportTask(BaseImportTask):
 
             self.reimport_metadata(lib)
 
-    def record_replaced(self, lib: library.Library):
+    def record_replaced(self, lib: library.Library) -> None:
         """Records the replaced items and albums in the `replaced_items`
         and `replaced_albums` dictionaries.
         """
@@ -539,7 +542,7 @@ class ImportTask(BaseImportTask):
                     replaced_album_ids.add(dup_item.album_id)
                     self.replaced_albums[replaced_album.path] = replaced_album
 
-    def reimport_metadata(self, lib: library.Library):
+    def reimport_metadata(self, lib: library.Library) -> None:
         """For reimports, preserves metadata for reimported items and
         albums.
         """
@@ -621,7 +624,7 @@ class ImportTask(BaseImportTask):
                 )
                 item.store()
 
-    def remove_replaced(self, lib):
+    def remove_replaced(self, lib: library.Library) -> None:
         """Removes all the items from the library that have the same
         path as an item from this task.
         """
@@ -635,13 +638,13 @@ class ImportTask(BaseImportTask):
             len(self.imported_items()),
         )
 
-    def choose_match(self, session):
+    def choose_match(self, session: ImportSession) -> None:
         """Ask the session which match should apply and apply it."""
         choice = session.choose_match(self)
         self.set_choice(choice)
         session.log_choice(self)
 
-    def reload(self):
+    def reload(self) -> None:
         """Reload albums and items from the database."""
         for item in self.imported_items():
             item.load()
@@ -649,7 +652,7 @@ class ImportTask(BaseImportTask):
 
     # Utilities.
 
-    def prune(self, filename):
+    def prune(self, filename: util.PathBytes) -> None:
         """Prune any empty directories above the given file. If this
         task has no `toppath` or the file path provided is not within
         the `toppath`, then this function has no effect. Similarly, if
@@ -658,7 +661,7 @@ class ImportTask(BaseImportTask):
         """
         if self.toppath and not os.path.exists(util.syspath(filename)):
             util.prune_dirs(
-                os.path.dirname(filename),
+                os.path.dirname(os.fsdecode(filename)),
                 self.toppath,
                 clutter=config["clutter"].as_str_seq(),
             )
@@ -667,13 +670,15 @@ class ImportTask(BaseImportTask):
 class SingletonImportTask(ImportTask):
     """ImportTask for a single track that is not associated to an album."""
 
-    def __init__(self, toppath: util.PathBytes | None, item: library.Item):
+    def __init__(
+        self, toppath: util.PathBytes | None, item: library.Item
+    ) -> None:
         super().__init__(toppath, [item.path], [item])
         self.item = item
         self.is_album = False
         self.paths = [item.path]
 
-    def chosen_info(self):
+    def chosen_info(self) -> dict[str, Any]:
         """Return a dictionary of metadata about the current choice.
         May only be called when the choice flag is ASIS or RETAG
         (in which case the data comes from the files' current metadata)
@@ -682,14 +687,14 @@ class SingletonImportTask(ImportTask):
         assert self.choice_flag in (Action.ASIS, Action.RETAG, Action.APPLY)
         if self.choice_flag in (Action.ASIS, Action.RETAG):
             return dict(self.item)
-        if self.choice_flag is Action.APPLY:
+        if self.choice_flag is Action.APPLY and self.match:
             return self.match.info.copy()
-        return None
+        assert False
 
-    def imported_items(self):
+    def imported_items(self) -> list[library.Item]:
         return [self.item]
 
-    def _emit_imported(self, lib):
+    def _emit_imported(self, lib: library.Library) -> None:
         for item in self.imported_items():
             plugins.send("item_imported", lib=lib, item=item)
 
@@ -719,7 +724,7 @@ class SingletonImportTask(ImportTask):
 
     duplicate_items = find_duplicates
 
-    def remove_duplicates(self, lib: library.Library):
+    def remove_duplicates(self, lib: library.Library) -> None:
         duplicate_items = self.find_duplicates(lib)
         log.debug("removing {} old duplicated items", len(duplicate_items))
         for item in duplicate_items:
@@ -733,26 +738,26 @@ class SingletonImportTask(ImportTask):
                     clutter=config["clutter"].as_str_seq(),
                 )
 
-    def add(self, lib):
+    def add(self, lib: library.Library) -> None:
         with lib.transaction():
             self.record_replaced(lib)
             self.remove_replaced(lib)
             lib.add(self.item)
             self.reimport_metadata(lib)
 
-    def infer_album_fields(self):
+    def infer_album_fields(self) -> None:
         raise NotImplementedError
 
-    def choose_match(self, session: ImportSession):
+    def choose_match(self, session: ImportSession) -> None:
         """Ask the session which match should apply and apply it."""
         choice = session.choose_item(self)
         self.set_choice(choice)
         session.log_choice(self)
 
-    def reload(self):
+    def reload(self) -> None:
         self.item.load()
 
-    def set_fields(self, lib):
+    def set_fields(self, lib: library.Library) -> None:
         """Sets the fields given at CLI or configuration to the specified
         values, for the singleton item.
         """
@@ -780,16 +785,20 @@ class SentinelImportTask(ImportTask):
     indicates the progress in the `toppath` import.
     """
 
-    def __init__(self, toppath, paths):
+    def __init__(
+        self,
+        toppath: util.PathBytes | None,
+        paths: Iterable[util.PathBytes] | None,
+    ) -> None:
         super().__init__(toppath, paths, ())
         # TODO Remove the remaining attributes eventually
         self.is_album = True
         self.choice_flag = None
 
-    def save_history(self):
+    def save_history(self) -> None:
         pass
 
-    def save_progress(self):
+    def save_progress(self) -> None:
         if not self.paths:
             # "Done" sentinel.
             ImportState().progress_reset(self.toppath)
@@ -801,19 +810,19 @@ class SentinelImportTask(ImportTask):
     def skip(self) -> bool:
         return True
 
-    def set_choice(self, choice):
+    def set_choice(self, choice: Action | AlbumMatch | TrackMatch) -> None:
         raise NotImplementedError
 
-    def cleanup(self, copy=False, delete=False, move=False):
+    def cleanup(
+        self, copy: bool = False, delete: bool = False, move: bool = False
+    ) -> None:
         pass
 
-    def _emit_imported(self, lib):
+    def _emit_imported(self, lib: library.Library) -> None:
         pass
 
 
-ArchiveHandler = tuple[
-    Callable[[util.StrPath], bool], Callable[[util.StrPath], Any]
-]
+ArchiveHandler = tuple[Callable[[util.StrPath], bool], Callable[..., Any]]
 
 
 class ArchiveImportTask(SentinelImportTask):
@@ -833,7 +842,9 @@ class ArchiveImportTask(SentinelImportTask):
       non-move modes.
     """
 
-    def __init__(self, toppath):
+    toppath: util.PathBytes
+
+    def __init__(self, toppath: util.PathBytes) -> None:
         super().__init__(toppath, ())
         self.extracted = False
         # ``extract()`` reassigns ``self.toppath`` to the temp extraction
@@ -842,7 +853,7 @@ class ArchiveImportTask(SentinelImportTask):
         self.archive_path = toppath
 
     @classmethod
-    def is_archive(cls, path):
+    def is_archive(cls, path: str) -> bool:
         """Returns true if the given path points to an archive that can
         be handled.
         """
@@ -885,7 +896,9 @@ class ArchiveImportTask(SentinelImportTask):
 
         return _handlers
 
-    def cleanup(self, copy=False, delete=False, move=False):
+    def cleanup(
+        self, copy: bool = False, delete: bool = False, move: bool = False
+    ) -> None:
         """Remove the temporary extraction directory and optionally the archive.
 
         In ``move`` mode, if the extraction directory is empty after the
@@ -918,7 +931,7 @@ class ArchiveImportTask(SentinelImportTask):
                 util.displayable_path(self.archive_path),
             )
 
-    def extract(self):
+    def extract(self) -> None:
         """Extracts the archive to a temporary directory and sets
         `toppath` to that directory.
         """
@@ -928,7 +941,9 @@ class ArchiveImportTask(SentinelImportTask):
             if path_test(os.fsdecode(self.toppath)):
                 break
         else:
-            raise ValueError(f"No handler found for archive: {self.toppath}")
+            raise ValueError(
+                f"No handler found for archive: {util.displayable_path(self.toppath)}"
+            )
         extract_to = mkdtemp()
         archive = handler_class(os.fsdecode(self.toppath), mode="r")
         try:
@@ -949,7 +964,7 @@ class ArchiveImportTask(SentinelImportTask):
         finally:
             archive.close()
         self.extracted = True
-        self.toppath = extract_to
+        self.toppath = os.fsencode(extract_to)
 
 
 class ImportTaskFactory:
@@ -957,7 +972,7 @@ class ImportTaskFactory:
     indicated by a path.
     """
 
-    def __init__(self, toppath: util.PathBytes, session: ImportSession):
+    def __init__(self, toppath: util.PathBytes, session: ImportSession) -> None:
         """Create a new task factory.
 
         `toppath` is the user-specified path to search for music to
@@ -1008,7 +1023,7 @@ class ImportTaskFactory:
         # the extracted directory).
         yield archive_task or self.sentinel()
 
-    def _create(self, task: ImportTask | None):
+    def _create(self, task: ImportTask | None) -> list[ImportTask]:
         """Handle a new task to be emitted by the factory.
 
         Emit the `import_task_created` event and increment the
@@ -1021,7 +1036,9 @@ class ImportTaskFactory:
             return tasks
         return []
 
-    def paths(self):
+    def paths(
+        self,
+    ) -> Iterable[tuple[list[util.PathBytes], list[util.PathBytes]]]:
         """Walk `self.toppath` and yield `(dirs, files)` pairs where
         `files` are individual music files and `dirs` the set of
         containing directories where the music was found.
@@ -1041,7 +1058,7 @@ class ImportTaskFactory:
             for dirs, paths in albums_in_dir(self.toppath):
                 yield dirs, paths
 
-    def singleton(self, path: util.PathBytes):
+    def singleton(self, path: util.PathBytes) -> SingletonImportTask | None:
         """Return a `SingletonImportTask` for the music file."""
         if self.session.already_imported(self.toppath, [path]):
             log.debug(
@@ -1056,7 +1073,11 @@ class ImportTaskFactory:
             return SingletonImportTask(self.toppath, item)
         return None
 
-    def album(self, paths: Iterable[util.PathBytes], dirs=None):
+    def album(
+        self,
+        paths: Iterable[util.PathBytes],
+        dirs: list[util.PathBytes] | None = None,
+    ) -> ImportTask | None:
         """Return a `ImportTask` with all media files from paths.
 
         `dirs` is a list of parent directories used to record already
@@ -1082,13 +1103,15 @@ class ImportTaskFactory:
             return ImportTask(self.toppath, dirs, items)
         return None
 
-    def sentinel(self, paths: Iterable[util.PathBytes] | None = None):
+    def sentinel(
+        self, paths: Iterable[util.PathBytes] | None = None
+    ) -> SentinelImportTask:
         """Return a `SentinelImportTask` indicating the end of a
         top-level directory import.
         """
         return SentinelImportTask(self.toppath, paths)
 
-    def unarchive(self):
+    def unarchive(self) -> ArchiveImportTask | None:
         """Extract the archive for this `toppath`.
 
         Extract the archive to a new directory, adjust `toppath` to
@@ -1117,7 +1140,7 @@ class ImportTaskFactory:
         log.debug("Archive extracted to: {.toppath}", self)
         return archive_task
 
-    def read_item(self, path: util.PathBytes):
+    def read_item(self, path: util.PathBytes) -> library.Item | None:
         """Return an `Item` read from the path.
 
         If an item cannot be read, return `None` instead and log an
@@ -1144,6 +1167,7 @@ class ImportTaskFactory:
             if isinstance(exc.reason, mediafile.FileTypeError):
                 # Silently ignore other non-music files.
                 pass
+        return None
 
 
 _MULTIDISC_MARKERS = (
@@ -1160,7 +1184,9 @@ MULTIDISC_PATTERNS = [
 ]
 
 
-def is_subdir_of_any_in_list(path, dirs):
+def is_subdir_of_any_in_list(
+    path: util.PathBytes, dirs: list[util.PathBytes]
+) -> bool:
     """Returns True if path os a subdirectory of any directory in dirs
     (a list). In other case, returns False.
     """
@@ -1168,7 +1194,9 @@ def is_subdir_of_any_in_list(path, dirs):
     return any(d in ancestors for d in dirs)
 
 
-def albums_in_dir(path: util.PathBytes):
+def albums_in_dir(
+    path: util.PathBytes,
+) -> Iterable[tuple[list[util.PathBytes], list[util.PathBytes]]]:
     """Recursively searches the given directory and returns an iterable
     of (paths, items) where paths is a list of directories and items is
     a list of Items that is probably an album. Specifically, any folder

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -314,9 +314,9 @@ class ImportTask(BaseImportTask):
             self.save_history()
 
         self.cleanup(
-            copy=session.config["copy"],
-            delete=session.config["delete"],
-            move=session.config["move"],
+            copy=session.config["copy"].get(bool),
+            delete=session.config["delete"].get(bool),
+            move=session.config["move"].get(bool),
         )
 
         if not self.skip:

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -24,7 +24,7 @@ from collections import defaultdict
 from functools import cached_property, wraps
 from importlib import import_module
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar, overload
 
 import mediafile
 from typing_extensions import ParamSpec
@@ -639,6 +639,14 @@ def album_field_getters() -> TFuncMap[Album]:
 # Event dispatch.
 
 
+@overload
+def send(
+    event: Literal["import_task_created"], **arguments: Any
+) -> list[list[ImportTask]]: ...
+
+
+@overload
+def send(event: EventType, **arguments: Any) -> list[Any]: ...
 def send(event: EventType, **arguments: Any) -> list[Any]:
     """Send an event to all assigned event listeners.
 

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -1529,8 +1529,12 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
 
             self._set_art(task.album, candidate, not removal_enabled)
 
-            if removal_enabled and not self._is_candidate_fallback(candidate):
-                task.prune(candidate.path)
+            if (
+                removal_enabled
+                and not self._is_candidate_fallback(candidate)
+                and (path := candidate.path)
+            ):
+                task.prune(path)
 
     # Manual album art fetching.
     def commands(self) -> list[ui.Subcommand]:

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -27,12 +27,7 @@ from mediafile import MediaFile
 
 from beets import config, plugins, ui
 from beets.dbcore import types
-from beets.importer import (
-    Action,
-    ArchiveImportTask,
-    SentinelImportTask,
-    SingletonImportTask,
-)
+from beets.importer import Action, SingletonImportTask
 from beets.library import Item
 from beets.test.helper import (
     RUNNING_IN_CI,
@@ -136,18 +131,9 @@ class TestEvents(PluginImportHelper):
                 )
 
             def import_task_created_event(self, session, task):
-                if (
-                    isinstance(task, SingletonImportTask)
-                    or isinstance(task, SentinelImportTask)
-                    or isinstance(task, ArchiveImportTask)
-                ):
-                    return task
-
-                new_tasks = []
-                for item in task.items:
-                    new_tasks.append(SingletonImportTask(task.toppath, item))
-
-                return new_tasks
+                return [
+                    SingletonImportTask(task.toppath, i) for i in task.items
+                ]
 
         to_singleton_plugin = ToSingletonPlugin
         self.register_plugin(to_singleton_plugin)


### PR DESCRIPTION
- This change tightens typing across the importer pipeline, mainly in `beets.importer.session`, `beets.importer.stages`, `beets.importer.tasks`, `beets.importer.state`, and `beets.util.pipeline`.

- Architecturally, it makes the importer's core flow more explicit:
  - session methods now declare clear input/output types
  - pipeline stage message types are named and propagated through `Pipeline`
  - task classes expose more precise return values and argument types
  - plugin event dispatch for `import_task_created` now has a typed contract

- A small but important part of the change is switching importer config handling to work with `confuse` views more safely, using `.set(...)` and `.get(...)` instead of replacing values directly. This keeps config mutation aligned with the config system instead of treating it like a plain dict.

- There are also a few correctness-oriented fixes uncovered while adding types, such as:
  - keeping byte/string path handling consistent in importer task cleanup and archive extraction
  - making nullable values explicit before use
  - returning `None` in places that already behaved that way implicitly

- High-level impact: no feature change to importer behavior is intended. The main benefit is a clearer, more strongly typed importer architecture that is easier to reason about, safer to refactor, and better at catching edge cases during development.
