### PR TITLE
missing: honor -f/--format in album mode

### DIFF
--- a/beetsplug/missing.py
+++ b/beetsplug/missing.py
@@ -9,7 +9,7 @@ import requests
 
 from beets import config, metadata_plugins
 from beets.dbcore import types
-from beets.library import Item
+from beets.library import Album, Item
 from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand, print_
 
@@ -18,7 +18,7 @@ from ._utils.musicbrainz import MusicBrainzAPIMixin
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from beets.library import Album, Library
+    from beets.library import Library
 
 # Valid MusicBrainz release types for filtering release groups
 VALID_RELEASE_TYPES = [
@@ -211,6 +211,7 @@ class MissingPlugin(MusicBrainzAPIMixin, BeetsPlugin):
         for rt in self.config["release_types"].as_str_seq():
             release_types.extend(rt.split(","))
         calculating_total = self.config["total"].get()
+        fmt = config["format_album"].get()
         for (artist, artist_id), album_ids in album_ids_by_artist.items():
             try:
                 resp = self.mb_api.browse_release_groups(
@@ -225,17 +226,22 @@ class MissingPlugin(MusicBrainzAPIMixin, BeetsPlugin):
                 )
                 continue
 
-            missing_titles = [
-                f"{artist} - {rg['title']}"
+            missing_albums = [
+                Album(
+                    albumartist=artist,
+                    album=rg["title"],
+                    mb_releasegroupid=rg["id"],
+                    albumtype=(rg.get("primary_type") or "").lower(),
+                )
                 for rg in resp
                 if rg["id"] not in album_ids
             ]
 
             if calculating_total:
-                total_missing += len(missing_titles)
+                total_missing += len(missing_albums)
             else:
-                for title in missing_titles:
-                    print(title)
+                for album in missing_albums:
+                    print_(format(album, fmt))
 
         if calculating_total:
             print(total_missing)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -45,6 +45,9 @@ Bug fixes
 
 - :doc:`plugins/subsonicupdate`: Log a clearer error when the Subsonic server
   returns a non-JSON response. :bug:`5635`
+- :doc:`plugins/missing`: Honor the ``-f``/``--format`` option (and the
+  ``format_album`` configuration) when listing missing albums in album mode.
+  :bug:`3804`
 - :doc:`plugins/importfeeds`: ``beet import`` no longer aborts the whole run
   when a symlink cannot be created (e.g. on Windows or a read-only directory);
   the failure is logged and the import continues. :bug:`840`
@@ -120,9 +123,6 @@ New features
 Bug fixes
 ~~~~~~~~~
 
-- :doc:`plugins/missing`: Honor the ``-f``/``--format`` option (and the
-  ``format_album`` configuration) when listing missing albums in album mode.
-  :bug:`3804`
 - :doc:`plugins/lyrics`: Add rate limiting and exponential backoff to HTTP
   requests to prevent ``429 Too Many Requests`` errors from lyrics sources
   during bulk imports. :bug:`6728`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -120,6 +120,9 @@ New features
 Bug fixes
 ~~~~~~~~~
 
+- :doc:`plugins/missing`: Honor the ``-f``/``--format`` option (and the
+  ``format_album`` configuration) when listing missing albums in album mode.
+  :bug:`3804`
 - :doc:`plugins/lyrics`: Add rate limiting and exponential backoff to HTTP
   requests to prevent ``429 Too Many Requests`` errors from lyrics sources
   during bulk imports. :bug:`6728`

--- a/test/plugins/test_missing.py
+++ b/test/plugins/test_missing.py
@@ -56,6 +56,43 @@ class TestMissingAlbums(MissingTestHelper):
         with self.configure_plugin({}):
             assert self.run_with_output("missing", "--album") == expected_output
 
+    def test_missing_albums_custom_format(self, requests_mock):
+        """Test -f/--format is honored when listing missing albums."""
+        artist_mbid = str(uuid.uuid4())
+        self.lib.add(
+            Album(
+                album="Album",
+                albumartist="Artist",
+                mb_albumartistid=artist_mbid,
+                mb_albumid="album",
+                mb_releasegroupid="release_group_in_lib",
+            )
+        )
+        requests_mock.get(
+            re.compile(
+                rf"/ws/2/release-group\?artist={artist_mbid}&.*type=album"
+            ),
+            json={
+                "release-groups": [
+                    {
+                        "id": "other",
+                        "title": "Other Album",
+                        "primary-type": "Album",
+                    }
+                ]
+            },
+        )
+
+        with self.configure_plugin({}):
+            output = self.run_with_output(
+                "missing",
+                "-a",
+                "-f",
+                "$mb_releasegroupid | $albumtype | $album",
+            )
+
+        assert output == "other | album | Other Album\n"
+
     def test_release_types_filters_results(self, requests_mock):
         """Test --release-types filters to only show specified type."""
         artist_mbid = str(uuid.uuid4())


### PR DESCRIPTION
Fixes #3804.

The `missing` plugin ignored `-f`/`--format` (and the `format_album` config) in album mode. `beet missing -a` always printed a hardcoded `<artist> - <title>` and never consulted the format string. Now each missing release group is turned into an `Album` and emitted with `format_album`, so the format option is respected. With the default `$albumartist - $album` the output is unchanged, matching the behavior already documented in `docs/plugins/missing.rst`.

TODOs:
- [x] ~Documentation.~ (The `format_album` behavior in album mode is already described in `docs/plugins/missing.rst`.)
- [x] Changelog.
- [x] Tests. (Added `test_missing_albums_custom_format`; confirmed it fails without the source change and passes with it.)

The missing-plugin tests pass (9 passed) and `ruff check`/`ruff format --check` are clean on the touched files.