### PR TITLE
use pathlib in tests: use only Path-based attributes on PathsMixin/TestHelper

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -253,3 +253,11 @@ f167dc29e41439e342c04c073758102b2a2e1af8
 9b375d0b2d2dc9388892f1b901aae67ab0ad8290
 # typing: type the rest of beets.library.models
 9022cb5ed7fddf60c1156dc3ca7e3a540dc8f7f2
+# Replace ImporterMixin.import_dir attribute with ImporterMixin.import_path
+7970a90214fcd64ab5fef1c71b7bf1413ad6ce86
+# Replace TestHelper.libdir attribute with TestHelper.lib_path
+dc2826fa4b32b625eb4ac9d71934176edde2443e
+# Replace PathsMixin.temp_dir attribute with PathsMixin.temp_dir_path
+2e9ace7b20e776ad10127b2f6ac76791e2a19704
+# Rename PathsMixin.temp_dir_path to PathsMixin.temp_path for consistency
+d24c0d341ec6074c343cd8054083fe358da8fa14

--- a/beets/dbcore/types.py
+++ b/beets/dbcore/types.py
@@ -6,6 +6,7 @@ import re
 import time
 import typing
 from abc import ABC
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar, cast
 
 import beets
@@ -374,6 +375,9 @@ class BasePathType(Type[bytes, N]):
         return util.normpath(string)
 
     def normalize(self, value: Any) -> bytes | N:
+        if isinstance(value, Path):
+            value = str(value)
+
         if isinstance(value, str):
             # Paths stored internally as encoded bytes.
             return util.bytestring_path(value)

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -171,7 +171,7 @@ class PathsMixin:
     resource_path = Path(os.fsdecode(_common.RSRC)) / "full.mp3"
 
     @cached_property
-    def temp_dir_path(self) -> Path:
+    def temp_path(self) -> Path:
         return Path(self.create_temp_dir())
 
     def create_temp_dir(self, **kwargs: Any) -> str:
@@ -179,7 +179,7 @@ class PathsMixin:
 
     def remove_temp_dir(self) -> None:
         """Delete the temporary directory created by `create_temp_dir`."""
-        shutil.rmtree(self.temp_dir_path)
+        shutil.rmtree(self.temp_path)
 
 
 class TestHelper(RunMixin, PathsMixin, ConfigMixin):
@@ -223,7 +223,7 @@ class TestHelper(RunMixin, PathsMixin, ConfigMixin):
 
     @cached_property
     def lib_path(self) -> Path:
-        lib_path = self.temp_dir_path / "libdir"
+        lib_path = self.temp_path / "libdir"
         lib_path.mkdir(exist_ok=True)
         return lib_path
 
@@ -238,10 +238,10 @@ class TestHelper(RunMixin, PathsMixin, ConfigMixin):
 
         Sets the following properties on itself.
 
-        - ``temp_dir_path`` Path to a temporary directory containing all
+        - ``temp_path`` Path to a temporary directory containing all
           files specific to beets
 
-        - ``lib_path`` Path to a subfolder of ``temp_dir_path``, containing the
+        - ``lib_path`` Path to a subfolder of ``temp_path``, containing the
           library's media files. Same as ``config['directory']``.
 
         - ``lib`` Library instance created with the settings from
@@ -249,7 +249,7 @@ class TestHelper(RunMixin, PathsMixin, ConfigMixin):
 
         Make sure you call ``teardown_beets()`` afterwards.
         """
-        temp_dir_str = str(self.temp_dir_path)
+        temp_dir_str = str(self.temp_path)
         self.env_patcher = patch.dict(
             "os.environ",
             {
@@ -390,14 +390,14 @@ class TestHelper(RunMixin, PathsMixin, ConfigMixin):
         images: list[str] | None = None,
         target_dir: util.PathLike | None = None,
     ) -> bytes:
-        """Copy a fixture mediafile with the extension to `temp_dir_path`.
+        """Copy a fixture mediafile with the extension to `temp_path`.
 
         `images` is a subset of 'png', 'jpg', and 'tiff'. For each
         specified extension a cover art image is added to the media
         file.
         """
         if not target_dir:
-            target_dir = self.temp_dir_path
+            target_dir = self.temp_path
         src = os.path.join(_common.RSRC, util.bytestring_path(f"full.{ext}"))
         handle, path = mkstemp(dir=target_dir)
         path = bytestring_path(path)
@@ -429,16 +429,14 @@ class TestHelper(RunMixin, PathsMixin, ConfigMixin):
 
         If `dir_` is given, it is prepended to `path`. After that, if the
         path is relative, it is resolved with respect to
-        `self.temp_dir_path`.
+        `self.temp_path`.
         """
         bytes_path = os.fsencode(path)
         if dir_:
             bytes_path = os.path.join(os.fsencode(dir_), bytes_path)
 
         if not os.path.isabs(bytes_path):
-            bytes_path = os.path.join(
-                os.fsencode(self.temp_dir_path), bytes_path
-            )
+            bytes_path = os.path.join(os.fsencode(self.temp_path), bytes_path)
 
         parent = os.path.dirname(bytes_path)
         if not os.path.isdir(syspath(parent)):
@@ -573,7 +571,7 @@ class ImporterMixin(PathsMixin, ConfigMixin):
 
     @cached_property
     def import_path(self) -> Path:
-        import_path = self.temp_dir_path / "import"
+        import_path = self.temp_path / "import"
         import_path.mkdir(exist_ok=True)
         return import_path
 

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -231,10 +231,6 @@ class TestHelper(RunMixin, PathsMixin, ConfigMixin):
         lib_path.mkdir(exist_ok=True)
         return lib_path
 
-    @cached_property
-    def libdir(self) -> bytes:
-        return bytestring_path(self.lib_path)
-
     # TODO automate teardown through hook registration
 
     def setup_beets(self) -> None:
@@ -249,7 +245,7 @@ class TestHelper(RunMixin, PathsMixin, ConfigMixin):
         - ``temp_dir`` Path to a temporary directory containing all
           files specific to beets
 
-        - ``libdir`` Path to a subfolder of ``temp_dir``, containing the
+        - ``lib_path`` Path to a subfolder of ``temp_dir``, containing the
           library's media files. Same as ``config['directory']``.
 
         - ``lib`` Library instance created with the settings from
@@ -637,7 +633,7 @@ class ImporterMixin(PathsMixin, ConfigMixin):
         for album_id in range(base_idx, count + base_idx):
             self.prepare_album_for_import(1, album_id=album_id)
 
-    def _get_import_session(self, import_dir: util.PathLike) -> ImportSession:
+    def _get_import_session(self, import_dir: Path) -> ImportSession:
         return ImportSessionFixture(
             self.lib,
             loghandler=None,
@@ -646,7 +642,7 @@ class ImporterMixin(PathsMixin, ConfigMixin):
         )
 
     def setup_importer(
-        self, import_dir: bytes | None = None, **kwargs: Any
+        self, import_dir: Path | None = None, **kwargs: Any
     ) -> ImportSession:
         self.config["import"].set_args({**self.default_import_config, **kwargs})
         self.importer = self._get_import_session(import_dir or self.import_path)
@@ -781,9 +777,7 @@ class TerminalImportSessionFixture(TerminalImportSession):
 class TerminalImportMixin(IOMixin, ImportHelper):
     """Provides_a terminal importer for the import session."""
 
-    def _get_import_session(
-        self, import_dir: util.PathLike
-    ) -> importer.ImportSession:
+    def _get_import_session(self, import_dir: Path) -> importer.ImportSession:
         return TerminalImportSessionFixture(
             self.lib,
             loghandler=None,

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -583,10 +583,6 @@ class ImporterMixin(PathsMixin, ConfigMixin):
         import_path.mkdir(exist_ok=True)
         return import_path
 
-    @cached_property
-    def import_dir(self) -> bytes:
-        return bytestring_path(self.import_path)
-
     def prepare_track_for_import(
         self, track_id: int, album_path: Path, album_id: int | None = None
     ) -> Path:
@@ -641,16 +637,19 @@ class ImporterMixin(PathsMixin, ConfigMixin):
         for album_id in range(base_idx, count + base_idx):
             self.prepare_album_for_import(1, album_id=album_id)
 
-    def _get_import_session(self, import_dir: bytes) -> ImportSession:
+    def _get_import_session(self, import_dir: util.PathLike) -> ImportSession:
         return ImportSessionFixture(
-            self.lib, loghandler=None, query=None, paths=[import_dir]
+            self.lib,
+            loghandler=None,
+            query=None,
+            paths=[os.fsencode(import_dir)],
         )
 
     def setup_importer(
         self, import_dir: bytes | None = None, **kwargs: Any
     ) -> ImportSession:
         self.config["import"].set_args({**self.default_import_config, **kwargs})
-        self.importer = self._get_import_session(import_dir or self.import_dir)
+        self.importer = self._get_import_session(import_dir or self.import_path)
         return self.importer
 
     def setup_singleton_importer(self, **kwargs: Any) -> ImportSession:
@@ -782,13 +781,15 @@ class TerminalImportSessionFixture(TerminalImportSession):
 class TerminalImportMixin(IOMixin, ImportHelper):
     """Provides_a terminal importer for the import session."""
 
-    def _get_import_session(self, import_dir: bytes) -> importer.ImportSession:
+    def _get_import_session(
+        self, import_dir: util.PathLike
+    ) -> importer.ImportSession:
         return TerminalImportSessionFixture(
             self.lib,
             loghandler=None,
             query=None,
             io=self.request.getfixturevalue("io"),
-            paths=[import_dir],
+            paths=[os.fsencode(import_dir)],
         )
 
 

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -222,10 +222,6 @@ class TestHelper(RunMixin, PathsMixin, ConfigMixin):
     db_on_disk: ClassVar[bool] = False
 
     @cached_property
-    def temp_dir(self) -> bytes:
-        return util.bytestring_path(self.temp_dir_path)
-
-    @cached_property
     def lib_path(self) -> Path:
         lib_path = self.temp_dir_path / "libdir"
         lib_path.mkdir(exist_ok=True)
@@ -242,10 +238,10 @@ class TestHelper(RunMixin, PathsMixin, ConfigMixin):
 
         Sets the following properties on itself.
 
-        - ``temp_dir`` Path to a temporary directory containing all
+        - ``temp_dir_path`` Path to a temporary directory containing all
           files specific to beets
 
-        - ``lib_path`` Path to a subfolder of ``temp_dir``, containing the
+        - ``lib_path`` Path to a subfolder of ``temp_dir_path``, containing the
           library's media files. Same as ``config['directory']``.
 
         - ``lib`` Library instance created with the settings from
@@ -394,14 +390,14 @@ class TestHelper(RunMixin, PathsMixin, ConfigMixin):
         images: list[str] | None = None,
         target_dir: util.PathLike | None = None,
     ) -> bytes:
-        """Copy a fixture mediafile with the extension to `temp_dir`.
+        """Copy a fixture mediafile with the extension to `temp_dir_path`.
 
         `images` is a subset of 'png', 'jpg', and 'tiff'. For each
         specified extension a cover art image is added to the media
         file.
         """
         if not target_dir:
-            target_dir = self.temp_dir
+            target_dir = self.temp_dir_path
         src = os.path.join(_common.RSRC, util.bytestring_path(f"full.{ext}"))
         handle, path = mkstemp(dir=target_dir)
         path = bytestring_path(path)
