### PR TITLE
edit: Keep rejected album fields visible per track

### DIFF
--- a/beetsplug/edit.py
+++ b/beetsplug/edit.py
@@ -456,19 +456,19 @@ class EditPlugin(plugins.BeetsPlugin):
             if not obj._db or obj.id is None:
                 obj.id = -i
 
-        # Decide which fields to show.
-        album_fields = set()
-        if getattr(task, "is_album", False):
-            album_fields = set(self.config["albumfields"].as_str_seq())
+        # Build the album header before deciding which fields to show for each
+        # track. Only fields actually present in the header should be omitted
+        # from the track documents.
+        header_data = self._importer_edit_album_header(task)
+        header_fields = set(header_data) if header_data is not None else set()
         item_fields = set(self.config["itemfields"].as_str_seq())
 
         # Track-level fields exclude any that are shown in the album header
         # to avoid duplication.
-        track_fields = item_fields - album_fields
+        track_fields = item_fields - header_fields
         track_fields.add("id")
 
         # Build the YAML document list.
-        header_data = self._importer_edit_album_header(task)
         old_track_data = [flatten(o, track_fields) for o in task.items]
         all_old_data = []
         if header_data is not None:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -87,6 +87,9 @@ Bug fixes
   have no value for ``field``.
 - :doc:`plugins/convert`: Fixed convert plugin not taking into account the new
   format when determining the target path. :bug:`1360`
+- :doc:`plugins/edit`: Item-only fields rejected from the album header remain
+  available in per-track documents during interactive import when they are also
+  configured in ``itemfields``. :bug:`6953`
 
 ..
     For plugin developers

--- a/docs/plugins/edit.rst
+++ b/docs/plugins/edit.rst
@@ -44,9 +44,9 @@ When editing an album during import (i.e., after you have chosen ``eDit`` or
 ``edit Candidates`` for an album import), the fields listed in ``albumfields``
 are shown as a YAML header section before the per-track documents. This allows
 you to edit album-level fields (such as ``album``, ``albumartist``, or any
-configured ``albumfields`` entry) for all tracks at once. Fields that appear in
-both ``itemfields`` and ``albumfields`` are shown only in the header section,
-not per-track.
+configured ``albumfields`` entry) for all tracks at once. Fields accepted into
+the album header are omitted from the per-track documents. Fields unsuitable
+for the header remain per-track when also configured in ``itemfields``.
 
 Also, please be aware that the ``edit Candidates`` choice can only be used with
 the matches found during the initial search (and currently not supporting the

--- a/docs/plugins/edit.rst
+++ b/docs/plugins/edit.rst
@@ -45,8 +45,8 @@ When editing an album during import (i.e., after you have chosen ``eDit`` or
 are shown as a YAML header section before the per-track documents. This allows
 you to edit album-level fields (such as ``album``, ``albumartist``, or any
 configured ``albumfields`` entry) for all tracks at once. Fields accepted into
-the album header are omitted from the per-track documents. Fields unsuitable
-for the header remain per-track when also configured in ``itemfields``.
+the album header are omitted from the per-track documents. Fields unsuitable for
+the header remain per-track when also configured in ``itemfields``.
 
 Also, please be aware that the ``edit Candidates`` choice can only be used with
 the matches found during the initial search (and currently not supporting the

--- a/test/plugins/test_edit.py
+++ b/test/plugins/test_edit.py
@@ -505,6 +505,46 @@ class EditDuringImporterNonSingletonTest(EditDuringImporterTestCase):
         assert len(set(tracks)) == len(tracks)
         assert all(i.album == "Modified Album" for i in self.lib.items())
 
+    def test_importer_edit_candidate_keeps_rejected_albumfields_in_tracks(self):
+        """Item-only album fields remain editable in candidate tracks."""
+        self.config["edit"]["albumfields"] = "album title track"
+        self.config["edit"]["itemfields"] = "album title track"
+
+        seen_docs = {}
+
+        def inspect_and_edit(filename, log):
+            with codecs.open(filename, encoding="utf-8") as f:
+                docs = load(f.read())
+
+            headers = [doc for doc in docs if "id" not in doc]
+            tracks = [doc for doc in docs if "id" in doc]
+            seen_docs["headers"] = headers
+            seen_docs["tracks"] = tracks
+            tracks[0]["title"] = "Issue 6953 edited title"
+
+            with codecs.open(filename, "w", encoding="utf-8") as f:
+                f.write(dump(docs))
+
+        with patch("beetsplug.edit.edit", side_effect=inspect_and_edit):
+            self.importer.add_choice("c")
+            self.importer.add_choice("1")
+            self.importer.add_choice("a")
+            self.importer.run()
+
+        assert len(seen_docs["headers"]) == 1
+        assert set(seen_docs["headers"][0]) == {"album"}
+        assert len(seen_docs["tracks"]) == 1
+        assert set(seen_docs["tracks"][0]) == {"id", "title", "track"}
+
+        items = list(self.lib.items())
+        assert len(items) == 1
+        assert items[0].title == "Issue 6953 edited title"
+        assert items[0].mb_trackid == "match 1"
+
+        albums = list(self.lib.albums())
+        assert len(albums) == 1
+        assert albums[0].mb_albumid == "albumid"
+
     def test_importer_edit_album_header_albumartist(self):
         """Edit albumartist in the header (default albumfields)."""
         self.run_mocked_interpreter(


### PR DESCRIPTION
Fixes #6953 

During interactive import, item-only fields configured in both `albumfields` and `itemfields` were removed from the album header and per-track documents.

Track fields are now excluded only when they are actually displayed in the album header. Added a regression test for the `edit Candidates` flow.

cc: @snejus 

## To Do

- [x] Documentation. (If you've added a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [x] Changelog. (Add an entry to `docs/changelog.rst` to the bottom of one of the lists near the top of the document.)
- [x] Tests. (Very much encouraged but not strictly required.)
