### PR TITLE
lyrics: add rate limiting and exponential backoff to prevent 429 errors

### DIFF
--- a/beetsplug/_utils/requests.py
+++ b/beetsplug/_utils/requests.py
@@ -162,7 +162,7 @@ class RequestHandler:
         HTTPNotFoundError
     ]
 
-    def create_session(self) -> TimeoutAndRetrySession:
+    def create_session(self) -> requests.Session:
         """Create a new HTTP session instance.
 
         Can be overridden by subclasses to provide custom session types.
@@ -170,7 +170,7 @@ class RequestHandler:
         return TimeoutAndRetrySession()
 
     @cached_property
-    def session(self) -> TimeoutAndRetrySession:
+    def session(self) -> requests.Session:
         return self.create_session()
 
     def status_to_error(

--- a/beetsplug/_utils/requests.py
+++ b/beetsplug/_utils/requests.py
@@ -162,7 +162,7 @@ class RequestHandler:
         HTTPNotFoundError
     ]
 
-    def create_session(self) -> requests.Session:
+    def create_session(self) -> TimeoutAndRetrySession:
         """Create a new HTTP session instance.
 
         Can be overridden by subclasses to provide custom session types.
@@ -170,7 +170,7 @@ class RequestHandler:
         return TimeoutAndRetrySession()
 
     @cached_property
