### PR TITLE
library: skip saving files with unchanged tags

### DIFF
--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -945,9 +945,10 @@ class Item(LibModel):
         def value(field: str) -> Any:
             value = getattr(mediafile, field)
             if isinstance(value, list):
-                # An empty list reads back as `[""]` from some formats. Keep
-                # the values themselves, so that dropping an empty one shows.
-                return value if any(v != "" for v in value) else None
+                # An absent list of tags reads back as an empty one from some
+                # formats. The values themselves are kept, empty ones
+                # included, so that dropping one shows.
+                return value or None
 
             if isinstance(value, float):
                 # A gain of zero decibels is a value, not the lack of one.

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -983,7 +983,9 @@ class Item(LibModel):
 
         Unless `force` is set, the item's own file is not saved when reading it
         back already gives the tags to be written. Saving it would give it a new
-        mtime without changing any of its tags.
+        mtime without changing any of its tags. A file whose tags still need
+        converting to another ID3 version is saved either way, since saving is
+        what converts them.
 
         Can raise either a `ReadError` or a `WriteError`.
         """
@@ -1020,6 +1022,10 @@ class Item(LibModel):
             # loses what the older version cannot hold, so a file written that
             # way is saved every time. `MediaFile` sets this for MP3s only.
             and not mediafile.id3v23
+            # Saving is also what converts older ID3 tags to the default
+            # v2.4. Reading translates them in memory, and `MediaFile` does
+            # not expose the version the file holds, hence mutagen's.
+            and getattr(mediafile.mgfile.tags, "version", (2, 4)) >= (2, 4)
             and path == self.path
             and written.isdisjoint(("art", "images"))
         )

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -931,11 +931,41 @@ class Item(LibModel):
 
         self.path = read_path
 
+    @staticmethod
+    def _read_tags(
+        mediafile: MediaFile, fields: Iterable[str]
+    ) -> dict[str, Any]:
+        """Read `fields` back from `mediafile`.
+
+        Reading the values back is what makes them comparable with the ones
+        about to be written, since a file only keeps what it can represent. It
+        rounds `rg_track_peak` to six decimal places, for instance.
+        """
+
+        def value(field: str) -> Any:
+            value = getattr(mediafile, field)
+            if isinstance(value, list):
+                # An empty list reads back as `[""]` from some formats. Keep
+                # the values themselves, so that dropping an empty one shows.
+                return value if any(v != "" for v in value) else None
+
+            if isinstance(value, float):
+                # A gain of zero decibels is a value, not the lack of one.
+                return value
+
+            # Formats differ on whether they keep a tag holding the null of its
+            # type, an empty string or a zero. Report it as no tag at all.
+            return value or None
+
+        return {f: value(f) for f in fields}
+
     def write(
         self,
         path: bytes | None = None,
         tags: Mapping[str, Any] | None = None,
         id3v23: bool | None = None,
+        *,
+        force: bool = False,
     ) -> None:
         """Write the item's metadata to a media file.
 
@@ -950,6 +980,10 @@ class Item(LibModel):
 
         `id3v23` will override the global `id3v23` config option if it is
         set to something other than `None`.
+
+        Unless `force` is set, the item's own file is not saved when reading it
+        back already gives the tags to be written. Saving it would give it a new
+        mtime without changing any of its tags.
 
         Can raise either a `ReadError` or a `WriteError`.
         """
@@ -976,8 +1010,32 @@ class Item(LibModel):
         except UnreadableFileError as exc:
             raise ReadError(path, exc)
 
+        # The tags the update below is going to write. Writing an image
+        # replaces the whole list of them, which none of the fields here would
+        # show, so a write that carries one is saved without comparing anything.
+        written = set(item_tags) & set(mediafile.fields())
+        compare = (
+            not force
+            # Saving is what converts the tags to ID3v2.3, and the conversion
+            # loses what the older version cannot hold, so a file written that
+            # way is saved every time. `MediaFile` sets this for MP3s only.
+            and not mediafile.id3v23
+            and path == self.path
+            and written.isdisjoint(("art", "images"))
+        )
+        old_tags = self._read_tags(mediafile, written) if compare else None
+
         # Write the tags to the file.
         mediafile.update(item_tags)
+
+        if compare and self._read_tags(mediafile, written) == old_tags:
+            # The file already holds these tags. Saving it would only give it a
+            # new mtime, which makes tools that sync the library copy the file
+            # again for nothing.
+            log.debug("no tags to write to {.filepath}", self)
+            self.mtime = self.current_mtime()
+            return
+
         try:
             mediafile.save()
         except UnreadableFileError as exc:
@@ -993,6 +1051,8 @@ class Item(LibModel):
         path: bytes | None = None,
         tags: Mapping[str, Any] | None = None,
         id3v23: bool | None = None,
+        *,
+        force: bool = False,
     ) -> bool:
         """Call `write()` but catch and log `FileOperationError`
         exceptions.
@@ -1000,28 +1060,34 @@ class Item(LibModel):
         Return `False` an exception was caught and `True` otherwise.
         """
         try:
-            self.write(path=path, tags=tags, id3v23=id3v23)
+            self.write(path=path, tags=tags, id3v23=id3v23, force=force)
             return True
         except FileOperationError as exc:
             log.error("{}", exc)
             return False
 
     def try_sync(
-        self, write: bool, move: bool, with_album: bool = True
+        self,
+        write: bool,
+        move: bool,
+        with_album: bool = True,
+        *,
+        force_write: bool = False,
     ) -> None:
         """Synchronize the item with the database and, possibly, update its
         tags on disk and its path (by moving the file).
 
