### PR TITLE
plexupdate: Add interactive plex.tv authentication and general plugin rewrite

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@
 # Specific ownerships:
 /beets/metadata_plugins.py @semohr
 /beetsplug/tidal/* @semohr
+/beetsplug/plexupdate.py @semohr
 
 /beetsplug/titlecase.py @henry-oberholtzer
 

--- a/beetsplug/plexupdate.py
+++ b/beetsplug/plexupdate.py
@@ -156,16 +156,17 @@ class PlexSession(TimeoutAndRetrySession):
         """
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            try:
+            data: JSONDict = {}
+            with suppress(requests.exceptions.RequestException):
                 data = (
                     super().request("get", f"{PLEX_API}/pins/{pin_id}").json()
                 )
-            except requests.exceptions.RequestException:
-                log.debug("Plex pin polling failed")
-                time.sleep(5)  # 5s polling
-                continue
+
             if token := data.get("authToken"):
                 return token
+
+            log.debug("Plex pin polling failed. Retrying in 5s...")
+            time.sleep(5)  # 5s polling
         return None
 
 

--- a/beetsplug/plexupdate.py
+++ b/beetsplug/plexupdate.py
@@ -19,6 +19,7 @@ import webbrowser
 from contextlib import suppress
 from functools import cached_property
 from http import HTTPStatus
+from json import JSONDecodeError
 from typing import TYPE_CHECKING, ClassVar, Protocol
 from urllib.parse import urlencode, urljoin
 
@@ -117,7 +118,7 @@ class PlexSession(TimeoutAndRetrySession):
         not-yet-existing file is re-checked until it appears.
         """
         if self._token_cache is None:
-            with suppress(FileNotFoundError):
+            with suppress(FileNotFoundError, JSONDecodeError, OSError):
                 self._token_cache = json.loads(self.token_path.read_text())
 
         return self._token_cache or {}

--- a/beetsplug/plexupdate.py
+++ b/beetsplug/plexupdate.py
@@ -1,6 +1,8 @@
-"""Updates an Plex library whenever the beets library is changed.
+"""Updates a Plex library whenever the beets library is changed.
 
-Plex Home users enter the Plex Token to enable updating.
+Plex Home users enter the Plex Token to enable updating, or run
+``beet plexupdate --auth`` once to log in via plex.tv: the obtained
+device token is stored in a token file next to the beets configuration.
 Put something like the following in your config.yaml to configure:
     plex:
         host: localhost
@@ -10,120 +12,358 @@ Put something like the following in your config.yaml to configure:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import json
+import time
+import uuid
+import webbrowser
+from contextlib import suppress
+from functools import cached_property
+from http import HTTPStatus
+from typing import TYPE_CHECKING, ClassVar, Protocol
 from urllib.parse import urlencode, urljoin
-from xml.etree import ElementTree
 
+import confuse
 import requests
 
-from beets import config
+from beets import __version__, ui
+from beets.exceptions import UserError
+from beets.logging import getLogger
 from beets.plugins import BeetsPlugin
+from beetsplug._utils.requests import (
+    BeetsHTTPError,
+    RequestHandler,
+    TimeoutAndRetrySession,
+)
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from beets.library import LibModel, Library
+    from beetsplug._typing import JSONDict
+
+log = getLogger("beets.plexupdate")
+
+# plex.tv endpoints used by the interactive PIN based authentication.
+PLEX_API = "https://plex.tv/api/v2"
+PLEX_AUTH_URL = "https://app.plex.tv/auth#?"
 
 
-def get_music_section(
-    host: str,
-    port: int,
-    token: str,
-    library_name: str,
-    secure: bool,
-    ignore_cert_errors: bool,
-) -> str | None:
-    """Getting the section key for the music library in Plex."""
-    api_endpoint = append_token("library/sections", token)
-    url = urljoin(f"{get_protocol(secure)}://{host}:{port}", api_endpoint)
-
-    # Sends request.
-    r = requests.get(url, verify=not ignore_cert_errors, timeout=10)
-
-    # Parse xml tree and extract music section key.
-    tree = ElementTree.fromstring(r.content)
-    for child in tree.findall("Directory"):
-        if child.get("title") == library_name:
-            return child.get("key")
-    return None
+class PlexUpdateCLIOpts(Protocol):
+    auth: bool
 
 
-def update_plex(
-    host: str,
-    port: int,
-    token: str,
-    library_name: str,
-    secure: bool,
-    ignore_cert_errors: bool,
-) -> requests.Response:
-    """Ignore certificate errors if configured to."""
-    if ignore_cert_errors:
-        import urllib3
+class PlexSession(TimeoutAndRetrySession):
+    """HTTP session for the Plex server and plex.tv with PIN auth.
 
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-    """Sends request to the Plex api to start a library refresh.
+    Plex does not offer a public OAuth2 flow (bummer). Instead, third-party
+    applications authenticate through Plex' PIN flow: the obtained access
+    token is exchanged for the token of the local server, which is stored
+    and used for updates.
+
+    see https://developer.plex.tv/pms/#section/API-Info/Authenticating-with-Plex
     """
-    # Getting section key and build url.
-    section_key = get_music_section(
-        host, port, token, library_name, secure, ignore_cert_errors
-    )
-    api_endpoint = f"library/sections/{section_key}/refresh"
-    api_endpoint = append_token(api_endpoint, token)
-    url = urljoin(f"{get_protocol(secure)}://{host}:{port}", api_endpoint)
 
-    # Sends request and returns requests object.
-    return requests.get(url, verify=not ignore_cert_errors, timeout=10)
+    def __init__(
+        self,
+        token_path: Path,
+        verify: bool = True,
+        token_override: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.token_path = token_path
+        self.token_override = token_override
+        # The token file is read at most once per run; `save_token` is the
+        # only writer and keeps the cache in sync.
+        self._token_cache: JSONDict | None = None
+
+        # Allow ignoring certificate errors for self-signed certs.
+        self.verify = verify
+
+        self.headers.update(
+            {
+                "accept": "application/json",
+                "X-Plex-Product": "beets",
+                "X-Plex-Product-Version": __version__,
+                "X-Plex-Client-Identifier": self.client_id,
+            }
+        )
+
+    @property
+    def token(self) -> str | None:
+        """The auth token: the configured override or the stored token."""
+        return self.token_override or self.load_token().get("X-Plex-Token")
+
+    @property
+    def client_id(self) -> str:
+        """The client identifier used for plex.tv authentication.
+
+        Either load from the token file or generate a new one and persist it
+        on first use.
+        """
+        data = self.load_token()
+        if client_id := data.get("client_identifier"):
+            return client_id
+
+        client_id = uuid.uuid4().hex
+        data["client_identifier"] = client_id
+        self.save_token(data)
+        log.debug("Generated and saved new client identifier")
+        return client_id
+
+    def load_token(self) -> JSONDict:
+        """Load the token data from the token file.
+
+        The contents are cached after the first successful read; a
+        not-yet-existing file is re-checked until it appears.
+        """
+        if self._token_cache is None:
+            with suppress(FileNotFoundError):
+                self._token_cache = json.loads(self.token_path.read_text())
+
+        return self._token_cache or {}
+
+    def save_token(self, data: JSONDict) -> None:
+        """Merge data into the token file and persist it."""
+        token = self.load_token()
+        token.update(data)
+        self.token_path.write_text(json.dumps(token, indent=2))
+
+    def request(self, *args, **kwargs) -> requests.Response:
+        """Send a request, attaching the auth token."""
+        headers = kwargs.setdefault("headers", {})
+        if token := self.token:
+            headers["X-Plex-Token"] = token
+        return super().request(*args, **kwargs)
+
+    def create_pin(self) -> JSONDict:
+        """Create a pin that yields the user's access token after
+        authorization."""
+        return (
+            super()
+            .request("post", f"{PLEX_API}/pins", params={"strong": True})
+            .json()
+        )
+
+    def wait_for_login(
+        self,
+        pin_id: int,
+        timeout: int = 300,  # 5min
+    ) -> str | None:
+        """Poll the pin endpoint until the user authorized the login.
+
+        Returns the plex.tv account token, or ``None`` on timeout.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                data = (
+                    super().request("get", f"{PLEX_API}/pins/{pin_id}").json()
+                )
+            except requests.exceptions.RequestException:
+                log.debug("Plex pin polling failed")
+                time.sleep(5)  # 5s polling
+                continue
+            if token := data.get("authToken"):
+                return token
+        return None
 
 
-def append_token(url: str, token: str) -> str:
-    """Appends the Plex Home token to the api call if required."""
-    if token:
-        url += f"?{urlencode({'X-Plex-Token': token})}"
-    return url
+class UnauthorizedPlexError(BeetsHTTPError):
+    """The Plex server rejected the request (401)."""
+
+    STATUS = HTTPStatus.UNAUTHORIZED
+
+    def __init__(self, *args, message: str | None = None, **kwargs) -> None:
+        message = (
+            f"HTTP Error: {self.STATUS.value} {self.STATUS.phrase}. "
+            "You may need to reauthenticate using `beet plexupdate --auth`."
+        )
+        super().__init__(*args, message=message, **kwargs)
 
 
-def get_protocol(secure: bool) -> str:
-    if secure:
-        return "https"
-    return "http"
+class PlexAPI(RequestHandler):
+    """API client for Plex.
+
+    Wraps the interactive plex.tv PIN authentication flow and the local
+    server API used to refresh the music library; the session deals with
+    the HTTP requests to plex.tv, token persistence and the PIN flow.
+    """
+
+    explicit_http_errors: ClassVar[list[type[BeetsHTTPError]]] = [
+        UnauthorizedPlexError
+    ]
+
+    def __init__(
+        self,
+        token_path: Path,
+        host: str,
+        port: int,
+        library_name: str,
+        secure: bool,
+        verify: bool,
+        token_override: str | None = None,
+    ) -> None:
+        self.token_path = token_path
+        self.token_override = token_override
+        self.library_name = library_name
+
+        self.base_url = f"{'https' if secure else 'http'}://{host}:{port}/"
+        self._verify = verify
+
+    @cached_property
+    def session(self) -> PlexSession:
+        """Session with token persistence and plex.tv identifying headers."""
+        return PlexSession(
+            token_path=self.token_path,
+            verify=self._verify,
+            token_override=self.token_override,
+        )
+
+    def ui_authenticate_flow(self) -> None:
+        """Interactive authentication with plex.tv (PIN flow).
+
+        1. Open the authentication URL in the browser
+        2. Wait for the user to authorize (~5 minutes)
+        3. Token is auto-saved for future use
+        """
+        try:
+            pin = self.session.create_pin()
+        except requests.exceptions.RequestException as e:
+            raise UserError(f"Plex login flow failed: {e}") from e
+
+        auth_url = PLEX_AUTH_URL + urlencode(
+            {
+                "clientID": self.session.client_id,
+                "code": pin["code"],
+                "context[device][product]": "beets",
+            }
+        )
+        ui.print_(f"Please visit: {auth_url}")
+        ui.print_("Waiting for authorization in your browser...")
+        with suppress(webbrowser.Error):
+            webbrowser.open(auth_url)
+
+        if not (account_token := self.session.wait_for_login(pin["id"])):
+            raise UserError(
+                "Plex authentication timed out. Please run "
+                "`beet plexupdate --auth` again."
+            )
+
+        # The pin flow token works for plex.tv and the local server
+        # alike, so it is stored directly.
+        self.session.save_token({"X-Plex-Token": account_token})
+        ui.print_(
+            f"Authentication successful! Token saved to {self.token_path}."
+        )
+
+    def get_music_section(self) -> str | None:
+        """The section key for the music library in Plex."""
+        data = self.get_json(urljoin(self.base_url, "library/sections"))
+
+        # Find the section with the configured name and return its key.
+        for directory in data.get("MediaContainer", {}).get("Directory", []):
+            if directory.get("title") == self.library_name:
+                return str(directory["key"])
+        return None
+
+    def update_library(self) -> requests.Response:
+        """Start a refresh of the music library."""
+        section_key = self.get_music_section()
+        if section_key is None:
+            raise UserError(
+                f"No music library named {self.library_name!r} found on "
+                "the Plex server. Check the `plex.library_name` setting."
+            )
+
+        return self.get(
+            urljoin(self.base_url, f"library/sections/{section_key}/refresh")
+        )
 
 
 class PlexUpdate(BeetsPlugin):
     def __init__(self) -> None:
-        super().__init__()
-
-        # Adding defaults.
-        config["plex"].add(
+        # Set name so the config is available under `plex:` in config.yaml
+        super().__init__("plex")
+        self.config.add(
             {
                 "host": "localhost",
                 "port": 32400,
-                "token": "",
                 "library_name": "Music",
                 "secure": False,
                 "ignore_cert_errors": False,
+                "tokenfile": "plex_token.json",
+                # Deprecated: use `beet plexupdate --auth` instead.
+                "token": "",
             }
         )
+        self.config["token"].redact = True
 
-        config["plex"]["token"].redact = True
+        # `cli_exit` is registered lazily on the first library change so
+        # read-only operations skip the refresh.
+        self._registered = False
         self.register_listener("database_change", self.listen_for_db_change)
 
+    @cached_property
+    def api(self) -> PlexAPI:
+        """API client for plex.tv authentication and the local server."""
+        return PlexAPI(
+            token_path=self._tokenfile(),
+            host=self.config["host"].get(str),
+            port=self.config["port"].get(),
+            library_name=self.config["library_name"].get(),
+            secure=self.config["secure"].get(bool),
+            verify=not self.config["ignore_cert_errors"].get(bool),
+            token_override=self.config["token"].get(str) or None,
+        )
+
+    def _tokenfile(self) -> Path:
+        """Path to the JSON file holding the plex.tv auth token."""
+        return self.config["tokenfile"].get(confuse.Path(in_app_dir=True))
+
     def listen_for_db_change(self, lib: Library, model: LibModel) -> None:
-        """Listens for beets db change and register the update for the end"""
-        self.register_listener("cli_exit", self.update)
+        """Register the exit-time Plex refresh on the first library change."""
+        if not self._registered:
+            self.register_listener("cli_exit", self.update)
+            self._registered = True
 
     def update(self, lib: Library) -> None:
-        """When the client exists try to send refresh request to Plex server."""
-        self._log.info("Updating Plex library...")
+        """Send a refresh request to the Plex server when the client exits."""
+        log.info("Updating Plex library...")
 
-        # Try to send update request.
         try:
-            update_plex(
-                config["plex"]["host"].get(),
-                config["plex"]["port"].get(),
-                config["plex"]["token"].get(),
-                config["plex"]["library_name"].get(),
-                config["plex"]["secure"].get(bool),
-                config["plex"]["ignore_cert_errors"].get(bool),
+            self.api.update_library()
+            log.info("Started library update successfully.")
+        except UserError as e:
+            log.exception("Plex library update failed: %s", e)
+        except UnauthorizedPlexError:
+            log.error(
+                "Plex library update failed: the server rejected the "
+                "request (401). If it requires authentication, run "
+                "`beet plexupdate --auth`."
             )
-            self._log.info("... started.")
-
         except requests.exceptions.RequestException:
-            self._log.warning("Update failed.")
+            log.exception("Library update failed!")
+
+    def commands(self) -> list[ui.Subcommand]:
+        plexupdate_cmd = ui.Subcommand(
+            "plexupdate", help="Update Plex library when beets library changes"
+        )
+        plexupdate_cmd.parser.add_option(
+            "-a",
+            "--auth",
+            action="store_true",
+            help="Authenticate and login to Plex",
+            default=False,
+        )
+
+        def auth_func(
+            lib: Library, opts: PlexUpdateCLIOpts, args: list[str]
+        ) -> None:
+            if opts.auth:
+                self.api.ui_authenticate_flow()
+            else:
+                plexupdate_cmd.print_help()
+
+        plexupdate_cmd.func = auth_func
+
+        return [plexupdate_cmd]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,10 @@ Unreleased
 New features
 ~~~~~~~~~~~~
 
+- :doc:`plugins/plexupdate`: Add ``beet plexupdate --auth``, an interactive
+  plex.tv login following Plex' traditional PIN authentication flow: the access
+  token for the local server is stored in a token file. The manual ``token``
+  configuration option is now deprecated.
 - :ref:`duplicate_action`: Add an ``upgrade`` option that replaces individual
   duplicate tracks only if the new copy has a higher bitrate, adds any genuinely
   new tracks, and keeps the album together rather than splitting it. The option

--- a/docs/plugins/plexupdate.rst
+++ b/docs/plugins/plexupdate.rst
@@ -1,45 +1,134 @@
 PlexUpdate Plugin
 =================
 
-``plexupdate`` is a very simple plugin for beets that lets you automatically
-update Plex_'s music library whenever you change your beets library.
+The ``plexupdate`` plugin automatically refreshes the music library on your
+Plex_ Media Server whenever your beets library changes.
 
-Firstly, install ``beets`` with ``plexupdate`` extra
+Why Use the PlexUpdate Plugin?
+------------------------------
 
-.. code-block:: console
+The PlexUpdate plugin allows you to:
+
+- Keep the music library on your Plex Media Server in sync with beets
+- Avoid having to trigger a library scan in Plex manually
+- Refresh Plex automatically after imports, edits, moves, and other commands
+  that modify your library
+
+Once configured, the refresh happens automatically whenever a beets command
+changes your library, so you don't need to think about it.
+
+Requirements
+------------
+
+- A running Plex Media Server instance that beets can reach over the network
+
+Installation
+------------
+
+To use the ``plexupdate`` plugin, first enable it in your configuration (see
+:ref:`using-plugins`). Then, install ``beets`` with the ``plexupdate`` extra:
+
+.. code-block:: bash
 
     pip install "beets[plexupdate]"
 
-Then, enable ``plexupdate`` plugin it in your configuration (see
-:ref:`using-plugins`). Optionally, configure the specifics of your Plex server.
-You can do this using a ``plex:`` section in your ``config.yaml``:
+Authentication
+--------------
 
-.. code-block:: yaml
+Plex requires an authentication token for API requests. The easiest way to
+obtain one is the interactive login:
 
-    plex:
-        host: "localhost"
-        port: 32400
-        token: "TOKEN"
+.. code-block:: bash
 
-The ``token`` key is optional: you'll need to use it when in a Plex Home (see
-Plex's own `documentation about tokens`_).
+    beet plexupdate --auth
 
-With that all in place, you'll see beets send the "update" command to your Plex
-server every time you change your beets library.
+This opens a browser window where you can log in to your Plex account and
+authorize beets. After a successful login, the access token is stored in the
+token file (see the ``tokenfile`` option below), and beets uses it to update
+your library on subsequent runs.
 
-.. _documentation about tokens: https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/
+.. dropdown:: Alternative Authentication
 
-.. _plex: https://watch.plex.tv/
+    Alternatively, the ``token`` configuration option provides a legacy way to
+    authenticate: it accepts a token from your Plex account directly (see Plex's
+    `documentation about tokens`_). It should not be used for new setups, though --
+    run ``beet plexupdate --auth`` instead, which stores the token in the token
+    file and keeps it out of your configuration.
+
+Basic Usage
+-----------
+
+Enable the ``plexupdate`` plugin (see :ref:`using-plugins`) and, optionally,
+configure your Plex server as described below. Whenever a beets command modifies
+your library (for example ``beet import``, ``beet modify``, or ``beet move``)
+the plugin tells Plex to refresh its music library when the command finishes.
+
+You can verify the refresh in the Plex web interface: the activity view of your
+music library shows the scan started by beets.
 
 Configuration
 -------------
 
-The available options under the ``plex:`` section are:
+The plugin is configured under the ``plex:`` section!
 
-- **host**: The Plex server name. Default: ``localhost``.
-- **port**: The Plex server port. Default: 32400.
-- **token**: The Plex Home token. Default: Empty.
-- **library_name**: The name of the Plex library to update. Default: ``Music``
-- **secure**: Use secure connections to the Plex server. Default: ``False``
-- **ignore_cert_errors**: Ignore TLS certificate errors when using secure
-  connections. Default: ``False``
+Default
+~~~~~~~
+
+.. code-block:: yaml
+
+    plex:
+        host: localhost
+        port: 32400
+        library_name: Music
+        secure: no
+        ignore_cert_errors: no
+        tokenfile: plex_token.json
+
+.. conf:: host
+    :default: localhost
+
+    The hostname or IP address of the Plex Media Server.
+
+.. conf:: port
+    :default: 32400
+
+    The port on which the Plex Media Server listens.
+
+.. conf:: library_name
+    :default: Music
+
+    The name of the Plex library to refresh.
+
+.. conf:: secure
+    :default: no
+
+    Use HTTPS instead of HTTP when connecting to the Plex Media Server.
+    Enable this when your server is only reachable over a secure connection,
+    for example through a reverse proxy.
+
+.. conf:: ignore_cert_errors
+    :default: no
+
+    Ignore TLS certificate errors when ``secure`` is enabled. Useful when
+    the server uses a self-signed certificate.
+
+.. conf:: tokenfile
+    :default: plex_token.json
+
+    The file where the token obtained via ``beet plexupdate --auth`` is
+    stored together with the client identifier used for the login. The file
+    is created in the beets configuration directory.
+
+.. conf:: token
+    :default: ""
+
+    .. deprecated:: 2.14 Use ``beet plexupdate --auth`` instead.
+
+    A Plex token that overrides the token stored by ``beet plexupdate
+    --auth``. Kept for legacy configurations that cannot use the interactive
+    login, for example Plex Home accounts. This value is never written to the
+    token file and is redacted in beets' configuration listings.
+
+.. _documentation about tokens: https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/
+
+.. _plex: https://www.plex.tv/

--- a/test/plugins/test_plexupdate.py
+++ b/test/plugins/test_plexupdate.py
@@ -1,132 +1,223 @@
-import responses
+"""Tests for the 'plexupdate' plugin."""
 
-from beets.test.helper import PluginTestCase
-from beetsplug.plexupdate import get_music_section, update_plex
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest import mock
+
+import pytest
+
+from beets.exceptions import UserError
+from beetsplug._utils.requests import SingletonMeta
+from beetsplug.plexupdate import (
+    PLEX_API,
+    PlexAPI,
+    PlexSession,
+    UnauthorizedPlexError,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from requests_mock import Mocker
 
 
-class PlexUpdateTest(PluginTestCase):
-    plugin = "plexupdate"
+@pytest.fixture(autouse=True)
+def reset_plex_session():
+    """Drop the PlexSession singleton so each test gets a fresh session."""
+    yield
+    SingletonMeta._instances.pop(PlexSession, None)
 
-    def add_response_get_music_section(self, section_name="Music"):
-        """Create response for mocking the get_music_section function."""
 
-        escaped_section_name = section_name.replace('"', '\\"')
+@pytest.fixture
+def api(tmp_path: Path) -> PlexAPI:
+    """PlexAPI for the local test server with a per-test token file."""
+    return PlexAPI(
+        token_path=tmp_path / "plex_token.json",
+        host="localhost",
+        port=32400,
+        library_name="Music",
+        secure=False,
+        verify=True,
+        token_override="",
+    )
 
-        body = (
-            '<?xml version="1.0" encoding="UTF-8"?>'
-            '<MediaContainer size="3" allowSync="0" '
-            'identifier="com.plexapp.plugins.library" '
-            'mediaTagPrefix="/system/bundle/media/flags/" '
-            'mediaTagVersion="1413367228" title1="Plex Library">'
-            '<Directory allowSync="0" art="/:/resources/movie-fanart.jpg" '
-            'filters="1" refreshing="0" thumb="/:/resources/movie.png" '
-            'key="3" type="movie" title="Movies" '
-            'composite="/library/sections/3/composite/1416232668" '
-            'agent="com.plexapp.agents.imdb" scanner="Plex Movie Scanner" '
-            'language="de" uuid="92f68526-21eb-4ee2-8e22-d36355a17f1f" '
-            'updatedAt="1416232668" createdAt="1415720680">'
-            '<Location id="3" path="/home/marv/Media/Videos/Movies" />'
-            "</Directory>"
-            '<Directory allowSync="0" art="/:/resources/artist-fanart.jpg" '
-            'filters="1" refreshing="0" thumb="/:/resources/artist.png" '
-            f'key="2" type="artist" title="{escaped_section_name}" '
-            'composite="/library/sections/2/composite/1416929243" '
-            'agent="com.plexapp.agents.lastfm" scanner="Plex Music Scanner" '
-            'language="en" uuid="90897c95-b3bd-4778-a9c8-1f43cb78f047" '
-            'updatedAt="1416929243" createdAt="1415691331">'
-            '<Location id="2" path="/home/marv/Media/Musik" />'
-            "</Directory>"
-            '<Directory allowSync="0" art="/:/resources/show-fanart.jpg" '
-            'filters="1" refreshing="0" thumb="/:/resources/show.png" '
-            'key="1" type="show" title="TV Shows" '
-            'composite="/library/sections/1/composite/1416320800" '
-            'agent="com.plexapp.agents.thetvdb" scanner="Plex Series Scanner" '
-            'language="de" uuid="04d2249b-160a-4ae9-8100-106f4ec1a218" '
-            'updatedAt="1416320800" createdAt="1415690983">'
-            '<Location id="1" path="/home/marv/Media/Videos/Series" />'
-            "</Directory>"
-            "</MediaContainer>"
-        )
-        status = 200
-        content_type = "text/xml;charset=utf-8"
 
-        responses.add(
-            responses.GET,
+@pytest.fixture
+def session(tmp_path: Path) -> PlexSession:
+    """PlexSession bound to a token file in a per-test directory."""
+    return PlexSession(token_path=tmp_path / "plex_token.json")
+
+
+@pytest.fixture
+def plex_tv(requests_mock: Mocker) -> Mocker:
+    """Mock the plex.tv PIN flow: issuing a pin and still-pending polls."""
+    requests_mock.post(
+        f"{PLEX_API}/pins", json={"id": 1, "code": "ABCD", "expiresIn": 1800}
+    )
+    requests_mock.get(f"{PLEX_API}/pins/1", json={"id": 1, "code": "ABCD"})
+    return requests_mock
+
+
+class TestUpdateLibrary:
+    def test_get_named_music_section(self, requests_mock, api):
+        requests_mock.get(
             "http://localhost:32400/library/sections",
-            body=body,
-            status=status,
-            content_type=content_type,
+            json={
+                "MediaContainer": {
+                    "Directory": [
+                        {"key": "3", "title": "Movies"},
+                        {"key": "2", "title": "My Music Library"},
+                    ]
+                }
+            },
+        )
+        api.library_name = "My Music Library"
+
+        assert api.get_music_section() == "2"
+
+    def test_update_library(self, requests_mock, api):
+        requests_mock.get(
+            "http://localhost:32400/library/sections",
+            json={
+                "MediaContainer": {
+                    "Directory": [{"key": "2", "title": "Music"}]
+                }
+            },
+        )
+        requests_mock.get("http://localhost:32400/library/sections/2/refresh")
+
+        assert api.update_library().status_code == 200
+
+    def test_update_library_unauthorized(self, requests_mock, api):
+        """A rejected token surfaces as an UnauthorizedPlexError."""
+        requests_mock.get(
+            "http://localhost:32400/library/sections",
+            json={
+                "MediaContainer": {
+                    "Directory": [{"key": "2", "title": "Music"}]
+                }
+            },
+        )
+        requests_mock.get(
+            "http://localhost:32400/library/sections/2/refresh", status_code=401
         )
 
-    def add_response_update_plex(self):
-        """Create response for mocking the update_plex function."""
-        body = ""
-        status = 200
-        content_type = "text/html"
+        with pytest.raises(UnauthorizedPlexError, match="reauthenticate"):
+            api.update_library()
 
-        responses.add(
-            responses.GET,
-            "http://localhost:32400/library/sections/2/refresh",
-            body=body,
-            status=status,
-            content_type=content_type,
+    def test_update_library_missing_section(self, requests_mock, api):
+        # The server has no section with the configured name.
+        requests_mock.get(
+            "http://localhost:32400/library/sections",
+            json={
+                "MediaContainer": {
+                    "Directory": [{"key": "3", "title": "Other Library"}]
+                }
+            },
         )
 
-    def setUp(self):
-        super().setUp()
+        with pytest.raises(UserError, match="No music library named"):
+            api.update_library()
 
-        self.config["plex"] = {"host": "localhost", "port": 32400}
 
-    @responses.activate
-    def test_get_music_section(self):
-        # Adding response.
-        self.add_response_get_music_section()
+class TestPlexSession:
+    def test_session_saves_token(self, session):
+        session.save_token({"X-Plex-Token": "TOKEN123"})
 
-        # Test if section key is "2" out of the mocking data.
+        assert session.token == "TOKEN123"
+        assert session.load_token() == {
+            "X-Plex-Token": "TOKEN123",
+            "client_identifier": session.client_id,
+        }
+
+    def test_wait_for_login_timeout(self, plex_tv, session):
+        # The pin never gets an auth token.
+        with mock.patch("beetsplug.plexupdate.time.sleep"):
+            assert session.wait_for_login(1, timeout=1) is None
+
+    def test_request_attaches_token_to_local_server(
+        self, requests_mock, session
+    ):
+        """The stored token is sent to the local server."""
+        requests_mock.get("http://localhost:32400/library/sections", json={})
+        session.save_token({"X-Plex-Token": "TOKEN123"})
+
+        session.get("http://localhost:32400/library/sections")
+
         assert (
-            get_music_section(
-                self.config["plex"]["host"],
-                self.config["plex"]["port"],
-                self.config["plex"]["token"],
-                self.config["plex"]["library_name"].get(),
-                self.config["plex"]["secure"],
-                self.config["plex"]["ignore_cert_errors"],
-            )
-            == "2"
+            requests_mock.request_history[0].headers["X-Plex-Token"]
+            == "TOKEN123"
         )
 
-    @responses.activate
-    def test_get_named_music_section(self):
-        # Adding response.
-        self.add_response_get_music_section("My Music Library")
+    def test_request_prefers_configured_token(self, requests_mock, tmp_path):
+        """The configured token wins over the stored plex.tv token."""
+        session = PlexSession(
+            token_path=tmp_path / "plex_token.json",
+            token_override="CONFIG_TOKEN",
+        )
+        session.save_token({"X-Plex-Token": "TOKEN123"})
+        requests_mock.get("http://localhost:32400/library/sections", json={})
+
+        session.get("http://localhost:32400/library/sections")
 
         assert (
-            get_music_section(
-                self.config["plex"]["host"],
-                self.config["plex"]["port"],
-                self.config["plex"]["token"],
-                "My Music Library",
-                self.config["plex"]["secure"],
-                self.config["plex"]["ignore_cert_errors"],
-            )
-            == "2"
+            requests_mock.request_history[0].headers["X-Plex-Token"]
+            == "CONFIG_TOKEN"
         )
 
-    @responses.activate
-    def test_update_plex(self):
-        # Adding responses.
-        self.add_response_get_music_section()
-        self.add_response_update_plex()
 
-        # Testing status code of the mocking request.
+class TestUIAuthenticateFlow:
+    def test_ui_authenticate_flow(self, requests_mock, plex_tv, api):
+        # The first poll is still pending, the second grants access.
+        requests_mock.get(
+            f"{PLEX_API}/pins/1",
+            response_list=[
+                {"json": {"id": 1, "code": "ABCD"}},
+                {"json": {"id": 1, "code": "ABCD", "authToken": "TOKEN123"}},
+            ],
+        )
+
+        with (
+            mock.patch("beetsplug.plexupdate.time.sleep"),
+            mock.patch("beetsplug.plexupdate.webbrowser.open") as open_mock,
+        ):
+            api.ui_authenticate_flow()
+
+        open_mock.assert_called_once()
+
+        # The pin request carries the identifying headers.
+        request = requests_mock.request_history[0]
         assert (
-            update_plex(
-                self.config["plex"]["host"],
-                self.config["plex"]["port"],
-                self.config["plex"]["token"],
-                self.config["plex"]["library_name"].get(),
-                self.config["plex"]["secure"],
-                self.config["plex"]["ignore_cert_errors"],
-            ).status_code
-            == 200
+            request.headers["X-Plex-Client-Identifier"] == api.session.client_id
         )
+
+        # The access token is persisted for later runs.
+        assert api.session.token == "TOKEN123"
+        assert json.loads(
+            api.session.token_path.read_text(encoding="utf-8")
+        ) == {
+            "X-Plex-Token": "TOKEN123",
+            "client_identifier": api.session.client_id,
+        }
+
+    def test_ui_authenticate_flow_timeout(self, plex_tv, api):
+        with (
+            mock.patch("beetsplug.plexupdate.time.sleep"),
+            mock.patch("beetsplug.plexupdate.webbrowser.open"),
+            mock.patch.object(api.session, "wait_for_login", return_value=None),
+        ):
+            with pytest.raises(UserError):
+                api.ui_authenticate_flow()
+
+        # No token is stored when the login is not completed.
+        assert api.session.token is None
+
+    def test_ui_authenticate_flow_network_error(self, requests_mock, api):
+        # A failing plex.tv request surfaces as a UserError instead of a
+        # raw requests exception.
+        requests_mock.post(f"{PLEX_API}/pins", status_code=500)
+
+        with pytest.raises(UserError, match="Plex login flow failed"):
+            api.ui_authenticate_flow()

--- a/uv.lock
+++ b/uv.lock
@@ -1248,7 +1248,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2790,13 +2790,13 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "accessible-pygments" },
-    { name = "babel" },
-    { name = "beautifulsoup4" },
-    { name = "docutils" },
-    { name = "pygments" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "accessible-pygments", marker = "python_full_version < '3.11'" },
+    { name = "babel", marker = "python_full_version < '3.11'" },
+    { name = "beautifulsoup4", marker = "python_full_version < '3.11'" },
+    { name = "docutils", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/39/7e/e3defb93f30557ae825a3b3fbc2c6728301e5e9505a85e00d8503345c42c/pydata_sphinx_theme-0.19.0.tar.gz", hash = "sha256:148ba092bd6937b3321385dc482cc69a29ad2ede36547b4f010ade782bc6a062", size = 5004933, upload-time = "2026-06-15T09:31:02.268Z" }
 wheels = [
@@ -2814,14 +2814,14 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "accessible-pygments" },
-    { name = "babel" },
-    { name = "beautifulsoup4" },
-    { name = "docutils" },
-    { name = "jinja2" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "accessible-pygments", marker = "python_full_version >= '3.11'" },
+    { name = "babel", marker = "python_full_version >= '3.11'" },
+    { name = "beautifulsoup4", marker = "python_full_version >= '3.11'" },
+    { name = "docutils", marker = "python_full_version >= '3.11'" },
+    { name = "jinja2", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "requests", marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/8e/add936feaaa9dade7d5b87c6852566d85e518b38ad32224dea32ef958984/pydata_sphinx_theme-0.20.0.tar.gz", hash = "sha256:0da172d41e19a66de875f4002f7054b385372ec65763852193791e658d50bb4a", size = 5004756, upload-time = "2026-07-09T09:09:14.693Z" }
 wheels = [
@@ -3411,7 +3411,7 @@ name = "roman-numerals-py"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "roman-numerals" },
+    { name = "roman-numerals", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cb/b5/de96fca640f4f656eb79bbee0e79aeec52e3e0e359f8a3e6a0d366378b64/roman_numerals_py-4.1.0.tar.gz", hash = "sha256:f5d7b2b4ca52dd855ef7ab8eb3590f428c0b1ea480736ce32b01fef2a5f8daf9", size = 4274, upload-time = "2025-12-17T18:25:41.153Z" }
 wheels = [
@@ -3460,10 +3460,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -3510,12 +3510,12 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "narwhals" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "joblib", marker = "python_full_version >= '3.11'" },
+    { name = "narwhals", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "threadpoolctl" },
+    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
 wheels = [
@@ -3559,7 +3559,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -3618,7 +3618,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -3694,7 +3694,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -3845,23 +3845,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
-    { name = "tomli" },
+    { name = "alabaster", marker = "python_full_version < '3.11'" },
+    { name = "babel", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version < '3.11'" },
+    { name = "imagesize", marker = "python_full_version < '3.11'" },
+    { name = "jinja2", marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "requests", marker = "python_full_version < '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -3879,23 +3879,23 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals-py" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
+    { name = "alabaster", marker = "python_full_version >= '3.11'" },
+    { name = "babel", marker = "python_full_version >= '3.11'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version >= '3.11'" },
+    { name = "imagesize", marker = "python_full_version >= '3.11'" },
+    { name = "jinja2", marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "requests", marker = "python_full_version >= '3.11'" },
+    { name = "roman-numerals-py", marker = "python_full_version >= '3.11'" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.11'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876, upload-time = "2025-03-02T22:31:59.658Z" }
 wheels = [
@@ -3910,7 +3910,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/f0/43c6a5ff3e7b08a8c3b32f81b859f1b518ccc31e45f22e2b41ced38be7b9/sphinx_autodoc_typehints-3.0.1.tar.gz", hash = "sha256:b9b40dd15dee54f6f810c924f863f9cf1c54f9f3265c495140ea01be7f44fa55", size = 36282, upload-time = "2025-01-16T18:25:30.958Z" }
 wheels = [
@@ -3928,7 +3928,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/34/4f/4fd5583678bb7dc8afa69e9b309e6a99ee8d79ad3a4728f4e52fd7cb37c7/sphinx_autodoc_typehints-3.5.2.tar.gz", hash = "sha256:5fcd4a3eb7aa89424c1e2e32bedca66edc38367569c9169a80f4b3e934171fdb", size = 37839, upload-time = "2025-10-16T00:50:15.743Z" }
 wheels = [
@@ -3956,7 +3956,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2b/69/b34e0cb5336f09c6866d53b4a19d76c227cdec1bbc7ac4de63ca7d58c9c7/sphinx_design-0.6.1.tar.gz", hash = "sha256:b44eea3719386d04d765c1a8257caca2b3e6f8421d7b3a5e742c0fd45f84e632", size = 2193689, upload-time = "2024-08-02T13:48:44.277Z" }
 wheels = [
@@ -3974,7 +3974,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/7b/804f311da4663a4aecc6cf7abd83443f3d4ded970826d0c958edc77d4527/sphinx_design-0.7.0.tar.gz", hash = "sha256:d2a3f5b19c24b916adb52f97c5f00efab4009ca337812001109084a740ec9b7a", size = 2203582, upload-time = "2026-01-19T13:12:53.297Z" }
 wheels = [
@@ -4016,12 +4016,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "certifi" },
-    { name = "docutils" },
-    { name = "idna" },
-    { name = "pygments" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "urllib3" },
+    { name = "certifi", marker = "python_full_version < '3.11'" },
+    { name = "docutils", marker = "python_full_version < '3.11'" },
+    { name = "idna", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "urllib3", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/34/fe/ac4e24f35b5148b31ac717ae7dcc7a2f7ec56eb729e22c7252ed8ad2d9a5/sphinx_prompt-1.9.0.tar.gz", hash = "sha256:471b3c6d466dce780a9b167d9541865fd4e9a80ed46e31b06a52a0529ae995a1", size = 5340, upload-time = "2024-08-07T15:46:51.428Z" }
 wheels = [
@@ -4039,14 +4039,14 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "certifi" },
-    { name = "docutils" },
-    { name = "idna" },
-    { name = "jinja2" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "urllib3" },
+    { name = "certifi", marker = "python_full_version >= '3.11'" },
+    { name = "docutils", marker = "python_full_version >= '3.11'" },
+    { name = "idna", marker = "python_full_version >= '3.11'" },
+    { name = "jinja2", marker = "python_full_version >= '3.11'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "requests", marker = "python_full_version >= '3.11'" },
+    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "urllib3", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/a3/91293c0e0f0b76d0697ba7a41541929ca3f5457671d008bd84a9bde17e21/sphinx_prompt-1.10.2.tar.gz", hash = "sha256:47b592ba75caebd044b0eddf7a5a1b6e0aef6df587b034377cd101a999b686ba", size = 5566, upload-time = "2025-11-28T09:23:18.057Z" }
 wheels = [
@@ -4159,8 +4159,8 @@ name = "standard-aifc"
 version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "audioop-lts" },
-    { name = "standard-chunk" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
+    { name = "standard-chunk", marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/53/6050dc3dde1671eb3db592c13b55a8005e5040131f7509cef0215212cb84/standard_aifc-3.13.0.tar.gz", hash = "sha256:64e249c7cb4b3daf2fdba4e95721f811bde8bdfc43ad9f936589b7bb2fae2e43", size = 15240, upload-time = "2024-10-30T16:01:31.772Z" }
 wheels = [
@@ -4190,7 +4190,7 @@ name = "standard-sunau"
 version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "audioop-lts" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/e3/ce8d38cb2d70e05ffeddc28bb09bad77cfef979eb0a299c9117f7ed4e6a9/standard_sunau-3.13.0.tar.gz", hash = "sha256:b319a1ac95a09a2378a8442f403c66f4fd4b36616d6df6ae82b8e536ee790908", size = 9368, upload-time = "2024-10-30T16:01:41.626Z" }
 wheels = [


### PR DESCRIPTION
Rewrite the `plexupdate` plugin around Plex's PIN authentication flow. `beet plexupdate --auth` opens a browser, authenticates with Plex, and stores the token and generated client identifier in `plex_token.json` next to the beets configuration.

* Add `PlexSession` for token persistence, PIN polling, and authenticated server requests.
* Use Plex's JSON API to find the music library section.
* Refresh the library once after modifying commands.
* Clearly report missing sections and `401` responses.
* Deprecate the manual `token` option in favor of interactive authentication.
* Update documentation, tests, and changelog.

### Motivation

`plexupdate` could easily break after Plex deployments or instances were updated, and manually obtaining a token isn't particularly straightforward... This rewrite makes recovery simple: if authentication breaks, users can just run the documented `beet plexupdate --auth` command. 

* [x] Documentation
* [x] Changelog
* [x] Tests



