### PR TITLE
docs: fix two dead external links

### DIFF
--- a/docs/plugins/autobpm.rst
+++ b/docs/plugins/autobpm.rst
@@ -67,6 +67,6 @@ Default
     Suppress the message indicating that a file already has a ``bpm`` value. Can also be
     set using the ``-q`` or ``--quiet`` flag.
 
-.. _beat_track: https://librosa.org/doc/latest/generated/librosa.beat.beat_track.html
+.. _beat_track: https://librosa.org/doc/latest/api/generated/librosa.beat.beat_track.html
 
 .. _librosa: https://github.com/librosa/librosa/

--- a/docs/plugins/chroma.rst
+++ b/docs/plugins/chroma.rst
@@ -88,7 +88,7 @@ audioread_ library:
 
 .. _audioread: https://github.com/beetbox/audioread
 
-.. _core audio: https://developer.apple.com/technologies/mac/audio-and-video.html
+.. _core audio: https://developer.apple.com/documentation/coreaudio
 
 .. _ffmpeg: https://ffmpeg.org/
 


### PR DESCRIPTION
## Summary

A live sweep of external URLs in `docs/` found two dead links. This PR fixes them:

| File | Dead URL | Replacement |
|------|----------|-------------|
| `docs/plugins/autobpm.rst` | `https://librosa.org/doc/latest/generated/librosa.beat.beat_track.html` (404) | `https://librosa.org/doc/latest/api/generated/librosa.beat.beat_track.html` (200) |
| `docs/plugins/chroma.rst` | `https://developer.apple.com/technologies/mac/audio-and-video.html` (404) | `https://developer.apple.com/documentation/coreaudio` (200) |

The ID3v2.4 URL in `docs/faq.rst` remains unchanged after review confirmed that it is accessible.

All replacement URLs were verified HTTP 200 before this PR. Other unique external URLs in `docs/` were checked as part of the sweep; remaining non-2xx results were example placeholders, localhost examples, or hosts that still exist but reject automated requests.