### PR TITLE
fix: do not delete .mp3 file remuxed from MPEGLAYER3 WAV

### DIFF
--- a/beets/util/extension.py
+++ b/beets/util/extension.py
@@ -170,10 +170,11 @@ def remux_mpeglayer3_wav(path: AnyPath) -> AnyPath | None:
     mp3_path = syspath.with_suffix(".mp3")
     mp3_path.write_bytes(mp3_data)
 
-    # When the source is already named `.mp3`, it has just been rewritten in
-    # place with the extracted stream, so there is no separate original left
-    # to remove.
-    if mp3_path != syspath:
+    # When the source already has an `.mp3` extension, it has just been
+    # rewritten in place with the extracted stream, so there is no separate
+    # original left to remove. Compare with `samefile` so that a case-only
+    # difference on a case-insensitive filesystem is caught too.
+    if not util.samefile(mp3_path, syspath):
         util.remove(path)
 
     if isinstance(path, str):

--- a/beets/util/extension.py
+++ b/beets/util/extension.py
@@ -170,7 +170,11 @@ def remux_mpeglayer3_wav(path: AnyPath) -> AnyPath | None:
     mp3_path = syspath.with_suffix(".mp3")
     mp3_path.write_bytes(mp3_data)
 
-    util.remove(path)
+    # When the source is already named `.mp3`, it has just been rewritten in
+    # place with the extracted stream, so there is no separate original left
+    # to remove.
+    if mp3_path != syspath:
+        util.remove(path)
 
     if isinstance(path, str):
         return str(mp3_path)

--- a/beets/util/extension.py
+++ b/beets/util/extension.py
@@ -167,7 +167,14 @@ def remux_mpeglayer3_wav(path: AnyPath) -> AnyPath | None:
     mp3_data = data[data_offset + 8 :]
 
     syspath = Path(util.syspath(path))
-    mp3_path = syspath.with_suffix(".mp3")
+    # If the source already carries an `.mp3` extension (in any case),
+    # rewrite the extracted stream in place: `with_suffix(".mp3")` would
+    # create a second file next to e.g. `track.MP3` on case-sensitive
+    # filesystems, and the original would then be wrongly removed below.
+    if syspath.suffix.lower() == ".mp3":
+        mp3_path = syspath
+    else:
+        mp3_path = syspath.with_suffix(".mp3")
     mp3_path.write_bytes(mp3_data)
 
     # When the source already has an `.mp3` extension, it has just been

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -96,8 +96,9 @@ Bug fixes
   ``KeyError``. A ``|`` was being accepted as a relative-date unit due to a
   regular expression character-class typo.
 - ``remux_mp3_in_wav`` no longer deletes the imported file when a
-  MPEGLAYER3 WAV is named ``.mp3``: the remuxed stream was written back to the
-  same path and then removed as if it were a leftover original. :bug:`6748`
+  MPEGLAYER3 WAV has an ``.mp3`` extension: the remuxed stream was written back
+  to the same path and then removed as if it were a leftover original.
+  :bug:`6748`
 
 ..
     For plugin developers

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -95,6 +95,9 @@ Bug fixes
   valid date/time string" error instead of crashing with an uncaught
   ``KeyError``. A ``|`` was being accepted as a relative-date unit due to a
   regular expression character-class typo.
+- ``remux_mp3_in_wav`` no longer deletes the imported file when a
+  MPEGLAYER3 WAV is named ``.mp3``: the remuxed stream was written back to the
+  same path and then removed as if it were a leftover original. :bug:`6748`
 
 ..
     For plugin developers

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -95,10 +95,9 @@ Bug fixes
   valid date/time string" error instead of crashing with an uncaught
   ``KeyError``. A ``|`` was being accepted as a relative-date unit due to a
   regular expression character-class typo.
-- ``remux_mp3_in_wav`` no longer deletes the imported file when a
-  MPEGLAYER3 WAV has an ``.mp3`` extension: the remuxed stream was written back
-  to the same path and then removed as if it were a leftover original.
-  :bug:`6748`
+- ``remux_mp3_in_wav`` no longer deletes the imported file when a MPEGLAYER3 WAV
+  has an ``.mp3`` extension: the remuxed stream was written back to the same
+  path and then removed as if it were a leftover original. :bug:`6748`
 
 ..
     For plugin developers

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -95,9 +95,9 @@ Bug fixes
   valid date/time string" error instead of crashing with an uncaught
   ``KeyError``. A ``|`` was being accepted as a relative-date unit due to a
   regular expression character-class typo.
