### PR TITLE
typing: add types to beets.util and beets.test.helper

### DIFF
--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -44,6 +44,7 @@ from beets.util import (
     clean_module_tempdir,
     syspath,
 )
+from beets.util.functemplate import template
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Sequence
@@ -60,7 +61,7 @@ if TYPE_CHECKING:
 RUNNING_IN_CI = os.environ.get("GITHUB_ACTIONS") == "true"
 
 
-def has_program(cmd: str, args: Iterable[str] = ["--version"]) -> bool:
+def has_program(cmd: str, args: Iterable[str] = ("--version",)) -> bool:
     """Returns `True` if `cmd` can be executed."""
     full_cmd = [cmd, *args]
     try:
@@ -166,7 +167,22 @@ class IOMixin(RunMixin):
         return self.io.getoutput()
 
 
-class TestHelper(RunMixin, ConfigMixin):
+class PathsMixin:
+    resource_path = Path(os.fsdecode(_common.RSRC)) / "full.mp3"
+
+    @cached_property
+    def temp_dir_path(self) -> Path:
+        return Path(self.create_temp_dir())
+
+    def create_temp_dir(self, **kwargs: Any) -> str:
+        return mkdtemp(**kwargs)
+
+    def remove_temp_dir(self) -> None:
+        """Delete the temporary directory created by `create_temp_dir`."""
+        shutil.rmtree(self.temp_dir_path)
+
+
+class TestHelper(RunMixin, PathsMixin, ConfigMixin):
     """Helper mixin for high-level cli and plugin tests.
 
     This mixin provides methods to isolate beets' global state.
@@ -203,13 +219,7 @@ class TestHelper(RunMixin, ConfigMixin):
 
     lib: Library
 
-    resource_path = Path(os.fsdecode(_common.RSRC)) / "full.mp3"
-
     db_on_disk: ClassVar[bool] = False
-
-    @cached_property
-    def temp_dir_path(self) -> Path:
-        return Path(self.create_temp_dir())
 
     @cached_property
     def temp_dir(self) -> bytes:
@@ -259,11 +269,12 @@ class TestHelper(RunMixin, ConfigMixin):
 
         self.config["directory"] = str(self.lib_path)
 
-        if self.db_on_disk:
-            dbpath = util.bytestring_path(self.config["library"].as_filename())
-        else:
-            dbpath = ":memory:"
-        self.lib = Library(dbpath, self.libdir)
+        dbpath = (
+            util.bytestring_path(self.config["library"].as_filename())
+            if self.db_on_disk
+            else ":memory:"
+        )
+        self.lib = Library(dbpath, str(self.lib_path))
 
     def teardown_beets(self) -> None:
         self.env_patcher.stop()
@@ -284,15 +295,14 @@ class TestHelper(RunMixin, ConfigMixin):
 
         The item is attached to the database from `self.lib`.
         """
