### PR TITLE
Fix filtered MusicBrainz track totals

### DIFF
--- a/beetsplug/musicbrainz.py
+++ b/beetsplug/musicbrainz.py
@@ -562,12 +562,6 @@ class MusicBrainzPlugin(
         if not self.ignore_data_tracks:
             all_tracks.extend(medium.get("data_tracks", []))
 
-        medium_data = {
-            "medium": medium["position"],
-            "medium_total": medium["track_count"],
-            "disctitle": medium["title"],
-            "media": medium["format"],
-        }
         valid_tracks = [
             t
             for t in all_tracks
@@ -578,6 +572,12 @@ class MusicBrainzPlugin(
                 and not (self.ignore_video_tracks and t["recording"]["video"])
             )
         ]
+        medium_data = {
+            "medium": medium["position"],
+            "medium_total": len(valid_tracks),
+            "disctitle": medium["title"],
+            "media": medium["format"],
+        }
         for track in valid_tracks:
             # make a copy since we need to modify it with track-level overrides
             recording = track["recording"].copy()

--- a/test/plugins/test_musicbrainz.py
+++ b/test/plugins/test_musicbrainz.py
@@ -411,23 +411,32 @@ class TestParseMedia(MusicBrainzPluginTestMixin):
         assert mb.album_info(release).mediums == 2
 
     @pytest.mark.parametrize(
-        "beets_match_config, expected_titles",
+        "beets_match_config, expected_titles, expected_medium_total",
         [
-            _p({}, ("Audio",), id="only audio tracks by default"),
+            _p({}, ("Audio",), 1, id="only audio tracks by default"),
             _p(
                 {"ignore_data_tracks": False},
                 ("Audio", "Data"),
+                2,
                 id="include data tracks",
             ),
             _p(
                 {"ignore_data_tracks": False, "ignore_video_tracks": False},
                 ("Audio", "Video: Video", "Data"),
+                3,
                 id="include data and video tracks",
             ),
-            _p({"ignored_media": "Vinyl"}, (), id="ignore all tracks"),
+            _p({"ignored_media": "Vinyl"}, (), 0, id="ignore all tracks"),
         ],
     )
-    def test_data_tracks(self, config, beets_match_config, mb, expected_titles):
+    def test_data_tracks(
+        self,
+        config,
+        beets_match_config,
+        mb,
+        expected_titles,
+        expected_medium_total,
+    ):
         medium = medium_factory(
             format="Vinyl",
             tracks=[
@@ -441,9 +450,11 @@ class TestParseMedia(MusicBrainzPluginTestMixin):
 
         config.set({"match": beets_match_config})
 
-        actual_titles = tuple(t.title for t in mb.album_info(release).tracks)
+        tracks = mb.album_info(release).tracks
+        actual_titles = tuple(t.title for t in tracks)
 
         assert actual_titles == expected_titles
+        assert all(t.medium_total == expected_medium_total for t in tracks)
 
 
 class TestParseRelease(MusicBrainzPluginTestMixin):


### PR DESCRIPTION
## Change

- derive each MusicBrainz track's `medium_total` from the tracks remaining after
  data/video filtering
- extend the existing data/video matrix to assert the reported medium total for
  every configuration

## Why

Video tracks live in MusicBrainz's normal track list, so filtering them left
`medium_total` at the original unfiltered count. Data tracks are represented
separately, which produced inconsistent metadata for the two equivalent ignore
options. Reporting the filtered count keeps the candidate's per-medium metadata
consistent with the tracks Beets actually imports.

## Checks

- `uv run ruff check beetsplug/musicbrainz.py test/plugins/test_musicbrainz.py`
- `uv run pytest -q test/plugins/test_musicbrainz.py` (55 passed)

Fixes #6836
