### PR TITLE
use pathlib in tests: migrate most tests to pathlib

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -263,3 +263,11 @@ dc2826fa4b32b625eb4ac9d71934176edde2443e
 d24c0d341ec6074c343cd8054083fe358da8fa14
 # Fix yoda typedefs
 5dcc35112d17976a11ffc468cf436bc3e2342e54
+# Replace item.path with item.filepath in tests
+04c2304879d088ea9be1fad475caf022608a3145
+# Use pathlib.Path wherever possible in tests
+951e32a852b48f87e3dd2ccf71753ee8f7ac2e34
+# Remove syspath
+b2f52ac12443c102712b735e456fd07a6525786b
+# Return Path from TestHelper.create_mediafile_fixture
+bb66b0c378e9bf7d97622a1582d93c4dfcf20fdd

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -38,12 +38,7 @@ from beets.importer import ImportSession
 from beets.library import Item, Library
 from beets.test import _common
 from beets.ui.commands.import_.session import TerminalImportSession
-from beets.util import (
-    MoveOperation,
-    bytestring_path,
-    clean_module_tempdir,
-    syspath,
-)
+from beets.util import MoveOperation, clean_module_tempdir, syspath
 from beets.util.functemplate import template
 
 if TYPE_CHECKING:
@@ -385,7 +380,7 @@ class TestHelper(RunMixin, PathsMixin, ConfigMixin):
         ext: str = "mp3",
         images: list[str] | None = None,
         target_dir: util.PathLike | None = None,
-    ) -> bytes:
+    ) -> Path:
         """Copy a fixture mediafile with the extension to `temp_path`.
 
         `images` is a subset of 'png', 'jpg', and 'tiff'. For each
@@ -395,8 +390,8 @@ class TestHelper(RunMixin, PathsMixin, ConfigMixin):
         if not target_dir:
             target_dir = self.temp_path
         src = _common.RSRC / f"full.{ext}"
-        handle, path = mkstemp(dir=target_dir)
-        path = bytestring_path(path)
+        handle, str_path = mkstemp(dir=target_dir)
+        path = Path(os.fsdecode(str_path))
         os.close(handle)
         shutil.copyfile(syspath(src), syspath(path))
 

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -412,35 +412,6 @@ class TestHelper(RunMixin, PathsMixin, ConfigMixin):
 
         return path
 
-    # Safe file operations
-
-    def touch(
-        self,
-        path: util.PathLike,
-        dir_: util.PathLike | None = None,
-        content: str = "",
-    ) -> bytes:
-        """Create a file at `path` with given content.
-
-        If `dir_` is given, it is prepended to `path`. After that, if the
-        path is relative, it is resolved with respect to
-        `self.temp_path`.
-        """
-        bytes_path = os.fsencode(path)
-        if dir_:
-            bytes_path = os.path.join(os.fsencode(dir_), bytes_path)
-
-        if not os.path.isabs(bytes_path):
-            bytes_path = os.path.join(os.fsencode(self.temp_path), bytes_path)
-
-        parent = os.path.dirname(bytes_path)
-        if not os.path.isdir(syspath(parent)):
-            os.makedirs(syspath(parent))
-
-        with open(syspath(bytes_path), "a+") as f:
-            f.write(content)
-        return bytes_path
-
 
 # A test harness for all beets tests.
 # Provides temporary, isolated configuration.

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -268,10 +268,14 @@ def path_as_posix(path: bytes) -> bytes:
     return path.replace(b"\\", b"/")
 
 
-def mkdirall(path: AnyStr) -> None:
+def mkdirall(path: AnyStr | Path) -> None:
     """Make all the enclosing directories of path (like mkdir -p on the
     parent).
     """
+    if isinstance(path, Path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return
+
     for ancestor in ancestry(path):
         if not os.path.isdir(syspath(ancestor)):
             try:

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -174,7 +174,7 @@ def normpath(path: PathLike) -> bytes:
     """Provide the canonical form of the path suitable for storing in
     the database.
     """
-    str_path = syspath(path, prefix=False)
+    str_path = os.fsdecode(path)
     str_path = os.path.normpath(os.path.abspath(os.path.expanduser(str_path)))
     return bytestring_path(str_path)
 
@@ -416,12 +416,10 @@ def displayable_path(
     return os.fsdecode(path)
 
 
-def syspath(path: PathLike, prefix: bool = True) -> str:
+def syspath(path: PathLike) -> str:
     """Convert a path for use by the operating system. In particular,
     paths on Windows must receive a magic prefix and must be converted
