### PR TITLE
Delay Dolphin metadata until thumbnails finish

### DIFF
--- a/beetsplug/thumbnails.py
+++ b/beetsplug/thumbnails.py
@@ -115,9 +115,6 @@ class ThumbnailsPlugin(BeetsPlugin):
             self._log.info("album {} has no art", album)
             return
 
-        if self.config["dolphin"]:
-            self.make_dolphin_cover_thumbnail(album)
-
         size = ArtResizer.shared.get_size(album.artpath)
         if not size:
             self._log.warning(
@@ -129,6 +126,9 @@ class ThumbnailsPlugin(BeetsPlugin):
         if max(size) >= 256:
             wrote &= self.make_cover_thumbnail(album, 256, LARGE_DIR)
         wrote &= self.make_cover_thumbnail(album, 128, NORMAL_DIR)
+
+        if self.config["dolphin"]:
+            self.make_dolphin_cover_thumbnail(album)
 
         if wrote:
             self._log.info("wrote thumbnail for {}", album)
@@ -161,8 +161,12 @@ class ThumbnailsPlugin(BeetsPlugin):
                 )
                 return False
         resized = ArtResizer.shared.resize(size, album.artpath, target)
+        if resized == album.artpath:
+            return False
+
         self.add_tags(album, resized)
-        shutil.move(syspath(resized), syspath(target))
+        if resized != target:
+            shutil.move(syspath(resized), syspath(target))
         return True
 
     def thumbnail_file_name(self, path):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,9 @@ Bug fixes
   example a multi-disc album whose cover lives in the album root rather than a
   per-disc directory); the missing art is skipped instead. :bug:`4692`
 - :doc:`plugins/tidal`: Normalize Tidal album types to lowercase.
+- :doc:`plugins/thumbnails`: Defer Dolphin ``.directory`` metadata until after
+  thumbnail generation, and avoid no-op moves when resizing already wrote the
+  target file. :bug:`3086`
 
 ..
     For plugin developers

--- a/test/plugins/test_thumbnails.py
+++ b/test/plugins/test_thumbnails.py
@@ -128,7 +128,7 @@ class ThumbnailsTest(BeetsTestCase):
         mock_resize = mock_artresizer.shared.resize
         mock_resize.return_value = path_to_resized_art
 
-        plugin.make_cover_thumbnail(album, 12345, thumbnail_dir)
+        assert plugin.make_cover_thumbnail(album, 12345, thumbnail_dir) is True
 
         mock_os.path.exists.assert_called_once_with(syspath(md5_file))
 
@@ -152,13 +152,33 @@ class ThumbnailsTest(BeetsTestCase):
 
         mock_os.stat.side_effect = os_stat
 
-        plugin.make_cover_thumbnail(album, 12345, thumbnail_dir)
+        assert plugin.make_cover_thumbnail(album, 12345, thumbnail_dir) is False
         assert mock_resize.call_count == 0
 
         # and with force
         plugin.config["force"] = True
-        plugin.make_cover_thumbnail(album, 12345, thumbnail_dir)
+        assert plugin.make_cover_thumbnail(album, 12345, thumbnail_dir) is True
         mock_resize.assert_called_once_with(12345, path_to_art, md5_file)
+
+        # no move is needed when the resizer already wrote the target
+        plugin.config["force"] = False
+        mock_os.path.exists.return_value = False
+        mock_resize.return_value = md5_file
+        plugin.add_tags.reset_mock()
+        mock_shutils.move.reset_mock()
+
+        assert plugin.make_cover_thumbnail(album, 12345, thumbnail_dir) is True
+        plugin.add_tags.assert_called_once_with(album, md5_file)
+        mock_shutils.move.assert_not_called()
+
+        # a resize failure returns the original art; keep it in place
+        mock_resize.return_value = path_to_art
+        plugin.add_tags.reset_mock()
+        mock_shutils.move.reset_mock()
+
+        assert plugin.make_cover_thumbnail(album, 12345, thumbnail_dir) is False
+        plugin.add_tags.assert_not_called()
+        mock_shutils.move.assert_not_called()
 
     @patch("beetsplug.thumbnails.ThumbnailsPlugin._check_local_ok", Mock())
     def test_make_dolphin_cover_thumbnail(self):
@@ -201,20 +221,34 @@ class ThumbnailsTest(BeetsTestCase):
         # cannot get art size
         album.artpath = b"/path/to/art"
         get_size.return_value = None
+        plugin.config["dolphin"] = True
         plugin.process_album(album)
         get_size.assert_called_once_with(b"/path/to/art")
         assert make_cover.call_count == 0
+        assert make_dolphin.call_count == 0
 
         # dolphin tests
         plugin.config["dolphin"] = False
         plugin.process_album(album)
         assert make_dolphin.call_count == 0
 
+        get_size.return_value = 200, 200
         plugin.config["dolphin"] = True
+        make_cover.reset_mock()
+        parent = Mock()
+        parent.attach_mock(make_cover, "make_cover")
+        parent.attach_mock(make_dolphin, "make_dolphin")
+
         plugin.process_album(album)
-        make_dolphin.assert_called_once_with(album)
+        assert parent.mock_calls == [
+            call.make_cover(album, 128, NORMAL_DIR),
+            call.make_dolphin(album),
+        ]
 
         # small art
+        make_cover.reset_mock()
+        make_dolphin.reset_mock()
+        plugin.config["dolphin"] = False
         get_size.return_value = 200, 200
         plugin.process_album(album)
         make_cover.assert_called_once_with(album, 128, NORMAL_DIR)


### PR DESCRIPTION
## Summary

- Create Dolphin `.directory` metadata after thumbnail generation has run.
- Skip thumbnail tagging and moves when resizing returns the original art path.
- Avoid moving resized output when the resizer already wrote the target file.

Fixes #3086.

## Checklist

- [x] Tests
- [x] Changelog
- [x] Documentation not needed for this bug fix

## Checks

- `poe test -- test/plugins/test_thumbnails.py test/test_art_resize.py test/plugins/test_art.py`
- `poe lint -- beetsplug/thumbnails.py test/plugins/test_thumbnails.py`
- `poe check-format -- beetsplug/thumbnails.py test/plugins/test_thumbnails.py`
- `git diff --check`

Note: GIO and ImageMagick backend tests skipped locally because those system libraries are not installed. The PIL-backed resize tests ran.
