### PR TITLE
tests: remove unused/redundant logic from tests

### DIFF
--- a/beets/test/fixtures.py
+++ b/beets/test/fixtures.py
@@ -1,16 +1,3 @@
-# This file is part of beets.
-# Copyright 2016, Adrian Sampson.
-#
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the
-# "Software"), to deal in the Software without restriction, including
-# without limitation the rights to use, copy, modify, merge, publish,
-# distribute, sublicense, and/or sell copies of the Software, and to
-# permit persons to whom the Software is furnished to do so, subject to
-# the following conditions:
-#
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
 """Provide lightweight dbcore model fixtures for tests.
 
 These fixtures supply predictable query, sort, and model behavior for tests that

--- a/beets/test/fixtures.py
+++ b/beets/test/fixtures.py
@@ -6,7 +6,7 @@ exercise metadata registration and model integration.
 
 from typing import ClassVar
 
-from beets.dbcore import query, sort, types
+from beets.dbcore import sort, types
 from beets.dbcore.db import FormattedMapping, Index
 from beets.library import LibModel
 from beets.util import cached_classproperty
@@ -15,17 +15,6 @@ from beets.util.artresizer import IMBackend
 
 class SortFixture(sort.FieldSort):
     pass
-
-
-class QueryFixture(query.FieldQuery):
-    def __init__(self, pattern):
-        self.pattern = pattern
-
-    def clause(self):
-        return None, ()
-
-    def match(self):
-        return True
 
 
 class ModelFixture1(LibModel):
@@ -47,15 +36,8 @@ class ModelFixture1(LibModel):
     def _types(cls):
         return {"some_float_field": types.FLOAT}
 
-    @cached_classproperty
-    def _queries(cls):
-        return {"some_query": QueryFixture}
-
     @classmethod
     def _getters(cls):
-        return {}
-
-    def _template_funcs(self):
         return {}
 
 

--- a/test/dbcore/test_db.py
+++ b/test/dbcore/test_db.py
@@ -2,7 +2,6 @@
 
 import os
 import shutil
-import sqlite3
 import unittest
 from tempfile import mkstemp
 from typing import ClassVar
@@ -96,9 +95,6 @@ class ModelFixtureWithGetters(dbcore.Model):
     def _getters(cls):
         return {"aComputedField": (lambda s: "thing")}
 
-    def _template_funcs(self):
-        return {}
-
 
 class MigrationTest(unittest.TestCase):
     """Tests the ability to change the database schema between
@@ -166,12 +162,9 @@ class MigrationTest(unittest.TestCase):
 
     def test_extra_model_adds_table(self):
         new_lib = DatabaseFixtureTwoModels(self.libfile)
-        try:
-            c = new_lib._connection()
-            c.execute("select * from another")
-            c.close()
-        except sqlite3.OperationalError:
-            self.fail("select failed")
+        c = new_lib._connection()
+        c.execute("select * from another")
+        c.close()
 
     def test_index_creation(self):
         """Test that declared indices are created on database initialization."""

--- a/test/dbcore/test_queryparse.py
+++ b/test/dbcore/test_queryparse.py
@@ -1,16 +1,3 @@
-# This file is part of beets.
-# Copyright 2016, Adrian Sampson.
-#
-# Permission is hereby granted, free of charge, to any person obtaining
-# a copy of this software and associated documentation files (the
-# "Software"), to deal in the Software without restriction, including
-# without limitation the rights to use, copy, modify, merge, publish,
-# distribute, sublicense, and/or sell copies of the Software, and to
-# permit persons to whom the Software is furnished to do so, subject to
-# the following conditions:
-#
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
 """Tests for dbcore query parsing helpers."""
 
 import unittest

--- a/test/plugins/test_chroma.py
+++ b/test/plugins/test_chroma.py
@@ -71,18 +71,12 @@ class TestChroma(IOMixin, PluginMixin, ImportHelper):
         assert TEST_TITLE_1 in output.split("\n")[0]
 
 