-        `write` indicates whether to write new tags into the file. Similarly,
-        `move` controls whether the path should be updated. In the
-        latter case, files are *only* moved when they are inside their
+        `write` indicates whether to write new tags into the file, and
+        `force_write` whether to do so even when the file already contains
+        them. Similarly, `move` controls whether the path should be updated.
+        In the latter case, files are *only* moved when they are inside their
         library's directory (if any).
 
         Similar to calling :meth:`write`, :meth:`move`, and :meth:`store`
         (conditionally).
         """
         if write:
-            self.try_write()
+            self.try_write(force=force_write)
         if move:
             # Check whether this file is inside the library directory.
             if self._db and self._db.directory in util.ancestry(self.path):

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -1007,6 +1007,14 @@ class Item(LibModel):
             item_tags.update(tags)
         plugins.send("write", item=self, path=path, tags=item_tags)
 
+        # The mtime of the file the tags are about to be read from. A save
+        # skipped below records this one, so a change landing once the file
+        # is read stays newer than the database and still shows.
+        mtime = 0
+        if path == self.path:
+            with suppress(OSError):
+                mtime = self.current_mtime()
+
         # Open the file.
         try:
             mediafile = MediaFile(syspath(path), id3v23=id3v23)
@@ -1040,7 +1048,7 @@ class Item(LibModel):
             # new mtime, which makes tools that sync the library copy the file
             # again for nothing.
             log.debug("no tags to write to {.filepath}", self)
-            self.mtime = self.current_mtime()
+            self.mtime = mtime
             return
 
         try:

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -1008,6 +1008,14 @@ class Item(LibModel):
             item_tags.update(tags)
         plugins.send("write", item=self, path=path, tags=item_tags)
 
+        # The mtime of the file the tags are about to be read from. A save
+        # skipped below records this one, so a change landing once the file
+        # is read stays newer than the database and still shows.
+        mtime = 0
+        if path == self.path:
+            with suppress(OSError):
+                mtime = self.current_mtime()
+
         # Open the file.
         try:
             mediafile = MediaFile(syspath(path), id3v23=id3v23)
@@ -1041,7 +1049,7 @@ class Item(LibModel):
             # new mtime, which makes tools that sync the library copy the file
             # again for nothing.
             log.debug("no tags to write to {.filepath}", self)
-            self.mtime = self.current_mtime()
+            self.mtime = mtime
             return
 
         try:

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -946,9 +946,10 @@ class Item(LibModel):
         def value(field: str) -> Any:
             value = getattr(mediafile, field)
             if isinstance(value, list):
-                # An empty list reads back as `[""]` from some formats. Keep
-                # the values themselves, so that dropping an empty one shows.
-                return value if any(v != "" for v in value) else None
+                # An absent list of tags reads back as an empty one from some
+                # formats. The values themselves are kept, empty ones
+                # included, so that dropping one shows.
+                return value or None
 
             if isinstance(value, float):
                 # A gain of zero decibels is a value, not the lack of one.

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -932,11 +932,41 @@ class Item(LibModel):
 
         self.path = read_path
 
+    @staticmethod
+    def _read_tags(
+        mediafile: MediaFile, fields: Iterable[str]
+    ) -> dict[str, Any]:
+        """Read `fields` back from `mediafile`.
+
+        Reading the values back is what makes them comparable with the ones
+        about to be written, since a file only keeps what it can represent. It
+        rounds `rg_track_peak` to six decimal places, for instance.
+        """
+
+        def value(field: str) -> Any:
+            value = getattr(mediafile, field)
+            if isinstance(value, list):
+                # An empty list reads back as `[""]` from some formats. Keep
+                # the values themselves, so that dropping an empty one shows.
+                return value if any(v != "" for v in value) else None
+
+            if isinstance(value, float):
+                # A gain of zero decibels is a value, not the lack of one.
+                return value
+
+            # Formats differ on whether they keep a tag holding the null of its
+            # type, an empty string or a zero. Report it as no tag at all.
+            return value or None
+
+        return {f: value(f) for f in fields}
+
     def write(
         self,
         path: bytes | None = None,
         tags: Mapping[str, Any] | None = None,
         id3v23: bool | None = None,
+        *,
+        force: bool = False,
     ) -> None:
         """Write the item's metadata to a media file.
 
@@ -951,6 +981,10 @@ class Item(LibModel):
 
         `id3v23` will override the global `id3v23` config option if it is
         set to something other than `None`.
+
+        Unless `force` is set, the item's own file is not saved when reading it
+        back already gives the tags to be written. Saving it would give it a new
+        mtime without changing any of its tags.
 
         Can raise either a `ReadError` or a `WriteError`.
         """
@@ -977,8 +1011,32 @@ class Item(LibModel):
         except UnreadableFileError as exc:
             raise ReadError(path, exc)
 
+        # The tags the update below is going to write. Writing an image
+        # replaces the whole list of them, which none of the fields here would
+        # show, so a write that carries one is saved without comparing anything.
+        written = set(item_tags) & set(mediafile.fields())
+        compare = (
+            not force
+            # Saving is what converts the tags to ID3v2.3, and the conversion
+            # loses what the older version cannot hold, so a file written that
+            # way is saved every time. `MediaFile` sets this for MP3s only.
+            and not mediafile.id3v23
+            and path == self.path
+            and written.isdisjoint(("art", "images"))
+        )
+        old_tags = self._read_tags(mediafile, written) if compare else None
+
         # Write the tags to the file.
         mediafile.update(item_tags)
+
+        if compare and self._read_tags(mediafile, written) == old_tags:
+            # The file already holds these tags. Saving it would only give it a
+            # new mtime, which makes tools that sync the library copy the file
+            # again for nothing.
+            log.debug("no tags to write to {.filepath}", self)
+            self.mtime = self.current_mtime()
+            return
+
         try:
             mediafile.save()
         except UnreadableFileError as exc:
@@ -994,6 +1052,8 @@ class Item(LibModel):
         path: bytes | None = None,
         tags: Mapping[str, Any] | None = None,
         id3v23: bool | None = None,
+        *,
+        force: bool = False,
     ) -> bool:
         """Call `write()` but catch and log `FileOperationError`
         exceptions.
@@ -1001,28 +1061,34 @@ class Item(LibModel):
         Return `False` an exception was caught and `True` otherwise.
         """
         try:
-            self.write(path=path, tags=tags, id3v23=id3v23)
+            self.write(path=path, tags=tags, id3v23=id3v23, force=force)
             return True
         except FileOperationError as exc:
             log.error("{}", exc)
             return False
 
     def try_sync(
-        self, write: bool, move: bool, with_album: bool = True
+        self,
+        write: bool,
+        move: bool,
+        with_album: bool = True,
+        *,
+        force_write: bool = False,
     ) -> None:
         """Synchronize the item with the database and, possibly, update its
         tags on disk and its path (by moving the file).
 
-        `write` indicates whether to write new tags into the file. Similarly,
-        `move` controls whether the path should be updated. In the
-        latter case, files are *only* moved when they are inside their
+        `write` indicates whether to write new tags into the file, and
+        `force_write` whether to do so even when the file already contains
+        them. Similarly, `move` controls whether the path should be updated.
+        In the latter case, files are *only* moved when they are inside their
         library's directory (if any).
 
         Similar to calling :meth:`write`, :meth:`move`, and :meth:`store`
         (conditionally).
         """
         if write:
-            self.try_write()
+            self.try_write(force=force_write)
         if move:
             # Check whether this file is inside the library directory.
             if self._db and self._db.directory in util.ancestry(self.path):

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -984,7 +984,9 @@ class Item(LibModel):
 
         Unless `force` is set, the item's own file is not saved when reading it
         back already gives the tags to be written. Saving it would give it a new
-        mtime without changing any of its tags.
+        mtime without changing any of its tags. A file whose tags still need
+        converting to another ID3 version is saved either way, since saving is
+        what converts them.
 
         Can raise either a `ReadError` or a `WriteError`.
         """
@@ -1021,6 +1023,10 @@ class Item(LibModel):
             # loses what the older version cannot hold, so a file written that
             # way is saved every time. `MediaFile` sets this for MP3s only.
             and not mediafile.id3v23
+            # Saving is also what converts older ID3 tags to the default
+            # v2.4. Reading translates them in memory, and `MediaFile` does
+            # not expose the version the file holds, hence mutagen's.
+            and getattr(mediafile.mgfile.tags, "version", (2, 4)) >= (2, 4)
             and path == self.path
             and written.isdisjoint(("art", "images"))
         )

