### PR TITLE
feat: add editor config option to editor_command()

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -947,9 +947,13 @@ def editor_command() -> str:
 
     """
     from beets import config
+
     return (
-        config["editor"].get(str) if config["editor"].exists() else None
-    ) or os.environ.get("VISUAL") or os.environ.get("EDITOR") or open_anything()
+        (config["editor"].get(str) if config["editor"].exists() else None)
+        or os.environ.get("VISUAL")
+        or os.environ.get("EDITOR")
+        or open_anything()
+    )
 
 
 def interactive_open(targets: Sequence[str], command: str):
@@ -1208,4 +1212,3 @@ def chunks(lst: Sequence[T], n: int) -> Iterator[list[T]]:
     """Yield successive n-sized chunks from lst."""
     for i in range(0, len(lst), n):
         yield list(lst[i : i + n])
-

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -941,14 +941,15 @@ def open_anything() -> str:
 def editor_command() -> str:
     """Get a command for opening a text file.
 
-    First try environment variable `VISUAL` followed by `EDITOR`. As last resort
-    fall back to `open_anything()`, the platform-specific tool for opening files
-    in general.
+    First checks the `editor` config option, then tries environment variable
+    `VISUAL` followed by `EDITOR`. As last resort fall back to `open_anything()`,
+    the platform-specific tool for opening files in general.
 
     """
+    from beets import config
     return (
-        os.environ.get("VISUAL") or os.environ.get("EDITOR") or open_anything()
-    )
+        config["editor"].get(str) if config["editor"].exists() else None
+    ) or os.environ.get("VISUAL") or os.environ.get("EDITOR") or open_anything()
 
 
 def interactive_open(targets: Sequence[str], command: str):
@@ -1207,3 +1208,4 @@ def chunks(lst: Sequence[T], n: int) -> Iterator[list[T]]:
     """Yield successive n-sized chunks from lst."""
     for i in range(0, len(lst), n):
         yield list(lst[i : i + n])
+

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,9 +29,10 @@ New features
 
 Bug fixes
 ~~~~~~~~~
-- Add ``editor`` config option to allow users to permanently set their preferred editor, overriding ``$VISUAL`` and ``$EDITOR`` environment variables. :bug:`6641`
 
-
+- Add ``editor`` config option to allow users to permanently set their preferred
+  editor, overriding ``$VISUAL`` and ``$EDITOR`` environment variables.
+  :bug:`6641`
 - :ref:`import-cmd`: Fix duplicate album merge during import when running in
   threaded mode. The merge action no longer creates a duplicate folder or
   reports ``could not get filesize`` errors. :bug:`6601`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,8 @@ New features
 
 Bug fixes
 ~~~~~~~~~
+- Add ``editor`` config option to allow users to permanently set their preferred editor, overriding ``$VISUAL`` and ``$EDITOR`` environment variables. :bug:`6641`
+
 
 - :ref:`import-cmd`: Fix duplicate album merge during import when running in
   threaded mode. The merge action no longer creates a duplicate folder or


### PR DESCRIPTION
Fixes #6641

Adds an `editor` config option so users can permanently set their preferred editor in `config.yaml`, overriding `$VISUAL` and `$EDITOR` environment variables which may not be available in virtualenv environments (e.g. pipx with uv backend).

**Usage:**
```yaml
editor: nano
```

**Changes:**
- Modified `beets/util/__init__.py` — `editor_command()` now checks `config["editor"]` first before falling back to `$VISUAL`/`$EDITOR`