### PR TITLE
tidal: respect search_limit when collecting candidates

### DIFF
--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -20,7 +20,7 @@ from .api import TidalAPI
 
 if TYPE_CHECKING:
     import optparse
-    from collections.abc import Callable, Iterable, Sequence
+    from collections.abc import Callable, Hashable, Iterable, Sequence
 
     from beets.autotag import Info
     from beets.dbcore.db import Results
@@ -137,6 +137,7 @@ class TidalPlugin(MetadataSourcePlugin):
                 for query in self._album_queries(items)
             ),
             self.config["search_limit"].get(int),
+            self._album_candidate_key,
         )
 
         log.debug("Found {0} candidates", len(candidates))
@@ -161,6 +162,7 @@ class TidalPlugin(MetadataSourcePlugin):
                 for query in self._item_queries(item)
             ),
             self.config["search_limit"].get(int),
+            self._track_candidate_key,
         )
 
         log.debug("Found {0} candidates", len(candidates))
@@ -168,9 +170,12 @@ class TidalPlugin(MetadataSourcePlugin):
 
     @staticmethod
     def _limited_round_robin(
-        iterables: Iterable[Iterable[_Candidate]], limit: int
+        iterables: Iterable[Iterable[_Candidate]],
+        limit: int,
+        candidate_key: Callable[[_Candidate], Hashable | None],
     ) -> list[_Candidate]:
         candidates: list[_Candidate] = []
+        seen: set[Hashable] = set()
         iterators = [iter(iterable) for iterable in iterables]
 
         while iterators and len(candidates) < limit:
@@ -179,13 +184,28 @@ class TidalPlugin(MetadataSourcePlugin):
                 if len(candidates) >= limit:
                     break
                 try:
-                    candidates.append(next(iterator))
+                    candidate = next(iterator)
                 except StopIteration:
                     continue
+                key = candidate_key(candidate)
+                if key is None or key not in seen:
+                    candidates.append(candidate)
+                    if key is not None:
+                        seen.add(key)
                 active_iterators.append(iterator)
             iterators = active_iterators
 
         return candidates
+
+    @staticmethod
+    def _album_candidate_key(candidate: AlbumInfo) -> Info.Identifier | None:
+        if candidate.album_id:
+            return candidate.identifier
+        return None
+
+    @staticmethod
+    def _track_candidate_key(candidate: TrackInfo) -> Info.Identifier:
+        return candidate.identifier
 
     @staticmethod
     def _item_queries(item: Item) -> Iterable[str]:

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -5,7 +5,7 @@ import os
 import re
 import time
 from functools import cached_property
-from typing import TYPE_CHECKING, ClassVar, Literal, overload
+from typing import TYPE_CHECKING, ClassVar, Literal, TypeVar, overload
 
 import confuse
 
@@ -39,6 +39,8 @@ if TYPE_CHECKING:
 
 
 log = getLogger("beets.tidal")
+
+_Candidate = TypeVar("_Candidate")
 
 
 class TidalPlugin(MetadataSourcePlugin):
@@ -129,8 +131,13 @@ class TidalPlugin(MetadataSourcePlugin):
         ):
             return candidates
 
-        for query in self._album_queries(items):
-            candidates += self.search_albums_by_query(query)
+        candidates = self._limited_round_robin(
+            (
+                self.search_albums_by_query(query)
+                for query in self._album_queries(items)
+            ),
+            self.config["search_limit"].get(int),
+        )
 
         log.debug("Found {0} candidates", len(candidates))
         return candidates
@@ -148,10 +155,36 @@ class TidalPlugin(MetadataSourcePlugin):
             ):
                 return candidates
 
-        for query in self._item_queries(item):
-            candidates += self.search_tracks_by_query(query)
+        candidates = self._limited_round_robin(
+            (
+                self.search_tracks_by_query(query)
+                for query in self._item_queries(item)
+            ),
+            self.config["search_limit"].get(int),
+        )
 
         log.debug("Found {0} candidates", len(candidates))
+        return candidates
+
+    @staticmethod
+    def _limited_round_robin(
+        iterables: Iterable[Iterable[_Candidate]], limit: int
+    ) -> list[_Candidate]:
+        candidates: list[_Candidate] = []
+        iterators = [iter(iterable) for iterable in iterables]
+
+        while iterators and len(candidates) < limit:
+            active_iterators = []
+            for iterator in iterators:
+                if len(candidates) >= limit:
+                    break
+                try:
+                    candidates.append(next(iterator))
+                except StopIteration:
+                    continue
+                active_iterators.append(iterator)
+            iterators = active_iterators
+
         return candidates
 
     @staticmethod

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,6 +30,8 @@ Bug fixes
 - :doc:`plugins/lyrics`: ``beet lyrics`` no longer crashes with an
   ``AttributeError`` on tracks that have no stored lyrics when ``force`` is
   enabled; a missing lyrics body is now treated as empty text. :bug:`6860`