-    to Unicode before they are sent to the OS. To disable the magic
-    prefix on Windows, set `prefix` to False---but only do this if you
-    *really* know what you're doing.
+    to Unicode before they are sent to the OS.
     """
     str_path = os.fsdecode(path)
     # Don't do anything if we're not on windows
@@ -430,7 +428,7 @@ def syspath(path: PathLike, prefix: bool = True) -> str:
 
     # Add the magic prefix if it isn't already there.
     # https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247.aspx
-    if prefix and not str_path.startswith(WINDOWS_MAGIC_PREFIX):
+    if not str_path.startswith(WINDOWS_MAGIC_PREFIX):
         if str_path.startswith("\\\\"):
             # UNC path. Final path should look like \\?\UNC\...
             str_path = f"UNC{str_path[1:]}"

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -239,7 +239,7 @@ class IMBackend(LocalBackend):
         # it here for the sake of explicitness.
         cmd: list[str] = [
             *self.convert_cmd,
-            syspath(path_in, prefix=False),
+            os.fsdecode(path_in),
             "-resize",
             f"{maxwidth}x>",
             "-interlace",
@@ -254,7 +254,7 @@ class IMBackend(LocalBackend):
         if max_filesize > 0:
             cmd += ["-define", f"jpeg:extent={max_filesize}b"]
 
-        cmd.append(syspath(path_out, prefix=False))
+        cmd.append(os.fsdecode(path_out))
 
         try:
             util.command_output(cmd)
@@ -272,7 +272,7 @@ class IMBackend(LocalBackend):
             *self.identify_cmd,
             "-format",
             "%w %h",
-            syspath(path_in, prefix=False),
+            os.fsdecode(path_in),
         ]
 
         try:
@@ -307,10 +307,10 @@ class IMBackend(LocalBackend):
 
         cmd = [
             *self.convert_cmd,
-            syspath(path_in, prefix=False),
+            os.fsdecode(path_in),
             "-interlace",
             "none",
-            syspath(path_out, prefix=False),
+            os.fsdecode(path_out),
         ]
 
         try:
@@ -363,12 +363,10 @@ class IMBackend(LocalBackend):
         # Converting images to grayscale tends to minimize the weight
         # of colors in the diff score. So we first convert both images
         # to grayscale and then pipe them into the `compare` command.
-        # On Windows, ImageMagick doesn't support the magic \\?\ prefix
-        # on paths, so we pass `prefix=False` to `syspath`.
         convert_cmd = [
             *self.convert_cmd,
-            syspath(im2, prefix=False),
-            syspath(im1, prefix=False),
+            os.fsdecode(im2),
+            os.fsdecode(im1),
             "-colorspace",
             "gray",
             "MIFF:-",

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -171,10 +171,7 @@ class IPFSPlugin(BeetsPlugin):
             lib, loghandler=None, query=None, paths=[_hash]
         )
         imp.run()
-        # This uses a relative path, hence we cannot use util.syspath(_hash,
-        # prefix=True). However, that should be fine since the hash will not
-        # exceed MAX_PATH.
-        shutil.rmtree(util.syspath(_hash, prefix=False))
+        shutil.rmtree(_hash)
         return None
 
     def ipfs_publish(self, lib):

--- a/test/dbcore/test_db.py
+++ b/test/dbcore/test_db.py
@@ -105,7 +105,7 @@ class TestDatabasePath:
 
     def test_bytes_filesystem_path_opens_decoded_path(self, tmp_path):
         db_path = tmp_path / "library.db"
-        db = DatabaseFixture1(os.fsencode(db_path))
+        db = DatabaseFixture1(db_path)
         try:
             assert db.path == db_path
             assert db_path.exists()
@@ -126,7 +126,8 @@ class MigrationTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        handle, cls.orig_libfile = mkstemp("orig_db")
+        handle, orig_libfile = mkstemp("orig_db")
+        cls.orig_libfile = Path(orig_libfile)
         os.close(handle)
         # Set up a database with the two-field schema.
         old_lib = DatabaseFixture2(cls.orig_libfile)
@@ -141,15 +142,16 @@ class MigrationTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        os.remove(cls.orig_libfile)
+        cls.orig_libfile.unlink()
 
     def setUp(self):
-        handle, self.libfile = mkstemp("db")
+        handle, libfile = mkstemp("db")
+        self.libfile = Path(libfile)
         os.close(handle)
         shutil.copyfile(self.orig_libfile, self.libfile)
 
     def tearDown(self):
-        os.remove(self.libfile)
+        self.libfile.unlink()
 
     def test_open_with_same_fields_leaves_untouched(self):
         new_lib = DatabaseFixture2(self.libfile)

--- a/test/library/test_migrations.py
+++ b/test/library/test_migrations.py
@@ -1,5 +1,6 @@
 import os
 import textwrap
+from pathlib import Path
 from typing import ClassVar
 
 import pytest
@@ -276,7 +277,7 @@ class TestRelativePathMigration(MigrationTestHelper):
 
     def test_migrate(self):
         """Ensure stored paths become relative while the public API stays stable."""
-        relative_path = os.path.join("foo", "bar", "baz.mp3")
+        relative_path = str(Path("foo") / "bar" / "baz.mp3")
         abs_string_path = str(self.lib_path / relative_path)
         abs_bytes_path = os.fsencode(abs_string_path)
 
@@ -342,7 +343,7 @@ class TestMigrationBackup(MigrationTestHelper):
 
         backups = [
             f
-            for f in os.listdir(os.path.dirname(db_path))
+            for f in db_path.parent.iterdir()
             if os.fsdecode(f).endswith(".bak")
         ]
         assert len(backups) == expected_count

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -930,7 +930,7 @@ class TestArtImporter(UseThePlugin):
             config["import"]["move"] = prev_move
 
     def test_do_not_delete_original_if_already_in_place(self):
-        artdest = os.path.join(os.path.dirname(self.i.path), b"cover.jpg")
+        artdest = self.i.filepath.parent / "cover.jpg"
         shutil.copyfile(self.art_file, syspath(artdest))
         self.afa_response = fetchart.Candidate(
             logger, source_name="test", path=artdest

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -91,7 +91,7 @@ class UseThePlugin(TestHelper):
     @pytest.fixture
     def dpath(self) -> bytes:
         dpath = self.temp_path / "arttest"
-        os.mkdir(syspath(dpath))
+        dpath.mkdir()
         return os.fsencode(dpath)
 
 

--- a/test/plugins/test_art.py
+++ b/test/plugins/test_art.py
@@ -22,7 +22,7 @@ from beets.test.helper import (
     has_program,
     is_importable,
 )
-from beets.util import clean_module_tempdir, syspath
+from beets.util import clean_module_tempdir
 from beets.util.artresizer import ArtResizer
 from beetsplug import fetchart
 
@@ -862,7 +862,7 @@ class TestArtImporter(UseThePlugin):
         # Test library.
         (self.lib_path / "album").mkdir()
         itempath = self.lib_path / "album" / "test.mp3"
-        shutil.copyfile(syspath(_common.RSRC / "full.mp3"), syspath(itempath))
+        shutil.copyfile(_common.RSRC / "full.mp3", itempath)
         self.i = _common.item()
         self.i.path = itempath
         self.album = self.lib.add_album([self.i])
@@ -931,7 +931,7 @@ class TestArtImporter(UseThePlugin):
 
     def test_do_not_delete_original_if_already_in_place(self):
         artdest = self.i.filepath.parent / "cover.jpg"
-        shutil.copyfile(self.art_file, syspath(artdest))
+        shutil.copyfile(self.art_file, artdest)
         self.afa_response = fetchart.Candidate(
             logger, source_name="test", path=artdest
         )

--- a/test/plugins/test_aura.py
+++ b/test/plugins/test_aura.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import os
 from http import HTTPStatus
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -93,7 +91,7 @@ class TestAuraResponse:
                 "album": item.album,
                 "albumartist": item.albumartist,
                 "artist": item.artist,
-                "size": Path(os.fsdecode(item.path)).stat().st_size,
+                "size": item.filepath.stat().st_size,
                 "title": item.title,
                 "track": 1,
             },

--- a/test/plugins/test_convert.py
+++ b/test/plugins/test_convert.py
@@ -178,10 +178,10 @@ class TestConvertCli(ConvertPluginHelper, ConvertCommand):
 
     def test_skip_existing(self):
         converted = self.converted_mp3
-        self.touch(converted, content="XXX")
+        util.mkdirall(converted)
+        converted.write_text("XXX")
         self.run_convert("--yes")
-        with open(converted) as f:
-            assert f.read() == "XXX"
+        assert converted.read_text() == "XXX"
 
     def test_pretend(self):
         self.run_convert("--pretend")

--- a/test/plugins/test_duplicates.py
+++ b/test/plugins/test_duplicates.py
@@ -49,7 +49,7 @@ class TestDuplicatesPlugin(PluginMixin, TestHelper, IOMixin):
         self.create_dups(2)
         out = self.run_cmd(path=True)
 
-        assert self.dup_item.path.decode() in out
+        assert str(self.dup_item.filepath) in out
 
     def test_duplicate_with_count(self):
         self.create_dups(4)
@@ -64,5 +64,5 @@ class TestDuplicatesPlugin(PluginMixin, TestHelper, IOMixin):
         self.create_dups(6)
         out = self.run_cmd(count=True, path=True)
 
-        assert self.dup_item.path.decode() in out
+        assert str(self.dup_item.filepath) in out
         assert out.endswith("5")

--- a/test/plugins/test_embedart.py
+++ b/test/plugins/test_embedart.py
@@ -83,7 +83,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
         item = album.items()[0]
         self.io.addinput("y")
         self.run_command("embedart", "-f", self.small_artpath)
-        mediafile = MediaFile(syspath(item.path))
+        mediafile = MediaFile(item.filepath)
         assert mediafile.images[0].data == self.image_data
 
     def test_embed_art_from_file_with_no_input(self):
@@ -92,7 +92,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
         item = album.items()[0]
         self.io.addinput("n")
         self.run_command("embedart", "-f", self.small_artpath)
-        mediafile = MediaFile(syspath(item.path))
+        mediafile = MediaFile(item.filepath)
         # make sure that images array is empty (nothing embedded)
         assert not mediafile.images
 
@@ -101,7 +101,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
         album = self.add_album_fixture()
         item = album.items()[0]
         self.run_command("embedart", "-y", "-f", self.small_artpath)
-        mediafile = MediaFile(syspath(item.path))
+        mediafile = MediaFile(item.filepath)
         assert mediafile.images[0].data == self.image_data
 
     def test_embed_art_from_album(self):
@@ -111,7 +111,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
         album.artpath = self.small_artpath
         album.store()
         self.run_command("embedart", "-y")
-        mediafile = MediaFile(syspath(item.path))
+        mediafile = MediaFile(item.filepath)
         assert mediafile.images[0].data == self.image_data
 
     def test_embed_art_remove_art_file(self):
@@ -157,7 +157,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
         finally:
             os.remove(syspath(tmp_path))
 
-        mediafile = MediaFile(syspath(album.items()[0].path))
+        mediafile = MediaFile(album.items()[0].filepath)
         assert not mediafile.images  # No image added.
 
     @require_artresizer_compare
@@ -168,7 +168,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
         self.run_command("embedart", "-y", "-f", self.abbey_artpath)
         config["embedart"]["compare_threshold"] = 20
         self.run_command("embedart", "-y", "-f", self.abbey_differentpath)
-        mediafile = MediaFile(syspath(item.path))
+        mediafile = MediaFile(item.filepath)
 
         assert mediafile.images[0].data == self.image_data, (
             f"Image written is not {self.abbey_artpath}"
@@ -182,7 +182,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
         self.run_command("embedart", "-y", "-f", self.abbey_artpath)
         config["embedart"]["compare_threshold"] = 20
         self.run_command("embedart", "-y", "-f", self.abbey_similarpath)
-        mediafile = MediaFile(syspath(item.path))
+        mediafile = MediaFile(item.filepath)
 
         assert mediafile.images[0].data == self.image_data, (
             f"Image written is not {self.abbey_similarpath}"
@@ -191,8 +191,8 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
     def test_non_ascii_album_path(self):
         resource_path = _common.RSRC / "image.mp3"
         album = self.add_album_fixture()
-        trackpath = album.items()[0].path
-        shutil.copy(syspath(resource_path), syspath(trackpath))
+        trackpath = album.items()[0].filepath
+        shutil.copy(syspath(resource_path), trackpath)
 
         self.run_command("extractart", "-n", "extracted")
 
@@ -201,8 +201,8 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
     def test_extracted_extension(self):
         resource_path = _common.RSRC / "image-jpeg.mp3"
         album = self.add_album_fixture()
-        trackpath = album.items()[0].path
-        shutil.copy(syspath(resource_path), syspath(trackpath))
+        trackpath = album.items()[0].filepath
+        shutil.copy(syspath(resource_path), trackpath)
 
         self.run_command("extractart", "-n", "extracted")
 
@@ -214,19 +214,19 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
         item = album.items()[0]
         self.io.addinput("y")
         self.run_command("embedart", "-f", self.small_artpath)
-        embedded_time = os.path.getmtime(syspath(item.path))
+        embedded_time = item.filepath.stat().st_mtime
 
         self.io.addinput("y")
         self.run_command("clearart")
-        mediafile = MediaFile(syspath(item.path))
+        mediafile = MediaFile(item.filepath)
         assert not mediafile.images
-        clear_time = os.path.getmtime(syspath(item.path))
+        clear_time = item.filepath.stat().st_mtime
         assert clear_time > embedded_time
 
         # A run on a file without an image should not be modified
         self.io.addinput("y")
         self.run_command("clearart")
-        no_clear_time = os.path.getmtime(syspath(item.path))
+        no_clear_time = item.filepath.stat().st_mtime
         assert no_clear_time == clear_time
 
     def test_clear_art_with_no_input(self):
@@ -237,7 +237,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
         self.run_command("embedart", "-f", self.small_artpath)
         self.io.addinput("n")
         self.run_command("clearart")
-        mediafile = MediaFile(syspath(item.path))
+        mediafile = MediaFile(item.filepath)
         assert mediafile.images[0].data == self.image_data
 
     def test_embed_art_from_url_with_yes_input(
@@ -251,7 +251,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
         )
         self.io.addinput("y")
         self.run_command("embedart", "-u", "http://example.com/test.jpg")
-        mediafile = MediaFile(syspath(item.path))
+        mediafile = MediaFile(item.filepath)
         assert mediafile.images[0].data == image_request_mock.IMAGE_HEADERS[
             "image/jpeg"
         ].ljust(32, b"\x00")
@@ -266,7 +266,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
             "http://example.com/test.png", content_type="image/png"
         )
         self.run_command("embedart", "-y", "-u", "http://example.com/test.png")
-        mediafile = MediaFile(syspath(item.path))
+        mediafile = MediaFile(item.filepath)
         assert mediafile.images[0].data == image_request_mock.IMAGE_HEADERS[
             "image/png"
         ].ljust(32, b"\x00")
@@ -281,7 +281,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
             "http://example.com/test.html", content_type="text/html"
         )
         self.run_command("embedart", "-y", "-u", "http://example.com/test.html")
-        mediafile = MediaFile(syspath(item.path))
+        mediafile = MediaFile(item.filepath)
         assert not mediafile.images
 
     @NEEDS_FFPROBE
@@ -295,7 +295,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
             importer.run()
 
         item = self.lib.items()[0]
-        assert MediaFile(os.path.join(item.path)).images
+        assert MediaFile(item.filepath).images
 
     @NEEDS_FFPROBE
     def test_clearart_on_import_enabled(self):
@@ -310,7 +310,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
             importer.run()
 
         item = self.lib.items()[0]
-        assert not MediaFile(os.path.join(item.path)).images
+        assert not MediaFile(item.filepath).images
 
 
 class DummyArtResizer(ArtResizer):

--- a/test/plugins/test_embedart.py
+++ b/test/plugins/test_embedart.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import os
-import os.path
 import shutil
 import tempfile
 import unittest
+from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
@@ -22,7 +22,7 @@ from beets.test.helper import (
     IOMixin,
     PluginMixin,
 )
-from beets.util import bytestring_path, displayable_path, syspath
+from beets.util import syspath
 from beets.util.artresizer import ArtResizer
 from beetsplug._utils import art
 
@@ -74,8 +74,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
     def _setup_data(self, artpath=None):
         if not artpath:
             artpath = self.small_artpath
-        with open(syspath(artpath), "rb") as f:
-            self.image_data = f.read()
+        self.image_data = artpath.read_bytes()
 
     def test_embed_art_from_file_with_yes_input(self):
         self._setup_data()
@@ -121,7 +120,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
         logging.getLogger("beets.embedart").setLevel(logging.DEBUG)
 
         handle, tmp_path = tempfile.mkstemp()
-        tmp_path = bytestring_path(tmp_path)
+        tmp_path = Path(tmp_path)
         os.write(handle, self.image_data)
         os.close(handle)
 
@@ -131,11 +130,9 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
         config["embedart"]["remove_art_file"] = True
         self.run_command("embedart", "-y")
 
-        if os.path.isfile(syspath(tmp_path)):
-            os.remove(syspath(tmp_path))
-            pytest.fail(
-                f"Artwork file {displayable_path(tmp_path)} was not deleted"
-            )
+        if tmp_path.is_file():
+            tmp_path.unlink()
+            pytest.fail(f"Artwork file {tmp_path} was not deleted")
 
     def test_art_file_missing(self):
         self.add_album_fixture()
@@ -148,14 +145,14 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
         logging.getLogger("beets.embedart").setLevel(logging.DEBUG)
 
         handle, tmp_path = tempfile.mkstemp()
-        tmp_path = bytestring_path(tmp_path)
+        tmp_path = Path(tmp_path)
         os.write(handle, b"I am not an image.")
         os.close(handle)
 
         try:
             self.run_command("embedart", "-y", "-f", tmp_path)
         finally:
-            os.remove(syspath(tmp_path))
+            tmp_path.unlink()
 
         mediafile = MediaFile(album.items()[0].filepath)
         assert not mediafile.images  # No image added.

--- a/test/plugins/test_embedart.py
+++ b/test/plugins/test_embedart.py
@@ -22,7 +22,6 @@ from beets.test.helper import (
     IOMixin,
     PluginMixin,
 )
-from beets.util import syspath
 from beets.util.artresizer import ArtResizer
 from beetsplug._utils import art
 
@@ -189,7 +188,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
         resource_path = _common.RSRC / "image.mp3"
         album = self.add_album_fixture()
         trackpath = album.items()[0].filepath
-        shutil.copy(syspath(resource_path), trackpath)
+        shutil.copy(resource_path, trackpath)
 
         self.run_command("extractart", "-n", "extracted")
 
@@ -199,7 +198,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
         resource_path = _common.RSRC / "image-jpeg.mp3"
         album = self.add_album_fixture()
         trackpath = album.items()[0].filepath
-        shutil.copy(syspath(resource_path), trackpath)
+        shutil.copy(resource_path, trackpath)
 
         self.run_command("extractart", "-n", "extracted")
 

--- a/test/plugins/test_fetchart.py
+++ b/test/plugins/test_fetchart.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import ctypes
-import os
 import sys
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 from unittest import mock
 
-from beets import importer, util
+from beets import importer
 from beets.test.helper import (
     AutotagImportHelper,
     IOMixin,
@@ -12,6 +13,9 @@ from beets.test.helper import (
     PluginTestHelper,
 )
 from beetsplug.fetchart import CoverArtArchive, FetchArtPlugin, FileSystem
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class TestFetchartImport(PluginMixin, AutotagImportHelper):
@@ -71,24 +75,25 @@ class TestFetchartCli(IOMixin, PluginTestHelper):
         self.config["fetchart"]["cover_names"] = "c\xc3\xb6ver.jpg"
         self.config["art_filename"] = "mycover"
         self.album = self.add_album()
+        self.album.filepath.mkdir(parents=True)
 
     def cover_path(self, ext: str = "jpg"):
-        return os.path.join(self.album.path, f"mycover.{ext}".encode())
+        return self.album.filepath / f"mycover.{ext}"
 
     def check_cover_is_stored(self, ext: str = "jpg"):
-        assert self.album["artpath"] == self.cover_path(ext)
-        with open(util.syspath(self.cover_path(ext))) as f:
-            assert f.read() == "IMAGE"
+        cover_path = self.cover_path(ext)
+        assert cover_path == self.album.art_filepath
+        assert cover_path.read_text() == "IMAGE"
 
-    def hide_file_windows(self, path: bytes) -> None:
+    def hide_file_windows(self, path: Path) -> None:
         if sys.platform == "win32":
             hidden_mask = 2
             assert ctypes.windll.kernel32.SetFileAttributesW(
-                util.syspath(path), hidden_mask
+                str(path), hidden_mask
             )
 
     def test_set_art_from_folder(self):
-        self.touch(b"c\xc3\xb6ver.jpg", dir_=self.album.path, content="IMAGE")
+        (self.album.filepath / "c\xc3\xb6ver.jpg").write_text("IMAGE")
 
         self.run_command("fetchart")
 
@@ -96,27 +101,27 @@ class TestFetchartCli(IOMixin, PluginTestHelper):
         self.check_cover_is_stored()
 
     def test_filesystem_does_not_pick_up_folder(self):
-        os.makedirs(os.path.join(self.album.path, b"mycover.jpg"))
         self.run_command("fetchart")
         self.album.load()
         assert self.album["artpath"] is None
 
     def test_filesystem_does_not_pick_up_ignored_file(self):
-        self.touch(b"co_ver.jpg", dir_=self.album.path, content="IMAGE")
+        (self.album.filepath / "co_ver.jpg").write_text("IMAGE")
         self.config["ignore"] = ["*_*"]
         self.run_command("fetchart")
         self.album.load()
         assert self.album["artpath"] is None
 
     def test_filesystem_picks_up_non_ignored_file(self):
-        self.touch(b"cover.jpg", dir_=self.album.path, content="IMAGE")
+        (self.album.filepath / "cover.jpg").write_text("IMAGE")
         self.config["ignore"] = ["*_*"]
         self.run_command("fetchart")
         self.album.load()
         self.check_cover_is_stored()
 
     def test_filesystem_does_not_pick_up_hidden_file(self):
-        path = self.touch(b".cover.jpg", dir_=self.album.path, content="IMAGE")
+        path = self.album.filepath / ".cover.jpg"
+        path.write_text("IMAGE")
         self.hide_file_windows(path)
         self.config["ignore"] = []  # By default, ignore includes '.*'.
         self.config["ignore_hidden"] = True
@@ -125,14 +130,15 @@ class TestFetchartCli(IOMixin, PluginTestHelper):
         assert self.album["artpath"] is None
 
     def test_filesystem_picks_up_non_hidden_file(self):
-        self.touch(b"cover.jpg", dir_=self.album.path, content="IMAGE")
+        (self.album.filepath / "cover.jpg").write_text("IMAGE")
         self.config["ignore_hidden"] = True
         self.run_command("fetchart")
         self.album.load()
         self.check_cover_is_stored()
 
     def test_filesystem_picks_up_hidden_file(self):
-        path = self.touch(b".cover.jpg", dir_=self.album.path, content="IMAGE")
+        path = self.album.filepath / ".cover.jpg"
+        path.write_text("IMAGE")
         self.hide_file_windows(path)
         self.config["ignore"] = []  # By default, ignore includes '.*'.
         self.config["ignore_hidden"] = False
@@ -141,13 +147,13 @@ class TestFetchartCli(IOMixin, PluginTestHelper):
         self.check_cover_is_stored()
 
     def test_filesystem_picks_up_webp_file(self):
-        self.touch(b"cover.webp", dir_=self.album.path, content="IMAGE")
+        (self.album.filepath / "cover.webp").write_text("IMAGE")
         self.run_command("fetchart")
         self.album.load()
         self.check_cover_is_stored("webp")
 
     def test_filesystem_picks_up_png_file(self):
-        self.touch(b"cover.png", dir_=self.album.path, content="IMAGE")
+        (self.album.filepath / "cover.png").write_text("IMAGE")
         self.run_command("fetchart")
         self.album.load()
         self.check_cover_is_stored("png")
@@ -161,7 +167,7 @@ class TestFetchartCli(IOMixin, PluginTestHelper):
         """OSError (e.g. PermissionError) in set_art is logged as a warning,
         not an unhandled crash. Regression test for #6193.
         """
-        self.touch(b"c\xc3\xb6ver.jpg", dir_=self.album.path, content="IMAGE")
+        (self.album.filepath / "c\xc3\xb6ver.jpg").write_text("IMAGE")
         with mock.patch(
             "beets.library.Album.set_art",
             side_effect=PermissionError("[WinError 32] file in use"),

--- a/test/plugins/test_filefilter.py
+++ b/test/plugins/test_filefilter.py
@@ -1,7 +1,6 @@
 """Tests for the `filefilter` plugin."""
 
 from beets.test.helper import ImportHelper, PluginMixin
-from beets.util import bytestring_path
 
 
 class FileFilterPluginHelper(PluginMixin, ImportHelper):
@@ -14,7 +13,7 @@ class FileFilterPluginHelper(PluginMixin, ImportHelper):
 
     def prepare_tracks_for_import(self):
         self.album_track, self.other_album_track, self.single_track = (
-            bytestring_path(self.prepare_album_for_import(1, album_path=p)[0])
+            self.prepare_album_for_import(1, album_path=p)[0]
             for p in [
                 self.import_path / "album",
                 self.import_path / "other_album",
@@ -32,7 +31,7 @@ class FileFilterPluginHelper(PluginMixin, ImportHelper):
             self.importer.run()
 
         assert len(self.lib.albums()) == expected_album_count
-        assert {i.path for i in self.lib.items()} == expected_paths
+        assert {i.filepath for i in self.lib.items()} == expected_paths
 
 
 class TestFileFilterPluginNonSingleton(FileFilterPluginHelper):

--- a/test/plugins/test_hook.py
+++ b/test/plugins/test_hook.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
 import pytest
@@ -91,7 +92,7 @@ class TestHookCommand(HookTestCase):
                     plugins.send(event, path=path)
                 else:
                     plugins.send(event)
-                assert os.path.isfile(path)
+                assert Path(os.fsdecode(path)).is_file()
 
     @pytest.mark.skipif(sys.platform == "win32", reason="win32")
     def test_hook_no_arguments(self):

--- a/test/plugins/test_importadded.py
+++ b/test/plugins/test_importadded.py
@@ -10,7 +10,6 @@ import pytest
 
 from beets import importer
 from beets.test.helper import AutotagImportTestCase, PluginMixin
-from beets.util import syspath
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -19,7 +18,7 @@ if TYPE_CHECKING:
 def modify_mtimes(paths: Iterable[Path], offset=-60000):
     for i, path in enumerate(paths, start=1):
         mstat = path.stat()
-        os.utime(syspath(path), (mstat.st_atime, mstat.st_mtime + offset * i))
+        os.utime(path, (mstat.st_atime, mstat.st_mtime + offset * i))
 
 
 class ImportAddedTest(PluginMixin, AutotagImportTestCase):

--- a/test/plugins/test_importadded.py
+++ b/test/plugins/test_importadded.py
@@ -6,7 +6,7 @@ import pytest
 
 from beets import importer
 from beets.test.helper import AutotagImportTestCase, PluginMixin
-from beets.util import displayable_path, syspath
+from beets.util import syspath
 
 
 def modify_mtimes(paths, offset=-60000):
@@ -37,9 +37,7 @@ class ImportAddedTest(PluginMixin, AutotagImportTestCase):
         for m in self.import_media:
             if m.title.replace("Tag", "Applied") == item.title:
                 return m
-        raise AssertionError(
-            f"No MediaFile found for Item {displayable_path(item.path)}"
-        )
+        raise AssertionError(f"No MediaFile found for Item {item.filepath}")
 
     def test_import_album_with_added_dates(self):
         self.importer.run()
@@ -68,7 +66,7 @@ class ImportAddedTest(PluginMixin, AutotagImportTestCase):
             assert item.added == pytest.approx(self.min_mtime, rel=1e-4)
             mediafile_mtime = os.path.getmtime(self.find_media_file(item).path)
             assert item.mtime == pytest.approx(mediafile_mtime, rel=1e-4)
-            assert os.path.getmtime(item.path) == pytest.approx(
+            assert item.filepath.stat().st_mtime == pytest.approx(
                 mediafile_mtime, rel=1e-4
             )
 
@@ -77,7 +75,9 @@ class ImportAddedTest(PluginMixin, AutotagImportTestCase):
         self.importer.run()
         album = self.lib.albums().get()
         album_added_before = album.added
-        items_added_before = {item.path: item.added for item in album.items()}
+        items_added_before = {
+            item.filepath: item.added for item in album.items()
+        }
         # Newer Item path mtimes as if Beets had modified them
         modify_mtimes(items_added_before.keys(), offset=10000)
         # Reimport
@@ -86,11 +86,13 @@ class ImportAddedTest(PluginMixin, AutotagImportTestCase):
         # Verify the reimported items
         album = self.lib.albums().get()
         assert album.added == pytest.approx(album_added_before, rel=1e-4)
-        items_added_after = {item.path: item.added for item in album.items()}
+        items_added_after = {
+            item.filepath: item.added for item in album.items()
+        }
         for item_path, added_after in items_added_after.items():
             assert items_added_before[item_path] == pytest.approx(
                 added_after, rel=1e-4
-            ), f"reimport modified Item.added for {displayable_path(item_path)}"
+            ), f"reimport modified Item.added for {item_path}"
 
     def test_import_singletons_with_added_dates(self):
         self.config["import"]["singletons"] = True
@@ -109,7 +111,7 @@ class ImportAddedTest(PluginMixin, AutotagImportTestCase):
             mediafile_mtime = os.path.getmtime(self.find_media_file(item).path)
             assert item.added == pytest.approx(mediafile_mtime, rel=1e-4)
             assert item.mtime == pytest.approx(mediafile_mtime, rel=1e-4)
-            assert os.path.getmtime(item.path) == pytest.approx(
+            assert item.filepath.stat().st_mtime == pytest.approx(
                 mediafile_mtime, rel=1e-4
             )
 
@@ -118,7 +120,7 @@ class ImportAddedTest(PluginMixin, AutotagImportTestCase):
         # Import and record the original added dates
         self.importer.run()
         items_added_before = {
-            item.path: item.added for item in self.lib.items()
+            item.filepath: item.added for item in self.lib.items()
         }
         # Newer Item path mtimes as if Beets had modified them
         modify_mtimes(items_added_before.keys(), offset=10000)
@@ -126,8 +128,10 @@ class ImportAddedTest(PluginMixin, AutotagImportTestCase):
         self.setup_importer(import_dir=self.lib_path, singletons=True)
         self.importer.run()
         # Verify the reimported items
-        items_added_after = {item.path: item.added for item in self.lib.items()}
+        items_added_after = {
+            item.filepath: item.added for item in self.lib.items()
+        }
         for item_path, added_after in items_added_after.items():
             assert items_added_before[item_path] == pytest.approx(
                 added_after, rel=1e-4
-            ), f"reimport modified Item.added for {displayable_path(item_path)}"
+            ), f"reimport modified Item.added for {item_path}"

--- a/test/plugins/test_importadded.py
+++ b/test/plugins/test_importadded.py
@@ -1,6 +1,10 @@
 """Tests for the `importadded` plugin."""
 
+from __future__ import annotations
+
 import os
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -8,10 +12,13 @@ from beets import importer
 from beets.test.helper import AutotagImportTestCase, PluginMixin
 from beets.util import syspath
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
-def modify_mtimes(paths, offset=-60000):
+
+def modify_mtimes(paths: Iterable[Path], offset=-60000):
     for i, path in enumerate(paths, start=1):
-        mstat = os.stat(path)
+        mstat = path.stat()
         os.utime(syspath(path), (mstat.st_atime, mstat.st_mtime + offset * i))
 
 
@@ -25,18 +32,17 @@ class ImportAddedTest(PluginMixin, AutotagImportTestCase):
         self.prepare_album_for_import(2)
         # Different mtimes on the files to be imported in order to test the
         # plugin
-        modify_mtimes(mfile.path for mfile in self.import_media)
-        self.min_mtime = min(
-            os.path.getmtime(mfile.path) for mfile in self.import_media
-        )
+        paths = [Path(mfile.path) for mfile in self.import_media]
+        modify_mtimes(paths)
+        self.min_mtime = min(p.stat().st_mtime for p in paths)
         self.importer = self.setup_importer()
         self.importer.add_choice(importer.Action.APPLY)
 
-    def find_media_file(self, item):
+    def find_media_file_mtime(self, item) -> float:
         """Find the pre-import MediaFile for an Item"""
         for m in self.import_media:
             if m.title.replace("Tag", "Applied") == item.title:
-                return m
+                return Path(m.path).stat().st_mtime
         raise AssertionError(f"No MediaFile found for Item {item.filepath}")
 
     def test_import_album_with_added_dates(self):
@@ -64,7 +70,7 @@ class ImportAddedTest(PluginMixin, AutotagImportTestCase):
         assert album.added == self.min_mtime
         for item in album.items():
             assert item.added == pytest.approx(self.min_mtime, rel=1e-4)
-            mediafile_mtime = os.path.getmtime(self.find_media_file(item).path)
+            mediafile_mtime = self.find_media_file_mtime(item)
             assert item.mtime == pytest.approx(mediafile_mtime, rel=1e-4)
             assert item.filepath.stat().st_mtime == pytest.approx(
                 mediafile_mtime, rel=1e-4
@@ -98,9 +104,8 @@ class ImportAddedTest(PluginMixin, AutotagImportTestCase):
         self.config["import"]["singletons"] = True
         self.importer.run()
         for item in self.lib.items():
-            mfile = self.find_media_file(item)
             assert item.added == pytest.approx(
-                os.path.getmtime(mfile.path), rel=1e-4
+                self.find_media_file_mtime(item), rel=1e-4
             )
 
     def test_import_singletons_with_preserved_mtimes(self):
@@ -108,7 +113,7 @@ class ImportAddedTest(PluginMixin, AutotagImportTestCase):
         self.config["importadded"]["preserve_mtimes"] = True
         self.importer.run()
         for item in self.lib.items():
-            mediafile_mtime = os.path.getmtime(self.find_media_file(item).path)
+            mediafile_mtime = self.find_media_file_mtime(item)
             assert item.added == pytest.approx(mediafile_mtime, rel=1e-4)
             assert item.mtime == pytest.approx(mediafile_mtime, rel=1e-4)
             assert item.filepath.stat().st_mtime == pytest.approx(

--- a/test/plugins/test_importfeeds.py
+++ b/test/plugins/test_importfeeds.py
@@ -1,5 +1,5 @@
 import datetime
-import os
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -22,7 +22,7 @@ class ImportFeedsTest(PluginTestCase):
     def test_multi_format_album_playlist(self):
         self.config["importfeeds"]["formats"] = "m3u_multi"
         album = Album(album="album/name", id=1)
-        item_path = os.path.join("path", "to", "item")
+        item_path = Path("path") / "to" / "item"
         item = Item(title="song", album_id=1, path=item_path)
         self.lib.add(album)
         self.lib.add(item)
@@ -30,31 +30,30 @@ class ImportFeedsTest(PluginTestCase):
         self.importfeeds.album_imported(self.lib, album)
         playlist_path = self.feeds_dir / next(self.feeds_dir.iterdir())
         assert str(playlist_path).endswith("album_name.m3u")
-        with open(playlist_path) as playlist:
-            assert item_path in playlist.read()
+        assert str(item_path) in playlist_path.read_text()
 
     def test_playlist_in_subdir(self):
         self.config["importfeeds"]["formats"] = "m3u"
-        self.config["importfeeds"]["m3u_name"] = os.path.join(
-            "subdir", "imported.m3u"
+        self.config["importfeeds"]["m3u_name"] = str(
+            Path("subdir") / "imported.m3u"
         )
         album = Album(album="album/name", id=1)
-        item_path = os.path.join("path", "to", "item")
+        item_path = Path("path") / "to" / "item"
         item = Item(title="song", album_id=1, path=item_path)
         self.lib.add(album)
         self.lib.add(item)
 
         self.importfeeds.album_imported(self.lib, album)
         playlist = self.feeds_dir / self.config["importfeeds"]["m3u_name"].get()
-        playlist_subdir = os.path.dirname(playlist)
-        assert os.path.isdir(playlist_subdir)
-        assert os.path.isfile(playlist)
+        playlist_subdir = playlist.parent
+        assert playlist_subdir.is_dir()
+        assert playlist.is_file()
 
     def test_playlist_per_session(self):
         self.config["importfeeds"]["formats"] = "m3u_session"
         self.config["importfeeds"]["m3u_name"] = "imports.m3u"
         album = Album(album="album/name", id=1)
-        item_path = os.path.join("path", "to", "item")
+        item_path = Path("path") / "to" / "item"
         item = Item(title="song", album_id=1, path=item_path)
         self.lib.add(album)
         self.lib.add(item)
@@ -63,17 +62,16 @@ class ImportFeedsTest(PluginTestCase):
         self.importfeeds.album_imported(self.lib, album)
         date = datetime.datetime.now().strftime("%Y%m%d_%Hh%M")
         playlist = self.feeds_dir / f"imports_{date}.m3u"
-        assert os.path.isfile(playlist)
-        with open(playlist) as playlist_contents:
-            assert item_path in playlist_contents.read()
+        assert playlist.is_file()
+        assert str(item_path) in playlist.read_text()
 
     def test_link_failure_warns_and_continues(self):
         """A symlink that can't be created is logged as a warning and
         skipped; remaining items are still processed (#840)."""
         self.config["importfeeds"]["formats"] = "link"
         album = Album(album="album/name", id=1)
-        item1 = Item(title="one", album_id=1, path=os.path.join("path", "one"))
-        item2 = Item(title="two", album_id=1, path=os.path.join("path", "two"))
+        item1 = Item(title="one", album_id=1, path=Path("path") / "one")
+        item2 = Item(title="two", album_id=1, path=Path("path") / "two")
         self.lib.add(album)
         self.lib.add(item1)
         self.lib.add(item2)
@@ -94,9 +92,8 @@ class ImportFeedsTest(PluginTestCase):
         """Only FilesystemError is caught; other errors still propagate."""
         self.config["importfeeds"]["formats"] = "link"
         album = Album(album="album/name", id=1)
-        item = Item(
-            title="song", album_id=1, path=os.path.join("path", "to", "item")
-        )
+        item_path = Path("path") / "to" / "item"
+        item = Item(title="song", album_id=1, path=item_path)
         self.lib.add(album)
         self.lib.add(item)
 
@@ -114,7 +111,7 @@ class ImportFeedsTest(PluginTestCase):
         self.config["importfeeds"]["formats"] = "link"
         self.feeds_dir.mkdir(parents=True, exist_ok=True)
         album = Album(album="album/name", id=1)
-        item_path = os.path.join("path", "to", "item")
+        item_path = Path("path") / "to" / "item"
         item = Item(title="song", album_id=1, path=item_path)
         self.lib.add(album)
         self.lib.add(item)
@@ -122,4 +119,4 @@ class ImportFeedsTest(PluginTestCase):
         self.importfeeds.album_imported(self.lib, album)
 
         linked = self.feeds_dir / item.filepath.name
-        assert os.path.islink(linked)
+        assert linked.is_symlink()

--- a/test/plugins/test_importsource.py
+++ b/test/plugins/test_importsource.py
@@ -65,9 +65,7 @@ class ImportSourceTest(IOMixin, PluginMixin, AutotagImportTestCase):
         import_paths = self.prepare_album_for_import(
             2, album_path=test_album_path
         )
-        original_mtimes = {
-            path: os.stat(path).st_mtime for path in import_paths
-        }
+        original_mtimes = {p: p.stat().st_mtime for p in import_paths}
 
         # Small delay to detect timestamp changes
         time.sleep(0.1)
@@ -79,7 +77,7 @@ class ImportSourceTest(IOMixin, PluginMixin, AutotagImportTestCase):
 
         # Verify timestamps haven't changed
         for path, original_mtime in original_mtimes.items():
-            current_mtime = os.stat(path).st_mtime
+            current_mtime = path.stat().st_mtime
             assert current_mtime == original_mtime, (
                 f"Source file timestamp changed: {path}"
             )

--- a/test/plugins/test_importsource.py
+++ b/test/plugins/test_importsource.py
@@ -5,7 +5,6 @@ import time
 
 from beets import importer, plugins
 from beets.test.helper import AutotagImportTestCase, IOMixin, PluginMixin
-from beets.util import syspath
 
 
 class ImportSourceTest(IOMixin, PluginMixin, AutotagImportTestCase):
@@ -26,7 +25,7 @@ class ImportSourceTest(IOMixin, PluginMixin, AutotagImportTestCase):
     def interact(self, stdin: list[str]):
         for char in stdin:
             self.io.addinput(char)
-        self.run_command("remove", f"path:{syspath(self.item_to_remove.path)}")
+        self.run_command("remove", f"path:{self.item_to_remove.filepath}")
 
     def test_do_nothing(self):
         self.interact(["N"])

--- a/test/plugins/test_info.py
+++ b/test/plugins/test_info.py
@@ -1,7 +1,8 @@
+import os
+
 from mediafile import MediaFile
 
 from beets.test.helper import IOMixin, PluginTestCase
-from beets.util import displayable_path
 
 
 class InfoTest(IOMixin, PluginTestCase):
@@ -18,7 +19,7 @@ class InfoTest(IOMixin, PluginTestCase):
         mediafile.save()
 
         out = self.run_with_output("info", path)
-        assert displayable_path(path) in out
+        assert os.fsdecode(path) in out
         assert "albumartist: AAA" in out
         assert "disctitle: DDD" in out
         assert "genres: a; b; c" in out

--- a/test/plugins/test_info.py
+++ b/test/plugins/test_info.py
@@ -32,10 +32,10 @@ class InfoTest(IOMixin, PluginTestCase):
         item1.store()
 
         out = self.run_with_output("info", "album:yyyy")
-        assert displayable_path(item1.path) in out
+        assert str(item1.filepath) in out
         assert "album: xxxx" in out
 
-        assert displayable_path(item2.path) not in out
+        assert str(item2.filepath) not in out
 
     def test_item_library_query(self):
         (item,) = self.add_item_fixtures()
@@ -43,7 +43,7 @@ class InfoTest(IOMixin, PluginTestCase):
         item.store()
 
         out = self.run_with_output("info", "--library", "album:xxxx")
-        assert displayable_path(item.path) in out
+        assert str(item.filepath) in out
         assert "album: xxxx" in out
 
     def test_collect_item_and_path(self):

--- a/test/plugins/test_info.py
+++ b/test/plugins/test_info.py
@@ -18,7 +18,7 @@ class InfoTest(IOMixin, PluginTestCase):
         mediafile.composer = None
         mediafile.save()
 
-        out = self.run_with_output("info", path)
+        out = self.run_with_output("info", str(path))
         assert os.fsdecode(path) in out
         assert "albumartist: AAA" in out
         assert "disctitle: DDD" in out
@@ -61,7 +61,9 @@ class InfoTest(IOMixin, PluginTestCase):
         item.store()
         mediafile.save()
 
-        out = self.run_with_output("info", "--summarize", "album:AAA", path)
+        out = self.run_with_output(
+            "info", "--summarize", "album:AAA", str(path)
+        )
         assert "album: AAA" in out
         assert "tracktotal: 5" in out
         assert "title: [various]" in out
@@ -86,7 +88,9 @@ class InfoTest(IOMixin, PluginTestCase):
         item.store()
         mediafile.save()
 
-        out = self.run_with_output("info", "--summarize", "album:AAA", path)
+        out = self.run_with_output(
+            "info", "--summarize", "album:AAA", str(path)
+        )
         assert "album: AAA" in out
         assert "tracktotal: 5" in out
         assert "title: [various]" in out

--- a/test/plugins/test_ipfs.py
+++ b/test/plugins/test_ipfs.py
@@ -1,7 +1,7 @@
-import os
+from pathlib import Path
 from unittest.mock import Mock, patch
 
-from beets import library, util
+from beets import library
 from beets.test import _common
 from beets.test.helper import PluginTestCase
 from beetsplug.ipfs import IPFSPlugin
@@ -22,11 +22,11 @@ class IPFSPluginTest(PluginTestCase):
             want_item = test_album.items()[2]
             for check_item in added_album.items():
                 if check_item.get("ipfs", with_album=False):
-                    ipfs_item = os.fsdecode(os.path.basename(want_item.path))
-                    want_path = util.normpath(
-                        os.path.join("/ipfs", test_album.ipfs, ipfs_item)
+                    ipfs_item = want_item.filepath.name
+                    want_path = (
+                        Path("/ipfs").resolve() / test_album.ipfs / ipfs_item
                     )
-                    assert check_item.path == want_path
+                    assert check_item.filepath == want_path
                     assert (
                         check_item.get("ipfs", with_album=False)
                         == want_item.ipfs

--- a/test/plugins/test_plugin_mediafield.py
+++ b/test/plugins/test_plugin_mediafield.py
@@ -31,7 +31,7 @@ class ExtendedFieldTestMixin(BeetsTestCase):
         name = f"{name}.{extension}"
         src = _common.RSRC / name
         target = self.temp_path / name
-        shutil.copy(syspath(src), syspath(target))
+        shutil.copy(src, syspath(target))
         return mediafile.MediaFile(target)
 
     def test_extended_field_write(self):

--- a/test/plugins/test_scrub.py
+++ b/test/plugins/test_scrub.py
@@ -1,5 +1,3 @@
-import os
-
 from mediafile import MediaFile
 
 from beets.test.helper import AsIsImporterMixin, ImportHelper, PluginMixin
@@ -14,7 +12,7 @@ class TestScrubbedImport(AsIsImporterMixin, PluginMixin, ImportHelper):
             self.run_asis_importer(write=True)
 
         for item in self.lib.items():
-            imported_file = MediaFile(os.path.join(item.path))
+            imported_file = MediaFile(item.filepath)
             assert imported_file.artist == "Tag Artist"
             assert imported_file.album == "Tag Album"
 
@@ -23,7 +21,7 @@ class TestScrubbedImport(AsIsImporterMixin, PluginMixin, ImportHelper):
             self.run_asis_importer(write=True)
 
         for item in self.lib.items():
-            imported_file = MediaFile(os.path.join(item.path))
+            imported_file = MediaFile(item.filepath)
             assert imported_file.artist == "Tag Artist"
             assert imported_file.album == "Tag Album"
 
@@ -32,6 +30,6 @@ class TestScrubbedImport(AsIsImporterMixin, PluginMixin, ImportHelper):
             self.run_asis_importer(write=False)
 
         for item in self.lib.items():
-            imported_file = MediaFile(os.path.join(item.path))
+            imported_file = MediaFile(item.filepath)
             assert imported_file.artist is None
             assert imported_file.album is None

--- a/test/plugins/test_smartplaylist.py
+++ b/test/plugins/test_smartplaylist.py
@@ -13,7 +13,7 @@ from beets.library import Album, Item, parse_query_string
 from beets.test._common import item
 from beets.test.helper import BeetsTestCase, IOMixin, PathsMixin, PluginTestCase
 from beets.ui import UserError
-from beets.util import CHAR_REPLACE, syspath
+from beets.util import CHAR_REPLACE
 from beetsplug.smartplaylist import SmartPlaylistPlugin
 
 if TYPE_CHECKING:
@@ -369,11 +369,11 @@ class SmartPlaylistCLITest(PlaylistDirMixin, IOMixin, PluginTestCase):
         m3u_path = self.playlist_dir / "my_playlist.m3u"
         assert m3u_path.exists()
         assert m3u_path.read_bytes() == self.item.path + b"\n"
-        os.remove(syspath(m3u_path))
+        m3u_path.unlink()
 
         self.run_with_output("splupdate", "my_playlist.m3u")
         assert m3u_path.read_bytes() == self.item.path + b"\n"
-        os.remove(syspath(m3u_path))
+        m3u_path.unlink()
 
         self.run_with_output("splupdate")
         for name in ("my_playlist.m3u", "all.m3u"):

--- a/test/plugins/test_thumbnails.py
+++ b/test/plugins/test_thumbnails.py
@@ -1,12 +1,10 @@
 import os.path
-from shutil import rmtree
-from tempfile import mkdtemp
 from unittest.mock import Mock, call, patch
 
 import pytest
 
 from beets.test.helper import BeetsTestCase
-from beets.util import bytestring_path, syspath
+from beets.util import syspath
 from beetsplug.thumbnails import (
     LARGE_DIR,
     NORMAL_DIR,
@@ -139,25 +137,18 @@ class ThumbnailsTest(BeetsTestCase):
     @patch("beetsplug.thumbnails.ThumbnailsPlugin._check_local_ok", Mock())
     def test_make_dolphin_cover_thumbnail(self):
         plugin = ThumbnailsPlugin()
-        tmp = bytestring_path(mkdtemp())
-        album = Mock(path=tmp, artpath=os.path.join(tmp, b"cover.jpg"))
+        tmp = self.temp_path
+        album = Mock(
+            path=os.fsencode(tmp), artpath=os.fsencode(tmp / "cover.jpg")
+        )
         plugin.make_dolphin_cover_thumbnail(album)
-        with open(os.path.join(tmp, b".directory"), "rb") as f:
-            assert f.read().splitlines() == [
-                b"[Desktop Entry]",
-                b"Icon=./cover.jpg",
-            ]
+        filename = tmp / ".directory"
+        assert filename.read_text() == "[Desktop Entry]\nIcon=./cover.jpg"
 
         # not rewritten when it already exists (yup that's a big limitation)
         album.artpath = b"/my/awesome/art.tiff"
         plugin.make_dolphin_cover_thumbnail(album)
-        with open(os.path.join(tmp, b".directory"), "rb") as f:
-            assert f.read().splitlines() == [
-                b"[Desktop Entry]",
-                b"Icon=./cover.jpg",
-            ]
-
-        rmtree(syspath(tmp))
+        assert filename.read_text() == "[Desktop Entry]\nIcon=./cover.jpg"
 
     @patch("beetsplug.thumbnails.ThumbnailsPlugin._check_local_ok", Mock())
     @patch("beetsplug.thumbnails.ArtResizer")

--- a/test/plugins/test_web.py
+++ b/test/plugins/test_web.py
@@ -1,10 +1,10 @@
 """Tests for the 'web' plugin"""
 
 import json
-import os.path
 import platform
 import shutil
 from collections import Counter
+from pathlib import Path
 
 import pytest
 
@@ -36,44 +36,33 @@ class WebPluginMixin(PluginMixin):
         self.client = web.app.test_client()
 
         # Set platform-specific path prefix
-        if platform.system() == "Windows":
-            self.path_prefix = "C:"
-        else:
-            self.path_prefix = ""
+        self.path_prefix = Path(
+            "C:\\" if platform.system() == "Windows" else "/"
+        )
 
         # Add library elements. Note that self.lib.add overrides any "id=<n>"
         # and assigns the next free id number.
         # The following adds will create items #1, #2 and #3
-        path1 = (
-            self.path_prefix + os.sep + os.path.join(b"path_1").decode("utf-8")
-        )
+        self.path1 = self.path_prefix / "path_1"
         self.lib.add(
-            Item(title="title", path=path1, album_id=2, artist="AAA Singers")
+            Item(
+                title="title", path=self.path1, album_id=2, artist="AAA Singers"
+            )
         )
-        path2 = (
-            self.path_prefix
-            + os.sep
-            + os.path.join(b"somewhere", b"a").decode("utf-8")
-        )
+        self.path2 = self.path_prefix / "somewhere" / "a"
         self.lib.add(
-            Item(title="another title", path=path2, artist="AAA Singers")
+            Item(title="another title", path=self.path2, artist="AAA Singers")
         )
-        path3 = (
-            self.path_prefix
-            + os.sep
-            + os.path.join(b"somewhere", b"abc").decode("utf-8")
-        )
+        self.path3 = self.path_prefix / "somewhere" / "abc"
         self.lib.add(
-            Item(title="and a third", testattr="ABC", path=path3, album_id=2)
+            Item(
+                title="and a third", testattr="ABC", path=self.path3, album_id=2
+            )
         )
         # The following adds will create albums #1 and #2
         self.lib.add(Album(album="album", albumtest="xyz"))
-        path4 = (
-            self.path_prefix
-            + os.sep
-            + os.path.join(b"somewhere2", b"art_path_2").decode("utf-8")
-        )
-        self.lib.add(Album(album="other album", artpath=path4))
+        self.path4 = self.path_prefix / "somewhere2" / "art_path_2"
+        self.lib.add(Album(album="other album", artpath=self.path4))
 
         return
 
@@ -85,12 +74,8 @@ class TestWebPlugin(WebPluginMixin, PytestTestHelper):
         web.app.config["INCLUDE_PATHS"] = True
         response = self.client.get("/item/1")
         res_json = json.loads(response.data.decode("utf-8"))
-        expected_path = (
-            self.path_prefix + os.sep + os.path.join(b"path_1").decode("utf-8")
-        )
-
         assert response.status_code == 200
-        assert res_json["path"] == expected_path
+        assert res_json["path"] == str(self.path1)
 
         web.app.config["INCLUDE_PATHS"] = False
 
@@ -98,14 +83,9 @@ class TestWebPlugin(WebPluginMixin, PytestTestHelper):
         web.app.config["INCLUDE_PATHS"] = True
         response = self.client.get("/album/2")
         res_json = json.loads(response.data.decode("utf-8"))
-        expected_path = (
-            self.path_prefix
-            + os.sep
-            + os.path.join(b"somewhere2", b"art_path_2").decode("utf-8")
-        )
 
         assert response.status_code == 200
-        assert res_json["artpath"] == expected_path
+        assert res_json["artpath"] == str(self.path4)
 
         web.app.config["INCLUDE_PATHS"] = False
 
@@ -225,9 +205,8 @@ class TestWebPlugin(WebPluginMixin, PytestTestHelper):
         from the root all the way to a directory, so this matches 1 item"""
         """ Note: filesystem separators in the query must be '\' """
 
-        response = self.client.get(
-            "/item/query/path:" + self.path_prefix + "\\somewhere\\a"
-        )
+        prefix = "C:" if platform.system() == "Windows" else ""
+        response = self.client.get(f"/item/query/path:{prefix}\\somewhere\\a")
         res_json = json.loads(response.data.decode("utf-8"))
 
         assert response.status_code == 200

--- a/test/plugins/test_zero.py
+++ b/test/plugins/test_zero.py
@@ -21,7 +21,7 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
         with self.configure_plugin({"fields": ["comments", "month"]}):
             item.write()
 
-        mf = MediaFile(syspath(item.path))
+        mf = MediaFile(item.filepath)
         assert mf.comments is None
         assert mf.month is None
         assert mf.title == "Title"
@@ -36,7 +36,7 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
         ):
             item.write()
 
-        mf = MediaFile(syspath(item.path))
+        mf = MediaFile(item.filepath)
         assert mf.comments is None
 
     def test_pattern_nomatch(self):
@@ -48,7 +48,7 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
         ):
             item.write()
 
-        mf = MediaFile(syspath(item.path))
+        mf = MediaFile(item.filepath)
         assert mf.comments == "recorded at place"
 
     def test_do_not_change_database(self):
@@ -105,7 +105,7 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
             self.io.addinput("y")
             self.run_command("zero")
 
-        mf = MediaFile(syspath(item.path))
+        mf = MediaFile(item.filepath)
         item = self.lib.get_item(item_id)
 
         assert item["year"] == 2016
@@ -126,7 +126,7 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
             self.io.addinput("y")
             self.run_command("zero")
 
-        mf = MediaFile(syspath(item.path))
+        mf = MediaFile(item.filepath)
         item = self.lib.get_item(item_id)
 
         assert item["year"] == 2016
@@ -146,7 +146,7 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
         ):
             self.run_command("zero", "year: 2016")
 
-        mf = MediaFile(syspath(item.path))
+        mf = MediaFile(item.filepath)
 
         assert mf.year == 2016
         assert mf.comments is None
@@ -163,7 +163,7 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
         ):
             self.run_command("zero", "year: 0000")
 
