### PR TITLE
Ignore empty deprecated genres

### DIFF
--- a/beets/autotag/hooks.py
+++ b/beets/autotag/hooks.py
@@ -249,7 +249,7 @@ class Info(AttrDict[Any]):
                 f"'{list_field}' (list)",
                 stacklevel=3,
             )
-            if not list_value:
+            if str_value and not list_value:
                 try:
                     sep = next(s for s in ["; ", ", ", " / "] if s in str_value)
                 except StopIteration:

--- a/test/autotag/test_hooks.py
+++ b/test/autotag/test_hooks.py
@@ -34,9 +34,6 @@ _p = pytest.param
             str_field_deprecation,
             None,
             id="empty str value should become None, warning raised",
-            marks=pytest.mark.xfail(
-                reason="Empty string should not become ['']"
-            ),
         ),
         _p(
             "value",

--- a/test/autotag/test_hooks.py
+++ b/test/autotag/test_hooks.py
@@ -29,6 +29,16 @@ _p = pytest.param
     "str_value, list_value, expected_warning, expected_list_value",
     [
         _p(
+            "",
+            None,
+            str_field_deprecation,
+            None,
+            id="empty str value should become None, warning raised",
+            marks=pytest.mark.xfail(
+                reason="Empty string should not become ['']"
+            ),
+        ),
+        _p(
             "value",
             None,
             str_field_deprecation,


### PR DESCRIPTION
While testing my custom out of date `soundcloud` autotagger which still sets `genre` instead of `genres`, I realised that empty (`genre = ''`) is converted to `genres = ['']` list by `Info._get_list_from_string_value`.
