### PR TITLE
typing: type `plugins.send` and `BeetsPlugin.register_listener` explicitly

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -271,3 +271,11 @@ d24c0d341ec6074c343cd8054083fe358da8fa14
 b2f52ac12443c102712b735e456fd07a6525786b
 # Return Path from TestHelper.create_mediafile_fixture
 bb66b0c378e9bf7d97622a1582d93c4dfcf20fdd
+# typing: type handlers and listeners explicitly
+6dbdb58464a875eb3c429a913aeeb7fc1b8eea21
+# typing: Define events in a separate module, import explicitly
+8c6f137a3f9764e371eac461b34e3f4ea4c7e935
+# typing: Import events module instead
+de8899efa1c42c319d1e58c1f30bac92b6b28838
+# typing: add types to event handlers
+301a8791a066f1776e9ab58cfed70283a08f8ce3

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -275,3 +275,11 @@ b2f52ac12443c102712b735e456fd07a6525786b
 bb66b0c378e9bf7d97622a1582d93c4dfcf20fdd
 # Move AttrDict under beets.util
 ea334bd977ee8ed0cdbd627b7e9564dd08dd43f7
+# typing: type handlers and listeners explicitly
+88627e062b452e936bf0e7e90554cd56e3713288
+# typing: Define events in a separate module, import explicitly
+e9021e17e9f14af8b4805ce1ec7f32843ada7970
+# typing: Import events module instead
+dcc1fd0e4a3e7137d126f224d8f5d9911291652e
+# typing: add types to event handlers
+5039c8f6cff474bec54b2106dd7c7d0cd39878f2

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -119,6 +119,7 @@ class Query(ABC):
 SQLiteType = str | bytes | float | int | memoryview | None
 AnySQLiteType = TypeVar("AnySQLiteType", bound=SQLiteType)
 FieldQueryType = type["FieldQuery"]
+AnyCollectionQuery = TypeVar("AnyCollectionQuery", bound="CollectionQuery")
 
 
 class FieldQuery(Query, Generic[P]):

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -149,11 +149,11 @@ def construct_query_part(
 
 # TYPING ERROR
 def query_from_strings(
-    query_cls: type[query.CollectionQuery],
+    query_cls: type[query.AnyCollectionQuery],
     model_cls: type[LibModel],
     prefixes: Prefixes,
     query_parts: Collection[str],
-) -> query.Query:
+) -> query.AnyCollectionQuery:
     """Creates a collection query of type `query_cls` from a list of
     strings in the format used by parse_query_part. `model_cls`
     determines how queries are constructed from strings.

--- a/beets/events.py
+++ b/beets/events.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from beets.autotag import AlbumInfo, TrackInfo
+    from beets.autotag.match import AlbumMatch
+    from beets.importer import ImportSession, ImportTask
+    from beets.library import Album, Item, LibModel, Library
+
+AfterWriteEventType = Literal["after_write"]
+ItemPathEventType = Literal[
+    "before_item_moved",
+    "item_copied",
+    "item_hardlinked",
+    "item_linked",
+    "item_moved",
+    "item_reflinked",
+]
+BeforeChooseCandidateEventType = Literal["before_choose_candidate"]
+ImportTaskBeforeChoiceEventType = Literal["import_task_before_choice"]
+ImportTaskCreatedEventType = Literal["import_task_created"]
+ImportTaskEventType = Literal[
+    "import_task_apply",
+    "import_task_choice",
+    "import_task_files",
+    "import_task_start",
+]
+ImportEventType = Literal["import"]
+AlbumImportedEventType = Literal["album_imported"]
+AlbumEventType = Literal["album_removed", "art_set"]
+AlbumInfoReceivedEventType = Literal["albuminfo_received"]
+TrackInfoReceivedEventType = Literal["trackinfo_received"]
+MetadataReceivedEventType = (
+    AlbumInfoReceivedEventType | TrackInfoReceivedEventType
+)
+AlbumMatchedEventType = Literal["album_matched"]
+LibraryEventType = Literal["cli_exit", "library_opened"]
+DatabaseChangeEventType = Literal["database_change"]
+ImportBeginEventType = Literal["import_begin"]
+ItemImportedEventType = Literal["item_imported"]
+ItemEventType = Literal["item_removed"]
+WriteEventType = Literal["write"]
+MusicBrainzExtractEventType = Literal["mb_album_extract", "mb_track_extract"]
+NoArgsEventType = Literal["pluginload", "smartplaylist_update"]
+AfterConvertEventType = Literal["after_convert"]
+EventType = (
+    AfterWriteEventType
+    | ItemPathEventType
+    | BeforeChooseCandidateEventType
+    | ImportTaskBeforeChoiceEventType
+    | ImportTaskCreatedEventType
+    | ImportTaskEventType
+    | ImportEventType
+    | AlbumImportedEventType
+    | AlbumEventType
+    | MetadataReceivedEventType
+    | AlbumMatchedEventType
+    | LibraryEventType
+    | DatabaseChangeEventType
+    | ImportBeginEventType
+    | ItemImportedEventType
+    | ItemEventType
+    | WriteEventType
+    | MusicBrainzExtractEventType
+    | NoArgsEventType
+    | AfterConvertEventType
+)
+
+
+class AfterWriteEventArgs(TypedDict):
+    item: Item
+    path: bytes
+
+
+class ItemPathEventArgs(TypedDict):
+    item: Item
+    source: bytes
+    destination: bytes
+
+
+class ImportTaskEventArgs(TypedDict):
+    session: ImportSession
+    task: ImportTask
+
+
+class ImportEventArgs(TypedDict):
+    lib: Library
+    paths: list[bytes]
+
+
+class AlbumImportedEventArgs(TypedDict):
+    lib: Library
+    album: Album
+
+
+class AlbumEventArgs(TypedDict):
+    album: Album
+
+
+class AlbumInfoReceivedEventArgs(TypedDict):
+    info: AlbumInfo
+
+
+class TrackInfoReceivedEventArgs(TypedDict):
+    info: TrackInfo
+
+
+class AlbumMatchedEventArgs(TypedDict):
+    match: AlbumMatch
+
+
+class LibraryEventArgs(TypedDict):
+    lib: Library
+
+
+class DatabaseChangeEventArgs(TypedDict):
+    lib: Library
+    model: LibModel
+
+
+class ImportBeginEventArgs(TypedDict):
+    session: ImportSession
+
+
+class ItemImportedEventArgs(TypedDict):
+    lib: Library
+    item: Item
+
+
+class ItemEventArgs(TypedDict):
+    item: Item
+
+
+class WriteEventArgs(TypedDict):
+    item: Item
+    path: bytes
+    tags: dict[str, Any]
+
+
+class MusicBrainzExtractEventArgs(TypedDict):
+    data: Mapping[str, Any]
+
+
+class AfterConvertEventArgs(TypedDict):
+    item: Item
+    dest: bytes
+    keepnew: bool

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -33,48 +33,7 @@ if TYPE_CHECKING:
     from beets.ui import Subcommand
     from beets.util import PromptChoice
 
-    from .events import (
-        AfterConvertEventArgs,
-        AfterConvertEventType,
-        AfterWriteEventArgs,
-        AfterWriteEventType,
-        AlbumEventArgs,
-        AlbumEventType,
-        AlbumImportedEventArgs,
-        AlbumImportedEventType,
-        AlbumInfoReceivedEventArgs,
-        AlbumInfoReceivedEventType,
-        AlbumMatchedEventArgs,
-        AlbumMatchedEventType,
-        BeforeChooseCandidateEventType,
-        DatabaseChangeEventArgs,
-        DatabaseChangeEventType,
-        EventType,
-        ImportBeginEventArgs,
-        ImportBeginEventType,
-        ImportEventArgs,
-        ImportEventType,
-        ImportTaskBeforeChoiceEventType,
-        ImportTaskCreatedEventType,
-        ImportTaskEventArgs,
-        ImportTaskEventType,
-        ItemEventArgs,
-        ItemEventType,
-        ItemImportedEventArgs,
-        ItemImportedEventType,
-        ItemPathEventArgs,
-        ItemPathEventType,
-        LibraryEventArgs,
-        LibraryEventType,
-        MetadataReceivedEventType,
-        MusicBrainzExtractEventArgs,
-        MusicBrainzExtractEventType,
-        NoArgsEventType,
-        TrackInfoReceivedEventArgs,
-        TrackInfoReceivedEventType,
-        WriteEventArgs,
-        WriteEventType,
-    )
+    from . import events
 
     # TYPE_CHECKING guard is needed for any derived type
     # which uses an import from `beets.library` and `beets.imported`
@@ -133,10 +92,12 @@ class BeetsPlugin(metaclass=BeetsPluginMeta):
     the abstract methods defined here.
     """
 