-        mf = MediaFile(syspath(item.path))
+        mf = MediaFile(item.filepath)
 
         assert mf.year == 2016
         assert mf.comments == "test comment"
@@ -171,7 +171,7 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
     def test_no_fields(self):
         item = self.add_item_fixture(year=2016)
         item.write()
-        mediafile = MediaFile(syspath(item.path))
+        mediafile = MediaFile(item.filepath)
         assert mediafile.year == 2016
 
         item_id = item.id
@@ -188,7 +188,7 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
     def test_whitelist_and_blacklist(self):
         item = self.add_item_fixture(year=2016)
         item.write()
-        mf = MediaFile(syspath(item.path))
+        mf = MediaFile(item.filepath)
         assert mf.year == 2016
 
         item_id = item.id
@@ -244,7 +244,7 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
         ):
             item.write()
 
-        mf = MediaFile(syspath(item.path))
+        mf = MediaFile(item.filepath)
         assert mf.comments is None
         assert mf.disc is None
         assert mf.disctotal is None
@@ -259,7 +259,7 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
         ):
             item.write()
 
-        mf = MediaFile(syspath(item.path))
+        mf = MediaFile(item.filepath)
         assert mf.comments is None
         assert mf.disc == 1
         assert mf.disctotal == 4
@@ -271,7 +271,7 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
         with self.configure_plugin({"omit_single_disc": True}):
             item.write()
 