--- a/beets/ui/commands/write.py
+++ b/beets/ui/commands/write.py
@@ -37,7 +37,7 @@ def write_items(lib, query, pretend, force):
         if (changed or force) and not pretend:
             # We use `try_sync` here to keep the mtime up to date in the
             # database.
-            item.try_sync(True, False)
+            item.try_sync(True, False, force_write=force)
 
 
 def write_func(lib, opts, args):

--- a/beets/ui/commands/write.py
+++ b/beets/ui/commands/write.py
@@ -55,7 +55,7 @@ def write_items(
         if (changed or force) and not pretend:
             # We use `try_sync` here to keep the mtime up to date in the
             # database.
-            item.try_sync(True, False)
+            item.try_sync(True, False, force_write=force)
 
 
 def write_func(lib: Library, opts: WriteCLIOpts, args: list[str]) -> None:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -95,10 +95,19 @@ Bug fixes
   valid date/time string" error instead of crashing with an uncaught
   ``KeyError``. A ``|`` was being accepted as a relative-date unit due to a
   regular expression character-class typo.
+- ``beet modify --write`` no longer re-saves a file that already holds the tags
+  being written, so changing a field only the database keeps, such as
+  ``data_source``, no longer gives the file a new modification time. Files
+  written with the ``id3v23`` option are still saved every time, since saving is
+  what converts their tags. :bug:`6529`
 
-..
-    For plugin developers
-    ~~~~~~~~~~~~~~~~~~~~~
+For plugin developers
+~~~~~~~~~~~~~~~~~~~~~
+
+- ``Item.write()`` no longer saves the item's own file, and no longer sends the
+  ``after_write`` event, when the file already holds the tags being written.
+  Pass ``force=True`` (or ``Item.try_sync(..., force_write=True)``) to save it
+  regardless.
 
 Other changes
 ~~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -98,16 +98,18 @@ Bug fixes
 - ``beet modify --write`` no longer re-saves a file that already holds the tags
   being written, so changing a field only the database keeps, such as
   ``data_source``, no longer gives the file a new modification time. Files
-  written with the ``id3v23`` option are still saved every time, since saving is
-  what converts their tags. :bug:`6529`
+  written with the ``id3v23`` option are still saved every time, and so are
+  files whose tags have yet to be converted to the default ID3v2.4, since saving
+  is what converts them. :bug:`6529`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~
 
 - ``Item.write()`` no longer saves the item's own file, and no longer sends the
-  ``after_write`` event, when the file already holds the tags being written.
-  Pass ``force=True`` (or ``Item.try_sync(..., force_write=True)``) to save it
-  regardless.
+  ``after_write`` event, when the file already holds the tags being written. A
+  file whose tags still need converting between ID3 versions is saved either
+  way. Pass ``force=True`` (or ``Item.try_sync(..., force_write=True)``) to save
+  it regardless.
 
 Other changes
 ~~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -80,10 +80,21 @@ Bug fixes
   select mode. :bug:`4880`
 - :ref:`move-cmd`: Fix moving albums in interactive select/timid mode.
   :bug:`2802`
+- ``beet modify --write`` no longer re-saves a file that already holds the tags
+  being written, so changing a field only the database keeps, such as
+  ``data_source``, no longer gives the file a new modification time. Files
+  written with the ``id3v23`` option are still saved every time, and so are
+  files whose tags have yet to be converted to the default ID3v2.4, since saving
+  is what converts them. :bug:`6529`
 
-..
-    For plugin developers
-    ~~~~~~~~~~~~~~~~~~~~~
+For plugin developers
+~~~~~~~~~~~~~~~~~~~~~
+
+- ``Item.write()`` no longer saves the item's own file, and no longer sends the
+  ``after_write`` event, when the file already holds the tags being written. A
+  file whose tags still need converting between ID3 versions is saved either
+  way. Pass ``force=True`` (or ``Item.try_sync(..., force_write=True)``) to save
+  it regardless.
 
 Other changes
 ~~~~~~~~~~~~~
@@ -188,21 +199,10 @@ Bug fixes
   valid date/time string" error instead of crashing with an uncaught
   ``KeyError``. A ``|`` was being accepted as a relative-date unit due to a
   regular expression character-class typo.
-- ``beet modify --write`` no longer re-saves a file that already holds the tags
-  being written, so changing a field only the database keeps, such as
-  ``data_source``, no longer gives the file a new modification time. Files
-  written with the ``id3v23`` option are still saved every time, and so are
-  files whose tags have yet to be converted to the default ID3v2.4, since saving
-  is what converts them. :bug:`6529`
 
-For plugin developers
-~~~~~~~~~~~~~~~~~~~~~
-
-- ``Item.write()`` no longer saves the item's own file, and no longer sends the
-  ``after_write`` event, when the file already holds the tags being written. A
-  file whose tags still need converting between ID3 versions is saved either
-  way. Pass ``force=True`` (or ``Item.try_sync(..., force_write=True)``) to save
-  it regardless.
+..
+    For plugin developers
+    ~~~~~~~~~~~~~~~~~~~~~
 
 Other changes
 ~~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -191,16 +191,18 @@ Bug fixes
 - ``beet modify --write`` no longer re-saves a file that already holds the tags
   being written, so changing a field only the database keeps, such as
   ``data_source``, no longer gives the file a new modification time. Files
-  written with the ``id3v23`` option are still saved every time, since saving is
-  what converts their tags. :bug:`6529`
+  written with the ``id3v23`` option are still saved every time, and so are
+  files whose tags have yet to be converted to the default ID3v2.4, since saving
+  is what converts them. :bug:`6529`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~
 
 - ``Item.write()`` no longer saves the item's own file, and no longer sends the
-  ``after_write`` event, when the file already holds the tags being written.
-  Pass ``force=True`` (or ``Item.try_sync(..., force_write=True)``) to save it
-  regardless.
+  ``after_write`` event, when the file already holds the tags being written. A
+  file whose tags still need converting between ID3 versions is saved either
+  way. Pass ``force=True`` (or ``Item.try_sync(..., force_write=True)``) to save
+  it regardless.
 
 Other changes
 ~~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -188,10 +188,19 @@ Bug fixes
   valid date/time string" error instead of crashing with an uncaught
   ``KeyError``. A ``|`` was being accepted as a relative-date unit due to a
   regular expression character-class typo.
+- ``beet modify --write`` no longer re-saves a file that already holds the tags
+  being written, so changing a field only the database keeps, such as
+  ``data_source``, no longer gives the file a new modification time. Files
+  written with the ``id3v23`` option are still saved every time, since saving is
+  what converts their tags. :bug:`6529`
 
-..
-    For plugin developers
-    ~~~~~~~~~~~~~~~~~~~~~
+For plugin developers
+~~~~~~~~~~~~~~~~~~~~~
+
+- ``Item.write()`` no longer saves the item's own file, and no longer sends the
+  ``after_write`` event, when the file already holds the tags being written.
+  Pass ``force=True`` (or ``Item.try_sync(..., force_write=True)``) to save it
+  regardless.
 
 Other changes
 ~~~~~~~~~~~~~

--- a/docs/dev/library.rst
+++ b/docs/dev/library.rst
@@ -115,8 +115,9 @@ When it is possible that the metadata is out of sync, beets can then just set
 
 This leads to the following implementation policy:
 
-    - On every write of disk metadata (``Item.write()``), the DB mtime is
-      updated to match the post-write disk mtime.
+    - On every call to ``Item.write()`` for the item's own file, the DB mtime is
+      updated to match the disk mtime. This includes the case where the file
+      already holds the tags and is therefore left alone.
     - Same for metadata reads (``Item.read()``).
     - On every modification to DB metadata (``item.field = ...``), the DB mtime
       is reset to zero.

--- a/docs/dev/plugins/events.rst
+++ b/docs/dev/plugins/events.rst
@@ -111,15 +111,15 @@ registration process in this case:
 
 ``write``
     :Parameters: ``item`` (|Item|), ``path`` (path), ``tags`` (dict)
-    :Description: Called before beets decides whether to write a file's
-        metadata to disk. Handlers may modify ``tags`` or raise
-        ``library.FileOperationError`` to abort. ``after_write`` is skipped
-        when the file being written is the item's own and already holds the
-        tags.
+    :Description: Called before beets decides whether to write a file's metadata
+        to disk. Handlers may modify ``tags`` or raise
+        ``library.FileOperationError`` to abort.
 
 ``after_write``
-    :Parameters: ``item`` (|Item|)
-    :Description: Called after a file's metadata is written to disk.
+    :Parameters: ``item`` (|Item|), ``path`` (path)
+    :Description: Called after a file's metadata is written to disk. Not sent
+        when the write was skipped because the item's own file already held the
+        tags (see ``Item.write()``).
 
 ``import_task_created``
     :Parameters: ``task`` (|ImportTask|), ``session`` (|ImportSession|)

--- a/docs/dev/plugins/events.rst
+++ b/docs/dev/plugins/events.rst
@@ -111,9 +111,11 @@ registration process in this case:
 
 ``write``
     :Parameters: ``item`` (|Item|), ``path`` (path), ``tags`` (dict)
-    :Description: Called just before a file's metadata is written to disk.
-        Handlers may modify ``tags`` or raise ``library.FileOperationError`` to
-        abort.
+    :Description: Called before beets decides whether to write a file's
+        metadata to disk. Handlers may modify ``tags`` or raise
+        ``library.FileOperationError`` to abort. ``after_write`` is skipped
+        when the file being written is the item's own and already holds the
+        tags.
 
 ``after_write``
     :Parameters: ``item`` (|Item|)

--- a/docs/dev/plugins/events.rst
+++ b/docs/dev/plugins/events.rst
@@ -111,15 +111,15 @@ registration process in this case:
 
 ``write``
     :Parameters: ``item`` (|Item|), ``path`` (path), ``tags`` (dict)
-    :Description: Called before beets decides whether to write a file's
-        metadata to disk. Handlers may modify ``tags`` or raise
-        ``library.FileOperationError`` to abort. ``after_write`` is skipped
-        when the file being written is the item's own and already holds the
-        tags.
+    :Description: Called before beets decides whether to write a file's metadata
+        to disk. Handlers may modify ``tags`` or raise
+        ``library.FileOperationError`` to abort.
 
 ``after_write``
     :Parameters: ``item`` (|Item|), ``path`` (path)
-    :Description: Called after a file's metadata is written to disk.
+    :Description: Called after a file's metadata is written to disk. Not sent
+        when the write was skipped because the item's own file already held the
+        tags (see ``Item.write()``).
 
 ``import_task_created``
     :Parameters: ``task`` (|ImportTask|), ``session`` (|ImportSession|)

--- a/docs/dev/plugins/events.rst
+++ b/docs/dev/plugins/events.rst
@@ -111,9 +111,11 @@ registration process in this case:
 
 ``write``
     :Parameters: ``item`` (|Item|), ``path`` (path), ``tags`` (dict)
-    :Description: Called just before a file's metadata is written to disk.
-        Handlers may modify ``tags`` or raise ``library.FileOperationError`` to
-        abort.
+    :Description: Called before beets decides whether to write a file's
+        metadata to disk. Handlers may modify ``tags`` or raise
+        ``library.FileOperationError`` to abort. ``after_write`` is skipped
+        when the file being written is the item's own and already holds the
+        tags.
 
 ``after_write``
     :Parameters: ``item`` (|Item|), ``path`` (path)

--- a/docs/plugins/importadded.rst
+++ b/docs/plugins/importadded.rst
@@ -47,9 +47,9 @@ file. There are two options available:
 - **preserve_mtimes**: After importing files, re-set their mtimes to their
   original value. Default: ``no``.
 - **preserve_write_mtimes**: After writing files, re-set their mtimes to their
-  original value. A file that already holds the tags being written is not
-  saved, so its mtime is not re-set either; pass ``-f`` to ``beet write`` to
-  force the save. Default: ``no``.
+  original value. A file that already holds the tags being written is not saved,
+  so its mtime is not re-set either; pass ``-f`` to ``beet write`` to force the
+  save. Default: ``no``.
 
 Reimport
 --------

--- a/docs/plugins/importadded.rst
+++ b/docs/plugins/importadded.rst
@@ -47,7 +47,9 @@ file. There are two options available:
 - **preserve_mtimes**: After importing files, re-set their mtimes to their
   original value. Default: ``no``.
 - **preserve_write_mtimes**: After writing files, re-set their mtimes to their
-  original value. Default: ``no``.
+  original value. A file that already holds the tags being written is not
+  saved, so its mtime is not re-set either; pass ``-f`` to ``beet write`` to
+  force the save. Default: ``no``.
 
 Reimport
 --------

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -309,6 +309,8 @@ Items will automatically be moved around when necessary if they're in your
 library directory, but you can disable that with ``-M``. Tags will be written to
 the files according to the settings you have for imports, but these can be
 overridden with ``-w`` (write tags, the default) and ``-W`` (don't write tags).
+A file that already holds the tags is left untouched, so changing a field that
+beets keeps only in its database does not give the file a new modification time.
 
 When you run the ``modify`` command, it prints a list of all affected items in
 the library and asks for your permission before making any changes. You can then

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -420,6 +420,10 @@ By default, beets writes MP3 tags using the ID3v2.4 standard, the latest version
 of ID3. Enable this option to instead use the older ID3v2.3 standard, which is
 preferred by certain older software such as Windows Media Player.
 
+Saving a file is what converts its tags to ID3v2.3, so beets saves your MP3s
+every time it writes them while this option is enabled, even the ones that
+already hold the tags it is writing.
+
 .. _va_name:
 
 va_name

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -431,6 +431,10 @@ By default, beets writes MP3 tags using the ID3v2.4 standard, the latest version
 of ID3. Enable this option to instead use the older ID3v2.3 standard, which is
 preferred by certain older software such as Windows Media Player.
 
+Saving a file is what converts its tags to ID3v2.3, so beets saves your MP3s
+every time it writes them while this option is enabled, even the ones that
+already hold the tags it is writing.
+
 .. _va_name:
 
 va_name

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 
 import mutagen
 import pytest
-from mediafile import MediaFile, UnreadableFileError
+from mediafile import Image, MediaFile, UnreadableFileError
 
 import beets.dbcore.query
 import beets.library
@@ -1394,9 +1394,39 @@ class TestWrite(TestHelper):
         assert item.current_mtime() != 1000000000
         assert MediaFile(syspath(item.path)).artists is None
 
+    def test_write_image_tag_always_saves(self):
+        # Images are never compared, so a write that carries one saves even
+        # when the file already embeds the same image.
+        item = self.add_item_fixture(format="MP3")
+        with open(os.path.join(_common.RSRC, b"image-2x3.jpg"), "rb") as f:
+            image = Image(f.read())
+        item.write(tags={"images": [image]})
+        os.utime(syspath(item.path), (1000000000, 1000000000))
+
+        item.write(tags={"images": [image]})
+
+        assert item.current_mtime() != 1000000000
+
+    def test_write_skip_records_the_compared_mtime(self):
+        # A change landing while the file is read and compared stays newer
+        # than the recorded mtime, so that a later sync still sees it.
+        item = self.add_item_fixture(format="MP3")
+        item.write()
+        mtime = item.current_mtime()
+        real_init = MediaFile.__init__
+
+        def racy_init(mediafile, *args, **kwargs):
+            os.utime(syspath(item.path), (mtime + 100, mtime + 100))
+            real_init(mediafile, *args, **kwargs)
+
+        with patch.object(MediaFile, "__init__", racy_init):
+            item.write()
+
+        assert item.mtime == mtime
+
     def test_write_file_with_an_unreadable_image(self):
-        # Images are not compared, so an unreadable one does not stop the
-        # write.
+        # Only the fields being written are compared, so an image beets
+        # cannot read does not stop the write.
         path = os.path.join(self.temp_dir, b"unreadable_image.ogg")
         shutil.copy(os.path.join(_common.RSRC, b"full.ogg"), path)
         mediafile = mutagen.File(syspath(path))

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1277,6 +1277,18 @@ class TestWrite(TestHelper):
         assert MediaFile(syspath(custom_path)).artist == "new artist"
         assert MediaFile(syspath(item.path)).artist != "new artist"
 
+    def test_write_custom_path_with_the_tags(self):
+        # A write to a path other than the item's own file always saves.
+        item = self.add_item_fixture()
+        item.write()
+        custom_path = os.path.join(self.temp_dir, b"custom.mp3")
+        shutil.copy(syspath(item.path), syspath(custom_path))
+        os.utime(syspath(custom_path), (1000000000, 1000000000))
+
+        item.write(custom_path)
+
+        assert os.path.getmtime(syspath(custom_path)) != 1000000000
+
     def test_write_custom_tags(self):
         item = self.add_item_fixture(artist="old artist")
         item.write(tags={"artist": "new artist"})

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1367,6 +1367,21 @@ class TestWrite(TestHelper):
             "another artist",
         ]
 
+    def test_write_drops_a_list_tag_of_empty_values(self):
+        # A tag holding only empty values is still a tag the file keeps, so
+        # removing it is a change to save.
+        item = self.add_item_fixture(format="FLAC")
+        item.write()
+        mediafile = MediaFile(syspath(item.path))
+        mediafile.artists = [""]
+        mediafile.save()
+        os.utime(syspath(item.path), (1000000000, 1000000000))
+
+        item.write()
+
+        assert item.current_mtime() != 1000000000
+        assert MediaFile(syspath(item.path)).artists is None
+
     def test_write_file_with_an_unreadable_image(self):
         # Images are not compared, so an unreadable one does not stop the
         # write.

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -10,6 +10,7 @@ import stat
 import unittest
 from unittest.mock import patch
 
+import mutagen
 import pytest
 from mediafile import MediaFile, UnreadableFileError
 
@@ -1308,6 +1309,53 @@ class TestWrite(TestHelper):
         item.date = "foo"
         item.write()
         assert MediaFile(syspath(item.path)).year == clean_year
+
+    @pytest.mark.parametrize("file_format", ["MP3", "FLAC"])
+    def test_no_write_when_file_has_the_tags(self, file_format):
+        item = self.add_item_fixture(format=file_format)
+        # The file keeps six decimal places of the peak, so the value read
+        # back from it never equals the one stored in the database.
+        item.rg_track_peak = 10 ** (-1.2 / 20)
+        item.write()
+        os.utime(syspath(item.path), (1000000000, 1000000000))
+
+        item.write()
+
+        assert item.current_mtime() == 1000000000
+
+    def test_write_list_tag_that_drops_an_empty_value(self):
+        # An empty value the file happens to hold is still a value there, so
+        # the file no longer holds the tags once it is gone.
+        item = self.add_item_fixture(format="FLAC")
+        item.write()
+        mediafile = MediaFile(syspath(item.path))
+        mediafile.artists = ["the artist", "", "another artist"]
+        mediafile.save()
+        item.artists = ["the artist", "another artist"]
+        os.utime(syspath(item.path), (1000000000, 1000000000))
+
+        item.write()
+
+        assert item.current_mtime() != 1000000000
+        assert MediaFile(syspath(item.path)).artists == [
+            "the artist",
+            "another artist",
+        ]
+
+    def test_write_file_with_an_unreadable_image(self):
+        # The images are not read, so a file beets cannot parse one from is
+        # written like any other.
+        path = os.path.join(self.temp_dir, b"unreadable_image.ogg")
+        shutil.copy(os.path.join(_common.RSRC, b"full.ogg"), path)
+        mediafile = mutagen.File(syspath(path))
+        mediafile["metadata_block_picture"] = ["not base64"]
+        mediafile.save()
+        item = beets.library.Item.from_path(path)
+        item.title = "another title"
+
+        item.write()
+
+        assert MediaFile(syspath(path)).title == "another title"
 
 
 class TestItemRead(PytestItemHelper):

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1323,6 +1323,31 @@ class TestWrite(TestHelper):
 
         assert item.current_mtime() == 1000000000
 
+    def test_write_converts_id3v23_file_to_v24(self):
+        # Saving is what converts the tags of an older MP3 to the default
+        # ID3v2.4, so a v2.3 file is saved even when it holds the tags.
+        item = self.add_item_fixture(format="MP3")
+        item.write()
+        mediafile = mutagen.File(syspath(item.path))
+        mediafile.tags.update_to_v23()
+        mediafile.save(v2_version=3)
+        item.read()
+
+        item.write()
+
+        assert mutagen.File(syspath(item.path)).tags.version >= (2, 4, 0)
+
+    def test_id3v23_write_saves_file_with_the_tags(self):
+        # Converting the tags to ID3v2.3 also happens when the file is saved,
+        # so a write with the option enabled never skips the save.
+        item = self.add_item_fixture(format="MP3")
+        item.write()
+        os.utime(syspath(item.path), (1000000000, 1000000000))
+
+        item.write(id3v23=True)
+
+        assert item.current_mtime() != 1000000000
+
     def test_write_list_tag_that_drops_an_empty_value(self):
         # An empty value the file happens to hold is still a value there, so
         # the file no longer holds the tags once it is gone.
@@ -1343,8 +1368,8 @@ class TestWrite(TestHelper):
         ]
 
     def test_write_file_with_an_unreadable_image(self):
