### PR TITLE
fix(deezer): detect compilations credited to a single main artist

### DIFF
--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -12,6 +12,7 @@ from beets import config, ui
 from beets.autotag import AlbumInfo, TrackInfo
 from beets.dbcore import types
 from beets.exceptions import UserError
+from beets.importer.tasks import SINGLE_ARTIST_THRESH
 from beets.metadata_plugins import IDResponse, SearchApiMetadataSourcePlugin
 
 VARIOUS_ARTISTS_ID = 5080
@@ -112,7 +113,15 @@ class DeezerPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
         for track in tracks:
             track.medium_total = medium_totals[track.medium]
 
-        is_va = str(album_data["artist"]["id"]) == str(VARIOUS_ARTISTS_ID)
+        album_artist_id = str(album_data["artist"]["id"])
+        # Deezer assigns some compilations a single "main" artist instead of
+        # the Various Artists entity, leaving them undetected. Treat a release
+        # as VA when its album artist performs on fewer tracks than the
+        # importer's own single-artist plurality threshold.
+        is_va = album_artist_id == str(VARIOUS_ARTISTS_ID) or (
+            sum(t.artist_id == album_artist_id for t in tracks)
+            < len(tracks) * SINGLE_ARTIST_THRESH
+        )
         if is_va:
             va_name = config["va_name"].as_str()
             artist = va_name

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -111,7 +111,14 @@ class DeezerPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
         for track in tracks:
             track.medium_total = medium_totals[track.medium]
 
-        is_va = str(album_data["artist"]["id"]) == str(VARIOUS_ARTISTS_ID)
+        album_artist_id = str(album_data["artist"]["id"])
+        # Deezer assigns some compilations a single "main" artist instead of
+        # the Various Artists entity, leaving them undetected. Treat a release
+        # as VA when its album artist performs on a minority of the tracks.
+        is_va = album_artist_id == str(VARIOUS_ARTISTS_ID) or (
+            sum(t.artist_id == album_artist_id for t in tracks) * 2
+            < len(tracks)
+        )
         if is_va:
             va_name = config["va_name"].as_str()
             artist = va_name

--- a/beetsplug/deezer.py
+++ b/beetsplug/deezer.py
@@ -12,6 +12,7 @@ from beets import config, ui
 from beets.autotag import AlbumInfo, TrackInfo
 from beets.dbcore import types
 from beets.exceptions import UserError
+from beets.importer.tasks import SINGLE_ARTIST_THRESH
 from beets.metadata_plugins import IDResponse, SearchApiMetadataSourcePlugin
 
 VARIOUS_ARTISTS_ID = 5080
@@ -114,10 +115,11 @@ class DeezerPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
         album_artist_id = str(album_data["artist"]["id"])
         # Deezer assigns some compilations a single "main" artist instead of
         # the Various Artists entity, leaving them undetected. Treat a release
-        # as VA when its album artist performs on a minority of the tracks.
+        # as VA when its album artist performs on fewer tracks than the
+        # importer's own single-artist plurality threshold.
         is_va = album_artist_id == str(VARIOUS_ARTISTS_ID) or (
-            sum(t.artist_id == album_artist_id for t in tracks) * 2
-            < len(tracks)
+            sum(t.artist_id == album_artist_id for t in tracks)
+            < len(tracks) * SINGLE_ARTIST_THRESH
         )
         if is_va:
             va_name = config["va_name"].as_str()

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -44,6 +44,9 @@ Bug fixes
 - :doc:`plugins/lyrics`: ``beet lyrics`` no longer crashes with an
   ``AttributeError`` on tracks that have no stored lyrics when ``force`` is
   enabled; a missing lyrics body is now treated as empty text. :bug:`6860`
+- :doc:`plugins/deezer`: Detect compilations that Deezer credits to a single
+  "main" artist instead of "Various Artists", so they are tagged as such rather
+  than getting every track artist in the album artist field. :bug:`4057`
 - Flexible attributes whose names contain uppercase characters (for example
   ``beet import --set Tag_With_Uppercase=true``) can now be found by queries.
   Field names are lowercased when a query is parsed, so such attributes could

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -260,6 +260,10 @@ Bug fixes
   queries.
 - :doc:`plugins/tidal`: Fix auth URL not printed in environments without a
   configured browser :bug:`6710`
