### PR TITLE
Fix ipfs plugin crash cleaning up a single-file download

### DIFF
--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -174,7 +174,16 @@ class IPFSPlugin(BeetsPlugin):
         # This uses a relative path, hence we cannot use util.syspath(_hash,
         # prefix=True). However, that should be fine since the hash will not
         # exceed MAX_PATH.
-        shutil.rmtree(util.syspath(_hash, prefix=False))
+        download_path = util.syspath(_hash, prefix=False)
+        # `ipfs get` produces a directory for a multi-file IPFS object,
+        # but a plain file for a single-file one -- which one depends
+        # entirely on what was originally added to IPFS at that hash,
+        # not something this plugin controls or can predict beforehand.
+        # rmtree() only handles the directory case. See GH #2555.
+        if os.path.isdir(download_path):
+            shutil.rmtree(download_path)
+        else:
+            os.remove(download_path)
         return None
 
     def ipfs_publish(self, lib):

--- a/test/plugins/test_ipfs.py
+++ b/test/plugins/test_ipfs.py
@@ -35,6 +35,39 @@ class IPFSPluginTest(PluginTestCase):
                     found = True
             assert found
 
+    def test_get_from_hash_cleans_up_single_file_download(self):
+        """
+        Regression test for
+        https://github.com/beetbox/beets/issues/2555
+
+        `ipfs get <hash>` produces a plain file (not a directory) for
+        a single-file IPFS object; which one it produces depends on
+        what was originally added to IPFS at that hash. Cleanup must
+        not assume it's always a directory and unconditionally call
+        shutil.rmtree(), which raises OSError: Not a directory on a
+        plain file, as in the issue's traceback.
+        """
+        test_hash = "QmTestHashForASingleFileDownload"
+        cwd = os.getcwd()
+        os.chdir(self.temp_path)
+        try:
+            # Simulate what `ipfs get` (mocked out above) would have
+            # produced on disk for a single-file IPFS object: a plain
+            # file named after the hash, not a directory.
+            with open(test_hash, "w") as f:
+                f.write("fake downloaded content")
+
+            ipfs = IPFSPlugin()
+            with patch(
+                "beetsplug.ipfs.ui.commands.TerminalImportSession"
+            ) as mock_session_cls:
+                mock_session_cls.return_value.run = Mock()
+                ipfs.ipfs_get_from_hash(self.lib, test_hash)
+
+            assert not os.path.exists(test_hash)
+        finally:
+            os.chdir(cwd)
+
     def test_get_remote_lib_accepts_library_path(self):
         self.lib.path = self.temp_path / "library.db"
         remote_dir = self.temp_path / "remotes"


### PR DESCRIPTION
Fixes #2555.

`ipfs_get_from_hash()` unconditionally called `shutil.rmtree()` on the path `ipfs get <hash>` downloads to. `ipfs get` produces a directory for a multi-file IPFS object, but a plain file for a single-file one -- which one depends entirely on what was originally added to IPFS at that hash, not something this plugin controls or can predict beforehand. For the single-file case, `rmtree()` raises `NotADirectoryError` (`OSError` errno 20 under Python 2, as in the issue's traceback), crashing the whole `beet ipfs -g <hash>` command after the import itself had already completed successfully.

**Fix**: check `os.path.isdir()` on the downloaded path and use `shutil.rmtree()` or `os.remove()` accordingly.

**Testing**: verified the underlying crash directly (`shutil.rmtree()` on a plain file reproduces the exact errno 20 from the issue) without needing a live IPFS network connection, since the actual bug is in the local cleanup step that runs after `ipfs get` and the import session complete, not in the IPFS interaction itself.

Added a regression test that exercises `ipfs_get_from_hash()` with the network call mocked out (matching this test file's existing `@patch("beets.util.command_output")` convention) and the import session mocked out, simulating what a single-file `ipfs get` produces on disk: a plain file named after the hash rather than a directory. I confirmed the test fails with the original code (`NotADirectoryError`) and passes with the fix, and that the file is correctly cleaned up either way. Ran the full existing `test_ipfs.py` suite (3 passed: 2 baseline + 1 new, no regressions).
