### PR TITLE
convert: skip missing album art instead of crashing

### DIFF
--- a/beetsplug/convert.py
+++ b/beetsplug/convert.py
@@ -532,6 +532,14 @@ class ConvertPlugin(BeetsPlugin):
         if not album or not album.artpath:
             return
 
+        # The stored art path may point to a missing file (e.g. the cover
+        # lives in the album's root directory rather than a per-disc one).
+        if not os.path.isfile(util.syspath(album.artpath)):
+            self._log.info(
+                "Skipping {.art_filepath} (source file not found)", album
+            )
+            return
+
         album_item = album.items().get()
         # Album shouldn't be empty.
         if not album_item:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,7 +26,7 @@ Bug fixes
 - :doc:`plugins/convert`: ``convert -a`` with ``copy_album_art`` enabled no
   longer crashes when the stored album art path points to a missing file (for
   example a multi-disc album whose cover lives in the album root rather than a
-  per-disc directory); the missing art is skipped instead. :bug:`4692`  
+  per-disc directory); the missing art is skipped instead. :bug:`4692`
 
 ..
     For plugin developers

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,9 +16,13 @@ New features
   specifying a reStructuredText output directory, semantically equivalent to
   ``-r, --write-rest``. :bug:`2806`
 
-..
-    Bug fixes
-    ~~~~~~~~~
+Bug fixes
+~~~~~~~~~
+
+- :doc:`plugins/convert`: ``convert -a`` with ``copy_album_art`` enabled no
+  longer crashes when the stored album art path points to a missing file (for
+  example a multi-disc album whose cover lives in the album root rather than a
+  per-disc directory); the missing art is skipped instead. :bug:`4692`
 
 ..
     For plugin developers

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -181,6 +181,21 @@ class TestConvertCli(ConvertPluginHelper, ConvertCommand):
         mediafile = MediaFile(self.converted_mp3)
         assert mediafile.images[0].data == image_data
 
+    def test_copy_album_art_missing_source(self, caplog):
+        # A missing/stale art source should be skipped instead of crashing
+        # the conversion (see #4692).
+        self.config["convert"]["copy_album_art"] = True
+        self.album.artpath = os.path.join(_common.RSRC, b"nonexistent.jpg")
+        self.album.store()
+
+        with caplog.at_level("INFO", logger="beets.convert"):
+            self.run_command("convert", "-a", "--yes")
+
+        assert any(
+            "source file not found" in message for message in caplog.messages
+        )
+        assert self.file_endswith(self.converted_mp3, "mp3")
+
     def test_skip_existing(self):
         converted = self.converted_mp3
         self.touch(converted, content="XXX")


### PR DESCRIPTION
## Description

Fixes #4692.

`convert -a` with `copy_album_art` enabled crashes with a `FileNotFoundError` when the album's stored art path points at a file that no longer exists on disk (for example a multi-disc album whose cover lives in the album root rather than in each per-disc directory). This adds an `os.path.isfile` guard in `copy_album_art` so a missing source is logged and skipped instead of aborting the conversion, using the same `util.syspath` convention already used for the destination check just below.

## To Do

- [x] ~Documentation.~ (No new flags or behaviour to document.)
- [x] Changelog.
- [x] Tests. (Added `test_copy_album_art_missing_source`, which reproduces the crash without this change and passes with it.)
