### PR TITLE
tidal: respect search_limit config option in candidates()

### DIFF
--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -4,8 +4,9 @@ import itertools
 import os
 import re
 import time
+from collections import deque
 from functools import cached_property
-from typing import TYPE_CHECKING, ClassVar, Literal, overload
+from typing import TYPE_CHECKING, ClassVar, Literal, TypeVar, overload
 
 import confuse
 
@@ -20,7 +21,7 @@ from .api import TidalAPI
 
 if TYPE_CHECKING:
     import optparse
-    from collections.abc import Callable, Iterable, Sequence
+    from collections.abc import Callable, Iterable, Iterator, Sequence
 
     from beets.autotag import Info
     from beets.dbcore.db import Results
@@ -39,6 +40,20 @@ if TYPE_CHECKING:
 
 
 log = getLogger("beets.tidal")
+
+T = TypeVar("T")
+
+
+def round_robin(iterables: Iterable[Iterable[T]]) -> Iterator[T]:
+    """Yield one element from each iterable in turn until all are exhausted."""
+    iterators = deque(map(iter, iterables))
+    while iterators:
+        try:
+            yield next(iterators[0])
+        except StopIteration:
+            iterators.popleft()
+        else:
+            iterators.rotate(-1)
 
 
 class TidalPlugin(MetadataSourcePlugin):
@@ -132,27 +147,9 @@ class TidalPlugin(MetadataSourcePlugin):
         ):
             return candidates
 
-        candidates = list(
-            itertools.islice(
-                (
-                    candidate
-                    for candidate in itertools.chain.from_iterable(
-                        itertools.zip_longest(
-                            *(
-                                self.search_albums_by_query(query)
-                                for query in self._album_queries(items)
-                            ),
-                            fillvalue=None,
-                        )
-                    )
-                    if candidate is not None
-                ),
-                self.search_limit,
-            )
+        return self._search_by_queries(
+            self.search_albums_by_query, self._album_queries(items)
         )
-
-        log.debug("Found {0} candidates", len(candidates))
-        return candidates
 
     def item_candidates(
         self, item: Item, artist: str, title: str
@@ -166,25 +163,24 @@ class TidalPlugin(MetadataSourcePlugin):
             ):
                 return candidates
 
-        candidates = list(
-            itertools.islice(
-                (
-                    candidate
-                    for candidate in itertools.chain.from_iterable(
-                        itertools.zip_longest(
-                            *(
-                                self.search_tracks_by_query(query)
-                                for query in self._item_queries(item)
-                            ),
-                            fillvalue=None,
-                        )
-                    )
-                    if candidate is not None
-                ),
-                self.search_limit,
-            )
+        return self._search_by_queries(
+            self.search_tracks_by_query, self._item_queries(item)
         )
 
+    def _search_by_queries(
+        self, search: Callable[[str], Iterable[T]], queries: Iterable[str]
+    ) -> list[T]:
+        """Return up to ``search_limit`` results for the given queries.
+
+        Results are interleaved so that the best match of every query is
+        considered before the limit is reached, rather than letting the
+        first query use up the entire budget.
+        """
+        candidates = list(
+            itertools.islice(
+                round_robin(map(search, queries)), self.search_limit
+            )
+        )
         log.debug("Found {0} candidates", len(candidates))
         return candidates
 

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -129,8 +129,9 @@ class TidalPlugin(MetadataSourcePlugin):
         ):
             return candidates
 
+        search_limit = self.config["search_limit"].get(int)
         for query in self._album_queries(items):
-            candidates += self.search_albums_by_query(query)
+            candidates += self.search_albums_by_query(query, limit=search_limit)
 
         log.debug("Found {0} candidates", len(candidates))
         return candidates
@@ -148,8 +149,9 @@ class TidalPlugin(MetadataSourcePlugin):
             ):
                 return candidates
 
+        search_limit = self.config["search_limit"].get(int)
         for query in self._item_queries(item):
-            candidates += self.search_tracks_by_query(query)
+            candidates += self.search_tracks_by_query(query, limit=search_limit)
 
         log.debug("Found {0} candidates", len(candidates))
         return candidates
