### PR TITLE
fix: sdist should include man pages

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,22 +9,10 @@ below!
 Unreleased
 ----------
 
-..
-    New features
-    ~~~~~~~~~~~~
-
 Bug fixes
 ~~~~~~~~~
 
 - Fixed source distributions not including the bundled man pages. :bug:`6882`
-
-..
-    For plugin developers
-    ~~~~~~~~~~~~~~~~~~~~~
-
-..
-    Other changes
-    ~~~~~~~~~~~~~
 
 2.13.0 (July 27, 2026)
 ----------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,9 +13,10 @@ Unreleased
     New features
     ~~~~~~~~~~~~
 
-..
-    Bug fixes
-    ~~~~~~~~~
+Bug fixes
+~~~~~~~~~
+
+- Fixed source distributions not including the bundled man pages. :bug:`6882`
 
 ..
     For plugin developers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,11 @@ Changelog = "https://github.com/beetbox/beets/blob/master/docs/changelog.rst"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build]
+artifacts = [
+    "man/**"
+]
+
 [tool.hatch.build.targets.wheel]
 packages = ["beets", "beetsplug"]
 


### PR DESCRIPTION
Seems like hatchling only includes files that are part of the vcs by default. Since we generating the man pages on build they were not part of the vcs and thus not included in the sdist.

Adding the `man/**` glob to the `artifacts` field seems to fix the issue.


**Before**:
```
./dist/beets-2.13.0.tar.gz
├── beets
├── beetsplug
├── docs
├── extra
└── test
```

**After**:
```
./dist/beets-2.13.0.tar.gz
├── beets
├── beetsplug
├── docs
├── extra
├── man
└── test
```

**Review:**

```
gh pr checkout 6884
poe build
# look into dist/beets-3.13.0.tar.gz for the man folder
```


closes #6882