-    _raw_listeners: ClassVar[dict[EventType, list[Listener]]] = defaultdict(
+    _raw_listeners: ClassVar[dict[events.EventType, list[Listener]]] = (
+        defaultdict(list)
+    )
+    listeners: ClassVar[dict[events.EventType, list[Listener]]] = defaultdict(
         list
     )
-    listeners: ClassVar[dict[EventType, list[Listener]]] = defaultdict(list)
 
     template_funcs: TFuncMap[str]
     template_fields: TFuncMap[Item]
@@ -337,128 +298,134 @@ class BeetsPlugin(metaclass=BeetsPluginMeta):
     @overload
     def register_listener(
         self,
-        event: AfterWriteEventType,
-        func: Callable[[Unpack[AfterWriteEventArgs]], None],
+        event: events.AfterWriteEventType,
+        func: Callable[[Unpack[events.AfterWriteEventArgs]], None],
     ) -> None: ...
     @overload
     def register_listener(
         self,
-        event: ItemPathEventType,
-        func: Callable[[Unpack[ItemPathEventArgs]], None],
+        event: events.ItemPathEventType,
+        func: Callable[[Unpack[events.ItemPathEventArgs]], None],
     ) -> None: ...
     @overload
     def register_listener(
         self,
-        event: BeforeChooseCandidateEventType,
-        func: Callable[[Unpack[ImportTaskEventArgs]], list[PromptChoice]],
+        event: events.BeforeChooseCandidateEventType,
+        func: Callable[
+            [Unpack[events.ImportTaskEventArgs]], list[PromptChoice]
+        ],
     ) -> None: ...
     @overload
     def register_listener(
         self,
-        event: ImportTaskBeforeChoiceEventType,
-        func: Callable[[Unpack[ImportTaskEventArgs]], Action | None],
+        event: events.ImportTaskBeforeChoiceEventType,
+        func: Callable[[Unpack[events.ImportTaskEventArgs]], Action | None],
     ) -> None: ...
     @overload
     def register_listener(
         self,
-        event: ImportTaskCreatedEventType,
-        func: Callable[[Unpack[ImportTaskEventArgs]], list[ImportTask] | None],
+        event: events.ImportTaskCreatedEventType,
+        func: Callable[
+            [Unpack[events.ImportTaskEventArgs]], list[ImportTask] | None
+        ],
     ) -> None: ...
     @overload
     def register_listener(
         self,
-        event: ImportTaskEventType,
-        func: Callable[[Unpack[ImportTaskEventArgs]], None],
+        event: events.ImportTaskEventType,
+        func: Callable[[Unpack[events.ImportTaskEventArgs]], None],
     ) -> None: ...
     @overload
     def register_listener(
         self,
-        event: ImportEventType,
-        func: Callable[[Unpack[ImportEventArgs]], None],
+        event: events.ImportEventType,
+        func: Callable[[Unpack[events.ImportEventArgs]], None],
     ) -> None: ...
     @overload
     def register_listener(
         self,
-        event: AlbumImportedEventType,
-        func: Callable[[Unpack[AlbumImportedEventArgs]], None],
+        event: events.AlbumImportedEventType,
+        func: Callable[[Unpack[events.AlbumImportedEventArgs]], None],
     ) -> None: ...
     @overload
     def register_listener(
         self,
-        event: AlbumEventType,
-        func: Callable[[Unpack[AlbumEventArgs]], None],
+        event: events.AlbumEventType,
+        func: Callable[[Unpack[events.AlbumEventArgs]], None],
     ) -> None: ...
     @overload
     def register_listener(
         self,
-        event: AlbumInfoReceivedEventType,
-        func: Callable[[Unpack[AlbumInfoReceivedEventArgs]], None],
+        event: events.AlbumInfoReceivedEventType,
+        func: Callable[[Unpack[events.AlbumInfoReceivedEventArgs]], None],
     ) -> None: ...
     @overload
     def register_listener(
         self,
-        event: TrackInfoReceivedEventType,
-        func: Callable[[Unpack[TrackInfoReceivedEventArgs]], None],
+        event: events.TrackInfoReceivedEventType,
+        func: Callable[[Unpack[events.TrackInfoReceivedEventArgs]], None],
     ) -> None: ...
     @overload
     def register_listener(
         self,
-        event: AlbumMatchedEventType,
-        func: Callable[[Unpack[AlbumMatchedEventArgs]], None],
+        event: events.AlbumMatchedEventType,
+        func: Callable[[Unpack[events.AlbumMatchedEventArgs]], None],
     ) -> None: ...
     @overload
     def register_listener(
         self,
-        event: LibraryEventType,
-        func: Callable[[Unpack[LibraryEventArgs]], None],
+        event: events.LibraryEventType,
+        func: Callable[[Unpack[events.LibraryEventArgs]], None],
     ) -> None: ...
     @overload
     def register_listener(
         self,
-        event: DatabaseChangeEventType,
-        func: Callable[[Unpack[DatabaseChangeEventArgs]], None],
+        event: events.DatabaseChangeEventType,
+        func: Callable[[Unpack[events.DatabaseChangeEventArgs]], None],
     ) -> None: ...
     @overload
     def register_listener(
         self,
-        event: ImportBeginEventType,
-        func: Callable[[Unpack[ImportBeginEventArgs]], None],
+        event: events.ImportBeginEventType,
+        func: Callable[[Unpack[events.ImportBeginEventArgs]], None],
     ) -> None: ...
     @overload
     def register_listener(
         self,
-        event: ItemImportedEventType,
-        func: Callable[[Unpack[ItemImportedEventArgs]], None],
+        event: events.ItemImportedEventType,
+        func: Callable[[Unpack[events.ItemImportedEventArgs]], None],
     ) -> None: ...
     @overload
     def register_listener(
         self,
-        event: ItemEventType,
-        func: Callable[[Unpack[ItemEventArgs]], None],
+        event: events.ItemEventType,
+        func: Callable[[Unpack[events.ItemEventArgs]], None],
     ) -> None: ...
     @overload
     def register_listener(
         self,
-        event: WriteEventType,
-        func: Callable[[Unpack[WriteEventArgs]], None],
+        event: events.WriteEventType,
+        func: Callable[[Unpack[events.WriteEventArgs]], None],
     ) -> None: ...
     @overload
     def register_listener(
         self,
-        event: MusicBrainzExtractEventType,
-        func: Callable[[Unpack[MusicBrainzExtractEventArgs]], None],
+        event: events.MusicBrainzExtractEventType,
+        func: Callable[[Unpack[events.MusicBrainzExtractEventArgs]], None],
     ) -> None: ...
     @overload
     def register_listener(
-        self, event: NoArgsEventType, func: Callable[[], None]
+        self, event: events.NoArgsEventType, func: Callable[[], None]
     ) -> None: ...
     @overload
     def register_listener(
         self,
-        event: AfterConvertEventType,
-        func: Callable[[Unpack[AfterConvertEventArgs]], None],
+        event: events.AfterConvertEventType,
+        func: Callable[[Unpack[events.AfterConvertEventArgs]], None],
     ) -> None: ...
-    def register_listener(self, event: EventType, func: Listener) -> None:
+    def register_listener(
+        self, event: events.EventType, func: Listener
+    ) -> None:
         """Add a function as a listener for the specified event."""
         if func not in self._raw_listeners[event]:
             self._raw_listeners[event].append(func)
@@ -644,18 +611,18 @@ def named_queries(model_cls: type[AnyModel]) -> dict[str, FieldQueryType]:
 
 @overload
 def notify_info_yielded(
-    event: AlbumInfoReceivedEventType,
+    event: events.AlbumInfoReceivedEventType,
 ) -> Callable[
     [Callable[P, Iterable[AlbumInfo]]], Callable[P, Iterator[AlbumInfo]]
 ]: ...
 @overload
 def notify_info_yielded(
-    event: TrackInfoReceivedEventType,
+    event: events.TrackInfoReceivedEventType,
 ) -> Callable[
     [Callable[P, Iterable[TrackInfo]]], Callable[P, Iterator[TrackInfo]]
 ]: ...
 def notify_info_yielded(
-    event: MetadataReceivedEventType,
+    event: events.MetadataReceivedEventType,
 ) -> Callable[[Callable[P, Iterable[Ret]]], Callable[P, Iterator[Ret]]]:
     """Makes a generator send the event 'event' every time it yields.
     This decorator is supposed to decorate a generator, but any function
@@ -749,92 +716,102 @@ def album_field_getters() -> TFuncMap[Album]:
 
 @overload
 def send(
-    event: AfterWriteEventType, **arguments: Unpack[AfterWriteEventArgs]
+    event: events.AfterWriteEventType,
+    **arguments: Unpack[events.AfterWriteEventArgs],
 ) -> list[Never]: ...
 @overload
 def send(
-    event: ItemPathEventType, **arguments: Unpack[ItemPathEventArgs]
+    event: events.ItemPathEventType,
+    **arguments: Unpack[events.ItemPathEventArgs],
 ) -> list[Never]: ...
 @overload
 def send(
-    event: BeforeChooseCandidateEventType,
-    **arguments: Unpack[ImportTaskEventArgs],
+    event: events.BeforeChooseCandidateEventType,
+    **arguments: Unpack[events.ImportTaskEventArgs],
 ) -> list[list[PromptChoice]]: ...
 @overload
 def send(
-    event: ImportTaskBeforeChoiceEventType,
-    **arguments: Unpack[ImportTaskEventArgs],
+    event: events.ImportTaskBeforeChoiceEventType,
+    **arguments: Unpack[events.ImportTaskEventArgs],
 ) -> list[Action]: ...
 @overload
 def send(
-    event: ImportTaskCreatedEventType, **arguments: Unpack[ImportTaskEventArgs]
+    event: events.ImportTaskCreatedEventType,
+    **arguments: Unpack[events.ImportTaskEventArgs],
 ) -> list[list[ImportTask]]: ...
 @overload
 def send(
-    event: ImportTaskEventType, **arguments: Unpack[ImportTaskEventArgs]
+    event: events.ImportTaskEventType,
+    **arguments: Unpack[events.ImportTaskEventArgs],
 ) -> list[Never]: ...
 @overload
 def send(
-    event: ImportEventType, **arguments: Unpack[ImportEventArgs]
+    event: events.ImportEventType, **arguments: Unpack[events.ImportEventArgs]
 ) -> list[Never]: ...
 @overload
 def send(
-    event: AlbumImportedEventType, **arguments: Unpack[AlbumImportedEventArgs]
+    event: events.AlbumImportedEventType,
+    **arguments: Unpack[events.AlbumImportedEventArgs],
 ) -> list[Never]: ...
 @overload
 def send(
-    event: AlbumEventType, **arguments: Unpack[AlbumEventArgs]
+    event: events.AlbumEventType, **arguments: Unpack[events.AlbumEventArgs]
 ) -> list[Never]: ...
 @overload
 def send(
-    event: AlbumInfoReceivedEventType,
-    **arguments: Unpack[AlbumInfoReceivedEventArgs],
+    event: events.AlbumInfoReceivedEventType,
+    **arguments: Unpack[events.AlbumInfoReceivedEventArgs],
 ) -> list[Never]: ...
 @overload
 def send(
-    event: TrackInfoReceivedEventType,
-    **arguments: Unpack[TrackInfoReceivedEventArgs],
+    event: events.TrackInfoReceivedEventType,
+    **arguments: Unpack[events.TrackInfoReceivedEventArgs],
 ) -> list[Never]: ...
 @overload
 def send(
-    event: AlbumMatchedEventType, **arguments: Unpack[AlbumMatchedEventArgs]
+    event: events.AlbumMatchedEventType,
+    **arguments: Unpack[events.AlbumMatchedEventArgs],
 ) -> list[Never]: ...
 @overload
 def send(
-    event: LibraryEventType, **arguments: Unpack[LibraryEventArgs]
+    event: events.LibraryEventType, **arguments: Unpack[events.LibraryEventArgs]
 ) -> list[Never]: ...
 @overload
 def send(
-    event: DatabaseChangeEventType, **arguments: Unpack[DatabaseChangeEventArgs]
+    event: events.DatabaseChangeEventType,
+    **arguments: Unpack[events.DatabaseChangeEventArgs],
 ) -> list[Never]: ...
 @overload
 def send(
-    event: ImportBeginEventType, **arguments: Unpack[ImportBeginEventArgs]
+    event: events.ImportBeginEventType,
+    **arguments: Unpack[events.ImportBeginEventArgs],
 ) -> list[Never]: ...
 @overload
 def send(
-    event: ItemImportedEventType, **arguments: Unpack[ItemImportedEventArgs]
+    event: events.ItemImportedEventType,
+    **arguments: Unpack[events.ItemImportedEventArgs],
 ) -> list[Never]: ...
 @overload
 def send(
-    event: ItemEventType, **arguments: Unpack[ItemEventArgs]
+    event: events.ItemEventType, **arguments: Unpack[events.ItemEventArgs]
 ) -> list[Never]: ...
 @overload
 def send(
-    event: WriteEventType, **arguments: Unpack[WriteEventArgs]
+    event: events.WriteEventType, **arguments: Unpack[events.WriteEventArgs]
 ) -> list[Never]: ...
 @overload
 def send(
-    event: MusicBrainzExtractEventType,
-    **arguments: Unpack[MusicBrainzExtractEventArgs],
+    event: events.MusicBrainzExtractEventType,
+    **arguments: Unpack[events.MusicBrainzExtractEventArgs],
 ) -> list[dict[str, Any]]: ...
 @overload
-def send(event: NoArgsEventType) -> list[Never]: ...
+def send(event: events.NoArgsEventType) -> list[Never]: ...
 @overload
 def send(
-    event: AfterConvertEventType, **arguments: Unpack[AfterConvertEventArgs]
+    event: events.AfterConvertEventType,
+    **arguments: Unpack[events.AfterConvertEventArgs],
 ) -> list[Never]: ...
-def send(event: EventType, **arguments: Any) -> list[Any]:
+def send(event: events.EventType, **arguments: Any) -> list[Any]:
     """Send an event to all assigned event listeners.
 
     `event` is the name of  the event to send, all other named arguments

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -10,15 +10,7 @@ from collections import defaultdict
 from functools import cached_property, wraps
 from importlib import import_module
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    Literal,
-    TypedDict,
-    TypeVar,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, overload
 
 import mediafile
 from typing_extensions import Never, ParamSpec, Unpack
@@ -29,18 +21,60 @@ from beets.util import unique_list
 from beets.util.deprecation import deprecate_for_maintainers, deprecate_for_user
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+    from collections.abc import Callable, Iterable, Iterator, Sequence
 
     from confuse import Subview
 
     from beets.autotag import AlbumInfo, TrackInfo
-    from beets.autotag.match import AlbumMatch
     from beets.dbcore.db import FieldQueryType
     from beets.dbcore.types import Type
     from beets.importer import Action, ImportSession, ImportTask
-    from beets.library import Album, Item, LibModel, Library
+    from beets.library import Album, Item, Library
     from beets.ui import Subcommand
     from beets.util import PromptChoice
+
+    from .events import (
+        AfterConvertEventArgs,
+        AfterConvertEventType,
+        AfterWriteEventArgs,
+        AfterWriteEventType,
+        AlbumEventArgs,
+        AlbumEventType,
+        AlbumImportedEventArgs,
+        AlbumImportedEventType,
+        AlbumInfoReceivedEventArgs,
+        AlbumInfoReceivedEventType,
+        AlbumMatchedEventArgs,
+        AlbumMatchedEventType,
+        BeforeChooseCandidateEventType,
+        DatabaseChangeEventArgs,
+        DatabaseChangeEventType,
+        EventType,
+        ImportBeginEventArgs,
+        ImportBeginEventType,
+        ImportEventArgs,
+        ImportEventType,
+        ImportTaskBeforeChoiceEventType,
+        ImportTaskCreatedEventType,
+        ImportTaskEventArgs,
+        ImportTaskEventType,
+        ItemEventArgs,
+        ItemEventType,
+        ItemImportedEventArgs,
+        ItemImportedEventType,
+        ItemPathEventArgs,
+        ItemPathEventType,
+        LibraryEventArgs,
+        LibraryEventType,
+        MetadataReceivedEventType,
+        MusicBrainzExtractEventArgs,
+        MusicBrainzExtractEventType,
+        NoArgsEventType,
+        TrackInfoReceivedEventArgs,
+        TrackInfoReceivedEventType,
+        WriteEventArgs,
+        WriteEventType,
+    )
 
     # TYPE_CHECKING guard is needed for any derived type
     # which uses an import from `beets.library` and `beets.imported`
@@ -60,146 +94,6 @@ PLUGIN_NAMESPACE = "beetsplug"
 
 # Plugins using the Last.fm API can share the same API key.
 LASTFM_KEY = "2dc3914abf35f0d9c92d97d8f8e42b43"
-
-AfterWriteEventType = Literal["after_write"]
-ItemPathEventType = Literal[
-    "before_item_moved",
-    "item_copied",
-    "item_hardlinked",
-    "item_linked",
-    "item_moved",
-    "item_reflinked",
-]
-BeforeChooseCandidateEventType = Literal["before_choose_candidate"]
-ImportTaskBeforeChoiceEventType = Literal["import_task_before_choice"]
-ImportTaskCreatedEventType = Literal["import_task_created"]
-ImportTaskEventType = Literal[
-    "import_task_apply",
-    "import_task_choice",
-    "import_task_files",
-    "import_task_start",
-]
-ImportEventType = Literal["import"]
-AlbumImportedEventType = Literal["album_imported"]
-AlbumEventType = Literal["album_removed", "art_set"]
-AlbumInfoReceivedEventType = Literal["albuminfo_received"]
-TrackInfoReceivedEventType = Literal["trackinfo_received"]
-MetadataReceivedEventType = (
-    AlbumInfoReceivedEventType | TrackInfoReceivedEventType
-)
-AlbumMatchedEventType = Literal["album_matched"]
-LibraryEventType = Literal["cli_exit", "library_opened"]
-DatabaseChangeEventType = Literal["database_change"]
-ImportBeginEventType = Literal["import_begin"]
-ItemImportedEventType = Literal["item_imported"]
-ItemEventType = Literal["item_removed"]
-WriteEventType = Literal["write"]
-MusicBrainzExtractEventType = Literal["mb_album_extract", "mb_track_extract"]
-NoArgsEventType = Literal["pluginload", "smartplaylist_update"]
-AfterConvertEventType = Literal["after_convert"]
-EventType = (
-    AfterWriteEventType
-    | ItemPathEventType
-    | BeforeChooseCandidateEventType
-    | ImportTaskBeforeChoiceEventType
-    | ImportTaskCreatedEventType
-    | ImportTaskEventType
-    | ImportEventType
-    | AlbumImportedEventType
-    | AlbumEventType
-    | MetadataReceivedEventType
-    | AlbumMatchedEventType
-    | LibraryEventType
-    | DatabaseChangeEventType
-    | ImportBeginEventType
-    | ItemImportedEventType
-    | ItemEventType
-    | WriteEventType
-    | MusicBrainzExtractEventType
-    | NoArgsEventType
-    | AfterConvertEventType
-)
-
-
-class AfterWriteEventArgs(TypedDict):
-    item: Item
-    path: bytes
-
-
-class ItemPathEventArgs(TypedDict):
-    item: Item
-    source: bytes
-    destination: bytes
-
-
-class ImportTaskEventArgs(TypedDict):
-    session: ImportSession
-    task: ImportTask
-
-
-class ImportEventArgs(TypedDict):
-    lib: Library
-    paths: list[bytes]
-
-
-class AlbumImportedEventArgs(TypedDict):
-    lib: Library
-    album: Album
-
-
-class AlbumEventArgs(TypedDict):
-    album: Album
-
-
-class AlbumInfoReceivedEventArgs(TypedDict):
-    info: AlbumInfo
-
-
-class TrackInfoReceivedEventArgs(TypedDict):
-    info: TrackInfo
-
-
-class AlbumMatchedEventArgs(TypedDict):
-    match: AlbumMatch
-
-
-class LibraryEventArgs(TypedDict):
-    lib: Library
-
-
-class DatabaseChangeEventArgs(TypedDict):
-    lib: Library
-    model: LibModel
-
-
-class ImportBeginEventArgs(TypedDict):
-    session: ImportSession
-
-
-class ItemImportedEventArgs(TypedDict):
-    lib: Library
-    item: Item
-
-
-class ItemEventArgs(TypedDict):
-    item: Item
-
-
-class WriteEventArgs(TypedDict):
-    item: Item
-    path: bytes
-    tags: dict[str, Any]
-
-
-class MusicBrainzExtractEventArgs(TypedDict):
-    data: Mapping[str, Any]
-
-
-class AfterConvertEventArgs(TypedDict):
-    item: Item
-    dest: bytes
-    keepnew: bool
-
 
 # Global logger.
 log = logging.getLogger("beets")

--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -10,10 +10,18 @@ from collections import defaultdict
 from functools import cached_property, wraps
 from importlib import import_module
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Literal,
+    TypedDict,
+    TypeVar,
+    overload,
+)
 
 import mediafile
-from typing_extensions import ParamSpec
+from typing_extensions import Never, ParamSpec, Unpack
 
 import beets
 from beets import logging
@@ -21,15 +29,18 @@ from beets.util import unique_list
 from beets.util.deprecation import deprecate_for_maintainers, deprecate_for_user
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Iterator, Sequence
+    from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 
     from confuse import Subview
 
+    from beets.autotag import AlbumInfo, TrackInfo
+    from beets.autotag.match import AlbumMatch
     from beets.dbcore.db import FieldQueryType
     from beets.dbcore.types import Type
-    from beets.importer import ImportSession, ImportTask
-    from beets.library import Album, Item, Library
+    from beets.importer import Action, ImportSession, ImportTask
+    from beets.library import Album, Item, LibModel, Library
     from beets.ui import Subcommand
+    from beets.util import PromptChoice
 
     # TYPE_CHECKING guard is needed for any derived type
     # which uses an import from `beets.library` and `beets.imported`
@@ -50,43 +61,146 @@ PLUGIN_NAMESPACE = "beetsplug"
 # Plugins using the Last.fm API can share the same API key.
 LASTFM_KEY = "2dc3914abf35f0d9c92d97d8f8e42b43"
 