+- :doc:`plugins/deezer`: Detect compilations that Deezer credits to a single
+  "main" artist instead of "Various Artists", so they are tagged as such
+  rather than getting every track artist in the album artist field.
+  :bug:`4057`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,9 @@ Bug fixes
 - :doc:`plugins/lyrics`: ``beet lyrics`` no longer crashes with an
   ``AttributeError`` on tracks that have no stored lyrics when ``force`` is
   enabled; a missing lyrics body is now treated as empty text. :bug:`6860`
+- :doc:`plugins/deezer`: Detect compilations that Deezer credits to a single
+  "main" artist instead of "Various Artists", so they are tagged as such rather
+  than getting every track artist in the album artist field. :bug:`4057`
 
 ..
     For plugin developers
@@ -260,10 +263,6 @@ Bug fixes
   queries.
 - :doc:`plugins/tidal`: Fix auth URL not printed in environments without a
   configured browser :bug:`6710`
-- :doc:`plugins/deezer`: Detect compilations that Deezer credits to a single
-  "main" artist instead of "Various Artists", so they are tagged as such
-  rather than getting every track artist in the album artist field.
-  :bug:`4057`
 
 For plugin developers
 ~~~~~~~~~~~~~~~~~~~~~

--- a/test/plugins/test_deezer.py
+++ b/test/plugins/test_deezer.py
@@ -1,16 +1,25 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 import pytest
 
 from beets.library import Item
 from beetsplug.deezer import DeezerPlugin
 
+if TYPE_CHECKING:
+    from requests_mock import Mocker
+
+JSONDict = dict[str, Any]
+
 
 @pytest.fixture
-def plugin():
+def plugin() -> DeezerPlugin:
     return DeezerPlugin()
 
 
 class TestSearchQuery:
-    def test_track_query_is_free_text(self, plugin):
+    def test_track_query_is_free_text(self, plugin: DeezerPlugin) -> None:
         query, filters = plugin.get_search_query_with_filters(
             "track", [Item()], "Artist", "Title", False
         )
@@ -18,14 +27,18 @@ class TestSearchQuery:
         assert query == "Title Artist"
         assert filters == {}
 
-    def test_track_query_tolerates_missing_artist(self, plugin):
+    def test_track_query_tolerates_missing_artist(
+        self, plugin: DeezerPlugin
+    ) -> None:
         query, _ = plugin.get_search_query_with_filters(
             "track", [Item()], "", "Title", False
         )
 
         assert query == "Title"
 
-    def test_album_query_filters_on_album_and_artist(self, plugin):
+    def test_album_query_filters_on_album_and_artist(
+        self, plugin: DeezerPlugin
+    ) -> None:
         query, filters = plugin.get_search_query_with_filters(
             "album", [Item()], "Artist", "Album", False
         )
@@ -33,7 +46,9 @@ class TestSearchQuery:
         assert query == 'album:"Album" artist:"Artist"'
         assert filters == {}
 
-    def test_album_query_omits_artist_for_various_artists(self, plugin):
+    def test_album_query_omits_artist_for_various_artists(
+        self, plugin: DeezerPlugin
+    ) -> None:
         query, _ = plugin.get_search_query_with_filters(
             "album", [Item()], "Various Artists", "Album", True
         )
@@ -41,8 +56,21 @@ class TestSearchQuery:
         assert query == 'album:"Album"'
 
 
+def make_track(artist_id: int, position: int) -> JSONDict:
+    """Build a minimal Deezer track payload credited to ``artist_id``."""
+    return {
+        "title": f"Track {position}",
+        "id": 1000 + position,
+        "link": f"https://www.deezer.com/track/{1000 + position}",
+        "duration": 200,
+        "track_position": position,
+        "disk_number": 1,
+        "artist": {"id": artist_id, "name": f"Artist {artist_id}"},
+    }
+
+
 class TestGetTrack:
