### PR TITLE
fix(lyrics): Reject LRCLib records with no lyrics

### DIFF
--- a/beetsplug/_typing.py
+++ b/beetsplug/_typing.py
@@ -18,7 +18,7 @@ class LRCLibAPI:
         albumName: str
         duration: float | None
         instrumental: bool
-        plainLyrics: str
+        plainLyrics: str | None
         syncedLyrics: str | None
 
 

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -260,7 +260,7 @@ class LRCLyrics:
     id: int
     duration: float
     instrumental: bool
-    plain: str
+    plain: str | None
     synced: str | None
 
     def __le__(self, other: LRCLyrics) -> bool:
@@ -308,13 +308,16 @@ class LRCLyrics:
     @cached_property
     def is_valid(self) -> bool:
         """Return whether the lyrics item is valid.
+
         Lyrics duration must be within the tolerance defined by
-        :attr:`DURATION_DIFF_TOLERANCE`.
+        :attr:`DURATION_DIFF_TOLERANCE`, and the item must carry some usable
+        text: LRCLib serves records that have neither plain nor synced lyrics
+        without flagging them as instrumental, and those match nothing.
         """
         return (
             self.duration_dist
             <= self.target_duration * self.DURATION_DIFF_TOLERANCE
-        )
+        ) and bool(self.instrumental or self.plain or self.synced)
 
     @cached_property
     def dist(self) -> tuple[bool, float]:
@@ -337,7 +340,7 @@ class LRCLyrics:
         if want_synced and self.synced:
             return "\n".join(map(str.strip, self.synced.splitlines()))
 
-        return self.plain
+        return self.plain or ""
 
 
 class LRCLib(Backend):

--- a/beetsplug/lyrics.py
+++ b/beetsplug/lyrics.py
@@ -332,13 +332,27 @@ class LRCLyrics:
         """
         return not self.synced, self.duration_dist
 
+    @staticmethod
+    def remove_timestamps(synced: str) -> str:
+        """Return synced lyrics with their LRC timestamps removed."""
+        return "\n".join(
+            m[2]
+            for line in synced.splitlines()
+            if (m := Lyrics.LINE_PARTS_PAT.match(line))
+        )
+
     def get_text(self, want_synced: bool) -> str:
         """Return the preferred text form for this candidate."""
         if self.instrumental:
             return INSTRUMENTAL_LYRICS
 
-        if want_synced and self.synced:
-            return "\n".join(map(str.strip, self.synced.splitlines()))
+        if self.synced:
+            if want_synced:
+                return "\n".join(map(str.strip, self.synced.splitlines()))
+
+            # A record may carry synced lyrics without the plain variant.
+            if not self.plain:
+                return self.remove_timestamps(self.synced)
 
         return self.plain or ""
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -38,6 +38,12 @@ Bug fixes
 - :doc:`plugins/lyrics`: ``beet lyrics`` no longer crashes with an
   ``AttributeError`` on tracks that have no stored lyrics when ``force`` is
   enabled; a missing lyrics body is now treated as empty text. :bug:`6860`
+- :doc:`plugins/lyrics`: LRCLib serves records that carry neither plain nor
+  synced lyrics without flagging them as instrumental. Such a record was
+  accepted as a match and produced lyrics whose body was ``None``, crashing the
+  importer with ``AttributeError: 'NoneType' object has no attribute
+  'splitlines'``. These records are now rejected as matches, so the search falls
+  through to the remaining candidates. :bug:`6888`
 - Flexible attributes whose names contain uppercase characters (for example
   ``beet import --set Tag_With_Uppercase=true``) can now be found by queries.
   Field names are lowercased when a query is parsed, so such attributes could

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -43,7 +43,9 @@ Bug fixes
   accepted as a match and produced lyrics whose body was ``None``, crashing the
   importer with ``AttributeError: 'NoneType' object has no attribute
   'splitlines'``. These records are now rejected as matches, so the search falls
-  through to the remaining candidates. :bug:`6888`
+  through to the remaining candidates. Relatedly, a record that carries only
+  synced lyrics now yields the plain variant with timestamps removed, rather
+  than nothing, when ``synced`` is disabled. :bug:`6888`
 - Flexible attributes whose names contain uppercase characters (for example
   ``beet import --set Tag_With_Uppercase=true``) can now be found by queries.
   Field names are lowercased when a query is parsed, so such attributes could

--- a/test/plugins/lyrics_pages.py
+++ b/test/plugins/lyrics_pages.py
@@ -278,7 +278,7 @@ lyrics_pages = [
         url_title="Lady Madonna - The Beatles - LETRAS.MUS.BR",
     ),
     LyricsPage.make(
-        "https://lrclib.net/api/get/19648857",
+        "https://lrclib.net/api/get/23863037",
         """
         [00:08.35] Lady Madonna, children at your feet
         [00:12.85] Wonder how you manage to make ends meet

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -630,6 +630,11 @@ class TestLRCLibLyrics(LyricsBackendTest):
                 [lyrics_match(instrumental=True)], "", id="instrumental track"
             ),
             pytest.param(
+                [lyrics_match(plainLyrics=None, syncedLyrics=None)],
+                None,
+                id="none: no lyrics and not flagged instrumental",
+            ),
+            pytest.param(
                 [lyrics_match(syncedLyrics=None)],
                 "plain",
                 id="plain by default",

--- a/test/plugins/test_lyrics.py
+++ b/test/plugins/test_lyrics.py
@@ -619,6 +619,20 @@ class TestLRCLibLyrics(LyricsBackendTest):
         assert lyrics.backend == backend_name
 
     @pytest.mark.parametrize(
+        "response_data", [[lyrics_match(plainLyrics=None)]]
+    )
+    @pytest.mark.parametrize("plugin_config", [{"synced": False}])
+    def test_plain_lyrics_derived_from_synced(self, fetch_lyrics):
+        """Derive plain lyrics from the synced text when the record omits them.
+
+        Returning nothing here would hide lyrics the match actually carries.
+        """
+        lyrics = fetch_lyrics()
+
+        assert lyrics
+        assert lyrics.text == "synced"
+
+    @pytest.mark.parametrize(
         "response_data, expected_lyrics",
         [
             pytest.param([], None, id="handle non-matching lyrics"),


### PR DESCRIPTION
## Description

Fixes #6888 

Some records on LRCLib have no lyrics, and aren't marked as instrumental, but are still returned (with a null text). #6864 fixed part of the issue, but didn't handle all of it.

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [ ] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
