### PR TITLE
Fix titlecase template documentation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -87,6 +87,8 @@ Other changes
 - :doc:`plugins/spotify`: ``spotifysync`` now batches its SQLite commit for a
   sync run, follows the standard beets write-before-store pattern, and logs
   audio-features API unavailability only once per run.
+- :doc:`plugins/titlecase`: Correct the path format example and document the
+  ``%titlecase{text}`` template function. :bug:`6697`
 
 2.11.0 (May 06, 2026)
 ---------------------

--- a/docs/plugins/titlecase.rst
+++ b/docs/plugins/titlecase.rst
@@ -37,7 +37,7 @@ your path formatter, and set ``auto`` to ``no`` in the configuration.
 ::
 
     paths:
-      default: %titlecase($albumartist)/$titlecase($albumtitle)/$track $title
+      default: %titlecase{$albumartist}/%titlecase{$album}/$track $title
 
 You can now configure ``titlecase`` to your preference.
 

--- a/docs/reference/pathformat.rst
+++ b/docs/reference/pathformat.rst
@@ -317,6 +317,8 @@ constructs include:
   it belongs to.
 - ``%the{text}`` by :doc:`/plugins/the`: Moves English articles to ends of
   strings.
+- ``%titlecase{text}`` by :doc:`/plugins/titlecase`: Format text according to
+  title case guidelines.
 
 The :doc:`/plugins/inline` lets you define template fields in your beets
 configuration file using Python snippets. And for more advanced processing, you


### PR DESCRIPTION
## Summary

- Correct the titlecase plugin path example to use `%titlecase{...}` syntax.
- Use the documented `$album` field in that example.
- Add the titlecase plugin to the plugin-provided template functions list.
- Add an unreleased changelog note.

Fixes #6697.

## Testing

- `git diff --check`
- Loaded `beets/util/functemplate.py` directly with `python3` to verify the corrected syntax expands as a template function.

Full docs tooling was not available in this environment, so I could not run the Sphinx documentation build.