@@ -433,14 +429,16 @@ class TestHelper(RunMixin, PathsMixin, ConfigMixin):
 
         If `dir_` is given, it is prepended to `path`. After that, if the
         path is relative, it is resolved with respect to
-        `self.temp_dir`.
+        `self.temp_dir_path`.
         """
         bytes_path = os.fsencode(path)
         if dir_:
             bytes_path = os.path.join(os.fsencode(dir_), bytes_path)
 
         if not os.path.isabs(bytes_path):
-            bytes_path = os.path.join(self.temp_dir, bytes_path)
+            bytes_path = os.path.join(
+                os.fsencode(self.temp_dir_path), bytes_path
+            )
 
         parent = os.path.dirname(bytes_path)
         if not os.path.isdir(syspath(parent)):

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -88,6 +88,12 @@ class UseThePlugin(TestHelper):
             for module in self.modules:
                 clean_module_tempdir(module)
 
+    @pytest.fixture
+    def dpath(self) -> bytes:
+        dpath = self.temp_dir_path / "arttest"
+        os.mkdir(syspath(dpath))
+        return os.fsencode(dpath)
+
 
 class CAAData:
     """Helper mixin for mocking requests to the Cover Art Archive."""
@@ -264,12 +270,6 @@ class TestFSArt(UseThePlugin):
         return Settings(cautious=False, cover_names=("art",), fallback=None)
 
     @pytest.fixture
-    def dpath(self) -> bytes:
-        dpath = os.path.join(self.temp_dir, b"arttest")
-        os.mkdir(syspath(dpath))
-        return dpath
-
-    @pytest.fixture
     def source(self) -> fetchart.FileSystem:
         return fetchart.FileSystem(logger, self.plugin.config)
 
@@ -300,8 +300,8 @@ class TestFSArt(UseThePlugin):
             next(source.get(Album(), settings, [dpath]))
 
     def test_configured_fallback_is_used(self, source, dpath, settings) -> None:
-        fallback = os.path.join(self.temp_dir, b"a.jpg")
-        _common.touch(fallback)
+        fallback = self.temp_dir_path / "a.jpg"
+        fallback.touch()
         settings.fallback = fallback  # type: ignore
         candidate = next(source.get(Album(), settings, [dpath]))
         assert candidate.path == fallback
@@ -329,9 +329,9 @@ class TestFSArt(UseThePlugin):
         self, mock_samefile, source
     ) -> None:
         mock_samefile.side_effect = OSError("os error")
-        fallback = os.path.join(self.temp_dir, b"a.jpg")
+        fallback = self.temp_dir_path / "a.jpg"
         self.plugin.fallback = str(fallback)
-        candidate = fetchart.Candidate(logger, source.ID, fallback)
+        candidate = fetchart.Candidate(logger, source.ID, os.fsencode(fallback))
         result = self.plugin._is_candidate_fallback(candidate)
         mock_samefile.assert_called_once()
         assert not result
@@ -343,12 +343,6 @@ class TestCombined(UseThePlugin, FetchImageHelper, CAAData):
     AMAZON_URL = f"https://images.amazon.com/images/P/{ASIN}.01.LZZZZZZZ.jpg"
     AMAZON_URL_2 = f"https://images.amazon.com/images/P/{ASIN}.02.LZZZZZZZ.jpg"
     AAO_URL = f"https://www.albumart.org/index_detail.php?asin={ASIN}"
-
-    @pytest.fixture
-    def dpath(self):
-        dpath = os.path.join(self.temp_dir, b"arttest")
-        os.mkdir(syspath(dpath))
-        return dpath
 
     def test_main_interface_returns_amazon_art(self, image_request_mock):
         image_request_mock.get(self.AMAZON_URL)

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -90,7 +90,7 @@ class UseThePlugin(TestHelper):
 
     @pytest.fixture
     def dpath(self) -> bytes:
-        dpath = self.temp_dir_path / "arttest"
+        dpath = self.temp_path / "arttest"
         os.mkdir(syspath(dpath))
         return os.fsencode(dpath)
 
@@ -300,7 +300,7 @@ class TestFSArt(UseThePlugin):
             next(source.get(Album(), settings, [dpath]))
 
     def test_configured_fallback_is_used(self, source, dpath, settings) -> None:
-        fallback = self.temp_dir_path / "a.jpg"
+        fallback = self.temp_path / "a.jpg"
         fallback.touch()
         settings.fallback = fallback  # type: ignore
         candidate = next(source.get(Album(), settings, [dpath]))
@@ -329,7 +329,7 @@ class TestFSArt(UseThePlugin):
         self, mock_samefile, source
     ) -> None:
         mock_samefile.side_effect = OSError("os error")
-        fallback = self.temp_dir_path / "a.jpg"
+        fallback = self.temp_path / "a.jpg"
         self.plugin.fallback = str(fallback)
         candidate = fetchart.Candidate(logger, source.ID, os.fsencode(fallback))
         result = self.plugin._is_candidate_fallback(candidate)
@@ -847,7 +847,7 @@ class TestArtImporter(UseThePlugin):
     def _setup(self, setup_plugin):
 
         # Mock the album art fetcher to always return our test file.
-        self.art_file = self.temp_dir_path / "tmpcover.jpg"
+        self.art_file = self.temp_path / "tmpcover.jpg"
         self.art_file.touch()
         self.old_afa = self.plugin.art_for_album
         self.afa_response = fetchart.Candidate(

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -866,8 +866,8 @@ class TestArtImporter(UseThePlugin):
         self.plugin.art_for_album = art_for_album
 
         # Test library.
-        os.mkdir(syspath(os.path.join(self.libdir, b"album")))
-        itempath = os.path.join(self.libdir, b"album", b"test.mp3")
+        (self.lib_path / "album").mkdir()
+        itempath = self.lib_path / "album" / "test.mp3"
         shutil.copyfile(
             syspath(os.path.join(_common.RSRC, b"full.mp3")), syspath(itempath)
         )

--- a/test/plugins/test_bpd.py
+++ b/test/plugins/test_bpd.py
@@ -264,7 +264,7 @@ class BPDTestHelper(PluginTestCase):
         """
         # Create a config file:
         config = {
-            "pluginpath": [str(self.temp_dir_path)],
+            "pluginpath": [str(self.temp_path)],
             "plugins": "bpd",
             # use port 0 to let the OS choose a free port
             "bpd": {"host": host, "port": 0, "control_port": 0},
@@ -272,7 +272,7 @@ class BPDTestHelper(PluginTestCase):
         if password:
             config["bpd"]["password"] = password
         config_file = tempfile.NamedTemporaryFile(
-            mode="wb", dir=str(self.temp_dir_path), suffix=".yaml", delete=False
+            mode="wb", dir=str(self.temp_path), suffix=".yaml", delete=False
         )
         config_file.write(
             yaml.dump(config, Dumper=confuse.Dumper, encoding="utf-8")

--- a/test/plugins/test_bpd.py
+++ b/test/plugins/test_bpd.py
@@ -288,7 +288,7 @@ class BPDTestHelper(PluginTestCase):
                     "--library",
                     self.config["library"].as_filename(),
                     "--directory",
-                    os.fsdecode(self.libdir),
+                    str(self.lib_path),
                     "--config",
                     os.fsdecode(config_file.name),
                     "bpd",

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -32,7 +32,7 @@ class ConvertPluginHelper(IOMixin, PluginTestHelper):
 
     def setup_beets(self):
         super().setup_beets()
-        self.convert_dest = self.temp_dir_path / "convert_dest"
+        self.convert_dest = self.temp_path / "convert_dest"
         self.config["convert"] = {"dest": str(self.convert_dest)}
 
     def tagged_copy_cmd(self, tag):

--- a/test/plugins/test_hook.py
+++ b/test/plugins/test_hook.py
@@ -60,7 +60,7 @@ class TestHookCommand(HookTestCase):
 
     @pytest.fixture(autouse=True)
     def setUp(self):
-        self.paths = [str(self.temp_dir_path / e) for e in self.EVENTS]
+        self.paths = [str(self.temp_path / e) for e in self.EVENTS]
 
     def _test_command(
         self,

--- a/test/plugins/test_importadded.py
+++ b/test/plugins/test_importadded.py
@@ -81,7 +81,7 @@ class ImportAddedTest(PluginMixin, AutotagImportTestCase):
         # Newer Item path mtimes as if Beets had modified them
         modify_mtimes(items_added_before.keys(), offset=10000)
         # Reimport
-        self.setup_importer(import_dir=self.libdir)
+        self.setup_importer(import_dir=self.lib_path)
         self.importer.run()
         # Verify the reimported items
         album = self.lib.albums().get()
@@ -123,7 +123,7 @@ class ImportAddedTest(PluginMixin, AutotagImportTestCase):
         # Newer Item path mtimes as if Beets had modified them
         modify_mtimes(items_added_before.keys(), offset=10000)
         # Reimport
-        self.setup_importer(import_dir=self.libdir, singletons=True)
+        self.setup_importer(import_dir=self.lib_path, singletons=True)
         self.importer.run()
         # Verify the reimported items
         items_added_after = {item.path: item.added for item in self.lib.items()}

--- a/test/plugins/test_importfeeds.py
+++ b/test/plugins/test_importfeeds.py
@@ -16,7 +16,7 @@ class ImportFeedsTest(PluginTestCase):
     def setUp(self):
         super().setUp()
         self.importfeeds = ImportFeedsPlugin()
-        self.feeds_dir = self.temp_dir_path / "importfeeds"
+        self.feeds_dir = self.temp_path / "importfeeds"
         self.config["importfeeds"]["dir"] = str(self.feeds_dir)
 
     def test_multi_format_album_playlist(self):

--- a/test/plugins/test_importsource.py
+++ b/test/plugins/test_importsource.py
@@ -91,7 +91,7 @@ class ImportSourceTest(IOMixin, PluginMixin, AutotagImportTestCase):
         mb_albumid = album.mb_albumid
 
         # Reimport from library
-        reimporter = self.setup_importer(import_dir=self.libdir)
+        reimporter = self.setup_importer(import_dir=self.lib_path)
         reimporter.add_choice(importer.Action.APPLY)
         reimporter.run()
 

--- a/test/plugins/test_ipfs.py
+++ b/test/plugins/test_ipfs.py
@@ -36,8 +36,8 @@ class IPFSPluginTest(PluginTestCase):
             assert found
 
     def test_get_remote_lib_accepts_library_path(self):
-        self.lib.path = self.temp_dir_path / "library.db"
-        remote_dir = self.temp_dir_path / "remotes"
+        self.lib.path = self.temp_path / "library.db"
+        remote_dir = self.temp_path / "remotes"
         remote_dir.mkdir()
 
         remote_lib = library.Library(remote_dir / "joined.db")

--- a/test/plugins/test_permissions.py
+++ b/test/plugins/test_permissions.py
@@ -6,7 +6,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from beets.test._common import touch
 from beets.test.helper import AsIsImporterMixin, ImportHelper, PluginMixin
 from beetsplug.permissions import (
     check_permissions,
@@ -61,7 +60,7 @@ class TestPermissionsPlugin(AsIsImporterMixin, PluginMixin, ImportHelper):
             pytest.skip("permissions not available on Windows")
         self.run_asis_importer()
         album = self.lib.albums().get()
-        artpath = os.path.join(self.temp_dir, b"cover.jpg")
-        touch(artpath)
+        artpath = self.temp_dir_path / "cover.jpg"
+        artpath.touch()
         album.set_art(artpath)
         assert expect_success == check_permissions(album.artpath, 0o777)

--- a/test/plugins/test_permissions.py
+++ b/test/plugins/test_permissions.py
@@ -60,7 +60,7 @@ class TestPermissionsPlugin(AsIsImporterMixin, PluginMixin, ImportHelper):
             pytest.skip("permissions not available on Windows")
         self.run_asis_importer()
         album = self.lib.albums().get()
-        artpath = self.temp_dir_path / "cover.jpg"
+        artpath = self.temp_path / "cover.jpg"
         artpath.touch()
         album.set_art(artpath)
         assert expect_success == check_permissions(album.artpath, 0o777)

--- a/test/plugins/test_permissions.py
+++ b/test/plugins/test_permissions.py
@@ -33,8 +33,8 @@ class TestPermissionsPlugin(AsIsImporterMixin, PluginMixin, ImportHelper):
         if platform.system() == "Windows":
             pytest.skip("permissions not available on Windows")
 
-        track_file = os.path.join(self.import_dir, b"album", b"track_1.mp3")
-        assert os.stat(track_file).st_mode & 0o777 != 511
+        track_file = self.import_path / "album" / "track_1.mp3"
+        assert track_file.stat().st_mode & 0o777 != 511
 
         self.run_asis_importer()
         item = self.lib.items().get()

--- a/test/plugins/test_playlist.py
+++ b/test/plugins/test_playlist.py
@@ -28,7 +28,7 @@ class PlaylistTestCase(PluginTestCase):
         ]:
             self.add_album(path=self.music_dir / p, title=title, album=album)
 
-        self.playlist_dir = self.temp_dir_path / "playlists"
+        self.playlist_dir = self.temp_path / "playlists"
         self.playlist_dir.mkdir(parents=True, exist_ok=True)
         self.config["directory"] = str(self.music_dir)
         self.config["playlist"]["playlist_dir"] = str(self.playlist_dir)

--- a/test/plugins/test_plugin_mediafield.py
+++ b/test/plugins/test_plugin_mediafield.py
@@ -31,7 +31,7 @@ class ExtendedFieldTestMixin(BeetsTestCase):
     def _mediafile_fixture(self, name, extension="mp3"):
         name = f"{name}.{extension}"
         src = os.path.join(os.fsdecode(_common.RSRC), name)
-        target = self.temp_dir_path / name
+        target = self.temp_path / name
         shutil.copy(syspath(src), syspath(target))
         return mediafile.MediaFile(target)
 

--- a/test/plugins/test_plugin_mediafield.py
+++ b/test/plugins/test_plugin_mediafield.py
@@ -10,7 +10,7 @@ from beets.library import Item
 from beets.plugins import BeetsPlugin
 from beets.test import _common
 from beets.test.helper import BeetsTestCase
-from beets.util import bytestring_path, syspath
+from beets.util import syspath
 
 field_extension = mediafile.MediaField(
     mediafile.MP3DescStorageStyle("customtag"),
@@ -29,9 +29,9 @@ list_field_extension = mediafile.ListMediaField(
 
 class ExtendedFieldTestMixin(BeetsTestCase):
     def _mediafile_fixture(self, name, extension="mp3"):
-        name = bytestring_path(f"{name}.{extension}")
-        src = os.path.join(_common.RSRC, name)
-        target = os.path.join(self.temp_dir, name)
+        name = f"{name}.{extension}"
+        src = os.path.join(os.fsdecode(_common.RSRC), name)
+        target = self.temp_dir_path / name
         shutil.copy(syspath(src), syspath(target))
         return mediafile.MediaFile(target)
 

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -25,7 +25,7 @@ _p = pytest.param
 class PlaylistDirMixin(PathsMixin):
     @property
     def playlist_dir(self) -> Path:
-        return self.temp_dir_path / "playlists"
+        return self.temp_path / "playlists"
 
 
 class SmartPlaylistTest(PlaylistDirMixin, BeetsTestCase):

--- a/test/plugins/test_web.py
+++ b/test/plugins/test_web.py
@@ -352,9 +352,9 @@ class TestWebPlugin(WebPluginMixin, PytestTestHelper):
         web.app.config["READONLY"] = False
 
         # Create an item with a file
-        ipath = os.path.join(self.temp_dir, b"testfile1.mp3")
+        ipath = self.temp_dir_path / "testfile1.mp3"
         shutil.copy(os.path.join(_common.RSRC, b"full.mp3"), ipath)
-        assert os.path.exists(ipath)
+        assert ipath.exists()
         item_id = self.lib.add(Item.from_path(ipath))
 
         # Check we can find the temporary item we just created
@@ -373,16 +373,16 @@ class TestWebPlugin(WebPluginMixin, PytestTestHelper):
         assert response.status_code == 404
 
         # Check the file has not gone
-        assert os.path.exists(ipath)
-        os.remove(ipath)
+        assert ipath.exists()
+        ipath.unlink()
 
     def test_delete_item_with_file(self):
         web.app.config["READONLY"] = False
 
         # Create an item with a file
-        ipath = os.path.join(self.temp_dir, b"testfile2.mp3")
+        ipath = self.temp_dir_path / "testfile2.mp3"
         shutil.copy(os.path.join(_common.RSRC, b"full.mp3"), ipath)
-        assert os.path.exists(ipath)
+        assert ipath.exists()
         item_id = self.lib.add(Item.from_path(ipath))
 
         # Check we can find the temporary item we just created
@@ -401,7 +401,7 @@ class TestWebPlugin(WebPluginMixin, PytestTestHelper):
         assert response.status_code == 404
 
         # Check the file has gone
-        assert not os.path.exists(ipath)
+        assert not ipath.exists()
 
     def test_delete_item_query(self):
         web.app.config["READONLY"] = False
@@ -687,9 +687,9 @@ class TestWebPlugin(WebPluginMixin, PytestTestHelper):
         self.lib.get_item(item_id).remove()
 
     def test_get_item_file(self):
-        ipath = os.path.join(self.temp_dir, b"testfile2.mp3")
+        ipath = self.temp_dir_path / "testfile2.mp3"
         shutil.copy(os.path.join(_common.RSRC, b"full.mp3"), ipath)
-        assert os.path.exists(ipath)
+        assert ipath.exists()
         item_id = self.lib.add(Item.from_path(ipath))
 
         response = self.client.get(f"/item/{item_id}/file")

--- a/test/plugins/test_web.py
+++ b/test/plugins/test_web.py
@@ -352,7 +352,7 @@ class TestWebPlugin(WebPluginMixin, PytestTestHelper):
         web.app.config["READONLY"] = False
 
         # Create an item with a file
-        ipath = self.temp_dir_path / "testfile1.mp3"
+        ipath = self.temp_path / "testfile1.mp3"
         shutil.copy(os.path.join(_common.RSRC, b"full.mp3"), ipath)
         assert ipath.exists()
         item_id = self.lib.add(Item.from_path(ipath))
@@ -380,7 +380,7 @@ class TestWebPlugin(WebPluginMixin, PytestTestHelper):
         web.app.config["READONLY"] = False
 
         # Create an item with a file
-        ipath = self.temp_dir_path / "testfile2.mp3"
+        ipath = self.temp_path / "testfile2.mp3"
         shutil.copy(os.path.join(_common.RSRC, b"full.mp3"), ipath)
         assert ipath.exists()
         item_id = self.lib.add(Item.from_path(ipath))
@@ -687,7 +687,7 @@ class TestWebPlugin(WebPluginMixin, PytestTestHelper):
         self.lib.get_item(item_id).remove()
 
     def test_get_item_file(self):
-        ipath = self.temp_dir_path / "testfile2.mp3"
+        ipath = self.temp_path / "testfile2.mp3"
         shutil.copy(os.path.join(_common.RSRC, b"full.mp3"), ipath)
         assert ipath.exists()
         item_id = self.lib.add(Item.from_path(ipath))

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -21,7 +21,7 @@ class MoveTest(BeetsTestCase):
 
         # make a temporary file
         self.temp_music_file_name = "temp.mp3"
-        self.path = self.temp_dir_path / self.temp_music_file_name
+        self.path = self.temp_path / self.temp_music_file_name
         shutil.copy(self.resource_path, self.path)
 
         # add it to a temporary library
@@ -37,7 +37,7 @@ class MoveTest(BeetsTestCase):
         self.i.title = "three"
         self.dest = self.lib_path / "one" / "two" / "three.mp3"
 
-        self.otherdir = self.temp_dir_path / "testotherdir"
+        self.otherdir = self.temp_path / "testotherdir"
 
     def test_move_arrives(self):
         self.i.move()
@@ -184,7 +184,7 @@ class MoveTest(BeetsTestCase):
 
     @unittest.skipUnless(_common.HAVE_HARDLINK, "need hardlinks")
     def test_hardlink_from_symlink(self):
-        link_path = self.temp_dir_path / "temp_link.mp3"
+        link_path = self.temp_path / "temp_link.mp3"
         link_path.symlink_to(self.temp_music_file_name)
         self.i.path = link_path
         self.i.move(operation=MoveOperation.HARDLINK)
@@ -213,7 +213,7 @@ class AlbumFileTest(BeetsTestCase):
         # Make an album.
         self.ai = self.lib.add_album((self.i,))
         # Alternate destination dir.
-        self.otherdir = os.fsencode(self.temp_dir_path / "testotherdir")
+        self.otherdir = os.fsencode(self.temp_path / "testotherdir")
 
     def test_albuminfo_move_changes_paths(self):
         self.ai.album = "newAlbumName"
@@ -280,7 +280,7 @@ class ArtFileTest(BeetsTestCase):
         self.ai.artpath = art_bytes
         self.ai.store()
         # Alternate destination dir.
-        self.otherdir = os.fsencode(self.temp_dir_path / "testotherdir")
+        self.otherdir = os.fsencode(self.temp_path / "testotherdir")
 
     def test_art_deleted_when_items_deleted(self):
         assert self.art.exists()
@@ -493,7 +493,7 @@ class RemoveTest(BeetsTestCase):
         assert self.lib_path.exists()
 
     def test_removing_last_item_in_album_with_albumart_prunes_dir(self):
-        artfile = self.temp_dir_path / "testart.jpg"
+        artfile = self.temp_path / "testart.jpg"
         artfile.touch()
         self.ai.set_art(artfile)
         self.ai.store()

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -315,8 +315,8 @@ class ArtFileTest(BeetsTestCase):
     def test_setart_copies_image(self):
         util.remove(self.art)
 
-        newart = os.path.join(self.libdir, b"newart.jpg")
-        touch(newart)
+        newart = self.lib_path / "newart.jpg"
+        newart.touch()
         i2 = item()
         i2.path = self.i.path
         i2.artist = "someArtist"
@@ -331,8 +331,8 @@ class ArtFileTest(BeetsTestCase):
         util.remove(self.art)
 
         # Original art.
-        newart = os.path.join(self.libdir, b"newart.jpg")
-        touch(newart)
+        newart = self.lib_path / "newart.jpg"
+        newart.touch()
         i2 = item()
         i2.path = self.i.path
         i2.artist = "someArtist"
@@ -345,8 +345,8 @@ class ArtFileTest(BeetsTestCase):
         assert ai.art_filepath.exists()
 
     def test_setart_to_existing_but_unset_art_works(self):
-        newart = os.path.join(self.libdir, b"newart.jpg")
-        touch(newart)
+        newart = self.lib_path / "newart.jpg"
+        newart.touch()
         i2 = item()
         i2.path = self.i.path
         i2.artist = "someArtist"
@@ -362,8 +362,8 @@ class ArtFileTest(BeetsTestCase):
         assert ai.art_filepath.exists()
 
     def test_setart_to_conflicting_file_replaces_it(self):
-        newart = os.path.join(self.libdir, b"newart.jpg")
-        touch(newart)
+        newart = self.lib_path / "newart.jpg"
+        newart.touch()
         i2 = item()
         i2.path = self.i.path
         i2.artist = "someArtist"
@@ -380,8 +380,8 @@ class ArtFileTest(BeetsTestCase):
         assert artdest == ai.artpath
 
     def test_setart_replaces_old_art_at_different_path(self):
-        newart = os.path.join(self.libdir, b"newart.png")
-        touch(newart)
+        newart = self.lib_path / "newart.png"
+        newart.touch()
         i2 = item()
         i2.path = self.i.path
         i2.artist = "someArtist"
@@ -394,8 +394,8 @@ class ArtFileTest(BeetsTestCase):
         assert os.path.exists(syspath(old_artpath))
 
         # Set new art with a different extension.
-        another_art = os.path.join(self.libdir, b"another.jpg")
-        touch(another_art)
+        another_art = self.lib_path / "another.jpg"
+        another_art.touch()
         ai.set_art(another_art)
 
         # Old art should be removed.
@@ -405,9 +405,9 @@ class ArtFileTest(BeetsTestCase):
     def test_setart_sets_permissions(self):
         util.remove(self.art)
 
-        newart = os.path.join(self.libdir, b"newart.jpg")
-        touch(newart)
-        os.chmod(syspath(newart), 0o400)  # read-only
+        newart = self.lib_path / "newart.jpg"
+        newart.touch()
+        newart.chmod(0o400)  # read-only
 
         try:
             i2 = item()

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -184,14 +184,13 @@ class MoveTest(BeetsTestCase):
 
     @unittest.skipUnless(_common.HAVE_HARDLINK, "need hardlinks")
     def test_hardlink_from_symlink(self):
-        link_path = join(self.temp_dir, b"temp_link.mp3")
-        link_source = join("./", self.temp_music_file_name)
-        os.symlink(syspath(link_source), syspath(link_path))
+        link_path = self.temp_dir_path / "temp_link.mp3"
+        link_path.symlink_to(self.temp_music_file_name)
         self.i.path = link_path
         self.i.move(operation=MoveOperation.HARDLINK)
 
-        s1 = os.stat(syspath(self.path))
-        s2 = os.stat(syspath(self.dest))
+        s1 = self.path.stat()
+        s2 = self.dest.stat()
         assert (s1[stat.ST_INO], s1[stat.ST_DEV]) == (
             s2[stat.ST_INO],
             s2[stat.ST_DEV],
@@ -214,7 +213,7 @@ class AlbumFileTest(BeetsTestCase):
         # Make an album.
         self.ai = self.lib.add_album((self.i,))
         # Alternate destination dir.
-        self.otherdir = os.path.join(self.temp_dir, b"testotherdir")
+        self.otherdir = os.fsencode(self.temp_dir_path / "testotherdir")
 
     def test_albuminfo_move_changes_paths(self):
         self.ai.album = "newAlbumName"
@@ -281,7 +280,7 @@ class ArtFileTest(BeetsTestCase):
         self.ai.artpath = art_bytes
         self.ai.store()
         # Alternate destination dir.
-        self.otherdir = os.path.join(self.temp_dir, b"testotherdir")
+        self.otherdir = os.fsencode(self.temp_dir_path / "testotherdir")
 
     def test_art_deleted_when_items_deleted(self):
         assert self.art.exists()
@@ -494,8 +493,8 @@ class RemoveTest(BeetsTestCase):
         assert self.lib_path.exists()
 
     def test_removing_last_item_in_album_with_albumart_prunes_dir(self):
-        artfile = os.path.join(self.temp_dir, b"testart.jpg")
-        touch(artfile)
+        artfile = self.temp_dir_path / "testart.jpg"
+        artfile.touch()
         self.ai.set_art(artfile)
         self.ai.store()
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -14,6 +14,7 @@ from io import StringIO
 from pathlib import Path
 from tarfile import TarFile
 from tempfile import mkstemp
+from typing import Literal
 from unittest.mock import Mock, patch
 from zipfile import ZipFile
 
@@ -37,7 +38,7 @@ from beets.test.helper import (
     TestHelper,
     has_program,
 )
-from beets.util import bytestring_path, displayable_path, syspath
+from beets.util import bytestring_path, syspath
 from beets.util.extension import remux_mpeglayer3_wav
 
 
@@ -233,7 +234,7 @@ class TestImportZip(AsIsImporterMixin, ImportHelper):
 
 class TestImportTar(TestImportZip):
     def create_archive(self):
-        (handle, path) = mkstemp(dir=syspath(self.temp_dir))
+        (handle, path) = mkstemp(dir=self.temp_dir_path)
         path = bytestring_path(path)
         os.close(handle)
         archive = TarFile(os.fsdecode(path), mode="w")
@@ -388,9 +389,9 @@ class TestImportFormat(ImportHelper):
 
     def test_recognize_format_already_exist(self, caplog):
         resource_path = os.path.join(_common.RSRC, b"no_ext")
-        temp_resource_path = os.path.join(self.temp_dir, b"no_ext")
+        temp_resource_path = self.temp_dir_path / "no_ext"
         util.copy(resource_path, temp_resource_path)
-        new_path = os.path.join(self.temp_dir, b"no_ext.mp3")
+        new_path = self.temp_dir_path / "no_ext.mp3"
         util.copy(temp_resource_path, new_path)
         self.setup_importer(autotag=False)
         self.importer.paths = [temp_resource_path]
@@ -412,22 +413,22 @@ class TestImportFormat(ImportHelper):
     def test_recognize_format_change_original(self):
         config["import"]["fix_ext_inplace"] = True
         resource_src = os.path.join(_common.RSRC, b"no_ext")
-        resource_path = os.path.join(self.temp_dir, b"no_ext")
+        resource_path = self.temp_dir_path / "no_ext"
         util.copy(resource_src, resource_path)
         self.setup_importer(autotag=False)
         self.importer.paths = [resource_path]
         self.importer.run()
-        assert not Path(os.path.join(self.temp_dir_path, "no_ext")).exists()
+        assert not Path(self.temp_dir_path / "no_ext").exists()
 
     def test_recognize_format_keep_original(self):
         config["import"]["fix_ext_inplace"] = False
         resource_src = os.path.join(_common.RSRC, b"no_ext")
-        resource_path = os.path.join(self.temp_dir, b"no_ext")
+        resource_path = self.temp_dir_path / "no_ext"
         util.copy(resource_src, resource_path)
         self.setup_importer(autotag=False)
         self.importer.paths = [resource_path]
         self.importer.run()
-        assert Path(os.path.join(self.temp_dir_path, "no_ext")).exists()
+        assert Path(self.temp_dir_path / "no_ext").exists()
 
 
 class TestImport(PathsMixin, AutotagImportHelper):
@@ -524,24 +525,24 @@ class TestImport(PathsMixin, AutotagImportHelper):
 
     @NEEDS_FFPROBE
     def test_empty_directory_warning(self, caplog):
-        import_dir = os.path.join(self.temp_dir, b"empty")
-        self.touch(b"non-audio", dir_=import_dir)
+        import_dir = self.temp_dir_path / "empty"
+        import_dir.mkdir()
+        (import_dir / "non-audio").touch()
         self.setup_importer(import_dir=import_dir)
         with caplog.at_level("DEBUG"):
             self.importer.run()
 
-        import_dir = displayable_path(import_dir)
         assert f"No files imported from {import_dir}" in caplog.messages
 
     @NEEDS_FFPROBE
     def test_empty_directory_singleton_warning(self, caplog):
-        import_dir = os.path.join(self.temp_dir, b"empty")
-        self.touch(b"non-audio", dir_=import_dir)
+        import_dir = self.temp_dir_path / "empty"
+        import_dir.mkdir()
+        (import_dir / "non-audio").touch()
         self.setup_singleton_importer(import_dir=import_dir)
         with caplog.at_level("DEBUG"):
             self.importer.run()
 
-        import_dir = displayable_path(import_dir)
         assert f"No files imported from {import_dir}" in caplog.messages
 
     def test_asis_no_data_source(self):
@@ -1394,20 +1395,24 @@ class AlbumsInDirTest(BeetsTestCase):
         super().setUp()
 
         # create a directory structure for testing
-        self.base = os.path.abspath(os.path.join(self.temp_dir, b"tempdir"))
-        os.mkdir(syspath(self.base))
+        base = (self.temp_dir_path / "tempdir").resolve()
+        base.mkdir()
 
-        os.mkdir(syspath(os.path.join(self.base, b"album1")))
-        os.mkdir(syspath(os.path.join(self.base, b"album2")))
-        os.mkdir(syspath(os.path.join(self.base, b"more")))
-        os.mkdir(syspath(os.path.join(self.base, b"more", b"album3")))
-        os.mkdir(syspath(os.path.join(self.base, b"more", b"album4")))
+        album1_dir = base / "album1"
+        album2_dir = base / "album2"
+        album3_dir = base / "more" / "album3"
+        album4_dir = base / "more" / "album4"
+        album1_dir.mkdir()
+        album2_dir.mkdir()
+        album3_dir.mkdir(parents=True)
+        album4_dir.mkdir(parents=True)
 
-        _mkmp3(os.path.join(self.base, b"album1", b"album1song1.mp3"))
-        _mkmp3(os.path.join(self.base, b"album1", b"album1song2.mp3"))
-        _mkmp3(os.path.join(self.base, b"album2", b"album2song.mp3"))
-        _mkmp3(os.path.join(self.base, b"more", b"album3", b"album3song.mp3"))
-        _mkmp3(os.path.join(self.base, b"more", b"album4", b"album4song.mp3"))
+        _mkmp3(album1_dir / "album1song1.mp3")
+        _mkmp3(album1_dir / "album1song2.mp3")
+        _mkmp3(album2_dir / "album2song.mp3")
+        _mkmp3(album3_dir / "album3song.mp3")
+        _mkmp3(album4_dir / "album4song.mp3")
+        self.base = str(base)
 
     def test_finds_all_albums(self):
         albums = list(albums_in_dir(self.base))
@@ -1416,16 +1421,16 @@ class AlbumsInDirTest(BeetsTestCase):
     def test_separates_contents(self):
         found = []
         for _, album in albums_in_dir(self.base):
-            found.append(re.search(rb"album(.)song", album[0]).group(1))
-        assert b"1" in found
-        assert b"2" in found
-        assert b"3" in found
-        assert b"4" in found
+            found.append(re.search(r"album(.)song", album[0]).group(1))
+        assert "1" in found
+        assert "2" in found
+        assert "3" in found
+        assert "4" in found
 
     def test_finds_multiple_songs(self):
         for _, album in albums_in_dir(self.base):
-            n = re.search(rb"album(.)song", album[0]).group(1)
-            if n == b"1":
+            n = re.search(r"album(.)song", album[0]).group(1)
+            if n == "1":
                 assert len(album) == 2
             else:
                 assert len(album) == 1
@@ -1439,67 +1444,55 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
         directories are made). `ascii_` indicates ACII-only filenames;
         otherwise, we use Unicode names.
         """
-        self.base = os.path.abspath(os.path.join(self.temp_dir, b"tempdir"))
-        os.mkdir(syspath(self.base))
+        self.base = (self.temp_dir_path / "tempdir").resolve()
+        self.base.mkdir()
 
-        name = b"CAT" if ascii_ else util.bytestring_path("C\xc1T")
-        name_alt_case = b"CAt" if ascii_ else util.bytestring_path("C\xc1t")
+        name = "CAT" if ascii_ else "C\xc1T"
+        name_alt_case = "CAt" if ascii_ else "C\xc1t"
 
         self.dirs = [
             # Nested album, multiple subdirs.
             # Also, false positive marker in root dir, and subtitle for disc 3.
-            os.path.join(self.base, b"ABCD1234"),
-            os.path.join(self.base, b"ABCD1234", b"cd 1"),
-            os.path.join(self.base, b"ABCD1234", b"cd 3 - bonus"),
+            self.base / "ABCD1234",
+            self.base / "ABCD1234" / "cd 1",
+            self.base / "ABCD1234" / "cd 3 - bonus",
             # Nested album, single subdir.
             # Also, punctuation between marker and disc number.
-            os.path.join(self.base, b"album"),
-            os.path.join(self.base, b"album", b"cd _ 1"),
+            self.base / "album",
+            self.base / "album" / "cd _ 1",
             # Flattened album, case typo.
             # Also, false positive marker in parent dir.
-            os.path.join(self.base, b"artist [CD5]"),
-            os.path.join(self.base, b"artist [CD5]", name + b" disc 1"),
-            os.path.join(
-                self.base, b"artist [CD5]", name_alt_case + b" disc 2"
-            ),
+            self.base / "artist [CD5]",
+            self.base / "artist [CD5]" / f"{name} disc 1",
+            self.base / "artist [CD5]" / f"{name_alt_case} disc 2",
             # Single disc album, sorted between CAT discs.
-            os.path.join(self.base, b"artist [CD5]", name + b"S"),
+            self.base / "artist [CD5]" / f"{name} S",
         ]
-        self.files = [
-            os.path.join(self.base, b"ABCD1234", b"cd 1", b"song1.mp3"),
-            os.path.join(self.base, b"ABCD1234", b"cd 3 - bonus", b"song2.mp3"),
-            os.path.join(self.base, b"ABCD1234", b"cd 3 - bonus", b"song3.mp3"),
-            os.path.join(self.base, b"album", b"cd _ 1", b"song4.mp3"),
-            os.path.join(
-                self.base, b"artist [CD5]", name + b" disc 1", b"song5.mp3"
-            ),
-            os.path.join(
-                self.base,
-                b"artist [CD5]",
-                name_alt_case + b" disc 2",
-                b"song6.mp3",
-            ),
-            os.path.join(self.base, b"artist [CD5]", name + b"S", b"song7.mp3"),
-        ]
+        deep_dirs = [*self.dirs[:3], self.dirs[4], *self.dirs[6:]]
+        self.files = [d / f"song{i}.mp3" for i, d in enumerate(deep_dirs)]
 
         if not ascii_:
             self.dirs = [self._normalize_path(p) for p in self.dirs]
             self.files = [self._normalize_path(p) for p in self.files]
 
         for path in self.dirs:
-            os.mkdir(syspath(path))
+            path.mkdir()
         if files:
             for path in self.files:
-                _mkmp3(util.syspath(path))
+                _mkmp3(syspath(path))
 
-    def _normalize_path(self, path):
+        self.dirs = list(map(str, self.dirs))
+        self.files = list(map(str, self.files))
+        self.base = str(self.base)
+
+    def _normalize_path(self, path: Path) -> Path:
         """Normalize a path's Unicode combining form according to the
         platform.
         """
-        path = path.decode("utf-8")
-        norm_form = "NFD" if sys.platform == "darwin" else "NFC"
-        path = unicodedata.normalize(norm_form, path)
-        return path.encode("utf-8")
+        norm_form: Literal["NFD", "NFC"] = (
+            "NFD" if sys.platform == "darwin" else "NFC"
+        )
+        return Path(unicodedata.normalize(norm_form, str(path)))
 
     def test_coalesce_nested_album_multiple_subdirs(self):
         self.create_music()
@@ -1553,30 +1546,28 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
     def test_coalesce_markers(self):
         for i, (marker, suffix1, suffix2) in enumerate(
             [
-                (b"Disc", b" 1", b" 02"),  # titlecase, space-separated
-                (b"disk 757", b" 1", b" 02"),  # lowercase, numerical suffix
-                (b"CD", b"01", b"02"),  # uppercase, no space (e.g. CD01)
-                (b"disc", b"_1", b"_2"),  # underscore separator (e.g. disc_1)
-                (b"cAsSeTtE", b" 1", b" 02"),  # mixed case
-                (b"Digital   Media", b" 1", b" 02"),  # multiple spaces
-                (b"vinyl", b" 1", b" 02"),  # lowercase
-                (b"12 vinyl", b" 1", b" 02"),  # common prefix
+                ("Disc", " 1", " 02"),  # titlecase, space-separated
+                ("disk 757", " 1", " 02"),  # lowercase, numerical suffix
+                ("CD", "01", "02"),  # uppercase, no space (e.g. CD01)
+                ("disc", "_1", "_2"),  # underscore separator (e.g. disc_1)
+                ("cAsSeTtE", " 1", " 02"),  # mixed case
+                ("Digital   Media", " 1", " 02"),  # multiple spaces
+                ("vinyl", " 1", " 02"),  # lowercase
+                ("12 vinyl", " 1", " 02"),  # common prefix
             ]
         ):
             with self.subTest(marker=marker, suffix1=suffix1, suffix2=suffix2):
-                base = os.path.abspath(
-                    os.path.join(self.temp_dir, b"marker_" + str(i).encode())
-                )
+                base = os.path.abspath(self.temp_dir_path / f"marker_{i}")
                 os.mkdir(syspath(base))
 
-                album_dir = os.path.join(base, b"Album Name")
+                album_dir = os.path.join(base, "Album Name")
                 os.mkdir(syspath(album_dir))
 
                 discs = []
                 for suffix in (suffix1, suffix2):
                     disc = os.path.join(album_dir, marker + suffix)
                     os.mkdir(syspath(disc))
-                    _mkmp3(syspath(os.path.join(disc, b"song.mp3")))
+                    _mkmp3(syspath(os.path.join(disc, "song.mp3")))
                     discs.append(disc)
 
                 albums = list(albums_in_dir(base))
@@ -1589,16 +1580,16 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
     def test_no_coalesce_mismatched_prefixes(self):
         # "CD 02" and "Enhanced CD 01" share the "cd" marker but have
         # different prefixes, so they should not be collapsed.
-        base = os.path.abspath(os.path.join(self.temp_dir, b"mismatched"))
+        base = os.path.abspath(self.temp_dir_path / "mismatched")
         os.mkdir(syspath(base))
 
-        album_dir = os.path.join(base, b"Album Name")
+        album_dir = os.path.join(base, "Album Name")
         os.mkdir(syspath(album_dir))
 
-        for subdir in (b"CD 02", b"Enhanced CD 01"):
+        for subdir in ("CD 02", "Enhanced CD 01"):
             d = os.path.join(album_dir, subdir)
             os.mkdir(syspath(d))
-            _mkmp3(syspath(os.path.join(d, b"song.mp3")))
+            _mkmp3(syspath(os.path.join(d, "song.mp3")))
 
         albums = list(albums_in_dir(base))
         assert len(albums) == 2
@@ -1896,21 +1887,21 @@ class TestMpeglayerWavImport(AsIsImporterMixin, ImportHelper):
     """Test remuxing of WAVE_FORMAT_MPEGLAYER3 WAV files."""
 
     def test_remux_mpeglayer3_wav(self):
-        src = os.path.join(_common.RSRC, b"mpeglayer3.wav")
-        dest = os.path.join(self.temp_dir, b"mpeglayer3.wav")
+        src = Path(os.fsdecode(_common.RSRC)) / "mpeglayer3.wav"
+        dest = self.temp_dir_path / "mpeglayer3.wav"
         shutil.copy(syspath(src), syspath(dest))
 
         mp3_path = remux_mpeglayer3_wav(dest)
 
         assert mp3_path is not None
-        assert mp3_path.endswith(b".mp3")
-        assert os.path.exists(mp3_path)
-        assert not os.path.exists(dest)
+        assert mp3_path.suffix == ".mp3"
+        assert mp3_path.exists()
+        assert not dest.exists()
 
     def test_remux_mpeglayer3_wav_disabled(self):
         """When remux_mp3_in_wav is disabled, WAV file should not be remuxed."""
         self.config["import"]["remux_mp3_in_wav"] = False
-        src = os.path.join(_common.RSRC, b"mpeglayer3.wav")
+        src = Path(os.fsdecode(_common.RSRC)) / "mpeglayer3.wav"
         dest = self.import_path / "mpeglayer3.wav"
         shutil.copy(syspath(src), syspath(dest))
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -745,7 +745,7 @@ class ImportExistingTest(PathsMixin, AutotagImportTestCase):
         super().setUp()
         self.prepare_album_for_import(1)
 
-        self.reimporter = self.setup_importer(import_dir=self.libdir)
+        self.reimporter = self.setup_importer(import_dir=self.lib_path)
         self.importer = self.setup_importer()
 
     def tearDown(self):
@@ -1630,7 +1630,7 @@ class ReimportTest(AutotagImportTestCase):
         item.store()
 
     def _setup_session(self, singletons=False):
-        self.setup_importer(import_dir=self.libdir, singletons=singletons)
+        self.setup_importer(import_dir=self.lib_path, singletons=singletons)
         self.importer.add_choice(importer.Action.APPLY)
 
     def _album(self):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -316,12 +316,12 @@ class ImportSingletonTest(AutotagImportTestCase):
 
     def test_import_single_files(self):
         resource_path = os.path.join(_common.RSRC, b"empty.mp3")
-        single_path = os.path.join(self.import_dir, b"track_2.mp3")
+        single_path = self.import_path / "track_2.mp3"
 
         util.copy(resource_path, single_path)
-        import_files = [os.path.join(self.import_dir, b"album"), single_path]
+        import_files = [self.import_path / "album", single_path]
         self.setup_importer()
-        self.importer.paths = import_files
+        self.importer.paths = list(map(os.fsencode, import_files))
 
         self.importer.add_choice(importer.Action.ASIS)
         self.importer.add_choice(importer.Action.ASIS)
@@ -379,7 +379,7 @@ class TestImportFormat(ImportHelper):
 
     def test_recognize_format(self):
         resource_src = os.path.join(_common.RSRC, b"no_ext")
-        resource_path = os.path.join(self.import_dir, b"no_ext")
+        resource_path = self.import_path / "no_ext"
         util.copy(resource_src, resource_path)
         self.setup_importer(autotag=False)
         self.importer.paths = [resource_path]
@@ -509,7 +509,7 @@ class TestImport(PathsMixin, AutotagImportHelper):
     @NEEDS_FFPROBE
     def test_skip_non_album_dirs(self):
         assert (self.import_path / "album").exists()
-        self.touch(b"cruft", dir_=self.import_dir)
+        (self.import_path / "cruft").touch()
         self.importer.add_choice(importer.Action.APPLY)
         self.importer.run()
 
@@ -1868,7 +1868,9 @@ class TestImportId(ImportHelper):
     def test_candidates_album(self):
         """Test directly ImportTask.lookup_candidates()."""
         task = importer.ImportTask(
-            paths=self.import_dir, toppath="top path", items=[_common.item()]
+            paths=os.fsencode(self.import_path),
+            toppath="top path",
+            items=[_common.item()],
         )
 
         task.lookup_candidates([self.ID_RELEASE_0, self.ID_RELEASE_1])
@@ -1909,8 +1911,8 @@ class TestMpeglayerWavImport(AsIsImporterMixin, ImportHelper):
         """When remux_mp3_in_wav is disabled, WAV file should not be remuxed."""
         self.config["import"]["remux_mp3_in_wav"] = False
         src = os.path.join(_common.RSRC, b"mpeglayer3.wav")
-        dest = os.path.join(self.import_dir, b"mpeglayer3.wav")
+        dest = self.import_path / "mpeglayer3.wav"
         shutil.copy(syspath(src), syspath(dest))
 
         self.run_asis_importer()
-        assert os.path.exists(dest)
+        assert dest.exists()

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -146,7 +146,7 @@ class TestNonAutotaggedImport(PathsMixin, AsIsImporterMixin, ImportHelper):
 
 
 def create_archive(session):
-    handle, path = mkstemp(dir=session.temp_dir_path)
+    handle, path = mkstemp(dir=session.temp_path)
     path = bytestring_path(path)
     os.close(handle)
     archive = ZipFile(os.fsdecode(path), mode="w")
@@ -234,7 +234,7 @@ class TestImportZip(AsIsImporterMixin, ImportHelper):
 
 class TestImportTar(TestImportZip):
     def create_archive(self):
-        (handle, path) = mkstemp(dir=self.temp_dir_path)
+        (handle, path) = mkstemp(dir=self.temp_path)
         path = bytestring_path(path)
         os.close(handle)
         archive = TarFile(os.fsdecode(path), mode="w")
@@ -389,9 +389,9 @@ class TestImportFormat(ImportHelper):
 
     def test_recognize_format_already_exist(self, caplog):
         resource_path = os.path.join(_common.RSRC, b"no_ext")
-        temp_resource_path = self.temp_dir_path / "no_ext"
+        temp_resource_path = self.temp_path / "no_ext"
         util.copy(resource_path, temp_resource_path)
-        new_path = self.temp_dir_path / "no_ext.mp3"
+        new_path = self.temp_path / "no_ext.mp3"
         util.copy(temp_resource_path, new_path)
         self.setup_importer(autotag=False)
         self.importer.paths = [temp_resource_path]
@@ -413,22 +413,22 @@ class TestImportFormat(ImportHelper):
     def test_recognize_format_change_original(self):
         config["import"]["fix_ext_inplace"] = True
         resource_src = os.path.join(_common.RSRC, b"no_ext")
-        resource_path = self.temp_dir_path / "no_ext"
+        resource_path = self.temp_path / "no_ext"
         util.copy(resource_src, resource_path)
         self.setup_importer(autotag=False)
         self.importer.paths = [resource_path]
         self.importer.run()
-        assert not Path(self.temp_dir_path / "no_ext").exists()
+        assert not Path(self.temp_path / "no_ext").exists()
 
     def test_recognize_format_keep_original(self):
         config["import"]["fix_ext_inplace"] = False
         resource_src = os.path.join(_common.RSRC, b"no_ext")
-        resource_path = self.temp_dir_path / "no_ext"
+        resource_path = self.temp_path / "no_ext"
         util.copy(resource_src, resource_path)
         self.setup_importer(autotag=False)
         self.importer.paths = [resource_path]
         self.importer.run()
-        assert Path(self.temp_dir_path / "no_ext").exists()
+        assert Path(self.temp_path / "no_ext").exists()
 
 
 class TestImport(PathsMixin, AutotagImportHelper):
@@ -525,7 +525,7 @@ class TestImport(PathsMixin, AutotagImportHelper):
 
     @NEEDS_FFPROBE
     def test_empty_directory_warning(self, caplog):
-        import_dir = self.temp_dir_path / "empty"
+        import_dir = self.temp_path / "empty"
         import_dir.mkdir()
         (import_dir / "non-audio").touch()
         self.setup_importer(import_dir=import_dir)
@@ -536,7 +536,7 @@ class TestImport(PathsMixin, AutotagImportHelper):
 
     @NEEDS_FFPROBE
     def test_empty_directory_singleton_warning(self, caplog):
-        import_dir = self.temp_dir_path / "empty"
+        import_dir = self.temp_path / "empty"
         import_dir.mkdir()
         (import_dir / "non-audio").touch()
         self.setup_singleton_importer(import_dir=import_dir)
@@ -1395,7 +1395,7 @@ class AlbumsInDirTest(BeetsTestCase):
         super().setUp()
 
         # create a directory structure for testing
-        base = (self.temp_dir_path / "tempdir").resolve()
+        base = (self.temp_path / "tempdir").resolve()
         base.mkdir()
 
         album1_dir = base / "album1"
@@ -1444,7 +1444,7 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
         directories are made). `ascii_` indicates ACII-only filenames;
         otherwise, we use Unicode names.
         """
-        self.base = (self.temp_dir_path / "tempdir").resolve()
+        self.base = (self.temp_path / "tempdir").resolve()
         self.base.mkdir()
 
         name = "CAT" if ascii_ else "C\xc1T"
@@ -1557,7 +1557,7 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
             ]
         ):
             with self.subTest(marker=marker, suffix1=suffix1, suffix2=suffix2):
-                base = os.path.abspath(self.temp_dir_path / f"marker_{i}")
+                base = os.path.abspath(self.temp_path / f"marker_{i}")
                 os.mkdir(syspath(base))
 
                 album_dir = os.path.join(base, "Album Name")
@@ -1580,7 +1580,7 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
     def test_no_coalesce_mismatched_prefixes(self):
         # "CD 02" and "Enhanced CD 01" share the "cd" marker but have
         # different prefixes, so they should not be collapsed.
-        base = os.path.abspath(self.temp_dir_path / "mismatched")
+        base = os.path.abspath(self.temp_path / "mismatched")
         os.mkdir(syspath(base))
 
         album_dir = os.path.join(base, "Album Name")
@@ -1737,7 +1737,7 @@ class TestImportPretend(ImportHelper):
         ]
 
     def test_import_pretend_empty(self, caplog):
-        empty_path = self.temp_dir_path / "empty"
+        empty_path = self.temp_path / "empty"
         empty_path.mkdir()
 
         importer = self.setup_importer(pretend=True, import_dir=empty_path)
@@ -1888,7 +1888,7 @@ class TestMpeglayerWavImport(AsIsImporterMixin, ImportHelper):
 
     def test_remux_mpeglayer3_wav(self):
         src = Path(os.fsdecode(_common.RSRC)) / "mpeglayer3.wav"
-        dest = self.temp_dir_path / "mpeglayer3.wav"
+        dest = self.temp_path / "mpeglayer3.wav"
         shutil.copy(syspath(src), syspath(dest))
 
         mp3_path = remux_mpeglayer3_wav(dest)

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -131,7 +131,7 @@ class TestAdd(PytestItemHelper):
     ):
         """Test library.add emits only one database_change event."""
 
-        item.path = beets.util.normpath(self.temp_dir_path / "a" / "b.mp3")
+        item.path = beets.util.normpath(self.temp_path / "a" / "b.mp3")
         item.album = "a"
         item.title = "b"
 
@@ -1150,7 +1150,7 @@ class TestPathString(PytestItemHelper):
 class TestMtime(TestHelper):
     @pytest.fixture(autouse=True)
     def item(self, setup):
-        self.ipath = self.temp_dir_path / "testfile.mp3"
+        self.ipath = self.temp_path / "testfile.mp3"
         shutil.copy(
             syspath(os.path.join(_common.RSRC, b"full.mp3")),
             syspath(self.ipath),
@@ -1258,7 +1258,7 @@ class TestWrite(TestHelper):
 
     def test_write_with_custom_path(self):
         item = self.add_item_fixture()
-        custom_path = self.temp_dir_path / "custom.mp3"
+        custom_path = self.temp_path / "custom.mp3"
         shutil.copy(syspath(item.path), syspath(custom_path))
 
         item["artist"] = "new artist"

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -131,9 +131,7 @@ class TestAdd(PytestItemHelper):
     ):
         """Test library.add emits only one database_change event."""
 
-        item.path = beets.util.normpath(
-            os.path.join(self.temp_dir, b"a", b"b.mp3")
-        )
+        item.path = beets.util.normpath(self.temp_dir_path / "a" / "b.mp3")
         item.album = "a"
         item.title = "b"
 
@@ -1152,7 +1150,7 @@ class TestPathString(PytestItemHelper):
 class TestMtime(TestHelper):
     @pytest.fixture(autouse=True)
     def item(self, setup):
-        self.ipath = os.path.join(self.temp_dir, b"testfile.mp3")
+        self.ipath = self.temp_dir_path / "testfile.mp3"
         shutil.copy(
             syspath(os.path.join(_common.RSRC, b"full.mp3")),
             syspath(self.ipath),
@@ -1160,11 +1158,11 @@ class TestMtime(TestHelper):
         item = beets.library.Item.from_path(self.ipath)
         self.lib.add(item)
         yield item
-        if os.path.exists(self.ipath):
-            os.remove(self.ipath)
+        if self.ipath.exists():
+            self.ipath.unlink()
 
     def _mtime(self):
-        return int(os.path.getmtime(self.ipath))
+        return int(self.ipath.stat().st_mtime)
 
     def test_mtime_initially_up_to_date(self, item):
         assert item.mtime >= self._mtime()
@@ -1260,7 +1258,7 @@ class TestWrite(TestHelper):
 
     def test_write_with_custom_path(self):
         item = self.add_item_fixture()
-        custom_path = os.path.join(self.temp_dir, b"custom.mp3")
+        custom_path = self.temp_dir_path / "custom.mp3"
         shutil.copy(syspath(item.path), syspath(custom_path))
 
         item["artist"] = "new artist"

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import stat
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -20,13 +21,7 @@ from beets.library import Album
 from beets.test import _common
 from beets.test._common import item
 from beets.test.helper import TestHelper
-from beets.util import (
-    as_string,
-    bytestring_path,
-    normpath,
-    path_as_posix,
-    syspath,
-)
+from beets.util import as_string, bytestring_path, normpath, syspath
 
 # Shortcut to path normalization.
 np = util.normpath
@@ -1076,18 +1071,18 @@ class TestPathString(PytestItemHelper):
         assert isinstance(self.get_first_item().path, bytes)
 
     def test_special_chars_preserved_in_database(self, item_in_db):
-        path = "b\xe1r".encode()
+        path = Path("b\xe1r")
         item_in_db.path = path
         item_in_db.store()
-        assert self.get_first_item().path == os.path.join(self.libdir, path)
+        assert self.get_first_item().filepath == self.lib_path / path
 
     def test_special_char_path_added_to_database(self, item, item_in_db):
         item_in_db.remove()
-        path = "b\xe1r".encode()
+        path = Path("b\xe1r")
         item = _common.item()
         item.path = path
         self.lib.add(item)
-        assert self.get_first_item().path == os.path.join(self.libdir, path)
+        assert self.get_first_item().filepath == self.lib_path / path
 
     def test_destination_returns_bytestring(self, item_in_db):
         item_in_db.artist = "b\xe1r"
@@ -1101,7 +1096,7 @@ class TestPathString(PytestItemHelper):
         assert isinstance(dest, bytes)
 
     def test_artpath_stores_special_chars(self, item_in_db):
-        path = bytestring_path("b\xe1r")
+        path = Path("b\xe1r")
         alb = self.lib.add_album([item_in_db])
         alb.artpath = path
         alb.store()
@@ -1111,8 +1106,8 @@ class TestPathString(PytestItemHelper):
             .fetchone()[0]
         )
         alb = self.lib.get_album(item_in_db)
-        assert stored_path == path
-        assert alb.artpath == os.path.join(self.libdir, path)
+        assert stored_path == os.fsencode(path)
+        assert alb.art_filepath == self.lib_path / path
 
     def test_sanitize_path_with_special_chars(self):
         path = "b\xe1r?"
@@ -1138,8 +1133,8 @@ class TestPathString(PytestItemHelper):
         assert isinstance(alb.artpath, bytes)
 
     def test_relative_path_is_stored(self, item_in_db):
-        relative_path = os.path.join(b"abc", b"foo.mp3")
-        absolute_path = os.path.join(self.libdir, relative_path)
+        relative_path = Path("abc") / "foo.mp3"
+        absolute_path = self.lib_path / relative_path
         item_in_db.path = absolute_path
         item_in_db.store()
         stored_path = (
@@ -1149,9 +1144,9 @@ class TestPathString(PytestItemHelper):
         )
         album = self.lib.add_album([item_in_db])
 
-        assert item_in_db.path == absolute_path
-        assert stored_path == path_as_posix(relative_path)
-        assert album.path == os.path.dirname(absolute_path)
+        assert item_in_db.filepath == absolute_path
+        assert stored_path == util.path_as_posix(os.fsencode(relative_path))
+        assert album.filepath == absolute_path.parent
 
 
 class TestMtime(TestHelper):

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -1,7 +1,6 @@
 import importlib
 import itertools
 import logging
-import os
 import pkgutil
 import sys
 from typing import ClassVar
@@ -101,7 +100,7 @@ class TestEvents(PluginImportHelper):
             if not msg.startswith("Sending event:")
         ]
         assert logs == [
-            f"Album: {displayable_path(os.path.join(self.import_dir, b'album'))}",
+            f"Album: {self.import_path / 'album'}",
             f"  {displayable_path(self.import_media[0].path)}",
             f"  {displayable_path(self.import_media[1].path)}",
         ]

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -14,9 +14,7 @@ import pytest
 from beets import util
 from beets.library import Item
 from beets.test import _common
