### PR TITLE
docs: mention terminal emulator for Windows

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -105,6 +105,9 @@ Other changes
 
 - :doc:`/guides/installation` Add Homebrew to the list of supported package
   managers in the installation guide.
+- :doc:`/guides/installation`: Note that Windows users should run beets in a
+  terminal emulator (such as Windows Terminal or cmder) for output to display
+  correctly. :bug:`2848`
 - :doc:`contributing`: The project now uses ``uv`` for packaging, virtual
   environment, and dependency management, replacing ``poetry``. The build
   backend has changed from ``poetry-core`` to ``hatchling``. Please see updates

--- a/docs/guides/installation.rst
+++ b/docs/guides/installation.rst
@@ -113,9 +113,9 @@ get it right:
     beets in a terminal emulator such as `Windows Terminal`_ or cmder_, or in a
     Unix-like shell such as Git Bash.
 
-.. _windows terminal: https://aka.ms/terminal
-
 .. _cmder: https://cmder.app/
+
+.. _windows terminal: https://aka.ms/terminal
 
 **Bonus: Windows Context Menu Integration**
 

--- a/docs/guides/installation.rst
+++ b/docs/guides/installation.rst
@@ -106,6 +106,17 @@ get it right:
 4. You're all set! Type ``beet version`` in a new command prompt to verify the
    installation.
 
+.. note::
+
+    The classic Windows console (``cmd.exe``) does not display beets' output
+    (special characters and colors) correctly. For a usable experience, run
+    beets in a terminal emulator such as `Windows Terminal`_ or cmder_, or in a
+    Unix-like shell such as Git Bash.
+
+.. _windows terminal: https://aka.ms/terminal
+
+.. _cmder: https://cmder.app/
+
 **Bonus: Windows Context Menu Integration**
 
 Windows users may also want to install a context menu item for importing files


### PR DESCRIPTION
## Description

Fixes #2848.

The classic Windows console (`cmd.exe`) doesn't render beets' output (special characters, colors) correctly. Added a note in the Windows installation guide pointing people at a terminal emulator like Windows Terminal or cmder, or a Unix-like shell such as Git Bash.

Docs-only change, plus a changelog entry.

## To Do

- [x] Documentation.
- [x] Changelog.
- [x] ~Tests.~ (docs-only change)