### PR TITLE
Fix tidal `search_limit` ignoring bug (#6770)

### DIFF
--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -242,10 +242,7 @@ class TidalPlugin(MetadataSourcePlugin):
         album_rels = search_doc["data"]["relationships"]["albums"]["data"]
         if limit is not None:
             album_rels = album_rels[:limit]
-        album_ids = [
-            album_rel["id"]
-            for album_rel in album_rels
-        ]
+        album_ids = [album_rel["id"] for album_rel in album_rels]
         yield from filter(None, self.search_albums_by_ids(tidal_ids=album_ids))
 
     @overload

--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -150,8 +150,12 @@ class TidalPlugin(MetadataSourcePlugin):
         ):
             return candidates
 
+        limit = self.config["search_limit"].get(int)
         for query in self._album_queries(items):
-            candidates += self.search_albums_by_query(query)
+            candidates += self.search_albums_by_query(query, limit=limit)
+            if limit is not None and len(candidates) >= limit:
+                candidates = candidates[:limit]
+                break
 
         log.debug("Found {0} candidates", len(candidates))
         return candidates
@@ -169,8 +173,12 @@ class TidalPlugin(MetadataSourcePlugin):
             ):
                 return candidates
 
+        limit = self.config["search_limit"].get(int)
         for query in self._item_queries(item):
-            candidates += self.search_tracks_by_query(query)
+            candidates += self.search_tracks_by_query(query, limit=limit)
+            if limit is not None and len(candidates) >= limit:
+                candidates = candidates[:limit]
+                break
 
         log.debug("Found {0} candidates", len(candidates))
         return candidates
@@ -193,7 +201,9 @@ class TidalPlugin(MetadataSourcePlugin):
         for album, artist in itertools.product(album_names, artist_names):
             yield f"{artist} {album}"
 
-    def search_tracks_by_query(self, query: str) -> Iterable[TrackInfo]:
+    def search_tracks_by_query(
+        self, query: str, limit: int | None = None
+    ) -> Iterable[TrackInfo]:
         """Search for tracks given a string query."""
         search_doc = self.api.search_results(query, include=["tracks.artists"])
         track_by_id: dict[str, TidalTrack] = {
@@ -206,7 +216,11 @@ class TidalPlugin(MetadataSourcePlugin):
             for item in search_doc.get("included", [])
             if item["type"] == "artists"
         }
-        for track_rel in search_doc["data"]["relationships"]["tracks"]["data"]:
+        track_rels = search_doc["data"]["relationships"]["tracks"]["data"]
+        if limit is not None:
+            track_rels = track_rels[:limit]
+
+        for track_rel in track_rels:
             if track := track_by_id.get(track_rel["id"]):
                 yield self._get_track_info(track, artist_by_id=artist_by_id)
             else:
@@ -214,7 +228,9 @@ class TidalPlugin(MetadataSourcePlugin):
                     "Track with id {0} not found in lookup", track_rel["id"]
                 )
 
-    def search_albums_by_query(self, query: str) -> Iterable[AlbumInfo]:
+    def search_albums_by_query(
+        self, query: str, limit: int | None = None
+    ) -> Iterable[AlbumInfo]:
         """Search for album given a string query."""
         search_doc = self.api.search_results(
             query,
@@ -223,11 +239,12 @@ class TidalPlugin(MetadataSourcePlugin):
             # This is a bit inconvenient, but we fetch the items and artists
             # for all albums separately.
         )
+        album_rels = search_doc["data"]["relationships"]["albums"]["data"]
+        if limit is not None:
+            album_rels = album_rels[:limit]
         album_ids = [
             album_rel["id"]
-            for album_rel in search_doc["data"]["relationships"]["albums"][
-                "data"
-            ]
+            for album_rel in album_rels
         ]
         yield from filter(None, self.search_albums_by_ids(tidal_ids=album_ids))
 

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -672,6 +672,49 @@ class TestCandidates(TidalPluginTest):
         assert len(candidates) == 1
         assert candidates[0].album == "Query Album"
 
+    def test_search_album_limit(self):
+        """Test that search_limit configuration is respected for album candidates."""
+        self.tidal.config["search_limit"] = 1
+        items = [Item(title="My Song", artist="My Artist", album="My Album")]
+
+        self.tidal.api.search_results = Mock(
+            return_value={
+                "data": {
+                    "relationships": {
+                        "albums": {
+                            "data": [
+                                {"id": "1", "type": "albums"},
+                                {"id": "2", "type": "albums"}
+                            ]
+                        }
+                    }
+                }
+            }
+        )
+
+        track = _make_track("101", "Album Track", "PT3M", "ISRC001", ["1001"])
+        album, track_lookup, artist_lookup = _make_album(
+            "1", "Query Album", [track], ["1001"]
+        )
+        self.tidal.api.get_albums = Mock(
+            return_value={
+                "data": [album],
+                "included": [*artist_lookup.values(), *track_lookup.values()],
+            }
+        )
+
+        candidates = list(
+            self.tidal.candidates(items, "My Artist", "My Album", False)
+        )
+
+        assert self.tidal.api.search_results.called
+        assert len(candidates) == 1
+        assert candidates[0].album == "Query Album"
+        # get_albums should only be called with the first album id
+        self.tidal.api.get_albums.assert_called_once_with(
+            ids=["1"], barcode_ids=[], include=["items.artists", "artists", "coverArt"]
+        )
+
 
 class TestItemCandidates(TidalPluginTest):
     """Tests for item_candidates method."""
@@ -723,6 +766,43 @@ class TestItemCandidates(TidalPluginTest):
 
         assert self.tidal.api.search_results.called
         assert results[0].title == "Query Track"