-    def track_data(self, **fields):
+    def track_data(self, **fields) -> JSONDict:
         return {
             "id": 1,
             "title": "Title",
@@ -51,7 +79,9 @@ class TestGetTrack:
             **fields,
         }
 
-    def test_uses_contributors_when_artist_is_missing(self, plugin):
+    def test_uses_contributors_when_artist_is_missing(
+        self, plugin: DeezerPlugin
+    ) -> None:
         track = plugin._get_track(
             self.track_data(contributors=[{"id": 2, "name": "Artist"}])
         )
@@ -59,7 +89,9 @@ class TestGetTrack:
         assert track.artist == "Artist"
         assert track.artist_id == "2"
 
-    def test_falls_back_to_artist_without_contributors(self, plugin):
+    def test_falls_back_to_artist_without_contributors(
+        self, plugin: DeezerPlugin
+    ) -> None:
         track = plugin._get_track(
             self.track_data(artist={"id": 2, "name": "Artist"})
         )
@@ -67,8 +99,113 @@ class TestGetTrack:
         assert track.artist == "Artist"
         assert track.artist_id == "2"
 
-    def test_tolerates_missing_artist_and_contributors(self, plugin):
+    def test_tolerates_missing_artist_and_contributors(
+        self, plugin: DeezerPlugin
+    ) -> None:
         track = plugin._get_track(self.track_data())
 
         assert track.artist is None
         assert track.artist_id is None
+
+
+class TestVariousArtistsDetection:
+    def make_album(
+        self, album_artist_id: int, contributor_ids: list[int]
+    ) -> JSONDict:
+        """Build a minimal Deezer album payload."""
+        return {
+            "title": "Some Album",
+            "link": "https://www.deezer.com/album/1",
+            "record_type": "album",
+            "label": "Some Label",
+            "release_date": "2017-01-01",
+            "artist": {
+                "id": album_artist_id,
+                "name": f"Artist {album_artist_id}",
+            },
+            "contributors": [
+                {"id": aid, "name": f"Artist {aid}"} for aid in contributor_ids
+            ],
+            "cover_xl": None,
+        }
+
+    def mock_album(
+        self,
+        requests_mock: Mocker,
+        album_artist_id: int,
+        track_artist_ids: list[int],
+        contributor_ids: list[int] | None = None,
+    ) -> None:
+        """Mock the album and album-tracks endpoints for album id 1.
+
+        ``contributor_ids`` overrides the album-level contributors, which
+        otherwise cover every artist involved.
+        """
+        if contributor_ids is None:
+            contributor_ids = list(
+                dict.fromkeys([album_artist_id, *track_artist_ids])
+            )
+        requests_mock.get(
+            f"{DeezerPlugin.album_url}1",
+            json=self.make_album(album_artist_id, contributor_ids),
+        )
+        requests_mock.get(
+            f"{DeezerPlugin.album_url}1/tracks",
+            json={
+                "data": [
+                    make_track(aid, i)
+                    for i, aid in enumerate(track_artist_ids, start=1)
+                ]
+            },
+        )
+
+    def test_compilation_with_non_va_album_artist(
+        self, plugin: DeezerPlugin, requests_mock: Mocker
+    ) -> None:
+        # Album credited to a single "main" artist that performs on only one
+        # of many tracks: this is a compilation and should be flagged as VA.
+        self.mock_album(
+            requests_mock,
+            album_artist_id=100,
+            track_artist_ids=[100, 200, 300, 400, 500, 600],
+        )
+
+        album_info = plugin.album_for_id("1")
+
+        assert album_info is not None
+        assert album_info.va is True
+        assert album_info.artist == "Various Artists"
+
+    def test_plurality_artist_album_not_va(
+        self, plugin: DeezerPlugin, requests_mock: Mocker
+    ) -> None:
+        # Album whose main artist performs on 2 of 5 tracks (40%) is above
+        # the importer's single-artist threshold and stays single-artist.
+        self.mock_album(
+            requests_mock,
+            album_artist_id=100,
+            track_artist_ids=[100, 100, 200, 300, 400],
+            contributor_ids=[100],
+        )
+
+        album_info = plugin.album_for_id("1")
+
+        assert album_info is not None
+        assert album_info.va is False
+        assert album_info.artist == "Artist 100"
+
+    def test_single_artist_album_not_va(
+        self, plugin: DeezerPlugin, requests_mock: Mocker
+    ) -> None:
+        # Album whose main artist performs on every track is not a compilation.
+        self.mock_album(
+            requests_mock,
+            album_artist_id=100,
+            track_artist_ids=[100, 100, 100, 100],
+        )
+
+        album_info = plugin.album_for_id("1")
+
+        assert album_info is not None
+        assert album_info.va is False
+        assert album_info.artist == "Artist 100"

