### PR TITLE
Catch UnicodeDecodeError from malformed terminal input

### DIFF
--- a/beets/ui/__init__.py
+++ b/beets/ui/__init__.py
@@ -169,6 +169,14 @@ def input_(prompt=None):
         resp = input()
     except EOFError:
         raise UserError("stdin stream ended while input required")
+    except UnicodeDecodeError:
+        # Can happen with malformed terminal input bytes (e.g. an
+        # invalid partial UTF-8 sequence from a terminal/paste glitch).
+        # Exit cleanly via UserError instead of propagating an
+        # unhandled UnicodeDecodeError, which aborts the whole import
+        # session with a raw traceback rather than a readable message.
+        # See GH #3651.
+        raise UserError("input could not be decoded as UTF-8")
 
     return resp
 

--- a/test/ui/test_ui_init.py
+++ b/test/ui/test_ui_init.py
@@ -4,6 +4,7 @@ import unittest
 from copy import deepcopy
 from pathlib import Path
 from random import random
+from unittest import mock
 
 import pytest
 
@@ -18,6 +19,28 @@ class InputMethodsTest(IOMixin, unittest.TestCase):
 
     def _print_helper2(self, s, prefix):
         print(prefix, s)
+
+    def test_input_unicode_decode_error_raises_user_error(self):
+        """
+        Regression test for
+        https://github.com/beetbox/beets/issues/3651
+
+        Malformed terminal input bytes (e.g. from a terminal/paste
+        glitch) can make the builtin input() raise UnicodeDecodeError.
+        This must be converted to a clean UserError -- matching the
+        existing handling for EOFError just above it -- rather than
+        propagating an unhandled UnicodeDecodeError and crashing the
+        whole import session.
+        """
+
+        def raise_unicode_decode_error(*args, **kwargs):
+            raise UnicodeDecodeError(
+                "utf-8", b"\xe3\x81\x82\x82", 3, 4, "invalid continuation byte"
+            )
+
+        with mock.patch("builtins.input", side_effect=raise_unicode_decode_error):
+            with pytest.raises(UserError):
+                ui.input_("Artist:")
 
     def test_input_select_objects(self):
         full_items = ["1", "2", "3", "4", "5"]


### PR DESCRIPTION
Fixes #3651.

`input_()` already caught `EOFError` from the builtin `input()` and converted it to a clean `UserError`, but not `UnicodeDecodeError`. The builtin `input()` can raise `UnicodeDecodeError` when the underlying stdin stream contains bytes that don't form valid UTF-8 -- e.g. from a terminal/paste glitch, as in the issue's reproduction (pasting non-ASCII text, backspacing partway through, then pasting again). This propagated as an unhandled `UnicodeDecodeError` all the way up through the interactive import pipeline, crashing the entire import session (potentially losing all progress on a large import) instead of giving a readable error.

**Fix**: catch `UnicodeDecodeError` the same way `EOFError` is already handled, converting it to a `UserError`. This is caught by `main()`'s existing top-level `UserError` handler, which prints a clean `"error: ..."` message and exits status 1 -- exactly the same graceful behavior already established for `EOFError`, applied consistently to this sibling "can't get input" failure mode, matching the reporter's own suggestion ("probably just need a try-except").

**Testing**: verified by simulating the exact scenario: patching `builtins.input` to raise the same `UnicodeDecodeError` shown in the issue's traceback. Confirmed `input_()` now raises a clean `UserError` instead of propagating the raw `UnicodeDecodeError`.

Added a regression test exercising this via `mock.patch` on `builtins.input`, matching the existing `IOMixin`-based test class's conventions in this file. I confirmed the test fails with the original code (propagates `UnicodeDecodeError`) and passes with the fix. Ran the full existing `test_ui_init.py` suite (5 passed: 4 baseline + 1 new) and the broader `test/ui/` suite (211 passed, 2 skipped for unrelated reasons), no regressions.