-        mf = MediaFile(syspath(item.path))
+        mf = MediaFile(item.filepath)
         assert mf.disc is None
         assert mf.disctotal is None
 
@@ -282,7 +282,7 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
         with self.configure_plugin({"omit_single_disc": True}):
             item.write()
 
-        mf = MediaFile(syspath(item.path))
+        mf = MediaFile(item.filepath)
         assert mf.disc == 1
         assert mf.disctotal == 4
 
@@ -298,7 +298,7 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
             self.io.addinput("n")
             self.run_command("zero")
 
-        mf = MediaFile(syspath(item.path))
+        mf = MediaFile(item.filepath)
         item = self.lib.get_item(item_id)
 
         assert item["year"] == 2016

--- a/test/plugins/test_zero.py
+++ b/test/plugins/test_zero.py
@@ -4,7 +4,6 @@ from mediafile import MediaFile
 
 from beets.library import Item
 from beets.test.helper import IOMixin, PluginTestCase
-from beets.util import syspath
 from beetsplug.zero import ZeroPlugin
 
 
@@ -78,7 +77,7 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
         with self.configure_plugin({"fields": ["images"]}):
             item.write()
 
-        mf = MediaFile(syspath(path))
+        mf = MediaFile(path)
         assert not mf.images
 
     def test_auto_false(self):
