### PR TITLE
fix(util): split_into_lines merges a word split across 2+ colored spans

### DIFF
--- a/beets/util/layout.py
+++ b/beets/util/layout.py
@@ -70,6 +70,15 @@ def split_into_lines(string: str, first_width: int, width: int) -> list[str]:
         words = string.split()
     else:
         # Use a regex to find escapes and the text within them.
+        # `pretext` is empty for every match after the first, since the
+        # previous match's `posttext` (being a greedy [^ESC]* group) already
+        # consumed all plain text up to this escape sequence. Whether that
+        # represents a real word boundary depends on whether the text
+        # preceding this escape actually ended in whitespace, so we track it
+        # explicitly across iterations instead of assuming pretext-empty
+        # always means "boundary" (which is only true for the very first
+        # match, i.e. the start of the string).
+        prev_ends_with_space = True
         for m in ESC_TEXT_REGEX.finditer(string):
             # m contains four groups:
             # pretext - any text before escape sequence
@@ -88,8 +97,7 @@ def split_into_lines(string: str, first_width: int, width: int) -> list[str]:
                     # Pretext ended mid-word, ensure next word
                     pass
             else:
-                # pretext empty, treat as if there is a space before
-                space_before_text = True
+                space_before_text = prev_ends_with_space
             if m.group("text")[0] == " ":
                 # First character of the text is a space
                 space_before_text = True
@@ -128,6 +136,15 @@ def split_into_lines(string: str, first_width: int, width: int) -> list[str]:
             else:
                 # Add any words after escape sequence
                 words += m.group("posttext").split()
+            # Determine the boundary state for the next match's pretext-empty
+            # case: look at whatever content immediately precedes the next
+            # escape sequence -- posttext if there is any, otherwise text
+            # itself (posttext being empty means reset is followed directly
+            # by the next escape, with nothing in between).
+            if m.group("posttext"):
+                prev_ends_with_space = m.group("posttext")[-1] == " "
+            else:
+                prev_ends_with_space = m.group("text")[-1] == " "
     result: list[str] = []
     next_substr = ""
     # Iterate over all words.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -95,6 +95,9 @@ Bug fixes
   valid date/time string" error instead of crashing with an uncaught
   ``KeyError``. A ``|`` was being accepted as a relative-date unit due to a
   regular expression character-class typo.
+- Fix word wrapping of colored diff output for a word containing two or more
+  separately-highlighted spans, which was incorrectly split into two words at
+  the second highlighted span.
 
 ..
     For plugin developers

--- a/test/util/test_layout.py
+++ b/test/util/test_layout.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+from beets.util.color import uncolorize
 from beets.util.layout import split_into_lines
 
 
@@ -28,3 +29,14 @@ class LayoutTestCase(TestCase):
         split_txt = ["\x1b[31mtest\x1b[39;49;00mt", "est", "test", "test"]
         txt = split_into_lines(colored_text, 5, 5)
         assert txt == split_txt
+
+    def test_split_into_lines_two_spans_in_one_word(self):
+        # A single word containing two separately-colored, non-adjacent
+        # spans (e.g. two highlighted typo fixes within one word) must stay
+        # one word, not get split at the second colored span.
+        red, reset = "\x1b[31m", "\x1b[39;49;00m"
+        colored_text = f"extra{red}A{reset}ordin{red}B{reset}ary"
+        txt = split_into_lines(colored_text, 100, 100)
+        assert len(txt) == 1
+        assert " " not in uncolorize(txt[0])
+        assert uncolorize(txt[0]) == "extraAordinBary"


### PR DESCRIPTION
## Bug

`split_into_lines()` in `beets/util/layout.py` reconstructs "words" from `ESC_TEXT_REGEX.finditer()` matches to correctly wrap colored diff text at whitespace. Each match has `pretext`/`esc`/`text`/`reset`/`posttext` groups; `posttext` is `[^ESC]*` (greedy), so it always consumes all plain text up to the *next* escape sequence. That means **`pretext` is structurally always empty for every match after the first** — the regex engine's next match simply starts right where the previous one's `posttext` left off.

The code treats an empty `pretext` as proof there's a word boundary ("space before") right there:

```python
else:
    # pretext empty, treat as if there is a space before
    space_before_text = True
```

This is only actually true for the *first* match (where empty pretext really does mean "start of string"). For every later match, it's a coincidence of the regex structure, not evidence of a real space — so a word containing **two or more separately-colored spans** (e.g. two highlighted typo-fix characters within one word) gets a spurious space inserted at the second span.

```python
from beets.util.color import uncolorize
from beets.util.layout import split_into_lines

RED, RESET = "\x1b[31m", "\x1b[39;49;00m"
text = f"extra{RED}A{RESET}ordin{RED}B{RESET}ary"   # one word: "extraAordinBary"
lines = split_into_lines(text, 100, 100)
uncolorize(lines[0])
# before: 'extraAordin Bary'  -- word incorrectly split
# after:  'extraAordinBary'   -- correct
```

`split_into_lines` is reachable from `get_layout_lines`/`get_column_layout`, used by `beets/ui/commands/import_/display.py` to wrap diff output during `beet import` when a line exceeds terminal width. The colored text comes from `colordiff()` (`beets/util/diff.py`), which produces exactly this multi-span-per-word coloring whenever a correction touches two non-adjacent parts of the same word.

## Fix

Track the real boundary state explicitly across `finditer` iterations, instead of inferring it purely from the current match's `pretext` being empty:

```python
prev_ends_with_space = True  # start of string is a boundary
for m in ESC_TEXT_REGEX.finditer(string):
    ...
    if m.group("pretext") != "":
        ...
    else:
        space_before_text = prev_ends_with_space
    ...
    # at the end of the loop body:
    if m.group("posttext"):
        prev_ends_with_space = m.group("posttext")[-1] == " "
    else:
        prev_ends_with_space = m.group("text")[-1] == " "
```

(`posttext` empty means `reset` is followed directly by the next escape with nothing in between, so the boundary question falls back to whether the current match's own `text` ended in a space.)

## Testing

Added `test_split_into_lines_two_spans_in_one_word` to `test/util/test_layout.py`. Verified red on `master` (`git stash` the source fix — the word gets split with a spurious space), green after. Full `test/util/` suite (191 passed, 8 skipped — no PIL/ImageMagick/platform-specific) passes with no regressions, including the existing multi-span test cases in `test_layout.py` (which cover the every-match-has-a-real-space case, e.g. `"test " * 3` — confirmed my fix's `text[-1]==" "` fallback keeps those correctly separated). `ruff check`/`ruff format --check`/`mypy` clean.

Added a changelog entry per `CONTRIBUTING.rst`'s reminder.

## Duplicate-work check

No open PR touches `layout.py`.

---
This PR was drafted with AI assistance (Claude); I independently reproduced the bug against the real, unmodified module and verified the fix. I reviewed the change and take responsibility for it.