--- a/test/plugins/test_deezer.py
+++ b/test/plugins/test_deezer.py
@@ -1,25 +1,20 @@
-from __future__ import annotations
-
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import pytest
 
 from beets.library import Item
 from beetsplug.deezer import DeezerPlugin
 
-if TYPE_CHECKING:
-    from requests_mock import Mocker
-
 JSONDict = dict[str, Any]
 
 
 @pytest.fixture
-def plugin() -> DeezerPlugin:
+def plugin():
     return DeezerPlugin()
 
 
 class TestSearchQuery:
-    def test_track_query_is_free_text(self, plugin: DeezerPlugin) -> None:
+    def test_track_query_is_free_text(self, plugin):
         query, filters = plugin.get_search_query_with_filters(
             "track", [Item()], "Artist", "Title", False
         )
@@ -27,18 +22,14 @@ class TestSearchQuery:
         assert query == "Title Artist"
         assert filters == {}
 
-    def test_track_query_tolerates_missing_artist(
-        self, plugin: DeezerPlugin
-    ) -> None:
+    def test_track_query_tolerates_missing_artist(self, plugin):
         query, _ = plugin.get_search_query_with_filters(
             "track", [Item()], "", "Title", False
         )
 
         assert query == "Title"
 
-    def test_album_query_filters_on_album_and_artist(
-        self, plugin: DeezerPlugin
-    ) -> None:
+    def test_album_query_filters_on_album_and_artist(self, plugin):
         query, filters = plugin.get_search_query_with_filters(
             "album", [Item()], "Artist", "Album", False
         )
@@ -46,9 +37,7 @@ class TestSearchQuery:
         assert query == 'album:"Album" artist:"Artist"'
         assert filters == {}
 
-    def test_album_query_omits_artist_for_various_artists(
-        self, plugin: DeezerPlugin
-    ) -> None:
+    def test_album_query_omits_artist_for_various_artists(self, plugin):
         query, _ = plugin.get_search_query_with_filters(
             "album", [Item()], "Various Artists", "Album", True
         )
@@ -70,7 +59,7 @@ def make_track(artist_id: int, position: int) -> JSONDict:
 
 
 class TestGetTrack:
-    def track_data(self, **fields) -> JSONDict:
+    def track_data(self, **fields):
         return {
             "id": 1,
             "title": "Title",
@@ -79,9 +68,7 @@ class TestGetTrack:
             **fields,
         }
 
-    def test_uses_contributors_when_artist_is_missing(
-        self, plugin: DeezerPlugin
-    ) -> None:
+    def test_uses_contributors_when_artist_is_missing(self, plugin):
         track = plugin._get_track(
             self.track_data(contributors=[{"id": 2, "name": "Artist"}])
         )
@@ -89,9 +76,7 @@ class TestGetTrack:
         assert track.artist == "Artist"
         assert track.artist_id == "2"
 
-    def test_falls_back_to_artist_without_contributors(
-        self, plugin: DeezerPlugin
-    ) -> None:
+    def test_falls_back_to_artist_without_contributors(self, plugin):
         track = plugin._get_track(
             self.track_data(artist={"id": 2, "name": "Artist"})
         )