-        # The images are not read, so a file beets cannot parse one from is
-        # written like any other.
+        # Images are not compared, so an unreadable one does not stop the
+        # write.
         path = os.path.join(self.temp_dir, b"unreadable_image.ogg")
         shutil.copy(os.path.join(_common.RSRC, b"full.ogg"), path)
         mediafile = mutagen.File(syspath(path))

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1266,13 +1266,13 @@ class TestWrite(TestHelper):
         # A write to a path other than the item's own file always saves.
         item = self.add_item_fixture()
         item.write()
-        custom_path = os.path.join(self.temp_dir, b"custom.mp3")
-        shutil.copy(syspath(item.path), syspath(custom_path))
-        os.utime(syspath(custom_path), (1000000000, 1000000000))
+        custom_path = self.temp_path / "custom.mp3"
+        shutil.copy(item.filepath, custom_path)
+        os.utime(custom_path, (1000000000, 1000000000))
 
         item.write(custom_path)
 
-        assert os.path.getmtime(syspath(custom_path)) != 1000000000
+        assert os.path.getmtime(custom_path) != 1000000000
 
     def test_write_custom_tags(self):
         item = self.add_item_fixture(artist="old artist")
@@ -1312,7 +1312,7 @@ class TestWrite(TestHelper):
         # back from it never equals the one stored in the database.
         item.rg_track_peak = 10 ** (-1.2 / 20)
         item.write()