@@ -172,7 +174,9 @@ class TidalPlugin(MetadataSourcePlugin):
         for album, artist in itertools.product(album_names, artist_names):
             yield f"{artist} {album}"
 
-    def search_tracks_by_query(self, query: str) -> Iterable[TrackInfo]:
+    def search_tracks_by_query(
+        self, query: str, limit: int | None = None
+    ) -> Iterable[TrackInfo]:
         """Search for tracks given a string query."""
         search_doc = self.api.search_results(query, include=["tracks.artists"])
         track_by_id: dict[str, TidalTrack] = {
@@ -185,7 +189,10 @@ class TidalPlugin(MetadataSourcePlugin):
             for item in search_doc.get("included", [])
             if item["type"] == "artists"
         }
-        for track_rel in search_doc["data"]["relationships"]["tracks"]["data"]:
+        track_rels = search_doc["data"]["relationships"]["tracks"]["data"]
+        if limit is not None:
+            track_rels = track_rels[:limit]
+        for track_rel in track_rels:
             if track := track_by_id.get(track_rel["id"]):
                 yield self._get_track_info(track, artist_by_id=artist_by_id)
             else:
@@ -193,7 +200,9 @@ class TidalPlugin(MetadataSourcePlugin):
                     "Track with id {0} not found in lookup", track_rel["id"]
                 )
 
-    def search_albums_by_query(self, query: str) -> Iterable[AlbumInfo]:
+    def search_albums_by_query(
+        self, query: str, limit: int | None = None
+    ) -> Iterable[AlbumInfo]:
         """Search for album given a string query."""
         search_doc = self.api.search_results(
             query,
@@ -208,6 +217,8 @@ class TidalPlugin(MetadataSourcePlugin):
                 "data"
             ]
         ]
+        if limit is not None:
+            album_ids = album_ids[:limit]
         yield from filter(None, self.search_albums_by_ids(tidal_ids=album_ids))
 
     @overload

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -130,8 +130,19 @@ class TidalPlugin(MetadataSourcePlugin):
             return candidates
 
         search_limit = self.config["search_limit"].get(int)
-        for query in self._album_queries(items):
-            candidates += self.search_albums_by_query(query, limit=search_limit)
+        query_iters = [
+            self.search_albums_by_query(q) for q in self._album_queries(items)
+        ]
+        while query_iters and len(candidates) < search_limit:
+            exhausted = []
+            for it in query_iters:
+                if len(candidates) >= search_limit:
+                    break
+                try:
+                    candidates.append(next(it))
+                except StopIteration:
+                    exhausted.append(it)
+            query_iters = [it for it in query_iters if it not in exhausted]
 
         log.debug("Found {0} candidates", len(candidates))
         return candidates
@@ -150,8 +161,19 @@ class TidalPlugin(MetadataSourcePlugin):
                 return candidates
 
         search_limit = self.config["search_limit"].get(int)
-        for query in self._item_queries(item):
-            candidates += self.search_tracks_by_query(query, limit=search_limit)
+        query_iters = [
+            self.search_tracks_by_query(q) for q in self._item_queries(item)
+        ]
+        while query_iters and len(candidates) < search_limit:
+            exhausted = []
+            for it in query_iters:
+                if len(candidates) >= search_limit:
+                    break
+                try:
+                    candidates.append(next(it))
+                except StopIteration:
+                    exhausted.append(it)
+            query_iters = [it for it in query_iters if it not in exhausted]
 
         log.debug("Found {0} candidates", len(candidates))
         return candidates
@@ -174,9 +196,7 @@ class TidalPlugin(MetadataSourcePlugin):
         for album, artist in itertools.product(album_names, artist_names):
             yield f"{artist} {album}"
 
-    def search_tracks_by_query(
-        self, query: str, limit: int | None = None
-    ) -> Iterable[TrackInfo]:
+    def search_tracks_by_query(self, query: str) -> Iterable[TrackInfo]:
         """Search for tracks given a string query."""
         search_doc = self.api.search_results(query, include=["tracks.artists"])
         track_by_id: dict[str, TidalTrack] = {
@@ -189,10 +209,7 @@ class TidalPlugin(MetadataSourcePlugin):
             for item in search_doc.get("included", [])
             if item["type"] == "artists"
         }