-EventType = Literal[
-    "after_write",
-    "album_imported",
-    "album_removed",
-    "albuminfo_received",
-    "album_matched",
-    "art_set",
-    "before_choose_candidate",
+AfterWriteEventType = Literal["after_write"]
+ItemPathEventType = Literal[
     "before_item_moved",
-    "cli_exit",
-    "database_change",
-    "import",
-    "import_begin",
-    "import_task_apply",
-    "import_task_before_choice",
-    "import_task_choice",
-    "import_task_created",
-    "import_task_files",
-    "import_task_start",
     "item_copied",
     "item_hardlinked",
-    "item_imported",
     "item_linked",
     "item_moved",
     "item_reflinked",
-    "item_removed",
-    "library_opened",
-    "mb_album_extract",
-    "mb_track_extract",
-    "pluginload",
-    "trackinfo_received",
-    "write",
-    # convert plugin
-    "after_convert",
-    # smartplaylist plugin
-    "smartplaylist_update",
 ]
+BeforeChooseCandidateEventType = Literal["before_choose_candidate"]
+ImportTaskBeforeChoiceEventType = Literal["import_task_before_choice"]
+ImportTaskCreatedEventType = Literal["import_task_created"]
+ImportTaskEventType = Literal[
+    "import_task_apply",
+    "import_task_choice",
+    "import_task_files",
+    "import_task_start",
+]
+ImportEventType = Literal["import"]
+AlbumImportedEventType = Literal["album_imported"]
+AlbumEventType = Literal["album_removed", "art_set"]
+AlbumInfoReceivedEventType = Literal["albuminfo_received"]
+TrackInfoReceivedEventType = Literal["trackinfo_received"]
+MetadataReceivedEventType = (
+    AlbumInfoReceivedEventType | TrackInfoReceivedEventType
+)
+AlbumMatchedEventType = Literal["album_matched"]
+LibraryEventType = Literal["cli_exit", "library_opened"]
+DatabaseChangeEventType = Literal["database_change"]
+ImportBeginEventType = Literal["import_begin"]
+ItemImportedEventType = Literal["item_imported"]
+ItemEventType = Literal["item_removed"]
+WriteEventType = Literal["write"]
+MusicBrainzExtractEventType = Literal["mb_album_extract", "mb_track_extract"]
+NoArgsEventType = Literal["pluginload", "smartplaylist_update"]
+AfterConvertEventType = Literal["after_convert"]
+EventType = (
+    AfterWriteEventType
+    | ItemPathEventType
+    | BeforeChooseCandidateEventType
+    | ImportTaskBeforeChoiceEventType
+    | ImportTaskCreatedEventType
+    | ImportTaskEventType
+    | ImportEventType
+    | AlbumImportedEventType
+    | AlbumEventType
+    | MetadataReceivedEventType
+    | AlbumMatchedEventType
+    | LibraryEventType
+    | DatabaseChangeEventType
+    | ImportBeginEventType
+    | ItemImportedEventType
+    | ItemEventType
+    | WriteEventType
+    | MusicBrainzExtractEventType
+    | NoArgsEventType
+    | AfterConvertEventType
+)
+
+
+class AfterWriteEventArgs(TypedDict):
+    item: Item
+    path: bytes
+
+
+class ItemPathEventArgs(TypedDict):
+    item: Item
+    source: bytes
+    destination: bytes
+
+
+class ImportTaskEventArgs(TypedDict):
+    session: ImportSession
+    task: ImportTask
+
+
+class ImportEventArgs(TypedDict):
+    lib: Library
+    paths: list[bytes]
+
+
+class AlbumImportedEventArgs(TypedDict):
+    lib: Library
+    album: Album
+
+
+class AlbumEventArgs(TypedDict):
+    album: Album
+
+
+class AlbumInfoReceivedEventArgs(TypedDict):
+    info: AlbumInfo
+
+
+class TrackInfoReceivedEventArgs(TypedDict):
+    info: TrackInfo
+
+
+class AlbumMatchedEventArgs(TypedDict):
+    match: AlbumMatch
+
+
+class LibraryEventArgs(TypedDict):
+    lib: Library
+
+
+class DatabaseChangeEventArgs(TypedDict):
+    lib: Library
+    model: LibModel
+
+
+class ImportBeginEventArgs(TypedDict):
+    session: ImportSession
+
+
+class ItemImportedEventArgs(TypedDict):
+    lib: Library
+    item: Item
+
+
+class ItemEventArgs(TypedDict):
+    item: Item
+
+
+class WriteEventArgs(TypedDict):
+    item: Item
+    path: bytes
+    tags: dict[str, Any]
+
+
+class MusicBrainzExtractEventArgs(TypedDict):
+    data: Mapping[str, Any]
+
+
+class AfterConvertEventArgs(TypedDict):
+    item: Item
+    dest: bytes
+    keepnew: bool
+
+
 # Global logger.
 log = logging.getLogger("beets")
 
@@ -326,6 +440,130 @@ class BeetsPlugin(metaclass=BeetsPluginMeta):
         mediafile.MediaFile.add_field(name, descriptor)
         library.Item._media_fields.add(name)
 
+    @overload
+    def register_listener(
+        self,
+        event: AfterWriteEventType,
+        func: Callable[[Unpack[AfterWriteEventArgs]], None],
+    ) -> None: ...
+    @overload
+    def register_listener(
+        self,
+        event: ItemPathEventType,
+        func: Callable[[Unpack[ItemPathEventArgs]], None],
+    ) -> None: ...
+    @overload
+    def register_listener(
+        self,
+        event: BeforeChooseCandidateEventType,
+        func: Callable[[Unpack[ImportTaskEventArgs]], list[PromptChoice]],
+    ) -> None: ...
+    @overload
+    def register_listener(
+        self,
+        event: ImportTaskBeforeChoiceEventType,
+        func: Callable[[Unpack[ImportTaskEventArgs]], Action | None],
+    ) -> None: ...
+    @overload
+    def register_listener(
+        self,
+        event: ImportTaskCreatedEventType,
+        func: Callable[[Unpack[ImportTaskEventArgs]], list[ImportTask] | None],
+    ) -> None: ...
+    @overload
+    def register_listener(
+        self,
+        event: ImportTaskEventType,
+        func: Callable[[Unpack[ImportTaskEventArgs]], None],
+    ) -> None: ...
+    @overload
+    def register_listener(
+        self,
+        event: ImportEventType,
+        func: Callable[[Unpack[ImportEventArgs]], None],
+    ) -> None: ...
+    @overload
+    def register_listener(
+        self,
+        event: AlbumImportedEventType,
+        func: Callable[[Unpack[AlbumImportedEventArgs]], None],
+    ) -> None: ...
+    @overload
+    def register_listener(
+        self,
+        event: AlbumEventType,
+        func: Callable[[Unpack[AlbumEventArgs]], None],
+    ) -> None: ...
+    @overload
+    def register_listener(
+        self,
+        event: AlbumInfoReceivedEventType,
+        func: Callable[[Unpack[AlbumInfoReceivedEventArgs]], None],
+    ) -> None: ...
+    @overload
+    def register_listener(
+        self,
+        event: TrackInfoReceivedEventType,
+        func: Callable[[Unpack[TrackInfoReceivedEventArgs]], None],
+    ) -> None: ...
+    @overload
+    def register_listener(
+        self,
+        event: AlbumMatchedEventType,
+        func: Callable[[Unpack[AlbumMatchedEventArgs]], None],
+    ) -> None: ...
+    @overload
+    def register_listener(
+        self,
+        event: LibraryEventType,
+        func: Callable[[Unpack[LibraryEventArgs]], None],
+    ) -> None: ...
+    @overload
+    def register_listener(
+        self,
+        event: DatabaseChangeEventType,
+        func: Callable[[Unpack[DatabaseChangeEventArgs]], None],
+    ) -> None: ...
+    @overload
+    def register_listener(
+        self,
+        event: ImportBeginEventType,
+        func: Callable[[Unpack[ImportBeginEventArgs]], None],
+    ) -> None: ...
+    @overload
+    def register_listener(
+        self,
+        event: ItemImportedEventType,
+        func: Callable[[Unpack[ItemImportedEventArgs]], None],
+    ) -> None: ...
+    @overload
+    def register_listener(
+        self,
+        event: ItemEventType,
+        func: Callable[[Unpack[ItemEventArgs]], None],
+    ) -> None: ...
+    @overload
+    def register_listener(
+        self,
+        event: WriteEventType,
+        func: Callable[[Unpack[WriteEventArgs]], None],
+    ) -> None: ...
+    @overload
+    def register_listener(
+        self,
+        event: MusicBrainzExtractEventType,
+        func: Callable[[Unpack[MusicBrainzExtractEventArgs]], None],
+    ) -> None: ...
+    @overload
+    def register_listener(
+        self, event: NoArgsEventType, func: Callable[[], None]
+    ) -> None: ...
+    @overload
+    def register_listener(
+        self,
+        event: AfterConvertEventType,
+        func: Callable[[Unpack[AfterConvertEventArgs]], None],
+    ) -> None: ...
     def register_listener(self, event: EventType, func: Listener) -> None:
         """Add a function as a listener for the specified event."""
         if func not in self._raw_listeners[event]:
@@ -510,8 +748,20 @@ def named_queries(model_cls: type[AnyModel]) -> dict[str, FieldQueryType]:
     }
 
 
+@overload
 def notify_info_yielded(
-    event: EventType,
+    event: AlbumInfoReceivedEventType,
+) -> Callable[
+    [Callable[P, Iterable[AlbumInfo]]], Callable[P, Iterator[AlbumInfo]]
+]: ...
+@overload
+def notify_info_yielded(
+    event: TrackInfoReceivedEventType,
+) -> Callable[
+    [Callable[P, Iterable[TrackInfo]]], Callable[P, Iterator[TrackInfo]]
+]: ...
+def notify_info_yielded(
+    event: MetadataReceivedEventType,
 ) -> Callable[[Callable[P, Iterable[Ret]]], Callable[P, Iterator[Ret]]]:
     """Makes a generator send the event 'event' every time it yields.
     This decorator is supposed to decorate a generator, but any function
@@ -526,7 +776,7 @@ def notify_info_yielded(
         @wraps(func)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> Iterator[Ret]:
             for v in func(*args, **kwargs):
-                send(event, info=v)
+                send(event, info=v)  # type: ignore[call-overload]
                 yield v
 
         return wrapper
@@ -605,12 +855,91 @@ def album_field_getters() -> TFuncMap[Album]:
 
 @overload
 def send(
-    event: Literal["import_task_created"], **arguments: Any
-) -> list[list[ImportTask]]: ...
-
-
+    event: AfterWriteEventType, **arguments: Unpack[AfterWriteEventArgs]
+) -> list[Never]: ...
 @overload
-def send(event: EventType, **arguments: Any) -> list[Any]: ...
+def send(
+    event: ItemPathEventType, **arguments: Unpack[ItemPathEventArgs]
+) -> list[Never]: ...
+@overload
+def send(
+    event: BeforeChooseCandidateEventType,
+    **arguments: Unpack[ImportTaskEventArgs],
+) -> list[list[PromptChoice]]: ...
+@overload
+def send(
+    event: ImportTaskBeforeChoiceEventType,
+    **arguments: Unpack[ImportTaskEventArgs],
+) -> list[Action]: ...
+@overload
+def send(
+    event: ImportTaskCreatedEventType, **arguments: Unpack[ImportTaskEventArgs]
+) -> list[list[ImportTask]]: ...
+@overload
+def send(
+    event: ImportTaskEventType, **arguments: Unpack[ImportTaskEventArgs]
+) -> list[Never]: ...
+@overload
+def send(
+    event: ImportEventType, **arguments: Unpack[ImportEventArgs]
+) -> list[Never]: ...
+@overload
+def send(
+    event: AlbumImportedEventType, **arguments: Unpack[AlbumImportedEventArgs]
+) -> list[Never]: ...
+@overload
+def send(
+    event: AlbumEventType, **arguments: Unpack[AlbumEventArgs]
+) -> list[Never]: ...
+@overload
+def send(
+    event: AlbumInfoReceivedEventType,
+    **arguments: Unpack[AlbumInfoReceivedEventArgs],
+) -> list[Never]: ...
+@overload
+def send(
+    event: TrackInfoReceivedEventType,
+    **arguments: Unpack[TrackInfoReceivedEventArgs],
+) -> list[Never]: ...
+@overload
+def send(
+    event: AlbumMatchedEventType, **arguments: Unpack[AlbumMatchedEventArgs]
+) -> list[Never]: ...
+@overload
+def send(
+    event: LibraryEventType, **arguments: Unpack[LibraryEventArgs]
+) -> list[Never]: ...
+@overload
+def send(
+    event: DatabaseChangeEventType, **arguments: Unpack[DatabaseChangeEventArgs]
+) -> list[Never]: ...
+@overload
+def send(
+    event: ImportBeginEventType, **arguments: Unpack[ImportBeginEventArgs]
+) -> list[Never]: ...
+@overload
+def send(
+    event: ItemImportedEventType, **arguments: Unpack[ItemImportedEventArgs]
+) -> list[Never]: ...
+@overload
+def send(
+    event: ItemEventType, **arguments: Unpack[ItemEventArgs]
+) -> list[Never]: ...
+@overload
+def send(
+    event: WriteEventType, **arguments: Unpack[WriteEventArgs]
+) -> list[Never]: ...
+@overload
+def send(
+    event: MusicBrainzExtractEventType,
+    **arguments: Unpack[MusicBrainzExtractEventArgs],
+) -> list[dict[str, Any]]: ...
+@overload
+def send(event: NoArgsEventType) -> list[Never]: ...
+@overload
+def send(
+    event: AfterConvertEventType, **arguments: Unpack[AfterConvertEventArgs]
+) -> list[Never]: ...
 def send(event: EventType, **arguments: Any) -> list[Any]:
     """Send an event to all assigned event listeners.
 

--- a/beets/util/color.py
+++ b/beets/util/color.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import os
 import re
 from functools import cache
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import confuse
 
 from beets import config
+
+if TYPE_CHECKING:
+    from beets.util import StrPath
 
 # ANSI terminal colorization code heavily inspired by pygments:
 # https://bitbucket.org/birkenfeld/pygments-main/src/default/pygments/console.py
@@ -148,8 +151,10 @@ def _colorize(color_name: ColorName, text: str) -> str:
     return f"{COLOR_ESCAPE}[{color_code}m{text}{RESET_COLOR}"
 
 
-def colorize(color_name: ColorName, text: str) -> str:
+def colorize(color_name: ColorName, text: StrPath) -> str:
     """Colorize text when color output is enabled."""
+    text = os.fspath(text)
+
     if config["ui"]["color"] and "NO_COLOR" not in os.environ:
         return _colorize(color_name, text)
 

--- a/beetsplug/acousticbrainz.py
+++ b/beetsplug/acousticbrainz.py
@@ -1,13 +1,19 @@
 """Fetch various AcousticBrainz metadata using MBID."""
 
+from __future__ import annotations
+
 from collections import defaultdict
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import requests
 
 from beets import plugins, ui
 from beets.dbcore import types
 from beets.exceptions import UserError
+
+if TYPE_CHECKING:
+    from beets.importer import ImportSession, ImportTask
+
 
 LEVELS = ["/low-level", "/high-level"]
 ABSCHEME = {
@@ -68,7 +74,7 @@ class AcousticPlugin(plugins.BeetsPlugin):
         "voice_instrumental": types.STRING,
     }
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
         self._log.warning("This plugin is deprecated.")
