### PR TITLE
Remove the dead args self-assignment in the web command

### DIFF
--- a/beetsplug/web/__init__.py
+++ b/beetsplug/web/__init__.py
@@ -467,7 +467,6 @@ class WebPlugin(BeetsPlugin):
         )
 
         def func(lib: Library, opts: WebCLIOpts, args: list[str]) -> None:
-            args = args
             if args:
                 self.config["host"] = args.pop(0)
             if args:


### PR DESCRIPTION
## Description

The `web` command handler opens with `args = args`, which rebinds the parameter to itself and does nothing. Nothing is missing behind it either: `args` is already the third parameter of `func` and the two `args.pop(0)` calls under it read the same list.

Going by the way beets used to receive command arguments, this reads like a leftover from when the callback had to pull them out of somewhere else.

## To Do

- [x] ~Documentation~ (removing a dead statement, nothing to describe)
- [x] ~Changelog~ (no user-visible change)
- [x] ~Tests~ (no behaviour to pin)