+- :doc:`plugins/tidal`: ``candidates()`` and ``item_candidates()`` now respect
+  the configured ``search_limit``. :bug:`6770`
 
 ..
     For plugin developers

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -673,6 +673,66 @@ class TestCandidates(TidalPluginTest):
         assert candidates[0].album == "Query Album"
 
 
+class TestSearchLimit(TidalPluginTest):
+    """Tests for Tidal search_limit handling."""
+
+    def test_candidates_respect_search_limit_across_album_queries(self):
+        """Album candidates are capped and interleaved across queries."""
+        items = [Item(title="Song", artist="Artist", album="Album")]
+        self.tidal.config["search_limit"] = 2
+        self.tidal._album_queries = Mock(return_value=["query a", "query b"])
+
+        def search_albums(query):
+            yield f"{query} first"
+            yield f"{query} second"
+
+        self.tidal.search_albums_by_query = Mock(side_effect=search_albums)
+
+        candidates = list(
+            self.tidal.candidates(items, "Artist", "Album", False)
+        )
+
+        assert candidates == ["query a first", "query b first"]
+
+    def test_candidates_stop_before_later_album_queries_at_limit(self):
+        """Album candidate collection stops before resolving unneeded queries."""
+        items = [Item(title="Song", artist="Artist", album="Album")]
+        resolved_queries = []
+        self.tidal.config["search_limit"] = 1
+        self.tidal._album_queries = Mock(return_value=["query a", "query b"])
+
+        def search_albums(query):
+            resolved_queries.append(query)
+            yield f"{query} first"
+
+        self.tidal.search_albums_by_query = Mock(side_effect=search_albums)
+
+        candidates = list(
+            self.tidal.candidates(items, "Artist", "Album", False)
+        )
+
+        assert candidates == ["query a first"]
+        assert resolved_queries == ["query a"]
+
+    def test_item_candidates_respect_search_limit_across_item_queries(self):
+        """Item candidates are capped and avoid resolving later queries."""
+        item = Item(title="Song", artist="Artist")
+        resolved_queries = []
+        self.tidal.config["search_limit"] = 1
+        self.tidal._item_queries = Mock(return_value=["Song", "Artist Song"])
+
+        def search_tracks(query):
+            resolved_queries.append(query)
+            yield f"{query} first"
+
+        self.tidal.search_tracks_by_query = Mock(side_effect=search_tracks)
+
+        candidates = list(self.tidal.item_candidates(item, "Artist", "Song"))
+
+        assert candidates == ["Song first"]
+        assert resolved_queries == ["Song"]
+
+
 class TestItemCandidates(TidalPluginTest):
     """Tests for item_candidates method."""
 

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from beets.autotag import AlbumInfo, TrackInfo
 from beets.library.models import Item
 from beets.test.helper import PluginTestHelper
 from beetsplug.tidal import TidalPlugin
@@ -26,6 +27,19 @@ if TYPE_CHECKING:
     )
 
 CURRENT_TS = 150000000
+
+
+def _album_info(album_id: str | None, album: str) -> AlbumInfo:
+    return AlbumInfo(
+        data_source="Tidal",
+        album_id=album_id,
+        album=album,
+        tracks=[TrackInfo(data_source="Tidal", track_id=f"{album}-track")],
+    )
+
+
+def _track_info(track_id: str | None, title: str) -> TrackInfo:
+    return TrackInfo(data_source="Tidal", track_id=track_id, title=title)
 
 
 def _make_artwork(id_: str, href: str = "") -> TidalArtwork:
@@ -683,8 +697,8 @@ class TestSearchLimit(TidalPluginTest):
         self.tidal._album_queries = Mock(return_value=["query a", "query b"])
 
         def search_albums(query):
-            yield f"{query} first"
-            yield f"{query} second"
+            yield _album_info(f"{query} first", f"{query} first")
+            yield _album_info(f"{query} second", f"{query} second")
 
         self.tidal.search_albums_by_query = Mock(side_effect=search_albums)
 
@@ -692,7 +706,10 @@ class TestSearchLimit(TidalPluginTest):
             self.tidal.candidates(items, "Artist", "Album", False)
         )
 
-        assert candidates == ["query a first", "query b first"]
+        assert [candidate.album for candidate in candidates] == [
+            "query a first",
+            "query b first",
+        ]
 
     def test_candidates_stop_before_later_album_queries_at_limit(self):
         """Album candidate collection stops before resolving unneeded queries."""
