### PR TITLE
Fix incorrect line numbers in logs

### DIFF
--- a/beets/logging.py
+++ b/beets/logging.py
@@ -152,7 +152,7 @@ class StrFormatLogger(Logger):
         exc_info: _ExcInfoType = None,
         extra: Mapping[str, Any] | None = None,
         stack_info: bool = False,
-        stacklevel: int = 1,
+        stacklevel: int = 2,
         **kwargs,
     ):
         """Log msg.format(*args, **kwargs)"""


### PR DESCRIPTION
Because beets wraps `logging.Logger`, the default `stacklevel=1` incorrectly reports all log messages being emitted from `beets/logging.py:163` at the `super()._log()` callsite. Change the default to `stacklevel=2` so that the reported line numbers in debug logging are the actual logging callsites.
