### PR TITLE
list command: add `-l`/``--limit`` flag, deprecate limit plugin

### DIFF
--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -1437,14 +1437,6 @@ class Database:
             f"WHERE {where or 1} "
             f"GROUP BY {table}.id "
         )
-        # Fetch flexible attributes for items matching the main query.
-        # Doing the per-item filtering in python is faster than issuing
-        # one query per item to sqlite.
-        flex_sql = (
-            "SELECT * "
-            f"FROM {model_cls._flex_table} "
-            f"WHERE entity_id IN (SELECT id FROM ({sql}))"
-        )
 
         if order_by:
             # the sort field may exist in both 'items' and 'albums' tables
@@ -1463,6 +1455,15 @@ class Database:
 
         if sql_limit is not None:
             sql += f"LIMIT {sql_limit}"
+
+        # Fetch flexible attributes for items matching the main query.
+        # Doing the per-item filtering in python is faster than issuing
+        # one query per item to sqlite.
+        flex_sql = (
+            "SELECT * "
+            f"FROM {model_cls._flex_table} "
+            f"WHERE entity_id IN (SELECT id FROM ({sql}))"
+        )
 
         with self.transaction() as tx:
             rows = tx.query(sql, subvals)

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -15,6 +15,7 @@ from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import cached_property
+from itertools import islice
 from pathlib import Path
 from sqlite3 import Connection, sqlite_version_info
 from typing import (
@@ -744,6 +745,7 @@ class Results(Sequence[AnyModel]):
         flex_rows: list[sqlite3.Row],
         query: Query | None = None,
         sort: Sort | None = None,
+        limit: int | None = None,
     ) -> None:
         """Create a result set that will construct objects of type
         `model_class`.
@@ -764,6 +766,7 @@ class Results(Sequence[AnyModel]):
         self.db = db
         self.query = query
         self.sort = sort
+        self.limit = limit
         self.flex_rows = flex_rows
 
         # We keep a queue of rows we haven't yet consumed for
@@ -815,13 +818,16 @@ class Results(Sequence[AnyModel]):
         """Construct and generate Model objects for all matching
         objects, in sorted order.
         """
+        # Objects are pre-sorted (i.e., by the database).
+        objects = self._get_objects()
         if self.sort:
             # Slow sort. Must build the full list first.
-            objects = self.sort.sort(list(self._get_objects()))
-            return iter(objects)
+            objects = iter(self.sort.sort(list(objects)))
 
-        # Objects are pre-sorted (i.e., by the database).
-        return self._get_objects()
+        if self.limit is not None:
+            objects = islice(objects, self.limit)
+
+        return objects
 
     def _get_indexed_flex_attrs(self) -> dict[int, FlexAttrs]:
         """Index flexible attributes by the entity id they belong to"""
@@ -1410,7 +1416,14 @@ class Database:
         sort = sort or NullSort()  # Unsorted.
         where, subvals = query.clause()
         order_by = sort.order_clause()
-        # TODO: handle flex fields sort
+        sql_limit = flex_limit = None
+        if limit is not None:
+            if sort.field_names - model_cls.all_db_fields:
+                # sorting by at least one flexible attr.
+                # Limit will be applied after slow field sort.
+                flex_limit = limit
+            else:
+                sql_limit = limit
 
         table = model_cls._table
         _from = table
@@ -1441,8 +1454,8 @@ class Database:
             # a subquery and order the result, which returns unique fields.
             sql = f"SELECT * FROM ({sql}) ORDER BY {order_by} "
 
-        if limit is not None:
-            sql += f"LIMIT {limit}"
+        if sql_limit is not None:
+            sql += f"LIMIT {sql_limit}"
 
         with self.transaction() as tx:
             rows = tx.query(sql, subvals)
@@ -1455,6 +1468,7 @@ class Database:
             flex_rows,
             None if where else query,  # Slow query component.
             sort if sort.is_slow() else None,  # Slow sort component.
+            flex_limit,
         )
 
     def _get(self, model_cls: type[AnyModel], id_: int) -> AnyModel | None:

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -1399,6 +1399,7 @@ class Database:
         model_cls: type[AnyModel],
         query: Query | None = None,
         sort: Sort | None = None,
+        limit: int | None = None,
     ) -> Results[AnyModel]:
         """Fetch the objects of type `model_cls` matching the given
         query. The query may be given as a string, string sequence, a
