### PR TITLE
lyrics: add rest_directory configuration option

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -31,6 +31,7 @@ from urllib.parse import quote, quote_plus, urlencode, urlparse
 
 import requests
 from bs4 import BeautifulSoup
+from confuse import Optional
 from unidecode import unidecode
 
 from beets import plugins, ui
@@ -1052,6 +1053,7 @@ class LyricsPlugin(LyricsRequestHandler, plugins.BeetsPlugin):
                 "keep_synced": False,
                 "local": False,
                 "print": False,
+                "rest_directory": None,
                 "synced": False,
                 # Musixmatch and Tekstowo are disabled by default as they
                 # currently block requests with the beets user agent.
@@ -1084,7 +1086,7 @@ class LyricsPlugin(LyricsRequestHandler, plugins.BeetsPlugin):
             "--write-rest",
             dest="rest_directory",
             action="store",
-            default=None,
+            default=self.config["rest_directory"].get(Optional(str)),
             metavar="dir",
             help="write lyrics to given directory as ReST files",
         )
@@ -1122,7 +1124,7 @@ class LyricsPlugin(LyricsRequestHandler, plugins.BeetsPlugin):
             if opts.rest_directory and (
                 items := [i for i in items if i.lyrics]
             ):
-                RestFiles(Path(opts.rest_directory)).write(items)
+                RestFiles(Path(opts.rest_directory).expanduser()).write(items)
 
         cmd.func = func
         return [cmd]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,9 +9,12 @@ below!
 Unreleased
 ----------
 
-..
-    New features
-    ~~~~~~~~~~~~
+New features
+~~~~~~~~~~~~
+
+- :doc:`plugins/lyrics`: Added a ``rest_directory`` configuration option for
+  specifying a reStructuredText output directory, semantically equivalent to
+  ``-r, --write-rest``. :bug:`2806`
 
 ..
     Bug fixes
@@ -46,9 +49,6 @@ New features
   :conf:`plugins.musicbrainz:aliases_as_credits` to make
   aliases-as-artist-credit optional.
 - :doc:`plugins/badfiles`: Added settings for auto error and warning actions.
-- :doc:`plugins/lyrics`: Added a ``rest_directory`` configuration option for
-  specifying a reStructuredText output directory, semantically equivalent to
-  ``-r, --write-rest``. :bug:`2806`
 - :doc:`plugins/tidal`: New flexible attributes are now populated during
   imports, including ``tidal_track_id``, ``tidal_album_id``,
   ``tidal_artist_id``, ``tidal_track_popularity``, ``tidal_album_popularity``,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,9 @@ New features
   :conf:`plugins.musicbrainz:aliases_as_credits` to make
   aliases-as-artist-credit optional.
 - :doc:`plugins/badfiles`: Added settings for auto error and warning actions.
+- :doc:`plugins/lyrics`: Added a ``rest_directory`` configuration option for
+  specifying a reStructuredText output directory, semantically equivalent to
+  ``-r, --write-rest``. :bug:`2806`
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -59,6 +59,7 @@ Default configuration:
         google_API_key: null
         google_engine_ID: 009217259823014548361:lndtuqkycfu
         print: no
+        rest_directory: null
         sources: [lrclib, google, genius]
         synced: no
 
