### PR TITLE
eDit: Enable album-level field editing during interactive import

### DIFF
--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -221,71 +221,47 @@ class EditPlugin(plugins.BeetsPlugin):
         """
         # Get the content to edit as raw data structures.
         old_data = [flatten(o, fields) for o in objs]
-
-        # Set up a temporary file with the initial data for editing.
-        new = NamedTemporaryFile(
-            mode="w", suffix=".yaml", delete=False, encoding="utf-8"
-        )
-        old_str = dump(old_data)
-        new.write(old_str)
-        new.close()
+        cur_str = dump(old_data)
 
         # Loop until we have parseable data and the user confirms.
-        try:
-            while True:
-                # Ask the user to edit the data.
-                edit(new.name, self._log)
+        while True:
+            result = self._edit_yaml(cur_str)
+            if result is None:
+                return False
+            new_data, new_str = result
 
-                # Read the data back after editing and check whether anything
-                # changed.
-                with codecs.open(new.name, encoding="utf-8") as f:
-                    new_str = f.read()
-                if new_str == old_str:
-                    ui.print_("No changes; aborting.")
-                    return False
+            # Show the changes.
+            # If the objects are not on the DB yet, we need a copy of their
+            # original state for show_model_changes.
+            objs_old = [obj.copy() if obj.id < 0 else None for obj in objs]
+            self.apply_data(objs, old_data, new_data)
+            changed = False
+            for obj, obj_old in zip(objs, objs_old):
+                changed |= ui.show_model_changes(obj, obj_old)
+            if not changed:
+                ui.print_("No changes to apply.")
+                return False
 
-                # Parse the updated data.
-                try:
-                    new_data = load(new_str)
-                except ParseError as e:
-                    ui.print_(f"Could not read data: {e}")
-                    if ui.input_yn("Edit again to fix? (Y/n)", True):
-                        continue
-                    return False
-
-                # Show the changes.
-                # If the objects are not on the DB yet, we need a copy of their
-                # original state for show_model_changes.
-                objs_old = [obj.copy() if obj.id < 0 else None for obj in objs]
-                self.apply_data(objs, old_data, new_data)
-                changed = False
-                for obj, obj_old in zip(objs, objs_old):
-                    changed |= ui.show_model_changes(obj, obj_old)
-                if not changed:
-                    ui.print_("No changes to apply.")
-                    return False
-
-                # For cancel/keep-editing, restore objects to their original
-                # in-memory state so temp edits don't leak into the session
-                choice = ui.input_options(
-                    ("continue Editing", "apply", "cancel")
-                )
-                if choice == "a":  # Apply.
-                    return True
-                if choice == "c":  # Cancel.
-                    self.apply_data(objs, new_data, old_data)
-                    return False
-                if choice == "e":  # Keep editing.
-                    self.apply_data(objs, new_data, old_data)
-                    continue
-
-        # Remove the temporary file before returning.
-        finally:
-            os.remove(new.name)
+            # For cancel/keep-editing, restore objects to their original
+            # in-memory state so temp edits don't leak into the session
+            choice = ui.input_options(("continue Editing", "apply", "cancel"))
+            if choice == "a":  # Apply.
+                return True
+            if choice == "c":  # Cancel.
+                self.apply_data(objs, new_data, old_data)
+                return False
+            if choice == "e":  # Keep editing.
+                self.apply_data(objs, new_data, old_data)
+                cur_str = new_str
+                continue
 
     def apply_data(self, objs, old_data, new_data):
         """Take potentially-updated data and apply it to a set of Model
         objects.
+
+        Documents are matched to objects by their ``id`` field rather than
+        by position, so a reordered or otherwise misaligned document list
+        cannot cause one object's data to be applied to a different object.
 
         The objects are not written back to the database, so the changes
         are temporary.
@@ -298,8 +274,16 @@ class EditPlugin(plugins.BeetsPlugin):
             )
 
         obj_by_id = {o.id: o for o in objs}
+        old_by_id = {d.get("id"): d for d in old_data}
         ignore_fields = self.config["ignore_fields"].as_str_seq()
-        for old_dict, new_dict in zip(old_data, new_data):
+        for new_dict in new_data:
+            new_id = new_dict.get("id")
+            old_dict = old_by_id.get(new_id)
+            obj = obj_by_id.get(new_id)
+            if old_dict is None or obj is None:
+                self._log.warning("ignoring object whose id changed")
+                continue
+
             # Prohibit any changes to forbidden fields to avoid
             # clobbering `id` and such by mistake.
             forbidden = False
@@ -311,8 +295,7 @@ class EditPlugin(plugins.BeetsPlugin):
             if forbidden:
                 continue
 
-            id_ = int(old_dict["id"])
-            apply_(obj_by_id[id_], new_dict)
+            apply_(obj, new_dict)
 
     def save_changes(self, objs):
         """Save a list of updated Model objects to the database."""
@@ -365,42 +348,6 @@ class EditPlugin(plugins.BeetsPlugin):
             return
         for item in items:
             apply_(item, header_data)