@@ -99,9 +84,7 @@ class TestGetTrack:
         assert track.artist == "Artist"
         assert track.artist_id == "2"
 
-    def test_tolerates_missing_artist_and_contributors(
-        self, plugin: DeezerPlugin
-    ) -> None:
+    def test_tolerates_missing_artist_and_contributors(self, plugin):
         track = plugin._get_track(self.track_data())
 
         assert track.artist is None
@@ -131,11 +114,11 @@ class TestVariousArtistsDetection:
 
     def mock_album(
         self,
-        requests_mock: Mocker,
-        album_artist_id: int,
-        track_artist_ids: list[int],
-        contributor_ids: list[int] | None = None,
-    ) -> None:
+        requests_mock,
+        album_artist_id,
+        track_artist_ids,
+        contributor_ids=None,
+    ):
         """Mock the album and album-tracks endpoints for album id 1.
 
         ``contributor_ids`` overrides the album-level contributors, which
@@ -159,9 +142,7 @@ class TestVariousArtistsDetection:
             },
         )
 
-    def test_compilation_with_non_va_album_artist(
-        self, plugin: DeezerPlugin, requests_mock: Mocker
-    ) -> None:
+    def test_compilation_with_non_va_album_artist(self, plugin, requests_mock):
         # Album credited to a single "main" artist that performs on only one
         # of many tracks: this is a compilation and should be flagged as VA.
         self.mock_album(
@@ -176,9 +157,7 @@ class TestVariousArtistsDetection:
         assert album_info.va is True
         assert album_info.artist == "Various Artists"
 
-    def test_plurality_artist_album_not_va(
-        self, plugin: DeezerPlugin, requests_mock: Mocker
-    ) -> None:
+    def test_plurality_artist_album_not_va(self, plugin, requests_mock):
         # Album whose main artist performs on 2 of 5 tracks (40%) is above
         # the importer's single-artist threshold and stays single-artist.
         self.mock_album(
@@ -194,9 +173,7 @@ class TestVariousArtistsDetection:
         assert album_info.va is False
         assert album_info.artist == "Artist 100"
 
-    def test_single_artist_album_not_va(
-        self, plugin: DeezerPlugin, requests_mock: Mocker
-    ) -> None:
+    def test_single_artist_album_not_va(self, plugin, requests_mock):
         # Album whose main artist performs on every track is not a compilation.
         self.mock_album(
             requests_mock,

--- a/test/plugins/test_deezer.py
+++ b/test/plugins/test_deezer.py
@@ -1,0 +1,93 @@
+"""Tests for the 'deezer' plugin"""
+
+import responses
+
+from beets.test.helper import PluginTestCase
+from beetsplug import deezer
+
+
+def _album_payload(album_artist_id, track_artist_ids):
+    """Build minimal Deezer album and tracks payloads.
+
+    ``album_artist_id`` is the release's "main" artist; ``track_artist_ids``
+    lists the primary artist of each track.
+    """
+    contributor_ids = dict.fromkeys([album_artist_id, *track_artist_ids])
+    album = {
+        "title": "Some Album",
+        "link": "https://www.deezer.com/album/1",
+        "record_type": "album",
+        "label": "Some Label",
+        "release_date": "2017-01-01",
+        "artist": {"id": album_artist_id, "name": f"Artist {album_artist_id}"},
+        "contributors": [
+            {"id": aid, "name": f"Artist {aid}"} for aid in contributor_ids
+        ],
+        "cover_xl": None,
+    }
+    tracks = {
+        "data": [
+            {
+                "title": f"Track {i}",
+                "id": 1000 + i,
+                "link": f"https://www.deezer.com/track/{1000 + i}",
+                "duration": 200,
+                "track_position": i,
+                "disk_number": 1,
+                "artist": {"id": aid, "name": f"Artist {aid}"},
+            }
+            for i, aid in enumerate(track_artist_ids, start=1)
+        ]
+    }
+    return album, tracks
+
+
+class DeezerPluginTest(PluginTestCase):
+    plugin = "deezer"
+
+    def setUp(self):
+        super().setUp()
+        self.deezer = deezer.DeezerPlugin()
+
+    def _mock_album(self, album_id, album, tracks):
+        responses.add(
+            responses.GET,
+            f"{deezer.DeezerPlugin.album_url}{album_id}",
+            json=album,
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            f"{deezer.DeezerPlugin.album_url}{album_id}/tracks",
+            json=tracks,
+            status=200,
+        )
+
+    @responses.activate
+    def test_compilation_with_non_va_album_artist(self):
+        # Album credited to a single "main" artist that performs on only one
+        # of many tracks: this is a compilation and should be flagged as VA.
+        album, tracks = _album_payload(
+            album_artist_id=100, track_artist_ids=[100, 200, 300, 400, 500, 600]
+        )
+        self._mock_album("1", album, tracks)
+
+        album_info = self.deezer.album_for_id("1")
+
+        assert album_info is not None
+        assert album_info.va is True
+        assert album_info.artist == "Various Artists"
+
+    @responses.activate
+    def test_single_artist_album_not_va(self):
+        # Album whose main artist performs on every track is not a compilation.
+        album, tracks = _album_payload(
+            album_artist_id=100, track_artist_ids=[100, 100, 100, 100]
+        )
+        self._mock_album("1", album, tracks)
+
+        album_info = self.deezer.album_for_id("1")
+
+        assert album_info is not None
+        assert album_info.va is False
+        assert album_info.artist == "Artist 100"

--- a/test/plugins/test_deezer.py
+++ b/test/plugins/test_deezer.py
@@ -6,13 +6,15 @@ from beets.test.helper import PluginTestCase
 from beetsplug import deezer
 
 
-def _album_payload(album_artist_id, track_artist_ids):
+def _album_payload(album_artist_id, track_artist_ids, contributor_ids=None):
     """Build minimal Deezer album and tracks payloads.
 
     ``album_artist_id`` is the release's "main" artist; ``track_artist_ids``
