### PR TITLE
feat(lyrics): Tidal as lyrics source

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import itertools
+import json
 import math
 import re
 import textwrap
@@ -30,6 +31,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, NamedTuple
 from urllib.parse import quote, quote_plus, urlencode, urlparse
 
+import confuse
 import requests
 from bs4 import BeautifulSoup
 from unidecode import unidecode
@@ -53,8 +55,6 @@ from ._utils.requests import (
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator
 
-    import confuse
-
     from beets.importer import ImportTask
     from beets.library import Library
     from beets.logging import BeetsLogger as Logger
@@ -65,6 +65,13 @@ if TYPE_CHECKING:
         JSONDict,
         LRCLibAPI,
         TranslatorAPI,
+    )
+    from .tidal.api import TidalAPI
+    from .tidal.api_types import (
+        ResourceIdentifier,
+        TidalArtist,
+        TidalLyrics,
+        TidalTrack,
     )
 
     HtmlTransformer = Callable[[str], str]
@@ -289,6 +296,10 @@ class Backend(LyricsRequestHandler, metaclass=BackendClass):
     def __init__(self, config: confuse.Subview, log: Logger) -> None:
         self._log = log
         self.config = config
+
+    @cached_property
+    def dist_thresh(self) -> float:
+        return self.config["dist_thresh"].get(float)
 
     def fetch(
         self, artist: str, title: str, album: str, length: int
@@ -588,10 +599,6 @@ class SearchResult(NamedTuple):
 
 
 class SearchBackend(SoupMixin, Backend):
-    @cached_property
-    def dist_thresh(self) -> float:
-        return self.config["dist_thresh"].get(float)
-
     def check_match(
         self, target_artist: str, target_title: str, result: SearchResult
     ) -> bool:
@@ -860,6 +867,258 @@ class Google(SearchBackend):
         return None
 
 
+class Tidal(Backend):
+    """Fetch lyrics from TIDAL's official API."""
+
+    TRACK_URL = "https://tidal.com/browse/track/{}"
+
+    @cached_property
+    def api(self) -> TidalAPI:
+        from .tidal.api import TidalAPI
+
+        return TidalAPI(
+            client_id=self.config["tidal"]["client_id"].as_str(),
+            scope=self.scope,
+            token_path=self.tokenfile,
+        )
+
+    @cached_property
+    def country_code(self) -> str:
+        return self.config["tidal"]["country_code"].as_str()
+
+    @cached_property
+    def scope(self) -> str:
+        return " ".join(sorted(self.required_scopes))
+
+    @cached_property
+    def tokenfile(self) -> str:
+        return self.config["tidal"]["tokenfile"].get(
+            confuse.Filename(in_app_dir=True)
+        )
+
+    @cached_property
+    def required_scopes(self) -> set[str]:
+        return self.scope_set(self.config["tidal"]["scope"].get())
+
+    @cached_property
+    def token_scopes(self) -> set[str]:
+        try:
+            with open(self.tokenfile) as f:
+                token = json.load(f)
+        except OSError:
+            self.warn(
+                "TIDAL token file not found: {}. Run `beet tidal --auth`.",
+                self.tokenfile,
+            )
+            return set()
+        except json.JSONDecodeError:
+            self.warn(
+                "Could not decode TIDAL token file: {}. "
+                "Run `beet tidal --auth` again.",
+                self.tokenfile,
+            )
+            return set()
+
+        return self.scope_set(token.get("scope") or token.get("scopes"))
+
+    @cached_property
+    def token_has_required_scopes(self) -> bool:
+        missing = self.required_scopes - self.token_scopes
+        if missing:
+            self.warn(
+                "TIDAL token is missing required OAuth scope(s): {}. "
+                "Set tidal.scope to `{}` and run `beet tidal --auth` again.",
+                ", ".join(sorted(missing)),
+                " ".join(sorted(self.required_scopes)),
+            )
+            return False
+
+        return True
+
+    @staticmethod
+    def scope_set(scope: object) -> set[str]:
+        if isinstance(scope, str):
+            return set(scope.split())
+        if isinstance(scope, list):
+            return {str(item) for item in scope}
+
+        return set()
+
+    @staticmethod
+    def track_title(track: TidalTrack) -> str:
+        attributes = track["attributes"]
+        if version := attributes.get("version"):
+            return f"{attributes['title']} ({version})"
+        return attributes["title"]
+
+    @staticmethod
+    def track_artist(
+        track: TidalTrack, artist_by_id: dict[str, TidalArtist]
+    ) -> str | None:
+        relationships = track.get("relationships")
+        artist_relationship = (
+            relationships.get("artists") if relationships else None
+        )
+        artist_relationships: list[ResourceIdentifier] = (
+            artist_relationship["data"] if artist_relationship else []
+        )
+        if not artist_relationships:
+            return None
+
+        artist_names = [
+            artist["attributes"]["name"]
+            for rel in artist_relationships
+            if (artist := artist_by_id.get(rel["id"]))
+        ]
+        if not artist_names:
+            return None
+
+        return ", ".join(artist_names)
+
+    def check_match(
+        self,
+        target_artist: str,
+        target_title: str,
+        track: TidalTrack,
+        artist: str | None,
+    ) -> bool:
+        title = self.track_title(track)
+        if artist is None:
+            max_dist = string_dist(target_title, title)
+        else:
+            max_dist = max(
+                string_dist(target_artist, artist),
+                string_dist(target_title, title),
+            )
+
+        if (max_dist := round(max_dist, 2)) <= self.dist_thresh:
+            return True
+
+        if math.isclose(max_dist, self.dist_thresh, abs_tol=0.4):
+            # log out the candidate that did not make it but was close.
+            # This may show a matching candidate with some noise in the name
+            self.debug(
+                "({0}, {1}) does not match ({2}, {3}) but dist"
+                " was close: {4:.2f}",
+                artist or "",
+                title,
+                target_artist,
+                target_title,
+                max_dist,
+            )
+
+        return False
+
+    def search(self, artist: str, title: str) -> Iterable[TidalTrack]:
+        """Search TIDAL tracks and yield matching track resources."""
+        search_data = self.api.search_results(
+            f"{artist} {title}",
+            include=["tracks.artists"],
+            country_code=self.country_code,
+        )
+
+        search_result = search_data.get("data")
+        if not search_result:
+            self.warn("TIDAL search response did not include result data")
+            return
+
+        track_by_id: dict[str, TidalTrack] = {}
+        artist_by_id: dict[str, TidalArtist] = {}
+        for item in search_data.get("included") or []:
+            if item["type"] == "tracks":
+                track_by_id[item["id"]] = item
+            elif item["type"] == "artists":
+                artist_by_id[item["id"]] = item
+
+        relationships = search_result.get("relationships")
+        track_relationship = (
+            relationships.get("tracks") if relationships else None
+        )
+        track_relationships = (
+            track_relationship["data"] if track_relationship else []
+        )
+        for track_rel in track_relationships:
+            if track := track_by_id.get(track_rel["id"]):
+                track_artist = self.track_artist(track, artist_by_id)
+                if self.check_match(artist, title, track, track_artist):
+                    yield track
+
+    @classmethod
+    def lyric_text(cls, lyric: TidalLyrics, synced: bool) -> str | None:
+        attributes = lyric["attributes"]
+        if attributes.get("technicalStatus") != "OK":
+            return None
+
+        if synced and (lrc_text := attributes.get("lrcText")):
+            return lrc_text.strip()
+
+        if text := attributes.get("text"):
+            return text.strip()
+
+        return None
+
+    def fetch_tracks_lyrics(
+        self, track_ids: list[str]
+    ) -> Iterable[tuple[str, TidalLyrics]]:
+        """Fetch lyric resources for TIDAL track IDs."""
+        tracks_data = self.api.get_tracks(
+            ids=track_ids, include=["lyrics"], country_code=self.country_code
+        )
+
+        tracks = tracks_data.get("data")
+        if tracks is None:
+            self.warn("TIDAL track response did not include track data")
+            return
+
+        track_by_id = {
+            item["id"]: item for item in tracks if item["type"] == "tracks"
+        }
+
+        lyric_by_id = {
+            item["id"]: item
+            for item in tracks_data.get("included") or []
+            if item["type"] == "lyrics"
+        }
+
+        for track_id in track_ids:
+            if track := track_by_id.get(track_id):
+                relationships = track.get("relationships")
+                lyric_relationship = (
+                    relationships.get("lyrics") if relationships else None
+                )
+                if lyric_relationship is None:
+                    self.warn(
+                        "TIDAL track response did not include lyric data for {}",
+                        track_id,
+                    )
+                    continue
+
+                lyric_relationships = lyric_relationship["data"]
+                for lyric_rel in lyric_relationships:
+                    if lyric := lyric_by_id.get(lyric_rel["id"]):
+                        yield track_id, lyric
+
+    def fetch(
+        self, artist: str, title: str, album: str, length: int
+    ) -> Lyrics | None:
+        """Fetch lyrics text for the given song data."""
+        if not self.token_has_required_scopes:
+            return None
+
+        synced = self.config["synced"].get(bool)
+        track_ids = [track["id"] for track in self.search(artist, title)]
+        if not track_ids:
+            return None
+
+        for track_id, lyric in self.fetch_tracks_lyrics(track_ids):
+            if text := self.lyric_text(lyric, synced):
+                return Lyrics(
+                    text, self.__class__.name, self.TRACK_URL.format(track_id)
+                )
+
+        return None
+
+
 @dataclass
 class Translator(LyricsRequestHandler):
     """Translate lyrics text while preserving existing structured metadata."""
@@ -1035,7 +1294,7 @@ class RestFiles:
 
 
 BACKEND_BY_NAME = {
-    b.name: b for b in [LRCLib, Google, Genius, Tekstowo, MusiXmatch]
+    b.name: b for b in [LRCLib, Google, Genius, Tekstowo, MusiXmatch, Tidal]
 }
 
 
@@ -1089,12 +1348,19 @@ class LyricsPlugin(LyricsRequestHandler, plugins.BeetsPlugin):
                 "local": False,
                 "print": False,
                 "synced": False,
+                "tidal": {
+                    "client_id": "mcjmpl1bPATJXcBT",
+                    "country_code": "US",
+                    "scope": "search.read user.read",
+                    "tokenfile": "tidal_token.json",
+                },
                 # Musixmatch and Tekstowo are disabled by default as they
-                # currently block requests with the beets user agent.
+                # currently block requests with the beets user agent. TIDAL
+                # is opt-in because it needs a user-authenticated token.
                 "sources": [
                     n
                     for n in BACKEND_BY_NAME
-                    if n not in {"musixmatch", "tekstowo"}
+                    if n not in {"musixmatch", "tekstowo", "tidal"}
                 ],
             }
         )