+
+    def test_search_track_limit(self):
+        """Test that search_limit configuration is respected for track candidates."""
+        self.tidal.config["search_limit"] = 1
+        item = Item(title="Query Song", artist="Query Artist")
+
+        self.tidal.api.search_results = Mock(
+            return_value={
+                "data": {
+                    "relationships": {
+                        "tracks": {
+                            "data": [
+                                {"id": "490839595", "type": "tracks"},
+                                {"id": "490839596", "type": "tracks"}
+                            ]
+                        }
+                    }
+                },
+                "included": [
+                    _make_track(
+                        "490839595", "Query Track 1", "PT3M", "ISRC001", ["1001"]
+                    ),
+                    _make_track(
+                        "490839596", "Query Track 2", "PT3M", "ISRC002", ["1001"]
+                    ),
+                    _make_artist("1001", "Query Artist"),
+                ],
+            }
+        )
+
+        results = list(
+            self.tidal.item_candidates(item, "Query Artist", "Query Song")
+        )
+
+        assert self.tidal.api.search_results.called
+        assert len(results) == 1
+        assert results[0].title == "Query Track 1"
 
 
 class TestStaticHelpers:

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -684,7 +684,7 @@ class TestCandidates(TidalPluginTest):
                         "albums": {
                             "data": [
                                 {"id": "1", "type": "albums"},
-                                {"id": "2", "type": "albums"}
+                                {"id": "2", "type": "albums"},
                             ]
                         }
                     }
@@ -712,8 +712,44 @@ class TestCandidates(TidalPluginTest):
         assert candidates[0].album == "Query Album"
         # get_albums should only be called with the first album id
         self.tidal.api.get_albums.assert_called_once_with(
-            ids=["1"], barcode_ids=[], include=["items.artists", "artists", "coverArt"]
+            ids=["1"],
+            barcode_ids=[],
+            include=["items.artists", "artists", "coverArt"],
         )
+
+    def test_search_album_limit_not_reached(self):
+        """Test candidates with limit set but fewer results than limit."""
+        self.tidal.config["search_limit"] = 5
+        items = [Item(title="My Song", artist="My Artist", album="My Album")]
+
+        self.tidal.api.search_results = Mock(
+            return_value={
+                "data": {
+                    "relationships": {
+                        "albums": {"data": [{"id": "1", "type": "albums"}]}
+                    }
+                }
+            }
+        )
+
+        track = _make_track("101", "Album Track", "PT3M", "ISRC001", ["1001"])
+        album, track_lookup, artist_lookup = _make_album(
+            "1", "Query Album", [track], ["1001"]
+        )
+        self.tidal.api.get_albums = Mock(
+            return_value={
+                "data": [album],
+                "included": [*artist_lookup.values(), *track_lookup.values()],
+            }
+        )
+
+        candidates = list(
+            self.tidal.candidates(items, "My Artist", "My Album", False)
+        )
+
+        # Only 1 result found, limit=5 not reached, no early break
+        assert len(candidates) == 1
+        assert candidates[0].album == "Query Album"
 
 
 class TestItemCandidates(TidalPluginTest):
@@ -779,17 +815,25 @@ class TestItemCandidates(TidalPluginTest):
                         "tracks": {
                             "data": [
                                 {"id": "490839595", "type": "tracks"},
-                                {"id": "490839596", "type": "tracks"}
+                                {"id": "490839596", "type": "tracks"},
                             ]
                         }
                     }
                 },
                 "included": [
                     _make_track(
-                        "490839595", "Query Track 1", "PT3M", "ISRC001", ["1001"]
+                        "490839595",
+                        "Query Track 1",
+                        "PT3M",
+                        "ISRC001",
+                        ["1001"],
                     ),
                     _make_track(
-                        "490839596", "Query Track 2", "PT3M", "ISRC002", ["1001"]
+                        "490839596",
+                        "Query Track 2",
+                        "PT3M",
+                        "ISRC002",
+                        ["1001"],
                     ),
                     _make_artist("1001", "Query Artist"),
                 ],
@@ -802,6 +846,43 @@ class TestItemCandidates(TidalPluginTest):
 
         assert self.tidal.api.search_results.called
         assert len(results) == 1
+        assert results[0].title == "Query Track 1"
+
+    def test_search_track_limit_not_reached(self):
+        """Test item_candidates with limit set but fewer results than limit."""
+        self.tidal.config["search_limit"] = 5
+        item = Item(title="Query Song", artist="Query Artist")
+
+        self.tidal.api.search_results = Mock(
+            return_value={
+                "data": {
+                    "relationships": {
+                        "tracks": {
+                            "data": [{"id": "490839595", "type": "tracks"}]
+                        }
+                    }
+                },
+                "included": [
+                    _make_track(
+                        "490839595",
+                        "Query Track 1",
+                        "PT3M",
+                        "ISRC001",
+                        ["1001"],
+                    ),
+                    _make_artist("1001", "Query Artist"),
+                ],
+            }
+        )
+
+        results = list(
+            self.tidal.item_candidates(item, "Query Artist", "Query Song")
+        )
+
+        # Only 1 result per query, 2 queries generated, limit=5 not reached
+        # (no early break). Both queries return the same track, so 2 results.
+        assert self.tidal.api.search_results.called
+        assert len(results) == 2
         assert results[0].title == "Query Track 1"
 
 


### PR DESCRIPTION
Fixes #6770.

Tidal previously bypassed the shared search orchestration that limits candidates, resulting in 20+ album and track hits from the API instead of respecting `search_limit`. This PR threads the limit properly and truncates the relationships slice so we avoid extraneous backend requests.

Tested by adding mock validation capping returned records to 1.