@@ -107,6 +108,8 @@ The available options are:
   custom search engine`_, which gathers an updated list of sources known to be
   scrapeable.
 - **print**: Print lyrics to the console.
+- **rest_directory**: The directory to which reStructuredText_ (ReST) rendered
+  lyric documents will be output. See :ref:`rendering-lyrics`.
 - **sources**: List of sources to search for lyrics. An asterisk ``*`` expands
   to all available sources. The ``google`` source will be automatically
   deactivated if no ``google_API_key`` is setup. By default, ``musixmatch`` and
@@ -146,6 +149,8 @@ lyrics without touching tracks that already have a synced version.
 
 Inversely, the ``-l, --local`` option restricts operations to lyrics that are
 locally available, which show lyrics faster without using the network at all.
+
+.. _rendering-lyrics:
 
 Rendering Lyrics into Other Formats
 -----------------------------------

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -857,7 +857,6 @@ class TestLyricsRestDirectory(PluginTestHelper):
             ),
             pytest.param("test/config", None, "test/config", id="config only"),
             pytest.param(None, "test/cmd", "test/cmd", id="cmd arg only"),
-            pytest.param(None, None, None, id="no output"),
             pytest.param(
                 "~/test/config", None, "~/test/config", id="user home path"
             ),
@@ -883,11 +882,7 @@ class TestLyricsRestDirectory(PluginTestHelper):
         cmd_args = [] if arg_path is None else ["-r", arg_path]
         self.run_command("lyrics", *cmd_args, lib=lib)
 
-        test_output = test_capture.get("directory")
-        if output_path is None:
-            assert test_output is None
-        else:
-            assert test_output == Path(output_path).expanduser()
+        assert test_capture.get("directory") == Path(output_path).expanduser()
 
 
 class TestLyricsSyltProperty:

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -20,23 +20,21 @@ import re
 import textwrap
 from functools import partial
 from http import HTTPStatus
+from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import pytest
 import requests
-from confuse.exceptions import ConfigTypeError
 
 from beets.library import Item
-from beets.test.helper import PluginMixin
+from beets.test.helper import PluginMixin, PluginTestHelper
 from beets.util.lyrics import Lyrics
 from beetsplug import lyrics
 
 from .lyrics_pages import lyrics_pages
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from .lyrics_pages import LyricsPage
 
 PHRASE_BY_TITLE = {
@@ -844,123 +842,89 @@ class TestRestFiles:
         )
 
 
-class TestLyricsRestDirectory(LyricsPluginMixin):
+class TestLyricsRestDirectory(PluginTestHelper):
+    plugin = "lyrics"
+
     @pytest.fixture
     def lib(self, helper):
         return helper.lib
 
-    @pytest.fixture
-    def backend_name(self):
-        return "lrclib"
-
-    def _setup_config(self, tmp_path, rest_directory):
-        config_file = tmp_path / "config.yaml"
-        with config_file.open("w") as f:
-            f.write(f"lyrics:\n  rest_directory: {rest_directory}")
-        self.config.set_file(config_file)
-        self.config.read(False, False)
-
-    def _test_helper(
-        self, tmp_path, lyrics_plugin, lib, config_path, arg_path, output_path
-    ):
-        if config_path:
-            self._setup_config(tmp_path, config_path)
-
-        cmd = lyrics_plugin.commands()[0]
-        cmd_args = [] if arg_path is None else ["-r", arg_path]
-        opts, args = cmd.parser.parse_args(cmd_args)
-        cmd.func(lib, opts, args)
-
-        if output_path is None:
-            for item in tmp_path.rglob("*"):
-                assert item.name != "index.rst"
-                assert item.name != "conf.py"
-        else:
-            assert (output_path / "index.rst").exists()
-            assert (output_path / "conf.py").exists()
-
     @pytest.mark.parametrize(
-        "config_path, arg_path, output_dir",
+        "config_path, arg_path, output_path",
         [
             pytest.param(
-                "test/config", "test/cmd", "test/cmd", id="config and cmd arg"
+                "test/config",
+                "test/cmd",
+                "test/cmd",
+                id="config and cmd arg, relative path",
             ),
-            pytest.param("test/config", None, "test/config", id="config only"),
-            pytest.param(None, "test/cmd", "test/cmd", id="cmd arg only"),
+            pytest.param(
+                "test/config",
+                None,
+                "test/config",
+                id="config only, relative path",
+            ),
+            pytest.param(
+                None, "test/cmd", "test/cmd", id="cmd arg only, relative path"
+            ),
+            pytest.param(
+                "/test/config",
+                "/test/cmd",
+                "/test/cmd",
+                id="config and cmd arg, absolute path",
+            ),
+            pytest.param(
+                "/test/config",
+                None,
+                "/test/config",
+                id="config only, absolute path",
+            ),
+            pytest.param(
+                None, "/test/cmd", "/test/cmd", id="cmd arg only, absolute path"
+            ),
+            pytest.param(
+                "~/test/config",
+                "~/test/cmd",
+                "~/test/cmd",
+                id="config and cmd arg, home path",
+            ),
+            pytest.param(
+                "~/test/config",
+                None,
+                "~/test/config",
+                id="config only, home path",
+            ),
+            pytest.param(
+                None, "~/test/cmd", "~/test/cmd", id="cmd arg only, home path"
+            ),
             pytest.param(None, None, None, id="no output"),
         ],
     )
     def test_rest_config(
-        self,
-        monkeypatch,
-        tmp_path,
-        lyrics_plugin,
-        lib,
-        config_path,
-        arg_path,
-        output_dir,
+        self, monkeypatch, lib, config_path, arg_path, output_path
     ):
-        monkeypatch.chdir(tmp_path)
-        if output_dir:
-            output_dir = tmp_path / output_dir
+        test_capture = {}
 
-        self._test_helper(
-            tmp_path, lyrics_plugin, lib, config_path, arg_path, output_dir
-        )
+        class MockRestFiles:
+            def __init__(self, directory):
+                test_capture["directory"] = directory
 
-    def test_config_path_types(self, monkeypatch, tmp_path, lyrics_plugin, lib):
+            def write(self, items):
+                test_capture["items"] = items
 
-        output_dir = "test"
-        absolute_dir = tmp_path / "absolute"
-        absolute_dir.mkdir()
-        relative_dir = tmp_path / "relative"
-        relative_dir.mkdir()
-        home_dir = tmp_path / "home"
-        home_dir.mkdir()
-        monkeypatch.chdir(relative_dir)
-        monkeypatch.setenv("HOME", str(home_dir))
-        monkeypatch.setenv("USERPROFILE", str(home_dir))
+        monkeypatch.setattr(lyrics, "RestFiles", MockRestFiles)
 
-        self._test_helper(
-            tmp_path,
-            lyrics_plugin,
-            lib,
-            str((absolute_dir / output_dir).absolute()),
-            None,
-            absolute_dir / output_dir,
-        )
-        self._test_helper(
-            tmp_path,
-            lyrics_plugin,
-            lib,
-            output_dir,
-            None,
-            relative_dir / output_dir,
-        )
-        self._test_helper(
-            tmp_path,
-            lyrics_plugin,
-            lib,
-            f"~/{output_dir}",
-            None,
-            home_dir / output_dir,
-        )
+        if config_path:
+            self.config["lyrics"]["rest_directory"] = config_path
 
-    @pytest.mark.parametrize(
-        "bad_config",
-        [
-            pytest.param(42),
-            pytest.param(3.14),
-            pytest.param(False),
-            pytest.param({}),
-            pytest.param([]),
-        ],
-    )
-    def test_bad_config(self, lyrics_plugin, bad_config):
-        lyrics_plugin.config["rest_directory"].set(bad_config)
+        cmd_args = [] if arg_path is None else ["-r", arg_path]
+        self.run_command("lyrics", *cmd_args, lib=lib)
 
-        with pytest.raises(ConfigTypeError):
-            lyrics_plugin.commands()
+        test_output = test_capture.get("directory")
+        if output_path is None:
+            assert test_output is None
+        else:
+            assert test_output == Path(output_path).expanduser()
 
 
 class TestLyricsSyltProperty:

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -853,51 +853,14 @@ class TestLyricsRestDirectory(PluginTestHelper):
         "config_path, arg_path, output_path",
         [
             pytest.param(
-                "test/config",
-                "test/cmd",
-                "test/cmd",
-                id="config and cmd arg, relative path",
+                "test/config", "test/cmd", "test/cmd", id="config and cmd arg"
             ),
-            pytest.param(
-                "test/config",
-                None,
-                "test/config",
-                id="config only, relative path",
-            ),
-            pytest.param(
-                None, "test/cmd", "test/cmd", id="cmd arg only, relative path"
-            ),
-            pytest.param(
-                "/test/config",
-                "/test/cmd",
-                "/test/cmd",
-                id="config and cmd arg, absolute path",
-            ),
-            pytest.param(
-                "/test/config",
-                None,
-                "/test/config",
-                id="config only, absolute path",
-            ),
-            pytest.param(
-                None, "/test/cmd", "/test/cmd", id="cmd arg only, absolute path"
-            ),
-            pytest.param(
-                "~/test/config",
-                "~/test/cmd",
-                "~/test/cmd",
-                id="config and cmd arg, home path",
-            ),
-            pytest.param(
-                "~/test/config",
-                None,
-                "~/test/config",
-                id="config only, home path",
-            ),
-            pytest.param(
-                None, "~/test/cmd", "~/test/cmd", id="cmd arg only, home path"
-            ),
+            pytest.param("test/config", None, "test/config", id="config only"),
+            pytest.param(None, "test/cmd", "test/cmd", id="cmd arg only"),
             pytest.param(None, None, None, id="no output"),
+            pytest.param(
+                "~/test/config", None, "~/test/config", id="user home path"
+            ),
         ],
     )
     def test_rest_config(

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 import requests
+from confuse.exceptions import ConfigTypeError
 
 from beets.library import Item
 from beets.test.helper import PluginMixin, TestHelper
@@ -839,6 +840,125 @@ class TestRestFiles:
             < c.index("Song Three")
             < c.index("Lyrics Three")
         )
+
+
+class TestLyricsRestDirectory(LyricsPluginMixin):
+    @pytest.fixture
+    def lib(self, helper):
+        return helper.lib
+
+    @pytest.fixture
+    def backend_name(self):
+        return "lrclib"
+
+    def _setup_config(self, tmp_path, rest_directory):
+        config_file = tmp_path / "config.yaml"
+        with config_file.open("w") as f:
+            f.write(f"lyrics:\n  rest_directory: {rest_directory}")
+        self.config.set_file(config_file)
+        self.config.read(False, False)
+
+    def _test_helper(
+        self, tmp_path, lyrics_plugin, lib, config_path, arg_path, output_path
+    ):
+        if config_path:
+            self._setup_config(tmp_path, config_path)
+
+        cmd = lyrics_plugin.commands()[0]
+        cmd_args = [] if arg_path is None else ["-r", arg_path]
+        opts, args = cmd.parser.parse_args(cmd_args)
+        cmd.func(lib, opts, args)
+
+        if output_path is None:
+            for item in tmp_path.rglob("*"):
+                assert item.name != "index.rst"
+                assert item.name != "conf.py"
+        else:
+            assert (output_path / "index.rst").exists()
+            assert (output_path / "conf.py").exists()
+
+    @pytest.mark.parametrize(
+        "config_path, arg_path, output_dir",
+        [
+            pytest.param(
+                "test/config", "test/cmd", "test/cmd", id="config and cmd arg"
+            ),
+            pytest.param("test/config", None, "test/config", id="config only"),
+            pytest.param(None, "test/cmd", "test/cmd", id="cmd arg only"),
+            pytest.param(None, None, None, id="no output"),
+        ],
+    )
+    def test_rest_config(
+        self,
+        monkeypatch,
+        tmp_path,
+        lyrics_plugin,
+        lib,
+        config_path,
+        arg_path,
+        output_dir,
+    ):
+        monkeypatch.chdir(tmp_path)
+        if output_dir:
+            output_dir = tmp_path / output_dir
+
+        self._test_helper(
+            tmp_path, lyrics_plugin, lib, config_path, arg_path, output_dir
+        )
+
+    def test_config_path_types(self, monkeypatch, tmp_path, lyrics_plugin, lib):
+
+        output_dir = "test"
+        absolute_dir = tmp_path / "absolute"
+        absolute_dir.mkdir()
+        relative_dir = tmp_path / "relative"
+        relative_dir.mkdir()
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        monkeypatch.chdir(relative_dir)
+        monkeypatch.setenv("HOME", str(home_dir))
+        monkeypatch.setenv("USERPROFILE", str(home_dir))
+
+        self._test_helper(
+            tmp_path,
+            lyrics_plugin,
+            lib,
+            str((absolute_dir / output_dir).absolute()),
+            None,
+            absolute_dir / output_dir,
+        )
+        self._test_helper(
+            tmp_path,
+            lyrics_plugin,
+            lib,
+            output_dir,
+            None,
+            relative_dir / output_dir,
+        )
+        self._test_helper(
+            tmp_path,
+            lyrics_plugin,
+            lib,
+            f"~/{output_dir}",
+            None,
+            home_dir / output_dir,
+        )
+
+    @pytest.mark.parametrize(
+        "bad_config",
+        [
+            pytest.param(42),
+            pytest.param(3.14),
+            pytest.param(False),
+            pytest.param({}),
+            pytest.param([]),
+        ],
+    )
+    def test_bad_config(self, lyrics_plugin, bad_config):
+        lyrics_plugin.config["rest_directory"].set(bad_config)
+
+        with pytest.raises(ConfigTypeError):
+            lyrics_plugin.commands()
 
 
 class TestLyricsSyltProperty:


### PR DESCRIPTION
## Description

Fixes #2806 

- Adds a `rest_directory` configuration option to the lyrics plugin that specifies a directory for ReST output, equivalent to the `-r, --write-rest` command line argument

- [x] Documentation.
- [x] Changelog.
- [x] Tests.
