### PR TITLE
Fix queries for flexible attributes with uppercase names

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -466,9 +466,9 @@ class Model(ABC, Generic[D]):
         # attributes are stored with their case preserved, so fall back to a
         # case-insensitive lookup.
         lower_key = key.lower()
-        for flex_key in self._values_flex:
-            if flex_key.lower() == lower_key:
-                return self._values_flex[flex_key]
+        flex_keys = {k.lower(): k for k in self._values_flex}
+        if lower_key in flex_keys:
+            return self._values_flex[flex_keys[lower_key]]
         if raise_:
             raise KeyError(key)
         return default

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -462,6 +462,13 @@ class Model(ABC, Generic[D]):
             return self._type(key).null
         if key in self._values_flex:  # Flexible.
             return self._values_flex[key]
+        # Field names are lowercased when queries are parsed, while flexible
+        # attributes are stored with their case preserved, so fall back to a
+        # case-insensitive lookup.
+        lower_key = key.lower()
+        for flex_key in self._values_flex:
+            if flex_key.lower() == lower_key:
+                return self._values_flex[flex_key]
         if raise_:
             raise KeyError(key)
         return default

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -36,6 +36,11 @@ Bug fixes
 - :doc:`plugins/lyrics`: ``beet lyrics`` no longer crashes with an
   ``AttributeError`` on tracks that have no stored lyrics when ``force`` is
   enabled; a missing lyrics body is now treated as empty text. :bug:`6860`
+- Flexible attributes whose names contain uppercase characters (for example
+  ``beet import --set Tag_With_Uppercase=true``) can now be found by queries.
+  Field names are lowercased when a query is parsed, so such attributes could
+  never be matched; flexible attribute lookups now fall back to a
+  case-insensitive key match. :bug:`4565`
 
 ..
     For plugin developers

--- a/test/dbcore/test_query.py
+++ b/test/dbcore/test_query.py
@@ -86,6 +86,7 @@ class TestGet:
             comp=False,
             genres=["Hard Rock"],
             comments="caf\xe9",
+            Flex_Attr="flex",
         )
 
         return helper.lib
@@ -115,6 +116,8 @@ class TestGet:
             ("comments:caf\xe9", ["third"]),
             ("comp:true", ["first", "second"]),
             ("comp:false", ["third"]),
+            ("flex_attr:flex", ["third"]),
+            ("Flex_Attr:flex", ["third"]),
             ("genres:=rock", ["first"]),
             ("genres:=Rock", ["second"]),
             ('genres:="Hard Rock"', ["third"]),


### PR DESCRIPTION
## Description

Fixes #4565.

Field names are lowercased when a query is parsed, but flexible attributes keep the case they were stored with, so an attribute set with uppercase characters can never be matched:

```
$ beet import --set Tag_With_Uppercase=true /some/album
$ beet ls Tag_With_Uppercase:true    # no results
$ beet ls tag_with_uppercase:true    # no results
```

`Model._get` now falls back to a case-insensitive lookup over the flexible attributes when the exact key misses, so both spellings above find the item. An exact-case match still takes precedence if two attributes differ only in case.

The new cases in `test/dbcore/test_query.py` fail without the fix, and the dbcore query tests pass with it.

## To Do

- [x] ~Documentation.~ (bug fix, nothing to document)
- [x] Changelog.
- [x] Tests.