@@ -313,7 +312,7 @@ class ZeroPluginTest(IOMixin, PluginTestCase):
         with self.configure_plugin({"fields": None, "keep_fields": ["images"]}):
             item.write()
 
-        mf = MediaFile(syspath(path))
+        mf = MediaFile(path)
         assert mf.images, (
             "images should be preserved when 'images' is in keep_fields"
         )

--- a/test/rsrc/convert_stub.py
+++ b/test/rsrc/convert_stub.py
@@ -5,17 +5,14 @@ a specified text tag.
 """
 
 import sys
+from pathlib import Path
 
 
-def convert(in_file, out_file, tag):
+def convert(in_file: str, out_file: str, tag: str) -> None:
     """Copy `in_file` to `out_file` and append the string `tag`."""
-    if not isinstance(tag, bytes):
-        tag = tag.encode("utf-8")
-
-    with open(out_file, "wb") as out_f:
-        with open(in_file, "rb") as in_f:
-            out_f.write(in_f.read())
-        out_f.write(tag)
+    with Path(out_file).open("wb") as out_f, Path(in_file).open("rb") as in_f:
+        out_f.write(in_f.read())
+        out_f.write(tag.encode())
 
 
 if __name__ == "__main__":

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -128,11 +128,11 @@ class MoveTest(BeetsTestCase):
 
         try:
             self.i.move(operation=MoveOperation.COPY)
-            assert os.access(syspath(self.i.path), os.W_OK)
+            assert os.access(self.i.filepath, os.W_OK)
         finally:
             # Make everything writable so it can be cleaned up.
             os.chmod(syspath(self.path), 0o777)
-            os.chmod(syspath(self.i.path), 0o777)
+            self.i.filepath.chmod(0o777)
 
     def test_move_avoids_collision_with_existing_file(self):
         # Make a conflicting file at the destination.
@@ -208,8 +208,8 @@ class AlbumFileTest(BeetsTestCase):
         self.i = item(self.lib)
         # Make a file for the item.
         self.i.path = self.i.destination()
-        util.mkdirall(self.i.path)
-        touch(self.i.path)
+        util.mkdirall(self.i.filepath)
+        self.i.filepath.touch()
         # Make an album.
         self.ai = self.lib.add_album((self.i,))
         # Alternate destination dir.
@@ -245,14 +245,14 @@ class AlbumFileTest(BeetsTestCase):
 
     @NEEDS_REFLINK
     def test_albuminfo_move_reflinks_file(self):
-        oldpath = self.i.path
+        oldpath = self.i.filepath
         self.ai.album = "newAlbumName"
         self.ai.move(operation=MoveOperation.REFLINK)
         self.ai.store()
         self.i.load()
 
-        assert os.path.exists(oldpath)
-        assert os.path.exists(self.i.path)
+        assert oldpath.exists()
+        assert self.i.filepath.exists()
 
     def test_albuminfo_move_to_custom_dir(self):
         self.ai.move(basedir=self.otherdir)
@@ -269,8 +269,8 @@ class ArtFileTest(BeetsTestCase):
         self.i = item(self.lib)
         self.i.path = self.i.destination()
         # Make a music file.
-        util.mkdirall(self.i.path)
-        touch(self.i.path)
+        util.mkdirall(self.i.filepath)
+        self.i.filepath.touch()
         # Make an album.
         self.ai = self.lib.add_album((self.i,))
         # Make an art file too.
@@ -376,7 +376,7 @@ class ArtFileTest(BeetsTestCase):
         # Set the art - should replace the existing file, not create a suffixed
         # duplicate like cover.2.jpg.
         ai.set_art(newart)
-        assert artdest == ai.artpath
+        assert artdest == ai.art_filepath
 
     def test_setart_replaces_old_art_at_different_path(self):
         newart = self.lib_path / "newart.png"
@@ -389,8 +389,8 @@ class ArtFileTest(BeetsTestCase):
 
         # Set initial art.
         ai.set_art(newart)
-        old_artpath = ai.artpath
-        assert os.path.exists(syspath(old_artpath))
+        old_artpath = ai.art_filepath
+        assert old_artpath.exists()
 
         # Set new art with a different extension.
         another_art = self.lib_path / "another.jpg"
@@ -416,14 +416,14 @@ class ArtFileTest(BeetsTestCase):
             i2.move(operation=MoveOperation.COPY)
             ai.set_art(newart)
 
-            mode = stat.S_IMODE(os.stat(syspath(ai.artpath)).st_mode)
+            mode = stat.S_IMODE(ai.art_filepath.stat().st_mode)
             assert mode & stat.S_IRGRP
-            assert os.access(syspath(ai.artpath), os.W_OK)
+            assert os.access(ai.art_filepath, os.W_OK)
 
         finally:
             # Make everything writable so it can be cleaned up.
-            os.chmod(syspath(newart), 0o777)
-            os.chmod(syspath(ai.artpath), 0o777)
+            newart.chmod(0o777)
+            ai.art_filepath.chmod(0o777)
 
     def test_move_last_file_moves_albumart(self):
         oldartpath = self.lib.albums()[0].art_filepath
@@ -464,8 +464,8 @@ class RemoveTest(BeetsTestCase):
         self.i = item(self.lib)
         self.i.path = self.i.destination()
         # Make a music file.
-        util.mkdirall(self.i.path)
-        touch(self.i.path)
+        util.mkdirall(self.i.filepath)
+        self.i.filepath.touch()
         # Make an album with the item.
         self.ai = self.lib.add_album((self.i,))
 

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -4,13 +4,12 @@ import os
 import shutil
 import stat
 import unittest
-from os.path import join
 from pathlib import Path
 
 import beets.library
 from beets import util
 from beets.test import _common
-from beets.test._common import item, touch
+from beets.test._common import item
 from beets.test.helper import NEEDS_REFLINK, BeetsTestCase
 from beets.util import MoveOperation, syspath
 
@@ -20,7 +19,7 @@ class MoveTest(BeetsTestCase):
         super().setUp()
 
         # make a temporary file
-        self.temp_music_file_name = "temp.mp3"
+        self.temp_music_file_name = Path("temp.mp3")
         self.path = self.temp_path / self.temp_music_file_name
         shutil.copy(self.resource_path, self.path)
 
@@ -30,7 +29,7 @@ class MoveTest(BeetsTestCase):
 
         # set up the destination
         self.lib.path_formats = [
-            ("default", join("$artist", "$album", "$title"))
+            ("default", str(Path("$artist") / "$album" / "$title"))
         ]
         self.i.artist = "one"
         self.i.album = "two"
@@ -124,31 +123,31 @@ class MoveTest(BeetsTestCase):
 
     def test_read_only_file_copied_writable(self):
         # Make the source file read-only.
-        os.chmod(syspath(self.path), 0o444)
+        self.path.chmod(0o444)
 
         try:
             self.i.move(operation=MoveOperation.COPY)
             assert os.access(self.i.filepath, os.W_OK)
         finally:
             # Make everything writable so it can be cleaned up.
-            os.chmod(syspath(self.path), 0o777)
+            self.path.chmod(0o777)
             self.i.filepath.chmod(0o777)
 
     def test_move_avoids_collision_with_existing_file(self):
         # Make a conflicting file at the destination.
-        dest = self.i.destination()
-        os.makedirs(syspath(os.path.dirname(dest)))
-        touch(dest)
+        dest = Path(os.fsdecode(self.i.destination()))
+        util.mkdirall(dest)
+        dest.touch()
 
         self.i.move()
-        assert self.i.path != dest
-        assert os.path.dirname(self.i.path) == os.path.dirname(dest)
+        assert self.i.filepath != dest
+        assert self.i.filepath.parent == dest.parent
 
     @unittest.skipUnless(_common.HAVE_SYMLINK, "need symlinks")
     def test_link_arrives(self):
         self.i.move(operation=MoveOperation.LINK)
         assert self.dest.exists()
-        assert os.path.islink(syspath(self.dest))
+        assert self.dest.is_symlink()
         assert self.dest.resolve() == self.path.resolve()
 
     @unittest.skipUnless(_common.HAVE_SYMLINK, "need symlinks")
@@ -165,8 +164,8 @@ class MoveTest(BeetsTestCase):
     def test_hardlink_arrives(self):
         self.i.move(operation=MoveOperation.HARDLINK)
         assert self.dest.exists()
-        s1 = os.stat(syspath(self.path))
-        s2 = os.stat(syspath(self.dest))
+        s1 = self.path.stat()
+        s2 = self.dest.stat()
         assert (s1[stat.ST_INO], s1[stat.ST_DEV]) == (
             s2[stat.ST_INO],
             s2[stat.ST_DEV],
@@ -203,7 +202,7 @@ class AlbumFileTest(BeetsTestCase):
 
         # Make library and item.
         self.lib.path_formats = [
-            ("default", join("$albumartist", "$album", "$title"))
+            ("default", str(Path("$albumartist") / "$album" / "$title"))
         ]
         self.i = item(self.lib)
         # Make a file for the item.
@@ -370,8 +369,8 @@ class ArtFileTest(BeetsTestCase):
         i2.move(operation=MoveOperation.COPY)
 
         # Make a file at the destination.
-        artdest = ai.art_destination(newart)
-        touch(artdest)
+        artdest = Path(os.fsdecode(ai.art_destination(newart)))
+        artdest.touch()
 
         # Set the art - should replace the existing file, not create a suffixed
         # duplicate like cover.2.jpg.
@@ -398,7 +397,7 @@ class ArtFileTest(BeetsTestCase):
         ai.set_art(another_art)
 
         # Old art should be removed.
-        assert not os.path.exists(syspath(old_artpath))
+        assert not old_artpath.exists()
         assert ai.art_filepath.exists()
 
     def test_setart_sets_permissions(self):

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -353,7 +353,7 @@ class ArtFileTest(BeetsTestCase):
 
         # Copy the art to the destination.
         artdest = ai.art_destination(newart)
-        shutil.copy(syspath(newart), syspath(artdest))
+        shutil.copy(newart, syspath(artdest))
 
         # Set the art again.
         ai.set_art(artdest)

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1376,8 +1376,7 @@ class TestIncrementalImport(AsIsImporterMixin, ImportHelper):
         assert len(self.lib.items()) == 2
 
     def test_invalid_state_file(self):
-        with open(self.config["statefile"].as_filename(), "wb") as f:
-            f.write(b"000")
+        self.config["statefile"].as_path().write_bytes(b"000")
         self.run_asis_importer(incremental=True)
         assert len(self.lib.albums()) == 1
 
@@ -1553,20 +1552,20 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
             ]
         ):
             with self.subTest(marker=marker, suffix1=suffix1, suffix2=suffix2):
-                base = os.path.abspath(self.temp_path / f"marker_{i}")
-                os.mkdir(syspath(base))
+                base = self.temp_path / f"marker_{i}"
+                base.mkdir()
 
-                album_dir = os.path.join(base, "Album Name")
-                os.mkdir(syspath(album_dir))
+                album_dir = base / "Album Name"
+                album_dir.mkdir()
 
                 discs = []
                 for suffix in (suffix1, suffix2):
-                    disc = os.path.join(album_dir, marker + suffix)
-                    os.mkdir(syspath(disc))
-                    _mkmp3(syspath(os.path.join(disc, "song.mp3")))
-                    discs.append(disc)
+                    disc = album_dir / f"{marker}{suffix}"
+                    disc.mkdir()
+                    _mkmp3(disc / "song.mp3")
+                    discs.append(str(disc))
 
-                albums = list(albums_in_dir(base))
+                albums = list(albums_in_dir(str(base)))
                 assert len(albums) == 1
                 root, items = albums[0]
                 for disc in discs:
@@ -1576,18 +1575,18 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
     def test_no_coalesce_mismatched_prefixes(self):
         # "CD 02" and "Enhanced CD 01" share the "cd" marker but have
         # different prefixes, so they should not be collapsed.
-        base = os.path.abspath(self.temp_path / "mismatched")
-        os.mkdir(syspath(base))
+        base = self.temp_path / "mismatched"
+        base.mkdir()
 
-        album_dir = os.path.join(base, "Album Name")
-        os.mkdir(syspath(album_dir))
+        album_dir = base / "Album Name"
+        album_dir.mkdir()
 
         for subdir in ("CD 02", "Enhanced CD 01"):
-            d = os.path.join(album_dir, subdir)
-            os.mkdir(syspath(d))
-            _mkmp3(syspath(os.path.join(d, "song.mp3")))
+            d = album_dir / subdir
+            d.mkdir()
+            _mkmp3(d / "song.mp3")
 
-        albums = list(albums_in_dir(base))
+        albums = list(albums_in_dir(str(base)))
         assert len(albums) == 2
 
 

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -150,7 +150,7 @@ def create_archive(session):
     path = bytestring_path(path)
     os.close(handle)
     archive = ZipFile(os.fsdecode(path), mode="w")
-    archive.write(syspath(_common.RSRC / "full.mp3"), "full.mp3")
+    archive.write(_common.RSRC / "full.mp3", "full.mp3")
     archive.close()
     return bytestring_path(path)
 
@@ -182,7 +182,7 @@ class TestRmTemp(TestHelper):
         zip_path = create_archive(self)
         archive_task = importer.ArchiveImportTask(zip_path)
         archive_task.extract()
-        for root, _, files in os.walk(syspath(archive_task.toppath)):
+        for root, _, files in os.walk(archive_task.toppath):
             for f in files:
                 os.remove(os.path.join(root, f))
         assert Path(os.fsdecode(zip_path)).exists()
@@ -238,7 +238,7 @@ class TestImportTar(TestImportZip):
         path = bytestring_path(path)
         os.close(handle)
         archive = TarFile(os.fsdecode(path), mode="w")
-        archive.add(syspath(_common.RSRC / "full.mp3"), "full.mp3")
+        archive.add(_common.RSRC / "full.mp3", "full.mp3")
         archive.close()
         return path
 
@@ -1382,7 +1382,7 @@ class TestIncrementalImport(AsIsImporterMixin, ImportHelper):
 
 
 def _mkmp3(path):
-    shutil.copyfile(syspath(_common.RSRC / "min.mp3"), syspath(path))
+    shutil.copyfile(_common.RSRC / "min.mp3", path)
 
 
 class AlbumsInDirTest(BeetsTestCase):
@@ -1474,7 +1474,7 @@ class MultiDiscAlbumsInDirTest(BeetsTestCase):
             path.mkdir()
         if files:
             for path in self.files:
-                _mkmp3(syspath(path))
+                _mkmp3(path)
 
         self.dirs = list(map(str, self.dirs))
         self.files = list(map(str, self.files))
@@ -1884,7 +1884,7 @@ class TestMpeglayerWavImport(AsIsImporterMixin, ImportHelper):
     def test_remux_mpeglayer3_wav(self):
         src = _common.RSRC / "mpeglayer3.wav"
         dest = self.temp_path / "mpeglayer3.wav"
-        shutil.copy(syspath(src), syspath(dest))
+        shutil.copy(src, syspath(dest))
 
         mp3_path = remux_mpeglayer3_wav(dest)
 
@@ -1898,7 +1898,7 @@ class TestMpeglayerWavImport(AsIsImporterMixin, ImportHelper):
         self.config["import"]["remux_mp3_in_wav"] = False
         src = _common.RSRC / "mpeglayer3.wav"
         dest = self.import_path / "mpeglayer3.wav"
-        shutil.copy(syspath(src), syspath(dest))
+        shutil.copy(src, syspath(dest))
 
         self.run_asis_importer()
         assert dest.exists()

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -376,7 +376,7 @@ class TestDestination(PytestItemHelper):
 
     def test_get_formatted_does_not_replace_separators(self, item_in_db):
         with _common.platform_posix():
-            name = os.path.join("a", "b")
+            name = str(Path("a") / "b")
             item_in_db.title = name
             newname = item_in_db.formatted().get("title")
         assert name == newname
@@ -441,7 +441,7 @@ class TestDestination(PytestItemHelper):
 
     def test_unicode_extension_in_fragment(self, item_in_db):
         self.lib.path_formats = [("default", "foo")]
-        item_in_db.path = util.bytestring_path("bar.caf\xe9")
+        item_in_db.path = Path("bar.caf\xe9")
         with patch("sys.platform", "linux"):
             dest = item_in_db.destination(relative_to_libdir=True)
         assert as_string(dest) == "foo.caf\xe9"

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -1237,8 +1237,7 @@ class TestWrite(TestHelper):
 
     def test_no_write_permission(self):
         item = self.add_item_fixture()
-        path = syspath(item.path)
-        os.chmod(path, stat.S_IRUSR)
+        item.filepath.chmod(stat.S_IRUSR)
 
         try:
             with pytest.raises(beets.library.WriteError) as exc_info:
@@ -1247,32 +1246,32 @@ class TestWrite(TestHelper):
 
         finally:
             # Restore write permissions so the file can be cleaned up.
-            os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+            item.filepath.chmod(stat.S_IRUSR | stat.S_IWUSR)
 
     def test_write_with_custom_path(self):
         item = self.add_item_fixture()
         custom_path = self.temp_path / "custom.mp3"
-        shutil.copy(syspath(item.path), syspath(custom_path))
+        shutil.copy(item.filepath, syspath(custom_path))
 
         item["artist"] = "new artist"
         assert MediaFile(syspath(custom_path)).artist != "new artist"
-        assert MediaFile(syspath(item.path)).artist != "new artist"
+        assert MediaFile(item.filepath).artist != "new artist"
 
         item.write(custom_path)
         assert MediaFile(syspath(custom_path)).artist == "new artist"
-        assert MediaFile(syspath(item.path)).artist != "new artist"
+        assert MediaFile(item.filepath).artist != "new artist"
 
     def test_write_custom_tags(self):
         item = self.add_item_fixture(artist="old artist")
         item.write(tags={"artist": "new artist"})
         assert item.artist != "new artist"
-        assert MediaFile(syspath(item.path)).artist == "new artist"
+        assert MediaFile(item.filepath).artist == "new artist"
 
     def test_write_multi_tags(self):
         item = self.add_item_fixture(artist="old artist")
         item.write(tags={"artists": ["old artist", "another artist"]})
 
-        assert MediaFile(syspath(item.path)).artists == [
+        assert MediaFile(item.filepath).artists == [
             "old artist",
             "another artist",
         ]
@@ -1283,9 +1282,7 @@ class TestWrite(TestHelper):
             tags={"artists": ["old artist", "another artist"]}, id3v23=True
         )
 
-        assert MediaFile(syspath(item.path)).artists == [
-            "old artist/another artist"
-        ]
+        assert MediaFile(item.filepath).artists == ["old artist/another artist"]
 
     def test_write_date_field(self):
         # Since `date` is not a MediaField, this should do nothing.
@@ -1293,7 +1290,7 @@ class TestWrite(TestHelper):
         clean_year = item.year
         item.date = "foo"
         item.write()
-        assert MediaFile(syspath(item.path)).year == clean_year
+        assert MediaFile(item.filepath).year == clean_year
 
 
 class TestItemRead(PytestItemHelper):
@@ -1340,18 +1337,17 @@ class TestFilesize(TestHelper):
 class TestItemPruneDirsClutter(TestHelper):
     """Regression tests: prune_dirs respects config["clutter"] during move/remove."""
 
-    def _drop_clutter(self, directory, filename=b"unwanted.log"):
+    def _drop_clutter(self, directory: Path) -> Path:
         """Create a clutter file in *directory* (bytes path)."""
-        path = os.path.join(directory, filename)
-        with open(syspath(path), "w"):
-            pass
+        path = directory / "unwanted.log"
+        path.touch()
         return path
 
     def test_move_prunes_dir_with_config_clutter(self):
         """After moving an item, old dir is removed even when only clutter remains."""
         config["clutter"] = ["*.log"]
         item = self.add_item_fixture()
-        old_dir = os.path.dirname(item.path)
+        old_dir = item.filepath.parent
         self._drop_clutter(old_dir)
 
         # Change artist so the destination path differs, forcing a real move.
@@ -1359,18 +1355,18 @@ class TestItemPruneDirsClutter(TestHelper):
         item.store()
         item.move()
 
-        assert not os.path.exists(syspath(old_dir))
+        assert not old_dir.exists()
 
     def test_remove_prunes_dir_with_config_clutter(self):
         """After deleting an item, its dir is removed even when only clutter remains."""
         config["clutter"] = ["*.log"]
         item = self.add_item_fixture()
-        old_dir = os.path.dirname(item.path)
+        old_dir = item.filepath.parent
         self._drop_clutter(old_dir)
 
         item.remove(delete=True)
 
-        assert not os.path.exists(syspath(old_dir))
+        assert not old_dir.exists()
 
 
 class TestParseQuery:

--- a/test/test_library.py
+++ b/test/test_library.py
@@ -21,7 +21,7 @@ from beets.library import Album
 from beets.test import _common
 from beets.test._common import item
 from beets.test.helper import TestHelper
-from beets.util import as_string, bytestring_path, normpath, syspath
+from beets.util import as_string, bytestring_path, normpath
 
 # Shortcut to path normalization.
 np = util.normpath
@@ -1149,7 +1149,7 @@ class TestMtime(TestHelper):
     @pytest.fixture(autouse=True)
     def item(self, setup):
         self.ipath = self.temp_path / "testfile.mp3"
-        shutil.copy(syspath(_common.RSRC / "full.mp3"), syspath(self.ipath))
+        shutil.copy(_common.RSRC / "full.mp3", self.ipath)
         item = beets.library.Item.from_path(self.ipath)
         self.lib.add(item)
         yield item
@@ -1251,14 +1251,14 @@ class TestWrite(TestHelper):
     def test_write_with_custom_path(self):
         item = self.add_item_fixture()
         custom_path = self.temp_path / "custom.mp3"
-        shutil.copy(item.filepath, syspath(custom_path))
+        shutil.copy(item.filepath, custom_path)
 
         item["artist"] = "new artist"
-        assert MediaFile(syspath(custom_path)).artist != "new artist"
+        assert MediaFile(custom_path).artist != "new artist"
         assert MediaFile(item.filepath).artist != "new artist"
 
         item.write(custom_path)
-        assert MediaFile(syspath(custom_path)).artist == "new artist"
+        assert MediaFile(custom_path).artist == "new artist"
         assert MediaFile(item.filepath).artist != "new artist"
 
     def test_write_custom_tags(self):
@@ -1317,7 +1317,7 @@ class TestItemReadGenre(TestHelper):
     def test_read_semicolon_delimited_genres(self):
         """Semicolon-delimited genre tags are split into individual genres on read."""
         path = self.create_mediafile_fixture()
-        mf = MediaFile(syspath(path))
+        mf = MediaFile(path)
         mf.genres = ["Jazz; Funk; Soul"]
         mf.save()
         item = beets.library.Item.from_path(path)

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -22,7 +22,7 @@ from beets.test.helper import (
     PluginTestHelper,
     TerminalImportMixin,
 )
-from beets.util import PromptChoice, displayable_path, syspath
+from beets.util import PromptChoice, displayable_path
 
 
 class TestPluginRegistration(IOMixin, PluginTestHelper):
@@ -66,7 +66,7 @@ class TestPluginRegistration(IOMixin, PluginTestHelper):
 
         item.write()
 
-        assert MediaFile(syspath(item.path)).artist == "YYY"
+        assert MediaFile(item.filepath).artist == "YYY"
 
     def test_multi_value_flex_field_type(self):
         item = Item(path="apath", artist="aaa")

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -122,7 +122,7 @@ class UtilTest(unittest.TestCase):
 class PathConversionTest(unittest.TestCase):
     def test_syspath_windows_format(self):
         with _common.platform_windows():
-            path = os.path.join("a", "b", "c")
+            path = Path("a") / "b" / "c"
             outpath = util.syspath(path)
         assert isinstance(outpath, str)
         assert outpath.startswith("\\\\?\\")
@@ -138,7 +138,7 @@ class PathConversionTest(unittest.TestCase):
 
     def test_syspath_posix_unchanged(self):
         with _common.platform_posix():
-            path = os.path.join("a", "b", "c")
+            path = str(Path("a") / "b" / "c")
             outpath = util.syspath(path)
         assert path == outpath
 

--- a/test/testall.py
+++ b/test/testall.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python3
-
-
-import os
-import sys
-
-pkgpath = os.path.dirname(os.path.dirname(os.path.realpath(__file__))) or ".."
-sys.path.insert(0, pkgpath)

--- a/test/ui/commands/test_completion.py
+++ b/test/ui/commands/test_completion.py
@@ -1,13 +1,13 @@
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
 from beets.test import _common
 from beets.test.helper import RUNNING_IN_CI, IOMixin, has_program
 from beets.ui.commands.completion import BASH_COMPLETION_PATHS
-from beets.util import syspath
 
 from ..test_ui import TestPluginTestCase
 
@@ -33,14 +33,15 @@ class CompletionTest(IOMixin, TestPluginTestCase):
         )
 
         # Load bash_completion library.
-        for path in BASH_COMPLETION_PATHS:
-            if os.path.exists(syspath(path)):
+        completion_paths = map(Path, map(os.fsdecode, BASH_COMPLETION_PATHS))
+        for path in completion_paths:
+            if path.exists():
                 bash_completion = path
                 break
         else:
             self.skipTest("bash-completion script not found")
         try:
-            with open(syspath(bash_completion), "rb") as f:
+            with bash_completion.open("rb") as f:
                 tester.stdin.writelines(f)
         except OSError:
             self.skipTest("could not read bash-completion script")

--- a/test/ui/commands/test_config.py
+++ b/test/ui/commands/test_config.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -18,15 +19,14 @@ class ConfigCommandTest(IOMixin, BeetsTestCase):
 
         temp_dir = self.temp_path
 
-        self.config_path = str(temp_dir / "config.yaml")
-        with open(self.config_path, "w") as file:
-            file.write("library: lib\n")
-            file.write("option: value\n")
-            file.write("password: password_value")
+        config_path = temp_dir / "config.yaml"
+        lines = ["library: lib", "option: value", "password: password_value"]
+        config_path.write_text("\n".join(lines))
+        self.config_path = str(config_path)
 
-        self.cli_config_path = str(temp_dir / "cli_config.yaml")
-        with open(self.cli_config_path, "w") as file:
-            file.write("option: cli overwrite")
+        cli_config_path = temp_dir / "cli_config.yaml"
+        cli_config_path.write_text("option: cli overwrite")
+        self.cli_config_path = str(cli_config_path)
 
         config.clear()
         config["password"].redact = True
@@ -120,8 +120,7 @@ class ConfigCommandTest(IOMixin, BeetsTestCase):
             self.run_command("config", "-e")
 
     def test_edit_invalid_config_file(self):
-        with open(self.config_path, "w") as file:
-            file.write("invalid: [")
+        Path(self.config_path).write_text("invalid: [")
         config.clear()
         config._materialized = False
 

--- a/test/ui/commands/test_modify.py
+++ b/test/ui/commands/test_modify.py
@@ -5,7 +5,6 @@ from beets import logging
 from beets.exceptions import UserError
 from beets.test.helper import BeetsTestCase, IOMixin, TestHelper
 from beets.ui.commands.modify import ModifyOperation, modify_parse_args
-from beets.util import syspath
 
 _p = pytest.param
 
@@ -181,7 +180,7 @@ class ModifyTest(ModifyHelper, BeetsTestCase):
     def test_write_initial_key_tag(self):
         self.modify("initial_key=C#m")
         item = self.lib.items().get()
-        mediafile = MediaFile(syspath(item.path))
+        mediafile = MediaFile(item.filepath)
         assert mediafile.initial_key == "C#m"
 
     def test_set_flexattr(self):
@@ -204,11 +203,11 @@ class ModifyTest(ModifyHelper, BeetsTestCase):
         item.write()
         item.store()
 
-        mediafile = MediaFile(syspath(item.path))
+        mediafile = MediaFile(item.filepath)
         assert mediafile.initial_key == "C#m"
 
         self.modify("initial_key!")
-        mediafile = MediaFile(syspath(item.path))
+        mediafile = MediaFile(item.filepath)
         assert mediafile.initial_key is None
 
     def test_arg_parsing_colon_query(self):

--- a/test/ui/commands/test_move.py
+++ b/test/ui/commands/test_move.py
@@ -1,10 +1,8 @@
-import os
 import shutil
 
 from beets import library
 from beets.test.helper import BeetsTestCase
 from beets.ui.commands.move import move_items
-from beets.util import syspath
 
 
 class MoveTest(BeetsTestCase):
@@ -105,16 +103,16 @@ class MoveTest(BeetsTestCase):
 
     def test_move_missing_singleton_continues(self):
         self.i.load()
-        old_path = self.i.path
-        os.remove(syspath(old_path))
+        old_path = self.i.filepath
+        old_path.unlink()
         self._move()
         self.i.load()
-        assert self.i.path == old_path
+        assert self.i.filepath == old_path
 
     def test_move_album_with_missing_track(self):
         self.i.load()
-        old_i_path = self.i.path
-        os.remove(syspath(old_i_path))
+        old_i_path = self.i.filepath
+        old_i_path.unlink()
 
         i2_path = self.lib_path / "srcfile2"
         shutil.copy(self.resource_path, i2_path)
@@ -126,13 +124,13 @@ class MoveTest(BeetsTestCase):
         self._move(album=True)
         self.i.load()
         i2.load()
-        assert self.i.path == old_i_path
+        assert self.i.filepath == old_i_path
         assert i2.filepath.is_relative_to(self.lib_path)
         assert i2.filepath.exists()
 
     def test_move_item_skips_missing_file(self):
         self.i.load()
-        old_path = self.i.path
-        os.remove(syspath(old_path))
+        old_path = self.i.filepath
+        old_path.unlink()
         self.i.move()
-        assert self.i.path == old_path
+        assert self.i.filepath == old_path

--- a/test/ui/commands/test_remove.py
+++ b/test/ui/commands/test_remove.py
@@ -1,9 +1,7 @@
-import os
-
 from beets import library
 from beets.test.helper import BeetsTestCase, IOMixin
 from beets.ui.commands.remove import remove_items
-from beets.util import MoveOperation, syspath
+from beets.util import MoveOperation
 
 
 class RemoveTest(IOMixin, BeetsTestCase):
@@ -56,15 +54,15 @@ class RemoveTest(IOMixin, BeetsTestCase):
         # To improve upon this, self.io would need to have the capability to
         # generate input that depends on previous output.
         num_existing = 0
-        num_existing += 1 if os.path.exists(syspath(self.i.path)) else 0
-        num_existing += 1 if os.path.exists(syspath(i2.path)) else 0
+        num_existing += 1 if self.i.filepath.exists() else 0
+        num_existing += 1 if i2.filepath.exists() else 0
         assert num_existing == 1
 
     def test_remove_albums_select_with_delete(self):
         a1 = self.add_album_fixture()
         a2 = self.add_album_fixture()
-        path1 = a1.items()[0].path
-        path2 = a2.items()[0].path
+        path1 = a1.items()[0].filepath
+        path2 = a2.items()[0].filepath
         items = self.lib.items()
         assert len(list(items)) == 3
 
@@ -75,6 +73,6 @@ class RemoveTest(IOMixin, BeetsTestCase):
         assert len(list(items)) == 2  # incl. the item from setUp()
         # See test_remove_items_select_with_delete()
         num_existing = 0
-        num_existing += 1 if os.path.exists(syspath(path1)) else 0
-        num_existing += 1 if os.path.exists(syspath(path2)) else 0
+        num_existing += 1 if path1.exists() else 0
+        num_existing += 1 if path2.exists() else 0
         assert num_existing == 1

--- a/test/ui/commands/test_update.py
+++ b/test/ui/commands/test_update.py
@@ -1,12 +1,10 @@
-import os
-
 from mediafile import MediaFile
 
 from beets import library
 from beets.test import _common
 from beets.test.helper import BeetsTestCase, IOMixin
 from beets.ui.commands.update import update_items
-from beets.util import MoveOperation, remove, syspath
+from beets.util import MoveOperation, remove
 
 
 class UpdateTest(IOMixin, BeetsTestCase):
@@ -77,7 +75,7 @@ class UpdateTest(IOMixin, BeetsTestCase):
         assert not art_filepath.exists()
 
     def test_modified_metadata_detected(self):
-        mf = MediaFile(syspath(self.i.path))
+        mf = MediaFile(self.i.filepath)
         mf.title = "differentTitle"
         mf.save()
         self._update()
@@ -85,7 +83,7 @@ class UpdateTest(IOMixin, BeetsTestCase):
         assert item.title == "differentTitle"
 
     def test_modified_metadata_moved(self):
-        mf = MediaFile(syspath(self.i.path))
+        mf = MediaFile(self.i.filepath)
         mf.title = "differentTitle"
         mf.save()
         self._update(move=True)
@@ -93,7 +91,7 @@ class UpdateTest(IOMixin, BeetsTestCase):
         assert b"differentTitle" in item.path
 
     def test_modified_metadata_not_moved(self):
-        mf = MediaFile(syspath(self.i.path))
+        mf = MediaFile(self.i.filepath)
         mf.title = "differentTitle"
         mf.save()
         self._update(move=False)
@@ -101,7 +99,7 @@ class UpdateTest(IOMixin, BeetsTestCase):
         assert b"differentTitle" not in item.path
 
     def test_selective_modified_metadata_moved(self):
-        mf = MediaFile(syspath(self.i.path))
+        mf = MediaFile(self.i.filepath)
         mf.title = "differentTitle"
         mf.genres = ["differentGenre"]
         mf.save()
@@ -111,7 +109,7 @@ class UpdateTest(IOMixin, BeetsTestCase):
         assert item.genres != ["differentGenre"]
 
     def test_selective_modified_metadata_not_moved(self):
-        mf = MediaFile(syspath(self.i.path))
+        mf = MediaFile(self.i.filepath)
         mf.title = "differentTitle"
         mf.genres = ["differentGenre"]
         mf.save()
@@ -121,7 +119,7 @@ class UpdateTest(IOMixin, BeetsTestCase):
         assert item.genres != ["differentGenre"]
 
     def test_modified_album_metadata_moved(self):
-        mf = MediaFile(syspath(self.i.path))
+        mf = MediaFile(self.i.filepath)
         mf.album = "differentAlbum"
         mf.save()
         self._update(move=True)
@@ -130,7 +128,7 @@ class UpdateTest(IOMixin, BeetsTestCase):
 
     def test_modified_album_metadata_art_moved(self):
         artpath = self.album.artpath
-        mf = MediaFile(syspath(self.i.path))
+        mf = MediaFile(self.i.filepath)
         mf.album = "differentAlbum"
         mf.save()
         self._update(move=True)
@@ -139,7 +137,7 @@ class UpdateTest(IOMixin, BeetsTestCase):
         assert album.artpath is not None
 
     def test_selective_modified_album_metadata_moved(self):
-        mf = MediaFile(syspath(self.i.path))
+        mf = MediaFile(self.i.filepath)
         mf.album = "differentAlbum"
         mf.genres = ["differentGenre"]
         mf.save()
@@ -149,7 +147,7 @@ class UpdateTest(IOMixin, BeetsTestCase):
         assert item.genres != ["differentGenre"]
 
     def test_selective_modified_album_metadata_not_moved(self):
-        mf = MediaFile(syspath(self.i.path))
+        mf = MediaFile(self.i.filepath)
         mf.album = "differentAlbum"
         mf.genres = ["differentGenre"]
         mf.save()
@@ -159,12 +157,12 @@ class UpdateTest(IOMixin, BeetsTestCase):
         assert item.genres == ["differentGenre"]
 
     def test_mtime_match_skips_update(self):
-        mf = MediaFile(syspath(self.i.path))
+        mf = MediaFile(self.i.filepath)
         mf.title = "differentTitle"
         mf.save()
 
         # Make in-memory mtime match on-disk mtime.
-        self.i.mtime = os.path.getmtime(syspath(self.i.path))
+        self.i.mtime = self.i.filepath.stat().st_mtime
         self.i.store()
 
         self._update(reset_mtime=False)
@@ -197,7 +195,7 @@ class UpdateTest(IOMixin, BeetsTestCase):
         assert album.albumtypes == correct_albumtypes
 
     def test_modified_metadata_excluded(self):
-        mf = MediaFile(syspath(self.i.path))
+        mf = MediaFile(self.i.filepath)
         mf.lyrics = "new lyrics"
         mf.save()
         self._update(exclude_fields=["lyrics"])

--- a/test/ui/commands/test_utils.py
+++ b/test/ui/commands/test_utils.py
@@ -7,13 +7,12 @@ from beets.exceptions import UserError
 from beets.test import _common
 from beets.test.helper import BeetsTestCase
 from beets.ui.commands.utils import do_query
-from beets.util import syspath
 
 
 class QueryTest(BeetsTestCase):
     def add_item(self):
         itempath = self.lib_path / "srcfile"
-        shutil.copy(_common.RSRC / "full.mp3", syspath(itempath))
+        shutil.copy(_common.RSRC / "full.mp3", itempath)
         item = library.Item.from_path(itempath)
         self.lib.add(item)
         return item

--- a/test/ui/test_ui.py
+++ b/test/ui/test_ui.py
@@ -15,7 +15,6 @@ from beets.exceptions import UserError
 from beets.test import _common
 from beets.test.helper import BeetsTestCase, IOMixin, PluginTestCase
 from beets.ui import _open_library, commands
-from beets.util import syspath
 
 
 class PrintTest(IOMixin, unittest.TestCase):
@@ -98,7 +97,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
     def tearDown(self):
         self.env_patcher.stop()
         commands.default_commands.pop()
-        os.chdir(syspath(self._orig_cwd))
+        os.chdir(self._orig_cwd)
         super().tearDown()
 
     def _make_test_cmd(self):
@@ -230,7 +229,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
 
     def test_command_line_option_relative_to_working_dir(self):
         config.read()
-        os.chdir(syspath(self.temp_path))
+        os.chdir(self.temp_path)
         self.run_command("--library", "foo.db", "test")
         assert config["library"].as_path() == Path.cwd() / "foo.db"
 

--- a/test/ui/test_ui.py
+++ b/test/ui/test_ui.py
@@ -63,7 +63,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
         # Also set APPDATA, the Windows equivalent of setting $HOME.
         appdata_dir = self.temp_path / "AppData" / "Roaming"
 
-        self._orig_cwd = os.getcwd()
+        self._orig_cwd = Path.cwd()
         self.test_cmd = self._make_test_cmd()
         commands.default_commands.append(self.test_cmd)
 
@@ -79,8 +79,8 @@ class ConfigTest(IOMixin, TestPluginTestCase):
         self.beetsdir = self.temp_path / "beetsdir"
         self.beetsdir.mkdir(parents=True, exist_ok=True)
 
-        self.env_config_path = str(self.beetsdir / "config.yaml")
-        self.cli_config_path = str(self.temp_path / "config.yaml")
+        self.env_config_path = self.beetsdir / "config.yaml"
+        self.cli_config_path = self.temp_path / "config.yaml"
         self.env_patcher = patch(
             "os.environ",
             {"HOME": str(self.temp_path), "APPDATA": str(appdata_dir)},
@@ -118,7 +118,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
         config._materialized = False
 
     def write_config_file(self):
-        return open(self.user_config_path, "w")
+        return self.user_config_path.open("w")
 
     def test_paths_section_respected(self):
         with self.write_config_file() as config:
@@ -162,28 +162,23 @@ class ConfigTest(IOMixin, TestPluginTestCase):
         assert repls == [("[xy]", "z"), ("foo", "bar")]
 
     def test_cli_config_option(self):
-        with open(self.cli_config_path, "w") as file:
-            file.write("anoption: value")
-        self.run_command("--config", self.cli_config_path, "test")
+        self.cli_config_path.write_text("anoption: value")
+        self.run_command("--config", str(self.cli_config_path), "test")
         assert config["anoption"].get() == "value"
 
     def test_cli_config_file_overwrites_user_defaults(self):
-        with open(self.user_config_path, "w") as file:
-            file.write("anoption: value")
+        self.user_config_path.write_text("anoption: value")
 
-        with open(self.cli_config_path, "w") as file:
-            file.write("anoption: cli overwrite")
-        self.run_command("--config", self.cli_config_path, "test")
+        self.cli_config_path.write_text("anoption: cli overwrite")
+        self.run_command("--config", str(self.cli_config_path), "test")
         assert config["anoption"].get() == "cli overwrite"
 
     def test_cli_config_file_overwrites_beetsdir_defaults(self):
         os.environ["BEETSDIR"] = str(self.beetsdir)
-        with open(self.env_config_path, "w") as file:
-            file.write("anoption: value")
+        self.env_config_path.write_text("anoption: value")
 
-        with open(self.cli_config_path, "w") as file:
-            file.write("anoption: cli overwrite")
-        self.run_command("--config", self.cli_config_path, "test")
+        self.cli_config_path.write_text("anoption: cli overwrite")
+        self.run_command("--config", str(self.cli_config_path), "test")
         assert config["anoption"].get() == "cli overwrite"
 
     #    @unittest.skip('Difficult to implement with optparse')
@@ -206,35 +201,30 @@ class ConfigTest(IOMixin, TestPluginTestCase):
     #    def test_multiple_cli_config_overwrite(self):
     #        cli_overwrite_config_path = self.temp_path / 'overwrite_config.yaml'
     #
-    #        with open(self.cli_config_path, 'w') as file:
-    #            file.write('anoption: value')
+    #        self.cli_config_path.write_text("anoption: value")
     #
     #        with open(cli_overwrite_config_path, 'w') as file:
     #            file.write('anoption: overwrite')
     #
-    #        self.run_command('--config', self.cli_config_path,
+    #        self.run_command('--config', str(self.cli_config_path),
     #                      '--config', cli_overwrite_config_path, 'test')
     #        assert config['anoption'].get() == 'cli overwrite'
 
     # FIXME: fails on windows
     @unittest.skipIf(sys.platform == "win32", "win32")
     def test_cli_config_paths_resolve_relative_to_user_dir(self):
-        with open(self.cli_config_path, "w") as file:
-            file.write("library: beets.db\n")
-            file.write("statefile: state")
+        self.cli_config_path.write_text("library: beets.db\nstatefile: state")
 
-        self.run_command("--config", self.cli_config_path, "test")
+        self.run_command("--config", str(self.cli_config_path), "test")
         assert config["library"].as_path() == self.user_config_dir / "beets.db"
         assert config["statefile"].as_path() == self.user_config_dir / "state"
 
     def test_cli_config_paths_resolve_relative_to_beetsdir(self):
         os.environ["BEETSDIR"] = str(self.beetsdir)
 
-        with open(self.cli_config_path, "w") as file:
-            file.write("library: beets.db\n")
-            file.write("statefile: state")
+        self.cli_config_path.write_text("library: beets.db\nstatefile: state")
 
-        self.run_command("--config", self.cli_config_path, "test")
+        self.run_command("--config", str(self.cli_config_path), "test")
         assert config["library"].as_path() == self.beetsdir / "beets.db"
         assert config["statefile"].as_path() == self.beetsdir / "state"
 
@@ -245,11 +235,11 @@ class ConfigTest(IOMixin, TestPluginTestCase):
         assert config["library"].as_path() == Path.cwd() / "foo.db"
 
     def test_cli_config_file_loads_plugin_commands(self):
-        with open(self.cli_config_path, "w") as file:
-            file.write(f"pluginpath: {_common.PLUGINPATH}\n")
-            file.write("plugins: test")
+        self.cli_config_path.write_text(
+            f"pluginpath: {_common.PLUGINPATH}\nplugins: test"
+        )
 
-        self.run_command("--config", self.cli_config_path, "plugin")
+        self.run_command("--config", str(self.cli_config_path), "plugin")
         plugs = plugins.find_plugins()
         assert len(plugs) == 1
         assert plugs[0].is_test_plugin
@@ -258,24 +248,22 @@ class ConfigTest(IOMixin, TestPluginTestCase):
     def test_beetsdir_config(self):
         os.environ["BEETSDIR"] = str(self.beetsdir)
 
-        with open(self.env_config_path, "w") as file:
-            file.write("anoption: overwrite")
+        self.env_config_path.write_text("anoption: overwrite")
 
         config.read()
         assert config["anoption"].get() == "overwrite"
 
     def test_beetsdir_points_to_file_error(self):
-        beetsdir = str(self.temp_path / "beetsfile")
-        open(beetsdir, "a").close()
-        os.environ["BEETSDIR"] = beetsdir
+        beetsdir = self.temp_path / "beetsfile"
+        beetsdir.touch()
+        os.environ["BEETSDIR"] = str(beetsdir)
         with pytest.raises(ConfigError):
             self.run_command("test")
 
     def test_beetsdir_config_does_not_load_default_user_config(self):
         os.environ["BEETSDIR"] = str(self.beetsdir)
 
-        with open(self.user_config_path, "w") as file:
-            file.write("anoption: value")
+        self.user_config_path.write_text("anoption: value")
 
         config.read()
         assert not config["anoption"].exists()
@@ -290,9 +278,7 @@ class ConfigTest(IOMixin, TestPluginTestCase):
     def test_beetsdir_config_paths_resolve_relative_to_beetsdir(self):
         os.environ["BEETSDIR"] = str(self.beetsdir)
 
-        with open(self.env_config_path, "w") as file:
-            file.write("library: beets.db\n")
-            file.write("statefile: state")
+        self.env_config_path.write_text("library: beets.db\nstatefile: state")
 
         config.read()
         assert config["library"].as_path() == self.beetsdir / "beets.db"

--- a/test/util/test_art_resize.py
+++ b/test/util/test_art_resize.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 from beets.test import _common
 from beets.test.fixtures import DummyIMBackend
 from beets.test.helper import BeetsTestCase, CleanupModulesMixin
-from beets.util import command_output, syspath
+from beets.util import command_output
 from beets.util.artresizer import IMBackend, PILBackend
 
 
@@ -33,14 +33,11 @@ class ArtResizerFileSizeTest(CleanupModulesMixin, BeetsTestCase):
             225,
             self.IMG_225x225,
             quality=95,
-            max_filesize=0.9 * os.stat(syspath(im_95_qual)).st_size,
+            max_filesize=0.9 * os.stat(im_95_qual).st_size,
         )
         assert Path(os.fsdecode(im_a)).exists()
         # target size was achieved
-        assert (
-            os.stat(syspath(im_a)).st_size
-            < os.stat(syspath(im_95_qual)).st_size
-        )
+        assert os.stat(im_a).st_size < os.stat(im_95_qual).st_size
 
         # Attempt with lower initial quality
         im_75_qual = backend.resize(
@@ -52,14 +49,11 @@ class ArtResizerFileSizeTest(CleanupModulesMixin, BeetsTestCase):
             225,
             self.IMG_225x225,
             quality=95,
-            max_filesize=0.9 * os.stat(syspath(im_75_qual)).st_size,
+            max_filesize=0.9 * os.stat(im_75_qual).st_size,
         )
         assert Path(os.fsdecode(im_b)).exists()
         # Check high (initial) quality still gives a smaller filesize
-        assert (
-            os.stat(syspath(im_b)).st_size
-            < os.stat(syspath(im_75_qual)).st_size
-        )
+        assert os.stat(im_b).st_size < os.stat(im_75_qual).st_size
 
     @unittest.skipUnless(PILBackend.available(), "PIL not available")
     def test_pil_file_resize(self):
@@ -93,12 +87,7 @@ class ArtResizerFileSizeTest(CleanupModulesMixin, BeetsTestCase):
         """
         im = IMBackend()
         path = im.deinterlace(self.IMG_225x225)