-
-    def _importer_edit_apply_tracks(
-        self,
-        old_track_data: list[dict[str, Any]],
-        new_track_data: list[dict[str, Any]],
-        items: list[Item],
-    ) -> bool:
-        """Apply per-track YAML document changes to the matching items.
-
-        Returns ``True`` if any change was made.
-        """
-        ignore_fields = set(self.config["ignore_fields"].as_str_seq())
-        items_by_id = {item.id: item for item in items}
-        old_by_id = {old_doc.get("id"): old_doc for old_doc in old_track_data}
-
-        changed = False
-        for new_doc in new_track_data:
-            new_id = new_doc.get("id")
-            old_doc = old_by_id.get(new_id)
-            item = items_by_id.get(new_id)
-            if old_doc is None or item is None:
-                self._log.warning("ignoring object whose id changed")
-                continue
-
-            forbidden = False
-            for key in ignore_fields:
-                if old_doc.get(key) != new_doc.get(key):
-                    self._log.warning("ignoring object whose {} changed", key)
-                    forbidden = True
-                    break
-            if forbidden:
-                continue
-
-            apply_(item, new_doc)
-            changed = True
-        return changed
 
     def _edit_yaml(
         self, old_str: str
@@ -502,9 +449,7 @@ class EditPlugin(plugins.BeetsPlugin):
                 self._importer_edit_apply_header(task.items, new_header_data[0])
 
             # Apply per-track changes.
-            self._importer_edit_apply_tracks(
-                old_track_data, new_track_data, task.items
-            )
+            self.apply_data(task.items, old_track_data, new_track_data)
 
             # Show the diff.
             changed = False

--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -377,10 +377,18 @@ class EditPlugin(plugins.BeetsPlugin):
         Returns ``True`` if any change was made.
         """
         ignore_fields = set(self.config["ignore_fields"].as_str_seq())
+        items_by_id = {item.id: item for item in items}
+        old_by_id = {old_doc.get("id"): old_doc for old_doc in old_track_data}
+
         changed = False
-        for old_doc, new_doc, item in zip(
-            old_track_data, new_track_data, items
-        ):
+        for new_doc in new_track_data:
+            new_id = new_doc.get("id")
+            old_doc = old_by_id.get(new_id)
+            item = items_by_id.get(new_id)
+            if old_doc is None or item is None:
+                self._log.warning("ignoring object whose id changed")
+                continue
+
             forbidden = False
             for key in ignore_fields:
                 if old_doc.get(key) != new_doc.get(key):
@@ -388,12 +396,6 @@ class EditPlugin(plugins.BeetsPlugin):
                     forbidden = True
                     break
             if forbidden:
-                continue
-
-            old_id = old_doc.get("id")
-            new_id = new_doc.get("id")
-            if old_id is not None and new_id is not None and old_id != new_id:
-                self._log.warning("ignoring object whose id changed")
                 continue
 
             apply_(item, new_doc)
@@ -409,11 +411,10 @@ class EditPlugin(plugins.BeetsPlugin):
         Returns ``(parsed_data, edited_str)`` on success, or ``None`` if the
         user aborted (no changes or unresolvable parse error).
         """
-        new = NamedTemporaryFile(
+        with NamedTemporaryFile(
             mode="w", suffix=".yaml", delete=False, encoding="utf-8"
-        )
-        new.write(old_str)
-        new.close()
+        ) as new:
+            new.write(old_str)
 
         try:
             while True:

--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -16,6 +16,7 @@ from beets import plugins, ui, util
 from beets.dbcore import types
 from beets.exceptions import UserError
 from beets.importer import Action
+from beets.library import Album
 from beets.ui.commands.utils import do_query
 from beets.util import PromptChoice
 
@@ -345,6 +346,21 @@ class EditPlugin(plugins.BeetsPlugin):
             return None
 
         album_fields = set(self.config["albumfields"].as_str_seq())
+        if not album_fields:
+            return None
+
+        # Restrict to fields that actually exist on the Album model. Item
+        # has every Album field plus track-only ones (title, track, path,
+        # ...); since the header is built from a single item and then
+        # applied to every item, an item-only field here would silently
+        # stamp that one item's value onto the whole album.
+        invalid_fields = album_fields - Album._field_names
+        if invalid_fields:
+            self._log.warning(
+                "ignoring albumfields not valid for albums: {}",
+                ", ".join(sorted(invalid_fields)),
+            )
+            album_fields &= Album._field_names
         if not album_fields:
             return None
 

--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -16,13 +16,12 @@ from beets import plugins, ui, util
 from beets.dbcore import types
 from beets.exceptions import UserError
 from beets.importer import Action
-from beets.library import Album
+from beets.library import Album, Item
 from beets.ui.commands.utils import do_query
 from beets.util import PromptChoice
 
 if TYPE_CHECKING:
     from beets.importer import ImportSession, ImportTask
-    from beets.library import Item
 
 # These "safe" types can avoid the format/parse cycle that most fields go
 # through: they are safe to edit with native YAML types.
@@ -32,6 +31,12 @@ SAFE_TYPES = (
     types.Boolean,
     types.DelimitedString,
 )
+
+# Fixed fields that only exist on Item, not Album (e.g. title, track, path).
+# Flexible attributes are deliberately excluded from this set: they aren't
+# part of either model's fixed schema, so they can't be told apart by name
+# alone and are left for the user to configure correctly.
+ITEM_ONLY_FIELDS = Item._field_names - Album._field_names
 
 
 class ParseError(Exception):
@@ -349,18 +354,18 @@ class EditPlugin(plugins.BeetsPlugin):
         if not album_fields:
             return None
 
-        # Restrict to fields that actually exist on the Album model. Item
-        # has every Album field plus track-only ones (title, track, path,
-        # ...); since the header is built from a single item and then
-        # applied to every item, an item-only field here would silently
-        # stamp that one item's value onto the whole album.
-        invalid_fields = album_fields - Album._field_names
-        if invalid_fields:
+        # Drop fields that only exist on Item (title, track, path, ...);
+        # since the header is built from a single item and then applied to
+        # every item, an item-only field here would silently stamp that
+        # one item's value onto the whole album. Flexible fields are left
+        # alone so they can still be edited at the album level.
+        item_only_fields = album_fields & ITEM_ONLY_FIELDS
+        if item_only_fields:
             self._log.warning(
-                "ignoring albumfields not valid for albums: {}",
-                ", ".join(sorted(invalid_fields)),
+                "ignoring item-only fields configured in albumfields: {}",
+                ", ".join(sorted(item_only_fields)),
             )
-            album_fields &= Album._field_names
+            album_fields -= ITEM_ONLY_FIELDS
         if not album_fields:
             return None
 

--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -331,6 +331,95 @@ class EditPlugin(plugins.BeetsPlugin):
 
         return choices
 
+    def _importer_edit_album_header(self, task):
+        """Build the album-header YAML document for import editing.
+
+        Returns a dict of album-level fields, or ``None`` when the current
+        task is not an album import.
+        """
+        if not getattr(task, "is_album", False) or not task.items:
+            return None
+
+        album_fields = set(self.config["albumfields"].as_str_seq())
+        if not album_fields:
+            return None
+
+        first_item = task.items[0]
+        header = flatten(first_item, album_fields)
+        return header if header else None
+
+    def _importer_edit_apply_header(self, items, header_data):
+        """Apply album-header changes (from ``_importer_edit_album_header``)
+        to every item in the list.
+        """
+        if not header_data:
+            return
+        for item in items:
+            apply_(item, header_data)
+
+    def _importer_edit_apply_tracks(
+        self, old_track_data, new_track_data, items
+    ):
+        """Apply per-track YAML document changes to the matching items.
+
+        Returns ``True`` if any change was made.
+        """
+        ignore_fields = set(self.config["ignore_fields"].as_str_seq())
+        changed = False
+        for old_doc, new_doc, item in zip(
+            old_track_data, new_track_data, items
+        ):
+            forbidden = False
+            for key in ignore_fields:
+                if old_doc.get(key) != new_doc.get(key):
+                    self._log.warning("ignoring object whose {} changed", key)
+                    forbidden = True
+                    break
+            if forbidden:
+                continue
+
+            old_id = old_doc.get("id")
+            new_id = new_doc.get("id")
+            if old_id is not None and new_id is not None and old_id != new_id:
+                self._log.warning("ignoring object whose id changed")
+                continue
+
+            apply_(item, new_doc)
+            changed = True
+        return changed
+
+    def _edit_yaml(self, old_str):
+        """Open a temporary file with `old_str`, let the user edit it, and
+        return the parsed list of YAML documents.
+
+        Returns ``(parsed_data, edited_str)`` on success, or ``None`` if the
+        user aborted (no changes or unresolvable parse error).
+        """
+        new = NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False, encoding="utf-8"
+        )
+        new.write(old_str)
+        new.close()
+
+        try:
+            while True:
+                edit(new.name, self._log)
+
+                with codecs.open(new.name, encoding="utf-8") as f:
+                    new_str = f.read()
+                if new_str == old_str:
+                    ui.print_("No changes; aborting.")
+                    return None
+
+                try:
+                    return load(new_str), new_str
+                except ParseError as e:
+                    ui.print_(f"Could not read data: {e}")
+                    if not ui.input_yn("Edit again to fix? (Y/n)", True):
+                        return None
+        finally:
+            os.remove(new.name)
+
     def importer_edit(self, session, task):
         """Callback for invoking the functionality during an interactive
         import session on the *original* item tags.
@@ -343,21 +432,104 @@ class EditPlugin(plugins.BeetsPlugin):
             if not obj._db or obj.id is None:
                 obj.id = -i
 
-        # Present the YAML to the user and let them change it.
-        fields = self._get_fields(album=False, extra=[])
-        success = self.edit_objects(task.items, fields)
+        # Decide which fields to show.
+        album_fields = set()
+        if getattr(task, "is_album", False):
+            album_fields = set(self.config["albumfields"].as_str_seq())
+        item_fields = set(self.config["itemfields"].as_str_seq())
 
-        # Remove temporary ids.
+        # Track-level fields exclude any that are shown in the album header
+        # to avoid duplication.
+        track_fields = item_fields - album_fields
+        track_fields.add("id")
+
+        # Build the YAML document list.
+        header_data = self._importer_edit_album_header(task)
+        old_track_data = [flatten(o, track_fields) for o in task.items]
+        all_old_data = []
+        if header_data is not None:
+            all_old_data.append(header_data)
+        all_old_data.extend(old_track_data)
+        has_header = header_data is not None
+        num_data_docs = 1 if has_header else 0
+
+        cur_str = dump(all_old_data)
+
+        while True:
+            result = self._edit_yaml(cur_str)
+            if result is None:
+                self._importer_edit_cleanup(task)
+                return None
+            new_all_data, new_str = result
+
+            expected_total = num_data_docs + len(task.items)
+            if len(new_all_data) != expected_total:
+                ui.print_(
+                    f"Number of documents changed from {expected_total} to "
+                    f"{len(new_all_data)}."
+                )
+                if ui.input_yn("Edit again to fix? (Y/n)", True):
+                    continue
+                self._importer_edit_cleanup(task)
+                return None
+
+            # Split into album header and per-track documents.
+            new_header_data = new_all_data[:num_data_docs] if has_header else []
+            new_track_data = new_all_data[num_data_docs:]
+
+            # Snapshot originals for diff display and restore.
+            objs_old = [obj.copy() for obj in task.items]
+
+            # Apply header changes to every item.
+            if new_header_data:
+                self._importer_edit_apply_header(task.items, new_header_data[0])
+
+            # Apply per-track changes.
+            self._importer_edit_apply_tracks(
+                old_track_data, new_track_data, task.items
+            )
+
+            # Show the diff.
+            changed = False
+            for item, old_copy in zip(task.items, objs_old):
+                changed |= ui.show_model_changes(item, old_copy)
+
+            if not changed:
+                ui.print_("No changes to apply.")
+                self._importer_edit_cleanup(task)
+                return None
+
+            choice = ui.input_options(("continue Editing", "apply", "cancel"))
+            if choice == "a":  # Apply.
+                self._importer_edit_cleanup(task)
+                return Action.RETAG
+            if choice == "c":  # Cancel.
+                self._importer_edit_restore_from_copies(task, objs_old)
+                self._importer_edit_cleanup(task)
+                return None
+            if choice == "e":  # Keep editing.
+                self._importer_edit_restore_from_copies(task, objs_old)
+                cur_str = new_str
+                continue
+
+    @staticmethod
+    def _importer_edit_cleanup(task):
+        """Remove temporary negative ids from task items."""
         for obj in task.items:
-            if obj.id < 0:
+            if obj.id is not None and obj.id < 0:
                 obj.id = None
 
-        # Save the new data.
-        if success:
-            # Return Action.RETAG, which makes the importer write the tags
-            # to the files if needed without re-applying metadata.
-            return Action.RETAG
-        return None
+    @staticmethod
+    def _importer_edit_restore_from_copies(task, copies):
+        """Restore items to their state before the last edit cycle.
+
+        ``copies`` must be a list of :class:`Item <beets.library.Item>` copies
+        taken *before* the changes were applied.
+        """
+        for i, item in enumerate(task.items):
+            if i < len(copies):
+                for key in item._fields:
+                    item[key] = copies[i][key]
 
     def importer_edit_candidate(self, session, task):
         """Callback for invoking the functionality during an interactive

