### PR TITLE
ci: test base installation dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,11 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Install Python tools
+        run: uv tool install "poethepoet>=0.26,<0.47.0"
+
       - name: Install base dependencies
-        run: uv sync --locked --no-dev
+        run: poe install --no-dev
 
       - name: Run beets
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,24 @@ env:
   PY_COLORS: 1
 
 jobs:
+  base-install:
+    name: Test base installation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          python-version: "3.10"
+
+      - name: Install base dependencies
+        run: uv sync --locked --no-dev
+
+      - name: Run beets
+        env:
+          BEETSDIR: ${{ runner.temp }}/beets
+        run: uv run --no-sync beet version
+
   test:
     name: Run tests
     strategy:


### PR DESCRIPTION
## Summary

- add a CI job that installs Beets without dependency groups or plugin extras
- run `beet version` with an isolated configuration directory to verify the base installation

## Validation

- `uv sync --locked --no-dev`
- `BEETSDIR=/tmp/beets-base-install-smoke-test uv run --no-sync beet version`
- `uv lock --check`

Fixes #5713
