### PR TITLE
Spotify: Improve 503 error handling

### DIFF
--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -296,10 +296,7 @@ class SpotifyPlugin(
                 )
                 time.sleep(DEFAULT_WAITING_TIME + 1)
                 return self._handle_response(
-                    method,
-                    url,
-                    params=params,
-                    retry_count=retry_count + 1,
+                    method, url, params=params, retry_count=retry_count + 1
                 )
             if e.response.status_code == 502:
                 self._log.error("Bad Gateway.")

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -290,8 +290,20 @@ class SpotifyPlugin(
                     method, url, params=params, retry_count=retry_count + 1
                 )
             if e.response.status_code == 503:
-                self._log.error("Service Unavailable.")
-                raise APIError("Service Unavailable.")
+                seconds = e.response.headers.get(
+                    "Retry-After", DEFAULT_WAITING_TIME
+                )
+                self._log.debug(
+                    "Service Unavailable. Retrying after {} seconds.",
+                    seconds,
+                )
+                time.sleep(int(seconds) + 1)
+                return self._handle_response(
+                    method,
+                    url,
+                    params=params,
+                    retry_count=retry_count + 1,
+                )
             if e.response.status_code == 502:
                 self._log.error("Bad Gateway.")
                 raise APIError("Bad Gateway.")

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -109,8 +109,8 @@ Other changes
   section to guide users in picking the right approach across genre fetching,
   filtering, and normalization.
 - :doc:`plugins/spotify`: Retry on ``503 Service Unavailable`` responses from
-  the Spotify API (with ``Retry-After`` backoff) instead of immediately
-  aborting, matching the existing ``429`` rate-limit retry behavior.
+  the Spotify API instead of immediately aborting, matching the existing ``429``
+  rate-limit retry behavior.
 
 2.12.0 (June 22, 2026)
 ----------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -108,6 +108,9 @@ Other changes
 - :doc:`plugins/lastgenre`: Add a new "Choosing the Right Tool" documentation
   section to guide users in picking the right approach across genre fetching,
   filtering, and normalization.
+- :doc:`plugins/spotify`: Retry on ``503 Service Unavailable`` responses from
+  the Spotify API (with ``Retry-After`` backoff) instead of immediately
+  aborting, matching the existing ``429`` rate-limit retry behavior.
 
 2.12.0 (June 22, 2026)
 ----------------------


### PR DESCRIPTION
Spotify currently crashes out on 503 errors. 
```bash
spotify: Service Unavailable.
Traceback (most recent call last):
  File "/home/arsaboo/.local/lib/python3.10/site-packages/beetsplug/spotify.py", line 244, in _handle_response
    response.raise_for_status()
  File "/home/arsaboo/.local/lib/python3.10/site-packages/requests/models.py", line 1167, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 503 Server Error: Service Unavailable for url: https://api.spotify.com/v1/tracks?ids=7ElISEDbwXtbB4xAvFRLqb%2C1DgdyYtZjfmBOxLuDLHXyH%2C0AeK8BB9Kk7qxyUgCfEwLO%2C6SJyEptZ7MiFJYe9FUbk7Q%2C5C9GZT725aQAdUT97hjaiO%2C0nGkSdNwjPh0tpqQU0FCCR%2C7EsWEd2s6hUUNw3I2QqKrn%2C3LfDSh8oDROFmebWrUq7De%2C036co96fRtoFd8n7pvklci%2C72sBOZVBWsfgKRWAF61jDA%2C3T6PwNpROC4WkWvrnqIcCJ%2C1USz6iqnhAnfHCcnjylrLa%2C7w6sxU9PQT8nJYzqGswOvM%2C4KeexCKGpjkBJS633QgxS2%2C0JuHzqHYYrauekCOUx4RrY%2C5cumiCqwlT9GAg2uktOZlg%2C2GbA6HFXqOGndhpPg42ifK%2C55nrl1ScrRDCv1ORLoEMlG%2C3YwLux5noWLxHhhE3OdIHS%2C1lCRbQsiWmNQUUSGYNvGT8

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/arsaboo/.local/bin/beet", line 6, in <module>
    sys.exit(main())
  File "/home/arsaboo/.local/lib/python3.10/site-packages/beets/ui/__init__.py", line 962, in main
    _raw_main(args)
  File "/home/arsaboo/.local/lib/python3.10/site-packages/beets/ui/__init__.py", line 903, in _raw_main
    subcommand.func(lib, suboptions, subargs)
  File "/home/arsaboo/.local/lib/python3.10/site-packages/beetsplug/spotify.py", line 570, in func
    self._fetch_info(lib, items, ui.should_write(), opts.force_refetch)
  File "/home/arsaboo/.local/lib/python3.10/site-packages/beetsplug/spotify.py", line 844, in _fetch_info
    track_details_by_id = self.get_track_details_by_id(unique_track_ids)
  File "/home/arsaboo/.local/lib/python3.10/site-packages/beetsplug/spotify.py", line 753, in get_track_details_by_id
    track_data = self._handle_response(
  File "/home/arsaboo/.local/lib/python3.10/site-packages/beetsplug/spotify.py", line 294, in _handle_response
    raise APIError("Service Unavailable.")
beetsplug.spotify.APIError: Service Unavailable.
```

This PR adds a retry mechanism that Spotify recommends for transient 503 errors. 

## To Do

- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
