### PR TITLE
Removed a few more unittests

### DIFF
--- a/test/plugins/test_acousticbrainz.py
+++ b/test/plugins/test_acousticbrainz.py
@@ -2,13 +2,12 @@
 
 import json
 import os.path
-import unittest
 
 from beets.test._common import RSRC
 from beetsplug.acousticbrainz import ABSCHEME, AcousticPlugin
 
 
-class MapDataToSchemeTest(unittest.TestCase):
+class TestMapDataToScheme:
     def test_basic(self):
         ab = AcousticPlugin()
         data = {"key 1": "value 1", "key 2": "value 2"}

--- a/test/plugins/test_advancedrewrite.py
+++ b/test/plugins/test_advancedrewrite.py
@@ -2,11 +2,11 @@
 
 import pytest
 
-from beets.test.helper import PluginTestCase
+from beets.test.helper import PluginTestHelper
 from beets.ui import UserError
 
 
-class AdvancedRewritePluginTest(PluginTestCase):
+class TestAdvancedRewritePlugin(PluginTestHelper):
     plugin = "advancedrewrite"
     preload_plugin = False
 

--- a/test/plugins/test_ihate.py
+++ b/test/plugins/test_ihate.py
@@ -1,13 +1,11 @@
 """Tests for the 'ihate' plugin"""
 
-import unittest
-
 from beets import importer
 from beets.library import Item
 from beetsplug.ihate import IHatePlugin
 
 