-        values_ = {
-            "title": "t\u00eftle {}",
+        values_: dict[str, Any] = {
+            "title": "t\u00eftle 1",
             "artist": "the \u00e4rtist",
             "album": "the \u00e4lbum",
             "track": 1,
             "format": "MP3",
         }
         values_.update(values)
-        values_["title"] = values_["title"].format(1)
         values_["db"] = self.lib
         item = Item(**values_)
         if "path" not in values:
@@ -385,7 +395,7 @@ class TestHelper(RunMixin, ConfigMixin):
     def create_mediafile_fixture(
         self,
         ext: str = "mp3",
-        images: list[str] = [],
+        images: list[str] | None = None,
         target_dir: util.PathLike | None = None,
     ) -> bytes:
         """Copy a fixture mediafile with the extension to `temp_dir`.
@@ -417,13 +427,6 @@ class TestHelper(RunMixin, ConfigMixin):
 
     # Safe file operations
 
-    def create_temp_dir(self, **kwargs: Any) -> str:
-        return mkdtemp(**kwargs)
-
-    def remove_temp_dir(self) -> None:
-        """Delete the temporary directory created by `create_temp_dir`."""
-        shutil.rmtree(self.temp_dir_path)
-
     def touch(
         self,
         path: util.PathLike,
@@ -432,23 +435,24 @@ class TestHelper(RunMixin, ConfigMixin):
     ) -> bytes:
         """Create a file at `path` with given content.
 
-        If `dir` is given, it is prepended to `path`. After that, if the
+        If `dir_` is given, it is prepended to `path`. After that, if the
         path is relative, it is resolved with respect to
         `self.temp_dir`.
         """
+        bytes_path = os.fsencode(path)
         if dir_:
-            path = os.path.join(dir_, path)
+            bytes_path = os.path.join(os.fsencode(dir_), bytes_path)
 
-        if not os.path.isabs(path):
-            path = os.path.join(self.temp_dir, path)
+        if not os.path.isabs(bytes_path):
+            bytes_path = os.path.join(self.temp_dir, bytes_path)
 
-        parent = os.path.dirname(path)
+        parent = os.path.dirname(bytes_path)
         if not os.path.isdir(syspath(parent)):
             os.makedirs(syspath(parent))
 
-        with open(syspath(path), "a+") as f:
+        with open(syspath(bytes_path), "a+") as f:
             f.write(content)
-        return path
+        return bytes_path
 
 
 # A test harness for all beets tests.
@@ -491,12 +495,12 @@ class PluginMixin(ConfigMixin):
     preload_plugin: ClassVar[bool] = True
 
     def setup_beets(self) -> None:
-        super().setup_beets()
+        super().setup_beets()  # type: ignore[misc]
         if self.preload_plugin:
             self.load_plugins()
 
     def teardown_beets(self) -> None:
-        super().teardown_beets()
+        super().teardown_beets()  # type: ignore[misc]
         self.unload_plugins()
 
     def register_plugin(
@@ -552,7 +556,7 @@ class PluginTestHelper(PluginMixin, TestHelper):
     """
 
 
-class ImportHelper(TestHelper):
+class ImporterMixin(PathsMixin, ConfigMixin):
     """Provides tools to setup a library, a directory containing files that are
     to be imported and an import session. The class also provides stubs for the
     autotagging library and several assertions for the library.
@@ -571,6 +575,7 @@ class ImportHelper(TestHelper):
 
     lib: Library
     importer: ImportSession
+    import_media: list[MediaFile]
 
     @cached_property
     def import_path(self) -> Path:
@@ -581,15 +586,6 @@ class ImportHelper(TestHelper):
     @cached_property
     def import_dir(self) -> bytes:
         return bytestring_path(self.import_path)
-
-    def setup_beets(self) -> None:
-        super().setup_beets()
-        self.import_media = []
-        self.lib.path_formats = [
-            ("default", os.path.join("$artist", "$album", "$title")),
-            ("singleton:true", os.path.join("singletons", "$title")),
-            ("comp:true", os.path.join("compilations", "$album", "$title")),
-        ]
 
     def prepare_track_for_import(
         self, track_id: int, album_path: Path, album_id: int | None = None
@@ -661,9 +657,23 @@ class ImportHelper(TestHelper):
         return self.setup_importer(singletons=True, **kwargs)
 
 
-class AsIsImporterMixin:
+class ImportHelper(TestHelper, ImporterMixin):
     def setup_beets(self) -> None:
         super().setup_beets()
+        self.import_media = []
+        self.lib.path_formats = [
+            ("default", template(os.path.join("$artist", "$album", "$title"))),
+            ("singleton:true", template(os.path.join("singletons", "$title"))),
+            (
+                "comp:true",
+                template(os.path.join("compilations", "$album", "$title")),
+            ),
+        ]
+
+
+class AsIsImporterMixin(ImporterMixin):
+    def setup_beets(self) -> None:
+        super().setup_beets()  # type: ignore[misc]
         self.prepare_album_for_import(1)
 
     def run_asis_importer(self, **kwargs: Any) -> ImportSession:
@@ -709,13 +719,16 @@ class ImportSessionFixture(ImportSession):
         except IndexError:
             choice = self.default_choice
 
-        if choice == importer.Action.APPLY:
-            return task.candidates[0]
-        if isinstance(choice, int):
-            return task.candidates[choice - 1]
+        if task.candidates:
+            if choice == importer.Action.APPLY:
+                return task.candidates[0]  # type: ignore[return-value]
+            if isinstance(choice, int):
+                return task.candidates[choice - 1]  # type: ignore[return-value]
+
+        assert not isinstance(choice, int), f"Invalid choice: {choice}"
         return choice
 
-    choose_item = choose_match
+    choose_item = choose_match  # type: ignore[assignment]
 
 
 class TerminalImportSessionFixture(TerminalImportSession):
@@ -862,10 +875,7 @@ class AutotagStub:
     ) -> AlbumInfo:
         id_ = f" {'M' * distance}" if distance else ""
 
-        if artist is None:
-            artist = "Various Artists"
-        else:
-            artist = f"{artist.replace('Tag', 'Applied')}{id_}"
+        artist = f"{artist.replace('Tag', 'Applied')}{id_}"
         album = f"{album.replace('Tag', 'Applied')}{id_}"
 
         track_infos = []

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -46,16 +46,21 @@ from beets.util import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Sequence
     from types import TracebackType
+    from unittest.mock import _patch
 
     from confuse import ConfigSource
     from requests_mock.mocker import Mocker
     from typing_extensions import Self
 
+    from beets.autotag import AlbumMatch, TrackMatch
+    from beets.library import Album
+
 RUNNING_IN_CI = os.environ.get("GITHUB_ACTIONS") == "true"
 
 
-def has_program(cmd, args=["--version"]):
+def has_program(cmd: str, args: Iterable[str] = ["--version"]) -> bool:
     """Returns `True` if `cmd` can be executed."""
     full_cmd = [cmd, *args]
     try:
@@ -136,7 +141,7 @@ class ConfigMixin:
 class RunMixin:
     lib: Library
 
-    def run_command(self, *args, lib: Library | None = None):
+    def run_command(self, *args: str, lib: Library | None = None) -> None:
         """Run a beets command with an arbitrary amount of arguments. The
         Library` defaults to `self.lib`, but can be overridden with
         the keyword argument `lib`.
@@ -155,7 +160,7 @@ class RunMixin:
 class IOMixin(RunMixin):
     io: _common.DummyIO
 
-    def run_with_output(self, *args):
+    def run_with_output(self, *args: str) -> str:
         self.io.getoutput()
         self.run_command(*args)
         return self.io.getoutput()
@@ -188,7 +193,7 @@ class TestHelper(RunMixin, ConfigMixin):
         return False
 
     @pytest.fixture(autouse=True)
-    def setup(self, request: pytest.FixtureRequest):
+    def setup(self, request: pytest.FixtureRequest) -> Iterator[None]:
         self.request = request
         self.setup_beets()
         try:
@@ -222,7 +227,7 @@ class TestHelper(RunMixin, ConfigMixin):
 
     # TODO automate teardown through hook registration
 
-    def setup_beets(self):
+    def setup_beets(self) -> None:
         """Setup pristine global configuration and library for testing.
 
         Sets ``beets.config`` so we can safely use any functionality
@@ -260,14 +265,14 @@ class TestHelper(RunMixin, ConfigMixin):
             dbpath = ":memory:"
         self.lib = Library(dbpath, self.libdir)
 
-    def teardown_beets(self):
+    def teardown_beets(self) -> None:
         self.env_patcher.stop()
         self.lib._close()
         self.remove_temp_dir()
 
     # Library fixtures methods
 
-    def create_item(self, **values):
+    def create_item(self, **values: Any) -> Item:
         """Return an `Item` instance with sensible default values.
 
         The item receives its attributes from `**values` paratmeter. The
@@ -296,7 +301,7 @@ class TestHelper(RunMixin, ConfigMixin):
         item.mtime = 12345
         return item
 
-    def add_item(self, **values):
+    def add_item(self, **values: Any) -> Item:
         """Add an item to the library and return it.
 
         Creates the item by passing the parameters to `create_item()`.
@@ -318,7 +323,7 @@ class TestHelper(RunMixin, ConfigMixin):
 
         return item
 
-    def add_item_fixture(self, **values):
+    def add_item_fixture(self, **values: Any) -> Item:
         """Add an item with an actual audio file to the library."""
         item = self.create_item(**values)
         extension = item["format"].lower()
@@ -330,11 +335,11 @@ class TestHelper(RunMixin, ConfigMixin):
         item.store()
         return item
 
-    def add_album(self, **values):
+    def add_album(self, **values: Any) -> Album:
         item = self.add_item(**values)
         return self.lib.add_album([item])
 
-    def add_item_fixtures(self, ext="mp3", count=1):
+    def add_item_fixtures(self, ext: str = "mp3", count: int = 1) -> list[Item]:
         """Add a number of items with files to the database."""
         # TODO base this on `add_item()`
         items = []
@@ -352,8 +357,12 @@ class TestHelper(RunMixin, ConfigMixin):
         return items
 
     def add_album_fixture(
-        self, track_count=1, fname="full", ext="mp3", disc_count=1
-    ):
+        self,
+        track_count: int = 1,
+        fname: str = "full",
+        ext: str = "mp3",
+        disc_count: int = 1,
+    ) -> Album:
         """Add an album with files to the database."""
         items = []
         path = os.path.join(
@@ -373,7 +382,12 @@ class TestHelper(RunMixin, ConfigMixin):
                 items.append(item)
         return self.lib.add_album(items)
 
-    def create_mediafile_fixture(self, ext="mp3", images=[], target_dir=None):
+    def create_mediafile_fixture(
+        self,
+        ext: str = "mp3",
+        images: list[str] = [],
+        target_dir: util.PathLike | None = None,
+    ) -> bytes:
         """Copy a fixture mediafile with the extension to `temp_dir`.
 
         `images` is a subset of 'png', 'jpg', and 'tiff'. For each
@@ -403,14 +417,19 @@ class TestHelper(RunMixin, ConfigMixin):
 
     # Safe file operations
 
-    def create_temp_dir(self, **kwargs) -> str:
+    def create_temp_dir(self, **kwargs: Any) -> str:
         return mkdtemp(**kwargs)
 
-    def remove_temp_dir(self):
+    def remove_temp_dir(self) -> None:
         """Delete the temporary directory created by `create_temp_dir`."""
         shutil.rmtree(self.temp_dir_path)
 
-    def touch(self, path, dir_=None, content=""):
+    def touch(
+        self,
+        path: util.PathLike,
+        dir_: util.PathLike | None = None,
+        content: str = "",
+    ) -> bytes:
         """Create a file at `path` with given content.
 
         If `dir` is given, it is prepended to `path`. After that, if the
@@ -450,7 +469,7 @@ class ItemInDBTestCase(BeetsTestCase):
     an item added to the library (`i`).
     """
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.i = _common.item(self.lib)
 
@@ -459,7 +478,7 @@ class PytestTestHelper(TestHelper):
     """Same as the BeetsTestCase unittest setup but for pytest."""
 
     @pytest.fixture(autouse=True)
-    def setup(self):
+    def setup(self) -> Iterator[None]:
         self.setup_beets()
         try:
             yield
@@ -471,12 +490,12 @@ class PluginMixin(ConfigMixin):
     plugin: ClassVar[str]
     preload_plugin: ClassVar[bool] = True
 
-    def setup_beets(self):
+    def setup_beets(self) -> None:
         super().setup_beets()
         if self.preload_plugin:
             self.load_plugins()
 
-    def teardown_beets(self):
+    def teardown_beets(self) -> None:
         super().teardown_beets()
         self.unload_plugins()
 
@@ -505,7 +524,7 @@ class PluginMixin(ConfigMixin):
         beets.plugins._instances.clear()
 
     @contextmanager
-    def configure_plugin(self, config: Any):
+    def configure_plugin(self, config: Any) -> Iterator[None]:
         self.config[self.plugin].set(config)
         self.load_plugins(self.plugin)
 
@@ -563,7 +582,7 @@ class ImportHelper(TestHelper):
     def import_dir(self) -> bytes:
         return bytestring_path(self.import_path)
 
-    def setup_beets(self):
+    def setup_beets(self) -> None:
         super().setup_beets()
         self.import_media = []
         self.lib.path_formats = [
@@ -632,22 +651,22 @@ class ImportHelper(TestHelper):
         )
 
     def setup_importer(
-        self, import_dir: bytes | None = None, **kwargs
+        self, import_dir: bytes | None = None, **kwargs: Any
     ) -> ImportSession:
         self.config["import"].set_args({**self.default_import_config, **kwargs})
         self.importer = self._get_import_session(import_dir or self.import_dir)
         return self.importer
 
-    def setup_singleton_importer(self, **kwargs) -> ImportSession:
+    def setup_singleton_importer(self, **kwargs: Any) -> ImportSession:
         return self.setup_importer(singletons=True, **kwargs)
 
 
 class AsIsImporterMixin:
-    def setup_beets(self):
+    def setup_beets(self) -> None:
         super().setup_beets()
         self.prepare_album_for_import(1)
 
-    def run_asis_importer(self, **kwargs):
+    def run_asis_importer(self, **kwargs: Any) -> ImportSession:
         importer = self.setup_importer(autotag=False, **kwargs)
         importer.run()
         return importer
@@ -668,19 +687,23 @@ class ImportSessionFixture(ImportSession):
     remaining albums, the metadata from the autotagger will be applied.
     """
 
-    def __init__(self, *args, **kwargs):
+    _choices: list[importer.Action | int]
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._choices = []
 
     default_choice = importer.Action.APPLY
 
-    def add_choice(self, choice):
+    def add_choice(self, choice: importer.Action | int) -> None:
         self._choices.append(choice)
 
-    def clear_choices(self):
+    def clear_choices(self) -> None:
         self._choices = []
 
-    def choose_match(self, task):
+    def choose_match(
+        self, task: importer.ImportTask
+    ) -> AlbumMatch | importer.Action:
         try:
             choice = self._choices.pop(0)
         except IndexError:
@@ -703,21 +726,25 @@ class TerminalImportSessionFixture(TerminalImportSession):
 
     default_choice = importer.Action.APPLY
 
-    def add_choice(self, choice):
+    def add_choice(self, choice: importer.Action | int) -> None:
         self._choices.append(choice)
 
-    def clear_choices(self):
+    def clear_choices(self) -> None:
         self._choices = []
 
-    def choose_match(self, task):
+    def choose_match(
+        self, task: importer.ImportTask
+    ) -> AlbumMatch | importer.Action:
         self._add_choice_input()
         return super().choose_match(task)
 
-    def choose_item(self, task):
+    def choose_item(
+        self, task: importer.ImportTask
+    ) -> TrackMatch | importer.Action:
         self._add_choice_input()
         return super().choose_item(task)
 
-    def _add_choice_input(self):
+    def _add_choice_input(self) -> None:
         try:
             choice = self._choices.pop(0)
         except IndexError:
@@ -767,8 +794,8 @@ class AutotagStub:
 
     length = 2
 
-    def install(self):
-        self.patchers = [
+    def install(self) -> Self:
+        self.patchers: list[_patch[Any]] = [
             patch("beets.metadata_plugins.album_for_id", lambda *_: None),
             patch("beets.metadata_plugins.track_for_id", lambda *_: None),
             patch("beets.metadata_plugins.candidates", self.candidates),
@@ -781,11 +808,13 @@ class AutotagStub:
 
         return self
 
-    def restore(self):
+    def restore(self) -> None:
         for p in self.patchers:
             p.stop()
 
-    def candidates(self, items, artist, album, va_likely):
+    def candidates(
+        self, items: Sequence[Item], artist: str, album: str, _: bool
+    ) -> Iterable[AlbumInfo]:
         if self.matching == self.IDENT:
             yield self._make_album_match(artist, album, len(items))
 
@@ -800,7 +829,9 @@ class AutotagStub:
         elif self.matching == self.MISSING:
             yield self._make_album_match(artist, album, len(items), missing=1)
 
-    def item_candidates(self, item, artist, title):
+    def item_candidates(
+        self, item: Item, artist: str, title: str
+    ) -> Iterable[TrackInfo]:
         yield TrackInfo(
             title=title.replace("Tag", "Applied"),
             track_id="trackid",
@@ -810,7 +841,9 @@ class AutotagStub:
             index=0,
         )
 
-    def _make_track_match(self, artist, album, number):
+    def _make_track_match(
+        self, artist: str, album: str, number: int
+    ) -> TrackInfo:
         return TrackInfo(
             title=f"Applied Track {number}",
             track_id=f"match {number}",
@@ -819,7 +852,14 @@ class AutotagStub:
             index=0,
         )
 
-    def _make_album_match(self, artist, album, tracks, distance=0, missing=0):
+    def _make_album_match(
+        self,
+        artist: str,
+        album: str,
+        tracks: int,
+        distance: int = 0,
+        missing: int = 0,
+    ) -> AlbumInfo:
         id_ = f" {'M' * distance}" if distance else ""
 
         if artist is None:
@@ -848,11 +888,11 @@ class AutotagStub:
 class AutotagImportHelper(ImportHelper):
     matching = AutotagStub.IDENT
 
-    def setup_beets(self):
+    def setup_beets(self) -> None:
         super().setup_beets()
         self.matcher = AutotagStub(self.matching).install()
 
-    def teardown_beets(self):
+    def teardown_beets(self) -> None:
         self.matcher.restore()
         super().teardown_beets()
 
@@ -913,7 +953,7 @@ class FetchImageHelper:
     """Pytest mixin providing image response mocking utilities."""
 
     @pytest.fixture
-    def image_request_mock(self, requests_mock):
+    def image_request_mock(self, requests_mock: Mocker) -> ImageRequestMocker:
         return ImageRequestMocker(requests_mock)
 
 

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -122,11 +122,13 @@ class FilesystemError(HumanReadableError):
     pathnames involved in the operation.
     """
 
+    paths: Sequence[PathLike]
+
     def __init__(
         self,
         reason: str | Exception,
         verb: str,
-        paths: Sequence[bytes | str],
+        paths: Sequence[PathLike],
         tb: str | None = None,
     ) -> None:
         self.paths = paths
@@ -272,7 +274,7 @@ def path_as_posix(path: bytes) -> bytes:
     return path.replace(b"\\", b"/")
 
 
-def mkdirall(path: bytes) -> None:
+def mkdirall(path: AnyStr) -> None:
     """Make all the enclosing directories of path (like mkdir -p on the
     parent).
     """
@@ -439,7 +441,7 @@ def syspath(path: PathLike, prefix: bool = True) -> str:
     return str_path
 
 
-def samefile(p1: bytes, p2: bytes) -> bool:
+def samefile(p1: PathLike, p2: PathLike) -> bool:
     """Safer equality for paths."""
     if p1 == p2:
         return True
@@ -464,7 +466,7 @@ def remove(path: PathLike, soft: bool = True) -> None:
         )
 
 
-def copy(path: bytes, dest: bytes, replace: bool = False) -> None:
+def copy(path: PathLike, dest: PathLike, replace: bool = False) -> None:
     """Copy a plain file. Permissions are not copied. If `dest` already
     exists, raises a FilesystemError unless `replace` is True. Has no
     effect if `path` is the same as `dest`. Paths are translated to
@@ -484,7 +486,7 @@ def copy(path: bytes, dest: bytes, replace: bool = False) -> None:
         )
 
 
-def move(path: bytes, dest: bytes, replace: bool = False) -> None:
+def move(path: PathLike, dest: PathLike, replace: bool = False) -> None:
     """Rename a file. `dest` may not be a directory. If `dest` already
     exists, raises an OSError unless `replace` is True. Has no effect if
     `path` is the same as `dest`. Paths are translated to system paths.
@@ -540,7 +542,7 @@ def move(path: bytes, dest: bytes, replace: bool = False) -> None:
                 os.remove(tmp_filename)
 
 
-def link(path: bytes, dest: bytes, replace: bool = False) -> None:
+def link(path: PathLike, dest: PathLike, replace: bool = False) -> None:
     """Create a symbolic link from path to `dest`. Raises an OSError if
     `dest` already exists, unless `replace` is True. Does nothing if
     `path` == `dest`.
@@ -564,7 +566,7 @@ def link(path: bytes, dest: bytes, replace: bool = False) -> None:
         raise FilesystemError(exc, "link", (path, dest), traceback.format_exc())
 
 
-def hardlink(path: bytes, dest: bytes, replace: bool = False) -> None:
+def hardlink(path: PathLike, dest: PathLike, replace: bool = False) -> None:
     """Create a hard link from path to `dest`. Raises an OSError if
     `dest` already exists, unless `replace` is True. Does nothing if
     `path` == `dest`.
@@ -599,7 +601,10 @@ def hardlink(path: bytes, dest: bytes, replace: bool = False) -> None:
 
 
 def reflink(
-    path: bytes, dest: bytes, replace: bool = False, fallback: bool = False
+    path: PathLike,
+    dest: PathLike,
+    replace: bool = False,
+    fallback: bool = False,
 ) -> None:
     """Create a reflink from `dest` to `path`.
 
@@ -961,7 +966,7 @@ def interactive_open(targets: Sequence[str], command: str) -> None:
     os.execlp(*args)
 
 
-def case_sensitive(path: bytes) -> bool:
+def case_sensitive(path: AnyStr) -> bool:
     """Check whether the filesystem at the given path is case sensitive.
 
     To work best, the path should point to a file or a directory. If the path

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -75,13 +75,15 @@ class HumanReadableError(Exception):
 
     error_kind = "Error"  # Human-readable description of error type.
 
-    def __init__(self, reason, verb, tb=None):
+    def __init__(
+        self, reason: str | Exception, verb: str, tb: str | None = None
+    ) -> None:
         self.reason = reason
         self.verb = verb
         self.tb = tb
         super().__init__(self.get_message())
 
-    def _gerund(self):
+    def _gerund(self) -> str:
         """Generate a (likely) gerund form of the English verb."""
         if " " in self.verb:
             return self.verb
@@ -89,23 +91,23 @@ class HumanReadableError(Exception):
         gerund += "ing"
         return gerund
 
-    def _reasonstr(self):
+    def _reasonstr(self) -> str:
         """Get the reason as a string."""
         if isinstance(self.reason, str):
             return self.reason
         if isinstance(self.reason, bytes):
             return self.reason.decode("utf-8", "ignore")
-        if hasattr(self.reason, "strerror"):  # i.e., EnvironmentError
-            return self.reason.strerror
+        if isinstance(self.reason, OSError):  # i.e., EnvironmentError
+            return self.reason.strerror or str(self.reason)
         return f'"{self.reason}"'
 
-    def get_message(self):
+    def get_message(self) -> str:
         """Create the human-readable description of the error, sans
         introduction.
         """
         raise NotImplementedError
 
-    def log(self, logger):
+    def log(self, logger: Logger) -> None:
         """Log to the provided `logger` a human-readable message as an
         error and a verbose traceback as a debug message.
         """
@@ -120,11 +122,17 @@ class FilesystemError(HumanReadableError):
     pathnames involved in the operation.
     """
 
-    def __init__(self, reason, verb, paths, tb=None):
+    def __init__(
+        self,
+        reason: str | Exception,
+        verb: str,
+        paths: Sequence[bytes | str],
+        tb: str | None = None,
+    ) -> None:
         self.paths = paths
         super().__init__(reason, verb, tb)
 
-    def get_message(self):
+    def get_message(self) -> str:
         # Use a nicer English phrasing for some specific verbs.
         if self.verb in ("move", "copy", "rename"):
             clause = (
@@ -264,7 +272,7 @@ def path_as_posix(path: bytes) -> bytes:
     return path.replace(b"\\", b"/")
 
 
-def mkdirall(path: bytes):
+def mkdirall(path: bytes) -> None:
     """Make all the enclosing directories of path (like mkdir -p on the
     parent).
     """
@@ -297,7 +305,7 @@ def prune_dirs(
     path: PathLike,
     root: PathLike | None = None,
     clutter: Sequence[str] = (".DS_Store", "Thumbs.db"),
-):
+) -> None:
     """If path is an empty directory, then remove it. Recursively remove
     path's ancestry up to root (which is never removed) where there are
     empty directories. If path is not contained in root, then nothing is
@@ -441,7 +449,7 @@ def samefile(p1: bytes, p2: bytes) -> bool:
     return False
 
 
-def remove(path: PathLike, soft: bool = True):
+def remove(path: PathLike, soft: bool = True) -> None:
     """Remove the file. If `soft`, then no error will be raised if the
     file does not exist.
     """
@@ -456,7 +464,7 @@ def remove(path: PathLike, soft: bool = True):
         )
 
 
-def copy(path: bytes, dest: bytes, replace: bool = False):
+def copy(path: bytes, dest: bytes, replace: bool = False) -> None:
     """Copy a plain file. Permissions are not copied. If `dest` already
     exists, raises a FilesystemError unless `replace` is True. Has no
     effect if `path` is the same as `dest`. Paths are translated to
@@ -476,7 +484,7 @@ def copy(path: bytes, dest: bytes, replace: bool = False):
         )
 
 
-def move(path: bytes, dest: bytes, replace: bool = False):
+def move(path: bytes, dest: bytes, replace: bool = False) -> None:
     """Rename a file. `dest` may not be a directory. If `dest` already
     exists, raises an OSError unless `replace` is True. Has no effect if
     `path` is the same as `dest`. Paths are translated to system paths.
@@ -505,12 +513,7 @@ def move(path: bytes, dest: bytes, replace: bool = False):
         )
         try:
             with open(syspath(path), "rb") as f:
-                # mypy bug:
-                # - https://github.com/python/mypy/issues/15031
-                # - https://github.com/python/mypy/issues/14943
-                # Fix not yet released:
-                # - https://github.com/python/mypy/pull/14975
-                shutil.copyfileobj(f, tmp)  # type: ignore[misc]
+                shutil.copyfileobj(f, tmp)
         finally:
             tmp.close()
 
@@ -537,7 +540,7 @@ def move(path: bytes, dest: bytes, replace: bool = False):
                 os.remove(tmp_filename)
 
 
-def link(path: bytes, dest: bytes, replace: bool = False):
+def link(path: bytes, dest: bytes, replace: bool = False) -> None:
     """Create a symbolic link from path to `dest`. Raises an OSError if
     `dest` already exists, unless `replace` is True. Does nothing if
     `path` == `dest`.
@@ -552,7 +555,8 @@ def link(path: bytes, dest: bytes, replace: bool = False):
     except NotImplementedError:
         # raised on python >= 3.2 and Windows versions before Vista
         raise FilesystemError(
-            "OS does not support symbolic links.link",
+            "OS does not support symbolic links.",
+            "link",
             (path, dest),
             traceback.format_exc(),
         )
@@ -560,7 +564,7 @@ def link(path: bytes, dest: bytes, replace: bool = False):
         raise FilesystemError(exc, "link", (path, dest), traceback.format_exc())
 
 
-def hardlink(path: bytes, dest: bytes, replace: bool = False):
+def hardlink(path: bytes, dest: bytes, replace: bool = False) -> None:
     """Create a hard link from path to `dest`. Raises an OSError if
     `dest` already exists, unless `replace` is True. Does nothing if
     `path` == `dest`.
@@ -578,14 +582,16 @@ def hardlink(path: bytes, dest: bytes, replace: bool = False):
         dest_path.hardlink_to(origin_path)
     except NotImplementedError:
         raise FilesystemError(
-            "OS does not support hard links.link",
+            "OS does not support hard links.",
+            "link",
             (path, dest),
             traceback.format_exc(),
         )
     except OSError as exc:
         if exc.errno == errno.EXDEV:
             raise FilesystemError(
-                "Cannot hard link across devices.link",
+                "Cannot hard link across devices.",
+                "link",
                 (path, dest),
                 traceback.format_exc(),
             )
@@ -594,7 +600,7 @@ def hardlink(path: bytes, dest: bytes, replace: bool = False):
 
 def reflink(
     path: bytes, dest: bytes, replace: bool = False, fallback: bool = False
-):
+) -> None:
     """Create a reflink from `dest` to `path`.
 
     Raise an `OSError` if `dest` already exists, unless `replace` is
@@ -933,7 +939,7 @@ def editor_command() -> str:
     )
 
 
-def interactive_open(targets: Sequence[str], command: str):
+def interactive_open(targets: Sequence[str], command: str) -> None:
     """Open the files in `targets` by `exec`ing a new `command`, given
     as a Unicode string. (The new program takes over, and Python
     execution ends: this does not fork a subprocess.)
@@ -952,7 +958,7 @@ def interactive_open(targets: Sequence[str], command: str):
 
     args += targets
 
-    return os.execlp(*args)
+    os.execlp(*args)
 
 
 def case_sensitive(path: bytes) -> bool:
@@ -1064,7 +1070,7 @@ class cached_classproperty(Generic[T]):
     # type check, for example:
     # >>> class Album:
     # >>>     @cached_classproperty
-    # >>>     def foo(cls):
+    # >>>     def foo(cls) -> Bar:
     # >>>         reveal_type(cls)  # mypy: revealed type is "Album"
     # >>>         return cls.bar
     #


### PR DESCRIPTION
I've started working on migrating the codebase to `pathlib.Path` and this is the very first step: fully type `beets.util` and `beets.test.helper`. Next, I will me migrating tests to use `pathlib.Path`.

Fixes: #6808

- Extracts shared path/temp-directory behavior into `PathsMixin`, and splits import-specific test setup into `ImporterMixin`. This makes `beets.test.helper` more modular and gives test helpers a clearer inheritance structure.

- Updates `TestHelper` and import helpers to use those smaller mixins, while keeping existing test behavior intact. The main architectural effect is better separation between core test setup, filesystem helpers, and importer-specific utilities.

- Tightens typing across `beets.test.helper` and `beets.util`, especially around path handling. `beets.util` now accepts a broader set of path types through `PathLike`/`AnyPath`, which reduces friction between `bytes`, `str`, and `Path` usage.

- Aligns helper internals with the typed interfaces by normalizing path handling in methods like `touch`, using typed `template(...)` entries for importer path formats, and fixing a few return-type/inheritance edge cases.

- High-level impact: this is mainly a typing and test-infrastructure cleanup. It improves maintainability and type-checker accuracy without changing production architecture or intended runtime behavior.
