### PR TITLE
fix(tidal): Pass track duration as length for matching

### DIFF
--- a/beetsplug/tidal/__init__.py
+++ b/beetsplug/tidal/__init__.py
@@ -454,7 +454,7 @@ class TidalPlugin(MetadataSourcePlugin):
             isrc=track["attributes"]["isrc"],
             artist=", ".join(artist_names),
             artists=artist_names,
-            duration=self._duration_to_seconds(track["attributes"]["duration"]),
+            length=self._duration_to_seconds(track["attributes"]["duration"]),
             label=self._parse_label(track["attributes"]),
             # Flexattrs
             tidal_track_id=track["id"],

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -90,6 +90,9 @@ Bug fixes
 - :doc:`plugins/edit`: Item-only fields rejected from the album header remain
   available in per-track documents during interactive import when they are also
   configured in ``itemfields``. :bug:`6953`
+- :doc:`plugins/tidal`: Pass the converted track duration as ``length`` so it
+  contributes to the autotagging track-length distance instead of being silently
+  stored as a ``duration`` flexible attribute.
 
 ..
     For plugin developers

--- a/test/plugins/test_tidal.py
+++ b/test/plugins/test_tidal.py
@@ -237,13 +237,12 @@ class TestParsing(TidalPluginTest):
                     "data_source": "Tidal",
                     "data_url": None,
                     "disctitle": None,
-                    "duration": 180,
                     "genres": None,
                     "index": 1,
                     "initial_key": None,
                     "isrc": "ISRC1",
                     "label": None,
-                    "length": None,
+                    "length": 180,
                     "lyricists": None,
                     "lyricists_ids": [],
                     "mb_workid": None,
@@ -283,13 +282,12 @@ class TestParsing(TidalPluginTest):
                     "data_source": "Tidal",
                     "data_url": None,
                     "disctitle": None,
-                    "duration": 240,
                     "genres": None,
                     "index": 2,
                     "initial_key": None,
                     "isrc": "ISRC2",
                     "label": None,
-                    "length": None,
+                    "length": 240,
                     "lyricists": None,
                     "lyricists_ids": [],
                     "mb_workid": None,
@@ -392,7 +390,7 @@ class TestTrackParsing(TidalPluginTest):
 
         assert info.title == "My Track"
         assert info.track_id == "101"
-        assert info.duration == 240  # PT4M = 240 seconds
+        assert info.length == 240  # PT4M = 240 seconds
         assert info.isrc == "ISRC456"
         assert info.artist == "My Artist"
         assert info.tidal_track_id == "101"


### PR DESCRIPTION
Closes #6966

Tidal candidates now contribute track-length distance: the converted ISO 8601 duration is passed as `TrackInfo.length` instead of being stored as a `duration` flex attribute.       

- [x] Changelog. 
- [x] Tests. 