-class IHatePluginTest(unittest.TestCase):
+class TestIHatePlugin:
     def test_hate(self):
         match_pattern = {}
         test_item = Item(

--- a/test/plugins/test_inline.py
+++ b/test/plugins/test_inline.py
@@ -1,12 +1,14 @@
+from typing import ClassVar
+
 from beets import config, plugins
-from beets.test.helper import PluginTestCase
+from beets.test.helper import PluginTestHelper
 from beetsplug.inline import InlinePlugin
 
 
-class TestInlineRecursion(PluginTestCase):
-    def test_no_recursion_when_inline_shadows_fixed_field(self):
-        config["plugins"] = ["inline"]
+class TestInlineRecursion(PluginTestHelper):
+    plugin: ClassVar[str] = "inline"
 
+    def test_no_recursion_when_inline_shadows_fixed_field(self):
         config["item_fields"] = {
             "track_no": (
                 "f'{disc:02d}-{track:02d}' if disctotal > 1 else f'{track:02d}'"

--- a/test/plugins/test_mpdstats.py
+++ b/test/plugins/test_mpdstats.py
@@ -3,11 +3,11 @@ from unittest.mock import ANY, Mock, call, patch
 
 from beets import util
 from beets.library import Item
-from beets.test.helper import PluginTestCase
+from beets.test.helper import PluginTestHelper
 from beetsplug.mpdstats import MPDStats, mpd_config
 
 
-class MPDStatsTest(PluginTestCase):
+class TestMPDStats(PluginTestHelper):
     plugin = "mpdstats"
 
     def test_update_rating(self):

--- a/test/plugins/test_replace.py
+++ b/test/plugins/test_replace.py
@@ -6,13 +6,13 @@ from mediafile import MediaFile
 
 from beets.exceptions import UserError
 from beets.test import _common
-from beets.test.helper import PluginTestCase
+from beets.test.helper import PluginTestHelper
 from beetsplug.replace import ReplacePlugin
 
 replace = ReplacePlugin()
 
 
-class ReplaceCommandTest(PluginTestCase):
+class TestReplaceCommand(PluginTestHelper):
     plugin = "replace"
 
     def test_command_callback_accepts_cli_arguments(self):

--- a/test/plugins/test_rewrite.py
+++ b/test/plugins/test_rewrite.py
@@ -1,11 +1,11 @@
 import pytest
 
-from beets.test.helper import PluginTestCase
+from beets.test.helper import PluginTestHelper
 from beets.ui import UserError
 from beetsplug.rewrite import RewritePlugin
 
 
-class RewritePluginTest(PluginTestCase):
+class TestRewritePlugin(PluginTestHelper):
     plugin = "rewrite"
     preload_plugin = False
 

--- a/test/plugins/test_substitute.py
+++ b/test/plugins/test_substitute.py
@@ -1,10 +1,10 @@
 """Test the substitute plugin regex functionality."""
 
-from beets.test.helper import PluginTestCase
+from beets.test.helper import PluginTestHelper
 from beetsplug.substitute import Substitute
 
 
-class SubstitutePluginTest(PluginTestCase):
+class TestSubstitutePlugin(PluginTestHelper):
     plugin = "substitute"
     preload_plugin = False
 

--- a/test/plugins/test_the.py
+++ b/test/plugins/test_the.py
@@ -1,12 +1,15 @@
 """Tests for the 'the' plugin"""
 
-import unittest
+from typing import ClassVar
 
 from beets import config
+from beets.test.helper import PluginTestHelper
 from beetsplug.the import FORMAT, PATTERN_A, PATTERN_THE, ThePlugin
 
 
-class ThePluginTest(unittest.TestCase):
+class TestThePlugin(PluginTestHelper):
+    plugin: ClassVar[str] = "the"
+
     def test_unthe_with_default_patterns(self):
         assert ThePlugin().unthe("", PATTERN_THE) == ""
         assert (

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock
 import pytest
 
 from beets.library.models import Item
-from beets.test.helper import PluginTestCase
+from beets.test.helper import PluginTestHelper
 from beetsplug.tidal import TidalPlugin
 
 if TYPE_CHECKING:
@@ -141,11 +141,11 @@ def set_current_ts(monkeypatch):
     monkeypatch.setattr("beetsplug.tidal.time.time", lambda: CURRENT_TS)
 
 
-class TidalPluginTest(PluginTestCase):
+class TidalPluginTest(PluginTestHelper):
     plugin = "tidal"
 
-    def setUp(self):
-        super().setUp()
+    def setup_beets(self):
+        super().setup_beets()
         self.tidal = TidalPlugin()
 
 

--- a/test/util/test_m3ufile.py
+++ b/test/util/test_m3ufile.py
@@ -1,7 +1,6 @@
 """Testsuite for the M3UFile class."""
 
 import sys
-import unittest
 from os import path
 from shutil import rmtree
 from tempfile import mkdtemp
@@ -13,7 +12,7 @@ from beets.util import bytestring_path
 from beets.util.m3u import EmptyPlaylistError, M3UFile
 
 
-class M3UFileTest(unittest.TestCase):
+class TestM3UFile:
     """Tests the M3UFile class."""
 
     def test_playlist_write_empty(self):
@@ -55,7 +54,7 @@ class M3UFileTest(unittest.TestCase):
         assert path.exists(the_playlist_file)
         rmtree(tempdir)
 
-    @unittest.skipUnless(sys.platform == "win32", "win32")
+    @pytest.mark.skipif(sys.platform != "win32", reason="win32")
     def test_playlist_write_and_read_unicode_windows(self):
         """Test saving unicode paths to a playlist file on Windows."""
         tempdir = bytestring_path(mkdtemp())
@@ -83,7 +82,7 @@ class M3UFileTest(unittest.TestCase):
         )
         rmtree(tempdir)
 
-    @unittest.skipIf(sys.platform == "win32", "win32")
+    @pytest.mark.skipif(sys.platform == "win32", reason="win32")
     def test_playlist_load_ascii(self):
         """Test loading ascii paths from a playlist file."""
         the_playlist_file = path.join(RSRC, b"playlist.m3u")
@@ -93,7 +92,7 @@ class M3UFileTest(unittest.TestCase):
             "/This/is/a/path/to_a_file.mp3"
         )
 
-    @unittest.skipIf(sys.platform == "win32", "win32")
+    @pytest.mark.skipif(sys.platform == "win32", reason="win32")
     def test_playlist_load_unicode(self):
         """Test loading unicode paths from a playlist file."""
         the_playlist_file = path.join(RSRC, b"playlist.m3u8")
@@ -103,7 +102,7 @@ class M3UFileTest(unittest.TestCase):
             "/This/is/å/path/to_a_file.mp3"
         )
 
-    @unittest.skipUnless(sys.platform == "win32", "win32")
+    @pytest.mark.skipif(sys.platform != "win32", reason="win32")
     def test_playlist_load_unicode_windows(self):
         """Test loading unicode paths from a playlist file."""
         the_playlist_file = path.join(RSRC, b"playlist_windows.m3u8")


### PR DESCRIPTION
Found a few more places were it is possible to easily get rid of the `unittest` setup in favor for `pytest`.


Touches and removes `unittest` from the following files:
- `test_ihate`
- `test_the`
- `test_substitute`
- `test_m3u`
- `test_acousticbrainz`
- `test_advancedwrite`
- `test_tidal`
- `test_inline`
- `test_mpdstats`
- `test_replace`
- `test_rewrite`

related to #5361
