### PR TITLE
musicbrainz: fetch composer/lyricist aliases

### DIFF
--- a/beetsplug/_utils/musicbrainz.py
+++ b/beetsplug/_utils/musicbrainz.py
@@ -700,6 +700,11 @@ class MusicBrainzAPI(RequestHandler):
         """Retrieve a work by its MusicBrainz ID."""
         return self._lookup("work", id_, **kwargs)
 
+    def get_artist(self, id_: str, **kwargs: Unpack[LookupKwargs]) -> Artist:
+        """Retrieve an artist by its MusicBrainz ID."""
+        kwargs.setdefault("includes", ["aliases"])
+        return self._lookup("artist", id_, **kwargs)
+
     @require_one_of("artist", "collection", "release", "work")
     def browse_recordings(
         self, **kwargs: Unpack[BrowseRecordingsKwargs]

--- a/beetsplug/musicbrainz.py
+++ b/beetsplug/musicbrainz.py
@@ -267,6 +267,26 @@ class MusicBrainzPlugin(
     def aliases_as_credits(self) -> bool:
         return self.config["aliases_as_credits"].get(bool)
 
+    @cached_property
+    def _artist_alias_cache(self) -> dict[str, Alias | None]:
+        return {}
+
+    def _fetch_artist_alias(self, artist_id: str) -> Alias | None:
+        """Look up an artist's preferred alias via a dedicated API call.
+
+        Composer/lyricist relations don't carry alias data inline the way
+        artist-credits do. This fetches that info with a separate artist
+        lookup. Results are cached per artist ID.
+        """
+        if artist_id not in self._artist_alias_cache:
+            alias = None
+            with suppress(HTTPNotFoundError):
+                artist = self.mb_api.get_artist(artist_id)
+                alias = _preferred_alias(artist.get("aliases", []))
+            self._artist_alias_cache[artist_id] = alias
+
+        return self._artist_alias_cache[artist_id]
+
     def __init__(self) -> None:
         """Set up the python-musicbrainz-ngs module according to settings
         from the beets configuration. This should be called at startup.
@@ -356,21 +376,27 @@ class MusicBrainzPlugin(
             "artists_credit": artists_credit,
         }
 
-    @staticmethod
     def _parse_work_relations(
-        relations: list[WorkRelation],
+        self, relations: list[WorkRelation]
     ) -> WorkRelationsInfo:
         """Extract composer and lyricist credits from work relations.
 
         Traverses performance-type relations to collect associated artist
         credits, separating them into composers and lyricists along with
         their MusicBrainz IDs and sort names.
+
+        MusicBrainz's API doesn't expose alias data on relation targets
+        (unlike artist-credits), so when the user has configured preferred
+        languages, a dedicated per-artist lookup (cached, see
+        `_fetch_artist_alias`) fills that gap.
         """
         lyricists: list[str] = []
         lyricists_ids: list[str] = []
         composers: list[str] = []
         composers_ids: list[str] = []
         composer_sort: list[str] = []
+
+        languages = config["import"]["languages"].as_str_seq()
 
         artist_relations = [
             ar
@@ -379,14 +405,20 @@ class MusicBrainzPlugin(
             for ar in r["work"].get("artist_relations", [])
         ]
         for artist_relation in artist_relations:
+            artist = artist_relation["artist"]
+            alias = _preferred_alias(artist.get("aliases", []))
+            if not alias and languages:
+                alias = self._fetch_artist_alias(artist["id"])
+            artist_object = alias or artist
+
             rel_type = artist_relation["type"]
             if rel_type == "lyricist":
-                lyricists.append(artist_relation["artist"]["name"])
-                lyricists_ids.append(artist_relation["artist"]["id"])
+                lyricists.append(artist_object["name"])
+                lyricists_ids.append(artist["id"])
             elif rel_type == "composer":
-                composers.append(artist_relation["artist"]["name"])
-                composers_ids.append(artist_relation["artist"]["id"])
-                composer_sort.append(artist_relation["artist"]["sort_name"])
+                composers.append(artist_object["name"])
+                composers_ids.append(artist["id"])
+                composer_sort.append(artist_object["sort_name"])
 
         return {
             # TODO: double-check if we should really use the last work here

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -50,6 +50,12 @@ Bug fixes
   relevance order and truncated to ``search_limit``. For artists with more
   releases than that window, the track being imported was never among the
   candidates offered.
+- :doc:`plugins/musicbrainz`: Composer and lyricist names now respect the
+  ``import.languages`` preferred-alias setting, the same way artist names
+  already did. Unlike artist credits, MusicBrainz's API doesn't include alias
+  data on composer/lyricist relations, so this requires an extra, cached,
+  per-artist lookup; it only runs for users who've configured
+  ``import.languages``. :bug:`5885`
 
 ..
     For plugin developers

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -760,8 +760,8 @@ MusicBrainz. You can use a space-separated list of language abbreviations, like
 ``en jp es``, to specify a preference order. Defaults to an empty list, meaning
 that no language is preferred.
 
-The alias is used for artist name, track title, release group title and album
-title.
+The alias is used for artist name, composer and lyricist names, track title,
+release group title and album title.
 
 .. _ignored_alias_types:
 

--- a/test/plugins/test_musicbrainz.py
+++ b/test/plugins/test_musicbrainz.py
@@ -11,6 +11,7 @@ import requests
 from beets.library import Item
 from beets.test.helper import PluginMixin
 from beetsplug import musicbrainz
+from beetsplug._utils.requests import HTTPNotFoundError
 from beetsplug.musicbrainz import MusicBrainzPlugin
 
 from .factories import musicbrainz as factories
@@ -280,6 +281,138 @@ class TestParseRecording(MusicBrainzPluginTestMixin):
             "work": "WORK TITLE",
             "work_disambig": None,
         }
+
+    def test_composer_lyricist_fetches_alias_when_not_inline(self, config, mb):
+        """The real-world case: MusicBrainz doesn't include alias data on
+        work-relation artists, so beets must fetch it separately, once per
+        distinct artist ID (cached), and only when languages are actually
+        configured.
+        """
+        config["import"]["languages"] = ["en"]
+
+        # Same artist (index=6) credited as both composer and lyricist, to
+        # verify the fetch is cached rather than repeated per relation.
+        recording = recording_factory(
+            work_relations=[
+                {
+                    "type": "performance",
+                    "work": {
+                        "id": "WORK ID",
+                        "title": "WORK TITLE",
+                        "artist_relations": [
+                            artist_relation_factory(
+                                type="composer",
+                                artist__index=6,
+                                artist__name="Recording Composer",
+                                artist__aliases=[],
+                            ),
+                            artist_relation_factory(
+                                type="lyricist",
+                                artist__index=6,
+                                artist__name="Recording Composer",
+                                artist__aliases=[],
+                            ),
+                        ],
+                    },
+                }
+            ]
+        )
+
+        fetched_ids = []
+
+        def fake_get_artist(artist_id, **kwargs):
+            fetched_ids.append(artist_id)
+            return {
+                "id": artist_id,
+                "name": "Recording Composer",
+                "sort_name": "Composer, Recording",
+                "aliases": [
+                    alias_factory(
+                        prefix="Recording Composer", locale="en", primary=True
+                    )
+                ],
+            }
+
+        mb.mb_api.get_artist = fake_get_artist
+
+        d = mb.track_info(recording)
+
+        assert d["composers"] == ["Recording Composer Alias en"]
+        assert d["composer_sort"] == "Recording Composer Alias en, The"
+        assert d["lyricists"] == ["Recording Composer Alias en"]
+        # Same artist ID for both relations -> fetched once, not twice.
+        assert fetched_ids == ["00000000-0000-0000-0000-000000000006"]
+
+    def test_composer_lyricist_alias_fetch_skipped_without_languages(self, mb):
+        """No import.languages configured -> no alias lookup is attempted
+        at all, not even a wasted network call.
+        """
+        recording = recording_factory(
+            work_relations=[
+                {
+                    "type": "performance",
+                    "work": {
+                        "id": "WORK ID",
+                        "title": "WORK TITLE",
+                        "artist_relations": [
+                            artist_relation_factory(
+                                type="composer",
+                                artist__index=6,
+                                artist__name="Recording Composer",
+                                artist__aliases=[],
+                            )
+                        ],
+                    },
+                }
+            ]
+        )
+
+        def fail_get_artist(*args, **kwargs):
+            raise AssertionError(
+                "get_artist should not be called without import.languages"
+            )
+
+        mb.mb_api.get_artist = fail_get_artist
+
+        d = mb.track_info(recording)
+
+        assert d["composers"] == ["Recording Composer"]
+
+    def test_composer_lyricist_alias_fetch_not_found(self, config, mb):
+        """A 404 while fetching a composer's aliases (e.g. an artist merged
+        or removed on MusicBrainz) falls back to the raw name instead of
+        failing the import.
+        """
+        config["import"]["languages"] = ["en"]
+
+        recording = recording_factory(
+            work_relations=[
+                {
+                    "type": "performance",
+                    "work": {
+                        "id": "WORK ID",
+                        "title": "WORK TITLE",
+                        "artist_relations": [
+                            artist_relation_factory(
+                                type="composer",
+                                artist__index=6,
+                                artist__name="Recording Composer",
+                                artist__aliases=[],
+                            )
+                        ],
+                    },
+                }
+            ]
+        )
+
+        def raise_not_found(*args, **kwargs):
+            raise HTTPNotFoundError()
+
+        mb.mb_api.get_artist = raise_not_found
+
+        d = mb.track_info(recording)
+
+        assert d["composers"] == ["Recording Composer"]
 
 
 class TestParseMedia(MusicBrainzPluginTestMixin):


### PR DESCRIPTION
## Description

Composer and lyrcist names were always read from the raw musicbrainz name, even when a preferred language was set. Because musicbrainz API doesn't include aliases for these credits, we need a per-artist lookup. This adds that, made to only run when `import.languages` is set up.

Worth noting that this comes at a cost! Additional API requests could slow things down, particularly if there are many different composers or lyricists.

Fixes #5885.

## To Do

- [x] Documentation.
- [x] Changelog.
- [x] Tests.