### PR TITLE
use pathlib in tests: make `_common.RSRC` a pathlib.Path

### DIFF
--- a/beets/test/_common.py
+++ b/beets/test/_common.py
@@ -5,44 +5,23 @@ from __future__ import annotations
 import os
 import sys
 from contextlib import contextmanager
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import beets
 import beets.library
 
 # Make sure the development versions of the plugins are used
-import beetsplug
-from beets import importer, logging, util
+from beets import importer, logging
 from beets.ui import commands
 from beets.util import syspath
 
 if TYPE_CHECKING:
     import pytest
 
-beetsplug.__path__ = [
-    os.path.abspath(
-        os.path.join(
-            os.path.dirname(__file__),
-            os.path.pardir,
-            os.path.pardir,
-            "beetsplug",
-        )
-    )
-]
-
 # Test resources path.
-RSRC = util.bytestring_path(
-    os.path.abspath(
-        os.path.join(
-            os.path.dirname(__file__),
-            os.path.pardir,
-            os.path.pardir,
-            "test",
-            "rsrc",
-        )
-    )
-)
-PLUGINPATH = os.path.join(RSRC.decode(), "beetsplug")
+RSRC = (Path(__file__).parent.parent.parent / "test" / "rsrc").resolve()
+PLUGINPATH = str(RSRC / "beetsplug")
 
 # Propagate to root logger so the test runner can capture it
 log = logging.getLogger("beets")

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -168,7 +168,7 @@ class IOMixin(RunMixin):
 
 
 class PathsMixin:
-    resource_path = Path(os.fsdecode(_common.RSRC)) / "full.mp3"
+    resource_path = _common.RSRC / "full.mp3"
 
     @cached_property
     def temp_path(self) -> Path:
@@ -329,9 +329,7 @@ class TestHelper(RunMixin, PathsMixin, ConfigMixin):
         """Add an item with an actual audio file to the library."""
         item = self.create_item(**values)
         extension = item["format"].lower()
-        item["path"] = os.path.join(
-            _common.RSRC, util.bytestring_path(f"min.{extension}")
-        )
+        item["path"] = _common.RSRC / f"min.{extension}"
         item.add(self.lib)
         item.move(operation=MoveOperation.COPY)
         item.store()
@@ -345,7 +343,7 @@ class TestHelper(RunMixin, PathsMixin, ConfigMixin):
         """Add a number of items with files to the database."""
         # TODO base this on `add_item()`
         items = []
-        path = os.path.join(_common.RSRC, util.bytestring_path(f"full.{ext}"))
+        path = _common.RSRC / f"full.{ext}"
         for i in range(count):
             item = Item.from_path(path)
             item.album = f"\u00e4lbum {i}"  # Check unicode paths
@@ -367,9 +365,7 @@ class TestHelper(RunMixin, PathsMixin, ConfigMixin):
     ) -> Album:
         """Add an album with files to the database."""
         items = []
-        path = os.path.join(
-            _common.RSRC, util.bytestring_path(f"{fname}.{ext}")
-        )
+        path = _common.RSRC / f"{fname}.{ext}"
         for discnumber in range(1, disc_count + 1):
             for i in range(track_count):
                 item = Item.from_path(path)
@@ -398,7 +394,7 @@ class TestHelper(RunMixin, PathsMixin, ConfigMixin):
         """
         if not target_dir:
             target_dir = self.temp_path
-        src = os.path.join(_common.RSRC, util.bytestring_path(f"full.{ext}"))
+        src = _common.RSRC / f"full.{ext}"
         handle, path = mkstemp(dir=target_dir)
         path = bytestring_path(path)
         os.close(handle)
@@ -408,9 +404,8 @@ class TestHelper(RunMixin, PathsMixin, ConfigMixin):
             mediafile = MediaFile(path)
             imgs = []
             for img_ext in images:
-                file = util.bytestring_path(f"image-2x3.{img_ext}")
-                img_path = os.path.join(_common.RSRC, file)
-                with open(img_path, "rb") as f:
+                img_path = _common.RSRC / f"image-2x3.{img_ext}"
+                with img_path.open("rb") as f:
                     imgs.append(Image(f.read()))
             mediafile.images = imgs
             mediafile.save()

--- a/test/plugins/test_acousticbrainz.py
+++ b/test/plugins/test_acousticbrainz.py
@@ -1,7 +1,6 @@
 """Tests for the 'acousticbrainz' plugin."""
 
 import json
-import os.path
 
 from beets.test._common import RSRC
 from beetsplug.acousticbrainz import ABSCHEME, AcousticPlugin
@@ -50,9 +49,8 @@ class TestMapDataToScheme:
 
     def test_realistic(self):
         ab = AcousticPlugin()
-        data_path = os.path.join(RSRC, b"acousticbrainz/data.json")
-        with open(data_path) as res:
-            data = json.load(res)
+        data_path = RSRC / "acousticbrainz/data.json"
+        data = json.loads(data_path.read_text())
         mapping = set(ab._map_data_to_scheme(data, ABSCHEME))
         expected = {
             ("chords_key", "A"),

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -862,9 +862,7 @@ class TestArtImporter(UseThePlugin):
         # Test library.
         (self.lib_path / "album").mkdir()
         itempath = self.lib_path / "album" / "test.mp3"
-        shutil.copyfile(
-            syspath(os.path.join(_common.RSRC, b"full.mp3")), syspath(itempath)
-        )
+        shutil.copyfile(syspath(_common.RSRC / "full.mp3"), syspath(itempath))
         self.i = _common.item()
         self.i.path = itempath
         self.album = self.lib.add_album([self.i])
@@ -961,8 +959,8 @@ class AlbumArtOperationMixin(UseThePlugin):
     up a mock filesystem source that returns a predefined test image.
     """
 
