### PR TITLE
lastgenre: Improve original fallback (better use of aliases and count)

### DIFF
--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -498,21 +498,31 @@ class LastGenrePlugin(plugins.BeetsPlugin):
     ) -> GenresWithLabel | None:
         """Attempt to fall back to existing original genres if configured.
 
-        ``genres`` are the original unchanged values and are checked as-is
-        first, then ``keep_genres`` are used for a lowercased canonicalization
-        retry.
+        ``genres`` (the original unchanged values) are alias-normalized and
+        validated first, then ``keep_genres`` are used for a lowercased
+        canonicalized parent fallback.
         """
-        if genres and self.config["keep_existing"].get():
-            artist = self._artist_for_filter(obj)
-            if valid_genres := self._filter_valid(genres, artist=artist):
-                return valid_genres, "original fallback"
-            # If the original genre doesn't match a whitelisted genre, check
-            # if we can canonicalize it to find a matching, whitelisted genre!
-            if resolved := self._try_resolve_stage(
-                "original fallback", keep_genres, [], artist=artist
-            ):
-                return resolved
-        return None
+        if not (genres and self.config["keep_existing"].get()):
+            return None
+
+        artist = self._artist_for_filter(obj)
+
+        # We do not run through _try_resolve_stage yet because count could drop
+        # existing genres, but we still apply aliases before whitelist
+        # filtering.
+        normalized = [
+            norm if norm != g.lower() else g
+            for g in genres
+            if (norm := normalize_genre(self._log, self.alias_patterns, g))
+        ]
+        if valid := self._filter_valid(normalized, artist=artist):
+            return valid, "original fallback"
+
+        # If no existing genre survived the whitelist even after aliasing,
+        # try canonicalization to find a valid whitelisted parent genre.
+        return self._try_resolve_stage(
+            "original fallback", keep_genres, [], artist=artist
+        )
 
     def _fetch_va_genres(self, album: Album) -> list[str]:
         """Fetch the most popular track or artist genre for a Various Artists album."""

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -67,6 +67,9 @@ Bug fixes
   (:doc:`plugins/musicbrainz`, :doc:`plugins/spotify`, :doc:`plugins/deezer` and
   :doc:`plugins/discogs`) no longer send a search request when both the query
   text and the filters are empty. :bug:`6862`
+- :doc:`plugins/lastgenre`: Improve original-genre fallback by applying aliases
+  before whitelist filtering, while preserving existing genres regardless of the
+  configured count. :bug:`6890`
 
 ..
     For plugin developers

--- a/test/plugins/test_lastgenre.py
+++ b/test/plugins/test_lastgenre.py
@@ -1050,6 +1050,38 @@ class TestAliases:
             "alias must normalize 'hip-hop' → 'hip hop' before whitelist check"
         )
 
+    def test_original_fallback_keeps_all_alias_normalized_genres(self, config):
+        """Original-fallback path alias-normalizes without truncating to count.
+
+        Covers force + keep_existing + whitelist + aliases with an empty
+        Last.fm response, so ``_get_genre`` falls back to the item's own
+        (alias-normalized) genres.
+
+        With ``count`` set to 1, both 'hip-hop' (whitelisted only after
+        normalizing to 'hip hop') and the already-whitelisted 'Jazz' must
+        survive, proving the count limit isn't applied early.
+        """
+        config["lastgenre"]["force"] = True
+        config["lastgenre"]["keep_existing"] = True
+        config["lastgenre"]["source"] = "album"
+        config["lastgenre"]["whitelist"] = True
+        config["lastgenre"]["count"] = 1
+        config["lastgenre"]["aliases"] = {"hip hop": ["hip-hop", "hiphop"]}
+        plugin = lastgenre.LastGenrePlugin()
+        plugin.setup()
+        plugin.whitelist = {"hip hop", "jazz"}
+
+        item = _common.item()
+        item.genres = ["hip-hop", "Jazz"]
+
+        with patch(
+            "beetsplug.lastgenre.client.LastFmClient.fetch", return_value=[]
+        ):
+            assert plugin._get_genre(item) == (
+                ["hip hop", "Jazz"],
+                "original fallback",
+            )
+
     def test_normalize_before_ignorelist(self, config):
         """Aliases normalize BEFORE ignorelist filtering.
 


### PR DESCRIPTION
## Description

When `_get_genre` runs with `force`, `whitelist` and `canonicalization` enabled, as a last resort it tries to fall back to the original genres. Of course this stage normalizes, canonicalizes, does all the stuff it's supposed to when _resolving_ the stage. That also includes reducing genres to the configured `count`. Now in that case that could reduce the list of genres and is not exactly what a _fall back to what we had before_ should look like.  

This PR changes the stage as follows:

We don't run through `_try_resolve_stage` instantly because we want to make sure the `count` setting doesn't kick out anything prematurely! We then apply `whitelist` checks and return if something valid is found.

The very last resort action is kept as we had it already: Use `keep_genres` (the lowercased originals) to canonicalize and hope that now we find a whitelisted parent genre.

## Additonal refactoring

Replace deprecated test helper class and use configuration helper method

Note: Requires https://github.com/beetbox/beets/pull/6474

## To Do


- [x] ~Documentation.~ (Not required IMO)
- [x] Changelog.
- [x] Tests.