### PR TITLE
Support hyphenated bash completion aliases

### DIFF
--- a/beets/ui/commands/completion.py
+++ b/beets/ui/commands/completion.py
@@ -9,6 +9,12 @@ from beets.util import syspath
 # Global logger.
 log = logging.getLogger("beets")
 
+COMPLETABLE_ALIAS = re.compile(r"^\w[\w-]*$")
+
+
+def _shell_var_suffix(value):
+    return value.replace("-", "_")
+
 
 def print_completion(*args):
     from beets.ui.commands import default_commands
@@ -63,7 +69,7 @@ def completion_script(commands):
         command_names.append(name)
 
         for alias in cmd.aliases:
-            if re.match(r"^\w+$", alias):
+            if COMPLETABLE_ALIAS.match(alias):
                 aliases[alias] = name
 
         options[name] = {"flags": [], "opts": []}
@@ -96,7 +102,7 @@ def completion_script(commands):
     # Command aliases
     yield f"  local aliases={' '.join(aliases.keys())!r}\n"
     for alias, cmd in aliases.items():
-        yield f"  local alias__{alias.replace('-', '_')}={cmd}\n"
+        yield f"  local alias__{_shell_var_suffix(alias)}={cmd}\n"
     yield "\n"
 
     # Fields
@@ -110,7 +116,8 @@ def completion_script(commands):
                 option_list = " ".join(option_list)
                 yield (
                     "  local"
-                    f" {option_type}__{cmd.replace('-', '_')}='{option_list}'\n"
+                    f" {option_type}__{_shell_var_suffix(cmd)}="
+                    f"'{option_list}'\n"
                 )
 
     yield "  _beet_dispatch\n"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,8 @@ Bug fixes
   example a multi-disc album whose cover lives in the album root rather than a
   per-disc directory); the missing art is skipped instead. :bug:`4692`
 - :doc:`plugins/tidal`: Normalize Tidal album types to lowercase.
+- Bash completion now includes plugin command aliases that contain hyphens,
+  matching the CLI's alias handling. :bug:`2836`
 
 ..
     For plugin developers

--- a/test/rsrc/beetsplug/test.py
+++ b/test/rsrc/beetsplug/test.py
@@ -14,6 +14,12 @@ class TestPlugin(BeetsPlugin):
         # Used in CompletionTest
         test.parser.add_option("-o", "--option", dest="my_opt")
 
+        hyphen = ui.Subcommand("test-plugin", aliases=["test-alias"])
+        hyphen.func = lambda *args: None
+
+        # Used in CompletionTest.
+        hyphen.parser.add_option("-o", "--option", dest="my_opt")
+
         plugin = ui.Subcommand("plugin")
         plugin.func = lambda *args: None
-        return [test, plugin]
+        return [test, hyphen, plugin]

--- a/test/rsrc/test_completion.sh
+++ b/test/rsrc/test_completion.sh
@@ -162,6 +162,15 @@ test_plugin_command() {
 
   initcli test - &&
   completes -o --option &&
+
+  initcli test-plugin - &&
+  completes -o --option &&
+
+  initcli test-alias &&
+  completes test-plugin &&
+
+  initcli test-alias - &&
+  completes -o --option &&
   true
 }
 

--- a/test/ui/commands/test_completion.py
+++ b/test/ui/commands/test_completion.py
@@ -4,12 +4,27 @@ import sys
 
 import pytest
 
+from beets import ui
 from beets.test import _common
 from beets.test.helper import RUNNING_IN_CI, IOMixin, has_program
-from beets.ui.commands.completion import BASH_COMPLETION_PATHS
+from beets.ui.commands.completion import (
+    BASH_COMPLETION_PATHS,
+    completion_script,
+)
 from beets.util import syspath
 
 from ..test_ui import TestPluginTestCase
+
+
+def test_completion_script_includes_hyphenated_aliases():
+    command = ui.Subcommand("test-plugin", aliases=["test-alias"])
+    command.parser.add_option("-o", "--option", dest="my_opt")
+
+    script = "".join(completion_script([command]))
+
+    assert "local aliases='test-alias'\n" in script
+    assert "local alias__test_alias=test-plugin\n" in script
+    assert "local opts__test_plugin='-o --option'\n" in script
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
## Summary

- Include hyphenated command aliases in bash completion metadata.
- Reuse the existing hyphen-to-underscore shell variable suffix for alias lookups.
- Cover hyphenated plugin commands and aliases in completion tests.

Fixes #2836.

## Checklist

- [x] Tests
- [x] Changelog
- [x] Documentation not needed for this bug fix

## Checks

- `poe test -- test/ui/commands/test_completion.py`
- `poe lint -- beets/ui/commands/completion.py test/ui/commands/test_completion.py test/rsrc/beetsplug/test.py`
- `poe check-format -- beets/ui/commands/completion.py test/ui/commands/test_completion.py test/rsrc/beetsplug/test.py`
- `git diff --check`

Note: one bash-completion integration assertion skipped locally because the system `bash-completion` script is not installed.
