### PR TITLE
fix: lyrics plugin crash for lyrics with None text

### DIFF
--- a/beets/util/lyrics.py
+++ b/beets/util/lyrics.py
@@ -46,6 +46,8 @@ class Lyrics:
 
     def __post_init__(self) -> None:
         """Normalize lyrics metadata and infer missing language information."""
+        if self.text is None:
+            self.text = ""
         self.handle_instrumental()
 
         try:
@@ -112,8 +114,6 @@ class Lyrics:
         Timestamps, when present, are kept separate so callers can translate or
         normalize text without losing synced timing information.
         """
-        if self.text is None:
-            return []
         return [
             (m[1], m[2]) if (m := self.LINE_PARTS_PAT.match(line)) else ("", "")
             for line in self.text.splitlines()

--- a/beets/util/lyrics.py
+++ b/beets/util/lyrics.py
@@ -112,6 +112,8 @@ class Lyrics:
         Timestamps, when present, are kept separate so callers can translate or
         normalize text without losing synced timing information.
         """
+        if self.text is None:
+            return []
         return [
             (m[1], m[2]) if (m := self.LINE_PARTS_PAT.match(line)) else ("", "")
             for line in self.text.splitlines()

--- a/test/util/test_lyrics.py
+++ b/test/util/test_lyrics.py
@@ -50,7 +50,7 @@ class TestLyrics:
         """
         lyrics = Lyrics(text=None, backend="lrclib")
 
-        assert lyrics.text is None
+        assert lyrics.text == ""
         assert not lyrics.synced
         assert lyrics.timestamps == []
         assert lyrics.text_lines == []

--- a/test/util/test_lyrics.py
+++ b/test/util/test_lyrics.py
@@ -40,3 +40,19 @@ class TestLyrics:
             "FR" if langdetect_available else None
         )
         assert not lyrics.instrumental
+
+    def test_none_text(self):
+        """Lyrics with None text should not crash when accessing synced properties.
+
+        Regression test for https://github.com/beetbox/beets/issues/5583
+        where LRCLib returns an empty JSON response, leading to text=None
+        and an AttributeError on .splitlines().
+        """
+        lyrics = Lyrics(text=None, backend="lrclib")
+
+        assert lyrics.text is None
+        assert not lyrics.synced
+        assert lyrics.timestamps == []
+        assert lyrics.text_lines == []
+        assert lyrics.sylt == []
+        assert not lyrics.translated


### PR DESCRIPTION
## Description
Fixes a Beets import crash with lyrics plugin for file w/o lyrics.

Complementary to #6864 which fixes from_item(). This adds a defensive normalization in __post_init__ to handle None text regardless of how the Lyrics object is instantiated (e.g., from backends or future code paths), plus a regression test.

Fixes #5583, fixes #6860, fixes #6888 

## To Do
- [x] Tests. (Very much encouraged but not strictly required.)