-from beets.test._common import touch
 from beets.test.helper import NEEDS_REFLINK, BeetsTestCase
-from beets.util import syspath
 
 _p = pytest.param
 
@@ -371,62 +369,64 @@ class WalkTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
-        self.base = os.path.join(self.temp_dir, b"testdir")
-        os.mkdir(syspath(self.base))
-        touch(os.path.join(self.base, b"y"))
-        touch(os.path.join(self.base, b"x"))
-        os.mkdir(syspath(os.path.join(self.base, b"d")))
-        touch(os.path.join(self.base, b"d", b"z"))
+        self.base = self.temp_dir_path / "testdir"
+        self.base.mkdir()
+        (self.base / "y").touch()
+        (self.base / "x").touch()
+        base_d = self.base / "d"
+        base_d.mkdir()
+        (base_d / "z").touch()
+        self.str_base = str(self.base)
 
     def test_sorted_files(self):
-        res = list(util.sorted_walk(self.base))
+        res = list(util.sorted_walk(self.str_base))
         assert len(res) == 2
-        assert res[0] == (self.base, [b"d"], [b"x", b"y"])
-        assert res[1] == (os.path.join(self.base, b"d"), [], [b"z"])
+        assert res[0] == (self.str_base, ["d"], ["x", "y"])
+        assert res[1] == (str(self.base / "d"), [], ["z"])
 
     def test_ignore_file(self):