-def _seed_acoustid_match(
-    item_path: bytes = b"/fake/path.mp3",
-    recording_ids: list[str] | None = None,
-    release_ids: list[str] | None = None,
-) -> Item:
+def _seed_acoustid_match(item_path: bytes = b"/fake/path.mp3") -> Item:
     """Seed the chroma module-level match cache as if acoustid had run."""
-    if recording_ids is None:
-        recording_ids = ["rec-id-1"]
-    if release_ids is None:
-        release_ids = ["rel-id-1", "rel-id-1", "rel-id-1"]
-
-    chroma._matches[item_path] = (recording_ids, release_ids)
+    chroma._matches[item_path] = (
+        ["rec-id-1"],
+        ["rel-id-1", "rel-id-1", "rel-id-1"],
+    )
     return Item(path=item_path)
 
 

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import fnmatch
 import os.path
-import re
 import shlex
 import sys
 from typing import TYPE_CHECKING
@@ -40,11 +39,6 @@ class ConvertPluginHelper(IOMixin, PluginTestHelper):
         """Return a conversion command that copies files and appends
         `tag` to the copy.
         """
-        if re.search("[^a-zA-Z0-9]", tag):
-            raise ValueError(
-                f"tag '{tag}' must only contain letters and digits"
-            )
-
         # A Python script that copies the file and appends a tag.
         stub = os.path.join(_common.RSRC, b"convert_stub.py").decode("utf-8")
         return f"{shlex.quote(sys.executable)} {shlex.quote(stub)} $source $dest {tag}"

--- a/test/plugins/test_discogs.py
+++ b/test/plugins/test_discogs.py
@@ -62,14 +62,12 @@ class TestDGAlbumInfo(TestHelper):
         )
 
     def _make_track(self, title, position="", duration="", type_=None):
