### PR TITLE
lastgenre: Album stage fall back to multi-valued albumartists

### DIFF
--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -514,6 +514,27 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 return resolved
         return None
 
+    def _try_resolve_original_fallback(
+        self, obj: LibModel, genres: list[str], keep_genres: list[str]
+    ) -> tuple[list[str], str] | None:
+        """Attempt to fall back to existing original genres if configured.
+
+        ``genres`` are the original unchanged values and are checked as-is
+        first, then ``keep_genres`` are used for a lowercased canonicalization
+        retry.
+        """
+        if genres and self.config["keep_existing"].get():
+            artist = self._artist_for_filter(obj)
+            if valid_genres := self._filter_valid(genres, artist=artist):
+                return valid_genres, "original fallback"
+            # If the original genre doesn't match a whitelisted genre, check
+            # if we can canonicalize it to find a matching, whitelisted genre!
+            if resolved := self._try_resolve_stage(
+                "original fallback", keep_genres, [], artist=artist
+            ):
+                return resolved
+        return None
+
     def _fetch_va_genres(self, album: Album) -> list[str]:
         """Fetch the most popular track or artist genre for a Various Artists album."""
         item_genres = []

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -529,17 +529,17 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         # album artist, or most popular track genre.
         if isinstance(obj, library.Item) and "track" in self.sources:
             if new_genres := self.client.fetch("track", obj):
