### PR TITLE
Dedupe individual tracks during import based on stable identifier

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -52,9 +52,9 @@ import:
         album: albumartist album
         item: artist title
     duplicate_action: ask
+    duplicate_tracks: no
+    duplicate_tracks_action: ''
     duplicate_verbose_prompt: no
-    duplicate_track_resolution: no
-    duplicate_track_action: ''
     bell: no
     set_fields: {}
     ignored_alias_types: []

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -54,6 +54,7 @@ import:
     duplicate_action: ask
     duplicate_verbose_prompt: no
     duplicate_track_resolution: no
+    duplicate_track_action: ''
     bell: no
     set_fields: {}
     ignored_alias_types: []

--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -53,6 +53,7 @@ import:
         item: artist title
     duplicate_action: ask
     duplicate_verbose_prompt: no
+    duplicate_track_resolution: no
     bell: no
     set_fields: {}
     ignored_alias_types: []

--- a/beets/importer/actions.py
+++ b/beets/importer/actions.py
@@ -40,6 +40,26 @@ class DuplicateAction(str, Enum):
     def choices(cls) -> dict[str, str]:
         return {d.name.lower(): d.value for d in cls}
 
+    @classmethod
+    def track_choices(cls) -> dict[str, str]:
+        """Choices valid for per-track duplicate resolution.
+
+        MERGE is excluded: merging is defined for whole albums only.
+        """
+        return {
+            d.name.lower(): d.value
+            for d in cls
+            if d is not DuplicateAction.MERGE
+        }
+
+    @classmethod
+    def track_options(cls) -> list[str]:
+        return [
+            d.text
+            for d in cls
+            if d not in (DuplicateAction.MERGE, DuplicateAction.ASK)
+        ]
+
     SKIP = "s", "Skip new"
     MERGE = "m", "Merge all"
     REMOVE = "r", "Remove old"

--- a/beets/importer/actions.py
+++ b/beets/importer/actions.py
@@ -43,6 +43,26 @@ class DuplicateAction(str, Enum):
     def choices(cls) -> dict[str, str]:
         return {d.name.lower(): d.value for d in cls}
 
+    @classmethod
+    def track_choices(cls) -> dict[str, str]:
+        """Choices valid for per-track duplicate resolution.
+
+        MERGE is excluded: merging is defined for whole albums only.
+        """
+        return {
+            d.name.lower(): d.value
+            for d in cls
+            if d is not DuplicateAction.MERGE
+        }
+
+    @classmethod
+    def track_options(cls) -> list[str]:
+        return [
+            d.text
+            for d in cls
+            if d not in (DuplicateAction.MERGE, DuplicateAction.ASK)
+        ]
+
     SKIP = "s", "Skip new"
     MERGE = "m", "Merge all"
     REMOVE = "r", "Remove old"

--- a/beets/importer/session.py
+++ b/beets/importer/session.py
@@ -187,9 +187,9 @@ class ImportSession:
 
     def resolve_track_duplicates(self, task: ImportTask, duplicates) -> str:
         """Decide what to do with album tracks that already exist in the
-        library. Return ``"s"`` (skip the duplicate tracks), ``"k"`` (keep
-        all), ``"r"`` (remove the old items) or ``"f"`` (fold the remaining
-        new tracks into the existing album).
+        library. Return ``"s"`` (skip the duplicate tracks and fold the
+        remaining new tracks into the existing album), ``"k"`` (keep all) or
+        ``"r"`` (remove the old items).
         """
         raise NotImplementedError
 

--- a/beets/importer/session.py
+++ b/beets/importer/session.py
@@ -188,7 +188,8 @@ class ImportSession:
     def resolve_track_duplicates(self, task: ImportTask, duplicates) -> str:
         """Decide what to do with album tracks that already exist in the
         library. Return ``"s"`` (skip the duplicate tracks), ``"k"`` (keep
-        all) or ``"r"`` (remove the old items).
+        all), ``"r"`` (remove the old items) or ``"f"`` (fold the remaining
+        new tracks into the existing album).
         """
         raise NotImplementedError
 

--- a/beets/importer/session.py
+++ b/beets/importer/session.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from beets import config, logging, plugins, util
 from beets.util import displayable_path, normpath, pipeline, syspath
@@ -46,7 +46,6 @@ class ImportSession:
     _is_resuming: dict[bytes, bool]
     _merged_items: set[PathBytes]
     _merged_dirs: set[PathBytes]
