### PR TITLE
release: sync project version in `uv.lock`

### DIFF
--- a/.github/workflows/make_release.yaml
+++ b/.github/workflows/make_release.yaml
@@ -30,7 +30,10 @@ jobs:
         run: poe install --group release --group docs
 
       - name: Bump project version
-        run: poe bump "${{ env.NEW_VERSION }}"
+        run: |
+          poe bump "${{ env.NEW_VERSION }}"
+          # make sure project version is updated in the lock file as well
+          uv lock
 
       - uses: EndBug/add-and-commit@v9
         id: commit_and_tag

--- a/uv.lock
+++ b/uv.lock
@@ -321,7 +321,7 @@ wheels = [
 
 [[package]]
 name = "beets"
-version = "2.13.0"
+version = "2.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },


### PR DESCRIPTION
- Small release-pipeline change: after `poe bump`, the workflow now also runs `uv lock`. Grug see this as keeping version bump and lockfile sync in one release step, instead of splitting responsibility.

- High-level impact: release commits now update the editable project entry in `uv.lock` as well as the main project version. In this PR, `beets` moves from `2.13.0` to `2.13.1` inside `uv.lock`.

- Reviewer takeaway: no app runtime behavior change. This is release-process hardening to prevent version drift between the project metadata and `uv.lock`.
