### PR TITLE
lyrics: add `--no-keep-synced` CLI option

### DIFF
--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -1088,7 +1088,14 @@ class LyricsPlugin(LyricsRequestHandler, plugins.BeetsPlugin):
             "--keep-synced",
             action="store_true",
             default=self.config["keep_synced"].get(),
-            help="re-download only unsynced lyrics",
+            help="skip items that already have synced lyrics",
+        )
+        cmd.parser.add_option(
+            "--no-keep-synced",
+            action="store_false",
+            dest="keep_synced",
+            default=self.config["keep_synced"].get(),
+            help="do not skip items that already have synced lyrics",
         )
         cmd.parser.add_option(
             "-l",

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,8 @@ New features
   album art from online sources even when imported files are not modified by the
   auto-tagger. Default is ``no`` which means ``fetchart`` looks for art only in
   the local filesystem when the user (or ``quiet_fallback``) chooses ``asis``.
+- :doc:`plugins/lyrics`: Added a ``--no-keep-synced`` command option to override
+  ``keep_synced: yes`` for a single manual lyrics fetch.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/plugins/lyrics.rst
+++ b/docs/plugins/lyrics.rst
@@ -149,7 +149,9 @@ that already have lyrics.
 
 The ``--keep-synced`` option skips tracks that already have synced lyrics,
 regardless of the ``force`` flag. This is handy when you want to re-fetch plain
-lyrics without touching tracks that already have a synced version.
+lyrics without touching tracks that already have a synced version. Use
+``--no-keep-synced`` to override a ``keep_synced: yes`` configuration for a
+single command run.
 
 Inversely, the ``-l, --local`` option restricts operations to lyrics that are
 locally available, which show lyrics faster without using the network at all.

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -863,6 +863,39 @@ class TestLyricsRestDirectory(PluginTestHelper):
         assert test_capture.get("directory") == Path(output_path).expanduser()
 
 
+class TestLyricsKeepSyncedCommand(PluginTestHelper):
+    plugin = "lyrics"
+
+    @pytest.mark.parametrize(
+        "config_keep_synced, cmd_args, expected_keep_synced",
+        [
+            pytest.param(False, (), False, id="disabled-by-default"),
+            pytest.param(True, (), True, id="enabled-by-config"),
+            pytest.param(False, ("--keep-synced",), True, id="cli-enables"),
+            pytest.param(
+                True, ("--no-keep-synced",), False, id="cli-disables-config"
+            ),
+        ],
+    )
+    def test_keep_synced_cli_option(
+        self, monkeypatch, config_keep_synced, cmd_args, expected_keep_synced
+    ):
+        self.config["lyrics"]["keep_synced"] = config_keep_synced
+        self.add_item(lyrics="[00:00.00] old synced")
+        observed_keep_synced = []
+
+        def capture_keep_synced(plugin, *_):
+            observed_keep_synced.append(plugin.config["keep_synced"].get(bool))
+
+        monkeypatch.setattr(
+            lyrics.LyricsPlugin, "add_item_lyrics", capture_keep_synced
+        )
+
+        self.run_command("lyrics", *cmd_args)
+
+        assert observed_keep_synced.pop(0) is expected_keep_synced
+
+
 class TestLyricsSyltProperty:
     """Unit tests for the Lyrics.sylt timestamp-to-millisecond converter."""
 


### PR DESCRIPTION
- This change adds a small CLI override to `beetsplug/lyrics.py`: `--no-keep-synced`. It is the inverse of `--keep-synced`, and lets one manual `lyrics` run ignore the configured `keep_synced: yes`.
