### PR TITLE
Improve subsonicupdate error for non-JSON responses

### DIFF
--- a/beetsplug/subsonicupdate.py
+++ b/beetsplug/subsonicupdate.py
@@ -121,7 +121,18 @@ class SubsonicUpdate(BeetsPlugin):
         try:
             response = requests.get(url, params=payload, timeout=10)
             json = response.json()
-
+        except requests.exceptions.JSONDecodeError:
+            self._log.error(
+                "Subsonic server returned a non-JSON response from {} "
+                "(HTTP {})",
+                url,
+                response.status_code,
+            )
+            return
+        except requests.exceptions.RequestException as error:
+            self._log.error("Error connecting to Subsonic server: {}", error)
+            return
+        try:
             if (
                 response.status_code == 200
                 and json["subsonic-response"]["status"] == "ok"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -43,6 +43,8 @@ New features
 Bug fixes
 ~~~~~~~~~
 
+- :doc:`plugins/subsonicupdate`: Log a clearer error when the Subsonic server
+  returns a non-JSON response. :bug:`5635`
 - :doc:`plugins/importfeeds`: ``beet import`` no longer aborts the whole run
   when a symlink cannot be created (e.g. on Windows or a read-only directory);
   the failure is logged and the import continues. :bug:`840`

--- a/test/plugins/test_subsonicupdate.py
+++ b/test/plugins/test_subsonicupdate.py
@@ -166,3 +166,21 @@ class SubsonicPluginTest(unittest.TestCase):
         )
 
         self.subsonicupdate.start_scan()
+
+    @responses.activate
+    def test_start_scan_failed_non_json_response(self):
+        """Tests failed path based on a non-JSON server response."""
+        responses.add(
+            responses.GET,
+            "http://localhost:4040/rest/startScan",
+            status=503,
+            body="<html>server unavailable</html>",
+            content_type="text/html",
+        )
+
+        with self.assertLogs("beets", level="ERROR") as logs:
+            self.subsonicupdate.start_scan()
+
+        assert "Subsonic server returned a non-JSON response" in "\n".join(
+            logs.output
+        )


### PR DESCRIPTION
## Description

Fixes #5635.

When the Subsonic server returns a non-JSON response, `subsonicupdate` currently logs the JSON decode error directly. This can produce a cryptic message like `Expecting value`.

This logs a clearer error with the server URL and HTTP status, and adds a regression test for an HTML error response.

## To Do

- [x] ~Documentation.~ Not needed for this error handling change.
- [x] Changelog.
- [x] Tests.