### PR TITLE
Add `fetch_for_asis` setting to FetchArt plugin

### DIFF
--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -1318,6 +1318,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         self.config.add(
             {
                 "auto": True,
+                "fetch_for_asis": False,
                 "minwidth": 0,
                 "maxwidth": 0,
                 "quality": 0,
@@ -1464,8 +1465,9 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
                 # Album already has art (probably a re-import); skip it.
                 return
             if task.choice_flag == importer.Action.ASIS:
-                # For as-is imports, don't search Web sources for art.
-                local = True
+                # For as-is imports, don't search Web sources for art,
+                # unless fetch_for_asis is set
+                local = not self.config["fetch_for_asis"]
             elif task.choice_flag in (
                 importer.Action.APPLY,
                 importer.Action.RETAG,

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -1439,6 +1439,10 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         except UnknownPairError as e:
             raise UserError(e)
 
+    @cached_property
+    def fetch_for_asis(self) -> bool:
+        return self.config["fetch_for_asis"].get(bool)
+
     @staticmethod
     def _is_source_file_removal_enabled() -> bool:
         return config["import"]["delete"].get(bool) or config["import"][
@@ -1467,7 +1471,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
             if task.choice_flag == importer.Action.ASIS:
                 # For as-is imports, don't search Web sources for art,
                 # unless fetch_for_asis is set
-                local = not self.config["fetch_for_asis"]
+                local = not self.fetch_for_asis
             elif task.choice_flag in (
                 importer.Action.APPLY,
                 importer.Action.RETAG,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,10 @@ New features
   :bug:`6587`
 - :doc:`plugins/ftintitle`: Apply featured-artist rewriting to fetched metadata
   before commands such as :doc:`plugins/mbsync` use it. :bug:`1153`
+- :doc:`plugins/fetchart`: Add ``fetch_for_asis`` setting that enables fetching
+  album art from online sources even when imported files are not modified by the
+  auto-tagger. Default is ``no`` which means ``fetchart`` looks for art only in
+  the local filesystem when the user (or ``quiet_fallback``) chooses ``asis``.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/plugins/fetchart.rst
+++ b/docs/plugins/fetchart.rst
@@ -38,6 +38,9 @@ file. The available options are:
   ``cover front art album folder``.
 - **fallback**: Path to a fallback album art file if no album art was found
   otherwise. Default: ``None`` (disabled).
+- **fetch_for_asis**: Fetch album art from online sources during import, even
+  when the as-is option is selected in the Auto-Tagger. When ``no``, only local
+  filesystem sources of art are considered for as-is imports. Default: ``no``.
 - **minwidth**: Only images with a width bigger or equal to ``minwidth`` are
   considered as valid album art candidates. Default: 0.
 - **maxwidth**: A maximum image width to downscale fetched images if they are

--- a/test/plugins/test_fetchart.py
+++ b/test/plugins/test_fetchart.py
@@ -1,11 +1,66 @@
 import ctypes
 import os
 import sys
+from typing import Any, ClassVar
 from unittest import mock
 
-from beets import util
-from beets.test.helper import IOMixin, PluginTestHelper
-from beetsplug.fetchart import FetchArtPlugin, FileSystem
+from beets import importer, util
+from beets.test.helper import (
+    AutotagImportHelper,
+    IOMixin,
+    PluginMixin,
+    PluginTestHelper,
+)
+from beetsplug.fetchart import CoverArtArchive, FetchArtPlugin, FileSystem
+
+
+class TestFetchartImport(PluginMixin, AutotagImportHelper):
+    plugin = "fetchart"
+    preload_plugin = False
+    plugin_defaults: ClassVar[Any] = {"sources": ["filesystem", "coverart"]}
+
+    def setup_beets(self):
+        super().setup_beets()
+
+        self.prepare_album_for_import(1)
+        self.setup_importer()
+
+        self.local_art_patcher = mock.patch.object(
+            FileSystem, "get", autospec=True, return_value=iter(())
+        )
+        self.local_art_mock = self.local_art_patcher.start()
+        self.remote_art_patcher = mock.patch.object(
+            CoverArtArchive, "get", autospec=True, return_value=iter(())
+        )
+        self.remote_art_mock = self.remote_art_patcher.start()
+
+    def teardown_beets(self):
+        super().teardown_beets()
+        self.local_art_patcher.stop()
+        self.remote_art_patcher.stop()
+
+    def test_asis_skips_network_sources(self):
+        self.importer.add_choice(importer.Action.ASIS)
+        with self.configure_plugin(self.plugin_defaults):
+            self.importer.run()
+        self.local_art_mock.assert_called()
+        self.remote_art_mock.assert_not_called()
+
+    def test_apply_uses_network_sources(self):
+        self.importer.add_choice(importer.Action.APPLY)
+        with self.configure_plugin(self.plugin_defaults):
+            self.importer.run()
+        self.local_art_mock.assert_called()
+        self.remote_art_mock.assert_called()
+
+    def test_fetch_for_asis_uses_network_sources(self):
+        self.importer.add_choice(importer.Action.ASIS)
+        with self.configure_plugin(
+            self.plugin_defaults | {"fetch_for_asis": True}
+        ):
+            self.importer.run()
+        self.local_art_mock.assert_called()
+        self.remote_art_mock.assert_called()
 
 
 class TestFetchartCli(IOMixin, PluginTestHelper):

--- a/test/plugins/test_fetchart.py
+++ b/test/plugins/test_fetchart.py
@@ -4,15 +4,15 @@ import sys
 from unittest import mock
 
 from beets import util
-from beets.test.helper import IOMixin, PluginTestCase
+from beets.test.helper import IOMixin, PluginTestHelper
 from beetsplug.fetchart import FetchArtPlugin, FileSystem
 
 
-class FetchartCliTest(IOMixin, PluginTestCase):
+class TestFetchartCli(IOMixin, PluginTestHelper):
     plugin = "fetchart"
 
-    def setUp(self):
-        super().setUp()
+    def setup_beets(self):
+        super().setup_beets()
         self.config["fetchart"]["cover_names"] = "c\xc3\xb6ver.jpg"
         self.config["art_filename"] = "mycover"
         self.album = self.add_album()


### PR DESCRIPTION
Add `fetch_for_asis` setting to FetchArt plugin

## Description

Enable fetching art for imports even when as-is is selected as the metadata source. Allows for the case when files with good metadata but without album art are being imported (e.g. digital download store).

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] Documentation.
- [x] Changelog.
- [x] Tests.
