### PR TITLE
tests: do not create db backups

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -1053,10 +1053,6 @@ class Migration(ABC):
         if not beets.config["create_backup_before_migrations"].get(bool):
             return
 
-        # In-memory databases have no persistent file to back up.
-        if self.db.path in (":memory:", b":memory:"):
-            return
-
         dest = os.fsdecode(self.db.path) + f"-before-{table}-{self.name}.bak"
         self.db.create_backup(dest)
 

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -118,6 +118,7 @@ class ConfigMixin:
         config["verbose"] = 1
         config["ui"]["color"] = False
         config["threaded"] = False
+        config["create_backup_before_migrations"] = False
         return config
 
 


### PR DESCRIPTION
This updates the test config setup in `beets/test/helper.py` so `ConfigMixin` always sets `config["create_backup_before_migrations"] = False`.

Tests no longer create database backups whenever `Database` is initialised. I saw a significant increase in test durations after #6742 was merged.
