### PR TITLE
tidal: replace `AlbumAttributes`/`TrackAttributes` union with `Attributes`

### DIFF
--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -78,7 +78,7 @@ class TidalPlugin(MetadataSourcePlugin):
         """Return the configured path to the token file in the app directory."""
         return self.config["tokenfile"].get(confuse.Filename(in_app_dir=True))
 
-    def require_authentication(self):
+    def require_authentication(self) -> None:
         if not os.path.isfile(self._tokenfile()):
             raise UserError(
                 "Please login to TIDAL"
@@ -432,7 +432,7 @@ class TidalPlugin(MetadataSourcePlugin):
         return artist_names, artist_ids
 
     @staticmethod
-    def _parse_title(attributes: MediaAttributes):
+    def _parse_title(attributes: MediaAttributes) -> str:
         """
         Tidal UIs append the version string at the end of the title. We do the same here
         by formatting it as ``"{title} ({version})"`` to stay consistent.
@@ -565,7 +565,9 @@ class TidalPlugin(MetadataSourcePlugin):
             default=False,
         )
 
-        def auth_func(lib: Library, opts: optparse.Values, args: list[str]):
+        def auth_func(
+            lib: Library, opts: optparse.Values, args: list[str]
+        ) -> None:
             if opts.auth:
                 self.api.ui_authenticate_flow()
             else:
@@ -603,7 +605,9 @@ class TidalPlugin(MetadataSourcePlugin):
             "Usage: beet tidalsync <query> [options]"
         )
 
-        def sync_func(lib: Library, opts: optparse.Values, args: list[str]):
+        def sync_func(
+            lib: Library, opts: optparse.Values, args: list[str]
+        ) -> None:
             query = ["data_source:tidal", *args]
 
             if opts.album:

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -29,11 +29,11 @@ if TYPE_CHECKING:
 
     from .api_types import (
         AlbumAttributes,
+        MediaAttributes,
         ResourceIdentifier,
         TidalAlbum,
         TidalArtist,
         TidalTrack,
-        TrackAttributes,
     )
 
 
@@ -432,7 +432,7 @@ class TidalPlugin(MetadataSourcePlugin):
         return artist_names, artist_ids
 
     @staticmethod
-    def _parse_title(attributes: AlbumAttributes | TrackAttributes):
+    def _parse_title(attributes: MediaAttributes):
         """
         Tidal UIs append the version string at the end of the title. We do the same here
         by formatting it as ``"{title} ({version})"`` to stay consistent.
@@ -442,9 +442,7 @@ class TidalPlugin(MetadataSourcePlugin):
         return attributes["title"]
 
     @staticmethod
-    def _parse_data_url(
-        attributes: AlbumAttributes | TrackAttributes,
-    ) -> str | None:
+    def _parse_data_url(attributes: MediaAttributes) -> str | None:
         if external_links := attributes.get("externalLinks"):
             return external_links[0].get("href")
         return None
@@ -460,9 +458,7 @@ class TidalPlugin(MetadataSourcePlugin):
         return parts["seconds"] + parts["minutes"] * 60 + parts["hours"] * 3600
 
     @staticmethod
-    def _parse_label(
-        attributes: AlbumAttributes | TrackAttributes,
-    ) -> str | None:
+    def _parse_label(attributes: MediaAttributes) -> str | None:
         if copyright_ := attributes.get("copyright"):
             return copyright_["text"]
         return None
@@ -482,7 +478,7 @@ class TidalPlugin(MetadataSourcePlugin):
         return None
 
     @staticmethod
-    def _parse_popularity(attributes: AlbumAttributes | TrackAttributes) -> int:
+    def _parse_popularity(attributes: MediaAttributes) -> int:
         return round(attributes["popularity"] * 100)
 
     def sync_item_popularity(

--- a/beetsplug/tidal/api_types.py
+++ b/beetsplug/tidal/api_types.py
@@ -42,38 +42,39 @@ class ArtistAttributes(TypedDict):
     spotlighted: NotRequired[bool]
 
 
-class AlbumAttributes(TypedDict):
+class MediaAttributes(TypedDict):
+    duration: str  # ISO 8601
+    title: str
+    explicit: bool
+    mediaTags: list[str]
+    popularity: float
+
+    accessType: NotRequired[Literal["PUBLIC", "UNLISTED", "PRIVATE"]]
+    copyright: NotRequired[Copyright]
+    createdAt: NotRequired[str]  # ISO 8601 datetime
+    externalLinks: NotRequired[list[ExternalLink]]
+    version: NotRequired[str]
+
+
+class AlbumAttributes(MediaAttributes):
     # see "Albums_Attributes"
     # in https://tidal-music.github.io/tidal-api-reference/tidal-api-oas.json
 
     # Required
     albumType: Literal["ALBUM", "EP", "SINGLE"]
     barcodeId: str
-    duration: str  # ISO 8601
-    explicit: bool
-    mediaTags: list[str]
     numberOfItems: int
     numberOfVolumes: int
-    popularity: float
-    title: str
 
     # Optional
-    accessType: NotRequired[Literal["PUBLIC", "UNLISTED", "PRIVATE"]]
-    copyright: NotRequired[Copyright]
-    createdAt: NotRequired[str]  # ISO 8601 datetime
-    externalLinks: NotRequired[list[ExternalLink]]
     releaseDate: NotRequired[str]  # ISO date YYYY-MM-DD
-    version: NotRequired[str]
 
 
-class TrackAttributes(TypedDict):
+class TrackAttributes(MediaAttributes):
     # see "Tracks_Attributes"
     # in https://tidal-music.github.io/tidal-api-reference/tidal-api-oas.json
 
     # Required
-    title: str
-    duration: str  # ISO 8601
-    explicit: bool
     isrc: str
     key: Literal[
         "UNKNOWN",
@@ -106,18 +107,11 @@ class TrackAttributes(TypedDict):
         "MELODIC_MINOR",
         "PENTATONIC_MINOR",
     ]
-    mediaTags: list[str]
-    popularity: float
 
     # Optional
-    accessType: NotRequired[Literal["PUBLIC", "UNLISTED", "PRIVATE"]]
     bpm: NotRequired[float]
-    copyright: NotRequired[Copyright]
-    createdAt: NotRequired[str]  # ISO 8601 datetime
-    externalLinks: NotRequired[list[ExternalLink]]
     spotlighted: NotRequired[bool]
     toneTags: NotRequired[list[str]]
-    version: NotRequired[str]
 
 
 class SearchAttributes(TypedDict):

--- a/beetsplug/tidal/api_types.py
+++ b/beetsplug/tidal/api_types.py
@@ -43,6 +43,17 @@ class ArtistAttributes(TypedDict):
 
 
 class MediaAttributes(TypedDict):
+    """Describe media metadata exposed by the TIDAL API.
+
+    Combines the core values needed to identify and present a media item with
+    optional publishing, attribution, and sharing details when TIDAL provides
+    them.
+
+    While this type is not part of the original TIDAL json:api schema itself, we
+    introduced it to simplify our type definitions and allow for easier reuse of
+    shared attributes.
+    """
+
     duration: str  # ISO 8601
     title: str
     explicit: bool
@@ -57,6 +68,12 @@ class MediaAttributes(TypedDict):
 
 
 class AlbumAttributes(MediaAttributes):
+    """Represent album-specific metadata returned by the TIDAL API.
+
+    Extends shared media fields with release packaging details that describe how
+    an album is published and how many items or volumes it contains.
+    """
+
     # see "Albums_Attributes"
     # in https://tidal-music.github.io/tidal-api-reference/tidal-api-oas.json
 
@@ -71,6 +88,12 @@ class AlbumAttributes(MediaAttributes):
 
 
 class TrackAttributes(MediaAttributes):
+    """Represent track-specific metadata returned by the TIDAL API.
+
+    Adds the musical and catalog information needed to describe an individual
+    recording, while allowing enrichment fields when TIDAL includes them.
+    """
+
     # see "Tracks_Attributes"
     # in https://tidal-music.github.io/tidal-api-reference/tidal-api-oas.json
 


### PR DESCRIPTION
@semohr, as discussed:

- Extracts the Tidal fields shared by albums and tracks into a new `Attributes` `TypedDict` in `beetsplug/tidal/api_types.py`.

- Updates parser helpers in `beetsplug/tidal/__init__.py` to depend on `Attributes` instead of the `AlbumAttributes | TrackAttributes` union when they only read common metadata like title, links, label, and popularity.

- High-level impact: this reduces duplicated type definitions, makes the shared contract clearer, and simplifies future changes to common Tidal metadata without changing album- and track-specific types.
