### PR TITLE
tidal: add cover art support via coverArt relationship

### DIFF
--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
         ResourceIdentifier,
         TidalAlbum,
         TidalArtist,
-        TidalCoverArt,
+        TidalArtwork,
         TidalTrack,
         TrackAttributes,
     )
@@ -313,7 +313,7 @@ class TidalPlugin(MetadataSourcePlugin):
             for item in albums_doc.get("included", [])
             if item["type"] == "artists"
         }
-        cover_art_by_id: dict[str, TidalCoverArt] = {
+        artwork_by_id: dict[str, TidalArtwork] = {
             item["id"]: item
             for item in albums_doc.get("included", [])
             if item["type"] == "artworks"
@@ -325,7 +325,7 @@ class TidalPlugin(MetadataSourcePlugin):
                     album,
                     track_by_id=track_by_id,
                     artist_by_id=artist_by_id,
-                    cover_art_by_id=cover_art_by_id,
+                    artwork_by_id=artwork_by_id,
                 )
             else:
                 yield None
@@ -341,7 +341,7 @@ class TidalPlugin(MetadataSourcePlugin):
                         album,
                         track_by_id=track_by_id,
                         artist_by_id=artist_by_id,
-                        cover_art_by_id=cover_art_by_id,
+                        artwork_by_id=artwork_by_id,
                     )
                 else:
                     yield None
@@ -351,7 +351,7 @@ class TidalPlugin(MetadataSourcePlugin):
         album: TidalAlbum,
         track_by_id: dict[str, TidalTrack],
         artist_by_id: dict[str, TidalArtist],
-        cover_art_by_id: dict[str, TidalCoverArt],
+        artwork_by_id: dict[str, TidalArtwork],
     ) -> AlbumInfo:
         track_infos: list[TrackInfo] = []
         for i, track_rel in enumerate(
@@ -373,7 +373,7 @@ class TidalPlugin(MetadataSourcePlugin):
             artists_ids=artist_ids,
             data_url=self._parse_data_url(album["attributes"]),
             barcode=album["attributes"]["barcodeId"],
-            cover_art_url=self._parse_cover_art_url(album, cover_art_by_id),
+            cover_art_url=self._parse_artwork_url(album, artwork_by_id),
             # Meta
             album=self._parse_title(album["attributes"]),
             tracks=track_infos,
@@ -393,8 +393,8 @@ class TidalPlugin(MetadataSourcePlugin):
         )
 
     @staticmethod
-    def _parse_cover_art_url(
-        album: TidalAlbum, cover_art_by_id: dict[str, TidalCoverArt]
+    def _parse_artwork_url(
+        album: TidalAlbum, artwork_by_id: dict[str, TidalArtwork]
     ) -> str | None:
         cover_rel = album["relationships"].get("coverArt")
         if cover_rel is None:
@@ -402,7 +402,7 @@ class TidalPlugin(MetadataSourcePlugin):
         ids = [ri["id"] for ri in cover_rel["data"] if ri["type"] == "artworks"]
         if not ids:
             return None
-        if cover_art := cover_art_by_id.get(ids[0]):
+        if cover_art := artwork_by_id.get(ids[0]):
             files = cover_art["attributes"]["files"]
             if files:
                 return files[0]["href"]

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -398,16 +398,14 @@ class TidalPlugin(MetadataSourcePlugin):
     ) -> str | None:
         if not cover_art_by_id:
             return None
-        cover_art_data = (
-            album.get("relationships", {}).get("coverArt", {}).get("data")
-        )
+        cover_art_data = album["relationships"].get("coverArt", {}).get("data")
         if not cover_art_data:
             return None
         ids = [ri["id"] for ri in cover_art_data if ri["type"] == "coverArts"]
         if not ids:
             return None
         if cover_art := cover_art_by_id.get(ids[0]):
-            if url := cover_art.get("attributes", {}).get("url"):
+            if url := cover_art["attributes"].get("url"):
                 return url
             return f"https://resources.tidal.com/images/{ids[0]}/1280x1280.jpg"
         return None

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -398,10 +398,12 @@ class TidalPlugin(MetadataSourcePlugin):
     ) -> str | None:
         if not cover_art_by_id:
             return None
-        cover_art_data = album["relationships"].get("coverArt", {}).get("data")
-        if not cover_art_data:
+        cover_rel = album["relationships"].get("coverArt")
+        if cover_rel is None:
             return None
-        ids = [ri["id"] for ri in cover_art_data if ri["type"] == "coverArts"]
+        ids = [
+            ri["id"] for ri in cover_rel["data"] if ri["type"] == "coverArts"
+        ]
         if not ids:
             return None
         if cover_art := cover_art_by_id.get(ids[0]):

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -351,7 +351,7 @@ class TidalPlugin(MetadataSourcePlugin):
         album: TidalAlbum,
         track_by_id: dict[str, TidalTrack],
         artist_by_id: dict[str, TidalArtist],
