### PR TITLE
Preview album item paths during move selection

### DIFF
--- a/beets/ui/commands/move.py
+++ b/beets/ui/commands/move.py
@@ -108,27 +108,24 @@ def move_items(
     if not objs:
         return
 
-    if pretend:
+    def path_changes(obj):
         if album:
-            show_path_changes(
-                [
-                    (item.path, item.destination(basedir=dest))
-                    for obj in objs
-                    for item in obj.items()
-                ]
-            )
-        else:
-            show_path_changes(
-                [(obj.path, obj.destination(basedir=dest)) for obj in objs]
-            )
+            return [
+                (item.path, item.destination(basedir=dest))
+                for item in obj.items()
+            ]
+        return [(obj.path, obj.destination(basedir=dest))]
+
+    if pretend:
+        show_path_changes(
+            [change for obj in objs for change in path_changes(obj)]
+        )
     else:
         if confirm:
             objs = ui.input_select_objects(
                 f"Really {act}",
                 objs,
-                lambda o: show_path_changes(
-                    [(o.path, o.destination(basedir=dest))]
-                ),
+                lambda o: show_path_changes(path_changes(o)),
             )
 
         for obj in objs:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,8 @@ Bug fixes
   example a multi-disc album whose cover lives in the album root rather than a
   per-disc directory); the missing art is skipped instead. :bug:`4692`
 - :doc:`plugins/tidal`: Normalize Tidal album types to lowercase.
+- :ref:`move-cmd`: Selecting albums during timid moves now previews the album's
+  item path changes instead of crashing. :bug:`2802`
 
 ..
     For plugin developers

--- a/test/ui/commands/test_move.py
+++ b/test/ui/commands/test_move.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from unittest.mock import patch
 
 from beets import library
 from beets.test.helper import BeetsTestCase
@@ -82,6 +83,39 @@ class MoveTest(BeetsTestCase):
 
     def test_pretend_move_album(self):
         self._move(album=True, pretend=True)
+        self.i.load()
+        assert self.i.filepath == self.initial_item_path
+
+    def test_select_move_album_previews_item_paths(self):
+        def select_first(prompt, objs, rep):
+            rep(objs[0])
+            return []
+
+        with (
+            patch(
+                "beets.ui.commands.move.ui.input_select_objects",
+                side_effect=select_first,
+            ),
+            patch("beets.ui.commands.move.show_path_changes") as show_paths,
+        ):
+            move_items(
+                self.lib,
+                self.otherdir,
+                (),
+                copy=True,
+                album=True,
+                pretend=False,
+                confirm=True,
+            )
+
+        show_paths.assert_called_once_with(
+            [
+                (
+                    self.i.path,
+                    self.i.destination(basedir=os.fsencode(self.otherdir)),
+                )
+            ]
+        )
         self.i.load()
         assert self.i.filepath == self.initial_item_path
 


### PR DESCRIPTION
## Summary

- Reuse the move preview path builder for both pretend mode and selection prompts.
- Expand album previews to the album item path changes during timid moves.
- Add regression coverage for selecting an album in move mode.

Fixes #2802.

## Checklist

- [x] Tests
- [x] Changelog
- [x] Documentation not needed for this bug fix

## Checks

- `poe test -- test/ui/commands/test_move.py`
- `poe lint -- beets/ui/commands/move.py test/ui/commands/test_move.py`
- `poe check-format -- beets/ui/commands/move.py test/ui/commands/test_move.py`
- `git diff --check`
