### PR TITLE
Add %tunique{} path template function for track disambiguation within albums

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -97,6 +97,11 @@ sunique:
     disambiguators: year trackdisambig
     bracket: '[]'
 
+tunique:
+    keys: title
+    disambiguators: track disc artist
+    bracket: '[]'
+
 # --------------- Tagging ---------------
 
 per_disc_numbering: no

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -99,7 +99,7 @@ sunique:
 
 tunique:
     keys: title
-    disambiguators: track disc artist
+    disambiguators: disc track artist
     bracket: '[]'
 
 # --------------- Tagging ---------------

--- a/beets/library/library.py
+++ b/beets/library/library.py
@@ -53,6 +53,11 @@ class Library(dbcore.Database):
     _memotable: dict[
         tuple[str | None, str | None, str | None, str | None, int | None], str
     ]
+    # Caches the per-collision-group work shared by every member of a group.
+    _group_memotable: dict[
+        tuple[str | None, str | None, str | None, int | None, tuple[str, ...]],
+        tuple[int, str | None],
+    ]
     replacements: Replacements
 
     @cached_property
@@ -87,6 +92,7 @@ class Library(dbcore.Database):
 
         self.replacements = self.get_replacements()
         self._memotable = {}
+        self._group_memotable = {}
 
     @contextmanager
     def music_dir_context(self) -> Iterator[Library]:
@@ -104,6 +110,7 @@ class Library(dbcore.Database):
         """
         obj.add(self)
         self._memotable = {}
+        self._group_memotable = {}
         return obj.id
 
     def add_album(self, items: Sequence[Item]) -> Album:
@@ -131,6 +138,8 @@ class Library(dbcore.Database):
                 else:
                     item.store()
 
+        self._memotable = {}
+        self._group_memotable = {}
         return album
 
     # Querying.

--- a/beets/library/library.py
+++ b/beets/library/library.py
@@ -50,7 +50,9 @@ class Library(dbcore.Database):
     )
 
     # Used for template substitution performance.
-    _memotable: dict[tuple[str | None, str | None, str | None, int | None], str]
+    _memotable: dict[
+        tuple[str | None, str | None, str | None, str | None, int | None], str
+    ]
     replacements: Replacements
 
     @cached_property

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -1467,6 +1467,56 @@ class DefaultTemplateFunctions:
             lambda i: i.album_id is not None,
         )
 
+    def tmpl_tunique(
+        self,
+        keys: str | None = None,
+        disam: str | None = None,
+        bracket: str | None = None,
+    ) -> str:
+        """Generate a string that is guaranteed to be unique among all
+        items in the same album that share the same set of keys.
+
+        A field from "disam" is used in the string if one is sufficient to
+        disambiguate the tracks. Otherwise, a fallback opaque value is
+        used. Both "keys" and "disam" should be given as
+        whitespace-separated lists of field names, while "bracket" is a
+        pair of characters to be used as brackets surrounding the
+        disambiguator or empty to have no brackets.
+        """
+        if not self.item or not self.lib:
+            return ""
+
+        if isinstance(self.item, Item):
+            item_id = self.item.id
+        else:
+            raise NotImplementedError("tunique is only implemented for items")
+
+        if item_id is None:
+            return ""
+
+        # Only applies to items in an album.
+        album_id = self.item.get("album_id")
+        if album_id is None:
+            return ""
+
+        resolved_keys = keys or beets.config["tunique"]["keys"].as_str()
+        key_fields = resolved_keys.split() or ["title"]
+        query = dbcore.AndQuery(
+            [dbcore.MatchQuery(f, self.item.get(f)) for f in key_fields]
+            + [dbcore.MatchQuery("album_id", album_id)]
+        )
+
+        return self._tmpl_unique(
+            "tunique",
+            keys,
+            disam,
+            bracket,
+            item_id,
+            self.item,
+            lambda i: i.album_id is None,
+            query=query,
+        )
+
     def _tmpl_unique_memokey(
         self,
         name: str | None,
@@ -1488,6 +1538,7 @@ class DefaultTemplateFunctions:
         item_id: int,
         db_item: LibModel,
         skip_item: Callable[[LibModel], bool],
+        query: dbcore.Query | None = None,
     ) -> str:
         """Generate a string that is guaranteed to be unique among all items of
         the same type as "db_item" who share the same set of keys.
@@ -1506,8 +1557,8 @@ class DefaultTemplateFunctions:
         "skip_item" is a function that must return True when the template
         should return an empty string.
 