-        os.utime(syspath(item.path), (1000000000, 1000000000))
+        os.utime(item.filepath, (1000000000, 1000000000))
 
         item.write()
 
@@ -1323,21 +1323,21 @@ class TestWrite(TestHelper):
         # ID3v2.4, so a v2.3 file is saved even when it holds the tags.
         item = self.add_item_fixture(format="MP3")
         item.write()
-        mediafile = mutagen.File(syspath(item.path))
+        mediafile = mutagen.File(item.filepath)
         mediafile.tags.update_to_v23()
         mediafile.save(v2_version=3)
         item.read()
 
         item.write()
 
-        assert mutagen.File(syspath(item.path)).tags.version >= (2, 4, 0)
+        assert mutagen.File(item.filepath).tags.version >= (2, 4, 0)
 
     def test_id3v23_write_saves_file_with_the_tags(self):
         # Converting the tags to ID3v2.3 also happens when the file is saved,
         # so a write with the option enabled never skips the save.
         item = self.add_item_fixture(format="MP3")
         item.write()
-        os.utime(syspath(item.path), (1000000000, 1000000000))
+        os.utime(item.filepath, (1000000000, 1000000000))
 
         item.write(id3v23=True)
 
@@ -1348,16 +1348,16 @@ class TestWrite(TestHelper):
         # the file no longer holds the tags once it is gone.
         item = self.add_item_fixture(format="FLAC")
         item.write()
