### PR TITLE
feat: add editor config option to editor_command()

### DIFF
--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -939,9 +939,13 @@ def editor_command() -> str:
 
     """
     from beets import config
+
     return (
-        config["editor"].get(str) if config["editor"].exists() else None
-    ) or os.environ.get("VISUAL") or os.environ.get("EDITOR") or open_anything()
+        (config["editor"].get(str) if config["editor"].exists() else None)
+        or os.environ.get("VISUAL")
+        or os.environ.get("EDITOR")
+        or open_anything()
+    )
 
 
 def interactive_open(targets: Sequence[str], command: str) -> None:
@@ -1202,4 +1206,3 @@ def chunks(lst: Sequence[T], n: int) -> Iterator[list[T]]:
     """Yield successive n-sized chunks from lst."""
     for i in range(0, len(lst), n):
         yield list(lst[i : i + n])
-

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -933,14 +933,15 @@ def open_anything() -> str:
 def editor_command() -> str:
     """Get a command for opening a text file.
 
-    First try environment variable `VISUAL` followed by `EDITOR`. As last resort
-    fall back to `open_anything()`, the platform-specific tool for opening files
-    in general.
+    First checks the `editor` config option, then tries environment variable
+    `VISUAL` followed by `EDITOR`. As last resort fall back to `open_anything()`,
+    the platform-specific tool for opening files in general.
 
     """
+    from beets import config
     return (
-        os.environ.get("VISUAL") or os.environ.get("EDITOR") or open_anything()
-    )
+        config["editor"].get(str) if config["editor"].exists() else None
+    ) or os.environ.get("VISUAL") or os.environ.get("EDITOR") or open_anything()
 
 
 def interactive_open(targets: Sequence[str], command: str) -> None:
@@ -1201,3 +1202,4 @@ def chunks(lst: Sequence[T], n: int) -> Iterator[list[T]]:
     """Yield successive n-sized chunks from lst."""
     for i in range(0, len(lst), n):
         yield list(lst[i : i + n])
+

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,9 @@ New features
 Bug fixes
 ~~~~~~~~~
 
+- Add ``editor`` config option to allow users to permanently set their preferred
+  editor, overriding ``$VISUAL`` and ``$EDITOR`` environment variables.
+  :bug:`6641`
 - A date range query written back to front (for example ``added:2024..2020``) no
   longer crashes with an uncaught ``ValueError``. The endpoints are now swapped,
   so such a range means the same as ``added:2020..2024``.
@@ -202,9 +205,6 @@ New features
 Bug fixes
 ~~~~~~~~~
 
-- Add ``editor`` config option to allow users to permanently set their preferred
-  editor, overriding ``$VISUAL`` and ``$EDITOR`` environment variables.
-  :bug:`6641`
 - :doc:`plugins/lyrics`: Add rate limiting and exponential backoff to HTTP
   requests to prevent ``429 Too Many Requests`` errors from lyrics sources
   during bulk imports. :bug:`6728`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -201,6 +201,8 @@ New features
 
 Bug fixes
 ~~~~~~~~~
+- Add ``editor`` config option to allow users to permanently set their preferred editor, overriding ``$VISUAL`` and ``$EDITOR`` environment variables. :bug:`6641`
+
 
 - :doc:`plugins/lyrics`: Add rate limiting and exponential backoff to HTTP
   requests to prevent ``429 Too Many Requests`` errors from lyrics sources

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -201,9 +201,10 @@ New features
 
 Bug fixes
 ~~~~~~~~~
-- Add ``editor`` config option to allow users to permanently set their preferred editor, overriding ``$VISUAL`` and ``$EDITOR`` environment variables. :bug:`6641`
 
-
+- Add ``editor`` config option to allow users to permanently set their preferred
+  editor, overriding ``$VISUAL`` and ``$EDITOR`` environment variables.
+  :bug:`6641`
 - :doc:`plugins/lyrics`: Add rate limiting and exponential backoff to HTTP
   requests to prevent ``429 Too Many Requests`` errors from lyrics sources
   during bulk imports. :bug:`6728`

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -63,9 +63,11 @@ library. Defaults to a folder called ``Music`` in your home directory.
 editor
 ~~~~~~
 
-The text editor to use when editing configuration files (e.g., via ``beet
-config -e``). Overrides the ``$VISUAL`` and ``$EDITOR`` environment variables.
-If none of these are set, beets falls back to the platform default. Example::
+The text editor to use when editing configuration files (e.g., via ``beet config
+-e``). Overrides the ``$VISUAL`` and ``$EDITOR`` environment variables. If none
+of these are set, beets falls back to the platform default. Example:
+
+::
 
     editor: nano
 

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -60,6 +60,15 @@ directory
 The directory to which files will be copied/moved when adding them to the
 library. Defaults to a folder called ``Music`` in your home directory.
 
+editor
+~~~~~~
+
+The text editor to use when editing configuration files (e.g., via ``beet
+config -e``). Overrides the ``$VISUAL`` and ``$EDITOR`` environment variables.
+If none of these are set, beets falls back to the platform default. Example::
+
+    editor: nano
+
 create_backup_before_migrations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -499,7 +499,6 @@ class TestAsciifyPath:
         assert util.asciify_path("caf\xe9\\na\xefve") == "cafe/naive"
 
 
-
 class EditorCommandTest(unittest.TestCase):
     def test_editor_command_from_config(self):
         """editor config option takes priority over environment variables."""
@@ -511,7 +510,9 @@ class EditorCommandTest(unittest.TestCase):
 
     def test_editor_command_falls_back_to_visual(self):
         """Falls back to $VISUAL when no editor config is set."""
-        with patch.dict(os.environ, {"VISUAL": "vim", "EDITOR": "emacs"}, clear=True):
+        with patch.dict(
+            os.environ, {"VISUAL": "vim", "EDITOR": "emacs"}, clear=True
+        ):
             assert util.editor_command() == "vim"
 
     def test_editor_command_falls_back_to_editor_env(self):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -497,3 +497,24 @@ class TestAsciifyPath:
         monkeypatch.setattr("beets.util.os.altsep", "\\")
 
         assert util.asciify_path("caf\xe9\\na\xefve") == "cafe/naive"
+
+
+
+class EditorCommandTest(unittest.TestCase):
+    def test_editor_command_from_config(self):
+        """editor config option takes priority over environment variables."""
+        from beets import config
+
+        config.set({"editor": "nano"})
+        with patch.dict(os.environ, {"VISUAL": "vim", "EDITOR": "emacs"}):
+            assert util.editor_command() == "nano"
+
+    def test_editor_command_falls_back_to_visual(self):
+        """Falls back to $VISUAL when no editor config is set."""
+        with patch.dict(os.environ, {"VISUAL": "vim"}, clear=True):
+            assert util.editor_command() == "vim"
+
+    def test_editor_command_falls_back_to_editor_env(self):
+        """Falls back to $EDITOR when no editor config or $VISUAL is set."""
+        with patch.dict(os.environ, {"EDITOR": "emacs"}, clear=True):
+            assert util.editor_command() == "emacs"

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -511,7 +511,7 @@ class EditorCommandTest(unittest.TestCase):
 
     def test_editor_command_falls_back_to_visual(self):
         """Falls back to $VISUAL when no editor config is set."""
-        with patch.dict(os.environ, {"VISUAL": "vim"}, clear=True):
+        with patch.dict(os.environ, {"VISUAL": "vim", "EDITOR": "emacs"}, clear=True):
             assert util.editor_command() == "vim"
 
     def test_editor_command_falls_back_to_editor_env(self):


### PR DESCRIPTION
Fixes #6641

Adds an `editor` config option so users can permanently set their preferred editor in `config.yaml`, overriding `$VISUAL` and `$EDITOR` environment variables which may not be available in virtualenv environments (e.g. pipx with uv backend).

**Usage:**
```yaml
editor: nano
```

**Changes:**
- Modified `beets/util/__init__.py` — `editor_command()` now checks `config["editor"]` first before falling back to `$VISUAL`/`$EDITOR`
- Added changelog entry to `docs/changelog.rst`
- Added documentation to `docs/reference/config.rst`
- Added 3 tests to `test/test_util.py`

@semohr — reopening here as a clean PR per your feedback. All previous review points addressed.