### PR TITLE
Test speedup: cache `config.sources` in `ConfigMixin`

### DIFF
--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -19,6 +19,7 @@ import subprocess
 import sys
 import unittest
 from contextlib import contextmanager
+from copy import deepcopy
 from dataclasses import dataclass
 from functools import cache, cached_property
 from pathlib import Path
@@ -47,6 +48,7 @@ from beets.util import (
 if TYPE_CHECKING:
     from types import TracebackType
 
+    from confuse import ConfigSource
     from requests_mock.mocker import Mocker
     from typing_extensions import Self
 
@@ -93,11 +95,24 @@ NEEDS_FFPROBE = pytest.mark.skipif(
 
 
 class ConfigMixin:
-    @cached_property
-    def config(self) -> beets.IncludeLazyConfig:
-        """Base beets configuration for tests."""
-        config = beets.config
-        config.sources = []
+    """Provide isolated configuration for tests."""
+
+    _default_config_sources: ClassVar[list[ConfigSource] | None] = None
+
+    @classmethod
+    def default_config_sources(cls) -> list[ConfigSource]:
+        """Return a reusable default configuration baseline.
+
+        This way, we only need to call very expensive ``config.read`` once per
+        test session.
+
+        NOTE: we're not using ``util.cached_classproperty`` here because its cache is
+        reset on every test.
+        """
+        if cls._default_config_sources is not None:
+            return deepcopy(cls._default_config_sources)
+
+        config = beets.IncludeLazyConfig("beets", beets.__name__)
         config.read(user=False, defaults=True)
 
         config["plugins"] = []
@@ -105,6 +120,16 @@ class ConfigMixin:
         config["ui"]["color"] = False
         config["threaded"] = False
         config["create_backup_before_migrations"] = False
+        cls._default_config_sources = deepcopy(config.sources)
+        return deepcopy(cls._default_config_sources)
+
+    @cached_property
+    def config(self) -> beets.IncludeLazyConfig:
+        """Reset the shared config to a fresh test baseline."""
+        config = beets.config
+        config.clear()
+        config._materialized = True
+        config.sources.extend(self.default_config_sources())
         return config
 
 

--- a/test/autotag/test_distance.py
+++ b/test/autotag/test_distance.py
@@ -18,7 +18,7 @@ _p = pytest.param
 
 
 class TestDistance:
-    @pytest.fixture(autouse=True, scope="class")
+    @pytest.fixture(autouse=True)
     def setup_config(self, config):
         config["match"]["distance_weights"]["data_source"] = 2.0
         config["match"]["distance_weights"]["album"] = 4.0

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -99,7 +99,7 @@ def clear_cached_classproperty():
 
 @pytest.fixture(scope="module")
 def config():
-    """Provide a fresh beets configuration for a module, when requested."""
+    """Provide a fresh beets configuration when requested."""
     return ConfigMixin().config
 
 
@@ -131,11 +131,6 @@ def is_importable():
     return check_import
 
 
-# Shared fixtures amortize the expensive TestHelper setup across multiple tests.
-#
-# TestHelper resets and reloads the beets configuration, so recreating it for
-# every test can slow large suites noticeably.
-#
 # Inheriting from TestHelper gives each test function isolated state. Use the
 # fixtures below instead when a broader scope is safe and the suite benefits
 # from reusing the same helper instance.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -97,7 +97,7 @@ def clear_cached_classproperty():
     cached_classproperty.cache.clear()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def config():
     """Provide a fresh beets configuration when requested."""
     return ConfigMixin().config

--- a/test/dbcore/test_sort.py
+++ b/test/dbcore/test_sort.py
@@ -25,11 +25,6 @@ def helper(class_helper):
 
 
 @pytest.fixture(scope="class")
-def config(config):
-    return config
-
-
-@pytest.fixture(scope="class")
 def setup_library(request: pytest.FixtureRequest, helper):
     album_ids = [
         helper.lib.add(

--- a/test/plugins/test_lastgenre.py
+++ b/test/plugins/test_lastgenre.py
@@ -267,16 +267,6 @@ class LastGenrePluginTest(IOMixin, PluginTestCase):
         )
 
 
-@pytest.fixture
-def config(config):
-    """Provide a fresh beets configuration for every test/parameterize call
-
-    This is necessary to prevent the following parameterized test to bleed
-    config test state in between test cases.
-    """
-    return config
-
-
 @pytest.mark.parametrize(
     "config_values, item_genre, mock_genres, expected_result",
     [

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -831,10 +831,6 @@ class TestRestFiles:
 class TestLyricsRestDirectory(PluginTestHelper):
     plugin = "lyrics"
 
-    @pytest.fixture
-    def lib(self, helper):
-        return helper.lib
-
     @pytest.mark.parametrize(
         "config_path, arg_path, output_path",
         [
@@ -848,9 +844,7 @@ class TestLyricsRestDirectory(PluginTestHelper):
             ),
         ],
     )
-    def test_rest_config(
-        self, monkeypatch, lib, config_path, arg_path, output_path
-    ):
+    def test_rest_config(self, monkeypatch, config_path, arg_path, output_path):
         test_capture = {}
 
         class MockRestFiles:
@@ -861,12 +855,11 @@ class TestLyricsRestDirectory(PluginTestHelper):
                 test_capture["items"] = items
 
         monkeypatch.setattr(lyrics, "RestFiles", MockRestFiles)
-
-        if config_path:
-            self.config["lyrics"]["rest_directory"] = config_path
+        self.add_item(lyrics="hello")
 
         cmd_args = [] if arg_path is None else ["-r", arg_path]
-        self.run_command("lyrics", *cmd_args, lib=lib)
+        with self.configure_plugin({"rest_directory": config_path}):
+            self.run_command("lyrics", *cmd_args)
 
         assert test_capture.get("directory") == Path(output_path).expanduser()
 


### PR DESCRIPTION
- Moves the expensive config setup into `ConfigMixin`, which now caches a default `config.sources` baseline once and rebuilds isolated test config from that baseline for each test instead of re-reading full config every time.
- Changes the shared test config flow so the `config` fixture is now function-scoped, giving each test and parametrized case a fresh config by default.
- Updates affected tests such as `test/autotag/test_distance.py`, `test/plugins/test_lastgenre.py`, and `test/plugins/test_lyrics.py` to use the new isolated flow, since per-test config setup is no longer too expensive.

**High-level impact**

- Improves test isolation by preventing shared config state from leaking across tests.
- Makes the suite easier to reason about because config lifecycle is handled in one place.
- Speeds up tests up to `2x` by avoiding repeated full config reads while keeping fresh per-test state.

See two test modules, for example, where `ConfigMixin` is used extensively:

### Before

```sh
$ pytest test/test_library.py
...
test/test_library.py ...............ss........................................................................................... [148/174]
..........................                                                                                                        [174/174]
...
================================= 172 passed, 2 skipped in 10.42s ==========================================================================
$ pytest test/test_importer.py
...
test/test_importer.py ..s.ss.........................................s.......s.........................................           [137/137]
...
================================= 129 passed, 8 skipped in 12.90s ==========================================================================
```

### After

```sh
$ pytest test/test_library.py
...
test/test_library.py ...............ss........................................................................................... [148/174]
..........................                                                                                                        [174/174]
...
================================== 172 passed, 2 skipped in 4.98s ==========================================================================
$ pytest test/test_importer.py
...
test/test_importer.py ..s.ss.........................................s.......s.........................................           [137/137]
...
================================== 129 passed, 8 skipped in 9.27s ==========================================================================
```