-- ``remux_mp3_in_wav`` no longer deletes the imported file when a MPEGLAYER3 WAV
-  has an ``.mp3`` extension: the remuxed stream was written back to the same
-  path and then removed as if it were a leftover original. :bug:`6748`
+- ``remux_mp3_in_wav`` no longer deletes the imported file when a MPEGLAYER3 WAV has an
+  ``.mp3`` extension: the remuxed stream was written back to the same path and then
+  removed as if it were a leftover original. :bug:`6748`
 
 ..
     For plugin developers

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1894,6 +1894,17 @@ class TestMpeglayerWavImport(AsIsImporterMixin, ImportHelper):
         assert mp3_path.exists()
         assert not dest.exists()
 
+    def test_remux_mpeglayer3_wav_mp3_extension(self):
+        """A MPEGLAYER3 WAV named `.mp3` must not be deleted (#6748)."""
+        src = _common.RSRC / "mpeglayer3.wav"
+        dest = self.temp_path / "mpeglayer3.mp3"
+        shutil.copy(syspath(src), syspath(dest))
+
+        mp3_path = remux_mpeglayer3_wav(dest)
+
+        assert mp3_path == dest
+        assert dest.exists()
+
     def test_remux_mpeglayer3_wav_disabled(self):
         """When remux_mp3_in_wav is disabled, WAV file should not be remuxed."""
         self.config["import"]["remux_mp3_in_wav"] = False

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1895,7 +1895,10 @@ class TestMpeglayerWavImport(AsIsImporterMixin, ImportHelper):
         assert not dest.exists()
 
     def test_remux_mpeglayer3_wav_mp3_extension(self):
-        """A MPEGLAYER3 WAV named `.mp3` must not be deleted (#6748)."""
+        """A MPEGLAYER3 WAV with an `.mp3` extension must not be deleted.
+
+        See #6748.
+        """
         src = _common.RSRC / "mpeglayer3.wav"
         dest = self.temp_path / "mpeglayer3.mp3"
         shutil.copy(syspath(src), syspath(dest))
@@ -1904,6 +1907,18 @@ class TestMpeglayerWavImport(AsIsImporterMixin, ImportHelper):
 
         assert mp3_path == dest
         assert dest.exists()
+
+    def test_remux_mpeglayer3_wav_mp3_extension_uppercase(self):
+        """The same holds when the extension differs only by case."""
+        src = _common.RSRC / "mpeglayer3.wav"
+        dest = self.temp_path / "mpeglayer3.MP3"
+        shutil.copy(syspath(src), syspath(dest))
+
+        mp3_path = remux_mpeglayer3_wav(dest)
+
+        assert dest.exists()
+        assert mp3_path is not None
+        assert mp3_path.exists()
 
     def test_remux_mpeglayer3_wav_disabled(self):
         """When remux_mp3_in_wav is disabled, WAV file should not be remuxed."""

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -1905,7 +1905,9 @@ class TestMpeglayerWavImport(AsIsImporterMixin, ImportHelper):
 
         mp3_path = remux_mpeglayer3_wav(dest)
 
-        assert mp3_path == dest
+        # `remux_mpeglayer3_wav` normalizes through `syspath` (on Windows
+        # this adds the `\\?\` prefix), so compare against the normalized form.
+        assert mp3_path == Path(syspath(dest))
         assert dest.exists()
 
     def test_remux_mpeglayer3_wav_mp3_extension_uppercase(self):


### PR DESCRIPTION
## Description

Fixes #6748.

`remux_mpeglayer3_wav()` writes the extracted MP3 stream to `path.with_suffix(".mp3")` and then removes the source. When the source is already named `.mp3` (a WAVE_FORMAT_MPEGLAYER3 file with an mp3 extension, which is exactly the case reported), both paths are identical, so the file it just wrote was immediately deleted and the track was lost. The source is now only removed when it is a distinct path from the remuxed output.

## To Do

- [x] ~Documentation~ (no user-facing option changed)
- [x] Changelog.
- [x] Tests. (New `test_remux_mpeglayer3_wav_mp3_extension` fails on master with the file missing and passes with the fix.)
