### PR TITLE
Add a global `editor` configuration option

### DIFF
--- a/beets/config_default.yaml
+++ b/beets/config_default.yaml
@@ -118,6 +118,7 @@ timeout: 5.0
 
 verbose: 0
 terminal_encoding:
+editor:
 
 ui:
     terminal_width: 80

--- a/beets/ui/commands/config.py
+++ b/beets/ui/commands/config.py
@@ -54,8 +54,8 @@ def config_edit(cli_options):
 
     if not editor:
         raise UserError(
-            "Please set the VISUAL or EDITOR environment variable to edit"
-            " configuration."
+            "Please set the `editor` configuration option or the VISUAL or"
+            " EDITOR environment variable to edit configuration."
         )
     try:
         if not os.path.isfile(path):
@@ -78,7 +78,7 @@ config_cmd.parser.add_option(
     "-e",
     "--edit",
     action="store_true",
-    help="edit user configuration with $VISUAL (or $EDITOR)",
+    help="edit user configuration with the configured editor, $VISUAL, or $EDITOR",
 )
 config_cmd.parser.add_option(
     "-d",

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -933,13 +933,16 @@ def open_anything() -> str:
 def editor_command() -> str:
     """Get a command for opening a text file.
 
-    First try environment variable `VISUAL` followed by `EDITOR`. As last resort
-    fall back to `open_anything()`, the platform-specific tool for opening files
-    in general.
+    First try the `editor` configuration option, then the environment variables
+    `VISUAL` and `EDITOR`. As last resort fall back to `open_anything()`, the
+    platform-specific tool for opening files in general.
 
     """
     return (
-        os.environ.get("VISUAL") or os.environ.get("EDITOR") or open_anything()
+        beets.config["editor"].get()
+        or os.environ.get("VISUAL")
+        or os.environ.get("EDITOR")
+        or open_anything()
     )
 
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,9 +9,12 @@ below!
 Unreleased
 ----------
 
-..
-    New features
-    ~~~~~~~~~~~~
+New features
+~~~~~~~~~~~~
+
+- Add a global ``editor`` configuration option, taking precedence over the
+  ``$VISUAL`` and ``$EDITOR`` environment variables, to choose the text editor
+  used by :ref:`config-cmd` and :doc:`/plugins/edit`. :bug:`6641`
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/plugins/edit.rst
+++ b/docs/plugins/edit.rst
@@ -11,9 +11,10 @@ then type:
 
     beet edit QUERY
 
-Your text editor (i.e., the command in your ``$VISUAL`` or ``$EDITOR``
-environment variable) will open with a list of tracks to edit. Make your changes
-and exit your text editor to apply them to your music.
+Your text editor (i.e., the command given by the :ref:`editor` configuration
+option, or by your ``$VISUAL`` or ``$EDITOR`` environment variable) will open
+with a list of tracks to edit. Make your changes and exit your text editor to
+apply them to your music.
 
 Command-Line Options
 --------------------

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -456,9 +456,10 @@ Show or edit the user configuration. This command does one of three things:
 - By default, sensitive information like passwords is removed when dumping the
   configuration. The ``--clear`` option includes this sensitive data.
 - With the ``--edit`` option, beets attempts to open your config file for
-  editing. It first tries the ``$EDITOR`` environment variable, followed by
-  ``$EDITOR`` and then a fallback option depending on your platform: ``open`` on
-  OS X, ``xdg-open`` on Unix, and direct invocation on Windows.
+  editing. It first tries the :ref:`editor` configuration option, followed by
+  the ``$VISUAL`` and ``$EDITOR`` environment variables, and then a fallback
+  option depending on your platform: ``open`` on OS X, ``xdg-open`` on Unix, and
+  direct invocation on Windows.
 
 .. _global-flags:
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -389,6 +389,19 @@ for messages printed to the standard output. It's also used to read messages
 from the standard input. By default, this is determined automatically from the
 locale environment variables.
 
+.. _editor:
+
+editor
+~~~~~~
+
+The command beets uses to open a text editor, for example for :ref:`config-cmd`
+with the ``--edit`` option or for the :doc:`/plugins/edit` plugin. When this
+option is not set, beets uses the ``$VISUAL`` and ``$EDITOR`` environment
+variables instead, falling back to the platform's default file handler.
+
+Set this option if the environment variables do not reach beets, for instance
+when beets runs from an isolated virtual environment.
+
 .. _clutter:
 
 clutter

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -497,3 +497,32 @@ class TestAsciifyPath:
         monkeypatch.setattr("beets.util.os.altsep", "\\")
 
         assert util.asciify_path("caf\xe9\\na\xefve") == "cafe/naive"
+
+
+class TestEditorCommand:
+    @pytest.fixture(autouse=True)
+    def _setup(self, config, monkeypatch):
+        monkeypatch.delenv("VISUAL", raising=False)
+        monkeypatch.delenv("EDITOR", raising=False)
+        monkeypatch.setattr("beets.util.open_anything", lambda: "fallback")
+
+    @pytest.mark.parametrize(
+        "configured, visual, editor, expected",
+        [
+            _p("nano", "vim", "emacs", "nano", id="config-beats-env"),
+            _p("nano", None, None, "nano", id="config-only"),
+            _p(None, "vim", "emacs", "vim", id="visual-beats-editor"),
+            _p(None, None, "emacs", "emacs", id="editor"),
+            _p("", "", "", "fallback", id="empty-values-ignored"),
+            _p(None, None, None, "fallback", id="nothing-configured"),
+        ],
+    )
+    def test_precedence(
+        self, config, monkeypatch, configured, visual, editor, expected
+    ):
+        config["editor"] = configured
+        for name, value in (("VISUAL", visual), ("EDITOR", editor)):
+            if value is not None:
+                monkeypatch.setenv(name, value)
+
+        assert util.editor_command() == expected

--- a/test/ui/commands/test_config.py
+++ b/test/ui/commands/test_config.py
@@ -136,3 +136,16 @@ class ConfigCommandTest(IOMixin, BeetsTestCase):
         execlp.assert_called_once_with(
             "myeditor", "myeditor", self.cli_config_path
         )
+
+    def test_edit_config_prefers_configured_editor(self):
+        with Path(self.config_path).open("a") as file:
+            file.write("\neditor: myconfigeditor")
+        config.clear()
+        config._materialized = False
+
+        os.environ["EDITOR"] = "myeditor"
+        with patch("os.execlp") as execlp:
+            self.run_command("config", "-e")
+        execlp.assert_called_once_with(
+            "myconfigeditor", "myconfigeditor", self.config_path
+        )


### PR DESCRIPTION
## Description

Fixes #6641.

`editor_command()` currently resolves the text editor from `$VISUAL`, then `$EDITOR`, then the platform's generic file opener. When beets runs from an isolated virtualenv — the reporter hit this with pipx's uv backend — neither variable reaches the process, so `beet config -e` and the `edit` plugin silently fall back to `xdg-open`, which doesn't wait for the editor to close (#4026).

This adds a top-level `editor` configuration option so the editor can be set once, permanently, without depending on the environment:

```yaml
editor: nano
```

The resolution order becomes `editor` → `$VISUAL` → `$EDITOR` → platform default. The config option comes first so that setting it actually overrides the environment, which is the point of the request; an unset or empty value falls through to the existing behaviour, so nothing changes for anyone who doesn't set it.

The issue proposed two shapes — a key under the `edit:` plugin section, or a global one. I went with the global key, which is what @semohr endorsed in the thread ("Having the editor as a standalone config option a good idea imo"). It's also the only one that works for `beet config -e`, since the lookup lives in `beets/util` and is shared by the `config` command and the `edit` plugin rather than belonging to either.

The bare `editor:` line in `config_default.yaml` is required — without it `config["editor"].get()` raises `confuse.NotFoundError` instead of returning `None`. This mirrors `terminal_encoding`, the adjacent option, which is read the same way.

Also updates the `-e/--edit` help text and the "please set..." error in the `config` command to mention the new option, matching what b47635dc2 did when `$VISUAL` support was added.

## To Do

- [x] Documentation. (New `editor` section in `docs/reference/config.rst`; updated the editor-resolution description in `docs/reference/cli.rst` and `docs/plugins/edit.rst`.)
- [x] Changelog.
- [x] Tests. (Parametrised coverage of the full precedence chain in `test/test_util.py`, plus an end-to-end test through `beet config -e` in `test/ui/commands/test_config.py`.)