-        res = list(util.sorted_walk(self.base, (b"x",)))
+        res = list(util.sorted_walk(self.str_base, ("x",)))
         assert len(res) == 2
-        assert res[0] == (self.base, [b"d"], [b"y"])
-        assert res[1] == (os.path.join(self.base, b"d"), [], [b"z"])
+        assert res[0] == (self.str_base, ["d"], ["y"])
+        assert res[1] == (str(self.base / "d"), [], ["z"])
 
     def test_ignore_directory(self):
-        res = list(util.sorted_walk(self.base, (b"d",)))
+        res = list(util.sorted_walk(self.str_base, ("d",)))
         assert len(res) == 1
-        assert res[0] == (self.base, [], [b"x", b"y"])
+        assert res[0] == (self.str_base, [], ["x", "y"])
 
     def test_ignore_everything(self):
-        res = list(util.sorted_walk(self.base, (b"*",)))
+        res = list(util.sorted_walk(self.str_base, ("*",)))
         assert len(res) == 1
-        assert res[0] == (self.base, [], [])
+        assert res[0] == (self.str_base, [], [])
 
 
 class UniquePathTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
-        self.base = os.path.join(self.temp_dir, b"testdir")
-        os.mkdir(syspath(self.base))
-        touch(os.path.join(self.base, b"x.mp3"))
-        touch(os.path.join(self.base, b"x.1.mp3"))
-        touch(os.path.join(self.base, b"x.2.mp3"))
-        touch(os.path.join(self.base, b"y.mp3"))
+        self.base = self.temp_dir_path / "testdir"
+        self.base.mkdir()
+        (self.base / "x.mp3").touch()
+        (self.base / "x.1.mp3").touch()
+        (self.base / "x.2.mp3").touch()
+        (self.base / "y.mp3").touch()
 
     def test_new_file_unchanged(self):