@@ -1409,6 +1410,7 @@ class Database:
         sort = sort or NullSort()  # Unsorted.
         where, subvals = query.clause()
         order_by = sort.order_clause()
+        # TODO: handle flex fields sort
 
         table = model_cls._table
         _from = table
@@ -1420,7 +1422,7 @@ class Database:
             f"SELECT {table}.* "
             f"FROM ({_from}) "
             f"WHERE {where or 1} "
-            f"GROUP BY {table}.id"
+            f"GROUP BY {table}.id "
         )
         # Fetch flexible attributes for items matching the main query.
         # Doing the per-item filtering in python is faster than issuing
@@ -1437,7 +1439,10 @@ class Database:
             # if we try to order directly.
             # Since the join is required only for filtering, we can filter in
             # a subquery and order the result, which returns unique fields.
-            sql = f"SELECT * FROM ({sql}) ORDER BY {order_by}"
+            sql = f"SELECT * FROM ({sql}) ORDER BY {order_by} "
+
+        if limit is not None:
+            sql += f"LIMIT {limit}"
 
         with self.transaction() as tx:
             rows = tx.query(sql, subvals)

--- a/beets/dbcore/db.py
+++ b/beets/dbcore/db.py
@@ -1452,7 +1452,14 @@ class Database:
             # if we try to order directly.
             # Since the join is required only for filtering, we can filter in
             # a subquery and order the result, which returns unique fields.
-            sql = f"SELECT * FROM ({sql}) ORDER BY {order_by} "
+            select = f"{table}.* FROM ({sql}) {table}"
+            if (
+                sort.field_names & model_cls.other_db_fields
+            ) - model_cls._getters().keys():
+                # only applies to db fields on the other model
+                select += f" {model_cls.relation_join}"
+
+            sql = f"SELECT {select} ORDER BY {order_by} "
 
         if sql_limit is not None:
             sql += f"LIMIT {sql_limit}"

