### PR TITLE
Write import log paths as JSON lists

### DIFF
--- a/beets/importer/logfile.py
+++ b/beets/importer/logfile.py
@@ -1,0 +1,28 @@
+"""Helpers for writing and reading import log paths."""
+
+from __future__ import annotations
+
+import json
+
+LOG_PATH_SEPARATOR = "; "
+
+
+def decode_log_paths(paths: str) -> list[str]:
+    """Parse an import log path list."""
+    if paths.startswith("["):
+        try:
+            decoded_paths = json.loads(paths)
+        except json.JSONDecodeError:
+            pass
+        else:
+            if isinstance(decoded_paths, list) and all(
+                isinstance(path, str) for path in decoded_paths
+            ):
+                return decoded_paths
+
+    return paths.split(LOG_PATH_SEPARATOR)
+
+
+def join_log_paths(paths: list[str]) -> str:
+    """Join paths for import logs with JSON string escaping."""
+    return json.dumps(paths, ensure_ascii=False)

--- a/beets/importer/session.py
+++ b/beets/importer/session.py
@@ -22,6 +22,7 @@ from beets.util import displayable_path, normpath, pipeline, syspath
 
 from . import stages as stagefuncs
 from .actions import Action, DuplicateAction
+from .logfile import join_log_paths
 from .state import ImportState
 
 if TYPE_CHECKING:
@@ -156,7 +157,11 @@ class ImportSession:
         """Log a message about a given album to the importer log. The status
         should reflect the reason the album couldn't be tagged.
         """
-        self.logger.info("{} {}", status, displayable_path(paths))
+        if isinstance(paths, (str, bytes)):
+            log_paths = [displayable_path(paths)]
+        else:
+            log_paths = [displayable_path(p) for p in paths]
+        self.logger.info("{} {}", status, join_log_paths(log_paths))
 
     def log_choice(self, task: ImportTask, duplicate: bool = False) -> None:
         """Logs the task's current choice if it should be logged. If

--- a/beets/ui/commands/import_/__init__.py
+++ b/beets/ui/commands/import_/__init__.py
@@ -4,6 +4,7 @@ import os
 
 from beets import config, logging, plugins, ui
 from beets.exceptions import UserError
+from beets.importer.logfile import decode_log_paths
 from beets.util import displayable_path, normpath, syspath
 
 from .session import TerminalImportSession
@@ -29,7 +30,7 @@ def paths_from_logfile(path):
             if verb not in {"asis", "skip", "duplicate-skip"}:
                 raise ValueError(f"line {i} contains unknown verb {verb}")
 
-            yield os.path.commonpath(paths.split("; "))
+            yield os.path.commonpath(decode_log_paths(paths))
 
 
 def parse_logfiles(logfiles):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,8 @@ Bug fixes
   example a multi-disc album whose cover lives in the album root rather than a
   per-disc directory); the missing art is skipped instead. :bug:`4692`
 - :doc:`plugins/tidal`: Normalize Tidal album types to lowercase.
+- :ref:`import-cmd`: Import log files now write skipped paths as JSON lists so
+  ``--from-logfile`` can parse paths containing semicolons. :bug:`4941`
 
 ..
     For plugin developers

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1310,14 +1310,14 @@ class TagLogTest(unittest.TestCase):
         handler = logging.StreamHandler(sio)
         session = _common.import_session(loghandler=handler)
         session.tag_log("status", "path")
-        assert "status path" in sio.getvalue()
+        assert 'status ["path"]' in sio.getvalue()
 
     def test_tag_log_unicode(self):
         sio = StringIO()
         handler = logging.StreamHandler(sio)
         session = _common.import_session(loghandler=handler)
         session.tag_log("status", "caf\xe9")  # send unicode
-        assert "status caf\xe9" in sio.getvalue()
+        assert 'status ["caf\xe9"]' in sio.getvalue()
 
 
 class TestResumeImport(ImportHelper):

--- a/test/ui/commands/test_import.py
+++ b/test/ui/commands/test_import.py
@@ -7,6 +7,8 @@ import pytest
 from beets import config, library
 from beets.autotag import AlbumInfo, AlbumMatch, TrackInfo, distance
 from beets.exceptions import UserError
+from beets.importer.logfile import join_log_paths
+from beets.importer.session import ImportSession
 from beets.test import _common
 from beets.test.helper import BeetsTestCase, IOMixin
 from beets.ui.commands.import_ import import_files, paths_from_logfile
@@ -54,6 +56,64 @@ class ImportTest(BeetsTestCase):
             fp.write(logfile_content)
         actual_paths = list(paths_from_logfile(logfile))
         assert actual_paths == expected_paths
+
+    def test_parse_bracketed_legacy_paths_from_logfile(self):
+        logfile_content = (
+            "skip [box set]/Artist/Album; [box set]/Artist/Album/CD 01\n"
+            "duplicate-skip [1]\n"
+        )
+        expected_paths = [os.path.join("[box set]", "Artist", "Album"), "[1]"]
+
+        logfile = os.path.join(self.temp_dir, b"logfile.log")
+        with open(logfile, mode="w") as fp:
+            fp.write(logfile_content)
+
+        assert list(paths_from_logfile(logfile)) == expected_paths
+
+    def test_parse_json_paths_from_logfile(self):
+        logfile_content = (
+            "asis "
+            + join_log_paths(
+                [
+                    "/music/Artist; Name/Album",
+                    "/music/Artist; Name/Album/Disc \\ One",
+                    "/music/Artist; Name/Album/Disc; Two",
+                ]
+            )
+            + "\n"
+            "duplicate-skip "
+            + join_log_paths(["/music/Other; Artist/Album"])
+            + "\n"
+        )
+        expected_paths = [
+            os.path.join(os.sep, "music", "Artist; Name", "Album"),
+            os.path.join(os.sep, "music", "Other; Artist", "Album"),
+        ]
+
+        logfile = os.path.join(self.temp_dir, b"logfile.log")
+        with open(logfile, mode="w") as fp:
+            fp.write(logfile_content)
+
+        assert list(paths_from_logfile(logfile)) == expected_paths
+
+    def test_tag_log_writes_json_paths(self):
+        session = Mock()
+
+        ImportSession.tag_log(
+            session,
+            "skip",
+            [
+                b"/music/Artist; Name/Album",
+                b"/music/Artist; Name/Album/CD \\ 1",
+            ],
+        )
+
+        session.logger.info.assert_called_once_with(
+            "{} {}",
+            "skip",
+            '["/music/Artist; Name/Album", '
+            '"/music/Artist; Name/Album/CD \\\\ 1"]',
+        )
 
 
 @patch("beets.ui.term_width", Mock(return_value=54))


### PR DESCRIPTION
## Summary

- Write new importer log path lists as JSON arrays, so paths can contain semicolons without confusing `--from-logfile`.
- Keep the legacy semicolon parser for existing import logs.
- Cover JSON log paths, legacy log parsing, bracketed legacy paths, unicode paths, and backslash paths.

Fixes #4941.

## Checklist

- [x] Tests
- [x] Changelog
- [x] Documentation not needed for this bug fix

## Checks

- `poe test -- test/ui/commands/test_import.py test/test_importer.py::TagLogTest`
- `poe lint -- beets/importer/logfile.py beets/importer/session.py beets/ui/commands/import_/__init__.py test/ui/commands/test_import.py test/test_importer.py`
- `poe check-format -- beets/importer/logfile.py beets/importer/session.py beets/ui/commands/import_/__init__.py test/ui/commands/test_import.py test/test_importer.py`
- `git diff --check`