@@ -1102,6 +1368,7 @@ class LyricsPlugin(LyricsRequestHandler, plugins.BeetsPlugin):
         self.config["google_API_key"].redact = True
         self.config["google_engine_ID"].redact = True
         self.config["genius_api_key"].redact = True
+        self.config["tidal"]["client_id"].redact = True
 
         if self.config["auto"]:
             self.import_stages = [self.imported]

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -888,7 +888,9 @@ class Tidal(Backend):
 
     @cached_property
     def scope(self) -> str:
-        return " ".join(sorted(self.required_scopes))
+        from .tidal.api import TIDAL_DEFAULT_SCOPE
+
+        return TIDAL_DEFAULT_SCOPE
 
     @cached_property
     def tokenfile(self) -> str:
@@ -898,7 +900,7 @@ class Tidal(Backend):
 
     @cached_property
     def required_scopes(self) -> set[str]:
-        return self.scope_set(self.config["tidal"]["scope"].get())
+        return self.scope_set(self.scope)
 
     @cached_property
     def token_scopes(self) -> set[str]:
@@ -927,9 +929,9 @@ class Tidal(Backend):
         if missing:
             self.warn(
                 "TIDAL token is missing required OAuth scope(s): {}. "
-                "Set tidal.scope to `{}` and run `beet tidal --auth` again.",
+                "Run `beet tidal --auth` again so the token includes: {}.",
                 ", ".join(sorted(missing)),
-                " ".join(sorted(self.required_scopes)),
+                self.scope,
             )
             return False
 