-        path = util.unique_path(os.path.join(self.base, b"z.mp3"))
-        assert path == os.path.join(self.base, b"z.mp3")
+        path = util.unique_path(self.base / "z.mp3")
+        assert path == self.base / "z.mp3"
 
     def test_conflicting_file_appends_1(self):
-        path = util.unique_path(os.path.join(self.base, b"y.mp3"))
-        assert path == os.path.join(self.base, b"y.1.mp3")
+        path = util.unique_path(self.base / "y.mp3")
+        assert path == str(self.base / "y.1.mp3")
 
     def test_conflicting_file_appends_higher_number(self):
-        path = util.unique_path(os.path.join(self.base, b"x.mp3"))
-        assert path == os.path.join(self.base, b"x.3.mp3")
+        path = util.unique_path(self.base / "x.mp3")
+        assert path == str(self.base / "x.3.mp3")
 
     def test_conflicting_file_with_number_increases_number(self):
-        path = util.unique_path(os.path.join(self.base, b"x.1.mp3"))
-        assert path == os.path.join(self.base, b"x.3.mp3")
+        path = util.unique_path(self.base / "x.1.mp3")
+        assert path == str(self.base / "x.3.mp3")
 
 
 class MkDirAllTest(BeetsTestCase):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -286,7 +286,7 @@ class FilePathTestCase(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
-        self.path = self.temp_dir_path / "testfile"
+        self.path = self.temp_path / "testfile"
         self.path.touch()
 
 
@@ -304,7 +304,7 @@ class SafeMoveCopyTest(FilePathTestCase):
     def setUp(self):
         super().setUp()
 
-        self.otherpath = self.temp_dir_path / "testfile2"
+        self.otherpath = self.temp_path / "testfile2"
         self.otherpath.touch()
         self.dest = Path(f"{self.path}.dest")
 
@@ -349,7 +349,7 @@ class PruneTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
-        self.base = self.temp_dir_path / "testdir"
+        self.base = self.temp_path / "testdir"
         self.base.mkdir()
         self.sub = self.base / "subdir"
         self.sub.mkdir()
@@ -369,7 +369,7 @@ class WalkTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
-        self.base = self.temp_dir_path / "testdir"
+        self.base = self.temp_path / "testdir"
         self.base.mkdir()
         (self.base / "y").touch()
         (self.base / "x").touch()
@@ -405,7 +405,7 @@ class UniquePathTest(BeetsTestCase):
     def setUp(self):
         super().setUp()
 
-        self.base = self.temp_dir_path / "testdir"
+        self.base = self.temp_path / "testdir"
         self.base.mkdir()
         (self.base / "x.mp3").touch()
         (self.base / "x.1.mp3").touch()
@@ -431,7 +431,7 @@ class UniquePathTest(BeetsTestCase):
 
 class MkDirAllTest(BeetsTestCase):
     def test_mkdirall(self):
-        child = self.temp_dir_path / "foo" / "bar" / "baz" / "quz.mp3"
+        child = self.temp_path / "foo" / "bar" / "baz" / "quz.mp3"
         util.mkdirall(child)
         assert not child.exists()
         assert child.parent.exists()

--- a/test/ui/commands/test_config.py
+++ b/test/ui/commands/test_config.py
@@ -16,7 +16,7 @@ class ConfigCommandTest(IOMixin, BeetsTestCase):
             if k in os.environ:
                 del os.environ[k]
 
-        temp_dir = self.temp_dir_path
+        temp_dir = self.temp_path
 
         self.config_path = str(temp_dir / "config.yaml")
         with open(self.config_path, "w") as file:

--- a/test/ui/commands/test_config.py
+++ b/test/ui/commands/test_config.py
@@ -16,15 +16,15 @@ class ConfigCommandTest(IOMixin, BeetsTestCase):
             if k in os.environ:
                 del os.environ[k]
 
-        temp_dir = self.temp_dir.decode()
+        temp_dir = self.temp_dir_path
 
-        self.config_path = os.path.join(temp_dir, "config.yaml")
+        self.config_path = str(temp_dir / "config.yaml")
         with open(self.config_path, "w") as file:
             file.write("library: lib\n")
             file.write("option: value\n")
             file.write("password: password_value")
 
-        self.cli_config_path = os.path.join(temp_dir, "cli_config.yaml")
+        self.cli_config_path = str(temp_dir / "cli_config.yaml")
         with open(self.cli_config_path, "w") as file:
             file.write("option: cli overwrite")
 

--- a/test/ui/commands/test_import.py
+++ b/test/ui/commands/test_import.py
@@ -49,7 +49,7 @@ class ImportTest(BeetsTestCase):
                 "/music/Soulwax/Any Minute Now",
             ]
 
