### PR TITLE
tidal: normalize copyright labels

### DIFF
--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -460,7 +460,11 @@ class TidalPlugin(MetadataSourcePlugin):
     @staticmethod
     def _parse_label(attributes: MediaAttributes) -> str | None:
         if copyright_ := attributes.get("copyright"):
-            return copyright_["text"]
+            label = LABEL_RIGHTS_PREFIX_RE.sub("", copyright_["text"], count=1)
+            label = LABEL_BOILERPLATE_RE.sub("", label)
+            label = LABEL_LEGAL_SUFFIX_RE.sub("", label)
+            label = re.sub(r"\s+", " ", label).strip(" ,.;")
+            return label or None
         return None
 
     @staticmethod
@@ -631,3 +635,20 @@ ISO_8601_RE = re.compile(
     r"(?:(?P<minutes>\d+)M)?"
     r"(?:(?P<seconds>\d+)S)?$"
 )
+
+LABEL_RIGHTS_PREFIX_RE = re.compile(
+    r"^\s*(?:(?:©|℗|\([cCpP]\))\s*)?(?:\d{4}\s*)?"
+)
+LABEL_BOILERPLATE_RE = re.compile(
+    r"\s*(?:,\s*)?(?:"
+    r"a\s+division\s+of"
+    r"|division\s+of"
+    r"|under\s+(?:exclusive\s+)?license\s+to"
+    r"|marketed\s+by"
+    r"|manufactured\s+by"
+    r"|distributed\s+by"
+    r"|for\s+the\s+(?:united\s+states|world)\b"
+    r").*",
+    re.IGNORECASE,
+)
+LABEL_LEGAL_SUFFIX_RE = re.compile(r"\s+L\.?L\.?C\.?$", re.IGNORECASE)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,8 @@ Bug fixes
   longer crashes when the stored album art path points to a missing file (for
   example a multi-disc album whose cover lives in the album root rather than a
   per-disc directory); the missing art is skipped instead. :bug:`4692`
+- :doc:`plugins/tidal`: Normalize Tidal copyright text before storing label
+  metadata. :bug:`6796`
 - :doc:`plugins/tidal`: Normalize Tidal album types to lowercase.
 
 ..

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -626,7 +626,37 @@ class TestStaticHelpers:
     @pytest.mark.parametrize(
         "attrs, expected",
         [
-            ({"copyright": {"text": "(P) 2024 Tidal"}}, "(P) 2024 Tidal"),
+            ({"copyright": {"text": "(P) 2024 Tidal"}}, "Tidal"),
+            (
+                {
+                    "copyright": {
+                        "text": (
+                            "© 2011 Motown Records, a Division of UMG "
+                            "Recordings, Inc."
+                        )
+                    }
+                },
+                "Motown Records",
+            ),
+            (
+                {
+                    "copyright": {
+                        "text": (
+                            "© 2019 Atlantic Recording Corporation for the "
+                            "United States and WEA International Inc. for the "
+                            "world outside of the United States"
+                        )
+                    }
+                },
+                "Atlantic Recording Corporation",
+            ),
+            (
+                {"copyright": {"text": "(P) 1992 Zomba Recording LLC"}},
+                "Zomba Recording",
+            ),
+            ({"copyright": {"text": "℗ 2024 Example Label"}}, "Example Label"),
+            ({"copyright": {"text": "Plain Label Name"}}, "Plain Label Name"),
+            ({"copyright": {"text": "© 2024"}}, None),
             ({}, None),
         ],
     )


### PR DESCRIPTION
## Summary
- normalize Tidal copyright text before storing it as label metadata
- strip rights markers, years, and explicit relationship or territory boilerplate while leaving plain labels intact
- add focused label parser coverage and a changelog entry

Fixes #6796.

## Tests
- `python -m pytest test/plugins/test_tidal.py`
- `python -m ruff format --check beetsplug/tidal/__init__.py test/plugins/test_tidal.py`
- `python -m ruff check beetsplug/tidal/__init__.py test/plugins/test_tidal.py`
- `python -m mypy --follow-imports=skip beetsplug/tidal/__init__.py`
- `git diff --check`