-        mediafile = MediaFile(syspath(item.path))
+        mediafile = MediaFile(item.filepath)
         mediafile.artists = ["the artist", "", "another artist"]
         mediafile.save()
         item.artists = ["the artist", "another artist"]
-        os.utime(syspath(item.path), (1000000000, 1000000000))
+        os.utime(item.filepath, (1000000000, 1000000000))
 
         item.write()
 
         assert item.current_mtime() != 1000000000
-        assert MediaFile(syspath(item.path)).artists == [
+        assert MediaFile(item.filepath).artists == [
             "the artist",
             "another artist",
         ]
@@ -1367,24 +1367,24 @@ class TestWrite(TestHelper):
         # removing it is a change to save.
         item = self.add_item_fixture(format="FLAC")
         item.write()
-        mediafile = MediaFile(syspath(item.path))
+        mediafile = MediaFile(item.filepath)
         mediafile.artists = [""]
         mediafile.save()
-        os.utime(syspath(item.path), (1000000000, 1000000000))
+        os.utime(item.filepath, (1000000000, 1000000000))
 
         item.write()
 
         assert item.current_mtime() != 1000000000
-        assert MediaFile(syspath(item.path)).artists is None
+        assert MediaFile(item.filepath).artists is None
 
     def test_write_image_tag_always_saves(self):
         # Images are never compared, so a write that carries one saves even
         # when the file already embeds the same image.
         item = self.add_item_fixture(format="MP3")
-        with open(os.path.join(_common.RSRC, b"image-2x3.jpg"), "rb") as f:
+        with open(_common.RSRC / "image-2x3.jpg", "rb") as f:
             image = Image(f.read())
         item.write(tags={"images": [image]})
-        os.utime(syspath(item.path), (1000000000, 1000000000))
+        os.utime(item.filepath, (1000000000, 1000000000))
 
         item.write(tags={"images": [image]})
 
@@ -1399,7 +1399,7 @@ class TestWrite(TestHelper):
         real_init = MediaFile.__init__
 
         def racy_init(mediafile, *args, **kwargs):
-            os.utime(syspath(item.path), (mtime + 100, mtime + 100))
+            os.utime(item.filepath, (mtime + 100, mtime + 100))
             real_init(mediafile, *args, **kwargs)
 
         with patch.object(MediaFile, "__init__", racy_init):
@@ -1410,9 +1410,9 @@ class TestWrite(TestHelper):
     def test_write_file_with_an_unreadable_image(self):
         # Only the fields being written are compared, so an image beets
         # cannot read does not stop the write.
-        path = os.path.join(self.temp_dir, b"unreadable_image.ogg")
-        shutil.copy(os.path.join(_common.RSRC, b"full.ogg"), path)
-        mediafile = mutagen.File(syspath(path))
+        path = self.temp_path / "unreadable_image.ogg"
+        shutil.copy(_common.RSRC / "full.ogg", path)
+        mediafile = mutagen.File(path)
         mediafile["metadata_block_picture"] = ["not base64"]
         mediafile.save()
         item = beets.library.Item.from_path(path)
@@ -1420,7 +1420,7 @@ class TestWrite(TestHelper):
 
         item.write()
 
-        assert MediaFile(syspath(path)).title == "another title"
+        assert MediaFile(path).title == "another title"
 
 
 class TestItemRead(PytestItemHelper):

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -11,6 +11,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+import mutagen
 import pytest
 from mediafile import MediaFile, UnreadableFileError
 
@@ -1291,6 +1292,53 @@ class TestWrite(TestHelper):
         item.date = "foo"
         item.write()
         assert MediaFile(item.filepath).year == clean_year
+
+    @pytest.mark.parametrize("file_format", ["MP3", "FLAC"])
+    def test_no_write_when_file_has_the_tags(self, file_format):
+        item = self.add_item_fixture(format=file_format)
+        # The file keeps six decimal places of the peak, so the value read
+        # back from it never equals the one stored in the database.
+        item.rg_track_peak = 10 ** (-1.2 / 20)
+        item.write()
+        os.utime(syspath(item.path), (1000000000, 1000000000))
+
+        item.write()
+
+        assert item.current_mtime() == 1000000000
+
+    def test_write_list_tag_that_drops_an_empty_value(self):
+        # An empty value the file happens to hold is still a value there, so
+        # the file no longer holds the tags once it is gone.
+        item = self.add_item_fixture(format="FLAC")
+        item.write()
+        mediafile = MediaFile(syspath(item.path))
+        mediafile.artists = ["the artist", "", "another artist"]
+        mediafile.save()
+        item.artists = ["the artist", "another artist"]
+        os.utime(syspath(item.path), (1000000000, 1000000000))
+
+        item.write()
+
+        assert item.current_mtime() != 1000000000
+        assert MediaFile(syspath(item.path)).artists == [
+            "the artist",
+            "another artist",
+        ]
+
+    def test_write_file_with_an_unreadable_image(self):
+        # The images are not read, so a file beets cannot parse one from is
+        # written like any other.
+        path = os.path.join(self.temp_dir, b"unreadable_image.ogg")
+        shutil.copy(os.path.join(_common.RSRC, b"full.ogg"), path)
+        mediafile = mutagen.File(syspath(path))
+        mediafile["metadata_block_picture"] = ["not base64"]
+        mediafile.save()
+        item = beets.library.Item.from_path(path)
+        item.title = "another title"
+
+        item.write()
+
+        assert MediaFile(syspath(path)).title == "another title"
 
 
 class TestItemRead(PytestItemHelper):

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1306,6 +1306,31 @@ class TestWrite(TestHelper):
 
         assert item.current_mtime() == 1000000000
 
+    def test_write_converts_id3v23_file_to_v24(self):
+        # Saving is what converts the tags of an older MP3 to the default
+        # ID3v2.4, so a v2.3 file is saved even when it holds the tags.
+        item = self.add_item_fixture(format="MP3")
+        item.write()
+        mediafile = mutagen.File(syspath(item.path))
+        mediafile.tags.update_to_v23()
+        mediafile.save(v2_version=3)
+        item.read()
+
+        item.write()
+
+        assert mutagen.File(syspath(item.path)).tags.version >= (2, 4, 0)
+
+    def test_id3v23_write_saves_file_with_the_tags(self):
+        # Converting the tags to ID3v2.3 also happens when the file is saved,
+        # so a write with the option enabled never skips the save.
+        item = self.add_item_fixture(format="MP3")
+        item.write()
+        os.utime(syspath(item.path), (1000000000, 1000000000))
+
+        item.write(id3v23=True)
+
+        assert item.current_mtime() != 1000000000
+
     def test_write_list_tag_that_drops_an_empty_value(self):
         # An empty value the file happens to hold is still a value there, so
         # the file no longer holds the tags once it is gone.
@@ -1326,8 +1351,8 @@ class TestWrite(TestHelper):
         ]
 
     def test_write_file_with_an_unreadable_image(self):
