### PR TITLE
Fix Tidal plugin to honor manual importer search overrides

### DIFF
--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import itertools
 import os
 import re
 import time
@@ -129,8 +128,12 @@ class TidalPlugin(MetadataSourcePlugin):
         ):
             return candidates
 
-        for query in self._album_queries(items):
-            candidates += self.search_albums_by_query(query)
+        query = (
+            album.strip()
+            if va_likely
+            else f"{artist.strip()} {album.strip()}".strip()
+        )
+        candidates += self.search_albums_by_query(query)
 
         log.debug("Found {0} candidates", len(candidates))
         return candidates
@@ -148,29 +151,15 @@ class TidalPlugin(MetadataSourcePlugin):
             ):
                 return candidates
 
-        for query in self._item_queries(item):
-            candidates += self.search_tracks_by_query(query)
+        query = (
+            f"{artist.strip()} {title.strip()}"
+            if artist.strip()
+            else title.strip()
+        )
+        candidates += self.search_tracks_by_query(query)
 
         log.debug("Found {0} candidates", len(candidates))
         return candidates
-
-    @staticmethod
-    def _item_queries(item: Item) -> Iterable[str]:
-        """Search queries for items."""
-        yield item.title
-
-        if item.artist:
-            yield f"{item.artist} {item.title}"
-
-    @staticmethod
-    def _album_queries(items: Sequence[Item]) -> Iterable[str]:
-        """Search queries for albums."""
-
-        album_names = set(i.album for i in items)
-        artist_names = set(i.artist for i in items)
-
-        for album, artist in itertools.product(album_names, artist_names):
-            yield f"{artist} {album}"
 
     def search_tracks_by_query(self, query: str) -> Iterable[TrackInfo]:
         """Search for tracks given a string query."""

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -672,6 +672,46 @@ class TestCandidates(TidalPluginTest):
         assert len(candidates) == 1
         assert candidates[0].album == "Query Album"
 
+    def test_candidates_with_manual_search_override(self):
+        """Test candidates uses manual search terms instead of items tags."""
+        items = [
+            Item(
+                title="Original Song",
+                artist="Original Artist",
+                album="Original Album",
+            )
+        ]
+
+        self.tidal.api.search_results = Mock(
+            return_value={
+                "data": {
+                    "relationships": {
+                        "albums": {"data": [{"id": "1", "type": "albums"}]}
+                    }
+                }
+            }
+        )
+
+        track = _make_track("101", "Album Track", "PT3M", "ISRC001", ["1001"])
+        album, track_lookup, artist_lookup = _make_album(
+            "1", "Query Album", [track], ["1001"]
+        )
+        self.tidal.api.get_albums = Mock(
+            return_value={
+                "data": [album],
+                "included": [*artist_lookup.values(), *track_lookup.values()],
+            }
+        )
+
+        list(
+            self.tidal.candidates(items, "Manual Artist", "Manual Album", False)
+        )
+
+        # Should search using manual query terms, not item tags
+        self.tidal.api.search_results.assert_called_once_with(
+            "Manual Artist Manual Album", include=["albums"]
+        )
+
 
 class TestItemCandidates(TidalPluginTest):
     """Tests for item_candidates method."""
@@ -723,6 +763,35 @@ class TestItemCandidates(TidalPluginTest):
 
         assert self.tidal.api.search_results.called
         assert results[0].title == "Query Track"
+
+    def test_item_candidates_with_manual_search_override(self):
+        """Test item_candidates uses manual search terms instead of item tags."""
+        item = Item(title="Original Song", artist="Original Artist")
+
+        self.tidal.api.search_results = Mock(
+            return_value={
+                "data": {
+                    "relationships": {
+                        "tracks": {
+                            "data": [{"id": "490839595", "type": "tracks"}]
+                        }
+                    }
+                },
+                "included": [
+                    _make_track(
+                        "490839595", "Query Track", "PT3M", "ISRC002", ["1001"]
+                    ),
+                    _make_artist("1001", "Query Artist"),
+                ],
+            }
+        )
+
+        list(self.tidal.item_candidates(item, "Manual Artist", "Manual Song"))
+
+        # Should search using manual query terms, not item tags
+        self.tidal.api.search_results.assert_called_once_with(
+            "Manual Artist Manual Song", include=["tracks.artists"]
+        )
 
 
 class TestStaticHelpers:


### PR DESCRIPTION
### PR Title

Fix Tidal plugin to honor manual importer search overrides

### PR Description

#### Problem

The Tidal plugin currently ignores the `artist` and `album`/`title` arguments passed to `TidalPlugin.candidates()` and `TidalPlugin.item_candidates()` during text query fallbacks. Instead, it builds search queries strictly from existing item tags via `_album_queries(items)` and `_item_queries(item)`.

This leads to a bug where using the importer's `Enter search` action to correct bad or missing tags simply repeats the original query, ignoring the manually entered search parameters.

Fixes #6795

#### Solution

* Updated `candidates()` to build queries using the passed `artist` and `album` arguments (i.e., `album` if `va_likely` is true, otherwise `artist album`).
* Updated `item_candidates()` to use the passed `artist` and `title` arguments.
* Kept the precedence of barcode and ISRC lookups before fallback query lookups.
* Removed the now-unused helper methods `_album_queries` and `_item_queries`, along with the unused `itertools` import.
* Added regression tests in `test/plugins/test_tidal.py` to ensure that manual overrides correctly direct the Tidal API search queries.

#### Tests

Ran tests locally using `pytest`:
`pytest test/plugins/test_tidal.py` -> 49 passed.