### PR TITLE
Recognize native Spotify URIs when extracting IDs

### DIFF
--- a/beets/util/id_extractors.py
+++ b/beets/util/id_extractors.py
@@ -10,7 +10,11 @@ log = logging.getLogger("beets")
 
 
 PATTERN_BY_SOURCE = {
-    "spotify": re.compile(r"(?:^|open\.spotify\.com/[^/]+/)([0-9A-Za-z]{22})"),
+    # Aceita o ID puro, URLs open.spotify.com e as URIs nativas
+    # (ex.: "spotify:album:<id>", "spotify:track:<id>").
+    "spotify": re.compile(
+        r"(?:^|open\.spotify\.com/[^/]+/|spotify:[a-z]+:)([0-9A-Za-z]{22})"
+    ),
     "deezer": re.compile(r"(?:^|deezer\.com/)(?:[a-z]*/)?(?:[^/]+/)?(\d+)"),
     "beatport": re.compile(r"(?:^|beatport\.com/release/.+/)(\d+)$"),
     "musicbrainz": re.compile(r"(\w{8}(?:-\w{4}){3}-\w{12})"),

--- a/beets/util/id_extractors.py
+++ b/beets/util/id_extractors.py
@@ -10,7 +10,7 @@ log = logging.getLogger("beets")
 
 
 PATTERN_BY_SOURCE = {
-    # Aceita o ID puro, URLs open.spotify.com e as URIs nativas
+    # Accepts the raw ID, open.spotify.com URLs, and native URIs.
     # (ex.: "spotify:album:<id>", "spotify:track:<id>").
     "spotify": re.compile(
         r"(?:^|open\.spotify\.com/[^/]+/|spotify:[a-z]+:)([0-9A-Za-z]{22})"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,9 @@ Unreleased
 New features
 ~~~~~~~~~~~~
 
+- Recognize native Spotify URIs (e.g. ``spotify:album:<id>`` and
+  ``spotify:track:<id>``) when extracting release/track IDs, in addition to full
+  ``open.spotify.com`` URLs and bare IDs.
 - :doc:`/plugins/convert`: Add new configuration option ``convert.refresh`` and
   command-line option ``--refresh``, allowing to force ``convert`` operation
   when original file is newer than existing converted file.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,9 +12,9 @@ Unreleased
 New features
 ~~~~~~~~~~~~
 
-- Recognize native Spotify URIs (e.g. ``spotify:album:<id>`` and
-  ``spotify:track:<id>``) when extracting release/track IDs, in addition to full
-  ``open.spotify.com`` URLs and bare IDs.
+- :doc:`plugins/spotify`: Recognize native Spotify URIs (e.g.
+  ``spotify:album:<id>`` and ``spotify:track:<id>``) when extracting
+  release/track IDs, in addition to full ``open.spotify.com`` URLs and bare IDs
 - :doc:`/plugins/convert`: Add new configuration option ``convert.refresh`` and
   command-line option ``--refresh``, allowing to force ``convert`` operation
   when original file is newer than existing converted file.

--- a/test/util/test_id_extractors.py
+++ b/test/util/test_id_extractors.py
@@ -11,6 +11,8 @@ from beets.util.id_extractors import extract_release_id
         ("spotify", "39WqpoPgZxygo6YQjehLJJ", "39WqpoPgZxygo6YQjehLJJ"),
         ("spotify", "blah blah", None),
         ("spotify", "https://open.spotify.com/album/39WqpoPgZxygo6YQjehLJJ", "39WqpoPgZxygo6YQjehLJJ"),
+        ("spotify", "spotify:album:39WqpoPgZxygo6YQjehLJJ", "39WqpoPgZxygo6YQjehLJJ"),
+        ("spotify", "spotify:track:39WqpoPgZxygo6YQjehLJJ", "39WqpoPgZxygo6YQjehLJJ"),
         ("deezer", "176356382", "176356382"),
         ("deezer", "blah blah", None),
         ("deezer", "https://www.deezer.com/album/176356382", "176356382"),


### PR DESCRIPTION
### Description

`extract_release_id` now accepts the native Spotify URI format
(`spotify:album:<id>`, `spotify:track:<id>`) in addition to the already
supported `open.spotify.com` URLs and bare IDs.

### To Do

- [x] Documentation (changelog entry under *New features*)
- [x] Tests (added URI cases to `test/util/test_id_extractors.py`)
- [x] Changelog