### PR TITLE
fix: keep remuxed MP3 files when source is .mp3

### DIFF
--- a/beets/util/extension.py
+++ b/beets/util/extension.py
@@ -178,5 +178,6 @@ def remux_mpeglayer3_wav(path: util.PathBytes) -> util.PathBytes | None:
     with open(util.syspath(mp3_path), "wb") as mp3_file:
         mp3_file.write(mp3_data)
 
-    util.remove(path)
+    if not util.samefile(path, mp3_path):
+        util.remove(path)
     return mp3_path

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,9 @@ New features
 Bug fixes
 ~~~~~~~~~
 
+- :ref:`import-cmd`: Remuxing a ``WAVE_FORMAT_MPEGLAYER3`` file that already has
+  an ``.mp3`` extension no longer deletes the extracted MP3 during import.
+  :bug:`6748`
 - Album ``store`` no longer copies ``artpath`` onto its items as an absolute
   path, which broke relative-path portability. A database migration removes any
   such stale ``artpath`` attributes left on items by earlier versions.

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -37,7 +37,7 @@ from mediafile import MediaFile
 
 from beets import config, importer, logging, util
 from beets.autotag import AlbumInfo, AlbumMatch, Distance, TrackInfo
-from beets.importer.tasks import albums_in_dir
+from beets.importer.tasks import ImportTaskFactory, albums_in_dir
 from beets.test import _common
 from beets.test.helper import (
     NEEDS_FFPROBE,
@@ -1919,6 +1919,30 @@ class TestMpeglayerWavImport(AsIsImporterMixin, ImportHelper):
         assert mp3_path.endswith(b".mp3")
         assert os.path.exists(mp3_path)
         assert not os.path.exists(dest)
+
+    def test_remux_mpeglayer3_wav_keeps_mp3_source(self):
+        src = os.path.join(_common.RSRC, b"mpeglayer3.wav")
+        dest = os.path.join(self.temp_dir, b"mpeglayer3.mp3")
+        shutil.copy(syspath(src), syspath(dest))
+
+        mp3_path = remux_mpeglayer3_wav(dest)
+
+        assert mp3_path == dest
+        assert os.path.exists(dest)
+        with open(syspath(dest), "rb") as mp3_file:
+            assert mp3_file.read(4) != b"RIFF"
+
+    def test_import_remux_mpeglayer3_wav_keeps_mp3_source(self):
+        src = os.path.join(_common.RSRC, b"mpeglayer3.wav")
+        dest = os.path.join(self.import_dir, b"mpeglayer3.mp3")
+        shutil.copy(syspath(src), syspath(dest))
+        factory = ImportTaskFactory(self.import_dir, self.setup_importer())
+
+        item = factory.read_item(dest)
+
+        assert item is not None
+        assert item.path == dest
+        assert os.path.exists(dest)
 
     def test_remux_mpeglayer3_wav_disabled(self):
         """When remux_mp3_in_wav is disabled, WAV file should not be remuxed."""


### PR DESCRIPTION
## Description

Fixes #6748.

When a WAV-container MP3 stream is named with an `.mp3` extension, `remux_mpeglayer3_wav` writes the extracted payload back to that same path and then deletes it. This keeps the file when the remux target is the original source path, while preserving the delete-original behavior for `.wav` sources.

## To Do

- [x] ~Documentation~
- [x] Changelog.
- [x] Tests.

## Tests

- `PYTHONPATH=. python -m pytest test/test_importer.py::TestMpeglayerWavImport -q`
- `PYTHONPATH=. python -m pytest test/test_importer.py -q`
- `ruff format --check --diff beets/util/extension.py test/test_importer.py`
- `ruff check beets/util/extension.py test/test_importer.py`
- `docstrfmt --preserve-adornments docs/changelog.rst --check`
- `git diff --check`
- changelog placement check from `.github/workflows/lint.yaml`