--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -6,6 +6,7 @@ import codecs
 import os
 import shlex
 import subprocess
+from collections import Counter
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Any, cast
 
@@ -275,9 +276,20 @@ class EditPlugin(plugins.BeetsPlugin):
 
         obj_by_id = {o.id: o for o in objs}
         old_by_id = {d.get("id"): d for d in old_data}
+        new_id_counts = Counter(d.get("id") for d in new_data)
         ignore_fields = self.config["ignore_fields"].as_str_seq()
         for new_dict in new_data:
             new_id = new_dict.get("id")
+            if new_id_counts[new_id] > 1:
+                # Two or more documents claim the same id: either a document's
+                # id was edited to collide with another one, or the same
+                # document was duplicated. We can't tell which document is
+                # the "real" one, so ignore all of them.
+                self._log.warning(
+                    "ignoring objects with duplicate id {}", new_id
+                )
+                continue
+
             old_dict = old_by_id.get(new_id)
             obj = obj_by_id.get(new_id)
             if old_dict is None or obj is None:
@@ -437,9 +449,28 @@ class EditPlugin(plugins.BeetsPlugin):
                 self._importer_edit_cleanup(task)
                 return None
 
-            # Split into album header and per-track documents.
-            new_header_data = new_all_data[:num_data_docs] if has_header else []
-            new_track_data = new_all_data[num_data_docs:]
+            # Split into album header and per-track documents. Every track
+            # document always has an `id` field (see `track_fields` above),
+            # while the header never does, so identify the header by the
+            # absence of `id` rather than by position. This keeps the split
+            # correct even if the user moves the header elsewhere in the
+            # file, since `apply_data` already matches track documents by
+            # id regardless of order.
+            if has_header:
+                new_header_data = [d for d in new_all_data if "id" not in d]
+                new_track_data = [d for d in new_all_data if "id" in d]
+                if len(new_header_data) != 1:
+                    ui.print_(
+                        "Could not identify the album header: exactly one "
+                        "document must have no `id` field."
+                    )
+                    if ui.input_yn("Edit again to fix? (Y/n)", True):
+                        continue
+                    self._importer_edit_cleanup(task)
+                    return None
+            else:
+                new_header_data = []
+                new_track_data = new_all_data
 
             # Snapshot originals for diff display and restore.
             objs_old = cast("list[Item]", [obj.copy() for obj in task.items])

