### PR TITLE
Detach stdin when running badfiles checker commands

### DIFF
--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -18,7 +18,13 @@ import errno
 import os
 import shlex
 import sys
-from subprocess import STDOUT, CalledProcessError, check_output, list2cmdline
+from subprocess import (
+    DEVNULL,
+    STDOUT,
+    CalledProcessError,
+    check_output,
+    list2cmdline,
+)
 from typing import Literal
 
 import confuse
@@ -66,7 +72,10 @@ class BadFiles(BeetsPlugin):
             "running command: {}", displayable_path(list2cmdline(cmd))
         )
         try:
-            output = check_output(cmd, stderr=STDOUT)
+            # The checker commands are non-interactive, so detach stdin from
+            # the controlling terminal. Otherwise a checker may leave the TTY
+            # in a modified state (e.g. with echo disabled). See #6750.
+            output = check_output(cmd, stderr=STDOUT, stdin=DEVNULL)
             errors = 0
             status = 0
         except CalledProcessError as e:

--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -6,7 +6,13 @@ import errno
 import os
 import shlex
 import sys
-from subprocess import STDOUT, CalledProcessError, check_output, list2cmdline
+from subprocess import (
+    DEVNULL,
+    STDOUT,
+    CalledProcessError,
+    check_output,
+    list2cmdline,
+)
 from typing import TYPE_CHECKING, Literal, Protocol
 
 import confuse
@@ -70,7 +76,10 @@ class BadFiles(BeetsPlugin):
             "running command: {}", displayable_path(list2cmdline(cmd))
         )
         try:
-            output = check_output(cmd, stderr=STDOUT)
+            # The checker commands are non-interactive, so detach stdin from
+            # the controlling terminal. Otherwise a checker may leave the TTY
+            # in a modified state (e.g. with echo disabled). See #6750.
+            output = check_output(cmd, stderr=STDOUT, stdin=DEVNULL)
             errors = 0
             status = 0
         except CalledProcessError as e:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,10 @@ Bug fixes
   example a multi-disc album whose cover lives in the album root rather than a
   per-disc directory); the missing art is skipped instead. :bug:`4692`
 - :doc:`plugins/tidal`: Normalize Tidal album types to lowercase.
+- :doc:`plugins/badfiles`: Detach stdin from the controlling terminal when
+  running checker commands, so a checker can no longer leave the terminal in a
+  modified state (e.g. with input echo disabled) after ``beet bad``.
+  :bug:`6750`
 
 ..
     For plugin developers

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -36,8 +36,7 @@ Bug fixes
 - :doc:`plugins/tidal`: Normalize Tidal album types to lowercase.
 - :doc:`plugins/badfiles`: Detach stdin from the controlling terminal when
   running checker commands, so a checker can no longer leave the terminal in a
-  modified state (e.g. with input echo disabled) after ``beet bad``.
-  :bug:`6750`
+  modified state (e.g. with input echo disabled) after ``beet bad``. :bug:`6750`
 
 ..
     For plugin developers

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -197,8 +197,7 @@ Bug fixes
   regular expression character-class typo.
 - :doc:`plugins/badfiles`: Detach stdin from the controlling terminal when
   running checker commands, so a checker can no longer leave the terminal in a
-  modified state (e.g. with input echo disabled) after ``beet bad``.
-  :bug:`6750`
+  modified state (e.g. with input echo disabled) after ``beet bad``. :bug:`6750`
 
 ..
     For plugin developers

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -87,6 +87,9 @@ Bug fixes
   have no value for ``field``.
 - :doc:`plugins/convert`: Fixed convert plugin not taking into account the new
   format when determining the target path. :bug:`1360`
+- :doc:`plugins/badfiles`: Detach stdin from the controlling terminal when
+  running checker commands, so a checker can no longer leave the terminal in a
+  modified state (e.g. with input echo disabled) after ``beet bad``. :bug:`6750`
 
 ..
     For plugin developers
@@ -195,9 +198,6 @@ Bug fixes
   valid date/time string" error instead of crashing with an uncaught
   ``KeyError``. A ``|`` was being accepted as a relative-date unit due to a
   regular expression character-class typo.
-- :doc:`plugins/badfiles`: Detach stdin from the controlling terminal when
-  running checker commands, so a checker can no longer leave the terminal in a
-  modified state (e.g. with input echo disabled) after ``beet bad``. :bug:`6750`
 
 ..
     For plugin developers

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -195,6 +195,10 @@ Bug fixes
   valid date/time string" error instead of crashing with an uncaught
   ``KeyError``. A ``|`` was being accepted as a relative-date unit due to a
   regular expression character-class typo.
+- :doc:`plugins/badfiles`: Detach stdin from the controlling terminal when
+  running checker commands, so a checker can no longer leave the terminal in a
+  modified state (e.g. with input echo disabled) after ``beet bad``.
+  :bug:`6750`
 
 ..
     For plugin developers

--- a/test/plugins/test_badfiles.py
+++ b/test/plugins/test_badfiles.py
@@ -14,6 +14,7 @@
 
 """Tests for the 'badfiles' plugin."""
 
+from subprocess import DEVNULL
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -46,3 +47,16 @@ class BadFilesPluginTest(PluginTestCase):
             result = plugin.on_import_task_before_choice(task, session=None)
 
         assert result == importer.Action.SKIP
+
+    def test_run_command_detaches_stdin(self):
+        # The checker commands are non-interactive; run_command must detach
+        # stdin from the terminal so a checker cannot leave the TTY in a
+        # modified state (e.g. with echo disabled). See #6750.
+        plugin = BadFiles()
+
+        with patch(
+            "beetsplug.badfiles.check_output", return_value=b""
+        ) as mock_check_output:
+            plugin.run_command(["mp3val", "foo.mp3"])
+
+        assert mock_check_output.call_args.kwargs["stdin"] is DEVNULL

--- a/test/plugins/test_badfiles.py
+++ b/test/plugins/test_badfiles.py
@@ -1,5 +1,6 @@
 """Tests for the 'badfiles' plugin."""
 
+from subprocess import DEVNULL
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -37,6 +38,19 @@ class BadFilesPluginTest(PluginTestCase):
             result = plugin.on_import_task_before_choice(task, session=None)
 
         assert result == importer.Action.SKIP
+
+    def test_run_command_detaches_stdin(self):
+        # The checker commands are non-interactive; run_command must detach
+        # stdin from the terminal so a checker cannot leave the TTY in a
+        # modified state (e.g. with echo disabled). See #6750.
+        plugin = BadFiles()
+
+        with patch(
+            "beetsplug.badfiles.check_output", return_value=b""
+        ) as mock_check_output:
+            plugin.run_command(["mp3val", "foo.mp3"])
+
+        assert mock_check_output.call_args.kwargs["stdin"] is DEVNULL
 
 
 class BadfilesOnImportTest(


### PR DESCRIPTION
Closes #6750.

The `badfiles` checker commands (`mp3val`, `flac`, custom) are non-interactive, but `run_command` launched them with the parent's stdin still attached to the controlling terminal. A checker can leave the TTY in a modified state (e.g. echo disabled), so after `beet bad` the terminal stops echoing typed input until `reset`/`stty sane`.

**Fix:** pass `stdin=DEVNULL` to `check_output` so checkers can't read from or modify the terminal.

**Note on verification:** the symptom is terminal-state-specific and I couldn't reproduce it on my (Windows) machine, but the root cause is clear from the code path. I've added a regression test asserting `run_command` calls `check_output` with `stdin=DEVNULL`, and a changelog entry.