@@ -1351,7 +1353,6 @@ class LyricsPlugin(LyricsRequestHandler, plugins.BeetsPlugin):
                 "tidal": {
                     "client_id": "mcjmpl1bPATJXcBT",
                     "country_code": "US",
-                    "scope": "search.read user.read",
                     "tokenfile": "tidal_token.json",
                 },
                 # Musixmatch and Tekstowo are disabled by default as they

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -40,7 +40,11 @@ class TidalPlugin(MetadataSourcePlugin):
         super().__init__()
 
         self.config.add(
-            {"client_id": "mcjmpl1bPATJXcBT", "tokenfile": "tidal_token.json"}
+            {
+                "client_id": "mcjmpl1bPATJXcBT",
+                "scope": "search.read",
+                "tokenfile": "tidal_token.json",
+            }
         )
         self.config["client_id"].redact = True
 
@@ -52,8 +56,19 @@ class TidalPlugin(MetadataSourcePlugin):
     def api(self) -> TidalAPI:
         return TidalAPI(
             client_id=self.config["client_id"].as_str(),
+            scope=self._scope(),
             token_path=self._tokenfile(),
         )
+
+    def _scope(self) -> str:
+        """Return the configured OAuth scope string."""
+        scope = self.config["scope"].get()
+        if isinstance(scope, str):
+            return " ".join(scope.split())
+        if isinstance(scope, list):
+            return " ".join(str(item) for item in scope)
+
+        return ""
 
     def _tokenfile(self) -> str:
         """Return the configured path to the token file in the app directory."""

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -14,7 +14,7 @@ from beets.exceptions import UserError
 from beets.logging import getLogger
 from beets.metadata_plugins import MetadataSourcePlugin
 
-from .api import TidalAPI
+from .api import TIDAL_DEFAULT_SCOPE, TidalAPI
 
 if TYPE_CHECKING:
     import optparse
@@ -40,11 +40,7 @@ class TidalPlugin(MetadataSourcePlugin):
         super().__init__()
 
         self.config.add(
-            {
-                "client_id": "mcjmpl1bPATJXcBT",
-                "scope": "search.read",
-                "tokenfile": "tidal_token.json",
-            }
+            {"client_id": "mcjmpl1bPATJXcBT", "tokenfile": "tidal_token.json"}
         )
         self.config["client_id"].redact = True
 
@@ -56,19 +52,9 @@ class TidalPlugin(MetadataSourcePlugin):
     def api(self) -> TidalAPI:
         return TidalAPI(
             client_id=self.config["client_id"].as_str(),
-            scope=self._scope(),
+            scope=TIDAL_DEFAULT_SCOPE,
             token_path=self._tokenfile(),
         )
-
-    def _scope(self) -> str:
-        """Return the configured OAuth scope string."""
-        scope = self.config["scope"].get()
-        if isinstance(scope, str):
-            return " ".join(scope.split())
-        if isinstance(scope, list):
-            return " ".join(str(item) for item in scope)
-
-        return ""
 
     def _tokenfile(self) -> str:
         """Return the configured path to the token file in the app directory."""

--- a/beetsplug/tidal/api.py
+++ b/beetsplug/tidal/api.py
@@ -28,6 +28,7 @@ log = getLogger("beets.tidal")
 
 API_BASE = "https://openapi.tidal.com/v2"
 MAX_FILTER_SIZE = 20
+TIDAL_DEFAULT_SCOPE = "search.read user.read"
 
 
 def _batched(iterable: Iterable[T], n: int) -> Iterable[list[T]]:
@@ -40,7 +41,7 @@ def _batched(iterable: Iterable[T], n: int) -> Iterable[list[T]]:
 
 class TidalAPI(RequestHandler):
     def __init__(
-        self, client_id: str, token_path: str, scope: str = "search.read"
+        self, client_id: str, token_path: str, scope: str = TIDAL_DEFAULT_SCOPE
     ) -> None:
         self.client_id = client_id
         self.token_path = token_path

--- a/beetsplug/tidal/api.py
+++ b/beetsplug/tidal/api.py
@@ -39,13 +39,16 @@ def _batched(iterable: Iterable[T], n: int) -> Iterable[list[T]]:
 
 
 class TidalAPI(RequestHandler):
-    def __init__(self, client_id: str, token_path: str) -> None:
+    def __init__(
+        self, client_id: str, token_path: str, scope: str = "search.read"
+    ) -> None:
         self.client_id = client_id
         self.token_path = token_path
+        self.scope = scope
 
     @cached_property
     def session(self) -> TidalSession:
