### PR TITLE
Fix list command query reference

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -50,6 +50,8 @@ Bug fixes
   relevance order and truncated to ``search_limit``. For artists with more
   releases than that window, the track being imported was never among the
   candidates offered.
+- :doc:`reference/cli`: The ``beet list`` query reference now uses clearer link
+  text in the generated man page. :bug:`3203`
 
 ..
     For plugin developers

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -206,7 +206,7 @@ list
 Want to search for "Gronlandic Edit" by of Montreal? Try ``beet list
 gronlandic``. Maybe you want to see everything released in 2009 with
 "vegetables" in the title? Try ``beet list year:2009 title:vegetables``. You can
-also specify the sort order. (Read more in :doc:`query`.)
+also specify the sort order. (Read more in :doc:`Queries <query>`.)
 
 You can use the ``-a`` switch to search for albums instead of individual items.
 In this case, the queries you use are restricted to album-level fields: for


### PR DESCRIPTION
Fixes #3203.

The list command docs used the target name as the visible text for the query docs link. In the generated man page, that reads as "Read more in query", which does not point to a clear section.

This keeps the same target but uses clearer link text for the query documentation.

Tested with:

```console
Not run: Sphinx is not installed in my local environment.
```