### PR TITLE
Typing follow up fixes

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -315,3 +315,7 @@ ee4d6eef36269fbf99e0f566487ab21069be279f
 6b4f8fa25b744adf05a3e9199e470d663f297502
 # typing: add types to duplicates plugin
 8e4fa56acb73216f36769090b322088ff2ed5364
+# typing: add missing types to plugins
+11d41aee7d3253ae702d1519a1b8f78df4596132
+# typing: various consistency fixes
+5c3695da262ec64e52ec8057302fe2d852b62afa

--- a/beetsplug/advancedrewrite.py
+++ b/beetsplug/advancedrewrite.py
@@ -50,8 +50,6 @@ def rewriter(
         for query, replacement in advanced_rules:
             if query.match(item):
                 # Rewrite activated.
-                # TODO: BeetsPlugin.template_fields and album_template_fields
-                # require return value 'str' but 'list' here is legit too
                 return replacement
         # Not activated; return original value.
         return value

--- a/beetsplug/chroma.py
+++ b/beetsplug/chroma.py
@@ -69,7 +69,7 @@ def prefix(it: Iterable[Any], count: int) -> Iterator[Any]:
 
 
 def releases_key(
-    release: JSONDict, countries: Sequence[re.Pattern[str]], original_year: str
+    release: JSONDict, countries: Sequence[re.Pattern[str]], original_year: bool
 ) -> tuple[int, int, int, int]:
     """Used as a key to sort releases by date then preferred country"""
     date = release.get("date")
@@ -148,7 +148,7 @@ def acoustid_match(log: Logger, path: bytes) -> None:
     # 'countries' to then sort preferred countries first.
     country_patterns = config["match"]["preferred"]["countries"].as_str_seq()
     countries = [re.compile(pat, re.I) for pat in country_patterns]
-    original_year = config["match"]["preferred"]["original_year"].as_str()
+    original_year = config["match"]["preferred"]["original_year"].get(bool)
     releases.sort(
         key=partial(
             releases_key, countries=countries, original_year=original_year


### PR DESCRIPTION
Two small follow up fixes after merging all typing changes:

1. Removed incorrect/outdated comment in `advancedrewrite`.
2. Included commits from the last PR to `.git-blame-ignore-revs`.
