### PR TITLE
Preserve null artpath in edit

### DIFF
--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -107,7 +107,9 @@ def flatten(obj, fields):
     d = {}
     for key in obj.keys():
         value = obj[key]
-        if _safe_value(obj, key, value):
+        if value is None:
+            d[key] = None
+        elif _safe_value(obj, key, value):
             # A safe value that is faithfully representable in YAML.
             d[key] = value
         else:
@@ -128,7 +130,9 @@ def apply_(obj, data):
     strings as values.
     """
     for key, value in data.items():
-        if _safe_value(obj, key, value):
+        if value is None:
+            obj[key] = None
+        elif _safe_value(obj, key, value):
             # A safe value *stayed* represented as a safe type. Assign it
             # directly.
             obj[key] = value

--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -91,6 +91,8 @@ def _safe_value(obj, key, value):
     This ensures that values do not change their type when the user edits their
     YAML representation.
     """
+    if value is None:
+        return True
     typ = obj._type(key)
     return isinstance(typ, SAFE_TYPES) and isinstance(value, typ.model_type)
 
@@ -107,9 +109,7 @@ def flatten(obj, fields):
     d = {}
     for key in obj.keys():
         value = obj[key]
-        if value is None:
-            d[key] = None
-        elif _safe_value(obj, key, value):
+        if _safe_value(obj, key, value):
             # A safe value that is faithfully representable in YAML.
             d[key] = value
         else:
@@ -130,9 +130,7 @@ def apply_(obj, data):
     strings as values.
     """
     for key, value in data.items():
-        if value is None:
-            obj[key] = None
-        elif _safe_value(obj, key, value):
+        if _safe_value(obj, key, value):
             # A safe value *stayed* represented as a safe type. Assign it
             # directly.
             obj[key] = value

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -44,8 +44,8 @@ Bug fixes
 ~~~~~~~~~
 
 - :doc:`plugins/edit`: Preserve missing album art paths when editing album
-  metadata, instead of turning ``artpath: null`` into a path ending in
-  ``None``. :bug:`2438`
+  metadata, instead of turning ``artpath: null`` into a path ending in ``None``.
+  :bug:`2438`
 - :doc:`plugins/subsonicupdate`: Log a clearer error when the Subsonic server
   returns a non-JSON response. :bug:`5635`
 - :doc:`plugins/missing`: Honor the ``-f``/``--format`` option (and the

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -43,6 +43,9 @@ New features
 Bug fixes
 ~~~~~~~~~
 
+- :doc:`plugins/edit`: Preserve missing album art paths when editing album
+  metadata, instead of turning ``artpath: null`` into a path ending in
+  ``None``. :bug:`2438`
 - :doc:`plugins/subsonicupdate`: Log a clearer error when the Subsonic server
   returns a non-JSON response. :bug:`5635`
 - :doc:`plugins/missing`: Honor the ``-f``/``--format`` option (and the

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -268,6 +268,25 @@ class EditCommandTest(IOMixin, EditMixin, BeetsTestCase):
             self.album.items(), self.items_orig, ["albumartist", "mtime"]
         )
 
+    def test_a_album_edit_preserves_missing_artpath(self, mock_write):
+        """Album query (-a), edit album field, preserve missing artpath."""
+        self.config["edit"]["albumfields"] = "album artpath"
+
+        self.run_mocked_command(
+            {"replacements": {"\u00e4lbum": "modified \u00e4lbum"}},
+            # Apply changes.
+            ["a"],
+            args=["-a"],
+        )
+
+        self.album.load()
+        assert mock_write.call_count == self.TRACK_COUNT
+        assert self.album.album == "modified \u00e4lbum"
+        assert self.album.artpath is None
+        self.assertItemFieldsModified(
+            self.album.items(), self.items_orig, ["album", "mtime"]
+        )
+
     def test_malformed_yaml(self, mock_write):
         """Edit the yaml file incorrectly (resulting in a malformed yaml
         document)."""


### PR DESCRIPTION
Fixes #2438.

When editing album metadata, `artpath: null` was converted through the string parsing path and could become a path ending in `None`.

This keeps YAML null values as `None` when dumping and applying edit data, and adds a regression test for editing album metadata while `artpath` is missing.

- Added a regression test.
- Added a changelog entry.