### PR TITLE
refactor: removed `capture_log`

### DIFF
--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -154,8 +154,11 @@ class TestHelper(RunMixin, ConfigMixin):
     fixtures.
     """
 
+    request: pytest.FixtureRequest
+
     @pytest.fixture(autouse=True)
-    def setup(self):
+    def setup(self, request: pytest.FixtureRequest):
+        self.request = request
         self.setup_beets()
         try:
             yield
@@ -714,24 +717,12 @@ class TerminalImportSessionFixture(TerminalImportSession):
 class TerminalImportMixin(IOMixin, ImportHelper):
     """Provides_a terminal importer for the import session."""
 
-    @pytest.fixture(autouse=True)
-    def setup(self, io):
-        # `io` has deps (monkeypatch, capteesys) so pytest schedules it
-        # after the dependency-free `setup` from `TestHelper`.
-        # Override with an explicit `io` dependency to fix ordering.
-        self.io = io
-        self.setup_beets()
-        try:
-            yield
-        finally:
-            self.teardown_beets()
-
     def _get_import_session(self, import_dir: bytes) -> importer.ImportSession:
         return TerminalImportSessionFixture(
             self.lib,
             loghandler=None,
             query=None,
-            io=self.io,
+            io=self.request.getfixturevalue("io"),
             paths=[import_dir],
         )
 

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -46,7 +46,7 @@ from mediafile import Image, MediaFile
 
 import beets
 import beets.plugins
-from beets import importer, logging, util
+from beets import importer, util
 from beets.autotag import AlbumInfo, TrackInfo
 from beets.importer import ImportSession
 from beets.library import Item, Library
@@ -713,6 +713,18 @@ class TerminalImportSessionFixture(TerminalImportSession):
 
 class TerminalImportMixin(IOMixin, ImportHelper):
     """Provides_a terminal importer for the import session."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, io):
+        # `io` has deps (monkeypatch, capteesys) so pytest schedules it
+        # after the dependency-free `setup` from `TestHelper`.
+        # Override with an explicit `io` dependency to fix ordering.
+        self.io = io
+        self.setup_beets()
+        try:
+            yield
+        finally:
+            self.teardown_beets()
 
     def _get_import_session(self, import_dir: bytes) -> importer.ImportSession:
         return TerminalImportSessionFixture(

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -74,17 +74,6 @@ class LogCapture(logging.Handler):
         self.messages.append(str(record.msg))
 
 
-@contextmanager
-def capture_log(logger="beets"):
-    capture = LogCapture()
-    log = logging.getLogger(logger)
-    log.addHandler(capture)
-    try:
-        yield capture.messages
-    finally:
-        log.removeHandler(capture)
-
-
 def has_program(cmd, args=["--version"]):
     """Returns `True` if `cmd` can be executed."""
     full_cmd = [cmd, *args]

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -826,13 +826,20 @@ class AutotagStub:
         )
 
 
-class AutotagImportTestCase(ImportHelper, BeetsTestCase):
+class AutotagImportHelper(ImportHelper):
     matching = AutotagStub.IDENT
 
-    def setUp(self):
-        super().setUp()
+    def setup_beets(self):
+        super().setup_beets()
         self.matcher = AutotagStub(self.matching).install()
-        self.addCleanup(self.matcher.restore)
+
+    def teardown_beets(self):
+        self.matcher.restore()
+        super().teardown_beets()
+
+
+class AutotagImportTestCase(AutotagImportHelper, BeetsTestCase):
+    """DEPRECATED: Use AutotagImportHelper instead."""
 
 
 @dataclass(slots=True)

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -65,15 +65,6 @@ if TYPE_CHECKING:
 RUNNING_IN_CI = os.environ.get("GITHUB_ACTIONS") == "true"
 
 
