### PR TITLE
Cast keys to list to avoid exception in optparse

### DIFF
--- a/beetsplug/fish.py
+++ b/beetsplug/fish.py
@@ -82,7 +82,7 @@ class FishPlugin(BeetsPlugin):
             "--extravalues",
             action="append",
             type="choice",
-            choices=library.Item.all_keys() | library.Album.all_keys(),
+            choices=list(library.Item.all_keys() | library.Album.all_keys()),
             help="include specified field *values* in completions",
         )
         cmd.parser.add_option(

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -81,6 +81,7 @@ Bug fixes
 - :ref:`move-cmd`: ``beet move`` no longer crashes when an item referenced in
   the database has been deleted from disk. Missing items are now skipped with a
   warning and the command continues. :bug:`6720`
+- :doc:`plugins/fish`: Fix error on plugin initialization.
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
In #6695, the Item and Album all_keys methods return sets now. This causes an error when used in optparse for choices as it doesn't accept sets:
```
Traceback (most recent call last):
  File "/home/user/.local/bin/beet", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/user/.local/lib/beets/beets/ui/__init__.py", line 964, in main
    _raw_main(args)
    ~~~~~~~~~^^^^^^
  File "/home/user/.local/lib/beets/beets/ui/__init__.py", line 940, in _raw_main
    subcommands, lib = _setup(options)
                       ~~~~~~^^^^^^^^^
  File "/home/user/.local/lib/beets/beets/ui/__init__.py", line 781, in _setup
    subcommands.extend(plugins.commands())
                       ~~~~~~~~~~~~~~~~^^
  File "/home/user/.local/lib/beets/beets/plugins.py", line 508, in commands
    out += plugin.commands()
           ~~~~~~~~~~~~~~~^^
  File "/home/user/.local/lib/beets/beetsplug/fish.py", line 80, in commands
    cmd.parser.add_option(
    ~~~~~~~~~~~~~~~~~~~~~^
        "-e",
        ^^^^^
    ...<4 lines>...
        help="include specified field *values* in completions",
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/lib/python3.14/optparse.py", line 990, in add_option
    option = self.option_class(*args, **kwargs)
  File "/usr/lib/python3.14/optparse.py", line 571, in __init__
    checker(self)
    ~~~~~~~^^^^^^
  File "/usr/lib/python3.14/optparse.py", line 658, in _check_choice
    raise OptionError(
        "choices must be a list of strings ('%s' supplied)"
        % str(type(self.choices)).split("'")[1], self)
optparse.OptionError: option -e/--extravalues: choices must be a list of strings ('set' supplied)
```

## Description

Fixes #X.  <!-- Insert issue number here if applicable. -->

(...)

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)~
- [x] ~Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)~ This just fixes an error from a previous PR
- [x] ~Tests. (Very much encouraged but not strictly required.)~ The previous PR didn't add tests.
