### PR TITLE
util: remove `prefix` parameter from `syspath`

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -174,7 +174,7 @@ def normpath(path: PathLike) -> bytes:
     """Provide the canonical form of the path suitable for storing in
     the database.
     """
-    str_path = syspath(path, prefix=False)
+    str_path = os.fsdecode(path)
     str_path = os.path.normpath(os.path.abspath(os.path.expanduser(str_path)))
     return bytestring_path(str_path)
 
@@ -416,12 +416,10 @@ def displayable_path(
     return os.fsdecode(path)
 
 
-def syspath(path: PathLike, prefix: bool = True) -> str:
+def syspath(path: PathLike) -> str:
     """Convert a path for use by the operating system. In particular,
     paths on Windows must receive a magic prefix and must be converted
-    to Unicode before they are sent to the OS. To disable the magic
-    prefix on Windows, set `prefix` to False---but only do this if you
-    *really* know what you're doing.
+    to Unicode before they are sent to the OS.
     """
     str_path = os.fsdecode(path)
     # Don't do anything if we're not on windows
@@ -430,7 +428,7 @@ def syspath(path: PathLike, prefix: bool = True) -> str:
 
     # Add the magic prefix if it isn't already there.
     # https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247.aspx
-    if prefix and not str_path.startswith(WINDOWS_MAGIC_PREFIX):
+    if not str_path.startswith(WINDOWS_MAGIC_PREFIX):
         if str_path.startswith("\\\\"):
             # UNC path. Final path should look like \\?\UNC\...
             str_path = f"UNC{str_path[1:]}"

--- a/beets/util/artresizer.py
+++ b/beets/util/artresizer.py
@@ -239,7 +239,7 @@ class IMBackend(LocalBackend):
         # it here for the sake of explicitness.
         cmd: list[str] = [
             *self.convert_cmd,
-            syspath(path_in, prefix=False),
+            os.fsdecode(path_in),
             "-resize",
             f"{maxwidth}x>",
             "-interlace",
@@ -254,7 +254,7 @@ class IMBackend(LocalBackend):
         if max_filesize > 0:
             cmd += ["-define", f"jpeg:extent={max_filesize}b"]
 
-        cmd.append(syspath(path_out, prefix=False))
+        cmd.append(os.fsdecode(path_out))
 
         try:
             util.command_output(cmd)
@@ -272,7 +272,7 @@ class IMBackend(LocalBackend):
             *self.identify_cmd,
             "-format",
             "%w %h",
-            syspath(path_in, prefix=False),
+            os.fsdecode(path_in),
         ]
 
         try:
@@ -307,10 +307,10 @@ class IMBackend(LocalBackend):
 
         cmd = [
             *self.convert_cmd,
-            syspath(path_in, prefix=False),
+            os.fsdecode(path_in),
             "-interlace",
             "none",
-            syspath(path_out, prefix=False),
+            os.fsdecode(path_out),
         ]
 
         try:
@@ -363,12 +363,10 @@ class IMBackend(LocalBackend):
         # Converting images to grayscale tends to minimize the weight
         # of colors in the diff score. So we first convert both images
         # to grayscale and then pipe them into the `compare` command.
-        # On Windows, ImageMagick doesn't support the magic \\?\ prefix
-        # on paths, so we pass `prefix=False` to `syspath`.
         convert_cmd = [
             *self.convert_cmd,
-            syspath(im2, prefix=False),
-            syspath(im1, prefix=False),
+            os.fsdecode(im2),
+            os.fsdecode(im1),
             "-colorspace",
             "gray",
             "MIFF:-",

--- a/beetsplug/ipfs.py
+++ b/beetsplug/ipfs.py
@@ -171,10 +171,7 @@ class IPFSPlugin(BeetsPlugin):
             lib, loghandler=None, query=None, paths=[_hash]
         )
         imp.run()
-        # This uses a relative path, hence we cannot use util.syspath(_hash,
-        # prefix=True). However, that should be fine since the hash will not
-        # exceed MAX_PATH.
-        shutil.rmtree(util.syspath(_hash, prefix=False))
+        shutil.rmtree(_hash)
         return None
 
     def ipfs_publish(self, lib):


### PR DESCRIPTION
Simplified `syspath` because `syspath(path, prefix=False)` == `os.fsdecode(path)`.