-        cover_art_by_id: dict[str, TidalCoverArt] | None = None,
+        cover_art_by_id: dict[str, TidalCoverArt],
     ) -> AlbumInfo:
         track_infos: list[TrackInfo] = []
         for i, track_rel in enumerate(
@@ -394,10 +394,8 @@ class TidalPlugin(MetadataSourcePlugin):
 
     @staticmethod
     def _parse_cover_art_url(
-        album: TidalAlbum, cover_art_by_id: dict[str, TidalCoverArt] | None
+        album: TidalAlbum, cover_art_by_id: dict[str, TidalCoverArt]
     ) -> str | None:
-        if not cover_art_by_id:
-            return None
         cover_rel = album["relationships"].get("coverArt")
         if cover_rel is None:
             return None
@@ -408,7 +406,6 @@ class TidalPlugin(MetadataSourcePlugin):
             files = cover_art["attributes"]["files"]
             if files:
                 return files[0]["href"]
-            return f"https://resources.tidal.com/images/{ids[0]}/1280x1280.jpg"
         return None
 
     def _get_track_info(

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -399,12 +399,12 @@ class TidalPlugin(MetadataSourcePlugin):
         cover_rel = album["relationships"].get("coverArt")
         if cover_rel is None:
             return None
-        ids = [ri["id"] for ri in cover_rel["data"] if ri["type"] == "artworks"]
-        if not ids:
-            return None
-        if cover_art := artwork_by_id.get(ids[0]):
-            files = cover_art["attributes"]["files"]
-            if files:
+        for rel_data in cover_rel["data"]:
+            if (
+                rel_data["type"] == "artworks"
+                and (artwork := artwork_by_id.get(rel_data["id"]))
+                and (files := artwork["attributes"]["files"])
+            ):
                 return files[0]["href"]
         return None
 

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -316,7 +316,7 @@ class TidalPlugin(MetadataSourcePlugin):
         cover_art_by_id: dict[str, TidalCoverArt] = {
             item["id"]: item
             for item in albums_doc.get("included", [])
-            if item["type"] == "coverArts"
+            if item["type"] == "artworks"
         }
 
         for _id in _ids:
@@ -401,14 +401,13 @@ class TidalPlugin(MetadataSourcePlugin):
         cover_rel = album["relationships"].get("coverArt")
         if cover_rel is None:
             return None
-        ids = [
-            ri["id"] for ri in cover_rel["data"] if ri["type"] == "coverArts"
-        ]
+        ids = [ri["id"] for ri in cover_rel["data"] if ri["type"] == "artworks"]
         if not ids:
             return None
         if cover_art := cover_art_by_id.get(ids[0]):
-            if url := cover_art["attributes"].get("url"):
-                return url
+            files = cover_art["attributes"]["files"]
+            if files:
+                return files[0]["href"]
             return f"https://resources.tidal.com/images/{ids[0]}/1280x1280.jpg"
         return None
 

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
         ResourceIdentifier,
         TidalAlbum,
         TidalArtist,
+        TidalCoverArt,
         TidalTrack,
         TrackAttributes,
     )
@@ -295,7 +296,7 @@ class TidalPlugin(MetadataSourcePlugin):
         albums_doc = self.api.get_albums(
             ids=list(filter(None, _ids)),
             barcode_ids=barcode_ids,
-            include=["items.artists", "artists"],
+            include=["items.artists", "artists", "coverArt"],
         )
         album_by_id: dict[str, TidalAlbum] = {
             item["id"]: item
@@ -312,11 +313,19 @@ class TidalPlugin(MetadataSourcePlugin):
             for item in albums_doc.get("included", [])
             if item["type"] == "artists"
         }
+        cover_art_by_id: dict[str, TidalCoverArt] = {
+            item["id"]: item
+            for item in albums_doc.get("included", [])
+            if item["type"] == "coverArts"
+        }
 
         for _id in _ids:
             if _id is not None and (album := album_by_id.get(_id)):
                 yield self._get_album_info(
-                    album, track_by_id=track_by_id, artist_by_id=artist_by_id
+                    album,
+                    track_by_id=track_by_id,
+                    artist_by_id=artist_by_id,
+                    cover_art_by_id=cover_art_by_id,
                 )
             else:
                 yield None
@@ -332,6 +341,7 @@ class TidalPlugin(MetadataSourcePlugin):
                         album,
                         track_by_id=track_by_id,
                         artist_by_id=artist_by_id,
+                        cover_art_by_id=cover_art_by_id,
                     )
                 else:
                     yield None
@@ -341,8 +351,8 @@ class TidalPlugin(MetadataSourcePlugin):
         album: TidalAlbum,
         track_by_id: dict[str, TidalTrack],
         artist_by_id: dict[str, TidalArtist],
+        cover_art_by_id: dict[str, TidalCoverArt] | None = None,
     ) -> AlbumInfo:
-
         track_infos: list[TrackInfo] = []
         for i, track_rel in enumerate(
             album["relationships"]["items"]["data"], start=1
@@ -363,6 +373,7 @@ class TidalPlugin(MetadataSourcePlugin):
             artists_ids=artist_ids,
             data_url=self._parse_data_url(album["attributes"]),
             barcode=album["attributes"]["barcodeId"],
+            cover_art_url=self._parse_cover_art_url(album, cover_art_by_id),
             # Meta
             album=self._parse_title(album["attributes"]),
             tracks=track_infos,
@@ -380,6 +391,26 @@ class TidalPlugin(MetadataSourcePlugin):
             tidal_album_popularity=self._parse_popularity(album["attributes"]),
             tidal_updated=time.time(),
         )
