### PR TITLE
Normalize digital media in Discogs searches

### DIFF
--- a/beetsplug/discogs/__init__.py
+++ b/beetsplug/discogs/__init__.py
@@ -286,6 +286,11 @@ class DiscogsPlugin(SearchApiMetadataSourcePlugin[IDResponse]):
             value = str(most_common)
             if tag == "catalognum":
                 value = value.replace(" ", "")
+            elif tag == "media" and value.casefold() in {
+                "digital media",
+                "web",
+            }:
+                value = "File"
 
             filters[api_field] = value
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -87,6 +87,8 @@ Bug fixes
   have no value for ``field``.
 - :doc:`plugins/convert`: Fixed convert plugin not taking into account the new
   format when determining the target path. :bug:`1360`
+- :doc:`plugins/discogs`: Normalize ``Digital Media`` and ``WEB`` to Discogs'
+  ``File`` format when using ``media`` in ``extra_tags`` search filters.
 
 ..
     For plugin developers

--- a/docs/plugins/discogs.rst
+++ b/docs/plugins/discogs.rst
@@ -180,6 +180,9 @@ Default
     * ``media``
     * ``year``
 
+    When ``media`` is included, ``Digital Media`` and ``WEB`` are normalized to
+    Discogs' ``File`` format when constructing the search query.
+
     Example:
 
     .. code-block:: yaml

--- a/test/plugins/test_discogs.py
+++ b/test/plugins/test_discogs.py
@@ -500,6 +500,23 @@ class TestDGSearchQuery(TestHelper):
         assert filters["catno"] == "ABC123"
         config["discogs"]["extra_tags"] = []
 
+    @pytest.mark.parametrize(
+        "media,expected",
+        [("Digital Media", "File"), ("WEB", "File"), ("Vinyl", "Vinyl")],
+    )
+    def test_extra_tags_normalize_media(self, media, expected):
+        plugin = DiscogsPlugin()
+        plugin.config["extra_tags"] = ["media"]
+
+        items = [Item(media=media)]
+
+        _query, filters = plugin.get_search_query_with_filters(
+            "album", items, "Artist", "Album", False
+        )
+
+        assert filters["format"] == expected
+        config["discogs"]["extra_tags"] = []
+
 
 class TestDGSearchResponse(DiscogsTestMixin):
     @staticmethod


### PR DESCRIPTION
The Discogs plugin supports `media` as an `extra_tags` search filter and maps it to Discogs' format parameter. 

Discogs uses the word `File` to describe digital releases. MusicBrainz on the other hand uses something different,  `Digital Media`

If you have music previously tagged against MusicBrainz, the metadata will usually say `Digital Media`. I have also seen `WEB` being quite common. 

As a result, enabling `media` in `discogs.extra_tags` can negatively impact the search accuracy, while in reality it should not. 

This PR normalizes `Digital Media` and `WEB` to `File` when constructing the Discogs search filter.

PS, this is my first PR in this project. So please let me know if there is something I need to correct. I tried following all the documentation to the best of my knowledge. 

- [✓] Documentation
- [✓] Changelog
- [✓] Tests