--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -1,10 +1,13 @@
 """Open metadata information in a text editor to let the user edit it."""
 
+from __future__ import annotations
+
 import codecs
 import os
 import shlex
 import subprocess
 from tempfile import NamedTemporaryFile
+from typing import TYPE_CHECKING, Any, cast
 
 import yaml
 
@@ -14,6 +17,10 @@ from beets.exceptions import UserError
 from beets.importer import Action
 from beets.ui.commands.utils import do_query
 from beets.util import PromptChoice
+
+if TYPE_CHECKING:
+    from beets.importer import ImportSession, ImportTask
+    from beets.library import Item
 
 # These "safe" types can avoid the format/parse cycle that most fields go
 # through: they are safe to edit with native YAML types.
@@ -331,7 +338,9 @@ class EditPlugin(plugins.BeetsPlugin):
 
         return choices
 
-    def _importer_edit_album_header(self, task):
+    def _importer_edit_album_header(
+        self, task: ImportTask
+    ) -> dict[str, Any] | None:
         """Build the album-header YAML document for import editing.
 
         Returns a dict of album-level fields, or ``None`` when the current
@@ -348,7 +357,9 @@ class EditPlugin(plugins.BeetsPlugin):
         header = flatten(first_item, album_fields)
         return header if header else None
 
-    def _importer_edit_apply_header(self, items, header_data):
+    def _importer_edit_apply_header(
+        self, items: list[Item], header_data: dict[str, Any]
+    ) -> None:
         """Apply album-header changes (from ``_importer_edit_album_header``)
         to every item in the list.
         """
@@ -358,8 +369,11 @@ class EditPlugin(plugins.BeetsPlugin):
             apply_(item, header_data)
 
     def _importer_edit_apply_tracks(
-        self, old_track_data, new_track_data, items
-    ):
+        self,
+        old_track_data: list[dict[str, Any]],
+        new_track_data: list[dict[str, Any]],
+        items: list[Item],
+    ) -> bool:
         """Apply per-track YAML document changes to the matching items.
 
         Returns ``True`` if any change was made.
