### PR TITLE
fix: match playlist queries with relative path storage

### DIFF
--- a/beetsplug/playlist.py
+++ b/beetsplug/playlist.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
 import beets
+from beets.dbcore.pathutils import normalize_path_for_db
 from beets.dbcore.query import BLOB_TYPE, InQuery
 from beets.util import path_as_posix
 
@@ -36,7 +37,7 @@ class PlaylistQuery(InQuery[bytes]):
 
     @property
     def subvals(self) -> Sequence[BLOB_TYPE]:
-        return [BLOB_TYPE(p) for p in self.pattern]
+        return [BLOB_TYPE(normalize_path_for_db(p)) for p in self.pattern]
 
     def __init__(self, _, pattern: str, __):
         config = beets.config["playlist"]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,8 @@ New features
 Bug fixes
 ~~~~~~~~~
 
+- :doc:`plugins/playlist`: Match playlist entries that point inside the active
+  library directory when paths are stored library-relative. :bug:`6784`
 - Album ``store`` no longer copies ``artpath`` onto its items as an absolute
   path, which broke relative-path portability. A database migration removes any
   such stale ``artpath`` attributes left on items by earlier versions.

--- a/test/plugins/test_playlist.py
+++ b/test/plugins/test_playlist.py
@@ -25,10 +25,13 @@ class PlaylistTestCase(PluginTestCase):
     plugin = "playlist"
     preload_plugin = False
 
+    def get_music_dir(self):
+        return os.path.expanduser(os.path.join("~", "Music"))
+
     def setUp(self):
         super().setUp()
 
-        self.music_dir = os.path.expanduser(os.path.join("~", "Music"))
+        self.music_dir = self.get_music_dir()
 
         i1 = _common.item()
         i1.path = beets.util.normpath(
@@ -122,6 +125,11 @@ class PlaylistTestRelativeToLib(PlaylistQueryTest, PlaylistTestCase):
             )
 
         self.config["playlist"]["relative_to"] = "library"
+
+
+class PlaylistTestRelativeToActiveLib(PlaylistTestRelativeToLib):
+    def get_music_dir(self):
+        return str(self.lib_path)
 
 
 class PlaylistTestRelativeToDir(PlaylistQueryTest, PlaylistTestCase):


### PR DESCRIPTION
## Summary
- normalize playlist query entries to the stored path form before the SQL `IN` lookup
- add coverage for playlists whose entries point inside the active library directory
- add the unreleased changelog entry for #6784

Fixes #6784.

## Tests
- `.venv/bin/python -m pytest test/plugins/test_playlist.py -q`
- `.venv/bin/python -m pytest test/plugins/test_playlist.py test/test_query.py -q`
- `.venv/bin/python -m pytest test/test_library.py test/library/test_migrations.py -q`
- `.venv/bin/ruff format --check --diff beetsplug/playlist.py test/plugins/test_playlist.py`
- `.venv/bin/ruff check beetsplug/playlist.py test/plugins/test_playlist.py`
- `git diff --check`