### PR TITLE
Use Deezer album artist for missing contributors

### DIFF
--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -77,11 +77,12 @@ class DeezerPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
         if not (album_data := self.fetch_data(album_url)):
             return None
 
+        album_artist, album_artist_id = self.get_artist([album_data["artist"]])
         contributors = album_data.get("contributors")
-        if contributors is not None:
+        if contributors:
             artist, artist_id = self.get_artist(contributors)
         else:
-            artist, artist_id = None, None
+            artist, artist_id = album_artist, album_artist_id
 
         release_date = album_data["release_date"]
         date_parts = [int(part) for part in release_date.split("-")]
@@ -135,10 +136,8 @@ class DeezerPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
             album_id=deezer_id,
             deezer_album_id=deezer_id,
             artist=artist,
-            artist_credit=(
-                artist if is_va else self.get_artist([album_data["artist"]])[0]
-            ),
-            artist_id=str(artist_id),
+            artist_credit=(artist if is_va else album_artist),
+            artist_id=str(artist_id) if artist_id is not None else None,
             tracks=tracks,
             albumtype=album_data["record_type"],
             va=is_va,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,8 @@ Bug fixes
   example a multi-disc album whose cover lives in the album root rather than a
   per-disc directory); the missing art is skipped instead. :bug:`4692`
 - :doc:`plugins/tidal`: Normalize Tidal album types to lowercase.
+- :doc:`plugins/deezer`: Use Deezer's album artist when album contributors are
+  missing. :bug:`4339`
 
 ..
     For plugin developers

--- a/test/plugins/test_deezer.py
+++ b/test/plugins/test_deezer.py
@@ -1,0 +1,89 @@
+"""Tests for the 'deezer' plugin."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from beets import config
+from beetsplug.deezer import VARIOUS_ARTISTS_ID, DeezerPlugin
+
+
+def _album_data(
+    artist_id: int = 321, artist_name: str = "Album Artist"
+) -> dict[str, Any]:
+    return {
+        "id": 123,
+        "title": "Album Title",
+        "artist": {"id": artist_id, "name": artist_name},
+        "release_date": "2024-04-05",
+        "record_type": "album",
+        "label": "Example Label",
+        "link": "https://www.deezer.com/album/123",
+        "cover_xl": "https://e-cdns-images.dzcdn.net/images/cover/example",
+    }
+
+
+def _track_data() -> dict[str, Any]:
+    return {
+        "id": 456,
+        "title": "Track Title",
+        "artist": {"id": 654, "name": "Track Artist"},
+        "duration": 180,
+        "track_position": 1,
+        "disk_number": 1,
+        "rank": 100,
+        "link": "https://www.deezer.com/track/456",
+    }
+
+
+def _plugin_with_album(monkeypatch, album_data: dict[str, Any]) -> DeezerPlugin:
+    plugin = DeezerPlugin()
+
+    def fetch_data(url: str):
+        if url == f"{plugin.album_url}123":
+            return album_data
+        if url == f"{plugin.album_url}123/tracks":
+            return {"data": [_track_data()]}
+        raise AssertionError(f"Unexpected Deezer URL: {url}")
+
+    monkeypatch.setattr(plugin, "fetch_data", fetch_data)
+    return plugin
+
+
+def test_album_for_id_uses_album_artist_when_contributors_missing(monkeypatch):
+    plugin = _plugin_with_album(monkeypatch, _album_data())
+
+    info = plugin.album_for_id("123")
+
+    assert info is not None
+    assert info.artist == "Album Artist"
+    assert info.artist_credit == "Album Artist"
+    assert info.artist_id == "321"
+
+
+def test_album_for_id_keeps_contributors_when_present(monkeypatch):
+    album_data = _album_data()
+    album_data["contributors"] = [
+        {"id": 654, "name": "Track Artist", "role": "Main"}
+    ]
+    plugin = _plugin_with_album(monkeypatch, album_data)
+
+    info = plugin.album_for_id("123")
+
+    assert info is not None
+    assert info.artist == "Track Artist"
+    assert info.artist_credit == "Album Artist"
+    assert info.artist_id == "654"
+
+
+def test_album_for_id_keeps_va_name_when_contributors_missing(monkeypatch):
+    plugin = _plugin_with_album(
+        monkeypatch, _album_data(VARIOUS_ARTISTS_ID, "Various Artists")
+    )
+
+    info = plugin.album_for_id("123")
+
+    assert info is not None
+    assert info.artist == config["va_name"].as_str()
+    assert info.artist_credit == config["va_name"].as_str()
+    assert info.artist_id == str(VARIOUS_ARTISTS_ID)


### PR DESCRIPTION
## Description

Fixes #4339.

The Deezer album endpoint can omit `contributors`. In that case, album lookup currently avoids the original `KeyError`, but leaves `AlbumInfo.artist` unset and emits `"None"` for `artist_id`. This uses the album `artist` object as the fallback, keeping contributor-derived artist data when Deezer provides it and preserving the configured Various Artists name.

## Checklist

- [x] Tests
- [x] Changelog
- [x] Documentation not needed for this bug fix

## Checks

- `poe test -- test/plugins/test_deezer.py`
- `poe lint -- beetsplug/deezer.py test/plugins/test_deezer.py`
- `poe check-format -- beetsplug/deezer.py test/plugins/test_deezer.py`
- `git diff --check`