@@ -388,7 +402,9 @@ class EditPlugin(plugins.BeetsPlugin):
             changed = True
         return changed
 
-    def _edit_yaml(self, old_str):
+    def _edit_yaml(
+        self, old_str: str
+    ) -> tuple[list[dict[str, Any]], str] | None:
         """Open a temporary file with `old_str`, let the user edit it, and
         return the parsed list of YAML documents.
 
@@ -420,7 +436,9 @@ class EditPlugin(plugins.BeetsPlugin):
         finally:
             os.remove(new.name)
 
-    def importer_edit(self, session, task):
+    def importer_edit(
+        self, session: ImportSession, task: ImportTask
+    ) -> Action | None:
         """Callback for invoking the functionality during an interactive
         import session on the *original* item tags.
         """
@@ -478,7 +496,7 @@ class EditPlugin(plugins.BeetsPlugin):
             new_track_data = new_all_data[num_data_docs:]
 
             # Snapshot originals for diff display and restore.
-            objs_old = [obj.copy() for obj in task.items]
+            objs_old = cast("list[Item]", [obj.copy() for obj in task.items])
 
             # Apply header changes to every item.
             if new_header_data:
@@ -513,14 +531,16 @@ class EditPlugin(plugins.BeetsPlugin):
                 continue
 
     @staticmethod
-    def _importer_edit_cleanup(task):
+    def _importer_edit_cleanup(task: ImportTask) -> None:
         """Remove temporary negative ids from task items."""
         for obj in task.items:
             if obj.id is not None and obj.id < 0:
                 obj.id = None
 
     @staticmethod
-    def _importer_edit_restore_from_copies(task, copies):
+    def _importer_edit_restore_from_copies(
+        task: ImportTask, copies: list[Item]
+    ) -> None:
         """Restore items to their state before the last edit cycle.
 
         ``copies`` must be a list of :class:`Item <beets.library.Item>` copies

--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -360,9 +360,7 @@ class EditPlugin(plugins.BeetsPlugin):
     def _importer_edit_apply_header(
         self, items: list[Item], header_data: dict[str, Any]
     ) -> None:
-        """Apply album-header changes (from ``_importer_edit_album_header``)
-        to every item in the list.
-        """
+        """Apply album-header changes to every item in the list."""
         if not header_data:
             return
         for item in items:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,9 +24,14 @@ New features
 - :doc:`plugins/tidal`: Add cover art support. Album metadata now includes
   ``cover_art_url`` from Tidal's ``coverArt`` relationship, which the
   :doc:`plugins/fetchart` plugin can retrieve.
+<<<<<<< HEAD
 - :ref:`modify-cmd`: Support ``+=`` and ``-=`` operators to add or remove
   individual values from multi-valued fields without replacing the whole field.
   :bug:`6587`
+- :doc:`plugins/edit`: The interactive import editor now shows album-level
+  fields (as configured by ``albumfields``) as a YAML header section when
+  editing an album import. Fields that appear in both ``itemfields`` and
+  ``albumfields`` are shown only in the header, not per-track.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,7 +24,6 @@ New features
 - :doc:`plugins/tidal`: Add cover art support. Album metadata now includes
   ``cover_art_url`` from Tidal's ``coverArt`` relationship, which the
   :doc:`plugins/fetchart` plugin can retrieve.
-<<<<<<< HEAD
 - :ref:`modify-cmd`: Support ``+=`` and ``-=`` operators to add or remove
   individual values from multi-valued fields without replacing the whole field.
   :bug:`6587`

--- a/docs/plugins/edit.rst
+++ b/docs/plugins/edit.rst
@@ -40,10 +40,13 @@ adds two new options to the user prompt:
 - ``edit Candidates``: use this option for using a candidate's metadata as the
   starting point for your edits.
 