-        "initial_subqueries" is a list of subqueries that should be included
-        in the query to find the ambiguous items.
+        "query" is a pre-built query to use instead of building one from
+        ``db_item.duplicates_query(keys)``.
         """
         lib = self.lib
         if lib is None:
@@ -1538,26 +1589,27 @@ class DefaultTemplateFunctions:
             bracket_r = ""
 
         # Find matching items to disambiguate with.
-        query = db_item.duplicates_query(keys_list)
-        ambigous_items = (
+        if query is None:
+            query = db_item.duplicates_query(keys_list)
+        ambiguous_items = (
             lib.items(query) if isinstance(db_item, Item) else lib.albums(query)
         )
 
         # If there's only one item to matching these details, then do
         # nothing.
-        if len(ambigous_items) == 1:
+        if len(ambiguous_items) == 1:
             lib._memotable[memokey] = ""
             return ""
 
         # Find the first disambiguator that distinguishes the items.
         for disambiguator in disam_list:
             # Get the value for each item for the current field.
-            disam_values = {s.get(disambiguator, "") for s in ambigous_items}
+            disam_values = {s.get(disambiguator, "") for s in ambiguous_items}
 
             # If the set of unique values is equal to the number of
             # items in the disambiguation set, we're done -- this is
             # sufficient disambiguation.
-            if len(disam_values) == len(ambigous_items):
+            if len(disam_values) == len(ambiguous_items):
                 break
         else:
             # No disambiguator distinguished all fields.

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -1503,7 +1503,10 @@ class DefaultTemplateFunctions:
         resolved_keys = keys or beets.config["tunique"]["keys"].as_str()
         key_fields = resolved_keys.split() or ["title"]
         query = dbcore.AndQuery(
-            [dbcore.MatchQuery(f, self.item.get(f)) for f in key_fields]
+            [
+                self.item.field_query(f, self.item.get(f), dbcore.MatchQuery)
+                for f in key_fields
+            ]
             + [dbcore.MatchQuery("album_id", album_id)]
         )
 
@@ -1603,9 +1606,15 @@ class DefaultTemplateFunctions:
             return ""
 
         # Find the first disambiguator that distinguishes the items.
+        # Use path-formatted values so separators like "/" in "AC/DC"
+        # are treated as they appear on disk (e.g., "AC_DC" after
+        # path_sep_replace).
         for disambiguator in disam_list:
             # Get the value for each item for the current field.
-            disam_values = {s.get(disambiguator, "") for s in ambiguous_items}
+            disam_values = {
+                s.formatted(for_path=True).get(disambiguator)
+                for s in ambiguous_items
+            }
 
             # If the set of unique values is equal to the number of
             # items in the disambiguation set, we're done -- this is

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -1163,6 +1163,7 @@ class Item(LibModel):
             )
 
         self.db._memotable = {}
+        self.db._group_memotable = {}
 
     def move(
         self,
@@ -1427,6 +1428,8 @@ class DefaultTemplateFunctions:
         if album_id is None:
             return ""
 
+        if bracket is None:
+            bracket = beets.config["aunique"]["bracket"].as_str()
         memokey = self._tmpl_unique_memokey(
             "aunique", keys, disam, bracket, album_id
         )
@@ -1534,6 +1537,7 @@ class DefaultTemplateFunctions:
             self.item,
             lambda i: i.album_id is None,
             query=query,
+            scope_id=album_id,
         )
 
     def _tmpl_unique_memokey(
@@ -1547,8 +1551,6 @@ class DefaultTemplateFunctions:
         """Get the memokey for the unique template named "name" for the
         specific parameters.
         """
-        if bracket is None and name is not None:
-            bracket = beets.config[name]["bracket"].as_str()
         return (name, keys, disam, bracket, item_id)
 
     def _tmpl_unique(
@@ -1561,6 +1563,7 @@ class DefaultTemplateFunctions:
         db_item: LibModel,
         skip_item: Callable[[LibModel], bool],
         query: dbcore.Query | None = None,
+        scope_id: int | None = None,
     ) -> str:
         """Generate a string that is guaranteed to be unique among all items of
         the same type as "db_item" who share the same set of keys.
@@ -1586,19 +1589,18 @@ class DefaultTemplateFunctions:
         if lib is None:
             return ""
 
+        if skip_item(db_item):
+            return ""
+
+        if bracket is None:
+            bracket = beets.config[name]["bracket"].as_str()
         memokey = self._tmpl_unique_memokey(name, keys, disam, bracket, item_id)
         memoval = lib._memotable.get(memokey)
         if memoval is not None:
             return memoval
 
-        if skip_item(db_item):
-            lib._memotable[memokey] = ""
-            return ""
-
         keys = keys or beets.config[name]["keys"].as_str()
         disam = disam or beets.config[name]["disambiguators"].as_str()
-        if bracket is None:
-            bracket = beets.config[name]["bracket"].as_str()
         keys_list = keys.split()
         disam_list = disam.split()
 
@@ -1610,47 +1612,54 @@ class DefaultTemplateFunctions:
             bracket_l = ""
             bracket_r = ""
 
-        # Find matching items to disambiguate with.
-        if query is None:
-            query = db_item.duplicates_query(keys_list)
-        candidate_items = (
-            lib.items(query) if isinstance(db_item, Item) else lib.albums(query)
-        )
-
         def normalized_field(item: LibModel, field: str) -> str:
             value = item.formatted(for_path=True).get(field)
             if beets.config["asciify_paths"]:
                 value = util.asciify_path(value)
             return util.sanitize_path(value, lib.replacements)
 
+        # Every member of a collision group reaches the same conclusion about
+        # which disambiguator to use, so compute it once per group.
         key_values = tuple(normalized_field(db_item, key) for key in keys_list)
-        ambiguous_items = [
-            item
-            for item in candidate_items
-            if tuple(normalized_field(item, key) for key in keys_list)
-            == key_values
-        ]
+        groupkey = (name, keys, disam, scope_id, key_values)
+        if (group := lib._group_memotable.get(groupkey)) is None:
+            scope_query = (
+                db_item.duplicates_query(keys_list) if query is None else query
+            )
+            candidate_items = (
+                lib.items(scope_query)
+                if isinstance(db_item, Item)
+                else lib.albums(scope_query)
+            )
+            ambiguous_items = [
+                item
+                for item in candidate_items
+                if tuple(normalized_field(item, key) for key in keys_list)
+                == key_values
+            ]
+
+            disambiguator = None
+            for candidate in disam_list:
+                disam_values = {
+                    normalized_field(item, candidate)
+                    for item in ambiguous_items
+                }
+                if len(disam_values) == len(ambiguous_items):
+                    disambiguator = candidate
+                    break
+
+            group = (len(ambiguous_items), disambiguator)
+            lib._group_memotable[groupkey] = group
+
+        ambiguous_count, disambiguator = group
 
         # If there's only one item to matching these details, then do
         # nothing.
-        if len(ambiguous_items) == 1:
+        if ambiguous_count <= 1:
             lib._memotable[memokey] = ""
             return ""
 
