### PR TITLE
lyrics: treat missing lyrics body as empty text instead of crashing

### DIFF
--- a/beets/util/lyrics.py
+++ b/beets/util/lyrics.py
@@ -46,9 +46,6 @@ class Lyrics:
 
     def __post_init__(self) -> None:
         """Normalize lyrics metadata and infer missing language information."""
-        # ``from_item`` may hand us ``None`` for a track without stored lyrics.
-        self.text = self.text or ""
-
         self.handle_instrumental()
 
         try:
@@ -96,11 +93,12 @@ class Lyrics:
     @classmethod
     def from_item(cls, item: Item) -> Lyrics:
         """Build lyrics from an item's canonical text and flexible metadata."""
-        data: dict[str, Any] = {"text": item.lyrics}
+        data: dict[str, Any] = {}
         for key in ("backend", "url", "language", "translation_language"):
             data[key] = item.get(f"lyrics_{key}", with_album=False)
 
-        return cls(**data)
+        # ``item.lyrics`` is ``None`` for a track without stored lyrics.
+        return cls(text=item.lyrics or "", **data)
 
     @cached_property
     def original_text(self) -> str:

--- a/beets/util/lyrics.py
+++ b/beets/util/lyrics.py
@@ -46,6 +46,9 @@ class Lyrics:
 
     def __post_init__(self) -> None:
         """Normalize lyrics metadata and infer missing language information."""
+        # ``from_item`` may hand us ``None`` for a track without stored lyrics.
+        self.text = self.text or ""
+
         self.handle_instrumental()
 
         try:
@@ -93,7 +96,7 @@ class Lyrics:
     @classmethod
     def from_item(cls, item: Item) -> Lyrics:
         """Build lyrics from an item's canonical text and flexible metadata."""
-        data = {"text": item.lyrics}
+        data: dict[str, Any] = {"text": item.lyrics}
         for key in ("backend", "url", "language", "translation_language"):
             data[key] = item.get(f"lyrics_{key}", with_album=False)
 

--- a/beets/util/lyrics.py
+++ b/beets/util/lyrics.py
@@ -94,7 +94,13 @@ class Lyrics:
     def from_item(cls, item: Item) -> Lyrics:
         """Build lyrics from an item's canonical text and flexible metadata."""
         data: dict[str, Any] = {}
-        for key in ("backend", "url", "language", "translation_language"):
+        for key in (
+            "backend",
+            "url",
+            "instrumental",
+            "language",
+            "translation_language",
+        ):
             data[key] = item.get(f"lyrics_{key}", with_album=False)
 
         # ``item.lyrics`` is ``None`` for a track without stored lyrics.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,9 @@ Bug fixes
   "ft" (such as "draft", "left", "gift", "craft") as a "featuring artist"
   suffix, which was silently making genuinely different titles/artists score as
   near-identical matches.
+- :doc:`plugins/lyrics`: ``beet lyrics`` no longer crashes with an
+  ``AttributeError`` on tracks that have no stored lyrics when ``force`` is
+  enabled; a missing lyrics body is now treated as empty text. :bug:`6860`
 
 ..
     For plugin developers
@@ -96,9 +99,6 @@ New features
 Bug fixes
 ~~~~~~~~~
 
-- :doc:`plugins/lyrics`: ``beet lyrics`` no longer crashes with an
-  ``AttributeError`` on tracks that have no stored lyrics when ``force`` is
-  enabled; a missing lyrics body is now treated as empty text. :bug:`6860`
 - :doc:`plugins/edit`: Preserve missing album art paths when editing album
   metadata, instead of turning ``artpath: null`` into a path ending in ``None``.
   :bug:`2438`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -96,6 +96,9 @@ New features
 Bug fixes
 ~~~~~~~~~
 
+- :doc:`plugins/lyrics`: ``beet lyrics`` no longer crashes with an
+  ``AttributeError`` on tracks that have no stored lyrics when ``force`` is
+  enabled; a missing lyrics body is now treated as empty text. :bug:`6860`
 - :doc:`plugins/edit`: Preserve missing album art paths when editing album
   metadata, instead of turning ``artpath: null`` into a path ending in ``None``.
   :bug:`2438`

--- a/test/util/test_lyrics.py
+++ b/test/util/test_lyrics.py
@@ -1,5 +1,6 @@
 import textwrap
 
+from beets.library import Item
 from beets.util.lyrics import Lyrics
 
 
@@ -16,8 +17,10 @@ class TestLyrics:
         assert lyrics.language is None
         assert lyrics.translation_language is None
 
-    def test_none_text(self):
-        lyrics = Lyrics(None)
+    def test_from_item_without_lyrics(self):
+        item = Item(lyrics=None)
+
+        lyrics = Lyrics.from_item(item)
 
         assert lyrics.text == ""
         assert not lyrics.synced

--- a/test/util/test_lyrics.py
+++ b/test/util/test_lyrics.py
@@ -16,6 +16,15 @@ class TestLyrics:
         assert lyrics.language is None
         assert lyrics.translation_language is None
 
+    def test_none_text(self):
+        lyrics = Lyrics(None)
+
+        assert lyrics.text == ""
+        assert not lyrics.synced
+        assert lyrics.full_text == ""
+        assert lyrics.sylt == []
+        assert lyrics.text_lines == []
+
     def test_from_legacy_text(self, is_importable):
         text = textwrap.dedent("""
         [00:00.00] Some synced lyrics / Quelques paroles synchronisées


### PR DESCRIPTION
## Description

Fixes #6860.

`beet lyrics` crashes with `AttributeError: 'NoneType' object has no attribute 'splitlines'` on tracks that have no stored lyrics when `force: yes` is set. `Lyrics.from_item()` passes `item.lyrics` straight into the `text` field, and `item.lyrics` is `None` for a track without lyrics. The first access of `existing_lyrics.synced` then reaches `_split_lines`, which calls `self.text.splitlines()` on `None`.

This normalizes a `None` body to an empty string in `Lyrics.__post_init__` (and widens the field annotation to `str | None` to match what `from_item` already feeds it), so the value object behaves like an empty lyrics set rather than crashing.

## To Do

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