-        track = {"title": title, "position": position, "duration": duration}
-        if type_ is not None:
-            # Test samples on discogs_client do not have a 'type_' field, but
-            # the API seems to return it. Values: 'track' for regular tracks,
-            # 'heading' for descriptive texts (ie. not real tracks - 12.13.2).
-            track["type_"] = type_
-
-        return track
+        return {
+            "title": title,
+            "position": position,
+            "duration": duration,
+            "type_": type_,
+        }
 
     def _make_release_from_positions(self, positions):
         """Return a Bag that mimics a discogs_client.Release with a

--- a/test/plugins/test_fetchart.py
+++ b/test/plugins/test_fetchart.py
@@ -25,13 +25,12 @@ class FetchartCliTest(IOMixin, PluginTestCase):
         with open(util.syspath(self.cover_path(ext))) as f:
             assert f.read() == "IMAGE"
 
-    def hide_file_windows(self, ext="jpg"):
-        hidden_mask = 2
-        success = ctypes.windll.kernel32.SetFileAttributesW(
-            self.cover_path(ext), hidden_mask
-        )
-        if not success:
-            self.skipTest("unable to set file attributes")
+    def hide_file_windows(self, path: bytes) -> None:
+        if sys.platform == "win32":
+            hidden_mask = 2
+            assert ctypes.windll.kernel32.SetFileAttributesW(
+                util.syspath(path), hidden_mask
+            )
 
     def test_set_art_from_folder(self):
         self.touch(b"c\xc3\xb6ver.jpg", dir_=self.album.path, content="IMAGE")
@@ -62,9 +61,8 @@ class FetchartCliTest(IOMixin, PluginTestCase):
         self.check_cover_is_stored()
 
     def test_filesystem_does_not_pick_up_hidden_file(self):
-        self.touch(b".cover.jpg", dir_=self.album.path, content="IMAGE")
-        if sys.platform == "win32":
-            self.hide_file_windows()
+        path = self.touch(b".cover.jpg", dir_=self.album.path, content="IMAGE")
+        self.hide_file_windows(path)
         self.config["ignore"] = []  # By default, ignore includes '.*'.
         self.config["ignore_hidden"] = True
         self.run_command("fetchart")
@@ -79,9 +77,8 @@ class FetchartCliTest(IOMixin, PluginTestCase):
         self.check_cover_is_stored()
 
     def test_filesystem_picks_up_hidden_file(self):
-        self.touch(b".cover.jpg", dir_=self.album.path, content="IMAGE")
-        if sys.platform == "win32":
-            self.hide_file_windows()
+        path = self.touch(b".cover.jpg", dir_=self.album.path, content="IMAGE")
+        self.hide_file_windows(path)
         self.config["ignore"] = []  # By default, ignore includes '.*'.
         self.config["ignore_hidden"] = False
         self.run_command("fetchart")

--- a/test/plugins/test_ftintitle.py
+++ b/test/plugins/test_ftintitle.py
@@ -389,10 +389,8 @@ def test_contains_feat(given: str, expected: bool) -> None:
     ],
 )
 def test_custom_words(
-    given: str, custom_words: list[str] | None, expected: bool
+    given: str, custom_words: list[str], expected: bool
 ) -> None:
-    if custom_words is None:
-        custom_words = []
     assert ftintitle.contains_feat(given, custom_words) is expected
 
 

--- a/test/plugins/test_importadded.py
+++ b/test/plugins/test_importadded.py
@@ -7,17 +7,6 @@ import pytest
 from beets import importer
 from beets.test.helper import AutotagImportTestCase, PluginMixin
 from beets.util import displayable_path, syspath
-from beetsplug.importadded import ImportAddedPlugin
-
-_listeners = ImportAddedPlugin.listeners
-
-
-def preserve_plugin_listeners():
-    """Preserve the initial plugin listeners as they would otherwise be
-    deleted after the first setup / tear down cycle.
-    """
-    if not ImportAddedPlugin.listeners:
-        ImportAddedPlugin.listeners = _listeners
 
 
 def modify_mtimes(paths, offset=-60000):
@@ -32,7 +21,6 @@ class ImportAddedTest(PluginMixin, AutotagImportTestCase):
     min_mtime = None
 
     def setUp(self):
-        preserve_plugin_listeners()
         super().setUp()
         self.prepare_album_for_import(2)
         # Different mtimes on the files to be imported in order to test the

--- a/test/plugins/test_importsource.py
+++ b/test/plugins/test_importsource.py
@@ -6,17 +6,6 @@ import time
 from beets import importer, plugins
 from beets.test.helper import AutotagImportTestCase, IOMixin, PluginMixin
 from beets.util import syspath
-from beetsplug.importsource import ImportSourcePlugin
-
-_listeners = ImportSourcePlugin.listeners
-
-
-def preserve_plugin_listeners():
-    """Preserve the initial plugin listeners as they would otherwise be
-    deleted after the first setup / tear down cycle.
-    """
-    if not ImportSourcePlugin.listeners:
-        ImportSourcePlugin.listeners = _listeners
 
 
 class ImportSourceTest(IOMixin, PluginMixin, AutotagImportTestCase):
@@ -24,7 +13,6 @@ class ImportSourceTest(IOMixin, PluginMixin, AutotagImportTestCase):
     preload_plugin = False
 
     def setUp(self):
-        preserve_plugin_listeners()
         super().setUp()
         self.config[self.plugin]["suggest_removal"] = True
         self.load_plugins()
@@ -120,9 +108,6 @@ class ImportSourceTest(IOMixin, PluginMixin, AutotagImportTestCase):
 
         class MockTask:
             skip = True
-
-            def imported_items(self):
-                return "whatever"
 
         plugin = plugins._instances[0]
         mock_task = MockTask()

--- a/test/plugins/test_ipfs.py
+++ b/test/plugins/test_ipfs.py
@@ -21,23 +21,18 @@ class IPFSPluginTest(PluginTestCase):
             found = False
             want_item = test_album.items()[2]
             for check_item in added_album.items():
-                try:
-                    if check_item.get("ipfs", with_album=False):
-                        ipfs_item = os.fsdecode(
-                            os.path.basename(want_item.path)
-                        )
-                        want_path = util.normpath(
-                            os.path.join("/ipfs", test_album.ipfs, ipfs_item)
-                        )
-                        assert check_item.path == want_path
-                        assert (
-                            check_item.get("ipfs", with_album=False)
-                            == want_item.ipfs
-                        )
-                        assert check_item.title == want_item.title
-                        found = True
-                except AttributeError:
-                    pass
+                if check_item.get("ipfs", with_album=False):
+                    ipfs_item = os.fsdecode(os.path.basename(want_item.path))
+                    want_path = util.normpath(
+                        os.path.join("/ipfs", test_album.ipfs, ipfs_item)
+                    )
+                    assert check_item.path == want_path
+                    assert (
+                        check_item.get("ipfs", with_album=False)
+                        == want_item.ipfs
+                    )
+                    assert check_item.title == want_item.title
+                    found = True
             assert found
 
     def mk_test_album(self):

--- a/test/plugins/test_listenbrainz.py
+++ b/test/plugins/test_listenbrainz.py
@@ -155,9 +155,7 @@ class TestListenBrainzPlugin(ConfigMixin):
             call_count += 1
             if call_count == 1:
                 return {"payload": {"listens": page1}}
-            if call_count == 2:
-                return {"payload": {"listens": page2}}
-            return {"payload": {"listens": []}}
+            return {"payload": {"listens": page2}}
 
         with patch.object(plugin, "_make_request", side_effect=mock_request):
             result = plugin.get_listens(count=5)

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -1,9 +1,8 @@
 # TODO: Tests in this fire are very bad. Stop using Mocks in this module.
+from __future__ import annotations
 
 import os
-from pathlib import Path
-from shutil import rmtree
-from tempfile import mkdtemp
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, Mock, PropertyMock
 
 import pytest
@@ -12,15 +11,24 @@ from beets import config
 from beets.dbcore.sort import FixedFieldSort, MultipleSort, NullSort
 from beets.library import Album, Item, parse_query_string
 from beets.test._common import item
-from beets.test.helper import BeetsTestCase, IOMixin, PluginTestCase
+from beets.test.helper import BeetsTestCase, IOMixin, PathsMixin, PluginTestCase
 from beets.ui import UserError
 from beets.util import CHAR_REPLACE, syspath
 from beetsplug.smartplaylist import SmartPlaylistPlugin
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 _p = pytest.param
 
 
-class SmartPlaylistTest(BeetsTestCase):
+class PlaylistDirMixin(PathsMixin):
+    @property
+    def playlist_dir(self) -> Path:
+        return self.temp_dir_path / "playlists"
+
+
+class SmartPlaylistTest(PlaylistDirMixin, BeetsTestCase):
     def test_build_queries(self):
         spl = SmartPlaylistPlugin()
         assert spl._matched_playlists == set()
@@ -174,22 +182,16 @@ class SmartPlaylistTest(BeetsTestCase):
         pl = b"$title-my<playlist>.m3u", (q, None), (a_q, None)
         spl._matched_playlists = {pl}
 
-        dir_ = mkdtemp()
         config["smartplaylist"]["relative_to"] = False
-        config["smartplaylist"]["playlist_dir"] = str(dir_)
-        try:
-            spl.update_playlists(lib)
-        except Exception:
-            rmtree(syspath(dir_))
-            raise
+        config["smartplaylist"]["playlist_dir"] = str(self.playlist_dir)
+        spl.update_playlists(lib)
 
         lib.items.assert_called_once_with(q, None)
         lib.albums.assert_called_once_with(a_q, None)
 
-        m3u_filepath = Path(dir_, "ta_ga_da-my_playlist_.m3u")
+        m3u_filepath = self.playlist_dir / "ta_ga_da-my_playlist_.m3u"
         assert m3u_filepath.exists()
         content = m3u_filepath.read_bytes()
-        rmtree(syspath(dir_))
 
         assert content == b"/tagada.mp3\n"
 
@@ -215,24 +217,18 @@ class SmartPlaylistTest(BeetsTestCase):
         pl = b"$title-my<playlist>.m3u", (q, None), (a_q, None)
         spl._matched_playlists = {pl}
 
-        dir_ = mkdtemp()
         config["smartplaylist"]["output"] = "extm3u"
         config["smartplaylist"]["prefix"] = "http://beets:8337/files"
         config["smartplaylist"]["relative_to"] = False
-        config["smartplaylist"]["playlist_dir"] = str(dir_)
-        try:
-            spl.update_playlists(lib)
-        except Exception:
-            rmtree(syspath(dir_))
-            raise
+        config["smartplaylist"]["playlist_dir"] = str(self.playlist_dir)
+        spl.update_playlists(lib)
 
         lib.items.assert_called_once_with(q, None)
         lib.albums.assert_called_once_with(a_q, None)
 
-        m3u_filepath = Path(dir_, "ta_ga_da-my_playlist_.m3u")
+        m3u_filepath = self.playlist_dir / "ta_ga_da-my_playlist_.m3u"
         assert m3u_filepath.exists()
         content = m3u_filepath.read_bytes()
-        rmtree(syspath(dir_))
 
         assert content == (
             b"#EXTM3U\n"
@@ -264,24 +260,18 @@ class SmartPlaylistTest(BeetsTestCase):
         pl = b"$title-my<playlist>.m3u", (q, None), (a_q, None)
         spl._matched_playlists = {pl}
 
-        dir_ = mkdtemp()
         config["smartplaylist"]["output"] = "extm3u"
         config["smartplaylist"]["relative_to"] = False
-        config["smartplaylist"]["playlist_dir"] = str(dir_)
+        config["smartplaylist"]["playlist_dir"] = str(self.playlist_dir)
         config["smartplaylist"]["fields"] = ["id", "genres"]
-        try:
-            spl.update_playlists(lib)
-        except Exception:
-            rmtree(syspath(dir_))
-            raise
+        spl.update_playlists(lib)
 
         lib.items.assert_called_once_with(q, None)
         lib.albums.assert_called_once_with(a_q, None)
 
-        m3u_filepath = Path(dir_, "ta_ga_da-my_playlist_.m3u")
+        m3u_filepath = self.playlist_dir / "ta_ga_da-my_playlist_.m3u"
         assert m3u_filepath.exists()
         content = m3u_filepath.read_bytes()
-        rmtree(syspath(dir_))
 
         assert content == (
             b"#EXTM3U\n"
@@ -308,10 +298,6 @@ class SmartPlaylistTest(BeetsTestCase):
 
 
 class TestGetItemURI:
-    @pytest.fixture
-    def plugin_config(self):
-        return {}
-
     @pytest.fixture
     def plugin(self, config, plugin_config):
         plugin_config = {"prefix": "http://beets:8337/files", **plugin_config}
@@ -360,7 +346,7 @@ class TestGetItemURI:
         assert plugin.get_item_uri(item) == expected_uri
 
 
-class SmartPlaylistCLITest(IOMixin, PluginTestCase):
+class SmartPlaylistCLITest(PlaylistDirMixin, IOMixin, PluginTestCase):
     plugin = "smartplaylist"
 
     def setUp(self):
@@ -373,14 +359,14 @@ class SmartPlaylistCLITest(IOMixin, PluginTestCase):
                 {"name": "all.m3u", "query": ""},
             ]
         )
-        config["smartplaylist"]["playlist_dir"].set(str(self.temp_dir_path))
+        config["smartplaylist"]["playlist_dir"] = str(self.playlist_dir)
 
     def test_splupdate(self):
         with pytest.raises(UserError):
             self.run_with_output("splupdate", "tagada")
 
         self.run_with_output("splupdate", "my_playlist")
-        m3u_path = self.temp_dir_path / "my_playlist.m3u"
+        m3u_path = self.playlist_dir / "my_playlist.m3u"
         assert m3u_path.exists()
         assert m3u_path.read_bytes() == self.item.path + b"\n"
         os.remove(syspath(m3u_path))
@@ -390,9 +376,10 @@ class SmartPlaylistCLITest(IOMixin, PluginTestCase):
         os.remove(syspath(m3u_path))
 
         self.run_with_output("splupdate")
-        for name in (b"my_playlist.m3u", b"all.m3u"):
-            with open(os.path.join(self.temp_dir, name), "rb") as f:
-                assert f.read() == self.item.path + b"\n"
+        for name in ("my_playlist.m3u", "all.m3u"):
+            assert (
+                self.playlist_dir / name
+            ).read_bytes() == self.item.path + b"\n"
 
     def test_splupdate_unknown_playlist_error_is_sorted_and_quoted(self):
         config["smartplaylist"]["playlists"].set(

--- a/test/plugins/test_thumbnails.py
+++ b/test/plugins/test_thumbnails.py
@@ -101,15 +101,6 @@ class ThumbnailsTest(BeetsTestCase):
         plugin.thumbnail_file_name = Mock(return_value=b"md5")
         mock_os.path.exists.return_value = False
 
-        def os_stat(target):
-            if target == syspath(md5_file):
-                return Mock(st_mtime=1)
-            if target == syspath(path_to_art):
-                return Mock(st_mtime=2)
-            raise ValueError(f"invalid target {target}")
-
-        mock_os.stat.side_effect = os_stat
-
         mock_resize = mock_artresizer.shared.resize
         mock_resize.return_value = path_to_resized_art
 

--- a/test/plugins/test_web.py
+++ b/test/plugins/test_web.py
@@ -41,10 +41,6 @@ class WebPluginMixin(PluginMixin):
         else:
             self.path_prefix = ""
 
-        # Add fixtures
-        for track in self.lib.items():
-            track.remove()
-
         # Add library elements. Note that self.lib.add overrides any "id=<n>"
         # and assigns the next free id number.
         # The following adds will create items #1, #2 and #3

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -972,11 +972,7 @@ class TestAlbumInfo(PytestItemHelper):
 
     def test_album_items_consistent(self, item_in_album):
         ai = self.lib.get_album(item_in_album)
-        for i in ai.items():
-            if i.id == item_in_album.id:
-                break
-        else:
-            self.fail("item not found")
+        assert item_in_album.id in {i.id for i in ai.items()}
 
     def test_albuminfo_changes_affect_items(self, item_in_album):
         ai = self.lib.get_album(item_in_album)

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -246,11 +246,6 @@ class TestConcurrentEvents(AsIsImporterMixin, ImportHelper):
             self.exc = None
             self.t1_step = self.t2_step = 0
 
-        def log_all(self, name):
-            self._log.debug("debug {}", name)
-            self._log.info("info {}", name)
-            self._log.warning("warning {}", name)
-
         def listener1(self):
             try:
                 assert self._log.level == log.INFO

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -299,10 +299,7 @@ class SoftRemoveTest(FilePathTestCase):
         assert not self.path.exists()
 
     def test_soft_remove_silent_on_no_file(self):
-        try:
-            util.remove(self.path / "XXX", True)
-        except OSError:
-            self.fail("OSError when removing path")
+        util.remove(self.path / "XXX", True)
 
 
 class SafeMoveCopyTest(FilePathTestCase):

--- a/test/ui/commands/test_modify.py
+++ b/test/ui/commands/test_modify.py
@@ -1,5 +1,3 @@
-import unittest
-
 import pytest
 from mediafile import MediaFile
 
@@ -195,9 +193,8 @@ class ModifyTest(IOMixin, BeetsTestCase):
         item = self.lib.items().get()
         assert "flexattr" not in item
 
-    @unittest.skip("not yet implemented")
     def test_delete_initial_key_tag(self):
-        item = self.lib.items().get()
+        item = self.add_item_fixture()
         item.initial_key = "C#m"
         item.write()
         item.store()

--- a/test/ui/test_ui.py
+++ b/test/ui/test_ui.py
@@ -20,37 +20,14 @@ from beets.util import syspath
 
 class PrintTest(IOMixin, unittest.TestCase):
     def test_print_without_locale(self):
-        lang = os.environ.get("LANG")
-        if lang:
-            del os.environ["LANG"]
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("LANG", None)
 
-        try:
             ui.print_("something")
-        except TypeError:
-            self.fail("TypeError during print")
-        finally:
-            if lang:
-                os.environ["LANG"] = lang
 
+    @patch.dict(os.environ, {"LANG": "", "LC_CTYPE": "UTF-8"}, clear=False)
     def test_print_with_invalid_locale(self):
-        old_lang = os.environ.get("LANG")
-        os.environ["LANG"] = ""
-        old_ctype = os.environ.get("LC_CTYPE")
-        os.environ["LC_CTYPE"] = "UTF-8"
-
-        try:
-            ui.print_("something")
-        except ValueError:
-            self.fail("ValueError during print")
-        finally:
-            if old_lang:
-                os.environ["LANG"] = old_lang
-            else:
-                del os.environ["LANG"]
-            if old_ctype:
-                os.environ["LC_CTYPE"] = old_ctype
-            else:
-                del os.environ["LC_CTYPE"]
+        ui.print_("something")
 
 
 class ShowModelChangesTest(IOMixin, BeetsTestCase):
@@ -502,25 +479,27 @@ class CommonOptionsParserTest(unittest.TestCase):
         )
 
 
-class EncodingTest(unittest.TestCase):
+class TestEncoding:
     """Tests for the `terminal_encoding` config option and our
     `_in_encoding` and `_out_encoding` utility functions.
     """
 
-    def out_encoding_overridden(self):
+    def test_out_encoding_overridden(self, config):
         config["terminal_encoding"] = "fake_encoding"
         assert ui._out_encoding() == "fake_encoding"
 
-    def in_encoding_overridden(self):
+    def test_in_encoding_overridden(self, config):
         config["terminal_encoding"] = "fake_encoding"
         assert ui._in_encoding() == "fake_encoding"
 
-    def out_encoding_default_utf8(self):
+    def test_out_encoding_default_utf8(self, config):
+        config["terminal_encoding"] = None
         with patch("sys.stdout") as stdout:
             stdout.encoding = None
             assert ui._out_encoding() == "utf-8"
 
-    def in_encoding_default_utf8(self):
+    def test_in_encoding_default_utf8(self, config):
+        config["terminal_encoding"] = None
         with patch("sys.stdin") as stdin:
             stdin.encoding = None
             assert ui._in_encoding() == "utf-8"

--- a/test/ui/test_ui_init.py
+++ b/test/ui/test_ui_init.py
@@ -1,10 +1,11 @@
 """Test module for file ui/__init__.py"""
 
 import os
-import shutil
 import unittest
 from copy import deepcopy
 from random import random
+
+import pytest
 
 from beets import config, ui
 from beets.exceptions import UserError
@@ -96,13 +97,6 @@ class ParentalDirCreation(IOMixin, BeetsTestCase):
         test_config["library"] = non_exist_path
 
         self.io.addinput("n")
-        try:
-            lib = ui._open_library(test_config)
-        except UserError:
-            if os.path.exists(non_exist_path_parent):
-                shutil.rmtree(non_exist_path_parent)
-                raise OSError("Parent directories should not be created.")
-        else:
-            if lib:
-                lib._close()
-            raise OSError("Parent directories should not be created.")
+        with pytest.raises(UserError):
+            ui._open_library(test_config)
+        assert not os.path.exists(non_exist_path_parent)


### PR DESCRIPTION
- This change simplifies the test architecture after full coverage exposed dead paths. Redundant helpers, fixtures, fallback branches, and defensive test-only code were removed across `test/*` and `beets/test/fixtures.py`.

- Biggest structural change is in `test/plugins/test_smartplaylist.py`, where repeated temporary playlist directory setup was pulled into a small shared `PlaylistDirMixin`. This keeps filesystem setup in one place and makes the affected tests more uniform.

- Several tests now rely on direct assertions instead of `try`/`except`, manual cleanup, or skipped paths. That makes failures more explicit and reduces hidden control flow in the suite.

- High-level impact: no production architecture changes, but the test suite becomes smaller, stricter, and easier to reason about. Reviewers can read this as a cleanup pass that removes unused test scaffolding while preserving existing behavior.
