### PR TITLE
Make InQuery hashable when its pattern is a list

### DIFF
--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -504,6 +504,11 @@ class InQuery(Generic[AnySQLiteType], FieldQuery[Sequence[AnySQLiteType]]):
     ) -> bool:
         return value in pattern
 
+    def __hash__(self) -> int:
+        # `pattern` is a sequence, so the base class hashing it directly
+        # raises for list patterns. Hash a tuple copy instead. See #5354.
+        return hash((self.field_name, tuple(self.pattern)))
+
 
 class CollectionQuery(Query):
     """An abstract query class that aggregates other queries. Can be

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -69,6 +69,9 @@ Bug fixes
   longer crashes with a ``TypeError``. Missing values are now grouped together,
   ordered before present ones when sorting ascending and after them when
   descending. :bug:`3461`
+- :doc:`plugins/smartplaylist`: ``splupdate`` no longer crashes with
+  ``TypeError: unhashable type: 'list'`` when a playlist configuration includes
+  a ``playlist:`` query. :bug:`5354`
 
 ..
     For plugin developers

--- a/test/dbcore/test_query.py
+++ b/test/dbcore/test_query.py
@@ -15,6 +15,7 @@ from beets.dbcore.query import (
     BooleanQuery,
     DateQuery,
     FalseQuery,
+    InQuery,
     MatchQuery,
     NoneQuery,
     NotQuery,
@@ -469,6 +470,12 @@ class TestQuery:
     @pytest.mark.parametrize("query_class", [MatchQuery, StringFieldQuery])
     def test_equality(self, query_class):
         assert query_class("foo", "bar") == query_class("foo", "bar")
+
+    def test_in_query_hashable(self):
+        # smartplaylist puts queries in a set; an InQuery whose pattern is a
+        # list used to raise `unhashable type: 'list'`. See #5354.
+        query = InQuery("field", [1, 2, 3])
+        assert query in {query}
 
     @pytest.mark.parametrize(
         "make_q, expected_msg",


### PR DESCRIPTION
Fixes #5354.

`beet splupdate` raises `TypeError: unhashable type: 'list'` whenever a smartplaylist configuration contains a `playlist:` query. smartplaylist collects playlists in a `set`, which hashes the query. `playlist:` parses to `PlaylistQuery`, a subclass of `InQuery` whose `pattern` is a list, and `InQuery` inherited `FieldQuery.__hash__`, which does `hash(self.pattern)` and fails on a list.

As @wisp3rwind suggested on the issue, this overrides `__hash__` on `InQuery` to hash a tuple copy of the pattern. It stays order-sensitive to match the inherited `FieldQuery.__eq__`, so the hash/eq contract holds.

Changes:
- `beets/dbcore/query.py`: add `InQuery.__hash__`.
- `test/dbcore/test_query.py`: regression test that an `InQuery` with a list pattern can be put in a set.
- changelog entry under Bug fixes.

Left the order-insensitive `__eq__`/`__hash__` and the smartplaylist `set`-vs-`dict` cleanup you also floated out of scope here; happy to follow up on either if you want them.
