### PR TITLE
Add "Rescan directory" import prompt choice (v2)

### DIFF
--- a/beets/importer/actions.py
+++ b/beets/importer/actions.py
@@ -17,6 +17,10 @@ class Action(Enum):
     # The RETAG action represents "don't apply any match, but do record
     # new metadata". It's not reachable via the standard command prompt but
     # can be used by plugins.
+    RESCAN = "RESCAN"
+    # Re-read the task's directories from disk and re-run the match, so the
+    # user can clean up files (duplicates, junk) and try again without
+    # restarting the whole import.
 
 
 class DuplicateAction(str, Enum):

--- a/beets/importer/session.py
+++ b/beets/importer/session.py
@@ -10,6 +10,7 @@ from beets.util import displayable_path, normpath, pipeline, syspath
 from . import stages as stagefuncs
 from .actions import Action, DuplicateAction
 from .state import ImportState
+from .tasks import is_subdir_of_any_in_list
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -46,6 +47,8 @@ class ImportSession:
     _is_resuming: dict[bytes, bool]
     _merged_items: set[PathBytes]
     _merged_dirs: set[PathBytes]
+    _rescanned_scopes: dict[PathBytes, int]
+    _rescan_generation: int
 
     def __init__(
         self,
@@ -74,6 +77,8 @@ class ImportSession:
         self._is_resuming = {}
         self._merged_items = set()
         self._merged_dirs = set()
+        self._rescanned_scopes = {}
+        self._rescan_generation = 0
 
         # Normalize the paths.
         self.paths = list(map(normpath, paths or []))
@@ -284,6 +289,72 @@ class ImportSession:
             for path in paths
         }
         self._merged_dirs.update(dirs)
+
+    def mark_rescanned(self, scopes: Sequence[PathBytes]) -> int:
+        """Record that each directory in `scopes` was just re-read from
+        disk by a "Rescan directory" choice, and return the rescan
+        "generation" this counts as.
+
+        Pass exactly the directories a rescan is actually re-reading --
+        not some broader ancestor it merely had to walk through to get
+        there, since anything outside those directories is still only
+        as current as whatever last read it.
+
+        Any other, not-yet-processed task discovered from within one of
+        `scopes` -- e.g. a plain subdirectory holding its own album,
+        found by the original scan -- is now stale relative to this
+        rescan and must be dropped rather than processed a second time
+        alongside whatever the rescan itself finds there (see
+        `already_rescanned`). A task produced by *this* rescan (or a
+        later one covering the same ground) is current, not stale --
+        that's what the returned generation number, stamped onto such a
+        task, is for.
+        """
+        self._rescan_generation += 1
+        for scope in scopes:
+            self._rescanned_scopes[scope] = self._rescan_generation
+        return self._rescan_generation
+
+    @property
+    def rescan_generation(self) -> int:
+        """The most recent generation number returned by
+        `mark_rescanned`, or 0 if no rescan has happened yet in this
+        session.
+
+        A task built fresh -- not read from disk, but assembled in
+        `user_query` from an existing task's items (duplicate-merge,
+        as-Tracks, Group albums) -- should be stamped with this rather
+        than with the task it was built from's own `rescan_generation`:
+        it reflects the *library*'s current state as of right now, not
+        just the directory that produced the original task, and a
+        merge in particular can pull in paths from anywhere in the
+        library that a completely unrelated rescan elsewhere in the
+        same session may have already marked at a higher generation.
+        """
+        return self._rescan_generation
+
+    def already_rescanned(
+        self, paths: Sequence[PathBytes], as_of_generation: int
+    ) -> bool:
+        """Returns true if any of `paths` falls inside a directory a
+        "Rescan directory" choice already re-read from disk *more
+        recently* than `as_of_generation` (see `mark_rescanned`) --
+        meaning these paths are stale relative to that rescan and must
+        be dropped rather than processed again.
+
+        `as_of_generation` should be the task's own
+        `ImportTask.rescan_generation`: 0 for a task straight from the
+        initial scan (never itself the output of a rescan, so any
+        rescan at all supersedes it), or the generation a rescan
+        stamped onto the tasks it produced (so only a *later* rescan
+        covering the same ground supersedes those).
+        """
+        return any(
+            (path == scope or is_subdir_of_any_in_list(path, [scope]))
+            and generation > as_of_generation
+            for path in paths
+            for scope, generation in self._rescanned_scopes.items()
+        )
 
     def is_resuming(self, toppath: PathBytes) -> bool:
         """Return `True` if user wants to resume import of this path.

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -107,81 +107,93 @@ def rescan_tasks(
     by "Group albums" (see ``group_albums`` below), whose items are
     grouped by tag rather than by directory and so have no directory
     scope a filesystem rescan could meaningfully reconstruct.
+
+    Discovery itself is never reimplemented here: every group this
+    yields comes from the exact same ``albums_in_dir`` / flat-mode /
+    single-file logic ``ImportTaskFactory.paths()`` uses for the
+    original scan (see below), so the two can't disagree about what
+    counts as an album. What *is* reconstructed is the narrowest
+    directory that walk needs to start from: rather than always
+    re-walking the task's entire ``toppath`` (correct, but potentially
+    very expensive -- rescanning one album inside a thousand-album
+    library shouldn't mean re-scanning the other 999), this picks the
+    smallest directory guaranteed to contain the whole original group
+    and re-derives which of that walk's results are the ones this task
+    actually came from. That reconstruction is the part genuinely
+    particular to rescanning, and it's what the comments below are
+    about.
     """
     assert task.toppath is not None
 
     # `task.paths` records the *original* directories this task was
     # discovered from -- e.g. `[album_root, disc1, disc2]` for a nested
     # multi-disc album, or `[disc1, disc2]` for two disc directories that
-    # sit side by side with no wrapping parent. Either way, the first
-    # entry is the directory `albums_in_dir` was walking when it started
-    # collapsing this group.
+    # sit side by side with no wrapping parent, possibly at different
+    # depths (`albums_in_dir`'s collapsing only cares whether the next
+    # walked directory's *basename* matches the pattern, not how deep it
+    # is, so one disc can sit nested a level deeper than its siblings).
     #
-    # If every directory in `task.paths` lives under that first entry
-    # (the common case: a single album directory, or a nested multi-disc
-    # album whose disc directories are children of the album root), its
-    # own subtree is the entire rescan scope -- walk it directly. Nothing
-    # outside it could have contributed to this task, so no filtering is
-    # needed either.
+    # The only directory guaranteed to be an ancestor of every one of
+    # them is their lowest common ancestor -- for a single album
+    # directory, or a nested multi-disc album whose disc directories are
+    # all children of the album root, that's just the album's own
+    # directory; for siblings, it's whatever parent they share. That
+    # ancestor is what gets walked, unrestricted, exactly as a normal
+    # scan would, so multi-disc collapsing is judged from the real
+    # directory listing rather than a fabricated one.
     #
-    # Otherwise (the sibling-disc case), some of the original directories
-    # sit *beside* the first entry rather than under it. A flattened
-    # group's directories aren't necessarily all at the same depth --
-    # `albums_in_dir`'s collapsing only cares whether the next walked
-    # directory's *basename* matches the pattern, not how deep it is, so
-    # one disc can sit nested a level deeper than its siblings. The only
-    # directory guaranteed to be an ancestor of all of them is their
-    # lowest common ancestor, so that -- not simply the first entry's
-    # parent -- is what must be walked to reconstruct the grouping.
-    # Walked unrestricted, exactly as a normal scan would, so multi-disc
-    # collapsing is judged from the real directory listing rather than a
-    # fabricated one.
-    #
-    # That walk will also discover unrelated things living under that
-    # ancestor (a third, unrelated album, or loose files dropped there),
-    # so keep only the group(s) still related to the directories this
-    # task originally came from -- either directly (unchanged), or
+    # That walk can also discover unrelated things living under that
+    # ancestor (a third, unrelated album, or loose files dropped there --
+    # nothing does, in the single-directory case, since there's nothing
+    # else *to* find under a directory that already fully bounds the
+    # group), so keep only the group(s) still related to the directories
+    # this task originally came from -- either directly (unchanged), or
     # nested under one of them (the user split a directory into
     # subdirectories, or merged one of its own subdirectories back into
     # it).
     #
-    # This never needs to treat the walked ancestor *itself* as a
-    # candidate merge target, even though it's an ancestor of every
-    # original directory: `albums_in_dir` only keeps collapsing a group
-    # from one walked directory into the next, so any real directory
-    # between an original directory and their lowest common ancestor
-    # would itself have been collapsed into the group and so would
-    # already be in `task.paths` -- matched directly, not through the
-    # ancestor. The ancestor itself is the sole exception, which is
-    # exactly why a group sitting right there can't be told apart from
-    # something that was never part of this task -- the same ambiguity
-    # behind the loose-file and unrelated-sibling cases above. So a user
-    # merging every original directory's files directly into that shared
-    # ancestor isn't reconstructed either; rare enough, and just as
-    # ambiguous, that it's left as a no-op rescan rather than guessed at
-    # -- see
+    # This never needs to treat a group living at the walked ancestor
+    # (or at any directory *between* the ancestor and where a given
+    # original directory's own collapsing began) as a candidate merge
+    # target: `albums_in_dir` only keeps collapsing a group from one
+    # walked directory into the next, so any such directory that really
+    # was part of reconstructing one of the original groups would
+    # itself have been collapsed in and so would already be in
+    # `task.paths` -- matched directly, not through an ancestor
+    # relationship. A group sitting at one of these directories instead
+    # can't be told apart from something that was never part of this
+    # task to begin with -- the same ambiguity behind the loose-file
+    # and unrelated-sibling cases above. So a user merging original
+    # directories' files upward into any of them isn't reconstructed
+    # either; rare enough, and just as ambiguous, that it's left as a
+    # no-op rescan rather than guessed at -- see
     # `test_rescan_of_sibling_multidisc_album_merged_into_parent_is_not_reimported`.