@@ -703,7 +720,7 @@ class TestSearchLimit(TidalPluginTest):
 
         def search_albums(query):
             resolved_queries.append(query)
-            yield f"{query} first"
+            yield _album_info(f"{query} first", f"{query} first")
 
         self.tidal.search_albums_by_query = Mock(side_effect=search_albums)
 
@@ -711,8 +728,88 @@ class TestSearchLimit(TidalPluginTest):
             self.tidal.candidates(items, "Artist", "Album", False)
         )
 
-        assert candidates == ["query a first"]
+        assert [candidate.album for candidate in candidates] == [
+            "query a first"
+        ]
         assert resolved_queries == ["query a"]
+
+    def test_candidates_count_distinct_album_ids_toward_search_limit(self):
+        """Album duplicates do not consume search_limit slots."""
+        items = [Item(title="Song", artist="Artist", album="Album")]
+        resolved_queries = []
+        consumed = []
+        self.tidal.config["search_limit"] = 4
+        self.tidal._album_queries = Mock(
+            return_value=["query a", "query b", "query c"]
+        )
+
+        albums_by_query = {
+            "query a": [
+                _album_info("1", "duplicate from a"),
+                _album_info("3", "unique from a"),
+            ],
+            "query b": [
+                _album_info("1", "duplicate from b"),
+                _album_info("4", "unique from b"),
+            ],
+            "query c": [
+                _album_info("2", "unique from c"),
+                _album_info("5", "unneeded from c"),
+            ],
+        }
+
+        def search_albums(query):
+            resolved_queries.append(query)
+            for album in albums_by_query[query]:
+                consumed.append(album.album)
+                yield album
+
+        self.tidal.search_albums_by_query = Mock(side_effect=search_albums)
+
+        candidates = list(
+            self.tidal.candidates(items, "Artist", "Album", False)
+        )
+
+        assert [candidate.album_id for candidate in candidates] == [
+            "1",
+            "2",
+            "3",
+            "4",
+        ]
+        assert [candidate.album for candidate in candidates] == [
+            "duplicate from a",
+            "unique from c",
+            "unique from a",
+            "unique from b",
+        ]
+        assert resolved_queries == ["query a", "query b", "query c"]
+        assert consumed == [
+            "duplicate from a",
+            "duplicate from b",
+            "unique from c",
+            "unique from a",
+            "unique from b",
+        ]
+
+    def test_candidates_keep_album_candidates_without_ids_distinct(self):
+        """Album candidates without IDs match downstream duplicate behavior."""
+        items = [Item(title="Song", artist="Artist", album="Album")]
+        self.tidal.config["search_limit"] = 2
+        self.tidal._album_queries = Mock(return_value=["query a", "query b"])
+
+        def search_albums(query):
+            yield _album_info(None, f"{query} missing id")
+
+        self.tidal.search_albums_by_query = Mock(side_effect=search_albums)
+
+        candidates = list(
+            self.tidal.candidates(items, "Artist", "Album", False)
+        )
+
+        assert [candidate.album for candidate in candidates] == [
+            "query a missing id",
+            "query b missing id",
+        ]
 
     def test_item_candidates_respect_search_limit_across_item_queries(self):
         """Item candidates are capped and avoid resolving later queries."""
@@ -723,14 +820,134 @@ class TestSearchLimit(TidalPluginTest):
 
         def search_tracks(query):
             resolved_queries.append(query)
-            yield f"{query} first"
+            yield _track_info(f"{query} first", f"{query} first")
 
         self.tidal.search_tracks_by_query = Mock(side_effect=search_tracks)
 
         candidates = list(self.tidal.item_candidates(item, "Artist", "Song"))
 
-        assert candidates == ["Song first"]
+        assert [candidate.title for candidate in candidates] == ["Song first"]
         assert resolved_queries == ["Song"]