-    IMAGE_PATH = os.path.join(_common.RSRC, b"abbey-similar.jpg")
-    IMAGE_FILESIZE = os.stat(util.syspath(IMAGE_PATH)).st_size
+    IMAGE_PATH = _common.RSRC / "abbey-similar.jpg"
+    IMAGE_FILESIZE = IMAGE_PATH.stat().st_size
     IMAGE_WIDTH = 500
     IMAGE_HEIGHT = 490
     IMAGE_WIDTH_HEIGHT_DIFF = IMAGE_WIDTH - IMAGE_HEIGHT

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import fnmatch
-import os.path
+import os
 import shlex
 import sys
 from typing import TYPE_CHECKING
@@ -40,7 +40,7 @@ class ConvertPluginHelper(IOMixin, PluginTestHelper):
         `tag` to the copy.
         """
         # A Python script that copies the file and appends a tag.
-        stub = os.path.join(_common.RSRC, b"convert_stub.py").decode("utf-8")
+        stub = str(_common.RSRC / "convert_stub.py")
         return f"{shlex.quote(sys.executable)} {shlex.quote(stub)} $source $dest {tag}"
 
     def file_endswith(self, path: Path, tag: str):
@@ -151,11 +151,10 @@ class TestConvertCli(ConvertPluginHelper, ConvertCommand):
 
     def test_embed_album_art(self):
         self.config["convert"]["embed"] = True
-        image_path = os.path.join(_common.RSRC, b"image-2x3.jpg")
+        image_path = _common.RSRC / "image-2x3.jpg"
         self.album.artpath = image_path
         self.album.store()
-        with open(os.path.join(image_path), "rb") as f:
-            image_data = f.read()
+        image_data = image_path.read_bytes()
 
         self.io.addinput("y")
         self.run_convert()
@@ -166,7 +165,7 @@ class TestConvertCli(ConvertPluginHelper, ConvertCommand):
         # A missing/stale art source should be skipped instead of crashing
         # the conversion (see #4692).
         self.config["convert"]["copy_album_art"] = True
-        self.album.artpath = os.path.join(_common.RSRC, b"nonexistent.jpg")
+        self.album.artpath = _common.RSRC / "nonexistent.jpg"
         self.album.store()
 
         with caplog.at_level("INFO", logger="beets.convert"):

--- a/test/plugins/test_embedart.py
+++ b/test/plugins/test_embedart.py
@@ -44,9 +44,9 @@ def require_artresizer_compare(test):
         # handle that in ArtResizer.IMBackend.{can_compare,compare}.
         # Skipping the tests as below is a quick fix to CI, but users may
         # still see unexpected behaviour.
-        abbey_artpath = os.path.join(_common.RSRC, b"abbey.jpg")
-        abbey_similarpath = os.path.join(_common.RSRC, b"abbey-similar.jpg")
-        abbey_differentpath = os.path.join(_common.RSRC, b"abbey-different.jpg")
+        abbey_artpath = _common.RSRC / "abbey.jpg"
+        abbey_similarpath = _common.RSRC / "abbey-similar.jpg"
+        abbey_differentpath = _common.RSRC / "abbey-different.jpg"
         compare_threshold = 20
 
         similar_compares_ok = ArtResizer.shared.compare(
@@ -66,10 +66,10 @@ def require_artresizer_compare(test):
 
 class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
     plugin = "embedart"
-    small_artpath = os.path.join(_common.RSRC, b"image-2x3.jpg")
-    abbey_artpath = os.path.join(_common.RSRC, b"abbey.jpg")
-    abbey_similarpath = os.path.join(_common.RSRC, b"abbey-similar.jpg")
-    abbey_differentpath = os.path.join(_common.RSRC, b"abbey-different.jpg")
+    small_artpath = _common.RSRC / "image-2x3.jpg"
+    abbey_artpath = _common.RSRC / "abbey.jpg"
+    abbey_similarpath = _common.RSRC / "abbey-similar.jpg"
+    abbey_differentpath = _common.RSRC / "abbey-different.jpg"
 
     def _setup_data(self, artpath=None):
         if not artpath:
@@ -171,7 +171,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
         mediafile = MediaFile(syspath(item.path))
 
         assert mediafile.images[0].data == self.image_data, (
-            f"Image written is not {displayable_path(self.abbey_artpath)}"
+            f"Image written is not {self.abbey_artpath}"
         )
 
     @require_artresizer_compare
@@ -185,11 +185,11 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
         mediafile = MediaFile(syspath(item.path))
 
         assert mediafile.images[0].data == self.image_data, (
-            f"Image written is not {displayable_path(self.abbey_similarpath)}"
+            f"Image written is not {self.abbey_similarpath}"
         )
 
     def test_non_ascii_album_path(self):
-        resource_path = os.path.join(_common.RSRC, b"image.mp3")
+        resource_path = _common.RSRC / "image.mp3"
         album = self.add_album_fixture()
         trackpath = album.items()[0].path
         shutil.copy(syspath(resource_path), syspath(trackpath))
@@ -199,7 +199,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
         assert (album.filepath / "extracted.png").exists()
 
     def test_extracted_extension(self):
-        resource_path = os.path.join(_common.RSRC, b"image-jpeg.mp3")
+        resource_path = _common.RSRC / "image-jpeg.mp3"
         album = self.add_album_fixture()
         trackpath = album.items()[0].path
         shutil.copy(syspath(resource_path), syspath(trackpath))

--- a/test/plugins/test_metasync.py
+++ b/test/plugins/test_metasync.py
@@ -18,10 +18,8 @@ def _is_windows():
 
 class MetaSyncTest(IOMixin, PluginTestCase):
     plugin = "metasync"
-    itunes_library_unix = os.path.join(_common.RSRC, b"itunes_library_unix.xml")
-    itunes_library_windows = os.path.join(
-        _common.RSRC, b"itunes_library_windows.xml"
-    )
+    itunes_library_unix = _common.RSRC / "itunes_library_unix.xml"
+    itunes_library_windows = _common.RSRC / "itunes_library_windows.xml"
 
     def setUp(self):
         super().setUp()

--- a/test/plugins/test_plugin_mediafield.py
+++ b/test/plugins/test_plugin_mediafield.py
@@ -1,6 +1,5 @@
 """Tests the facility that lets plugins add custom field to MediaFile."""
 
-import os
 import shutil
 
 import mediafile
@@ -30,7 +29,7 @@ list_field_extension = mediafile.ListMediaField(
 class ExtendedFieldTestMixin(BeetsTestCase):
     def _mediafile_fixture(self, name, extension="mp3"):
         name = f"{name}.{extension}"
-        src = os.path.join(os.fsdecode(_common.RSRC), name)
+        src = _common.RSRC / name
         target = self.temp_path / name
         shutil.copy(syspath(src), syspath(target))
         return mediafile.MediaFile(target)

--- a/test/plugins/test_replace.py
+++ b/test/plugins/test_replace.py
@@ -43,7 +43,7 @@ class TestReplace:
 
     def test_path_is_supported_file(self):
         dest = self.fake_file / "full.mp3"
-        src = Path(_common.RSRC.decode()) / "full.mp3"
+        src = _common.RSRC / "full.mp3"
         shutil.copyfile(src, dest)
 
         mediafile = MediaFile(dest)
@@ -102,7 +102,7 @@ class TestReplace:
             replace.confirm_replacement("test", song)
 
     def test_confirm_replacement_yes(self, monkeypatch):
-        src = Path(_common.RSRC.decode()) / "full.mp3"
+        src = _common.RSRC / "full.mp3"
         monkeypatch.setattr("builtins.input", lambda _: "YES    ")
 
         class Song:
@@ -113,7 +113,7 @@ class TestReplace:
         assert replace.confirm_replacement("test", song) is True
 
     def test_confirm_replacement_no(self, monkeypatch):
-        src = Path(_common.RSRC.decode()) / "full.mp3"
+        src = _common.RSRC / "full.mp3"
         monkeypatch.setattr("builtins.input", lambda _: "test123")
 
         class Song:

--- a/test/plugins/test_spotify.py
+++ b/test/plugins/test_spotify.py
@@ -1,7 +1,6 @@
 """Tests for the 'spotify' plugin"""
 
 import json
-import os
 from urllib.parse import parse_qs, urlparse
 
 import responses
@@ -58,11 +57,8 @@ class SpotifyPluginTest(PluginTestCase):
 
     @responses.activate
     def test_missing_request(self):
-        json_file = os.path.join(
-            _common.RSRC, b"spotify", b"missing_request.json"
-        )
-        with open(json_file, "rb") as f:
-            response_body = f.read()
+        json_file = _common.RSRC / "spotify" / "missing_request.json"
+        response_body = json_file.read_bytes()
 
         responses.add(
             responses.GET,
@@ -90,11 +86,8 @@ class SpotifyPluginTest(PluginTestCase):
 
     @responses.activate
     def test_track_request(self):
-        json_file = os.path.join(
-            _common.RSRC, b"spotify", b"track_request.json"
-        )
-        with open(json_file, "rb") as f:
-            response_body = f.read()
+        json_file = _common.RSRC / "spotify" / "track_request.json"
+        response_body = json_file.read_bytes()
 
         responses.add(
             responses.GET,
@@ -128,9 +121,8 @@ class SpotifyPluginTest(PluginTestCase):
         """Tests if plugin is able to fetch a track by its Spotify ID"""
 
         # Mock the Spotify 'Get Track' call
-        json_file = os.path.join(_common.RSRC, b"spotify", b"track_info.json")
-        with open(json_file, "rb") as f:
-            response_body = f.read()
+        json_file = _common.RSRC / "spotify" / "track_info.json"
+        response_body = json_file.read_bytes()
 
         responses.add(
             responses.GET,
@@ -141,9 +133,8 @@ class SpotifyPluginTest(PluginTestCase):
         )
 
         # Mock the Spotify 'Get Album' call
-        json_file = os.path.join(_common.RSRC, b"spotify", b"album_info.json")
-        with open(json_file, "rb") as f:
-            response_body = f.read()
+        json_file = _common.RSRC / "spotify" / "album_info.json"
+        response_body = json_file.read_bytes()
 
         responses.add(
             responses.GET,
@@ -154,11 +145,8 @@ class SpotifyPluginTest(PluginTestCase):
         )
 
         # Mock the Spotify 'Search' call
-        json_file = os.path.join(
-            _common.RSRC, b"spotify", b"track_request.json"
-        )
-        with open(json_file, "rb") as f:
-            response_body = f.read()
+        json_file = _common.RSRC / "spotify" / "track_request.json"
+        response_body = json_file.read_bytes()
 
         responses.add(
             responses.GET,
@@ -186,13 +174,10 @@ class SpotifyPluginTest(PluginTestCase):
         """Ensure non-ASCII characters remain unchanged in search queries"""
 
         # Path to the mock JSON file for the Japanese track
-        json_file = os.path.join(
-            _common.RSRC, b"spotify", b"japanese_track_request.json"
-        )
+        json_file = _common.RSRC / "spotify" / "japanese_track_request.json"
 
         # Load the mock JSON response
-        with open(json_file, "rb") as f:
-            response_body = f.read()
+        response_body = json_file.read_bytes()
 
         # Mock Spotify Search API response
         responses.add(
@@ -250,11 +235,8 @@ class SpotifyPluginTest(PluginTestCase):
         track info correctly"""
 
         # Mock the Spotify 'Get Album' call
