### PR TITLE
fix: disambiguate path-equivalent aunique keys

### DIFF
--- a/beets/library/library.py
+++ b/beets/library/library.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from contextlib import contextmanager
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import platformdirs
 
@@ -73,7 +73,7 @@ class Library(dbcore.Database):
         self.replacements = self.get_replacements()
 
         # Used for template substitution performance.
-        self._memotable: dict[tuple[str, ...], str] = {}
+        self._memotable: dict[tuple[Any, ...], Any] = {}
 
     @contextmanager
     def music_dir_context(self):

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -1438,6 +1438,53 @@ class DefaultTemplateFunctions:
         """
         return (name, keys, disam, item_id)
 
+    def _tmpl_unique_path_value(self, db_item, key):
+        value = db_item.formatted(for_path=True).get(key, "")
+        if not value:
+            return ""
+        return util.legalize_path(value, self.lib.replacements, "")[0]
+
+    def _tmpl_unique_path_key(self, db_item, keys):
+        return tuple(self._tmpl_unique_path_value(db_item, key) for key in keys)
+
+    def _tmpl_unique_path_index(self, name, keys, db_item, skip_item):
+        memokey = ("_tmpl_unique_path_index", name, tuple(keys))
+        path_index = self.lib._memotable.get(memokey)
+        if path_index is not None:
+            return path_index
+
+        path_index = {}
+        candidates = (
+            self.lib.items() if isinstance(db_item, Item) else self.lib.albums()
+        )
+        for candidate in candidates:
+            if skip_item(candidate):
+                continue
+            key = self._tmpl_unique_path_key(candidate, keys)
+            path_index.setdefault(key, []).append(candidate)
+
+        self.lib._memotable[memokey] = path_index
+        return path_index
+
+    def _tmpl_unique_items(self, name, keys, db_item, query, skip_item):
+        ambigous_items = (
+            self.lib.items(query)
+            if isinstance(db_item, Item)
+            else self.lib.albums(query)
+        )
+        items_by_id = {item.id: item for item in ambigous_items}
+
+        path_key = self._tmpl_unique_path_key(db_item, keys)
+        path_index = self._tmpl_unique_path_index(
+            name, keys, db_item, skip_item
+        )
+        for item in path_index.get(path_key, []):
+            if item.id in items_by_id:
+                continue
+            items_by_id[item.id] = item
+
+        return list(items_by_id.values())
+
     def _tmpl_unique(
         self, name, keys, disam, bracket, item_id, db_item, item_keys, skip_item
     ):
@@ -1487,10 +1534,8 @@ class DefaultTemplateFunctions:
 
         # Find matching items to disambiguate with.
         query = db_item.duplicates_query(keys)
-        ambigous_items = (
-            self.lib.items(query)
-            if isinstance(db_item, Item)
-            else self.lib.albums(query)
+        ambigous_items = self._tmpl_unique_items(
+            name, keys, db_item, query, skip_item
         )
 
         # If there's only one item to matching these details, then do
@@ -1502,7 +1547,10 @@ class DefaultTemplateFunctions:
         # Find the first disambiguator that distinguishes the items.
         for disambiguator in disam:
             # Get the value for each item for the current field.
-            disam_values = {s.get(disambiguator, "") for s in ambigous_items}
+            disam_values = {
+                self._tmpl_unique_path_value(s, disambiguator)
+                for s in ambigous_items
+            }
 
             # If the set of unique values is equal to the number of
             # items in the disambiguation set, we're done -- this is
@@ -1516,7 +1564,7 @@ class DefaultTemplateFunctions:
             return res
 
         # Flatten disambiguation value into a string.
-        disam_value = db_item.formatted(for_path=True).get(disambiguator)
+        disam_value = self._tmpl_unique_path_value(db_item, disambiguator)
 
         # Return empty string if disambiguator is empty.
         if disam_value:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,9 @@ New features
 Bug fixes
 ~~~~~~~~~
 
+- :ref:`aunique` and :ref:`sunique`: Detect identifier values that become equal
+  after path replacements, so albums or singletons such as ``1/1`` and ``1?1``
+  get a disambiguator instead of sharing a destination. :bug:`6462`
 - Album ``store`` no longer copies ``artpath`` onto its items as an absolute
   path, which broke relative-path portability. A database migration removes any
   such stale ``artpath`` attributes left on items by earlier versions.

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -796,6 +796,33 @@ class TestDisambiguation(TestHelper, PathFormattingMixin):
         self._setf("foo%aunique{albumartist album,albumtype}/$title")
         self._assert_dest(b"/base/foo [foo_bar]/the title", i1)
 
+    def test_unique_path_sanitized_keys(self, items):
+        i1, i2 = items
+        album1 = self.lib.get_album(i1)
+        album1.album = "1/1"
+        album2 = self.lib.get_album(i2)
+        album2.album = "1?1"
+        album1.store()
+        album2.store()
+        self._setf("foo/$album%aunique{albumartist album,year}/$title")
+
+        self._assert_dest(b"/base/foo/1_1 [2001]/the title", i1)
+        self._assert_dest(b"/base/foo/1_1 [2002]/the title", i2)
+
+    def test_unique_path_sanitized_keys_use_fallback_numbers(self, items):
+        i1, i2 = items
+        album1 = self.lib.get_album(i1)
+        album1.album = "1/1"
+        album2 = self.lib.get_album(i2)
+        album2.album = "1?1"
+        album2.year = 2001
+        album1.store()
+        album2.store()
+        self._setf("foo/$album%aunique{albumartist album,year}/$title")
+
+        self._assert_dest(b"/base/foo/1_1 [1]/the title", i1)
+        self._assert_dest(b"/base/foo/1_1 [2]/the title", i2)
+
     def test_drop_empty_disambig_string(self, items):
         i1, i2 = items
         album1 = self.lib.get_album(i1)
@@ -891,6 +918,17 @@ class TestSingletonDisambiguation(TestHelper, PathFormattingMixin):
         i1.store()
         self._setf("foo/$title%sunique{artist title,trackdisambig}")
         self._assert_dest(b"/base/foo/the title [foo_bar]", i1)
+
+    def test_sunique_path_sanitized_keys(self, items):
+        i1, i2 = items
+        i1.title = "1/1"
+        i2.title = "1?1"
+        i1.store()
+        i2.store()
+        self._setf("foo/$title%sunique{artist title,year}")
+
+        self._assert_dest(b"/base/foo/1_1 [2001]", i1)
+        self._assert_dest(b"/base/foo/1_1 [2002]", i2)
 
     def test_drop_empty_disambig_string(self, items):
         i1, i2 = items


### PR DESCRIPTION
## Description

Fixes #6462.

This makes `%aunique{}` and `%sunique{}` compare identifier fields after the same path replacements used for destinations. Albums or singletons with different raw values that land on the same path component now enter the disambiguation set.

## To Do

- [x] ~Documentation~
- [x] Changelog.
- [x] Tests.

## Tests

- `PYTHONPATH=. python -m pytest test/test_library.py::TestDisambiguation test/test_library.py::TestSingletonDisambiguation -q`
- `PYTHONPATH=. python -m pytest test/test_library.py -q`
- `PYTHONPATH=. python -m pytest test/test_library.py test/util/test_pathformats.py test/test_query.py -q`
- `ruff format --check --diff beets/library/models.py beets/library/library.py test/test_library.py`
- `ruff check beets/library/models.py beets/library/library.py test/test_library.py`
- `PYTHONPATH=. mypy beets/library/models.py beets/library/library.py`
- `docstrfmt --preserve-adornments docs/changelog.rst --check`
- `git diff --check`
- changelog placement check from `.github/workflows/lint.yaml`