### PR TITLE
Keep redirected mbcollection releases

### DIFF
--- a/beetsplug/mbcollection.py
+++ b/beetsplug/mbcollection.py
@@ -28,7 +28,7 @@ from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand
 
 from ._utils.musicbrainz import MusicBrainzAPI
-from ._utils.requests import BeetsHTTPError
+from ._utils.requests import BeetsHTTPError, HTTPNotFoundError
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -149,6 +149,14 @@ class MBCollection:
             # Need to escape semicolons: https://github.com/psf/requests/issues/6990
             self.mb_api.delete(f"{self.releases_url}/{'%3B'.join(chunk)}")
 
+    def refresh(self) -> MBCollection:
+        """Return this collection with current metadata from MusicBrainz."""
+        for collection in self.mb_api.browse_collections():
+            if collection["id"] == self.id:
+                return type(self)(collection, self.mb_api)
+
+        raise UserError(f"collection no longer exists: {self.id}")
+
 
 class MusicBrainzCollectionPlugin(BeetsPlugin):
     def __init__(self) -> None:
@@ -215,6 +223,7 @@ class MusicBrainzCollectionPlugin(BeetsPlugin):
         """Update the MusicBrainz collection from a list of Beets albums"""
         try:
             collection = self.collection
+            albums = list(albums)
 
             # Get a list of all the album IDs.
             album_ids = [
@@ -227,10 +236,47 @@ class MusicBrainzCollectionPlugin(BeetsPlugin):
             )
             collection.add_releases(album_ids)
             if remove_missing:
+                collection = collection.refresh()
                 lib_ids = {x.mb_albumid for x in lib.albums()}
                 albums_in_collection = {r["id"] for r in collection.releases}
+                lib_ids.update(
+                    self._canonical_release_ids(
+                        album_ids,
+                        albums_in_collection,
+                        albums_in_collection - lib_ids,
+                    )
+                )
                 collection.remove_releases(list(albums_in_collection - lib_ids))
 
             self._log.info("...MusicBrainz collection updated.")
         except BeetsHTTPError as exc:
             self._log.error("Failed to update MusicBrainz collection: {}", exc)
+
+    def _canonical_release_ids(
+        self,
+        release_ids: Iterable[str],
+        collection_ids: set[str],
+        removal_candidates: set[str],
+    ) -> set[str]:
+        """Find canonical MusicBrainz IDs for redirected local releases."""
+        remaining_candidates = set(removal_candidates)
+        canonical_ids = set()
+
+        for release_id in release_ids:
+            if not remaining_candidates:
+                break
+            if release_id in collection_ids:
+                continue
+
+            try:
+                canonical_id = self.mb_api.get_release(release_id, includes=[])[
+                    "id"
+                ]
+            except HTTPNotFoundError:
+                continue
+
+            if canonical_id in remaining_candidates:
+                canonical_ids.add(canonical_id)
+                remaining_candidates.remove(canonical_id)
+
+        return canonical_ids

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,8 @@ Bug fixes
   example a multi-disc album whose cover lives in the album root rather than a
   per-disc directory); the missing art is skipped instead. :bug:`4692`
 - :doc:`plugins/tidal`: Normalize Tidal album types to lowercase.
+- :doc:`/plugins/mbcollection`: ``mbupdate --remove`` now keeps MusicBrainz
+  releases that are canonical redirect targets for local album IDs. :bug:`2914`
 
 ..
     For plugin developers

--- a/test/plugins/test_mbcollection.py
+++ b/test/plugins/test_mbcollection.py
@@ -79,18 +79,33 @@ class TestMbCollectionPlugin(PluginMixin, TestHelper):
         ]:
             self.lib.add(Album(mb_albumid=mb_albumid))
 
-        # The relevant collection
+        # The relevant collection, before and after adding local releases.
         requests_mock.get(
             "/ws/2/collection",
-            json={
-                "collections": [
-                    {
-                        "id": self.COLLECTION_ID,
-                        "entity_type": "release",
-                        "release_count": 3,
+            [
+                {
+                    "json": {
+                        "collections": [
+                            {
+                                "id": self.COLLECTION_ID,
+                                "entity_type": "release",
+                                "release_count": 3,
+                            }
+                        ]
                     }
-                ]
-            },
+                },
+                {
+                    "json": {
+                        "collections": [
+                            {
+                                "id": self.COLLECTION_ID,
+                                "entity_type": "release",
+                                "release_count": 5,
+                            }
+                        ]
+                    }
+                },
+            ],
         )
 
         collection_releases = f"/ws/2/collection/{self.COLLECTION_ID}/releases"
@@ -107,7 +122,16 @@ class TestMbCollectionPlugin(PluginMixin, TestHelper):
         )
         requests_mock.get(
             re.compile(rf".*{collection_releases}\b.*&offset=2.*"),
-            json={"releases": [{"id": "in_collection2"}]},
+            json={
+                "releases": [
+                    {"id": "in_collection2"},
+                    {"id": "00000000-0000-0000-0000-000000000001"},
+                ]
+            },
+        )
+        requests_mock.get(
+            re.compile(rf".*{collection_releases}\b.*&offset=4.*"),
+            json={"releases": [{"id": "00000000-0000-0000-0000-000000000002"}]},
         )
 
         # Force small submission chunk
