### PR TITLE
utils: centralise path asciification

### DIFF
--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import os
 import string
-import sys
 import time
-import unicodedata
 from contextlib import suppress
 from functools import cached_property
 from pathlib import Path
@@ -529,9 +527,7 @@ class Album(LibModel):
         filename_tmpl = template(beets.config["art_filename"].as_str())
         subpath = self.evaluate_template(filename_tmpl, True)
         if beets.config["asciify_paths"]:
-            subpath = util.asciify_path(
-                subpath, beets.config["path_sep_replace"].as_str()
-            )
+            subpath = util.asciify_path(subpath)
         subpath = util.sanitize_path(
             subpath, replacements=self._db.replacements
         )
@@ -1220,16 +1216,8 @@ class Item(LibModel):
         # Evaluate the selected template.
         subpath = self.evaluate_template(subpath_tmpl, True)
 
-        # Prepare path for output: normalize Unicode characters.
-        if sys.platform == "darwin":
-            subpath = unicodedata.normalize("NFD", subpath)
-        else:
-            subpath = unicodedata.normalize("NFC", subpath)
-
         if beets.config["asciify_paths"]:
-            subpath = util.asciify_path(
-                subpath, beets.config["path_sep_replace"].as_str()
-            )
+            subpath = util.asciify_path(subpath)
 
         lib_path_str, fallback = util.legalize_path(
             subpath, self.db.replacements, self.filepath.suffix
@@ -1347,7 +1335,7 @@ class DefaultTemplateFunctions:
     @staticmethod
     def tmpl_asciify(s):
         """Translate non-ASCII characters to their ASCII equivalents."""
-        return util.asciify_path(s, beets.config["path_sep_replace"].as_str())
+        return util.asciify_path(s)
 
     @staticmethod
     def tmpl_time(s, fmt):

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import tempfile
 import traceback
+import unicodedata
 from collections import Counter
 from collections.abc import Sequence
 from contextlib import suppress
@@ -29,6 +30,7 @@ from typing import (
     AnyStr,
     ClassVar,
     Generic,
+    Literal,
     NamedTuple,
     TypeVar,
     cast,
@@ -1001,27 +1003,29 @@ def case_sensitive(path: bytes) -> bool:
         return not os.path.samefile(lower_sys, upper_sys)
 
 
-def asciify_path(path: str, sep_replace: str) -> str:
+def asciify_path(path: str) -> str:
     """Decodes all unicode characters in a path into ASCII equivalents.
 
     Substitutions are provided by the unidecode module. Path separators in the
     input are preserved.
-
-    Keyword arguments:
-    path -- The path to be asciified.
-    sep_replace -- the string to be used to replace extraneous path separators.
     """
+    # Prepare path for output: normalize Unicode characters.
+    form: Literal["NFD", "NFC"] = "NFD" if sys.platform == "darwin" else "NFC"
+    path = unicodedata.normalize(form, path)
+    replacements = [os.sep]
     # if this platform has an os.altsep, change it to os.sep.
     if os.altsep:
         path = path.replace(os.altsep, os.sep)
-    path_components: list[str] = path.split(os.sep)
-    for index, item in enumerate(path_components):
-        path_components[index] = unidecode(item).replace(os.sep, sep_replace)
-        if os.altsep:
-            path_components[index] = unidecode(item).replace(
-                os.altsep, sep_replace
-            )
-    return os.sep.join(path_components)
+        replacements.append(os.altsep)
+
+    sep_replace = beets.config["path_sep_replace"].as_str()
+
+    def replace(path: str) -> str:
+        for repl in replacements:
+            path = path.replace(repl, sep_replace)
+        return path
+
+    return os.sep.join(replace(unidecode(p)) for p in path.split(os.sep))
 
 
 def par_map(transform: Callable[[T], Any], items: Sequence[T]) -> None:

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -455,6 +455,13 @@ class TestDestination(PytestItemHelper):
             dest = item_in_db.destination(relative_to_libdir=True)
         assert as_string(dest) == "foo.caf\xe9"
 
+    def test_asciify_character_expanding_to_slash(self, item_in_db):
+        config["asciify_paths"] = True
+        self.lib.directory = b"lib"
+        self.lib.path_formats = [("default", "$title")]
+        item_in_db.title = "ab\xa2\xbdd"
+        assert item_in_db.destination() == np("lib/abC_ 1_2d")
+
     def test_destination_with_replacements(self, item_in_db):
         self.lib.directory = b"base"
         self.lib.replacements = [(re.compile(r"a"), "e")]

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -7,7 +7,6 @@ import os.path
 import re
 import shutil
 import stat
-import unicodedata
 import unittest
 from unittest.mock import patch
 
@@ -449,41 +448,12 @@ class TestDestination(PytestItemHelper):
         p = item_in_db.destination()
         assert p.rsplit(util.PATH_SEP, 1)[1] == b"something"
 
-    def test_unicode_normalized_nfd_on_mac(self, item_in_db):
-        instr = unicodedata.normalize("NFC", "caf\xe9")
-        self.lib.path_formats = [("default", instr)]
-        with patch("sys.platform", "darwin"):
-            dest = item_in_db.destination(relative_to_libdir=True)
-        assert as_string(dest) == unicodedata.normalize("NFD", instr)
-
-    def test_unicode_normalized_nfc_on_linux(self, item_in_db):
-        instr = unicodedata.normalize("NFD", "caf\xe9")
-        self.lib.path_formats = [("default", instr)]
-        with patch("sys.platform", "linux"):
-            dest = item_in_db.destination(relative_to_libdir=True)
-        assert as_string(dest) == unicodedata.normalize("NFC", instr)
-
     def test_unicode_extension_in_fragment(self, item_in_db):
         self.lib.path_formats = [("default", "foo")]
         item_in_db.path = util.bytestring_path("bar.caf\xe9")
         with patch("sys.platform", "linux"):
             dest = item_in_db.destination(relative_to_libdir=True)
         assert as_string(dest) == "foo.caf\xe9"
-
-    def test_asciify_and_replace(self, item_in_db):
-        config["asciify_paths"] = True
-        self.lib.replacements = [(re.compile('"'), "q")]
-        self.lib.directory = b"lib"
-        self.lib.path_formats = [("default", "$title")]
-        item_in_db.title = "\u201c\u00f6\u2014\u00cf\u201d"
-        assert item_in_db.destination() == np("lib/qo--Iq")
-
-    def test_asciify_character_expanding_to_slash(self, item_in_db):
-        config["asciify_paths"] = True
-        self.lib.directory = b"lib"
-        self.lib.path_formats = [("default", "$title")]
-        item_in_db.title = "ab\xa2\xbdd"
-        assert item_in_db.destination() == np("lib/abC_ 1_2d")
 
     def test_destination_with_replacements(self, item_in_db):
         self.lib.directory = b"base"

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -437,3 +437,23 @@ class MkDirAllTest(BeetsTestCase):
         assert not child.exists()
         assert child.parent.exists()
         assert child.parent.is_dir()
+
+
+class TestAsciifyPath:
+    @pytest.fixture(autouse=True)
+    def _setup_config(self, config):
+        config["asciify_paths"] = True
+
+    def test_unicode_normalized_nfd_on_mac(self, monkeypatch):
+        monkeypatch.setattr("sys.platform", "darwin")
+        assert util.asciify_path("caf\xe9") == "cafe"
+
+    def test_unicode_normalized_nfc_on_linux(self, monkeypatch):
+        monkeypatch.setattr("sys.platform", "linux")
+        assert util.asciify_path("caf\xe9") == "cafe"
+
+    def test_asciify_and_replace(self):
+        assert util.asciify_path("\u201c\u00f6\u2014\u00cf\u201d") == '"o--I"'
+
+    def test_asciify_character_expanding_to_slash(self):
+        assert util.asciify_path("ab\xa2\xbdd") == "abC_ 1_2d"

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -18,6 +18,8 @@ from beets.test._common import touch
 from beets.test.helper import NEEDS_REFLINK, BeetsTestCase
 from beets.util import syspath
 
+_p = pytest.param
+
 
 class UtilTest(unittest.TestCase):
     def test_open_anything(self):
@@ -442,18 +444,54 @@ class MkDirAllTest(BeetsTestCase):
 class TestAsciifyPath:
     @pytest.fixture(autouse=True)
     def _setup_config(self, config):
-        config["asciify_paths"] = True
+        config["path_sep_replace"] = "_"
 
-    def test_unicode_normalized_nfd_on_mac(self, monkeypatch):
-        monkeypatch.setattr("sys.platform", "darwin")
+    @pytest.mark.parametrize(
+        "platform, normalization",
+        [
+            _p("darwin", "NFD", id="macos"),
+            _p("linux", "NFC", id="other-platform"),
+        ],
+    )
+    def test_normalizes_unicode_for_platform(
+        self, monkeypatch, platform, normalization
+    ):
+        normalize = Mock(wraps=util.unicodedata.normalize)
+        monkeypatch.setattr("sys.platform", platform)
+        monkeypatch.setattr("beets.util.unicodedata.normalize", normalize)
+
         assert util.asciify_path("caf\xe9") == "cafe"
+        normalize.assert_called_once_with(normalization, "caf\xe9")
 
-    def test_unicode_normalized_nfc_on_linux(self, monkeypatch):
-        monkeypatch.setattr("sys.platform", "linux")
-        assert util.asciify_path("caf\xe9") == "cafe"
+    @pytest.mark.parametrize(
+        "path, expected",
+        [
+            _p("plain", "plain", id="ascii"),
+            _p("\u201c\u00f6\u2014\u00cf\u201d", '"o--I"', id="unicode"),
+            _p(
+                f"caf\xe9{os.sep}na\xefve",
+                f"cafe{os.sep}naive",
+                id="path-components",
+            ),
+        ],
+    )
+    def test_transliterates_path(self, path, expected):
+        assert util.asciify_path(path) == expected
 
-    def test_asciify_and_replace(self):
-        assert util.asciify_path("\u201c\u00f6\u2014\u00cf\u201d") == '"o--I"'
+    @pytest.mark.parametrize(
+        "replacement, expected",
+        [
+            _p("_", "abC_ 1_2d", id="default"),
+            _p("-", "abC- 1-2d", id="configured"),
+        ],
+    )
+    def test_replaces_generated_separators(self, config, replacement, expected):
+        config["path_sep_replace"] = replacement
 
-    def test_asciify_character_expanding_to_slash(self):
-        assert util.asciify_path("ab\xa2\xbdd") == "abC_ 1_2d"
+        assert util.asciify_path("ab\xa2\xbdd") == expected
+
+    def test_normalizes_alternate_path_separator(self, monkeypatch):
+        monkeypatch.setattr("beets.util.os.sep", "/")
+        monkeypatch.setattr("beets.util.os.altsep", "\\")
+
+        assert util.asciify_path("caf\xe9\\na\xefve") == "cafe/naive"


### PR DESCRIPTION
- This change moves path Unicode normalization and separator cleanup into `beets.util.asciify_path()`, so path shaping now lives in one place instead of being split between `beets.library.models` and `util`.

- Callers in `Item.destination()`, `art_destination()`, and `tmpl_asciify()` now use the same `util.asciify_path()` flow. This makes path generation more consistent and removes duplicate platform-specific normalization logic from the library layer.

- High-level impact: when `asciify_paths` is enabled, all asciified paths now get the same normalization, transliteration, and separator-replacement behavior through one shared utility. This should make path handling easier to reason about and safer to change later.

- Test coverage follows the architecture change: focused asciify behavior tests move from `test/test_library.py` to `test/test_util.py`, so `asciify_path()` is tested directly where the behavior now lives.