-    _seen_track_keys: set[tuple[Any, ...]]
 
     def __init__(
         self,
@@ -75,7 +74,6 @@ class ImportSession:
         self._is_resuming = {}
         self._merged_items = set()
         self._merged_dirs = set()
-        self._seen_track_keys = set()
 
         # Normalize the paths.
         self.paths = list(map(normpath, paths or []))
@@ -187,24 +185,62 @@ class ImportSession:
     def choose_item(self, task: SingletonImportTask) -> TrackMatch | Action:
         raise NotImplementedError
 
-    def resolve_track_duplicates(
+    def get_track_duplicate_actions(
         self,
         task: ImportTask,
-        duplicates: dict[library.Item, list[library.Item]],
-    ) -> DuplicateAction:
-        """Decide what to do with album tracks that already exist in the
-        library: :attr:`~DuplicateAction.SKIP` (drop the duplicate tracks and
-        fold the remaining new tracks into the existing album),
-        :attr:`~DuplicateAction.KEEP` (import everything) or
-        :attr:`~DuplicateAction.REMOVE` (remove the old items).
+        track_duplicates: dict[library.Item, list[library.Item]],
+    ) -> dict[library.Item, DuplicateAction]:
+        """Get the configured action for each track that duplicates items
+        already in the library.
 
-        ``duplicates`` maps each incoming :class:`~beets.library.Item` to the
-        existing library items it duplicates.
+        ``track_duplicates`` maps each :class:`~beets.library.Item` of the
+        task to the existing library items it duplicates.
         """
-        raise NotImplementedError
+        view = config["import"]["duplicate_tracks_action"]
+        if view.get():
+            # MERGE is not offered per track, so reject it loudly here.
+            choice = view.as_choice(DuplicateAction.track_choices())
+            action = DuplicateAction(choice)  # type: ignore[call-arg]
+        else:
+            choice = config["import"]["duplicate_action"].as_choice(
+                DuplicateAction.choices()
+            )
+            action = DuplicateAction(choice)  # type: ignore[call-arg]
+            if action is DuplicateAction.MERGE:
+                log.debug(
+                    "merge is not available for duplicate tracks; keeping all"
+                )
+                action = DuplicateAction.KEEP
+        log.debug("default action for duplicate tracks: {}", action.value)
+        return dict.fromkeys(track_duplicates, action)
 
-    def choose_item(self, task: ImportTask):
-        raise NotImplementedError
+    def resolve_duplicates(
+        self,
+        task: ImportTask,
+        found_duplicates: list[AnyLibModel],
+        track_duplicates: dict[library.Item, list[library.Item]],
+    ) -> None:
+        """Decide, at a single point, what to do about the album- and
+        track-level duplicates found for ``task``.
+
+        Sets ``task.duplicate_action`` from the album-level duplicates or
+        ``task.track_duplicate_actions`` from the track-level ones. When only
+        *some* tracks duplicate existing items, the import is a partial
+        overlap (e.g. completing a partially-imported album), so per-track
+        resolution applies and the whole-album action is suppressed. When
+        every track is a duplicate, the task is a whole-album duplicate and
+        the album-level action decides.
+        """
+        partial = 0 < len(track_duplicates) < len(task.imported_items())
+
+        if found_duplicates and not partial:
+            task.duplicate_action = self.get_duplicate_action(
+                task, found_duplicates
+            )
+        elif track_duplicates:
+            task.track_duplicate_actions = self.get_track_duplicate_actions(
+                task, track_duplicates
+            )
 
     def run(self):
         """Run the import task."""
@@ -225,10 +261,6 @@ class ImportSession:
             if self.config["group_albums"] and not self.config["singletons"]:
                 # Split directory tasks into one task for each album.
                 stages += [stagefuncs.group_albums(self)]
-
-            # Optionally drop or replace album tracks that already exist in
-            # the library before the autotag lookup runs.
-            stages += [stagefuncs.resolve_track_duplicates(self)]
 
             # These stages either talk to the user to get a decision or,
             # in the case of a non-autotagged import, just choose to
@@ -309,25 +341,6 @@ class ImportSession:
             for path in paths
         }
         self._merged_dirs.update(dirs)
-
-    def track_key_seen(self, key: tuple[Any, ...]) -> bool:
-        """Return whether a per-track duplicate ``key`` was already claimed by
-        an earlier task in this import run (see :ref:`duplicate_track_resolution`).
-
-        This lets the track-level duplicate check catch tracks imported earlier
-        in the *same* run before they reach the database, which matters under
-        the default threaded import where a later task may be checked before an
-        earlier one has been added.
-        """
-        return key in self._seen_track_keys
-
-    def remember_track_key(self, key: tuple[Any, ...]) -> None:
-        """Record a per-track duplicate ``key`` claimed by the current task.
-
-        Only ever called from the single-threaded ``resolve_track_duplicates``
-        pipeline stage, so the shared set needs no locking.
-        """
-        self._seen_track_keys.add(key)
 
     def is_resuming(self, toppath: PathBytes) -> bool:
         """Return `True` if user wants to resume import of this path.

--- a/beets/importer/session.py
+++ b/beets/importer/session.py
@@ -185,11 +185,19 @@ class ImportSession:
     def choose_item(self, task: SingletonImportTask) -> TrackMatch | Action:
         raise NotImplementedError
 
-    def resolve_track_duplicates(self, task: ImportTask, duplicates) -> str:
+    def resolve_track_duplicates(
+        self,
+        task: ImportTask,
+        duplicates: dict[library.Item, list[library.Item]],
+    ) -> DuplicateAction:
         """Decide what to do with album tracks that already exist in the
-        library. Return ``"s"`` (skip the duplicate tracks and fold the
-        remaining new tracks into the existing album), ``"k"`` (keep all) or
-        ``"r"`` (remove the old items).
+        library: :attr:`~DuplicateAction.SKIP` (drop the duplicate tracks and
+        fold the remaining new tracks into the existing album),
+        :attr:`~DuplicateAction.KEEP` (import everything) or
+        :attr:`~DuplicateAction.REMOVE` (remove the old items).
+
+        ``duplicates`` maps each incoming :class:`~beets.library.Item` to the
+        existing library items it duplicates.
         """
         raise NotImplementedError
 

--- a/beets/importer/session.py
+++ b/beets/importer/session.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from beets import config, logging, plugins, util
 from beets.util import displayable_path, normpath, pipeline, syspath
@@ -46,6 +46,7 @@ class ImportSession:
     _is_resuming: dict[bytes, bool]
     _merged_items: set[PathBytes]
     _merged_dirs: set[PathBytes]
+    _seen_track_keys: set[tuple[Any, ...]]
 
     def __init__(
         self,
@@ -74,6 +75,7 @@ class ImportSession:
         self._is_resuming = {}
         self._merged_items = set()
         self._merged_dirs = set()
+        self._seen_track_keys = set()
 
         # Normalize the paths.
         self.paths = list(map(normpath, paths or []))
@@ -307,6 +309,25 @@ class ImportSession:
             for path in paths
         }
         self._merged_dirs.update(dirs)
+
+    def track_key_seen(self, key: tuple[Any, ...]) -> bool:
+        """Return whether a per-track duplicate ``key`` was already claimed by
+        an earlier task in this import run (see :ref:`duplicate_track_resolution`).
+
+        This lets the track-level duplicate check catch tracks imported earlier
+        in the *same* run before they reach the database, which matters under
+        the default threaded import where a later task may be checked before an
+        earlier one has been added.
+        """
+        return key in self._seen_track_keys
+
+    def remember_track_key(self, key: tuple[Any, ...]) -> None:
+        """Record a per-track duplicate ``key`` claimed by the current task.
+
+        Only ever called from the single-threaded ``resolve_track_duplicates``
+        pipeline stage, so the shared set needs no locking.
+        """
+        self._seen_track_keys.add(key)
 
     def is_resuming(self, toppath: PathBytes) -> bool:
         """Return `True` if user wants to resume import of this path.

--- a/beets/importer/session.py
+++ b/beets/importer/session.py
@@ -185,7 +185,17 @@ class ImportSession:
     def choose_item(self, task: SingletonImportTask) -> TrackMatch | Action:
         raise NotImplementedError
 
-    def run(self) -> None:
+    def resolve_track_duplicates(self, task: ImportTask, duplicates) -> str:
+        """Decide what to do with album tracks that already exist in the
+        library. Return ``"s"`` (skip the duplicate tracks), ``"k"`` (keep
+        all) or ``"r"`` (remove the old items).
+        """
+        raise NotImplementedError
+
+    def choose_item(self, task: ImportTask):
+        raise NotImplementedError
+
+    def run(self):
         """Run the import task."""
         self.logger.info("import started {}", time.asctime())
         self.set_config(config["import"])
@@ -204,6 +214,10 @@ class ImportSession:
             if self.config["group_albums"] and not self.config["singletons"]:
                 # Split directory tasks into one task for each album.
                 stages += [stagefuncs.group_albums(self)]
+
+            # Optionally drop or replace album tracks that already exist in
+            # the library before the autotag lookup runs.
+            stages += [stagefuncs.resolve_track_duplicates(self)]
 
             # These stages either talk to the user to get a decision or,
             # in the case of a non-autotagged import, just choose to

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -165,10 +165,10 @@ def group_albums(session: ImportSession) -> StageCoro:
         return
 
     action = _track_duplicate_action()
-    if action == "a":
+    if action is DuplicateAction.ASK:
         action = session.resolve_track_duplicates(task, duplicates)
 
-    if action == "s":
+    if action is DuplicateAction.SKIP:
         for item in duplicates:
             log.info(
                 colorize("text_warning", "Skipping duplicate track: {}"),
@@ -189,27 +189,28 @@ def group_albums(session: ImportSession) -> StageCoro:
         # Only some tracks were duplicates; we have already dropped them, so
         # don't let the album-level check skip the rest.
         task.duplicate_tracks_resolved = True
-        # Fold the remaining new tracks into the existing album, if the
-        # matched duplicates all belong to a single one.
+        # Fold the remaining new tracks into the existing album only when
+        # every matched duplicate belongs to that same album. A singleton
+        # match (``album_id`` is ``None``) means the duplicates do not all
+        # belong to one album, so the new tracks are imported as their own.
         album_ids = {
             match.album_id
             for matches in duplicates.values()
             for match in matches
-            if match.album_id is not None
         }
-        if len(album_ids) == 1:
+        if len(album_ids) == 1 and None not in album_ids:
             task.fold_into_album_id = album_ids.pop()
         else:
             log.warning(
                 "cannot fold tracks into a single existing album; "
                 "importing them as a new album"
             )
-    elif action == "r":
+    elif action is DuplicateAction.REMOVE:
         for matches in duplicates.values():
             task.duplicate_track_items_to_remove.extend(matches)
         task.duplicate_tracks_resolved = True
-    # "k" (keep) and "m" (merge) leave the incoming tracks untouched; whole
-    # album duplicates are still handled by the regular resolution stage.
+    # KEEP and MERGE leave the incoming tracks untouched; whole-album
+    # duplicates are still handled by the regular resolution stage.
 
 
 @pipeline.mutator_stage
@@ -423,26 +424,20 @@ def _apply_choice(session: ImportSession, task: ImportTask) -> None:
         task.set_fields(session.lib)
 
 
-def _track_duplicate_action() -> str:
-    """Return the single-letter action for per-track duplicate resolution.
+def _track_duplicate_action() -> DuplicateAction:
+    """Return the configured :class:`DuplicateAction` for per-track resolution.
 
     Uses ``import.duplicate_track_action`` when set, otherwise falls back to
     ``import.duplicate_action``.
     """
-    choices = {
-        "skip": "s",
-        "keep": "k",
-        "remove": "r",
-        "merge": "m",
-        "ask": "a",
-    }
     cfg = config["import"]
     view = (
         cfg["duplicate_track_action"]
         if cfg["duplicate_track_action"].get()
         else cfg["duplicate_action"]
     )
-    return view.as_choice(choices)
+    choice = view.as_choice(DuplicateAction.choices())
+    return DuplicateAction(choice)  # type: ignore[call-arg]
 
 
 def _find_track_duplicates(

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -120,7 +120,70 @@ def group_albums(session: ImportSession) -> StageCoro:
 
 
 @pipeline.mutator_stage
-def lookup_candidates(session: ImportSession, task: ImportTask) -> None:
+    """Resolve tracks of an album that already exist in the library.
+
+    When ``import.duplicate_track_resolution`` is enabled, each item of an
+    album import is checked against the library using
+    ``import.duplicate_keys.item``. Matched tracks are resolved according to
+    ``import.duplicate_action``:
+
+    * ``skip`` drops the duplicate tracks and imports the rest of the album
+      (if every track is a duplicate, the whole album is skipped);
+    * ``remove`` removes the matching old library items;
+    * ``keep`` (and ``merge``) import everything as-is;
+    * ``ask`` prompts the session for one of the above.
+
+    This runs before :func:`lookup_candidates` so that dropped tracks are
+    excluded from the autotag match. Singleton imports are handled by the
+    regular duplicate resolution and are ignored here.
+    """
+    if (
+        task.skip
+        or not task.is_album
+        or not task.items
+        or not config["import"]["duplicate_track_resolution"].get(bool)
+    ):
+        return
+
+    keys = config["import"]["duplicate_keys"]["item"].as_str_seq()
+    if not keys:
+        return
+
+    # Map each incoming item to the existing library items it duplicates.
+    duplicates: dict[library.Item, list[library.Item]] = {}
+    for item in task.items:
+        if not any(item.get(k) for k in keys):
+            continue
+        matches = _find_track_duplicates(session.lib, item, keys)
+        if matches:
+            duplicates[item] = matches
+
+    if not duplicates:
+        return
+
+    action = config["import"]["duplicate_action"].as_choice(
+        {"skip": "s", "keep": "k", "remove": "r", "merge": "m", "ask": "a"}
+    )
+    if action == "a":
+        action = session.resolve_track_duplicates(task, duplicates)
+
+    if action == "s":
+        for item in duplicates:
+            log.info(
+                "skipping duplicate track: {}", displayable_path(item.path)
+            )
+            task.items.remove(item)
+        if not task.items:
+            task.set_choice(Action.SKIP)
+    elif action == "r":
+        for matches in duplicates.values():
+            task.duplicate_track_items_to_remove.extend(matches)
+    # "k" (keep) and "m" (merge) leave the incoming tracks untouched; whole
+    # album duplicates are still handled by the regular resolution stage.
+
+
+@pipeline.mutator_stage
+def lookup_candidates(session: ImportSession, task: ImportTask):
     """A coroutine for performing the initial MusicBrainz lookup for an
     album. It accepts lists of Items and yields
     (items, cur_artist, cur_album, candidates, rec) tuples. If no match
@@ -275,6 +338,9 @@ def manipulate_files(session: ImportSession, task: ImportTask) -> None:
         if task.duplicate_action is DuplicateAction.REMOVE:
             task.remove_duplicates(session.lib)
 
+        if task.duplicate_track_items_to_remove:
+            task.remove_duplicate_track_items(session.lib)
+
         if session.config["move"]:
             operation = MoveOperation.MOVE
         elif session.config["copy"]:
@@ -327,7 +393,17 @@ def _apply_choice(session: ImportSession, task: ImportTask) -> None:
         task.set_fields(session.lib)
 
 
-def _resolve_duplicates(session: ImportSession, task: ImportTask) -> None:
+def _find_track_duplicates(
+    lib: library.Library, item: library.Item, keys: list[str]
+) -> list[library.Item]:
+    """Return library items matching `item` on all `keys`, excluding the
+    item itself (so re-imports do not match their own files).
+    """
+    query = item.duplicates_query(keys)
+    return [other for other in lib.items(query) if other.path != item.path]
+
+
+def _resolve_duplicates(session: ImportSession, task: ImportTask):
     """Check if a task conflicts with items or albums already imported
     and ask the session to resolve this.
     """

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -5,7 +5,7 @@ import itertools
 import logging
 from typing import TYPE_CHECKING, TypeAlias
 
-from beets import config, plugins
+from beets import config, dbcore, plugins
 from beets.util import MoveOperation, displayable_path, pipeline
 
 from .actions import Action, DuplicateAction
@@ -125,11 +125,14 @@ def group_albums(session: ImportSession) -> StageCoro:
     When ``import.duplicate_track_resolution`` is enabled, each item of an
     album import is checked against the library using
     ``import.duplicate_keys.item``. Matched tracks are resolved according to
-    ``import.duplicate_action``:
+    ``import.duplicate_track_action`` (which falls back to
+    ``import.duplicate_action`` when unset):
 
     * ``skip`` drops the duplicate tracks and imports the rest of the album
       (if every track is a duplicate, the whole album is skipped);
     * ``remove`` removes the matching old library items;
+    * ``fold`` drops the duplicate tracks and adds the remaining new tracks to
+      the existing album they belong to;
     * ``keep`` (and ``merge``) import everything as-is;
     * ``ask`` prompts the session for one of the above.
 
@@ -161,23 +164,43 @@ def group_albums(session: ImportSession) -> StageCoro:
     if not duplicates:
         return
 
-    action = config["import"]["duplicate_action"].as_choice(
-        {"skip": "s", "keep": "k", "remove": "r", "merge": "m", "ask": "a"}
-    )
+    action = _track_duplicate_action()
     if action == "a":
         action = session.resolve_track_duplicates(task, duplicates)
 
-    if action == "s":
+    if action in ("s", "f"):
         for item in duplicates:
             log.info(
                 "skipping duplicate track: {}", displayable_path(item.path)
             )
             task.items.remove(item)
         if not task.items:
+            # Every track was a duplicate: skip the whole album.
             task.set_choice(Action.SKIP)
+            return
+        # Only some tracks were duplicates; we have already dropped them, so
+        # don't let the album-level check skip the rest.
+        task.duplicate_tracks_resolved = True
+        if action == "f":
+            # Fold the remaining new tracks into the existing album, if the
+            # matched duplicates all belong to a single one.
+            album_ids = {
+                match.album_id
+                for matches in duplicates.values()
+                for match in matches
+                if match.album_id is not None
+            }
+            if len(album_ids) == 1:
+                task.fold_into_album_id = album_ids.pop()
+            else:
+                log.warning(
+                    "cannot fold tracks into a single existing album; "
+                    "importing them as a new album"
+                )
     elif action == "r":
         for matches in duplicates.values():
             task.duplicate_track_items_to_remove.extend(matches)
+        task.duplicate_tracks_resolved = True
     # "k" (keep) and "m" (merge) leave the incoming tracks untouched; whole
     # album duplicates are still handled by the regular resolution stage.
 
@@ -393,13 +416,42 @@ def _apply_choice(session: ImportSession, task: ImportTask) -> None:
         task.set_fields(session.lib)
 
 
+def _track_duplicate_action() -> str:
+    """Return the single-letter action for per-track duplicate resolution.
+
+    Uses ``import.duplicate_track_action`` when set, otherwise falls back to
+    ``import.duplicate_action``.
+    """
+    choices = {
+        "skip": "s",
+        "keep": "k",
+        "remove": "r",
+        "merge": "m",
+        "fold": "f",
+        "ask": "a",
+    }
+    cfg = config["import"]
+    view = (
+        cfg["duplicate_track_action"]
+        if cfg["duplicate_track_action"].get()
+        else cfg["duplicate_action"]
+    )
+    return view.as_choice(choices)
+
+
 def _find_track_duplicates(
     lib: library.Library, item: library.Item, keys: list[str]
 ) -> list[library.Item]:
     """Return library items matching `item` on all `keys`, excluding the
     item itself (so re-imports do not match their own files).
+
+    Unlike :meth:`Item.duplicates_query`, this matches *every* library item,
+    including tracks that belong to an album -- not just singletons -- so a
+    track is caught regardless of how it was originally imported.
     """
-    query = item.duplicates_query(keys)
+    query = dbcore.AndQuery(
+        [item.field_query(k, item.get(k), dbcore.MatchQuery) for k in keys]
+    )
     return [other for other in lib.items(query) if other.path != item.path]
 
 
@@ -407,6 +459,12 @@ def _resolve_duplicates(session: ImportSession, task: ImportTask):
     """Check if a task conflicts with items or albums already imported
     and ask the session to resolve this.
     """
+    if task.duplicate_tracks_resolved:
+        # Per-track duplicate resolution already pruned (or recorded for
+        # removal) the tracks of this album that exist in the library; the
+        # rest are new and should be imported without a whole-album skip.
+        return
+
     if task.choice_flag in (Action.ASIS, Action.APPLY, Action.RETAG):
         found_duplicates = task.find_duplicates(session.lib)
         if found_duplicates:

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -189,16 +189,20 @@ def group_albums(session: ImportSession) -> StageCoro:
         # Only some tracks were duplicates; we have already dropped them, so
         # don't let the album-level check skip the rest.
         task.duplicate_tracks_resolved = True
-        # Fold the remaining new tracks into the existing album only when
-        # every matched duplicate belongs to that same album. A singleton
-        # match (``album_id`` is ``None``) means the duplicates do not all
-        # belong to one album, so the new tracks are imported as their own.
+        # Fold the remaining new tracks into the existing album the matched
+        # duplicates belong to. Tracks matching a *singleton* are skipped
+        # individually but do not affect the fold target (their ``album_id``
+        # is ``None``), so a mix of album-member and singleton matches still
+        # completes the album. Only when the matched album members span more
+        # than one album -- or none of the matches belong to an album at all
+        # -- are the new tracks imported as their own album.
         album_ids = {
             match.album_id
             for matches in duplicates.values()
             for match in matches
+            if match.album_id is not None
         }
-        if len(album_ids) == 1 and None not in album_ids:
+        if len(album_ids) == 1:
             task.fold_into_album_id = album_ids.pop()
         else:
             log.warning(

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextvars
 import itertools
 import logging
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 from beets import config, dbcore, plugins
 from beets.util import MoveOperation, displayable_path, pipeline
@@ -152,16 +152,34 @@ def group_albums(session: ImportSession) -> StageCoro:
     if not keys:
         return
 
-    # Map each incoming item to the existing library items it duplicates.
+    def item_key(item: library.Item) -> tuple[Any, ...]:
+        return tuple(item.get(k) for k in keys)
+
+    def has_key(item: library.Item) -> bool:
+        return any(item.get(k) for k in keys)
+
+    def remember(items: Iterable[library.Item]) -> None:
+        # Claim the keys of the tracks this task will import so that later
+        # tasks in the same run recognise them as duplicates before they reach
+        # the database (see ``ImportSession.track_key_seen``).
+        for item in items:
+            if has_key(item):
+                session.remember_track_key(item_key(item))
+
+    # Map each incoming item to the existing library items it duplicates. A
+    # track also counts as a duplicate when its key was already claimed by an
+    # earlier task in this same import run, even if that task has not been
+    # added to the library yet.
     duplicates: dict[library.Item, list[library.Item]] = {}
     for item in task.items:
-        if not any(item.get(k) for k in keys):
+        if not has_key(item):
             continue
         matches = _find_track_duplicates(session.lib, item, keys)
-        if matches:
+        if matches or session.track_key_seen(item_key(item)):
             duplicates[item] = matches
 
     if not duplicates:
+        remember(task.items)
         return
 
     action = _track_duplicate_action()
@@ -215,6 +233,9 @@ def group_albums(session: ImportSession) -> StageCoro:
         task.duplicate_tracks_resolved = True
     # KEEP and MERGE leave the incoming tracks untouched; whole-album
     # duplicates are still handled by the regular resolution stage.
+
+    # Claim the keys of the tracks that remain to be imported.
+    remember(task.items)
 
 
 @pipeline.mutator_stage

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import contextvars
 import itertools
 import logging
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, TypeAlias
 
-from beets import config, dbcore, plugins
+from beets import config, plugins
+from beets.autotag import AlbumMatch
 from beets.util import MoveOperation, displayable_path, pipeline
-from beets.util.color import colorize
 
 from .actions import Action, DuplicateAction
 from .tasks import (
@@ -121,125 +121,7 @@ def group_albums(session: ImportSession) -> StageCoro:
 
 
 @pipeline.mutator_stage
-    """Resolve tracks of an album that already exist in the library.
-
-    When ``import.duplicate_track_resolution`` is enabled, each item of an
-    album import is checked against the library using
-    ``import.duplicate_keys.item``. Matched tracks are resolved according to
-    ``import.duplicate_track_action`` (which falls back to
-    ``import.duplicate_action`` when unset):
-
-    * ``skip`` drops the duplicate tracks and adds the remaining new tracks to
-      the existing album they belong to (if every track is a duplicate, the
-      whole album is skipped);
-    * ``remove`` removes the matching old library items;
-    * ``keep`` (and ``merge``) import everything as-is;
-    * ``ask`` prompts the session for one of the above.
-
-    This runs before :func:`lookup_candidates` so that dropped tracks are
-    excluded from the autotag match. Singleton imports are handled by the
-    regular duplicate resolution and are ignored here.
-    """
-    if (
-        task.skip
-        or not task.is_album
-        or not task.items
-        or not config["import"]["duplicate_track_resolution"].get(bool)
-    ):
-        return
-
-    keys = config["import"]["duplicate_keys"]["item"].as_str_seq()
-    if not keys:
-        return
-
-    def item_key(item: library.Item) -> tuple[Any, ...]:
-        return tuple(item.get(k) for k in keys)
-
-    def has_key(item: library.Item) -> bool:
-        return any(item.get(k) for k in keys)
-
-    def remember(items: Iterable[library.Item]) -> None:
-        # Claim the keys of the tracks this task will import so that later
-        # tasks in the same run recognise them as duplicates before they reach
-        # the database (see ``ImportSession.track_key_seen``).
-        for item in items:
-            if has_key(item):
-                session.remember_track_key(item_key(item))
-
-    # Map each incoming item to the existing library items it duplicates. A
-    # track also counts as a duplicate when its key was already claimed by an
-    # earlier task in this same import run, even if that task has not been
-    # added to the library yet.
-    duplicates: dict[library.Item, list[library.Item]] = {}
-    for item in task.items:
-        if not has_key(item):
-            continue
-        matches = _find_track_duplicates(session.lib, item, keys)
-        if matches or session.track_key_seen(item_key(item)):
-            duplicates[item] = matches
-
-    if not duplicates:
-        remember(task.items)
-        return
-
-    action = _track_duplicate_action()
-    if action is DuplicateAction.ASK:
-        action = session.resolve_track_duplicates(task, duplicates)
-
-    if action is DuplicateAction.SKIP:
-        for item in duplicates:
-            log.info(
-                colorize("text_warning", "Skipping duplicate track: {}"),
-                displayable_path(item.path),
-            )
-            task.items.remove(item)
-        if not task.items:
-            # Every track was a duplicate: skip the whole album.
-            log.info(
-                colorize(
-                    "text_warning",
-                    "Skipping album, all tracks are duplicates: {}",
-                ),
-                next(iter(duplicates)).album,
-            )
-            task.set_choice(Action.SKIP)
-            return
-        # Only some tracks were duplicates; we have already dropped them, so
-        # don't let the album-level check skip the rest.
-        task.duplicate_tracks_resolved = True
-        # Fold the remaining new tracks into the existing album the matched
-        # duplicates belong to. Tracks matching a *singleton* are skipped
-        # individually but do not affect the fold target (their ``album_id``
-        # is ``None``), so a mix of album-member and singleton matches still
-        # completes the album. Only when the matched album members span more
-        # than one album -- or none of the matches belong to an album at all
-        # -- are the new tracks imported as their own album.
-        album_ids = {
-            match.album_id
-            for matches in duplicates.values()
-            for match in matches
-            if match.album_id is not None
-        }
-        if len(album_ids) == 1:
-            task.fold_into_album_id = album_ids.pop()
-        else:
-            log.warning(
-                "cannot fold tracks into a single existing album; "
-                "importing them as a new album"
-            )
-    elif action is DuplicateAction.REMOVE:
-        for matches in duplicates.values():
-            task.duplicate_track_items_to_remove.extend(matches)
-        task.duplicate_tracks_resolved = True
-    # KEEP and MERGE leave the incoming tracks untouched; whole-album
-    # duplicates are still handled by the regular resolution stage.
-
-    # Claim the keys of the tracks that remain to be imported.
-    remember(task.items)
-
-
-@pipeline.mutator_stage
-def lookup_candidates(session: ImportSession, task: ImportTask):
+def lookup_candidates(session: ImportSession, task: ImportTask) -> None:
     """A coroutine for performing the initial MusicBrainz lookup for an
     album. It accepts lists of Items and yields
     (items, cur_artist, cur_album, candidates, rec) tuples. If no match
@@ -393,9 +275,7 @@ def manipulate_files(session: ImportSession, task: ImportTask) -> None:
     if not task.skip:
         if task.duplicate_action is DuplicateAction.REMOVE:
             task.remove_duplicates(session.lib)
-
-        if task.duplicate_track_items_to_remove:
-            task.remove_duplicate_track_items(session.lib)
+        task.remove_track_duplicates(session.lib)
 
         if session.config["move"]:
             operation = MoveOperation.MOVE
@@ -433,12 +313,22 @@ def _apply_choice(session: ImportSession, task: ImportTask) -> None:
     if task.skip:
         return
 
+    # Drop tracks resolved as duplicates before anything is added to the
+    # library; this may skip the whole task.
+    _apply_track_duplicate_skips(task)
+    if task.skip:
+        return
+
     # Change metadata.
     if task.apply:
         task.apply_metadata()
         plugins.send("import_task_apply", session=session, task=task)
 
     task.add(session.lib)
+
+    # When duplicate tracks were skipped, complete the existing album with
+    # the remaining new tracks instead of keeping them as a new album.
+    _fold_into_existing_album(session, task)
 
     # If ``set_fields`` is set, set those fields to the
     # configured values.
@@ -449,58 +339,109 @@ def _apply_choice(session: ImportSession, task: ImportTask) -> None:
         task.set_fields(session.lib)
 
 
-def _track_duplicate_action() -> DuplicateAction:
-    """Return the configured :class:`DuplicateAction` for per-track resolution.
-
-    Uses ``import.duplicate_track_action`` when set, otherwise falls back to
-    ``import.duplicate_action``.
-    """
-    cfg = config["import"]
-    view = (
-        cfg["duplicate_track_action"]
-        if cfg["duplicate_track_action"].get()
-        else cfg["duplicate_action"]
-    )
-    choice = view.as_choice(DuplicateAction.choices())
-    return DuplicateAction(choice)  # type: ignore[call-arg]
-
-
-def _find_track_duplicates(
-    lib: library.Library, item: library.Item, keys: list[str]
-) -> list[library.Item]:
-    """Return library items matching `item` on all `keys`, excluding the
-    item itself (so re-imports do not match their own files).
-
-    Unlike :meth:`Item.duplicates_query`, this matches *every* library item,
-    including tracks that belong to an album -- not just singletons -- so a
-    track is caught regardless of how it was originally imported.
-    """
-    query = dbcore.AndQuery(
-        [item.field_query(k, item.get(k), dbcore.MatchQuery) for k in keys]
-    )
-    return [other for other in lib.items(query) if other.path != item.path]
-
-
-def _resolve_duplicates(session: ImportSession, task: ImportTask):
+def _resolve_duplicates(session: ImportSession, task: ImportTask) -> None:
     """Check if a task conflicts with items or albums already imported
     and ask the session to resolve this.
+
+    For album tasks with ``import.duplicate_tracks`` enabled, individual
+    tracks that duplicate existing library items are detected here as well,
+    so both levels are decided at a single point before anything is added
+    to the library.
     """
-    if task.duplicate_tracks_resolved:
-        # Per-track duplicate resolution already pruned (or recorded for
-        # removal) the tracks of this album that exist in the library; the
-        # rest are new and should be imported without a whole-album skip.
+    if task.choice_flag not in (Action.ASIS, Action.APPLY, Action.RETAG):
         return
 
-    if task.choice_flag in (Action.ASIS, Action.APPLY, Action.RETAG):
-        found_duplicates = task.find_duplicates(session.lib)
-        if found_duplicates:
-            log.debug("found duplicates: {}", [o.id for o in found_duplicates])
+    found_duplicates = task.find_duplicates(session.lib)
 
-            task.duplicate_action = session.get_duplicate_action(
-                task, found_duplicates
-            )
+    track_duplicates: dict[library.Item, list[library.Item]] = {}
+    if task.is_album and session.config["duplicate_tracks"].get(bool):
+        track_duplicates = task.find_track_duplicates(session.lib)
 
-            session.log_choice(task, True)
+    if not found_duplicates and not track_duplicates:
+        return
+
+    if found_duplicates:
+        log.debug("found duplicates: {}", [o.id for o in found_duplicates])
+    if track_duplicates:
+        log.debug(
+            "found track duplicates: {}",
+            [o.id for matches in track_duplicates.values() for o in matches],
+        )
+
+    task.track_duplicates = track_duplicates
+    session.resolve_duplicates(task, found_duplicates, track_duplicates)
+    session.log_choice(task, True)
+
+
+def _apply_track_duplicate_skips(task: ImportTask) -> None:
+    """Drop items whose per-track duplicate action is SKIP from the task,
+    before anything is added to the library. If no items remain, skip the
+    whole task.
+    """
+    skipped = [
+        item
+        for item, action in task.track_duplicate_actions.items()
+        if action is DuplicateAction.SKIP
+    ]
+    if not skipped:
+        return
+
+    for item in skipped:
+        log.info("Skipping duplicate track: {}", displayable_path(item.path))
+        if item in task.items:
+            task.items.remove(item)
+        if isinstance(task.match, AlbumMatch):
+            task.match.mapping.pop(item, None)
+
+    if not task.imported_items():
+        log.info(
+            "Skipping album, all tracks are duplicates: {}", skipped[0].album
+        )
+        task.set_choice(Action.SKIP)
+
+
+def _fold_into_existing_album(session: ImportSession, task: ImportTask) -> None:
+    """After skipping duplicate tracks, fold the newly added tracks into the
+    existing album the skipped tracks' duplicates belong to.
+
+    Matched *singletons* have no ``album_id`` and do not affect the fold
+    target, so a mix of album-member and singleton matches still completes
+    the album. Only when the matched album members span more than one album
+    -- or none of the matches belong to an album at all -- do the new tracks
+    stay in their own album.
+    """
+    skipped = [
+        item
+        for item, action in task.track_duplicate_actions.items()
+        if action is DuplicateAction.SKIP
+    ]
+    if not skipped or task.skip or not task.is_album:
+        return
+
+    album_ids = {
+        match.album_id
+        for item in skipped
+        for match in task.track_duplicates.get(item, [])
+        if match.album_id is not None
+    }
+    existing_album = (
+        session.lib.get_album(album_ids.pop()) if len(album_ids) == 1 else None
+    )
+    if existing_album is None:
+        log.warning(
+            "cannot fold tracks into a single existing album; "
+            "keeping them as a new album"
+        )
+        return
+
+    new_album = task.album
+    for item in task.imported_items():
+        item.album_id = existing_album.id
+        item.store()
+    task.album = existing_album
+    if new_album is not None and new_album.id != existing_album.id:
+        # The freshly created album container is now empty.
+        new_album.remove(with_items=False)
 
 
 def _freshen_items(items: Iterable[library.Item]) -> None:

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, TypeAlias
 
 from beets import config, dbcore, plugins
 from beets.util import MoveOperation, displayable_path, pipeline
+from beets.util.color import colorize
 
 from .actions import Action, DuplicateAction
 from .tasks import (
@@ -128,11 +129,10 @@ def group_albums(session: ImportSession) -> StageCoro:
     ``import.duplicate_track_action`` (which falls back to
     ``import.duplicate_action`` when unset):
 
-    * ``skip`` drops the duplicate tracks and imports the rest of the album
-      (if every track is a duplicate, the whole album is skipped);
+    * ``skip`` drops the duplicate tracks and adds the remaining new tracks to
+      the existing album they belong to (if every track is a duplicate, the
+      whole album is skipped);
     * ``remove`` removes the matching old library items;
-    * ``fold`` drops the duplicate tracks and adds the remaining new tracks to
-      the existing album they belong to;
     * ``keep`` (and ``merge``) import everything as-is;
     * ``ask`` prompts the session for one of the above.
 
@@ -168,35 +168,42 @@ def group_albums(session: ImportSession) -> StageCoro:
     if action == "a":
         action = session.resolve_track_duplicates(task, duplicates)
 
-    if action in ("s", "f"):
+    if action == "s":
         for item in duplicates:
             log.info(
-                "skipping duplicate track: {}", displayable_path(item.path)
+                colorize("text_warning", "Skipping duplicate track: {}"),
+                displayable_path(item.path),
             )
             task.items.remove(item)
         if not task.items:
             # Every track was a duplicate: skip the whole album.
+            log.info(
+                colorize(
+                    "text_warning",
+                    "Skipping album, all tracks are duplicates: {}",
+                ),
+                next(iter(duplicates)).album,
+            )
             task.set_choice(Action.SKIP)
             return
         # Only some tracks were duplicates; we have already dropped them, so
         # don't let the album-level check skip the rest.
         task.duplicate_tracks_resolved = True
-        if action == "f":
-            # Fold the remaining new tracks into the existing album, if the
-            # matched duplicates all belong to a single one.
-            album_ids = {
-                match.album_id
-                for matches in duplicates.values()
-                for match in matches
-                if match.album_id is not None
-            }
-            if len(album_ids) == 1:
-                task.fold_into_album_id = album_ids.pop()
-            else:
-                log.warning(
-                    "cannot fold tracks into a single existing album; "
-                    "importing them as a new album"
-                )
+        # Fold the remaining new tracks into the existing album, if the
+        # matched duplicates all belong to a single one.
+        album_ids = {
+            match.album_id
+            for matches in duplicates.values()
+            for match in matches
+            if match.album_id is not None
+        }
+        if len(album_ids) == 1:
+            task.fold_into_album_id = album_ids.pop()
+        else:
+            log.warning(
+                "cannot fold tracks into a single existing album; "
+                "importing them as a new album"
+            )
     elif action == "r":
         for matches in duplicates.values():
             task.duplicate_track_items_to_remove.extend(matches)
@@ -427,7 +434,6 @@ def _track_duplicate_action() -> str:
         "keep": "k",
         "remove": "r",
         "merge": "m",
-        "fold": "f",
         "ask": "a",
     }
     cfg = config["import"]

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -121,7 +121,70 @@ def group_albums(session: ImportSession) -> StageCoro:
 
 
 @pipeline.mutator_stage
-def lookup_candidates(session: ImportSession, task: ImportTask) -> None:
+    """Resolve tracks of an album that already exist in the library.
+
+    When ``import.duplicate_track_resolution`` is enabled, each item of an
+    album import is checked against the library using
+    ``import.duplicate_keys.item``. Matched tracks are resolved according to
+    ``import.duplicate_action``:
+
+    * ``skip`` drops the duplicate tracks and imports the rest of the album
+      (if every track is a duplicate, the whole album is skipped);
+    * ``remove`` removes the matching old library items;
+    * ``keep`` (and ``merge``) import everything as-is;
+    * ``ask`` prompts the session for one of the above.
+
+    This runs before :func:`lookup_candidates` so that dropped tracks are
+    excluded from the autotag match. Singleton imports are handled by the
+    regular duplicate resolution and are ignored here.
+    """
+    if (
+        task.skip
+        or not task.is_album
+        or not task.items
+        or not config["import"]["duplicate_track_resolution"].get(bool)
+    ):
+        return
+
+    keys = config["import"]["duplicate_keys"]["item"].as_str_seq()
+    if not keys:
+        return
+
+    # Map each incoming item to the existing library items it duplicates.
+    duplicates: dict[library.Item, list[library.Item]] = {}
+    for item in task.items:
+        if not any(item.get(k) for k in keys):
+            continue
+        matches = _find_track_duplicates(session.lib, item, keys)
+        if matches:
+            duplicates[item] = matches
+
+    if not duplicates:
+        return
+
+    action = config["import"]["duplicate_action"].as_choice(
+        {"skip": "s", "keep": "k", "remove": "r", "merge": "m", "ask": "a"}
+    )
+    if action == "a":
+        action = session.resolve_track_duplicates(task, duplicates)
+
+    if action == "s":
+        for item in duplicates:
+            log.info(
+                "skipping duplicate track: {}", displayable_path(item.path)
+            )
+            task.items.remove(item)
+        if not task.items:
+            task.set_choice(Action.SKIP)
+    elif action == "r":
+        for matches in duplicates.values():
+            task.duplicate_track_items_to_remove.extend(matches)
+    # "k" (keep) and "m" (merge) leave the incoming tracks untouched; whole
+    # album duplicates are still handled by the regular resolution stage.
+
+
+@pipeline.mutator_stage
+def lookup_candidates(session: ImportSession, task: ImportTask):
     """A coroutine for performing the initial MusicBrainz lookup for an
     album. It accepts lists of Items and yields
     (items, cur_artist, cur_album, candidates, rec) tuples. If no match
@@ -279,6 +342,9 @@ def manipulate_files(session: ImportSession, task: ImportTask) -> None:
         ):
             task.remove_duplicates(session.lib)
 
+        if task.duplicate_track_items_to_remove:
+            task.remove_duplicate_track_items(session.lib)
+
         if session.config["move"]:
             operation = MoveOperation.MOVE
         elif session.config["copy"]:
@@ -331,7 +397,17 @@ def _apply_choice(session: ImportSession, task: ImportTask) -> None:
         task.set_fields(session.lib)
 
 
-def _resolve_duplicates(session: ImportSession, task: ImportTask) -> None:
+def _find_track_duplicates(
+    lib: library.Library, item: library.Item, keys: list[str]
+) -> list[library.Item]:
+    """Return library items matching `item` on all `keys`, excluding the
+    item itself (so re-imports do not match their own files).
+    """
+    query = item.duplicates_query(keys)
+    return [other for other in lib.items(query) if other.path != item.path]
+
+
+def _resolve_duplicates(session: ImportSession, task: ImportTask):
     """Check if a task conflicts with items or albums already imported
     and ask the session to resolve this.
     """

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -166,10 +166,10 @@ def group_albums(session: ImportSession) -> StageCoro:
         return
 
     action = _track_duplicate_action()
-    if action == "a":
+    if action is DuplicateAction.ASK:
         action = session.resolve_track_duplicates(task, duplicates)
 
-    if action == "s":
+    if action is DuplicateAction.SKIP:
         for item in duplicates:
             log.info(
                 colorize("text_warning", "Skipping duplicate track: {}"),
@@ -190,27 +190,28 @@ def group_albums(session: ImportSession) -> StageCoro:
         # Only some tracks were duplicates; we have already dropped them, so
         # don't let the album-level check skip the rest.
         task.duplicate_tracks_resolved = True
-        # Fold the remaining new tracks into the existing album, if the
-        # matched duplicates all belong to a single one.
+        # Fold the remaining new tracks into the existing album only when
+        # every matched duplicate belongs to that same album. A singleton
+        # match (``album_id`` is ``None``) means the duplicates do not all
+        # belong to one album, so the new tracks are imported as their own.
         album_ids = {
             match.album_id
             for matches in duplicates.values()
             for match in matches
-            if match.album_id is not None
         }
-        if len(album_ids) == 1:
+        if len(album_ids) == 1 and None not in album_ids:
             task.fold_into_album_id = album_ids.pop()
         else:
             log.warning(
                 "cannot fold tracks into a single existing album; "
                 "importing them as a new album"
             )
-    elif action == "r":
+    elif action is DuplicateAction.REMOVE:
         for matches in duplicates.values():
             task.duplicate_track_items_to_remove.extend(matches)
         task.duplicate_tracks_resolved = True
-    # "k" (keep) and "m" (merge) leave the incoming tracks untouched; whole
-    # album duplicates are still handled by the regular resolution stage.
+    # KEEP and MERGE leave the incoming tracks untouched; whole-album
+    # duplicates are still handled by the regular resolution stage.
 
 
 @pipeline.mutator_stage
@@ -427,26 +428,20 @@ def _apply_choice(session: ImportSession, task: ImportTask) -> None:
         task.set_fields(session.lib)
 
 
-def _track_duplicate_action() -> str:
-    """Return the single-letter action for per-track duplicate resolution.
+def _track_duplicate_action() -> DuplicateAction:
+    """Return the configured :class:`DuplicateAction` for per-track resolution.
 
     Uses ``import.duplicate_track_action`` when set, otherwise falls back to
     ``import.duplicate_action``.
     """
-    choices = {
-        "skip": "s",
-        "keep": "k",
-        "remove": "r",
-        "merge": "m",
-        "ask": "a",
-    }
     cfg = config["import"]
     view = (
         cfg["duplicate_track_action"]
         if cfg["duplicate_track_action"].get()
         else cfg["duplicate_action"]
     )
-    return view.as_choice(choices)
+    choice = view.as_choice(DuplicateAction.choices())
+    return DuplicateAction(choice)  # type: ignore[call-arg]
 
 
 def _find_track_duplicates(

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, TypeAlias
 
 from beets import config, dbcore, plugins
 from beets.util import MoveOperation, displayable_path, pipeline
+from beets.util.color import colorize
 
 from .actions import Action, DuplicateAction
 from .tasks import (
@@ -129,11 +130,10 @@ def group_albums(session: ImportSession) -> StageCoro:
     ``import.duplicate_track_action`` (which falls back to
     ``import.duplicate_action`` when unset):
 
-    * ``skip`` drops the duplicate tracks and imports the rest of the album
-      (if every track is a duplicate, the whole album is skipped);
+    * ``skip`` drops the duplicate tracks and adds the remaining new tracks to
+      the existing album they belong to (if every track is a duplicate, the
+      whole album is skipped);
     * ``remove`` removes the matching old library items;
-    * ``fold`` drops the duplicate tracks and adds the remaining new tracks to
-      the existing album they belong to;
     * ``keep`` (and ``merge``) import everything as-is;
     * ``ask`` prompts the session for one of the above.
 
@@ -169,35 +169,42 @@ def group_albums(session: ImportSession) -> StageCoro:
     if action == "a":
         action = session.resolve_track_duplicates(task, duplicates)
 
-    if action in ("s", "f"):
+    if action == "s":
         for item in duplicates:
             log.info(
-                "skipping duplicate track: {}", displayable_path(item.path)
+                colorize("text_warning", "Skipping duplicate track: {}"),
+                displayable_path(item.path),
             )
             task.items.remove(item)
         if not task.items:
             # Every track was a duplicate: skip the whole album.
+            log.info(
+                colorize(
+                    "text_warning",
+                    "Skipping album, all tracks are duplicates: {}",
+                ),
+                next(iter(duplicates)).album,
+            )
             task.set_choice(Action.SKIP)
             return
         # Only some tracks were duplicates; we have already dropped them, so
         # don't let the album-level check skip the rest.
         task.duplicate_tracks_resolved = True
-        if action == "f":
-            # Fold the remaining new tracks into the existing album, if the
-            # matched duplicates all belong to a single one.
-            album_ids = {
-                match.album_id
-                for matches in duplicates.values()
-                for match in matches
-                if match.album_id is not None
-            }
-            if len(album_ids) == 1:
-                task.fold_into_album_id = album_ids.pop()
-            else:
-                log.warning(
-                    "cannot fold tracks into a single existing album; "
-                    "importing them as a new album"
-                )
+        # Fold the remaining new tracks into the existing album, if the
+        # matched duplicates all belong to a single one.
+        album_ids = {
+            match.album_id
+            for matches in duplicates.values()
+            for match in matches
+            if match.album_id is not None
+        }
+        if len(album_ids) == 1:
+            task.fold_into_album_id = album_ids.pop()
+        else:
+            log.warning(
+                "cannot fold tracks into a single existing album; "
+                "importing them as a new album"
+            )
     elif action == "r":
         for matches in duplicates.values():
             task.duplicate_track_items_to_remove.extend(matches)
@@ -431,7 +438,6 @@ def _track_duplicate_action() -> str:
         "keep": "k",
         "remove": "r",
         "merge": "m",
-        "fold": "f",
         "ask": "a",
     }
     cfg = config["import"]

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -5,7 +5,7 @@ import itertools
 import logging
 from typing import TYPE_CHECKING, TypeAlias
 
-from beets import config, plugins
+from beets import config, dbcore, plugins
 from beets.util import MoveOperation, displayable_path, pipeline
 
 from .actions import Action, DuplicateAction
@@ -126,11 +126,14 @@ def group_albums(session: ImportSession) -> StageCoro:
     When ``import.duplicate_track_resolution`` is enabled, each item of an
     album import is checked against the library using
     ``import.duplicate_keys.item``. Matched tracks are resolved according to
-    ``import.duplicate_action``:
+    ``import.duplicate_track_action`` (which falls back to
+    ``import.duplicate_action`` when unset):
 
     * ``skip`` drops the duplicate tracks and imports the rest of the album
       (if every track is a duplicate, the whole album is skipped);
     * ``remove`` removes the matching old library items;
+    * ``fold`` drops the duplicate tracks and adds the remaining new tracks to
+      the existing album they belong to;
     * ``keep`` (and ``merge``) import everything as-is;
     * ``ask`` prompts the session for one of the above.
 
@@ -162,23 +165,43 @@ def group_albums(session: ImportSession) -> StageCoro:
     if not duplicates:
         return
 
-    action = config["import"]["duplicate_action"].as_choice(
-        {"skip": "s", "keep": "k", "remove": "r", "merge": "m", "ask": "a"}
-    )
+    action = _track_duplicate_action()
     if action == "a":
         action = session.resolve_track_duplicates(task, duplicates)
 
-    if action == "s":
+    if action in ("s", "f"):
         for item in duplicates:
             log.info(
                 "skipping duplicate track: {}", displayable_path(item.path)
             )
             task.items.remove(item)
         if not task.items:
+            # Every track was a duplicate: skip the whole album.
             task.set_choice(Action.SKIP)
+            return
+        # Only some tracks were duplicates; we have already dropped them, so
+        # don't let the album-level check skip the rest.
+        task.duplicate_tracks_resolved = True
+        if action == "f":
+            # Fold the remaining new tracks into the existing album, if the
+            # matched duplicates all belong to a single one.
+            album_ids = {
+                match.album_id
+                for matches in duplicates.values()
+                for match in matches
+                if match.album_id is not None
+            }
+            if len(album_ids) == 1:
+                task.fold_into_album_id = album_ids.pop()
+            else:
+                log.warning(
+                    "cannot fold tracks into a single existing album; "
+                    "importing them as a new album"
+                )
     elif action == "r":
         for matches in duplicates.values():
             task.duplicate_track_items_to_remove.extend(matches)
+        task.duplicate_tracks_resolved = True
     # "k" (keep) and "m" (merge) leave the incoming tracks untouched; whole
     # album duplicates are still handled by the regular resolution stage.
 
@@ -397,13 +420,42 @@ def _apply_choice(session: ImportSession, task: ImportTask) -> None:
         task.set_fields(session.lib)
 
 
+def _track_duplicate_action() -> str:
+    """Return the single-letter action for per-track duplicate resolution.
+
+    Uses ``import.duplicate_track_action`` when set, otherwise falls back to
+    ``import.duplicate_action``.
+    """
+    choices = {
+        "skip": "s",
+        "keep": "k",
+        "remove": "r",
+        "merge": "m",
+        "fold": "f",
+        "ask": "a",
+    }
+    cfg = config["import"]
+    view = (
+        cfg["duplicate_track_action"]
+        if cfg["duplicate_track_action"].get()
+        else cfg["duplicate_action"]
+    )
+    return view.as_choice(choices)
+
+
 def _find_track_duplicates(
     lib: library.Library, item: library.Item, keys: list[str]
 ) -> list[library.Item]:
     """Return library items matching `item` on all `keys`, excluding the
     item itself (so re-imports do not match their own files).
+
+    Unlike :meth:`Item.duplicates_query`, this matches *every* library item,
+    including tracks that belong to an album -- not just singletons -- so a
+    track is caught regardless of how it was originally imported.
     """
-    query = item.duplicates_query(keys)
+    query = dbcore.AndQuery(
+        [item.field_query(k, item.get(k), dbcore.MatchQuery) for k in keys]
+    )
     return [other for other in lib.items(query) if other.path != item.path]
 
 
@@ -411,6 +463,12 @@ def _resolve_duplicates(session: ImportSession, task: ImportTask):
     """Check if a task conflicts with items or albums already imported
     and ask the session to resolve this.
     """
+    if task.duplicate_tracks_resolved:
+        # Per-track duplicate resolution already pruned (or recorded for
+        # removal) the tracks of this album that exist in the library; the
+        # rest are new and should be imported without a whole-album skip.
+        return
+
     if task.choice_flag in (Action.ASIS, Action.APPLY, Action.RETAG):
         found_duplicates = task.find_duplicates(session.lib)
         if found_duplicates:

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextvars
 import itertools
 import logging
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 from beets import config, dbcore, plugins
 from beets.util import MoveOperation, displayable_path, pipeline
@@ -153,16 +153,34 @@ def group_albums(session: ImportSession) -> StageCoro:
     if not keys:
         return
 
-    # Map each incoming item to the existing library items it duplicates.
+    def item_key(item: library.Item) -> tuple[Any, ...]:
+        return tuple(item.get(k) for k in keys)
+
+    def has_key(item: library.Item) -> bool:
+        return any(item.get(k) for k in keys)
+
+    def remember(items: Iterable[library.Item]) -> None:
+        # Claim the keys of the tracks this task will import so that later
+        # tasks in the same run recognise them as duplicates before they reach
+        # the database (see ``ImportSession.track_key_seen``).
+        for item in items:
+            if has_key(item):
+                session.remember_track_key(item_key(item))
+
+    # Map each incoming item to the existing library items it duplicates. A
+    # track also counts as a duplicate when its key was already claimed by an
+    # earlier task in this same import run, even if that task has not been
+    # added to the library yet.
     duplicates: dict[library.Item, list[library.Item]] = {}
     for item in task.items:
-        if not any(item.get(k) for k in keys):
+        if not has_key(item):
             continue
         matches = _find_track_duplicates(session.lib, item, keys)
-        if matches:
+        if matches or session.track_key_seen(item_key(item)):
             duplicates[item] = matches
 
     if not duplicates:
+        remember(task.items)
         return
 
     action = _track_duplicate_action()
@@ -216,6 +234,9 @@ def group_albums(session: ImportSession) -> StageCoro:
         task.duplicate_tracks_resolved = True
     # KEEP and MERGE leave the incoming tracks untouched; whole-album
     # duplicates are still handled by the regular resolution stage.
+
+    # Claim the keys of the tracks that remain to be imported.
+    remember(task.items)
 
 
 @pipeline.mutator_stage

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import contextvars
 import itertools
 import logging
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, TypeAlias
 
-from beets import config, dbcore, plugins
+from beets import config, plugins
+from beets.autotag import AlbumMatch
 from beets.util import MoveOperation, displayable_path, pipeline
-from beets.util.color import colorize
 
 from .actions import Action, DuplicateAction
 from .tasks import (
@@ -122,125 +122,7 @@ def group_albums(session: ImportSession) -> StageCoro:
 
 
 @pipeline.mutator_stage
-    """Resolve tracks of an album that already exist in the library.
-
-    When ``import.duplicate_track_resolution`` is enabled, each item of an
-    album import is checked against the library using
-    ``import.duplicate_keys.item``. Matched tracks are resolved according to
-    ``import.duplicate_track_action`` (which falls back to
-    ``import.duplicate_action`` when unset):
-
-    * ``skip`` drops the duplicate tracks and adds the remaining new tracks to
-      the existing album they belong to (if every track is a duplicate, the
-      whole album is skipped);
-    * ``remove`` removes the matching old library items;
-    * ``keep`` (and ``merge``) import everything as-is;
-    * ``ask`` prompts the session for one of the above.
-
-    This runs before :func:`lookup_candidates` so that dropped tracks are
-    excluded from the autotag match. Singleton imports are handled by the
-    regular duplicate resolution and are ignored here.
-    """
-    if (
-        task.skip
-        or not task.is_album
-        or not task.items
-        or not config["import"]["duplicate_track_resolution"].get(bool)
-    ):
-        return
-
-    keys = config["import"]["duplicate_keys"]["item"].as_str_seq()
-    if not keys:
-        return
-
-    def item_key(item: library.Item) -> tuple[Any, ...]:
-        return tuple(item.get(k) for k in keys)
-
-    def has_key(item: library.Item) -> bool:
-        return any(item.get(k) for k in keys)
-
-    def remember(items: Iterable[library.Item]) -> None:
-        # Claim the keys of the tracks this task will import so that later
-        # tasks in the same run recognise them as duplicates before they reach
-        # the database (see ``ImportSession.track_key_seen``).
-        for item in items:
-            if has_key(item):
-                session.remember_track_key(item_key(item))
-
-    # Map each incoming item to the existing library items it duplicates. A
-    # track also counts as a duplicate when its key was already claimed by an
-    # earlier task in this same import run, even if that task has not been
-    # added to the library yet.
-    duplicates: dict[library.Item, list[library.Item]] = {}
-    for item in task.items:
-        if not has_key(item):
-            continue
-        matches = _find_track_duplicates(session.lib, item, keys)
-        if matches or session.track_key_seen(item_key(item)):
-            duplicates[item] = matches
-
-    if not duplicates:
-        remember(task.items)
-        return
-
-    action = _track_duplicate_action()
-    if action is DuplicateAction.ASK:
-        action = session.resolve_track_duplicates(task, duplicates)
-
-    if action is DuplicateAction.SKIP:
-        for item in duplicates:
-            log.info(
-                colorize("text_warning", "Skipping duplicate track: {}"),
-                displayable_path(item.path),
-            )
-            task.items.remove(item)
-        if not task.items:
-            # Every track was a duplicate: skip the whole album.
-            log.info(
-                colorize(
-                    "text_warning",
-                    "Skipping album, all tracks are duplicates: {}",
-                ),
-                next(iter(duplicates)).album,
-            )
-            task.set_choice(Action.SKIP)
-            return
-        # Only some tracks were duplicates; we have already dropped them, so
-        # don't let the album-level check skip the rest.
-        task.duplicate_tracks_resolved = True
-        # Fold the remaining new tracks into the existing album the matched
-        # duplicates belong to. Tracks matching a *singleton* are skipped
-        # individually but do not affect the fold target (their ``album_id``
-        # is ``None``), so a mix of album-member and singleton matches still
-        # completes the album. Only when the matched album members span more
-        # than one album -- or none of the matches belong to an album at all
-        # -- are the new tracks imported as their own album.
-        album_ids = {
-            match.album_id
-            for matches in duplicates.values()
-            for match in matches
-            if match.album_id is not None
-        }
-        if len(album_ids) == 1:
-            task.fold_into_album_id = album_ids.pop()
-        else:
-            log.warning(
-                "cannot fold tracks into a single existing album; "
-                "importing them as a new album"
-            )
-    elif action is DuplicateAction.REMOVE:
-        for matches in duplicates.values():
-            task.duplicate_track_items_to_remove.extend(matches)
-        task.duplicate_tracks_resolved = True
-    # KEEP and MERGE leave the incoming tracks untouched; whole-album
-    # duplicates are still handled by the regular resolution stage.
-
-    # Claim the keys of the tracks that remain to be imported.
-    remember(task.items)
-
-
-@pipeline.mutator_stage
-def lookup_candidates(session: ImportSession, task: ImportTask):
+def lookup_candidates(session: ImportSession, task: ImportTask) -> None:
     """A coroutine for performing the initial MusicBrainz lookup for an
     album. It accepts lists of Items and yields
     (items, cur_artist, cur_album, candidates, rec) tuples. If no match
@@ -397,9 +279,7 @@ def manipulate_files(session: ImportSession, task: ImportTask) -> None:
             DuplicateAction.UPGRADE,
         ):
             task.remove_duplicates(session.lib)
-
-        if task.duplicate_track_items_to_remove:
-            task.remove_duplicate_track_items(session.lib)
+        task.remove_track_duplicates(session.lib)
 
         if session.config["move"]:
             operation = MoveOperation.MOVE
@@ -437,12 +317,22 @@ def _apply_choice(session: ImportSession, task: ImportTask) -> None:
     if task.skip:
         return
 
+    # Drop tracks resolved as duplicates before anything is added to the
+    # library; this may skip the whole task.
+    _apply_track_duplicate_skips(task)
+    if task.skip:
+        return
+
     # Change metadata.
     if task.apply:
         task.apply_metadata()
         plugins.send("import_task_apply", session=session, task=task)
 
     task.add(session.lib)
+
+    # When duplicate tracks were skipped, complete the existing album with
+    # the remaining new tracks instead of keeping them as a new album.
+    _fold_into_existing_album(session, task)
 
     # If ``set_fields`` is set, set those fields to the
     # configured values.
@@ -453,76 +343,128 @@ def _apply_choice(session: ImportSession, task: ImportTask) -> None:
         task.set_fields(session.lib)
 
 
-def _track_duplicate_action() -> DuplicateAction:
-    """Return the configured :class:`DuplicateAction` for per-track resolution.
-
-    Uses ``import.duplicate_track_action`` when set, otherwise falls back to
-    ``import.duplicate_action``.
-    """
-    cfg = config["import"]
-    view = (
-        cfg["duplicate_track_action"]
-        if cfg["duplicate_track_action"].get()
-        else cfg["duplicate_action"]
-    )
-    choice = view.as_choice(DuplicateAction.choices())
-    return DuplicateAction(choice)  # type: ignore[call-arg]
-
-
-def _find_track_duplicates(
-    lib: library.Library, item: library.Item, keys: list[str]
-) -> list[library.Item]:
-    """Return library items matching `item` on all `keys`, excluding the
-    item itself (so re-imports do not match their own files).
-
-    Unlike :meth:`Item.duplicates_query`, this matches *every* library item,
-    including tracks that belong to an album -- not just singletons -- so a
-    track is caught regardless of how it was originally imported.
-    """
-    query = dbcore.AndQuery(
-        [item.field_query(k, item.get(k), dbcore.MatchQuery) for k in keys]
-    )
-    return [other for other in lib.items(query) if other.path != item.path]
-
-
-def _resolve_duplicates(session: ImportSession, task: ImportTask):
+def _resolve_duplicates(session: ImportSession, task: ImportTask) -> None:
     """Check if a task conflicts with items or albums already imported
     and ask the session to resolve this.
+
+    For album tasks with ``import.duplicate_tracks`` enabled, individual
+    tracks that duplicate existing library items are detected here as well,
+    so both levels are decided at a single point before anything is added
+    to the library.
     """
-    if task.duplicate_tracks_resolved:
-        # Per-track duplicate resolution already pruned (or recorded for
-        # removal) the tracks of this album that exist in the library; the
-        # rest are new and should be imported without a whole-album skip.
+    if task.choice_flag not in (Action.ASIS, Action.APPLY, Action.RETAG):
         return
 
-    if task.choice_flag in (Action.ASIS, Action.APPLY, Action.RETAG):
-        found_duplicates = task.find_duplicates(session.lib)
-        if found_duplicates:
-            log.debug("found duplicates: {}", [o.id for o in found_duplicates])
+    found_duplicates = task.find_duplicates(session.lib)
 
-            task.duplicate_action = session.get_duplicate_action(
-                task, found_duplicates
-            )
+    track_duplicates: dict[library.Item, list[library.Item]] = {}
+    if task.is_album and session.config["duplicate_tracks"].get(bool):
+        track_duplicates = task.find_track_duplicates(session.lib)
 
-            if task.duplicate_action is DuplicateAction.UPGRADE:
-                if task.apply:
-                    # Apply metadata early so items carry their final
-                    # (post-tag) identity before we match them against
-                    # old library items, which store post-tag metadata
-                    # too. `_apply_choice` re-applies it later, which is
-                    # harmless (metadata application is idempotent).
-                    task.apply_metadata()
-                keys = config["import"]["duplicate_keys"]["item"].as_str_seq()
-                kept, superseded, old_album_ids = resolve_upgrade_target(
-                    task.imported_items(), found_duplicates, keys
-                )
-                if not kept:
-                    log.debug("upgrade: no track was an improvement, declining")
-                    task.duplicate_action = DuplicateAction.SKIP
-                else:
-                    task.apply_upgrade(kept, superseded, old_album_ids)
+    if not found_duplicates and not track_duplicates:
+        return
 
-            session.log_choice(task, True)
+    if found_duplicates:
+        log.debug("found duplicates: {}", [o.id for o in found_duplicates])
+    if track_duplicates:
+        log.debug(
+            "found track duplicates: {}",
+            [o.id for matches in track_duplicates.values() for o in matches],
+        )
+
+    task.track_duplicates = track_duplicates
+    session.resolve_duplicates(task, found_duplicates, track_duplicates)
+
+    if task.duplicate_action is DuplicateAction.UPGRADE:
+        if task.apply:
+            # Apply metadata early so items carry their final (post-tag)
+            # identity before we match them against old library items,
+            # which store post-tag metadata too. `_apply_choice`
+            # re-applies it later, which is harmless (metadata
+            # application is idempotent).
+            task.apply_metadata()
+        keys = config["import"]["duplicate_keys"]["item"].as_str_seq()
+        kept, superseded, old_album_ids = resolve_upgrade_target(
+            task.imported_items(), found_duplicates, keys
+        )
+        if not kept:
+            log.debug("upgrade: no track was an improvement, declining")
+            task.duplicate_action = DuplicateAction.SKIP
+        else:
+            task.apply_upgrade(kept, superseded, old_album_ids)
+
+    session.log_choice(task, True)
+
+
+def _apply_track_duplicate_skips(task: ImportTask) -> None:
+    """Drop items whose per-track duplicate action is SKIP from the task,
+    before anything is added to the library. If no items remain, skip the
+    whole task.
+    """
+    skipped = [
+        item
+        for item, action in task.track_duplicate_actions.items()
+        if action is DuplicateAction.SKIP
+    ]
+    if not skipped:
+        return
+
+    for item in skipped:
+        log.info("Skipping duplicate track: {}", displayable_path(item.path))
+        if item in task.items:
+            task.items.remove(item)
+        if isinstance(task.match, AlbumMatch):
+            task.match.mapping.pop(item, None)
+
+    if not task.imported_items():
+        log.info(
+            "Skipping album, all tracks are duplicates: {}", skipped[0].album
+        )
+        task.set_choice(Action.SKIP)
+
+
+def _fold_into_existing_album(session: ImportSession, task: ImportTask) -> None:
+    """After skipping duplicate tracks, fold the newly added tracks into the
+    existing album the skipped tracks' duplicates belong to.
+
+    Matched *singletons* have no ``album_id`` and do not affect the fold
+    target, so a mix of album-member and singleton matches still completes
+    the album. Only when the matched album members span more than one album
+    -- or none of the matches belong to an album at all -- do the new tracks
+    stay in their own album.
+    """
+    skipped = [
+        item
+        for item, action in task.track_duplicate_actions.items()
+        if action is DuplicateAction.SKIP
+    ]
+    if not skipped or task.skip or not task.is_album:
+        return
+
+    album_ids = {
+        match.album_id
+        for item in skipped
+        for match in task.track_duplicates.get(item, [])
+        if match.album_id is not None
+    }
+    existing_album = (
+        session.lib.get_album(album_ids.pop()) if len(album_ids) == 1 else None
+    )
+    if existing_album is None:
+        log.warning(
+            "cannot fold tracks into a single existing album; "
+            "keeping them as a new album"
+        )
+        return
+
+    new_album = task.album
+    for item in task.imported_items():
+        item.album_id = existing_album.id
+        item.store()
+    task.album = existing_album
+    if new_album is not None and new_album.id != existing_album.id:
+        # The freshly created album container is now empty.
+        new_album.remove(with_items=False)
 
 
 def _freshen_items(items: Iterable[library.Item]) -> None:

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -190,16 +190,20 @@ def group_albums(session: ImportSession) -> StageCoro:
         # Only some tracks were duplicates; we have already dropped them, so
         # don't let the album-level check skip the rest.
         task.duplicate_tracks_resolved = True
-        # Fold the remaining new tracks into the existing album only when
-        # every matched duplicate belongs to that same album. A singleton
-        # match (``album_id`` is ``None``) means the duplicates do not all
-        # belong to one album, so the new tracks are imported as their own.
+        # Fold the remaining new tracks into the existing album the matched
+        # duplicates belong to. Tracks matching a *singleton* are skipped
+        # individually but do not affect the fold target (their ``album_id``
+        # is ``None``), so a mix of album-member and singleton matches still
+        # completes the album. Only when the matched album members span more
+        # than one album -- or none of the matches belong to an album at all
+        # -- are the new tracks imported as their own album.
         album_ids = {
             match.album_id
             for matches in duplicates.values()
             for match in matches
+            if match.album_id is not None
         }
-        if len(album_ids) == 1 and None not in album_ids:
+        if len(album_ids) == 1:
             task.fold_into_album_id = album_ids.pop()
         else:
             log.warning(

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, AnyStr
 
 import mediafile
 
-from beets import config, library, plugins, util
+from beets import config, dbcore, library, plugins, util
 from beets.autotag import AlbumMatch, tag_album, tag_item
 from beets.dbcore.query import PathQuery
 from beets.util import extension
@@ -170,19 +170,12 @@ class ImportTask(BaseImportTask):
         items: Iterable[library.Item] | None,
     ) -> None:
         super().__init__(toppath, paths, items)
-        self.should_remove_duplicates = False
-        self.should_merge_duplicates = False
-        # Existing library items to remove because individual tracks of this
-        # album duplicate them (see ``duplicate_track_resolution``).
-        self.duplicate_track_items_to_remove: list[library.Item] = []
-        # Set once per-track duplicate resolution has handled this task, so the
-        # album-level duplicate check does not then skip the remaining tracks.
-        self.duplicate_tracks_resolved = False
-        # Id of an existing album to fold the imported items into (instead of
-        # creating a new album), set when skipping per-track duplicates leaves
-        # new tracks belonging to an existing album.
-        self.fold_into_album_id: int | None = None
         self.is_album = True
+        # Per-track duplicate state: each entry maps an item of this task
+        # to the existing library items it duplicates, and to the action
+        # chosen for it.
+        self.track_duplicates: dict[library.Item, list[library.Item]] = {}
+        self.track_duplicate_actions: dict[library.Item, DuplicateAction] = {}
 
     def set_choice(self, choice: Action | AlbumMatch | TrackMatch) -> None:
         """Given an AlbumMatch or TrackMatch object or an action constant,
@@ -293,18 +286,7 @@ class ImportTask(BaseImportTask):
                     clutter=config["clutter"].as_str_seq(),
                 )
 
-    def remove_duplicate_track_items(self, lib: library.Library):
-        """Remove the old library items that individual tracks of this album
-        duplicate, as recorded in ``duplicate_track_items_to_remove``.
-        """
-        seen: set[int] = set()
-        for item in self.duplicate_track_items_to_remove:
-            if item.id in seen:
-                continue
-            seen.add(item.id)
-            _remove_duplicate_item(lib, item)
-
-    def set_fields(self, lib: library.Library):
+    def set_fields(self, lib: library.Library) -> None:
         """Sets the fields given at CLI or configuration to the specified
         values, for both the album and all its items.
         """
@@ -430,6 +412,77 @@ class ImportTask(BaseImportTask):
 
         return duplicates
 
+    def find_track_duplicates(
+        self, lib: library.Library
+    ) -> dict[library.Item, list[library.Item]]:
+        """Return a mapping from each of this task's items to the existing
+        library items it duplicates.
+
+        Items are compared on the ``import.duplicate_keys.item`` fields using
+        the metadata the import would end up with: for an applied album match,
+        the chosen candidate's per-track metadata; for as-is/retag imports,
+        the items' current tags. Existing items with the same path as a task
+        item (i.e. re-imports) are not considered duplicates.
+        """
+        keys: list[str] = config["import"]["duplicate_keys"][
+            "item"
+        ].as_str_seq()
+        if not keys:
+            return {}
+
+        pairs: list[tuple[library.Item, library.Item]]
+        if self.choice_flag is Action.APPLY and isinstance(
+            self.match, AlbumMatch
+        ):
+            # Build temporary items carrying the candidate metadata, the
+            # same way `apply_metadata` would modify them.
+            pairs = []
+            for item, data in self.match.merged_pairs:
+                tmp_item = library.Item(lib, **dict(item))
+                tmp_item.update(data)
+                pairs.append((item, tmp_item))
+        elif self.choice_flag in (Action.ASIS, Action.RETAG):
+            pairs = [(item, item) for item in self.items]
+        else:
+            return {}
+
+        task_paths = {i.path for i in self.items if i}
+        duplicates: dict[library.Item, list[library.Item]] = {}
+        for item, tmp_item in pairs:
+            if not any(tmp_item.get(k) for k in keys):
+                continue
+            # Unlike `Item.duplicates_query`, do not restrict matches to
+            # singletons: an existing album member duplicates an incoming
+            # track just the same.
+            dup_query = dbcore.AndQuery(
+                [
+                    tmp_item.field_query(k, tmp_item.get(k), dbcore.MatchQuery)
+                    for k in keys
+                ]
+            )
+            if found := [
+                other
+                for other in lib.items(dup_query)
+                if other.path not in task_paths
+            ]:
+                duplicates[item] = found
+        return duplicates
+
+    def remove_track_duplicates(self, lib: library.Library) -> None:
+        """Remove the old library items duplicated by tracks whose duplicate
+        action is REMOVE.
+        """
+        seen: set[int] = set()
+        for item, action in self.track_duplicate_actions.items():
+            if action is not DuplicateAction.REMOVE:
+                continue
+            for old_item in self.track_duplicates.get(item, []):
+                if old_item.id is None or old_item.id in seen:
+                    continue
+                seen.add(old_item.id)
+                log.debug("removing duplicate {.filepath}", old_item)
+                _remove_duplicate_item(lib, old_item)
+
     def align_album_level_fields(self) -> None:
         """Make some album fields equal across `self.items`. For the
         RETAG action, we assume that the responsible for returning it
@@ -528,23 +581,6 @@ class ImportTask(BaseImportTask):
         with lib.transaction():
             self.record_replaced(lib)
             self.remove_replaced(lib)
-
-            fold_album = (
-                lib.get_album(self.fold_into_album_id)
-                if self.fold_into_album_id is not None
-                else None
-            )
-            if fold_album is not None:
-                # Fold the imported items into an existing album rather than
-                # creating a new one.
-                self.album = fold_album
-                for item in self.imported_items():
-                    item.album_id = self.album.id
-                    if item.id is None:
-                        item.add(lib)
-                    else:
-                        item.store()
-                return
 
             self.album = lib.add_album(self.imported_items())
             if self.choice_flag == Action.APPLY and isinstance(

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -63,6 +63,23 @@ REIMPORT_FRESH_FIELDS_ALBUM = [*REIMPORT_FRESH_FIELDS_ITEM, "media"]
 log = logging.getLogger("beets")
 
 
+def _remove_duplicate_item(
+    lib: library.Library, item: library.Item, with_album: bool = True
+):
+    """Remove ``item`` from ``lib`` and delete its file when it lives inside
+    the library directory, pruning any newly-empty parent directories.
+    """
+    item.remove(with_album=with_album)
+    if lib.directory in util.ancestry(item.path):
+        log.debug("deleting duplicate {.filepath}", item)
+        util.remove(item.path)
+        util.prune_dirs(
+            os.path.dirname(item.path),
+            lib.directory,
+            clutter=config["clutter"].as_str_seq(),
+        )
+
+
 class ImportAbortError(Exception):
     """Raised when the user aborts the tagging operation."""
 
@@ -153,6 +170,11 @@ class ImportTask(BaseImportTask):
         items: Iterable[library.Item] | None,
     ) -> None:
         super().__init__(toppath, paths, items)
+        self.should_remove_duplicates = False
+        self.should_merge_duplicates = False
+        # Existing library items to remove because individual tracks of this
+        # album duplicate them (see ``duplicate_track_resolution``).
+        self.duplicate_track_items_to_remove: list[library.Item] = []
         self.is_album = True
 
     def set_choice(self, choice: Action | AlbumMatch | TrackMatch) -> None:
@@ -251,15 +273,7 @@ class ImportTask(BaseImportTask):
             artpath = album.artpath
 
             for item in album.items():
-                item.remove(with_album=False)
-                if lib.directory in util.ancestry(item.path):
-                    log.debug("deleting duplicate {.filepath}", item)
-                    util.remove(item.path)
-                    util.prune_dirs(
-                        os.path.dirname(item.path),
-                        lib.directory,
-                        clutter=config["clutter"].as_str_seq(),
-                    )
+                _remove_duplicate_item(lib, item, with_album=False)
 
             album.remove(with_items=False)
 
@@ -272,7 +286,18 @@ class ImportTask(BaseImportTask):
                     clutter=config["clutter"].as_str_seq(),
                 )
 
-    def set_fields(self, lib: library.Library) -> None:
+    def remove_duplicate_track_items(self, lib: library.Library):
+        """Remove the old library items that individual tracks of this album
+        duplicate, as recorded in ``duplicate_track_items_to_remove``.
+        """
+        seen: set[int] = set()
+        for item in self.duplicate_track_items_to_remove:
+            if item.id in seen:
+                continue
+            seen.add(item.id)
+            _remove_duplicate_item(lib, item)
+
+    def set_fields(self, lib: library.Library):
         """Sets the fields given at CLI or configuration to the specified
         values, for both the album and all its items.
         """
@@ -719,15 +744,7 @@ class SingletonImportTask(ImportTask):
         duplicate_items = self.find_duplicates(lib)
         log.debug("removing {} old duplicated items", len(duplicate_items))
         for item in duplicate_items:
-            item.remove()
-            if lib.directory in util.ancestry(item.path):
-                log.debug("deleting duplicate {.filepath}", item)
-                util.remove(item.path)
-                util.prune_dirs(
-                    os.path.dirname(item.path),
-                    lib.directory,
-                    clutter=config["clutter"].as_str_seq(),
-                )
+            _remove_duplicate_item(lib, item)
 
     def add(self, lib: library.Library) -> None:
         with lib.transaction():

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -179,7 +179,8 @@ class ImportTask(BaseImportTask):
         # album-level duplicate check does not then skip the remaining tracks.
         self.duplicate_tracks_resolved = False
         # Id of an existing album to fold the imported items into (instead of
-        # creating a new album), set by the ``fold`` track duplicate action.
+        # creating a new album), set when skipping per-track duplicates leaves
+        # new tracks belonging to an existing album.
         self.fold_into_album_id: int | None = None
         self.is_album = True
 

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -175,6 +175,12 @@ class ImportTask(BaseImportTask):
         # Existing library items to remove because individual tracks of this
         # album duplicate them (see ``duplicate_track_resolution``).
         self.duplicate_track_items_to_remove: list[library.Item] = []
+        # Set once per-track duplicate resolution has handled this task, so the
+        # album-level duplicate check does not then skip the remaining tracks.
+        self.duplicate_tracks_resolved = False
+        # Id of an existing album to fold the imported items into (instead of
+        # creating a new album), set by the ``fold`` track duplicate action.
+        self.fold_into_album_id: int | None = None
         self.is_album = True
 
     def set_choice(self, choice: Action | AlbumMatch | TrackMatch) -> None:
@@ -521,6 +527,23 @@ class ImportTask(BaseImportTask):
         with lib.transaction():
             self.record_replaced(lib)
             self.remove_replaced(lib)
+
+            fold_album = (
+                lib.get_album(self.fold_into_album_id)
+                if self.fold_into_album_id is not None
+                else None
+            )
+            if fold_album is not None:
+                # Fold the imported items into an existing album rather than
+                # creating a new one.
+                self.album = fold_album
+                for item in self.imported_items():
+                    item.album_id = self.album.id
+                    if item.id is None:
+                        item.add(lib)
+                    else:
+                        item.store()
+                return
 
             self.album = lib.add_album(self.imported_items())
             if self.choice_flag == Action.APPLY and isinstance(

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -63,6 +63,23 @@ REIMPORT_FRESH_FIELDS_ALBUM = [*REIMPORT_FRESH_FIELDS_ITEM, "media"]
 log = logging.getLogger("beets")
 
 
+def _remove_duplicate_item(
+    lib: library.Library, item: library.Item, with_album: bool = True
+):
+    """Remove ``item`` from ``lib`` and delete its file when it lives inside
+    the library directory, pruning any newly-empty parent directories.
+    """
+    item.remove(with_album=with_album)
+    if lib.directory in util.ancestry(item.path):
+        log.debug("deleting duplicate {.filepath}", item)
+        util.remove(item.path)
+        util.prune_dirs(
+            os.path.dirname(item.path),
+            lib.directory,
+            clutter=config["clutter"].as_str_seq(),
+        )
+
+
 class ImportAbortError(Exception):
     """Raised when the user aborts the tagging operation."""
 
@@ -258,6 +275,11 @@ class ImportTask(BaseImportTask):
         items: Iterable[library.Item] | None,
     ) -> None:
         super().__init__(toppath, paths, items)
+        self.should_remove_duplicates = False
+        self.should_merge_duplicates = False
+        # Existing library items to remove because individual tracks of this
+        # album duplicate them (see ``duplicate_track_resolution``).
+        self.duplicate_track_items_to_remove: list[library.Item] = []
         self.is_album = True
 
     def set_choice(self, choice: Action | AlbumMatch | TrackMatch) -> None:
@@ -388,15 +410,7 @@ class ImportTask(BaseImportTask):
             artpath = album.artpath
 
             for item in album.items():
-                item.remove(with_album=False)
-                if lib.directory in util.ancestry(item.path):
-                    log.debug("deleting duplicate {.filepath}", item)
-                    util.remove(item.path)
-                    util.prune_dirs(
-                        os.path.dirname(item.path),
-                        lib.directory,
-                        clutter=config["clutter"].as_str_seq(),
-                    )
+                _remove_duplicate_item(lib, item, with_album=False)
 
             album.remove(with_items=False)
 
@@ -463,6 +477,17 @@ class ImportTask(BaseImportTask):
             # else: a second old album also has survivors; an item can
             # only belong to one album, so leave it untouched rather than
             # arbitrarily choosing between two candidates.
+
+    def remove_duplicate_track_items(self, lib: library.Library) -> None:
+        """Remove the old library items that individual tracks of this album
+        duplicate, as recorded in ``duplicate_track_items_to_remove``.
+        """
+        seen: set[int] = set()
+        for item in self.duplicate_track_items_to_remove:
+            if item.id in seen:
+                continue
+            seen.add(item.id)
+            _remove_duplicate_item(lib, item)
 
     def set_fields(self, lib: library.Library) -> None:
         """Sets the fields given at CLI or configuration to the specified
@@ -933,15 +958,7 @@ class SingletonImportTask(ImportTask):
         duplicate_items = self.find_duplicates(lib)
         log.debug("removing {} old duplicated items", len(duplicate_items))
         for item in duplicate_items:
-            item.remove()
-            if lib.directory in util.ancestry(item.path):
-                log.debug("deleting duplicate {.filepath}", item)
-                util.remove(item.path)
-                util.prune_dirs(
-                    os.path.dirname(item.path),
-                    lib.directory,
-                    clutter=config["clutter"].as_str_seq(),
-                )
+            _remove_duplicate_item(lib, item)
 
     def _remove_upgrade_duplicates(self, lib: library.Library) -> None:
         """Remove the superseded old item(s).

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -284,7 +284,8 @@ class ImportTask(BaseImportTask):
         # album-level duplicate check does not then skip the remaining tracks.
         self.duplicate_tracks_resolved = False
         # Id of an existing album to fold the imported items into (instead of
-        # creating a new album), set by the ``fold`` track duplicate action.
+        # creating a new album), set when skipping per-track duplicates leaves
+        # new tracks belonging to an existing album.
         self.fold_into_album_id: int | None = None
         self.is_album = True
 

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, AnyStr
 
 import mediafile
 
-from beets import config, library, plugins, util
+from beets import config, dbcore, library, plugins, util
 from beets.autotag import AlbumMatch, tag_album, tag_item
 from beets.dbcore.query import PathQuery
 from beets.util import extension
@@ -275,19 +275,12 @@ class ImportTask(BaseImportTask):
         items: Iterable[library.Item] | None,
     ) -> None:
         super().__init__(toppath, paths, items)
-        self.should_remove_duplicates = False
-        self.should_merge_duplicates = False
-        # Existing library items to remove because individual tracks of this
-        # album duplicate them (see ``duplicate_track_resolution``).
-        self.duplicate_track_items_to_remove: list[library.Item] = []
-        # Set once per-track duplicate resolution has handled this task, so the
-        # album-level duplicate check does not then skip the remaining tracks.
-        self.duplicate_tracks_resolved = False
-        # Id of an existing album to fold the imported items into (instead of
-        # creating a new album), set when skipping per-track duplicates leaves
-        # new tracks belonging to an existing album.
-        self.fold_into_album_id: int | None = None
         self.is_album = True
+        # Per-track duplicate state: each entry maps an item of this task
+        # to the existing library items it duplicates, and to the action
+        # chosen for it.
+        self.track_duplicates: dict[library.Item, list[library.Item]] = {}
+        self.track_duplicate_actions: dict[library.Item, DuplicateAction] = {}
 
     def set_choice(self, choice: Action | AlbumMatch | TrackMatch) -> None:
         """Given an AlbumMatch or TrackMatch object or an action constant,
@@ -485,17 +478,6 @@ class ImportTask(BaseImportTask):
             # only belong to one album, so leave it untouched rather than
             # arbitrarily choosing between two candidates.
 
-    def remove_duplicate_track_items(self, lib: library.Library) -> None:
-        """Remove the old library items that individual tracks of this album
-        duplicate, as recorded in ``duplicate_track_items_to_remove``.
-        """
-        seen: set[int] = set()
-        for item in self.duplicate_track_items_to_remove:
-            if item.id in seen:
-                continue
-            seen.add(item.id)
-            _remove_duplicate_item(lib, item)
-
     def set_fields(self, lib: library.Library) -> None:
         """Sets the fields given at CLI or configuration to the specified
         values, for both the album and all its items.
@@ -622,6 +604,77 @@ class ImportTask(BaseImportTask):
 
         return duplicates
 
+    def find_track_duplicates(
+        self, lib: library.Library
+    ) -> dict[library.Item, list[library.Item]]:
+        """Return a mapping from each of this task's items to the existing
+        library items it duplicates.
+
+        Items are compared on the ``import.duplicate_keys.item`` fields using
+        the metadata the import would end up with: for an applied album match,
+        the chosen candidate's per-track metadata; for as-is/retag imports,
+        the items' current tags. Existing items with the same path as a task
+        item (i.e. re-imports) are not considered duplicates.
+        """
+        keys: list[str] = config["import"]["duplicate_keys"][
+            "item"
+        ].as_str_seq()
+        if not keys:
+            return {}
+
+        pairs: list[tuple[library.Item, library.Item]]
+        if self.choice_flag is Action.APPLY and isinstance(
+            self.match, AlbumMatch
+        ):
+            # Build temporary items carrying the candidate metadata, the
+            # same way `apply_metadata` would modify them.
+            pairs = []
+            for item, data in self.match.merged_pairs:
+                tmp_item = library.Item(lib, **dict(item))
+                tmp_item.update(data)
+                pairs.append((item, tmp_item))
+        elif self.choice_flag in (Action.ASIS, Action.RETAG):
+            pairs = [(item, item) for item in self.items]
+        else:
+            return {}
+
+        task_paths = {i.path for i in self.items if i}
+        duplicates: dict[library.Item, list[library.Item]] = {}
+        for item, tmp_item in pairs:
+            if not any(tmp_item.get(k) for k in keys):
+                continue
+            # Unlike `Item.duplicates_query`, do not restrict matches to
+            # singletons: an existing album member duplicates an incoming
+            # track just the same.
+            dup_query = dbcore.AndQuery(
+                [
+                    tmp_item.field_query(k, tmp_item.get(k), dbcore.MatchQuery)
+                    for k in keys
+                ]
+            )
+            if found := [
+                other
+                for other in lib.items(dup_query)
+                if other.path not in task_paths
+            ]:
+                duplicates[item] = found
+        return duplicates
+
+    def remove_track_duplicates(self, lib: library.Library) -> None:
+        """Remove the old library items duplicated by tracks whose duplicate
+        action is REMOVE.
+        """
+        seen: set[int] = set()
+        for item, action in self.track_duplicate_actions.items():
+            if action is not DuplicateAction.REMOVE:
+                continue
+            for old_item in self.track_duplicates.get(item, []):
+                if old_item.id is None or old_item.id in seen:
+                    continue
+                seen.add(old_item.id)
+                log.debug("removing duplicate {.filepath}", old_item)
+                _remove_duplicate_item(lib, old_item)
+
     def align_album_level_fields(self) -> None:
         """Make some album fields equal across `self.items`. For the
         RETAG action, we assume that the responsible for returning it
@@ -720,23 +773,6 @@ class ImportTask(BaseImportTask):
         with lib.transaction():
             self.record_replaced(lib)
             self.remove_replaced(lib)
-
-            fold_album = (
-                lib.get_album(self.fold_into_album_id)
-                if self.fold_into_album_id is not None
-                else None
-            )
-            if fold_album is not None:
-                # Fold the imported items into an existing album rather than
-                # creating a new one.
-                self.album = fold_album
-                for item in self.imported_items():
-                    item.album_id = self.album.id
-                    if item.id is None:
-                        item.add(lib)
-                    else:
-                        item.store()
-                return
 
             self.album = lib.add_album(self.imported_items())
             if self.choice_flag == Action.APPLY and isinstance(

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -280,6 +280,12 @@ class ImportTask(BaseImportTask):
         # Existing library items to remove because individual tracks of this
         # album duplicate them (see ``duplicate_track_resolution``).
         self.duplicate_track_items_to_remove: list[library.Item] = []
+        # Set once per-track duplicate resolution has handled this task, so the
+        # album-level duplicate check does not then skip the remaining tracks.
+        self.duplicate_tracks_resolved = False
+        # Id of an existing album to fold the imported items into (instead of
+        # creating a new album), set by the ``fold`` track duplicate action.
+        self.fold_into_album_id: int | None = None
         self.is_album = True
 
     def set_choice(self, choice: Action | AlbumMatch | TrackMatch) -> None:
@@ -713,6 +719,23 @@ class ImportTask(BaseImportTask):
         with lib.transaction():
             self.record_replaced(lib)
             self.remove_replaced(lib)
+
+            fold_album = (
+                lib.get_album(self.fold_into_album_id)
+                if self.fold_into_album_id is not None
+                else None
+            )
+            if fold_album is not None:
+                # Fold the imported items into an existing album rather than
+                # creating a new one.
+                self.album = fold_album
+                for item in self.imported_items():
+                    item.album_id = self.album.id
+                    if item.id is None:
+                        item.add(lib)
+                    else:
+                        item.store()
+                return
 
             self.album = lib.add_album(self.imported_items())
             if self.choice_flag == Action.APPLY and isinstance(

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -730,7 +730,7 @@ class ImportSessionFixture(ImportSession):
 
     choose_item = choose_match  # type: ignore[assignment]
 
-    Resolution = Enum("Resolution", "REMOVE SKIP KEEPBOTH MERGE FOLD")
+    Resolution = Enum("Resolution", "REMOVE SKIP KEEPBOTH MERGE")
 
     default_resolution = "REMOVE"
 
@@ -757,7 +757,6 @@ class ImportSessionFixture(ImportSession):
             self.Resolution.SKIP: "s",
             self.Resolution.KEEPBOTH: "k",
             self.Resolution.REMOVE: "r",
-            self.Resolution.FOLD: "f",
         }.get(res, "k")
 
 

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -730,6 +730,23 @@ class ImportSessionFixture(ImportSession):
 
     choose_item = choose_match  # type: ignore[assignment]
 
+    Resolution = Enum("Resolution", "REMOVE SKIP KEEPBOTH MERGE FOLD")
+
+    default_resolution = "REMOVE"
+
+    def resolve_duplicate(self, task, found_duplicates):
+        try:
+            res = self._resolutions.pop(0)
+        except IndexError:
+            res = self.default_resolution
+
+        if res == self.Resolution.SKIP:
+            task.set_choice(importer.Action.SKIP)
+        elif res == self.Resolution.REMOVE:
+            task.should_remove_duplicates = True
+        elif res == self.Resolution.MERGE:
+            task.should_merge_duplicates = True
+
     def resolve_track_duplicates(self, task, duplicates):
         try:
             res = self._resolutions.pop(0)
@@ -740,6 +757,7 @@ class ImportSessionFixture(ImportSession):
             self.Resolution.SKIP: "s",
             self.Resolution.KEEPBOTH: "k",
             self.Resolution.REMOVE: "r",
+            self.Resolution.FOLD: "f",
         }.get(res, "k")
 
 

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -730,35 +730,6 @@ class ImportSessionFixture(ImportSession):
 
     choose_item = choose_match  # type: ignore[assignment]
 
-    Resolution = Enum("Resolution", "REMOVE SKIP KEEPBOTH MERGE")
-
-    default_resolution = "REMOVE"
-
-    def resolve_duplicate(self, task, found_duplicates):
-        try:
-            res = self._resolutions.pop(0)
-        except IndexError:
-            res = self.default_resolution
-
-        if res == self.Resolution.SKIP:
-            task.set_choice(importer.Action.SKIP)
-        elif res == self.Resolution.REMOVE:
-            task.should_remove_duplicates = True
-        elif res == self.Resolution.MERGE:
-            task.should_merge_duplicates = True
-
-    def resolve_track_duplicates(self, task, duplicates):
-        try:
-            res = self._resolutions.pop(0)
-        except IndexError:
-            res = self.default_resolution
-
-        return {
-            self.Resolution.SKIP: "s",
-            self.Resolution.KEEPBOTH: "k",
-            self.Resolution.REMOVE: "r",
-        }.get(res, "k")
-
 
 class TerminalImportSessionFixture(TerminalImportSession):
     def __init__(self, *args, **kwargs):

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -730,6 +730,18 @@ class ImportSessionFixture(ImportSession):
 
     choose_item = choose_match  # type: ignore[assignment]
 
+    def resolve_track_duplicates(self, task, duplicates):
+        try:
+            res = self._resolutions.pop(0)
+        except IndexError:
+            res = self.default_resolution
+
+        return {
+            self.Resolution.SKIP: "s",
+            self.Resolution.KEEPBOTH: "k",
+            self.Resolution.REMOVE: "r",
+        }.get(res, "k")
+
 
 class TerminalImportSessionFixture(TerminalImportSession):
     def __init__(self, *args, **kwargs):

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -678,6 +678,23 @@ class ImportSessionFixture(ImportSession):
 
     choose_item = choose_match  # type: ignore[assignment]
 
+    Resolution = Enum("Resolution", "REMOVE SKIP KEEPBOTH MERGE FOLD")
+
+    default_resolution = "REMOVE"
+
+    def resolve_duplicate(self, task, found_duplicates):
+        try:
+            res = self._resolutions.pop(0)
+        except IndexError:
+            res = self.default_resolution
+
+        if res == self.Resolution.SKIP:
+            task.set_choice(importer.Action.SKIP)
+        elif res == self.Resolution.REMOVE:
+            task.should_remove_duplicates = True
+        elif res == self.Resolution.MERGE:
+            task.should_merge_duplicates = True
+
     def resolve_track_duplicates(self, task, duplicates):
         try:
             res = self._resolutions.pop(0)
@@ -688,6 +705,7 @@ class ImportSessionFixture(ImportSession):
             self.Resolution.SKIP: "s",
             self.Resolution.KEEPBOTH: "k",
             self.Resolution.REMOVE: "r",
+            self.Resolution.FOLD: "f",
         }.get(res, "k")
 
 

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -678,6 +678,18 @@ class ImportSessionFixture(ImportSession):
 
     choose_item = choose_match  # type: ignore[assignment]
 
+    def resolve_track_duplicates(self, task, duplicates):
+        try:
+            res = self._resolutions.pop(0)
+        except IndexError:
+            res = self.default_resolution
+
+        return {
+            self.Resolution.SKIP: "s",
+            self.Resolution.KEEPBOTH: "k",
+            self.Resolution.REMOVE: "r",
+        }.get(res, "k")
+
 
 class TerminalImportSessionFixture(TerminalImportSession):
     def __init__(self, *args, **kwargs):

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -678,7 +678,7 @@ class ImportSessionFixture(ImportSession):
 
     choose_item = choose_match  # type: ignore[assignment]
 
-    Resolution = Enum("Resolution", "REMOVE SKIP KEEPBOTH MERGE FOLD")
+    Resolution = Enum("Resolution", "REMOVE SKIP KEEPBOTH MERGE")
 
     default_resolution = "REMOVE"
 
@@ -705,7 +705,6 @@ class ImportSessionFixture(ImportSession):
             self.Resolution.SKIP: "s",
             self.Resolution.KEEPBOTH: "k",
             self.Resolution.REMOVE: "r",
-            self.Resolution.FOLD: "f",
         }.get(res, "k")
 
 

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -678,35 +678,6 @@ class ImportSessionFixture(ImportSession):
 
     choose_item = choose_match  # type: ignore[assignment]
 
-    Resolution = Enum("Resolution", "REMOVE SKIP KEEPBOTH MERGE")
-
-    default_resolution = "REMOVE"
-
-    def resolve_duplicate(self, task, found_duplicates):
-        try:
-            res = self._resolutions.pop(0)
-        except IndexError:
-            res = self.default_resolution
-
-        if res == self.Resolution.SKIP:
-            task.set_choice(importer.Action.SKIP)
-        elif res == self.Resolution.REMOVE:
-            task.should_remove_duplicates = True
-        elif res == self.Resolution.MERGE:
-            task.should_merge_duplicates = True
-
-    def resolve_track_duplicates(self, task, duplicates):
-        try:
-            res = self._resolutions.pop(0)
-        except IndexError:
-            res = self.default_resolution
-
-        return {
-            self.Resolution.SKIP: "s",
-            self.Resolution.KEEPBOTH: "k",
-            self.Resolution.REMOVE: "r",
-        }.get(res, "k")
-
 
 class TerminalImportSessionFixture(TerminalImportSession):
     def __init__(self, *args, **kwargs):

--- a/beets/ui/commands/import_/session.py
+++ b/beets/ui/commands/import_/session.py
@@ -201,27 +201,30 @@ class TerminalImportSession(importer.ImportSession):
 
         return action
 
-    def resolve_track_duplicates(self, task, duplicates) -> str:
+    def resolve_track_duplicates(
+        self, task: importer.ImportTask, duplicates: dict[Item, list[Item]]
+    ) -> DuplicateAction:
         """Decide what to do with album tracks already in the library."""
         log.warning("Some tracks are already in the library!")
 
-        if config["import"]["quiet"]:
+        if config["import"]["quiet"].get(bool):
             # In quiet mode, don't prompt -- just skip the duplicate tracks.
             log.info("Skipping duplicate tracks.")
-            return "s"
+            return DuplicateAction.SKIP
 
         existing = [item for matches in duplicates.values() for item in matches]
         ui.print_("Old: " + summarize_items(existing, True))
-        if config["import"]["duplicate_verbose_prompt"]:
+        if config["import"]["duplicate_verbose_prompt"].get(bool):
             for item in existing:
                 print(f"  {item}")
 
         ui.print_("New: " + summarize_items(list(duplicates), True))
-        if config["import"]["duplicate_verbose_prompt"]:
+        if config["import"]["duplicate_verbose_prompt"].get(bool):
             for item in duplicates:
                 print(f"  {item}")
 
-        return ui.input_options(("Skip dupes", "Keep all", "Remove old"))
+        selection = ui.input_options(("Skip dupes", "Keep all", "Remove old"))
+        return DuplicateAction(selection)  # type: ignore[call-arg]
 
     def should_resume(self, path):
         return ui.input_yn(

--- a/beets/ui/commands/import_/session.py
+++ b/beets/ui/commands/import_/session.py
@@ -201,6 +201,28 @@ class TerminalImportSession(importer.ImportSession):
 
         return action
 
+    def resolve_track_duplicates(self, task, duplicates) -> str:
+        """Decide what to do with album tracks already in the library."""
+        log.warning("Some tracks are already in the library!")
+
+        if config["import"]["quiet"]:
+            # In quiet mode, don't prompt -- just skip the duplicate tracks.
+            log.info("Skipping duplicate tracks.")
+            return "s"
+
+        existing = [item for matches in duplicates.values() for item in matches]
+        ui.print_("Old: " + summarize_items(existing, True))
+        if config["import"]["duplicate_verbose_prompt"]:
+            for item in existing:
+                print(f"  {item}")
+
+        ui.print_("New: " + summarize_items(list(duplicates), True))
+        if config["import"]["duplicate_verbose_prompt"]:
+            for item in duplicates:
+                print(f"  {item}")
+
+        return ui.input_options(("Skip dupes", "Keep all", "Remove old"))
+
     def should_resume(self, path):
         return ui.input_yn(
             f"Import of the directory:\n{displayable_path(path)}\n"

--- a/beets/ui/commands/import_/session.py
+++ b/beets/ui/commands/import_/session.py
@@ -221,9 +221,7 @@ class TerminalImportSession(importer.ImportSession):
             for item in duplicates:
                 print(f"  {item}")
 
-        return ui.input_options(
-            ("Skip dupes", "Keep all", "Remove old", "Fold into album")
-        )
+        return ui.input_options(("Skip dupes", "Keep all", "Remove old"))
 
     def should_resume(self, path):
         return ui.input_yn(

--- a/beets/ui/commands/import_/session.py
+++ b/beets/ui/commands/import_/session.py
@@ -201,30 +201,56 @@ class TerminalImportSession(importer.ImportSession):
 
         return action
 
-    def resolve_track_duplicates(
-        self, task: importer.ImportTask, duplicates: dict[Item, list[Item]]
-    ) -> DuplicateAction:
-        """Decide what to do with album tracks already in the library."""
-        log.warning("Some tracks are already in the library!")
+    def get_track_duplicate_actions(
+        self,
+        task: importer.ImportTask,
+        track_duplicates: dict[Item, list[Item]],
+    ) -> dict[Item, DuplicateAction]:
+        actions = super().get_track_duplicate_actions(task, track_duplicates)
+        if DuplicateAction.ASK not in actions.values():
+            return actions
 
-        if config["import"]["quiet"].get(bool):
+        log.warning(
+            "Some tracks ({} of {}) are already in the library!",
+            len(track_duplicates),
+            len(task.imported_items()),
+        )
+        if config["import"]["quiet"]:
             # In quiet mode, don't prompt -- just skip the duplicate tracks.
             log.info("Skipping duplicate tracks.")
-            return DuplicateAction.SKIP
+            return dict.fromkeys(track_duplicates, DuplicateAction.SKIP)
 
-        existing = [item for matches in duplicates.values() for item in matches]
-        ui.print_("Old: " + summarize_items(existing, True))
-        if config["import"]["duplicate_verbose_prompt"].get(bool):
-            for item in existing:
-                print(f"  {item}")
+        # Print some detail about the existing and new items so the user
+        # can make an informed decision.
+        existing = [
+            item for matches in track_duplicates.values() for item in matches
+        ]
+        self._report_item_summary("Old", existing, is_album=True)
+        self._report_item_summary("New", list(track_duplicates), is_album=True)
 
-        ui.print_("New: " + summarize_items(list(duplicates), True))
-        if config["import"]["duplicate_verbose_prompt"].get(bool):
-            for item in duplicates:
-                print(f"  {item}")
+        choice = ui.input_options(
+            [*DuplicateAction.track_options(), "sElect per track"]
+        )
+        if choice != "e":
+            return dict.fromkeys(
+                track_duplicates,
+                DuplicateAction(choice),  # type: ignore[call-arg]
+            )
 
-        selection = ui.input_options(("Skip dupes", "Keep all", "Remove old"))
-        return DuplicateAction(selection)  # type: ignore[call-arg]
+        # Ask for each duplicate track individually.
+        return {
+            item: self._get_single_track_duplicate_action(item, matches)
+            for item, matches in track_duplicates.items()
+        }
+
+    def _get_single_track_duplicate_action(
+        self, item: Item, matches: list[Item]
+    ) -> DuplicateAction:
+        self._report_item_summary("Old", matches, is_album=False)
+        self._report_item_summary("New", [item], is_album=False)
+        return DuplicateAction(
+            ui.input_options(DuplicateAction.track_options())
+        )  # type: ignore[call-arg]
 
     def should_resume(self, path):
         return ui.input_yn(

--- a/beets/ui/commands/import_/session.py
+++ b/beets/ui/commands/import_/session.py
@@ -221,7 +221,9 @@ class TerminalImportSession(importer.ImportSession):
             for item in duplicates:
                 print(f"  {item}")
 
-        return ui.input_options(("Skip dupes", "Keep all", "Remove old"))
+        return ui.input_options(
+            ("Skip dupes", "Keep all", "Remove old", "Fold into album")
+        )
 
     def should_resume(self, path):
         return ui.input_yn(

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -150,8 +150,8 @@ New features
   modify data_source:tidal tidal_track_id='$mb_trackid'`` for items.
 
 - Add the :ref:`duplicate_track_resolution` import option, which checks each
-  track of an album import against the library (using the
-  :ref:`duplicate_keys` ``item`` fields) and resolves matches via the new
+  track of an album import against the library (using the :ref:`duplicate_keys`
+  ``item`` fields) and resolves matches via the new
   :ref:`duplicate_track_action` option (falling back to :ref:`duplicate_action`
   when unset). ``skip`` drops already-imported tracks and adds the remaining new
   tracks to the existing album, completing a partially-imported album. Disabled

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,8 +21,8 @@ New features
 - :doc:`plugins/lyrics`: Added a ``rest_directory`` configuration option for
   specifying a reStructuredText output directory, semantically equivalent to
   ``-r, --write-rest``. :bug:`2806`
-  migrations. Control with the ``create_backup_before_migrations`` option
-  (default: yes).
+- A database backup is now automatically created before running schema (default:
+  yes).
 - :doc:`plugins/tidal`: Add cover art support. Album metadata now includes
   ``cover_art_url`` from Tidal's ``coverArt`` relationship, which the
   :doc:`plugins/fetchart` plugin can retrieve.
@@ -53,13 +53,15 @@ New features
   various other sources.
 - :doc:`plugins/replaygain`: Add a ``metaflac`` backend that computes ReplayGain
   for FLAC files using the ``metaflac`` command-line tool. :bug:`1203`
-
-  track of an album import against the library (using the :ref:`duplicate_keys`
-  ``item`` fields) and resolves matches via the new
-  :ref:`duplicate_track_action` option (falling back to :ref:`duplicate_action`
-  when unset). ``skip`` drops already-imported tracks and adds the remaining new
+- :ref:`duplicate_tracks`: When enabled, each track of an album import is
+  checked against the library using the chosen candidate's metadata and the
+  :ref:`duplicate_keys` ``item`` fields, and matches are resolved together with
+  the whole-album duplicate check via the :ref:`duplicate_tracks_action` option
+  (falling back to :ref:`duplicate_action` when unset), including per-track
+  decisions. ``skip`` drops already-imported tracks and adds the remaining new
   tracks to the existing album, completing a partially-imported album. Disabled
   by default.
+
 Bug fixes
 ~~~~~~~~~
 
@@ -153,14 +155,6 @@ New features
   the new flexible attributes with ``beet modify``: run ``beet modify
   data_source:tidal tidal_album_id='$mb_albumid' -a`` for albums and ``beet
   modify data_source:tidal tidal_track_id='$mb_trackid'`` for items.
-
-- Add the :ref:`duplicate_track_resolution` import option, which checks each
-  track of an album import against the library (using the :ref:`duplicate_keys`
-  ``item`` fields) and resolves matches via the new
-  :ref:`duplicate_track_action` option (falling back to :ref:`duplicate_action`
-  when unset). ``skip`` drops already-imported tracks and adds the remaining new
-  tracks to the existing album, completing a partially-imported album. Disabled
-  by default.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,7 +21,6 @@ New features
 - :doc:`plugins/lyrics`: Added a ``rest_directory`` configuration option for
   specifying a reStructuredText output directory, semantically equivalent to
   ``-r, --write-rest``. :bug:`2806`
-- A database backup is now automatically created before running schema
   migrations. Control with the ``create_backup_before_migrations`` option
   (default: yes).
 - :doc:`plugins/tidal`: Add cover art support. Album metadata now includes
@@ -55,6 +54,12 @@ New features
 - :doc:`plugins/replaygain`: Add a ``metaflac`` backend that computes ReplayGain
   for FLAC files using the ``metaflac`` command-line tool. :bug:`1203`
 
+  track of an album import against the library (using the :ref:`duplicate_keys`
+  ``item`` fields) and resolves matches via the new
+  :ref:`duplicate_track_action` option (falling back to :ref:`duplicate_action`
+  when unset). ``skip`` drops already-imported tracks and adds the remaining new
+  tracks to the existing album, completing a partially-imported album. Disabled
+  by default.
 Bug fixes
 ~~~~~~~~~
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -150,10 +150,12 @@ New features
   modify data_source:tidal tidal_track_id='$mb_trackid'`` for items.
 
 - Add the :ref:`duplicate_track_resolution` import option, which checks each
-  track of an album import against the library's singleton items (using the
-  :ref:`duplicate_keys` ``item`` fields) and resolves matches via
-  :ref:`duplicate_action`. With ``skip`` this drops already-imported tracks and
-  imports the rest of the album. Disabled by default.
+  track of an album import against the library (using the
+  :ref:`duplicate_keys` ``item`` fields) and resolves matches via the new
+  :ref:`duplicate_track_action` option (falling back to :ref:`duplicate_action`
+  when unset). ``skip`` drops already-imported tracks and imports the rest of
+  the album; ``fold`` instead adds the remaining new tracks to the existing
+  album, completing a partially-imported album. Disabled by default.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -153,9 +153,9 @@ New features
   track of an album import against the library (using the
   :ref:`duplicate_keys` ``item`` fields) and resolves matches via the new
   :ref:`duplicate_track_action` option (falling back to :ref:`duplicate_action`
-  when unset). ``skip`` drops already-imported tracks and imports the rest of
-  the album; ``fold`` instead adds the remaining new tracks to the existing
-  album, completing a partially-imported album. Disabled by default.
+  when unset). ``skip`` drops already-imported tracks and adds the remaining new
+  tracks to the existing album, completing a partially-imported album. Disabled
+  by default.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -149,6 +149,12 @@ New features
   data_source:tidal tidal_album_id='$mb_albumid' -a`` for albums and ``beet
   modify data_source:tidal tidal_track_id='$mb_trackid'`` for items.
 
+- Add the :ref:`duplicate_track_resolution` import option, which checks each
+  track of an album import against the library's singleton items (using the
+  :ref:`duplicate_keys` ``item`` fields) and resolves matches via
+  :ref:`duplicate_action`. With ``skip`` this drops already-imported tracks and
+  imports the rest of the album. Disabled by default.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -217,10 +217,12 @@ New features
   modify data_source:tidal tidal_track_id='$mb_trackid'`` for items.
 
 - Add the :ref:`duplicate_track_resolution` import option, which checks each
-  track of an album import against the library's singleton items (using the
-  :ref:`duplicate_keys` ``item`` fields) and resolves matches via
-  :ref:`duplicate_action`. With ``skip`` this drops already-imported tracks and
-  imports the rest of the album. Disabled by default.
+  track of an album import against the library (using the
+  :ref:`duplicate_keys` ``item`` fields) and resolves matches via the new
+  :ref:`duplicate_track_action` option (falling back to :ref:`duplicate_action`
+  when unset). ``skip`` drops already-imported tracks and imports the rest of
+  the album; ``fold`` instead adds the remaining new tracks to the existing
+  album, completing a partially-imported album. Disabled by default.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -82,7 +82,6 @@ New features
 - :doc:`plugins/lyrics`: Added a ``rest_directory`` configuration option for
   specifying a reStructuredText output directory, semantically equivalent to
   ``-r, --write-rest``. :bug:`2806`
-- A database backup is now automatically created before running schema
   migrations. Control with the ``create_backup_before_migrations`` option
   (default: yes).
 - :doc:`plugins/tidal`: Add cover art support. Album metadata now includes
@@ -116,6 +115,12 @@ New features
 - :doc:`plugins/replaygain`: Add a ``metaflac`` backend that computes ReplayGain
   for FLAC files using the ``metaflac`` command-line tool. :bug:`1203`
 
+  track of an album import against the library (using the :ref:`duplicate_keys`
+  ``item`` fields) and resolves matches via the new
+  :ref:`duplicate_track_action` option (falling back to :ref:`duplicate_action`
+  when unset). ``skip`` drops already-imported tracks and adds the remaining new
+  tracks to the existing album, completing a partially-imported album. Disabled
+  by default.
 Bug fixes
 ~~~~~~~~~
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,14 @@ New features
 - :ref:`duplicate_action`: Add an ``upgrade`` option that replaces individual
   duplicate tracks only if the new copy has a higher bitrate, adds any genuinely
   new tracks, and keeps the album together rather than splitting it. :bug:`4471`
+- :ref:`duplicate_tracks`: When enabled, each track of an album import is
+  checked against the library using the chosen candidate's metadata and the
+  :ref:`duplicate_keys` ``item`` fields, and matches are resolved together with
+  the whole-album duplicate check via the :ref:`duplicate_tracks_action` option
+  (falling back to :ref:`duplicate_action` when unset), including per-track
+  decisions. ``skip`` drops already-imported tracks and adds the remaining new
+  tracks to the existing album, completing a partially-imported album. Disabled
+  by default.
 
 Bug fixes
 ~~~~~~~~~
@@ -82,8 +90,8 @@ New features
 - :doc:`plugins/lyrics`: Added a ``rest_directory`` configuration option for
   specifying a reStructuredText output directory, semantically equivalent to
   ``-r, --write-rest``. :bug:`2806`
-  migrations. Control with the ``create_backup_before_migrations`` option
-  (default: yes).
+- A database backup is now automatically created before running schema (default:
+  yes).
 - :doc:`plugins/tidal`: Add cover art support. Album metadata now includes
   ``cover_art_url`` from Tidal's ``coverArt`` relationship, which the
   :doc:`plugins/fetchart` plugin can retrieve.
@@ -115,12 +123,6 @@ New features
 - :doc:`plugins/replaygain`: Add a ``metaflac`` backend that computes ReplayGain
   for FLAC files using the ``metaflac`` command-line tool. :bug:`1203`
 
-  track of an album import against the library (using the :ref:`duplicate_keys`
-  ``item`` fields) and resolves matches via the new
-  :ref:`duplicate_track_action` option (falling back to :ref:`duplicate_action`
-  when unset). ``skip`` drops already-imported tracks and adds the remaining new
-  tracks to the existing album, completing a partially-imported album. Disabled
-  by default.
 Bug fixes
 ~~~~~~~~~
 
@@ -220,14 +222,6 @@ New features
   the new flexible attributes with ``beet modify``: run ``beet modify
   data_source:tidal tidal_album_id='$mb_albumid' -a`` for albums and ``beet
   modify data_source:tidal tidal_track_id='$mb_trackid'`` for items.
-
-- Add the :ref:`duplicate_track_resolution` import option, which checks each
-  track of an album import against the library (using the :ref:`duplicate_keys`
-  ``item`` fields) and resolves matches via the new
-  :ref:`duplicate_track_action` option (falling back to :ref:`duplicate_action`
-  when unset). ``skip`` drops already-imported tracks and adds the remaining new
-  tracks to the existing album, completing a partially-imported album. Disabled
-  by default.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -217,8 +217,8 @@ New features
   modify data_source:tidal tidal_track_id='$mb_trackid'`` for items.
 
 - Add the :ref:`duplicate_track_resolution` import option, which checks each
-  track of an album import against the library (using the
-  :ref:`duplicate_keys` ``item`` fields) and resolves matches via the new
+  track of an album import against the library (using the :ref:`duplicate_keys`
+  ``item`` fields) and resolves matches via the new
   :ref:`duplicate_track_action` option (falling back to :ref:`duplicate_action`
   when unset). ``skip`` drops already-imported tracks and adds the remaining new
   tracks to the existing album, completing a partially-imported album. Disabled

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -220,9 +220,9 @@ New features
   track of an album import against the library (using the
   :ref:`duplicate_keys` ``item`` fields) and resolves matches via the new
   :ref:`duplicate_track_action` option (falling back to :ref:`duplicate_action`
-  when unset). ``skip`` drops already-imported tracks and imports the rest of
-  the album; ``fold`` instead adds the remaining new tracks to the existing
-  album, completing a partially-imported album. Disabled by default.
+  when unset). ``skip`` drops already-imported tracks and adds the remaining new
+  tracks to the existing album, completing a partially-imported album. Disabled
+  by default.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -216,6 +216,12 @@ New features
   data_source:tidal tidal_album_id='$mb_albumid' -a`` for albums and ``beet
   modify data_source:tidal tidal_track_id='$mb_trackid'`` for items.
 
+- Add the :ref:`duplicate_track_resolution` import option, which checks each
+  track of an album import against the library's singleton items (using the
+  :ref:`duplicate_keys` ``item`` fields) and resolves matches via
+  :ref:`duplicate_action`. With ``skip`` this drops already-imported tracks and
+  imports the rest of the album. Disabled by default.
+
 Bug fixes
 ~~~~~~~~~
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -897,16 +897,16 @@ How to resolve individual album tracks that already exist in the library when
 When left empty, this falls back to :ref:`duplicate_action`.
 
 A typical configuration for completing partially-imported albums while
-autotagging looks like this:
+autotagging looks like this (values other than the defaults are commented):
 
-::
+.. code-block:: yaml
 
     import:
-        duplicate_track_resolution: yes
-        duplicate_action: ask          # whole-album duplicates
-        duplicate_track_action: skip   # per-track duplicates: fold new tracks into the existing album
+        duplicate_track_resolution: yes  # default: no
+        duplicate_action: ask            # default: ask -- whole-album duplicates
+        duplicate_track_action: skip     # default: '' -- per-track duplicates; fold new tracks into the existing album
         duplicate_keys:
-            item: mb_trackid           # match on a stable id (recommended when autotagging)
+            item: mb_trackid             # default: artist title -- match on a stable id (recommended when autotagging)
 
 Default: empty (inherit :ref:`duplicate_action`).
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -850,6 +850,36 @@ is applied, which would, considering the default, look like this:
 
 Default: ``no``.
 
+.. _duplicate_track_resolution:
+
+duplicate_track_resolution
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When enabled, album imports also check each *individual track* against the
+library, using the same fields as :ref:`duplicate_keys` ``item`` (by default
+``artist`` and ``title``; set it to e.g. ``mb_trackid`` to match on the
+MusicBrainz track ID). Tracks already in the library are resolved according to
+:ref:`duplicate_action`:
+
+- ``skip`` drops the duplicate tracks and imports the rest of the album. If
+  every track is already present, the whole album is skipped.
+- ``remove`` removes the matching old items from the library before importing.
+- ``keep`` (and ``merge``) import the album unchanged.
+- ``ask`` prompts you to choose one of the above.
+
+This complements the album-level duplicate check (which matches whole albums on
+:ref:`duplicate_keys` ``album``): it catches the case where some loose tracks of
+an album are already in your library as singletons.
+
+.. note::
+
+    Only **singleton** library items (tracks not attached to an album) are
+    considered. Tracks that already belong to an album in your library are not
+    matched, so importing a fuller version of an album you already have will not
+    deduplicate against that existing album's tracks.
+
+Default: ``no``.
+
 .. _bell:
 
 bell

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -885,19 +885,16 @@ duplicate_track_action
 How to resolve individual album tracks that already exist in the library when
 :ref:`duplicate_track_resolution` is enabled. The available actions are:
 
-- ``skip`` drops the duplicate tracks and imports the rest of the album. If
-  every track is already present, the whole album is skipped.
-- ``remove`` removes the matching old items from the library before importing.
-- ``fold`` drops the duplicate tracks and adds the remaining *new* tracks to the
+- ``skip`` drops the duplicate tracks and adds the remaining *new* tracks to the
   existing album they belong to, instead of importing them as a separate album.
-  Use this to complete a partially-imported album. (If the matching tracks do
-  not all belong to a single album, the new tracks are imported as their own
-  album.)
+  Use this to complete a partially-imported album. If every track is already
+  present, the whole album is skipped. (If the matching tracks do not all belong
+  to a single album, the new tracks are imported as their own album.)
+- ``remove`` removes the matching old items from the library before importing.
 - ``keep`` (and ``merge``) import the album unchanged.
 - ``ask`` prompts you to choose one of the above.
 
-When left empty, this falls back to :ref:`duplicate_action` (so ``fold`` is only
-available by setting this option explicitly).
+When left empty, this falls back to :ref:`duplicate_action`.
 
 A typical configuration for completing partially-imported albums while
 autotagging looks like this::
@@ -905,7 +902,7 @@ autotagging looks like this::
     import:
         duplicate_track_resolution: yes
         duplicate_action: ask          # whole-album duplicates
-        duplicate_track_action: fold   # per-track duplicates: fold into the existing album
+        duplicate_track_action: skip   # per-track duplicates: fold new tracks into the existing album
         duplicate_keys:
             item: mb_trackid           # match on a stable id (recommended when autotagging)
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -888,8 +888,11 @@ How to resolve individual album tracks that already exist in the library when
 - ``skip`` drops the duplicate tracks and adds the remaining *new* tracks to the
   existing album they belong to, instead of importing them as a separate album.
   Use this to complete a partially-imported album. If every track is already
-  present, the whole album is skipped. (If the matching tracks do not all belong
-  to a single album, the new tracks are imported as their own album.)
+  present, the whole album is skipped. A track matching an existing *singleton*
+  is skipped individually but does not affect where the new tracks go, so a mix
+  of album-member and singleton matches still completes the album. The new
+  tracks are imported as their own album only when the matched album members
+  span more than one album, or when none of the matches belong to an album.
 - ``remove`` removes the matching old items from the library before importing.
 - ``keep`` (and ``merge``) import the album unchanged.
 - ``ask`` prompts you to choose one of the above.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -853,7 +853,7 @@ Default: ``no``.
 .. _duplicate_track_resolution:
 
 duplicate_track_resolution
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When enabled, album imports also check each *individual track* against the
 library, using the same fields as :ref:`duplicate_keys` ``item`` (by default
@@ -869,9 +869,9 @@ part of another album.
 
 .. note::
 
-    The check runs *before* the autotagger lookup, so it matches on the
-    incoming files' existing tags rather than the metadata beets would apply.
-    When importing with autotagging on, match on a stable identifier such as
+    The check runs *before* the autotagger lookup, so it matches on the incoming
+    files' existing tags rather than the metadata beets would apply. When
+    importing with autotagging on, match on a stable identifier such as
     ``mb_trackid`` (via :ref:`duplicate_keys` ``item``); ``artist`` and
     ``title`` may not yet agree with what is in your library.
 
@@ -880,7 +880,7 @@ Default: ``no``.
 .. _duplicate_track_action:
 
 duplicate_track_action
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 How to resolve individual album tracks that already exist in the library when
 :ref:`duplicate_track_resolution` is enabled. The available actions are:
@@ -897,7 +897,9 @@ How to resolve individual album tracks that already exist in the library when
 When left empty, this falls back to :ref:`duplicate_action`.
 
 A typical configuration for completing partially-imported albums while
-autotagging looks like this::
+autotagging looks like this:
+
+::
 
     import:
         duplicate_track_resolution: yes

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -859,26 +859,57 @@ When enabled, album imports also check each *individual track* against the
 library, using the same fields as :ref:`duplicate_keys` ``item`` (by default
 ``artist`` and ``title``; set it to e.g. ``mb_trackid`` to match on the
 MusicBrainz track ID). Tracks already in the library are resolved according to
-:ref:`duplicate_action`:
+:ref:`duplicate_track_action`.
+
+This complements the album-level duplicate check (which matches whole albums on
+:ref:`duplicate_keys` ``album``): it catches the case where some tracks of an
+album are already in your library even though the album itself is not. Matching
+considers *all* library items, whether they were imported as singletons or as
+part of another album.
+
+.. note::
+
+    The check runs *before* the autotagger lookup, so it matches on the
+    incoming files' existing tags rather than the metadata beets would apply.
+    When importing with autotagging on, match on a stable identifier such as
+    ``mb_trackid`` (via :ref:`duplicate_keys` ``item``); ``artist`` and
+    ``title`` may not yet agree with what is in your library.
+
+Default: ``no``.
+
+.. _duplicate_track_action:
+
+duplicate_track_action
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+How to resolve individual album tracks that already exist in the library when
+:ref:`duplicate_track_resolution` is enabled. The available actions are:
 
 - ``skip`` drops the duplicate tracks and imports the rest of the album. If
   every track is already present, the whole album is skipped.
 - ``remove`` removes the matching old items from the library before importing.
+- ``fold`` drops the duplicate tracks and adds the remaining *new* tracks to the
+  existing album they belong to, instead of importing them as a separate album.
+  Use this to complete a partially-imported album. (If the matching tracks do
+  not all belong to a single album, the new tracks are imported as their own
+  album.)
 - ``keep`` (and ``merge``) import the album unchanged.
 - ``ask`` prompts you to choose one of the above.
 
-This complements the album-level duplicate check (which matches whole albums on
-:ref:`duplicate_keys` ``album``): it catches the case where some loose tracks of
-an album are already in your library as singletons.
+When left empty, this falls back to :ref:`duplicate_action` (so ``fold`` is only
+available by setting this option explicitly).
 
-.. note::
+A typical configuration for completing partially-imported albums while
+autotagging looks like this::
 
-    Only **singleton** library items (tracks not attached to an album) are
-    considered. Tracks that already belong to an album in your library are not
-    matched, so importing a fuller version of an album you already have will not
-    deduplicate against that existing album's tracks.
+    import:
+        duplicate_track_resolution: yes
+        duplicate_action: ask          # whole-album duplicates
+        duplicate_track_action: fold   # per-track duplicates: fold into the existing album
+        duplicate_keys:
+            item: mb_trackid           # match on a stable id (recommended when autotagging)
 
-Default: ``no``.
+Default: empty (inherit :ref:`duplicate_action`).
 
 .. _bell:
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -875,6 +875,12 @@ part of another album.
     ``mb_trackid`` (via :ref:`duplicate_keys` ``item``); ``artist`` and
     ``title`` may not yet agree with what is in your library.
 
+    Matching on ``mb_trackid`` only works for files that actually carry that
+    tag: a track missing it is not compared at all and will import as a
+    duplicate. If your files are reliably tagged with ``artist`` and ``title``
+    but not always with MusicBrainz IDs, the default ``item: artist title``
+    catches more duplicates.
+
 Default: ``no``.
 
 .. _duplicate_track_action:
@@ -910,6 +916,19 @@ autotagging looks like this (values other than the defaults are commented):
         duplicate_track_action: skip     # default: '' -- per-track duplicates; fold new tracks into the existing album
         duplicate_keys:
             item: mb_trackid             # default: artist title -- match on a stable id (recommended when autotagging)
+
+If some of your files are missing ``mb_trackid`` but are otherwise correctly
+tagged, keep the default ``item`` keys instead, so tracks are matched on their
+names rather than an ID that may be absent:
+
+.. code-block:: yaml
+
+    import:
+        duplicate_track_resolution: yes
+        duplicate_track_action: skip
+        duplicate_keys:
+            album: albumartist album  # default
+            item: artist title        # default
 
 Default: empty (inherit :ref:`duplicate_action`).
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -828,6 +828,79 @@ track) will be skipped; "keep" means keep both old and new items; "remove" means
 remove old item; "merge" means merge into one album; "ask" means the user should
 be prompted for the action each time. The default is ``ask``.
 
+.. _duplicate_tracks:
+
+duplicate_tracks
+~~~~~~~~~~~~~~~~
+
+Whether album imports also check each *individual track* against the library, in
+addition to the whole-album duplicate check. This catches the case where some
+tracks of an album are already in your library even though the album itself is
+not (for example, previously imported as singletons or as part of a partial
+album import).
+
+Both checks are resolved at the same decision point during import. When only
+*some* of the incoming tracks duplicate existing items (a partial overlap, e.g.
+completing a partially-imported album), per-track resolution applies and the
+whole-album :ref:`duplicate_action` is not triggered. When *every* track is
+already present, the import is a whole-album duplicate and the
+:ref:`duplicate_action` decision applies. Tracks are compared *after* tagging
+metadata has been chosen, using the fields listed in :ref:`duplicate_keys`
+``item`` (by default ``artist`` and ``title``; set it to e.g. ``mb_trackid`` to
+match on the MusicBrainz track ID, which is reliable when autotagging). Matching
+considers all library items, whether they were imported as singletons or as part
+of another album.
+
+Tracks found to be duplicates are resolved according to
+:ref:`duplicate_tracks_action`.
+
+Default: ``no``.
+
+.. _duplicate_tracks_action:
+
+duplicate_tracks_action
+~~~~~~~~~~~~~~~~~~~~~~~
+
+How to resolve individual album tracks that already exist in the library. The
+available actions are:
+
+- ``skip`` drops the duplicate tracks and adds the remaining *new* tracks to the
+  existing album they belong to, instead of importing them as a separate album.
+  Use this to complete a partially-imported album. If every track is already
+  present, the whole album is skipped. A track matching an existing *singleton*
+  is skipped individually but does not affect where the new tracks go, so a mix
+  of album-member and singleton matches still completes the album. The new
+  tracks are imported as their own album only when the matched album members
+  span more than one album, or when none of the matches belong to an album.
+- ``remove`` removes the matching old items from the library.
+- ``keep`` imports everything, keeping both old and new items.
+- ``ask`` prompts you to choose one of the above for all duplicate tracks at
+  once, or to decide for each track individually.
+
+Unlike :ref:`duplicate_action`, ``merge`` is not available: merging is defined
+for whole albums only.
+
+When left empty, this falls back to :ref:`duplicate_action` (where a configured
+``merge`` behaves like ``keep`` for tracks).
+
+Default: empty (inherit :ref:`duplicate_action`).
+
+A typical configuration for completing partially-imported albums while
+autotagging looks like this:
+
+.. code-block:: yaml
+
+    import:
+        duplicate_tracks: yes           # default: no
+        duplicate_tracks_action: skip   # default: '' -- inherit duplicate_action
+        duplicate_action: ask           # default -- whole-album duplicates
+        duplicate_keys:
+            item: mb_trackid   # default: artist title -- stable id, recommended when autotagging
+
+If some of your files are missing ``mb_trackid`` but are otherwise correctly
+tagged, keep the default ``item`` keys instead, so tracks are matched on their
+names rather than an ID that may be absent.
+
 .. _duplicate_verbose_prompt:
 
 duplicate_verbose_prompt
@@ -849,88 +922,6 @@ is applied, which would, considering the default, look like this:
     [S]kip new, Keep all, Remove old, Merge all?
 
 Default: ``no``.
-
-.. _duplicate_track_resolution:
-
-duplicate_track_resolution
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-When enabled, album imports also check each *individual track* against the
-library, using the same fields as :ref:`duplicate_keys` ``item`` (by default
-``artist`` and ``title``; set it to e.g. ``mb_trackid`` to match on the
-MusicBrainz track ID). Tracks already in the library are resolved according to
-:ref:`duplicate_track_action`.
-
-This complements the album-level duplicate check (which matches whole albums on
-:ref:`duplicate_keys` ``album``): it catches the case where some tracks of an
-album are already in your library even though the album itself is not. Matching
-considers *all* library items, whether they were imported as singletons or as
-part of another album.
-
-.. note::
-
-    The check runs *before* the autotagger lookup, so it matches on the incoming
-    files' existing tags rather than the metadata beets would apply. When
-    importing with autotagging on, match on a stable identifier such as
-    ``mb_trackid`` (via :ref:`duplicate_keys` ``item``); ``artist`` and
-    ``title`` may not yet agree with what is in your library.
-
-    Matching on ``mb_trackid`` only works for files that actually carry that
-    tag: a track missing it is not compared at all and will import as a
-    duplicate. If your files are reliably tagged with ``artist`` and ``title``
-    but not always with MusicBrainz IDs, the default ``item: artist title``
-    catches more duplicates.
-
-Default: ``no``.
-
-.. _duplicate_track_action:
-
-duplicate_track_action
-~~~~~~~~~~~~~~~~~~~~~~
-
-How to resolve individual album tracks that already exist in the library when
-:ref:`duplicate_track_resolution` is enabled. The available actions are:
-
-- ``skip`` drops the duplicate tracks and adds the remaining *new* tracks to the
-  existing album they belong to, instead of importing them as a separate album.
-  Use this to complete a partially-imported album. If every track is already
-  present, the whole album is skipped. A track matching an existing *singleton*
-  is skipped individually but does not affect where the new tracks go, so a mix
-  of album-member and singleton matches still completes the album. The new
-  tracks are imported as their own album only when the matched album members
-  span more than one album, or when none of the matches belong to an album.
-- ``remove`` removes the matching old items from the library before importing.
-- ``keep`` (and ``merge``) import the album unchanged.
-- ``ask`` prompts you to choose one of the above.
-
-When left empty, this falls back to :ref:`duplicate_action`.
-
-A typical configuration for completing partially-imported albums while
-autotagging looks like this (values other than the defaults are commented):
-
-.. code-block:: yaml
-
-    import:
-        duplicate_track_resolution: yes  # default: no
-        duplicate_action: ask            # default: ask -- whole-album duplicates
-        duplicate_track_action: skip     # default: '' -- per-track duplicates; fold new tracks into the existing album
-        duplicate_keys:
-            item: mb_trackid             # default: artist title -- match on a stable id (recommended when autotagging)
-
-If some of your files are missing ``mb_trackid`` but are otherwise correctly
-tagged, keep the default ``item`` keys instead, so tracks are matched on their
-names rather than an ID that may be absent:
-
-.. code-block:: yaml
-
-    import:
-        duplicate_track_resolution: yes
-        duplicate_track_action: skip
-        duplicate_keys:
-            album: albumartist album  # default
-            item: artist title        # default
-
-Default: empty (inherit :ref:`duplicate_action`).
 
 .. _bell:
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -872,6 +872,36 @@ is applied, which would, considering the default, look like this:
 
 Default: ``no``.
 
+.. _duplicate_track_resolution:
+
+duplicate_track_resolution
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When enabled, album imports also check each *individual track* against the
+library, using the same fields as :ref:`duplicate_keys` ``item`` (by default
+``artist`` and ``title``; set it to e.g. ``mb_trackid`` to match on the
+MusicBrainz track ID). Tracks already in the library are resolved according to
+:ref:`duplicate_action`:
+
+- ``skip`` drops the duplicate tracks and imports the rest of the album. If
+  every track is already present, the whole album is skipped.
+- ``remove`` removes the matching old items from the library before importing.
+- ``keep`` (and ``merge``) import the album unchanged.
+- ``ask`` prompts you to choose one of the above.
+
+This complements the album-level duplicate check (which matches whole albums on
+:ref:`duplicate_keys` ``album``): it catches the case where some loose tracks of
+an album are already in your library as singletons.
+
+.. note::
+
+    Only **singleton** library items (tracks not attached to an album) are
+    considered. Tracks that already belong to an album in your library are not
+    matched, so importing a fuller version of an album you already have will not
+    deduplicate against that existing album's tracks.
+
+Default: ``no``.
+
 .. _bell:
 
 bell

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -875,7 +875,7 @@ Default: ``no``.
 .. _duplicate_track_resolution:
 
 duplicate_track_resolution
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When enabled, album imports also check each *individual track* against the
 library, using the same fields as :ref:`duplicate_keys` ``item`` (by default
@@ -891,9 +891,9 @@ part of another album.
 
 .. note::
 
-    The check runs *before* the autotagger lookup, so it matches on the
-    incoming files' existing tags rather than the metadata beets would apply.
-    When importing with autotagging on, match on a stable identifier such as
+    The check runs *before* the autotagger lookup, so it matches on the incoming
+    files' existing tags rather than the metadata beets would apply. When
+    importing with autotagging on, match on a stable identifier such as
     ``mb_trackid`` (via :ref:`duplicate_keys` ``item``); ``artist`` and
     ``title`` may not yet agree with what is in your library.
 
@@ -902,7 +902,7 @@ Default: ``no``.
 .. _duplicate_track_action:
 
 duplicate_track_action
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 How to resolve individual album tracks that already exist in the library when
 :ref:`duplicate_track_resolution` is enabled. The available actions are:
@@ -919,7 +919,9 @@ How to resolve individual album tracks that already exist in the library when
 When left empty, this falls back to :ref:`duplicate_action`.
 
 A typical configuration for completing partially-imported albums while
-autotagging looks like this::
+autotagging looks like this:
+
+::
 
     import:
         duplicate_track_resolution: yes

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -897,6 +897,12 @@ part of another album.
     ``mb_trackid`` (via :ref:`duplicate_keys` ``item``); ``artist`` and
     ``title`` may not yet agree with what is in your library.
 
+    Matching on ``mb_trackid`` only works for files that actually carry that
+    tag: a track missing it is not compared at all and will import as a
+    duplicate. If your files are reliably tagged with ``artist`` and ``title``
+    but not always with MusicBrainz IDs, the default ``item: artist title``
+    catches more duplicates.
+
 Default: ``no``.
 
 .. _duplicate_track_action:
@@ -932,6 +938,19 @@ autotagging looks like this (values other than the defaults are commented):
         duplicate_track_action: skip     # default: '' -- per-track duplicates; fold new tracks into the existing album
         duplicate_keys:
             item: mb_trackid             # default: artist title -- match on a stable id (recommended when autotagging)
+
+If some of your files are missing ``mb_trackid`` but are otherwise correctly
+tagged, keep the default ``item`` keys instead, so tracks are matched on their
+names rather than an ID that may be absent:
+
+.. code-block:: yaml
+
+    import:
+        duplicate_track_resolution: yes
+        duplicate_track_action: skip
+        duplicate_keys:
+            album: albumartist album  # default
+            item: artist title        # default
 
 Default: empty (inherit :ref:`duplicate_action`).
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -910,8 +910,11 @@ How to resolve individual album tracks that already exist in the library when
 - ``skip`` drops the duplicate tracks and adds the remaining *new* tracks to the
   existing album they belong to, instead of importing them as a separate album.
   Use this to complete a partially-imported album. If every track is already
-  present, the whole album is skipped. (If the matching tracks do not all belong
-  to a single album, the new tracks are imported as their own album.)
+  present, the whole album is skipped. A track matching an existing *singleton*
+  is skipped individually but does not affect where the new tracks go, so a mix
+  of album-member and singleton matches still completes the album. The new
+  tracks are imported as their own album only when the matched album members
+  span more than one album, or when none of the matches belong to an album.
 - ``remove`` removes the matching old items from the library before importing.
 - ``keep`` (and ``merge``) import the album unchanged.
 - ``ask`` prompts you to choose one of the above.

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -881,26 +881,57 @@ When enabled, album imports also check each *individual track* against the
 library, using the same fields as :ref:`duplicate_keys` ``item`` (by default
 ``artist`` and ``title``; set it to e.g. ``mb_trackid`` to match on the
 MusicBrainz track ID). Tracks already in the library are resolved according to
-:ref:`duplicate_action`:
+:ref:`duplicate_track_action`.
+
+This complements the album-level duplicate check (which matches whole albums on
+:ref:`duplicate_keys` ``album``): it catches the case where some tracks of an
+album are already in your library even though the album itself is not. Matching
+considers *all* library items, whether they were imported as singletons or as
+part of another album.
+
+.. note::
+
+    The check runs *before* the autotagger lookup, so it matches on the
+    incoming files' existing tags rather than the metadata beets would apply.
+    When importing with autotagging on, match on a stable identifier such as
+    ``mb_trackid`` (via :ref:`duplicate_keys` ``item``); ``artist`` and
+    ``title`` may not yet agree with what is in your library.
+
+Default: ``no``.
+
+.. _duplicate_track_action:
+
+duplicate_track_action
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+How to resolve individual album tracks that already exist in the library when
+:ref:`duplicate_track_resolution` is enabled. The available actions are:
 
 - ``skip`` drops the duplicate tracks and imports the rest of the album. If
   every track is already present, the whole album is skipped.
 - ``remove`` removes the matching old items from the library before importing.
+- ``fold`` drops the duplicate tracks and adds the remaining *new* tracks to the
+  existing album they belong to, instead of importing them as a separate album.
+  Use this to complete a partially-imported album. (If the matching tracks do
+  not all belong to a single album, the new tracks are imported as their own
+  album.)
 - ``keep`` (and ``merge``) import the album unchanged.
 - ``ask`` prompts you to choose one of the above.
 
-This complements the album-level duplicate check (which matches whole albums on
-:ref:`duplicate_keys` ``album``): it catches the case where some loose tracks of
-an album are already in your library as singletons.
+When left empty, this falls back to :ref:`duplicate_action` (so ``fold`` is only
+available by setting this option explicitly).
 
-.. note::
+A typical configuration for completing partially-imported albums while
+autotagging looks like this::
 
-    Only **singleton** library items (tracks not attached to an album) are
-    considered. Tracks that already belong to an album in your library are not
-    matched, so importing a fuller version of an album you already have will not
-    deduplicate against that existing album's tracks.
+    import:
+        duplicate_track_resolution: yes
+        duplicate_action: ask          # whole-album duplicates
+        duplicate_track_action: fold   # per-track duplicates: fold into the existing album
+        duplicate_keys:
+            item: mb_trackid           # match on a stable id (recommended when autotagging)
 
-Default: ``no``.
+Default: empty (inherit :ref:`duplicate_action`).
 
 .. _bell:
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -907,19 +907,16 @@ duplicate_track_action
 How to resolve individual album tracks that already exist in the library when
 :ref:`duplicate_track_resolution` is enabled. The available actions are:
 
-- ``skip`` drops the duplicate tracks and imports the rest of the album. If
-  every track is already present, the whole album is skipped.
-- ``remove`` removes the matching old items from the library before importing.
-- ``fold`` drops the duplicate tracks and adds the remaining *new* tracks to the
+- ``skip`` drops the duplicate tracks and adds the remaining *new* tracks to the
   existing album they belong to, instead of importing them as a separate album.
-  Use this to complete a partially-imported album. (If the matching tracks do
-  not all belong to a single album, the new tracks are imported as their own
-  album.)
+  Use this to complete a partially-imported album. If every track is already
+  present, the whole album is skipped. (If the matching tracks do not all belong
+  to a single album, the new tracks are imported as their own album.)
+- ``remove`` removes the matching old items from the library before importing.
 - ``keep`` (and ``merge``) import the album unchanged.
 - ``ask`` prompts you to choose one of the above.
 
-When left empty, this falls back to :ref:`duplicate_action` (so ``fold`` is only
-available by setting this option explicitly).
+When left empty, this falls back to :ref:`duplicate_action`.
 
 A typical configuration for completing partially-imported albums while
 autotagging looks like this::
@@ -927,7 +924,7 @@ autotagging looks like this::
     import:
         duplicate_track_resolution: yes
         duplicate_action: ask          # whole-album duplicates
-        duplicate_track_action: fold   # per-track duplicates: fold into the existing album
+        duplicate_track_action: skip   # per-track duplicates: fold new tracks into the existing album
         duplicate_keys:
             item: mb_trackid           # match on a stable id (recommended when autotagging)
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -919,16 +919,16 @@ How to resolve individual album tracks that already exist in the library when
 When left empty, this falls back to :ref:`duplicate_action`.
 
 A typical configuration for completing partially-imported albums while
-autotagging looks like this:
+autotagging looks like this (values other than the defaults are commented):
 
-::
+.. code-block:: yaml
 
     import:
-        duplicate_track_resolution: yes
-        duplicate_action: ask          # whole-album duplicates
-        duplicate_track_action: skip   # per-track duplicates: fold new tracks into the existing album
+        duplicate_track_resolution: yes  # default: no
+        duplicate_action: ask            # default: ask -- whole-album duplicates
+        duplicate_track_action: skip     # default: '' -- per-track duplicates; fold new tracks into the existing album
         duplicate_keys:
-            item: mb_trackid           # match on a stable id (recommended when autotagging)
+            item: mb_trackid             # default: artist title -- match on a stable id (recommended when autotagging)
 
 Default: empty (inherit :ref:`duplicate_action`).
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -850,6 +850,79 @@ other candidate album is left completely untouched, since a track can only ever
 be added to one album. Unlike the other options, "upgrade" is config-only and is
 not offered when ``duplicate_action`` is ``ask``.
 
+.. _duplicate_tracks:
+
+duplicate_tracks
+~~~~~~~~~~~~~~~~
+
+Whether album imports also check each *individual track* against the library, in
+addition to the whole-album duplicate check. This catches the case where some
+tracks of an album are already in your library even though the album itself is
+not (for example, previously imported as singletons or as part of a partial
+album import).
+
+Both checks are resolved at the same decision point during import. When only
+*some* of the incoming tracks duplicate existing items (a partial overlap, e.g.
+completing a partially-imported album), per-track resolution applies and the
+whole-album :ref:`duplicate_action` is not triggered. When *every* track is
+already present, the import is a whole-album duplicate and the
+:ref:`duplicate_action` decision applies. Tracks are compared *after* tagging
+metadata has been chosen, using the fields listed in :ref:`duplicate_keys`
+``item`` (by default ``artist`` and ``title``; set it to e.g. ``mb_trackid`` to
+match on the MusicBrainz track ID, which is reliable when autotagging). Matching
+considers all library items, whether they were imported as singletons or as part
+of another album.
+
+Tracks found to be duplicates are resolved according to
+:ref:`duplicate_tracks_action`.
+
+Default: ``no``.
+
+.. _duplicate_tracks_action:
+
+duplicate_tracks_action
+~~~~~~~~~~~~~~~~~~~~~~~
+
+How to resolve individual album tracks that already exist in the library. The
+available actions are:
+
+- ``skip`` drops the duplicate tracks and adds the remaining *new* tracks to the
+  existing album they belong to, instead of importing them as a separate album.
+  Use this to complete a partially-imported album. If every track is already
+  present, the whole album is skipped. A track matching an existing *singleton*
+  is skipped individually but does not affect where the new tracks go, so a mix
+  of album-member and singleton matches still completes the album. The new
+  tracks are imported as their own album only when the matched album members
+  span more than one album, or when none of the matches belong to an album.
+- ``remove`` removes the matching old items from the library.
+- ``keep`` imports everything, keeping both old and new items.
+- ``ask`` prompts you to choose one of the above for all duplicate tracks at
+  once, or to decide for each track individually.
+
+Unlike :ref:`duplicate_action`, ``merge`` is not available: merging is defined
+for whole albums only.
+
+When left empty, this falls back to :ref:`duplicate_action` (where a configured
+``merge`` behaves like ``keep`` for tracks).
+
+Default: empty (inherit :ref:`duplicate_action`).
+
+A typical configuration for completing partially-imported albums while
+autotagging looks like this:
+
+.. code-block:: yaml
+
+    import:
+        duplicate_tracks: yes           # default: no
+        duplicate_tracks_action: skip   # default: '' -- inherit duplicate_action
+        duplicate_action: ask           # default -- whole-album duplicates
+        duplicate_keys:
+            item: mb_trackid   # default: artist title -- stable id, recommended when autotagging
+
+If some of your files are missing ``mb_trackid`` but are otherwise correctly
+tagged, keep the default ``item`` keys instead, so tracks are matched on their
+names rather than an ID that may be absent.
+
 .. _duplicate_verbose_prompt:
 
 duplicate_verbose_prompt
@@ -871,88 +944,6 @@ is applied, which would, considering the default, look like this:
     [S]kip new, Keep all, Remove old, Merge all?
 
 Default: ``no``.
-
-.. _duplicate_track_resolution:
-
-duplicate_track_resolution
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-When enabled, album imports also check each *individual track* against the
-library, using the same fields as :ref:`duplicate_keys` ``item`` (by default
-``artist`` and ``title``; set it to e.g. ``mb_trackid`` to match on the
-MusicBrainz track ID). Tracks already in the library are resolved according to
-:ref:`duplicate_track_action`.
-
-This complements the album-level duplicate check (which matches whole albums on
-:ref:`duplicate_keys` ``album``): it catches the case where some tracks of an
-album are already in your library even though the album itself is not. Matching
-considers *all* library items, whether they were imported as singletons or as
-part of another album.
-
-.. note::
-
-    The check runs *before* the autotagger lookup, so it matches on the incoming
-    files' existing tags rather than the metadata beets would apply. When
-    importing with autotagging on, match on a stable identifier such as
-    ``mb_trackid`` (via :ref:`duplicate_keys` ``item``); ``artist`` and
-    ``title`` may not yet agree with what is in your library.
-
-    Matching on ``mb_trackid`` only works for files that actually carry that
-    tag: a track missing it is not compared at all and will import as a
-    duplicate. If your files are reliably tagged with ``artist`` and ``title``
-    but not always with MusicBrainz IDs, the default ``item: artist title``
-    catches more duplicates.
-
-Default: ``no``.
-
-.. _duplicate_track_action:
-
-duplicate_track_action
-~~~~~~~~~~~~~~~~~~~~~~
-
-How to resolve individual album tracks that already exist in the library when
-:ref:`duplicate_track_resolution` is enabled. The available actions are:
-
-- ``skip`` drops the duplicate tracks and adds the remaining *new* tracks to the
-  existing album they belong to, instead of importing them as a separate album.
-  Use this to complete a partially-imported album. If every track is already
-  present, the whole album is skipped. A track matching an existing *singleton*
-  is skipped individually but does not affect where the new tracks go, so a mix
-  of album-member and singleton matches still completes the album. The new
-  tracks are imported as their own album only when the matched album members
-  span more than one album, or when none of the matches belong to an album.
-- ``remove`` removes the matching old items from the library before importing.
-- ``keep`` (and ``merge``) import the album unchanged.
-- ``ask`` prompts you to choose one of the above.
-
-When left empty, this falls back to :ref:`duplicate_action`.
-
-A typical configuration for completing partially-imported albums while
-autotagging looks like this (values other than the defaults are commented):
-
-.. code-block:: yaml
-
-    import:
-        duplicate_track_resolution: yes  # default: no
-        duplicate_action: ask            # default: ask -- whole-album duplicates
-        duplicate_track_action: skip     # default: '' -- per-track duplicates; fold new tracks into the existing album
-        duplicate_keys:
-            item: mb_trackid             # default: artist title -- match on a stable id (recommended when autotagging)
-
-If some of your files are missing ``mb_trackid`` but are otherwise correctly
-tagged, keep the default ``item`` keys instead, so tracks are matched on their
-names rather than an ID that may be absent:
-
-.. code-block:: yaml
-
-    import:
-        duplicate_track_resolution: yes
-        duplicate_track_action: skip
-        duplicate_keys:
-            album: albumartist album  # default
-            item: artist title        # default
-
-Default: empty (inherit :ref:`duplicate_action`).
 
 .. _bell:
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -33,6 +33,7 @@ from beets.test.helper import (
     AutotagStub,
     BeetsTestCase,
     ImportHelper,
+    ImportSessionFixture,
     PluginMixin,
     TestHelper,
     has_program,
@@ -1287,6 +1288,115 @@ class TestImportDuplicateSingleton(ImportHelper):
         item.update(kwargs)
         item.store()
         return item
+
+
+class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
+    """``import.duplicate_track_resolution``: per-track dedup on album import.
+
+    The imported album has two tracks (``Tag Track 1`` and ``Tag Track 2``);
+    tests seed the library with singletons matching one or both of them.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.prepare_album_for_import(2)
+
+    def add_item_fixture(self, **kwargs):
+        item = self.add_item_fixtures()[0]
+        item.update(kwargs)
+        item.store()
+        return item
+
+    def _import(self, action="skip", enabled=True, resolution=None):
+        self.setup_importer(
+            autotag=False,
+            duplicate_track_resolution=enabled,
+            duplicate_action=action,
+        )
+        if resolution is not None:
+            self.importer.default_resolution = resolution
+        self.importer.run()
+
+    def test_skip_drops_duplicate_track(self):
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        self._import(action="skip")
+
+        # The duplicate "Tag Track 1" is dropped; "Tag Track 2" is imported.
+        assert len(self.lib.albums()) == 1
+        assert {i.title for i in self.lib.items()} == {
+            "Tag Track 1",
+            "Tag Track 2",
+        }
+        assert len(self.lib.items()) == 2
+
+    def test_skip_all_duplicates_skips_album(self):
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 2")
+
+        self._import(action="skip")
+
+        # Every track is a duplicate, so the whole album is skipped.
+        assert len(self.lib.albums()) == 0
+        assert len(self.lib.items()) == 2
+
+    def test_remove_replaces_old_item(self):
+        old = self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+        assert old.filepath.exists()
+
+        self._import(action="remove")
+
+        # The old matching item (and its file) is removed; both album tracks
+        # are imported.
+        assert not old.filepath.exists()
+        assert sorted(i.title for i in self.lib.items()) == [
+            "Tag Track 1",
+            "Tag Track 2",
+        ]
+        assert len(self.lib.albums()) == 1
+
+    def test_keep_imports_all(self):
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        self._import(action="keep")
+
+        # Nothing is dropped or removed.
+        assert len(self.lib.items()) == 3
+        assert len(self.lib.albums()) == 1
+
+    def test_disabled_by_default(self):
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        self._import(action="skip", enabled=False)
+
+        # With the option off, no track-level resolution happens.
+        assert len(self.lib.items()) == 3
+
+    def test_ask_skip_drops_duplicate_track(self):
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        # With "ask", the session is prompted; answer SKIP.
+        self._import(
+            action="ask", resolution=ImportSessionFixture.Resolution.SKIP
+        )
+
+        assert len(self.lib.albums()) == 1
+        assert len(self.lib.items()) == 2
+
+    def test_ask_remove_replaces_old_item(self):
+        old = self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        # With "ask", the session is prompted; answer REMOVE.
+        self._import(
+            action="ask", resolution=ImportSessionFixture.Resolution.REMOVE
+        )
+
+        assert not old.filepath.exists()
+        assert len(self.lib.albums()) == 1
+        assert sorted(i.title for i in self.lib.items()) == [
+            "Tag Track 1",
+            "Tag Track 2",
+        ]
 
 
 class TagLogTest(unittest.TestCase):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1290,7 +1290,7 @@ class TestImportDuplicateSingleton(ImportHelper):
 
 
 class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
-    """``import.duplicate_track_resolution``: per-track dedup on album import.
+    """``duplicate_tracks``: per-track dedup on album import.
 
     The imported album has two tracks (``Tag Track 1`` and ``Tag Track 2``);
     tests seed the library with items matching one or both of them (as
@@ -1317,12 +1317,9 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
         return item
 
     def _import(self, action="skip", enabled=True, track_action=None):
-        self.setup_importer(
-            autotag=False,
-            duplicate_track_resolution=enabled,
-            duplicate_action=action,
-            duplicate_track_action=track_action or "",
-        )
+        self.config["import"]["duplicate_tracks"] = enabled
+        self.config["import"]["duplicate_tracks_action"] = track_action or ""
+        self.setup_importer(autotag=False, duplicate_action=action)
         self.importer.run()
 
     def test_skip_singleton_dup_imports_remainder_as_new_album(self):
@@ -1455,56 +1452,16 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
             "Tag Track 3",
         }
 
-    def test_within_run_dedup_sequential(self):
-        # Two identical albums imported in one (sequential) run: the second
-        # album's tracks are caught against the first, so only two items land
-        # overall. The session's seen-key cache makes this hold regardless of
-        # ordering (see the threaded variant below).
+    def test_within_run_dedup(self):
+        # Two identical albums imported in one run: the second album's tracks
+        # are caught against the first, so only two items land overall. This
+        # holds because tasks are resolved in order, after the previous task's
+        # items have been added to the library.
         self.prepare_album_for_import(2, album_id=2)  # a second album dir
-        self.setup_importer(
-            autotag=False,
-            duplicate_track_resolution=True,
-            duplicate_action="skip",
-            threaded=False,
-        )
-        self.importer.run()
+        self._import(action="skip")
 
         titles = sorted(i.title for i in self.lib.items())
         assert titles == ["Tag Track 1", "Tag Track 2"]
-
-    def test_seen_key_cache_catches_within_run_duplicate(self):
-        # Deterministically isolate the seen-key cache: drive the stage over
-        # two tasks with *no* DB add() in between (as can happen under a
-        # threaded import, where a later task is checked before an earlier one
-        # is added). The second task's matching track must be caught purely via
-        # the cache, against an empty library.
-        from beets.importer.stages import resolve_track_duplicates
-        from beets.importer.tasks import ImportTask
-        from beets.library import Item
-
-        session = self.setup_importer(
-            autotag=False,
-            duplicate_track_resolution=True,
-            duplicate_action="skip",
-        )
-
-        def make_task(path):
-            item = Item(artist="Tag Artist", title="Tag Track 1")
-            item.path = path
-            return ImportTask(None, [path], [item])
-
-        task1 = make_task(b"/import/a/track.mp3")
-        task2 = make_task(b"/import/b/track.mp3")
-
-        coro = resolve_track_duplicates(session)
-        next(coro)  # prime the coroutine
-        coro.send(task1)  # first occurrence: nothing dropped, key remembered
-        coro.send(task2)  # second occurrence: caught via the cache alone
-
-        assert not task1.skip
-        assert [i.title for i in task1.items] == ["Tag Track 1"]
-        assert task2.skip
-        assert task2.items == []
 
     def test_inherits_duplicate_action_when_unset(self):
         self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
@@ -1539,6 +1496,30 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
 
         # "keep" wins, so nothing is dropped.
         assert len(self.lib.items()) == 3
+
+    def test_merge_track_action_rejected(self):
+        # ``merge`` is only defined for whole albums; configuring it as the
+        # per-track action is a configuration error.
+        import confuse
+
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        with pytest.raises(confuse.ConfigValueError):
+            self._import(action="keep", track_action="merge")
+
+    def test_skipped_tracks_never_added_to_library(self):
+        # Duplicate tracks are dropped before the task is added, so no
+        # library row ever exists for them, even transiently.
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+        max_id_before = max(i.id for i in self.lib.items())
+
+        self._import(action="skip")
+
+        new_ids = [i.id for i in self.lib.items() if i.id > max_id_before]
+        # Only one new row: the non-duplicate track.
+        assert len(new_ids) == 1
+        # No gap in row ids: nothing was inserted and removed again.
+        assert new_ids[0] == max_id_before + 1
 
 
 class TagLogTest(unittest.TestCase):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1457,12 +1457,9 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
 
     def test_within_run_dedup_sequential(self):
         # Two identical albums imported in one (sequential) run: the second
-        # album's tracks are caught against the first once it is in the
-        # library, so only two items land overall. In threaded mode (the
-        # default) this guarantee does not hold -- both albums can pass the
-        # check before either is added -- which matches the existing
-        # album-level duplicate behaviour, since both check the library
-        # before ``add()``.
+        # album's tracks are caught against the first, so only two items land
+        # overall. The session's seen-key cache makes this hold regardless of
+        # ordering (see the threaded variant below).
         self.prepare_album_for_import(2, album_id=2)  # a second album dir
         self.setup_importer(
             autotag=False,
@@ -1474,6 +1471,40 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
 
         titles = sorted(i.title for i in self.lib.items())
         assert titles == ["Tag Track 1", "Tag Track 2"]
+
+    def test_seen_key_cache_catches_within_run_duplicate(self):
+        # Deterministically isolate the seen-key cache: drive the stage over
+        # two tasks with *no* DB add() in between (as can happen under a
+        # threaded import, where a later task is checked before an earlier one
+        # is added). The second task's matching track must be caught purely via
+        # the cache, against an empty library.
+        from beets.importer.stages import resolve_track_duplicates
+        from beets.importer.tasks import ImportTask
+        from beets.library import Item
+
+        session = self.setup_importer(
+            autotag=False,
+            duplicate_track_resolution=True,
+            duplicate_action="skip",
+        )
+
+        def make_task(path):
+            item = Item(artist="Tag Artist", title="Tag Track 1")
+            item.path = path
+            return ImportTask(None, [path], [item])
+
+        task1 = make_task(b"/import/a/track.mp3")
+        task2 = make_task(b"/import/b/track.mp3")
+
+        coro = resolve_track_duplicates(session)
+        next(coro)  # prime the coroutine
+        coro.send(task1)  # first occurrence: nothing dropped, key remembered
+        coro.send(task2)  # second occurrence: caught via the cache alone
+
+        assert not task1.skip
+        assert [i.title for i in task1.items] == ["Tag Track 1"]
+        assert task2.skip
+        assert task2.items == []
 
     def test_inherits_duplicate_action_when_unset(self):
         self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -33,7 +33,6 @@ from beets.test.helper import (
     AutotagStub,
     BeetsTestCase,
     ImportHelper,
-    ImportSessionFixture,
     PluginMixin,
     TestHelper,
     has_program,
@@ -1317,17 +1316,13 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
         item.store()
         return item
 
-    def _import(
-        self, action="skip", enabled=True, resolution=None, track_action=None
-    ):
+    def _import(self, action="skip", enabled=True, track_action=None):
         self.setup_importer(
             autotag=False,
             duplicate_track_resolution=enabled,
             duplicate_action=action,
             duplicate_track_action=track_action or "",
         )
-        if resolution is not None:
-            self.importer.default_resolution = resolution
         self.importer.run()
 
     def test_skip_singleton_dup_imports_remainder_as_new_album(self):
@@ -1435,31 +1430,45 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
         # With the option off, no track-level resolution happens.
         assert len(self.lib.items()) == 3
 
-    def test_ask_skip_drops_duplicate_track(self):
-        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
-
-        # With "ask", the session is prompted; answer SKIP.
-        self._import(
-            action="ask", resolution=ImportSessionFixture.Resolution.SKIP
+    def test_singleton_match_leaves_new_track_as_own_album(self):
+        # Incoming album has tracks 1, 2 and 3. Track 1 matches an album
+        # member (album X); track 2 matches a singleton. Track 3 is new. The
+        # mixed matches must prevent folding, so track 3 becomes its own album.
+        self.prepare_album_for_import(3)
+        member = self.add_album_member_fixture(
+            artist="Tag Artist", title="Tag Track 1"
         )
+        album_x = member.get_album()
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 2")
 
-        assert len(self.lib.albums()) == 1
-        assert len(self.lib.items()) == 2
+        self._import(action="skip")
 
-    def test_ask_remove_replaces_old_item(self):
-        old = self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+        # Track 3 is imported into a brand-new album, not folded into X.
+        new_track = self.lib.items("title:'Tag Track 3'").get()
+        assert new_track is not None
+        assert new_track.album_id != album_x.id
+        new_album = self.lib.get_album(new_track.album_id)
+        assert {i.title for i in new_album.items()} == {"Tag Track 3"}
 
-        # With "ask", the session is prompted; answer REMOVE.
-        self._import(
-            action="ask", resolution=ImportSessionFixture.Resolution.REMOVE
+    def test_within_run_dedup_sequential(self):
+        # Two identical albums imported in one (sequential) run: the second
+        # album's tracks are caught against the first once it is in the
+        # library, so only two items land overall. In threaded mode (the
+        # default) this guarantee does not hold -- both albums can pass the
+        # check before either is added -- which matches the existing
+        # album-level duplicate behaviour, since both check the library
+        # before ``add()``.
+        self.prepare_album_for_import(2, album_id=2)  # a second album dir
+        self.setup_importer(
+            autotag=False,
+            duplicate_track_resolution=True,
+            duplicate_action="skip",
+            threaded=False,
         )
+        self.importer.run()
 
-        assert not old.filepath.exists()
-        assert len(self.lib.albums()) == 1
-        assert sorted(i.title for i in self.lib.items()) == [
-            "Tag Track 1",
-            "Tag Track 2",
-        ]
+        titles = sorted(i.title for i in self.lib.items())
+        assert titles == ["Tag Track 1", "Tag Track 2"]
 
     def test_inherits_duplicate_action_when_unset(self):
         self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
@@ -1482,22 +1491,18 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
         # The duplicate was dropped (skip), not kept, so only two items exist.
         assert len(self.lib.items()) == 2
 
-    def test_ask_skip_folds_into_existing_album(self):
-        self._import(action="skip")
-        missing = self.lib.items("title:'Tag Track 2'").get()
-        missing.remove(delete=True)
+    def test_track_action_ask_falls_back_to_duplicate_action(self):
+        # duplicate_track_action="ask" with a non-interactive session would
+        # need a prompt, so exercise the ask dispatch through the terminal
+        # session instead (see test/ui/test_ui_importer.py). Here we simply
+        # confirm the config plumbing: an explicit track action of "keep"
+        # overrides duplicate_action=skip.
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
 
-        # With "ask", the session is prompted; answer SKIP, which folds the
-        # remaining track into the existing album.
-        self._import(
-            action="ask", resolution=ImportSessionFixture.Resolution.SKIP
-        )
+        self._import(action="skip", track_action="keep")
 
-        assert len(self.lib.albums()) == 1
-        assert {i.title for i in self.lib.albums().get().items()} == {
-            "Tag Track 1",
-            "Tag Track 2",
-        }
+        # "keep" wins, so nothing is dropped.
+        assert len(self.lib.items()) == 3
 
 
 class TagLogTest(unittest.TestCase):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1430,10 +1430,12 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
         # With the option off, no track-level resolution happens.
         assert len(self.lib.items()) == 3
 
-    def test_singleton_match_leaves_new_track_as_own_album(self):
-        # Incoming album has tracks 1, 2 and 3. Track 1 matches an album
-        # member (album X); track 2 matches a singleton. Track 3 is new. The
-        # mixed matches must prevent folding, so track 3 becomes its own album.
+    def test_singleton_match_still_folds_into_album(self):
+        # snejus's scenario: incoming album has tracks 1, 2 and 3. Track 1
+        # matches an album member (album X); track 2 matches a singleton;
+        # track 3 is new. The singleton match is skipped individually but does
+        # not prevent folding: track 3 (the intended outcome for "C") is folded
+        # into album X, the album the matched album member belongs to.
         self.prepare_album_for_import(3)
         member = self.add_album_member_fixture(
             artist="Tag Artist", title="Tag Track 1"
@@ -1443,12 +1445,15 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
 
         self._import(action="skip")
 
-        # Track 3 is imported into a brand-new album, not folded into X.
+        # No new album is created; track 3 joins album X.
+        assert len(self.lib.albums()) == 1
         new_track = self.lib.items("title:'Tag Track 3'").get()
         assert new_track is not None
-        assert new_track.album_id != album_x.id
-        new_album = self.lib.get_album(new_track.album_id)
-        assert {i.title for i in new_album.items()} == {"Tag Track 3"}
+        assert new_track.album_id == album_x.id
+        assert {i.title for i in album_x.items()} == {
+            "Tag Track 1",
+            "Tag Track 3",
+        }
 
     def test_within_run_dedup_sequential(self):
         # Two identical albums imported in one (sequential) run: the second

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1330,12 +1330,14 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
             self.importer.default_resolution = resolution
         self.importer.run()
 
-    def test_skip_drops_duplicate_track(self):
+    def test_skip_singleton_dup_imports_remainder_as_new_album(self):
+        # The matching track is a singleton, so there is no single album to
+        # fold into: the duplicate is dropped and the remaining track is
+        # imported as its own album.
         self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
 
         self._import(action="skip")
 
-        # The duplicate "Tag Track 1" is dropped; "Tag Track 2" is imported.
         assert len(self.lib.albums()) == 1
         assert {i.title for i in self.lib.items()} == {
             "Tag Track 1",
@@ -1343,13 +1345,14 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
         }
         assert len(self.lib.items()) == 2
 
-    def test_partial_album_reimports_missing_tracks(self):
+    def test_skip_folds_missing_tracks_into_existing_album(self):
         # Import the album fully, then lose one track from the library and
         # re-import the same folder. The present track is skipped as a
-        # duplicate and the missing one is re-added, even though the album
-        # itself still matches the album-level duplicate check.
+        # duplicate and the missing one is folded back into the *same* album
+        # (no second album is created).
         self._import(action="skip")
-        assert {i.title for i in self.lib.items()} == {
+        album = self.lib.albums().get()
+        assert {i.title for i in album.items()} == {
             "Tag Track 1",
             "Tag Track 2",
         }
@@ -1360,14 +1363,20 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
 
         self._import(action="skip")
 
-        assert {i.title for i in self.lib.items()} == {
+        assert len(self.lib.albums()) == 1
+        album = self.lib.albums().get()
+        folded = self.lib.items("title:'Tag Track 2'").get()
+        assert folded.album_id == album.id
+        assert folded.filepath.exists()
+        assert {i.title for i in album.items()} == {
             "Tag Track 1",
             "Tag Track 2",
         }
 
     def test_skip_matches_existing_album_member(self):
         # A matching track that already belongs to an album in the library
-        # (not a singleton) must still be caught.
+        # (not a singleton) must still be caught, and the remaining new track
+        # folded into that album.
         item = self.add_album_member_fixture(
             artist="Tag Artist", title="Tag Track 1"
         )
@@ -1375,13 +1384,14 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
 
         self._import(action="skip")
 
-        # The duplicate "Tag Track 1" is dropped; only "Tag Track 2" is added,
-        # alongside the pre-existing album member.
-        assert sorted(i.title for i in self.lib.items()) == [
+        # The duplicate "Tag Track 1" is dropped; "Tag Track 2" is folded into
+        # the existing album.
+        assert len(self.lib.albums()) == 1
+        album = self.lib.albums().get()
+        assert {i.title for i in album.items()} == {
             "Tag Track 1",
             "Tag Track 2",
-        ]
-        assert len(self.lib.items()) == 2
+        }
 
     def test_skip_all_duplicates_skips_album(self):
         self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
@@ -1463,61 +1473,24 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
             "Tag Track 2",
         }
 
-    def test_fold_into_existing_album(self):
-        # Import the album fully, lose one track, then re-import with "fold":
-        # the present track is skipped and the missing one is added back to
-        # the *same* album (no second album is created).
-        self._import(track_action="fold")
-        album = self.lib.albums().get()
-        assert {i.title for i in album.items()} == {
-            "Tag Track 1",
-            "Tag Track 2",
-        }
-
-        missing = self.lib.items("title:'Tag Track 2'").get()
-        missing.remove(delete=True)
-
-        self._import(track_action="fold")
-
-        assert len(self.lib.albums()) == 1
-        album = self.lib.albums().get()
-        folded = self.lib.items("title:'Tag Track 2'").get()
-        assert folded.album_id == album.id
-        assert folded.filepath.exists()
-        assert {i.title for i in album.items()} == {
-            "Tag Track 1",
-            "Tag Track 2",
-        }
-
-    def test_fold_all_duplicates_skips_album(self):
-        self.add_album_member_fixture(artist="Tag Artist", title="Tag Track 1")
-        self.add_album_member_fixture(artist="Tag Artist", title="Tag Track 2")
-
-        # Every track is a duplicate: nothing new to fold, album is skipped.
-        self._import(track_action="fold")
-
-        assert len(self.lib.items()) == 2
-
-    def test_fold_falls_back_when_no_single_album(self):
-        # Matching tracks are singletons (no album), so there is no single
-        # album to fold into: the new track is imported as its own album.
+    def test_track_action_overrides_duplicate_action(self):
         self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
 
-        self._import(track_action="fold")
+        # duplicate_action says keep, but the track-specific action skips.
+        self._import(action="keep", track_action="skip")
 
-        assert {i.title for i in self.lib.items()} == {
-            "Tag Track 1",
-            "Tag Track 2",
-        }
+        # The duplicate was dropped (skip), not kept, so only two items exist.
+        assert len(self.lib.items()) == 2
 
-    def test_ask_fold(self):
-        self._import(track_action="fold")
+    def test_ask_skip_folds_into_existing_album(self):
+        self._import(action="skip")
         missing = self.lib.items("title:'Tag Track 2'").get()
         missing.remove(delete=True)
 
-        # With "ask", the session is prompted; answer FOLD.
+        # With "ask", the session is prompted; answer SKIP, which folds the
+        # remaining track into the existing album.
         self._import(
-            action="ask", resolution=ImportSessionFixture.Resolution.FOLD
+            action="ask", resolution=ImportSessionFixture.Resolution.SKIP
         )
 
         assert len(self.lib.albums()) == 1

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1294,7 +1294,8 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
     """``import.duplicate_track_resolution``: per-track dedup on album import.
 
     The imported album has two tracks (``Tag Track 1`` and ``Tag Track 2``);
-    tests seed the library with singletons matching one or both of them.
+    tests seed the library with items matching one or both of them (as
+    singletons unless noted otherwise).
     """
 
     def setUp(self):
@@ -1307,11 +1308,23 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
         item.store()
         return item
 
-    def _import(self, action="skip", enabled=True, resolution=None):
+    def add_album_member_fixture(self, **kwargs):
+        """Seed the library with a track that belongs to an album (i.e. not a
+        singleton), so its ``album_id`` is set.
+        """
+        item = self.add_item_fixture(**kwargs)
+        self.lib.add_album([item])
+        item.store()
+        return item
+
+    def _import(
+        self, action="skip", enabled=True, resolution=None, track_action=None
+    ):
         self.setup_importer(
             autotag=False,
             duplicate_track_resolution=enabled,
             duplicate_action=action,
+            duplicate_track_action=track_action or "",
         )
         if resolution is not None:
             self.importer.default_resolution = resolution
@@ -1328,6 +1341,46 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
             "Tag Track 1",
             "Tag Track 2",
         }
+        assert len(self.lib.items()) == 2
+
+    def test_partial_album_reimports_missing_tracks(self):
+        # Import the album fully, then lose one track from the library and
+        # re-import the same folder. The present track is skipped as a
+        # duplicate and the missing one is re-added, even though the album
+        # itself still matches the album-level duplicate check.
+        self._import(action="skip")
+        assert {i.title for i in self.lib.items()} == {
+            "Tag Track 1",
+            "Tag Track 2",
+        }
+
+        missing = self.lib.items("title:'Tag Track 2'").get()
+        missing.remove(delete=True)
+        assert {i.title for i in self.lib.items()} == {"Tag Track 1"}
+
+        self._import(action="skip")
+
+        assert {i.title for i in self.lib.items()} == {
+            "Tag Track 1",
+            "Tag Track 2",
+        }
+
+    def test_skip_matches_existing_album_member(self):
+        # A matching track that already belongs to an album in the library
+        # (not a singleton) must still be caught.
+        item = self.add_album_member_fixture(
+            artist="Tag Artist", title="Tag Track 1"
+        )
+        assert item.album_id is not None
+
+        self._import(action="skip")
+
+        # The duplicate "Tag Track 1" is dropped; only "Tag Track 2" is added,
+        # alongside the pre-existing album member.
+        assert sorted(i.title for i in self.lib.items()) == [
+            "Tag Track 1",
+            "Tag Track 2",
+        ]
         assert len(self.lib.items()) == 2
 
     def test_skip_all_duplicates_skips_album(self):
@@ -1397,6 +1450,81 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
             "Tag Track 1",
             "Tag Track 2",
         ]
+
+    def test_inherits_duplicate_action_when_unset(self):
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        # No duplicate_track_action: should inherit duplicate_action=skip.
+        self._import(action="skip", track_action=None)
+
+        assert len(self.lib.albums()) == 1
+        assert {i.title for i in self.lib.items()} == {
+            "Tag Track 1",
+            "Tag Track 2",
+        }
+
+    def test_fold_into_existing_album(self):
+        # Import the album fully, lose one track, then re-import with "fold":
+        # the present track is skipped and the missing one is added back to
+        # the *same* album (no second album is created).
+        self._import(track_action="fold")
+        album = self.lib.albums().get()
+        assert {i.title for i in album.items()} == {
+            "Tag Track 1",
+            "Tag Track 2",
+        }
+
+        missing = self.lib.items("title:'Tag Track 2'").get()
+        missing.remove(delete=True)
+
+        self._import(track_action="fold")
+
+        assert len(self.lib.albums()) == 1
+        album = self.lib.albums().get()
+        folded = self.lib.items("title:'Tag Track 2'").get()
+        assert folded.album_id == album.id
+        assert folded.filepath.exists()
+        assert {i.title for i in album.items()} == {
+            "Tag Track 1",
+            "Tag Track 2",
+        }
+
+    def test_fold_all_duplicates_skips_album(self):
+        self.add_album_member_fixture(artist="Tag Artist", title="Tag Track 1")
+        self.add_album_member_fixture(artist="Tag Artist", title="Tag Track 2")
+
+        # Every track is a duplicate: nothing new to fold, album is skipped.
+        self._import(track_action="fold")
+
+        assert len(self.lib.items()) == 2
+
+    def test_fold_falls_back_when_no_single_album(self):
+        # Matching tracks are singletons (no album), so there is no single
+        # album to fold into: the new track is imported as its own album.
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        self._import(track_action="fold")
+
+        assert {i.title for i in self.lib.items()} == {
+            "Tag Track 1",
+            "Tag Track 2",
+        }
+
+    def test_ask_fold(self):
+        self._import(track_action="fold")
+        missing = self.lib.items("title:'Tag Track 2'").get()
+        missing.remove(delete=True)
+
+        # With "ask", the session is prompted; answer FOLD.
+        self._import(
+            action="ask", resolution=ImportSessionFixture.Resolution.FOLD
+        )
+
+        assert len(self.lib.albums()) == 1
+        assert {i.title for i in self.lib.albums().get().items()} == {
+            "Tag Track 1",
+            "Tag Track 2",
+        }
 
 
 class TagLogTest(unittest.TestCase):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1779,12 +1779,9 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
 
     def test_within_run_dedup_sequential(self):
         # Two identical albums imported in one (sequential) run: the second
-        # album's tracks are caught against the first once it is in the
-        # library, so only two items land overall. In threaded mode (the
-        # default) this guarantee does not hold -- both albums can pass the
-        # check before either is added -- which matches the existing
-        # album-level duplicate behaviour, since both check the library
-        # before ``add()``.
+        # album's tracks are caught against the first, so only two items land
+        # overall. The session's seen-key cache makes this hold regardless of
+        # ordering (see the threaded variant below).
         self.prepare_album_for_import(2, album_id=2)  # a second album dir
         self.setup_importer(
             autotag=False,
@@ -1796,6 +1793,40 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
 
         titles = sorted(i.title for i in self.lib.items())
         assert titles == ["Tag Track 1", "Tag Track 2"]
+
+    def test_seen_key_cache_catches_within_run_duplicate(self):
+        # Deterministically isolate the seen-key cache: drive the stage over
+        # two tasks with *no* DB add() in between (as can happen under a
+        # threaded import, where a later task is checked before an earlier one
+        # is added). The second task's matching track must be caught purely via
+        # the cache, against an empty library.
+        from beets.importer.stages import resolve_track_duplicates
+        from beets.importer.tasks import ImportTask
+        from beets.library import Item
+
+        session = self.setup_importer(
+            autotag=False,
+            duplicate_track_resolution=True,
+            duplicate_action="skip",
+        )
+
+        def make_task(path):
+            item = Item(artist="Tag Artist", title="Tag Track 1")
+            item.path = path
+            return ImportTask(None, [path], [item])
+
+        task1 = make_task(b"/import/a/track.mp3")
+        task2 = make_task(b"/import/b/track.mp3")
+
+        coro = resolve_track_duplicates(session)
+        next(coro)  # prime the coroutine
+        coro.send(task1)  # first occurrence: nothing dropped, key remembered
+        coro.send(task2)  # second occurrence: caught via the cache alone
+
+        assert not task1.skip
+        assert [i.title for i in task1.items] == ["Tag Track 1"]
+        assert task2.skip
+        assert task2.items == []
 
     def test_inherits_duplicate_action_when_unset(self):
         self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1752,10 +1752,12 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
         # With the option off, no track-level resolution happens.
         assert len(self.lib.items()) == 3
 
-    def test_singleton_match_leaves_new_track_as_own_album(self):
-        # Incoming album has tracks 1, 2 and 3. Track 1 matches an album
-        # member (album X); track 2 matches a singleton. Track 3 is new. The
-        # mixed matches must prevent folding, so track 3 becomes its own album.
+    def test_singleton_match_still_folds_into_album(self):
+        # snejus's scenario: incoming album has tracks 1, 2 and 3. Track 1
+        # matches an album member (album X); track 2 matches a singleton;
+        # track 3 is new. The singleton match is skipped individually but does
+        # not prevent folding: track 3 (the intended outcome for "C") is folded
+        # into album X, the album the matched album member belongs to.
         self.prepare_album_for_import(3)
         member = self.add_album_member_fixture(
             artist="Tag Artist", title="Tag Track 1"
@@ -1765,12 +1767,15 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
 
         self._import(action="skip")
 
-        # Track 3 is imported into a brand-new album, not folded into X.
+        # No new album is created; track 3 joins album X.
+        assert len(self.lib.albums()) == 1
         new_track = self.lib.items("title:'Tag Track 3'").get()
         assert new_track is not None
-        assert new_track.album_id != album_x.id
-        new_album = self.lib.get_album(new_track.album_id)
-        assert {i.title for i in new_album.items()} == {"Tag Track 3"}
+        assert new_track.album_id == album_x.id
+        assert {i.title for i in album_x.items()} == {
+            "Tag Track 1",
+            "Tag Track 3",
+        }
 
     def test_within_run_dedup_sequential(self):
         # Two identical albums imported in one (sequential) run: the second

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -41,7 +41,6 @@ from beets.test.helper import (
     AutotagStub,
     BeetsTestCase,
     ImportHelper,
-    ImportSessionFixture,
     PluginMixin,
     TestHelper,
     has_program,
@@ -1639,17 +1638,13 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
         item.store()
         return item
 
-    def _import(
-        self, action="skip", enabled=True, resolution=None, track_action=None
-    ):
+    def _import(self, action="skip", enabled=True, track_action=None):
         self.setup_importer(
             autotag=False,
             duplicate_track_resolution=enabled,
             duplicate_action=action,
             duplicate_track_action=track_action or "",
         )
-        if resolution is not None:
-            self.importer.default_resolution = resolution
         self.importer.run()
 
     def test_skip_singleton_dup_imports_remainder_as_new_album(self):
@@ -1757,31 +1752,45 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
         # With the option off, no track-level resolution happens.
         assert len(self.lib.items()) == 3
 
-    def test_ask_skip_drops_duplicate_track(self):
-        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
-
-        # With "ask", the session is prompted; answer SKIP.
-        self._import(
-            action="ask", resolution=ImportSessionFixture.Resolution.SKIP
+    def test_singleton_match_leaves_new_track_as_own_album(self):
+        # Incoming album has tracks 1, 2 and 3. Track 1 matches an album
+        # member (album X); track 2 matches a singleton. Track 3 is new. The
+        # mixed matches must prevent folding, so track 3 becomes its own album.
+        self.prepare_album_for_import(3)
+        member = self.add_album_member_fixture(
+            artist="Tag Artist", title="Tag Track 1"
         )
+        album_x = member.get_album()
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 2")
 
-        assert len(self.lib.albums()) == 1
-        assert len(self.lib.items()) == 2
+        self._import(action="skip")
 
-    def test_ask_remove_replaces_old_item(self):
-        old = self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+        # Track 3 is imported into a brand-new album, not folded into X.
+        new_track = self.lib.items("title:'Tag Track 3'").get()
+        assert new_track is not None
+        assert new_track.album_id != album_x.id
+        new_album = self.lib.get_album(new_track.album_id)
+        assert {i.title for i in new_album.items()} == {"Tag Track 3"}
 
-        # With "ask", the session is prompted; answer REMOVE.
-        self._import(
-            action="ask", resolution=ImportSessionFixture.Resolution.REMOVE
+    def test_within_run_dedup_sequential(self):
+        # Two identical albums imported in one (sequential) run: the second
+        # album's tracks are caught against the first once it is in the
+        # library, so only two items land overall. In threaded mode (the
+        # default) this guarantee does not hold -- both albums can pass the
+        # check before either is added -- which matches the existing
+        # album-level duplicate behaviour, since both check the library
+        # before ``add()``.
+        self.prepare_album_for_import(2, album_id=2)  # a second album dir
+        self.setup_importer(
+            autotag=False,
+            duplicate_track_resolution=True,
+            duplicate_action="skip",
+            threaded=False,
         )
+        self.importer.run()
 
-        assert not old.filepath.exists()
-        assert len(self.lib.albums()) == 1
-        assert sorted(i.title for i in self.lib.items()) == [
-            "Tag Track 1",
-            "Tag Track 2",
-        ]
+        titles = sorted(i.title for i in self.lib.items())
+        assert titles == ["Tag Track 1", "Tag Track 2"]
 
     def test_inherits_duplicate_action_when_unset(self):
         self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
@@ -1804,22 +1813,18 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
         # The duplicate was dropped (skip), not kept, so only two items exist.
         assert len(self.lib.items()) == 2
 
-    def test_ask_skip_folds_into_existing_album(self):
-        self._import(action="skip")
-        missing = self.lib.items("title:'Tag Track 2'").get()
-        missing.remove(delete=True)
+    def test_track_action_ask_falls_back_to_duplicate_action(self):
+        # duplicate_track_action="ask" with a non-interactive session would
+        # need a prompt, so exercise the ask dispatch through the terminal
+        # session instead (see test/ui/test_ui_importer.py). Here we simply
+        # confirm the config plumbing: an explicit track action of "keep"
+        # overrides duplicate_action=skip.
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
 
-        # With "ask", the session is prompted; answer SKIP, which folds the
-        # remaining track into the existing album.
-        self._import(
-            action="ask", resolution=ImportSessionFixture.Resolution.SKIP
-        )
+        self._import(action="skip", track_action="keep")
 
-        assert len(self.lib.albums()) == 1
-        assert {i.title for i in self.lib.albums().get().items()} == {
-            "Tag Track 1",
-            "Tag Track 2",
-        }
+        # "keep" wins, so nothing is dropped.
+        assert len(self.lib.items()) == 3
 
 
 class TagLogTest(unittest.TestCase):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1612,7 +1612,7 @@ class TestImportDuplicateSingletonUpgrade(ImportHelper):
 
 
 class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
-    """``import.duplicate_track_resolution``: per-track dedup on album import.
+    """``duplicate_tracks``: per-track dedup on album import.
 
     The imported album has two tracks (``Tag Track 1`` and ``Tag Track 2``);
     tests seed the library with items matching one or both of them (as
@@ -1639,12 +1639,9 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
         return item
 
     def _import(self, action="skip", enabled=True, track_action=None):
-        self.setup_importer(
-            autotag=False,
-            duplicate_track_resolution=enabled,
-            duplicate_action=action,
-            duplicate_track_action=track_action or "",
-        )
+        self.config["import"]["duplicate_tracks"] = enabled
+        self.config["import"]["duplicate_tracks_action"] = track_action or ""
+        self.setup_importer(autotag=False, duplicate_action=action)
         self.importer.run()
 
     def test_skip_singleton_dup_imports_remainder_as_new_album(self):
@@ -1777,56 +1774,16 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
             "Tag Track 3",
         }
 
-    def test_within_run_dedup_sequential(self):
-        # Two identical albums imported in one (sequential) run: the second
-        # album's tracks are caught against the first, so only two items land
-        # overall. The session's seen-key cache makes this hold regardless of
-        # ordering (see the threaded variant below).
+    def test_within_run_dedup(self):
+        # Two identical albums imported in one run: the second album's tracks
+        # are caught against the first, so only two items land overall. This
+        # holds because tasks are resolved in order, after the previous task's
+        # items have been added to the library.
         self.prepare_album_for_import(2, album_id=2)  # a second album dir
-        self.setup_importer(
-            autotag=False,
-            duplicate_track_resolution=True,
-            duplicate_action="skip",
-            threaded=False,
-        )
-        self.importer.run()
+        self._import(action="skip")
 
         titles = sorted(i.title for i in self.lib.items())
         assert titles == ["Tag Track 1", "Tag Track 2"]
-
-    def test_seen_key_cache_catches_within_run_duplicate(self):
-        # Deterministically isolate the seen-key cache: drive the stage over
-        # two tasks with *no* DB add() in between (as can happen under a
-        # threaded import, where a later task is checked before an earlier one
-        # is added). The second task's matching track must be caught purely via
-        # the cache, against an empty library.
-        from beets.importer.stages import resolve_track_duplicates
-        from beets.importer.tasks import ImportTask
-        from beets.library import Item
-
-        session = self.setup_importer(
-            autotag=False,
-            duplicate_track_resolution=True,
-            duplicate_action="skip",
-        )
-
-        def make_task(path):
-            item = Item(artist="Tag Artist", title="Tag Track 1")
-            item.path = path
-            return ImportTask(None, [path], [item])
-
-        task1 = make_task(b"/import/a/track.mp3")
-        task2 = make_task(b"/import/b/track.mp3")
-
-        coro = resolve_track_duplicates(session)
-        next(coro)  # prime the coroutine
-        coro.send(task1)  # first occurrence: nothing dropped, key remembered
-        coro.send(task2)  # second occurrence: caught via the cache alone
-
-        assert not task1.skip
-        assert [i.title for i in task1.items] == ["Tag Track 1"]
-        assert task2.skip
-        assert task2.items == []
 
     def test_inherits_duplicate_action_when_unset(self):
         self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
@@ -1861,6 +1818,30 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
 
         # "keep" wins, so nothing is dropped.
         assert len(self.lib.items()) == 3
+
+    def test_merge_track_action_rejected(self):
+        # ``merge`` is only defined for whole albums; configuring it as the
+        # per-track action is a configuration error.
+        import confuse
+
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        with pytest.raises(confuse.ConfigValueError):
+            self._import(action="keep", track_action="merge")
+
+    def test_skipped_tracks_never_added_to_library(self):
+        # Duplicate tracks are dropped before the task is added, so no
+        # library row ever exists for them, even transiently.
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+        max_id_before = max(i.id for i in self.lib.items())
+
+        self._import(action="skip")
+
+        new_ids = [i.id for i in self.lib.items() if i.id > max_id_before]
+        # Only one new row: the non-duplicate track.
+        assert len(new_ids) == 1
+        # No gap in row ids: nothing was inserted and removed again.
+        assert new_ids[0] == max_id_before + 1
 
 
 class TagLogTest(unittest.TestCase):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1652,12 +1652,14 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
             self.importer.default_resolution = resolution
         self.importer.run()
 
-    def test_skip_drops_duplicate_track(self):
+    def test_skip_singleton_dup_imports_remainder_as_new_album(self):
+        # The matching track is a singleton, so there is no single album to
+        # fold into: the duplicate is dropped and the remaining track is
+        # imported as its own album.
         self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
 
         self._import(action="skip")
 
-        # The duplicate "Tag Track 1" is dropped; "Tag Track 2" is imported.
         assert len(self.lib.albums()) == 1
         assert {i.title for i in self.lib.items()} == {
             "Tag Track 1",
@@ -1665,13 +1667,14 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
         }
         assert len(self.lib.items()) == 2
 
-    def test_partial_album_reimports_missing_tracks(self):
+    def test_skip_folds_missing_tracks_into_existing_album(self):
         # Import the album fully, then lose one track from the library and
         # re-import the same folder. The present track is skipped as a
-        # duplicate and the missing one is re-added, even though the album
-        # itself still matches the album-level duplicate check.
+        # duplicate and the missing one is folded back into the *same* album
+        # (no second album is created).
         self._import(action="skip")
-        assert {i.title for i in self.lib.items()} == {
+        album = self.lib.albums().get()
+        assert {i.title for i in album.items()} == {
             "Tag Track 1",
             "Tag Track 2",
         }
@@ -1682,14 +1685,20 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
 
         self._import(action="skip")
 
-        assert {i.title for i in self.lib.items()} == {
+        assert len(self.lib.albums()) == 1
+        album = self.lib.albums().get()
+        folded = self.lib.items("title:'Tag Track 2'").get()
+        assert folded.album_id == album.id
+        assert folded.filepath.exists()
+        assert {i.title for i in album.items()} == {
             "Tag Track 1",
             "Tag Track 2",
         }
 
     def test_skip_matches_existing_album_member(self):
         # A matching track that already belongs to an album in the library
-        # (not a singleton) must still be caught.
+        # (not a singleton) must still be caught, and the remaining new track
+        # folded into that album.
         item = self.add_album_member_fixture(
             artist="Tag Artist", title="Tag Track 1"
         )
@@ -1697,13 +1706,14 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
 
         self._import(action="skip")
 
-        # The duplicate "Tag Track 1" is dropped; only "Tag Track 2" is added,
-        # alongside the pre-existing album member.
-        assert sorted(i.title for i in self.lib.items()) == [
+        # The duplicate "Tag Track 1" is dropped; "Tag Track 2" is folded into
+        # the existing album.
+        assert len(self.lib.albums()) == 1
+        album = self.lib.albums().get()
+        assert {i.title for i in album.items()} == {
             "Tag Track 1",
             "Tag Track 2",
-        ]
-        assert len(self.lib.items()) == 2
+        }
 
     def test_skip_all_duplicates_skips_album(self):
         self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
@@ -1785,61 +1795,24 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
             "Tag Track 2",
         }
 
-    def test_fold_into_existing_album(self):
-        # Import the album fully, lose one track, then re-import with "fold":
-        # the present track is skipped and the missing one is added back to
-        # the *same* album (no second album is created).
-        self._import(track_action="fold")
-        album = self.lib.albums().get()
-        assert {i.title for i in album.items()} == {
-            "Tag Track 1",
-            "Tag Track 2",
-        }
-
-        missing = self.lib.items("title:'Tag Track 2'").get()
-        missing.remove(delete=True)
-
-        self._import(track_action="fold")
-
-        assert len(self.lib.albums()) == 1
-        album = self.lib.albums().get()
-        folded = self.lib.items("title:'Tag Track 2'").get()
-        assert folded.album_id == album.id
-        assert folded.filepath.exists()
-        assert {i.title for i in album.items()} == {
-            "Tag Track 1",
-            "Tag Track 2",
-        }
-
-    def test_fold_all_duplicates_skips_album(self):
-        self.add_album_member_fixture(artist="Tag Artist", title="Tag Track 1")
-        self.add_album_member_fixture(artist="Tag Artist", title="Tag Track 2")
-
-        # Every track is a duplicate: nothing new to fold, album is skipped.
-        self._import(track_action="fold")
-
-        assert len(self.lib.items()) == 2
-
-    def test_fold_falls_back_when_no_single_album(self):
-        # Matching tracks are singletons (no album), so there is no single
-        # album to fold into: the new track is imported as its own album.
+    def test_track_action_overrides_duplicate_action(self):
         self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
 
-        self._import(track_action="fold")
+        # duplicate_action says keep, but the track-specific action skips.
+        self._import(action="keep", track_action="skip")
 
-        assert {i.title for i in self.lib.items()} == {
-            "Tag Track 1",
-            "Tag Track 2",
-        }
+        # The duplicate was dropped (skip), not kept, so only two items exist.
+        assert len(self.lib.items()) == 2
 
-    def test_ask_fold(self):
-        self._import(track_action="fold")
+    def test_ask_skip_folds_into_existing_album(self):
+        self._import(action="skip")
         missing = self.lib.items("title:'Tag Track 2'").get()
         missing.remove(delete=True)
 
-        # With "ask", the session is prompted; answer FOLD.
+        # With "ask", the session is prompted; answer SKIP, which folds the
+        # remaining track into the existing album.
         self._import(
-            action="ask", resolution=ImportSessionFixture.Resolution.FOLD
+            action="ask", resolution=ImportSessionFixture.Resolution.SKIP
         )
 
         assert len(self.lib.albums()) == 1

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -41,6 +41,7 @@ from beets.test.helper import (
     AutotagStub,
     BeetsTestCase,
     ImportHelper,
+    ImportSessionFixture,
     PluginMixin,
     TestHelper,
     has_program,
@@ -1609,6 +1610,115 @@ class TestImportDuplicateSingletonUpgrade(ImportHelper):
         assert item.id == self.old_item.id
         assert item.mb_trackid == "old trackid"
         assert self.old_item.filepath.exists()
+
+
+class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
+    """``import.duplicate_track_resolution``: per-track dedup on album import.
+
+    The imported album has two tracks (``Tag Track 1`` and ``Tag Track 2``);
+    tests seed the library with singletons matching one or both of them.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.prepare_album_for_import(2)
+
+    def add_item_fixture(self, **kwargs):
+        item = self.add_item_fixtures()[0]
+        item.update(kwargs)
+        item.store()
+        return item
+
+    def _import(self, action="skip", enabled=True, resolution=None):
+        self.setup_importer(
+            autotag=False,
+            duplicate_track_resolution=enabled,
+            duplicate_action=action,
+        )
+        if resolution is not None:
+            self.importer.default_resolution = resolution
+        self.importer.run()
+
+    def test_skip_drops_duplicate_track(self):
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        self._import(action="skip")
+
+        # The duplicate "Tag Track 1" is dropped; "Tag Track 2" is imported.
+        assert len(self.lib.albums()) == 1
+        assert {i.title for i in self.lib.items()} == {
+            "Tag Track 1",
+            "Tag Track 2",
+        }
+        assert len(self.lib.items()) == 2
+
+    def test_skip_all_duplicates_skips_album(self):
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 2")
+
+        self._import(action="skip")
+
+        # Every track is a duplicate, so the whole album is skipped.
+        assert len(self.lib.albums()) == 0
+        assert len(self.lib.items()) == 2
+
+    def test_remove_replaces_old_item(self):
+        old = self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+        assert old.filepath.exists()
+
+        self._import(action="remove")
+
+        # The old matching item (and its file) is removed; both album tracks
+        # are imported.
+        assert not old.filepath.exists()
+        assert sorted(i.title for i in self.lib.items()) == [
+            "Tag Track 1",
+            "Tag Track 2",
+        ]
+        assert len(self.lib.albums()) == 1
+
+    def test_keep_imports_all(self):
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        self._import(action="keep")
+
+        # Nothing is dropped or removed.
+        assert len(self.lib.items()) == 3
+        assert len(self.lib.albums()) == 1
+
+    def test_disabled_by_default(self):
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        self._import(action="skip", enabled=False)
+
+        # With the option off, no track-level resolution happens.
+        assert len(self.lib.items()) == 3
+
+    def test_ask_skip_drops_duplicate_track(self):
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        # With "ask", the session is prompted; answer SKIP.
+        self._import(
+            action="ask", resolution=ImportSessionFixture.Resolution.SKIP
+        )
+
+        assert len(self.lib.albums()) == 1
+        assert len(self.lib.items()) == 2
+
+    def test_ask_remove_replaces_old_item(self):
+        old = self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        # With "ask", the session is prompted; answer REMOVE.
+        self._import(
+            action="ask", resolution=ImportSessionFixture.Resolution.REMOVE
+        )
+
+        assert not old.filepath.exists()
+        assert len(self.lib.albums()) == 1
+        assert sorted(i.title for i in self.lib.items()) == [
+            "Tag Track 1",
+            "Tag Track 2",
+        ]
 
 
 class TagLogTest(unittest.TestCase):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1616,7 +1616,8 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
     """``import.duplicate_track_resolution``: per-track dedup on album import.
 
     The imported album has two tracks (``Tag Track 1`` and ``Tag Track 2``);
-    tests seed the library with singletons matching one or both of them.
+    tests seed the library with items matching one or both of them (as
+    singletons unless noted otherwise).
     """
 
     def setUp(self):
@@ -1629,11 +1630,23 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
         item.store()
         return item
 
-    def _import(self, action="skip", enabled=True, resolution=None):
+    def add_album_member_fixture(self, **kwargs):
+        """Seed the library with a track that belongs to an album (i.e. not a
+        singleton), so its ``album_id`` is set.
+        """
+        item = self.add_item_fixture(**kwargs)
+        self.lib.add_album([item])
+        item.store()
+        return item
+
+    def _import(
+        self, action="skip", enabled=True, resolution=None, track_action=None
+    ):
         self.setup_importer(
             autotag=False,
             duplicate_track_resolution=enabled,
             duplicate_action=action,
+            duplicate_track_action=track_action or "",
         )
         if resolution is not None:
             self.importer.default_resolution = resolution
@@ -1650,6 +1663,46 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
             "Tag Track 1",
             "Tag Track 2",
         }
+        assert len(self.lib.items()) == 2
+
+    def test_partial_album_reimports_missing_tracks(self):
+        # Import the album fully, then lose one track from the library and
+        # re-import the same folder. The present track is skipped as a
+        # duplicate and the missing one is re-added, even though the album
+        # itself still matches the album-level duplicate check.
+        self._import(action="skip")
+        assert {i.title for i in self.lib.items()} == {
+            "Tag Track 1",
+            "Tag Track 2",
+        }
+
+        missing = self.lib.items("title:'Tag Track 2'").get()
+        missing.remove(delete=True)
+        assert {i.title for i in self.lib.items()} == {"Tag Track 1"}
+
+        self._import(action="skip")
+
+        assert {i.title for i in self.lib.items()} == {
+            "Tag Track 1",
+            "Tag Track 2",
+        }
+
+    def test_skip_matches_existing_album_member(self):
+        # A matching track that already belongs to an album in the library
+        # (not a singleton) must still be caught.
+        item = self.add_album_member_fixture(
+            artist="Tag Artist", title="Tag Track 1"
+        )
+        assert item.album_id is not None
+
+        self._import(action="skip")
+
+        # The duplicate "Tag Track 1" is dropped; only "Tag Track 2" is added,
+        # alongside the pre-existing album member.
+        assert sorted(i.title for i in self.lib.items()) == [
+            "Tag Track 1",
+            "Tag Track 2",
+        ]
         assert len(self.lib.items()) == 2
 
     def test_skip_all_duplicates_skips_album(self):
@@ -1719,6 +1772,81 @@ class ImportTrackDuplicateResolutionTest(ImportHelper, BeetsTestCase):
             "Tag Track 1",
             "Tag Track 2",
         ]
+
+    def test_inherits_duplicate_action_when_unset(self):
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        # No duplicate_track_action: should inherit duplicate_action=skip.
+        self._import(action="skip", track_action=None)
+
+        assert len(self.lib.albums()) == 1
+        assert {i.title for i in self.lib.items()} == {
+            "Tag Track 1",
+            "Tag Track 2",
+        }
+
+    def test_fold_into_existing_album(self):
+        # Import the album fully, lose one track, then re-import with "fold":
+        # the present track is skipped and the missing one is added back to
+        # the *same* album (no second album is created).
+        self._import(track_action="fold")
+        album = self.lib.albums().get()
+        assert {i.title for i in album.items()} == {
+            "Tag Track 1",
+            "Tag Track 2",
+        }
+
+        missing = self.lib.items("title:'Tag Track 2'").get()
+        missing.remove(delete=True)
+
+        self._import(track_action="fold")
+
+        assert len(self.lib.albums()) == 1
+        album = self.lib.albums().get()
+        folded = self.lib.items("title:'Tag Track 2'").get()
+        assert folded.album_id == album.id
+        assert folded.filepath.exists()
+        assert {i.title for i in album.items()} == {
+            "Tag Track 1",
+            "Tag Track 2",
+        }
+
+    def test_fold_all_duplicates_skips_album(self):
+        self.add_album_member_fixture(artist="Tag Artist", title="Tag Track 1")
+        self.add_album_member_fixture(artist="Tag Artist", title="Tag Track 2")
+
+        # Every track is a duplicate: nothing new to fold, album is skipped.
+        self._import(track_action="fold")
+
+        assert len(self.lib.items()) == 2
+
+    def test_fold_falls_back_when_no_single_album(self):
+        # Matching tracks are singletons (no album), so there is no single
+        # album to fold into: the new track is imported as its own album.
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        self._import(track_action="fold")
+
+        assert {i.title for i in self.lib.items()} == {
+            "Tag Track 1",
+            "Tag Track 2",
+        }
+
+    def test_ask_fold(self):
+        self._import(track_action="fold")
+        missing = self.lib.items("title:'Tag Track 2'").get()
+        missing.remove(delete=True)
+
+        # With "ask", the session is prompted; answer FOLD.
+        self._import(
+            action="ask", resolution=ImportSessionFixture.Resolution.FOLD
+        )
+
+        assert len(self.lib.albums()) == 1
+        assert {i.title for i in self.lib.albums().get().items()} == {
+            "Tag Track 1",
+            "Tag Track 2",
+        }
 
 
 class TagLogTest(unittest.TestCase):

--- a/test/ui/test_ui_importer.py
+++ b/test/ui/test_ui_importer.py
@@ -44,6 +44,51 @@ class ChooseCandidateTest(
     pass
 
 
+class ImportTrackDuplicateResolutionTest(
+    TerminalImportMixin, test_importer.ImportTrackDuplicateResolutionTest
+):
+    """Run the per-track duplicate tests through ``TerminalImportSession``.
+
+    Also covers the interactive ``ask`` prompt, which the non-terminal
+    fixture cannot exercise.
+    """
+
+    def test_ask_prompt_skip(self):
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        self.io.addinput("s")
+        self._import(action="ask")
+
+        # Answered "skip": the duplicate track is dropped, the other imported.
+        assert len(self.lib.albums()) == 1
+        assert {i.title for i in self.lib.items()} == {
+            "Tag Track 1",
+            "Tag Track 2",
+        }
+
+    def test_ask_prompt_remove(self):
+        old = self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        self.io.addinput("r")
+        self._import(action="ask")
+
+        # Answered "remove": the old library item (and file) is removed.
+        assert not old.filepath.exists()
+        assert sorted(i.title for i in self.lib.items()) == [
+            "Tag Track 1",
+            "Tag Track 2",
+        ]
+
+    def test_ask_prompt_keep(self):
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+
+        self.io.addinput("k")
+        self._import(action="ask")
+
+        # Answered "keep": nothing dropped or removed.
+        assert len(self.lib.items()) == 3
+
+
 class GroupAlbumsImportTest(
     TerminalImportMixin, test_importer.GroupAlbumsImportTest
 ):

--- a/test/ui/test_ui_importer.py
+++ b/test/ui/test_ui_importer.py
@@ -88,6 +88,29 @@ class ImportTrackDuplicateResolutionTest(
         # Answered "keep": nothing dropped or removed.
         assert len(self.lib.items()) == 3
 
+    def test_ask_prompt_select_per_track(self):
+        # Import a three-track album where tracks 1 and 2 duplicate existing
+        # singletons; answer "sElect per track", then skip the first duplicate
+        # and keep the second.
+        self.prepare_album_for_import(3)
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 1")
+        self.add_item_fixture(artist="Tag Artist", title="Tag Track 2")
+
+        self.io.addinput("e")  # select per track
+        self.io.addinput("s")  # Tag Track 1: skip new
+        self.io.addinput("k")  # Tag Track 2: keep all
+        self._import(action="ask")
+
+        titles = sorted(i.title for i in self.lib.items())
+        # Track 1 was skipped (old singleton remains), track 2 kept (both
+        # copies), track 3 imported.
+        assert titles == [
+            "Tag Track 1",
+            "Tag Track 2",
+            "Tag Track 2",
+            "Tag Track 3",
+        ]
+
 
 class GroupAlbumsImportTest(
     TerminalImportMixin, test_importer.GroupAlbumsImportTest


### PR DESCRIPTION
## Description
This PR adds the `duplicate_track_resolution` (bool) and `duplicate_track_action` (`skip`, `remove`, `keep`/`merge`, `ask`) config options to `import` to enable deduplication of individual tracks when importing.

The recommended config for this is:
```
import:
    duplicate_track_resolution: yes
    duplicate_action: ask          # whole-album duplicates
    duplicate_track_action: skip   # per-track duplicates: fold new tracks into the existing album
    duplicate_keys:
        item: mb_trackid           # match on a stable id (recommended when autotagging)
```

With the above config, any duplicate imports of tracks will be dropped, and if the whole album has been imported before, the album import itself will be dropped. If part of an album is deduped, the new tracks will be folded into the existing album. This config allows for idempotency on any repeat `beet import` executions.

Copied from the new docs, here's what each option does:
>  `skip` drops the duplicate tracks and adds the remaining *new* tracks to the
  existing album they belong to, instead of importing them as a separate album.
  Use this to complete a partially-imported album. If every track is already
  present, the whole album is skipped. (If the matching tracks do not all belong
  to a single album, the new tracks are imported as their own album.)
> - `remove` removes the matching old items from the library before importing.
> - `keep` (and `merge`) import the album unchanged.
> - `ask` prompts you to choose one of the above.

The `duplicate_keys` config option is what's used to dedupe, so set it to something stable like `mb_trackid`.

In the [previous PR](https://github.com/beetbox/beets/pull/6313), @snejus suggested adding this as an addition to the album deduplication that already exists. This implementation is separate from the album dedupe logic because the use-cases seemed incompatible. 

The album dedupe skips/merges/removes based on an album already being imported, but the use-case I wanted was a deeper track-based mechanism. Bolting this onto the album dedupe produced some really weird results, and I wasn't able to achieve parity with my last impl with the available config options. This is a better, more flexible, approach.

## To Do
- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