@@ -132,7 +156,130 @@ class TestMbCollectionPlugin(PluginMixin, TestHelper):
 
         self.run_command("mbupdate", "--remove")
 
-        assert requests_mock.call_count == 6
+        assert requests_mock.call_count == 8
+
+    def test_mbupdate_remove_keeps_redirected_local_release(
+        self, requests_mock
+    ):
+        original_id = "d49a8839-f5f5-467d-a4ce-2d3d7e03908b"
+        canonical_id = "1b27bf95-17e9-48c2-82f6-087b7142b4d2"
+        remote_only_id = "00000000-0000-0000-0000-000000000003"
+        self.lib.add(Album(mb_albumid=original_id))
+
+        requests_mock.get(
+            "/ws/2/collection",
+            json={
+                "collections": [
+                    {
+                        "id": self.COLLECTION_ID,
+                        "entity_type": "release",
+                        "release_count": 2,
+                    }
+                ]
+            },
+        )
+
+        collection_releases = f"/ws/2/collection/{self.COLLECTION_ID}/releases"
+        requests_mock.put(re.compile(rf".*{collection_releases}/{original_id}"))
+        requests_mock.get(
+            re.compile(rf".*{collection_releases}\b.*&offset=0.*"),
+            json={"releases": [{"id": canonical_id}, {"id": remote_only_id}]},
+        )
+        requests_mock.get(
+            re.compile(rf".*/ws/2/release/{original_id}\b.*"),
+            status_code=301,
+            headers={
+                "Location": (
+                    "https://musicbrainz.org/ws/2/release/"
+                    f"{canonical_id}?fmt=json"
+                )
+            },
+        )
+        requests_mock.get(
+            re.compile(rf".*/ws/2/release/{canonical_id}\b.*"),
+            json={"id": canonical_id},
+        )
+        requests_mock.delete(
+            re.compile(rf".*{collection_releases}/{remote_only_id}")
+        )
+
+        self.run_command("mbupdate", "--remove")
+
+        delete_urls = [
+            request.url
+            for request in requests_mock.request_history
+            if request.method == "DELETE"
+        ]
+        assert len(delete_urls) == 1
+        assert remote_only_id in delete_urls[0]
+        assert canonical_id not in delete_urls[0]
+
+    def test_refresh_rejects_missing_collection(self):
+        class FakeAPI:
+            def browse_collections(self):
+                return [
+                    {
+                        "id": str(uuid.uuid4()),
+                        "entity_type": "release",
+                        "release_count": 0,
+                    }
+                ]
+
+        collection = mbcollection.MBCollection(
+            {"id": self.COLLECTION_ID, "release_count": 0}, FakeAPI()
+        )
+
+        with pytest.raises(UserError, match="collection no longer exists"):
+            collection.refresh()
+
+    def test_canonical_release_ids_stops_without_removal_candidates(self):
+        class FakeAPI:
+            def get_release(self, release_id, includes=None):
+                raise AssertionError("release lookup should not be called")
+
+        plugin = mbcollection.MusicBrainzCollectionPlugin()
+        plugin.__dict__["mb_api"] = FakeAPI()
+
+        assert (
+            plugin._canonical_release_ids(
+                ["00000000-0000-0000-0000-000000000001"], set(), set()
+            )
+            == set()
+        )
+
+    def test_canonical_release_ids_skips_missing_release(self):
+        class FakeAPI:
+            def get_release(self, release_id, includes=None):
+                raise mbcollection.HTTPNotFoundError()
+
+        plugin = mbcollection.MusicBrainzCollectionPlugin()
+        plugin.__dict__["mb_api"] = FakeAPI()
+
+        assert (
+            plugin._canonical_release_ids(
+                ["00000000-0000-0000-0000-000000000001"],
+                set(),
+                {"00000000-0000-0000-0000-000000000002"},
+            )
+            == set()
+        )
+
+    def test_canonical_release_ids_ignores_non_candidate(self):
+        class FakeAPI:
+            def get_release(self, release_id, includes=None):
+                return {"id": "00000000-0000-0000-0000-000000000003"}
+
+        plugin = mbcollection.MusicBrainzCollectionPlugin()
+        plugin.__dict__["mb_api"] = FakeAPI()
+
+        assert (
+            plugin._canonical_release_ids(
+                ["00000000-0000-0000-0000-000000000001"],
+                set(),
+                {"00000000-0000-0000-0000-000000000002"},
+            )
+            == set()
+        )
 
     def test_mbupdate_logs_unauthorized_errors(self, requests_mock, caplog):
         response = requests.Response()


### PR DESCRIPTION
## Summary

- Refresh mbcollection metadata after submitting releases when `--remove` is active.
- Keep canonical release IDs returned by MusicBrainz for redirected local album MBIDs before pruning remote-only releases.
- Cover a merged release MBID plus refreshed collection pagination.

Fixes #2914.

## Checklist

- [x] Tests
- [x] Changelog
- [x] Documentation not needed for this bug fix

## Checks

- `poe test -- test/plugins/test_mbcollection.py test/plugins/utils/test_musicbrainz.py`
- `poe lint -- beetsplug/mbcollection.py test/plugins/test_mbcollection.py`
- `poe check-format -- beetsplug/mbcollection.py test/plugins/test_mbcollection.py`
- `git diff --check`
