### PR TITLE
Document art_set event

### DIFF
--- a/docs/dev/plugins/events.rst
+++ b/docs/dev/plugins/events.rst
@@ -65,6 +65,11 @@ registration process in this case:
     :Description: Called every time an album is removed from the library (even
         when its files are not deleted from disk).
 
+``art_set``
+    :Parameters: ``album`` (|Album|)
+    :Description: Called after cover art is copied or moved into place for an
+        album.
+
 ``item_copied``
     :Parameters: ``item`` (|Item|), ``source`` (path), ``destination`` (path)
     :Description: Called whenever an item file is copied.


### PR DESCRIPTION
# Document art_set event

## Summary

Documents the missing `art_set` plugin event in the developer event reference. The entry records that the event fires after album cover art is copied or moved into place and that handlers receive the affected album.

Fixes #6845

## Changes

- Add the `art_set` event and its `album` handler parameter to the plugin-events documentation.

## Testing

- `git diff --check` (passed)
- Attempted `cd repo && sandbox-run "uv run poe lint-docs"`; validation could not run because the local Docker/Colima socket was unavailable (`/Users/dodobaum/.colima/default/docker.sock`).

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
