### PR TITLE
fix(tidal): Auth URL not printed in environments without a   configured browser

### DIFF
--- a/beetsplug/tidal/api.py
+++ b/beetsplug/tidal/api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import urllib.parse
 import webbrowser
+from contextlib import suppress
 from functools import cached_property
 from itertools import islice, zip_longest
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -154,10 +155,9 @@ class TidalAPI(RequestHandler):
         auth_url, _ = self.session.authorization_url(
             "https://login.tidal.com/authorize"
         )
-        try:
+        ui.print_(f"Visit: {auth_url}")
+        with suppress(webbrowser.Error):
             webbrowser.open(auth_url)
-        except webbrowser.Error:
-            ui.print_(f"Visit: {auth_url}")
         redirect_url = ui.input_("Paste redirected URL: ")
         self.session.fetch_token(
             "https://auth.tidal.com/v1/oauth2/token",

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -98,6 +98,8 @@ Bug fixes
 - :doc:`plugins/fish`: Fix error on plugin initialization.
 - :doc:`plugins/spotify`: Use single instead of double quotes in spotify
   queries.
+- :doc:`plugins/tidal`: Fix auth URL not printed in environments without a
+  configured browser :bug:`6710`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
closes #6710

- [x] Changelog