### PR TITLE
Fix update with plugin media flex fields

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -597,7 +597,7 @@ class Model(ABC, Generic[D]):
         assignments = []
         subvars: list[SQLiteType] = []
         for key in fields:
-            if key != "id" and key in self._dirty:
+            if key != "id" and key in self._fields and key in self._dirty:
                 self._dirty.remove(key)
                 assignments.append(f"{key}=?")
                 value = self._type(key).to_sql(self[key])

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,8 @@ Bug fixes
 - Add ``editor`` config option to allow users to permanently set their preferred
   editor, overriding ``$VISUAL`` and ``$EDITOR`` environment variables.
   :bug:`6641`
+- ``beet update`` no longer crashes when a plugin-added media field is stored as
+  a flexible attribute. :bug:`5580`
 - A date range query written back to front (for example ``added:2024..2020``) no
   longer crashes with an uncaught ``ValueError``. The endpoints are now swapped,
   so such a range means the same as ``added:2020..2024``.

--- a/test/dbcore/test_db.py
+++ b/test/dbcore/test_db.py
@@ -283,6 +283,15 @@ class ModelTest(unittest.TestCase):
         other_model = self.db._get(ModelFixture1, model.id)
         assert other_model.foo == "bar"
 
+    def test_store_flexattr_in_fields(self):
+        model = ModelFixture1()
+        model.add(self.db)
+        model.foo = "bar"
+        model.store(fields=["foo"])
+
+        other_model = self.db._get(ModelFixture1, model.id)
+        assert other_model.foo == "bar"
+
     def test_delete_flexattr(self):
         model = ModelFixture1()
         model["foo"] = "bar"

--- a/test/ui/commands/test_update.py
+++ b/test/ui/commands/test_update.py
@@ -1,6 +1,8 @@
+import mediafile
 from mediafile import MediaFile
 
 from beets import library
+from beets.plugins import BeetsPlugin
 from beets.test import _common
 from beets.test.helper import BeetsTestCase, IOMixin
 from beets.ui.commands.update import update_items
@@ -81,6 +83,29 @@ class UpdateTest(IOMixin, BeetsTestCase):
         self._update()
         item = self.lib.items().get()
         assert item.title == "differentTitle"
+
+    def test_modified_plugin_media_field_detected(self):
+        plugin = BeetsPlugin()
+        plugin.add_media_field(
+            "customtag",
+            mediafile.MediaField(
+                mediafile.MP3DescStorageStyle("customtag"),
+                mediafile.StorageStyle("customtag"),
+            ),
+        )
+
+        try:
+            mf = MediaFile(self.i.filepath)
+            mf.customtag = "F#"
+            mf.save()
+
+            self._update()
+
+            item = self.lib.get_item(self.i.id)
+            assert item["customtag"] == "F#"
+        finally:
+            delattr(mediafile.MediaFile, "customtag")
+            library.Item._media_fields.remove("customtag")
 
     def test_modified_metadata_moved(self):
         mf = MediaFile(self.i.filepath)


### PR DESCRIPTION
## Summary
- avoid treating flexible attributes passed to Model.store(fields=...) as fixed table columns
- add a dbcore regression test for storing a flexattr included in fields
- add an update command regression test for plugin-added media fields
- add a changelog note for #5580

Fixes #5580.

## Tests
- `poe test test/test_dbcore.py test/ui/commands/test_update.py`
- `poe lint`
- `poe check-format`
