### PR TITLE
fix: spotify query format does not accept double quotes (") (anymore?)

### DIFF
--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -516,7 +516,7 @@ class SpotifyPlugin(
                 headers={"Authorization": f"Bearer {self.access_token}"},
                 params={
                     **params.filters,
-                    "q": params.query,
+                    "q": params.query.replace('"', "'"),
                     "type": params.query_type,
                     "limit": str(params.limit),
                 },

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -96,6 +96,8 @@ Bug fixes
   the database has been deleted from disk. Missing items are now skipped with a
   warning and the command continues. :bug:`6720`
 - :doc:`plugins/fish`: Fix error on plugin initialization.
+- :doc:`plugins/spotify`: Use single instead of double quotes in spotify
+  queries.
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Spotify search no longer appears to accept double quotes (`"`) around query values reliably.

For example:

* ❌ `album:"Signs (Calibre Remix)" artist:"Badmarsh & Shri, Calibre"` → no results
* ✅ `album:'Signs (Calibre Remix)' artist:'Badmarsh & Shri, Calibre'` → returns results

This change switches generated search queries to use single quotes instead of double quotes.


<img width="867" height="1017" alt="image" src="https://github.com/user-attachments/assets/15de9da4-4b40-4c18-878f-78b0d20c18d4" />

vs
<img width="874" height="1319" alt="image" src="https://github.com/user-attachments/assets/22ecce0c-8fc0-49a7-a0d0-b2f17140016b" />


---

I could swear this worked before, maybe the spotify AI agents merged a PR without review :rofl: 