@@ -114,7 +120,9 @@ class AcousticPlugin(plugins.BeetsPlugin):
         cmd.func = func
         return [cmd]
 
-    def import_task_files(self, session, task):
+    def import_task_files(
+        self, session: ImportSession, task: ImportTask
+    ) -> None:
         """Function is called upon beet import."""
         self._fetch_info(task.imported_items(), False, True)
 

--- a/beetsplug/advancedrewrite.py
+++ b/beetsplug/advancedrewrite.py
@@ -1,8 +1,11 @@
 """Plugin to rewrite fields based on a given query."""
 
+from __future__ import annotations
+
 import re
 import shlex
 from collections import defaultdict
+from typing import TYPE_CHECKING, ClassVar, TypedDict
 
 import confuse
 
@@ -13,6 +16,14 @@ from beets.plugins import BeetsPlugin
 from beets.ui import UserError
 
 from .rewrite import apply_rewrite_rules
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+class AdvancedRewriteConfig(TypedDict):
+    match: str
+    replacements: dict[str, str | list[str]]
 
 
 def rewriter(field, simple_rules, advanced_rules):
@@ -43,14 +54,89 @@ def rewriter(field, simple_rules, advanced_rules):
 class AdvancedRewritePlugin(BeetsPlugin):
     """Plugin to rewrite fields based on a given query."""
 
+    # Used to apply the same rewrite to the corresponding album field.
+    corresponding_album_fields: ClassVar[dict[str, str]] = {
+        "artist": "albumartist",
+        "artists": "albumartists",
+        "artist_sort": "albumartist_sort",
+        "artists_sort": "albumartists_sort",
+    }
+
     def __init__(self) -> None:
         """Parse configuration and register template fields for rewriting."""
         super().__init__()
         self.register_listener("pluginload", self.loaded)
 