--- a/beets/dbcore/queryparse.py
+++ b/beets/dbcore/queryparse.py
@@ -183,16 +183,7 @@ def construct_sort_part(
     assert direction in ("+", "-"), "part must end with + or -"
     is_ascending = direction == "+"
 
-    if sort_cls := model_cls._sorts.get(field):
-        if isinstance(sort_cls, sort.SmartArtistSort):
-            field = "albumartist" if model_cls.__name__ == "Album" else "artist"
-    elif field in model_cls._fields:
-        sort_cls = sort.FixedFieldSort
-    else:
-        # Flexible or computed.
-        sort_cls = sort.SlowFieldSort
-
-    return sort_cls(field, is_ascending, case_insensitive)
+    return model_cls.field_sort(field, is_ascending, case_insensitive)
 
 
 def sort_from_strings(

--- a/beets/dbcore/sort.py
+++ b/beets/dbcore/sort.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from functools import reduce
+from operator import or_
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -14,6 +16,11 @@ class Sort:
     """An abstract class representing a sort operation for a query into
     the database.
     """
+
+    @property
+    def field_names(self) -> set[str]:
+        """A set with fields in this sort."""
+        return set()
 
     def order_clause(self) -> str | None:
         """Generates a SQL fragment to be used in a ORDER BY clause, or
@@ -46,6 +53,11 @@ class MultipleSort(Sort):
 
     def __init__(self, sorts: list[Sort] | None = None) -> None:
         self.sorts = sorts or []
+
+    @property
+    def field_names(self) -> set[str]:
+        """A set with fields in this sort."""
+        return reduce(or_, (s.field_names for s in self.sorts), set())
 
     def add_sort(self, sort: Sort) -> None:
         self.sorts.append(sort)
@@ -115,6 +127,11 @@ class FieldSort(Sort):
         self.field = field
         self.ascending = ascending
         self.case_insensitive = case_insensitive
+
+    @property
+    def field_names(self) -> set[str]:
+        """A set with fields in this sort."""
+        return {self.field}
 
     def sort(self, objs: Sequence[AnyModel]) -> Sequence[AnyModel]:
         # TODO: Support flexible attributes with different types (e.g. a mix

--- a/beets/dbcore/sort.py
+++ b/beets/dbcore/sort.py
@@ -122,27 +122,36 @@ class FieldSort(Sort):
     """
 
     def __init__(
-        self, field: str, ascending: bool = True, case_insensitive: bool = True
+        self,
+        field_name: str,
+        ascending: bool = True,
+        case_insensitive: bool = True,
     ) -> None:
-        self.field = field
+        self.table, _, self.field_name = field_name.rpartition(".")
         self.ascending = ascending
         self.case_insensitive = case_insensitive
 
     @property
+    def field(self) -> str:
+        return (
+            f"{self.table}.{self.field_name}" if self.table else self.field_name
+        )
+
+    @property
     def field_names(self) -> set[str]:
         """A set with fields in this sort."""
-        return {self.field}
+        return {self.field_name}
 
     def sort(self, objs: Sequence[AnyModel]) -> Sequence[AnyModel]:
         # TODO: Support flexible attributes with different types (e.g. a mix
         # of strings and numbers) without falling over.
 
         def key(obj: Model) -> Any:
-            field_val = obj.get(self.field, None)
+            field_val = obj.get(self.field_name, None)
             if field_val is None:
-                if _type := obj._types.get(self.field):
+                if _type := obj._types.get(self.field_name):
                     # If the field is typed, use its null value.
-                    field_val = obj._types[self.field].null
+                    field_val = obj._types[self.field_name].null
                 else:
                     # If not, fall back to using an empty string.
                     field_val = ""

--- a/beets/library/library.py
+++ b/beets/library/library.py
@@ -138,6 +138,7 @@ class Library(dbcore.Database):
         model_cls: type[LM],
         query: str | Sequence[str] | Query | None = None,
         sort: Sort | None = None,
+        limit: int | None = None,
     ) -> dbcore.Results[LM]:
         """Parse a query and fetch.
 
@@ -169,7 +170,7 @@ class Library(dbcore.Database):
         if parsed_sort and not isinstance(parsed_sort, NullSort):
             sort = parsed_sort
 
-        return super()._get_results(model_cls, parsed_query, sort)
+        return super()._get_results(model_cls, parsed_query, sort, limit)
 
     @staticmethod
     def get_default_album_sort() -> Sort:
@@ -189,17 +190,23 @@ class Library(dbcore.Database):
         self,
         query: str | Sequence[str] | Query | None = None,
         sort: Sort | None = None,
+        limit: int | None = None,
     ) -> dbcore.Results[Album]:
         """Get :class:`Album` objects matching the query."""
-        return self._fetch(Album, query, sort or self.get_default_album_sort())
+        return self._fetch(
+            Album, query, sort or self.get_default_album_sort(), limit
+        )
 
     def items(
         self,
         query: str | Sequence[str] | Query | None = None,
         sort: Sort | None = None,
+        limit: int | None = None,
     ) -> dbcore.Results[Item]:
         """Get :class:`Item` objects matching the query."""
-        return self._fetch(Item, query, sort or self.get_default_item_sort())
+        return self._fetch(
+            Item, query, sort or self.get_default_item_sort(), limit
+        )
 
     # Convenience accessors.
     def get_item(self, id_: int) -> Item | None:

--- a/beets/library/models.py
+++ b/beets/library/models.py
@@ -13,10 +13,9 @@ from typing_extensions import Self
 
 import beets
 from beets import dbcore, logging, plugins, util
-from beets.dbcore import types
+from beets.dbcore import sort, types
 from beets.dbcore.db import FormattedMapping
 from beets.dbcore.pathutils import normalize_path_for_db
-from beets.dbcore.sort import SmartArtistSort
 from beets.util import (
     MoveOperation,
     bytestring_path,
@@ -116,6 +115,22 @@ class LibModel(dbcore.Model["Library"]):
         return self.__str__().encode("utf-8")
 
     # Convenient queries.
+    @classmethod
+    def field_sort(
+        cls, field: str, is_ascending: bool, case_insensitive: bool
+    ) -> FieldSort:
+        if sort_cls := cls._sorts.get(field):
+            if issubclass(sort_cls, sort.SmartArtistSort):
+                field = "albumartist" if cls.__name__ == "Album" else "artist"
+        elif field in cls.all_db_fields and field not in cls._getters():
+            sort_cls = sort.FixedFieldSort
+            if field in cls.other_db_fields:
+                field = f"{cls._relation._table}.{field}"
+        else:
+            # Flexible or computed.
+            sort_cls = sort.SlowFieldSort
+
+        return sort_cls(field, is_ascending, case_insensitive)
 
     @classmethod
     def field_query(
@@ -326,8 +341,8 @@ class Album(LibModel):
     _formatter = FormattedMapping
 
     _sorts: ClassVar[dict[str, type[FieldSort]]] = {
-        "albumartist": SmartArtistSort,
-        "artist": SmartArtistSort,
+        "albumartist": sort.SmartArtistSort,
+        "artist": sort.SmartArtistSort,
     }
 
     # List of keys that are set on an album's items.
@@ -740,7 +755,9 @@ class Item(LibModel):
 
     _formatter = FormattedItemMapping
 
-    _sorts: ClassVar[dict[str, type[FieldSort]]] = {"artist": SmartArtistSort}
+    _sorts: ClassVar[dict[str, type[FieldSort]]] = {
+        "artist": sort.SmartArtistSort
+    }
 
     @cached_classproperty
     def _queries(cls) -> dict[str, FieldQueryType]:

--- a/beets/ui/commands/list.py
+++ b/beets/ui/commands/list.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol
 
 from beets import ui
+from beets.exceptions import UserError
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -14,24 +15,27 @@ if TYPE_CHECKING:
 
 class ListCLIOpts(Protocol):
     album: bool
+    limit: int | None
 
 
 def list_items(
-    lib: Library, query: Sequence[str], album: bool, fmt: str = ""
+    lib: Library, query: Sequence[str], opts: ListCLIOpts, fmt: str = ""
 ) -> None:
     """Print out items in lib matching query. If album, then search for
     albums instead of single items.
     """
-    if album:
-        for _album in lib.albums(query):
+    if opts.album:
+        for _album in lib.albums(query, limit=opts.limit):
             ui.print_(format(_album, fmt))
     else:
-        for item in lib.items(query):
+        for item in lib.items(query, limit=opts.limit):
             ui.print_(format(item, fmt))
 
 
 def list_func(lib: Library, opts: ListCLIOpts, args: list[str]) -> None:
-    list_items(lib, args, opts.album)
+    if opts.limit is not None and opts.limit < 0:
+        raise UserError("-l / --limit argument must be a non-negative integer")
+    list_items(lib, args, opts)
 
 
 list_cmd = ui.Subcommand("list", help="query the library", aliases=("ls",))
@@ -40,4 +44,7 @@ list_cmd.parser.set_usage(
     + "\nExample: %prog -f '$album: $title' artist:beatles"
 )
 list_cmd.parser.add_all_common_options()
+list_cmd.parser.add_option(
+    "-l", "--limit", type=int, help="limit query results"
+)
 list_cmd.func = list_func

--- a/beetsplug/limit.py
+++ b/beetsplug/limit.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Protocol
 from beets.dbcore import FieldQuery
 from beets.plugins import BeetsPlugin
 from beets.ui import Subcommand, print_
+from beets.util.deprecation import deprecate_for_user
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -70,6 +71,12 @@ lslimit_cmd.func = lslimit
 
 class LimitPlugin(BeetsPlugin):
     """Query limit functionality via command and query prefix."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        deprecate_for_user(
+            self._log, "LimitPlugin ('limit')", "'beet ls -l <number>'"
+        )
 
     def commands(self) -> list[Subcommand]:
         """Expose `lslimit` subcommand."""

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,7 +26,7 @@ New features
   files can be cleaned up (duplicates, junk) while the import is paused at the
   prompt, without restarting the whole ``beet import`` run.
 - :ref:`list-cmd` Add ``-l / --limit LIMIT`` flag to the ``list`` command to