-        # Find the first disambiguator that distinguishes the items.
-        for disambiguator in disam_list:
-            # Get the value for each item for the current field.
-            disam_values = {
-                normalized_field(item, disambiguator)
-                for item in ambiguous_items
-            }
-
-            # If the set of unique values is equal to the number of
-            # items in the disambiguation set, we're done -- this is
-            # sufficient disambiguation.
-            if len(disam_values) == len(ambiguous_items):
-                break
-        else:
+        if disambiguator is None:
             # No disambiguator distinguished all fields.
             res = f" {bracket_l}{item_id}{bracket_r}"
             lib._memotable[memokey] = res

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -1468,6 +1468,56 @@ class DefaultTemplateFunctions:
             lambda i: i.album_id is not None,
         )
 
+    def tmpl_tunique(
+        self,
+        keys: str | None = None,
+        disam: str | None = None,
+        bracket: str | None = None,
+    ) -> str:
+        """Generate a string that is guaranteed to be unique among all
+        items in the same album that share the same set of keys.
+
+        A field from "disam" is used in the string if one is sufficient to
+        disambiguate the tracks. Otherwise, a fallback opaque value is
+        used. Both "keys" and "disam" should be given as
+        whitespace-separated lists of field names, while "bracket" is a
+        pair of characters to be used as brackets surrounding the
+        disambiguator or empty to have no brackets.
+        """
+        if not self.item or not self.lib:
+            return ""
+
+        if isinstance(self.item, Item):
+            item_id = self.item.id
+        else:
+            raise NotImplementedError("tunique is only implemented for items")
+
+        if item_id is None:
+            return ""
+
+        # Only applies to items in an album.
+        album_id = self.item.get("album_id")
+        if album_id is None:
+            return ""
+
+        resolved_keys = keys or beets.config["tunique"]["keys"].as_str()
+        key_fields = resolved_keys.split() or ["title"]
+        query = dbcore.AndQuery(
+            [dbcore.MatchQuery(f, self.item.get(f)) for f in key_fields]
+            + [dbcore.MatchQuery("album_id", album_id)]
+        )
+
+        return self._tmpl_unique(
+            "tunique",
+            keys,
+            disam,
+            bracket,
+            item_id,
+            self.item,
+            lambda i: i.album_id is None,
+            query=query,
+        )
+
     def _tmpl_unique_memokey(
         self,
         name: str | None,
@@ -1489,6 +1539,7 @@ class DefaultTemplateFunctions:
         item_id: int,
         db_item: LibModel,
         skip_item: Callable[[LibModel], bool],
+        query: dbcore.Query | None = None,
     ) -> str:
         """Generate a string that is guaranteed to be unique among all items of
         the same type as "db_item" who share the same set of keys.
@@ -1507,8 +1558,8 @@ class DefaultTemplateFunctions:
         "skip_item" is a function that must return True when the template
         should return an empty string.
 
-        "initial_subqueries" is a list of subqueries that should be included
-        in the query to find the ambiguous items.
+        "query" is a pre-built query to use instead of building one from
+        ``db_item.duplicates_query(keys)``.
         """
         lib = self.lib
         if lib is None:
@@ -1539,26 +1590,27 @@ class DefaultTemplateFunctions:
             bracket_r = ""
 
         # Find matching items to disambiguate with.
-        query = db_item.duplicates_query(keys_list)
-        ambigous_items = (
+        if query is None:
+            query = db_item.duplicates_query(keys_list)
+        ambiguous_items = (
             lib.items(query) if isinstance(db_item, Item) else lib.albums(query)
         )
 
         # If there's only one item to matching these details, then do
         # nothing.
-        if len(ambigous_items) == 1:
+        if len(ambiguous_items) == 1:
             lib._memotable[memokey] = ""
             return ""
 
         # Find the first disambiguator that distinguishes the items.
         for disambiguator in disam_list:
             # Get the value for each item for the current field.
-            disam_values = {s.get(disambiguator, "") for s in ambigous_items}
+            disam_values = {s.get(disambiguator, "") for s in ambiguous_items}
 
             # If the set of unique values is equal to the number of
             # items in the disambiguation set, we're done -- this is
             # sufficient disambiguation.
-            if len(disam_values) == len(ambigous_items):
+            if len(disam_values) == len(ambiguous_items):
                 break
         else:
             # No disambiguator distinguished all fields.

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -1427,7 +1427,9 @@ class DefaultTemplateFunctions:
         if album_id is None:
             return ""
 
-        memokey = self._tmpl_unique_memokey("aunique", keys, disam, album_id)
+        memokey = self._tmpl_unique_memokey(
+            "aunique", keys, disam, bracket, album_id
+        )
         memoval = self.lib._memotable.get(memokey)
         if memoval is not None:
             return memoval
@@ -1518,18 +1520,14 @@ class DefaultTemplateFunctions:
             return ""
 
         resolved_keys = keys or beets.config["tunique"]["keys"].as_str()
-        key_fields = resolved_keys.split() or ["title"]
-        query = dbcore.AndQuery(
-            [
-                self.item.field_query(f, self.item.get(f), dbcore.MatchQuery)
-                for f in key_fields
-            ]
-            + [dbcore.MatchQuery("album_id", album_id)]
-        )
+        if not resolved_keys.split():
+            resolved_keys = "title"
+
+        query = self.item.field_query("album_id", album_id, dbcore.MatchQuery)
 
         return self._tmpl_unique(
             "tunique",
-            keys,
+            resolved_keys,
             disam,
             bracket,
             item_id,
@@ -1543,12 +1541,15 @@ class DefaultTemplateFunctions:
         name: str | None,
         keys: str | None,
         disam: str | None,
+        bracket: str | None,
         item_id: int | None,
-    ) -> tuple[str | None, str | None, str | None, int | None]:
+    ) -> tuple[str | None, str | None, str | None, str | None, int | None]:
         """Get the memokey for the unique template named "name" for the
         specific parameters.
         """