+    def parse_simple_rule(
+        self, rule: dict[str, str]
+    ) -> Iterator[tuple[str, tuple[re.Pattern[str], str]]]:
+        if len(rule) != 1:
+            raise UserError(
+                "Simple rewrites must have only one rule, "
+                "but found multiple entries. "
+                "Did you forget to prepend a dash (-)?"
+            )
+        key, value = next(iter(rule.items()))
+        try:
+            fieldname, pattern = key.split(None, 1)
+        except ValueError:
+            raise UserError(f"Invalid simple rewrite specification {key}")
+        if fieldname not in Item._fields:
+            raise UserError(f"invalid field name {fieldname} in rewriter")
+        self._log.debug(
+            f"adding simple rewrite '{pattern}' → '{value}' "
+            f"for field {fieldname}"
+        )
+        compiled_pattern = re.compile(pattern.lower())
+        yield fieldname, (compiled_pattern, value)
+
+        # Apply the same rewrite to the corresponding album field.
+        if album_field := self.corresponding_album_fields.get(fieldname):
+            yield album_field, (compiled_pattern, value)
+
+    def parse_advanced_rule(
+        self, rule: AdvancedRewriteConfig
+    ) -> Iterator[tuple[str, tuple[AndQuery, str | list[str]]]]:
+        match = rule["match"]
+        replacements = rule["replacements"]
+        if len(replacements) == 0:
+            raise UserError(
+                "Advanced rewrites must have at least one replacement"
+            )
+        query = query_from_strings(
+            AndQuery, Item, prefixes={}, query_parts=shlex.split(match)
+        )
+        for fieldname, replacement in replacements.items():
+            if fieldname not in Item._fields:
+                raise UserError(f"Invalid field name {fieldname} in rewriter")
+            self._log.debug(
+                f"adding advanced rewrite to '{replacement}' "
+                f"for field {fieldname}"
+            )
+            if isinstance(replacement, list):
+                if Item._fields[fieldname] is not MULTI_VALUE_DSV:
+                    raise UserError(
+                        f"Field {fieldname} is not a multi-valued field "
+                        f"but a list was given: {', '.join(replacement)}"
+                    )
+            elif isinstance(replacement, str):
+                if Item._fields[fieldname] is MULTI_VALUE_DSV:
+                    replacement = [replacement]
+            else:
+                raise UserError(
+                    f"Invalid type of replacement {replacement} "
+                    f"for field {fieldname}"
+                )
+
+            yield fieldname, (query, replacement)
+
+            # Apply the same rewrite to the corresponding album field.
+            if album_field := self.corresponding_album_fields.get(fieldname):
+                yield album_field, (query, replacement)
+
     def loaded(self) -> None:
         template = confuse.Sequence(
-            confuse.OneOf(
+            confuse.OneOf[dict[str, str] | AdvancedRewriteConfig](
                 [
                     confuse.MappingValues(str),
                     {
@@ -63,95 +149,23 @@ class AdvancedRewritePlugin(BeetsPlugin):
             )
         )
 
-        # Used to apply the same rewrite to the corresponding album field.
-        corresponding_album_fields = {
-            "artist": "albumartist",
-            "artists": "albumartists",
-            "artist_sort": "albumartist_sort",
-            "artists_sort": "albumartists_sort",
-        }
-
         # Gather all the rewrite rules for each field.
         class RulesContainer:
+            simple: list[tuple[re.Pattern[str], str]]
+            advanced: list[tuple[AndQuery, str | list[str]]]
+
             def __init__(self) -> None:
                 self.simple = []
                 self.advanced = []
 
-        rules = defaultdict(RulesContainer)
+        rules = defaultdict[str, RulesContainer](RulesContainer)
         for rule in self.config.get(template):
             if "match" not in rule:
-                # Simple syntax
-                if len(rule) != 1:
-                    raise UserError(
-                        "Simple rewrites must have only one rule, "
-                        "but found multiple entries. "
-                        "Did you forget to prepend a dash (-)?"
-                    )
-                key, value = next(iter(rule.items()))
-                try:
-                    fieldname, pattern = key.split(None, 1)
-                except ValueError:
-                    raise UserError(
-                        f"Invalid simple rewrite specification {key}"
-                    )
-                if fieldname not in Item._fields:
-                    raise UserError(
-                        f"invalid field name {fieldname} in rewriter"
-                    )
-                self._log.debug(
-                    f"adding simple rewrite '{pattern}' → '{value}' "
-                    f"for field {fieldname}"
-                )
-                pattern = re.compile(pattern.lower())
-                rules[fieldname].simple.append((pattern, value))
-
-                # Apply the same rewrite to the corresponding album field.
-                if fieldname in corresponding_album_fields:
-                    album_fieldname = corresponding_album_fields[fieldname]
-                    rules[album_fieldname].simple.append((pattern, value))
+                for field, repl in self.parse_simple_rule(rule):
+                    rules[field].simple.append(repl)
             else:
-                # Advanced syntax
-                match = rule["match"]
-                replacements = rule["replacements"]
-                if len(replacements) == 0:
-                    raise UserError(
-                        "Advanced rewrites must have at least one replacement"
-                    )
-                query = query_from_strings(
-                    AndQuery, Item, prefixes={}, query_parts=shlex.split(match)
-                )
-                for fieldname, replacement in replacements.items():
-                    if fieldname not in Item._fields:
-                        raise UserError(
-                            f"Invalid field name {fieldname} in rewriter"
-                        )
-                    self._log.debug(
-                        f"adding advanced rewrite to '{replacement}' "
-                        f"for field {fieldname}"
-                    )
-                    if isinstance(replacement, list):
-                        if Item._fields[fieldname] is not MULTI_VALUE_DSV:
-                            raise UserError(
-                                f"Field {fieldname} is not a multi-valued field "
-                                f"but a list was given: {', '.join(replacement)}"
-                            )
-                    elif isinstance(replacement, str):
-                        if Item._fields[fieldname] is MULTI_VALUE_DSV:
-                            replacement = [replacement]
-                    else:
-                        raise UserError(
-                            f"Invalid type of replacement {replacement} "
-                            f"for field {fieldname}"
-                        )
-
-                    rules[fieldname].advanced.append((query, replacement))
-
-                    # Apply the same rewrite to the corresponding album field.
-                    if fieldname in corresponding_album_fields:
-                        album_fieldname = corresponding_album_fields[fieldname]
-                        rules[album_fieldname].advanced.append(
-                            (query, replacement)
-                        )
+                for field, advanced_repl in self.parse_advanced_rule(rule):  # type: ignore[arg-type]
+                    rules[field].advanced.append(advanced_repl)
 
         # Replace each template field with the new rewriter function.
         for fieldname, fieldrules in rules.items():

--- a/beetsplug/advancedrewrite.py
+++ b/beetsplug/advancedrewrite.py
@@ -43,12 +43,12 @@ def rewriter(field, simple_rules, advanced_rules):
 class AdvancedRewritePlugin(BeetsPlugin):
     """Plugin to rewrite fields based on a given query."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Parse configuration and register template fields for rewriting."""
         super().__init__()
         self.register_listener("pluginload", self.loaded)
 
-    def loaded(self):
+    def loaded(self) -> None:
         template = confuse.Sequence(
             confuse.OneOf(
                 [
@@ -73,7 +73,7 @@ class AdvancedRewritePlugin(BeetsPlugin):
 
         # Gather all the rewrite rules for each field.
         class RulesContainer:
-            def __init__(self):
+            def __init__(self) -> None:
                 self.simple = []
                 self.advanced = []
 

--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -20,6 +20,8 @@ from beets.util.color import colorize
 if TYPE_CHECKING:
     from beets.importer import ImportSession, ImportTask
 
+ImportAction = Literal["abort", "skip", "continue"]
+
 
 class CheckerCommandError(Exception):
     """Raised when running a checker failed.
@@ -44,7 +46,11 @@ class BadFiles(BeetsPlugin):
         self.verbose = False
 
         self.config.add(
-            {"import_action_on_warning": "ask", "import_action_on_error": "ask"}
+            {
+                "check_on_import": False,
+                "import_action_on_warning": "ask",
+                "import_action_on_error": "ask",
+            }
         )
 
         self.register_listener("import_task_start", self.on_import_task_start)
@@ -154,7 +160,7 @@ class BadFiles(BeetsPlugin):
     def on_import_task_start(
         self, task: ImportTask, session: ImportSession
     ) -> None:
-        if not self.config["check_on_import"].get(False):
+        if not self.config["check_on_import"].get(bool):
             return
 
         checks_failed = []
@@ -165,12 +171,10 @@ class BadFiles(BeetsPlugin):
                 checks_failed.append(error_lines)
 
         if checks_failed:
-            task._badfiles_checks_failed = checks_failed
+            task._badfiles_checks_failed = checks_failed  # type: ignore[attr-defined]
 
     def handle_import_action(
-        self,
-        action: Literal["abort", "skip", "continue"],
-        failure_type: Literal["error", "warning"],
+        self, action: ImportAction, failure_type: Literal["error", "warning"]
     ) -> importer.Action | None:
         action_name_by_action = {
             "abort": "Aborting",
@@ -191,7 +195,9 @@ class BadFiles(BeetsPlugin):
         self, task: ImportTask, session: ImportSession
     ) -> importer.Action | None:
         if hasattr(task, "_badfiles_checks_failed"):
-            actions = confuse.Choice(["ask", "abort", "skip", "continue"])
+            actions = confuse.Choice[ImportAction | Literal["ask"]](
+                ["ask", "abort", "skip", "continue"]
+            )
             warning_action = self.config["import_action_on_warning"].get(
                 actions
             )

--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -1,11 +1,13 @@
 """Use command-line tools to check for audio file corruption."""
 
+from __future__ import annotations
+
 import errno
 import os
 import shlex
 import sys
 from subprocess import STDOUT, CalledProcessError, check_output, list2cmdline
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import confuse
 
@@ -14,6 +16,9 @@ from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand
 from beets.util import displayable_path, par_map
 from beets.util.color import colorize
+
+if TYPE_CHECKING:
+    from beets.importer import ImportSession, ImportTask
 
 
 class CheckerCommandError(Exception):
@@ -26,7 +31,7 @@ class CheckerCommandError(Exception):
         msg: Message from the checker execution error.
     """
 
-    def __init__(self, cmd, oserror):
+    def __init__(self, cmd, oserror) -> None:
         self.checker = cmd[0]
         self.path = cmd[-1]
         self.errno = oserror.errno
@@ -34,7 +39,7 @@ class CheckerCommandError(Exception):
 
 
 class BadFiles(BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.verbose = False
 
@@ -146,7 +151,9 @@ class BadFiles(BeetsPlugin):
 
         return error_lines
 
-    def on_import_task_start(self, task, session):
+    def on_import_task_start(
+        self, task: ImportTask, session: ImportSession
+    ) -> None:
         if not self.config["check_on_import"].get(False):
             return
 
@@ -180,7 +187,9 @@ class BadFiles(BeetsPlugin):
             return importer.Action.SKIP
         return None
 
-    def on_import_task_before_choice(self, task, session):
+    def on_import_task_before_choice(
+        self, task: ImportTask, session: ImportSession
+    ) -> None:
         if hasattr(task, "_badfiles_checks_failed"):
             actions = confuse.Choice(["ask", "abort", "skip", "continue"])
             warning_action = self.config["import_action_on_warning"].get(

--- a/beetsplug/badfiles.py
+++ b/beetsplug/badfiles.py
@@ -189,7 +189,7 @@ class BadFiles(BeetsPlugin):
 
     def on_import_task_before_choice(
         self, task: ImportTask, session: ImportSession
-    ) -> None:
+    ) -> importer.Action | None:
         if hasattr(task, "_badfiles_checks_failed"):
             actions = confuse.Choice(["ask", "abort", "skip", "continue"])
             warning_action = self.config["import_action_on_warning"].get(

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -43,7 +43,9 @@ class BeatportAPIError(Exception):
 class BeatportClient:
     _api_base = "https://oauth-api.beatport.com"
 
-    def __init__(self, c_key, c_secret, auth_key=None, auth_secret=None):
+    def __init__(
+        self, c_key, c_secret, auth_key=None, auth_secret=None
+    ) -> None:
         """Initiate the client with OAuth information.
 
         For the initial authentication with the backend `auth_key` and
@@ -208,7 +210,7 @@ class BeatportObject:
     artists: list[tuple[str, str]] | None = None
     # tuple of artist id and artist name
 
-    def __init__(self, data: JSONDict):
+    def __init__(self, data: JSONDict) -> None:
         self.beatport_id = str(data["id"])  # given as int in the response
         self.name = str(data["name"])
         if "releaseDate" in data:
@@ -243,7 +245,7 @@ class BeatportRelease(BeatportObject):
 
     tracks: list[BeatportTrack] | None = None
 
-    def __init__(self, data: JSONDict):
+    def __init__(self, data: JSONDict) -> None:
         super().__init__(data)
 
         self.catalog_number = data.get("catalogNumber")
@@ -271,7 +273,7 @@ class BeatportTrack(BeatportObject):
     bpm: str | None
     initial_key: str | None
 
-    def __init__(self, data: JSONDict):
+    def __init__(self, data: JSONDict) -> None:
         super().__init__(data)
         if "title" in data:
             self.title = str(data["title"])
@@ -294,7 +296,7 @@ class BeatportTrack(BeatportObject):
 class BeatportPlugin(MetadataSourcePlugin):
     _client: BeatportClient | None = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         deprecate_for_user(self._log, "The 'beatport' plugin")
         self.config.add(
@@ -316,7 +318,7 @@ class BeatportPlugin(MetadataSourcePlugin):
             )
         return self._client
 
-    def setup(self, session: ImportSession):
+    def setup(self, session: ImportSession) -> None:
         c_key: str = self.config["apikey"].as_str()
         c_secret: str = self.config["apisecret"].as_str()
 

--- a/beetsplug/chroma.py
+++ b/beetsplug/chroma.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
     from beets.autotag import TrackInfo
+    from beets.importer import ImportSession, ImportTask
     from beets.library.models import Item
     from beetsplug.musicbrainz import MusicBrainzPlugin
 
@@ -170,7 +171,7 @@ def _all_releases(items):
 
 
 class AcoustidPlugin(MetadataSourcePlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.config.add({"auto": True})
         config["acoustid"]["apikey"].redact = True
@@ -200,7 +201,9 @@ class AcoustidPlugin(MetadataSourcePlugin):
             )
         return plugin  # type: ignore[return-value]
 
-    def fingerprint_task(self, task, session):
+    def fingerprint_task(
+        self, task: ImportTask, session: ImportSession
+    ) -> None:
         return fingerprint_task(self._log, task, session)
 
     def track_distance(self, item, info):
@@ -356,7 +359,7 @@ class AcoustidPlugin(MetadataSourcePlugin):
 # Hooks into import process.
 
 
-def fingerprint_task(log, task, session):
+def fingerprint_task(log, task: ImportTask, session: ImportSession) -> None:
     """Fingerprint each item in the task for later use during the
     autotagging candidate search.
     """
@@ -365,7 +368,7 @@ def fingerprint_task(log, task, session):
         acoustid_match(log, item.path)
 
 
-def apply_acoustid_metadata(task, session):
+def apply_acoustid_metadata(task: ImportTask, session: ImportSession) -> None:
     """Apply Acoustid metadata (fingerprint and ID) to the task's items."""
     for item in task.imported_items():
         if item.path in _fingerprints:
@@ -459,7 +462,7 @@ def fingerprint_item(log, item, write=False, quiet=False):
 
 
 class ScoredItem:
-    def __init__(self, item: Item, score: float):
+    def __init__(self, item: Item, score: float) -> None:
         self.item = item
         self.score = score
 
@@ -482,7 +485,7 @@ class ScoredItem:
 
 
 class TopN:
-    def __init__(self, n: int):
+    def __init__(self, n: int) -> None:
         self.n = n
         self.heap: list[ScoredItem] = []
 

--- a/beetsplug/chroma.py
+++ b/beetsplug/chroma.py
@@ -363,8 +363,7 @@ def fingerprint_task(log, task: ImportTask, session: ImportSession) -> None:
     """Fingerprint each item in the task for later use during the
     autotagging candidate search.
     """
-    items = task.items if task.is_album else [task.item]
-    for item in items:
+    for item in task.items:
         acoustid_match(log, item.path)
 
 

--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -329,7 +329,7 @@ class EditPlugin(plugins.BeetsPlugin):
 
     def before_choose_candidate_listener(
         self, session: ImportSession, task: ImportTask
-    ) -> None:
+    ) -> list[PromptChoice]:
         """Append an "Edit" choice and an "edit Candidates" choice (if
         there are candidates) to the interactive importer prompt.
         """

--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -141,7 +141,7 @@ def apply_(obj, data):
 
 
 class EditPlugin(plugins.BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
         self.config.add(
@@ -327,7 +327,9 @@ class EditPlugin(plugins.BeetsPlugin):
 
     # Methods for interactive importer execution.
 
-    def before_choose_candidate_listener(self, session, task):
+    def before_choose_candidate_listener(
+        self, session: ImportSession, task: ImportTask
+    ) -> None:
         """Append an "Edit" choice and an "edit Candidates" choice (if
         there are candidates) to the interactive importer prompt.
         """

--- a/beetsplug/embyupdate.py
+++ b/beetsplug/embyupdate.py
@@ -8,12 +8,18 @@ emby:
     password: password
 """
 
+from __future__ import annotations
+
 import hashlib
+from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urlencode, urljoin, urlsplit, urlunsplit
 
 import requests
 
 from beets.plugins import BeetsPlugin
+
+if TYPE_CHECKING:
+    from beets.library import LibModel, Library
 
 
 def api_url(host, port, endpoint):
@@ -132,7 +138,7 @@ def get_user(host, port, username):
 
 
 class EmbyUpdate(BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("emby")
 
         # Adding defaults.
@@ -153,11 +159,11 @@ class EmbyUpdate(BeetsPlugin):
 
         self.register_listener("database_change", self.listen_for_db_change)
 
-    def listen_for_db_change(self, lib, model):
+    def listen_for_db_change(self, lib: Library, model: LibModel) -> None:
         """Listens for beets db change and register the update for the end."""
         self.register_listener("cli_exit", self.update)
 
-    def update(self, lib):
+    def update(self, lib: Library) -> None:
         """When the client exists try to send refresh request to Emby."""
         self._log.info("Updating Emby library...")
 

--- a/beetsplug/fetchart.py
+++ b/beetsplug/fetchart.py
@@ -79,7 +79,7 @@ class Candidate:
         url: str | None = None,
         match: MetadataMatch | None = None,
         size: tuple[int, int] | None = None,
-    ):
+    ) -> None:
         self._log = log
         self.path = path
         self.url = url
@@ -639,7 +639,7 @@ class GoogleImages(RemoteArtSource):
     ID = "google"
     URL = "https://www.googleapis.com/customsearch/v1"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.key = (self._config["google_key"].get(),)
         self.cx = (self._config["google_engine"].get(),)
@@ -717,7 +717,7 @@ class FanartTV(RemoteArtSource):
     API_ALBUMS = f"{API_URL}music/albums/"
     PROJECT_KEY = "61a7d0ab4e67162b7a0c7c35915cd48e"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.client_key = self._config["fanarttv_key"].get()
 
@@ -1513,7 +1513,7 @@ class FetchArtPlugin(plugins.BeetsPlugin, RequestMixin):
         return True
 
     # Synchronous; after music files are put in place.
-    def assign_art(self, session: ImportSession, task: ImportTask):
+    def assign_art(self, session: ImportSession, task: ImportTask) -> None:
         """Place the discovered art in the filesystem."""
         if task in self.art_candidates:
             candidate = self.art_candidates.pop(task)

--- a/beetsplug/filefilter.py
+++ b/beetsplug/filefilter.py
@@ -1,15 +1,21 @@
 """Filter imported files using a regular expression."""
 
+from __future__ import annotations
+
 import re
+from typing import TYPE_CHECKING
 
 from beets import config
 from beets.importer import SingletonImportTask
 from beets.plugins import BeetsPlugin
 from beets.util import bytestring_path
 
+if TYPE_CHECKING:
+    from beets.importer import ImportSession, ImportTask
+
 
 class FileFilterPlugin(BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.register_listener(
             "import_task_created", self.import_task_created_event
@@ -30,7 +36,9 @@ class FileFilterPlugin(BeetsPlugin):
                 bytestring_path(self.config["singleton_path"].get())
             )
 
-    def import_task_created_event(self, session, task):
+    def import_task_created_event(
+        self, session: ImportSession, task: ImportTask
+    ) -> None:
         if task.items and len(task.items) > 0:
             items_to_import = []
             for item in task.items:

--- a/beetsplug/filefilter.py
+++ b/beetsplug/filefilter.py
@@ -38,7 +38,7 @@ class FileFilterPlugin(BeetsPlugin):
 
     def import_task_created_event(
         self, session: ImportSession, task: ImportTask
-    ) -> None:
+    ) -> list[ImportTask] | None:
         if task.items and len(task.items) > 0:
             items_to_import = []
             for item in task.items:

--- a/beetsplug/fromfilename.py
+++ b/beetsplug/fromfilename.py
@@ -2,11 +2,18 @@
 (possibly also extract track and artist)
 """
 
+from __future__ import annotations
+
 import os
 import re
+from typing import TYPE_CHECKING
 
 from beets import plugins
 from beets.util import displayable_path
+
+if TYPE_CHECKING:
+    from beets.importer import ImportSession, ImportTask
+
 
 # Filename field extraction patterns.
 PATTERNS = [
@@ -119,11 +126,11 @@ def apply_matches(d, log):
 
 
 class FromFilenamePlugin(plugins.BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.register_listener("import_task_start", self.filename_task)
 
-    def filename_task(self, task, session):
+    def filename_task(self, task: ImportTask, session: ImportSession) -> None:
         """Examine each item in the task to see if we can extract a title
         from the filename. Try to match all filenames to a number of
         regexps, starting with the most complex patterns and successively

--- a/beetsplug/fromfilename.py
+++ b/beetsplug/fromfilename.py
@@ -138,7 +138,7 @@ class FromFilenamePlugin(plugins.BeetsPlugin):
         same regex we can make an educated guess of which part of the
         regex that contains the title.
         """
-        items = task.items if task.is_album else [task.item]
+        items = task.items
 
         # Look for suspicious (empty or meaningless) titles.
         missing_titles = sum(bad_title(i.title) for i in items)

--- a/beetsplug/hook.py
+++ b/beetsplug/hook.py
@@ -77,4 +77,4 @@ class HookPlugin(BeetsPlugin):
             except OSError as exc:
                 self._log.error("hook for {} failed: {}", event, exc)
 
-        self.register_listener(event, hook_function)
+        self.register_listener(event, hook_function)  # type: ignore[arg-type]

--- a/beetsplug/hook.py
+++ b/beetsplug/hook.py
@@ -6,9 +6,12 @@ import os
 import shlex
 import string
 import subprocess
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from beets.plugins import BeetsPlugin
+
+if TYPE_CHECKING:
+    from beets.events import EventType
 
 
 class BytesToStrFormatter(string.Formatter):
@@ -45,8 +48,8 @@ class HookPlugin(BeetsPlugin):
 
             self.create_and_register_hook(hook_event, hook_command)
 
-    def create_and_register_hook(self, event, command):
-        def hook_function(**kwargs):
+    def create_and_register_hook(self, event: EventType, command):
+        def hook_function(**kwargs) -> None:
             if command is None or len(command) == 0:
                 self._log.error('invalid command "{}"', command)
                 return

--- a/beetsplug/ihate.py
+++ b/beetsplug/ihate.py
@@ -1,15 +1,23 @@
 """Warns you about things you hate (or even blocks import)."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from beets.importer import Action
 from beets.library import Album, Item, parse_query_string
 from beets.plugins import BeetsPlugin
+
+if TYPE_CHECKING:
+    from beets.importer import ImportSession, ImportTask
+
 
 __author__ = "baobab@heresiarch.info"
 __version__ = "2.0"
 
 
 class IHatePlugin(BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.register_listener(
             "import_task_choice", self.import_task_choice_event
@@ -30,7 +38,9 @@ class IHatePlugin(BeetsPlugin):
                     return True
         return False
 
-    def import_task_choice_event(self, session, task):
+    def import_task_choice_event(
+        self, session: ImportSession, task: ImportTask
+    ) -> None:
         skip_queries = self.config["skip"].as_str_seq()
         warn_queries = self.config["warn"].as_str_seq()
 

--- a/beetsplug/ihate.py
+++ b/beetsplug/ihate.py
@@ -1,8 +1,16 @@
 """Warns you about things you hate (or even blocks import)."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from beets.importer import Action
 from beets.library import Album, Item, parse_query_string
 from beets.plugins import BeetsPlugin
+
+if TYPE_CHECKING:
+    from beets.importer import ImportSession, ImportTask
+
 
 __author__ = "baobab@heresiarch.info"
 __version__ = "2.0"
@@ -18,7 +26,7 @@ def summary(task):
 
 
 class IHatePlugin(BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.register_listener(
             "import_task_choice", self.import_task_choice_event
@@ -39,7 +47,9 @@ class IHatePlugin(BeetsPlugin):
                     return True
         return False
 
-    def import_task_choice_event(self, session, task):
+    def import_task_choice_event(
+        self, session: ImportSession, task: ImportTask
+    ) -> None:
         skip_queries = self.config["skip"].as_str_seq()
         warn_queries = self.config["warn"].as_str_seq()
 

--- a/beetsplug/importadded.py
+++ b/beetsplug/importadded.py
@@ -18,6 +18,10 @@ if TYPE_CHECKING:
 
 
 class ImportAddedPlugin(BeetsPlugin):
+    item_mtime: dict[bytes, float]
+    reimported_item_ids: set[int | None]
+    replaced_album_paths: set[bytes]
+
     def __init__(self) -> None:
         super().__init__()
         self.config.add(
@@ -25,9 +29,9 @@ class ImportAddedPlugin(BeetsPlugin):
         )
 
         # item.id for new items that were reimported
-        self.reimported_item_ids = None
+        self.reimported_item_ids = set()
         # album.path for old albums that were replaced by a reimported album
-        self.replaced_album_paths = None
+        self.replaced_album_paths = set()
         # item path in the library to the mtime of the source file
         self.item_mtime = {}
 

--- a/beetsplug/importadded.py
+++ b/beetsplug/importadded.py
@@ -44,8 +44,11 @@ class ImportAddedPlugin(BeetsPlugin):
         register("item_imported", self.update_item_times)
         register("after_write", self.update_after_write_time)
 
-    def check_config(self, task: ImportTask, session: ImportSession) -> None:
+    def check_config(
+        self, task: ImportTask, session: ImportSession
+    ) -> list[ImportTask] | None:
         self.config["preserve_mtimes"].get(bool)
+        return None
 
     def reimported_item(self, item):
         return item.id in self.reimported_item_ids
@@ -55,7 +58,7 @@ class ImportAddedPlugin(BeetsPlugin):
 
     def record_if_inplace(
         self, task: ImportTask, session: ImportSession
-    ) -> None:
+    ) -> list[ImportTask] | None:
         if not (
             session.config["copy"]
             or session.config["move"]
@@ -73,6 +76,8 @@ class ImportAddedPlugin(BeetsPlugin):
             )
             for item in items:
                 self.record_import_mtime(item, item.path, item.path)
+
+        return None
 
     def record_reimported(
         self, task: ImportTask, session: ImportSession

--- a/beetsplug/importadded.py
+++ b/beetsplug/importadded.py
@@ -4,14 +4,21 @@ modification time (mtime) of the item's source file before import.
 Reimported albums and items are skipped.
 """
 
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING
 
 from beets import importer, util
 from beets.plugins import BeetsPlugin
 
+if TYPE_CHECKING:
+    from beets.importer import ImportSession, ImportTask
+    from beets.library import Album, Item, Library
+
 
 class ImportAddedPlugin(BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.config.add(
             {"preserve_mtimes": False, "preserve_write_mtimes": False}
@@ -37,7 +44,7 @@ class ImportAddedPlugin(BeetsPlugin):
         register("item_imported", self.update_item_times)
         register("after_write", self.update_after_write_time)
 
-    def check_config(self, task, session):
+    def check_config(self, task: ImportTask, session: ImportSession) -> None:
         self.config["preserve_mtimes"].get(bool)
 
     def reimported_item(self, item):
@@ -46,7 +53,9 @@ class ImportAddedPlugin(BeetsPlugin):
     def reimported_album(self, album):
         return album.path in self.replaced_album_paths
 
-    def record_if_inplace(self, task, session):
+    def record_if_inplace(
+        self, task: ImportTask, session: ImportSession
+    ) -> None:
         if not (
             session.config["copy"]
             or session.config["move"]
@@ -65,7 +74,9 @@ class ImportAddedPlugin(BeetsPlugin):
             for item in items:
                 self.record_import_mtime(item, item.path, item.path)
 
-    def record_reimported(self, task, session):
+    def record_reimported(
+        self, task: ImportTask, session: ImportSession
+    ) -> None:
         self.reimported_item_ids = {
             item.id
             for item, replaced_items in task.replaced_items.items()
@@ -86,7 +97,9 @@ class ImportAddedPlugin(BeetsPlugin):
         self.write_file_mtime(util.syspath(item.path), mtime)
         item.mtime = mtime
 
-    def record_import_mtime(self, item, source, destination):
+    def record_import_mtime(
+        self, item: Item, source: bytes, destination: bytes
+    ) -> None:
         """Record the file mtime of an item's path before its import."""
         mtime = os.stat(util.syspath(source)).st_mtime
         self.item_mtime[destination] = mtime
@@ -97,7 +110,7 @@ class ImportAddedPlugin(BeetsPlugin):
             util.displayable_path(source),
         )
 
-    def update_album_times(self, lib, album):
+    def update_album_times(self, lib: Library, album: Album) -> None:
         if self.reimported_album(album):
             self._log.debug(
                 "Album '{.filepath}' is reimported, skipping import of "
@@ -122,7 +135,7 @@ class ImportAddedPlugin(BeetsPlugin):
         )
         album.store()
 
-    def update_item_times(self, lib, item):
+    def update_item_times(self, lib: Library, item: Item) -> None:
         if self.reimported_item(item):
             self._log.debug(
                 "Item '{.filepath}' is reimported, skipping import of added date.",
@@ -140,7 +153,7 @@ class ImportAddedPlugin(BeetsPlugin):
             )
             item.store()
 
-    def update_after_write_time(self, item, path):
+    def update_after_write_time(self, item: Item, path: bytes) -> None:
         """Update the mtime of the item's file with the item.added value
         after each write of the item if `preserve_write_mtimes` is enabled.
         """

--- a/beetsplug/importfeeds.py
+++ b/beetsplug/importfeeds.py
@@ -3,9 +3,12 @@ music player. Also allow printing the new file locations to stdout in case
 one wants to manually add music to a player by its path.
 """
 
+from __future__ import annotations
+
 import datetime
 import os
 import re
+from typing import TYPE_CHECKING
 
 from beets import config
 from beets.plugins import BeetsPlugin
@@ -17,6 +20,11 @@ from beets.util import (
     normpath,
     syspath,
 )
+
+if TYPE_CHECKING:
+    from beets.importer import ImportSession
+    from beets.library import Album, Item, Library
+
 
 M3U_DEFAULT_NAME = "imported.m3u"
 
@@ -54,7 +62,7 @@ def _write_m3u(m3u_path, items_paths):
 
 
 class ImportFeedsPlugin(BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
         self.config.add(
@@ -132,13 +140,13 @@ class ImportFeedsPlugin(BeetsPlugin):
             for path in paths:
                 self._log.info("  {}", path)
 
-    def album_imported(self, lib, album):
+    def album_imported(self, lib: Library, album: Album) -> None:
         self._record_items(lib, album.album, album.items())
 
-    def item_imported(self, lib, item):
+    def item_imported(self, lib: Library, item: Item) -> None:
         self._record_items(lib, item.title, [item])
 
-    def import_begin(self, session):
+    def import_begin(self, session: ImportSession) -> None:
         formats = self.config["formats"].as_str_seq()
         if "m3u_session" in formats:
             self.m3u_session = _build_m3u_session_filename(

--- a/beetsplug/importsource.py
+++ b/beetsplug/importsource.py
@@ -4,20 +4,27 @@ you've removed the album from the library.
 
 """
 
+from __future__ import annotations
+
 import os
 from pathlib import Path
 from shutil import rmtree
+from typing import TYPE_CHECKING
 
 from beets.dbcore.query import PathQuery
 from beets.plugins import BeetsPlugin
 from beets.ui import input_options
 from beets.util.color import colorize
 
+if TYPE_CHECKING:
+    from beets.importer import ImportSession, ImportTask
+    from beets.library import Item
+
 
 class ImportSourcePlugin(BeetsPlugin):
     """Main plugin class."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the plugin and read configuration."""
         super().__init__()
         self.config.add({"suggest_removal": False})
@@ -34,7 +41,9 @@ class ImportSourcePlugin(BeetsPlugin):
             "import_task_choice", self.prevent_suggest_removal
         )
 
-    def prevent_suggest_removal(self, session, task):
+    def prevent_suggest_removal(
+        self, session: ImportSession, task: ImportTask
+    ) -> None:
         if task.skip:
             return
         for item in task.imported_items():
@@ -54,7 +63,7 @@ class ImportSourcePlugin(BeetsPlugin):
             item["source_path"] = item.path
             item.try_sync(write=False, move=False)
 
-    def suggest_removal(self, item):
+    def suggest_removal(self, item: Item) -> None:
         """Prompts the user to delete the original path the item was imported from."""
         if (
             not self.config["suggest_removal"]

--- a/beetsplug/importsource.py
+++ b/beetsplug/importsource.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
 class ImportSourcePlugin(BeetsPlugin):
     """Main plugin class."""
 
+    stop_suggestions_for_albums: set[str]
+
     def __init__(self) -> None:
         """Initialize the plugin and read configuration."""
         super().__init__()
@@ -130,14 +132,14 @@ class ImportSourcePlugin(BeetsPlugin):
 
             source_dir_query = PathQuery(
                 "source_path",
-                srcpath.parent,
+                os.fsencode(srcpath.parent),
                 # The "source_path" attribute may not be present in all
                 # items of the library, so we avoid errors with this:
                 fast=False,
             )
 
             print("Doing so will delete the following items' sources as well:")
-            for searched_item in item._db.items(source_dir_query):
+            for searched_item in item.db.items(source_dir_query):
                 print(colorize("text_warning", searched_item.filepath))
 
             print("Would you like to continue?")

--- a/beetsplug/kodiupdate.py
+++ b/beetsplug/kodiupdate.py
@@ -9,9 +9,16 @@ Put something like the following in your config.yaml to configure:
         pwd: secret
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import requests
 
 from beets.plugins import BeetsPlugin
+
+if TYPE_CHECKING:
+    from beets.library import LibModel, Library
 
 
 def update_kodi(host, port, user, password):
@@ -31,7 +38,7 @@ def update_kodi(host, port, user, password):
 
 
 class KodiUpdate(BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("kodi")
 
         # Adding defaults.
@@ -43,11 +50,11 @@ class KodiUpdate(BeetsPlugin):
         self.config["pwd"].redact = True
         self.register_listener("database_change", self.listen_for_db_change)
 
-    def listen_for_db_change(self, lib, model):
+    def listen_for_db_change(self, lib: Library, model: LibModel) -> None:
         """Listens for beets db change and register the update"""
         self.register_listener("cli_exit", self.update)
 
-    def update(self, lib):
+    def update(self, lib: Library) -> None:
         """When the client exists try to send refresh request to Kodi server."""
         self._log.info("Requesting a Kodi library update...")
 

--- a/beetsplug/loadext.py
+++ b/beetsplug/loadext.py
@@ -1,13 +1,19 @@
 """Load SQLite extensions."""
 
+from __future__ import annotations
+
 import sqlite3
+from typing import TYPE_CHECKING
 
 from beets.dbcore import Database
 from beets.plugins import BeetsPlugin
 
+if TYPE_CHECKING:
+    from beets.library import Library
+
 
 class LoadExtPlugin(BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
         if not Database.supports_extensions:
@@ -19,7 +25,7 @@ class LoadExtPlugin(BeetsPlugin):
 
         self.register_listener("library_opened", self.library_opened)
 
-    def library_opened(self, lib):
+    def library_opened(self, lib: Library) -> None:
         for v in self.config:
             ext = v.as_filename()
 

--- a/beetsplug/loadext.py
+++ b/beetsplug/loadext.py
@@ -26,7 +26,7 @@ class LoadExtPlugin(BeetsPlugin):
         self.register_listener("library_opened", self.library_opened)
 
     def library_opened(self, lib: Library) -> None:
-        for v in self.config:
+        for v in self.config.sequence():
             ext = v.as_filename()
 
             self._log.debug("loading extension {}", ext)

--- a/beetsplug/mbpseudo.py
+++ b/beetsplug/mbpseudo.py
@@ -86,7 +86,7 @@ class MusicBrainzPseudoReleasePlugin(MusicBrainzPlugin):
         self.register_listener("album_matched", self._adjust_final_album_match)
 
     # noinspection PyMethodMayBeStatic
-    def _on_plugins_loaded(self):
+    def _on_plugins_loaded(self) -> None:
         for plugin in find_plugins():
             if isinstance(plugin, MusicBrainzPlugin) and not isinstance(
                 plugin, MusicBrainzPseudoReleasePlugin
@@ -234,7 +234,7 @@ class MusicBrainzPseudoReleasePlugin(MusicBrainzPlugin):
             for tag_key, pseudo_key in track_custom_tags:
                 track[tag_key] = pseudo_track[pseudo_key]
 
-    def _adjust_final_album_match(self, match: AlbumMatch):
+    def _adjust_final_album_match(self, match: AlbumMatch) -> None:
         album_info = match.info
         if isinstance(album_info, PseudoAlbumInfo):
             self._log.debug(
@@ -270,7 +270,7 @@ class PseudoAlbumInfo(AlbumInfo):
 
     def __init__(
         self, pseudo_release: AlbumInfo, official_release: AlbumInfo, **kwargs
-    ):
+    ) -> None:
         super().__init__(pseudo_release.tracks, **kwargs)
         self.__dict__["_pseudo_source"] = True
         self.__dict__["_official_release"] = official_release

--- a/beetsplug/mbsubmit.py
+++ b/beetsplug/mbsubmit.py
@@ -50,13 +50,13 @@ class MBSubmitPlugin(BeetsPlugin):
 
     def before_choose_candidate_event(
         self, session: ImportSession, task: ImportTask
-    ) -> None:
+    ) -> list[PromptChoice]:
         if task.rec <= self.threshold:
             return [
                 PromptChoice("p", "Print tracks", self.print_tracks),
                 PromptChoice("o", "Open files with Picard", self.picard),
             ]
-        return None
+        return []
 
     def picard(self, session, task):
         paths = []

--- a/beetsplug/mbsubmit.py
+++ b/beetsplug/mbsubmit.py
@@ -51,7 +51,7 @@ class MBSubmitPlugin(BeetsPlugin):
     def before_choose_candidate_event(
         self, session: ImportSession, task: ImportTask
     ) -> list[PromptChoice]:
-        if task.rec <= self.threshold:
+        if task.rec and task.rec <= self.threshold:
             return [
                 PromptChoice("p", "Print tracks", self.print_tracks),
                 PromptChoice("o", "Open files with Picard", self.picard),

--- a/beetsplug/mbsubmit.py
+++ b/beetsplug/mbsubmit.py
@@ -7,7 +7,10 @@ implemented by MusicBrainz yet.
 [1] https://wiki.musicbrainz.org/History:How_To_Parse_Track_Listings
 """
 
+from __future__ import annotations
+
 import subprocess
+from typing import TYPE_CHECKING
 
 from beets import ui
 from beets.autotag import Recommendation
@@ -15,9 +18,12 @@ from beets.plugins import BeetsPlugin
 from beets.util import PromptChoice, displayable_path
 from beetsplug.info import print_data
 
+if TYPE_CHECKING:
+    from beets.importer import ImportSession, ImportTask
+
 
 class MBSubmitPlugin(BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
         self.config.add(
@@ -42,7 +48,9 @@ class MBSubmitPlugin(BeetsPlugin):
             "before_choose_candidate", self.before_choose_candidate_event
         )
 
-    def before_choose_candidate_event(self, session, task):
+    def before_choose_candidate_event(
+        self, session: ImportSession, task: ImportTask
+    ) -> None:
         if task.rec <= self.threshold:
             return [
                 PromptChoice("p", "Print tracks", self.print_tracks),

--- a/beetsplug/mpdupdate.py
+++ b/beetsplug/mpdupdate.py
@@ -7,11 +7,17 @@ Put something like the following in your config.yaml to configure:
         password: seekrit
 """
 
+from __future__ import annotations
+
 import os
 import socket
+from typing import TYPE_CHECKING
 
 from beets import config
 from beets.plugins import BeetsPlugin
+
+if TYPE_CHECKING:
+    from beets.library import LibModel, Library
 
 
 # No need to introduce a dependency on an MPD library for such a
@@ -20,7 +26,7 @@ from beets.plugins import BeetsPlugin
 class BufferedSocket:
     """Socket abstraction that allows reading by line."""
 
-    def __init__(self, host, port, sep=b"\n"):
+    def __init__(self, host, port, sep=b"\n") -> None:
         if host[0] in ["/", "~"]:
             self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             self.sock.connect(os.path.expanduser(host))
@@ -49,7 +55,7 @@ class BufferedSocket:
 
 
 class MPDUpdatePlugin(BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         config["mpd"].add(
             {
@@ -68,17 +74,17 @@ class MPDUpdatePlugin(BeetsPlugin):
 
         self.register_listener("database_change", self.db_change)
 
-    def db_change(self, lib, model):
+    def db_change(self, lib: Library, model: LibModel) -> None:
         self.register_listener("cli_exit", self.update)
 
-    def update(self, lib):
+    def update(self, lib: Library) -> None:
         self.update_mpd(
             config["mpd"]["host"].as_str(),
             config["mpd"]["port"].get(int),
             config["mpd"]["password"].as_str(),
         )
 
-    def update_mpd(self, host="localhost", port=6600, password=None):
+    def update_mpd(self, host="localhost", port=6600, password=None) -> None:
         """Sends the "update" command to the MPD server indicated,
         possibly authenticating with a password first.
         """

--- a/beetsplug/permissions.py
+++ b/beetsplug/permissions.py
@@ -6,12 +6,18 @@ like the following in your config.yaml to configure:
             dir: 755
 """
 
+from __future__ import annotations
+
 import os
 import stat
+from typing import TYPE_CHECKING
 
 from beets import config
 from beets.plugins import BeetsPlugin
 from beets.util import ancestry, displayable_path, syspath
+
+if TYPE_CHECKING:
+    from beets.library import Album, Item, Library
 
 
 def convert_perm(perm):
@@ -53,7 +59,7 @@ def dirs_in_library(library, item):
 
 
 class Permissions(BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
         # Adding defaults.
@@ -63,7 +69,7 @@ class Permissions(BeetsPlugin):
         self.register_listener("album_imported", self.fix)
         self.register_listener("art_set", self.fix_art)
 
-    def fix(self, lib, item=None, album=None):
+    def fix(self, lib: Library, item: Item = None, album: Album = None) -> None:
         """Fix the permissions for an imported Item or Album."""
         files = []
         dirs = set()
@@ -76,7 +82,7 @@ class Permissions(BeetsPlugin):
                 dirs.update(dirs_in_library(lib.directory, album_item.path))
         self.set_permissions(files=files, dirs=dirs)
 
-    def fix_art(self, album):
+    def fix_art(self, album: Album) -> None:
         """Fix the permission for Album art file."""
         if album.artpath:
             self.set_permissions(files=[album.artpath])

--- a/beetsplug/permissions.py
+++ b/beetsplug/permissions.py
@@ -65,21 +65,21 @@ class Permissions(BeetsPlugin):
         # Adding defaults.
         self.config.add({"file": "644", "dir": "755"})
 
-        self.register_listener("item_imported", self.fix)
-        self.register_listener("album_imported", self.fix)
+        self.register_listener("item_imported", self.fix_item)
+        self.register_listener("album_imported", self.fix_album)
         self.register_listener("art_set", self.fix_art)
 
-    def fix(self, lib: Library, item: Item = None, album: Album = None) -> None:
-        """Fix the permissions for an imported Item or Album."""
+    def fix_item(self, lib: Library, item: Item) -> None:
+        self.set_permissions(
+            files=[item.path], dirs=dirs_in_library(lib.directory, item.path)
+        )
+
+    def fix_album(self, lib: Library, album: Album) -> None:
         files = []
         dirs = set()
-        if item:
+        for item in album.items():
             files.append(item.path)
             dirs.update(dirs_in_library(lib.directory, item.path))
-        elif album:
-            for album_item in album.items():
-                files.append(album_item.path)
-                dirs.update(dirs_in_library(lib.directory, album_item.path))
         self.set_permissions(files=files, dirs=dirs)
 
     def fix_art(self, album: Album) -> None:

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -224,7 +224,7 @@ class PlayPlugin(BeetsPlugin):
 
     def before_choose_candidate_listener(
         self, session: ImportSession, task: ImportTask
-    ) -> None:
+    ) -> list[PromptChoice]:
         """Append a "Play" choice to the interactive importer prompt."""
         return [PromptChoice("y", "plaY", self.importer_play)]
 

--- a/beetsplug/play.py
+++ b/beetsplug/play.py
@@ -1,9 +1,12 @@
 """Send the results of a query to the configured music player as a playlist."""
 
+from __future__ import annotations
+
 import random
 import shlex
 import subprocess
 from os.path import relpath
+from typing import TYPE_CHECKING
 
 from beets import config, ui, util
 from beets.exceptions import UserError
@@ -11,6 +14,10 @@ from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand
 from beets.util import PromptChoice, get_temp_filename
 from beets.util.color import colorize
+
+if TYPE_CHECKING:
+    from beets.importer import ImportSession, ImportTask
+
 
 # Indicate where arguments should be inserted into the command string.
 # If this is missing, they're placed at the end.
@@ -51,7 +58,7 @@ def play(
 
 
 class PlayPlugin(BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
         config["play"].add(
@@ -215,7 +222,9 @@ class PlayPlugin(BeetsPlugin):
 
         return filename
 
-    def before_choose_candidate_listener(self, session, task):
+    def before_choose_candidate_listener(
+        self, session: ImportSession, task: ImportTask
+    ) -> None:
         """Append a "Play" choice to the interactive importer prompt."""
         return [PromptChoice("y", "plaY", self.importer_play)]
 

--- a/beetsplug/playlist.py
+++ b/beetsplug/playlist.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from beets.dbcore.query import FieldQueryType
+    from beets.library import Item, Library
 
 
 def is_m3u_file(path: str) -> bool:
@@ -26,7 +27,7 @@ class PlaylistQuery(InQuery[bytes]):
     def subvals(self) -> Sequence[BLOB_TYPE]:
         return [BLOB_TYPE(p) for p in self.pattern]
 
-    def __init__(self, _, pattern: str, __):
+    def __init__(self, _, pattern: str, __) -> None:
         config = beets.config["playlist"]
 
         # Get the full path to the playlist
@@ -78,7 +79,7 @@ class PlaylistPlugin(beets.plugins.BeetsPlugin):
         "playlist": PlaylistQuery
     }
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.config.add(
             {
@@ -108,14 +109,14 @@ class PlaylistPlugin(beets.plugins.BeetsPlugin):
             self.register_listener("item_removed", self.item_removed)
             self.register_listener("cli_exit", self.cli_exit)
 
-    def item_moved(self, item, source, destination):
+    def item_moved(self, item: Item, source: bytes, destination: bytes) -> None:
         self.changes[source] = destination
 
-    def item_removed(self, item):
+    def item_removed(self, item: Item) -> None:
         if not os.path.exists(beets.util.syspath(item.path)):
             self.changes[item.path] = None
 
-    def cli_exit(self, lib):
+    def cli_exit(self, lib: Library) -> None:
         for playlist in self.find_playlists():
             self._log.info("Updating playlist: {}", playlist)
             base_dir = beets.util.bytestring_path(

--- a/beetsplug/playlist.py
+++ b/beetsplug/playlist.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import os
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, Literal
+
+import confuse
 
 import beets
 from beets.dbcore.query import BLOB_TYPE, InQuery
@@ -79,6 +81,8 @@ class PlaylistPlugin(beets.plugins.BeetsPlugin):
         "playlist": PlaylistQuery
     }
 
+    changes: dict[bytes, bytes | None]
+
     def __init__(self) -> None:
         super().__init__()
         self.config.add(
@@ -93,16 +97,22 @@ class PlaylistPlugin(beets.plugins.BeetsPlugin):
         self.playlist_dir = self.config["playlist_dir"].as_filename()
         self.changes = {}
 
-        if self.config["relative_to"].get() == "library":
-            self.relative_to = beets.util.bytestring_path(
-                beets.config["directory"].as_filename()
+        relative_to_val: Literal["library", "playlist"] | Path = self.config[
+            "relative_to"
+        ].get(
+            confuse.OneOf(
+                [confuse.Choice(["library", "playlist"]), confuse.Path()]
             )
-        elif self.config["relative_to"].get() != "playlist":
-            self.relative_to = beets.util.bytestring_path(
-                self.config["relative_to"].as_filename()
-            )
+        )
+        if relative_to_val == "playlist":
+            relative_to = None
         else:
-            self.relative_to = None
+            if relative_to_val == "library":
+                relative_to_filename = beets.config["directory"].as_filename()
+            else:
+                relative_to_filename = self.config["relative_to"].as_filename()
+            relative_to = beets.util.bytestring_path(relative_to_filename)
+        self.relative_to = relative_to
 
         if self.config["auto"]:
             self.register_listener("item_moved", self.item_moved)

--- a/beetsplug/plexupdate.py
+++ b/beetsplug/plexupdate.py
@@ -8,6 +8,9 @@ Put something like the following in your config.yaml to configure:
         token: token
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from urllib.parse import urlencode, urljoin
 from xml.etree import ElementTree
 
@@ -15,6 +18,9 @@ import requests
 
 from beets import config
 from beets.plugins import BeetsPlugin
+
+if TYPE_CHECKING:
+    from beets.library import LibModel, Library
 
 
 def get_music_section(
@@ -69,7 +75,7 @@ def get_protocol(secure):
 
 
 class PlexUpdate(BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
         # Adding defaults.
@@ -87,11 +93,11 @@ class PlexUpdate(BeetsPlugin):
         config["plex"]["token"].redact = True
         self.register_listener("database_change", self.listen_for_db_change)
 
-    def listen_for_db_change(self, lib, model):
+    def listen_for_db_change(self, lib: Library, model: LibModel) -> None:
         """Listens for beets db change and register the update for the end"""
         self.register_listener("cli_exit", self.update)
 
-    def update(self, lib):
+    def update(self, lib: Library) -> None:
         """When the client exists try to send refresh request to Plex server."""
         self._log.info("Updating Plex library...")
 

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -114,7 +114,7 @@ class RgTask:
         peak_method: PeakMethod | None,
         backend_name: str,
         log: Logger,
-    ):
+    ) -> None:
         self.items = items
         self.album = album
         self.target_level = target_level
@@ -212,7 +212,7 @@ class R128Task(RgTask):
         target_level: float,
         backend_name: str,
         log: Logger,
-    ):
+    ) -> None:
         # R128_* tags do not store the track/album peak
         super().__init__(items, album, target_level, None, backend_name, log)
 
@@ -244,7 +244,7 @@ class Backend(ABC):
     NAME = ""
     do_parallel = False
 
-    def __init__(self, config: ConfigView, log: Logger):
+    def __init__(self, config: ConfigView, log: Logger) -> None:
         """Initialize the backend with the configuration view for the
         plugin.
         """
@@ -272,7 +272,7 @@ class FfmpegBackend(Backend):
     NAME = "ffmpeg"
     do_parallel = True
 
-    def __init__(self, config: ConfigView, log: Logger):
+    def __init__(self, config: ConfigView, log: Logger) -> None:
         super().__init__(config, log)
         self._ffmpeg_path = "ffmpeg"
 
@@ -533,7 +533,7 @@ class CommandBackend(Backend):
 
     cmd_name: Tool
 
-    def __init__(self, config: ConfigView, log: Logger):
+    def __init__(self, config: ConfigView, log: Logger) -> None:
         super().__init__(config, log)
         config.add({"command": "", "noclip": True})
 
@@ -664,7 +664,7 @@ class MetaflacBackend(Backend):
 
     SUPPORTED_FORMATS: ClassVar[set[str]] = {"FLAC"}
 
-    def __init__(self, config: ConfigView, log: Logger):
+    def __init__(self, config: ConfigView, log: Logger) -> None:
         super().__init__(config, log)
         config.add({"metaflac": "metaflac"})
 
@@ -754,7 +754,7 @@ class MetaflacBackend(Backend):
 class GStreamerBackend(Backend):
     NAME = "gstreamer"
 
-    def __init__(self, config: ConfigView, log: Logger):
+    def __init__(self, config: ConfigView, log: Logger) -> None:
         super().__init__(config, log)
         self._import_gst()
 
@@ -1052,7 +1052,7 @@ class AudioToolsBackend(Backend):
 
     NAME = "audiotools"
 
-    def __init__(self, config: ConfigView, log: Logger):
+    def __init__(self, config: ConfigView, log: Logger) -> None:
         super().__init__(config, log)
         self._import_audiotools()
 
@@ -1215,7 +1215,7 @@ class ExceptionWatcher(Thread):
 
     def __init__(
         self, queue: queue.Queue[Exception], callback: Callable[[], None]
-    ):
+    ) -> None:
         self._queue = queue
         self._callback = callback
         self._stopevent = Event()
@@ -1541,7 +1541,7 @@ class ReplayGainPlugin(BeetsPlugin):
             self.exc_watcher.join()
             self.pool = None
 
-    def import_begin(self, session: ImportSession):
+    def import_begin(self, session: ImportSession) -> None:
         """Handle `import_begin` event -> open pool"""
         threads: int = self.config["threads"].get(int)
 
@@ -1552,7 +1552,7 @@ class ReplayGainPlugin(BeetsPlugin):
         ):
             self.open_pool(threads)
 
-    def import_end(self, paths):
+    def import_end(self, paths: list[bytes]) -> None:
         """Handle `import` event -> close pool"""
         self.close_pool()
 

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -1552,7 +1552,7 @@ class ReplayGainPlugin(BeetsPlugin):
         ):
             self.open_pool(threads)
 
-    def import_end(self, paths: list[bytes]) -> None:
+    def import_end(self, lib: Library, paths: list[bytes]) -> None:
         """Handle `import` event -> close pool"""
         self.close_pool()
 

--- a/beetsplug/scrub.py
+++ b/beetsplug/scrub.py
@@ -2,11 +2,19 @@
 automatically whenever tags are written.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import mediafile
 import mutagen
 
 from beets import config, ui, util
 from beets.plugins import BeetsPlugin
+
+if TYPE_CHECKING:
+    from beets.importer import ImportSession, ImportTask
+
 
 _MUTAGEN_FORMATS = {
     "asf": "ASF",
@@ -30,7 +38,7 @@ _MUTAGEN_FORMATS = {
 class ScrubPlugin(BeetsPlugin):
     """Removes extraneous metadata from files' tags."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.config.add({"auto": True})
 
@@ -126,7 +134,9 @@ class ScrubPlugin(BeetsPlugin):
                 except mediafile.UnreadableFileError as exc:
                     self._log.error("could not write tags: {}", exc)
 
-    def import_task_files(self, session, task):
+    def import_task_files(
+        self, session: ImportSession, task: ImportTask
+    ) -> None:
         """Automatically scrub imported files."""
         for item in task.imported_items():
             self._log.debug("auto-scrubbing {.filepath}", item)

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -29,7 +29,7 @@ from beets.util import (
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from beets.library import Library
+    from beets.library import LibModel, Library
 
 QueryAndSort = tuple[Query, Sort]
 PlaylistQuery = Query | tuple[QueryAndSort, ...] | None
@@ -263,10 +263,7 @@ class SmartPlaylistPlugin(plugins.BeetsPlugin):
         return query.match(model)
 
     def matches(
-        self,
-        model: Item | Album,
-        query: PlaylistQuery,
-        album_query: PlaylistQuery,
+        self, model: LibModel, query: PlaylistQuery, album_query: PlaylistQuery
     ) -> bool:
         if isinstance(model, Album):
             return self._matches_query(model, album_query)
@@ -274,7 +271,7 @@ class SmartPlaylistPlugin(plugins.BeetsPlugin):
             return self._matches_query(model, query)
         return False
 
-    def db_change(self, lib: Library, model: Item | Album) -> None:
+    def db_change(self, lib: Library, model: LibModel) -> None:
         if self._unmatched_playlists is None:
             self.build_queries()
 

--- a/beetsplug/sonosupdate.py
+++ b/beetsplug/sonosupdate.py
@@ -2,21 +2,28 @@
 This is based on the Kodi Update plugin.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import soco
 
 from beets.plugins import BeetsPlugin
 
+if TYPE_CHECKING:
+    from beets.library import LibModel, Library
+
 
 class SonosUpdate(BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.register_listener("database_change", self.listen_for_db_change)
 
-    def listen_for_db_change(self, lib, model):
+    def listen_for_db_change(self, lib: Library, model: LibModel) -> None:
         """Listens for beets db change and register the update"""
         self.register_listener("cli_exit", self.update)
 
-    def update(self, lib):
+    def update(self, lib: Library) -> None:
         """When the client exists try to send refresh request to a Sonos
         controller.
         """

--- a/beetsplug/subsonicupdate.py
+++ b/beetsplug/subsonicupdate.py
@@ -96,7 +96,7 @@ class SubsonicUpdate(BeetsPlugin):
 
         return f"{url}/rest/{endpoint}"
 
-    def start_scan(self) -> None:
+    def start_scan(self, lib: Library) -> None:
         user = self.config["user"].as_str()
         auth = self.config["auth"].as_str()
         url = self.__format_url("startScan")

--- a/beetsplug/subsonicupdate.py
+++ b/beetsplug/subsonicupdate.py
@@ -15,20 +15,27 @@ is not supported, use password instead:
         auth: pass
 """
 
+from __future__ import annotations
+
 import hashlib
 import random
 import string
 from binascii import hexlify
+from typing import TYPE_CHECKING
 
 import requests
 
 from beets.plugins import BeetsPlugin
 
+if TYPE_CHECKING:
+    from beets.library import LibModel, Library
+
+
 __author__ = "https://github.com/maffo999"
 
 
 class SubsonicUpdate(BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("subsonic")
         # Set default configuration values
         self.config.add(
@@ -44,10 +51,10 @@ class SubsonicUpdate(BeetsPlugin):
         self.register_listener("database_change", self.db_change)
         self.register_listener("smartplaylist_update", self.spl_update)
 
-    def db_change(self, lib, model):
+    def db_change(self, lib: Library, model: LibModel) -> None:
         self.register_listener("cli_exit", self.start_scan)
 
-    def spl_update(self):
+    def spl_update(self) -> None:
         self.register_listener("cli_exit", self.start_scan)
 
     def __create_token(self):
@@ -89,7 +96,7 @@ class SubsonicUpdate(BeetsPlugin):
 
         return f"{url}/rest/{endpoint}"
 
-    def start_scan(self):
+    def start_scan(self) -> None:
         user = self.config["user"].as_str()
         auth = self.config["auth"].as_str()
         url = self.__format_url("startScan")

--- a/beetsplug/thumbnails.py
+++ b/beetsplug/thumbnails.py
@@ -4,12 +4,15 @@ This plugin is POSIX-only.
 Spec: standards.freedesktop.org/thumbnail-spec/latest/index.html
 """
 
+from __future__ import annotations
+
 import ctypes
 import ctypes.util
 import os
 import shutil
 from hashlib import md5
 from pathlib import PurePosixPath
+from typing import TYPE_CHECKING
 
 from xdg import BaseDirectory
 
@@ -19,12 +22,16 @@ from beets.util import bytestring_path, displayable_path, syspath
 from beets.util.artresizer import ArtResizer
 
 BASE_DIR = os.path.join(BaseDirectory.xdg_cache_home, "thumbnails")
+if TYPE_CHECKING:
+    from beets.library import Album
+
+
 NORMAL_DIR = bytestring_path(os.path.join(BASE_DIR, "normal"))
 LARGE_DIR = bytestring_path(os.path.join(BASE_DIR, "large"))
 
 
 class ThumbnailsPlugin(BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.config.add({"auto": True, "force": False, "dolphin": False})
 
@@ -94,7 +101,7 @@ class ThumbnailsPlugin(BeetsPlugin):
 
         return True
 
-    def process_album(self, album):
+    def process_album(self, album: Album) -> None:
         """Produce thumbnails for the album folder."""
         self._log.debug("generating thumbnail for {}", album)
         if not album.artpath:
@@ -218,7 +225,7 @@ class GioURI(URIGetter):
 
     name = "GIO"
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.libgio = self.get_library()
         self.available = bool(self.libgio)
         if self.available:

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
     from beets.autotag import Info
     from beets.dbcore.db import Results
+    from beets.importer import ImportSession
     from beets.library import Library
     from beets.library.models import Album, Item
 
@@ -79,7 +80,7 @@ class TidalPlugin(MetadataSourcePlugin):
         """Return the configured path to the token file in the app directory."""
         return self.config["tokenfile"].get(confuse.Filename(in_app_dir=True))
 
-    def require_authentication(self) -> None:
+    def require_authentication(self, session: ImportSession) -> None:
         if not os.path.isfile(self._tokenfile()):
             raise UserError(
                 "Please login to TIDAL"

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
     from beets.autotag import Info
     from beets.dbcore.db import Results
+    from beets.importer import ImportSession
     from beets.library import Library
     from beets.library.models import Album, Item
 
@@ -92,7 +93,7 @@ class TidalPlugin(MetadataSourcePlugin):
         """Return the configured path to the token file in the app directory."""
         return self.config["tokenfile"].get(confuse.Filename(in_app_dir=True))
 
-    def require_authentication(self) -> None:
+    def require_authentication(self, session: ImportSession) -> None:
         if not os.path.isfile(self._tokenfile()):
             raise UserError(
                 "Please login to TIDAL"

--- a/beetsplug/titlecase.py
+++ b/beetsplug/titlecase.py
@@ -145,7 +145,7 @@ class TitlecasePlugin(BeetsPlugin):
             return preserved_word
         return None
 
-    def received_info_handler(self, info: Info):
+    def received_info_handler(self, info: Info) -> None:
         """Calls titlecase fields for AlbumInfo or TrackInfo
         Processes the tracks field for AlbumInfo
         """

--- a/beetsplug/zero.py
+++ b/beetsplug/zero.py
@@ -24,6 +24,8 @@ ARTWORK_FIELDS = {"images", "art"}
 
 
 class ZeroPlugin(BeetsPlugin):
+    fields_to_progs: dict[str, list[re.Pattern[str]]]
+
     def __init__(self) -> None:
         super().__init__()
 

--- a/beetsplug/zero.py
+++ b/beetsplug/zero.py
@@ -1,6 +1,9 @@
 """Clears tag fields in media files."""
 
+from __future__ import annotations
+
 import re
+from typing import TYPE_CHECKING, Any
 
 import confuse
 from mediafile import MediaFile
@@ -9,6 +12,11 @@ from beets.importer import Action
 from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand, input_yn
 
+if TYPE_CHECKING:
+    from beets.importer import ImportSession, ImportTask
+    from beets.library import Item
+
+
 __author__ = "baobab@heresiarch.info"
 
 
@@ -16,7 +24,7 @@ ARTWORK_FIELDS = {"images", "art"}
 
 
 class ZeroPlugin(BeetsPlugin):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
         self.register_listener("write", self.write_event)
@@ -98,13 +106,17 @@ class ZeroPlugin(BeetsPlugin):
                 # Matches everything
                 self.fields_to_progs[field] = []
 
-    def import_task_choice_event(self, session, task):
+    def import_task_choice_event(
+        self, session: ImportSession, task: ImportTask
+    ) -> None:
         if task.choice_flag == Action.ASIS and not self.warned:
             self._log.warning('cannot zero in "as-is" mode')
             self.warned = True
         # TODO request write in as-is mode
 
-    def write_event(self, item, path, tags):
+    def write_event(
+        self, item: Item, path: bytes, tags: dict[str, Any]
+    ) -> None:
         if self.config["auto"]:
             self.set_fields(item, tags)
 

--- a/docs/dev/plugins/events.rst
+++ b/docs/dev/plugins/events.rst
@@ -52,7 +52,7 @@ registration process in this case:
         command starts.
 
 ``import``
-    :Parameters: ``lib`` (|Library|), ``paths`` (list of path strings)
+    :Parameters: ``lib`` (|Library|), ``paths`` (list of byte paths)
     :Description: Called after the ``import`` command finishes.
 
 ``album_imported``
@@ -61,7 +61,7 @@ registration process in this case:
         library.
 
 ``album_removed``
-    :Parameters: ``lib`` (|Library|), ``album`` (|Album|)
+    :Parameters: ``album`` (|Album|)
     :Description: Called every time an album is removed from the library (even
         when its files are not deleted from disk).
 
@@ -78,11 +78,6 @@ registration process in this case:
     :Parameters: ``lib`` (|Library|), ``item`` (|Item|)
     :Description: Called every time the importer adds a singleton to the library
         (not called for full-album imports).
-
-``before_item_imported``
-    :Parameters: ``item`` (|Item|), ``source`` (path), ``destination`` (path)
-    :Description: Called with an ``Item`` object immediately before it is
-        imported.
 
 ``before_item_moved``
     :Parameters: ``item`` (|Item|), ``source`` (path), ``destination`` (path)
@@ -121,7 +116,7 @@ registration process in this case:
         abort.
 
 ``after_write``
-    :Parameters: ``item`` (|Item|)
+    :Parameters: ``item`` (|Item|), ``path`` (path)
     :Description: Called after a file's metadata is written to disk.
 
 ``import_task_created``
@@ -161,7 +156,7 @@ registration process in this case:
         object.
 
 ``database_change``
-    :Parameters: ``lib`` (|Library|), ``model`` (|Model|)
+    :Parameters: ``lib`` (|Library|), ``model`` (|Album| or |Item|)
     :Description: A modification has been made to the library database (may not
         yet be committed).
 
@@ -205,6 +200,19 @@ registration process in this case:
     :Parameters: ``data`` (dict)
     :Description: Like ``mb_track_extract`` but for album tags. Overwrites tags
         set at the track level with the same field.
+
+``after_convert``
+    :Parameters: ``item`` (|Item|), ``dest`` (path), ``keepnew`` (bool)
+    :Description: Called by the :doc:`/plugins/convert` plugin after it
+        successfully converts or copies an item. When ``keepnew`` is false,
+        ``dest`` is the converted file. When ``keepnew`` is true, ``dest`` is
+        where the original file was moved and ``item.path`` identifies the
+        converted file retained in the library.
+
+``smartplaylist_update``
+    :Parameters: (none)
+    :Description: Called by the :doc:`/plugins/smartplaylist` plugin after it
+        writes updated playlist files. It is not called in pretend mode.
 
 The included ``mpdupdate`` plugin provides an example use case for event
 listeners.

--- a/docs/plugins/convert.rst
+++ b/docs/plugins/convert.rst
@@ -75,6 +75,12 @@ files. If an original file is newer than a converted file, the converted file
 will be removed from the filesystem, and the original file will be converted
 once again.
 
+Plugin Event
+------------
+
+After successfully converting or copying an item, this plugin sends the
+``after_convert`` event. See :ref:`plugin_events` for its listener parameters.
+
 Configuration
 -------------
 

--- a/docs/plugins/smartplaylist.rst
+++ b/docs/plugins/smartplaylist.rst
@@ -95,6 +95,13 @@ You can also use this plugin together with the :doc:`mpdupdate`, in order to
 automatically notify MPD of the playlist change, by adding ``mpdupdate`` to the
 ``plugins`` line in your config file *after* the ``smartplaylist`` plugin.
 
+Plugin Event
+------------
+
+After writing updated playlist files, this plugin sends the
+``smartplaylist_update`` event. See :ref:`plugin_events` for its listener
+parameters. The event is not sent in pretend mode.
+
 While working on smart playlist queries in the beets configuration it can help
 to use the ``--pretend`` option to find out if the edits work as expected before
 writing changes. To list the tracks matching the query, switch to the DEBUG log

--- a/test/plugins/test_hook.py
+++ b/test/plugins/test_hook.py
@@ -13,6 +13,8 @@ from beets.test.helper import PluginTestHelper
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from beets.events import EventType
+
 
 class HookTestCase(PluginTestHelper):
     plugin = "hook"
@@ -23,13 +25,13 @@ class HookTestCase(PluginTestHelper):
 
 
 class TestHookLogs(HookTestCase):
-    HOOK: plugins.EventType = "write"
+    HOOK: EventType = "write"
 
     def _configure_hook(self, command: str) -> None:
         config = {"hooks": [self._get_hook(self.HOOK, command)]}
 
         with self.configure_plugin(config):
-            plugins.send(self.HOOK)
+            plugins.send(self.HOOK)  # type: ignore[arg-type]
 
     def test_hook_empty_command(self, caplog: pytest.LogCaptureFixture):
         with caplog.at_level("DEBUG"):
@@ -57,7 +59,7 @@ class TestHookLogs(HookTestCase):
 
 
 class TestHookCommand(HookTestCase):
-    EVENTS: ClassVar[list[plugins.EventType]] = ["write", "after_write"]
+    EVENTS: ClassVar[list[EventType]] = ["write", "after_write"]
 
     @pytest.fixture(autouse=True)
     def setUp(self):
@@ -80,7 +82,9 @@ class TestHookCommand(HookTestCase):
         2. Assert that a file has been created under the original path, which proves
            that the configured hook command has been executed.
         """
-        events_with_paths = list(zip(self.EVENTS, self.paths))
+        events_with_paths: list[tuple[EventType, str]] = list(
+            zip(self.EVENTS, self.paths)
+        )
         hooks = [
             self._get_hook(e, f"touch {make_test_path(e, p)}")
             for e, p in events_with_paths
@@ -89,9 +93,9 @@ class TestHookCommand(HookTestCase):
         with self.configure_plugin({"hooks": hooks}):
             for event, path in events_with_paths:
                 if send_path_kwarg:
-                    plugins.send(event, path=path)
+                    plugins.send(event, path=path)  # type: ignore[call-overload]
                 else:
-                    plugins.send(event)
+                    plugins.send(event)  # type: ignore[arg-type]
                 assert Path(os.fsdecode(path)).is_file()
 
     @pytest.mark.skipif(sys.platform == "win32", reason="win32")

--- a/test/plugins/test_subsonicupdate.py
+++ b/test/plugins/test_subsonicupdate.py
@@ -1,14 +1,13 @@
 """Tests for the 'subsonic' plugin."""
 
-import unittest
-
 import responses
 
 from beets import config
+from beets.test.helper import TestHelper
 from beetsplug import subsonicupdate
 
 
-class SubsonicPluginTest(unittest.TestCase):
+class SubsonicPluginTest(TestHelper):
     """Test class for subsonicupdate."""
 
     @responses.activate
@@ -81,7 +80,7 @@ class SubsonicPluginTest(unittest.TestCase):
             body=self.SUCCESS_BODY,
         )
 
-        self.subsonicupdate.start_scan()
+        self.subsonicupdate.start_scan(self.lib)
 
     @responses.activate
     def test_start_scan_failed_bad_credentials(self):
@@ -93,7 +92,7 @@ class SubsonicPluginTest(unittest.TestCase):
             body=self.FAILED_BODY,
         )
 
-        self.subsonicupdate.start_scan()
+        self.subsonicupdate.start_scan(self.lib)
 
     @responses.activate
     def test_start_scan_failed_not_found(self):
@@ -105,11 +104,11 @@ class SubsonicPluginTest(unittest.TestCase):
             body=self.ERROR_BODY,
         )
 
-        self.subsonicupdate.start_scan()
+        self.subsonicupdate.start_scan(self.lib)
 
     def test_start_scan_failed_unreachable(self):
         """Tests failed path based on service not available."""
-        self.subsonicupdate.start_scan()
+        self.subsonicupdate.start_scan(self.lib)
 
     @responses.activate
     def test_url_with_context_path(self):
@@ -123,7 +122,7 @@ class SubsonicPluginTest(unittest.TestCase):
             body=self.SUCCESS_BODY,
         )
 
-        self.subsonicupdate.start_scan()
+        self.subsonicupdate.start_scan(self.lib)
 
     @responses.activate
     def test_url_with_trailing_forward_slash_url(self):
@@ -137,7 +136,7 @@ class SubsonicPluginTest(unittest.TestCase):
             body=self.SUCCESS_BODY,
         )
 
-        self.subsonicupdate.start_scan()
+        self.subsonicupdate.start_scan(self.lib)
 
     @responses.activate
     def test_url_with_missing_port(self):
@@ -151,7 +150,7 @@ class SubsonicPluginTest(unittest.TestCase):
             body=self.SUCCESS_BODY,
         )
 
-        self.subsonicupdate.start_scan()
+        self.subsonicupdate.start_scan(self.lib)
 
     @responses.activate
     def test_url_with_missing_schema(self):
@@ -165,7 +164,7 @@ class SubsonicPluginTest(unittest.TestCase):
             body=self.SUCCESS_BODY,
         )
 
-        self.subsonicupdate.start_scan()
+        self.subsonicupdate.start_scan(self.lib)
 
     @responses.activate
     def test_start_scan_failed_non_json_response(self):
@@ -179,7 +178,7 @@ class SubsonicPluginTest(unittest.TestCase):
         )
 
         with self.assertLogs("beets", level="ERROR") as logs:
-            self.subsonicupdate.start_scan()
+            self.subsonicupdate.start_scan(self.lib)
 
         assert "Subsonic server returned a non-JSON response" in "\n".join(
             logs.output


### PR DESCRIPTION
Fixes: https://github.com/beetbox/beets/issues/6921

- Adds explicit typing to the plugin event system in `beets.plugins`, including per-event argument shapes and return types for `register_listener()` and `send()`. This makes the listener API much clearer and turns implicit plugin contracts into checked interfaces.

- Updates all plugins to match those typed event signatures, by adding concrete parameter/return types and aligning handlers with the events they subscribe to. The architectural effect is better consistency across plugin boundaries, especially around importer hooks and metadata callbacks.

- Includes a small set of follow-up fixes uncovered by the typing work in places like `advancedrewrite`, `badfiles`, `playlist`, `permissions`, `importsource`, and query/path handling. These are mostly correctness and config/path-type cleanups rather than new features.

- High-level impact: this change improves maintainability and static analysis across the plugin layer, reduces ambiguity in hook behavior, and makes future plugin changes safer without changing the overall architecture or user-facing workflows in a major way.