-        return TidalSession(self.client_id, self.token_path)
+        return TidalSession(self.client_id, self.token_path, self.scope)
 
     def search_results(
         self,

--- a/beetsplug/tidal/api_types.py
+++ b/beetsplug/tidal/api_types.py
@@ -125,6 +125,13 @@ class SearchAttributes(TypedDict):
     trackingId: str
 
 
+class LyricsAttributes(TypedDict):
+    technicalStatus: Literal["PENDING", "PROCESSING", "ERROR", "OK"]
+    direction: NotRequired[Literal["LEFT_TO_RIGHT", "RIGHT_TO_LEFT"]]
+    lrcText: NotRequired[str]
+    text: NotRequired[str]
+
+
 class TidalArtist(TypedDict):
     id: str
     type: Literal["artists"]
@@ -152,12 +159,21 @@ class TidalSearch(TypedDict):
     relationships: dict[str, RelationshipData]
 
 
+class TidalLyrics(TypedDict):
+    id: str
+    type: Literal["lyrics"]
+    attributes: LyricsAttributes
+    relationships: NotRequired[dict[str, RelationshipData]]
+
+
 T = TypeVar("T")
 
 
 class Document(TypedDict, Generic[T]):
     data: T
-    included: NotRequired[list[TidalArtist | TidalAlbum | TidalTrack]]
+    included: NotRequired[
+        list[TidalArtist | TidalAlbum | TidalTrack | TidalLyrics]
+    ]
     links: NotRequired[dict[str, str]]
 
 

--- a/beetsplug/tidal/session.py
+++ b/beetsplug/tidal/session.py
@@ -34,7 +34,9 @@ class TidalSession(OAuth2Session, TimeoutAndRetrySession):
 
     token_path: Path
 
-    def __init__(self, client_id: str, token_path: str | Path) -> None:
+    def __init__(
+        self, client_id: str, token_path: str | Path, scope: str
+    ) -> None:
         self.token_path = Path(token_path)
 
         # Load token & init parent
@@ -42,7 +44,7 @@ class TidalSession(OAuth2Session, TimeoutAndRetrySession):
         super().__init__(
             client_id,
             token=token,
-            scope="search.read",
+            scope=scope,
             auto_refresh_url="https://auth.tidal.com/v1/oauth2/token",
             redirect_uri="https://localhost",
             auto_refresh_kwargs={"client_id": client_id},

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,8 @@ New features
   :conf:`plugins.musicbrainz:aliases_as_credits` to make
   aliases-as-artist-credit optional.
 - :doc:`plugins/badfiles`: Added settings for auto error and warning actions.
+- :doc:`plugins/lyrics`: Add TIDAL as an opt-in lyrics source using TIDAL's
+  authenticated API.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -66,7 +66,6 @@ Default configuration:
         tidal:
             client_id: mcjmpl1bPATJXcBT
             country_code: US
-            scope: search.read user.read
             tokenfile: tidal_token.json
 
 The available options are:
@@ -134,9 +133,6 @@ The available options are:
     create the token file.
   - **country_code**: ISO 3166-1 alpha-2 country code used for TIDAL catalog and
     lyrics availability.
-  - **scope**: OAuth scopes to request when authenticating. The TIDAL lyrics
-    source needs an app and token with ``user.read`` access. This can be a
-    space-delimited string or a YAML list.
   - **tokenfile**: The path to the TIDAL token file. Relative paths are stored
     in the beets application directory.
 
@@ -150,7 +146,6 @@ The ``tidal`` source is opt-in. To use it, install both extras, enable the
 
     tidal:
         client_id: YOUR_TIDAL_CLIENT_ID
-        scope: search.read user.read
         tokenfile: tidal_token.json
 
     lyrics:
@@ -165,9 +160,9 @@ Then run:
 
     beet tidal --auth
 
-If you authenticated before adding ``user.read`` to the configured
-``tidal.scope``, rerun ``beet tidal --auth`` so the saved token has the scopes
-needed by the lyrics source.
+If the saved TIDAL token predates lyrics support or lacks the required scopes,
+rerun ``beet tidal --auth`` so the token has the scopes needed by the lyrics
+source.
 
 .. _beets custom search engine: https://cse.google.com/cse?cx=009217259823014548361:lndtuqkycfu
 

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -3,13 +3,15 @@ Lyrics Plugin
 
 The ``lyrics`` plugin fetches and stores song lyrics from databases on the Web.
 Namely, the current version of the plugin uses Genius.com_, Tekstowo.pl_,
-LRCLIB_ and, optionally, the Google Custom Search API.
+LRCLIB_, TIDAL_ and, optionally, the Google Custom Search API.
 
 .. _genius.com: https://genius.com/
 
 .. _lrclib: https://lrclib.net/
 
 .. _tekstowo.pl: https://www.tekstowo.pl/
+
+.. _tidal: https://tidal.com/
 
 Install
 -------
@@ -61,6 +63,11 @@ Default configuration:
         print: no
         sources: [lrclib, google, genius]
         synced: no
+        tidal:
+            client_id: mcjmpl1bPATJXcBT
+            country_code: US
+            scope: search.read user.read
+            tokenfile: tidal_token.json
 
 The available options are:
 
@@ -110,9 +117,10 @@ The available options are:
 - **sources**: List of sources to search for lyrics. An asterisk ``*`` expands
   to all available sources. The ``google`` source will be automatically
   deactivated if no ``google_API_key`` is setup. By default, ``musixmatch`` and
-  ``tekstowo`` are excluded because they block the beets User-Agent.
+  ``tekstowo`` are excluded because they block the beets User-Agent. ``tidal``
+  is excluded by default because it requires authentication.
 - **synced**: Prefer synced lyrics over plain lyrics if a source offers them.
-  Currently ``lrclib`` is the only source that provides them. Using this option,
+  Currently ``lrclib`` and ``tidal`` can provide them. Using this option,
   existing synced lyrics are not replaced by newly fetched plain lyrics (even
   when ``force`` is enabled). To allow that replacement, disable ``synced``.
   When synced lyrics are written to an ID3-tagged file (MP3, AIFF, etc.) the
@@ -120,6 +128,46 @@ The available options are:
   and plain text (without timestamps) in the ``USLT`` (unsynchronized lyrics)
   frame, so players that support only one of the two formats can still show the
   correct lyrics.
+- **tidal**: TIDAL API settings for the ``tidal`` source.
+
+  - **client_id**: TIDAL API client ID. This must match the client ID used to
+    create the token file.
+  - **country_code**: ISO 3166-1 alpha-2 country code used for TIDAL catalog and
+    lyrics availability.
+  - **scope**: OAuth scopes to request when authenticating. The TIDAL lyrics
+    source needs an app and token with ``user.read`` access. This can be a
+    space-delimited string or a YAML list.
+  - **tokenfile**: The path to the TIDAL token file. Relative paths are stored
+    in the beets application directory.
+
+The ``tidal`` source is opt-in. To use it, install both extras, enable the
+``tidal`` plugin long enough to authenticate, and include ``tidal`` in
+``lyrics.sources``:
+
+.. code-block:: yaml
+
+    plugins: lyrics tidal
+
+    tidal:
+        client_id: YOUR_TIDAL_CLIENT_ID
+        scope: search.read user.read
+        tokenfile: tidal_token.json
+
+    lyrics:
+        sources: [tidal, lrclib, google, genius]
+        tidal:
+            client_id: YOUR_TIDAL_CLIENT_ID
+            tokenfile: tidal_token.json
+
+Then run:
+
+.. code-block:: bash
+
+    beet tidal --auth
+
+If you authenticated before adding ``user.read`` to the configured
+``tidal.scope``, rerun ``beet tidal --auth`` so the saved token has the scopes
+needed by the lyrics source.
 
 .. _beets custom search engine: https://cse.google.com/cse?cx=009217259823014548361:lndtuqkycfu
 

--- a/docs/plugins/tidal.rst
+++ b/docs/plugins/tidal.rst
@@ -93,7 +93,6 @@ Default
 
     tidal:
         client_id: mcjmpl1bPATJXcBT
-        scope: search.read
         tokenfile: tidal_token.json
         data_source_mismatch_penalty: 0.5
         search_limit: 5
@@ -104,14 +103,6 @@ Default
     The Tidal API client ID. The default value is the public demo client ID.
     You can register your own application at Tidal's developer portal for
     production use.
-
-.. conf:: scope
-    :default: search.read
-
-    The OAuth scopes requested during ``beet tidal --auth``. The default is
-    enough for metadata lookup. Add ``user.read`` when creating a token for the
-    :doc:`lyrics` plugin's TIDAL source. This can be a space-delimited string
-    or a YAML list.
 
 .. conf:: tokenfile
     :default: tidal_token.json

--- a/docs/plugins/tidal.rst
+++ b/docs/plugins/tidal.rst
@@ -52,6 +52,13 @@ This will open a browser window where you can log in to your Tidal account.
 After successful authentication, your token will be saved to the configured
 token file and you won't need to re-authenticate on subsequent runs.
 
+On headless installations, setting ``BROWSER=echo`` may print the redirect URL
+to the console so you can open it on another machine:
+
+.. code-block:: bash
+
+    BROWSER=echo beet tidal --auth
+
 Basic Usage
 -----------
 
@@ -86,6 +93,7 @@ Default
 
     tidal:
         client_id: mcjmpl1bPATJXcBT
+        scope: search.read
         tokenfile: tidal_token.json
         data_source_mismatch_penalty: 0.5
         search_limit: 5
@@ -96,6 +104,14 @@ Default
     The Tidal API client ID. The default value is the public demo client ID.
     You can register your own application at Tidal's developer portal for
     production use.
+
+.. conf:: scope
+    :default: search.read
+
+    The OAuth scopes requested during ``beet tidal --auth``. The default is
+    enough for metadata lookup. Add ``user.read`` when creating a token for the
+    :doc:`lyrics` plugin's TIDAL source. This can be a space-delimited string
+    or a YAML list.
 
 .. conf:: tokenfile
     :default: tidal_token.json

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -1072,12 +1072,18 @@ class TestTidalLyrics(LyricsBackendTest):
         tidal_api.search_results.assert_not_called()
         tidal_api.get_tracks.assert_not_called()
 
-    def test_rejects_token_missing_required_scopes(self, backend, tmp_path):
+    def test_rejects_token_missing_required_scopes(
+        self, backend, tmp_path, caplog
+    ):
         tokenfile = tmp_path / "tidal_token.json"
         tokenfile.write_text('{"scope": "search.read"}')
         backend.config["tidal"]["tokenfile"].set(str(tokenfile))
 
         assert not backend.token_has_required_scopes
+        assert "TIDAL token is missing required OAuth scope(s): user.read" in (
+            caplog.text
+        )
+        assert "Run `beet tidal --auth` again" in caplog.text
 
     def test_rejects_invalid_token_file(self, backend, tmp_path: Path, caplog):
         tokenfile = tmp_path / "tidal_token.json"
@@ -1097,13 +1103,12 @@ class TestTidalLyrics(LyricsBackendTest):
     def test_scope_set_ignores_unknown_config(self, backend):
         assert backend.scope_set(42) == set()
 
-    @pytest.mark.parametrize(
-        "plugin_config", [{"tidal": {"scope": ["search.read", "user.read"]}}]
-    )
-    def test_accepts_scope_list_config(self, backend):
+    def test_uses_default_requested_scope(self, backend):
+        from beetsplug.tidal.api import TIDAL_DEFAULT_SCOPE
+
         assert backend.required_scopes == {"search.read", "user.read"}
-        assert backend.scope == "search.read user.read"
-        assert backend.api.scope == "search.read user.read"
+        assert backend.scope == TIDAL_DEFAULT_SCOPE
+        assert backend.api.scope == TIDAL_DEFAULT_SCOPE
 
 
 @pytest.mark.requires_import("langdetect")

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -16,12 +16,14 @@
 
 from __future__ import annotations
 
+import logging
 import re
 import textwrap
 from functools import partial
 from http import HTTPStatus
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
+from unittest.mock import Mock
 
 import pytest
 import requests
@@ -693,6 +695,415 @@ class TestLRCLibLyrics(LyricsBackendTest):
         else:
             assert lyrics
             assert lyrics.text == expected_lyrics
+
+
+class TestTidalLyrics(LyricsBackendTest):
+    @pytest.fixture(scope="class")
+    def backend_name(self):
+        return "tidal"
+
+    @staticmethod
+    def search_doc(
+        *,
+        track_id="track-1",
+        artist="Target Artist",
+        title="Target Title",
+        include_artist=True,
+    ):
+        included = [
+            {
+                "id": track_id,
+                "type": "tracks",
+                "attributes": {"title": title},
+                "relationships": {
+                    "artists": {"data": [{"id": "artist-1", "type": "artists"}]}
+                },
+            }
+        ]
+        if include_artist:
+            included.append(
+                {
+                    "id": "artist-1",
+                    "type": "artists",
+                    "attributes": {"name": artist},
+                }
+            )
+
+        return {
+            "data": {
+                "id": "search",
+                "type": "searchResults",
+                "attributes": {"trackingId": "tracking-id"},
+                "relationships": {
+                    "tracks": {"data": [{"id": track_id, "type": "tracks"}]}
+                },
+            },
+            "included": included,
+        }
+
+    @staticmethod
+    def lyrics_doc(
+        *,
+        track_id="track-1",
+        lyric_id="lyric-1",
+        text="plain lyrics",
+        lrc_text="[00:00.00] synced lyrics",
+        status="OK",
+    ):
+        attributes = {"text": text, "lrcText": lrc_text}
+        if status is not None:
+            attributes["technicalStatus"] = status
+
+        return {
+            "data": [
+                {
+                    "id": track_id,
+                    "type": "tracks",
+                    "relationships": {
+                        "lyrics": {"data": [{"id": lyric_id, "type": "lyrics"}]}
+                    },
+                }
+            ],
+            "included": [
+                {"id": lyric_id, "type": "lyrics", "attributes": attributes}
+            ],
+        }
+
+    @pytest.fixture
+    def tidal_api(self):
+        return Mock(
+            search_results=Mock(return_value=self.search_doc()),
+            get_tracks=Mock(return_value=self.lyrics_doc()),
+        )
+
+    @pytest.fixture
+    def fetch_lyrics(self, backend, monkeypatch, tidal_api):
+        monkeypatch.setattr(backend, "api", tidal_api)
+        monkeypatch.setattr(backend, "token_has_required_scopes", True)
+        return partial(backend.fetch, "Target Artist", "Target Title", "", 0)
+
+    @pytest.mark.parametrize(
+        "plugin_config, expected_lyrics",
+        [
+            pytest.param({"synced": False}, "plain lyrics", id="plain"),
+            pytest.param(
+                {"synced": True}, "[00:00.00] synced lyrics", id="synced"
+            ),
+        ],
+    )
+    def test_synced_config_option(
+        self, fetch_lyrics, expected_lyrics, backend_name
+    ):
+        actual = fetch_lyrics()
+
+        assert actual
+        assert actual.text == expected_lyrics
+        assert actual.backend == backend_name
+        assert actual.url == "https://tidal.com/browse/track/track-1"
+
+    def test_uses_tidal_country_code(self, fetch_lyrics, tidal_api):
+        fetch_lyrics()
+
+        tidal_api.search_results.assert_called_once_with(
+            "Target Artist Target Title",
+            include=["tracks.artists"],
+            country_code="US",
+        )
+        tidal_api.get_tracks.assert_called_once_with(
+            ids=["track-1"], include=["lyrics"], country_code="US"
+        )
+
+    def test_fetches_matched_tracks_in_batch(self, fetch_lyrics, tidal_api):
+        search_data = self.search_doc()
+        search_data["data"]["relationships"]["tracks"]["data"].append(
+            {"id": "track-2", "type": "tracks"}
+        )
+        search_data["included"].append(
+            {
+                "id": "track-2",
+                "type": "tracks",
+                "attributes": {"title": "Target Title"},
+                "relationships": {
+                    "artists": {"data": [{"id": "artist-1", "type": "artists"}]}
+                },
+            }
+        )
+        tidal_api.search_results.return_value = search_data
+        tidal_api.get_tracks.return_value = {
+            "data": [
+                {
+                    "id": "track-1",
+                    "type": "tracks",
+                    "relationships": {"lyrics": {"data": []}},
+                },
+                {
+                    "id": "track-2",
+                    "type": "tracks",
+                    "relationships": {
+                        "lyrics": {
+                            "data": [{"id": "lyric-2", "type": "lyrics"}]
+                        }
+                    },
+                },
+            ],
+            "included": [
+                {
+                    "id": "lyric-2",
+                    "type": "lyrics",
+                    "attributes": {
+                        "technicalStatus": "OK",
+                        "text": "second track lyrics",
+                    },
+                }
+            ],
+        }
+
+        actual = fetch_lyrics()
+
+        assert actual
+        assert actual.text == "second track lyrics"
+        assert actual.url == "https://tidal.com/browse/track/track-2"
+        tidal_api.get_tracks.assert_called_once_with(
+            ids=["track-1", "track-2"], include=["lyrics"], country_code="US"
+        )
+
+    def test_ignores_unrelated_search_included_items(
+        self, fetch_lyrics, tidal_api
+    ):
+        search_data = self.search_doc()
+        search_data["included"].append({"id": "album-1", "type": "albums"})
+        tidal_api.search_results.return_value = search_data
+
+        actual = fetch_lyrics()
+
+        assert actual
+        assert actual.text == "plain lyrics"
+
+    def test_skips_search_without_tracks_relationship(
+        self, fetch_lyrics, tidal_api
+    ):
+        search_data = self.search_doc()
+        search_data["data"]["relationships"] = {}
+        tidal_api.search_results.return_value = search_data
+
+        assert fetch_lyrics() is None
+        tidal_api.get_tracks.assert_not_called()
+
+    def test_skips_search_result_missing_sideloaded_track(
+        self, fetch_lyrics, tidal_api
+    ):
+        search_data = self.search_doc()
+        search_data["included"] = [
+            item for item in search_data["included"] if item["type"] != "tracks"
+        ]
+        tidal_api.search_results.return_value = search_data
+
+        assert fetch_lyrics() is None
+        tidal_api.get_tracks.assert_not_called()
+
+    def test_skips_track_missing_from_batched_response(
+        self, fetch_lyrics, tidal_api
+    ):
+        tidal_api.get_tracks.return_value = {"data": [], "included": []}
+
+        assert fetch_lyrics() is None
+
+    def test_skips_lyrics_missing_from_batched_response(
+        self, fetch_lyrics, tidal_api
+    ):
+        tidal_api.get_tracks.return_value = {
+            "data": [
+                {
+                    "id": "track-1",
+                    "type": "tracks",
+                    "relationships": {
+                        "lyrics": {
+                            "data": [{"id": "lyric-1", "type": "lyrics"}]
+                        }
+                    },
+                }
+            ],
+            "included": [],
+        }
+
+        assert fetch_lyrics() is None
+
+    @pytest.mark.parametrize(
+        "search_data, lyrics_data",
+        [
+            pytest.param(
+                search_doc(title="Different Title"),
+                lyrics_doc(),
+                id="skip-nonmatching-track",
+            ),
+            pytest.param(
+                search_doc(),
+                {
+                    "data": [
+                        {
+                            "id": "track-1",
+                            "type": "tracks",
+                            "relationships": {"lyrics": {"data": []}},
+                        }
+                    ],
+                    "included": [],
+                },
+                id="skip-track-without-lyrics",
+            ),
+            pytest.param(
+                search_doc(),
+                lyrics_doc(status="PROCESSING"),
+                id="skip-unready-lyrics",
+            ),
+            pytest.param(
+                search_doc(),
+                lyrics_doc(status=None),
+                id="skip-lyric-without-status",
+            ),
+            pytest.param(
+                {"errors": [{"detail": "invalid token"}]},
+                lyrics_doc(),
+                id="skip-search-error-document",
+            ),
+            pytest.param(
+                search_doc(),
+                {"errors": [{"detail": "lyrics unavailable"}]},
+                id="skip-lyrics-error-document",
+            ),
+        ],
+    )
+    def test_fetch_lyrics_none(
+        self, fetch_lyrics, tidal_api, search_data, lyrics_data
+    ):
+        tidal_api.search_results.return_value = search_data
+        tidal_api.get_tracks.return_value = lyrics_data
+
+        assert fetch_lyrics() is None
+
+    def test_warns_for_null_track_data(self, fetch_lyrics, tidal_api, caplog):
+        tidal_api.get_tracks.return_value = {
+            "data": None,
+            "errors": [{"detail": "lyrics unavailable"}],
+        }
+
+        assert fetch_lyrics() is None
+        assert "TIDAL track response did not include track data" in caplog.text
+
+    def test_warns_for_missing_lyrics_data(
+        self, fetch_lyrics, tidal_api, caplog
+    ):
+        tidal_api.get_tracks.return_value = {
+            "data": [{"id": "track-1", "type": "tracks"}]
+        }
+
+        assert fetch_lyrics() is None
+        assert "TIDAL track response did not include lyric data" in caplog.text
+
+    def test_matches_by_title_when_artist_not_sideloaded(
+        self, fetch_lyrics, tidal_api
+    ):
+        tidal_api.search_results.return_value = self.search_doc(
+            include_artist=False
+        )
+
+        actual = fetch_lyrics()
+
+        assert actual
+        assert actual.text == "plain lyrics"
+
+    def test_logs_near_miss(self, backend, caplog):
+        track = self.search_doc(title="Target Tale")["included"][0]
+
+        with caplog.at_level(logging.DEBUG):
+            assert not backend.check_match(
+                "Target Artist", "Target Title", track, "Target Artist"
+            )
+
+        assert (
+            "Tidal: (Target Artist, Target Tale) does not match" in caplog.text
+        )
+        assert "but dist was close: 0.18" in caplog.text
+
+    def test_far_miss_does_not_log_debug(self, backend, caplog):
+        track = self.search_doc(artist="Other Artist", title="Unrelated Song")[
+            "included"
+        ][0]
+
+        with caplog.at_level(logging.DEBUG):
+            assert not backend.check_match(
+                "Target Artist", "Target Title", track, "Other Artist"
+            )
+
+        assert "does not match" not in caplog.text
+
+    def test_matches_versioned_track_title(self, backend):
+        track = self.search_doc()["included"][0]
+        track["attributes"]["version"] = "Remastered"
+
+        assert backend.track_title(track) == "Target Title (Remastered)"
+
+    def test_matches_by_title_when_artist_relationship_missing(
+        self, fetch_lyrics, tidal_api
+    ):
+        search_data = self.search_doc(include_artist=False)
+        del search_data["included"][0]["relationships"]
+        tidal_api.search_results.return_value = search_data
+
+        actual = fetch_lyrics()
+
+        assert actual
+        assert actual.text == "plain lyrics"
+
+    @pytest.mark.parametrize("plugin_config", [{"synced": False}])
+    def test_no_lrc_fallback_when_unsynced(self, fetch_lyrics, tidal_api):
+        tidal_api.get_tracks.return_value = self.lyrics_doc(
+            text=None, lrc_text="[00:00.00] synced lyrics"
+        )
+
+        assert fetch_lyrics() is None
+
+    def test_skips_api_without_required_token_scopes(
+        self, backend, monkeypatch, tidal_api
+    ):
+        monkeypatch.setattr(backend, "api", tidal_api)
+        monkeypatch.setattr(backend, "token_has_required_scopes", False)
+
+        assert backend.fetch("Target Artist", "Target Title", "", 0) is None
+        tidal_api.search_results.assert_not_called()
+        tidal_api.get_tracks.assert_not_called()
+
+    def test_rejects_token_missing_required_scopes(self, backend, tmp_path):
+        tokenfile = tmp_path / "tidal_token.json"
+        tokenfile.write_text('{"scope": "search.read"}')
+        backend.config["tidal"]["tokenfile"].set(str(tokenfile))
+
+        assert not backend.token_has_required_scopes
+
+    def test_rejects_invalid_token_file(self, backend, tmp_path: Path, caplog):
+        tokenfile = tmp_path / "tidal_token.json"
+        tokenfile.write_text("{")
+        backend.config["tidal"]["tokenfile"].set(str(tokenfile))
+
+        assert not backend.token_has_required_scopes
+        assert "Could not decode TIDAL token file" in caplog.text
+
+    def test_accepts_token_with_required_scopes(self, backend, tmp_path):
+        tokenfile = tmp_path / "tidal_token.json"
+        tokenfile.write_text('{"scope": "search.read user.read"}')
+        backend.config["tidal"]["tokenfile"].set(str(tokenfile))
+
+        assert backend.token_has_required_scopes
+
+    def test_scope_set_ignores_unknown_config(self, backend):
+        assert backend.scope_set(42) == set()
+
+    @pytest.mark.parametrize(
+        "plugin_config", [{"tidal": {"scope": ["search.read", "user.read"]}}]
+    )
+    def test_accepts_scope_list_config(self, backend):
+        assert backend.required_scopes == {"search.read", "user.read"}
+        assert backend.scope == "search.read user.read"
+        assert backend.api.scope == "search.read user.read"
 
 
 @pytest.mark.requires_import("langdetect")

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -119,6 +119,18 @@ class TidalPluginTest(PluginTestCase):
         self.tidal = TidalPlugin()
 
 
+class TestTidalPluginConfig(TidalPluginTest):
+    def test_scope_accepts_list_config(self):
+        self.tidal.config["scope"].set(["search.read", "user.read"])
+
+        assert self.tidal._scope() == "search.read user.read"
+
+    def test_scope_rejects_unknown_config_type(self):
+        self.tidal.config["scope"].set(42)
+
+        assert self.tidal._scope() == ""
+
+
 class TestAlbumParsing(TidalPluginTest):
     """High-level tests for album parsing."""
 

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -11,6 +11,7 @@ import pytest
 from beets.library.models import Item
 from beets.test.helper import PluginTestCase
 from beetsplug.tidal import TidalPlugin
+from beetsplug.tidal.api import TIDAL_DEFAULT_SCOPE
 
 if TYPE_CHECKING:
     from beetsplug.tidal.api_types import (
@@ -120,15 +121,8 @@ class TidalPluginTest(PluginTestCase):
 
 
 class TestTidalPluginConfig(TidalPluginTest):
-    def test_scope_accepts_list_config(self):
-        self.tidal.config["scope"].set(["search.read", "user.read"])
-
-        assert self.tidal._scope() == "search.read user.read"
-
-    def test_scope_rejects_unknown_config_type(self):
-        self.tidal.config["scope"].set(42)
-
-        assert self.tidal._scope() == ""
+    def test_uses_default_scope(self):
+        assert self.tidal.api.scope == TIDAL_DEFAULT_SCOPE
 
 
 class TestAlbumParsing(TidalPluginTest):


### PR DESCRIPTION
## Description

- Add TIDAL API support for fetching track lyric relationships, including typed lyric resources and configurable OAuth scopes.
- Add `tidal` as an opt-in lyrics source with plain/synced lyric selection, token scope validation, defensive JSON:API response handling, and match-debug parity with search backends.
- Document TIDAL lyrics configuration, `user.read` authentication requirements, and scope formats.

## Testing

- `poetry run ruff format --check --diff beetsplug/tidal/__init__.py beetsplug/tidal/api.py beetsplug/tidal/api_types.py beetsplug/tidal/session.py test/plugins/test_tidal.py`
- `poetry run ruff check beetsplug/tidal/__init__.py beetsplug/tidal/api.py beetsplug/tidal/api_types.py beetsplug/tidal/session.py test/plugins/test_tidal.py`
- `poetry run pytest test/plugins/test_tidal.py`
- `poetry run ruff format --check --diff beetsplug/lyrics.py test/plugins/test_lyrics.py`
- `poetry run ruff check beetsplug/lyrics.py test/plugins/test_lyrics.py`
- `poetry run pytest test/plugins/test_lyrics.py`
- `poetry run docstrfmt --preserve-adornments --check docs/plugins/lyrics.rst docs/plugins/tidal.rst docs/changelog.rst`
- `poetry run sphinx-lint --enable all --disable default-role docs/plugins/lyrics.rst docs/plugins/tidal.rst docs/changelog.rst`
- `env -u NO_COLOR poetry run pytest`

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