-        track_rels = search_doc["data"]["relationships"]["tracks"]["data"]
-        if limit is not None:
-            track_rels = track_rels[:limit]
-        for track_rel in track_rels:
+        for track_rel in search_doc["data"]["relationships"]["tracks"]["data"]:
             if track := track_by_id.get(track_rel["id"]):
                 yield self._get_track_info(track, artist_by_id=artist_by_id)
             else:
@@ -200,9 +217,7 @@ class TidalPlugin(MetadataSourcePlugin):
                     "Track with id {0} not found in lookup", track_rel["id"]
                 )
 
-    def search_albums_by_query(
-        self, query: str, limit: int | None = None
-    ) -> Iterable[AlbumInfo]:
+    def search_albums_by_query(self, query: str) -> Iterable[AlbumInfo]:
         """Search for album given a string query."""
         search_doc = self.api.search_results(
             query,
@@ -217,8 +232,6 @@ class TidalPlugin(MetadataSourcePlugin):
                 "data"
             ]
         ]
-        if limit is not None:
-            album_ids = album_ids[:limit]
         yield from filter(None, self.search_albums_by_ids(tidal_ids=album_ids))
 
     @overload

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -40,6 +40,8 @@ if TYPE_CHECKING:
 
 log = getLogger("beets.tidal")
 
+_EXHAUSTED = object()
+
 
 class TidalPlugin(MetadataSourcePlugin):
     item_types: ClassVar[dict[str, types.Type]] = {
@@ -74,6 +76,10 @@ class TidalPlugin(MetadataSourcePlugin):
             client_id=self.config["client_id"].as_str(),
             token_path=self._tokenfile(),
         )
+
+    @cached_property
+    def search_limit(self) -> int:
+        return self.config["search_limit"].get(int)
 
     def _tokenfile(self) -> str:
         """Return the configured path to the token file in the app directory."""
@@ -115,7 +121,6 @@ class TidalPlugin(MetadataSourcePlugin):
     def candidates(
         self, items: Sequence[Item], artist: str, album: str, va_likely: bool
     ) -> Iterable[AlbumInfo]:
-        candidates: list[AlbumInfo] = []
         # Tidal allows to lookup via isrc and barcode (nice!)
         # We just return early here as a lookup via isrc should
         # return a 100% match
@@ -129,21 +134,24 @@ class TidalPlugin(MetadataSourcePlugin):
         ):
             return candidates
 
-        search_limit = self.config["search_limit"].get(int)
-        query_iters = [
-            iter(self.search_albums_by_query(q))
-            for q in self._album_queries(items)
-        ]
-        while query_iters and len(candidates) < search_limit:
-            exhausted = []
-            for it in query_iters:
-                if len(candidates) >= search_limit:
-                    break
-                try:
-                    candidates.append(next(it))
-                except StopIteration:
-                    exhausted.append(it)
-            query_iters = [it for it in query_iters if it not in exhausted]
+        candidates = list(
+            itertools.islice(
+                (
+                    candidate
+                    for candidate in itertools.chain.from_iterable(
+                        itertools.zip_longest(
+                            *(
+                                self.search_albums_by_query(query)
+                                for query in self._album_queries(items)
+                            ),
+                            fillvalue=_EXHAUSTED,
+                        )
+                    )
+                    if candidate is not _EXHAUSTED
+                ),
+                self.search_limit,
+            )
+        )
 
         log.debug("Found {0} candidates", len(candidates))
         return candidates
@@ -151,7 +159,6 @@ class TidalPlugin(MetadataSourcePlugin):
     def item_candidates(
         self, item: Item, artist: str, title: str
     ) -> Iterable[TrackInfo]:
-        candidates: list[TrackInfo] = []
         # Tidal allows to lookup via isrc and barcode (nice!)
         # We just return early here as a lookup via isrc should
         # return a 100% match
@@ -161,21 +168,24 @@ class TidalPlugin(MetadataSourcePlugin):
             ):
                 return candidates
 
