### PR TITLE
test: fix requests_mock setup in test_art.py

### DIFF
--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -10,8 +10,6 @@ from unittest.mock import patch
 
 import confuse
 import pytest
-from requests_mock import ANY as ANYREEQUEST
-from requests_mock.exceptions import NoMockAddress
 
 from beets import config, importer, logging, util
 from beets.autotag import AlbumInfo, AlbumMatch, Distance
@@ -79,8 +77,8 @@ class UseThePlugin(TestHelper):
         # Register some “safe” mocks you actually want to allow, if any:
         # requests_mock.get("https://example.com/health", json={"status": "ok"})
 
-        # Optional: disable any URL not explicitly mocked
-        requests_mock.register_uri(ANYREEQUEST, ANYREEQUEST, exc=NoMockAddress)
+        # Disable any URL not explicitly mocked
+        return
 
     @pytest.fixture(autouse=True, scope="class")
     def cleanup(self):
@@ -343,6 +341,7 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
     ASIN = "xxxx"
     MBID = "releaseid"
     AMAZON_URL = f"https://images.amazon.com/images/P/{ASIN}.01.LZZZZZZZ.jpg"
+    AMAZON_URL_2 = f"https://images.amazon.com/images/P/{ASIN}.02.LZZZZZZZ.jpg"
     AAO_URL = f"https://www.albumart.org/index_detail.php?asin={ASIN}"
 
     @pytest.fixture
@@ -394,6 +393,7 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
 
     def test_main_interface_falls_back_to_aao(self, dpath, image_request_mock):
         image_request_mock.get(self.AMAZON_URL, content_type="text/html")
+        image_request_mock.get(self.AMAZON_URL_2, content_type="text/html")
         image_request_mock.get(self.AAO_URL, content_type="image/jpeg")
         album = Album(asin=self.ASIN)
         self.plugin.art_for_album(album, [dpath])


### PR DESCRIPTION
## Description

`requests_mock` was configured with a fallback matcher to return an exception on any request. The intent was to have tests fail if any requests are attempted in tests without matching mocks. This is the default behavior of `requests_mock`, so no fallback matcher is necessary. The side-effect of the fallback matcher, removed by this commit, was that 1) the `NoMockAddress` exception was raised to the function under test rather than to the test harness and 2) the `NoMockAddress` exception was not able to be constructed because the `exc` parameter to `requests_mock.register_uri` does not support exceptions that require arguments. This behavior is visible in the following log snippet, taken from an incorrectly-passing test:

```
DEBUG    beets.fetchart:logging.py:163 downloading image: https://images.amazon.com/images/P/xxxx.01.LZZZZZZZ.jpg
DEBUG    requests_mock.adapter:adapter.py:256 GET https://images.amazon.com/images/P/xxxx.01.LZZZZZZZ.jpg 200
DEBUG    beets.fetchart:logging.py:163 not a supported image: text/html
DEBUG    beets.fetchart:logging.py:163 downloading image: https://images.amazon.com/images/P/xxxx.02.LZZZZZZZ.jpg
DEBUG    beets.fetchart:logging.py:163 error fetching art: NoMockAddress.__init__() missing 1 required positional argument: 'request'
```

The test that emitted these logs passed because the `FetchArt` plugin is written to handle exceptions raised by art sources, skipping and logging an error. For the exception to cause a failing test, the default behavior of `requests_mock` of raising an exception to the test harness when no matching mock requests can be found must be allowed.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation~
- [x] ~Changelog~ (no user-facing changes)
- [x] Tests (change to existing tests)
