### PR TITLE
fix(functemplate): empty ${} inside a call argument truncates the argument list

### DIFF
--- a/beets/util/functemplate.py
+++ b/beets/util/functemplate.py
@@ -380,8 +380,13 @@ class Parser:
             # A symbol like ${this}.
             self.pos += 1  # Skip opening.
             closer = self.string.find(GROUP_CLOSE, self.pos)
-            if closer == -1 or closer == self.pos:
-                # No closing brace found or identifier is empty.
+            if closer == -1:
+                # No closing brace found.
+                self.parts.append(self.string[start_pos : self.pos])
+            elif closer == self.pos:
+                # Empty identifier: consume through the closing brace so it
+                # cannot be mistaken for an enclosing call's terminator.
+                self.pos = closer + 1
                 self.parts.append(self.string[start_pos : self.pos])
             else:
                 # Closer found.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -95,6 +95,9 @@ Bug fixes
   valid date/time string" error instead of crashing with an uncaught
   ``KeyError``. A ``|`` was being accepted as a relative-date unit due to a
   regular expression character-class typo.
+- Path formats: an empty ``${}`` inside a function call argument no longer
+  truncates the argument list and leaks the rest of the template as literal
+  text.
 
 ..
     For plugin developers

--- a/test/util/test_functemplate.py
+++ b/test/util/test_functemplate.py
@@ -115,6 +115,19 @@ class ParseTest(unittest.TestCase):
     def test_empty_braces_symbol(self):
         assert list(_normparse("a ${} b")) == ["a ${} b"]
 
+    def test_empty_braces_symbol_inside_call_arg(self):
+        parts = list(_normparse("%foo{a${}b}"))
+        assert len(parts) == 1
+        self._assert_call(parts[0], "foo", 1)
+        assert list(_normexpr(parts[0].args[0])) == ["a${}b"]
+
+    def test_empty_braces_symbol_inside_call_arg_list(self):
+        parts = list(_normparse("%foo{a${}b,baz}"))
+        assert len(parts) == 1
+        self._assert_call(parts[0], "foo", 2)
+        assert list(_normexpr(parts[0].args[0])) == ["a${}b"]
+        assert list(_normexpr(parts[0].args[1])) == ["baz"]
+
     def test_call_without_args_at_end(self):
         assert list(_normparse("foo %bar")) == ["foo %bar"]
 


### PR DESCRIPTION
A path format like `%upper{a${}b}` evaluates to `A${b}` instead of `A${}B`, and `%if{1,a${}b,c}` collapses to `a${}b` — the rest of the template leaks out as literal text.

### Cause

`Parser.parse_symbol` handles "no closing brace found" and "identifier is empty" in the same branch:

```python
closer = self.string.find(GROUP_CLOSE, self.pos)
if closer == -1 or closer == self.pos:
    # No closing brace found or identifier is empty.
    self.parts.append(self.string[start_pos : self.pos])
```

Both emit `${` as literal text, but the two cases need different amounts of input consumed. With an empty identifier the closing brace exists and is left unconsumed, so `parse_argument_list` reads it as the enclosing call's terminator. The argument list ends early and the remainder becomes raw text:

```
%foo{a${}b}     -> Call('foo', [Expression(['a', '${'])]), 'b}'
%foo{a${}b,baz} -> Call('foo', [Expression(['a', '${'])]), 'b,baz}'
```

At the top level `}` is not a terminator, so `a ${} b` parses correctly — which is why the existing `test_empty_braces_symbol` passes and this went unnoticed. Only nesting inside a function-call argument triggers it.

### Fix

Split the branch so an empty identifier consumes through the closing brace. `${}` stays literal text in both contexts; the `closer == -1` path is unchanged.

### Verification

Both new tests fail on master (`assert 2 == 1` — the leaked `'b,baz}'` part) and pass with the fix. Full `test/util/test_functemplate.py` passes (49/49), as does `test/test_library.py` (170 passed). `ruff check`, `ruff format --check`, `mypy`, and `docstrfmt --check` on the changelog are all clean.

---

AI disclosure: drafted with Claude Code (Opus 4.8), including the root-cause trace and tests. I ran the repro and the full test suite locally and reviewed the diff before opening this.