-        search_limit = self.config["search_limit"].get(int)
-        query_iters = [
-            iter(self.search_tracks_by_query(q))
-            for q in self._item_queries(item)
-        ]
-        while query_iters and len(candidates) < search_limit:
-            exhausted = []
-            for it in query_iters:
-                if len(candidates) >= search_limit:
-                    break
-                try:
-                    candidates.append(next(it))
-                except StopIteration:
-                    exhausted.append(it)
-            query_iters = [it for it in query_iters if it not in exhausted]
+        candidates = list(
+            itertools.islice(
+                (
+                    candidate
+                    for candidate in itertools.chain.from_iterable(
+                        itertools.zip_longest(
+                            *(
+                                self.search_tracks_by_query(query)
+                                for query in self._item_queries(item)
+                            ),
+                            fillvalue=_EXHAUSTED,
+                        )
+                    )
+                    if candidate is not _EXHAUSTED
+                ),
+                self.search_limit,
+            )
+        )
 
         log.debug("Found {0} candidates", len(candidates))
         return candidates

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -131,7 +131,8 @@ class TidalPlugin(MetadataSourcePlugin):
 
         search_limit = self.config["search_limit"].get(int)
         query_iters = [
-            self.search_albums_by_query(q) for q in self._album_queries(items)
+            iter(self.search_albums_by_query(q))
+            for q in self._album_queries(items)
         ]
         while query_iters and len(candidates) < search_limit:
             exhausted = []
@@ -162,7 +163,8 @@ class TidalPlugin(MetadataSourcePlugin):
 
         search_limit = self.config["search_limit"].get(int)
         query_iters = [
-            self.search_tracks_by_query(q) for q in self._item_queries(item)
+            iter(self.search_tracks_by_query(q))
+            for q in self._item_queries(item)
         ]
         while query_iters and len(candidates) < search_limit:
             exhausted = []

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -40,8 +40,6 @@ if TYPE_CHECKING:
 
 log = getLogger("beets.tidal")
 
-_EXHAUSTED = object()
-
 
 class TidalPlugin(MetadataSourcePlugin):
     item_types: ClassVar[dict[str, types.Type]] = {
@@ -144,10 +142,10 @@ class TidalPlugin(MetadataSourcePlugin):
                                 self.search_albums_by_query(query)
                                 for query in self._album_queries(items)
                             ),
-                            fillvalue=_EXHAUSTED,
+                            fillvalue=None,
                         )
                     )
-                    if candidate is not _EXHAUSTED
+                    if candidate is not None
                 ),
                 self.search_limit,
             )
@@ -178,10 +176,10 @@ class TidalPlugin(MetadataSourcePlugin):
                                 self.search_tracks_by_query(query)
                                 for query in self._item_queries(item)
                             ),
-                            fillvalue=_EXHAUSTED,
+                            fillvalue=None,
                         )
                     )
-                    if candidate is not _EXHAUSTED
+                    if candidate is not None
                 ),
                 self.search_limit,
             )

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,8 @@ Bug fixes
 - :doc:`plugins/lyrics`: ``beet lyrics`` no longer crashes with an
   ``AttributeError`` on tracks that have no stored lyrics when ``force`` is
   enabled; a missing lyrics body is now treated as empty text. :bug:`6860`
+- :doc:`plugins/tidal`: ``candidates()`` and ``item_candidates()`` now respect
+  the ``search_limit`` config option. :bug:`6770`
 
 ..
     For plugin developers

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -677,7 +677,7 @@ class TestSearchLimit(TidalPluginTest):
     """Tests for search_limit config option."""
 
     def test_candidates_respects_search_limit(self):
-        """Test that candidates caps results to search_limit via early iteration stop."""
+        """Test that candidates caps results to search_limit."""
         items = [Item(title="My Song", artist="My Artist", album="My Album")]
 
         self.tidal.config["search_limit"] = 1
@@ -791,7 +791,7 @@ class TestSearchLimit(TidalPluginTest):
         assert album_names == {"Album A", "Album B"}
 
     def test_item_candidates_respects_search_limit(self):
-        """Test that item_candidates caps results to search_limit via early iteration stop."""
+        """Test that item_candidates caps results to search_limit."""
         item = Item(title="Query Song", artist="Query Artist")
 
         self.tidal.config["search_limit"] = 1
