### PR TITLE
test: fix ffprobe tests incorrectly skipped

### DIFF
--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -95,7 +95,7 @@ NEEDS_REFLINK = pytest.mark.skipif(
     not check_reflink_support(gettempdir()), reason="need reflink"
 )
 NEEDS_FFPROBE = pytest.mark.skipif(
-    not has_program("ffprobe") and not RUNNING_IN_CI,
+    not has_program("ffprobe", ("-version",)) and not RUNNING_IN_CI,
     reason="ffprobe (ffmpeg) is not available",
 )
 


### PR DESCRIPTION
## Description

The `@NEEDS_FFPROBE` decorator was incorrectly skipping tests when `ffprobe` is available, because it was calling `ffprobe --version`, while the valid option is `ffprobe -version` (with a single dash).

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation~
- [x] ~Changelog~ (No user-facing changes)
- [x] Tests. (Fix to existing tests)
