### PR TITLE
Increase test verbosity

### DIFF
--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -122,7 +122,7 @@ class ConfigMixin:
         config.read(user=False, defaults=True)
 
         config["plugins"] = []
-        config["verbose"] = 1
+        config["verbose"] = 2
         config["ui"]["color"] = False
         config["threaded"] = False
         config["create_backup_before_migrations"] = False


### PR DESCRIPTION
## Description

Change `config["verbose"]` from `1` to `2` so that DEBUG-level logging from plugin import tasks and event hooks are emitted. (See `beets.plugins._set_log_level_and_params`.)

`config["verbose"] == 2` does not appear to affect logging anywhere else in the codebase, while `config["verbose"] == 3` would enable output of messages logged via `BeetsLogger.extra_debug()`.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~Documentation~
- [x] ~Changelog~
- [x] Tests