### PR TITLE
fix(scrub): skip scrubbing when --nowrite is passed

### DIFF
--- a/beetsplug/scrub.py
+++ b/beetsplug/scrub.py
@@ -145,6 +145,8 @@ class ScrubPlugin(BeetsPlugin):
         self, session: ImportSession, task: ImportTask
     ) -> None:
         """Automatically scrub imported files."""
+        if not ui.should_write():
+            return
         for item in task.imported_items():
             self._log.debug("auto-scrubbing {.filepath}", item)
-            self._scrub_item(item, ui.should_write())
+            self._scrub_item(item, True)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -86,9 +86,9 @@ Bug fixes
 - :doc:`plugins/aura`: When sorting by ``field``, do not exclude resources that
   have no value for ``field``.
 - :doc:`plugins/scrub`: The scrub plugin now respects the ``--nowrite`` (``-W``)
-  flag during import. Previously, ``beet import -W`` with the scrub plugin enabled
-  would still remove tags from imported files; the plugin now skips scrubbing when
-  ``should_write()`` returns ``False``. :bug:`6958`
+  flag during import. Previously, ``beet import -W`` with the scrub plugin
+  enabled would still remove tags from imported files; the plugin now skips
+  scrubbing when ``should_write()`` returns ``False``. :bug:`6958`
 - :doc:`plugins/convert`: Fixed convert plugin not taking into account the new
   format when determining the target path. :bug:`1360`
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -85,6 +85,10 @@ Bug fixes
   ``sqlite3.InterfaceError``.
 - :doc:`plugins/aura`: When sorting by ``field``, do not exclude resources that
   have no value for ``field``.
+- :doc:`plugins/scrub`: The scrub plugin now respects the ``--nowrite`` (``-W``)
+  flag during import. Previously, ``beet import -W`` with the scrub plugin enabled
+  would still remove tags from imported files; the plugin now skips scrubbing when
+  ``should_write()`` returns ``False``. :bug:`6958`
 - :doc:`plugins/convert`: Fixed convert plugin not taking into account the new
   format when determining the target path. :bug:`1360`
 

--- a/test/plugins/test_scrub.py
+++ b/test/plugins/test_scrub.py
@@ -25,11 +25,12 @@ class TestScrubbedImport(AsIsImporterMixin, PluginMixin, ImportHelper):
             assert imported_file.artist == "Tag Artist"
             assert imported_file.album == "Tag Album"
 
-    def test_tags_not_restored(self):
+    def test_tags_not_scrubbed_when_nowrite(self):
+        """When --nowrite is passed, scrubbing should be skipped entirely."""
         with self.configure_plugin({"auto": True}):
             self.run_asis_importer(write=False)
 
         for item in self.lib.items():
             imported_file = MediaFile(item.filepath)
-            assert imported_file.artist is None
-            assert imported_file.album is None
+            assert imported_file.artist == "Tag Artist"
+            assert imported_file.album == "Tag Album"


### PR DESCRIPTION
## Description

When `beet import -W` (`--nowrite`) is run with the scrub plugin enabled (`auto=True`), the plugin was scrubbing (removing) tags even though `--nowrite` means "don't write to files". This caused tags to be lost.

The fix adds a guard at the start of `import_task_files` to skip the entire scrub operation when `should_write()` returns `False`, making the scrub plugin respect the `--nowrite` flag like other plugins do.

## Fixes

Fixes #6958

## Changes

- `beetsplug/scrub.py`: Add guard in `import_task_files` to skip scrubbing when `should_write()` returns `False`
- `test/plugins/test_scrub.py`: Update test to expect tags to remain unchanged when `--nowrite` is passed (rename `test_tags_not_restored` to `test_tags_not_scrubbed_when_nowrite`)

## Behavior Change

Before: `beet import -W` with scrub plugin would remove all tags from imported files
After: `beet import -W` with scrub plugin will not modify files at all, respecting `--nowrite`