-  limit query results.
+  limit query results. :bug:`5076`
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -125,6 +125,8 @@ Bug fixes
   Previously all queries were combined, so a listen for "Song" also updated
   "Song (inst.)" or any other item whose title only contained the listened
   title.
+- :doc:`plugins/limit` Deprecate the ``limit`` plugin in favor of the new ``-l``
+  / ``--limit`` flag for the :ref:`list-cmd` command.
 
 ..
     For plugin developers

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,8 @@ New features
   tasks. It re-reads the album's directory from disk and re-runs the match, so
   files can be cleaned up (duplicates, junk) while the import is paused at the
   prompt, without restarting the whole ``beet import`` run.
+- :ref:`list-cmd` Add ``-l / --limit LIMIT`` flag to the ``list`` command to
+  limit query results.
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/plugins/limit.rst
+++ b/docs/plugins/limit.rst
@@ -1,6 +1,11 @@
 Limit Query Plugin
 ==================
 
+.. deprecated:: 2.14
+
+    Use the built-in ``-l`` / ``--limit`` flag on the :ref:`list-cmd` command
+    instead.
+
 ``limit`` is a plugin to limit a query to the first or last set of results. We
 also provide a query prefix ``'<n'`` to inline the same behavior in the ``list``
 command. They are analogous to piping results:

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -199,7 +199,7 @@ list
 
 ::
 
