### PR TITLE
Update move command to handle missing files gracefully

### DIFF
--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -1139,7 +1139,14 @@ class Item(LibModel):
         if not os.path.exists(syspath(self.path)):
             log.warning(
                 "{}: file not found at {.filepath}, skipping",
-                "Moving" if operation == MoveOperation.MOVE else "Copying",
+                {
+                    MoveOperation.MOVE: "Moving",
+                    MoveOperation.COPY: "Copying",
+                    MoveOperation.LINK: "Linking",
+                    MoveOperation.HARDLINK: "Hardlinking",
+                    MoveOperation.REFLINK: "Reflinking",
+                    MoveOperation.REFLINK_AUTO: "Reflinking",
+                }[operation],
                 self,
             )
             return

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -1136,7 +1136,7 @@ class Item(LibModel):
         dest = self.destination(basedir=basedir)
 
         # If the source file is missing, skip the move.
-        if not os.path.exists(syspath(self.path)):
+        if not self.filepath.exists():
             log.warning(
                 "{}: file not found at {.filepath}, skipping",
                 {

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -394,12 +394,16 @@ class Album(LibModel):
             for item in self.items():
                 item.remove(delete, False)
 
-    def move_art(self, operation=MoveOperation.MOVE):
+    def move_art(self, operation=MoveOperation.MOVE, item_dir=None):
         """Move, copy, link or hardlink (depending on `operation`) any
         existing album art so that it remains in the same directory as
         the items.
 
         `operation` should be an instance of `util.MoveOperation`.
+
+        `item_dir` may be provided to specify the target directory for
+        the art. If not provided, the directory of the album's first
+        item is used.
         """
         old_art = self.artpath
         if not old_art:
@@ -413,7 +417,7 @@ class Album(LibModel):
             self.artpath = None
             return
 
-        new_art = self.art_destination(old_art)
+        new_art = self.art_destination(old_art, item_dir=item_dir)
         if new_art == old_art:
             return
 
@@ -466,11 +470,15 @@ class Album(LibModel):
 
         # Move items.
         items = list(self.items())
+        moved_item_dir = None
         for item in items:
+            old_path = item.path
             item.move(operation, basedir=basedir, with_album=False, store=store)
+            if moved_item_dir is None and item.path != old_path:
+                moved_item_dir = os.path.dirname(item.path)
 
         # Move art.
-        self.move_art(operation)
+        self.move_art(operation, item_dir=moved_item_dir)
         if store:
             self.store()
 
@@ -1126,6 +1134,15 @@ class Item(LibModel):
         have to be manually stored after invoking this method.
         """
         dest = self.destination(basedir=basedir)
+
+        # If the source file is missing, skip the move.
+        if not os.path.exists(syspath(self.path)):
+            log.warning(
+                "{}: file not found at {.filepath}, skipping",
+                "Moving" if operation == MoveOperation.MOVE else "Copying",
+                self,
+            )
+            return
 
         # Create necessary ancestry for the move.
         util.mkdirall(dest)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -73,6 +73,9 @@ Bug fixes
   awkward indentation in CLI output.
 - :doc:`plugins/spotify`: Improved Spotify API parsing to handle missing label
   data :bug:`6679`
+- :ref:`move-cmd`: ``beet move`` no longer crashes when an item referenced in
+  the database has been deleted from disk. Missing items are now skipped with a
+  warning and the command continues. :bug:`6720`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~

--- a/test/ui/commands/test_move.py
+++ b/test/ui/commands/test_move.py
@@ -127,7 +127,7 @@ class MoveTest(BeetsTestCase):
         self.i.load()
         i2.load()
         assert self.i.path == old_i_path
-        assert b"libdir" in i2.path
+        assert i2.path.startswith(self.libdir)
         assert i2.filepath.exists()
 
     def test_move_item_skips_missing_file(self):

--- a/test/ui/commands/test_move.py
+++ b/test/ui/commands/test_move.py
@@ -1,8 +1,10 @@
+import os
 import shutil
 
 from beets import library
 from beets.test.helper import BeetsTestCase
 from beets.ui.commands.move import move_items
+from beets.util import syspath
 
 
 class MoveTest(BeetsTestCase):
@@ -100,3 +102,37 @@ class MoveTest(BeetsTestCase):
         self.i.load()
         assert self.i.filepath == self.initial_item_path
         assert not self.otherdir.exists()
+
+    def test_move_missing_singleton_continues(self):
+        self.i.load()
+        old_path = self.i.path
+        os.remove(syspath(old_path))
+        self._move()
+        self.i.load()
+        assert self.i.path == old_path
+
+    def test_move_album_with_missing_track(self):
+        self.i.load()
+        old_i_path = self.i.path
+        os.remove(syspath(old_i_path))
+
+        i2_path = self.lib_path / "srcfile2"
+        shutil.copy(self.resource_path, i2_path)
+        i2 = library.Item.from_path(i2_path)
+        self.lib.add(i2)
+        i2.album_id = self.album.id
+        i2.store()
+
+        self._move(album=True)
+        self.i.load()
+        i2.load()
+        assert self.i.path == old_i_path
+        assert b"libdir" in i2.path
+        assert i2.filepath.exists()
+
+    def test_move_item_skips_missing_file(self):
+        self.i.load()
+        old_path = self.i.path
+        os.remove(syspath(old_path))
+        self.i.move()
+        assert self.i.path == old_path


### PR DESCRIPTION
## Description

Fixes #6720 

Changes: :
- Added a guard at the top that checks `os.path.exists(syspath(self.path))`. If the source file is missing, logs a warning and returns early, preventing the crash and allowing the loop to continue to the next item.
- Added optional `item_dir` parameter passed through to `art_destination()`, so album art can be placed in the correct directory when the first item is missing.

- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
