### PR TITLE
Reformat beatport/bpsync docs

### DIFF
--- a/docs/plugins/beatport.rst
+++ b/docs/plugins/beatport.rst
@@ -1,7 +1,10 @@
 Beatport Plugin
 ===============
 
-.. deprecated:: 2.8 Beatport retired the API this plugin relies on. See :bug:`3862` and :bug:`4477`.
+.. deprecated:: 2.8
+
+    Beatport retired the API this plugin relies on. See :bug:`3862` and
+    :bug:`4477`.
 
 The ``beatport`` plugin adds support for querying the Beatport_ catalogue during
 the autotagging process. This can potentially be helpful for users whose

--- a/docs/plugins/bpsync.rst
+++ b/docs/plugins/bpsync.rst
@@ -1,7 +1,10 @@
 BPSync Plugin
 =============
 
-.. deprecated:: 2.8 Depends on the deprecated :doc:`beatport` plugin. See :bug:`3862` and :bug:`4477`.
+.. deprecated:: 2.8
+
+    Depends on the deprecated :doc:`beatport` plugin. See :bug:`3862` and
+    :bug:`4477`.
 
 This plugin provides the ``bpsync`` command, which lets you fetch metadata from
 Beatport for albums and tracks that already have Beatport IDs. This plugin works


### PR DESCRIPTION
The builds are currently broken:
```
Run poe format-docs --check
Poe => docstrfmt --preserve-adornments docs /home/runner/work/beets/beets/CODE_OF_CONDUCT.rst /home/runner/work/beets/beets/README.rst /home/runner/work/beets/beets/README_kr.rst /home/runner/work/beets/beets/CONTRIBUTING.rst --check
File '/home/runner/work/beets/beets/docs/plugins/beatport.rst' could be reformatted.
File '/home/runner/work/beets/beets/docs/plugins/bpsync.rst' could be reformatted.
2 out of 122 files could be reformatted.
Done! 🎉
Error: Process completed with exit code 1.
```
Formatted both the docs:
```bash
$ conda run -n py311 docstrfmt --preserve-adornments docs/plugins/beatport.rst docs/plugins/bpsync.rst
Reformatted 'C:\Users\arsab\Documents\GitHub\beets\docs\plugins\beatport.rst'.
Reformatted 'C:\Users\arsab\Documents\GitHub\beets\docs\plugins\bpsync.rst'.
2 out of 2 files were reformatted.
Done! 🎉
```