-    beet list [-apf] QUERY
+    beet list [-apf] [-l LIMIT] QUERY
 
 :doc:`Queries <query>` the database for music.
 
@@ -213,6 +213,9 @@ In this case, the queries you use are restricted to album-level fields: for
 example, you can search for ``year:1969`` but query parts for item-level fields
 like ``title:foo`` will be ignored. Remember that ``artist`` is an item-level
 field; ``albumartist`` is the corresponding album field.
+
+Use the ``-l LIMIT`` (``--limit=LIMIT``) flag when you want to cap the maximum
+number of items that are returned.
 
 The ``-p`` option makes beets print out filenames of matched items, which might
 be useful for piping into other Unix commands (such as `xargs

--- a/test/dbcore/test_sort.py
+++ b/test/dbcore/test_sort.py
@@ -1,7 +1,5 @@
 """Various tests for querying the library database."""
 
-import os
-
 import pytest
 
 import beets.library
@@ -15,8 +13,8 @@ from beets.test import _common
 _p = pytest.param
 
 
-def abs_test_path(path: str) -> str:
-    return os.fsdecode(util.normpath(path))
+def abs_test_path(path: str) -> bytes:
+    return util.normpath(path)
 
 
 @pytest.fixture(scope="class")
@@ -36,6 +34,7 @@ def setup_library(request: pytest.FixtureRequest, helper):
                 flex1=flex1,
                 flex2=flex2,
                 albumartist=albumartist,
+                artpath=abs_test_path(f"{id_}cover.jpg"),
             )
         )
         for id_, album, genres, year, flex1, flex2, albumartist in (
@@ -114,6 +113,8 @@ class TestSort:
             _p(Album, "path+ year+", [1, 2, 3], id="computed"),
             _p(Album, "year+ path+", [1, 2, 3], id="computed-reverse"),
             _p(Item, "flex2- flex1+", [1, 2, 4, 3], id="item-multi-flex-field"),
+            _p(Item, "artpath+", [1, 2, 3, 4], id="item-album-field"),
+            _p(Item, "artpath-", [4, 3, 1, 2], id="item-album-field-reverse"),
         ],
     )
     def test_sort(self, model, query, expected_ids):

--- a/test/ui/commands/test_list.py
+++ b/test/ui/commands/test_list.py
@@ -1,3 +1,6 @@
+import pytest
+
+from beets.exceptions import UserError
 from beets.test import _common
 from beets.test.helper import BeetsTestCase, IOMixin
 
@@ -5,10 +8,11 @@ from beets.test.helper import BeetsTestCase, IOMixin
 class ListTest(IOMixin, BeetsTestCase):
     def setUp(self):
         super().setUp()
-        self.item = _common.item()
-        self.item.path = "xxx/yyy"
+        self.item = _common.item(path="xxx/yyy", flex=1)
         self.lib.add(self.item)
         self.lib.add_album([self.item])
+        self.another_item = _common.item(path="another/path", flex=2)
+        self.lib.add(self.another_item)
 
     def test_list_outputs_item(self):
         stdout = self.run_with_output("list")
@@ -25,7 +29,7 @@ class ListTest(IOMixin, BeetsTestCase):
 
     def test_list_item_path(self):
         stdout = self.run_with_output("list", "-f", "$path")
-        assert stdout.strip() == str(self.lib_path / "xxx/yyy")
+        assert stdout.strip().splitlines()[0] == str(self.lib_path / "xxx/yyy")
 
     def test_list_album_outputs_something(self):
         stdout = self.run_with_output("list", "-a")
@@ -55,9 +59,21 @@ class ListTest(IOMixin, BeetsTestCase):
 
     def test_list_item_format_multiple(self):
         stdout = self.run_with_output("list", "-f", "$artist - $album - $year")
-        assert "the artist - the album - 0001" == stdout.strip()
+        assert "the artist - the album - 0001" == stdout.strip().splitlines()[0]
 
     def test_list_album_format(self):
         stdout = self.run_with_output("list", "-a", "-f", "$genres")
         assert "the genre" in stdout
         assert "the album" not in stdout
+
+    def test_limit_query_results(self):
+        args = "list", "-p"
+
+        stdout = self.run_with_output(*args).strip()
+        assert len(stdout.splitlines()) == 2
+
+        stdout = self.run_with_output(*args, "-l", "1").strip()
+        assert len(stdout.splitlines()) == 1
+
+        with pytest.raises(UserError, match="must be a non-negative integer"):
+            self.run_with_output(*args, "-l", "-1")

--- a/test/ui/commands/test_list.py
+++ b/test/ui/commands/test_list.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from beets.exceptions import UserError
@@ -8,10 +10,14 @@ from beets.test.helper import BeetsTestCase, IOMixin
 class ListTest(IOMixin, BeetsTestCase):
     def setUp(self):
         super().setUp()
-        self.item = _common.item(path="xxx/yyy", flex=1)
+        self.item = _common.item(
+            path=os.fsencode(self.lib_path / "xxx/yyy"), flex=1
+        )
         self.lib.add(self.item)
         self.lib.add_album([self.item])
-        self.another_item = _common.item(path="another/path", flex=2)
+        self.another_item = _common.item(
+            path=os.fsencode(self.lib_path / "another/path"), flex=2
+        )
         self.lib.add(self.another_item)
 
     def test_list_outputs_item(self):
@@ -28,8 +34,8 @@ class ListTest(IOMixin, BeetsTestCase):
         assert "na\xefve" in out
 
     def test_list_item_path(self):
-        stdout = self.run_with_output("list", "-f", "$path")
-        assert stdout.strip().splitlines()[0] == str(self.lib_path / "xxx/yyy")
+        stdout = self.run_with_output("list", "flex:1", "-f", "$path")
+        assert stdout.strip() == str(self.lib_path / "xxx/yyy")
 
     def test_list_album_outputs_something(self):
         stdout = self.run_with_output("list", "-a")
@@ -58,8 +64,10 @@ class ListTest(IOMixin, BeetsTestCase):
         assert "the artist" in stdout
 
     def test_list_item_format_multiple(self):
-        stdout = self.run_with_output("list", "-f", "$artist - $album - $year")
-        assert "the artist - the album - 0001" == stdout.strip().splitlines()[0]
+        stdout = self.run_with_output(
+            "list", "flex:1", "-f", "$artist - $album - $year"
+        )
+        assert stdout.strip() == "the artist - the album - 0001"
 
     def test_list_album_format(self):
         stdout = self.run_with_output("list", "-a", "-f", "$genres")
@@ -77,3 +85,12 @@ class ListTest(IOMixin, BeetsTestCase):
 
         with pytest.raises(UserError, match="must be a non-negative integer"):
             self.run_with_output(*args, "-l", "-1")
+
+    def test_limit_sort_by_flex_attr(self):
+        args = "list", "-p", "-l", "1"
+
+        stdout = self.run_with_output(*args, "flex+").strip()
+        assert stdout == os.fsdecode(self.item.path)
+
+        stdout = self.run_with_output(*args, "flex-").strip()
+        assert stdout == os.fsdecode(self.another_item.path)


### PR DESCRIPTION
Closes #5076 
Supersedes #6690

#### What changed

- Added a built-in `-l` / `--limit` flag to the `list` command, so result limiting now lives in `beets` core instead of the `limit` plugin.
- Threaded `limit` support through the main query path: `beets.ui.commands.list` -> `Library.items()` / `Library.albums()` -> `dbcore._get_results()`.
- Updated query execution so limits are applied in the database when possible, and after in-memory sorting when sorting depends on flexible or computed fields.
- Refactored sort selection into model-level `field_sort()` logic, which also improves sorting for related database fields.
- Deprecated `LimitPlugin` and updated docs/changelog to point users to `beet ls -l <number>`.

#### Architecture impact

- This moves result limiting from optional plugin behavior into the main `list` command flow, making it a first-class CLI capability.
- The database layer now has clearer responsibility for deciding whether `LIMIT` can be pushed into SQL or must be applied after slow sorting.
- Sort handling is more centralized and model-aware, which reduces special-case logic in query parsing and improves support for related fields.

#### High-level outcome

- Users get a simpler and more discoverable way to limit `list` results.
- `list` now works correctly with `limit` even when sorting by flexible attributes or related fields.
- The old `limit` plugin is being phased out in favor of a smaller, more integrated command path.
- We can later add this flag to other commands such as `modify`, `write` and `update`.
