### PR TITLE
Handle nonexisting refs in release formatting

### DIFF
--- a/extra/release.py
+++ b/extra/release.py
@@ -101,8 +101,12 @@ def create_rst_replacements() -> list[Replacement]:
     def make_ref_link(ref_id: str, name: str | None = None) -> str:
         if ref_id.endswith("-cmd"):
             name = f"{ref_id.removesuffix('-cmd')} command"
-        ref = refs[ref_id]
-        return rf"`{name or ref.name} <{ref.url}>`_"
+        try:
+            ref = refs[ref_id]
+        except KeyError:
+            return f"``{name or ref_id}``"
+        else:
+            return rf"`{name or ref.name} <{ref.url}>`_"
 
     commands = "|".join(r.split("-")[0] for r in refs if r.endswith("-cmd"))
     plugins = "|".join(

--- a/test/test_release.py
+++ b/test/test_release.py
@@ -34,6 +34,8 @@ New features
 - :ref:`list-cmd` Update.
 - |BeetsPlugin| Some plugin change.
 - See :class:`~beetsplug._utils.musicbrainz.MusicBrainzAPI` for documentation.
+- See :class:`~nonexisting_ref` for non-existing reference.
+- See :ref:`Nice title <nonexisting_ref>` for non-existing named reference.
 
 You can do something with this command:
 
@@ -95,6 +97,8 @@ def md_changelog():
 - [list command](https://beets.readthedocs.io/en/stable/reference/cli.html#list-cmd) Update.
 - [Substitute Plugin](https://beets.readthedocs.io/en/stable/plugins/substitute.html): Some substitute multi-line change. :bug: (#5467)
 - See [beetsplug.\_utils.musicbrainz.MusicBrainzAPI](https://beets.readthedocs.io/en/stable/api/generated/beetsplug._utils.musicbrainz.MusicBrainzAPI.html#beetsplug._utils.musicbrainz.MusicBrainzAPI) for documentation.
+- See `Nice title` for non-existing named reference.
+- See `nonexisting_ref` for non-existing reference.
 
 You can do something with this command:
 


### PR DESCRIPTION
See https://github.com/beetbox/beets/actions/runs/27871722905/job/82484625599

- `extra/release.py` now makes release-note reference formatting resilient to missing Sphinx refs instead of failing with a `KeyError`.
- The core change is in `make_ref_link()`: known refs still become links, but unknown refs now fall back to inline code like `` `nonexisting_ref` ``.
- This keeps the release formatting pipeline working even when changelog text contains refs that are not present in the generated reference map.
- `test/test_release.py` adds coverage for this fallback path to confirm missing refs are rendered safely in the final Markdown output.


I tried adding `TimeoutAndRetrySession` to the docs however I received this error:

<img width="1260" height="565" alt="image" src="https://github.com/user-attachments/assets/f63eacfa-b805-4630-9697-0aac031f3697" />

