### PR TITLE
Fix regex queries for multi-value fields

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -1224,10 +1224,13 @@ class Database:
         return conn
 
     def add_functions(self, conn: sqlite3.Connection) -> None:
-        def regexp(value: Any, pattern: str) -> bool:
+        def regexp(
+            value: Any, pattern: str, delimiter: str | None = None
+        ) -> bool:
             if isinstance(value, bytes):
                 value = value.decode()
-            return re.search(pattern, str(value)) is not None
+            values = str(value).split(delimiter) if delimiter else (str(value),)
+            return any(re.search(pattern, item) is not None for item in values)
 
         def bytelower(bytestring: AnyStr | None) -> AnyStr | None:
             """A custom ``bytelower`` sqlite function so we can compare
@@ -1250,6 +1253,7 @@ class Database:
             )
 
         create_function("regexp", 2, regexp)
+        create_function("regexp", 3, regexp)
         create_function("unidecode", 1, unidecode)
         create_function("bytelower", 1, bytelower)
 

--- a/beets/dbcore/query.py
+++ b/beets/dbcore/query.py
@@ -377,7 +377,11 @@ class RegexpQuery(StringFieldQuery[Pattern[str]]):
     """
 
     def __init__(
-        self, field_name: str, pattern: str, fast: bool = True
+        self,
+        field_name: str,
+        pattern: str,
+        fast: bool = True,
+        delimiter: str | None = None,
     ) -> None:
         pattern = self._normalize(pattern)
         try:
@@ -388,9 +392,15 @@ class RegexpQuery(StringFieldQuery[Pattern[str]]):
                 pattern, "a regular expression", format(exc)
             )
 
+        self.delimiter = delimiter
         super().__init__(field_name, pattern_re, fast)
 
     def col_clause(self) -> tuple[str, Sequence[SQLiteType]]:
+        if self.delimiter:
+            return f" regexp({self.field}, ?, ?)", [
+                self.pattern.pattern,
+                self.delimiter,
+            ]
         return f" regexp({self.field}, ?)", [self.pattern.pattern]
 
     @staticmethod

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -123,9 +123,10 @@ class LibModel(dbcore.Model["Library"]):
         """Get a `FieldQuery` for the given field on this model."""
         field = maybe_replace_legacy_field(field, cls is Album)
 
+        field_type = cls._type(field)
         fast = field in cls.all_db_fields
         if (
-            cls._type(field).query is dbcore.query.PathQuery
+            field_type.query is dbcore.query.PathQuery
             and query_cls is not dbcore.query.PathQuery
         ):
             # Regex, exact, and string queries operate on the raw DB value, so
@@ -140,6 +141,13 @@ class LibModel(dbcore.Model["Library"]):
             # an OperationalError if we try to use it in a query.
             # Using an explicit table name resolves this.
             field = f"{cls._table}.{field}"
+
+        if query_cls is dbcore.query.RegexpQuery and isinstance(
+            field_type, types.DelimitedString
+        ):
+            return dbcore.query.RegexpQuery(
+                field, pattern, fast, field_type.db_delimiter
+            )
 
         return query_cls(field, pattern, fast)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -81,6 +81,9 @@ Bug fixes
 - :ref:`move-cmd`: Fix moving albums in interactive select/timid mode.
   :bug:`2802`
 - :doc:`plugins/bpd`: Fix ``search`` command when ``any`` field is used.
+- Regular expression queries on multi-valued fields now match each value
+  separately instead of matching their serialized database representation.
+  :bug:`6961`
 
 ..
     For plugin developers

--- a/test/dbcore/test_query.py
+++ b/test/dbcore/test_query.py
@@ -294,6 +294,22 @@ class TestMatch:
         assert not NotQuery(q).match(item) == should_match
 
 
+class TestMultiValueQueries:
+    def test_regexp_matches_individual_value(self, helper):
+        helper.add_item(
+            title="multiple genres",
+            genres=["Electro", "Electroclash", "Synth-pop"],
+        )
+        helper.add_item(title="prefix only", genres=["Electroclash"])
+
+        query = Item.field_query("genres", "^Electro$", RegexpQuery)
+        assert query.fast
+        assert query.delimiter == types.MULTI_VALUE_DELIMITER
+        assert {item.title for item in helper.lib.items(query)} == {
+            "multiple genres"
+        }
+
+
 class TestPathQuery:
     """Tests for path-based querying functionality in the database system.
 


### PR DESCRIPTION
## Description

Fixes #6961.

Regular-expression queries on `DelimitedString` fields now pass the field's database delimiter to SQLite's `regexp` function and match each stored value independently. This keeps the SQL fast path aligned with the existing Python slow-path semantics, so an anchored expression such as `genres::^Electro$` matches the `Electro` value without also matching `Electroclash`.

The regression test asserts that the query remains on the fast path, uses the actual multi-value database delimiter, and rejects a prefix-only value.

## Validation

- `uv run pytest test/dbcore/test_query.py::TestMultiValueQueries::test_regexp_matches_individual_value -q` (1 passed)
- `uv run pytest test/dbcore -q` (349 passed, 11 skipped)
- `uv run ruff check beets/dbcore/db.py beets/dbcore/query.py beets/library/models.py test/dbcore/test_query.py`
- `uv run ruff format --check beets/dbcore/db.py beets/dbcore/query.py beets/library/models.py test/dbcore/test_query.py`
- `uv run mypy beets/dbcore/db.py beets/dbcore/query.py beets/library/models.py`
- `uv run sphinx-lint docs/changelog.rst`
- Full suite: 2567 passed, 200 skipped, 16 failed; the same 16 Windows/media/color-tag failures reproduced in isolation and do not touch the query/database changes.

## To Do

- [x] ~Documentation~ (bug fix; no user-facing API or command change)
- [x] Changelog
- [x] Tests