### PR TITLE
fix(tidal): honor search_limit when searching albums and tracks

### DIFF
--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -174,6 +174,7 @@ class TidalPlugin(MetadataSourcePlugin):
 
     def search_tracks_by_query(self, query: str) -> Iterable[TrackInfo]:
         """Search for tracks given a string query."""
+        limit = self.config["search_limit"].get(int)
         search_doc = self.api.search_results(query, include=["tracks.artists"])
         track_by_id: dict[str, TidalTrack] = {
             item["id"]: item
@@ -185,7 +186,9 @@ class TidalPlugin(MetadataSourcePlugin):
             for item in search_doc.get("included", [])
             if item["type"] == "artists"
         }
-        for track_rel in search_doc["data"]["relationships"]["tracks"]["data"]:
+        for track_rel in search_doc["data"]["relationships"]["tracks"]["data"][
+            :limit
+        ]:
             if track := track_by_id.get(track_rel["id"]):
                 yield self._get_track_info(track, artist_by_id=artist_by_id)
             else:
@@ -195,6 +198,7 @@ class TidalPlugin(MetadataSourcePlugin):
 
     def search_albums_by_query(self, query: str) -> Iterable[AlbumInfo]:
         """Search for album given a string query."""
+        limit = self.config["search_limit"].get(int)
         search_doc = self.api.search_results(
             query,
             include=["albums"],
@@ -206,7 +210,7 @@ class TidalPlugin(MetadataSourcePlugin):
             album_rel["id"]
             for album_rel in search_doc["data"]["relationships"]["albums"][
                 "data"
-            ]
+            ][:limit]
         ]
         yield from filter(None, self.search_albums_by_ids(tidal_ids=album_ids))
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,9 @@ New features
 Bug fixes
 ~~~~~~~~~
 
+- :doc:`plugins/tidal`: The ``search_limit`` option is now honored when
+  searching for albums and tracks; search candidates are capped at the
+  configured limit instead of returning the full result set. :bug:`6770`
 - Add ``editor`` config option to allow users to permanently set their preferred
   editor, overriding ``$VISUAL`` and ``$EDITOR`` environment variables.
   :bug:`6641`

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -725,6 +725,85 @@ class TestItemCandidates(TidalPluginTest):
         assert results[0].title == "Query Track"
 
 
+class TestSearchLimit(TidalPluginTest):
+    """Tests for the ``search_limit`` configuration."""
+
+    def test_tracks_by_query_respects_search_limit(self):
+        search_doc = {
+            "data": {
+                "relationships": {
+                    "tracks": {
+                        "data": [
+                            {"id": "1", "type": "tracks"},
+                            {"id": "2", "type": "tracks"},
+                            {"id": "3", "type": "tracks"},
+                        ]
+                    }
+                }
+            },
+            "included": [
+                _make_track("1", "Track One", "PT3M", "ISRC001", ["1001"]),
+                _make_track("2", "Track Two", "PT3M", "ISRC002", ["1001"]),
+                _make_track("3", "Track Three", "PT3M", "ISRC003", ["1001"]),
+                _make_artist("1001", "Query Artist"),
+            ],
+        }
+        self.tidal.api.search_results = Mock(return_value=search_doc)
+
+        with self.configure_plugin({"search_limit": 1}):
+            results = list(self.tidal.search_tracks_by_query("Query Song"))
+
+        assert len(results) == 1
+        assert results[0].title == "Track One"
+
+    def test_albums_by_query_respects_search_limit(self):
+        tracks = [
+            _make_track("101", "Album Track", "PT3M", "ISRC001", ["1001"]),
+            _make_track("102", "Album Track", "PT3M", "ISRC002", ["1001"]),
+            _make_track("103", "Album Track", "PT3M", "ISRC003", ["1001"]),
+        ]
+        albums = [
+            _make_album("1", "Album One", [tracks[0]], ["1001"]),
+            _make_album("2", "Album Two", [tracks[1]], ["1001"]),
+            _make_album("3", "Album Three", [tracks[2]], ["1001"]),
+        ]
+        search_doc = {
+            "data": {
+                "relationships": {
+                    "albums": {
+                        "data": [
+                            {"id": "1", "type": "albums"},
+                            {"id": "2", "type": "albums"},
+                            {"id": "3", "type": "albums"},
+                        ]
+                    }
+                }
+            }
+        }
+        self.tidal.api.search_results = Mock(return_value=search_doc)
+        self.tidal.api.get_albums = Mock(
+            return_value={
+                "data": [album for album, _, _ in albums],
+                "included": [
+                    *tracks,
+                    *[
+                        artist
+                        for _, _, artist_lookup in albums
+                        for artist in artist_lookup.values()
+                    ],
+                ],
+            }
+        )
+
+        with self.configure_plugin({"search_limit": 1}):
+            results = list(self.tidal.search_albums_by_query("Query Album"))
+
+        assert len(results) == 1
+        assert results[0].album == "Album One"
+        # Only the first album ID should be resolved from the search results.
+        assert self.tidal.api.get_albums.call_args.kwargs["ids"] == ["1"]
+
+
 class TestStaticHelpers:
     """Tests for static helper methods."""
 


### PR DESCRIPTION
## What changed

The Tidal plugin now honors the `search_limit` configuration option when
searching for albums and tracks. `search_albums_by_query()` and
`search_tracks_by_query()` read the configured limit and cap the candidate
lists returned by the Tidal search results endpoint, matching the behavior of
the other metadata source plugins.

## Why

`tidal.search_limit` is documented (default 5) but was previously ignored: the
plugin implements its own candidate search path that calls the Tidal API
directly and returns the full result set. Users setting `search_limit: 1` still
received 20+ candidates. See #6770.

## How

The Tidal searchResults API reference does not document a server-side `limit`
parameter, so the candidate relationship lists are truncated client-side to the
configured limit before track/album IDs are resolved. This guarantees the
option is honored regardless of API pagination defaults.

## Testing

- Added `TestSearchLimit` with focused tests for both album and track search
  using `search_limit: 1` in `test/plugins/test_tidal.py`.
- `pytest test/plugins/test_tidal.py`: 49 passed.
- `ruff check`, `ruff format --check`, and `mypy` on the changed module pass.
- Full `test/plugins/` run: 273 passed; the single failure
  (`test_fetchart.py::TestFetchartCli::test_colorization`) is a pre-existing
  environment issue (ANSI color output disabled in the local shell) and also
  fails on `master` without this change.
- Not verified against the live Tidal API (requires Tidal account
  authentication); tests use mocked API responses consistent with the existing
  suite.

Fixes #6770