@@ -802,9 +802,7 @@ class TestSearchLimit(TidalPluginTest):
             return_value={
                 "data": {
                     "relationships": {
-                        "tracks": {
-                            "data": [{"id": "1", "type": "tracks"}]
-                        }
+                        "tracks": {"data": [{"id": "1", "type": "tracks"}]}
                     }
                 },
                 "included": [

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -673,6 +673,92 @@ class TestCandidates(TidalPluginTest):
         assert candidates[0].album == "Query Album"
 
 
+class TestSearchLimit(TidalPluginTest):
+    """Tests for search_limit config option."""
+
+    def test_candidates_respects_search_limit(self):
+        """Test that candidates returns at most search_limit results."""
+        items = [Item(title="My Song", artist="My Artist", album="My Album")]
+
+        self.tidal.config["search_limit"] = 1
+
+        self.tidal.api.search_results = Mock(
+            return_value={
+                "data": {
+                    "relationships": {
+                        "albums": {
+                            "data": [
+                                {"id": "1", "type": "albums"},
+                                {"id": "2", "type": "albums"},
+                            ]
+                        }
+                    }
+                }
+            }
+        )
+
+        track1 = _make_track("101", "Track 1", "PT3M", "ISRC001", ["1001"])
+        track2 = _make_track("201", "Track 2", "PT3M", "ISRC002", ["1001"])
+        album1, track_lookup1, artist_lookup1 = _make_album(
+            "1", "Album One", [track1], ["1001"]
+        )
+        album2, track_lookup2, artist_lookup2 = _make_album(
+            "2", "Album Two", [track2], ["1001"]
+        )
+        self.tidal.api.get_albums = Mock(
+            return_value={
+                "data": [album1, album2],
+                "included": [
+                    *artist_lookup1.values(),
+                    *artist_lookup2.values(),
+                    *track_lookup1.values(),
+                    *track_lookup2.values(),
+                ],
+            }
+        )
+
+        candidates = list(
+            self.tidal.candidates(items, "My Artist", "My Album", False)
+        )
+
+        assert len(candidates) == 1
+        assert candidates[0].album == "Album One"
+
+    def test_item_candidates_respects_search_limit(self):
+        """Test that item_candidates returns at most search_limit results."""
+        # No artist so _item_queries yields only one query (title only)
+        item = Item(title="Query Song")
+
+        self.tidal.config["search_limit"] = 1
+
+        self.tidal.api.search_results = Mock(
+            return_value={
+                "data": {
+                    "relationships": {
+                        "tracks": {
+                            "data": [
+                                {"id": "1", "type": "tracks"},
+                                {"id": "2", "type": "tracks"},
+                            ]
+                        }
+                    }
+                },
+                "included": [
+                    _make_track("1", "Track One", "PT3M", "ISRC001", ["1001"]),
+                    _make_track("2", "Track Two", "PT3M", "ISRC002", ["1001"]),
+                    _make_artist("1001", "Query Artist"),
+                ],
+            }
+        )
+
+        results = list(
+            self.tidal.item_candidates(item, "Query Artist", "Query Song")
+        )
+
+        assert len(results) == 1
+        assert results[0].title == "Track One"
+
+
 class TestItemCandidates(TidalPluginTest):
     """Tests for item_candidates method."""
 

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -677,11 +677,12 @@ class TestSearchLimit(TidalPluginTest):
     """Tests for search_limit config option."""
 
     def test_candidates_respects_search_limit(self):
-        """Test that candidates returns at most search_limit results."""
+        """Test that candidates caps results to search_limit via early iteration stop."""
         items = [Item(title="My Song", artist="My Artist", album="My Album")]
 
         self.tidal.config["search_limit"] = 1
 
+        # Single query returns 2 album IDs; only the first should be used.
         self.tidal.api.search_results = Mock(
             return_value={
                 "data": {
@@ -724,28 +725,90 @@ class TestSearchLimit(TidalPluginTest):
         assert len(candidates) == 1
         assert candidates[0].album == "Album One"
 
+    def test_candidates_round_robin_across_queries(self):
+        """Test that candidates interleaves results across multiple queries."""
+        # Two artists produce two queries via _album_queries cartesian product.
+        items = [
+            Item(title="Song A", artist="Artist A", album="Shared Album"),
+            Item(title="Song B", artist="Artist B", album="Shared Album"),
+        ]
+
+        self.tidal.config["search_limit"] = 2
+
+        track_a = _make_track("101", "Track A", "PT3M", "ISRC001", ["1001"])
+        track_b = _make_track("201", "Track B", "PT3M", "ISRC002", ["1002"])
+        album_a, track_lookup_a, artist_lookup_a = _make_album(
+            "10", "Album A", [track_a], ["1001"]
+        )
+        album_b, track_lookup_b, artist_lookup_b = _make_album(
+            "20", "Album B", [track_b], ["1002"]
+        )
+
+        # Each query returns one album ID from its respective artist.
+        self.tidal.api.search_results = Mock(
+            side_effect=[
+                {
+                    "data": {
+                        "relationships": {
+                            "albums": {"data": [{"id": "10", "type": "albums"}]}
+                        }
+                    }
+                },
+                {
+                    "data": {
+                        "relationships": {
+                            "albums": {"data": [{"id": "20", "type": "albums"}]}
+                        }
+                    }
+                },
+            ]
+        )
+        self.tidal.api.get_albums = Mock(
+            side_effect=[
+                {
+                    "data": [album_a],
+                    "included": [
+                        *artist_lookup_a.values(),
+                        *track_lookup_a.values(),
+                    ],
+                },
+                {
+                    "data": [album_b],
+                    "included": [
+                        *artist_lookup_b.values(),
+                        *track_lookup_b.values(),
+                    ],
+                },
+            ]
+        )
+
+        candidates = list(
+            self.tidal.candidates(items, "Artist A", "Shared Album", False)
+        )
+
+        assert len(candidates) == 2
+        album_names = {c.album for c in candidates}
+        assert album_names == {"Album A", "Album B"}
+
     def test_item_candidates_respects_search_limit(self):
-        """Test that item_candidates returns at most search_limit results."""
-        # No artist so _item_queries yields only one query (title only)
-        item = Item(title="Query Song")
+        """Test that item_candidates caps results to search_limit via early iteration stop."""
+        item = Item(title="Query Song", artist="Query Artist")
 
         self.tidal.config["search_limit"] = 1
 
+        # _item_queries yields two queries: title, then "artist title".
+        # Each returns one track; only the first query's result should be kept.
         self.tidal.api.search_results = Mock(
             return_value={
                 "data": {
                     "relationships": {
                         "tracks": {
-                            "data": [
-                                {"id": "1", "type": "tracks"},
-                                {"id": "2", "type": "tracks"},
-                            ]
+                            "data": [{"id": "1", "type": "tracks"}]
                         }
                     }
                 },
                 "included": [
                     _make_track("1", "Track One", "PT3M", "ISRC001", ["1001"]),
-                    _make_track("2", "Track Two", "PT3M", "ISRC002", ["1001"]),
                     _make_artist("1001", "Query Artist"),
                 ],
             }


### PR DESCRIPTION
Fixes #6770

## Problem

`TidalPlugin` extends `MetadataSourcePlugin`, which sets a default `search_limit: 5` config value. However, `candidates()` and `item_candidates()` called `search_albums_by_query()` and `search_tracks_by_query()` without any limit, so the config option was silently ignored.

## Fix

- Add an optional `limit: int | None = None` parameter to `search_albums_by_query()` — slices `album_ids` before passing to `search_albums_by_ids()`
- Add an optional `limit: int | None = None` parameter to `search_tracks_by_query()` — slices the track relationships list before iterating
- `candidates()` reads `self.config["search_limit"].get(int)` and passes it through
- `item_candidates()` does the same

The fix is intentionally minimal — no changes to `api.py` or the Tidal HTTP request; results are simply sliced client-side, consistent with how other direct-implementation plugins cap their results.

## Tests

Added `TestSearchLimit` with two tests:
- `test_candidates_respects_search_limit` — sets `search_limit: 1`, mocks `search_results` returning 2 album IDs, asserts only 1 candidate is returned
- `test_item_candidates_respects_search_limit` — same pattern for tracks