### PR TITLE
fix(discogs): retry malformed search responses

### DIFF
--- a/beetsplug/discogs/__init__.py
+++ b/beetsplug/discogs/__init__.py
@@ -292,9 +292,19 @@ class DiscogsPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
 
     def get_search_response(self, params: SearchParams) -> Sequence[IDResponse]:
         """Search Discogs releases and return raw result mappings with IDs."""
-        results = self.discogs_client.search(params.query, **params.filters)
-        results.per_page = params.limit
-        return [r.data for r in results.page(1)]
+
+        def search() -> list[IDResponse]:
+            results = self.discogs_client.search(params.query, **params.filters)
+            results.per_page = params.limit
+            return [r.data for r in results.page(1)]
+
+        try:
+            return search()
+        except json.JSONDecodeError:
+            self._log.debug(
+                "Discogs returned an invalid JSON search response; retrying"
+            )
+            return search()
 
     @cache
     def get_master_year(self, master_id: str) -> int | None:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -54,6 +54,8 @@ Bug fixes
   copyright/rights-statement text verbatim. It's now normalized to a concise
   label name, stripping copyright markers, years, and corporate, licensing, and
   territorial boilerplate. Affects both album and track metadata. :bug:`6796`
+- :doc:`plugins/discogs`: Retry a search once when Discogs returns an invalid
+  JSON response instead of immediately discarding all Discogs candidates.
 
 ..
     For plugin developers

--- a/test/plugins/test_discogs.py
+++ b/test/plugins/test_discogs.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
 
 import pytest
 from discogs_client import Client, Release
 
 from beets import config
 from beets.library import Item
+from beets.metadata_plugins import SearchParams
 from beets.test.helper import TestHelper
 from beetsplug.discogs import ArtistState, DiscogsPlugin
 
@@ -496,6 +499,41 @@ class TestDGSearchQuery(TestHelper):
         # Catalog number should have whitespace removed.
         assert filters["catno"] == "ABC123"
         config["discogs"]["extra_tags"] = []
+
+
+class TestDGSearchResponse(DiscogsTestMixin):
+    @staticmethod
+    def _decode_error():
+        return json.JSONDecodeError("Expecting value", "", 0)
+
+    @pytest.fixture
+    def params(self):
+        return SearchParams("album", "Album", {"type": "release"}, 5)
+
+    @pytest.fixture
+    def client(self, plugin):
+        plugin.discogs_client = MagicMock()
+        return plugin.discogs_client
+
+    def test_retries_invalid_json_response(self, plugin, client, params):
+        result = MagicMock(data={"id": 123})
+        results = client.search.return_value
+        results.page.side_effect = [self._decode_error(), [result]]
+
+        assert plugin.get_search_response(params) == [{"id": 123}]
+        assert client.search.call_count == 2
+        assert results.page.call_count == 2
+        assert results.per_page == params.limit
+
+    def test_raises_after_invalid_json_retry(self, plugin, client, params):
+        results = client.search.return_value
+        results.page.side_effect = [self._decode_error(), self._decode_error()]
+
+        with pytest.raises(json.JSONDecodeError):
+            plugin.get_search_response(params)
+
+        assert client.search.call_count == 2
+        assert results.page.call_count == 2
 
 
 class TestAnv:


### PR DESCRIPTION
## Summary

Retry Discogs searches once when the API returns an invalid JSON response. If the retry also fails, flow through existing error handling. Includes regression tests for successful recovery and retry exhaustion.

Reference: https://github.com/joalla/discogs_client/issues/163

Originating stack trace:

```
discogs: Error searching Discogs: Expecting value: line 1 column 1 (char 0)
Traceback (most recent call last):
  File "/usr/local/lib/python3.14/site-packages/beets/metadata_plugins.py", line 420, in _search_api
    response_data = self.get_search_response(params)
  File "/usr/local/lib/python3.14/site-packages/beetsplug/discogs/__init__.py", line 297, in get_search_response
    return [r.data for r in results.page(1)]
                            ~~~~~~~~~~~~^^^
  File "/usr/local/lib/python3.14/site-packages/discogs_client/models.py", line 347, in page
    data = self.client._get(self._url_for_page(index))
  File "/usr/local/lib/python3.14/site-packages/discogs_client/client.py", line 115, in _get
    return self._request('GET', url)
           ~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/site-packages/discogs_client/client.py", line 107, in _request
    body = json.loads(content)
  File "/usr/local/lib/python3.14/json/__init__.py", line 352, in loads
    return _default_decoder.decode(s)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^
  File "/usr/local/lib/python3.14/json/decoder.py", line 345, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.14/json/decoder.py", line 363, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

## Testing

- Full test suite on Python 3.14
- Ruff, mypy, and Sphinx lint

## To Do

<!--
- If you believe one of below checkpoints is not required for the change you
  are submitting, cross it out and check the box nonetheless to let us know.
  For example: - [x] ~Changelog~
- Regarding the changelog, often it makes sense to add your entry only once
  reviewing is finished. That way you might prevent conflicts from other PR's in
  that file, as well as keep the chance high your description fits with the
  latest revision of your feature/fix.
- Regarding documentation, bugfixes often don't require additions to the docs.
- Please remove the descriptive sentences in braces from the enumeration below,
  which helps to unclutter your PR description.
-->

- [x] ~~Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)~~
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