-Please note that currently the interactive usage of the plugin will only allow
-you to change the item-level fields. In case you need to edit the album-level
-fields, the recommended approach is to invoke the plugin via the command line in
-album mode (``beet edit -a QUERY``) after the import.
+When editing an album during import (i.e., after you have chosen ``eDit`` or
+``edit Candidates`` for an album import), the fields listed in ``albumfields``
+are shown as a YAML header section before the per-track documents. This allows
+you to edit album-level fields (such as ``album``, ``albumartist``, or any
+configured ``albumfields`` entry) for all tracks at once. Fields that appear in
+both ``itemfields`` and ``albumfields`` are shown only in the header section,
+not per-track.
 
 Also, please be aware that the ``edit Candidates`` choice can only be used with
 the matches found during the initial search (and currently not supporting the
@@ -60,4 +63,5 @@ The available options are:
 - **itemfields**: A space-separated list of item fields to include in the editor
   by default. Default: ``track title artist album``
 - **albumfields**: The same when editing albums (with the ``-a`` option).
-  Default: ``album albumartist``
+  Default: ``album albumartist``. These fields are also shown as a YAML header
+  during interactive import when editing an album import.

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -455,6 +455,30 @@ class EditDuringImporterNonSingletonTest(EditDuringImporterTestCase):
 
         assert all("Edited Track" in i.title for i in self.lib.items())
 
+    def test_importer_edit_album_header_ignores_item_only_fields(self):
+        """`albumfields` may be misconfigured with item-only fields (e.g.
+        `track`, `title`, `path`) that vary per track. Those must not end
+        up in the header, since the header gets applied to every item and
+        would otherwise stamp one track's values onto the whole album.
+        """
+        self.prepare_album_for_import(3)
+        self.items_orig = [Item.from_path(f.path) for f in self.import_media]
+
+        self.config["edit"]["itemfields"] = "track title artist album"
+        self.config["edit"]["albumfields"] = "album albumartist track title"
+
+        self.run_mocked_interpreter(
+            {"replacements": {"Tag Album": "Modified Album"}},
+            # eDit, Apply changes.
+            ["d", "a"],
+        )
+
+        titles = [i.title for i in self.lib.items()]
+        tracks = [i.track for i in self.lib.items()]
+        assert len(set(titles)) == len(titles)
+        assert len(set(tracks)) == len(tracks)
+        assert all(i.album == "Modified Album" for i in self.lib.items())
+
     def test_importer_edit_album_header_albumartist(self):
         """Edit albumartist in the header (default albumfields)."""
         self.run_mocked_interpreter(

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -378,6 +378,33 @@ class ApplyDataMatchingTest(PluginMixin, BeetsTestCase):
         assert items[1].track == 2
 
 
+class AlbumHeaderFieldsTest(PluginMixin, BeetsTestCase):
+    """`_importer_edit_album_header` must strip item-only fixed fields
+    (title, track, path, ...), since the header is built from a single
+    item and then applied to every item in the album. Flexible fields
+    are not part of either model's fixed schema, so they must be left
+    alone rather than discarded by an overly broad filter.
+    """
+
+    plugin = "edit"
+
+    class _StubTask:
+        is_album = True
+
+        def __init__(self, items):
+            self.items = items
+
+    def test_keeps_flexible_fields_but_drops_item_only_fields(self):
+        item = Item(id=1, title="Title 1", track=1, album="Album", mood="Happy")
+        task = self._StubTask([item])
+
+        self.config["edit"]["albumfields"] = "album mood track title"
+
+        header = EditPlugin()._importer_edit_album_header(task)
+
+        assert header == {"album": "Album", "mood": "Happy"}
+
+
 class EditDuringImporterTestCase(
     EditMixin, TerminalImportMixin, AutotagImportTestCase
 ):

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -313,6 +313,78 @@ class EditDuringImporterNonSingletonTest(EditDuringImporterTestCase):
         super().setUp()
         self.importer = self.setup_importer()
 
+    def test_importer_edit_album_header_album(self):
+        """Edit an album-level field (album) using the import header section,
+        apply changes, and verify all items and the album are updated.
+        """
+        # Show only album in the header and title per track.
+        self.config["edit"]["itemfields"] = "title"
+        self.config["edit"]["albumfields"] = "album"
+
+        self.run_mocked_interpreter(
+            {"replacements": {"Tag Album": "Modified Album"}},
+            # eDit, Apply changes.
+            ["d", "a"],
+        )
+
+        # All items should have the new album name.
+        assert all(i.album == "Modified Album" for i in self.lib.items())
+
+        # The imported album record should also be updated.
+        assert self.lib.albums()[0].album == "Modified Album"
+
+    def test_importer_edit_album_header_and_items(self):
+        """Edit both the album header and per-track fields simultaneously."""
+        self.config["edit"]["itemfields"] = "title"
+        self.config["edit"]["albumfields"] = "album"
+
+        self.run_mocked_interpreter(
+            {
+                "replacements": {
+                    "Tag Album": "Modified Album",
+                    "Tag Track": "Modified Track",
+                }
+            },
+            # eDit, Apply changes.
+            ["d", "a"],
+        )
+
+        # All items should have the new album and new title.
+        assert all(i.album == "Modified Album" for i in self.lib.items())
+        assert all("Modified Track" in i.title for i in self.lib.items())
+        assert self.lib.albums()[0].album == "Modified Album"
+
+    def test_importer_edit_album_header_skip_no_albumfields(self):
+        """When albumfields is empty, no header section is produced; editing
+        works as before.
+        """
+        self.config["edit"]["itemfields"] = "title"
+        self.config["edit"]["albumfields"] = ""
+
+        self.run_mocked_interpreter(
+            {"replacements": {"Tag Track": "Edited Track"}},
+            # eDit, Apply changes.
+            ["d", "a"],
+        )
+
+        assert all("Edited Track" in i.title for i in self.lib.items())
+
+    def test_importer_edit_album_header_albumartist(self):
+        """Edit albumartist in the header (default albumfields)."""
+        self.run_mocked_interpreter(
+            {"replacements": {"Tag Artist": "Modified Artist"}},
+            # eDit, Apply changes.
+            ["d", "a"],
+        )
+
+        assert all(
+            i.albumartist is not None and "Modified Artist" in i.albumartist
+            for i in self.lib.items()
+        ) or all(
+            i.albumartist is None and "Tag Artist" in i.artist
+            for i in self.lib.items()
+        )
+
     def test_edit_apply_asis(self):
         """Edit the album field for all items in the library, apply changes,
         using the original item tags.

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -13,7 +13,7 @@ from beets.test.helper import (
     PluginMixin,
     TerminalImportMixin,
 )
-from beetsplug.edit import EditPlugin
+from beetsplug.edit import EditPlugin, dump, load
 
 
 class ModifyFileMocker:
@@ -354,6 +354,29 @@ class ApplyDataMatchingTest(PluginMixin, BeetsTestCase):
         assert items[0].title == "Title 1"
         assert items[0].track == 1
 
+    def test_ignores_documents_with_duplicate_id(self):
+        plugin = EditPlugin()
+        items = self.make_items()
+        old_data = [
+            {"id": i.id, "title": i.title, "track": i.track} for i in items
+        ]
+
+        # The user changed document 2's `id` to 1, an id that already
+        # belongs to another document. Neither document should be applied:
+        # we can't tell which one is legitimately item 1's data.
+        new_data = [
+            {"id": 1, "title": "Title 1", "track": 1},
+            {"id": 1, "title": "Modified Title 2", "track": 2},
+            {"id": 3, "title": "Title 3", "track": 3},
+        ]
+
+        plugin.apply_data(items, old_data, new_data)
+
+        assert items[0].title == "Title 1"
+        assert items[0].track == 1
+        assert items[1].title == "Title 2"
+        assert items[1].track == 2
+
 
 class EditDuringImporterTestCase(
     EditMixin, TerminalImportMixin, AutotagImportTestCase
@@ -447,6 +470,32 @@ class EditDuringImporterNonSingletonTest(EditDuringImporterTestCase):
             i.albumartist is None and "Tag Artist" in i.artist
             for i in self.lib.items()
         )
+
+    def test_importer_edit_album_header_reordered(self):
+        """If the user moves the album header document below the track
+        documents, it must still be recognized as the header (identified by
+        the absence of an `id` field) rather than misapplying a track's
+        fields to every item.
+        """
+        self.config["edit"]["itemfields"] = "title"
+        self.config["edit"]["albumfields"] = "album"
+
+        def reorder_and_edit(filename, log):
+            with codecs.open(filename, encoding="utf-8") as f:
+                docs = load(f.read())
+            header = next(d for d in docs if "id" not in d)
+            tracks = [d for d in docs if "id" in d]
+            header["album"] = "Modified Album"
+            with codecs.open(filename, "w", encoding="utf-8") as f:
+                f.write(dump([*tracks, header]))
+
+        with patch("beetsplug.edit.edit", side_effect=reorder_and_edit):
+            self.importer.add_choice("d")
+            self.importer.add_choice("a")
+            self.importer.run()
+
+        assert all(i.album == "Modified Album" for i in self.lib.items())
+        assert all("Tag Track" in i.title for i in self.lib.items())
 
     def test_edit_apply_asis(self):
         """Edit the album field for all items in the library, apply changes,

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -13,6 +13,7 @@ from beets.test.helper import (
     PluginMixin,
     TerminalImportMixin,
 )
+from beetsplug.edit import EditPlugin
 
 
 class ModifyFileMocker:
@@ -290,6 +291,73 @@ class EditCommandTest(IOMixin, EditMixin, BeetsTestCase):
         )
 
         assert mock_write.call_count == 0
+
+
+class ApplyTracksMatchingTest(PluginMixin, BeetsTestCase):
+    """`_importer_edit_apply_tracks` must match documents to items by their
+    ``id`` field, not by their position in the list. A reordered or
+    otherwise misaligned document list must not cause one track's data to
+    be applied to a different item.
+    """
+
+    plugin = "edit"
+
+    def make_items(self):
+        items = []
+        for i in (1, 2, 3):
+            item = Item(id=i, title=f"Title {i}", track=i, artist="Artist")
+            items.append(item)
+        return items
+
+    def test_matches_by_id_when_documents_are_reordered(self):
+        plugin = EditPlugin()
+        items = self.make_items()
+        old_track_data = [
+            {"id": i.id, "title": i.title, "track": i.track} for i in items
+        ]
+
+        # The saved documents come back in a different order than `items`,
+        # as could happen after a "keep editing" round-trip or a reordering
+        # editor action. Only track 2's title was actually edited.
+        new_track_data = [
+            {"id": 3, "title": "Title 3", "track": 3},
+            {"id": 1, "title": "Title 1", "track": 1},
+            {"id": 2, "title": "Modified Title 2", "track": 2},
+        ]
+
+        changed = plugin._importer_edit_apply_tracks(
+            old_track_data, new_track_data, items
+        )
+
+        assert changed
+        assert [i.title for i in items] == [
+            "Title 1",
+            "Modified Title 2",
+            "Title 3",
+        ]
+        assert [i.track for i in items] == [1, 2, 3]
+
+    def test_ignores_document_with_missing_id(self):
+        plugin = EditPlugin()
+        items = self.make_items()
+        old_track_data = [
+            {"id": i.id, "title": i.title, "track": i.track} for i in items
+        ]
+
+        # A document without an `id` must never be silently applied to an
+        # unrelated item.
+        new_track_data = [
+            {"title": "Header-like doc", "track": 99},
+            {"id": 2, "title": "Modified Title 2", "track": 2},
+            {"id": 3, "title": "Title 3", "track": 3},
+        ]
+
+        plugin._importer_edit_apply_tracks(
+            old_track_data, new_track_data, items
+        )
+
+        assert items[0].title == "Title 1"
+        assert items[0].track == 1
 
 
 class EditDuringImporterTestCase(

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -426,26 +426,6 @@ class EditDuringImporterNonSingletonTest(EditDuringImporterTestCase):
         super().setUp()
         self.importer = self.setup_importer()
 
-    def test_importer_edit_album_header_album(self):
-        """Edit an album-level field (album) using the import header section,
-        apply changes, and verify all items and the album are updated.
-        """
-        # Show only album in the header and title per track.
-        self.config["edit"]["itemfields"] = "title"
-        self.config["edit"]["albumfields"] = "album"
-
-        self.run_mocked_interpreter(
-            {"replacements": {"Tag Album": "Modified Album"}},
-            # eDit, Apply changes.
-            ["d", "a"],
-        )
-
-        # All items should have the new album name.
-        assert all(i.album == "Modified Album" for i in self.lib.items())
-
-        # The imported album record should also be updated.
-        assert self.lib.albums()[0].album == "Modified Album"
-
     def test_importer_edit_album_header_and_items(self):
         """Edit both the album header and per-track fields simultaneously."""
         self.config["edit"]["itemfields"] = "title"

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -293,11 +293,11 @@ class EditCommandTest(IOMixin, EditMixin, BeetsTestCase):
         assert mock_write.call_count == 0
 
 
-class ApplyTracksMatchingTest(PluginMixin, BeetsTestCase):
-    """`_importer_edit_apply_tracks` must match documents to items by their
-    ``id`` field, not by their position in the list. A reordered or
-    otherwise misaligned document list must not cause one track's data to
-    be applied to a different item.
+class ApplyDataMatchingTest(PluginMixin, BeetsTestCase):
+    """`apply_data` must match documents to objects by their ``id`` field,
+    not by their position in the list. A reordered or otherwise misaligned
+    document list must not cause one object's data to be applied to a
+    different object.
     """
 
     plugin = "edit"
@@ -312,24 +312,21 @@ class ApplyTracksMatchingTest(PluginMixin, BeetsTestCase):
     def test_matches_by_id_when_documents_are_reordered(self):
         plugin = EditPlugin()
         items = self.make_items()
-        old_track_data = [
+        old_data = [
             {"id": i.id, "title": i.title, "track": i.track} for i in items
         ]
 
         # The saved documents come back in a different order than `items`,
         # as could happen after a "keep editing" round-trip or a reordering
         # editor action. Only track 2's title was actually edited.
-        new_track_data = [
+        new_data = [
             {"id": 3, "title": "Title 3", "track": 3},
             {"id": 1, "title": "Title 1", "track": 1},
             {"id": 2, "title": "Modified Title 2", "track": 2},
         ]
 
-        changed = plugin._importer_edit_apply_tracks(
-            old_track_data, new_track_data, items
-        )
+        plugin.apply_data(items, old_data, new_data)
 
-        assert changed
         assert [i.title for i in items] == [
             "Title 1",
             "Modified Title 2",
@@ -340,21 +337,19 @@ class ApplyTracksMatchingTest(PluginMixin, BeetsTestCase):
     def test_ignores_document_with_missing_id(self):
         plugin = EditPlugin()
         items = self.make_items()
-        old_track_data = [
+        old_data = [
             {"id": i.id, "title": i.title, "track": i.track} for i in items
         ]
 
         # A document without an `id` must never be silently applied to an
-        # unrelated item.
-        new_track_data = [
+        # unrelated object.
+        new_data = [
             {"title": "Header-like doc", "track": 99},
             {"id": 2, "title": "Modified Title 2", "track": 2},
             {"id": 3, "title": "Title 3", "track": 3},
         ]
 
-        plugin._importer_edit_apply_tracks(
-            old_track_data, new_track_data, items
-        )
+        plugin.apply_data(items, old_data, new_data)
 
         assert items[0].title == "Title 1"
         assert items[0].track == 1


### PR DESCRIPTION
## Description

During interactive import, the `edit` plugin only exposed item-level fields — the `albumfields` configuration was completely ignored in `importer_edit()`. Users who wanted to modify album-level fields such as `album` or `year` had to complete the import, then run `beet edit -a QUERY` as a separate step.

### Solution

Updated `importer_edit()` to support editing album-level fields during import. Album fields (configured via `albumfields`) are presented as a YAML header section prepended to the per-track documents. Changes to the header are applied to all items in the album, making album-level edits work in both the `eDit` and `edit Candidates` choices.

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