-class LogCapture(logging.Handler):
-    def __init__(self):
-        logging.Handler.__init__(self)
-        self.messages = []
-
-    def emit(self, record):
-        self.messages.append(str(record.msg))
-
-
 def has_program(cmd, args=["--version"]):
     """Returns `True` if `cmd` can be executed."""
     full_cmd = [cmd, *args]

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -43,6 +43,7 @@ from beets.test.helper import (
     NEEDS_FFPROBE,
     NEEDS_REFLINK,
     AsIsImporterMixin,
+    AutotagImportHelper,
     AutotagImportTestCase,
     AutotagStub,
     BeetsTestCase,
@@ -444,11 +445,11 @@ class TestImportFormat(ImportHelper):
         assert Path(os.path.join(self.temp_dir_path, "no_ext")).exists()
 
 
-class ImportTest(PathsMixin, AutotagImportTestCase):
+class TestImport(PathsMixin, AutotagImportHelper):
     """Test APPLY, ASIS and SKIP choices."""
 
-    def setUp(self):
-        super().setUp()
+    def setup_beets(self):
+        super().setup_beets()
         self.prepare_album_for_import(1)
         self.setup_importer()
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -402,7 +402,7 @@ class TestImportFormat(ImportHelper):
         self.importer.run()
         assert self.lib.items().get().path.endswith(b".mp3")
 
-    def test_recognize_format_already_exist(self):
+    def test_recognize_format_already_exist(self, caplog):
         resource_path = os.path.join(_common.RSRC, b"no_ext")
         temp_resource_path = os.path.join(self.temp_dir, b"no_ext")
         util.copy(resource_path, temp_resource_path)
@@ -410,9 +410,12 @@ class TestImportFormat(ImportHelper):
         util.copy(temp_resource_path, new_path)
         self.setup_importer(autotag=False)
         self.importer.paths = [temp_resource_path]
-        with capture_log() as logs:
+        with caplog.at_level("DEBUG"):
             self.importer.run()
-        assert "Import file with matching format to original target" in logs
+        assert (
+            "Import file with matching format to original target"
+            in caplog.messages
+        )
         assert self.lib.items().get().path.endswith(b".mp3")
 
     def test_recognize_format_not_music(self):
@@ -536,26 +539,26 @@ class ImportTest(PathsMixin, AutotagImportTestCase):
         assert len(self.lib.items()) == 1
 
     @NEEDS_FFPROBE
-    def test_empty_directory_warning(self):
+    def test_empty_directory_warning(self, caplog):
         import_dir = os.path.join(self.temp_dir, b"empty")
         self.touch(b"non-audio", dir_=import_dir)
         self.setup_importer(import_dir=import_dir)
-        with capture_log() as logs:
+        with caplog.at_level("DEBUG"):
             self.importer.run()
 
         import_dir = displayable_path(import_dir)
-        assert f"No files imported from {import_dir}" in logs
+        assert f"No files imported from {import_dir}" in caplog.messages
 
     @NEEDS_FFPROBE
-    def test_empty_directory_singleton_warning(self):
+    def test_empty_directory_singleton_warning(self, caplog):
         import_dir = os.path.join(self.temp_dir, b"empty")
         self.touch(b"non-audio", dir_=import_dir)
         self.setup_singleton_importer(import_dir=import_dir)
-        with capture_log() as logs:
+        with caplog.at_level("DEBUG"):
             self.importer.run()
 
         import_dir = displayable_path(import_dir)
-        assert f"No files imported from {import_dir}" in logs
+        assert f"No files imported from {import_dir}" in caplog.messages
 
     def test_asis_no_data_source(self):
         assert self.lib.items().get() is None

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -47,10 +47,8 @@ from beets.test.helper import (
     AutotagStub,
     BeetsTestCase,
     ImportHelper,
-    IOMixin,
     PluginMixin,
     TestHelper,
-    capture_log,
     has_program,
 )
 from beets.util import bytestring_path, displayable_path, syspath

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1725,45 +1725,51 @@ class ReimportTest(AutotagImportTestCase):
         assert self._album().data_source == "match_source"
 
 
-class ImportPretendTest(IOMixin, AutotagImportTestCase):
-    """Test the pretend commandline option"""
+class TestImportPretend(ImportHelper):
+    """Test the pretend commandline option."""
 
-    def setUp(self):
-        super().setUp()
+    def setup_beets(self):
+        super().setup_beets()
         self.album_track_path = self.prepare_album_for_import(1)[0]
         self.single_path = self.prepare_track_for_import(2, self.import_path)
         self.album_path = self.album_track_path.parent
 
-    def __run(self, importer):
-        with capture_log() as logs:
+    def _run(self, importer, caplog):
+        with caplog.at_level("DEBUG"):
             importer.run()
-
         assert len(self.lib.items()) == 0
         assert len(self.lib.albums()) == 0
+        return [
+            r.message
+            for r in caplog.records
+            if not r.message.startswith("Sending event:")
+        ]
 
-        return [line for line in logs if not line.startswith("Sending event:")]
-
-    def test_import_singletons_pretend(self):
-        assert self.__run(self.setup_singleton_importer(pretend=True)) == [
+    def test_import_singletons_pretend(self, caplog):
+        assert self._run(
+            self.setup_singleton_importer(pretend=True), caplog
+        ) == [
             f"Singleton: {self.single_path}",
             f"Singleton: {self.album_track_path}",
         ]
 
-    def test_import_album_pretend(self):
-        assert self.__run(self.setup_importer(pretend=True)) == [
+    def test_import_album_pretend(self, caplog):
+        assert self._run(self.setup_importer(pretend=True), caplog) == [
             f"Album: {self.import_path}",
             f"  {self.single_path}",
             f"Album: {self.album_path}",
             f"  {self.album_track_path}",
         ]
 
-    def test_import_pretend_empty(self):
+    def test_import_pretend_empty(self, caplog):
         empty_path = self.temp_dir_path / "empty"
         empty_path.mkdir()
 
         importer = self.setup_importer(pretend=True, import_dir=empty_path)
 
-        assert self.__run(importer) == [f"No files imported from {empty_path}"]
+        assert self._run(importer, caplog) == [
+            f"No files imported from {empty_path}"
+        ]
 
 
 def mocked_get_albums_by_ids(ids):

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -9,7 +9,6 @@ import pytest
 
 import beets.logging as blog
 from beets import plugins, ui
-from beets.test import helper
 from beets.test.helper import AsIsImporterMixin, ImportHelper, PluginMixin
 
 

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -155,77 +155,77 @@ class TestLoggingLevel(AsIsImporterMixin, PluginMixin, ImportHelper):
     def _patch_dummy_module(self, monkeypatch):
         monkeypatch.setitem(sys.modules, "beetsplug.dummy", DummyModule())
 
-    def test_command_level0(self):
+    def test_command_level0(self, caplog):
         self.config["verbose"] = 0
-        with helper.capture_log() as logs:
+        with caplog.at_level("DEBUG"):
             self.run_command("dummy")
-        assert "dummy: warning cmd" in logs
-        assert "dummy: info cmd" in logs
-        assert "dummy: debug cmd" not in logs
+        assert "dummy: warning cmd" in caplog.messages
+        assert "dummy: info cmd" in caplog.messages
+        assert "dummy: debug cmd" not in caplog.messages
 
-    def test_command_level1(self):
+    def test_command_level1(self, caplog):
         self.config["verbose"] = 1
-        with helper.capture_log() as logs:
+        with caplog.at_level("DEBUG"):
             self.run_command("dummy")
-        assert "dummy: warning cmd" in logs
-        assert "dummy: info cmd" in logs
-        assert "dummy: debug cmd" in logs
+        assert "dummy: warning cmd" in caplog.messages
+        assert "dummy: info cmd" in caplog.messages
+        assert "dummy: debug cmd" in caplog.messages
 
-    def test_command_level2(self):
+    def test_command_level2(self, caplog):
         self.config["verbose"] = 2
-        with helper.capture_log() as logs:
+        with caplog.at_level("DEBUG"):
             self.run_command("dummy")
-        assert "dummy: warning cmd" in logs
-        assert "dummy: info cmd" in logs
-        assert "dummy: debug cmd" in logs
+        assert "dummy: warning cmd" in caplog.messages
+        assert "dummy: info cmd" in caplog.messages
+        assert "dummy: debug cmd" in caplog.messages
 
-    def test_listener_level0(self):
+    def test_listener_level0(self, caplog):
         self.config["verbose"] = 0
-        with helper.capture_log() as logs:
+        with caplog.at_level("DEBUG"):
             plugins.send("dummy_event")
-        assert "dummy: warning listener" in logs
-        assert "dummy: info listener" not in logs
-        assert "dummy: debug listener" not in logs
+        assert "dummy: warning listener" in caplog.messages
+        assert "dummy: info listener" not in caplog.messages
+        assert "dummy: debug listener" not in caplog.messages
 
-    def test_listener_level1(self):
+    def test_listener_level1(self, caplog):
         self.config["verbose"] = 1
-        with helper.capture_log() as logs:
+        with caplog.at_level("DEBUG"):
             plugins.send("dummy_event")
-        assert "dummy: warning listener" in logs
-        assert "dummy: info listener" in logs
-        assert "dummy: debug listener" not in logs
+        assert "dummy: warning listener" in caplog.messages
+        assert "dummy: info listener" in caplog.messages
+        assert "dummy: debug listener" not in caplog.messages
 
-    def test_listener_level2(self):
+    def test_listener_level2(self, caplog):
         self.config["verbose"] = 2
-        with helper.capture_log() as logs:
+        with caplog.at_level("DEBUG"):
             plugins.send("dummy_event")
-        assert "dummy: warning listener" in logs
-        assert "dummy: info listener" in logs
-        assert "dummy: debug listener" in logs
+        assert "dummy: warning listener" in caplog.messages
+        assert "dummy: info listener" in caplog.messages
+        assert "dummy: debug listener" in caplog.messages
 
-    def test_import_stage_level0(self):
+    def test_import_stage_level0(self, caplog):
         self.config["verbose"] = 0
-        with helper.capture_log() as logs:
+        with caplog.at_level("DEBUG"):
             self.run_asis_importer()
-        assert "dummy: warning import_stage" in logs
-        assert "dummy: info import_stage" not in logs
-        assert "dummy: debug import_stage" not in logs
+        assert "dummy: warning import_stage" in caplog.messages
+        assert "dummy: info import_stage" not in caplog.messages
+        assert "dummy: debug import_stage" not in caplog.messages
 
-    def test_import_stage_level1(self):
+    def test_import_stage_level1(self, caplog):
         self.config["verbose"] = 1
-        with helper.capture_log() as logs:
+        with caplog.at_level("DEBUG"):
             self.run_asis_importer()
-        assert "dummy: warning import_stage" in logs
-        assert "dummy: info import_stage" in logs
-        assert "dummy: debug import_stage" not in logs
+        assert "dummy: warning import_stage" in caplog.messages
+        assert "dummy: info import_stage" in caplog.messages
+        assert "dummy: debug import_stage" not in caplog.messages
 
-    def test_import_stage_level2(self):
+    def test_import_stage_level2(self, caplog):
         self.config["verbose"] = 2
-        with helper.capture_log() as logs:
+        with caplog.at_level("DEBUG"):
             self.run_asis_importer()
-        assert "dummy: warning import_stage" in logs
-        assert "dummy: info import_stage" in logs
-        assert "dummy: debug import_stage" in logs
+        assert "dummy: warning import_stage" in caplog.messages
+        assert "dummy: info import_stage" in caplog.messages
+        assert "dummy: debug import_stage" in caplog.messages
 
 
 class TestConcurrentEvents(AsIsImporterMixin, ImportHelper):
@@ -325,23 +325,23 @@ class TestConcurrentEvents(AsIsImporterMixin, ImportHelper):
             print("Alive threads:", threading.enumerate())
             raise
 
-    def test_root_logger_levels(self):
+    def test_root_logger_levels(self, caplog):
         """Root logger level should be shared between threads."""
         self.config["threaded"] = True
 
         blog.getLogger("beets").set_global_level(blog.WARNING)
-        with helper.capture_log() as logs:
+        with caplog.at_level("DEBUG"):
             self.run_asis_importer()
-        assert logs == []
+        assert caplog.messages == []
 
         blog.getLogger("beets").set_global_level(blog.INFO)
-        with helper.capture_log() as logs:
+        with caplog.at_level("DEBUG"):
             self.run_asis_importer()
-        for line in logs:
+        for line in caplog.messages:
             assert "import" in line
             assert "album" in line
 
         blog.getLogger("beets").set_global_level(blog.DEBUG)
-        with helper.capture_log() as logs:
+        with caplog.at_level("DEBUG"):
             self.run_asis_importer()
-        assert "Sending event: database_change" in logs
+        assert "Sending event: database_change" in caplog.messages

--- a/test/ui/test_ui_importer.py
+++ b/test/ui/test_ui_importer.py
@@ -28,7 +28,7 @@ class TestNonAutotaggedImport(
     pass
 
 
-class ImportTest(TerminalImportMixin, test_importer.ImportTest):
+class TestImport(TerminalImportMixin, test_importer.TestImport):
     pass
 
 


### PR DESCRIPTION
This pull request remove the last remnants of the `capture_log` context-manager used previously in the testing module.

This touches:
- `test_logging`
- `test_importer`

TODOs:
- [x] ~~Changelog~~ Not needed as this is an internal refactor only, will add an entry once all logging related changes are done.

---
This is related to the multi-step efforts to improve logging in beets https://github.com/beetbox/beets/issues/6553