-        cmd = [
-            *im.identify_cmd,
-            "-format",
-            "%[interlace]",
-            syspath(path, prefix=False),
-        ]
+        cmd = [*im.identify_cmd, "-format", "%[interlace]", os.fsdecode(path)]
         out = command_output(cmd).stdout
         assert out == b"None"
 

--- a/test/util/test_hidden.py
+++ b/test/util/test_hidden.py
@@ -7,8 +7,7 @@ import sys
 import tempfile
 import unittest
 
-from beets import util
-from beets.util import bytestring_path, hidden
+from beets.util import hidden
 
 
 class HiddenFileTest(unittest.TestCase):
@@ -30,7 +29,7 @@ class HiddenFileTest(unittest.TestCase):
                 else:
                     raise e
 
-            assert hidden.is_hidden(bytestring_path(f.name))
+            assert hidden.is_hidden(f.name)
 
     def test_windows_hidden(self):
         if not sys.platform == "win32":
@@ -57,5 +56,5 @@ class HiddenFileTest(unittest.TestCase):
             return
 
         with tempfile.NamedTemporaryFile(prefix=".tmp") as f:
-            fn = util.bytestring_path(f.name)
+            fn = f.name
             assert hidden.is_hidden(fn)

--- a/test/util/test_m3ufile.py
+++ b/test/util/test_m3ufile.py
@@ -1,33 +1,29 @@
 """Testsuite for the M3UFile class."""
 
 import sys
