### PR TITLE
fix(library): don't propagate album artpath to items

### DIFF
--- a/beets/library/library.py
+++ b/beets/library/library.py
@@ -36,6 +36,7 @@ class Library(dbcore.Database):
         (migrations.MultiComposerFieldMigration, (Item,)),
         (migrations.MultiArrangerFieldMigration, (Item,)),
         (migrations.RelativePathMigration, (Item, Album)),
+        (migrations.RemoveInheritedArtpathMigration, (Item,)),
     )
     replacements: Replacements
 

--- a/beets/library/migrations.py
+++ b/beets/library/migrations.py
@@ -261,3 +261,26 @@ class RelativePathMigration(Migration):
     ) -> None:
         for field in {"path", "artpath"} & current_fields:
             self._migrate_field(model_cls, field)
+
+
+class RemoveInheritedArtpathMigration(Migration):
+    """Remove artpath flex attribute erroneously inherited onto items."""
+
+    def _migrate_data(self, model_cls: type[Model], _: set[str]) -> None:
+        table = model_cls._table
+        flex_table = model_cls._flex_table
+
+        with self.db.transaction() as tx:
+            rows = tx.query(
+                f"SELECT entity_id FROM {flex_table} WHERE key == 'artpath'"
+            )
+
+        total = len(rows)
+        if not total:
+            return
+
+        ui.print_(f"Removing inherited artpath from {total} {table}...")
+        with self.db.transaction() as tx:
+            tx.mutate(f"DELETE FROM {flex_table} WHERE key == 'artpath'")
+
+        ui.print_(f"Migration complete: {total} {table} updated")

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -589,11 +589,13 @@ class Album(LibModel):
         track_deletes = set()
         for key in self._dirty:
             if inherit:
-                if key in self.item_keys:  # is a fixed attribute
+                if key in self.item_keys:  # is an inheritable fixed attribute
                     track_updates[key] = self[key]
-                elif key not in self:  # is a fixed or a flexible attribute
+                elif key in self._fields:  # excluded fixed attr (artpath, id)
+                    continue
+                elif key not in self:  # is a removed flexible attribute
                     track_deletes.add(key)
-                elif key != "id":  # is a flexible attribute
+                else:  # is a flexible attribute
                     track_updates[key] = self[key]
 
         with self._db.transaction():

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -122,6 +122,10 @@ Bug fixes
   queries.
 - :doc:`plugins/tidal`: Fix auth URL not printed in environments without a
   configured browser :bug:`6710`
+- Album ``store`` no longer copies ``artpath`` onto its items as an absolute
+  path, which broke relative-path portability. A database migration removes any
+  such stale ``artpath`` attributes left on items by earlier versions.
+  :bug:`6756`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,9 +16,13 @@ New features
   specifying a reStructuredText output directory, semantically equivalent to
   ``-r, --write-rest``. :bug:`2806`
 
-..
-    Bug fixes
-    ~~~~~~~~~
+Bug fixes
+~~~~~~~~~
+
+- Album ``store`` no longer copies ``artpath`` onto its items as an absolute
+  path, which broke relative-path portability. A database migration removes any
+  such stale ``artpath`` attributes left on items by earlier versions.
+  :bug:`6756`
 
 ..
     For plugin developers
@@ -122,10 +126,6 @@ Bug fixes
   queries.
 - :doc:`plugins/tidal`: Fix auth URL not printed in environments without a
   configured browser :bug:`6710`
-- Album ``store`` no longer copies ``artpath`` onto its items as an absolute
-  path, which broke relative-path portability. A database migration removes any
-  such stale ``artpath`` attributes left on items by earlier versions.
-  :bug:`6756`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~

--- a/test/library/test_migrations.py
+++ b/test/library/test_migrations.py
@@ -249,6 +249,32 @@ class TestLyricsMetadataInFlexFieldsMigration(MigrationTestHelper):
         )
 
 
+class TestRemoveInheritedArtpathMigration(MigrationTestHelper):
+    """Verify inherited artpath flex attributes are removed from items."""
+
+    migration = (migrations.RemoveInheritedArtpathMigration, (Item,))
+
+    def test_migrate(self):
+        """Ensure the inherited artpath flex attribute is removed from items."""
+        item = self.add_item()
+        # insert the flex attribute directly, as the buggy album store used to
+        self.lib._connection().execute(
+            "INSERT INTO item_attributes (entity_id, key, value) "
+            "VALUES (?, 'artpath', ?)",
+            (item.id, "/abs/path/to/cover.jpg"),
+        )
+
+        self.lib._migrate()
+
+        item.load()
+        with pytest.raises(AttributeError):
+            item.artpath
+
+        # remove cached initial db tables data
+        del self.lib.db_tables
+        assert self.lib.migration_exists("remove_inherited_artpath", "items")
+
+
 class TestRelativePathMigration(MigrationTestHelper):
     """Verify stored item paths are rewritten to library-relative values."""
 

--- a/test/library/test_migrations.py
+++ b/test/library/test_migrations.py
@@ -256,13 +256,7 @@ class TestRemoveInheritedArtpathMigration(MigrationTestHelper):
 
     def test_migrate(self):
         """Ensure the inherited artpath flex attribute is removed from items."""
-        item = self.add_item()
-        # insert the flex attribute directly, as the buggy album store used to
-        self.lib._connection().execute(
-            "INSERT INTO item_attributes (entity_id, key, value) "
-            "VALUES (?, 'artpath', ?)",
-            (item.id, "/abs/path/to/cover.jpg"),
-        )
+        item = self.add_item(artpath="/abs/path/to/cover.jpg")
 
         self.lib._migrate()
 

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -107,6 +107,17 @@ class TestStore(PytestItemHelper):
         assert "flex1" not in album
         assert "flex1" not in album.items()[0]
 
+    def test_store_does_not_propagate_artpath_to_items(self):
+        item = _common.item()
+        self.lib.add(item)
+        album = self.lib.add_album([item])
+        assert "artpath" not in Album.item_keys
+        album.artpath = b"/abs/path/to/cover.jpg"
+        album.store()
+        stored = self.lib.get_item(item.id)
+        assert "artpath" not in stored._values_flex
+        assert "artpath" not in stored._values_fixed
+
 
 class TestAdd(PytestItemHelper):
     def test_item_add_inserts_row(self, item):

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -115,8 +115,7 @@ class TestStore(PytestItemHelper):
         album.artpath = b"/abs/path/to/cover.jpg"
         album.store()
         stored = self.lib.get_item(item.id)
-        assert "artpath" not in stored._values_flex
-        assert "artpath" not in stored._values_fixed
+        assert not stored.get("artpath", with_album=False)
 
 
 class TestAdd(PytestItemHelper):


### PR DESCRIPTION
**Disclaimer**: Code changes were implemented with AI assistance, since I'm not familiar with the code base

## Description

Album.store(inherit=True) copied artpath onto items as a flexible attribute, defeating its exclusion from item_keys and persisting it as an absolute path that bypasses relative-path storage. Skip fixed album fields that aren't inheritable instead of treating them as flex attrs.

Fixes #6756

## To Do

- [x] Documentation
- [x] Changelog
- [x] Tests