-        logfile = self.temp_dir_path / "logfile.log"
+        logfile = self.temp_path / "logfile.log"
         logfile.write_text(logfile_content)
         actual_paths = list(paths_from_logfile(logfile))
         assert actual_paths == expected_paths

--- a/test/ui/commands/test_import.py
+++ b/test/ui/commands/test_import.py
@@ -49,9 +49,8 @@ class ImportTest(BeetsTestCase):
                 "/music/Soulwax/Any Minute Now",
             ]
 
-        logfile = os.path.join(self.temp_dir, b"logfile.log")
-        with open(logfile, mode="w") as fp:
-            fp.write(logfile_content)
+        logfile = self.temp_dir_path / "logfile.log"
+        logfile.write_text(logfile_content)
         actual_paths = list(paths_from_logfile(logfile))
         assert actual_paths == expected_paths
 

--- a/test/ui/commands/test_move.py
+++ b/test/ui/commands/test_move.py
@@ -20,7 +20,7 @@ class MoveTest(BeetsTestCase):
         self.album = self.lib.add_album([self.i])
 
         # Alternate destination directory.
-        self.otherdir = self.temp_dir_path / "testotherdir"
+        self.otherdir = self.temp_path / "testotherdir"
 
     def _move(
         self,

--- a/test/ui/commands/test_move.py
+++ b/test/ui/commands/test_move.py
@@ -127,7 +127,7 @@ class MoveTest(BeetsTestCase):
         self.i.load()
         i2.load()
         assert self.i.path == old_i_path
-        assert i2.path.startswith(self.libdir)
+        assert i2.filepath.is_relative_to(self.lib_path)
         assert i2.filepath.exists()
 
     def test_move_item_skips_missing_file(self):

--- a/test/ui/commands/test_update.py
+++ b/test/ui/commands/test_update.py
@@ -25,11 +25,11 @@ class UpdateTest(IOMixin, BeetsTestCase):
         self.album = self.lib.add_album([self.i, self.i2])
 
         # Album art.
-        artfile = os.path.join(self.temp_dir, b"testart.jpg")
-        _common.touch(artfile)
+        artfile = self.temp_dir_path / "testart.jpg"
+        artfile.touch()
         self.album.set_art(artfile)
         self.album.store()
-        remove(artfile)
+        artfile.unlink()
 
     def _update(
         self,

--- a/test/ui/commands/test_update.py
+++ b/test/ui/commands/test_update.py
@@ -25,7 +25,7 @@ class UpdateTest(IOMixin, BeetsTestCase):
         self.album = self.lib.add_album([self.i, self.i2])
 
         # Album art.
-        artfile = self.temp_dir_path / "testart.jpg"
+        artfile = self.temp_path / "testart.jpg"
         artfile.touch()
         self.album.set_art(artfile)
         self.album.store()

--- a/test/ui/commands/test_utils.py
+++ b/test/ui/commands/test_utils.py
@@ -12,10 +12,10 @@ from beets.util import syspath
 
 
 class QueryTest(BeetsTestCase):
-    def add_item(self, filename=b"srcfile", templatefile=b"full.mp3"):
-        itempath = os.path.join(self.libdir, filename)
+    def add_item(self):
+        itempath = self.lib_path / "srcfile"
         shutil.copy(
-            syspath(os.path.join(_common.RSRC, templatefile)), syspath(itempath)
+            syspath(os.path.join(_common.RSRC, b"full.mp3")), syspath(itempath)
         )
         item = library.Item.from_path(itempath)
         self.lib.add(item)

--- a/test/ui/test_ui.py
+++ b/test/ui/test_ui.py
@@ -188,8 +188,8 @@ class ConfigTest(IOMixin, TestPluginTestCase):
 
     #    @unittest.skip('Difficult to implement with optparse')
     #    def test_multiple_cli_config_files(self):
-    #        cli_config_path_1 = os.path.join(self.temp_dir, b'config.yaml')
-    #        cli_config_path_2 = os.path.join(self.temp_dir, b'config_2.yaml')
+    #        cli_config_path_1 = self.temp_dir_path / 'config.yaml'
+    #        cli_config_path_2 = self.temp_dir_path / 'config_2.yaml'
     #
     #        with open(cli_config_path_1, 'w') as file:
     #            file.write('first: value')
@@ -204,8 +204,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
     #
     #    @unittest.skip('Difficult to implement with optparse')
     #    def test_multiple_cli_config_overwrite(self):
-    #        cli_overwrite_config_path = os.path.join(self.temp_dir,
-    #                                                 b'overwrite_config.yaml')
+    #        cli_overwrite_config_path = self.temp_dir_path / 'overwrite_config.yaml'
     #
     #        with open(self.cli_config_path, 'w') as file:
     #            file.write('anoption: value')
@@ -241,7 +240,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
 
     def test_command_line_option_relative_to_working_dir(self):
         config.read()
-        os.chdir(syspath(self.temp_dir))
+        os.chdir(syspath(self.temp_dir_path))
         self.run_command("--library", "foo.db", "test")
         assert config["library"].as_path() == Path.cwd() / "foo.db"
 

--- a/test/ui/test_ui.py
+++ b/test/ui/test_ui.py
@@ -61,7 +61,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
         del os.environ["BEETSDIR"]
 
         # Also set APPDATA, the Windows equivalent of setting $HOME.
-        appdata_dir = self.temp_dir_path / "AppData" / "Roaming"
+        appdata_dir = self.temp_path / "AppData" / "Roaming"
 
         self._orig_cwd = os.getcwd()
         self.test_cmd = self._make_test_cmd()
@@ -71,19 +71,19 @@ class ConfigTest(IOMixin, TestPluginTestCase):
         if platform.system() == "Windows":
             self.user_config_dir = appdata_dir / "beets"
         else:
-            self.user_config_dir = self.temp_dir_path / ".config" / "beets"
+            self.user_config_dir = self.temp_path / ".config" / "beets"
         self.user_config_dir.mkdir(parents=True, exist_ok=True)
         self.user_config_path = self.user_config_dir / "config.yaml"
 
         # Custom BEETSDIR
-        self.beetsdir = self.temp_dir_path / "beetsdir"
+        self.beetsdir = self.temp_path / "beetsdir"
         self.beetsdir.mkdir(parents=True, exist_ok=True)
 
         self.env_config_path = str(self.beetsdir / "config.yaml")
-        self.cli_config_path = str(self.temp_dir_path / "config.yaml")
+        self.cli_config_path = str(self.temp_path / "config.yaml")
         self.env_patcher = patch(
             "os.environ",
-            {"HOME": str(self.temp_dir_path), "APPDATA": str(appdata_dir)},
+            {"HOME": str(self.temp_path), "APPDATA": str(appdata_dir)},
         )
         self.env_patcher.start()
 
@@ -188,8 +188,8 @@ class ConfigTest(IOMixin, TestPluginTestCase):
 
     #    @unittest.skip('Difficult to implement with optparse')
     #    def test_multiple_cli_config_files(self):
-    #        cli_config_path_1 = self.temp_dir_path / 'config.yaml'
-    #        cli_config_path_2 = self.temp_dir_path / 'config_2.yaml'
+    #        cli_config_path_1 = self.temp_path / 'config.yaml'
+    #        cli_config_path_2 = self.temp_path / 'config_2.yaml'
     #
     #        with open(cli_config_path_1, 'w') as file:
     #            file.write('first: value')
@@ -204,7 +204,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
     #
     #    @unittest.skip('Difficult to implement with optparse')
     #    def test_multiple_cli_config_overwrite(self):
-    #        cli_overwrite_config_path = self.temp_dir_path / 'overwrite_config.yaml'
+    #        cli_overwrite_config_path = self.temp_path / 'overwrite_config.yaml'
     #
     #        with open(self.cli_config_path, 'w') as file:
     #            file.write('anoption: value')
@@ -240,7 +240,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
 
     def test_command_line_option_relative_to_working_dir(self):
         config.read()
-        os.chdir(syspath(self.temp_dir_path))
+        os.chdir(syspath(self.temp_path))
         self.run_command("--library", "foo.db", "test")
         assert config["library"].as_path() == Path.cwd() / "foo.db"
 
@@ -265,7 +265,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
         assert config["anoption"].get() == "overwrite"
 
     def test_beetsdir_points_to_file_error(self):
-        beetsdir = str(self.temp_dir_path / "beetsfile")
+        beetsdir = str(self.temp_path / "beetsfile")
         open(beetsdir, "a").close()
         os.environ["BEETSDIR"] = beetsdir
         with pytest.raises(ConfigError):

--- a/test/ui/test_ui_init.py
+++ b/test/ui/test_ui_init.py
@@ -1,6 +1,5 @@
 """Test module for file ui/__init__.py"""
 
-import os
 import unittest
 from copy import deepcopy
 from pathlib import Path
@@ -10,7 +9,6 @@ import pytest
 
 from beets import config, ui
 from beets.exceptions import UserError
-from beets.test import _common
 from beets.test.helper import BeetsTestCase, IOMixin
 
 
@@ -80,28 +78,22 @@ class ParentalDirCreation(IOMixin, BeetsTestCase):
         assert not self.io.getoutput()
 
     def test_create_yes(self):
-        non_exist_path = _common.os.fsdecode(
-            os.path.join(self.temp_dir, b"nonexist", str(random()).encode())
-        )
+        non_exist_path = self.temp_dir_path / "nonexist" / str(random())
         # Deepcopy instead of recovering because exceptions might
         # occur; wish I can use a golang defer here.
         test_config = deepcopy(config)
-        test_config["library"] = non_exist_path
+        test_config["library"] = str(non_exist_path)
         self.io.addinput("y")
         lib = ui._open_library(test_config)
         lib._close()
 
     def test_create_no(self):
-        non_exist_path_parent = _common.os.fsdecode(
-            os.path.join(self.temp_dir, b"nonexist")
-        )
-        non_exist_path = _common.os.fsdecode(
-            os.path.join(non_exist_path_parent.encode(), str(random()).encode())
-        )
+        non_exist_path_parent = self.temp_dir_path / "nonexist"
+        non_exist_path = non_exist_path_parent / str(random())
         test_config = deepcopy(config)
-        test_config["library"] = non_exist_path
+        test_config["library"] = str(non_exist_path)
 
         self.io.addinput("n")
         with pytest.raises(UserError):
             ui._open_library(test_config)
-        assert not os.path.exists(non_exist_path_parent)
+        assert not non_exist_path_parent.exists()

--- a/test/ui/test_ui_init.py
+++ b/test/ui/test_ui_init.py
@@ -78,7 +78,7 @@ class ParentalDirCreation(IOMixin, BeetsTestCase):
         assert not self.io.getoutput()
 
     def test_create_yes(self):
-        non_exist_path = self.temp_dir_path / "nonexist" / str(random())
+        non_exist_path = self.temp_path / "nonexist" / str(random())
         # Deepcopy instead of recovering because exceptions might
         # occur; wish I can use a golang defer here.
         test_config = deepcopy(config)
@@ -88,7 +88,7 @@ class ParentalDirCreation(IOMixin, BeetsTestCase):
         lib._close()
 
     def test_create_no(self):
-        non_exist_path_parent = self.temp_dir_path / "nonexist"
+        non_exist_path_parent = self.temp_path / "nonexist"
         non_exist_path = non_exist_path_parent / str(random())
         test_config = deepcopy(config)
         test_config["library"] = str(non_exist_path)


### PR DESCRIPTION
Part of #6807

- This change standardizes the test helper path API around `pathlib.Path`. Main shared helpers now use `temp_path`, `lib_path`, and `import_path` instead of older mixed names like `temp_dir`, `temp_dir_path`, `libdir`, and `import_dir`.

- Architecturally, path handling is pushed toward one clear model: use `Path` objects inside helpers and tests, and only encode to bytes at boundaries that still require it, like importer session setup.

- `beets.dbcore.types` also now accepts `Path` values for `item.path`, so code can pass `Path` objects directly without manual conversion.

- High-level impact: the test infrastructure becomes more consistent, path-related code gets easier to read, and there is less bytes/string/path conversion scattered across the suite. This is mostly a cleanup and API consistency change, not a behavior change.