-from os import path
-from shutil import rmtree
-from tempfile import mkdtemp
+from pathlib import Path
 
 import pytest
 
 from beets.test._common import RSRC
+from beets.test.helper import PathsMixin
 from beets.util import bytestring_path
 from beets.util.m3u import EmptyPlaylistError, M3UFile
 
 
-class TestM3UFile:
+class TestM3UFile(PathsMixin):
     """Tests the M3UFile class."""
 
     def test_playlist_write_empty(self):
         """Test whether saving an empty playlist file raises an error."""
-        tempdir = bytestring_path(mkdtemp())
-        the_playlist_file = path.join(tempdir, b"playlist.m3u8")
+        the_playlist_file = self.temp_path / "playlist.m3u8"
         m3ufile = M3UFile(the_playlist_file)
         with pytest.raises(EmptyPlaylistError):
             m3ufile.write()
-        rmtree(tempdir)
 
     def test_playlist_write(self):
         """Test saving ascii paths to a playlist file."""
-        tempdir = bytestring_path(mkdtemp())
-        the_playlist_file = path.join(tempdir, b"playlist.m3u")
+        the_playlist_file = self.temp_path / "playlist.m3u8"
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.set_contents(
             [
@@ -36,13 +32,11 @@ class TestM3UFile:
             ]
         )
         m3ufile.write()
