### PR TITLE
Include `uv.lock` in docs changes

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,6 +31,7 @@ jobs:
         with:
           files: |
             docs/**
+            uv.lock
       - name: Get changed python files
         id: raw-changed-python-files
         uses: tj-actions/changed-files@v46


### PR DESCRIPTION
This triggers `docs` action group workflow under `.github/workflows/lint.yaml` whenever `uv.lock` is updated, preventing issues like #6883.
