### PR TITLE
docs: add Homebrew to package manager installation list

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,9 +35,11 @@ Bug fixes
     For plugin developers
     ~~~~~~~~~~~~~~~~~~~~~
 
-..
-    Other changes
-    ~~~~~~~~~~~~~
+Other changes
+~~~~~~~~~~~~~
+
+- :doc:`/guides/installation` Add Homebrew to the list of supported package
+  managers in the installation guide.
 
 2.12.0 (June 22, 2026)
 ----------------------
@@ -154,11 +156,9 @@ Other changes
   sync run, follows the standard beets write-before-store pattern, and logs
   audio-features API unavailability only once per run.
 - :doc:`plugins/titlecase`: Correct the path format example and document the
-  ``%titlecase{text}`` template function. :bug:`6697``
+  ``%titlecase{text}`` template function. :bug:`6697`
 - Log message prefix formatting (``musicbrainz: msg``) moved from a filter to
   ``LegacyFormatter``, making future customization easier.
-- Add Homebrew to the list of supported package managers in the installation
-  guide. :doc:`/guides/installation
 
 2.11.0 (May 06, 2026)
 ---------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -105,6 +105,8 @@ Other changes
   audio-features API unavailability only once per run.
 - :doc:`plugins/titlecase`: Correct the path format example and document the
   ``%titlecase{text}`` template function. :bug:`6697`
+- Add Homebrew to the list of supported package managers in the installation
+  guide. :doc:`/guides/installation`
 
 2.11.0 (May 06, 2026)
 ---------------------

--- a/docs/guides/installation.rst
+++ b/docs/guides/installation.rst
@@ -172,6 +172,8 @@ here are the options available:
 
 .. _freebsd: https://www.freshports.org/audio/beets/
 
+.. _homebrew: https://formulae.brew.sh/formula/beets
+
 .. _nixos: https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/python-modules/beets
 
 .. _openbsd: https://openports.pl/path/audio/beets
@@ -179,5 +181,3 @@ here are the options available:
 .. _ubuntu details: https://launchpad.net/ubuntu/+source/beets
 
 .. _void package: https://github.com/void-linux/void-packages/tree/master/srcpkgs/beets
-
-.. _homebrew: https://formulae.brew.sh/formula/beets

--- a/docs/guides/installation.rst
+++ b/docs/guides/installation.rst
@@ -156,6 +156,7 @@ here are the options available:
   beets-doc``
 - **Solus**: ``eopkg install beets``
 - **NixOS** (`package <nixos_>`_): ``nix-env -i beets``
+- **Homebrew** (`formula <homebrew_>`_): ``brew install beets``
 - **MacPorts**: ``port install beets`` or ``port install beets-full`` (includes
   third-party plugins)
 
@@ -178,3 +179,5 @@ here are the options available:
 .. _ubuntu details: https://launchpad.net/ubuntu/+source/beets
 
 .. _void package: https://github.com/void-linux/void-packages/tree/master/srcpkgs/beets
+
+.. _homebrew: https://formulae.brew.sh/formula/beets


### PR DESCRIPTION
## What

Add Homebrew (`brew install beets`) to the OS package manager list in the installation guide, alongside the existing MacPorts entry.

## Why

The beets formula was recently merged into [homebrew-core](https://github.com/Homebrew/homebrew-core/pull/288148), making `brew install beets` available to macOS (and Linux) users via Homebrew. The installation guide already lists MacPorts and many Linux package managers — Homebrew is a natural addition.

## Changes

- `docs/guides/installation.rst`: Add Homebrew entry to the Package Manager Installation list with a link to the formula page
- `docs/changelog.rst`: Add changelog entry under Unreleased > Other changes