### PR TITLE
fix(ftintitle): parenthetical features

### DIFF
--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -676,9 +676,10 @@ def feat_tokens(
         feat_words += custom_words
     if for_artist:
         feat_words += ["with", "vs", "and", "con", "&"]
-    return (
-        rf"(?<=[\s(\[])(?:{'|'.join(re.escape(x) for x in feat_words)})(?=\s)"
-    )
+    tokens = "|".join(re.escape(x) for x in feat_words)
+    bracketed = rf"(?:(?<=\s)|^)(?:\(|\[)(?:{tokens})(?=\s)"
+    plain = rf"(?<=[\s(\[])(?:{tokens})(?=\s)"
+    return rf"(?:{bracketed}|{plain})"
 
 
 def apply_item_changes(

--- a/beetsplug/ftintitle.py
+++ b/beetsplug/ftintitle.py
@@ -51,6 +51,33 @@ DEFAULT_BRACKET_KEYWORDS: tuple[str, ...] = (
 )
 
 
+def _split_on_feat_token(
+    regex: re.Pattern[str], artist: str
+) -> tuple[str, str] | None:
+    match = regex.search(artist)
+    if not match:
+        return None
+
+    left = artist[: match.start()].strip()
+    right = artist[match.end() :].strip()
+    opener = match.group(0)[0]
+
+    if opener == "(":
+        closing = ")"
+    elif opener == "[":
+        closing = "]"
+    else:
+        closing = None
+
+    if closing:
+        if right.endswith(closing):
+            right = right[:-1].strip()
+        else:
+            left = f"{left} {opener}".strip()
+
+    return left, right
+
+
 def split_on_feat(
     artist: str, for_artist: bool = True, custom_words: list[str] | None = None
 ) -> tuple[str, str | None]:
@@ -65,8 +92,8 @@ def split_on_feat(
         plugins.feat_tokens(for_artist=False, custom_words=custom_words),
         re.IGNORECASE,
     )
-    parts = tuple(s.strip() for s in regex_explicit.split(artist, 1))
-    if len(parts) == 2:
+    parts = _split_on_feat_token(regex_explicit, artist)
+    if parts:
         return parts
 
     # Try comma as separator
@@ -80,12 +107,11 @@ def split_on_feat(
         regex = re.compile(
             plugins.feat_tokens(for_artist, custom_words), re.IGNORECASE
         )
-        parts = tuple(s.strip() for s in regex.split(artist, 1))
+        parts = _split_on_feat_token(regex, artist)
+        if parts:
+            return parts
 
-    if len(parts) == 1:
-        return parts[0], None
-    assert len(parts) == 2  # help mypy out
-    return parts
+    return artist.strip(), None
 
 
 def contains_feat(title: str, custom_words: list[str] | None = None) -> bool:
@@ -105,6 +131,11 @@ def find_feat_part(
     """Attempt to find featured artists in the item's artist fields and
     return the results. Returns None if no featured artist found.
     """
+    # If the album artist is featured, move the remaining artist to the title.
+    artist_part, feat_part = split_on_feat(artist, custom_words=custom_words)
+    if albumartist and feat_part == albumartist and artist_part:
+        return artist_part
+
     # Handle a wider variety of extraction cases if the album artist is
     # contained within the track artist.
     if albumartist and albumartist in artist:

--- a/test/plugins/test_ftintitle.py
+++ b/test/plugins/test_ftintitle.py
@@ -115,6 +115,13 @@ class TestFtInTitlePluginFunctional(PluginTestHelper):
                 ("Alice", "Song 1 with Bob"),
                 id="custom-format-with",
             ),
+            pytest.param(
+                {"format": "ft. {}"},
+                ("ftintitle",),
+                ("Alice (ft. Bob)", "Song 1", "Alice"),
+                ("Alice", "Song 1 ft. Bob"),
+                id="featured-artist-in-parentheses",
+            ),
             # ---- keep_in_artist variants ----
             pytest.param(
                 {"format": "feat. {}", "keep_in_artist": True},
@@ -249,6 +256,8 @@ class TestFtInTitlePluginFunctional(PluginTestHelper):
         ("Alice & Bob", "Alice", "Bob"),
         ("Alice and Bob", "Alice", "Bob"),
         ("Alice With Bob", "Alice", "Bob"),
+        ("Alice (ft. Bob)", "Alice", "Bob"),
+        ("Alice [ft. Bob]", "Bob", "Alice"),
         ("Alice defeat Bob", "Alice", None),
         ("Alice & Bob", "Bob", "Alice"),
         ("Alice ft. Bob", "Bob", "Alice"),
@@ -281,6 +290,8 @@ def test_find_feat_part(
         ("Alice & Bob ft. Charlie", ("Alice & Bob", "Charlie")),
         ("Alice & Bob featuring Charlie", ("Alice & Bob", "Charlie")),
         ("Alice and Bob feat Charlie", ("Alice and Bob", "Charlie")),
+        ("Alice (ft. Bob)", ("Alice", "Bob")),
+        ("Alice [& Bob]", ("Alice", "Bob")),
     ],
 )
 def test_split_on_feat(given: str, expected: tuple[str, str | None]) -> None:


### PR DESCRIPTION
## Description

Fixes https://github.com/beetbox/beets/issues/6715: `ftintitle` handling for featured artists wrapped in parentheses or square brackets.

Before this change, parenthetical features were split at the feature token but the surrounding delimiters were left behind on both sides. For example:
```text
Alice (ft. Bob) - Song
```

became:

```text
Alice ( - Song ft. Bob)
```

With this PR, we get the intended:

```text
Alice - Song ft. Bob
```

The same cleanup applies to square brackets, e.g. `Alice [ft. Bob]`.

## Details

- Strip a matching `()` or `[]` pair when it encloses the feature marker split.
- Ensures artist names with parens or brackets retain them, e.g. `Alice ft. (Bob)` still extracts `(Bob)`.
- Handle album-artist matching when the album artist is the bracketed featured artist, e.g. `Alice [ft. Bob]` on Bob’s album extracts `Alice`.
- Doc update explaining the behavior.

## Tests

- Added focused `ftintitle` cases for:
  - functional parenthetical feature cleanup
  - bracketed `find_feat_part` album-artist behavior
  - `split_on_feat` delimiter cleanup and non-cleanup boundaries

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