-        return (name, keys, disam, item_id)
+        if bracket is None and name is not None:
+            bracket = beets.config[name]["bracket"].as_str()
+        return (name, keys, disam, bracket, item_id)
 
     def _tmpl_unique(
         self,
@@ -1578,14 +1579,14 @@ class DefaultTemplateFunctions:
         "skip_item" is a function that must return True when the template
         should return an empty string.
 
-        "query" is a pre-built query to use instead of building one from
-        ``db_item.duplicates_query(keys)``.
+        "query" is a pre-built query selecting candidate items instead of
+        using ``db_item.duplicates_query(keys)``.
         """
         lib = self.lib
         if lib is None:
             return ""
 
-        memokey = self._tmpl_unique_memokey(name, keys, disam, item_id)
+        memokey = self._tmpl_unique_memokey(name, keys, disam, bracket, item_id)
         memoval = lib._memotable.get(memokey)
         if memoval is not None:
             return memoval
@@ -1612,9 +1613,23 @@ class DefaultTemplateFunctions:
         # Find matching items to disambiguate with.
         if query is None:
             query = db_item.duplicates_query(keys_list)
-        ambiguous_items = (
+        candidate_items = (
             lib.items(query) if isinstance(db_item, Item) else lib.albums(query)
         )
+
+        def normalized_field(item: LibModel, field: str) -> str:
+            value = item.formatted(for_path=True).get(field)
+            if beets.config["asciify_paths"]:
+                value = util.asciify_path(value)
+            return util.sanitize_path(value, lib.replacements)
+
+        key_values = tuple(normalized_field(db_item, key) for key in keys_list)
+        ambiguous_items = [
+            item
+            for item in candidate_items
+            if tuple(normalized_field(item, key) for key in keys_list)
+            == key_values
+        ]
 
         # If there's only one item to matching these details, then do
         # nothing.
@@ -1623,14 +1638,11 @@ class DefaultTemplateFunctions:
             return ""
 
         # Find the first disambiguator that distinguishes the items.
-        # Use path-formatted values so separators like "/" in "AC/DC"
-        # are treated as they appear on disk (e.g., "AC_DC" after
-        # path_sep_replace).
         for disambiguator in disam_list:
             # Get the value for each item for the current field.
             disam_values = {
-                s.formatted(for_path=True).get(disambiguator)
-                for s in ambiguous_items
+                normalized_field(item, disambiguator)
+                for item in ambiguous_items
             }
 
             # If the set of unique values is equal to the number of

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,11 @@ Unreleased
 New features
 ~~~~~~~~~~~~
 
+- :ref:`tunique` (``%tunique{}``): New path template function to disambiguate
+  tracks within the same album that share the same title (e.g., identical-titled
+  tracks on different discs). It has the same arguments as :ref:`%aunique
+  <aunique>`; the default identifiers are ``title`` and the default
+  disambiguators are ``track disc artist``.
 - :ref:`duplicate_action`: Add an ``upgrade`` option that replaces individual
   duplicate tracks only if the new copy has a higher bitrate, adds any genuinely
   new tracks, and keeps the album together rather than splitting it. :bug:`4471`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,9 +9,14 @@ below!
 Unreleased
 ----------
 
-..
-    New features
-    ~~~~~~~~~~~~
+New features
+~~~~~~~~~~~~
+
+- :ref:`tunique` (``%tunique{}``): New path template function to disambiguate
+  tracks within the same album that share the same title (e.g., identical-titled
+  tracks on different discs). It has the same arguments as :ref:`%aunique
+  <aunique>`; the default identifiers are ``title`` and the default
+  disambiguators are ``track disc artist``.
 
 ..
     Bug fixes
@@ -31,11 +36,6 @@ Unreleased
 New features
 ~~~~~~~~~~~~
 
-- :ref:`tunique` (``%tunique{}``): New path template function to disambiguate
-  tracks within the same album that share the same title (e.g., identical-titled
-  tracks on different discs). It has the same arguments as :ref:`%aunique
-  <aunique>`; the default identifiers are ``title`` and the default
-  disambiguators are ``track disc artist``.
 - :doc:`plugins/plexupdate`: Add ``beet plexupdate --auth``, an interactive
   plex.tv login following Plex' traditional PIN authentication flow: the access
   token for the local server is stored in a token file. The manual ``token``

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,11 @@ Unreleased
 New features
 ~~~~~~~~~~~~
 
+- :ref:`tunique` (``%tunique{}``): New path template function to disambiguate
+  tracks within the same album that share the same title (e.g., identical-titled
+  tracks on different discs). It has the same arguments as :ref:`%aunique
+  <aunique>`; the default identifiers are ``title`` and the default
+  disambiguators are ``track disc artist``.
 - :doc:`plugins/plexupdate`: Add ``beet plexupdate --auth``, an interactive
   plex.tv login following Plex' traditional PIN authentication flow: the access
   token for the local server is stored in a token file. The manual ``token``

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -378,6 +378,26 @@ The defaults look like this:
 
 See :ref:`sunique` for more details.
 
+.. _config-tunique:
+
+tunique
+~~~~~~~
+
+Like :ref:`config-aunique` above for albums, these options control the
+generation of a unique string to disambiguate tracks that share the same title
+within an album.
+
+The defaults look like this:
+
+::
+
+    tunique:
+        keys: title
+        disambiguators: track disc artist
+        bracket: '[]'
+
+See :ref:`tunique` for more details.
+
 .. _terminal_encoding:
 
 terminal_encoding

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -389,6 +389,26 @@ The defaults look like this:
 
 See :ref:`sunique` for more details.
 
+.. _config-tunique:
+
+tunique
+~~~~~~~
+
+Like :ref:`config-aunique` above for albums, these options control the
+generation of a unique string to disambiguate tracks that share the same title
+within an album.
+
+The defaults look like this:
+
+::
+
+    tunique:
+        keys: title
+        disambiguators: track disc artist
+        bracket: '[]'
+
+See :ref:`tunique` for more details.
+
 .. _terminal_encoding:
 
 terminal_encoding

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -404,7 +404,7 @@ The defaults look like this:
 
     tunique:
         keys: title
-        disambiguators: track disc artist
+        disambiguators: disc track artist
         bracket: '[]'
 
 See :ref:`tunique` for more details.

--- a/docs/reference/pathformat.rst
+++ b/docs/reference/pathformat.rst
@@ -179,6 +179,19 @@ It has the same arguments as the :ref:`%aunique <aunique>` template, but the
 default values are different. The default identifiers are ``artist title`` and
 the default disambiguators are ``year trackdisambig``.
 
+.. _tunique:
+
+Track Disambiguation
+--------------------
+
+Some tracks on the same album might share the same title (e.g., identical-titled
+tracks on different discs). Beets provides the ``%tunique{}`` template to avoid
+giving these tracks the same file path.
+
+It has the same arguments as the :ref:`%aunique <aunique>` template, but the
+default values are different. The default identifiers are ``title`` and the
+default disambiguators are ``track disc artist``.
+
 Syntax Details
 --------------
 

--- a/docs/reference/pathformat.rst
+++ b/docs/reference/pathformat.rst
@@ -190,7 +190,7 @@ giving these tracks the same file path.
 
 It has the same arguments as the :ref:`%aunique <aunique>` template, but the
 default values are different. The default identifiers are ``title`` and the
-default disambiguators are ``track disc artist``.
+default disambiguators are ``disc track artist``.
 
 Syntax Details
 --------------

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -875,6 +875,123 @@ class TestSingletonDisambiguation(TestHelper, PathFormattingMixin):
         self._assert_dest(b"/base/foo/the title", i1)
 
 
+class TestTrackDisambiguation(TestHelper, PathFormattingMixin):
+    @pytest.fixture(autouse=True)
+    def items(self, setup):
+        self.lib.directory = b"/base"
+        self.lib.path_formats = [("default", "path")]
+
+        i1 = item()
+        i1.title = "Common Title"
+        i1.track = 7
+        i1.disc = 1
+        i1.artist = "Some Artist"
+        i2 = item()
+        i2.title = "Common Title"
+        i2.track = 11
+        i2.disc = 1
+        i2.artist = "Some Artist"
+        self.lib.add_album([i1, i2])
+        self.lib._connection().commit()
+
+        self._setf("$title%tunique{title,track}")
+        return i1, i2
+
+    def test_tunique_expands_to_disambiguating_track(self, items):
+        i1, i2 = items
+        self._assert_dest(b"/base/Common Title [07]", i1)
+        self._assert_dest(b"/base/Common Title [11]", i2)
+
+    def test_tunique_with_default_arguments_uses_track(self, items):
+        i1, i2 = items
+        self._setf("$title%tunique{}")
+        self._assert_dest(b"/base/Common Title [07]", i1)
+        self._assert_dest(b"/base/Common Title [11]", i2)
+
+    def test_tunique_expands_to_nothing_for_unique_titles(self, items):
+        i1, i2 = items
+        i2.title = "Different"
+        i2.store()
+
+        self._assert_dest(b"/base/Common Title", i1)
+
+    def test_tunique_does_not_match_singletons(self, items):
+        i1, _i2 = items
+        i3 = item()
+        i3.title = "Common Title"
+        self.lib.add(i3)
+
+        # i1 still needs disambiguation from i2 in the same album
+        self._assert_dest(b"/base/Common Title [07]", i1)
+        # Singleton should NOT get track disambiguation
+        self._assert_dest(b"/base/Common Title", i3)
+
+    def test_tunique_does_not_match_cross_album(self, items):
+        i1, _i2 = items
+        i3 = item()
+        i3.title = "Common Title"
+        i3.track = 7
+        self.lib.add_album([i3])
+
+        # i1 still needs disambiguation from i2 in the same album
+        self._assert_dest(b"/base/Common Title [07]", i1)
+        # Other album's tracks should NOT be matched
+        self._assert_dest(b"/base/Common Title", i3)
+
+    def test_tunique_use_fallback_numbers_when_identical(self, items):
+        i1, i2 = items
+        i2.track = i1.track
+        i2.disc = i1.disc
+        i2.artist = i1.artist
+        i2.store()
+
+        self._assert_dest(b"/base/Common Title [%d]" % i1.id, i1)
+        self._assert_dest(b"/base/Common Title [%d]" % i2.id, i2)
+
+    def test_tunique_falls_back_to_second_distinguishing_field(self, items):
+        i1, i2 = items
+        i2.track = i1.track
+        i2.disc = 2
+        i2.store()
+
+        self._setf("$title%tunique{title,track disc}")
+        self._assert_dest(b"/base/Common Title [01]", i1)
+        self._assert_dest(b"/base/Common Title [02]", i2)
+
+    def test_tunique_expands_to_disambiguating_disc(self, items):
+        i1, i2 = items
+        i2.track = i1.track
+        i2.disc = 2
+        i2.store()
+
+        self._setf("$title%tunique{title,disc}")
+        self._assert_dest(b"/base/Common Title [01]", i1)
+        self._assert_dest(b"/base/Common Title [02]", i2)
+
+    def test_tunique_change_brackets(self, items):
+        i1, _i2 = items
+        self._setf("$title%tunique{title,track,()}")
+        self._assert_dest(b"/base/Common Title (07)", i1)
+
+    def test_tunique_remove_brackets(self, items):
+        i1, _i2 = items
+        self._setf("$title%tunique{title,track,}")
+        self._assert_dest(b"/base/Common Title 07", i1)
+
+    def test_tunique_drop_empty_disambig(self, items):
+        i1, i2 = items
+        i1.trackdisambig = "live version"
+        i2.trackdisambig = None
+        i1.store()
+        i2.store()
+
+        self._setf("$title%tunique{title,trackdisambig}")
+        # i1 has trackdisambig, so gets suffixed
+        self._assert_dest(b"/base/Common Title [live version]", i1)
+        # i2 has no trackdisambig, so no suffix
+        self._assert_dest(b"/base/Common Title", i2)
+
+
 class TestPluginDestination(TestHelper):
     @pytest.fixture(autouse=True)
     def item(self, setup):

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -991,6 +991,37 @@ class TestTrackDisambiguation(TestHelper, PathFormattingMixin):
         # i2 has no trackdisambig, so no suffix
         self._assert_dest(b"/base/Common Title", i2)
 
+    def test_tunique_with_flex_key_field(self, items):
+        # Flexible field as key must be queried via field_query.
+        i1, i2 = items
+        i1.title = "Diff1"
+        i2.title = "Diff2"
+        i1["flexkey"] = "same"
+        i2["flexkey"] = "same"
+        i1.store()
+        i2.store()
+
+        self._setf("$title%tunique{flexkey,track}")
+        self._assert_dest(b"/base/Diff1 [07]", i1)
+        self._assert_dest(b"/base/Diff2 [11]", i2)
+
+    def test_tunique_path_formatted_disambiguator_collision(self, items):
+        # AC/DC vs AC_DC collide after for_path sanitization.
+        i1, i2 = items
+        i1.track = 1
+        i2.track = 1
+        i1.disc = 1
+        i2.disc = 1
+        i1.artist = "AC/DC"
+        i2.artist = "AC_DC"
+        i1.store()
+        i2.store()
+
+        self._setf("$title%tunique{title,artist}")
+        # No disambiguator distinguishes path-formatted values -> fallback IDs.
+        self._assert_dest(b"/base/Common Title [%d]" % i1.id, i1)
+        self._assert_dest(b"/base/Common Title [%d]" % i2.id, i2)
+
 
 class TestPluginDestination(TestHelper):
     @pytest.fixture(autouse=True)

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -725,6 +725,18 @@ class TestDisambiguation(TestHelper, PathFormattingMixin):
 
         self._assert_dest(b"/base/foo/the title", i1)
 
+    def test_adding_album_invalidates_memoized_result(self, items):
+        i1, i2 = items
+        album2 = self.lib.get_album(i2)
+        album2.album = "different album"
+        album2.store()
+        self._assert_dest(b"/base/foo/the title", i1)
+
+        i3 = item(year=2003)
+        self.lib.add_album([i3])
+
+        self._assert_dest(b"/base/foo [2001]/the title", i1)
+
     def test_use_fallback_numbers_when_identical(self, items):
         i1, i2 = items
         album2 = self.lib.get_album(i2)
@@ -832,6 +844,12 @@ class TestSingletonDisambiguation(TestHelper, PathFormattingMixin):
         self.lib.add_album([i2])
         self._assert_dest(b"/base/foo/the title", i1)
 
+    def test_sunique_skips_config_for_album_item(self, items):
+        _i1, i2 = items
+        self.lib.add_album([i2])
+        config["sunique"]["bracket"] = 5
+        self._assert_dest(b"/base/foo/the title", i2)
+
     def test_sunique_use_fallback_numbers_when_identical(self, items):
         i1, i2 = items
         i2.year = i1.year
@@ -889,41 +907,35 @@ class TestTrackDisambiguation(TestHelper, PathFormattingMixin):
         self.lib.directory = b"/base"
         self.lib.path_formats = [("default", "path")]
 
-        i1 = item()
-        i1.title = "Common Title"
-        i1.track = 7
-        i1.disc = 1
-        i1.artist = "Some Artist"
-        i2 = item()
-        i2.title = "Common Title"
-        i2.track = 11
-        i2.disc = 1
-        i2.artist = "Some Artist"
+        i1 = item(title="Common Title", track=7, disc=1, artist="Some Artist")
+        i2 = item(title="Common Title", track=11, disc=1, artist="Some Artist")
         self.lib.add_album([i1, i2])
         self.lib._connection().commit()
 
         self._setf("$title%tunique{title,track}")
         return i1, i2
 
-    def test_tunique_expands_to_disambiguating_track(self, items):
+    def test_expands_to_disambiguating_track(self, items):
         i1, i2 = items
         self._assert_dest(b"/base/Common Title [07]", i1)
         self._assert_dest(b"/base/Common Title [11]", i2)
 
-    def test_tunique_with_default_arguments_uses_track(self, items):
+    def test_with_default_arguments_uses_disc(self, items):
         i1, i2 = items
+        i2.disc = 2
+        i2.store()
         self._setf("$title%tunique{}")
-        self._assert_dest(b"/base/Common Title [07]", i1)
-        self._assert_dest(b"/base/Common Title [11]", i2)
+        self._assert_dest(b"/base/Common Title [01]", i1)
+        self._assert_dest(b"/base/Common Title [02]", i2)
 
-    def test_tunique_expands_to_nothing_for_unique_titles(self, items):
+    def test_expands_to_nothing_for_unique_titles(self, items):
         i1, i2 = items
         i2.title = "Different"
         i2.store()
 
         self._assert_dest(b"/base/Common Title", i1)
 
-    def test_tunique_does_not_match_singletons(self, items):
+    def test_does_not_match_singletons(self, items):
         i1, _i2 = items
         i3 = item()
         i3.title = "Common Title"
@@ -934,7 +946,7 @@ class TestTrackDisambiguation(TestHelper, PathFormattingMixin):
         # Singleton should NOT get track disambiguation
         self._assert_dest(b"/base/Common Title", i3)
 
-    def test_tunique_does_not_match_cross_album(self, items):
+    def test_does_not_match_cross_album(self, items):
         i1, _i2 = items
         i3 = item()
         i3.title = "Common Title"
@@ -946,7 +958,7 @@ class TestTrackDisambiguation(TestHelper, PathFormattingMixin):
         # Other album's tracks should NOT be matched
         self._assert_dest(b"/base/Common Title", i3)
 
-    def test_tunique_use_fallback_numbers_when_identical(self, items):
+    def test_use_fallback_numbers_when_identical(self, items):
         i1, i2 = items
         i2.track = i1.track
         i2.disc = i1.disc
@@ -956,37 +968,28 @@ class TestTrackDisambiguation(TestHelper, PathFormattingMixin):
         self._assert_dest(b"/base/Common Title [%d]" % i1.id, i1)
         self._assert_dest(b"/base/Common Title [%d]" % i2.id, i2)
 
-    def test_tunique_falls_back_to_second_distinguishing_field(self, items):
+    @pytest.mark.parametrize("disambiguators", ["track disc", "disc"])
+    def test_expands_to_disambiguating_disc(self, items, disambiguators):
         i1, i2 = items
         i2.track = i1.track
         i2.disc = 2
         i2.store()
 
-        self._setf("$title%tunique{title,track disc}")
+        self._setf(f"$title%tunique{{title,{disambiguators}}}")
         self._assert_dest(b"/base/Common Title [01]", i1)
         self._assert_dest(b"/base/Common Title [02]", i2)
 
-    def test_tunique_expands_to_disambiguating_disc(self, items):
-        i1, i2 = items
-        i2.track = i1.track
-        i2.disc = 2
-        i2.store()
-
-        self._setf("$title%tunique{title,disc}")
-        self._assert_dest(b"/base/Common Title [01]", i1)
-        self._assert_dest(b"/base/Common Title [02]", i2)
-
-    def test_tunique_change_brackets(self, items):
+    def test_change_brackets(self, items):
         i1, _i2 = items
         self._setf("$title%tunique{title,track,()}")
         self._assert_dest(b"/base/Common Title (07)", i1)
 
-    def test_tunique_remove_brackets(self, items):
+    def test_remove_brackets(self, items):
         i1, _i2 = items
         self._setf("$title%tunique{title,track,}")
         self._assert_dest(b"/base/Common Title 07", i1)
 
-    def test_tunique_drop_empty_disambig(self, items):
+    def test_drop_empty_disambig(self, items):
         i1, i2 = items
         i1.trackdisambig = "live version"
         i2.trackdisambig = None
@@ -999,38 +1002,48 @@ class TestTrackDisambiguation(TestHelper, PathFormattingMixin):
         # i2 has no trackdisambig, so no suffix
         self._assert_dest(b"/base/Common Title", i2)
 
-    def test_tunique_with_flex_key_field(self, items):
-        # Flexible field as key must be queried via field_query.
+    def test_with_flex_key_field(self, items):
         i1, i2 = items
         i1.title = "Diff1"
         i2.title = "Diff2"
-        i1["flexkey"] = "same"
-        i2["flexkey"] = "same"
+        i1["flexkey"] = "one"
+        i2["flexkey"] = "two"
         i1.store()
         i2.store()
 
         self._setf("$title%tunique{flexkey,track}")
-        self._assert_dest(b"/base/Diff1 [07]", i1)
-        self._assert_dest(b"/base/Diff2 [11]", i2)
+        self._assert_dest(b"/base/Diff1", i1)
+        self._assert_dest(b"/base/Diff2", i2)
 
-    def test_tunique_path_formatted_disambiguator_collision(self, items):
-        # AC/DC vs AC_DC collide after for_path sanitization.
+    @pytest.mark.parametrize(
+        "first_artist, second_artist, replacement, asciify",
+        [
+            ("AC/DC", "AC_DC", None, False),
+            ("AC~DC", "AC_DC", (re.compile("~"), "_"), False),
+            ("Beyonc\u00e9", "Beyonce", None, True),
+        ],
+    )
+    def test_disambiguator_collision_after_path_formatting(
+        self, items, first_artist, second_artist, replacement, asciify
+    ):
         i1, i2 = items
         i1.track = 1
         i2.track = 1
         i1.disc = 1
         i2.disc = 1
-        i1.artist = "AC/DC"
-        i2.artist = "AC_DC"
+        i1.artist = first_artist
+        i2.artist = second_artist
+        if replacement:
+            self.lib.replacements = [replacement]
+        config["asciify_paths"] = asciify
         i1.store()
         i2.store()
 
         self._setf("$title%tunique{title,artist}")
-        # No disambiguator distinguishes path-formatted values -> fallback IDs.
         self._assert_dest(b"/base/Common Title [%d]" % i1.id, i1)
         self._assert_dest(b"/base/Common Title [%d]" % i2.id, i2)
 
-    def test_tunique_path_formatted_key_collision(self, items):
+    def test_path_formatted_key_collision(self, items):
         i1, i2 = items
         i1.title = "AC/DC"
         i2.title = "AC_DC"
@@ -1040,34 +1053,18 @@ class TestTrackDisambiguation(TestHelper, PathFormattingMixin):
         self._assert_dest(b"/base/AC_DC [07]", i1)
         self._assert_dest(b"/base/AC_DC [11]", i2)
 
-    def test_tunique_replaced_disambiguator_collision(self, items):
-        i1, i2 = items
-        self.lib.replacements = [(re.compile(":"), "_")]
-        i1.artist = "AC:DC"
-        i2.artist = "AC_DC"
-        i1.store()
-        i2.store()
-
-        self._setf("$title%tunique{title,artist}")
-        self._assert_dest(b"/base/Common Title [%d]" % i1.id, i1)
-        self._assert_dest(b"/base/Common Title [%d]" % i2.id, i2)
-
-    def test_tunique_asciified_disambiguator_collision(self, items):
-        i1, i2 = items
-        config["asciify_paths"] = True
-        i1.artist = "Beyonc\u00e9"
-        i2.artist = "Beyonce"
-        i1.store()
-        i2.store()
-
-        self._setf("$title%tunique{title,artist}")
-        self._assert_dest(b"/base/Common Title [%d]" % i1.id, i1)
-        self._assert_dest(b"/base/Common Title [%d]" % i2.id, i2)
-
-    def test_tunique_memoizes_brackets_independently(self, items):
+    def test_memoizes_brackets_independently(self, items):
         i1, _i2 = items
         self._setf("$title%tunique{title,track,()}%tunique{title,track,[]}")
         self._assert_dest(b"/base/Common Title (07) [07]", i1)
+
+    def test_reuses_collision_group_analysis(self, items):
+        i1, i2 = items
+        with patch.object(self.lib, "items", wraps=self.lib.items) as lib_items:
+            self._assert_dest(b"/base/Common Title [07]", i1)
+            self._assert_dest(b"/base/Common Title [11]", i2)
+
+        assert lib_items.call_count == 1
 
 
 class TestPluginDestination(TestHelper):

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -771,6 +771,14 @@ class TestDisambiguation(TestHelper, PathFormattingMixin):
         self._setf("foo%aunique{albumartist album,year,}/$title")
         self._assert_dest(b"/base/foo 2001/the title", i1)
 
+    def test_unique_memoizes_brackets_independently(self, items):
+        i1, _i2 = items
+        self._setf(
+            "foo%aunique{albumartist album,year,()}"
+            "%aunique{albumartist album,year,[]}/$title"
+        )
+        self._assert_dest(b"/base/foo (2001) [2001]/the title", i1)
+
     def test_key_flexible_attribute(self, items):
         i1, i2 = items
         album1 = self.lib.get_album(i1)
@@ -1021,6 +1029,45 @@ class TestTrackDisambiguation(TestHelper, PathFormattingMixin):
         # No disambiguator distinguishes path-formatted values -> fallback IDs.
         self._assert_dest(b"/base/Common Title [%d]" % i1.id, i1)
         self._assert_dest(b"/base/Common Title [%d]" % i2.id, i2)
+
+    def test_tunique_path_formatted_key_collision(self, items):
+        i1, i2 = items
+        i1.title = "AC/DC"
+        i2.title = "AC_DC"
+        i1.store()
+        i2.store()
+
+        self._assert_dest(b"/base/AC_DC [07]", i1)
+        self._assert_dest(b"/base/AC_DC [11]", i2)
+
+    def test_tunique_replaced_disambiguator_collision(self, items):
+        i1, i2 = items
+        self.lib.replacements = [(re.compile(":"), "_")]
+        i1.artist = "AC:DC"
+        i2.artist = "AC_DC"
+        i1.store()
+        i2.store()
+
+        self._setf("$title%tunique{title,artist}")
+        self._assert_dest(b"/base/Common Title [%d]" % i1.id, i1)
+        self._assert_dest(b"/base/Common Title [%d]" % i2.id, i2)
+
+    def test_tunique_asciified_disambiguator_collision(self, items):
+        i1, i2 = items
+        config["asciify_paths"] = True
+        i1.artist = "Beyonc\u00e9"
+        i2.artist = "Beyonce"
+        i1.store()
+        i2.store()
+
+        self._setf("$title%tunique{title,artist}")
+        self._assert_dest(b"/base/Common Title [%d]" % i1.id, i1)
+        self._assert_dest(b"/base/Common Title [%d]" % i2.id, i2)
+
+    def test_tunique_memoizes_brackets_independently(self, items):
+        i1, _i2 = items
+        self._setf("$title%tunique{title,track,()}%tunique{title,track,[]}")
+        self._assert_dest(b"/base/Common Title (07) [07]", i1)
 
 
 class TestPluginDestination(TestHelper):


### PR DESCRIPTION
Adds a new `%tunique{}` path template function (analogous to `%aunique{}` for albums and `%sunique{}` for singletons) that disambiguates tracks within the same album that would otherwise produce identical filenames (e.g., two tracks with the same title on the same album or across different discs). This follows the structure and logic used in `aunique` or `sunique`.

Fixes #5950 

**Default configuration:**

```yaml
tunique:
    keys: title
    disambiguators: track disc artist
    bracket: '[]'
```
The function first finds all sibling items (same `album_id`) with matching key values (default: same `title`). If duplicates exist, it iterates through the disambiguator fields looking for one that uniquely separates all duplicates. If no field suffices, the stable database ID is used as a fallback. For items without a duplicate, no suffix is added.

This solves the problem where `beet move` would non-deterministically append .1/.2 suffixes via `unique_path()` for duplicate-titled tracks, which would change every time the command was re-run.

Example usage in path config:
```yaml
paths:
    default: $albumartist/$album/$album ($year) - $title%tunique{}
```
For an album with two identically-titled tracks:
```yaml
- Artist/Album/Album (1993) - Common Title [07].mp3
- Artist/Album/Album (1993) - Common Title [11].mp3
```
## To Do
- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