+
+    def test_item_candidates_count_distinct_track_ids_toward_search_limit(self):
+        """Track duplicates do not consume search_limit slots."""
+        item = Item(title="Song", artist="Artist")
+        resolved_queries = []
+        consumed = []
+        self.tidal.config["search_limit"] = 4
+        self.tidal._item_queries = Mock(
+            return_value=["Song", "Artist Song", "Remix Song"]
+        )
+
+        tracks_by_query = {
+            "Song": [
+                _track_info("1", "duplicate from title"),
+                _track_info("3", "unique from title"),
+            ],
+            "Artist Song": [
+                _track_info("1", "duplicate from artist/title"),
+                _track_info("4", "unique from artist/title"),
+            ],
+            "Remix Song": [
+                _track_info("2", "unique from remix"),
+                _track_info("5", "unneeded from remix"),
+            ],
+        }
+
+        def search_tracks(query):
+            resolved_queries.append(query)
+            for track in tracks_by_query[query]:
+                consumed.append(track.title)
+                yield track
+
+        self.tidal.search_tracks_by_query = Mock(side_effect=search_tracks)
+
+        candidates = list(self.tidal.item_candidates(item, "Artist", "Song"))
+
+        assert [candidate.track_id for candidate in candidates] == [
+            "1",
+            "2",
+            "3",
+            "4",
+        ]
+        assert [candidate.title for candidate in candidates] == [
+            "duplicate from title",
+            "unique from remix",
+            "unique from title",
+            "unique from artist/title",
+        ]
+        assert resolved_queries == ["Song", "Artist Song", "Remix Song"]
+        assert consumed == [
+            "duplicate from title",
+            "duplicate from artist/title",
+            "unique from remix",
+            "unique from title",
+            "unique from artist/title",
+        ]
+
+    def test_search_limits_do_not_consume_generators_when_not_positive(self):
+        """Zero and negative search limits avoid advancing result generators."""
+        items = [Item(title="Song", artist="Artist", album="Album")]
+        item = Item(title="Song", artist="Artist")
+        consumed = []
+
+        self.tidal._album_queries = Mock(return_value=["album query"])
+        self.tidal._item_queries = Mock(return_value=["track query"])
+
+        def search_albums(query):
+            consumed.append(query)
+            yield _album_info("1", "album")
+
+        def search_tracks(query):
+            consumed.append(query)
+            yield _track_info("1", "track")
+
+        self.tidal.search_albums_by_query = Mock(side_effect=search_albums)
+        self.tidal.search_tracks_by_query = Mock(side_effect=search_tracks)
+
+        self.tidal.config["search_limit"] = 0
+        assert (
+            list(self.tidal.candidates(items, "Artist", "Album", False)) == []
+        )
+
+        self.tidal.config["search_limit"] = -1
+        assert list(self.tidal.item_candidates(item, "Artist", "Song")) == []
+
+        assert consumed == []
+
+    def test_item_candidates_collapse_track_candidates_without_ids(self):
+        """Track candidates without IDs match downstream duplicate behavior."""
+        item = Item(title="Song", artist="Artist")
+        consumed = []
+        self.tidal.config["search_limit"] = 2
+        self.tidal._item_queries = Mock(
+            return_value=["Song", "Artist Song", "Remix Song"]
+        )
+
+        tracks_by_query = {
+            "Song": [_track_info(None, "missing id from title")],
+            "Artist Song": [_track_info(None, "missing id from artist/title")],
+            "Remix Song": [_track_info("2", "unique from remix")],
+        }
+
+        def search_tracks(query):
+            for track in tracks_by_query[query]:
+                consumed.append(track.title)
+                yield track
+
+        self.tidal.search_tracks_by_query = Mock(side_effect=search_tracks)
+
+        candidates = list(self.tidal.item_candidates(item, "Artist", "Song"))
+
+        assert [candidate.title for candidate in candidates] == [
+            "missing id from title",
+            "unique from remix",
+        ]
+        assert consumed == [
+            "missing id from title",
+            "missing id from artist/title",
+            "unique from remix",
+        ]
 
 
 class TestItemCandidates(TidalPluginTest):


### PR DESCRIPTION
## Summary

- Respect `search_limit` while collecting Tidal album and track candidates.
- Use a small round-robin helper so candidate sources are consumed fairly and collection stops as soon as the configured limit is reached.
- Keep the limiting behaviour inside `candidates()` and `item_candidates()`.
- Preserve barcode and ISRC fast paths and leave the lower-level query helpers unchanged.
- Add focused tests for limiting, ordering and early stopping.
- Add a changelog entry.

## Validation

- `uv run pytest test/plugins/test_tidal.py`
- `uv run ruff format --check --diff beetsplug/tidal/__init__.py test/plugins/test_tidal.py`
- `uv run ruff check --config=pyproject.toml beetsplug/tidal/__init__.py test/plugins/test_tidal.py`
- `uv run mypy beetsplug/tidal/__init__.py`
- `git diff --check`

The tests use mocks and generators only. No Tidal credentials or network calls are required.

## Related work

PR #6781 also addresses this issue. This implementation takes a narrower approach by keeping the limit at the candidate aggregation layer, leaving the lower-level query helpers unchanged, and using focused early-stopping tests.

Closes #6770