-    lists the primary artist of each track.
+    lists the primary artist of each track. ``contributor_ids`` overrides the
+    album-level contributors, which otherwise cover every artist involved.
     """
-    contributor_ids = dict.fromkeys([album_artist_id, *track_artist_ids])
+    if contributor_ids is None:
+        contributor_ids = dict.fromkeys([album_artist_id, *track_artist_ids])
     album = {
         "title": "Some Album",
         "link": "https://www.deezer.com/album/1",
@@ -77,6 +79,23 @@ class DeezerPluginTest(PluginTestCase):
         assert album_info is not None
         assert album_info.va is True
         assert album_info.artist == "Various Artists"
+
+    @responses.activate
+    def test_plurality_artist_album_not_va(self):
+        # Album whose main artist performs on 2 of 5 tracks (40%) is above
+        # the importer's single-artist threshold and stays single-artist.
+        album, tracks = _album_payload(
+            album_artist_id=100,
+            track_artist_ids=[100, 100, 200, 300, 400],
+            contributor_ids=[100],
+        )
+        self._mock_album("1", album, tracks)
+
+        album_info = self.deezer.album_for_id("1")
+
+        assert album_info is not None
+        assert album_info.va is False
+        assert album_info.artist == "Artist 100"
 
     @responses.activate
     def test_single_artist_album_not_va(self):


### PR DESCRIPTION
## Description

Fixes #4057.

Deezer credits some compilations to a single "main" artist instead of the Various Artists entity, so beets never flagged them as VA and ended up dumping every track artist into the album artist field. This treats a release as a compilation when its album artist only performs on a minority of the tracks, in addition to the existing Various Artists id check.

Added two tests for the deezer plugin (a compilation credited to a single artist, and a normal single-artist album that should not be flagged); both pass locally.

## To Do

- [x] ~Documentation.~ No user-facing options changed.
- [x] Changelog.
- [x] Tests.