-        json_file = os.path.join(
-            _common.RSRC, b"spotify", b"multiartist_album.json"
-        )
-        with open(json_file, "rb") as f:
-            album_response_body = f.read()
+        json_file = _common.RSRC / "spotify" / "multiartist_album.json"
+        album_response_body = json_file.read_bytes()
 
         responses.add(
             responses.GET,
@@ -265,11 +247,8 @@ class SpotifyPluginTest(PluginTestCase):
         )
 
         # Mock the Spotify 'Get Track' call
-        json_file = os.path.join(
-            _common.RSRC, b"spotify", b"multiartist_track.json"
-        )
-        with open(json_file, "rb") as f:
-            track_response_body = f.read()
+        json_file = _common.RSRC / "spotify" / "multiartist_track.json"
+        track_response_body = json_file.read_bytes()
 
         responses.add(
             responses.GET,

--- a/test/plugins/test_web.py
+++ b/test/plugins/test_web.py
@@ -161,19 +161,19 @@ class TestWebPlugin(WebPluginMixin, PytestTestHelper):
         assert response.status_code == 404
 
     def test_get_single_item_by_path(self):
-        data_path = os.path.join(_common.RSRC, b"full.mp3")
+        data_path = _common.RSRC / "full.mp3"
         self.lib.add(Item.from_path(data_path))
-        response = self.client.get(f"/item/path/{data_path.decode('utf-8')}")
+        response = self.client.get(f"/item/path/{data_path}")
         res_json = json.loads(response.data.decode("utf-8"))
 
         assert response.status_code == 200
         assert res_json["title"] == "full"
 
     def test_get_single_item_by_path_not_found_if_not_in_library(self):
-        data_path = os.path.join(_common.RSRC, b"full.mp3")
+        data_path = _common.RSRC / "full.mp3"
         # data_path points to a valid file, but we have not added the file
         # to the library.
-        response = self.client.get(f"/item/path/{data_path.decode('utf-8')}")
+        response = self.client.get(f"/item/path/{data_path}")
 
         assert response.status_code == 404
 
@@ -353,7 +353,7 @@ class TestWebPlugin(WebPluginMixin, PytestTestHelper):
 
         # Create an item with a file
         ipath = self.temp_path / "testfile1.mp3"
-        shutil.copy(os.path.join(_common.RSRC, b"full.mp3"), ipath)
+        shutil.copy(_common.RSRC / "full.mp3", ipath)
         assert ipath.exists()
         item_id = self.lib.add(Item.from_path(ipath))
 
@@ -381,7 +381,7 @@ class TestWebPlugin(WebPluginMixin, PytestTestHelper):
 
         # Create an item with a file
         ipath = self.temp_path / "testfile2.mp3"
-        shutil.copy(os.path.join(_common.RSRC, b"full.mp3"), ipath)
+        shutil.copy(_common.RSRC / "full.mp3", ipath)
         assert ipath.exists()
         item_id = self.lib.add(Item.from_path(ipath))
 
@@ -688,7 +688,7 @@ class TestWebPlugin(WebPluginMixin, PytestTestHelper):
 
     def test_get_item_file(self):
         ipath = self.temp_path / "testfile2.mp3"
-        shutil.copy(os.path.join(_common.RSRC, b"full.mp3"), ipath)
+        shutil.copy(_common.RSRC / "full.mp3", ipath)
         assert ipath.exists()
         item_id = self.lib.add(Item.from_path(ipath))
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -150,7 +150,7 @@ def create_archive(session):
     path = bytestring_path(path)
     os.close(handle)
     archive = ZipFile(os.fsdecode(path), mode="w")
-    archive.write(syspath(os.path.join(_common.RSRC, b"full.mp3")), "full.mp3")
+    archive.write(syspath(_common.RSRC / "full.mp3"), "full.mp3")
     archive.close()
     return bytestring_path(path)
 
@@ -238,9 +238,7 @@ class TestImportTar(TestImportZip):
         path = bytestring_path(path)
         os.close(handle)
         archive = TarFile(os.fsdecode(path), mode="w")
-        archive.add(
-            syspath(os.path.join(_common.RSRC, b"full.mp3")), "full.mp3"
-        )
+        archive.add(syspath(_common.RSRC / "full.mp3"), "full.mp3")
         archive.close()
         return path
 
@@ -248,18 +246,18 @@ class TestImportTar(TestImportZip):
 @pytest.mark.skipif(not has_program("unrar"), reason="unrar program not found")
 class TestImportRar(TestImportZip):
     def create_archive(self):
-        return os.path.join(_common.RSRC, b"archive.rar")
+        return _common.RSRC / "archive.rar"
 
 
 class TestImport7z(TestImportZip):
     def create_archive(self):
-        return os.path.join(_common.RSRC, b"archive.7z")
+        return _common.RSRC / "archive.7z"
 
 
 @pytest.mark.skip(reason="Implement me!")
 class TestImportPasswordRar(TestImportZip):
     def create_archive(self):
-        return os.path.join(_common.RSRC, b"password.rar")
+        return _common.RSRC / "password.rar"
 
 
 class ImportSingletonTest(AutotagImportTestCase):
@@ -316,7 +314,7 @@ class ImportSingletonTest(AutotagImportTestCase):
         assert len(self.lib.items()) == 1
 
     def test_import_single_files(self):
-        resource_path = os.path.join(_common.RSRC, b"empty.mp3")
+        resource_path = _common.RSRC / "empty.mp3"
         single_path = self.import_path / "track_2.mp3"
 
         util.copy(resource_path, single_path)
@@ -379,22 +377,22 @@ class TestImportFormat(ImportHelper):
     """Test fix_extension during import."""
 
     def test_recognize_format(self):
-        resource_src = os.path.join(_common.RSRC, b"no_ext")
+        resource_src = _common.RSRC / "no_ext"
         resource_path = self.import_path / "no_ext"
         util.copy(resource_src, resource_path)
         self.setup_importer(autotag=False)
-        self.importer.paths = [resource_path]
+        self.importer.paths = [os.fsencode(resource_path)]
         self.importer.run()
         assert self.lib.items().get().path.endswith(b".mp3")
 
     def test_recognize_format_already_exist(self, caplog):
-        resource_path = os.path.join(_common.RSRC, b"no_ext")
+        resource_path = _common.RSRC / "no_ext"
         temp_resource_path = self.temp_path / "no_ext"
         util.copy(resource_path, temp_resource_path)
         new_path = self.temp_path / "no_ext.mp3"
         util.copy(temp_resource_path, new_path)
         self.setup_importer(autotag=False)
-        self.importer.paths = [temp_resource_path]
+        self.importer.paths = [os.fsencode(temp_resource_path)]
         with caplog.at_level("DEBUG"):
             self.importer.run()
         assert (
@@ -404,29 +402,29 @@ class TestImportFormat(ImportHelper):
         assert self.lib.items().get().path.endswith(b".mp3")
 
     def test_recognize_format_not_music(self):
-        resource_path = os.path.join(_common.RSRC, b"no_ext_not_music")
+        resource_path = _common.RSRC / "no_ext_not_music"
         self.setup_importer(autotag=False)
-        self.importer.paths = [resource_path]
+        self.importer.paths = [os.fsencode(resource_path)]
         self.importer.run()
         assert len(self.lib.items()) == 0
 
     def test_recognize_format_change_original(self):
         config["import"]["fix_ext_inplace"] = True
-        resource_src = os.path.join(_common.RSRC, b"no_ext")
+        resource_src = _common.RSRC / "no_ext"
         resource_path = self.temp_path / "no_ext"
         util.copy(resource_src, resource_path)
         self.setup_importer(autotag=False)
-        self.importer.paths = [resource_path]
+        self.importer.paths = [os.fsencode(resource_path)]
         self.importer.run()
         assert not Path(self.temp_path / "no_ext").exists()
 
     def test_recognize_format_keep_original(self):
         config["import"]["fix_ext_inplace"] = False
-        resource_src = os.path.join(_common.RSRC, b"no_ext")
+        resource_src = _common.RSRC / "no_ext"
         resource_path = self.temp_path / "no_ext"
         util.copy(resource_src, resource_path)
         self.setup_importer(autotag=False)
-        self.importer.paths = [resource_path]
+        self.importer.paths = [os.fsencode(resource_path)]
         self.importer.run()
         assert Path(self.temp_path / "no_ext").exists()
 
@@ -1046,7 +1044,7 @@ class TestImportDuplicateAlbum(PluginMixin, ImportHelper):
 
     def test_remove_duplicate_album_deletes_art(self):
         album = self.lib.albums().get()
-        art_source = os.path.join(_common.RSRC, b"abbey.jpg")
+        art_source = _common.RSRC / "abbey.jpg"
         album.set_art(art_source)
         album.store()
         old_artpath = album.art_filepath
@@ -1385,9 +1383,7 @@ class TestIncrementalImport(AsIsImporterMixin, ImportHelper):
 
 
 def _mkmp3(path):
-    shutil.copyfile(
-        syspath(os.path.join(_common.RSRC, b"min.mp3")), syspath(path)
-    )
+    shutil.copyfile(syspath(_common.RSRC / "min.mp3"), syspath(path))
 
 
 class AlbumsInDirTest(BeetsTestCase):
@@ -1674,7 +1670,7 @@ class ReimportTest(AutotagImportTestCase):
 
     def test_reimported_item_preserves_art(self):
         self._setup_session()
-        art_source = os.path.join(_common.RSRC, b"abbey.jpg")
+        art_source = _common.RSRC / "abbey.jpg"
         replaced_album = self._album()
         replaced_album.set_art(art_source)
         replaced_album.store()
@@ -1887,7 +1883,7 @@ class TestMpeglayerWavImport(AsIsImporterMixin, ImportHelper):
     """Test remuxing of WAVE_FORMAT_MPEGLAYER3 WAV files."""
 
     def test_remux_mpeglayer3_wav(self):
-        src = Path(os.fsdecode(_common.RSRC)) / "mpeglayer3.wav"
+        src = _common.RSRC / "mpeglayer3.wav"
         dest = self.temp_path / "mpeglayer3.wav"
         shutil.copy(syspath(src), syspath(dest))
 
@@ -1901,7 +1897,7 @@ class TestMpeglayerWavImport(AsIsImporterMixin, ImportHelper):
     def test_remux_mpeglayer3_wav_disabled(self):
         """When remux_mp3_in_wav is disabled, WAV file should not be remuxed."""
         self.config["import"]["remux_mp3_in_wav"] = False
-        src = Path(os.fsdecode(_common.RSRC)) / "mpeglayer3.wav"
+        src = _common.RSRC / "mpeglayer3.wav"
         dest = self.import_path / "mpeglayer3.wav"
         shutil.copy(syspath(src), syspath(dest))
 

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -112,9 +112,7 @@ class TestAdd(PytestItemHelper):
         assert new_grouping == item.grouping
 
     def test_library_add_path_inserts_row(self):
-        item = beets.library.Item.from_path(
-            os.path.join(_common.RSRC, b"full.mp3")
-        )
+        item = beets.library.Item.from_path(_common.RSRC / "full.mp3")
         self.lib.add(item)
         new_grouping = (
             self.lib._connection()
@@ -1151,10 +1149,7 @@ class TestMtime(TestHelper):
     @pytest.fixture(autouse=True)
     def item(self, setup):
         self.ipath = self.temp_path / "testfile.mp3"
-        shutil.copy(
-            syspath(os.path.join(_common.RSRC, b"full.mp3")),
-            syspath(self.ipath),
-        )
+        shutil.copy(syspath(_common.RSRC / "full.mp3"), syspath(self.ipath))
         item = beets.library.Item.from_path(self.ipath)
         self.lib.add(item)
         yield item
@@ -1226,9 +1221,7 @@ class TestTemplate(PytestItemHelper):
 
 class TestUnicodePath(PytestItemHelper):
     def test_unicode_path(self, item_in_db):
-        item_in_db.path = os.path.join(
-            _common.RSRC, "unicode\u2019d.mp3".encode()
-        )
+        item_in_db.path = _common.RSRC / "unicode\u2019d.mp3"
         # If there are any problems with unicode paths, we will raise
         # here and fail.
         item_in_db.read()
@@ -1305,7 +1298,7 @@ class TestWrite(TestHelper):
 
 class TestItemRead(PytestItemHelper):
     def test_unreadable_raise_read_error(self, item_in_db):
-        unreadable = os.path.join(_common.RSRC, b"image-2x3.png")
+        unreadable = _common.RSRC / "image-2x3.png"
         with pytest.raises(beets.library.ReadError) as exc_info:
             item_in_db.read(unreadable)
         assert isinstance(exc_info.value.reason, UnreadableFileError)
@@ -1315,7 +1308,7 @@ class TestItemRead(PytestItemHelper):
             item_in_db.read("/thisfiledoesnotexist")
 
     def test_read_error_str_includes_reason(self, item_in_db):
-        unreadable = os.path.join(_common.RSRC, b"image-2x3.png")
+        unreadable = _common.RSRC / "image-2x3.png"
         with pytest.raises(beets.library.ReadError) as exc_info:
             item_in_db.read(unreadable)
         message = str(exc_info.value)

--- a/test/ui/commands/test_completion.py
+++ b/test/ui/commands/test_completion.py
@@ -51,8 +51,8 @@ class CompletionTest(IOMixin, TestPluginTestCase):
         tester.stdin.writelines(completion_script.splitlines(True))
 
         # Load test suite.
-        test_script_name = os.path.join(_common.RSRC, b"test_completion.sh")
-        with open(test_script_name, "rb") as test_script_file:
+        test_script_name = _common.RSRC / "test_completion.sh"
+        with test_script_name.open("rb") as test_script_file:
             tester.stdin.writelines(test_script_file)
         out, _ = tester.communicate()
         assert tester.returncode == 0

--- a/test/ui/commands/test_update.py
+++ b/test/ui/commands/test_update.py
@@ -14,8 +14,8 @@ class UpdateTest(IOMixin, BeetsTestCase):
         super().setUp()
 
         # Copy a file into the library.
-        item_path = os.path.join(_common.RSRC, b"full.mp3")
-        item_path_two = os.path.join(_common.RSRC, b"full.flac")
+        item_path = _common.RSRC / "full.mp3"
+        item_path_two = _common.RSRC / "full.flac"
         self.i = library.Item.from_path(item_path)
         self.i2 = library.Item.from_path(item_path_two)
         self.lib.add(self.i)

--- a/test/ui/commands/test_utils.py
+++ b/test/ui/commands/test_utils.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 
 import pytest
@@ -14,9 +13,7 @@ from beets.util import syspath
 class QueryTest(BeetsTestCase):
     def add_item(self):
         itempath = self.lib_path / "srcfile"
-        shutil.copy(
-            syspath(os.path.join(_common.RSRC, b"full.mp3")), syspath(itempath)
-        )
+        shutil.copy(_common.RSRC / "full.mp3", syspath(itempath))
         item = library.Item.from_path(itempath)
         self.lib.add(item)
         return item

--- a/test/util/test_art_resize.py
+++ b/test/util/test_art_resize.py
@@ -17,7 +17,7 @@ class ArtResizerFileSizeTest(CleanupModulesMixin, BeetsTestCase):
 
     modules = (IMBackend.__module__,)
 
-    IMG_225x225 = os.path.join(_common.RSRC, b"abbey.jpg")
+    IMG_225x225 = _common.RSRC / "abbey.jpg"
 
     def _test_img_resize(self, backend):
         """Test resizing based on file size, given a resize_func."""

--- a/test/util/test_m3ufile.py
+++ b/test/util/test_m3ufile.py
@@ -85,7 +85,7 @@ class TestM3UFile:
     @pytest.mark.skipif(sys.platform == "win32", reason="win32")
     def test_playlist_load_ascii(self):
         """Test loading ascii paths from a playlist file."""
-        the_playlist_file = path.join(RSRC, b"playlist.m3u")
+        the_playlist_file = RSRC / "playlist.m3u"
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.load()
         assert m3ufile.media_list[0] == bytestring_path(
@@ -95,7 +95,7 @@ class TestM3UFile:
     @pytest.mark.skipif(sys.platform == "win32", reason="win32")
     def test_playlist_load_unicode(self):
         """Test loading unicode paths from a playlist file."""
-        the_playlist_file = path.join(RSRC, b"playlist.m3u8")
+        the_playlist_file = RSRC / "playlist.m3u8"
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.load()
         assert m3ufile.media_list[0] == bytestring_path(
@@ -105,7 +105,7 @@ class TestM3UFile:
     @pytest.mark.skipif(sys.platform != "win32", reason="win32")
     def test_playlist_load_unicode_windows(self):
         """Test loading unicode paths from a playlist file."""
-        the_playlist_file = path.join(RSRC, b"playlist_windows.m3u8")
+        the_playlist_file = RSRC / "playlist_windows.m3u8"
         winpath = bytestring_path(
             path.join("x:\\", "This", "is", "å", "path", "to_a_file.mp3")
         )
@@ -115,14 +115,14 @@ class TestM3UFile:
 
     def test_playlist_load_extm3u(self):
         """Test loading a playlist with an #EXTM3U header."""
-        the_playlist_file = path.join(RSRC, b"playlist.m3u")
+        the_playlist_file = RSRC / "playlist.m3u"
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.load()
         assert m3ufile.extm3u
 
     def test_playlist_load_non_extm3u(self):
         """Test loading a playlist without an #EXTM3U header."""
-        the_playlist_file = path.join(RSRC, b"playlist_non_ext.m3u")
+        the_playlist_file = RSRC / "playlist_non_ext.m3u"
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.load()
         assert not m3ufile.extm3u


### PR DESCRIPTION
Part of #6807

#### What changed

- This change standardizes test resource paths by making `_common.RSRC` a `pathlib.Path` instead of a bytes path.
- Test code now builds paths with `/` and uses `Path` helpers like `read_text()`, `read_bytes()`, `open()`, `stat()`, and `resolve()`.
- Path handling setup in `beets/test/_common.py` is simplified, and old byte-string path conversions are removed from many tests.

#### Why

- Before, test code mixed `os.path`, byte paths, string decoding, and utility conversions.
- Now, resource path handling has one clear shape: `Path` objects.
- This reduces path-conversion noise and makes test helpers easier to read and reuse.
