### PR TITLE
fix(dbcore): NumericQuery range crashes on a null value

### DIFF
--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -472,6 +472,12 @@ class NumericQuery(FieldQuery[str]):
 
         if self.point is not None:
             return value == self.point
+        if value is None:
+            # Nullable types (``NullInteger``/``NullFloat``) use ``None`` as
+            # their null value, so the field may be missing on some objects.
+            # ``col_clause`` compares against NULL in SQL, which is never true,
+            # so a range never matches a null value.
+            return False
         if self.rangemin is not None and value < self.rangemin:
             return False
         if self.rangemax is not None and value > self.rangemax:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -97,8 +97,8 @@ Bug fixes
   regular expression character-class typo.
 - A range query against a nullable numeric field (such as ``rg_track_gain`` on
   an item without ReplayGain data, or ``album_id`` on a singleton) no longer
-  crashes with a ``TypeError``. The range now matches nothing, as it already
-  did on the SQL side.
+  crashes with a ``TypeError``. The range now matches nothing, as it already did
+  on the SQL side.
 
 ..
     For plugin developers

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -95,6 +95,10 @@ Bug fixes
   valid date/time string" error instead of crashing with an uncaught
   ``KeyError``. A ``|`` was being accepted as a relative-date unit due to a
   regular expression character-class typo.
+- A range query against a nullable numeric field (such as ``rg_track_gain`` on
+  an item without ReplayGain data, or ``album_id`` on a singleton) no longer
+  crashes with a ``TypeError``. The range now matches nothing, as it already
+  did on the SQL side.
 
 ..
     For plugin developers

--- a/test/dbcore/test_query.py
+++ b/test/dbcore/test_query.py
@@ -293,6 +293,18 @@ class TestMatch:
         assert q.match(item) == should_match
         assert not NotQuery(q).match(item) == should_match
 
+    @pytest.mark.parametrize("pattern", ["-10..0", "0..", "..0"])
+    def test_numeric_range_match_null_field(self, pattern):
+        """A range never matches a null value, as in the SQL clause.
+
+        Nullable types (``NullFloat``/``NullInteger``) use ``None`` as their
+        null value, so e.g. ``rg_track_gain`` is None until ReplayGain runs.
+        Comparing that against the range bounds used to raise a TypeError.
+        """
+        item = Item(rg_track_gain=None)
+
+        assert NumericQuery("rg_track_gain", pattern).match(item) is False
+
 
 class TestPathQuery:
     """Tests for path-based querying functionality in the database system.


### PR DESCRIPTION
A range query against a nullable numeric field raises instead of returning `False`:

```python
NumericQuery("rg_track_gain", "-10..0").match(Item())
TypeError: '<' not supported between instances of 'NoneType' and 'int'
```

`NumericQuery.match()` compares the value against `rangemin`/`rangemax` with no `None` guard. Nullable types (`NullFloat`, `NullInteger`) use `None` as their null value — unlike `Integer`/`Float`, whose null is `0`, which is why `year` queries never hit this and the bug stayed hidden. Affected fields: `album_id` (`None` for **every singleton**) and the whole `rg_*` / `r128_*` family (`None` until ReplayGain has been run, i.e. by default). Point queries (`rg_track_gain:5`) were already fine — only the range branches.

### What the correct behaviour is

The query's own `col_clause()` defines it: `rg_track_gain >= ? AND rg_track_gain <= ?` against `NULL` is never true in SQL, so the row is quietly excluded. `match()` should agree — this is the classic SQL-path/match-path divergence, and `test_fast_vs_slow` in the test file exists precisely to pin that contract (it just never covered a nullable field).

### Reachability

Two callers, and **the first has no SQL path at all**:

- **`library/models.py:1203`** — `Item.destination()` evaluates `paths:` config rules through `match()` unconditionally. A rule like `rg_track_gain:0..` crashes on any item lacking ReplayGain. Verified end-to-end:
  ```python
  item.destination(path_formats=[("rg_track_gain:0..", "loud/$title"), ("default", "$title")])
  # TypeError
  ```
- **`dbcore/db.py:805`** — the `Results` slow path, used whenever `clause()` returns `None` (any flexattr subquery forces this). `beet ls "rg_track_gain:0.. someflex:x"` raises, while the same data through a fast SQL-only query returns `[]` cleanly.

### Precedent

This is the sibling of #3461. Commit `2293d2f6` (*"Fix crash when sorting by a nullable field missing on some items"*) fixed the identical `None`-comparison crash on the **sort** side — `sort.py` deliberately groups nulls together "matching SQLite's default ordering of NULLs", and its comment names `NullInteger`/`NullFloat` explicitly. The **query** side was missed.

### Tests

Three cases (`-10..0`, `0..`, `..0`) asserting a range never matches a null value. All fail on `master` with the `TypeError` and pass here. No existing test fed a nullable field to `NumericQuery` — `test/dbcore/test_query.py` only uses `year`.

- `pytest test/dbcore/test_query.py` — 146 passed (143 baseline + 3 new)
- `pytest test/test_library.py test/dbcore/` — 518 passed, no regressions
- `ruff check` / `ruff format --check` / `mypy` clean; changelog checked with `docstrfmt`, `sphinx-lint`, and the unreleased-section check.

---

AI disclosure: drafted with Claude Code (Opus 4.8), including the root-cause trace and the tests. I ran the repro and the test suite locally and reviewed the diff before opening.