+
+    @staticmethod
+    def _parse_cover_art_url(
+        album: TidalAlbum, cover_art_by_id: dict[str, TidalCoverArt] | None
+    ) -> str | None:
+        if not cover_art_by_id:
+            return None
+        cover_art_data = (
+            album.get("relationships", {}).get("coverArt", {}).get("data")
+        )
+        if not cover_art_data:
+            return None
+        ids = [ri["id"] for ri in cover_art_data if ri["type"] == "coverArts"]
+        if not ids:
+            return None
+        if cover_art := cover_art_by_id.get(ids[0]):
+            if url := cover_art.get("attributes", {}).get("url"):
+                return url
+            return f"https://resources.tidal.com/images/{ids[0]}/1280x1280.jpg"
+        return None
 
     def _get_track_info(
         self, track: TidalTrack, artist_by_id: dict[str, TidalArtist]

--- a/beetsplug/tidal/api_types.py
+++ b/beetsplug/tidal/api_types.py
@@ -145,13 +145,25 @@ class TidalTrack(TypedDict):
     relationships: dict[str, RelationshipData]
 
 
+class FileMeta(TypedDict):
+    width: int
+    height: int
+
+
+class ArtworkFile(TypedDict):
+    href: str
+    meta: FileMeta
+
+
 class CoverArtAttributes(TypedDict):
-    url: NotRequired[str]
+    mediaType: Literal["IMAGE"]
+    files: list[ArtworkFile]
+    visualMetadata: NotRequired[dict[str, str]]
 
 
 class TidalCoverArt(TypedDict):
     id: str
-    type: Literal["coverArts"]
+    type: Literal["artworks"]
     attributes: CoverArtAttributes
 
 

--- a/beetsplug/tidal/api_types.py
+++ b/beetsplug/tidal/api_types.py
@@ -155,16 +155,16 @@ class ArtworkFile(TypedDict):
     meta: FileMeta
 
 
-class CoverArtAttributes(TypedDict):
+class ArtworkAttributes(TypedDict):
     mediaType: Literal["IMAGE"]
     files: list[ArtworkFile]
     visualMetadata: NotRequired[dict[str, str]]
 
 
-class TidalCoverArt(TypedDict):
+class TidalArtwork(TypedDict):
     id: str
     type: Literal["artworks"]
-    attributes: CoverArtAttributes
+    attributes: ArtworkAttributes
 
 
 class TidalSearch(TypedDict):
@@ -180,7 +180,7 @@ T = TypeVar("T")
 class Document(TypedDict, Generic[T]):
     data: T
     included: NotRequired[
-        list[TidalArtist | TidalAlbum | TidalTrack | TidalCoverArt]
+        list[TidalArtist | TidalAlbum | TidalTrack | TidalArtwork]
     ]
     links: NotRequired[dict[str, str]]
 

--- a/beetsplug/tidal/api_types.py
+++ b/beetsplug/tidal/api_types.py
@@ -145,6 +145,16 @@ class TidalTrack(TypedDict):
     relationships: dict[str, RelationshipData]
 
 
+class CoverArtAttributes(TypedDict):
+    url: str
+
+
+class TidalCoverArt(TypedDict):
+    id: str
+    type: Literal["coverArts"]
+    attributes: CoverArtAttributes
+
+
 class TidalSearch(TypedDict):
     id: str
     type: Literal["searchResults"]
@@ -157,7 +167,9 @@ T = TypeVar("T")
 
 class Document(TypedDict, Generic[T]):
     data: T
-    included: NotRequired[list[TidalArtist | TidalAlbum | TidalTrack]]
+    included: NotRequired[
+        list[TidalArtist | TidalAlbum | TidalTrack | TidalCoverArt]
+    ]
     links: NotRequired[dict[str, str]]
 
 

--- a/beetsplug/tidal/api_types.py
+++ b/beetsplug/tidal/api_types.py
@@ -146,7 +146,7 @@ class TidalTrack(TypedDict):
 
 
 class CoverArtAttributes(TypedDict):
-    url: str
+    url: NotRequired[str]
 
 
 class TidalCoverArt(TypedDict):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,9 @@ New features
 - A database backup is now automatically created before running schema
   migrations. Control with the ``create_backup_before_migrations`` option
   (default: yes).
+- :doc:`plugins/tidal`: Add cover art support. Album metadata now includes
+  ``cover_art_url`` from Tidal's ``coverArt`` relationship, which the
+  :doc:`plugins/fetchart` plugin can retrieve.
 
 Bug fixes
 ~~~~~~~~~
@@ -77,10 +80,6 @@ New features
   the new flexible attributes with ``beet modify``: run ``beet modify
   data_source:tidal tidal_album_id='$mb_albumid' -a`` for albums and ``beet
   modify data_source:tidal tidal_track_id='$mb_trackid'`` for items.
-
-- :doc:`plugins/tidal`: Add cover art support. Album metadata now includes
-  ``cover_art_url`` from Tidal's ``coverArt`` relationship, which the
-  :doc:`plugins/fetchart` plugin can retrieve.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -77,6 +77,7 @@ New features
   the new flexible attributes with ``beet modify``: run ``beet modify
   data_source:tidal tidal_album_id='$mb_albumid' -a`` for albums and ``beet
   modify data_source:tidal tidal_track_id='$mb_trackid'`` for items.
+
 - :doc:`plugins/tidal`: Add cover art support. Album metadata now includes
   ``cover_art_url`` from Tidal's ``coverArt`` relationship, which the
   :doc:`plugins/fetchart` plugin can retrieve.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -77,6 +77,9 @@ New features
   the new flexible attributes with ``beet modify``: run ``beet modify
   data_source:tidal tidal_album_id='$mb_albumid' -a`` for albums and ``beet
   modify data_source:tidal tidal_track_id='$mb_trackid'`` for items.
+- :doc:`plugins/tidal`: Add cover art support. Album metadata now includes
+  ``cover_art_url`` from Tidal's ``coverArt`` relationship, which the
+  :doc:`plugins/fetchart` plugin can retrieve.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/plugins/tidal.rst
+++ b/docs/plugins/tidal.rst
@@ -105,10 +105,9 @@ Default
 Cover Art
 ---------
 
-When the :doc:`fetchart` plugin is enabled, beets can retrieve album
-cover art from Tidal. The Tidal plugin automatically includes the cover art URL
-when looking up albums. No additional configuration is needed to enable this
-feature.
+When the :doc:`fetchart` plugin is enabled, beets can retrieve album cover art
+from Tidal. The Tidal plugin automatically includes the cover art URL when
+looking up albums. No additional configuration is needed to enable this feature.
 
 .. include:: ./shared_metadata_source_config.rst
 

--- a/docs/plugins/tidal.rst
+++ b/docs/plugins/tidal.rst
@@ -102,6 +102,14 @@ Default
 
     The path to the file where the Tidal authentication token is stored.
 
+Cover Art
+---------
+
+When the :doc:`plugins/fetchart` plugin is enabled, beets can retrieve album
+cover art from Tidal. The Tidal plugin automatically includes the cover art URL
+when looking up albums. No additional configuration is needed to enable this
+feature.
+
 .. include:: ./shared_metadata_source_config.rst
 
 Flexible Attributes

--- a/docs/plugins/tidal.rst
+++ b/docs/plugins/tidal.rst
@@ -105,7 +105,7 @@ Default
 Cover Art
 ---------
 
-When the :doc:`plugins/fetchart` plugin is enabled, beets can retrieve album
+When the :doc:`fetchart` plugin is enabled, beets can retrieve album
 cover art from Tidal. The Tidal plugin automatically includes the cover art URL
 when looking up albums. No additional configuration is needed to enable this
 feature.

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -27,11 +27,16 @@ if TYPE_CHECKING:
 CURRENT_TS = 150000000
 
 
-def _make_cover_art(id_: str, url: str = "") -> TidalCoverArt:
+def _make_cover_art(id_: str, href: str = "") -> TidalCoverArt:
     return {
         "id": id_,
-        "type": "coverArts",
-        "attributes": {"url": url} if url else {},
+        "type": "artworks",
+        "attributes": {
+            "mediaType": "IMAGE",
+            "files": [{"href": href, "meta": {"width": 1280, "height": 1280}}]
+            if href
+            else [],
+        },
     }
 
 
@@ -84,7 +89,7 @@ def _make_album(
     }
     if cover_art_id:
         relationships["coverArt"] = {
-            "data": [{"id": cover_art_id, "type": "coverArts"}],
+            "data": [{"id": cover_art_id, "type": "artworks"}],
             "links": {},
         }
 
@@ -962,25 +967,39 @@ class TestTidalsync(TidalPluginTest):
         "cover_art_data, cover_art_by_id, expected",
         [
             (
-                [{"id": "ca1", "type": "coverArts"}],
+                [{"id": "ca1", "type": "artworks"}],
                 {
                     "ca1": {
                         "id": "ca1",
-                        "type": "coverArts",
-                        "attributes": {"url": "https://example.com/cover.jpg"},
+                        "type": "artworks",
+                        "attributes": {
+                            "mediaType": "IMAGE",
+                            "files": [
+                                {
+                                    "href": "https://example.com/cover.jpg",
+                                    "meta": {"width": 1280, "height": 1280},
+                                }
+                            ],
+                        },
                     }
                 },
                 "https://example.com/cover.jpg",
             ),
             (
-                [{"id": "ca1", "type": "coverArts"}],
-                {"ca1": {"id": "ca1", "type": "coverArts", "attributes": {}}},
+                [{"id": "ca1", "type": "artworks"}],
+                {
+                    "ca1": {
+                        "id": "ca1",
+                        "type": "artworks",
+                        "attributes": {"mediaType": "IMAGE", "files": []},
+                    }
+                },
                 "https://resources.tidal.com/images/ca1/1280x1280.jpg",
             ),
-            # No coverArts in relationship data
-            ([{"id": "ca1", "type": "artworks"}], {}, None),
+            # No artworks in relationship data
+            ([{"id": "ca1", "type": "coverArts"}], {}, None),
             # No cover art lookup
-            ([{"id": "ca1", "type": "coverArts"}], None, None),
+            ([{"id": "ca1", "type": "artworks"}], None, None),
             # Empty relationships
             ({}, {}, None),
         ],

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -16,10 +16,11 @@ from beetsplug.tidal import TidalPlugin
 if TYPE_CHECKING:
     from beetsplug.tidal.api_types import (
         AlbumAttributes,
+        RelationshipData,
         ResourceIdentifier,
         TidalAlbum,
         TidalArtist,
-        TidalCoverArt,
+        TidalArtwork,
         TidalTrack,
         TrackAttributes,
     )
@@ -27,7 +28,7 @@ if TYPE_CHECKING:
 CURRENT_TS = 150000000
 
 
-def _make_cover_art(id_: str, href: str = "") -> TidalCoverArt:
+def _make_artwork(id_: str, href: str = "") -> TidalArtwork:
     return {
         "id": id_,
         "type": "artworks",
@@ -77,7 +78,7 @@ def _make_album(
     if version:
         attrs["version"] = version
 
-    relationships: dict[str, object] = {
+    relationships: dict[str, RelationshipData] = {
         "artists": {
             "data": [{"id": aid, "type": "artists"} for aid in artist_ids],
             "links": {},
@@ -97,7 +98,7 @@ def _make_album(
         "id": id_,
         "type": "albums",
         "attributes": attrs,
-        "relationships": relationships,  # type: ignore[typeddict-item]
+        "relationships": relationships,
     }
     return album, track_lookup, artist_lookup
 
@@ -328,23 +329,23 @@ class TestParsing(TidalPluginTest):
         assert info.album == "My Album (Deluxe Edition)"
 
 
-class TestCoverArtParsing(TidalPluginTest):
-    """Tests for cover art URL parsing."""
+class TestArtworkParsing(TidalPluginTest):
+    """Tests for artwork URL parsing."""
 
-    def test_cover_art_with_url(self):
+    def test_artwork_with_url(self):
         """Cover art URL from included resources."""
         track = _make_track("t1", "Song", "PT3M", "ISRC001", ["a1"])
         album, track_lookup, artist_lookup = _make_album(
             "al1", "Album", [track], ["a1"], cover_art_id="ca1"
         )
-        cover_art_lookup = {
-            "ca1": _make_cover_art(
+        artwork_lookup = {
+            "ca1": _make_artwork(
                 "ca1", "https://resources.tidal.com/images/ca1/1280x1280.jpg"
             )
         }
 
         info = self.tidal._get_album_info(
-            album, track_lookup, artist_lookup, cover_art_lookup
+            album, track_lookup, artist_lookup, artwork_lookup
         )
 
         assert (
@@ -352,21 +353,21 @@ class TestCoverArtParsing(TidalPluginTest):
             == "https://resources.tidal.com/images/ca1/1280x1280.jpg"
         )
 
-    def test_cover_art_without_files_returns_none(self):
+    def test_artwork_without_files_returns_none(self):
         """Cover art returns None when files array is empty."""
         track = _make_track("t1", "Song", "PT3M", "ISRC001", ["a1"])
         album, track_lookup, artist_lookup = _make_album(
             "al1", "Album", [track], ["a1"], cover_art_id="ca1"
         )
-        cover_art_lookup = {"ca1": _make_cover_art("ca1")}
+        artwork_lookup = {"ca1": _make_artwork("ca1")}
 
         info = self.tidal._get_album_info(
-            album, track_lookup, artist_lookup, cover_art_lookup
+            album, track_lookup, artist_lookup, artwork_lookup
         )
 
         assert info.cover_art_url is None
 
-    def test_cover_art_without_relationship_returns_none(self):
+    def test_artwork_without_relationship_returns_none(self):
         """No cover_art_url when album has no coverArt relationship."""
         track = _make_track("t1", "Song", "PT3M", "ISRC001", ["a1"])
         album, track_lookup, artist_lookup = _make_album(
@@ -967,7 +968,7 @@ class TestTidalsync(TidalPluginTest):
 
 
     @pytest.mark.parametrize(
-        "cover_art_data, cover_art_by_id, expected",
+        "artwork_data, artwork_by_id, expected",
         [
             (
                 [{"id": "ca1", "type": "artworks"}],
@@ -1007,9 +1008,7 @@ class TestTidalsync(TidalPluginTest):
             ({}, {}, None),
         ],
     )
-    def test_parse_cover_art_url(
-        self, cover_art_data, cover_art_by_id, expected
-    ):
+    def test_parse_artwork_url(self, artwork_data, artwork_by_id, expected):
         album: TidalAlbum = {
             "id": "al1",
             "type": "albums",
@@ -1024,10 +1023,8 @@ class TestTidalsync(TidalPluginTest):
                 "popularity": 0.5,
                 "title": "Album",
             },
-            "relationships": {"coverArt": {"data": cover_art_data, "links": {}}}
-            if cover_art_data
+            "relationships": {"coverArt": {"data": artwork_data, "links": {}}}
+            if artwork_data
             else {},
         }
-        assert (
-            TidalPlugin._parse_cover_art_url(album, cover_art_by_id) == expected
-        )
+        assert TidalPlugin._parse_artwork_url(album, artwork_by_id) == expected

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -19,11 +19,20 @@ if TYPE_CHECKING:
         ResourceIdentifier,
         TidalAlbum,
         TidalArtist,
+        TidalCoverArt,
         TidalTrack,
         TrackAttributes,
     )
 
 CURRENT_TS = 150000000
+
+
+def _make_cover_art(id_: str, url: str = "") -> TidalCoverArt:
+    return {
+        "id": id_,
+        "type": "coverArts",
+        "attributes": {"url": url} if url else {},
+    }
 
 
 def _make_artist(id_: str, name: str) -> TidalArtist:
@@ -41,6 +50,7 @@ def _make_album(
     artist_ids: list[str],
     release_date: str = "2024-01-15",
     version: str | None = None,
+    cover_art_id: str | None = None,
 ) -> tuple[TidalAlbum, dict[str, TidalTrack], dict[str, TidalArtist]]:
     artist_lookup = {
         aid: _make_artist(aid, f"Artist {aid}") for aid in artist_ids
@@ -62,20 +72,27 @@ def _make_album(
     if version:
         attrs["version"] = version
 
+    relationships: dict[str, object] = {
+        "artists": {
+            "data": [{"id": aid, "type": "artists"} for aid in artist_ids],
+            "links": {},
+        },
+        "items": {
+            "data": [{"id": t["id"], "type": "tracks"} for t in tracks],
+            "links": {},
+        },
+    }
+    if cover_art_id:
+        relationships["coverArt"] = {
+            "data": [{"id": cover_art_id, "type": "coverArts"}],
+            "links": {},
+        }
+
     album: TidalAlbum = {
         "id": id_,
         "type": "albums",
         "attributes": attrs,
-        "relationships": {
-            "artists": {
-                "data": [{"id": aid, "type": "artists"} for aid in artist_ids],
-                "links": {},
-            },
-            "items": {
-                "data": [{"id": t["id"], "type": "tracks"} for t in tracks],
-                "links": {},
-            },
-        },
+        "relationships": relationships,  # type: ignore[typeddict-item]
     }
     return album, track_lookup, artist_lookup
 
@@ -166,6 +183,7 @@ class TestParsing(TidalPluginTest):
             "barcode": "123456",
             "catalognum": None,
             "country": None,
+            "cover_art_url": None,
             "data_source": "Tidal",
             "data_url": None,
             "day": 15,
@@ -288,6 +306,101 @@ class TestParsing(TidalPluginTest):
             "va": False,
             "year": 2024,
         }
+
+    def test_parse_album_with_version(self):
+        """Album title should have version appended."""
+        track = _make_track("101", "My Song", "PT3M", "ISRC001", ["1001"])
+        album, track_lookup, artist_lookup = _make_album(
+            "3", "My Album", [track], ["1001"], version="Deluxe Edition"
+        )
+
+        info = self.tidal._get_album_info(album, track_lookup, artist_lookup)
+
+        assert info.album == "My Album (Deluxe Edition)"
+
+
+class TestCoverArtParsing(TidalPluginTest):
+    """Tests for cover art URL parsing."""
+
+    def test_cover_art_with_url(self):
+        """Cover art URL from included resources."""
+        track = _make_track("t1", "Song", "PT3M", "ISRC001", ["a1"])
+        album, track_lookup, artist_lookup = _make_album(
+            "al1", "Album", [track], ["a1"], cover_art_id="ca1"
+        )
+        cover_art_lookup = {
+            "ca1": _make_cover_art(
+                "ca1", "https://resources.tidal.com/images/ca1/1280x1280.jpg"
+            )
+        }
+
+        info = self.tidal._get_album_info(
+            album, track_lookup, artist_lookup, cover_art_lookup
+        )
+
+        assert (
+            info.cover_art_url
+            == "https://resources.tidal.com/images/ca1/1280x1280.jpg"
+        )
+
+    def test_cover_art_without_url_falls_back_to_constructed(self):
+        """Cover art URL constructed from ID when no URL in attributes."""
+        track = _make_track("t1", "Song", "PT3M", "ISRC001", ["a1"])
+        album, track_lookup, artist_lookup = _make_album(
+            "al1", "Album", [track], ["a1"], cover_art_id="ca1"
+        )
+        cover_art_lookup = {"ca1": _make_cover_art("ca1")}
+
+        info = self.tidal._get_album_info(
+            album, track_lookup, artist_lookup, cover_art_lookup
+        )
+
+        assert (
+            info.cover_art_url
+            == "https://resources.tidal.com/images/ca1/1280x1280.jpg"
+        )
+
+    def test_cover_art_without_relationship_returns_none(self):
+        """No cover_art_url when album has no coverArt relationship."""
+        track = _make_track("t1", "Song", "PT3M", "ISRC001", ["a1"])
+        album, track_lookup, artist_lookup = _make_album(
+            "al1", "Album", [track], ["a1"]
+        )
+
+        info = self.tidal._get_album_info(album, track_lookup, artist_lookup)
+
+        assert info.cover_art_url is None
+
+
+class TestTrackParsing(TidalPluginTest):
+    """High-level tests for track parsing."""
+
+    def test_parse_track(self):
+        track = _make_track("101", "My Track", "PT4M", "ISRC456", ["1001"])
+        artist_lookup = {"1001": _make_artist("1001", "My Artist")}
+
+        info = self.tidal._get_track_info(track, artist_lookup)
+
+        assert info.title == "My Track"
+        assert info.track_id == "101"
+        assert info.duration == 240  # PT4M = 240 seconds
+        assert info.isrc == "ISRC456"
+        assert info.artist == "My Artist"
+        assert info.tidal_track_id == "101"
+        assert info.tidal_artist_id == "1001"
+        assert info.tidal_track_popularity == 50
+
+    def test_parse_track_with_version(self):
+        """Track title should have version appended."""
+        track = _make_track(
+            "102", "My Song", "PT3M", "ISRC002", ["1001"], version="Remastered"
+        )
+        artist_lookup = {"1001": _make_artist("1001", "My Artist")}
+
+        info = self.tidal._get_track_info(track, artist_lookup)
+
+        assert info.title == "My Song (Remastered)"
+        assert info.tidal_track_id == "102"
 
 
 class TestTrackForID(TidalPluginTest):
@@ -843,3 +956,56 @@ class TestTidalsync(TidalPluginTest):
             ["albums"], write=False, force=False
         )
         self.tidal.sync_item_popularity.assert_not_called()
+
+
+    @pytest.mark.parametrize(
+        "cover_art_data, cover_art_by_id, expected",
+        [
+            (
+                [{"id": "ca1", "type": "coverArts"}],
+                {
+                    "ca1": {
+                        "id": "ca1",
+                        "type": "coverArts",
+                        "attributes": {"url": "https://example.com/cover.jpg"},
+                    }
+                },
+                "https://example.com/cover.jpg",
+            ),
+            (
+                [{"id": "ca1", "type": "coverArts"}],
+                {"ca1": {"id": "ca1", "type": "coverArts", "attributes": {}}},
+                "https://resources.tidal.com/images/ca1/1280x1280.jpg",
+            ),
+            # No coverArts in relationship data
+            ([{"id": "ca1", "type": "artworks"}], {}, None),
+            # No cover art lookup
+            ([{"id": "ca1", "type": "coverArts"}], None, None),
+            # Empty relationships
+            ({}, {}, None),
+        ],
+    )
+    def test_parse_cover_art_url(
+        self, cover_art_data, cover_art_by_id, expected
+    ):
+        album: TidalAlbum = {
+            "id": "al1",
+            "type": "albums",
+            "attributes": {
+                "albumType": "ALBUM",
+                "barcodeId": "123",
+                "duration": "PT45M",
+                "explicit": False,
+                "mediaTags": [],
+                "numberOfItems": 1,
+                "numberOfVolumes": 1,
+                "popularity": 0.5,
+                "title": "Album",
+            },
+            "relationships": {"coverArt": {"data": cover_art_data, "links": {}}}
+            if cover_art_data
+            else {},
+        }
+        assert (
+            TidalPlugin._parse_cover_art_url(album, cover_art_by_id) == expected
+        )

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -789,6 +789,68 @@ class TestStaticHelpers:
         assert TidalPlugin._parse_popularity({"popularity": 1.0}) == 100
         assert TidalPlugin._parse_popularity({"popularity": 0.0}) == 0
 
+    @pytest.mark.parametrize(
+        "artwork_data, artwork_by_id, expected",
+        [
+            (
+                [{"id": "ca1", "type": "artworks"}],
+                {
+                    "ca1": {
+                        "id": "ca1",
+                        "type": "artworks",
+                        "attributes": {
+                            "mediaType": "IMAGE",
+                            "files": [
+                                {
+                                    "href": "https://example.com/cover.jpg",
+                                    "meta": {"width": 1280, "height": 1280},
+                                }
+                            ],
+                        },
+                    }
+                },
+                "https://example.com/cover.jpg",
+            ),
+            (
+                [{"id": "ca1", "type": "artworks"}],
+                {
+                    "ca1": {
+                        "id": "ca1",
+                        "type": "artworks",
+                        "attributes": {"mediaType": "IMAGE", "files": []},
+                    }
+                },
+                None,
+            ),
+            # No artworks in relationship data
+            ([{"id": "ca1", "type": "coverArts"}], {}, None),
+            # No cover art lookup
+            ([{"id": "ca1", "type": "artworks"}], {}, None),
+            # Empty relationships
+            ({}, {}, None),
+        ],
+    )
+    def test_parse_artwork_url(self, artwork_data, artwork_by_id, expected):
+        album: TidalAlbum = {
+            "id": "al1",
+            "type": "albums",
+            "attributes": {
+                "albumType": "ALBUM",
+                "barcodeId": "123",
+                "duration": "PT45M",
+                "explicit": False,
+                "mediaTags": [],
+                "numberOfItems": 1,
+                "numberOfVolumes": 1,
+                "popularity": 0.5,
+                "title": "Album",
+            },
+            "relationships": {"coverArt": {"data": artwork_data, "links": {}}}
+            if artwork_data
+            else {},
+        }
+        assert TidalPlugin._parse_artwork_url(album, artwork_by_id) == expected
+
 
 class TestTidalsync(TidalPluginTest):
     """Tests for the tidalsync command."""
@@ -965,66 +1027,3 @@ class TestTidalsync(TidalPluginTest):
             ["albums"], write=False, force=False
         )
         self.tidal.sync_item_popularity.assert_not_called()
-
-
-    @pytest.mark.parametrize(
-        "artwork_data, artwork_by_id, expected",
-        [
-            (
-                [{"id": "ca1", "type": "artworks"}],
-                {
-                    "ca1": {
-                        "id": "ca1",
-                        "type": "artworks",
-                        "attributes": {
-                            "mediaType": "IMAGE",
-                            "files": [
-                                {
-                                    "href": "https://example.com/cover.jpg",
-                                    "meta": {"width": 1280, "height": 1280},
-                                }
-                            ],
-                        },
-                    }
-                },
-                "https://example.com/cover.jpg",
-            ),
-            (
-                [{"id": "ca1", "type": "artworks"}],
-                {
-                    "ca1": {
-                        "id": "ca1",
-                        "type": "artworks",
-                        "attributes": {"mediaType": "IMAGE", "files": []},
-                    }
-                },
-                None,
-            ),
-            # No artworks in relationship data
-            ([{"id": "ca1", "type": "coverArts"}], {}, None),
-            # No cover art lookup
-            ([{"id": "ca1", "type": "artworks"}], {}, None),
-            # Empty relationships
-            ({}, {}, None),
-        ],
-    )
-    def test_parse_artwork_url(self, artwork_data, artwork_by_id, expected):
-        album: TidalAlbum = {
-            "id": "al1",
-            "type": "albums",
-            "attributes": {
-                "albumType": "ALBUM",
-                "barcodeId": "123",
-                "duration": "PT45M",
-                "explicit": False,
-                "mediaTags": [],
-                "numberOfItems": 1,
-                "numberOfVolumes": 1,
-                "popularity": 0.5,
-                "title": "Album",
-            },
-            "relationships": {"coverArt": {"data": artwork_data, "links": {}}}
-            if artwork_data
-            else {},
-        }
-        assert TidalPlugin._parse_artwork_url(album, artwork_by_id) == expected

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -167,7 +167,9 @@ class TestParsing(TidalPluginTest):
             "1", "My Album", tracks, ["1001"], version="Deluxe Edition"
         )
 
-        info = self.tidal._get_album_info(album, track_lookup, artist_lookup)
+        info = self.tidal._get_album_info(
+            album, track_lookup, artist_lookup, {}
+        )
 
         assert info.raw_data == {
             "album": "My Album (Deluxe Edition)",
@@ -319,7 +321,9 @@ class TestParsing(TidalPluginTest):
             "3", "My Album", [track], ["1001"], version="Deluxe Edition"
         )
 
-        info = self.tidal._get_album_info(album, track_lookup, artist_lookup)
+        info = self.tidal._get_album_info(
+            album, track_lookup, artist_lookup, {}
+        )
 
         assert info.album == "My Album (Deluxe Edition)"
 
@@ -348,8 +352,8 @@ class TestCoverArtParsing(TidalPluginTest):
             == "https://resources.tidal.com/images/ca1/1280x1280.jpg"
         )
 
-    def test_cover_art_without_url_falls_back_to_constructed(self):
-        """Cover art URL constructed from ID when no URL in attributes."""
+    def test_cover_art_without_files_returns_none(self):
+        """Cover art returns None when files array is empty."""
         track = _make_track("t1", "Song", "PT3M", "ISRC001", ["a1"])
         album, track_lookup, artist_lookup = _make_album(
             "al1", "Album", [track], ["a1"], cover_art_id="ca1"
@@ -360,10 +364,7 @@ class TestCoverArtParsing(TidalPluginTest):
             album, track_lookup, artist_lookup, cover_art_lookup
         )
 
-        assert (
-            info.cover_art_url
-            == "https://resources.tidal.com/images/ca1/1280x1280.jpg"
-        )
+        assert info.cover_art_url is None
 
     def test_cover_art_without_relationship_returns_none(self):
         """No cover_art_url when album has no coverArt relationship."""
@@ -372,7 +373,9 @@ class TestCoverArtParsing(TidalPluginTest):
             "al1", "Album", [track], ["a1"]
         )
 
-        info = self.tidal._get_album_info(album, track_lookup, artist_lookup)
+        info = self.tidal._get_album_info(
+            album, track_lookup, artist_lookup, {}
+        )
 
         assert info.cover_art_url is None
 
@@ -994,12 +997,12 @@ class TestTidalsync(TidalPluginTest):
                         "attributes": {"mediaType": "IMAGE", "files": []},
                     }
                 },
-                "https://resources.tidal.com/images/ca1/1280x1280.jpg",
+                None,
             ),
             # No artworks in relationship data
             ([{"id": "ca1", "type": "coverArts"}], {}, None),
             # No cover art lookup
-            ([{"id": "ca1", "type": "artworks"}], None, None),
+            ([{"id": "ca1", "type": "artworks"}], {}, None),
             # Empty relationships
             ({}, {}, None),
         ],


### PR DESCRIPTION
## Description

Include `coverArt` in album API requests and parse the `coverArts` resources from the included array. The `cover_art_url` is passed to `AlbumInfo(cover_art_url=...)`, which the fetchart plugin uses to retrieve album art. Falls back to constructing a URL from the cover art resource ID when no direct URL is available in the API response.


- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)

cc: @semohr This is the first PR. I will add another one for `popularity` soon. 
