### PR TITLE
lrclib: skip tracks where both plainLyrics and syncedLyrics are null

### DIFF
--- a/beets/util/lyrics.py
+++ b/beets/util/lyrics.py
@@ -105,7 +105,7 @@ class Lyrics:
         """
         return [
             (m[1], m[2]) if (m := self.LINE_PARTS_PAT.match(line)) else ("", "")
-            for line in self.text.splitlines()
+            for line in (self.text or "").splitlines()
         ]
 
     @cached_property

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -398,10 +398,10 @@ class LRCLib(Backend):
         for group in self.fetch_candidates(artist, title, album, length):
             candidates = [evaluate_item(item) for item in group]
             if item := self.pick_best_match(candidates):
-                lyrics = item.get_text(self.config["synced"].get(bool))
-                return Lyrics(
-                    lyrics, self.__class__.name, f"{self.GET_URL}/{item.id}"
-                )
+                if lyrics := item.get_text(self.config["synced"].get(bool)):
+                    return Lyrics(
+                        lyrics, self.__class__.name, f"{self.GET_URL}/{item.id}"
+                    )
 
         return None
 

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -645,6 +645,11 @@ class TestLRCLibLyrics(LyricsBackendTest):
                 id="plain by default",
             ),
             pytest.param(
+                [lyrics_match(syncedLyrics=None, plainLyrics=None)],
+                None,
+                id="no lyrics when both fields are null",
+            ),
+            pytest.param(
                 [
                     lyrics_match(
                         duration=ITEM_DURATION,


### PR DESCRIPTION
lrclib occasionally returns records with `instrumental: false` but `plainLyrics: null` and `syncedLyrics: null` — tracks that simply have no lyrics stored yet.  A concrete example is Daft Punk - Nightvision (id 249829): lrclib has the record but no lyrics text for it:

```console
$ curl 'https://lrclib.net/api/get?artist_name=Daft+Punk&track_name=Nightvision&album_name=Discovery' | jq
{
  "id": 249829,
  "name": "Nightvision",
  "trackName": "Nightvision",
  "artistName": "Daft Punk",
  "albumName": "Discovery",
  "duration": 104.0,
  "instrumental": false,
  "plainLyrics": null,
  "syncedLyrics": null,
  "lyricsfile": null
}
```

Before this change, `LRCLyrics.get_text()` would return `None` (the value of `self.plain`) and `LRCLib.fetch()` would pass it straight to `Lyrics(None, ...)`, causing an `AttributeError` in `Lyrics._split_lines` when it called `None.splitlines()`.

Fix both layers:

- `LRCLib.fetch`: guard the `Lyrics` construction with `if lyrics := item.get_text(...)` so a null result is treated as "not found" and the backend continues searching other candidates.
- `Lyrics._split_lines`: add a defensive `(self.text or "")` guard so the dataclass does not crash if it is ever constructed with `text=None` through another code path.

Add a test case that exercises the null/null response path.

- [x] ~Documentation.~
- [x] ~Changelog.~
- [x] Tests.