-        # The images are not read, so a file beets cannot parse one from is
-        # written like any other.
+        # Images are not compared, so an unreadable one does not stop the
+        # write.
         path = os.path.join(self.temp_dir, b"unreadable_image.ogg")
         shutil.copy(os.path.join(_common.RSRC, b"full.ogg"), path)
         mediafile = mutagen.File(syspath(path))

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1262,6 +1262,18 @@ class TestWrite(TestHelper):
         assert MediaFile(custom_path).artist == "new artist"
         assert MediaFile(item.filepath).artist != "new artist"
 
+    def test_write_custom_path_with_the_tags(self):
+        # A write to a path other than the item's own file always saves.
+        item = self.add_item_fixture()
+        item.write()
+        custom_path = os.path.join(self.temp_dir, b"custom.mp3")
+        shutil.copy(syspath(item.path), syspath(custom_path))
+        os.utime(syspath(custom_path), (1000000000, 1000000000))
+
+        item.write(custom_path)
+
+        assert os.path.getmtime(syspath(custom_path)) != 1000000000
+
     def test_write_custom_tags(self):
         item = self.add_item_fixture(artist="old artist")
         item.write(tags={"artist": "new artist"})

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1350,6 +1350,21 @@ class TestWrite(TestHelper):
             "another artist",
         ]
 
+    def test_write_drops_a_list_tag_of_empty_values(self):
+        # A tag holding only empty values is still a tag the file keeps, so
+        # removing it is a change to save.
+        item = self.add_item_fixture(format="FLAC")
+        item.write()
+        mediafile = MediaFile(syspath(item.path))
+        mediafile.artists = [""]
+        mediafile.save()
+        os.utime(syspath(item.path), (1000000000, 1000000000))
+
+        item.write()
+
+        assert item.current_mtime() != 1000000000
+        assert MediaFile(syspath(item.path)).artists is None
+
     def test_write_file_with_an_unreadable_image(self):
         # Images are not compared, so an unreadable one does not stop the
         # write.

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -13,7 +13,7 @@ from unittest.mock import patch
 
 import mutagen
 import pytest
-from mediafile import MediaFile, UnreadableFileError
+from mediafile import Image, MediaFile, UnreadableFileError
 
 import beets.dbcore.query
 import beets.library
@@ -1377,9 +1377,39 @@ class TestWrite(TestHelper):
         assert item.current_mtime() != 1000000000
         assert MediaFile(syspath(item.path)).artists is None
 
+    def test_write_image_tag_always_saves(self):
+        # Images are never compared, so a write that carries one saves even
+        # when the file already embeds the same image.
+        item = self.add_item_fixture(format="MP3")
+        with open(os.path.join(_common.RSRC, b"image-2x3.jpg"), "rb") as f:
+            image = Image(f.read())
+        item.write(tags={"images": [image]})
+        os.utime(syspath(item.path), (1000000000, 1000000000))
+
+        item.write(tags={"images": [image]})
+
+        assert item.current_mtime() != 1000000000
+
+    def test_write_skip_records_the_compared_mtime(self):
+        # A change landing while the file is read and compared stays newer
+        # than the recorded mtime, so that a later sync still sees it.
+        item = self.add_item_fixture(format="MP3")
+        item.write()
+        mtime = item.current_mtime()
+        real_init = MediaFile.__init__
+
+        def racy_init(mediafile, *args, **kwargs):
+            os.utime(syspath(item.path), (mtime + 100, mtime + 100))
+            real_init(mediafile, *args, **kwargs)
+
+        with patch.object(MediaFile, "__init__", racy_init):
+            item.write()
+
+        assert item.mtime == mtime
+
     def test_write_file_with_an_unreadable_image(self):
