### PR TITLE
typing: type utils and modules that are mostly missing annotations

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -283,3 +283,19 @@ e9021e17e9f14af8b4805ce1ec7f32843ada7970
 dcc1fd0e4a3e7137d126f224d8f5d9911291652e
 # typing: add types to event handlers
 5039c8f6cff474bec54b2106dd7c7d0cd39878f2
+# typing: make dbcore.db.Results a Sequence
+9adcb601f86b8758cb179ac5d39ca4857846cb27
+# typing: add types to embedart
+26713de0d64b8412ac922d0402929504f6f3c6c7
+# typing: add types to beetsplug._utils.art
+6acef1d5864716300f2c4add4e19cc6e737cce46
+# typing: add types to beets.ui.import_
+2a9786aad7bc8114276e1fda2a3d141abf2608f3
+# typing: add types to beets.util.functemplate
+d8fc064e9c3b428ee6aad5f50d34dc66aba742f2
+# typing: remove redundant types
+f37306b0cc17f17291ea5010178f190a95b29fd5
+# Prefer imports from modules that provide import aliases
+27900f58fbeba06483b77c677045ad1df8e9af45
+# typing: rename AnyLibModel -> AlbumOrItem
+33a01fe0b37942a38c8b88d0fc8167edd02ca81b

--- a/beets/autotag/distance.py
+++ b/beets/autotag/distance.py
@@ -13,7 +13,7 @@ from beets.util import as_string, cached_classproperty
 from beets.util.color import colorize
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, KeysView, Sequence
+    from collections.abc import Iterator, KeysView
 
     from beets.library import Item
     from beets.util import Likelies