-    def session(self) -> requests.Session:
+    def session(self) -> TimeoutAndRetrySession:
         return self.create_session()
 
     def status_to_error(

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -35,7 +35,7 @@ from bs4 import BeautifulSoup
 from unidecode import unidecode
 from urllib3.util.retry import Retry
 
-from beets import __version__, plugins, ui
+from beets import plugins, ui
 from beets.autotag import string_dist
 from beets.dbcore import types
 from beets.dbcore.query import FalseQuery
@@ -43,7 +43,12 @@ from beets.library import Item, parse_query_string
 from beets.util.config import sanitize_choices
 from beets.util.lyrics import INSTRUMENTAL_LYRICS, Lyrics
 
-from ._utils.requests import HTTPNotFoundError, RateLimitAdapter, RequestHandler
+from ._utils.requests import (
+    HTTPNotFoundError,
+    RateLimitAdapter,
+    RequestHandler,
+    TimeoutAndRetrySession,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator
@@ -167,12 +172,13 @@ def slug(text: str) -> str:
     return re.sub(r"\W+", "-", unidecode(text).lower().strip()).strip("-")
 
 
-class LyricsSession(requests.Session):
+class LyricsSession(TimeoutAndRetrySession):
     """HTTP session for lyrics backends with rate limiting and exponential backoff.
 
-    Each backend instance gets its own session so rate limits apply independently
-    per API source. Combines a fixed rate limit with exponential backoff on rate
-    limit (429) responses.
+    Builds on :class:`TimeoutAndRetrySession` — inherits User-Agent header,
+    default timeout, and response status checking. Adds a :class:`RateLimitAdapter`
+    to enforce a minimum interval between requests, and configures urllib3 Retry
+    with exponential backoff on rate limit (429) responses.
     """
 
     def __init__(self, rate_limit: float = 0.25):
@@ -183,10 +189,6 @@ class LyricsSession(requests.Session):
                 requests (default 0.25s = 4 requests/sec).
         """
         super().__init__()
-        self.headers.setdefault(
-            "User-Agent", f"beets/{__version__} https://beets.io/"
-        )
-
         retry = Retry(
             total=6,
             backoff_factor=1.0,
@@ -201,12 +203,6 @@ class LyricsSession(requests.Session):
         adapter = RateLimitAdapter(rate_limit=rate_limit, max_retries=retry)
         self.mount("https://", adapter)
         self.mount("http://", adapter)
-
-    def request(self, *args, **kwargs):
-        kwargs.setdefault("timeout", 10)
-        r = super().request(*args, **kwargs)
-        r.raise_for_status()
-        return r
 
 
 class LyricsRequestHandler(RequestHandler):

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -208,7 +208,7 @@ class LyricsSession(TimeoutAndRetrySession):
 class LyricsRequestHandler(RequestHandler):
     _log: Logger
 
-    def create_session(self) -> requests.Session:
+    def create_session(self) -> TimeoutAndRetrySession:
         """Return a rate-limited session for lyrics HTTP requests."""
         return LyricsSession()
 

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -176,8 +176,16 @@ class LyricsSession(requests.Session):
     """
 
     def __init__(self, rate_limit: float = 0.25):
+        """Initialize session with rate limiting and retry/backoff.
+
+        Args:
+            rate_limit: Minimum interval in seconds between consecutive
+                requests (default 0.25s = 4 requests/sec).
+        """
         super().__init__()
-        self.headers["User-Agent"] = f"beets/{__version__} https://beets.io/"
+        self.headers.setdefault(
+            "User-Agent", f"beets/{__version__} https://beets.io/"
+        )
 
         retry = Retry(
             total=6,

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -24,6 +24,7 @@ from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from functools import cached_property, partial, total_ordering
 from html import unescape
+from http import HTTPStatus
 from itertools import filterfalse, groupby
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, NamedTuple
@@ -32,8 +33,9 @@ from urllib.parse import quote, quote_plus, urlencode, urlparse
 import requests
 from bs4 import BeautifulSoup
 from unidecode import unidecode
+from urllib3.util.retry import Retry
 
-from beets import plugins, ui
+from beets import __version__, plugins, ui
 from beets.autotag import string_dist
 from beets.dbcore import types
 from beets.dbcore.query import FalseQuery
@@ -41,7 +43,7 @@ from beets.library import Item, parse_query_string
 from beets.util.config import sanitize_choices
 from beets.util.lyrics import INSTRUMENTAL_LYRICS, Lyrics
 
-from ._utils.requests import HTTPNotFoundError, RequestHandler
+from ._utils.requests import HTTPNotFoundError, RateLimitAdapter, RequestHandler
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator
@@ -165,8 +167,46 @@ def slug(text: str) -> str:
     return re.sub(r"\W+", "-", unidecode(text).lower().strip()).strip("-")
 
 
+class LyricsSession(requests.Session):
+    """HTTP session for lyrics backends with rate limiting and exponential backoff.
+
+    Each backend instance gets its own session so rate limits apply independently
+    per API source. Combines a fixed rate limit with exponential backoff on rate
+    limit (429) responses.
+    """
+
+    def __init__(self, rate_limit: float = 0.25):
+        super().__init__()
+        self.headers["User-Agent"] = f"beets/{__version__} https://beets.io/"
+
+        retry = Retry(
+            total=6,
+            backoff_factor=1.0,
+            status_forcelist=[
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                HTTPStatus.BAD_GATEWAY,
+                HTTPStatus.SERVICE_UNAVAILABLE,
+                HTTPStatus.GATEWAY_TIMEOUT,
+                HTTPStatus.TOO_MANY_REQUESTS,
+            ],
+        )
+        adapter = RateLimitAdapter(rate_limit=rate_limit, max_retries=retry)
+        self.mount("https://", adapter)
+        self.mount("http://", adapter)
+
+    def request(self, *args, **kwargs):
+        kwargs.setdefault("timeout", 10)
+        r = super().request(*args, **kwargs)
+        r.raise_for_status()
+        return r
+
+
 class LyricsRequestHandler(RequestHandler):
     _log: Logger
+
+    def create_session(self) -> requests.Session:
+        """Return a rate-limited session for lyrics HTTP requests."""
+        return LyricsSession()
 
     def status_to_error(self, code: int) -> type[requests.HTTPError] | None:
         if err := super().status_to_error(code):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,9 @@ New features
 Bug fixes
 ~~~~~~~~~
 
+- :doc:`plugins/lyrics`: Add rate limiting and exponential backoff to HTTP
+  requests to prevent ``429 Too Many Requests`` errors from lyrics sources
+  during bulk imports. :bug:`6728`
 - :doc:`plugins/replace`: Fix ``TypeError`` when invoking the ``replace``
   command. :bug:`6260`
 - :doc:`plugins/mpdstats`: Fix crashes and invalid configuration when passing


### PR DESCRIPTION
Add a LyricsSession class that mounts RateLimitAdapter (4 req/sec) and configures urllib3 Retry with exponential backoff on 429 responses. Each backend instance gets its own session so rate limits apply independently per API source.

Fixes #6728

- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)