-    scan_root = task.paths[0]
-    filter_to_scope = not all(
-        d == scan_root or is_subdir_of_any_in_list(d, [scan_root])
-        for d in task.paths
-    )
-    if filter_to_scope:
-        scan_root = os.path.commonpath(task.paths)
-
+    scan_root = os.path.commonpath(task.paths)
     discovery_factory = ImportTaskFactory(scan_root, session)
-    groups = discovery_factory.paths()
-    if filter_to_scope:
-        original_dirs = task.paths
-        groups = (
-            (dirs, paths)
-            for dirs, paths in groups
-            if any(
-                d == o or is_subdir_of_any_in_list(d, [o])
-                for d in dirs
-                for o in original_dirs
-            )
+    original_dirs = task.paths
+    groups = (
+        (dirs, paths)
+        for dirs, paths in discovery_factory.paths()
+        if any(
+            d == o or is_subdir_of_any_in_list(d, [o])
+            for d in dirs
+            for o in original_dirs
         )
+    )
+
+    # The directories actually being re-read here (`task.paths`) may
+    # have already been the source of *other*, separately-discovered
+    # tasks still waiting further down the pipeline (e.g. a plain,
+    # non-disc-named subdirectory holding its own album). This rescan
+    # is now the authoritative re-read of those directories, so mark
+    # them: `user_query` drops any such stale task rather than letting
+    # it get processed a second time alongside whatever this rescan
+    # itself finds there. Marking only `task.paths`, not the wider
+    # `scan_root` they were walked from, matters when they're siblings
+    # under a shared parent -- that parent can hold unrelated content
+    # this rescan never touched, which must stay untouched by the mark
+    # too.
+    generation = session.mark_rescanned(task.paths)
 
     # Tasks must keep the *original* toppath, not the rescanned
     # directory: it's used for cleanup (pruning stops at `toppath`, so a
@@ -194,7 +206,14 @@ def rescan_tasks(
     for dirs, paths in groups:
         if (album_task := factory.album(paths, dirs)) is not None:
             found = True
-            yield from album_task.handle_created(session)
+            for created_task in album_task.handle_created(session):
+                # See `ImportTask.rescan_generation`: this rescan is
+                # what's making `created_task` current, so it must not
+                # be dropped by the very check that exists to drop
+                # everything else `mark_rescanned` above just made
+                # stale.
+                created_task.rescan_generation = generation
+                yield created_task
 
     if not found:
         log.info(
@@ -231,10 +250,22 @@ def group_albums(session: ImportSession) -> StageCoro:
         for _, items in itertools.groupby(sorted_items, group):
             l_items = list(items)
             task = ImportTask(task.toppath, [i.path for i in l_items], l_items)
-            # Items are grouped by tag here, not by directory, so there's
-            # no directory scope a filesystem rescan could reconstruct.
+            # Items are grouped by tag here, not by directory, so
+            # there's no directory scope a filesystem rescan could
+            # reconstruct. Set before `handle_created` so a plugin
+            # inspecting the task from its `import_task_created`
+            # handler sees it too.
             task.is_grouped = True
-            tasks += task.handle_created(session)
+            for created_task in task.handle_created(session):
+                # Re-applied to whatever `handle_created` actually
+                # returns, not just `task` itself: a plugin listening
+                # for `import_task_created` can replace it with
+                # different task objects, which would otherwise
+                # silently lose both of these (see
+                # `_inherit_rescan_generation`).
+                created_task.is_grouped = True
+                _inherit_rescan_generation(session, created_task)
+                tasks.append(created_task)
         tasks.append(SentinelImportTask(task.toppath, task.paths))
 
         out = pipeline.multiple(tasks)
@@ -260,6 +291,38 @@ def lookup_candidates(session: ImportSession, task: ImportTask) -> None:
     task.lookup_candidates(session.config["search_ids"].as_str_seq())
 
 
+def _inherit_rescan_generation(
+    session: ImportSession, child: ImportTask
+) -> None:
+    """Stamp `child` -- a new task freshly built in `user_query` from
+    an existing task's items -- with `session`'s current rescan
+    generation (see `ImportSession.rescan_generation`).
+
+    Call this on every task actually about to continue through the
+    pipeline wherever one task gets split or rebuilt into new ones
+    derived from it -- as-Tracks, Group albums, duplicate-merge, and
+    anywhere else added in the future -- so it doesn't look stale to
+    `user_query`'s `already_rescanned` check relative to whatever's
+    already happened in this session. Forgetting this at any one of
+    those sites silently drops the derived task's items instead of
+    raising an error, so it's easy to miss. Stamping the *session's*
+    current generation rather than the source task's own is
+    deliberate: for duplicate-merge in particular, the new task's
+    paths can include library paths pulled in from anywhere, not just
+    the source task's own directory scope, so a completely unrelated
+    rescan elsewhere in the same session could otherwise still make it
+    look stale.
+
+    Call it on what `ImportTask.handle_created` *returns*, not on the
+    task passed into it: a plugin listening for `import_task_created`
+    can replace that task with different objects, and stamping only
+    the original leaves the replacements at the default `0` -- silently
+    dropped all the same, just one step further downstream. See
+    `rescan_tasks` for the pattern this follows.
+    """
+    child.rescan_generation = session.rescan_generation
+
+
 @pipeline.stage
 def user_query(session: ImportSession, task: ImportTask) -> StageReturn:
     """A coroutine for interfacing with the user about the tagging
@@ -278,6 +341,18 @@ def user_query(session: ImportSession, task: ImportTask) -> StageReturn:
         return task
 
     if session.already_merged(task.paths):
+        return pipeline.BUBBLE
+
+    # A "Rescan directory" choice on an earlier task may have already
+    # re-read this task's directory from disk more recently than this
+    # task was created (e.g. this task is a plain subdirectory that a
+    # rescan of its parent walked back over) -- drop it rather than
+    # processing stale, pre-rescan state a second time. Comparing
+    # against `task.rescan_generation` (0 unless this task is itself a
+    # rescan's output) exempts a rescan's own output from being
+    # considered stale by its own marking, while still letting a
+    # *later* rescan correctly supersede it.
+    if session.already_rescanned(task.paths, task.rescan_generation):
         return pipeline.BUBBLE
 
     # Ask the user for a choice.
@@ -314,7 +389,15 @@ def user_query(session: ImportSession, task: ImportTask) -> StageReturn:
         def emitter(task: ImportTask) -> Iterator[BaseImportTask]:
             for item in task.items:
                 task = SingletonImportTask(task.toppath, item)
-                yield from task.handle_created(session)
+                for created_task in task.handle_created(session):
+                    # Stamped on what `handle_created` actually
+                    # returns, not on `task` itself: a plugin listening
+                    # for `import_task_created` can replace it with a
+                    # different task object, which would otherwise
+                    # silently lose this (see
+                    # `_inherit_rescan_generation`).
+                    _inherit_rescan_generation(session, created_task)
+                    yield created_task
             yield SentinelImportTask(task.toppath, task.paths)
 
         return _extend_pipeline(
@@ -347,6 +430,7 @@ def user_query(session: ImportSession, task: ImportTask) -> StageReturn:
         merged_task = ImportTask(
             None, task.paths + duplicate_paths, task.items + duplicate_items
         )
+        _inherit_rescan_generation(session, merged_task)
 
         return _extend_pipeline(
             [merged_task], lookup_candidates(session), user_query(session)

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextvars
 import itertools
 import logging
+import os
 from typing import TYPE_CHECKING, TypeAlias
 
 from beets import config, plugins
@@ -14,6 +15,7 @@ from .tasks import (
     ImportTaskFactory,
     SentinelImportTask,
     SingletonImportTask,
+    is_subdir_of_any_in_list,
     resolve_upgrade_target,
 )
 
@@ -87,6 +89,96 @@ def query_tasks(session: ImportSession) -> Iterator[BaseImportTask]:
                 yield task
 
 
+def rescan_tasks(
+    session: ImportSession, task: ImportTask
+) -> Iterator[BaseImportTask]:
+    """Re-read `task`'s directories from disk and yield fresh tasks for
+    whatever music is found there now.
+
+    Used to implement the "Rescan directory" prompt choice: the user may
+    have manually cleaned up (removed duplicates, deleted junk files, etc.)
+    the directory while the import was paused at the prompt, so we must not
+    reuse `task.items`, which reflect the stale, pre-cleanup listing.
+
+    Only reachable for album tasks that were discovered directly from the
+    filesystem: the "Rescan directory" choice is only ever offered when
+    ``task.is_album`` is true and ``task.toppath`` is set (both of which
+    exclude singleton-mode sessions), and is withheld for tasks produced
+    by "Group albums" (see ``group_albums`` below), whose items are
+    grouped by tag rather than by directory and so have no directory
+    scope a filesystem rescan could meaningfully reconstruct.
+    """
+    assert task.toppath is not None
+
+    # `task.paths` records the *original* directories this task was
+    # discovered from -- e.g. `[album_root, disc1, disc2]` for a nested
+    # multi-disc album, or `[disc1, disc2]` for two disc directories that
+    # sit side by side with no wrapping parent. Either way, the first
+    # entry is always the outermost directory the original discovery
+    # walked from.
+    #
+    # If every directory in `task.paths` lives under that first entry
+    # (the common case: a single album directory, or a nested multi-disc
+    # album whose disc directories are children of the album root), its
+    # own subtree is the entire rescan scope -- walk it directly. Nothing
+    # outside it could have contributed to this task, so no filtering is
+    # needed either.
+    #
+    # Otherwise (the sibling-disc case), some of the original directories
+    # sit *beside* the first entry rather than under it, so the grouping
+    # can only be reconstructed by walking one level *up*, from their
+    # shared parent directory. That walk will also discover unrelated
+    # sibling albums (e.g. a third, unrelated album next to the two disc
+    # directories), so keep only the group(s) that are still related to
+    # the directories this task originally came from -- either directly
+    # (unchanged), nested under one of them (the user split the original
+    # directory into subdirectories), or an ancestor of one of them (the
+    # user merged what were separate subdirectories back together).
+    scan_root = task.paths[0]
+    filter_to_scope = not all(
+        d == scan_root or is_subdir_of_any_in_list(d, [scan_root])
+        for d in task.paths
+    )
+    if filter_to_scope:
+        scan_root = os.path.dirname(scan_root)
+
+    discovery_factory = ImportTaskFactory(scan_root, session)
+    groups = discovery_factory.paths()
+    if filter_to_scope:
+        original_dirs = task.paths
+        groups = (
+            (dirs, paths)
+            for dirs, paths in groups
+            if any(
+                d == o
+                or is_subdir_of_any_in_list(d, [o])
+                or is_subdir_of_any_in_list(o, [d])
+                for d in dirs
+                for o in original_dirs
+            )
+        )
+
+    # Tasks must keep the *original* toppath, not the rescanned
+    # directory: it's used for cleanup (pruning stops at `toppath`, so a
+    # wrong value would leave the emptied source directory behind after a
+    # move) and for resume bookkeeping (progress is recorded and later
+    # reset keyed by `toppath`, so a wrong value would leave stale,
+    # never-reset progress state behind).
+    factory = ImportTaskFactory(task.toppath, session)
+    found = False
+    for dirs, paths in groups:
+        if (album_task := factory.album(paths, dirs)) is not None:
+            found = True
+            yield from album_task.handle_created(session)
+
+    if not found:
+        log.info(
+            "No music found after rescanning: {}", displayable_path(task.paths)
+        )
+
+    yield SentinelImportTask(task.toppath, task.paths)
+
+
 # ---------------------------------- Stages ---------------------------------- #
 # Functions that process import tasks, may transform or filter them
 # They are chained together in the pipeline e.g. stage2(stage1(task)) -> task
@@ -114,6 +206,9 @@ def group_albums(session: ImportSession) -> StageCoro:
         for _, items in itertools.groupby(sorted_items, group):
             l_items = list(items)
             task = ImportTask(task.toppath, [i.path for i in l_items], l_items)
+            # Items are grouped by tag here, not by directory, so there's
+            # no directory scope a filesystem rescan could reconstruct.
+            task.is_grouped = True
             tasks += task.handle_created(session)
         tasks.append(SentinelImportTask(task.toppath, task.paths))
 
@@ -163,6 +258,30 @@ def user_query(session: ImportSession, task: ImportTask) -> StageReturn:
     # Ask the user for a choice.
     task.choose_match(session)
     plugins.send("import_task_choice", session=session, task=task)
+
+    # Rescan: re-read the directory from disk and re-run the match.
+    if task.choice_flag is Action.RESCAN:
+        # `choice_flag` can also be set by a plugin listening for
+        # `import_task_choice`, not only via the choices `_get_choices`
+        # actually offers. Guard against being asked to rescan a task
+        # with no filesystem scope to rescan: a singleton task (e.g.
+        # one produced by "as Tracks", whose `paths` is a single item
+        # file, not an album directory), one with no `toppath` (e.g. a
+        # query- or merge-produced task), or one produced by "Group
+        # albums" (see `rescan_tasks`'s docstring).
+        if not task.is_album or task.toppath is None or task.is_grouped:
+            log.warning(
+                "Ignoring a Rescan directory choice for a task with no "
+                "directory scope to rescan: {}",
+                displayable_path(task.paths),
+            )
+            task.choice_flag = Action.SKIP
+        else:
+            return _extend_pipeline(
+                rescan_tasks(session, task),
+                lookup_candidates(session),
+                user_query(session),
+            )
 
     # As-tracks: transition to singleton workflow.
     if task.choice_flag is Action.TRACKS:

--- a/beets/importer/stages.py
+++ b/beets/importer/stages.py
@@ -114,8 +114,8 @@ def rescan_tasks(
     # discovered from -- e.g. `[album_root, disc1, disc2]` for a nested
     # multi-disc album, or `[disc1, disc2]` for two disc directories that
     # sit side by side with no wrapping parent. Either way, the first
-    # entry is always the outermost directory the original discovery
-    # walked from.
+    # entry is the directory `albums_in_dir` was walking when it started
+    # collapsing this group.
     #
     # If every directory in `task.paths` lives under that first entry
     # (the common case: a single album directory, or a nested multi-disc
@@ -125,22 +125,49 @@ def rescan_tasks(
     # needed either.
     #
     # Otherwise (the sibling-disc case), some of the original directories
-    # sit *beside* the first entry rather than under it, so the grouping
-    # can only be reconstructed by walking one level *up*, from their
-    # shared parent directory. That walk will also discover unrelated
-    # sibling albums (e.g. a third, unrelated album next to the two disc
-    # directories), so keep only the group(s) that are still related to
-    # the directories this task originally came from -- either directly
-    # (unchanged), nested under one of them (the user split the original
-    # directory into subdirectories), or an ancestor of one of them (the
-    # user merged what were separate subdirectories back together).
+    # sit *beside* the first entry rather than under it. A flattened
+    # group's directories aren't necessarily all at the same depth --
+    # `albums_in_dir`'s collapsing only cares whether the next walked
+    # directory's *basename* matches the pattern, not how deep it is, so
+    # one disc can sit nested a level deeper than its siblings. The only
+    # directory guaranteed to be an ancestor of all of them is their
+    # lowest common ancestor, so that -- not simply the first entry's
+    # parent -- is what must be walked to reconstruct the grouping.
+    # Walked unrestricted, exactly as a normal scan would, so multi-disc
+    # collapsing is judged from the real directory listing rather than a
+    # fabricated one.
+    #
+    # That walk will also discover unrelated things living under that
+    # ancestor (a third, unrelated album, or loose files dropped there),
+    # so keep only the group(s) still related to the directories this
+    # task originally came from -- either directly (unchanged), or
+    # nested under one of them (the user split a directory into
+    # subdirectories, or merged one of its own subdirectories back into
+    # it).
+    #
+    # This never needs to treat the walked ancestor *itself* as a
+    # candidate merge target, even though it's an ancestor of every
+    # original directory: `albums_in_dir` only keeps collapsing a group
+    # from one walked directory into the next, so any real directory
+    # between an original directory and their lowest common ancestor
+    # would itself have been collapsed into the group and so would
+    # already be in `task.paths` -- matched directly, not through the
+    # ancestor. The ancestor itself is the sole exception, which is
+    # exactly why a group sitting right there can't be told apart from
+    # something that was never part of this task -- the same ambiguity
+    # behind the loose-file and unrelated-sibling cases above. So a user
+    # merging every original directory's files directly into that shared
+    # ancestor isn't reconstructed either; rare enough, and just as
+    # ambiguous, that it's left as a no-op rescan rather than guessed at
+    # -- see
+    # `test_rescan_of_sibling_multidisc_album_merged_into_parent_is_not_reimported`.
     scan_root = task.paths[0]
     filter_to_scope = not all(
         d == scan_root or is_subdir_of_any_in_list(d, [scan_root])
         for d in task.paths
     )
     if filter_to_scope:
-        scan_root = os.path.dirname(scan_root)
+        scan_root = os.path.commonpath(task.paths)
 
     discovery_factory = ImportTaskFactory(scan_root, session)
     groups = discovery_factory.paths()
@@ -150,9 +177,7 @@ def rescan_tasks(
             (dirs, paths)
             for dirs, paths in groups
             if any(
-                d == o
-                or is_subdir_of_any_in_list(d, [o])
-                or is_subdir_of_any_in_list(o, [d])
+                d == o or is_subdir_of_any_in_list(d, [o])
                 for d in dirs
                 for o in original_dirs
             )

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -236,6 +236,12 @@ class ImportTask(BaseImportTask):
     choice_flag: Action | None = None
     match: AlbumMatch | TrackMatch | None = None
 
+    # Set by `group_albums` when this task's items were grouped by tag
+    # rather than by directory. Such a task has no directory scope a
+    # filesystem rescan could meaningfully reconstruct, so the "Rescan
+    # directory" choice is withheld for it (see `_get_choices`).
+    is_grouped: bool = False
+
     # Set by `add()`; only valid afterwards (see class docstring).
     album: library.Album
 
@@ -279,6 +285,7 @@ class ImportTask(BaseImportTask):
             Action.TRACKS,
             Action.ALBUMS,
             Action.RETAG,
+            Action.RESCAN,
         ):
             # TODO: redesign to stricten the type
             self.choice_flag = choice  # type: ignore[assignment]

--- a/beets/importer/tasks.py
+++ b/beets/importer/tasks.py
@@ -242,6 +242,24 @@ class ImportTask(BaseImportTask):
     # directory" choice is withheld for it (see `_get_choices`).
     is_grouped: bool = False
 
+    # Set by `rescan_tasks` to the rescan "generation" (see
+    # `ImportSession.mark_rescanned`) it created this task as part of;
+    # 0 for a task straight from the initial scan. Exempts a rescan's
+    # own output from `user_query`'s `already_rescanned` check against
+    # that same rescan -- without it, the output would immediately look
+    # stale by the same test that's meant to drop *other*, pre-rescan
+    # tasks falling within the directories it just re-read -- while
+    # still allowing a *later* rescan covering the same ground to
+    # correctly supersede it. Anywhere a task is split or rebuilt into
+    # new tasks derived from it (as-Tracks, Group albums,
+    # duplicate-merge, ...) must copy this onto each one actually
+    # continuing through the pipeline -- via
+    # `stages._inherit_rescan_generation`, applied to what
+    # `handle_created` returns rather than to the task passed into it,
+    # since a plugin can replace it there too -- or they'll silently
+    # look stale and get dropped instead of imported.
+    rescan_generation: int = 0
+
     # Set by `add()`; only valid afterwards (see class docstring).
     album: library.Album
 

--- a/beets/ui/commands/import_/session.py
+++ b/beets/ui/commands/import_/session.py
@@ -97,7 +97,12 @@ class TerminalImportSession(importer.ImportSession):
             # or, basic choices that require no more action here.
             if isinstance(choice, AlbumMatch) or (
                 isinstance(choice, importer.Action)
-                and choice in (importer.Action.SKIP, importer.Action.ASIS)
+                and choice
+                in (
+                    importer.Action.SKIP,
+                    importer.Action.ASIS,
+                    importer.Action.RESCAN,
+                )
             ):
                 # Pass selection to main control flow.
                 return choice
@@ -249,6 +254,17 @@ class TerminalImportSession(importer.ImportSession):
                     "g", "Group albums", lambda s, t: importer.Action.ALBUMS
                 ),
             ]
+            # Withheld for tasks produced by "Group albums": their items
+            # are grouped by tag rather than by directory, so there's no
+            # directory scope a filesystem rescan could reconstruct.
+            if task.toppath and not task.is_grouped:
+                choices.append(
+                    PromptChoice(
+                        "r",
+                        "Rescan directory",
+                        lambda s, t: importer.Action.RESCAN,
+                    )
+                )
         choices += [
             # TODO: introduce beets.autotag.Candidates to remove these ignores
             #  context: Candidates is a Sequence which will be updated in place

--- a/beets/ui/commands/import_/session.py
+++ b/beets/ui/commands/import_/session.py
@@ -97,12 +97,7 @@ class TerminalImportSession(importer.ImportSession):
             # or, basic choices that require no more action here.
             if isinstance(choice, AlbumMatch) or (
                 isinstance(choice, importer.Action)
-                and choice
-                in (
-                    importer.Action.SKIP,
-                    importer.Action.ASIS,
-                    importer.Action.RESCAN,
-                )
+                and choice in (importer.Action.SKIP, importer.Action.ASIS)
             ):
                 # Pass selection to main control flow.
                 return choice

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,10 @@ New features
   new tracks, and keeps the album together rather than splitting it. The option
   is available both through configuration and from the interactive duplicate
   prompt. :bug:`4471`
+- The interactive import prompt now offers a "Rescan directory" choice for album
+  tasks. It re-reads the album's directory from disk and re-runs the match, so
+  files can be cleaned up (duplicates, junk) while the import is paused at the
+  prompt, without restarting the whole ``beet import`` run.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,7 +20,10 @@ New features
 - The interactive import prompt now offers a "Rescan directory" choice for album
   tasks. It re-reads the album's directory from disk and re-runs the match, so
   files can be cleaned up (duplicates, junk) while the import is paused at the
-  prompt, without restarting the whole ``beet import`` run.
+  prompt, without restarting the whole ``beet import`` run. Note that ``r`` is
+  now reserved for this by the default prompt: a plugin-provided choice bound to
+  the same letter will lose the conflict and be dropped, with a warning.
+  :bug:`166`
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/guides/tagger.rst
+++ b/docs/guides/tagger.rst
@@ -165,10 +165,10 @@ When beets needs your input about a match, it says something like this:
         Beirut - Lon Gisland
     (Similarity: 94.4%)
     * Scenic World (Second Version) -> Scenic World
-    [A]pply, More candidates, Skip, Use as-is, as Tracks, Enter search, enter Id, or aBort?
+    [A]pply, More candidates, Skip, Use as-is, as Tracks, Group albums, Rescan directory, Enter search, enter Id, or aBort?
 
 When beets asks you this question, it wants you to enter one of the capital
-letters: A, M, S, U, T, G, E, I or B. That is, you can choose one of the
+letters: A, M, S, U, T, G, R, E, I or B. That is, you can choose one of the
 following:
 
 - *A*: Apply the suggested changes shown and move on.
@@ -185,6 +185,10 @@ following:
   groups as albums. If the album artist for a track is not set then the artist
   is used to group that track. For each group importing proceeds as for
   directories. This is helpful if a directory contains multiple albums.
+- *R*: Rescan the directory from disk and re-run the match. Use this if you want
+  to clean up the files (remove duplicates or junk, add missing tracks, etc.)
+  without restarting the whole ``beet import`` run---just make your changes on
+  disk before choosing this option.
 - *E*: Enter an artist and album to use as a search in the database. Use this
   option if beets hasn't found any good options because the album is mistagged
   or untagged.

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -664,13 +664,22 @@ class ImportRescanTest(AutotagImportTestCase):
         is being answered -- simulating the user editing the directory
         while paused there, before choosing Rescan.
         """
+        self._run_with_cleanup_before_nth_prompt(0, cleanup)
+
+    def _run_with_cleanup_before_nth_prompt(self, n, cleanup):
+        """Like `_run_with_cleanup_before_first_prompt`, but the
+        directory edit happens right as the (0-indexed) `n`th prompt is
+        being answered instead of always the first -- for tests that
+        need the edit to land on a specific *later* task, once every
+        prompt before it has already been discovered and answered.
+        """
         original_choose_match = self.importer.choose_match
-        state = {"done": False}
+        state = {"count": 0}
 
         def choose_match_and_cleanup(task):
-            if not state["done"]:
-                state["done"] = True
+            if state["count"] == n:
                 cleanup()
+            state["count"] += 1
             return original_choose_match(task)
 
         with patch.object(
@@ -856,6 +865,248 @@ class ImportRescanTest(AutotagImportTestCase):
         # "Other Album" sorts before the disc directories and is
         # processed first; leave it as-is, then rescan the two-disc
         # album (a no-op change, since nothing on disk moved).
+        self.importer.add_choice(importer.Action.ASIS)
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(lambda: None)
+
+        albums = self.lib.albums()
+        assert len(albums) == 2
+        assert sorted(len(list(a.items())) for a in albums) == [1, 2]
+
+    def test_rescan_of_sibling_multidisc_album_ignores_loose_files_in_shared_parent(
+        self,
+    ):
+        """The disc directories' shared parent may also hold loose files
+        that already form their own separate album, sitting right next
+        to the discs rather than off in some other directory (see
+        ``test_rescan_of_sibling_multidisc_album_does_not_duplicate_tasks``
+        for the analogous case with an unrelated sibling *directory*).
+        Rescanning the disc album must not scoop those loose files into
+        it just because their directory happens to be an ancestor of
+        the two disc directories.
+        """
+        for track in self.album_path.glob("*.mp3"):
+            track.unlink()
+        self.album_path.rmdir()
+        self.prepare_track_for_import(1, self.import_path)
+        self.prepare_album_for_import(
+            1, album_path=self.import_path / "Set Disc 1"
+        )
+        self.prepare_album_for_import(
+            1, album_path=self.import_path / "Set Disc 2"
+        )
+        self.setup_importer()
+
+        # The loose file at the shared parent is processed first; leave
+        # it as-is, then rescan the two-disc album (a no-op change,
+        # since nothing on disk moved).
+        self.importer.add_choice(importer.Action.ASIS)
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(lambda: None)
+
+        albums = self.lib.albums()
+        assert len(albums) == 2
+        assert sorted(len(list(a.items())) for a in albums) == [1, 2]
+
+    def test_rescan_of_sibling_multidisc_album_records_history_under_original_paths(
+        self,
+    ):
+        """The rescanned disc album's `task.paths` -- and so its
+        incremental-import history entry -- must be exactly the two
+        disc directories, not the shared parent walked to reconstruct
+        them. Recording the parent would make a later incremental scan
+        (which never includes the parent, since normal discovery
+        doesn't either) fail to recognize the album as already
+        imported and re-offer it.
+        """
+        for track in self.album_path.glob("*.mp3"):
+            track.unlink()
+        self.album_path.rmdir()
+        self.prepare_track_for_import(1, self.import_path)
+        disc_1 = self.import_path / "Set Disc 1"
+        disc_2 = self.import_path / "Set Disc 2"
+        self.prepare_album_for_import(1, album_path=disc_1)
+        self.prepare_album_for_import(1, album_path=disc_2)
+        self.setup_importer(incremental=True)
+
+        self.importer.add_choice(importer.Action.ASIS)
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(lambda: None)
+
+        expected = tuple(sorted(os.fsencode(str(d)) for d in (disc_1, disc_2)))
+        assert expected in ImportState().taghistory
+        # The loose track's own (legitimate) history entry is exactly
+        # `(import_path,)` -- what must not appear is the parent
+        # showing up *alongside* the two disc directories in a single
+        # entry, which is what recording the rescanned task's `paths`
+        # unchanged from the parent walk would produce.
+        parent = os.fsencode(str(self.import_path))
+        assert not any(
+            parent in entry and len(entry) > 1
+            for entry in ImportState().taghistory
+        )
+
+    def test_rescan_of_sibling_multidisc_album_can_be_rescanned_again(self):
+        """Rescanning the disc album must not pull the shared parent
+        into the resulting task's directory scope -- if it did, a
+        *second* rescan of that task would then walk the parent
+        unrestricted and re-offer the already-imported loose album
+        living there.
+        """
+        for track in self.album_path.glob("*.mp3"):
+            track.unlink()
+        self.album_path.rmdir()
+        self.prepare_track_for_import(1, self.import_path)
+        self.prepare_album_for_import(
+            1, album_path=self.import_path / "Set Disc 1"
+        )
+        self.prepare_album_for_import(
+            1, album_path=self.import_path / "Set Disc 2"
+        )
+        self.setup_importer()
+
+        self.importer.add_choice(importer.Action.ASIS)
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(lambda: None)
+
+        albums = self.lib.albums()
+        assert len(albums) == 2
+        assert sorted(len(list(a.items())) for a in albums) == [1, 2]
+
+    def test_rescan_of_sibling_multidisc_album_merged_into_parent_is_not_reimported(
+        self,
+    ):
+        """A user merging both disc directories' files directly into
+        their shared parent can't be told apart from that parent
+        holding an unrelated, already-processed album (see
+        ``test_rescan_of_sibling_multidisc_album_ignores_loose_files_in_shared_parent``)
+        -- so it isn't guessed at. The rescan finds nothing there rather
+        than risking a false positive; the merged files simply aren't
+        picked back up by it.
+        """
+        for track in self.album_path.glob("*.mp3"):
+            track.unlink()
+        self.album_path.rmdir()
+        disc_1 = self.import_path / "Set Disc 1"
+        disc_2 = self.import_path / "Set Disc 2"
+        self.prepare_album_for_import(1, album_path=disc_1)
+        self.prepare_album_for_import(1, album_path=disc_2)
+        self.prepare_album_for_import(
+            1, album_path=self.import_path / "Other Album"
+        )
+        self.setup_importer()
+
+        def merge_discs_into_parent():
+            for disc in (disc_1, disc_2):
+                for track in disc.glob("*.mp3"):
+                    # Disc 1 and disc 2 each have their own
+                    # "track_1.mp3"; give the merged copies distinct
+                    # names so neither clobbers the other.
+                    track.rename(self.import_path / f"{disc.name}-{track.name}")
+                disc.rmdir()
+
+        # "Other Album" sorts before the disc directories and is
+        # processed first; leave it as-is (this also forces the two
+        # disc directories to be discovered as *siblings* rather than a
+        # nested multi-disc album, since it means their shared parent
+        # has other content of its own). The merge must happen once the
+        # *disc* task's own prompt is reached, not any earlier -- doing
+        # it before the disc directories are even discovered would
+        # delete them out from under the initial scan and the disc task
+        # would never get created (and its Rescan choice never used) in
+        # the first place, silently passing this test without ever
+        # exercising a rescan at all.
+        self.importer.add_choice(importer.Action.ASIS)
+        self.importer.add_choice(importer.Action.RESCAN)
+
+        self._run_with_cleanup_before_nth_prompt(1, merge_discs_into_parent)
+
+        # Only "Other Album" made it in; the merged tracks were left
+        # untouched, loose in the parent directory.
+        assert len(self.lib.items()) == 1
+        assert sorted(p.name for p in self.import_path.glob("*.mp3")) == [
+            "Set Disc 1-track_1.mp3",
+            "Set Disc 2-track_1.mp3",
+        ]
+
+    def test_rescan_of_sibling_multidisc_album_with_disc_in_its_own_subdirectory(
+        self,
+    ):
+        """A flattened sibling group's directories aren't necessarily
+        all at the same depth below their shared parent: one disc can
+        sit in its own subdirectory (e.g. the user already organized
+        that one disc further) while the others sit directly beside it.
+        `task.paths[0]` is then *not* the shared parent's immediate
+        child that every other original directory descends from -- the
+        rescan must still walk the true shared parent and reconstruct
+        the whole group without duplicating or dropping anything.
+        """
+        for track in self.album_path.glob("*.mp3"):
+            track.unlink()
+        self.album_path.rmdir()
+        self.prepare_album_for_import(
+            1, album_path=self.import_path / "Set Disc 1"
+        )
+        (self.import_path / "Set Disc 2").mkdir()
+        self.prepare_album_for_import(
+            1, album_path=self.import_path / "Set Disc 2" / "Sub"
+        )
+        self.prepare_album_for_import(
+            1, album_path=self.import_path / "Other Album"
+        )
+        self.setup_importer()
+
+        # "Other Album" sorts before the disc directories and is
+        # processed first; leave it as-is, then rescan the two-disc
+        # album (a no-op change, since nothing on disk moved).
+        self.importer.add_choice(importer.Action.ASIS)
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(lambda: None)
+
+        albums = self.lib.albums()
+        assert len(albums) == 2
+        assert sorted(len(list(a.items())) for a in albums) == [1, 2]
+
+    def test_rescan_of_sibling_multidisc_album_with_shallower_sibling_disc(
+        self,
+    ):
+        """The flattened-group collapse can also jump the *other*
+        direction from ``..._with_disc_in_its_own_subdirectory`` above:
+        one disc nested a level deeper than its shared parent's other
+        content, its sibling disc sitting a level *shallower*, directly
+        beside that parent. `task.paths[0]` (the deeper disc) then has a
+        parent that is *not* an ancestor of the shallower one at all --
+        walking just `dirname(task.paths[0])` would miss it entirely and
+        silently drop that disc from the rescanned album, rather than
+        merely mis-scoping the walk.
+        """
+        for track in self.album_path.glob("*.mp3"):
+            track.unlink()
+        self.album_path.rmdir()
+        (self.import_path / "A").mkdir()
+        self.prepare_track_for_import(1, self.import_path / "A")
+        self.prepare_album_for_import(
+            1, album_path=self.import_path / "A" / "Set Disc 1"
+        )
+        self.prepare_album_for_import(
+            1, album_path=self.import_path / "Set Disc 2"
+        )
+        self.setup_importer()
+
+        # "A"'s own loose track sorts and is discovered first; leave it
+        # as-is, then rescan the two-disc album (a no-op change, since
+        # nothing on disk moved).
         self.importer.add_choice(importer.Action.ASIS)
         self.importer.add_choice(importer.Action.RESCAN)
         self.importer.add_choice(importer.Action.APPLY)

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -22,8 +22,9 @@ from zipfile import ZipFile
 import pytest
 from mediafile import MediaFile
 
-from beets import config, importer, logging, util
+from beets import config, importer, logging, plugins, ui, util
 from beets.autotag import AlbumInfo, AlbumMatch, Distance, TrackInfo
+from beets.importer.state import ImportState
 from beets.importer.tasks import (
     ImportTaskFactory,
     albums_in_dir,
@@ -42,6 +43,8 @@ from beets.test.helper import (
     BeetsTestCase,
     ImportHelper,
     PluginMixin,
+    TerminalImportMixin,
+    TerminalImportSessionFixture,
     TestHelper,
     has_program,
 )
@@ -637,6 +640,374 @@ class ImportTracksTest(AutotagImportTestCase):
         self.importer.run()
 
         assert (self.lib_path / "singletons" / "Applied Track 1.mp3").exists()
+
+
+class ImportRescanTest(AutotagImportTestCase):
+    """Test the Rescan directory action.
+
+    Each test's directory mutation must happen exactly when the first
+    prompt is answered, not before ``self.importer.run()`` starts: since
+    ``ImportSessionFixture.choose_match`` just pops preset choices off a
+    queue, a plain filesystem edit made before ``run()`` would already be
+    visible to the *initial* scan too, which wouldn't actually exercise
+    rescanning (it would test a static directory that happens to include a
+    no-op Rescan choice along the way).
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.album_path = self.prepare_album_for_import(2)[0].parent
+        self.setup_importer()
+
+    def _run_with_cleanup_before_first_prompt(self, cleanup):
+        """Run the importer, calling `cleanup` right as the first prompt
+        is being answered -- simulating the user editing the directory
+        while paused there, before choosing Rescan.
+        """
+        original_choose_match = self.importer.choose_match
+        state = {"done": False}
+
+        def choose_match_and_cleanup(task):
+            if not state["done"]:
+                state["done"] = True
+                cleanup()
+            return original_choose_match(task)
+
+        with patch.object(
+            self.importer, "choose_match", side_effect=choose_match_and_cleanup
+        ):
+            self.importer.run()
+
+    def test_rescan_picks_up_file_added_after_initial_scan(self):
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(
+            lambda: self.prepare_track_for_import(3, self.album_path)
+        )
+
+        assert len(self.lib.items()) == 3
+
+    def test_rescan_picks_up_file_removed_after_initial_scan(self):
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(
+            lambda: (self.album_path / "track_2.mp3").unlink()
+        )
+
+        assert len(self.lib.items()) == 1
+
+    def test_rescan_of_emptied_directory_imports_nothing(self):
+        self.importer.add_choice(importer.Action.RESCAN)
+
+        def cleanup():
+            for track in self.album_path.glob("*.mp3"):
+                track.unlink()
+
+        self._run_with_cleanup_before_first_prompt(cleanup)
+
+        assert not self.lib.items()
+
+    def test_rescan_with_only_unreadable_files_imports_nothing(self):
+        self.importer.add_choice(importer.Action.RESCAN)
+
+        def cleanup():
+            # Directory still has a music file by extension, but it can't
+            # actually be read as an item.
+            for track in self.album_path.glob("*.mp3"):
+                track.unlink()
+            (self.album_path / "track_1.mp3").write_bytes(b"not a real mp3")
+
+        self._run_with_cleanup_before_first_prompt(cleanup)
+
+        assert not self.lib.items()
+
+    def test_rescan_with_multiple_subdirectories_finds_all_albums(self):
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        def cleanup():
+            # Simulate the user splitting the messy directory into two
+            # proper album subdirectories.
+            for track in self.album_path.glob("*.mp3"):
+                track.unlink()
+            self.prepare_album_for_import(2, album_path=self.album_path / "one")
+            self.prepare_album_for_import(2, album_path=self.album_path / "two")
+
+        self._run_with_cleanup_before_first_prompt(cleanup)
+
+        assert len(self.lib.albums()) == 2
+
+    def test_rescan_of_multidisc_album_does_not_duplicate_tasks(self):
+        """`task.paths` for a multi-disc album holds the album root *and*
+        each disc subdirectory. Rescanning must not walk each of those
+        independently -- that used to produce three tasks (the combined
+        album plus each disc on its own) for a two-disc album.
+        """
+        for track in self.album_path.glob("*.mp3"):
+            track.unlink()
+        self.prepare_album_for_import(1, album_path=self.album_path / "CD1")
+        self.prepare_album_for_import(1, album_path=self.album_path / "CD2")
+        self.setup_importer()
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(lambda: None)
+
+        assert len(self.lib.albums()) == 1
+        assert len(self.lib.items()) == 2
+
+    def test_rescan_preserves_multidisc_album_grouping(self):
+        for track in self.album_path.glob("*.mp3"):
+            track.unlink()
+        self.prepare_album_for_import(1, album_path=self.album_path / "CD1")
+        self.prepare_album_for_import(1, album_path=self.album_path / "CD2")
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(lambda: None)
+
+        assert len(self.lib.albums()) == 1
+
+    def test_rescan_preserves_flat_album_grouping(self):
+        self.prepare_album_for_import(2, album_id=2)
+        self.setup_importer(flat=True)
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(lambda: None)
+
+        assert len(self.lib.albums()) == 1
+
+    def test_rescan_of_single_file_import(self):
+        """When the import path is a single file rather than a
+        directory, rescanning must still find it -- it used to always
+        report nothing, since walking a file with `albums_in_dir` finds
+        no music.
+        """
+        track_path = self.prepare_album_for_import(1)[0]
+        self.setup_importer(import_dir=track_path)
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(lambda: None)
+
+        assert len(self.lib.items()) == 1
+
+    def test_rescan_preserves_toppath_for_move_pruning(self):
+        """Rescanned tasks must keep the *original* `toppath`, not the
+        rescanned directory. Pruning treats `toppath` as the boundary
+        above which directories must not be removed, so using the album
+        directory itself as `toppath` would leave it behind, empty and
+        un-pruned, after a move.
+        """
+        self.setup_importer(move=True)
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(lambda: None)
+
+        assert not self.album_path.exists()
+
+    def test_rescan_preserves_toppath_for_resume_state(self):
+        """Rescanned tasks must keep the *original* `toppath`, not the
+        rescanned directory. Resume progress is recorded (and later
+        reset) keyed by `toppath`, so using the album directory itself
+        as `toppath` would leave stale, never-reset progress state
+        behind under that key.
+        """
+        self.setup_importer(resume=True)
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(lambda: None)
+
+        # A fully-completed, non-aborted import always resets progress
+        # for its toppath at the end -- so no entries (correct or stale)
+        # should remain.
+        assert not ImportState().tagprogress
+
+    def test_rescan_of_sibling_multidisc_album_does_not_duplicate_tasks(self):
+        """A multi-disc album whose disc directories sit directly beside
+        each other, with no wrapping album directory, can only be
+        reconstructed by walking their *shared parent* -- but that walk
+        also finds an unrelated sibling album. Rescanning must regroup
+        the two disc directories into one task and leave the unrelated
+        sibling alone.
+        """
+        for track in self.album_path.glob("*.mp3"):
+            track.unlink()
+        self.album_path.rmdir()
+        self.prepare_album_for_import(
+            1, album_path=self.import_path / "Set Disc 1"
+        )
+        self.prepare_album_for_import(
+            1, album_path=self.import_path / "Set Disc 2"
+        )
+        self.prepare_album_for_import(
+            1, album_path=self.import_path / "Other Album"
+        )
+        self.setup_importer()
+
+        # "Other Album" sorts before the disc directories and is
+        # processed first; leave it as-is, then rescan the two-disc
+        # album (a no-op change, since nothing on disk moved).
+        self.importer.add_choice(importer.Action.ASIS)
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(lambda: None)
+
+        albums = self.lib.albums()
+        assert len(albums) == 2
+        assert sorted(len(list(a.items())) for a in albums) == [1, 2]
+
+    def test_rescan_of_normal_album_scans_only_its_own_directory(self):
+        """A plain album living under a larger toppath must discover
+        from its own directory, not from `toppath`. Walking `toppath`
+        (or any other ancestor) is only needed to reconstruct sibling
+        disc directories that have no common parent recorded in
+        `task.paths` -- doing it unconditionally would make every
+        rescan walk far more of the filesystem than necessary.
+        """
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        with patch(
+            "beets.importer.stages.ImportTaskFactory", wraps=ImportTaskFactory
+        ) as mock_factory:
+            self._run_with_cleanup_before_first_prompt(lambda: None)
+
+        scanned_toppaths = [
+            call.args[0] for call in mock_factory.call_args_list
+        ]
+        album_path_bytes = os.fsencode(str(self.album_path))
+        import_path_bytes = os.fsencode(str(self.import_path))
+
+        # Discovery is scoped to the album's own directory...
+        assert scanned_toppaths.count(album_path_bytes) == 1
+        # ...and `toppath` is only touched by the initial scan and by
+        # the factory that stamps it onto rescanned tasks (see
+        # `rescan_tasks`), never by a parent-directory discovery walk.
+        assert scanned_toppaths.count(import_path_bytes) == 2
+
+
+class TestRescanChoiceAvailability(
+    TerminalImportMixin, PluginMixin, AutotagImportHelper
+):
+    """The "Rescan directory" choice must not be offered for tasks
+    produced by "Group albums": their items are grouped by tag rather
+    than by directory, so there's no directory scope a filesystem
+    rescan could reconstruct.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_prompt_choice(self, io):
+        self.prepare_album_for_import(2)
+        self.setup_importer()
+        self.input_options_patcher = patch(
+            "beets.ui.input_options", side_effect=ui.input_options
+        )
+        self.mock_input_options = self.input_options_patcher.start()
+        yield
+        self.input_options_patcher.stop()
+
+    def test_rescan_choice_withheld_after_group_albums(self):
+        self.importer.add_choice(importer.Action.ALBUMS)
+        self.importer.add_choice(importer.Action.SKIP)
+        self.importer.run()
+
+        assert self.mock_input_options.call_count >= 2
+        first_opts, second_opts = (
+            call.args[0] for call in self.mock_input_options.call_args_list[:2]
+        )
+        assert "Rescan directory" in first_opts
+        assert "Rescan directory" not in second_opts
+
+    def test_rescan_choice_forced_by_plugin_on_singleton_task_is_ignored(self):
+        """`task.is_album` is False for singleton tasks (e.g. produced
+        by "as Tracks"), whose `paths` holds a single item file rather
+        than an album directory. A plugin forcing Rescan there must
+        not wrap it back into a mismatched album-style task.
+        """
+
+        class ForceRescanPlugin(plugins.BeetsPlugin):
+            def __init__(self):
+                super().__init__()
+                self.register_listener("import_task_choice", self.force_rescan)
+
+            def force_rescan(self, session, task):
+                if not task.is_album:
+                    task.choice_flag = importer.Action.RESCAN
+
+        self.register_plugin(ForceRescanPlugin)
+        self.importer.add_choice(importer.Action.TRACKS)
+        self.importer.run()
+
+        assert not self.lib.items()
+
+    def test_rescan_choice_forced_by_plugin_on_grouped_task_is_ignored(self):
+        """`task.choice_flag` can be set by a plugin listening for
+        `import_task_choice`, not only through the choices offered at
+        the prompt. A plugin forcing Rescan onto a Group-albums task
+        must be ignored (falling back to Skip) rather than misbehave.
+        """
+
+        class ForceRescanPlugin(plugins.BeetsPlugin):
+            def __init__(self):
+                super().__init__()
+                self.register_listener("import_task_choice", self.force_rescan)
+
+            def force_rescan(self, session, task):
+                if task.is_grouped:
+                    task.choice_flag = importer.Action.RESCAN
+
+        self.register_plugin(ForceRescanPlugin)
+        self.importer.add_choice(importer.Action.ALBUMS)
+        self.importer.run()
+
+        assert not self.lib.albums()
+
+    def test_rescan_choice_forced_by_plugin_on_toppathless_task_is_ignored(
+        self,
+    ):
+        """`task.toppath` is None for tasks produced by a library query
+        (e.g. reimporting via `beet import -L`). A plugin forcing
+        Rescan there must not crash `rescan_tasks`'s
+        `assert task.toppath is not None`.
+        """
+
+        class ForceRescanPlugin(plugins.BeetsPlugin):
+            def __init__(self):
+                super().__init__()
+                self.register_listener("import_task_choice", self.force_rescan)
+
+            def force_rescan(self, session, task):
+                task.choice_flag = importer.Action.RESCAN
+
+        # Get an album into the library first, via the normal importer.
+        self.importer.add_choice(importer.Action.ASIS)
+        self.importer.run()
+        assert len(self.lib.albums()) == 1
+
+        self.register_plugin(ForceRescanPlugin)
+
+        query_session = TerminalImportSessionFixture(
+            self.lib,
+            loghandler=None,
+            query="album:'Tag Album'",
+            io=self.io,
+            paths=None,
+        )
+        query_session.default_choice = importer.Action.APPLY
+
+        query_session.run()  # Must not raise.
+
+        assert len(self.lib.albums()) == 1
 
 
 class ImportCompilationTest(AutotagImportTestCase):

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -642,7 +642,7 @@ class ImportTracksTest(AutotagImportTestCase):
         assert (self.lib_path / "singletons" / "Applied Track 1.mp3").exists()
 
 
-class ImportRescanTest(AutotagImportTestCase):
+class ImportRescanTest(PluginMixin, AutotagImportTestCase):
     """Test the Rescan directory action.
 
     Each test's directory mutation must happen exactly when the first
@@ -748,6 +748,273 @@ class ImportRescanTest(AutotagImportTestCase):
         self._run_with_cleanup_before_first_prompt(cleanup)
 
         assert len(self.lib.albums()) == 2
+
+    def test_rescan_of_album_with_preexisting_plain_subdirectory_does_not_duplicate_it(
+        self,
+    ):
+        """A plain, non-disc-named subdirectory holding its own album
+        (e.g. a bonus-tracks folder) is discovered as its own separate
+        task, independent of its parent album -- unlike a disc
+        subdirectory, which gets collapsed into the parent's own task
+        (see ``test_rescan_of_multidisc_album_does_not_duplicate_tasks``).
+
+        Rescanning the *parent* album walks its own directory
+        unrestricted (nothing outside it is in scope, so there's
+        normally nothing to filter) and so rediscovers that
+        subdirectory too. Without dropping the subdirectory's original,
+        still-pending task, it would get imported twice: once from the
+        original scan, once from the rescan re-finding it fresh.
+        """
+        self.prepare_album_for_import(1, album_path=self.album_path / "extras")
+        self.setup_importer()
+
+        # The parent album is discovered (and prompted) before its
+        # "extras" subdirectory. Rescan it -- a no-op change, since
+        # nothing on disk moved -- then apply both the reconstructed
+        # parent album and the rediscovered "extras" album exactly
+        # once each.
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(lambda: None)
+
+        albums = self.lib.albums()
+        assert len(albums) == 2
+        assert sorted(len(list(a.items())) for a in albums) == [1, 2]
+
+    def test_rescan_of_album_with_plain_subdirectory_survives_a_second_rescan(
+        self,
+    ):
+        """Rescanning the same task twice must not leave the *first*
+        rescan's still-pending output -- e.g. its own fresh copy of a
+        rediscovered "extras" subdirectory -- stranded behind the
+        second rescan without a scope current enough to drop it too.
+
+        Item/album counts alone can't tell a truly-dropped stale task
+        apart from one that was merely prompted twice and then deduped
+        by the unrelated, pre-existing duplicate-detection machinery --
+        so count prompts by path instead of just the final totals.
+        """
+        self.prepare_album_for_import(1, album_path=self.album_path / "extras")
+        self.setup_importer()
+
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        prompted: list[tuple[bytes, ...]] = []
+        original_choose_match = self.importer.choose_match
+
+        def choose_match_and_record(task):
+            prompted.append(tuple(task.paths))
+            return original_choose_match(task)
+
+        # Patch for the whole run, not just from the first prompt: the
+        # count must include every prompt, and there's nothing to
+        # mutate on disk for this test (both rescans are no-ops).
+        with patch.object(
+            self.importer, "choose_match", side_effect=choose_match_and_record
+        ):
+            self.importer.run()
+
+        extras_path = os.fsencode(str(self.album_path / "extras"))
+        assert sum(1 for paths in prompted if paths == (extras_path,)) == 1
+
+        albums = self.lib.albums()
+        assert len(albums) == 2
+        assert sorted(len(list(a.items())) for a in albums) == [1, 2]
+
+    def test_rescan_then_merge_duplicate_is_not_dropped(self):
+        """A duplicate-merge decision made on a task that came out of a
+        rescan must not be silently discarded just because the merged
+        task's paths fall inside the directory the rescan already
+        marked as re-read (see ``ImportSession.mark_rescanned``): the
+        merged task is freshly built right there in ``user_query``, not
+        itself the stale product of an earlier scan.
+        """
+        # The library already has this album, but with only one track.
+        (self.album_path / "track_2.mp3").unlink()
+        self.setup_importer()
+        self.importer.add_choice(importer.Action.APPLY)
+        self.importer.run()
+        assert len(self.lib.items()) == 1
+
+        # Re-import with both tracks present and duplicates merged,
+        # choosing Rescan first -- a no-op change, since nothing on
+        # disk moved before the match is applied.
+        self.prepare_track_for_import(2, self.album_path)
+        self.config["import"]["duplicate_action"] = "merge"
+        self.setup_importer()
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+        self.importer.run()
+
+        # The merge must actually have happened -- the point being
+        # tested is that it isn't silently dropped, leaving the album
+        # exactly as it was before the second import (still 1 item).
+        assert len(self.lib.albums()) == 1
+        assert len(self.lib.items()) > 1
+
+    def test_merge_duplicate_of_an_unrelated_rescanned_album_is_not_dropped(
+        self,
+    ):
+        """A duplicate-merge task's paths aren't limited to the
+        directory scope of the task it was built from -- they also
+        include the *library* paths of whatever it's merging with,
+        which can be anywhere, including inside a directory some
+        completely unrelated rescan earlier in the same session already
+        marked as re-read. Inheriting that unrelated task's rescan
+        "generation" would make the merge look stale relative to a
+        rescan it has nothing to do with; it must be stamped current as
+        of the session's own state instead (see
+        ``ImportSession.rescan_generation``).
+        """
+        for track in self.album_path.glob("*.mp3"):
+            track.unlink()
+        self.album_path.rmdir()
+        album_a = self.import_path / "Album A"
+        album_b = self.import_path / "Album B"
+        self.prepare_album_for_import(2, album_path=album_a)
+        # Same (default) artist/album tags as "Album A", so this
+        # duplicates against it once "Album A" is in the library.
+        self.prepare_album_for_import(2, album_path=album_b)
+        self.config["import"]["duplicate_action"] = "merge"
+        self.setup_importer(copy=False)
+
+        # "Album A" is imported in place (so its library item paths
+        # stay under its own import directory) via a no-op rescan, then
+        # "Album B" -- unrelated to that rescan -- duplicate-merges
+        # against it.
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(lambda: None)
+
+        assert len(self.lib.albums()) == 1
+        assert len(self.lib.items()) > 2
+
+    def test_rescan_then_as_tracks_does_not_drop_items(self):
+        """ "As Tracks", chosen on a task that came out of a rescan,
+        must not be silently discarded either: the resulting singleton
+        tasks are freshly built from `task.items`, not themselves the
+        stale product of an earlier scan, so they must inherit the
+        rescanned task's exemption the same way a duplicate-merge task
+        does (see ``ImportSession.mark_rescanned``).
+        """
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.TRACKS)
+        self.importer.add_choice(importer.Action.APPLY)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(lambda: None)
+
+        assert len(self.lib.items()) == 2
+        assert not self.lib.albums()
+
+    def test_rescan_then_group_albums_does_not_drop_items(self):
+        """ "Group albums", chosen on a task that came out of a rescan,
+        must not be silently discarded either: the per-group tasks it
+        builds are freshly derived from `task.items`, not themselves
+        the stale product of an earlier scan.
+        """
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.ALBUMS)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(lambda: None)
+
+        assert len(self.lib.items()) == 2
+        assert len(self.lib.albums()) == 1
+
+    def test_rescan_then_as_tracks_does_not_drop_items_when_a_plugin_replaces_tasks(
+        self,
+    ):
+        """A plugin listening for `import_task_created` can replace a
+        task with different objects entirely (see
+        ``TestEvents.test_import_task_created_with_plugin`` in
+        test_plugins.py) -- the replacements must inherit the
+        pre-replacement task's `rescan_generation` too, not just the
+        task that was passed into `handle_created` in the first place.
+        """
+
+        fired = []
+
+        class RebuildSingletonPlugin(plugins.BeetsPlugin):
+            def __init__(self):
+                super().__init__()
+                self.register_listener("import_task_created", self.rebuild)
+
+            def rebuild(self, session, task):
+                if isinstance(task, importer.SingletonImportTask):
+                    fired.append(task)
+                    return [
+                        importer.SingletonImportTask(task.toppath, task.item)
+                    ]
+                return None
+
+        self.register_plugin(RebuildSingletonPlugin)
+
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.TRACKS)
+        self.importer.add_choice(importer.Action.APPLY)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(lambda: None)
+
+        # Confirms the plugin's replacement path was actually exercised
+        # -- otherwise this test would just be a duplicate of
+        # test_rescan_then_as_tracks_does_not_drop_items and could pass
+        # even if the plugin never fired.
+        assert len(fired) == 2
+        assert len(self.lib.items()) == 2
+        assert not self.lib.albums()
+
+    def test_rescan_then_group_albums_does_not_drop_items_when_a_plugin_replaces_tasks(
+        self,
+    ):
+        """The `Action.ALBUMS` analogue of
+        ``test_rescan_then_as_tracks_does_not_drop_items_when_a_plugin_replaces_tasks``.
+        """
+
+        fired = []
+
+        class RebuildAlbumPlugin(plugins.BeetsPlugin):
+            def __init__(self):
+                super().__init__()
+                self.register_listener("import_task_created", self.rebuild)
+
+            def rebuild(self, session, task):
+                if (
+                    isinstance(task, importer.ImportTask)
+                    and not isinstance(task, importer.SingletonImportTask)
+                    and task.is_grouped
+                ):
+                    fired.append(task)
+                    return [
+                        importer.ImportTask(
+                            task.toppath, task.paths, task.items
+                        )
+                    ]
+                return None
+
+        self.register_plugin(RebuildAlbumPlugin)
+
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.ALBUMS)
+        self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(lambda: None)
+
+        # Confirms the plugin's replacement path was actually exercised
+        # -- otherwise this test would just be a duplicate of
+        # test_rescan_then_group_albums_does_not_drop_items and could
+        # pass even if the plugin never fired (e.g. if `is_grouped`
+        # weren't set in time for the plugin to see it).
+        assert len(fired) == 1
+        assert len(self.lib.items()) == 2
+        assert len(self.lib.albums()) == 1
 
     def test_rescan_of_multidisc_album_does_not_duplicate_tasks(self):
         """`task.paths` for a multi-disc album holds the album root *and*
@@ -868,6 +1135,44 @@ class ImportRescanTest(AutotagImportTestCase):
         self.importer.add_choice(importer.Action.ASIS)
         self.importer.add_choice(importer.Action.RESCAN)
         self.importer.add_choice(importer.Action.APPLY)
+
+        self._run_with_cleanup_before_first_prompt(lambda: None)
+
+        albums = self.lib.albums()
+        assert len(albums) == 2
+        assert sorted(len(list(a.items())) for a in albums) == [1, 2]
+
+    def test_rescan_of_sibling_multidisc_album_does_not_drop_unrelated_album_after_it(
+        self,
+    ):
+        """The mirror of
+        ``test_rescan_of_sibling_multidisc_album_does_not_duplicate_tasks``:
+        an unrelated album sharing the disc directories' parent, but
+        sorting *after* them so it's still an unanswered, pending task
+        at rescan time. The rescan must not drop it -- the shared
+        parent it happens to sit under is not itself the rescan's
+        scope, only the disc directories are (see `rescan_tasks`).
+        """
+        for track in self.album_path.glob("*.mp3"):
+            track.unlink()
+        self.album_path.rmdir()
+        self.prepare_album_for_import(
+            1, album_path=self.import_path / "Set Disc 1"
+        )
+        self.prepare_album_for_import(
+            1, album_path=self.import_path / "Set Disc 2"
+        )
+        self.prepare_album_for_import(
+            1, album_path=self.import_path / "Zzz Album"
+        )
+        self.setup_importer()
+
+        # The disc directories sort and are processed first; rescan
+        # them (a no-op change, since nothing on disk moved), then
+        # leave the still-pending "Zzz Album" as-is.
+        self.importer.add_choice(importer.Action.RESCAN)
+        self.importer.add_choice(importer.Action.APPLY)
+        self.importer.add_choice(importer.Action.ASIS)
 
         self._run_with_cleanup_before_first_prompt(lambda: None)
 
@@ -1179,6 +1484,77 @@ class TestRescanChoiceAvailability(
         assert "Rescan directory" in first_opts
         assert "Rescan directory" not in second_opts
 
+    def test_rescan_choice_withheld_after_group_albums_with_a_task_replacing_plugin(
+        self,
+    ):
+        """`group_albums` sets `is_grouped` on the task it builds
+        *before* sending `import_task_created`, so a plugin listening
+        for that event and inspecting the task sees it -- but a plugin
+        that *replaces* the task with a new object entirely gets one
+        with `is_grouped` still at its default `False`, unless
+        `group_albums` re-applies it to whatever `handle_created`
+        actually returns. Confirms that re-application is real: without
+        it, this test would offer "Rescan directory" for a task with no
+        directory scope to rescan.
+        """
+
+        class RebuildAlbumPlugin(plugins.BeetsPlugin):
+            def __init__(self):
+                super().__init__()
+                self.register_listener("import_task_created", self.rebuild)
+
+            def rebuild(self, session, task):
+                if (
+                    isinstance(task, importer.ImportTask)
+                    and not isinstance(task, importer.SingletonImportTask)
+                    and task.is_grouped
+                ):
+                    return [
+                        importer.ImportTask(
+                            task.toppath, task.paths, task.items
+                        )
+                    ]
+                return None
+
+        self.register_plugin(RebuildAlbumPlugin)
+        self.importer.add_choice(importer.Action.ALBUMS)
+        self.importer.add_choice(importer.Action.SKIP)
+        self.importer.run()
+
+        assert self.mock_input_options.call_count >= 2
+        first_opts, second_opts = (
+            call.args[0] for call in self.mock_input_options.call_args_list[:2]
+        )
+        assert "Rescan directory" in first_opts
+        assert "Rescan directory" not in second_opts
+
+    def test_rescan_choice_withheld_for_toppathless_task(self):
+        """Withheld for the same reason as Group-albums tasks (see
+        `test_rescan_choice_withheld_after_group_albums`): a
+        toppath-less task -- e.g. produced by a library query, as with
+        `beet import -L` -- has no directory scope a filesystem rescan
+        could reconstruct either, and `task.is_album` alone doesn't
+        capture that (a query-produced `ImportTask` is still an album
+        task).
+        """
+        self.importer.add_choice(importer.Action.ASIS)
+        self.importer.run()
+        assert len(self.lib.albums()) == 1
+
+        query_session = TerminalImportSessionFixture(
+            self.lib,
+            loghandler=None,
+            query="album:'Tag Album'",
+            io=self.io,
+            paths=None,
+        )
+        query_session.add_choice(importer.Action.SKIP)
+        query_session.run()
+
+        assert self.mock_input_options.call_count >= 2
+        opts = self.mock_input_options.call_args_list[-1].args[0]
+        assert "Rescan directory" not in opts
+
     def test_rescan_choice_forced_by_plugin_on_singleton_task_is_ignored(self):
         """`task.is_album` is False for singleton tasks (e.g. produced
         by "as Tracks"), whose `paths` holds a single item file rather
@@ -1201,11 +1577,20 @@ class TestRescanChoiceAvailability(
 
         assert not self.lib.items()
 
-    def test_rescan_choice_forced_by_plugin_on_grouped_task_is_ignored(self):
+    def test_rescan_choice_forced_by_plugin_on_grouped_task_is_ignored(
+        self, caplog
+    ):
         """`task.choice_flag` can be set by a plugin listening for
         `import_task_choice`, not only through the choices offered at
         the prompt. A plugin forcing Rescan onto a Group-albums task
         must be ignored (falling back to Skip) rather than misbehave.
+
+        Asserts the actual guard fired (the warning log and the
+        resulting `Action.SKIP`), not just the coarse "nothing got
+        imported" symptom: a grouped task's item-file paths can never
+        match anything a directory walk discovers, so the rescan
+        silently finding nothing would produce the same empty-library
+        symptom even if the `is_grouped` guard itself were missing.
         """
 
         class ForceRescanPlugin(plugins.BeetsPlugin):
@@ -1219,8 +1604,11 @@ class TestRescanChoiceAvailability(
 
         self.register_plugin(ForceRescanPlugin)
         self.importer.add_choice(importer.Action.ALBUMS)
-        self.importer.run()
 
+        with caplog.at_level("WARNING"):
+            self.importer.run()
+
+        assert "Ignoring a Rescan directory choice" in caplog.text
         assert not self.lib.albums()
 
     def test_rescan_choice_forced_by_plugin_on_toppathless_task_is_ignored(

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -271,7 +271,7 @@ class TestPromptChoices(TerminalImportMixin, PluginImportHelper):
             def return_choices(self, session, task):
                 return [
                     PromptChoice("f", "Foo", None),
-                    PromptChoice("r", "baR", None),
+                    PromptChoice("z", "baZ", None),
                 ]
 
         self.register_plugin(DummyPlugin)
@@ -283,11 +283,12 @@ class TestPromptChoices(TerminalImportMixin, PluginImportHelper):
             "Use as-is",
             "as Tracks",
             "Group albums",
+            "Rescan directory",
             "Enter search",
             "enter Id",
             "aBort",
             "Foo",
-            "baR",
+            "baZ",
         )
 
         self.importer.add_choice(Action.SKIP)
@@ -360,6 +361,7 @@ class TestPromptChoices(TerminalImportMixin, PluginImportHelper):
             "Use as-is",
             "as Tracks",
             "Group albums",
+            "Rescan directory",
             "Enter search",
             "enter Id",
             "aBort",
@@ -396,6 +398,7 @@ class TestPromptChoices(TerminalImportMixin, PluginImportHelper):
             "Use as-is",
             "as Tracks",
             "Group albums",
+            "Rescan directory",
             "Enter search",
             "enter Id",
             "aBort",
@@ -440,6 +443,7 @@ class TestPromptChoices(TerminalImportMixin, PluginImportHelper):
             "Use as-is",
             "as Tracks",
             "Group albums",
+            "Rescan directory",
             "Enter search",
             "enter Id",
             "aBort",

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -310,6 +310,11 @@ class TestPromptChoices(TerminalImportMixin, PluginImportHelper):
             def return_choices(self, session, task):
                 return [
                     PromptChoice("f", "Foo", None),
+                    # Unlike the album-prompt variant of this test below,
+                    # "r" is safe here: "Rescan directory" is never
+                    # offered for singleton tasks (see
+                    # `_get_choices`'s `task.is_album` gate), so there's
+                    # nothing for this to collide with.
                     PromptChoice("r", "baR", None),
                 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -321,7 +321,7 @@ wheels = [
 
 [[package]]
 name = "beets"
-version = "2.13.0"
+version = "2.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },


### PR DESCRIPTION
## Description

Draft companion to #6945 ("Add 'Rescan directory' import prompt choice"). This branch redoes the "Rescan directory" scoping/reconstruction logic that #6945's review has been iterating on, in response to snejus's feedback that rescanning shouldn't reimplement directory-grouping logic separately from the normal scan.

Opening this as a separate draft (rather than pushing straight to #6945) to work through Copilot's automated review here first, since the review thread on #6945 has already been long. Once this settles, I'll bring it back into #6945 (or this can simply replace it, whichever's easier on your end).

### What changed relative to #6945's current state

- `rescan_tasks` now reuses the exact same discovery/grouping logic (`ImportTaskFactory.paths()` / `albums_in_dir`) the normal scan uses, rather than a separate reconstruction — it only ever has to figure out the smallest directory that logic needs to be re-run from (`os.path.commonpath(task.paths)`), then filters the walk's output back down to the groups related to the original task.
- Fixes a real bug found during review: rescanning an album whose directory also holds an unrelated, already-discovered task (e.g. a bonus-tracks subdirectory, or an unrelated sibling album under a shared parent) could either duplicate-import that other task or silently drop it. `ImportSession` now tracks which directories a rescan has authoritatively re-read, with a small generation counter so a task built fresh from a rescanned task's items (duplicate-merge, "as Tracks", "Group albums") isn't mistaken for stale output.
- Extensive regression test coverage for the above, including multi-disc (nested and flattened/sibling, at varying depths), toppath preservation for move-pruning and resume state, and interaction with plugins that replace tasks via `import_task_created`.

### Known items

- `uv.lock` has a one-line version bump (`2.13.0` → `2.13.1`) picked up incidentally: `pyproject.toml` on master already says `2.13.1`, but master's `uv.lock` doesn't, and this repo's local pre-commit hook re-syncs it on every commit. Happy to drop it if you'd rather keep that separate.

## To Do

- [x] Tests
- [ ] Work through Copilot's review