-                if result := self._try_resolve_stage(
+                if resolved := self._try_resolve_stage(
                     "track", keep_genres, new_genres, artist=obj.artist
                 ):
-                    return result
+                    return resolved
 
         if "album" in self.sources:
             if new_genres := self.client.fetch("album", obj):
-                if result := self._try_resolve_stage(
+                if resolved := self._try_resolve_stage(
                     "album", keep_genres, new_genres, artist=obj.albumartist
                 ):
-                    return result
+                    return resolved
 
         if "artist" in self.sources:
             new_genres = []
@@ -593,10 +593,10 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                     )
 
             if new_genres:
-                if result := self._try_resolve_stage(
+                if resolved := self._try_resolve_stage(
                     stage_label, keep_genres, new_genres, artist=stage_artist
                 ):
-                    return result
+                    return resolved
 
         # Nothing found, leave original if configured and valid.
         if genres and self.config["keep_existing"].get():
@@ -605,10 +605,10 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 return valid_genres, "original fallback"
             # If the original genre doesn't match a whitelisted genre, check
             # if we can canonicalize it to find a matching, whitelisted genre!
-            if result := self._try_resolve_stage(
+            if resolved := self._try_resolve_stage(
                 "original fallback", keep_genres, [], artist=artist
             ):
-                return result
+                return resolved
 
         return self.fallback
 

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import os
 import re
 from collections import defaultdict
-from functools import singledispatchmethod
+from functools import cached_property, singledispatchmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -441,7 +441,8 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         combined = old + new
         return self._resolve_genres(combined, artist=artist)
 
-    def _configured_fallback(self) -> tuple[list[str], str]:
+    @cached_property
+    def fallback(self) -> tuple[list[str], str]:
         """Return the configured fallback genre and label."""
         if fallback := self.config["fallback"].get():
             return [fallback], "fallback"
@@ -465,6 +466,23 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 label = f"keep + {label}"
             return self._format_genres(resolved_genres), label
         return None
+
+    def _try_resolve_existing_genres(
+        self, obj: LibModel, genres: list[str]
+    ) -> tuple[list[str], str] | None:
+        """Handle existing genres when not forcing.
+
+        Clean up existing genres if enabled, or return them unchanged. Return
+        ``None`` if cleanup is enabled but fails to resolve, leaving fallback
+        handling to the caller.
+        """
+        if self.config["cleanup_existing"]:
+            keep_genres = [g.lower() for g in genres]
+            return self._try_resolve_stage(
+                "cleanup", keep_genres, [], artist=self._artist_for_filter(obj)
+            )
+
+        return genres, "keep any, no-force"
 
     def _get_genre(self, obj: LibModel) -> tuple[list[str], str]:
         """Get the final genre list for an Album or Item object.
@@ -490,24 +508,11 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         genres = self._get_existing_genres(obj)
 
         if genres and not self.config["force"]:
-            # Without force, but cleanup_existing enabled, we attempt
-            # to canonicalize pre-populated tags before returning them.
-            # If none are found, we use the fallback (if set).
-            if self.config["cleanup_existing"]:
-                keep_genres = [g.lower() for g in genres]
-                if result := self._try_resolve_stage(
-                    "cleanup",
-                    keep_genres,
-                    [],
-                    artist=self._artist_for_filter(obj),
-                ):
-                    return result
-
-                return self._configured_fallback()
-
-            # If cleanup_existing is not set, the pre-populated tags are
-            # returned as-is.
-            return genres, "keep any, no-force"
+            if resolved := self._try_resolve_existing_genres(
+                obj, genres
+            ):
+                return resolved
+            return self.fallback
 
         keep_genres = (
             [g.lower() for g in genres]
@@ -600,7 +605,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
             ):
                 return result
 
-        return self._configured_fallback()
+        return self.fallback
 
     # Beets plugin hooks and CLI.
 

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -441,6 +441,31 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         combined = old + new
         return self._resolve_genres(combined, artist=artist)
 
+    def _configured_fallback(self) -> tuple[list[str], str]:
+        """Return the configured fallback genre and label."""
+        if fallback := self.config["fallback"].get():
+            return [fallback], "fallback"
+        return [], "fallback unconfigured"
+
+    def _try_resolve_stage(
+        self,
+        stage_label: str,
+        keep_genres: list[str],
+        new_genres: list[str],
+        artist: str | None = None,
+    ) -> tuple[list[str], str] | None:
+        """Try to resolve genres for a given stage and log the result."""
+        resolved_genres = self._combine_resolve_and_log(
+            keep_genres, new_genres, artist=artist
+        )
+        if resolved_genres:
+            suffix = "whitelist" if self.whitelist else "any"
+            label = f"{stage_label}, {suffix}"
+            if keep_genres:
+                label = f"keep + {label}"
+            return self._format_genres(resolved_genres), label
+        return None
+
     def _get_genre(self, obj: LibModel) -> tuple[list[str], str]:
         """Get the final genre list for an Album or Item object.
 
@@ -461,30 +486,6 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         and the whitelist feature was disabled.
         """
 
-        def _fallback_stage() -> tuple[list[str], str]:
-            """Return the fallback genre and label."""
-            if fallback := self.config["fallback"].get():
-                return [fallback], "fallback"
-            return [], "fallback unconfigured"
-
-        def _try_resolve_stage(
-            stage_label: str,
-            keep_genres: list[str],
-            new_genres: list[str],
-            artist: str | None = None,
-        ) -> tuple[list[str], str] | None:
-            """Try to resolve genres for a given stage and log the result."""
-            resolved_genres = self._combine_resolve_and_log(
-                keep_genres, new_genres, artist=artist
-            )
-            if resolved_genres:
-                suffix = "whitelist" if self.whitelist else "any"
-                label = f"{stage_label}, {suffix}"
-                if keep_genres:
-                    label = f"keep + {label}"
-                return self._format_genres(resolved_genres), label
-            return None
-
         keep_genres = []
         new_genres = []
         genres = self._get_existing_genres(obj)
@@ -495,7 +496,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
             # If none are found, we use the fallback (if set).
             if self.config["cleanup_existing"]:
                 keep_genres = [g.lower() for g in genres]
-                if result := _try_resolve_stage(
+                if result := self._try_resolve_stage(
                     "cleanup",
                     keep_genres,
                     [],
@@ -503,7 +504,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 ):
                     return result
 
-                return _fallback_stage()
+                return self._configured_fallback()
 
             # If cleanup_existing is not set, the pre-populated tags are
             # returned as-is.
@@ -519,14 +520,14 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         # album artist, or most popular track genre.
         if isinstance(obj, library.Item) and "track" in self.sources:
             if new_genres := self.client.fetch("track", obj):
-                if result := _try_resolve_stage(
+                if result := self._try_resolve_stage(
                     "track", keep_genres, new_genres, artist=obj.artist
                 ):
                     return result
 
         if "album" in self.sources:
             if new_genres := self.client.fetch("album", obj):
-                if result := _try_resolve_stage(
+                if result := self._try_resolve_stage(
                     "album", keep_genres, new_genres, artist=obj.albumartist
                 ):
                     return result
@@ -583,7 +584,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                     )
 
             if new_genres:
-                if result := _try_resolve_stage(
+                if result := self._try_resolve_stage(
                     stage_label, keep_genres, new_genres, artist=stage_artist
                 ):
                     return result
@@ -595,12 +596,12 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 return valid_genres, "original fallback"
             # If the original genre doesn't match a whitelisted genre, check
             # if we can canonicalize it to find a matching, whitelisted genre!
-            if result := _try_resolve_stage(
+            if result := self._try_resolve_stage(
                 "original fallback", keep_genres, [], artist=artist
             ):
                 return result
 
-        return _fallback_stage()
+        return self._configured_fallback()
 
     # Beets plugin hooks and CLI.
 

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -514,6 +514,49 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 return resolved
         return None
 
+    def _try_resolve_album_stage(
+        self, obj: LibModel, keep_genres: list[str]
+    ) -> tuple[list[str], str] | None:
+        """Try to resolve album genres for an Item or Album object.
+
+        Fall back to multi-valued albumartists if no genre is found for the
+        main albumartist.
+        """
+        new_genres = self.client.fetch("album", obj)
+
+        if new_genres and (
+            resolved := self._try_resolve_stage(
+                "album", keep_genres, new_genres, artist=obj.albumartist
+            )
+        ):
+            return resolved
+
+        if not new_genres and obj.albumartist != config["va_name"].as_str():
+            self._log.extra_debug(
+                'No album genre found for "{}", '
+                "trying multi-valued albumartists field...",
+                obj.albumartist,
+            )
+            multi_album_genres = []
+            for albumartist in obj.albumartists:
+                self._log.extra_debug(
+                    'Fetching album genre for "{}"', albumartist
+                )
+                multi_album_genres += self.client.fetch(
+                    "album", obj, albumartist, obj.album
+                )
+            if multi_album_genres and (
+                resolved := self._try_resolve_stage(
+                    "multi-valued albumartist album",
+                    keep_genres,
+                    multi_album_genres,
+                    artist=None,
+                )
+            ):
+                return resolved
+
+        return None
+
     def _try_resolve_original_fallback(
         self, obj: LibModel, genres: list[str], keep_genres: list[str]
     ) -> tuple[list[str], str] | None:
@@ -651,11 +694,8 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                     return resolved
 
         if "album" in self.sources:
-            if new_genres := self.client.fetch("album", obj):
-                if resolved := self._try_resolve_stage(
-                    "album", keep_genres, new_genres, artist=obj.albumartist
-                ):
-                    return resolved
+            if resolved := self._try_resolve_album_stage(obj, keep_genres):
+                return resolved
 
         if "artist" in self.sources:
             stage_label, new_genres, stage_artist = self._fetch_artist_stage(

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -519,21 +519,31 @@ class LastGenrePlugin(plugins.BeetsPlugin):
     ) -> tuple[list[str], str] | None:
         """Attempt to fall back to existing original genres if configured.
 
-        ``genres`` are the original unchanged values and are checked as-is
-        first, then ``keep_genres`` are used for a lowercased canonicalization
-        retry.
+        ``genres`` (the original unchanged values) are alias-normalized and
+        validated first, then ``keep_genres`` are used for a lowercased
+        canonicalized parent fallback.
         """
-        if genres and self.config["keep_existing"].get():
-            artist = self._artist_for_filter(obj)
-            if valid_genres := self._filter_valid(genres, artist=artist):
-                return valid_genres, "original fallback"
-            # If the original genre doesn't match a whitelisted genre, check
-            # if we can canonicalize it to find a matching, whitelisted genre!
-            if resolved := self._try_resolve_stage(
-                "original fallback", keep_genres, [], artist=artist
-            ):
-                return resolved
-        return None
+        if not (genres and self.config["keep_existing"].get()):
+            return None
+
+        artist = self._artist_for_filter(obj)
+
+        # We do not run through _try_resolve_stage yet because count could drop
+        # existing genres, but we still apply aliases before whitelist
+        # filtering.
+        normalized = [
+            norm if norm != g.lower() else g
+            for g in genres
+            if (norm := normalize_genre(self._log, self.alias_patterns, g))
+        ]
+        if valid := self._filter_valid(normalized, artist=artist):
+            return valid, "original fallback"
+
+        # If no existing genre survived the whitelist even after aliasing,
+        # try canonicalization to find a valid whitelisted parent genre.
+        return self._try_resolve_stage(
+            "original fallback", keep_genres, [], artist=artist
+        )
 
     def _fetch_va_genres(self, album: Album) -> list[str]:
         """Fetch the most popular track or artist genre for a Various Artists album."""

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -489,6 +489,68 @@ class LastGenrePlugin(plugins.BeetsPlugin):
 
         return genres, "keep any, no-force"
 
+    def _fetch_va_genres(self, album: Album) -> list[str]:
+        """Fetch the most popular track or artist genre for a Various Artists album."""
+        item_genres = []
+        for item in album.items():
+            item_genre = None
+            if "track" in self.sources:
+                item_genre = self.client.fetch("track", item)
+            if not item_genre:
+                item_genre = self.client.fetch("artist", item)
+            if item_genre:
+                item_genres += item_genre
+
+        if item_genres:
+            most_popular, rank = plurality(item_genres)
+            self._log.debug(
+                'Most popular track genre "{}" ({}) for VA album.',
+                most_popular,
+                rank,
+            )
+            return [most_popular]
+
+        return []
+
+    def _fetch_artist_stage(
+        self, obj: LibModel
+    ) -> tuple[str, list[str], str | None]:
+        """Fetch artist genres for an Item or Album object.
+
+        Return a tuple of ``(stage_label, genres, stage_artist)``.
+        """
+        if isinstance(obj, library.Item):
+            return "artist", self.client.fetch("artist", obj), obj.artist
+
+        if obj.albumartist != config["va_name"].as_str():
+            new_genres = self.client.fetch("album_artist", obj)
+            if new_genres:
+                return "album artist", new_genres, obj.albumartist
+
+            self._log.extra_debug(
+                'No album artist genre found for "{}", '
+                "trying multi-valued field...",
+                obj.albumartist,
+            )
+            for albumartist in obj.albumartists:
+                self._log.extra_debug(
+                    'Fetching artist genre for "{}"', albumartist
+                )
+                new_genres += self.client.fetch(
+                    "album_artist", obj, albumartist
+                )
+            if new_genres:
+                # Already filtered per-artist in client
+                return "multi-valued album artist", new_genres, None
+            return "album artist", [], None
+
+        # For "Various Artists", pick the most popular track genre.
+        assert isinstance(obj, Album)  # Type narrowing for mypy
+        if va_genres := self._fetch_va_genres(obj):
+            return "most popular track", va_genres, None
+
+        return "most popular track", [], None
+
     def _get_genre(self, obj: LibModel) -> tuple[list[str], str]:
         """Get the final genre list for an Album or Item object.
 
@@ -542,56 +604,9 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                     return resolved
 
         if "artist" in self.sources:
-            new_genres = []
-            stage_artist: str | None = None
-            if isinstance(obj, library.Item):
-                new_genres = self.client.fetch("artist", obj)
-                stage_label = "artist"
-                stage_artist = obj.artist
-            elif obj.albumartist != config["va_name"].as_str():
-                new_genres = self.client.fetch("album_artist", obj)
-                stage_label = "album artist"
-                stage_artist = obj.albumartist
-                if not new_genres:
-                    self._log.extra_debug(
-                        'No album artist genre found for "{}", '
-                        "trying multi-valued field...",
-                        obj.albumartist,
-                    )
-                    for albumartist in obj.albumartists:
-                        self._log.extra_debug(
-                            'Fetching artist genre for "{}"', albumartist
-                        )
-                        new_genres += self.client.fetch(
-                            "album_artist", obj, albumartist
-                        )
-                    if new_genres:
-                        stage_label = "multi-valued album artist"
-                        stage_artist = (
-                            None  # Already filtered per-artist in client
-                        )
-            else:
-                # For "Various Artists", pick the most popular track genre.
-                item_genres = []
-                assert isinstance(obj, Album)  # Type narrowing for mypy
-                for item in obj.items():
-                    item_genre = None
-                    if "track" in self.sources:
-                        item_genre = self.client.fetch("track", item)
-                    if not item_genre:
-                        item_genre = self.client.fetch("artist", item)
-                    if item_genre:
-                        item_genres += item_genre
-                if item_genres:
-                    most_popular, rank = plurality(item_genres)
-                    new_genres = [most_popular]
-                    stage_label = "most popular track"
-                    self._log.debug(
-                        'Most popular track genre "{}" ({}) for VA album.',
-                        most_popular,
-                        rank,
-                    )
-
+            stage_label, new_genres, stage_artist = self._fetch_artist_stage(
+                obj
+            )
             if new_genres:
                 if resolved := self._try_resolve_stage(
                     stage_label, keep_genres, new_genres, artist=stage_artist

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -486,7 +486,6 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         and the whitelist feature was disabled.
         """
 
-        keep_genres = []
         new_genres = []
         genres = self._get_existing_genres(obj)
 
@@ -510,11 +509,11 @@ class LastGenrePlugin(plugins.BeetsPlugin):
             # returned as-is.
             return genres, "keep any, no-force"
 
-        if self.config["force"]:
-            # Force doesn't keep any unless keep_existing is set.
-            # Whitelist validation is handled in _resolve_genres.
-            if self.config["keep_existing"]:
-                keep_genres = [g.lower() for g in genres]
+        keep_genres = (
+            [g.lower() for g in genres]
+            if self.config["keep_existing"] and self.config["force"]
+            else []
+        )
 
         # Run through stages: track, album, artist,
         # album artist, or most popular track genre.

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -42,6 +42,10 @@ if TYPE_CHECKING:
     """Genre hierarchy as list of paths from general to specific.
     Example: [['electronic', 'house'], ['electronic', 'techno']]"""
 
+    GenresWithLabel = tuple[list[str], str]
+    """A pair of (genre list, label) returned by a genre resolution stage.
+    The label is used for logging and describes the source and filtering applied."""
+
 
 # Canonicalization tree processing.
 
@@ -442,7 +446,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         return self._resolve_genres(combined, artist=artist)
 
     @cached_property
-    def fallback(self) -> tuple[list[str], str]:
+    def fallback(self) -> GenresWithLabel:
         """Return the configured fallback genre and label."""
         if fallback := self.config["fallback"].get():
             return [fallback], "fallback"
@@ -454,7 +458,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         keep_genres: list[str],
         new_genres: list[str],
         artist: str | None = None,
-    ) -> tuple[list[str], str] | None:
+    ) -> GenresWithLabel | None:
         """Try to resolve genres for a given stage and log the result.
 
         If any newly fetched genres and/or existing genres are resolved, return
@@ -474,7 +478,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
 
     def _try_resolve_existing_genres(
         self, obj: LibModel, genres: list[str]
-    ) -> tuple[list[str], str] | None:
+    ) -> GenresWithLabel | None:
         """Handle existing genres when not forcing.
 
         Clean up existing genres if enabled, or return them unchanged. Return
@@ -487,11 +491,11 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 "cleanup", keep_genres, [], artist=self._artist_for_filter(obj)
             )
 
-        return genres, "keep any, no-force"
+        return genres, "keep any, no-force"  # type: ignore
 
     def _try_resolve_original_fallback(
         self, obj: LibModel, genres: list[str], keep_genres: list[str]
-    ) -> tuple[list[str], str] | None:
+    ) -> GenresWithLabel | None:
         """Attempt to fall back to existing original genres if configured.
 
         ``genres`` are the original unchanged values and are checked as-is
@@ -533,9 +537,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
 
         return []
 
-    def _fetch_artist_stage(
-        self, obj: LibModel
-    ) -> tuple[str, list[str], str | None]:
+    def _fetch_artist_stage(self, obj: LibModel) -> GenresWithLabel:
         """Fetch artist genres for an Item or Album object.
 
         Return a tuple of ``(stage_label, genres, stage_artist)``.
@@ -572,7 +574,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
 
         return "most popular track", [], None
 
-    def _get_genre(self, obj: LibModel) -> tuple[list[str], str]:
+    def _get_genre(self, obj: LibModel) -> GenresWithLabel:
         """Get the final genre list for an Album or Item object.
 
         `self.sources` specifies allowed genre sources. Starting with the first

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -593,17 +593,17 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         """
 
         new_genres = []
-        genres = self._get_existing_genres(obj)
+        existing_genres = self._get_existing_genres(obj)
 
-        if genres and not self.config["force"]:
+        if existing_genres and not self.config["force"]:
             if resolved := self._try_resolve_existing_genres(
-                obj, genres
+                obj, existing_genres
             ):
                 return resolved
             return self.fallback
 
         keep_genres = (
-            [g.lower() for g in genres]
+            [g.lower() for g in existing_genres]
             if self.config["keep_existing"] and self.config["force"]
             else []
         )
@@ -635,7 +635,7 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                     return resolved
 
         if resolved := self._try_resolve_original_fallback(
-            obj, genres, keep_genres
+            obj, existing_genres, keep_genres
         ):
             return resolved
 

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -455,7 +455,12 @@ class LastGenrePlugin(plugins.BeetsPlugin):
         new_genres: list[str],
         artist: str | None = None,
     ) -> tuple[list[str], str] | None:
-        """Try to resolve genres for a given stage and log the result."""
+        """Try to resolve genres for a given stage and log the result.
+
+        If any newly fetched genres and/or existing genres are resolved, return
+        a tuple of the resolved genres and a label describing the source and
+        filtering applied. Otherwise, return ``None``.
+        """
         resolved_genres = self._combine_resolve_and_log(
             keep_genres, new_genres, artist=artist
         )

--- a/beetsplug/lastgenre/__init__.py
+++ b/beetsplug/lastgenre/__init__.py
@@ -489,6 +489,27 @@ class LastGenrePlugin(plugins.BeetsPlugin):
 
         return genres, "keep any, no-force"
 
+    def _try_resolve_original_fallback(
+        self, obj: LibModel, genres: list[str], keep_genres: list[str]
+    ) -> tuple[list[str], str] | None:
+        """Attempt to fall back to existing original genres if configured.
+
+        ``genres`` are the original unchanged values and are checked as-is
+        first, then ``keep_genres`` are used for a lowercased canonicalization
+        retry.
+        """
+        if genres and self.config["keep_existing"].get():
+            artist = self._artist_for_filter(obj)
+            if valid_genres := self._filter_valid(genres, artist=artist):
+                return valid_genres, "original fallback"
+            # If the original genre doesn't match a whitelisted genre, check
+            # if we can canonicalize it to find a matching, whitelisted genre!
+            if resolved := self._try_resolve_stage(
+                "original fallback", keep_genres, [], artist=artist
+            ):
+                return resolved
+        return None
+
     def _fetch_va_genres(self, album: Album) -> list[str]:
         """Fetch the most popular track or artist genre for a Various Artists album."""
         item_genres = []
@@ -613,17 +634,10 @@ class LastGenrePlugin(plugins.BeetsPlugin):
                 ):
                     return resolved
 
-        # Nothing found, leave original if configured and valid.
-        if genres and self.config["keep_existing"].get():
-            artist = self._artist_for_filter(obj)
-            if valid_genres := self._filter_valid(genres, artist=artist):
-                return valid_genres, "original fallback"
-            # If the original genre doesn't match a whitelisted genre, check
-            # if we can canonicalize it to find a matching, whitelisted genre!
-            if resolved := self._try_resolve_stage(
-                "original fallback", keep_genres, [], artist=artist
-            ):
-                return resolved
+        if resolved := self._try_resolve_original_fallback(
+            obj, genres, keep_genres
+        ):
+            return resolved
 
         return self.fallback
 

--- a/docs/plugins/lastgenre.rst
+++ b/docs/plugins/lastgenre.rst
@@ -88,6 +88,11 @@ might want all the albums for a certain artist to carry the same genre. The
 default is "album". When set to "track", the plugin will fetch *both*
 album-level and track-level genres for your music when importing albums.
 
+For multi-artist albums, if Last.fm has no album genre for the primary
+``albumartist``, the plugin also tries the album against each artist listed in
+the multi-valued ``albumartists`` field before falling back to the artist
+source.
+
 Multiple Genres
 ~~~~~~~~~~~~~~~
 

--- a/test/plugins/test_lastgenre.py
+++ b/test/plugins/test_lastgenre.py
@@ -160,6 +160,49 @@ class LastGenrePluginTest(IOMixin, PluginTestCase):
         self._setup_config(count=99)
         assert self.plugin._resolve_genres(["blues", "blues"]) == ["blues"]
 
+    def test_fetch_va_genres_picks_most_popular_track_genre(self):
+        """Among fetched track genres, the most common one wins."""
+        self._setup_config()
+        self.config["lastgenre"]["source"] = "track"
+        self.plugin.setup()
+        item1 = self.add_item(artist="Artist A")
+        item2 = self.add_item(artist="Artist B")
+        item3 = self.add_item(artist="Artist C")
+        album = self.lib.add_album([item1, item2, item3])
+
+        track_genres = {
+            "Artist A": ["Rock"],
+            "Artist B": ["Rock"],
+            "Artist C": ["Jazz"],
+        }
+        self.plugin.client.fetch = lambda kind, obj, *args: (
+            track_genres[obj.artist] if kind == "track" else []
+        )
+
+        assert self.plugin._fetch_va_genres(album) == ["Rock"]
+
+    def test_fetch_va_genres_falls_back_to_artist_genre(self):
+        """When a track has no genre, fall back to its artist's genre."""
+        self._setup_config()
+        item = self.add_item(artist="Artist A")
+        album = self.lib.add_album([item])
+
+        self.plugin.client.fetch = lambda kind, obj, *args: (
+            ["Jazz"] if kind == "artist" else []
+        )
+
+        assert self.plugin._fetch_va_genres(album) == ["Jazz"]
+
+    def test_fetch_va_genres_empty_when_nothing_found(self):
+        """Return an empty list when neither track nor artist genres exist."""
+        self._setup_config()
+        item = self.add_item(artist="Artist A")
+        album = self.lib.add_album([item])
+
+        self.plugin.client.fetch = lambda kind, obj, *args: []
+
+        assert self.plugin._fetch_va_genres(album) == []
+
     def test_fetch_genre(self):
         class MockPylastElem:
             def __init__(self, name):

--- a/test/plugins/test_lastgenre.py
+++ b/test/plugins/test_lastgenre.py
@@ -1050,6 +1050,38 @@ class TestAliases:
             "alias must normalize 'hip-hop' → 'hip hop' before whitelist check"
         )
 
+    def test_original_fallback_keeps_all_alias_normalized_genres(self, config):
+        """Original-fallback path alias-normalizes without truncating to count.
+
+        Covers force + keep_existing + whitelist + aliases with an empty
+        Last.fm response, so ``_get_genre`` falls back to the item's own
+        (alias-normalized) genres.
+
+        With ``count`` set to 1, both 'hip-hop' (whitelisted only after
+        normalizing to 'hip hop') and the already-whitelisted 'Jazz' must
+        survive, proving the count limit isn't applied early.
+        """
+        config["lastgenre"]["force"] = True
+        config["lastgenre"]["keep_existing"] = True
+        config["lastgenre"]["source"] = "album"
+        config["lastgenre"]["whitelist"] = True
+        config["lastgenre"]["count"] = 1
+        config["lastgenre"]["aliases"] = {"hip hop": ["hip-hop", "hiphop"]}
+        plugin = lastgenre.LastGenrePlugin()
+        plugin.setup()
+        plugin.whitelist = {"hip hop", "jazz"}
+
+        item = _common.item()
+        item.genres = ["hip-hop", "Jazz"]
+
+        with patch(
+            "beetsplug.lastgenre.client.LastFmClient.fetch", return_value=[]
+        ):
+            assert plugin._get_genre(item) == (
+                ["hip hop", "Jazz"],
+                "original fallback",
+            )
+
     def test_normalize_before_ignorelist(self, config):
         """Aliases normalize BEFORE ignorelist filtering.
 

--- a/test/plugins/test_lastgenre.py
+++ b/test/plugins/test_lastgenre.py
@@ -750,6 +750,40 @@ def test_get_genre(
     assert plugin._get_genre(item) == expected_result
 
 
+class TestTryResolveAlbumStage:
+    """Direct tests for `_try_resolve_album_stage`.
+
+    `test_get_genre` mocks `LastFmClient.fetch` with a fixed 3-arg lambda that
+    can't distinguish per-albumartist calls, and its items never populate
+    `albumartists`, so the multi-valued albumartists fallback is never
+    exercised there. These tests target `_try_resolve_album_stage` directly.
+    """
+
+    def _make_plugin(self):
+        plugin = lastgenre.LastGenrePlugin()
+        plugin.config.set({"whitelist": False})
+        plugin.setup()
+        return plugin
+
+    @pytest.mark.usefixtures("config")
+    def test_falls_back_to_multi_valued_albumartists(self):
+        """No genre for main albumartist; a secondary albumartist has one."""
+        plugin = self._make_plugin()
+        item = _common.item(albumartists=["Artist A", "Artist B"])
+
+        def fetch(kind, obj, *args):
+            if args == ("Artist B", item.album):
+                return ["Rock"]
+            return []
+
+        plugin.client.fetch = Mock(side_effect=fetch)
+
+        assert plugin._try_resolve_album_stage(item, []) == (
+            ["Rock"],
+            "multi-valued albumartist album, any",
+        )
+
+
 class TestIgnorelist:
     """Ignorelist pattern matching tests independent of resolve_genres."""
 


### PR DESCRIPTION
## Description

Fixes: #6238 

If last.fm returns no album genres for `albumartist`, fall back to querying the album against each artist in `albumartists` (falling through to the artist stage if that also yields nothing.)

The album stage reasoning is now slightly more complex and was moved to its own helper method.

Note: Requires https://github.com/beetbox/beets/pull/6474

## To Do

- [x] Documentation. 
- [ ] Changelog.
- [x] Tests. 
