### PR TITLE
tidal: honor manual search terms

### DIFF
--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import itertools
 import os
 import re
 import time
@@ -128,7 +127,7 @@ class TidalPlugin(MetadataSourcePlugin):
         ):
             return candidates
 
-        for query in self._album_queries(items):
+        for query in self._album_queries(items, artist, album):
             candidates += self.search_albums_by_query(query)
 
         log.debug("Found {0} candidates", len(candidates))
@@ -147,29 +146,36 @@ class TidalPlugin(MetadataSourcePlugin):
             ):
                 return candidates
 
-        for query in self._item_queries(item):
+        for query in self._item_queries(artist, title):
             candidates += self.search_tracks_by_query(query)
 
         log.debug("Found {0} candidates", len(candidates))
         return candidates
 
     @staticmethod
-    def _item_queries(item: Item) -> Iterable[str]:
+    def _item_queries(artist: str, title: str) -> Iterable[str]:
         """Search queries for items."""
-        yield item.title
+        yield title
 
-        if item.artist:
-            yield f"{item.artist} {item.title}"
+        if artist:
+            yield f"{artist} {title}"
 
     @staticmethod
-    def _album_queries(items: Sequence[Item]) -> Iterable[str]:
+    def _album_queries(
+        items: Sequence[Item], artist: str, album: str
+    ) -> Iterable[str]:
         """Search queries for albums."""
 
-        album_names = set(i.album for i in items)
-        artist_names = set(i.artist for i in items)
-
-        for album, artist in itertools.product(album_names, artist_names):
+        if artist:
             yield f"{artist} {album}"
+            return
+
+        artist_names = {i.artist for i in items if i.artist}
+        for item_artist in artist_names:
+            yield f"{item_artist} {album}"
+
+        if not artist_names:
+            yield album
 
     def search_tracks_by_query(self, query: str) -> Iterable[TrackInfo]:
         """Search for tracks given a string query."""

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,8 @@ Bug fixes
   example a multi-disc album whose cover lives in the album root rather than a
   per-disc directory); the missing art is skipped instead. :bug:`4692`
 - :doc:`plugins/tidal`: Normalize Tidal album types to lowercase.
+- :doc:`plugins/tidal`: Honor manually entered artist, album, and track search
+  terms during import instead of repeating file metadata queries. :bug:`6795`
 
 ..
     For plugin developers

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -550,6 +550,56 @@ class TestCandidates(TidalPluginTest):
         assert len(candidates) == 1
         assert candidates[0].album == "Query Album"
 
+    def test_candidates_use_explicit_search_terms(self):
+        """Test album query search uses the supplied search terms."""
+        items = [
+            Item(
+                title="Stored Song",
+                artist="Stored Artist",
+                album="Stored Album",
+            )
+        ]
+        self.tidal.search_albums_by_query = Mock(return_value=[])
+
+        candidates = list(
+            self.tidal.candidates(
+                items, "Entered Artist", "Entered Album", False
+            )
+        )
+
+        assert candidates == []
+        self.tidal.search_albums_by_query.assert_called_once_with(
+            "Entered Artist Entered Album"
+        )
+
+    def test_candidates_use_item_artists_when_artist_missing(self):
+        """Test album query search keeps item artist fallback."""
+        items = [Item(title="Stored Song", artist="Stored Artist")]
+        self.tidal.search_albums_by_query = Mock(return_value=[])
+
+        candidates = list(
+            self.tidal.candidates(items, "", "Entered Album", True)
+        )
+
+        assert candidates == []
+        self.tidal.search_albums_by_query.assert_called_once_with(
+            "Stored Artist Entered Album"
+        )
+
+    def test_candidates_use_album_when_no_artist_available(self):
+        """Test album query search can fall back to album-only search."""
+        items = [Item(title="Stored Song")]
+        self.tidal.search_albums_by_query = Mock(return_value=[])
+
+        candidates = list(
+            self.tidal.candidates(items, "", "Entered Album", True)
+        )
+
+        assert candidates == []
+        self.tidal.search_albums_by_query.assert_called_once_with(
+            "Entered Album"
+        )
+
 
 class TestItemCandidates(TidalPluginTest):
     """Tests for item_candidates method."""
@@ -601,6 +651,33 @@ class TestItemCandidates(TidalPluginTest):
 
         assert self.tidal.api.search_results.called
         assert results[0].title == "Query Track"
+
+    def test_item_candidates_use_explicit_search_terms(self):
+        """Test track query search uses the supplied search terms."""
+        item = Item(title="Stored Title", artist="Stored Artist")
+        self.tidal.search_tracks_by_query = Mock(return_value=[])
+
+        results = list(
+            self.tidal.item_candidates(item, "Entered Artist", "Entered Title")
+        )
+
+        assert results == []
+        assert [
+            call.args[0]
+            for call in self.tidal.search_tracks_by_query.call_args_list
+        ] == ["Entered Title", "Entered Artist Entered Title"]
+
+    def test_item_candidates_use_title_when_artist_missing(self):
+        """Test track query search can use the supplied title alone."""
+        item = Item(title="Stored Title", artist="Stored Artist")
+        self.tidal.search_tracks_by_query = Mock(return_value=[])
+
+        results = list(self.tidal.item_candidates(item, "", "Entered Title"))
+
+        assert results == []
+        self.tidal.search_tracks_by_query.assert_called_once_with(
+            "Entered Title"
+        )
 
 
 class TestStaticHelpers:


### PR DESCRIPTION
## Description

Fixes #6795.

The Tidal metadata plugin already receives explicit artist, album, and track terms from the importer, including Enter search. Album and track query fallback now use those terms instead of rebuilding queries from stored item metadata, while barcode and ISRC lookups still return first.

For album searches with no resolved artist, the previous per-item-artist fallback is kept and paired with the supplied album term.

## To Do

- [x] ~Documentation~
- [x] Changelog
- [x] Tests

## Validation

- `python -m pytest -q test/plugins/test_tidal.py test/test_metadata_plugins.py test/autotag/test_match.py`
- `ruff format --check beetsplug/tidal/__init__.py test/plugins/test_tidal.py`
- `ruff check beetsplug/tidal/__init__.py test/plugins/test_tidal.py`
- `mypy --follow-imports=skip beetsplug/tidal/__init__.py test/plugins/test_tidal.py`
- `git diff --check`