### PR TITLE
Fix `Model.store()` crash when `fields=` contains a flexible attribute

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -586,10 +586,19 @@ class Model(ABC, Generic[D]):
         if fields is None:
             fields = self._fields
 
+        # Separate the requested fields into fixed (real columns in the main
+        # table) and flexible (persisted via ``_flex_table``). Callers such as
+        # ``beet update`` may pass a flex attribute through ``fields=`` -- for
+        # example, when a plugin registers it via both ``item_types`` and
+        # ``add_media_field``. Treating a flex attribute as a column here used
+        # to build ``UPDATE <table> SET <flex>=?`` and crash with
+        # ``sqlite3.OperationalError: no such column: <flex>`` (see #5580).
+        column_fields = [f for f in fields if f in self._fields]
+
         # Build assignments for query.
         assignments = []
         subvars: list[SQLiteType] = []
-        for key in fields:
+        for key in column_fields:
             if key != "id" and key in self._dirty:
                 self._dirty.remove(key)
                 assignments.append(f"{key}=?")

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -58,6 +58,13 @@ New features
 Bug fixes
 ~~~~~~~~~
 
+- Fixed a ``sqlite3.OperationalError: no such column`` crash in ``Model.store``
+  when a field passed via the ``fields`` argument was a flexible attribute
+  rather than a fixed column. The fields set is now filtered to fixed columns
+  for the main-table ``UPDATE``; flexible attributes continue to be persisted
+  via the ``_flex_table`` path. This affected plugins that register fields via
+  both ``item_types`` and ``add_media_field`` and were later updated with
+  ``beet update``. :bug:`5580`
 - :doc:`plugins/edit`: Preserve missing album art paths when editing album
   metadata, instead of turning ``artpath: null`` into a path ending in ``None``.
   :bug:`2438`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -63,8 +63,8 @@ Bug fixes
   rather than a fixed column. The fields set is now filtered to fixed columns
   for the main-table ``UPDATE``; flexible attributes continue to be persisted
   via the ``_flex_table`` path. This affected plugins that register fields via
-  both ``item_types`` and ``add_media_field`` and were later updated with
-  ``beet update``. :bug:`5580`
+  both ``item_types`` and ``add_media_field`` and were later updated with ``beet
+  update``. :bug:`5580`
 - :doc:`plugins/edit`: Preserve missing album art paths when editing album
   metadata, instead of turning ``artpath: null`` into a path ending in ``None``.
   :bug:`2438`

--- a/test/dbcore/test_db.py
+++ b/test/dbcore/test_db.py
@@ -281,6 +281,27 @@ class ModelTest(unittest.TestCase):
         other_model = self.db._get(ModelFixture1, model.id)
         assert other_model.foo == "bar"
 
+    def test_store_with_flex_field_in_fields_argument(self):
+        """A flex attribute passed via ``fields=`` must not crash.
+
+        Regression test for #5580: when a plugin registers a typed flex
+        attribute (via ``item_types``) and a caller such as ``beet update``
+        passes its name through ``fields=`` to ``Model.store()``, the store
+        loop used to build ``UPDATE <table> SET <flex_field>=?`` and crash
+        with ``sqlite3.OperationalError: no such column: <flex_field>``.
+        Flex attributes have no column in the main table; they live in the
+        ``_flex_table`` and must be persisted via the INSERT path.
+        """
+        model = ModelFixture1()
+        model.add(self.db)
+        model.field_one = 42
+        model.some_float_field = 1.5
+        model.store(fields=["field_one", "some_float_field"])
+
+        other_model = self.db._get(ModelFixture1, model.id)
+        assert other_model.field_one == 42
+        assert other_model.some_float_field == 1.5
+
     def test_delete_flexattr(self):
         model = ModelFixture1()
         model["foo"] = "bar"


### PR DESCRIPTION
## Summary

`Model.store(fields=...)` filters the requested field set to fixed columns before building the main-table `UPDATE`, so a flexible attribute passed via `fields=` is routed through the existing `_flex_table` INSERT path instead of crashing.

Fixes #5580.

## Root cause

A plugin can register the same field name two ways:

​```python
class FooPlugin(BeetsPlugin):
    item_types = {"foo": types.Float()}          # typed flex attribute

    def __init__(self):
        super().__init__()
        self.add_media_field("foo", mediafile.MediaField(...))  # adds to Item._media_fields
​```

`item_types` keeps the field as a flexible attribute (no schema column). `add_media_field` adds the name to `library.Item._media_fields`. When `beet update` is called without `--fields`, `update_items` falls back to `library.Item._media_fields`, which now contains the flex attribute name. It is then forwarded to `Model.store(fields=...)`, whose store loop built `UPDATE <table> SET <flex_field>=?` for every dirty field without checking whether the field had a real column. For flex attributes the column does not exist, so:

​```
sqlite3.OperationalError: no such column: foo
  File ".../beets/dbcore/db.py", line 608, in store
    tx.mutate(query, subvars)
​```

This matches the trace in #5580 (originally reported for beets 2.2.0; still reproducible on current `master`).

## Fix

In `Model.store()`, partition the incoming `fields`:

​```python
column_fields = [f for f in fields if f in self._fields]
​```

and use `column_fields` for the main-table `UPDATE`. Flexible attributes are already persisted just below via the `_values_flex` INSERT path, so they keep round-tripping correctly — no behaviour change for the common case (no plugin, or plugin that only uses `item_types`). The previous code already iterated `self._values_flex` separately, so the only missing piece was the filter.

The `fields=None` default path (`fields = self._fields`) is already all-columns, so it is unaffected.

## How I validated

- Added a regression test in `test/dbcore/test_db.py::ModelTest::test_store_with_flex_field_in_fields_argument` that stores a typed flex attribute (`some_float_field`, declared in `ModelFixture1._types`) through `store(fields=[...])` and asserts the value survives a fresh load. The test fails on `master` with `OperationalError: no such column: some_float_field` and passes with this change.
- Full test suite (`poe test`, deselecting the two known root-in-container / `poe docs` expected failures documented in the dev guide): **2572 passed, 156 skipped** — one more than the clean-HEAD baseline of 2571 (the new test), with no regressions.
- `poe lint`, `poe format`, and `poe check-types .` all clean.

## Why not roll back commit acff5095 (the alternative proposed in the issue)

The issue author suggests reverting [`acff509`](https://github.com/beetbox/beets/commit/acff509585eacc4c4735cedf725ba33bcf17ceab) so that `update_items` falls back to `Item._fields.keys()` instead of `Item._media_fields`. That treats the symptom in one caller; this fix treats the root cause in `Model.store()` so any future caller that forwards a flex attribute through `fields=` is also safe. The change is also strictly narrower: existing fixed-column behaviour is byte-identical (the filter is a no-op when every entry of `fields` is a column).

## Checklist

- [x] Tests added
- [x] Changelog entry added under "Bug fixes"
- [x] `poe test`, `poe lint`, `poe format`, `poe check-types` all pass