### PR TITLE
Migration backup

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -3,6 +3,7 @@
 library: library.db
 directory: ~/Music
 statefile: state.pickle
+create_backup_before_migrations: yes
 
 # --------------- Plugins ---------------
 

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -1045,8 +1045,22 @@ class Migration(ABC):
         """Run this migration once for a model's backing table."""
         table = model_cls._table
         if not self.db.migration_exists(self.name, table):
+            self._before_migration_backup(table)
             self._migrate_data(model_cls, *args, **kwargs)
             self.db.record_migration(self.name, table)
+
+    def _before_migration_backup(self, table: str) -> None:
+        if not beets.config["create_backup_before_migrations"].get(bool):
+            return
+
+        # In-memory databases have no persistent file to back up.
+        if self.db.path in (":memory:", b":memory:"):
+            return
+
+        dest = os.fsdecode(self.db.path) + f"-before-{table}-{self.name}.bak"
+        self.db.create_backup(dest)
+
+        print(f"Created database backup at: {dest!r}.")
 
     @abstractmethod
     def _migrate_data(
@@ -1353,6 +1367,15 @@ class Database:
                 migration.migrate_model(
                     model_cls, self.db_tables[model_cls._table]["columns"]
                 )
+
+    def create_backup(self, dest: str) -> None:
+        """Create a backup of the database at `dest`."""
+        # Use the SQLite backup API so the copy is consistent even when the
+        # database is open and may have a journal/WAL.
+        dest_conn = sqlite3.connect(dest)
+        with self.transaction():
+            self._connection().backup(dest_conn)
+        dest_conn.close()
 
     def migration_exists(self, name: str, table: str) -> bool:
         """Return whether a named migration has been marked complete."""

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,9 @@ New features
 - :doc:`plugins/lyrics`: Added a ``rest_directory`` configuration option for
   specifying a reStructuredText output directory, semantically equivalent to
   ``-r, --write-rest``. :bug:`2806`
+- A database backup is now automatically created before running schema
+  migrations. Control with the ``create_backup_before_migrations`` option
+  (default: yes).
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -60,6 +60,14 @@ directory
 The directory to which files will be copied/moved when adding them to the
 library. Defaults to a folder called ``Music`` in your home directory.
 
+create_backup_before_migrations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Either ``yes`` or ``no``, indicating whether a backup of the database file
+should be created before applying any pending schema migrations after a beets
+upgrade. The backup is only made when there are actually migrations to run.
+Defaults to ``yes``.
+
 .. _plugins-config:
 
 plugins

--- a/test/library/test_migrations.py
+++ b/test/library/test_migrations.py
@@ -315,3 +315,34 @@ class TestRelativePathMigration(MigrationTestHelper):
         str_item = self.lib.get_item(2)
         assert str_item
         assert str_item.path == abs_bytes_path
+
+
+class TestMigrationBackup(MigrationTestHelper):
+    """Tests for the backup-before-migration feature."""
+
+    migration = (migrations.LyricsMetadataInFlexFieldsMigration, (Item,))
+    db_on_disk = True
+
+    @classmethod
+    def setup_previous_state(cls, monkeypatch):
+        monkeypatch.setattr(
+            "beets.library.models.Item._fields",
+            {**Item._fields, "lyrics": types.STRING},
+        )
+
+    @pytest.mark.parametrize(
+        "config_value, expected_count", [(True, 1), (False, 0)]
+    )
+    def test_backup_config(self, config_value, expected_count):
+        self.config["create_backup_before_migrations"] = config_value
+        self.add_item(lyrics="some lyrics")
+        db_path = self.lib.path
+
+        self.lib._migrate()
+
+        backups = [
+            f
+            for f in os.listdir(os.path.dirname(db_path))
+            if os.fsdecode(f).endswith(".bak")
+        ]
+        assert len(backups) == expected_count


### PR DESCRIPTION
## Description

Creates a timestamped `.bak` copy of the database before any pending schema migration runs, so users can recover if a migration goes wrong. Controlled by the new `create_backup_before_migrations` config option (default: `yes`).

**Changes**:
- `Migration.migrate_model`: before running migration data, copies the database file to `<library.db>.<timestamp>.bak` (once per startup, guarded by a `ClassVar` flag)
- `Database.create_copy(dest)`: copies the SQLite file to the given path

TODOs:
- [x] Documentation.
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