-        # Images are not compared, so an unreadable one does not stop the
-        # write.
+        # Only the fields being written are compared, so an image beets
+        # cannot read does not stop the write.
         path = os.path.join(self.temp_dir, b"unreadable_image.ogg")
         shutil.copy(os.path.join(_common.RSRC, b"full.ogg"), path)
         mediafile = mutagen.File(syspath(path))

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -69,6 +69,26 @@ class TestPluginRegistration(IOMixin, PluginTestHelper):
 
         assert MediaFile(syspath(item.path)).artist == "YYY"
 
+    def test_after_write_skipped_when_file_has_the_tags(self):
+        events = []
+
+        class EventPlugin(plugins.BeetsPlugin):
+            def __init__(self):
+                super().__init__()
+                self.register_listener(
+                    "after_write", lambda item, path: events.append(path)
+                )
+
+        self.register_plugin(EventPlugin)
+        item = self.add_item_fixture()
+        item.write()
+        assert events
+
+        events.clear()
+        item.write()
+
+        assert not events
+
     def test_multi_value_flex_field_type(self):
         item = Item(path="apath", artist="aaa")
         item.multi_value = ["one", "two", "three"]

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -75,9 +75,10 @@ class TestPluginRegistration(IOMixin, PluginTestHelper):
         class EventPlugin(plugins.BeetsPlugin):
             def __init__(self):
                 super().__init__()
-                self.register_listener(
-                    "after_write", lambda item, path: events.append(path)
-                )
+                self.register_listener("after_write", self.on_after_write)
+
+            def on_after_write(self, item, path):
+                events.append(path)
 
         self.register_plugin(EventPlugin)
         item = self.add_item_fixture()

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -74,9 +74,10 @@ class TestPluginRegistration(IOMixin, PluginTestHelper):
         class EventPlugin(plugins.BeetsPlugin):
             def __init__(self):
                 super().__init__()
-                self.register_listener(
-                    "after_write", lambda item, path: events.append(path)
-                )
+                self.register_listener("after_write", self.on_after_write)
+
+            def on_after_write(self, item, path):
+                events.append(path)
 
         self.register_plugin(EventPlugin)
         item = self.add_item_fixture()

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -68,6 +68,26 @@ class TestPluginRegistration(IOMixin, PluginTestHelper):
 
         assert MediaFile(item.filepath).artist == "YYY"
 
+    def test_after_write_skipped_when_file_has_the_tags(self):
+        events = []
+
+        class EventPlugin(plugins.BeetsPlugin):
+            def __init__(self):
+                super().__init__()
+                self.register_listener(
+                    "after_write", lambda item, path: events.append(path)
+                )
+
+        self.register_plugin(EventPlugin)
+        item = self.add_item_fixture()
+        item.write()
+        assert events
+
+        events.clear()
+        item.write()
+
+        assert not events
+
     def test_multi_value_flex_field_type(self):
         item = Item(path="apath", artist="aaa")
         item.multi_value = ["one", "two", "three"]

--- a/test/ui/commands/test_modify.py
+++ b/test/ui/commands/test_modify.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from mediafile import MediaFile
 
@@ -238,6 +240,24 @@ class ModifyTest(ModifyHelper, BeetsTestCase):
         )
         assert query == ["title:foo=bar"]
         assert mods == {"title": ModifyOperation(None, "newTitle")}
+
+
+class TestWriteTags(ModifyHelper, TestHelper):
+    @pytest.fixture
+    def item(self):
+        album = self.add_album_fixture()
+        [item] = album.items()
+        item.write()
+        item.store()
+        os.utime(syspath(item.path), (1000000000, 1000000000))
+        return item
+
+    def test_keep_file_when_only_database_field_changes(self, item):
+        self.modify("--nomove", "data_source=bandcamp")
+
+        item.load()
+        assert item.data_source == "bandcamp"
+        assert item.current_mtime() == 1000000000
 
 
 class TestMultiValue(ModifyHelper, TestHelper):

--- a/test/ui/commands/test_modify.py
+++ b/test/ui/commands/test_modify.py
@@ -267,7 +267,7 @@ class TestWriteTags(ModifyHelper, TestHelper):
         [item] = album.items()
         item.write()
         item.store()
-        os.utime(syspath(item.path), (1000000000, 1000000000))
+        os.utime(item.filepath, (1000000000, 1000000000))
         return item
 
     def test_keep_file_when_only_database_field_changes(self, item):

--- a/test/ui/commands/test_modify.py
+++ b/test/ui/commands/test_modify.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 import pytest
@@ -257,6 +258,24 @@ class ModifyTest(ModifyHelper, BeetsTestCase):
         )
         assert query == ["title:foo=bar"]
         assert mods == {"title": ModifyOperation(None, "newTitle")}
+
+
+class TestWriteTags(ModifyHelper, TestHelper):
+    @pytest.fixture
+    def item(self):
+        album = self.add_album_fixture()
+        [item] = album.items()
+        item.write()
+        item.store()
+        os.utime(syspath(item.path), (1000000000, 1000000000))
+        return item
+
+    def test_keep_file_when_only_database_field_changes(self, item):
+        self.modify("--nomove", "data_source=bandcamp")
+
+        item.load()
+        assert item.data_source == "bandcamp"
+        assert item.current_mtime() == 1000000000
 
 
 class TestMultiValue(ModifyHelper, TestHelper):

--- a/test/ui/commands/test_write.py
+++ b/test/ui/commands/test_write.py
@@ -1,9 +1,21 @@
+import os
+
 from beets.test.helper import BeetsTestCase, IOMixin
+from beets.util import syspath
 
 
 class WriteTest(IOMixin, BeetsTestCase):
     def write_cmd(self, *args):
         return self.run_with_output("write", *args)
+
+    def test_force_write_file_with_the_tags(self):
+        item = self.add_item_fixture()
+        item.write()
+        os.utime(syspath(item.path), (1000000000, 1000000000))
+
+        self.write_cmd("-f")
+
+        assert item.current_mtime() != 1000000000
 
     def test_update_mtime(self):
         item = self.add_item_fixture()


### PR DESCRIPTION
## Description

Fixes #6529.

`Item.write()` called `mediafile.save()` whether or not the tags it was about to write differed from the ones already in the file. `beet modify --write` on a field that only the database keeps, `data_source` for instance, gave the file a new modification time without changing a single tag, and tools that sync the library copied it again for nothing.

The tags the write is about to touch are now read back from the file, compared with the ones already there, and the save is skipped when they match.

Comparing what the file reads back, rather than what the database holds, keeps a file that cannot store a value exactly, such as one carrying a replaygain peak, from looking changed on every write. Images stay out of the comparison, since a write that carries one replaces the whole list of them.

`beet write --force` still rewrites. So does a file written with the `id3v23` option, and so does one whose tags still need converting to the default ID3v2.4, since saving is what converts them either way.

## To Do

- [x] Documentation. (The `modify` command, the `id3v23` option, the mtime policy in the library docs, the `write` and `after_write` events, and the importadded plugin.)
- [x] Changelog
- [x] Tests
