### PR TITLE
Fix tar/7z archive import crashing with missing infolist() attribute

### DIFF
--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -942,15 +942,45 @@ class ArchiveImportTask(SentinelImportTask):
 
             # Adjust the files' mtimes to match the information from the
             # archive. Inspired by: https://stackoverflow.com/q/9813243
-            for f in archive.infolist():
-                # The date_time will need to adjusted otherwise
-                # the item will have the current date_time of extraction.
-                # The (0, 0, -1) is added to date_time because the
-                # function time.mktime expects a 9-element tuple.
-                # The -1 indicates that the DST flag is unknown.
-                date_time = time.mktime((*f.date_time, 0, 0, -1))
-                fullpath = os.path.join(extract_to, f.filename)
-                os.utime(fullpath, (date_time, date_time))
+            #
+            # tarfile.TarFile and py7zr.SevenZipFile don't implement
+            # infolist()/.date_time (those are zipfile.ZipInfo-specific
+            # attributes; the ZipFileCompat shim that used to provide
+            # them on TarFile was removed). Handle their own member-
+            # listing APIs instead; ZipFile and RarFile (whose
+            # infolist() is intentionally zipfile-compatible) keep
+            # using the existing path. See GH #5664.
+            import tarfile
+
+            try:
+                from py7zr import SevenZipFile
+            except ImportError:
+                SevenZipFile = None
+
+            if isinstance(archive, tarfile.TarFile):
+                for member in archive.getmembers():
+                    # TarInfo.mtime is already a Unix timestamp, unlike
+                    # ZipInfo.date_time's 6-element tuple.
+                    fullpath = os.path.join(extract_to, member.name)
+                    os.utime(fullpath, (member.mtime, member.mtime))
+            elif SevenZipFile is not None and isinstance(archive, SevenZipFile):
+                for info in archive.list():
+                    # FileInfo.creationtime is a timezone-aware
+                    # datetime, unlike ZipInfo.date_time's 6-element
+                    # tuple.
+                    mtime = info.creationtime.timestamp()
+                    fullpath = os.path.join(extract_to, info.filename)
+                    os.utime(fullpath, (mtime, mtime))
+            else:
+                for f in archive.infolist():
+                    # The date_time will need to adjusted otherwise
+                    # the item will have the current date_time of extraction.
+                    # The (0, 0, -1) is added to date_time because the
+                    # function time.mktime expects a 9-element tuple.
+                    # The -1 indicates that the DST flag is unknown.
+                    date_time = time.mktime((*f.date_time, 0, 0, -1))
+                    fullpath = os.path.join(extract_to, f.filename)
+                    os.utime(fullpath, (date_time, date_time))
 
         finally:
             archive.close()

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -222,8 +222,11 @@ class TestRmTemp(TestHelper):
 
 
 class TestImportZip(AsIsImporterMixin, ImportHelper):
+    def create_archive(self):
+        return create_archive(self)
+
     def test_import_zip(self):
-        zip_path = create_archive(self)
+        zip_path = self.create_archive()
         assert len(self.lib.items()) == 0
         assert len(self.lib.albums()) == 0
 


### PR DESCRIPTION
Fixes #5664.

`ArchiveImportTask.extract()` adjusts each extracted file's mtime after extraction by iterating `archive.infolist()` and reading each entry's `.filename` and `.date_time`. That's a `zipfile.ZipInfo`-specific interface. `tarfile.TarFile` used to also expose it via a `ZipFileCompat` shim, which was removed from the standard library; `py7zr.SevenZipFile` never had it either. Both raise `AttributeError: '...' object has no attribute 'infolist'` as soon as `extract()` reaches that loop, which the caller (`unarchive()`) catches and logs as `"extraction failed: ..."`, silently skipping the entire import -- exactly as reported in the issue.

**Fix**: handle `tarfile.TarFile` via its own `getmembers()`/`.name`/`.mtime` (`mtime` is already a Unix timestamp, unlike `ZipInfo.date_time`'s 6-tuple), and `py7zr.SevenZipFile` via its own `list()`/`.filename`/`.creationtime` (a timezone-aware `datetime`, converted via `.timestamp()`). `ZipFile` and `RarFile` (whose `infolist()` is intentionally zipfile-compatible, per `rarfile`'s own docs) keep using the existing path unchanged.

**A related discovery while verifying this**: while checking this fix against the project's own archive import tests (`TestImportTar`, `TestImportRar`, `TestImport7z`), I found those tests weren't actually exercising their respective archive formats at all. `TestImportZip.test_import_zip` called the module-level `create_archive()` free function directly rather than `self.create_archive()`, so Python's name resolution never dispatched to the `create_archive()` *method* that `TestImportTar`/`TestImportRar`/`TestImport7z` each override -- every one of those "format-specific" tests was silently creating and importing a plain zip file instead. This is why the `infolist()` bug (and, as I discovered while fixing this, the identical bug affecting 7z archives too) went undetected. Fixed by giving `TestImportZip` its own `create_archive()` method that calls the free function, and changing `test_import_zip` to call `self.create_archive()` so the override chain actually works. With that test-infra fix alone (`extract()` still unpatched), `TestImportTar` and `TestImport7z` now correctly fail with the exact reported `AttributeError`; with the `extract()` fix applied, both pass genuinely, actually exercising tar/7z extraction for the first time.

**Verification**: verified end-to-end with real archives: a real `.tar` file no longer raises and correctly preserves each extracted file's original mtime; same for a real `.7z` archive (installed `py7zr` to confirm, since it isn't a required dependency); confirmed `.zip` extraction is completely unaffected (unchanged code path, verified with a real `.zip` round-trip too). RAR extraction code path is untouched by this fix (still uses the original `infolist()` branch, since `RarFile` intentionally mimics zipfile's interface); `TestImportRar` remains skipped in my sandbox only because the `unrar` binary isn't detected there, unrelated to this change.

Ran the full existing `test_importer.py` suite: 132 passed, 5 skipped (unrelated: missing `unrar` binary, three pre-existing "write me"/"Implement me" stubs, one needing reflink support), no regressions.