@@ -454,7 +454,7 @@ def distance(
     # Current or preferred media.
     if album_info.media:
         # Preferred media options.
-        media_patterns: Sequence[str] = preferred_config["media"].as_str_seq()
+        media_patterns = preferred_config["media"].as_str_seq()
         options = [
             re.compile(rf"(\d+x)?({pat})", re.I) for pat in media_patterns
         ]
@@ -493,7 +493,7 @@ def distance(
             dist.add("year", 1.0)
 
     # Preferred countries.
-    country_patterns: Sequence[str] = preferred_config["countries"].as_str_seq()
+    country_patterns = preferred_config["countries"].as_str_seq()
     options = [re.compile(pat, re.I) for pat in country_patterns]
     if album_info.country and options:
         dist.add_priority("country", album_info.country, options)

--- a/beets/autotag/match.py
+++ b/beets/autotag/match.py
@@ -352,7 +352,7 @@ def _add_candidate(
         return
 
     # Discard matches without required tags.
-    required_tags: Sequence[str] = config["match"]["required"].as_str_seq()
+    required_tags = config["match"]["required"].as_str_seq()
     for req_tag in required_tags:
         if getattr(info, req_tag) is None:
             log.debug("Ignored. Missing required tag: {}", req_tag)
@@ -368,7 +368,7 @@ def _add_candidate(
 
     # Skip matches with ignored penalties.
     penalties = [key for key, _ in dist]
-    ignored_tags: Sequence[str] = config["match"]["ignored"].as_str_seq()
+    ignored_tags = config["match"]["ignored"].as_str_seq()
     for penalty in ignored_tags:
         if penalty in penalties:
             log.debug("Ignored. Penalty: {}", penalty)

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -149,8 +149,8 @@ class FormattedMapping(Mapping[str, str]):
             value = value.decode("utf-8", "ignore")
 
         if self.for_path:
-            sep_repl: str = beets.config["path_sep_replace"].as_str()
-            sep_drive: str = beets.config["drive_sep_replace"].as_str()
+            sep_repl = beets.config["path_sep_replace"].as_str()
+            sep_drive = beets.config["drive_sep_replace"].as_str()
 
             if re.match(r"^[a-zA-Z]:", value):
                 value = re.sub(r"(?<=[a-zA-Z]):", sep_drive, value)

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -11,7 +11,7 @@ import threading
 import time
 from abc import ABC, abstractmethod
 from collections import UserDict, defaultdict
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import cached_property
@@ -26,6 +26,7 @@ from typing import (
     Literal,
     NamedTuple,
     TypedDict,
+    overload,
 )
 
 from typing_extensions import (
@@ -49,7 +50,6 @@ if TYPE_CHECKING:
         Iterable,
         Iterator,
         KeysView,
-        Sequence,
     )
     from sqlite3 import Connection
     from types import TracebackType
@@ -729,7 +729,7 @@ class Model(ABC, Generic[D]):
 AnyModel = TypeVar("AnyModel", bound=Model)
 
 
-class Results(Generic[AnyModel]):
+class Results(Sequence[AnyModel]):
     """An item query result set. Iterating over the collection lazily
     constructs Model objects that reflect database rows.
     """
@@ -868,22 +868,29 @@ class Results(Generic[AnyModel]):
         """Does this result contain any objects?"""
         return bool(len(self))
 
-    def __getitem__(self, n: int) -> AnyModel:
-        """Get the nth item in this result set. This is inefficient: all
-        items up to n are materialized and thrown away.
-        """
+    @overload
+    def __getitem__(self, index: int) -> AnyModel: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> list[AnyModel]: ...
+
+    def __getitem__(self, index: int | slice) -> AnyModel | list[AnyModel]:
+        """Return indexed or sliced objects using standard sequence rules."""
+        if isinstance(index, slice) or index < 0:
+            return list(self)[index]
+
         if not self._rows and not self.sort:
             # Fully materialized and already in order. Just look up the
             # object.
-            return self._objects[n]
+            return self._objects[index]
 
         it = iter(self)
         try:
-            for i in range(n):
+            for _ in range(index):
                 next(it)
             return next(it)
         except StopIteration:
-            raise IndexError(f"result index {n} out of range")
+            raise IndexError(f"result index {index} out of range")
 
     def get(self) -> AnyModel | None:
         """Return the first matching object, or None if no objects

--- a/beets/importer/session.py
+++ b/beets/importer/session.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
     from beets import dbcore, library
     from beets.autotag import AlbumMatch, TrackMatch
-    from beets.library import AnyLibModel
+    from beets.library import AlbumOrItem
     from beets.util import PathBytes
 
     from .tasks import ImportTask, SingletonImportTask
@@ -173,7 +173,7 @@ class ImportSession:
         raise NotImplementedError
 
     def get_duplicate_action(
-        self, task: ImportTask, found_duplicates: list[AnyLibModel]
+        self, task: ImportTask, found_duplicates: list[AlbumOrItem]
     ) -> DuplicateAction:
         """Get the configured duplicate action."""
         choice = config["import"]["duplicate_action"].as_choice(

--- a/beets/importer/session.py
+++ b/beets/importer/session.py
@@ -52,7 +52,7 @@ class ImportSession:
         lib: library.Library,
         loghandler: logging.Handler | None,
         paths: Sequence[PathBytes] | None,
-        query: dbcore.Query | None,
+        query: str | Sequence[str] | dbcore.Query | None = None,
     ) -> None:
         """Create a session.
 

--- a/beets/library/__init__.py
+++ b/beets/library/__init__.py
@@ -2,7 +2,7 @@ from beets.util.deprecation import deprecate_imports
 
 from .exceptions import FileOperationError, ReadError, WriteError
 from .library import Library
-from .models import Album, AnyLibModel, Item, LibModel
+from .models import Album, AlbumOrItem, Item, LibModel
 from .queries import parse_query_parts, parse_query_string
 
 NEW_MODULE_BY_NAME = dict.fromkeys(
@@ -18,7 +18,7 @@ def __getattr__(name: str):
 
 __all__ = [
     "Album",
-    "AnyLibModel",
+    "AlbumOrItem",
     "FileOperationError",
     "Item",
     "LibModel",

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
 
 log = logging.getLogger("beets")
 
-AnyLibModel = TypeVar("AnyLibModel", "Album", "Item")
+AlbumOrItem = TypeVar("AlbumOrItem", "Album", "Item")
 
 
 class LibModel(dbcore.Model["Library"]):

--- a/beets/test/fixtures.py
+++ b/beets/test/fixtures.py
@@ -6,8 +6,8 @@ exercise metadata registration and model integration.
 
 from typing import ClassVar
 
-from beets.dbcore import sort, types
-from beets.dbcore.db import FormattedMapping, Index
+from beets.dbcore import Index, sort, types
+from beets.dbcore.db import FormattedMapping
 from beets.library import LibModel
 from beets.util import cached_classproperty
 from beets.util.artresizer import IMBackend

--- a/beets/test/helper.py
+++ b/beets/test/helper.py
@@ -676,7 +676,7 @@ class ImportSessionFixture(ImportSession):
         assert not isinstance(choice, int), f"Invalid choice: {choice}"
         return choice
 
-    choose_item = choose_match  # type: ignore[assignment]
+    choose_item = choose_match  # type: ignore[arg-type, assignment]
 
 
 class TerminalImportSessionFixture(TerminalImportSession):
@@ -712,7 +712,7 @@ class TerminalImportSessionFixture(TerminalImportSession):
         return super().choose_match(task)
 
     def choose_item(
-        self, task: importer.ImportTask
+        self, task: importer.SingletonImportTask
     ) -> TrackMatch | importer.Action:
         self._add_choice_input()
         return super().choose_item(task)

--- a/beets/ui/commands/import_/__init__.py
+++ b/beets/ui/commands/import_/__init__.py
@@ -114,7 +114,7 @@ def import_func(lib: Library, opts: optparse.Values, args: list[str]) -> None:
             raise UserError("no path specified")
 
         byte_paths = [os.fsencode(p) for p in paths]
-        paths_from_logfiles = [os.fsencode(p) for p in paths_from_logfiles]
+        byte_paths_from_logfiles = [os.fsencode(p) for p in paths_from_logfiles]
 
         # Check the user-specified directories.
         for path in byte_paths:
@@ -127,7 +127,7 @@ def import_func(lib: Library, opts: optparse.Values, args: list[str]) -> None:
         # case those paths don't exist. Maybe some of those paths have already
         # been imported and moved separately, so logging a warning should
         # suffice.
-        for path in paths_from_logfiles:
+        for path in byte_paths_from_logfiles:
             if not os.path.exists(syspath(normpath(path))):
                 log.warning(
                     "No such file or directory: {}", displayable_path(path)
@@ -154,7 +154,7 @@ def _store_dict(
     pairs as values. All such pairs passed for this option are
     aggregated into a dictionary.
     """
-    dest = option.dest
+    dest: str = option.dest  # type: ignore[assignment]
     option_values = getattr(parser.values, dest, None)
 
     if option_values is None:

--- a/beets/ui/commands/import_/__init__.py
+++ b/beets/ui/commands/import_/__init__.py
@@ -1,6 +1,9 @@
 """The `import` command: import new music into the library."""
 
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING
 
 from beets import config, logging, plugins, ui
 from beets.exceptions import UserError
@@ -8,11 +11,18 @@ from beets.util import displayable_path, normpath, syspath
 
 from .session import TerminalImportSession
 
+if TYPE_CHECKING:
+    import optparse
+    from collections.abc import Iterator
+
+    from beets.library import Library
+    from beets.ui import SubcommandsOptionParser
+
 # Global logger.
 log = logging.getLogger("beets")
 
 
-def paths_from_logfile(path):
+def paths_from_logfile(path: str) -> Iterator[str]:
     """Parse the logfile and yield skipped paths to pass to the `import`
     command.
     """
@@ -32,7 +42,7 @@ def paths_from_logfile(path):
             yield os.path.commonpath(paths.split("; "))
 
 
-def parse_logfiles(logfiles):
+def parse_logfiles(logfiles: list[str]) -> Iterator[str]:
     """Parse all `logfiles` and yield paths from it."""
     for logfile in logfiles:
         try:
@@ -47,7 +57,9 @@ def parse_logfiles(logfiles):
             ) from err
 
 
-def import_files(lib, paths: list[bytes], query):
+def import_files(
+    lib: Library, paths: list[bytes], query: list[str] | None
+) -> None:
     """Import the files in the given list of paths or matching the
     query.
     """
@@ -79,7 +91,7 @@ def import_files(lib, paths: list[bytes], query):
     plugins.send("import", lib=lib, paths=paths)
 
 
-def import_func(lib, opts, args: list[str]):
+def import_func(lib: Library, opts: optparse.Values, args: list[str]) -> None:
     config["import"].set_args(opts)
 
     # Special case: --copy flag suppresses import_move (which would
@@ -132,7 +144,12 @@ def import_func(lib, opts, args: list[str]):
     import_files(lib, byte_paths, query)
 
 
-def _store_dict(option, opt_str, value, parser):
+def _store_dict(
+    option: optparse.Option,
+    opt_str: str,
+    value: str,
+    parser: SubcommandsOptionParser,
+) -> None:
     """Custom action callback to parse options which have ``key=value``
     pairs as values. All such pairs passed for this option are
     aggregated into a dictionary.

--- a/beets/ui/commands/import_/display.py
+++ b/beets/ui/commands/import_/display.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     import confuse
 
     from beets.autotag import AlbumMatch, Match, Source, TrackMatch
-    from beets.library.models import Item
+    from beets.library import Item
     from beets.util.color import ColorName
 
 VARIOUS_ARTISTS = "Various Artists"

--- a/beets/ui/commands/import_/session.py
+++ b/beets/ui/commands/import_/session.py
@@ -7,13 +7,12 @@ from typing import TYPE_CHECKING, Literal
 from beets import config, importer, logging, plugins, ui
 from beets.autotag import (
     AlbumMatch,
-    Proposal,
     Recommendation,
     TrackMatch,
     tag_album,
     tag_item,
 )
-from beets.importer import DuplicateAction, SingletonImportTask
+from beets.importer import DuplicateAction, Proposal, SingletonImportTask
 from beets.library import Album
 from beets.util import PromptChoice, displayable_path
 from beets.util.color import colorize
@@ -22,9 +21,12 @@ from beets.util.units import human_bytes, human_seconds_short
 from .display import show_change, show_item_change
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from beets.autotag import Source
     from beets.importer import ImportSession, ImportTask
     from beets.library import AnyLibModel, Item
+    from beets.util import PathBytes
 
 # Global logger.
 log = logging.getLogger("beets")
@@ -33,7 +35,7 @@ log = logging.getLogger("beets")
 class TerminalImportSession(importer.ImportSession):
     """An import session that runs in a terminal."""
 
-    def choose_match(self, task):
+    def choose_match(self, task: ImportTask) -> AlbumMatch | importer.Action:
         """Given an initial autotagging of items, go through an interactive
         dance with the user to ask for a choice of metadata. Returns an
         AlbumMatch object, ASIS, or SKIP.
@@ -105,7 +107,9 @@ class TerminalImportSession(importer.ImportSession):
                 assert isinstance(choice, AlbumMatch)
                 return choice
 
-    def choose_item(self, task):
+    def choose_item(
+        self, task: SingletonImportTask
+    ) -> TrackMatch | importer.Action:
         """Ask the user for a choice about tagging a single item. Returns
         either an action constant or a TrackMatch object.
         """
@@ -194,13 +198,13 @@ class TerminalImportSession(importer.ImportSession):
 
         return action
 
-    def should_resume(self, path):
+    def should_resume(self, path: PathBytes) -> bool:
         return ui.input_yn(
             f"Import of the directory:\n{displayable_path(path)}\n"
             "was interrupted. Resume (Y/n)?"
         )
 
-    def _get_choices(self, task):
+    def _get_choices(self, task: ImportTask) -> list[PromptChoice]:
         """Get the list of prompt choices that should be presented to the
         user. This consists of both built-in choices and ones provided by
         plugins.
@@ -275,7 +279,7 @@ class TerminalImportSession(importer.ImportSession):
         return choices + extra_choices
 
 
-def summarize_items(items, singleton):
+def summarize_items(items: list[Item], singleton: bool) -> str:
     """Produces a brief summary line describing a set of items. Used for
     manually resolving duplicates during import.
 
@@ -353,7 +357,12 @@ def _summary_judgment(rec: Recommendation) -> importer.Action | None:
     return action
 
 
-def choose_candidate(candidates, rec, source: Source, choices=[]):
+def choose_candidate(
+    candidates: Sequence[AlbumMatch | TrackMatch],
+    rec: Recommendation,
+    source: Source,
+    choices: list[PromptChoice] = [],
+) -> AlbumMatch | TrackMatch | PromptChoice:
     """Ask the user for a selection of which candidate to use.
 
     Applies to both full albums and singletons (tracks). Candidates are either
@@ -500,6 +509,6 @@ def manual_id(session: ImportSession, task: ImportTask) -> Proposal:
     return method(task.source, search_ids=search_id.split())
 
 
-def abort_action(session, task):
+def abort_action(session: ImportSession, task: ImportTask) -> None:
     """A prompt choice callback that aborts the importer."""
     raise importer.ImportAbortError()

--- a/beets/ui/commands/import_/session.py
+++ b/beets/ui/commands/import_/session.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
     from beets.autotag import Proposal, Source
     from beets.importer import ImportSession, ImportTask
-    from beets.library import AnyLibModel, Item
+    from beets.library import AlbumOrItem, Item
     from beets.util import PathBytes
 
 # Global logger.
@@ -173,7 +173,7 @@ class TerminalImportSession(importer.ImportSession):
                 print(f"  {dup}")
 
     def _get_duplicate_action_from_user(
-        self, task: importer.ImportTask, found_duplicates: list[AnyLibModel]
+        self, task: importer.ImportTask, found_duplicates: list[AlbumOrItem]
     ) -> str:
         """Decide what to do when a new album or item seems similar to one
         that's already in the library.
@@ -203,7 +203,7 @@ class TerminalImportSession(importer.ImportSession):
         return ui.input_options(DuplicateAction.strict_options())
 
     def get_duplicate_action(
-        self, task: importer.ImportTask, found_duplicates: list[AnyLibModel]
+        self, task: importer.ImportTask, found_duplicates: list[AlbumOrItem]
     ) -> DuplicateAction:
         action = super().get_duplicate_action(task, found_duplicates)
         if action is DuplicateAction.ASK:

--- a/beets/ui/commands/import_/session.py
+++ b/beets/ui/commands/import_/session.py
@@ -12,7 +12,7 @@ from beets.autotag import (
     tag_album,
     tag_item,
 )
-from beets.importer import DuplicateAction, Proposal, SingletonImportTask
+from beets.importer import DuplicateAction, SingletonImportTask
 from beets.library import Album
 from beets.util import PromptChoice, displayable_path
 from beets.util.color import colorize
@@ -23,7 +23,7 @@ from .display import show_change, show_item_change
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from beets.autotag import Source
+    from beets.autotag import Proposal, Source
     from beets.importer import ImportSession, ImportTask
     from beets.library import AnyLibModel, Item
     from beets.util import PathBytes
@@ -65,9 +65,14 @@ class TerminalImportSession(importer.ImportSession):
             )
 
         # Take immediate action if appropriate.
+        # TODO: introduce beets.autotag.Candidates to remove these assertions
+        assert task.rec is not None
+        assert task.candidates is not None
         action = _summary_judgment(task.rec)
         if action == importer.Action.APPLY:
             match = task.candidates[0]
+            # TODO: introduce AlbumImportTask to remove this assertion
+            assert isinstance(match, AlbumMatch)
             show_change(task.source, match)
             return match
         if action is not None:
@@ -81,26 +86,28 @@ class TerminalImportSession(importer.ImportSession):
             # `PromptChoice`.
             choices = self._get_choices(task)
             choice = choose_candidate(
-                task.candidates, task.rec, task.source, choices=choices
+                # TODO: introduce AlbumImportTask to remove this ignore
+                task.candidates,  # type: ignore[arg-type]
+                task.rec,
+                task.source,
+                choices=choices,
             )
 
-            # Basic choices that require no more action here.
-            if choice in (importer.Action.SKIP, importer.Action.ASIS):
+            # We have a specific match selection.
+            # or, basic choices that require no more action here.
+            if isinstance(choice, AlbumMatch) or (
+                isinstance(choice, importer.Action)
+                and choice in (importer.Action.SKIP, importer.Action.ASIS)
+            ):
                 # Pass selection to main control flow.
                 return choice
 
             # Plugin-provided choices. We invoke the associated callback
             # function.
-            if choice in choices:
+            if isinstance(choice, PromptChoice) and choice.callback:
                 post_choice = choice.callback(self, task)
                 if isinstance(post_choice, importer.Action):
                     return post_choice
-                if isinstance(post_choice, Proposal):
-                    # Use the new candidates and continue around the loop.
-                    task.candidates = post_choice.candidates
-                    task.rec = post_choice.recommendation
-
-            # Otherwise, we have a specific match selection.
             else:
                 # We have a candidate! Finish tagging. Here, choice is an
                 # AlbumMatch object.
@@ -115,12 +122,16 @@ class TerminalImportSession(importer.ImportSession):
         """
         ui.print_()
         ui.print_(displayable_path(task.item.path))
-        candidates, rec = task.candidates, task.rec
 
         # Take immediate action if appropriate.
+        # TODO: introduce beets.autotag.Candidates to remove these assertions
+        assert task.rec is not None
+        assert task.candidates is not None
         action = _summary_judgment(task.rec)
         if action == importer.Action.APPLY:
-            match = candidates[0]
+            match = task.candidates[0]
+            # TODO: introduce AlbumImportTask to remove this assertion
+            assert isinstance(match, TrackMatch)
             show_item_change(task.source, match)
             return match
         if action is not None:
@@ -130,24 +141,28 @@ class TerminalImportSession(importer.ImportSession):
             # Ask for a choice.
             choices = self._get_choices(task)
             choice = choose_candidate(
-                candidates, rec, task.source, choices=choices
+                # TODO: introduce AlbumImportTask to remove this ignore
+                task.candidates,  # type: ignore[arg-type]
+                task.rec,
+                task.source,
+                choices=choices,
             )
 
-            if choice in (importer.Action.SKIP, importer.Action.ASIS):
+            # We have a specific match selection.
+            # or, basic choices that require no more action here.
+            if isinstance(choice, TrackMatch) or (
+                isinstance(choice, importer.Action)
+                and choice in (importer.Action.SKIP, importer.Action.ASIS)
+            ):
+                # Pass selection to main control flow.
                 return choice
 
-            if choice in choices:
+            # Plugin-provided choices. We invoke the associated callback
+            # function.
+            if isinstance(choice, PromptChoice) and choice.callback:
                 post_choice = choice.callback(self, task)
                 if isinstance(post_choice, importer.Action):
                     return post_choice
-                if isinstance(post_choice, Proposal):
-                    candidates = post_choice.candidates
-                    rec = post_choice.recommendation
-
-            else:
-                # Chose a candidate.
-                assert isinstance(choice, TrackMatch)
-                return choice
 
     def _report_item_summary(
         self, prefix: Literal["Old", "New"], items: list[Item], is_album: bool
@@ -235,8 +250,11 @@ class TerminalImportSession(importer.ImportSession):
                 ),
             ]
         choices += [
-            PromptChoice("e", "Enter search", manual_search),
-            PromptChoice("i", "enter Id", manual_id),
+            # TODO: introduce beets.autotag.Candidates to remove these ignores
+            #  context: Candidates is a Sequence which will be updated in place
+            #  by manual_search and manual_id, with return types as None.
+            PromptChoice("e", "Enter search", manual_search),  # type: ignore[arg-type]
+            PromptChoice("i", "enter Id", manual_id),  # type: ignore[arg-type]
             PromptChoice("b", "aBort", abort_action),
         ]
 
@@ -252,7 +270,7 @@ class TerminalImportSession(importer.ImportSession):
         # Add a "dummy" choice for the other baked-in option, for
         # duplicate checking.
         all_choices = [
-            PromptChoice("a", "Apply", None),
+            PromptChoice("a", "Apply", lambda s, t: importer.Action.APPLY),
             *choices,
             *extra_choices,
         ]
@@ -291,7 +309,7 @@ def summarize_items(items: list[Item], singleton: bool) -> str:
     if not singleton:
         summary_parts.append(f"{len(items)} items")
 
-    format_counts = {}
+    format_counts: dict[str, int] = {}
     for item in items:
         format_counts[item.format] = format_counts.get(item.format, 0) + 1
     if len(format_counts) == 1:
@@ -455,10 +473,11 @@ def choose_candidate(
         bypass_candidates = False
 
         # Show what we're about to do.
+        # TODO: introduce AlbumImportTask to remove these ignores
         if source.type == "track":
-            show_item_change(source, match)
+            show_item_change(source, match)  # type: ignore[arg-type]
         else:
-            show_change(source, match)
+            show_change(source, match)  # type: ignore[arg-type]
 
         # Exact match => tag automatically if we're not in timid mode.
         if rec == Recommendation.strong and not config["import"]["timid"]:

--- a/beets/util/__init__.py
+++ b/beets/util/__init__.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator
     from logging import Logger
 
+    from beets.importer import Action, ImportSession, ImportTask
     from beets.library import Item
 
 MAX_FILENAME_LENGTH = 200
@@ -169,7 +170,7 @@ class MoveOperation(Enum):
 class PromptChoice(NamedTuple):
     short: str
     long: str
-    callback: Any
+    callback: Callable[[ImportSession, ImportTask], Action | None] | None
 
 
 def normpath(path: PathLike) -> bytes:

--- a/beets/util/diff.py
+++ b/beets/util/diff.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from beets.dbcore.db import FormattedMapping
-    from beets.library.models import LibModel
+    from beets.library import LibModel
 
 
 def colordiff(a: str, b: str) -> tuple[str, str]:

--- a/beets/util/functemplate.py
+++ b/beets/util/functemplate.py
@@ -18,11 +18,13 @@ import ast
 import dis
 import re
 import types
-from functools import lru_cache
-from typing import TYPE_CHECKING
+from functools import cached_property, lru_cache
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
+
+Part: TypeAlias = "str | Symbol | Call"
 
 SYMBOL_DELIM = "$"
 FUNC_DELIM = "%"
@@ -72,12 +74,11 @@ def ex_call(func: str | ast.expr, args: Sequence[ast.expr]) -> ast.Call:
     if isinstance(func, str):
         func = ex_rvalue(func)
 
-    args = list(args)
-    for i in range(len(args)):
-        if not isinstance(args[i], ast.expr):
-            args[i] = ex_literal(args[i])
-
-    return ast.Call(func, args, [])
+    return ast.Call(
+        func,
+        [(a if isinstance(a, ast.expr) else ex_literal(a)) for a in args],
+        [],
+    )
 
 
 def compile_func(
@@ -90,17 +91,16 @@ def compile_func(
     the resulting Python function. If `debug`, then print out the
     bytecode of the compiled function.
     """
-    args_fields = {
-        "args": [ast.arg(arg=n, annotation=None) for n in arg_names],
-        "kwonlyargs": [],
-        "kw_defaults": [],
-        "defaults": [ex_literal(None) for _ in arg_names],
-    }
-    args_fields["posonlyargs"] = []
-    args = ast.arguments(**args_fields)
+    ast_args = ast.arguments(
+        args=[ast.arg(arg=n, annotation=None) for n in arg_names],
+        kwonlyargs=[],
+        kw_defaults=[],
+        defaults=[ex_literal(None) for _ in arg_names],
+        posonlyargs=[],
+    )
 
     func_def = ast.FunctionDef(
-        name=name, args=args, body=statements, decorator_list=[]
+        name=name, args=ast_args, body=statements, decorator_list=[]
     )
 
     mod = ast.Module([func_def], [])
@@ -116,7 +116,7 @@ def compile_func(
             if isinstance(const, types.CodeType):
                 dis.dis(const)
 
-    the_locals = {}
+    the_locals: dict[str, Any] = {}
     exec(prog, {}, the_locals)
     return the_locals[name]
 
@@ -216,6 +216,8 @@ class Expression:
     Symbols, and Calls.
     """
 
+    parts: list[Part]
+
     def __init__(self, parts: list[Part]) -> None:
         self.parts = parts
 
@@ -238,7 +240,7 @@ class Expression:
         """Compile the expression to a list of Python AST expressions, a
         set of variable names used, and a set of function names.
         """
-        expressions = []
+        expressions: list[ast.expr] = []
         varnames = set()
         funcnames = set()
         for part in self.parts:
@@ -273,6 +275,8 @@ class Parser:
     generator, etc.).
     """
 
+    parts: list[Part]
+
     def __init__(self, string: str, in_argument: bool = False) -> None:
         """Create a new parser.
         :param in_arguments: boolean that indicates the parser is to be
@@ -284,16 +288,30 @@ class Parser:
         self.pos = 0
         self.parts = []
 
-    # Common parsing resources.
-    special_chars = (
-        SYMBOL_DELIM,
-        FUNC_DELIM,
-        GROUP_OPEN,
-        GROUP_CLOSE,
-        ESCAPE_CHAR,
-    )
     escapable_chars = (SYMBOL_DELIM, FUNC_DELIM, GROUP_CLOSE, ARG_SEP)
     terminator_chars = (GROUP_CLOSE,)
+
+    @cached_property
+    def extra_special_chars(self) -> tuple[str, ...]:
+        return (ARG_SEP,) if self.in_argument else ()
+
+    @cached_property
+    def special_chars(self) -> tuple[str, ...]:
+        """Common parsing resources."""
+        return (
+            SYMBOL_DELIM,
+            FUNC_DELIM,
+            GROUP_OPEN,
+            GROUP_CLOSE,
+            ESCAPE_CHAR,
+            *self.extra_special_chars,
+        )
+
+    @cached_property
+    def special_char_re(self) -> re.Pattern[str]:
+        return re.compile(
+            rf"[{''.join(map(re.escape, self.special_chars))}]|\Z"
+        )
 
     def parse_expression(self) -> None:
         """Parse a template expression starting at ``pos``. Resulting
@@ -303,40 +321,32 @@ class Parser:
         """
         # Append comma (ARG_SEP) to the list of special characters only when
         # parsing function arguments.
-        extra_special_chars = (ARG_SEP,) if self.in_argument else ()
-        special_chars = (*self.special_chars, *extra_special_chars)
-        special_char_re = re.compile(
-            rf"[{''.join(map(re.escape, special_chars))}]|\Z"
-        )
-
         text_parts = []
 
         while self.pos < len(self.string):
             char = self.string[self.pos]
 
-            if char not in special_chars:
+            if char not in self.special_chars:
                 # A non-special character. Skip to the next special
                 # character, treating the interstice as literal text.
-                next_pos = (
-                    special_char_re.search(self.string[self.pos :]).start()
-                    + self.pos
-                )
-                text_parts.append(self.string[self.pos : next_pos])
-                self.pos = next_pos
-                continue
+                if m := self.special_char_re.search(self.string[self.pos :]):
+                    next_pos = m.start() + self.pos
+                    text_parts.append(self.string[self.pos : next_pos])
+                    self.pos = next_pos
+                    continue
 
             if self.pos == len(self.string) - 1:
                 # The last character can never begin a structure, so we
                 # just interpret it as a literal character (unless it
                 # terminates the expression, as with , and }).
-                if char not in self.terminator_chars + extra_special_chars:
+                if char not in self.terminator_chars + self.extra_special_chars:
                     text_parts.append(char)
                     self.pos += 1
                 break
 
             next_char = self.string[self.pos + 1]
             if char == ESCAPE_CHAR and next_char in (
-                self.escapable_chars + extra_special_chars
+                self.escapable_chars + self.extra_special_chars
             ):
                 # An escaped special character ($$, $}, etc.). Note that
                 # ${ is not an escape sequence: this is ambiguous with
@@ -357,7 +367,7 @@ class Parser:
             elif char == FUNC_DELIM:
                 # Parse a function call.
                 self.parse_call()
-            elif char in self.terminator_chars + extra_special_chars:
+            elif char in self.terminator_chars + self.extra_special_chars:
                 # Template terminated.
                 break
             elif char == GROUP_OPEN:
@@ -408,11 +418,10 @@ class Parser:
 
         else:
             # A bare-word symbol.
-            ident = self._parse_ident()
-            if ident:
+            if _ident := self._parse_ident():
                 # Found a real symbol.
                 self.parts.append(
-                    Symbol(ident, self.string[start_pos : self.pos])
+                    Symbol(_ident, self.string[start_pos : self.pos])
                 )
             else:
                 # A standalone $.
@@ -487,14 +496,17 @@ class Parser:
 
         return expressions
 
-    def _parse_ident(self) -> str:
+    def _parse_ident(self) -> str | None:
         """Parse an identifier and return it (possibly an empty string).
         Updates ``pos``.
         """
         remainder = self.string[self.pos :]
-        ident = re.match(r"\w*", remainder).group(0)
-        self.pos += len(ident)
-        return ident
+        if m := re.match(r"\w*", remainder):
+            ident = m.group(0)
+            self.pos += len(ident)
+            return ident
+
+        return None
 
 
 def _parse(template: str) -> Expression:
@@ -526,7 +538,7 @@ class Template:
         self.compiled = self.translate()
 
     def __eq__(self, other: object) -> bool:
-        return self.original == other.original
+        return type(self) is type(other) and self.original == other.original
 
     def interpret(
         self,
@@ -571,7 +583,7 @@ class Template:
             values: Mapping[str, str] = {},
             functions: Mapping[str, Callable[[str], str]] = {},
         ) -> str:
-            args = {}
+            args: dict[str, str | Callable[[str], str]] = {}
             for varname in varnames:
                 args[f"{VARIABLE_PREFIX}{varname}"] = values[varname]
             for funcname in funcnames:

--- a/beets/util/functemplate.py
+++ b/beets/util/functemplate.py
@@ -19,6 +19,10 @@ import dis
 import re
 import types
 from functools import lru_cache
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping, Sequence
 
 SYMBOL_DELIM = "$"
 FUNC_DELIM = "%"
@@ -36,7 +40,11 @@ class Environment:
     template.
     """
 
-    def __init__(self, values, functions):
+    def __init__(
+        self,
+        values: Mapping[str, str] = {},
+        functions: Mapping[str, Callable[[str], str]] = {},
+    ) -> None:
         self.values = values
         self.functions = functions
 
@@ -44,19 +52,19 @@ class Environment:
 # Code generation helpers.
 
 
-def ex_rvalue(name):
+def ex_rvalue(name: str) -> ast.Name:
     """A variable store expression."""
     return ast.Name(name, ast.Load())
 
 
-def ex_literal(val):
+def ex_literal(val: str | bytes | bool | float | None) -> ast.Constant:
     """An int, float, long, bool, string, or None literal with the given
     value.
     """
     return ast.Constant(val)
 
 
-def ex_call(func, args):
+def ex_call(func: str | ast.expr, args: Sequence[ast.expr]) -> ast.Call:
     """A function-call expression with only positional parameters. The
     function may be an expression or the name of a function. Each
     argument may be an expression or a value to be used as a literal.
@@ -72,7 +80,12 @@ def ex_call(func, args):
     return ast.Call(func, args, [])
 
 
-def compile_func(arg_names, statements, name="_the_func", debug=False):
+def compile_func(
+    arg_names: list[str],
+    statements: list[ast.stmt],
+    name: str = "_the_func",
+    debug: bool = False,
+) -> Callable[..., list[str]]:
     """Compile a list of statements as the body of a function and return
     the resulting Python function. If `debug`, then print out the
     bytecode of the compiled function.
@@ -114,14 +127,14 @@ def compile_func(arg_names, statements, name="_the_func", debug=False):
 class Symbol:
     """A variable-substitution symbol in a template."""
 
-    def __init__(self, ident, original):
+    def __init__(self, ident: str, original: str) -> None:
         self.ident = ident
         self.original = original
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Symbol({self.ident!r})"
 
-    def evaluate(self, env):
+    def evaluate(self, env: Environment) -> str:
         """Evaluate the symbol in the environment, returning a Unicode
         string.
         """
@@ -131,7 +144,7 @@ class Symbol:
         # Keep original text.
         return self.original
 
-    def translate(self):
+    def translate(self) -> tuple[list[ast.expr], set[str], set[str]]:
         """Compile the variable lookup."""
         ident = self.ident
         expr = ex_rvalue(f"{VARIABLE_PREFIX}{ident}")
@@ -141,15 +154,17 @@ class Symbol:
 class Call:
     """A function call in a template."""
 
-    def __init__(self, ident, args, original):
+    def __init__(
+        self, ident: str, args: list[Expression], original: str
+    ) -> None:
         self.ident = ident
         self.args = args
         self.original = original
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Call({self.ident!r}, {self.args!r}, {self.original!r})"
 
-    def evaluate(self, env):
+    def evaluate(self, env: Environment) -> str:
         """Evaluate the function call in the environment, returning a
         Unicode string.
         """
@@ -164,7 +179,7 @@ class Call:
             return str(out)
         return self.original
 
-    def translate(self):
+    def translate(self) -> tuple[list[ast.expr], set[str], set[str]]:
         """Compile the function call."""
         varnames = set()
         funcnames = {self.ident}
@@ -201,13 +216,13 @@ class Expression:
     Symbols, and Calls.
     """
 
-    def __init__(self, parts):
+    def __init__(self, parts: list[Part]) -> None:
         self.parts = parts
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Expression({self.parts!r})"
 
-    def evaluate(self, env):
+    def evaluate(self, env: Environment) -> str:
         """Evaluate the entire expression in the environment, returning
         a Unicode string.
         """
@@ -219,7 +234,7 @@ class Expression:
                 out.append(part.evaluate(env))
         return "".join(map(str, out))
 
-    def translate(self):
+    def translate(self) -> tuple[list[ast.expr], set[str], set[str]]:
         """Compile the expression to a list of Python AST expressions, a
         set of variable names used, and a set of function names.
         """
@@ -258,7 +273,7 @@ class Parser:
     generator, etc.).
     """
 
-    def __init__(self, string, in_argument=False):
+    def __init__(self, string: str, in_argument: bool = False) -> None:
         """Create a new parser.
         :param in_arguments: boolean that indicates the parser is to be
         used for parsing function arguments, ie. considering commas
@@ -280,7 +295,7 @@ class Parser:
     escapable_chars = (SYMBOL_DELIM, FUNC_DELIM, GROUP_CLOSE, ARG_SEP)
     terminator_chars = (GROUP_CLOSE,)
 
-    def parse_expression(self):
+    def parse_expression(self) -> None:
         """Parse a template expression starting at ``pos``. Resulting
         components (Unicode strings, Symbols, and Calls) are added to
         the ``parts`` field, a list.  The ``pos`` field is updated to be
@@ -357,7 +372,7 @@ class Parser:
         if text_parts:
             self.parts.append("".join(text_parts))
 
-    def parse_symbol(self):
+    def parse_symbol(self) -> None:
         """Parse a variable reference (like ``$foo`` or ``${foo}``)
         starting at ``pos``. Possibly appends a Symbol object (or,
         failing that, text) to the ``parts`` field and updates ``pos``.
@@ -403,7 +418,7 @@ class Parser:
                 # A standalone $.
                 self.parts.append(SYMBOL_DELIM)
 
-    def parse_call(self):
+    def parse_call(self) -> None:
         """Parse a function call (like ``%foo{bar,baz}``) starting at
         ``pos``.  Possibly appends a Call object to ``parts`` and update
         ``pos``. The character at ``pos`` must be ``%``.
@@ -441,7 +456,7 @@ class Parser:
         self.pos += 1  # Move past closing brace.
         self.parts.append(Call(ident, args, self.string[start_pos : self.pos]))
 
-    def parse_argument_list(self):
+    def parse_argument_list(self) -> list[Expression]:
         """Parse a list of arguments starting at ``pos``, returning a
         list of Expression objects. Does not modify ``parts``. Should
         leave ``pos`` pointing to a } character or the end of the
@@ -472,7 +487,7 @@ class Parser:
 
         return expressions
 
-    def _parse_ident(self):
+    def _parse_ident(self) -> str:
         """Parse an identifier and return it (possibly an empty string).
         Updates ``pos``.
         """
@@ -482,7 +497,7 @@ class Parser:
         return ident
 
 
-def _parse(template):
+def _parse(template: str) -> Expression:
     """Parse a top-level template string Expression. Any extraneous text
     is considered literal text.
     """
@@ -505,15 +520,19 @@ def get_template(fmt: str) -> Template:
 class Template:
     """A string template, including text, Symbols, and Calls."""
 
-    def __init__(self, template):
+    def __init__(self, template: str) -> None:
         self.expr = _parse(template)
         self.original = template
         self.compiled = self.translate()
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return self.original == other.original
 
-    def interpret(self, values={}, functions={}):
+    def interpret(
+        self,
+        values: Mapping[str, str] = {},
+        functions: Mapping[str, Callable[[str], str]] = {},
+    ) -> str:
         """Like `substitute`, but forces the interpreter (rather than
         the compiled version) to be used. The interpreter includes
         exception-handling code for missing variables and buggy template
@@ -521,7 +540,11 @@ class Template:
         """
         return self.expr.evaluate(Environment(values, functions))
 
-    def substitute(self, values={}, functions={}):
+    def substitute(
+        self,
+        values: Mapping[str, str] = {},
+        functions: Mapping[str, Callable[[str], str]] = {},
+    ) -> str:
         """Evaluate the template given the values and functions."""
         try:
             res = self.compiled(values, functions)
@@ -530,7 +553,7 @@ class Template:
 
         return res
 
-    def translate(self):
+    def translate(self) -> Callable[..., str]:
         """Compile the template to a Python function."""
         expressions, varnames, funcnames = self.expr.translate()
 
@@ -544,7 +567,10 @@ class Template:
             argnames, [ast.Return(ast.List(expressions, ast.Load()))]
         )
 
-        def wrapper_func(values={}, functions={}):
+        def wrapper_func(
+            values: Mapping[str, str] = {},
+            functions: Mapping[str, Callable[[str], str]] = {},
+        ) -> str:
             args = {}
             for varname in varnames:
                 args[f"{VARIABLE_PREFIX}{varname}"] = values[varname]

--- a/beetsplug/_utils/art.py
+++ b/beetsplug/_utils/art.py
@@ -2,16 +2,29 @@
 music and items' embedded album art.
 """
 
+from __future__ import annotations
+
 import os
 from tempfile import NamedTemporaryFile
+from typing import TYPE_CHECKING
 
 import mediafile
 
 from beets.util import bytestring_path, displayable_path, syspath
 from beets.util.artresizer import ArtResizer
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
 
-def mediafile_image(image_path, maxwidth=None):
+    from beets.dbcore import Query
+    from beets.library import Album, Item, Library
+    from beets.logging import BeetsLogger as Logger
+    from beets.util import PathLike
+
+
+def mediafile_image(
+    image_path: bytes, maxwidth: int | None = None
+) -> mediafile.Image:
     """Return a `mediafile.Image` object for the path."""
 
     with open(syspath(image_path), "rb") as f:
@@ -19,7 +32,7 @@ def mediafile_image(image_path, maxwidth=None):
     return mediafile.Image(data, type=mediafile.ImageType.front)
 
 
-def get_art(log, item):
+def get_art(log: Logger, item: Item) -> bytes | None:
     # Extract the art.
     try:
         mf = mediafile.MediaFile(syspath(item.path))
@@ -31,17 +44,17 @@ def get_art(log, item):
 
 
 def embed_item(
-    log,
-    item,
-    imagepath,
-    maxwidth=None,
-    itempath=None,
-    compare_threshold=0,
-    ifempty=False,
-    as_album=False,
-    id3v23=None,
-    quality=0,
-):
+    log: Logger,
+    item: Item,
+    imagepath: bytes,
+    maxwidth: int | None = None,
+    itempath: bytes | None = None,
+    compare_threshold: int = 0,
+    ifempty: bool = False,
+    as_album: bool = False,
+    id3v23: bool | None = None,
+    quality: int = 0,
+) -> None:
     """Embed an image into the item's media file."""
     # Conditions.
     if compare_threshold:
@@ -81,14 +94,14 @@ def embed_item(
 
 
 def embed_album(
-    log,
-    album,
-    maxwidth=None,
-    quiet=False,
-    compare_threshold=0,
-    ifempty=False,
-    quality=0,
-):
+    log: Logger,
+    album: Album,
+    maxwidth: int | None = None,
+    quiet: bool = False,
+    compare_threshold: int = 0,
+    ifempty: bool = False,
+    quality: int = 0,
+) -> None:
     """Embed album art into all of the album's items."""
     imagepath = album.artpath
     if not imagepath:
@@ -120,7 +133,9 @@ def embed_album(
         )
 
 
-def resize_image(log, imagepath, maxwidth, quality):
+def resize_image(
+    log: Logger, imagepath: bytes, maxwidth: int, quality: int
+) -> bytes:
     """Returns path to an image resized to maxwidth and encoded with the
     specified quality level.
     """
@@ -135,8 +150,12 @@ def resize_image(log, imagepath, maxwidth, quality):
 
 
 def check_art_similarity(
-    log, item, imagepath, compare_threshold, artresizer=None
-):
+    log: Logger,
+    item: Item,
+    imagepath: bytes,
+    compare_threshold: int,
+    artresizer: ArtResizer | None = None,
+) -> bool | None:
     """A boolean indicating if an image is similar to embedded item art.
 
     If no embedded art exists, always return `True`. If the comparison fails
@@ -156,7 +175,7 @@ def check_art_similarity(
         return artresizer.compare(art, imagepath, compare_threshold)
 
 
-def extract(log, outpath, item):
+def extract(log: Logger, outpath: PathLike, item: Item) -> bytes | None:
     art = get_art(log, item)
     outpath = bytestring_path(outpath)
     if not art:
@@ -178,7 +197,9 @@ def extract(log, outpath, item):
     return outpath
 
 
-def extract_first(log, outpath, items):
+def extract_first(
+    log: Logger, outpath: bytes, items: Iterable[Item]
+) -> bytes | None:
     for item in items:
         real_path = extract(log, outpath, item)
         if real_path:
@@ -186,13 +207,15 @@ def extract_first(log, outpath, items):
     return None
 
 
-def clear_item(item, log):
+def clear_item(item: Item, log: Logger) -> None:
     if mediafile.MediaFile(syspath(item.path)).images:
         log.debug("Clearing art for {}", item)
         item.try_write(tags={"images": None})
 
 
-def clear(log, lib, query):
+def clear(
+    log: Logger, lib: Library, query: str | Sequence[str] | Query | None = None
+) -> None:
     items = lib.items(query)
     log.info("Clearing album art from {} items", len(items))
     for item in items:

--- a/beetsplug/_utils/art.py
+++ b/beetsplug/_utils/art.py
@@ -144,9 +144,7 @@ def resize_image(
         maxwidth,
         quality,
     )
-    return ArtResizer.shared.resize(
-        maxwidth, syspath(imagepath), quality=quality
-    )
+    return ArtResizer.shared.resize(maxwidth, imagepath, quality=quality)
 
 
 def check_art_similarity(

--- a/beetsplug/_utils/playcount.py
+++ b/beetsplug/_utils/playcount.py
@@ -4,12 +4,13 @@ from typing import TYPE_CHECKING, TypedDict
 
 from typing_extensions import NotRequired
 
-from beets.dbcore.query import AndQuery, MatchQuery, OrQuery, SubstringQuery
+from beets.dbcore import AndQuery, MatchQuery, OrQuery
+from beets.dbcore.query import SubstringQuery
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from beets.dbcore.query import Query
+    from beets.dbcore import Query
     from beets.library import Item, Library
     from beets.logging import BeetsLogger
 

--- a/beetsplug/aura.py
+++ b/beetsplug/aura.py
@@ -19,7 +19,8 @@ from flask import (
 from typing_extensions import Self
 
 from beets import config
-from beets.dbcore.query import AndQuery, MatchQuery, NotQuery, RegexpQuery
+from beets.dbcore import AndQuery, MatchQuery
+from beets.dbcore.query import NotQuery, RegexpQuery
 from beets.dbcore.sort import FixedFieldSort, MultipleSort, SlowFieldSort
 from beets.library import Album, Item
 from beets.plugins import BeetsPlugin

--- a/beetsplug/beatport.py
+++ b/beetsplug/beatport.py
@@ -319,8 +319,8 @@ class BeatportPlugin(MetadataSourcePlugin):
         return self._client
 
     def setup(self, session: ImportSession) -> None:
-        c_key: str = self.config["apikey"].as_str()
-        c_secret: str = self.config["apisecret"].as_str()
+        c_key = self.config["apikey"].as_str()
+        c_secret = self.config["apisecret"].as_str()
 
         # Get the OAuth token from a file or log in.
         try:

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import os.path
+import os
 import tempfile
 from mimetypes import guess_extension
 from typing import TYPE_CHECKING
@@ -147,7 +147,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                     self._log.error("Invalid image file")
                     return
                 file = f"image{extension}"
-                tempimg = os.path.join(tempfile.gettempdir(), file)
+                tempimg = os.fsencode(os.path.join(tempfile.gettempdir(), file))
                 try:
                     with open(tempimg, "wb") as f:
                         f.write(response.content)
@@ -226,11 +226,13 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                     )
                     return
                 for album in lib.albums(args):
-                    artpath = normpath(os.path.join(album.path, filename))
-                    artpath = art.extract_first(
-                        self._log, artpath, album.items()
-                    )
-                    if artpath and opts.associate:
+                    if opts.associate and (
+                        artpath := art.extract_first(
+                            self._log,
+                            normpath(os.path.join(album.path, filename)),
+                            album.items(),
+                        )
+                    ):
                         album.set_art(artpath)
                         album.store()
 

--- a/beetsplug/embedart.py
+++ b/beetsplug/embedart.py
@@ -1,8 +1,11 @@
 """Allows beets to embed album art into file metadata."""
 
+from __future__ import annotations
+
 import os.path
 import tempfile
 from mimetypes import guess_extension
+from typing import TYPE_CHECKING
 
 import requests
 
@@ -14,8 +17,15 @@ from beets.util import bytestring_path, displayable_path, normpath, syspath
 from beets.util.artresizer import ArtResizer
 from beetsplug._utils import art
 
+if TYPE_CHECKING:
+    import optparse
+    from collections.abc import Sequence
 
-def _confirm(objs, album):
+    from beets.importer import ImportSession, ImportTask
+    from beets.library import Album, LibModel, Library
+
+
+def _confirm(objs: Sequence[LibModel], album: bool) -> bool:
     """Show the list of affected objects (items or albums) and confirm
     that the user wants to modify their artwork.
 
@@ -39,7 +49,7 @@ def _confirm(objs, album):
 class EmbedCoverArtPlugin(BeetsPlugin):
     """Allows albumart to be embedded into the actual files."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.config.add(
             {
@@ -73,7 +83,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
         if self.config["clearart_on_import"].get(bool):
             self.register_listener("import_task_files", self.import_task_files)
 
-    def commands(self):
+    def commands(self) -> list[ui.Subcommand]:
         # Embed command.
         embed_cmd = ui.Subcommand(
             "embedart", help="embed image files into file metadata"
@@ -98,7 +108,9 @@ class EmbedCoverArtPlugin(BeetsPlugin):
         compare_threshold = self.config["compare_threshold"].get(int)
         ifempty = self.config["ifempty"].get(bool)
 
-        def embed_func(lib, opts, args):
+        def embed_func(
+            lib: Library, opts: optparse.Values, args: list[str]
+        ) -> None:
             if opts.file:
                 imagepath = normpath(opts.file)
                 if not os.path.isfile(syspath(imagepath)):
@@ -197,7 +209,9 @@ class EmbedCoverArtPlugin(BeetsPlugin):
             help="associate the extracted images with the album",
         )
 
-        def extract_func(lib, opts, args):
+        def extract_func(
+            lib: Library, opts: optparse.Values, args: list[str]
+        ) -> None:
             if opts.outpath:
                 art.extract_first(
                     self._log, normpath(opts.outpath), lib.items(args)
@@ -230,7 +244,9 @@ class EmbedCoverArtPlugin(BeetsPlugin):
             "-y", "--yes", action="store_true", help="skip confirmation"
         )
 
-        def clear_func(lib, opts, args):
+        def clear_func(
+            lib: Library, opts: optparse.Values, args: list[str]
+        ) -> None:
             items = lib.items(args)
             # Confirm with user.
             if not opts.yes and not _confirm(items, False):
@@ -241,7 +257,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
 
         return [embed_cmd, extract_cmd, clear_cmd]
 
-    def process_album(self, album):
+    def process_album(self, album: Album) -> None:
         """Automatically embed art after art has been set"""
         if self.config["auto"] and ui.should_write():
             max_width = self.config["maxwidth"].get(int)
@@ -255,7 +271,7 @@ class EmbedCoverArtPlugin(BeetsPlugin):
             )
             self.remove_artfile(album)
 
-    def remove_artfile(self, album):
+    def remove_artfile(self, album: Album) -> None:
         """Possibly delete the album art file for an album (if the
         appropriate configuration option is enabled).
         """
@@ -266,7 +282,9 @@ class EmbedCoverArtPlugin(BeetsPlugin):
                 album.artpath = None
                 album.store()
 
-    def import_task_files(self, session, task):
+    def import_task_files(
+        self, session: ImportSession, task: ImportTask
+    ) -> None:
         """Automatically clearart of imported files."""
         for item in task.imported_items():
             self._log.debug("clearart-on-import {.filepath}", item)

--- a/beetsplug/replaygain.py
+++ b/beetsplug/replaygain.py
@@ -537,7 +537,7 @@ class CommandBackend(Backend):
         super().__init__(config, log)
         config.add({"command": "", "noclip": True})
 
-        cmd_path: Path = Path(config["command"].as_str())
+        cmd_path = Path(config["command"].as_str())
         supported_tools = set(self.SUPPORTED_FORMATS_BY_TOOL)
 
         if (cmd_name := cmd_path.name) not in supported_tools:

--- a/beetsplug/smartplaylist.py
+++ b/beetsplug/smartplaylist.py
@@ -13,7 +13,8 @@ from urllib.request import pathname2url
 import confuse
 
 from beets import plugins, ui
-from beets.dbcore.query import ParsingError, Query
+from beets.dbcore import Query
+from beets.dbcore.query import ParsingError
 from beets.dbcore.sort import Sort
 from beets.exceptions import UserError
 from beets.library import Album, Item, parse_query_string

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -29,7 +29,6 @@ from beets.util import chunks
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from beets.dbcore.db import Results
     from beets.library import Item, Library
     from beets.metadata_plugins import QueryType, SearchParams
     from beetsplug._typing import JSONDict
@@ -811,11 +810,7 @@ class SpotifyPlugin(
         return features_by_id
 
     def _fetch_info(
-        self,
-        lib: Library,
-        items: Results[Item] | Sequence[Item],
-        write: bool,
-        force: bool,
+        self, lib: Library, items: Sequence[Item], write: bool, force: bool
     ) -> None:
         """Obtain track information from Spotify."""
 

--- a/beetsplug/spotify.py
+++ b/beetsplug/spotify.py
@@ -184,8 +184,8 @@ class SpotifyPlugin(
 
     def _authenticate(self) -> None:
         """Request an access token via the Client Credentials Flow: https://developer.spotify.com/documentation/general/guides/authorization-guide/#client-credentials-flow"""
-        c_id: str = self.config["client_id"].as_str()
-        c_secret: str = self.config["client_secret"].as_str()
+        c_id = self.config["client_id"].as_str()
+        c_secret = self.config["client_secret"].as_str()
 
         headers = {
             "Authorization": (

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -24,8 +24,7 @@ if TYPE_CHECKING:
 
     from beets.autotag import Info
     from beets.importer import ImportSession
-    from beets.library import LibModel, Library
-    from beets.library.models import Album, Item
+    from beets.library import Album, Item, LibModel, Library
 
     from .api_types import (
         AlbumAttributes,

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -23,9 +23,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Sequence
 
     from beets.autotag import Info
-    from beets.dbcore.db import Results
     from beets.importer import ImportSession
-    from beets.library import Library
+    from beets.library import LibModel, Library
     from beets.library.models import Album, Item
 
     from .api_types import (
@@ -530,7 +529,7 @@ class TidalPlugin(MetadataSourcePlugin):
         return round(attributes["popularity"] * 100)
 
     def sync_item_popularity(
-        self, results: Results[Item], write: bool, force: bool = False
+        self, results: Sequence[Item], write: bool, force: bool = False
     ) -> None:
         """Sync Tidal popularity data for library items."""
         self._sync_popularity(
@@ -544,7 +543,7 @@ class TidalPlugin(MetadataSourcePlugin):
         )
 
     def sync_album_popularity(
-        self, results: Results[Album], write: bool, force: bool = False
+        self, results: Sequence[Album], write: bool, force: bool = False
     ) -> None:
         """Sync Tidal popularity data for library albums."""
         self._sync_popularity(
@@ -560,7 +559,7 @@ class TidalPlugin(MetadataSourcePlugin):
     def _sync_popularity(
         self,
         *,
-        results: Results[Item] | Results[Album],
+        results: Sequence[LibModel],
         write: bool,
         force: bool,
         id_field: str,

--- a/test/dbcore/test_db.py
+++ b/test/dbcore/test_db.py
@@ -582,6 +582,17 @@ class ResultsIteratorTest(unittest.TestCase):
         assert objs[0].foo == "bar"
         assert objs[1].foo == "baz"
 
+    def test_negative_subscript(self):
+        objs = self.db._get_results(ModelFixture1)
+        assert objs[-1].foo == "bar"
+        assert objs[-2].foo == "baz"
+
+    def test_slice(self):
+        objs = self.db._get_results(ModelFixture1)
+        assert [obj.foo for obj in objs[:]] == ["baz", "bar"]
+        assert [obj.foo for obj in objs[1:]] == ["bar"]
+        assert [obj.foo for obj in objs[::-1]] == ["bar", "baz"]
+
     def test_length(self):
         objs = self.db._get_results(ModelFixture1)
         assert len(objs) == 2

--- a/test/dbcore/test_db.py
+++ b/test/dbcore/test_db.py
@@ -10,8 +10,8 @@ from typing import ClassVar
 import pytest
 
 from beets import dbcore
-from beets.dbcore import query, sort, types
-from beets.dbcore.db import DBCustomFunctionError, Index
+from beets.dbcore import Index, query, sort, types
+from beets.dbcore.db import DBCustomFunctionError
 from beets.library import Album, Item
 from beets.test.fixtures import ModelFixture1
 

--- a/test/dbcore/test_query.py
+++ b/test/dbcore/test_query.py
@@ -9,18 +9,15 @@ from pathlib import Path
 import pytest
 
 from beets import util
-from beets.dbcore import types
+from beets.dbcore import AndQuery, MatchQuery, OrQuery, types
 from beets.dbcore.query import (
-    AndQuery,
     BooleanQuery,
     DateQuery,
     FalseQuery,
     InQuery,
-    MatchQuery,
     NoneQuery,
     NotQuery,
     NumericQuery,
-    OrQuery,
     ParsingError,
     PathQuery,
     RegexpQuery,

--- a/test/library/test_migrations.py
+++ b/test/library/test_migrations.py
@@ -6,8 +6,7 @@ from typing import ClassVar
 import pytest
 
 from beets.dbcore import types
-from beets.library import migrations
-from beets.library.models import Album, Item
+from beets.library import Album, Item, migrations
 from beets.test.helper import TestHelper
 from beets.util import cached_classproperty, path_as_posix
 

--- a/test/plugins/test_embedart.py
+++ b/test/plugins/test_embedart.py
@@ -190,7 +190,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
         trackpath = album.items()[0].filepath
         shutil.copy(resource_path, trackpath)
 
-        self.run_command("extractart", "-n", "extracted")
+        self.run_command("extractart", "-a", "-n", "extracted")
 
         assert (album.filepath / "extracted.png").exists()
 
@@ -200,7 +200,7 @@ class TestEmbedartCli(PluginMixin, IOMixin, ImportHelper, FetchImageHelper):
         trackpath = album.items()[0].filepath
         shutil.copy(resource_path, trackpath)
 
-        self.run_command("extractart", "-n", "extracted")
+        self.run_command("extractart", "-a", "-n", "extracted")
 
         assert (album.filepath / "extracted.jpg").exists()
 

--- a/test/plugins/test_ftintitle.py
+++ b/test/plugins/test_ftintitle.py
@@ -9,7 +9,7 @@ import pytest
 from beets import plugins
 from beets.autotag import AlbumInfo, TrackInfo
 from beets.importer import ImportSession, SingletonImportTask
-from beets.library.models import Album
+from beets.library import Album
 from beets.test.helper import PluginTestHelper
 from beetsplug import ftintitle
 

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from beets.library.models import Item
+from beets.library import Item
 from beets.test.helper import PluginTestHelper
 from beetsplug.tidal import TidalPlugin
 


### PR DESCRIPTION
Fixes: https://github.com/beetbox/beets/issues/6923

### What changed

- This PR is mostly a typing and module-boundary cleanup.
- Code now prefers public package exports like `beets.library` and `beets.dbcore` instead of reaching into deeper internal modules.
- Shared model typing was renamed from `AnyLibModel` to `AlbumOrItem`, which makes intent clearer where code handles either an `Album` or an `Item`.
- Several typing fixes were added around `import`, `embedart`, `_utils.art`, and `beets.util.functemplate`.

### Architecture impact

- The main architectural shift is toward using stable, package-level APIs such as `beets.library` and `beets.dbcore` as the import boundary.
- `dbcore.Results` now behaves like a `Sequence`, which lets callers depend on a simpler, more general interface instead of a concrete internal result type.
- `beets.util.functemplate` got a deeper type pass and some small internal cleanup, but its role in the system stays the same.

### High-level impact

- Improves type safety and IDE support across importer, library, plugin, and template code.
- Reduces coupling to internal module layout, which should make future refactors safer.
- Makes a few core interfaces easier to understand and reuse, especially around library model collections and import-session callbacks.
- Overall, this looks like low-risk maintenance work with small correctness improvements and no intended feature change.