-        assert path.exists(the_playlist_file)
-        rmtree(tempdir)
+        assert the_playlist_file.exists()
 
     def test_playlist_write_unicode(self):
         """Test saving unicode paths to a playlist file."""
-        tempdir = bytestring_path(mkdtemp())
-        the_playlist_file = path.join(tempdir, b"playlist.m3u8")
+        the_playlist_file = self.temp_path / "playlist.m3u8"
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.set_contents(
             [
@@ -51,15 +45,13 @@ class TestM3UFile:
             ]
         )
         m3ufile.write()
-        assert path.exists(the_playlist_file)
-        rmtree(tempdir)
+        assert the_playlist_file.exists()
 
     @pytest.mark.skipif(sys.platform != "win32", reason="win32")
     def test_playlist_write_and_read_unicode_windows(self):
         """Test saving unicode paths to a playlist file on Windows."""
-        tempdir = bytestring_path(mkdtemp())
-        the_playlist_file = path.join(
-            tempdir, b"playlist_write_and_read_windows.m3u8"
+        the_playlist_file = (
+            self.temp_path / "playlist_write_and_read_windows.m3u8"
         )
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.set_contents(
@@ -69,18 +61,17 @@ class TestM3UFile:
             ]
         )
         m3ufile.write()
-        assert path.exists(the_playlist_file)
+        assert the_playlist_file.exists()
         m3ufile_read = M3UFile(the_playlist_file)
         m3ufile_read.load()
         assert m3ufile.media_list[0] == bytestring_path(
-            path.join("x:\\", "This", "is", "å", "path", "to_a_file.mp3")
+            Path("x:\\") / "This" / "is" / "å" / "path" / "to_a_file.mp3"
         )
         assert m3ufile.media_list[1] == bytestring_path(
             r"x:\This\is\another\path\tö_a_file.mp3"
         ), bytestring_path(
-            path.join("x:\\", "This", "is", "another", "path", "tö_a_file.mp3")
+            Path("x:\\") / "This" / "is" / "another" / "path" / "tö_a_file.mp3"
         )
-        rmtree(tempdir)
 
     @pytest.mark.skipif(sys.platform == "win32", reason="win32")
     def test_playlist_load_ascii(self):
@@ -107,7 +98,7 @@ class TestM3UFile:
         """Test loading unicode paths from a playlist file."""
         the_playlist_file = RSRC / "playlist_windows.m3u8"
         winpath = bytestring_path(
-            path.join("x:\\", "This", "is", "å", "path", "to_a_file.mp3")
+            Path("x:\\") / "This" / "is" / "å" / "path" / "to_a_file.mp3"
         )
         m3ufile = M3UFile(the_playlist_file)
         m3ufile.load()


### PR DESCRIPTION
- This PR continues the test suite's move from mixed string/bytes path handling to `pathlib.Path`-based filesystem usage.
- The main architectural change is that shared test helpers now produce `Path` objects directly, especially `TestHelper.create_mediafile_fixture`, so tests can use one consistent path model end-to-end.
- Tests are updated to prefer higher-level path APIs like `item.filepath` and `album.art_filepath` instead of raw `item.path` bytes, reducing manual conversions and direct `os.path` usage.
- Supporting utilities were adjusted where needed, such as allowing `beets.util.mkdirall` to accept `Path` inputs, so existing filesystem helpers still work during the transition.

- High-level impact:
  - makes path handling in tests more consistent and readable
  - reduces bytes/string/path conversion noise
  - aligns tests with the newer object-level path interfaces already exposed by the app
  - lowers the chance of platform-specific path bugs, especially around encoding and separator handling

- In practice, this is mostly a test infrastructure cleanup and API alignment change. It should not change product behavior, but it makes future path-related test updates simpler and safer.

Fixes #6807

The rest of tests require refactoring of associated source code.
